### PR TITLE
Travis: Remove `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ os:
   - osx
   - windows
 
-sudo: false
-
 branches:
   # Don't build these branches
   except:


### PR DESCRIPTION
`sudo: false` won't be available anymore from Dec. 7th.

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration