### PR TITLE
Don't suggest cloned() for map Box deref

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -79,7 +79,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                         lint(cx, e.span, args[0].span, name, closure_expr);
                     },
                     hir::PatKind::Binding(hir::BindingAnnotation::Unannotated, _, name, None) => match closure_expr.node {
-                        hir::ExprKind::Unary(hir::UnOp::UnDeref, ref inner) => lint(cx, e.span, args[0].span, name, inner),
+                        hir::ExprKind::Unary(hir::UnOp::UnDeref, ref inner) if !cx.tables.expr_ty(inner).is_box() => lint(cx, e.span, args[0].span, name, inner),
                         hir::ExprKind::MethodCall(ref method, _, ref obj) => if method.ident.as_str() == "clone" && match_trait_method(cx, closure_expr, &paths::CLONE_TRAIT) {
                             lint(cx, e.span, args[0].span, name, &obj[0]);
                         }

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -16,4 +16,5 @@ fn main() {
     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
+    let _: Option<u64> = Some(Box::new(16)).map(|b| *b);
 }


### PR DESCRIPTION
Boxes are a bit magic in that they need to use `*` to get an owned value out of the box. They implement `Deref` but that only returns a reference. This means an easy way to convert an `Option<Box<T>>` to an `<Option<T>` is:

```
box_option.map(|b| *b)
```

However, since b36bb0a6 the `map_clone` lint is detecting this as an attempt to copy the box. Fix by excluding boxes completely from the deref part of this lint.

Fixes #3274