### PR TITLE
WIP: Add lint for hex and binary literals that aren't grouped by bytes or nibbles

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -591,6 +591,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         literal_representation::LARGE_DIGIT_GROUPS,
         literal_representation::MISTYPED_LITERAL_SUFFIXES,
         literal_representation::UNREADABLE_LITERAL,
+        literal_representation::QUESTIONABLE_BYTE_GROUPING,
         loops::EMPTY_LOOP,
         loops::EXPLICIT_COUNTER_LOOP,
         loops::FOR_KV_MAP,


### PR DESCRIPTION
Still needs tests, documentation and general cleanup. An informal survey of existing rust code shows that hex literals are only ever grouped by byte, binary literals are only ever grouped by nibble and nobody seems to group octal literals at all.

Fixes #2538

I'd be happy to get suggestions for the lint name, this is mostly a placeholder because I cannot think of a good name right now.