### PR TITLE
Don't flag if_not_else when else block is longer than then block

### DIFF
--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -61,8 +61,12 @@ impl EarlyLintPass for IfNotElse {
         if in_external_macro(cx.sess(), item.span) {
             return;
         }
-        if let ExprKind::If(ref cond, _, Some(ref els)) = item.node {
-            if let ExprKind::Block(..) = els.node {
+        if let ExprKind::If(ref cond, ref thn, Some(ref els)) = item.node {
+            if let ExprKind::Block(ref els_block, ..) = els.node {
+                if thn.stmts.len() < els_block.stmts.len() {
+                    return;
+                }
+
                 match cond.node {
                     ExprKind::Unary(UnOp::Not, _) => {
                         span_help_and_lint(

--- a/tests/ui/if_not_else.rs
+++ b/tests/ui/if_not_else.rs
@@ -26,4 +26,21 @@ fn main() {
     } else {
         println!("Bunny");
     }
+
+    // These won't get flagged because the body of the `else` block is
+    // longer than the body of the then-block.
+    if !bla() {
+        println!("Bugs");
+    } else {
+        println!("Bunny");
+        println!("Daffy");
+        println!("Duck");
+    }
+    if 4 != 5 {
+        println!("Bugs");
+    } else {
+        println!("Bunny");
+        println!("Daffy");
+        println!("Duck");
+    }
 }


### PR DESCRIPTION
Consider the following if/else block:

    if !failure_condition {
        proceed_as_normal();
    } else {
        handle_error();
        clean_up();
        notify();
        etc();
    }

Currently, clippy will flag this block with if_not_else and suggest
that it be rewritten as

    if failure_condition {
        handle_error();
        clean_up();
        notify();
        etc();
    } else {
        proceed_as_normal();
    }

But top-heavy blocks are hard to read, and the suggested rewrite is
worse than the original. So if_not_else should only be raised when the
else block is no longer than the then block.