### PR TITLE
Fix dogfood tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,18 +168,6 @@ Manually testing against an example file is useful if you have added some
 local modifications, run `env CLIPPY_TESTS=true cargo run --bin clippy-driver -- -L ./target/debug input.rs`
 from the working copy root.
 
-### Linting Clippy with your local changes
-
-Clippy CI only passes if all lints defined in the version of the Clippy being
-tested pass (that is, don’t report any suggestions). You can avoid prolonging
-the CI feedback cycle for PRs you submit by running these lints yourself ahead
-of time and addressing any issues found:
-
-```
-cargo build
-`pwd`/target/debug/cargo-clippy clippy --all-targets --all-features -- -D clippy::all -D clippy::internal -D clippy::pedantic
-```
-
 ### How Clippy works
 
 Clippy is a [rustc compiler plugin][compiler_plugin]. The main entry point is at [`src/lib.rs`][main_entry]. In there, the lint registration is delegated to the [`clippy_lints`][lint_crate] crate.

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -27,23 +27,3 @@ cd clippy_dev && cargo test && cd ..
 # Perform various checks for lint registration
 ./util/dev update_lints --check
 cargo +nightly fmt --all -- --check
-
-# Add bin to PATH for windows
-PATH=$PATH:$(rustc --print sysroot)/bin
-
-CLIPPY="`pwd`/target/debug/cargo-clippy clippy"
-# run clippy on its own codebase...
-${CLIPPY} --all-targets --all-features -- -D clippy::all -D clippy::internal -Dclippy::pedantic
-# ... and some test directories
-for dir in clippy_workspace_tests clippy_workspace_tests/src clippy_workspace_tests/subcrate clippy_workspace_tests/subcrate/src clippy_dev rustc_tools_util
-do
-    cd ${dir}
-    ${CLIPPY} -- -D clippy::all -D clippy::pedantic
-    cd -
-done
-
-
-# test --manifest-path
-${CLIPPY} --manifest-path=clippy_workspace_tests/Cargo.toml -- -D clippy::all
-cd clippy_workspace_tests/subcrate && ${CLIPPY} --manifest-path=../Cargo.toml -- -D clippy::all && cd ../..
-set +x

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -18,10 +18,14 @@ fn dogfood() {
         return;
     }
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let clippy_cmd = std::path::Path::new(&root_dir).join("target/debug/cargo-clippy");
+    let clippy_cmd = std::path::Path::new(&root_dir)
+        .join("target")
+        .join(env!("PROFILE"))
+        .join("cargo-clippy");
 
     std::env::set_current_dir(root_dir).unwrap();
     let output = std::process::Command::new(clippy_cmd)
+        .env("CLIPPY_DOGFOOD", "1")
         .arg("clippy")
         .arg("--all-targets")
         .arg("--all-features")
