### PR TITLE
Note calls to other functions that need the ref instead of a slice

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -680,6 +680,19 @@ pub fn multispan_sugg(db: &mut DiagnosticBuilder, help_msg: String, sugg: Vec<(S
     db.suggestions.push(sugg);
 }
 
+/// Returns the dereferenced expression (also walks single-expr-blocks)
+pub fn walk_ptrs_expr(expr: &hir::Expr) -> &hir::Expr {
+    match expr.node {
+        ExprAddrOf(_, ref e) => walk_ptrs_expr(e),
+        ExprBlock(ref block) => if block.stmts.is_empty() {
+                block.expr.as_ref().map_or(expr, |e| walk_ptrs_expr(e))
+            } else {
+                expr
+            },
+        _ => expr
+    }
+}
+
 /// Return the base type for HIR references and pointers.
 pub fn walk_ptrs_hir_ty(ty: &hir::Ty) -> &hir::Ty {
     match ty.node {

--- a/clippy_lints/src/utils/ptr.rs
+++ b/clippy_lints/src/utils/ptr.rs
@@ -4,19 +4,29 @@ use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::lint::LateContext;
 use syntax::ast::Name;
 use syntax::codemap::Span;
-use utils::{get_pat_name, match_var, snippet};
+use utils::{get_pat_name, is_adjusted, match_var, snippet, walk_ptrs_expr};
 
+/// a `Vec` of `Span`s
+pub type Spans = Vec<Span>;
+
+/// a `Vec` of `Span`s with replacements
+pub type SpansAndRepls = Vec<(Span, Cow<'static, str>)>;
+
+/// for each `.clone()`, etc. call, get the list of spans of method calls that
+/// need to be changed with suggestions and the list of spans of method calls
+/// whose methods need to be changed, too
 pub fn get_spans(
     cx: &LateContext,
     opt_body_id: Option<BodyId>,
     idx: usize,
     replacements: &'static [(&'static str, &'static str)],
-) -> Option<Vec<(Span, Cow<'static, str>)>> {
+) -> Option<(SpansAndRepls, Spans)> {
     if let Some(body) = opt_body_id.map(|id| cx.tcx.hir.body(id)) {
         get_binding_name(&body.arguments[idx])
-            .map_or_else(|| Some(vec![]), |name| extract_clone_suggestions(cx, name, replacements, body))
+            .map_or_else(|| Some((vec![], vec![])),
+                         |name| extract_clone_suggestions(cx, name, replacements, body))
     } else {
-        Some(vec![])
+        Some((vec![], vec![]))
     }
 }
 
@@ -25,19 +35,20 @@ fn extract_clone_suggestions<'a, 'tcx: 'a>(
     name: Name,
     replace: &'static [(&'static str, &'static str)],
     body: &'tcx Body,
-) -> Option<Vec<(Span, Cow<'static, str>)>> {
+) -> Option<(SpansAndRepls, Spans)> {
     let mut visitor = PtrCloneVisitor {
         cx,
         name,
         replace,
         spans: vec![],
+        ref_calls: vec![],
         abort: false,
     };
     visitor.visit_body(body);
     if visitor.abort {
         None
     } else {
-        Some(visitor.spans)
+        Some((visitor.spans, visitor.ref_calls))
     }
 }
 
@@ -46,7 +57,18 @@ struct PtrCloneVisitor<'a, 'tcx: 'a> {
     name: Name,
     replace: &'static [(&'static str, &'static str)],
     spans: Vec<(Span, Cow<'static, str>)>,
+    ref_calls: Vec<Span>,
     abort: bool,
+}
+
+fn check_args(v: &PtrCloneVisitor, args: &[Expr]) -> bool {
+    for arg in args {
+        let deref_arg = walk_ptrs_expr(arg);
+        if match_var(deref_arg, v.name) && !is_adjusted(v.cx, deref_arg) {
+            return true;
+        }
+    }
+    false
 }
 
 impl<'a, 'tcx: 'a> Visitor<'tcx> for PtrCloneVisitor<'a, 'tcx> {
@@ -54,21 +76,31 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for PtrCloneVisitor<'a, 'tcx> {
         if self.abort {
             return;
         }
-        if let ExprMethodCall(ref seg, _, ref args) = expr.node {
-            if args.len() == 1 && match_var(&args[0], self.name) {
-                if seg.name == "capacity" {
-                    self.abort = true;
-                    return;
-                }
-                for &(fn_name, suffix) in self.replace {
-                    if seg.name == fn_name {
-                        self.spans
-                            .push((expr.span, snippet(self.cx, args[0].span, "_") + suffix));
+        match expr.node {
+            ExprMethodCall(ref seg, _, ref args) => {
+                if args.len() == 1 && match_var(&args[0], self.name) {
+                    if seg.name == "capacity" {
+                        self.abort = true;
                         return;
                     }
+                    for &(fn_name, suffix) in self.replace {
+                        if seg.name == fn_name {
+                            self.spans
+                                .push((expr.span, snippet(self.cx, args[0].span, "_") + suffix));
+                            return;
+                        }
+                    }
+                    return;
+                } else if check_args(self, args) {
+                    self.ref_calls.push(expr.span);
                 }
             }
-            return;
+            ExprCall(_, ref args) => {
+                if check_args(self, args) {
+                    self.ref_calls.push(expr.span)
+                }
+            }
+            _ => ()
         }
         walk_expr(self, expr);
     }

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -56,6 +56,10 @@ fn str_cloned(x: &String) -> String {
     x.clone()
 }
 
+fn sub_function(x: &String) {
+    let _ = str_cloned(x);
+}
+
 fn false_positive_capacity(x: &Vec<u8>, y: &String) {
     let a = x.capacity();
     let b = y.clone();

--- a/tests/ui/ptr_arg.stderr
+++ b/tests/ui/ptr_arg.stderr
@@ -61,21 +61,33 @@ help: change `x.clone()` to
    |     ^^^^^^^^^^^^^
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do.
-  --> $DIR/ptr_arg.rs:59:44
+  --> $DIR/ptr_arg.rs:59:20
    |
-59 | fn false_positive_capacity(x: &Vec<u8>, y: &String) {
+59 | fn sub_function(x: &String) {
+   |                    ^^^^^^^ help: change this to: `&str`
+   |
+note: You will also need to change the function called here
+  --> $DIR/ptr_arg.rs:60:13
+   |
+60 |     let _ = str_cloned(x);
+   |             ^^^^^^^^^^^^^
+
+error: writing `&String` instead of `&str` involves a new object where a slice will do.
+  --> $DIR/ptr_arg.rs:63:44
+   |
+63 | fn false_positive_capacity(x: &Vec<u8>, y: &String) {
    |                                            ^^^^^^^
    |
 help: change this to
    |
-59 | fn false_positive_capacity(x: &Vec<u8>, y: &str) {
+63 | fn false_positive_capacity(x: &Vec<u8>, y: &str) {
    |                                            ^^^^
 help: change `y.clone()` to
    |
-61 |     let b = y.to_string();
+65 |     let b = y.to_string();
    |             ^^^^^^^^^^^^^
 help: change `y.as_str()` to
    |
-62 |     let c = y;
+66 |     let c = y;
    |             ^
 


### PR DESCRIPTION
This also applies to the needless_pass_by_value lint, though I haven't taken the time to figure out how to test it. Apart from that it will only note the calls/method calls, not the called functions/methods. Perhaps we should be able to avoid linting if the called functions are in external crates.

I'll leave both of those weaknesses to followup PRs.