@@ -43,6 +47,10 @@ fn dogfood_tests() {
         return;
     }
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let clippy_cmd = std::path::Path::new(&root_dir)
+        .join("target")
+        .join(env!("PROFILE"))
+        .join("cargo-clippy");
 
     for d in &[
         "clippy_workspace_tests",
@@ -52,10 +60,9 @@ fn dogfood_tests() {
         "clippy_dev",
         "rustc_tools_util",
     ] {
-        let clippy_cmd = std::path::Path::new(&root_dir)
-            .join("target/debug/cargo-clippy");
         std::env::set_current_dir(root_dir.join(d)).unwrap();
-        let output = std::process::Command::new(clippy_cmd)
+        let output = std::process::Command::new(&clippy_cmd)
+            .env("CLIPPY_DOGFOOD", "1")
             .arg("clippy")
             .arg("--")
             .args(&["-D", "clippy::all"])

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -12,18 +12,50 @@ fn dogfood() {
     if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
         return;
     }
-    let root_dir = std::env::current_dir().unwrap();
-    for d in &[".", "clippy_lints", "rustc_tools_util", "clippy_dev"] {
+    let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let clippy_cmd = std::path::Path::new(&root_dir).join("target/debug/cargo-clippy");
+
+    println!("{:?}", clippy_cmd);
+    let output = std::process::Command::new(clippy_cmd)
+        .arg("clippy")
+        .arg("--all-targets")
+        .arg("--all-features")
+        .arg("--")
+        .args(&["-D", "clippy::all"])
+        .args(&["-D", "clippy::internal"])
+        .args(&["-D", "clippy::pedantic"])
+        .output()
+        .unwrap();
+    println!("status: {}", output.status);
+    println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success());
+}
+
+#[test]
+fn dogfood_tests() {
+    if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
+        return;
+    }
+    let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    for d in &[
+        "clippy_workspace_tests",
+        "clippy_workspace_tests/src",
+        "clippy_workspace_tests/subcrate",
+        "clippy_workspace_tests/subcrate/src",
+        "clippy_dev",
+        "rustc_tools_util",
+    ] {
+        let clippy_cmd = std::path::Path::new(&root_dir)
+            .join("target/debug/cargo-clippy");
         std::env::set_current_dir(root_dir.join(d)).unwrap();
-        let output = std::process::Command::new("cargo")
-            .arg("run")
-            .arg("--bin")
-            .arg("cargo-clippy")
-            .arg("--all-features")
-            .arg("--manifest-path")
-            .arg(root_dir.join("Cargo.toml"))
-            .args(&["--", "-W clippy::internal -W clippy::pedantic"])
-            .env("CLIPPY_DOGFOOD", "true")
+        let output = std::process::Command::new(clippy_cmd)
+            .arg("clippy")
+            .arg("--")
+            .args(&["-D", "clippy::all"])
+            .args(&["-D", "clippy::pedantic"])
             .output()
             .unwrap();
         println!("status: {}", output.status);
@@ -32,4 +64,5 @@ fn dogfood() {
 
         assert!(output.status.success());
     }
+    std::env::set_current_dir(root_dir).unwrap();
 }

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -8,6 +8,11 @@
 // except according to those terms.
 
 #[test]
+fn dogfood_runner() {
+    dogfood();
+    dogfood_tests();
+}
+
 fn dogfood() {
     if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
         return;
@@ -15,7 +20,7 @@ fn dogfood() {
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let clippy_cmd = std::path::Path::new(&root_dir).join("target/debug/cargo-clippy");
 
-    println!("{:?}", clippy_cmd);
+    std::env::set_current_dir(root_dir).unwrap();
     let output = std::process::Command::new(clippy_cmd)
         .arg("clippy")
         .arg("--all-targets")
@@ -33,7 +38,6 @@ fn dogfood() {
     assert!(output.status.success());
 }
 
-#[test]
 fn dogfood_tests() {
     if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
         return;
@@ -64,5 +68,4 @@ fn dogfood_tests() {
 
         assert!(output.status.success());
     }
-    std::env::set_current_dir(root_dir).unwrap();
 }

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -8,11 +8,6 @@
 // except according to those terms.
 
 #[test]
-fn dogfood_runner() {
-    dogfood();
-    dogfood_tests();
-}
-
 fn dogfood() {
     if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
         return;
@@ -23,8 +18,8 @@ fn dogfood() {
         .join(env!("PROFILE"))
         .join("cargo-clippy");
 
-    std::env::set_current_dir(root_dir).unwrap();
     let output = std::process::Command::new(clippy_cmd)
+        .current_dir(root_dir)
         .env("CLIPPY_DOGFOOD", "1")
         .arg("clippy")
         .arg("--all-targets")
@@ -42,6 +37,7 @@ fn dogfood() {
     assert!(output.status.success());
 }
 
+#[test]
 fn dogfood_tests() {
     if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
         return;
@@ -60,8 +56,8 @@ fn dogfood_tests() {
         "clippy_dev",
         "rustc_tools_util",
     ] {
-        std::env::set_current_dir(root_dir.join(d)).unwrap();
         let output = std::process::Command::new(&clippy_cmd)
+            .current_dir(root_dir.join(d))
             .env("CLIPPY_DOGFOOD", "1")
             .arg("clippy")
             .arg("--")


### PR DESCRIPTION
@mati865 @flip1995 following up on the discussion in #3443.

I'm currently having trouble getting the dogfood test to fail consistently when there is a known lint failure in the clippy_lints subdirectory. The problem seems to be that if the `dogfood` test case is run before the `dogfood_tests` test case, the former will always pass whereas it fails correctly if it is second.