### PR TITLE
Add Applicability to suggestion lints: Take 2

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -532,6 +532,7 @@ impl EarlyLintPass for CfgAttrPass {
                     "`cfg_attr` is deprecated for rustfmt and got replaced by tool_attributes",
                     "use",
                     format!("{}rustfmt::skip]", attr_style),
+                    Applicability::Unspecified,
                 );
             }
         }

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -532,7 +532,7 @@ impl EarlyLintPass for CfgAttrPass {
                     "`cfg_attr` is deprecated for rustfmt and got replaced by tool_attributes",
                     "use",
                     format!("{}rustfmt::skip]", attr_style),
-                    Applicability::Unspecified,
+                    Applicability::MachineApplicable,
                 );
             }
         }

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -10,12 +10,14 @@
 
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
 use crate::rustc::ty;
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::{Name, UintTy};
-use crate::utils::{contains_name, get_pat_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg,
-            walk_ptrs_ty};
+use crate::utils::{
+    contains_name, get_pat_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg, walk_ptrs_ty,
+};
+use if_chain::if_chain;
 
 /// **What it does:** Checks for naive byte counts
 ///
@@ -89,14 +91,17 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
                         } else {
                             &filter_args[0]
                         };
-                        span_lint_and_sugg(cx,
-                                           NAIVE_BYTECOUNT,
-                                           expr.span,
-                                           "You appear to be counting bytes the naive way",
-                                           "Consider using the bytecount crate",
-                                           format!("bytecount::count({}, {})",
-                                                    snippet(cx, haystack.span, ".."),
-                                                    snippet(cx, needle.span, "..")));
+                        span_lint_and_sugg(
+                            cx,
+                            NAIVE_BYTECOUNT,
+                            expr.span,
+                            "You appear to be counting bytes the naive way",
+                            "Consider using the bytecount crate",
+                            format!("bytecount::count({}, {})",
+                                    snippet(cx, haystack.span, ".."),
+                                    snippet(cx, needle.span, "..")),
+                            Applicability::Unspecified,
+                        );
                     }
                 };
             }

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -102,7 +102,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
                             format!("bytecount::count({}, {})",
                                     snippet_with_applicability(cx, haystack.span, "..", &mut applicability),
                                     snippet_with_applicability(cx, needle.span, "..", &mut applicability)),
-                            Applicability::Unspecified,
+                            applicability,
                         );
                     }
                 };

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -15,7 +15,8 @@ use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::ast::{Name, UintTy};
 use crate::utils::{
-    contains_name, get_pat_name, match_type, paths, single_segment_path, snippet, span_lint_and_sugg, walk_ptrs_ty,
+    contains_name, get_pat_name, match_type, paths, single_segment_path, snippet_with_applicability,
+    span_lint_and_sugg, walk_ptrs_ty,
 };
 use if_chain::if_chain;
 
@@ -91,6 +92,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
                         } else {
                             &filter_args[0]
                         };
+                        let mut applicability = Applicability::MachineApplicable;
                         span_lint_and_sugg(
                             cx,
                             NAIVE_BYTECOUNT,
@@ -98,8 +100,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
                             "You appear to be counting bytes the naive way",
                             "Consider using the bytecount crate",
                             format!("bytecount::count({}, {})",
-                                    snippet(cx, haystack.span, ".."),
-                                    snippet(cx, needle.span, "..")),
+                                    snippet_with_applicability(cx, haystack.span, "..", &mut applicability),
+                                    snippet_with_applicability(cx, needle.span, "..", &mut applicability)),
                             Applicability::Unspecified,
                         );
                     }

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -27,7 +27,7 @@ use crate::rustc::{declare_tool_lint, lint_array};
 use if_chain::if_chain;
 use crate::syntax::ast;
 
-use crate::utils::{in_macro, snippet_block, span_lint_and_sugg, span_lint_and_then};
+use crate::utils::{in_macro, snippet_block, snippet_block_with_applicability, span_lint_and_sugg, span_lint_and_then};
 use crate::utils::sugg::Sugg;
 use crate::rustc_errors::Applicability;
 
@@ -128,14 +128,15 @@ fn check_collapsible_maybe_if_let(cx: &EarlyContext<'_>, else_: &ast::Expr) {
         then {
             match else_.node {
                 ast::ExprKind::If(..) | ast::ExprKind::IfLet(..) => {
+                    let mut applicability = Applicability::MachineApplicable;
                     span_lint_and_sugg(
                         cx,
                         COLLAPSIBLE_IF,
                         block.span,
                         "this `else { if .. }` block can be collapsed",
                         "try",
-                        snippet_block(cx, else_.span, "..").into_owned(),
-                        Applicability::Unspecified,
+                        snippet_block_with_applicability(cx, else_.span, "..", &mut applicability).into_owned(),
+                        applicability,
                     );
                 }
                 _ => (),

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -128,12 +128,15 @@ fn check_collapsible_maybe_if_let(cx: &EarlyContext<'_>, else_: &ast::Expr) {
         then {
             match else_.node {
                 ast::ExprKind::If(..) | ast::ExprKind::IfLet(..) => {
-                    span_lint_and_sugg(cx,
-                                       COLLAPSIBLE_IF,
-                                       block.span,
-                                       "this `else { if .. }` block can be collapsed",
-                                       "try",
-                                       snippet_block(cx, else_.span, "..").into_owned());
+                    span_lint_and_sugg(
+                        cx,
+                        COLLAPSIBLE_IF,
+                        block.span,
+                        "this `else { if .. }` block can be collapsed",
+                        "try",
+                        snippet_block(cx, else_.span, "..").into_owned(),
+                        Applicability::Unspecified,
+                    );
                 }
                 _ => (),
             }

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -10,9 +10,10 @@
 
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
 use crate::rustc::ty::TyKind;
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
+use if_chain::if_chain;
 
 use crate::utils::{any_parent_is_automatically_derived, match_def_path, opt_def_id, paths, span_lint_and_sugg};
 
@@ -80,7 +81,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DefaultTraitAccess {
                                 expr.span,
                                 &format!("Calling {} is more clear than this expression", replacement),
                                 "try",
-                                replacement);
+                                replacement,
+                                Applicability::Unspecified,
+                            );
                          }
                     },
                     QPath::TypeRelative(..) => {},

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -82,7 +82,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DefaultTraitAccess {
                                 &format!("Calling {} is more clear than this expression", replacement),
                                 "try",
                                 replacement,
-                                Applicability::Unspecified,
+                                Applicability::Unspecified, // First resolve the TODO above
                             );
                          }
                     },

--- a/clippy_lints/src/double_comparison.rs
+++ b/clippy_lints/src/double_comparison.rs
@@ -13,6 +13,7 @@
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::source_map::Span;
 
 use crate::utils::{snippet, span_lint_and_sugg, SpanlessEq};
@@ -73,9 +74,15 @@ impl<'a, 'tcx> Pass {
                 let lhs_str = snippet(cx, llhs.span, "");
                 let rhs_str = snippet(cx, lrhs.span, "");
                 let sugg = format!("{} {} {}", lhs_str, stringify!($op), rhs_str);
-                span_lint_and_sugg(cx, DOUBLE_COMPARISONS, span,
-                                   "This binary expression can be simplified",
-                                   "try", sugg);
+                span_lint_and_sugg(
+                    cx,
+                    DOUBLE_COMPARISONS,
+                    span,
+                    "This binary expression can be simplified",
+                    "try",
+                    sugg,
+                    Applicability::Unspecified,
+                );
             }}
         }
         match (op, lkind, rkind) {

--- a/clippy_lints/src/double_comparison.rs
+++ b/clippy_lints/src/double_comparison.rs
@@ -16,7 +16,7 @@ use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::source_map::Span;
 
-use crate::utils::{snippet, span_lint_and_sugg, SpanlessEq};
+use crate::utils::{snippet_with_applicability, span_lint_and_sugg, SpanlessEq};
 
 /// **What it does:** Checks for double comparions that could be simpified to a single expression.
 ///
@@ -71,8 +71,9 @@ impl<'a, 'tcx> Pass {
         }
         macro_rules! lint_double_comparison {
             ($op:tt) => {{
-                let lhs_str = snippet(cx, llhs.span, "");
-                let rhs_str = snippet(cx, lrhs.span, "");
+                let mut applicability = Applicability::MachineApplicable;
+                let lhs_str = snippet_with_applicability(cx, llhs.span, "", &mut applicability);
+                let rhs_str = snippet_with_applicability(cx, lrhs.span, "", &mut applicability);
                 let sugg = format!("{} {} {}", lhs_str, stringify!($op), rhs_str);
                 span_lint_and_sugg(
                     cx,
@@ -81,7 +82,7 @@ impl<'a, 'tcx> Pass {
                     "This binary expression can be simplified",
                     "try",
                     sugg,
-                    Applicability::Unspecified,
+                    applicability,
                 );
             }}
         }

--- a/clippy_lints/src/duration_subsec.rs
+++ b/clippy_lints/src/duration_subsec.rs
@@ -17,7 +17,7 @@ use if_chain::if_chain;
 
 use crate::consts::{constant, Constant};
 use crate::utils::paths;
-use crate::utils::{match_type, snippet, span_lint_and_sugg, walk_ptrs_ty};
+use crate::utils::{match_type, snippet_with_applicability, span_lint_and_sugg, walk_ptrs_ty};
 
 /// **What it does:** Checks for calculation of subsecond microseconds or milliseconds
 /// from other `Duration` methods.
@@ -61,14 +61,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DurationSubsec {
                     ("subsec_nanos", 1_000) => "subsec_micros",
                     _ => return,
                 };
+                let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(
                     cx,
                     DURATION_SUBSEC,
                     expr.span,
                     &format!("Calling `{}()` is more concise than this calculation", suggested_fn),
                     "try",
-                    format!("{}.{}()", snippet(cx, args[0].span, "_"), suggested_fn),
-                    Applicability::Unspecified,
+                    format!("{}.{}()", snippet_with_applicability(cx, args[0].span, "_", &mut applicability), suggested_fn),
+                    applicability,
                 );
             }
         }

--- a/clippy_lints/src/duration_subsec.rs
+++ b/clippy_lints/src/duration_subsec.rs
@@ -11,8 +11,9 @@
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
+use crate::rustc_errors::Applicability;
 use crate::syntax::source_map::Spanned;
+use if_chain::if_chain;
 
 use crate::consts::{constant, Constant};
 use crate::utils::paths;
@@ -67,6 +68,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DurationSubsec {
                     &format!("Calling `{}()` is more concise than this calculation", suggested_fn),
                     "try",
                     format!("{}.{}()", snippet(cx, args[0].span, "_"), suggested_fn),
+                    Applicability::Unspecified,
                 );
             }
         }

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -12,6 +12,7 @@
 
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass, in_external_macro, LintContext};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 
 use crate::utils::span_lint_and_sugg;
@@ -72,7 +73,8 @@ impl EarlyLintPass for ElseIfWithoutElse {
                     els.span,
                     "if expression with an `else if`, but without a final `else`",
                     "add an `else` block here",
-                    String::new()
+                    String::new(),
+                    Applicability::Unspecified,
                 );
             }
 

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -12,10 +12,9 @@
 
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass, in_external_macro, LintContext};
 use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 
-use crate::utils::span_lint_and_sugg;
+use crate::utils::span_help_and_lint;
 
 /// **What it does:** Checks for usage of if expressions with an `else if` branch,
 /// but without a final `else` branch.
@@ -67,14 +66,12 @@ impl EarlyLintPass for ElseIfWithoutElse {
 
         while let ExprKind::If(_, _, Some(ref els)) = item.node {
             if let ExprKind::If(_, _, None) = els.node {
-                span_lint_and_sugg(
+                span_help_and_lint(
                     cx,
                     ELSE_IF_WITHOUT_ELSE,
                     els.span,
                     "if expression with an `else if`, but without a final `else`",
                     "add an `else` block here",
-                    String::new(),
-                    Applicability::Unspecified,
                 );
             }
 

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -69,7 +69,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExcessivePrecision {
                     "float has excessive precision",
                     "consider changing the type or truncating it to",
                     sugg,
-                    Applicability::Unspecified,
+                    Applicability::MachineApplicable,
                 );
             }
         }

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -10,15 +10,16 @@
 
 use crate::rustc::hir;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
 use crate::rustc::ty::TyKind;
-use std::f32;
-use std::f64;
-use std::fmt;
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 use crate::syntax_pos::symbol::Symbol;
 use crate::utils::span_lint_and_sugg;
+use if_chain::if_chain;
+use std::f32;
+use std::f64;
+use std::fmt;
 
 /// **What it does:** Checks for float literals with a precision greater
 /// than that supported by the underlying type
@@ -68,6 +69,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExcessivePrecision {
                     "float has excessive precision",
                     "consider changing the type or truncating it to",
                     sugg,
+                    Applicability::Unspecified,
                 );
             }
         }

--- a/clippy_lints/src/infallible_destructuring_match.rs
+++ b/clippy_lints/src/infallible_destructuring_match.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 
-use super::utils::{get_arg_name, match_var, remove_blocks, snippet, span_lint_and_sugg};
+use super::utils::{get_arg_name, match_var, remove_blocks, snippet_with_applicability, span_lint_and_sugg};
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
@@ -72,6 +72,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if match_var(body, arg);
 
             then {
+                let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(
                     cx,
                     INFALLIBLE_DESTRUCTURING_MATCH,
@@ -81,11 +82,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                     "try this",
                     format!(
                         "let {}({}) = {};",
-                        snippet(cx, variant_name.span, ".."),
-                        snippet(cx, local.pat.span, ".."),
-                        snippet(cx, target.span, ".."),
+                        snippet_with_applicability(cx, variant_name.span, "..", &mut applicability),
+                        snippet_with_applicability(cx, local.pat.span, "..", &mut applicability),
+                        snippet_with_applicability(cx, target.span, "..", &mut applicability),
                     ),
-                    Applicability::Unspecified,
+                    applicability,
                 );
             }
         }

--- a/clippy_lints/src/infallible_destructuring_match.rs
+++ b/clippy_lints/src/infallible_destructuring_match.rs
@@ -12,6 +12,7 @@ use super::utils::{get_arg_name, match_var, remove_blocks, snippet, span_lint_an
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use if_chain::if_chain;
 
 /// **What it does:** Checks for matches being used to destructure a single-variant enum
@@ -84,6 +85,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                         snippet(cx, local.pat.span, ".."),
                         snippet(cx, target.span, ".."),
                     ),
+                    Applicability::Unspecified,
                 );
             }
         }

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -11,9 +11,10 @@
 use crate::rustc::hir::def_id::DefId;
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc::ty;
+use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_data_structures::fx::FxHashSet;
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::{Lit, LitKind, Name};
 use crate::syntax::source_map::{Span, Spanned};
 use crate::utils::{get_item_name, in_macro, snippet, span_lint, span_lint_and_sugg, walk_ptrs_ty};
@@ -242,6 +243,7 @@ fn check_len(cx: &LateContext<'_, '_>, span: Span, method_name: Name, args: &[Ex
                 &format!("length comparison to {}", if compare_to == 0 { "zero" } else { "one" }),
                 "using `is_empty` is clearer and more explicit",
                 format!("{}{}.is_empty()", op, snippet(cx, args[0].span, "_")),
+                Applicability::Unspecified,
             );
         }
     }

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -17,7 +17,7 @@ use crate::rustc_data_structures::fx::FxHashSet;
 use crate::rustc_errors::Applicability;
 use crate::syntax::ast::{Lit, LitKind, Name};
 use crate::syntax::source_map::{Span, Spanned};
-use crate::utils::{get_item_name, in_macro, snippet, span_lint, span_lint_and_sugg, walk_ptrs_ty};
+use crate::utils::{get_item_name, in_macro, snippet_with_applicability, span_lint, span_lint_and_sugg, walk_ptrs_ty};
 
 /// **What it does:** Checks for getting the length of something via `.len()`
 /// just to compare to zero, and suggests using `.is_empty()` where applicable.
@@ -224,7 +224,15 @@ fn check_cmp(cx: &LateContext<'_, '_>, span: Span, method: &Expr, lit: &Expr, op
     }
 }
 
-fn check_len(cx: &LateContext<'_, '_>, span: Span, method_name: Name, args: &[Expr], lit: &Lit, op: &str, compare_to: u32) {
+fn check_len(
+    cx: &LateContext<'_, '_>,
+    span: Span,
+    method_name: Name,
+    args: &[Expr],
+    lit: &Lit,
+    op: &str,
+    compare_to: u32,
+) {
     if let Spanned {
         node: LitKind::Int(lit, _),
         ..
@@ -236,14 +244,15 @@ fn check_len(cx: &LateContext<'_, '_>, span: Span, method_name: Name, args: &[Ex
         }
 
         if method_name == "len" && args.len() == 1 && has_is_empty(cx, &args[0]) {
+            let mut applicability = Applicability::MachineApplicable;
             span_lint_and_sugg(
                 cx,
                 LEN_ZERO,
                 span,
                 &format!("length comparison to {}", if compare_to == 0 { "zero" } else { "one" }),
                 "using `is_empty` is clearer and more explicit",
-                format!("{}{}.is_empty()", op, snippet(cx, args[0].span, "_")),
-                Applicability::Unspecified,
+                format!("{}{}.is_empty()", op, snippet_with_applicability(cx, args[0].span, "_", &mut applicability)),
+                applicability,
             );
         }
     }

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -12,6 +12,7 @@
 
 use crate::rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 use crate::syntax_pos;
 use crate::utils::{snippet_opt, span_lint_and_sugg};
@@ -300,6 +301,7 @@ impl WarningType {
                 "mistyped literal suffix",
                 "did you mean to write",
                 grouping_hint.to_string(),
+                Applicability::Unspecified,
             ),
             WarningType::UnreadableLiteral => span_lint_and_sugg(
                 cx,
@@ -308,6 +310,7 @@ impl WarningType {
                 "long literal lacking separators",
                 "consider",
                 grouping_hint.to_owned(),
+                Applicability::Unspecified,
             ),
             WarningType::LargeDigitGroups => span_lint_and_sugg(
                 cx,
@@ -316,6 +319,7 @@ impl WarningType {
                 "digit groups should be smaller",
                 "consider",
                 grouping_hint.to_owned(),
+                Applicability::Unspecified,
             ),
             WarningType::InconsistentDigitGrouping => span_lint_and_sugg(
                 cx,
@@ -324,6 +328,7 @@ impl WarningType {
                 "digits grouped inconsistently by underscores",
                 "consider",
                 grouping_hint.to_owned(),
+                Applicability::Unspecified,
             ),
             WarningType::DecimalRepresentation => span_lint_and_sugg(
                 cx,
@@ -332,6 +337,7 @@ impl WarningType {
                 "integer literal has a better hexadecimal representation",
                 "consider",
                 grouping_hint.to_owned(),
+                Applicability::Unspecified,
             ),
         };
     }

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -301,7 +301,7 @@ impl WarningType {
                 "mistyped literal suffix",
                 "did you mean to write",
                 grouping_hint.to_string(),
-                Applicability::Unspecified,
+                Applicability::MachineApplicable,
             ),
             WarningType::UnreadableLiteral => span_lint_and_sugg(
                 cx,
@@ -310,7 +310,7 @@ impl WarningType {
                 "long literal lacking separators",
                 "consider",
                 grouping_hint.to_owned(),
-                Applicability::Unspecified,
+                Applicability::MachineApplicable,
             ),
             WarningType::LargeDigitGroups => span_lint_and_sugg(
                 cx,
@@ -319,7 +319,7 @@ impl WarningType {
                 "digit groups should be smaller",
                 "consider",
                 grouping_hint.to_owned(),
-                Applicability::Unspecified,
+                Applicability::MachineApplicable,
             ),
             WarningType::InconsistentDigitGrouping => span_lint_and_sugg(
                 cx,
@@ -328,7 +328,7 @@ impl WarningType {
                 "digits grouped inconsistently by underscores",
                 "consider",
                 grouping_hint.to_owned(),
-                Applicability::Unspecified,
+                Applicability::MachineApplicable,
             ),
             WarningType::DecimalRepresentation => span_lint_and_sugg(
                 cx,
@@ -337,7 +337,7 @@ impl WarningType {
                 "integer literal has a better hexadecimal representation",
                 "consider",
                 grouping_hint.to_owned(),
-                Applicability::Unspecified,
+                Applicability::MachineApplicable,
             ),
         };
     }

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -301,7 +301,7 @@ impl WarningType {
                 "mistyped literal suffix",
                 "did you mean to write",
                 grouping_hint.to_string(),
-                Applicability::MachineApplicable,
+                Applicability::MaybeIncorrect,
             ),
             WarningType::UnreadableLiteral => span_lint_and_sugg(
                 cx,

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -512,6 +512,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                                         snippet(cx, arms[0].pats[0].span, ".."),
                                         snippet(cx, matchexpr.span, "..")
                                     ),
+                                    Applicability::Unspecified,
                                 );
                             }
                         },
@@ -549,6 +550,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                         "this loop could be written as a `for` loop",
                         "try",
                         format!("for {} in {} {{ .. }}", loop_var, iterator),
+                        Applicability::Unspecified,
                     );
                 }
             }
@@ -1027,6 +1029,7 @@ fn detect_manual_memcpy<'a, 'tcx>(
                     "it looks like you're manually copying between slices",
                     "try replacing the loop by",
                     big_sugg,
+                    Applicability::Unspecified,
                 );
             }
         }
@@ -1316,6 +1319,7 @@ fn lint_iter_method(cx: &LateContext<'_, '_>, args: &[Expr], arg: &Expr, method_
          iteration methods",
         "to write this more concisely, try",
         format!("&{}{}", muta, object),
+        Applicability::Unspecified,
     )
 }
 
@@ -1354,6 +1358,7 @@ fn check_for_loop_arg(cx: &LateContext<'_, '_>, pat: &Pat, arg: &Expr, expr: &Ex
                          iteration methods`",
                         "to write this more concisely, try",
                         object.to_string(),
+                        Applicability::Unspecified,
                     );
                 }
             } else if method_name == "next" && match_trait_method(cx, arg, &paths::ITERATOR) {

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -11,15 +11,12 @@
 use crate::rustc::hir;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
+use crate::syntax::ast::Ident;
 use crate::syntax::source_map::Span;
 use crate::utils::paths;
-use crate::utils::{
-    in_macro, match_trait_method, match_type,
-    remove_blocks, snippet,
-    span_lint_and_sugg,
-};
+use crate::utils::{in_macro, match_trait_method, match_type, remove_blocks, snippet, span_lint_and_sugg};
 use if_chain::if_chain;
-use crate::syntax::ast::Ident;
 
 #[derive(Clone)]
 pub struct Pass;
@@ -102,6 +99,7 @@ fn lint(cx: &LateContext<'_, '_>, replace: Span, root: Span, name: Ident, path: 
                 "You are using an explicit closure for cloning elements",
                 "Consider calling the dedicated `cloned` method",
                 format!("{}.cloned()", snippet(cx, root, "..")),
+                Applicability::Unspecified,
             )
         }
     }

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -15,7 +15,7 @@ use crate::rustc_errors::Applicability;
 use crate::syntax::ast::Ident;
 use crate::syntax::source_map::Span;
 use crate::utils::paths;
-use crate::utils::{in_macro, match_trait_method, match_type, remove_blocks, snippet, span_lint_and_sugg};
+use crate::utils::{in_macro, match_trait_method, match_type, remove_blocks, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
 
 #[derive(Clone)]
@@ -92,14 +92,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 fn lint(cx: &LateContext<'_, '_>, replace: Span, root: Span, name: Ident, path: &hir::Expr) {
     if let hir::ExprKind::Path(hir::QPath::Resolved(None, ref path)) = path.node {
         if path.segments.len() == 1 && path.segments[0].ident == name {
+            let mut applicability = Applicability::MachineApplicable;
             span_lint_and_sugg(
                 cx,
                 MAP_CLONE,
                 replace,
                 "You are using an explicit closure for cloning elements",
                 "Consider calling the dedicated `cloned` method",
-                format!("{}.cloned()", snippet(cx, root, "..")),
-                Applicability::Unspecified,
+                format!("{}.cloned()", snippet_with_applicability(cx, root, "..", &mut applicability)),
+                applicability,
             )
         }
     }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -268,8 +268,9 @@ fn report_single_match_single_pattern(cx: &LateContext<'_, '_>, ex: &Expr, arms:
             snippet(cx, arms[0].pats[0].span, ".."),
             snippet(cx, ex.span, ".."),
             expr_block(cx, &arms[0].body, None, ".."),
-            els_str
+            els_str,
         ),
+        Applicability::Unspecified,
     );
 }
 
@@ -483,7 +484,8 @@ fn check_match_as_ref(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &
                 expr.span,
                 &format!("use {}() instead", suggestion),
                 "try this",
-                format!("{}.{}()", snippet(cx, ex.span, "_"), suggestion)
+                format!("{}.{}()", snippet(cx, ex.span, "_"), suggestion),
+                Applicability::Unspecified,
             )
         }
     }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -19,7 +19,7 @@ use crate::syntax::ast::LitKind;
 use crate::syntax::source_map::Span;
 use crate::utils::paths;
 use crate::utils::{expr_block, in_macro, is_allowed, is_expn_of, match_qpath, match_type,
-    multispan_sugg, remove_blocks, snippet, span_lint_and_sugg, span_lint_and_then,
+    multispan_sugg, remove_blocks, snippet, snippet_with_applicability, span_lint_and_sugg, span_lint_and_then,
     span_note_and_lint, walk_ptrs_ty};
 use crate::utils::sugg::Sugg;
 use crate::consts::{constant, Constant};
@@ -270,7 +270,7 @@ fn report_single_match_single_pattern(cx: &LateContext<'_, '_>, ex: &Expr, arms:
             expr_block(cx, &arms[0].body, None, ".."),
             els_str,
         ),
-        Applicability::Unspecified,
+        Applicability::HasPlaceholders,
     );
 }
 
@@ -478,14 +478,15 @@ fn check_match_as_ref(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &
         };
         if let Some(rb) = arm_ref {
             let suggestion = if rb == BindingAnnotation::Ref { "as_ref" } else { "as_mut" };
+            let mut applicability = Applicability::MachineApplicable;
             span_lint_and_sugg(
                 cx,
                 MATCH_AS_REF,
                 expr.span,
                 &format!("use {}() instead", suggestion),
                 "try this",
-                format!("{}.{}()", snippet(cx, ex.span, "_"), suggestion),
-                Applicability::Unspecified,
+                format!("{}.{}()", snippet_with_applicability(cx, ex.span, "_", &mut applicability), suggestion),
+                applicability,
             )
         }
     }

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -12,7 +12,7 @@ use crate::rustc::hir::{Expr, ExprKind, MutMutable, QPath};
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
-use crate::utils::{match_def_path, match_qpath, opt_def_id, paths, snippet, span_lint_and_sugg};
+use crate::utils::{match_def_path, match_qpath, opt_def_id, paths, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
 
 /// **What it does:** Checks for `mem::replace()` on an `Option` with
@@ -80,14 +80,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemReplace {
                     _ => return,
                 };
 
+                let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(
                     cx,
                     MEM_REPLACE_OPTION_WITH_NONE,
                     expr.span,
                     "replacing an `Option` with `None`",
                     "consider `Option::take()` instead",
-                    format!("{}.take()", snippet(cx, replaced_path.span, "")),
-                    Applicability::Unspecified,
+                    format!("{}.take()", snippet_with_applicability(cx, replaced_path.span, "", &mut applicability)),
+                    applicability,
                 );
             }
         }

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -11,6 +11,7 @@
 use crate::rustc::hir::{Expr, ExprKind, MutMutable, QPath};
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::utils::{match_def_path, match_qpath, opt_def_id, paths, snippet, span_lint_and_sugg};
 use if_chain::if_chain;
 
@@ -85,7 +86,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemReplace {
                     expr.span,
                     "replacing an `Option` with `None`",
                     "consider `Option::take()` instead",
-                    format!("{}.take()", snippet(cx, replaced_path.span, ""))
+                    format!("{}.take()", snippet(cx, replaced_path.span, "")),
+                    Applicability::Unspecified,
                 );
             }
         }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1042,6 +1042,7 @@ fn lint_or_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span: Spa
                             &format!("use of `{}` followed by a call to `{}`", name, path),
                             "try this",
                             format!("{}.unwrap_or_default()", snippet(cx, self_expr.span, "_")),
+                            Applicability::Unspecified,
                         );
                         return true;
                     }
@@ -1111,6 +1112,7 @@ fn lint_or_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span: Spa
             &format!("use of `{}` followed by a function call", name),
             "try this",
             format!("{}_{}({})", name, suffix, sugg),
+            Applicability::Unspecified,
         );
     }
 
@@ -1224,6 +1226,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
                 &format!("use of `{}` followed by a function call", name),
                 "try this",
                 format!("unwrap_or_else({} panic!({}))", closure, sugg),
+                Applicability::Unspecified,
             );
 
             return;
@@ -1238,6 +1241,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
             &format!("use of `{}` followed by a function call", name),
             "try this",
             format!("unwrap_or_else({} {{ let msg = {}; panic!(msg) }}))", closure, sugg),
+            Applicability::Unspecified,
         );
     }
 
@@ -1354,6 +1358,7 @@ fn lint_clone_on_ref_ptr(cx: &LateContext<'_, '_>, expr: &hir::Expr, arg: &hir::
             "using '.clone()' on a ref-counted pointer",
             "try this",
             format!("{}::<{}>::clone(&{})", caller_type, subst.type_at(0), snippet(cx, arg.span, "_")),
+            Applicability::Unspecified,
         );
     }
 }
@@ -1384,6 +1389,7 @@ fn lint_string_extend(cx: &LateContext<'_, '_>, expr: &hir::Expr, args: &[hir::E
                 ref_str,
                 snippet(cx, target.span, "_")
             ),
+            Applicability::Unspecified,
         );
     }
 }
@@ -1482,6 +1488,7 @@ fn lint_unnecessary_fold(cx: &LateContext<'_, '_>, expr: &hir::Expr, fold_args: 
                     "this `.fold` can be written more succinctly using another method",
                     "try",
                     sugg,
+                    Applicability::Unspecified,
                 );
             }
         }
@@ -1589,6 +1596,7 @@ fn lint_get_unwrap(cx: &LateContext<'_, '_>, expr: &hir::Expr, get_args: &[hir::
             snippet(cx, get_args[0].span, "_"),
             get_args_str
         ),
+        Applicability::Unspecified,
     );
 }
 
@@ -2010,16 +2018,19 @@ fn lint_chars_cmp(
                 return false;
             }
 
-            span_lint_and_sugg(cx,
-                               lint,
-                               info.expr.span,
-                               &format!("you should use the `{}` method", suggest),
-                               "like this",
-                               format!("{}{}.{}({})",
-                                       if info.eq { "" } else { "!" },
-                                       snippet(cx, args[0][0].span, "_"),
-                                       suggest,
-                                       snippet(cx, arg_char[0].span, "_")));
+            span_lint_and_sugg(
+                cx,
+                lint,
+                info.expr.span,
+                &format!("you should use the `{}` method", suggest),
+                "like this",
+                format!("{}{}.{}({})",
+                        if info.eq { "" } else { "!" },
+                        snippet(cx, args[0][0].span, "_"),
+                        suggest,
+                        snippet(cx, arg_char[0].span, "_")),
+                Applicability::Unspecified,
+            );
 
             return true;
         }
@@ -2065,7 +2076,8 @@ fn lint_chars_cmp_with_unwrap<'a, 'tcx>(
                         if info.eq { "" } else { "!" },
                         snippet(cx, args[0][0].span, "_"),
                         suggest,
-                        c)
+                        c),
+                Applicability::Unspecified,
             );
 
             return true;
@@ -2105,6 +2117,7 @@ fn lint_single_char_pattern<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, _expr: &'tcx h
                 "single-character string constant used as pattern",
                 "try using a char instead",
                 hint,
+                Applicability::Unspecified,
             );
         }
     }
@@ -2129,6 +2142,7 @@ fn lint_asref(cx: &LateContext<'_, '_>, expr: &hir::Expr, call_name: &str, as_re
                 &format!("this call to `{}` does nothing", call_name),
                 "try this",
                 snippet(cx, recvr.span, "_").into_owned(),
+                Applicability::Unspecified,
             );
         }
     }
@@ -2194,6 +2208,7 @@ fn lint_into_iter(cx: &LateContext<'_, '_>, expr: &hir::Expr, self_ref_ty: ty::T
             ),
             "call directly",
             method_name.to_owned(),
+            Applicability::Unspecified,
         );
     }
 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2046,10 +2046,10 @@ fn lint_chars_next_cmp<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, info: &BinaryExprIn
 
 /// Checks for the `CHARS_LAST_CMP` lint.
 fn lint_chars_last_cmp<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, info: &BinaryExprInfo<'_>) -> bool {
-    if lint_chars_cmp(cx, info, &["chars", "last"], CHARS_NEXT_CMP, "ends_with") {
+    if lint_chars_cmp(cx, info, &["chars", "last"], CHARS_LAST_CMP, "ends_with") {
         true
     } else {
-        lint_chars_cmp(cx, info, &["chars", "next_back"], CHARS_NEXT_CMP, "ends_with")
+        lint_chars_cmp(cx, info, &["chars", "next_back"], CHARS_LAST_CMP, "ends_with")
     }
 }
 

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -12,13 +12,14 @@
 //!
 //! This lint is **warn** by default
 
+use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc::hir::*;
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::LitKind;
 use crate::syntax::source_map::Spanned;
-use crate::utils::{in_macro, snippet, span_lint, span_lint_and_sugg};
 use crate::utils::sugg::Sugg;
+use crate::utils::{in_macro, snippet, span_lint, span_lint_and_sugg};
 
 /// **What it does:** Checks for expressions of the form `if c { true } else {
 /// false }`
@@ -89,6 +90,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBool {
                     "this if-then-else expression returns a bool literal",
                     "you can reduce it to",
                     hint,
+                    Applicability::Unspecified,
                 );
             };
             if let ExprKind::Block(ref then_block, _) = then_block.node {
@@ -150,6 +152,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                         "equality checks against true are unnecessary",
                         "try simplifying it as shown",
                         hint,
+                        Applicability::Unspecified,
                     );
                 },
                 (Other, Bool(true)) => {
@@ -161,6 +164,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                         "equality checks against true are unnecessary",
                         "try simplifying it as shown",
                         hint,
+                        Applicability::Unspecified,
                     );
                 },
                 (Bool(false), Other) => {
@@ -172,6 +176,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                         "equality checks against false can be replaced by a negation",
                         "try simplifying it as shown",
                         (!hint).to_string(),
+                        Applicability::Unspecified,
                     );
                 },
                 (Other, Bool(false)) => {
@@ -183,6 +188,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                         "equality checks against false can be replaced by a negation",
                         "try simplifying it as shown",
                         (!hint).to_string(),
+                        Applicability::Unspecified,
                     );
                 },
                 _ => (),

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -19,7 +19,7 @@ use crate::rustc_errors::Applicability;
 use crate::syntax::ast::LitKind;
 use crate::syntax::source_map::Spanned;
 use crate::utils::sugg::Sugg;
-use crate::utils::{in_macro, snippet, span_lint, span_lint_and_sugg};
+use crate::utils::{in_macro, snippet_with_applicability, span_lint, span_lint_and_sugg};
 
 /// **What it does:** Checks for expressions of the form `if c { true } else {
 /// false }`
@@ -74,7 +74,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBool {
         use self::Expression::*;
         if let ExprKind::If(ref pred, ref then_block, Some(ref else_expr)) = e.node {
             let reduce = |ret, not| {
-                let snip = Sugg::hir(cx, pred, "<predicate>");
+                let mut applicability = Applicability::MachineApplicable;
+                let snip = Sugg::hir_with_applicability(cx, pred, "<predicate>", &mut applicability);
                 let snip = if not { !snip } else { snip };
 
                 let hint = if ret {
@@ -90,7 +91,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBool {
                     "this if-then-else expression returns a bool literal",
                     "you can reduce it to",
                     hint,
-                    Applicability::Unspecified,
+                    applicability,
                 );
             };
             if let ExprKind::Block(ref then_block, _) = then_block.node {
@@ -142,33 +143,34 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
         }
 
         if let ExprKind::Binary(Spanned { node: BinOpKind::Eq, .. }, ref left_side, ref right_side) = e.node {
+            let mut applicability = Applicability::MachineApplicable;
             match (fetch_bool_expr(left_side), fetch_bool_expr(right_side)) {
                 (Bool(true), Other) => {
-                    let hint = snippet(cx, right_side.span, "..").into_owned();
+                    let hint = snippet_with_applicability(cx, right_side.span, "..", &mut applicability);
                     span_lint_and_sugg(
                         cx,
                         BOOL_COMPARISON,
                         e.span,
                         "equality checks against true are unnecessary",
                         "try simplifying it as shown",
-                        hint,
-                        Applicability::Unspecified,
+                        hint.to_string(),
+                        applicability,
                     );
                 },
                 (Other, Bool(true)) => {
-                    let hint = snippet(cx, left_side.span, "..").into_owned();
+                    let hint = snippet_with_applicability(cx, left_side.span, "..", &mut applicability);
                     span_lint_and_sugg(
                         cx,
                         BOOL_COMPARISON,
                         e.span,
                         "equality checks against true are unnecessary",
                         "try simplifying it as shown",
-                        hint,
-                        Applicability::Unspecified,
+                        hint.to_string(),
+                        applicability,
                     );
                 },
                 (Bool(false), Other) => {
-                    let hint = Sugg::hir(cx, right_side, "..");
+                    let hint = Sugg::hir_with_applicability(cx, right_side, "..", &mut applicability);
                     span_lint_and_sugg(
                         cx,
                         BOOL_COMPARISON,
@@ -176,11 +178,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                         "equality checks against false can be replaced by a negation",
                         "try simplifying it as shown",
                         (!hint).to_string(),
-                        Applicability::Unspecified,
+                        applicability,
                     );
                 },
                 (Other, Bool(false)) => {
-                    let hint = Sugg::hir(cx, left_side, "..");
+                    let hint = Sugg::hir_with_applicability(cx, left_side, "..", &mut applicability);
                     span_lint_and_sugg(
                         cx,
                         BOOL_COMPARISON,
@@ -188,7 +190,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                         "equality checks against false can be replaced by a negation",
                         "try simplifying it as shown",
                         (!hint).to_string(),
-                        Applicability::Unspecified,
+                        applicability,
                     );
                 },
                 _ => (),

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -8,10 +8,11 @@
 // except according to those terms.
 
 
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc::hir::def::Def;
 use crate::rustc::hir::{BinOpKind, BlockCheckMode, Expr, ExprKind, Stmt, StmtKind, UnsafeSource};
+use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::utils::{has_drop, in_macro, snippet_opt, span_lint, span_lint_and_sugg};
 use std::ops::Deref;
 
@@ -131,6 +132,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                     "statement can be reduced",
                     "replace it with",
                     snippet,
+                    Applicability::Unspecified,
                 );
             }
         }

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -132,7 +132,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                     "statement can be reduced",
                     "replace it with",
                     snippet,
-                    Applicability::Unspecified,
+                    Applicability::MachineApplicable,
                 );
             }
         }

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -10,6 +10,7 @@
 
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 use crate::syntax::source_map::Spanned;
 use crate::utils::{in_macro, snippet, span_lint_and_sugg};
@@ -61,6 +62,7 @@ impl EarlyLintPass for Precedence {
                     "operator precedence can trip the unwary",
                     "consider parenthesizing your expression",
                     sugg,
+                    Applicability::Unspecified,
                 );
             };
 
@@ -112,6 +114,7 @@ impl EarlyLintPass for Precedence {
                                     "unary minus has lower precedence than method call",
                                     "consider adding parentheses to clarify your intent",
                                     format!("-({})", snippet(cx, rhs.span, "..")),
+                                    Applicability::Unspecified,
                                 );
                             },
                             _ => (),

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -13,7 +13,7 @@ use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 use crate::syntax::source_map::Spanned;
-use crate::utils::{in_macro, snippet, span_lint_and_sugg};
+use crate::utils::{in_macro, snippet_with_applicability, span_lint_and_sugg};
 
 /// **What it does:** Checks for operations where precedence may be unclear
 /// and suggests to add parentheses. Currently it catches the following:
@@ -54,7 +54,7 @@ impl EarlyLintPass for Precedence {
         }
 
         if let ExprKind::Binary(Spanned { node: op, .. }, ref left, ref right) = expr.node {
-            let span_sugg = |expr: &Expr, sugg| {
+            let span_sugg = |expr: &Expr, sugg, appl| {
                 span_lint_and_sugg(
                     cx,
                     PRECEDENCE,
@@ -62,40 +62,41 @@ impl EarlyLintPass for Precedence {
                     "operator precedence can trip the unwary",
                     "consider parenthesizing your expression",
                     sugg,
-                    Applicability::Unspecified,
+                    appl,
                 );
             };
 
             if !is_bit_op(op) {
                 return;
             }
+            let mut applicability = Applicability::MachineApplicable;
             match (is_arith_expr(left), is_arith_expr(right)) {
                 (true, true) => {
                     let sugg = format!(
                         "({}) {} ({})",
-                        snippet(cx, left.span, ".."),
+                        snippet_with_applicability(cx, left.span, "..", &mut applicability),
                         op.to_string(),
-                        snippet(cx, right.span, "..")
+                        snippet_with_applicability(cx, right.span, "..", &mut applicability)
                     );
-                    span_sugg(expr, sugg);
+                    span_sugg(expr, sugg, applicability);
                 },
                 (true, false) => {
                     let sugg = format!(
                         "({}) {} {}",
-                        snippet(cx, left.span, ".."),
+                        snippet_with_applicability(cx, left.span, "..", &mut applicability),
                         op.to_string(),
-                        snippet(cx, right.span, "..")
+                        snippet_with_applicability(cx, right.span, "..", &mut applicability)
                     );
-                    span_sugg(expr, sugg);
+                    span_sugg(expr, sugg, applicability);
                 },
                 (false, true) => {
                     let sugg = format!(
                         "{} {} ({})",
-                        snippet(cx, left.span, ".."),
+                        snippet_with_applicability(cx, left.span, "..", &mut applicability),
                         op.to_string(),
-                        snippet(cx, right.span, "..")
+                        snippet_with_applicability(cx, right.span, "..", &mut applicability)
                     );
-                    span_sugg(expr, sugg);
+                    span_sugg(expr, sugg, applicability);
                 },
                 (false, false) => (),
             }
@@ -107,14 +108,15 @@ impl EarlyLintPass for Precedence {
                     if let ExprKind::Lit(ref lit) = slf.node {
                         match lit.node {
                             LitKind::Int(..) | LitKind::Float(..) | LitKind::FloatUnsuffixed(..) => {
+                                let mut applicability = Applicability::MachineApplicable;
                                 span_lint_and_sugg(
                                     cx,
                                     PRECEDENCE,
                                     expr.span,
                                     "unary minus has lower precedence than method call",
                                     "consider adding parentheses to clarify your intent",
-                                    format!("-({})", snippet(cx, rhs.span, "..")),
-                                    Applicability::Unspecified,
+                                    format!("-({})", snippet_with_applicability(cx, rhs.span, "..", &mut applicability)),
+                                    applicability,
                                 );
                             },
                             _ => (),

--- a/clippy_lints/src/ptr_offset_with_cast.rs
+++ b/clippy_lints/src/ptr_offset_with_cast.rs
@@ -9,6 +9,7 @@
 
 
 use crate::rustc::{declare_tool_lint, hir, lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::utils;
 use std::fmt;
 
@@ -69,7 +70,15 @@ impl<'a, 'tcx> lint::LateLintPass<'a, 'tcx> for Pass {
 
         let msg = format!("use of `{}` with a `usize` casted to an `isize`", method);
         if let Some(sugg) = build_suggestion(cx, method, receiver_expr, cast_lhs_expr) {
-            utils::span_lint_and_sugg(cx, PTR_OFFSET_WITH_CAST, expr.span, &msg, "try", sugg);
+            utils::span_lint_and_sugg(
+                cx,
+                PTR_OFFSET_WITH_CAST,
+                expr.span,
+                &msg,
+                "try",
+                sugg,
+                Applicability::Unspecified,
+            );
         } else {
             utils::span_lint(cx, PTR_OFFSET_WITH_CAST, expr.span, &msg);
         }

--- a/clippy_lints/src/ptr_offset_with_cast.rs
+++ b/clippy_lints/src/ptr_offset_with_cast.rs
@@ -77,7 +77,7 @@ impl<'a, 'tcx> lint::LateLintPass<'a, 'tcx> for Pass {
                 &msg,
                 "try",
                 sugg,
-                Applicability::Unspecified,
+                Applicability::MachineApplicable,
             );
         } else {
             utils::span_lint(cx, PTR_OFFSET_WITH_CAST, expr.span, &msg);

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -66,7 +66,7 @@ impl EarlyLintPass for RedundantFieldNames {
                             "redundant field names in struct initialization",
                             "replace it with",
                             field.ident.to_string(),
-                            Applicability::Unspecified,
+                            Applicability::MachineApplicable,
                         );
                     }
                 }

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -10,6 +10,7 @@
 
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 use crate::utils::{span_lint_and_sugg};
 
@@ -58,13 +59,14 @@ impl EarlyLintPass for RedundantFieldNames {
                 }
                 if let ExprKind::Path(None, path) = &field.expr.node {
                     if path.segments.len() == 1 && path.segments[0].ident == field.ident {
-                        span_lint_and_sugg (
+                        span_lint_and_sugg(
                             cx,
                             REDUNDANT_FIELD_NAMES,
                             field.span,
                             "redundant field names in struct initialization",
                             "replace it with",
-                            field.ident.to_string()
+                            field.ident.to_string(),
+                            Applicability::Unspecified,
                         );
                     }
                 }

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -12,7 +12,7 @@ use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::ast::{Expr, ExprKind, UnOp};
-use crate::utils::{snippet, span_lint_and_sugg};
+use crate::utils::{snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
 
 /// **What it does:** Checks for usage of `*&` and `*&mut` in expressions.
@@ -55,14 +55,15 @@ impl EarlyLintPass for Pass {
             if let ExprKind::Unary(UnOp::Deref, ref deref_target) = e.node;
             if let ExprKind::AddrOf(_, ref addrof_target) = without_parens(deref_target).node;
             then {
+                let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(
                     cx,
                     DEREF_ADDROF,
                     e.span,
                     "immediately dereferencing a reference",
                     "try this",
-                    format!("{}", snippet(cx, addrof_target.span, "_")),
-                    Applicability::Unspecified,
+                    format!("{}", snippet_with_applicability(cx, addrof_target.span, "_", &mut applicability)),
+                    applicability,
                 );
             }
         }
@@ -102,6 +103,7 @@ impl EarlyLintPass for DerefPass {
             if let ExprKind::Paren(ref parened) = object.node;
             if let ExprKind::AddrOf(_, ref inner) = parened.node;
             then {
+                let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(
                     cx,
                     REF_IN_DEREF,
@@ -110,10 +112,10 @@ impl EarlyLintPass for DerefPass {
                     "try this",
                     format!(
                         "{}.{}",
-                        snippet(cx, inner.span, "_"),
-                        snippet(cx, field_name.span, "_")
+                        snippet_with_applicability(cx, inner.span, "_", &mut applicability),
+                        snippet_with_applicability(cx, field_name.span, "_", &mut applicability)
                     ),
-                    Applicability::Unspecified,
+                    applicability,
                 );
             }
         }

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -8,11 +8,12 @@
 // except according to those terms.
 
 
-use crate::syntax::ast::{Expr, ExprKind, UnOp};
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
+use crate::rustc_errors::Applicability;
+use crate::syntax::ast::{Expr, ExprKind, UnOp};
 use crate::utils::{snippet, span_lint_and_sugg};
+use if_chain::if_chain;
 
 /// **What it does:** Checks for usage of `*&` and `*&mut` in expressions.
 ///
@@ -61,6 +62,7 @@ impl EarlyLintPass for Pass {
                     "immediately dereferencing a reference",
                     "try this",
                     format!("{}", snippet(cx, addrof_target.span, "_")),
+                    Applicability::Unspecified,
                 );
             }
         }
@@ -110,7 +112,8 @@ impl EarlyLintPass for DerefPass {
                         "{}.{}",
                         snippet(cx, inner.span, "_"),
                         snippet(cx, field_name.span, "_")
-                    )
+                    ),
+                    Applicability::Unspecified,
                 );
             }
         }

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -8,12 +8,13 @@
 // except according to those terms.
 
 
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
 use crate::rustc::hir;
 use crate::rustc::hir::def::Def;
+use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::utils::{match_def_path, span_lint_and_sugg};
+use if_chain::if_chain;
 
 /// **What it does:** Checks for usage of `ATOMIC_X_INIT`, `ONCE_INIT`, and
 /// `uX/iX::MIN/MAX`.
@@ -61,6 +62,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ReplaceConsts {
                             &format!("using `{}`", const_path.last().expect("empty path")),
                             "try this",
                             repl_snip.to_string(),
+                            Applicability::Unspecified,
                         );
                         return;
                     }

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -62,7 +62,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ReplaceConsts {
                             &format!("using `{}`", const_path.last().expect("empty path")),
                             "try this",
                             repl_snip.to_string(),
-                            Applicability::Unspecified,
+                            Applicability::MachineApplicable,
                         );
                         return;
                     }

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -10,6 +10,7 @@
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::source_map::Spanned;
 use crate::utils::SpanlessEq;
 use crate::utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty};
@@ -185,6 +186,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
                                 "calling `as_bytes()` on `include_str!(..)`",
                                 "consider using `include_bytes!(..)` instead",
                                 snippet(cx, args[0].span, r#""foo""#).replacen("include_str", "include_bytes", 1),
+                                Applicability::Unspecified,
                             );
                         } else if callsite == expanded
                             && lit_content.as_str().chars().all(|c| c.is_ascii())
@@ -197,6 +199,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
                                 "calling `as_bytes()` on a string literal",
                                 "consider using a byte string literal instead",
                                 format!("b{}", snippet(cx, args[0].span, r#""foo""#)),
+                                Applicability::Unspecified,
                             );
                         }
                     }

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -10,21 +10,21 @@
 
 use std::cmp;
 
-use matches::matches;
 use crate::rustc::hir;
-use crate::rustc::hir::*;
 use crate::rustc::hir::intravisit::FnKind;
+use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
-use crate::rustc::ty::TyKind;
-use crate::rustc::ty::FnSig;
 use crate::rustc::session::config::Config as SessionConfig;
-use crate::rustc_target::spec::abi::Abi;
+use crate::rustc::ty::TyKind;
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::rustc_target::abi::LayoutOf;
+use crate::rustc_target::spec::abi::Abi;
 use crate::syntax::ast::NodeId;
 use crate::syntax_pos::Span;
-use crate::utils::{in_macro, is_copy, is_self_ty, span_lint_and_sugg, snippet};
+use crate::utils::{in_macro, is_copy, is_self, snippet, span_lint_and_sugg};
+use if_chain::if_chain;
+use matches::matches;
 
 /// **What it does:** Checks for functions taking arguments by reference, where
 /// the argument type is `Copy` and small enough to be more efficient to always

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -15,14 +15,14 @@ use crate::rustc::hir::intravisit::FnKind;
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::session::config::Config as SessionConfig;
-use crate::rustc::ty::TyKind;
+use crate::rustc::ty::{FnSig, TyKind};
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::rustc_target::abi::LayoutOf;
 use crate::rustc_target::spec::abi::Abi;
 use crate::syntax::ast::NodeId;
 use crate::syntax_pos::Span;
-use crate::utils::{in_macro, is_copy, is_self, snippet, span_lint_and_sugg};
+use crate::utils::{in_macro, is_copy, is_self_ty, snippet, span_lint_and_sugg};
 use if_chain::if_chain;
 use matches::matches;
 
@@ -141,7 +141,9 @@ impl<'a, 'tcx> TriviallyCopyPassByRef {
                         input.span,
                         "this argument is passed by reference, but would be more efficient if passed by value",
                         "consider passing by value instead",
-                        value_type);
+                        value_type,
+                        Applicability::Unspecified,
+                    );
                 }
             }
         }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -10,28 +10,31 @@
 
 #![allow(clippy::default_hash_types)]
 
+use crate::consts::{constant, Constant};
 use crate::reexport::*;
 use crate::rustc::hir;
-use crate::rustc::hir::*;
 use crate::rustc::hir::intravisit::{walk_body, walk_expr, walk_ty, FnKind, NestedVisitorMap, Visitor};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass, in_external_macro, LintContext};
-use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
-use crate::rustc::ty::{self, Ty, TyCtxt, TypeckTables};
+use crate::rustc::hir::*;
+use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use crate::rustc::ty::layout::LayoutOf;
+use crate::rustc::ty::{self, Ty, TyCtxt, TypeckTables};
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
+use crate::rustc_target::spec::abi::Abi;
 use crate::rustc_typeck::hir_ty_to_ty;
+use crate::syntax::ast::{FloatTy, IntTy, UintTy};
+use crate::syntax::errors::DiagnosticBuilder;
+use crate::syntax::source_map::Span;
+use crate::utils::paths;
+use crate::utils::{
+    clip, comparisons, differing_macro_contexts, higher, in_constant, in_macro, int_bits, last_path_segment,
+    match_def_path, match_path, match_type, multispan_sugg, opt_def_id, same_tys, sext, snippet, snippet_opt,
+    span_help_and_lint, span_lint, span_lint_and_sugg, span_lint_and_then, unsext,
+};
+use if_chain::if_chain;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::borrow::Cow;
-use crate::syntax::ast::{FloatTy, IntTy, UintTy};
-use crate::syntax::source_map::Span;
-use crate::syntax::errors::DiagnosticBuilder;
-use crate::rustc_target::spec::abi::Abi;
-use crate::utils::{comparisons, differing_macro_contexts, higher, in_constant, in_macro, last_path_segment, match_def_path, match_path,
-            match_type, multispan_sugg, opt_def_id, same_tys, snippet, snippet_opt, span_help_and_lint, span_lint,
-            span_lint_and_sugg, span_lint_and_then, clip, unsext, sext, int_bits};
-use crate::utils::paths;
-use crate::consts::{constant, Constant};
 
 /// Handles all the linting of funky types
 pub struct TypePass;
@@ -338,12 +341,14 @@ fn check_ty_rptr(cx: &LateContext<'_, '_>, ast_ty: &hir::Ty, is_local: bool, lt:
                     } else {
                         ""
                     };
-                    span_lint_and_sugg(cx,
+                    span_lint_and_sugg(
+                        cx,
                         BORROWED_BOX,
                         ast_ty.span,
                         "you seem to be trying to use `&Box<T>`. Consider using just `&T`",
                         "try",
-                        format!("&{}{}{}", ltopt, mutopt, &snippet(cx, inner.span, ".."))
+                        format!("&{}{}{}", ltopt, mutopt, &snippet(cx, inner.span, "..")),
+                        Applicability::Unspecified,
                     );
                     return; // don't recurse into the type
                 }
@@ -537,6 +542,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnitArg {
                                         "passing a unit value to a function",
                                         "if you intended to pass a unit value, use a unit literal instead",
                                         "()".to_string(),
+                                        Applicability::Unspecified,
                                     );
                                 }
                             }
@@ -874,6 +880,7 @@ fn span_lossless_lint(cx: &LateContext<'_, '_>, expr: &Expr, op: &Expr, cast_fro
         &format!("casting {} to {} may become silently lossy if types change", cast_from, cast_to),
         "try",
         format!("{}::from({})", cast_to, sugg),
+        Applicability::Unspecified,
     );
 }
 
@@ -1103,7 +1110,8 @@ fn lint_fn_to_numeric_cast(cx: &LateContext<'_, '_>, expr: &Expr, cast_expr: &Ex
                     expr.span,
                     &format!("casting function pointer `{}` to `{}`, which truncates the value", from_snippet, cast_to),
                     "try",
-                    format!("{} as usize", from_snippet)
+                    format!("{} as usize", from_snippet),
+                    Applicability::Unspecified,
                 );
 
             } else if cast_to.sty != ty::Uint(UintTy::Usize) {
@@ -1113,7 +1121,8 @@ fn lint_fn_to_numeric_cast(cx: &LateContext<'_, '_>, expr: &Expr, cast_expr: &Ex
                     expr.span,
                     &format!("casting function pointer `{}` to `{}`", from_snippet, cast_to),
                     "try",
-                    format!("{} as usize", from_snippet)
+                    format!("{} as usize", from_snippet),
+                    Applicability::Unspecified,
                 );
             }
         },

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -71,7 +71,7 @@ fn span_use_self_lint(cx: &LateContext<'_, '_>, path: &Path) {
         "unnecessary structure name repetition",
         "use the applicable keyword",
         "Self".to_owned(),
-        Applicability::Unspecified,
+        Applicability::MachineApplicable,
     );
 }
 

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -8,15 +8,16 @@
 // except according to those terms.
 
 
-use crate::utils::{in_macro, span_lint_and_sugg};
-use if_chain::if_chain;
 use crate::rustc::hir::intravisit::{walk_path, walk_ty, NestedVisitorMap, Visitor};
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::ty;
 use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax_pos::symbol::keywords::SelfType;
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::NodeId;
+use crate::syntax_pos::symbol::keywords::SelfType;
+use crate::utils::{in_macro, span_lint_and_sugg};
+use if_chain::if_chain;
 
 /// **What it does:** Checks for unnecessary repetition of structure name when a
 /// replacement with `Self` is applicable.
@@ -70,6 +71,7 @@ fn span_use_self_lint(cx: &LateContext<'_, '_>, path: &Path) {
         "unnecessary structure name repetition",
         "use the applicable keyword",
         "Self".to_owned(),
+        Applicability::Unspecified,
     );
 }
 

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -282,7 +282,7 @@ impl EarlyLintPass for DefaultHashTypes {
                 &msg,
                 "use",
                 replace.to_string(),
-                Applicability::Unspecified,
+                Applicability::MaybeIncorrect, // FxHashMap, ... needs another import
             );
         }
     }

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -18,6 +18,7 @@ use crate::rustc::hir::*;
 use crate::rustc::hir::def::Def;
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use crate::syntax::ast::{Crate as AstCrate, Ident, ItemKind, Name};
 use crate::syntax::source_map::Span;
@@ -281,6 +282,7 @@ impl EarlyLintPass for DefaultHashTypes {
                 &msg,
                 "use",
                 replace.to_string(),
+                Applicability::Unspecified,
             );
         }
     }

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -657,9 +657,10 @@ pub fn span_lint_and_sugg<'a, 'tcx: 'a, T: LintContext<'tcx>>(
     msg: &str,
     help: &str,
     sugg: String,
+    applicability: Applicability,
 ) {
     span_lint_and_then(cx, lint, sp, msg, |db| {
-        db.span_suggestion_with_applicability(sp, help, sugg, Applicability::Unspecified);
+        db.span_suggestion_with_applicability(sp, help, sugg, applicability);
     });
 }
 

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -96,6 +96,15 @@ impl<'a> Sugg<'a> {
         Self::hir_opt(cx, expr).unwrap_or_else(|| Sugg::NonParen(Cow::Borrowed(default)))
     }
 
+    pub fn hir_with_applicability(cx: &LateContext<'_, '_>, expr: &hir::Expr, default: &'a str, applicability: &mut Applicability) -> Self {
+        Self::hir_opt(cx, expr).unwrap_or_else(|| {
+            if *applicability == Applicability::MachineApplicable {
+                *applicability = Applicability::HasPlaceholders;
+            }
+            Sugg::NonParen(Cow::Borrowed(default))
+        })
+    }
+
     /// Prepare a suggestion from an expression.
     pub fn ast(cx: &EarlyContext<'_>, expr: &ast::Expr, default: &'a str) -> Self {
         use crate::syntax::ast::RangeLimits;

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -8,14 +8,15 @@
 // except according to those terms.
 
 
+use crate::consts::constant;
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use if_chain::if_chain;
 use crate::rustc::ty::{self, Ty};
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::rustc_errors::Applicability;
 use crate::syntax::source_map::Span;
 use crate::utils::{higher, is_copy, snippet, span_lint_and_sugg};
-use crate::consts::constant;
+use if_chain::if_chain;
 
 /// **What it does:** Checks for usage of `&vec![..]` when using `&[..]` would
 /// be possible.
@@ -100,6 +101,7 @@ fn check_vec_macro<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, vec_args: &higher::VecA
         "useless use of `vec!`",
         "you can use a slice directly",
         snippet,
+        Applicability::Unspecified,
     );
 }
 

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -264,8 +264,8 @@ impl EarlyLintPass for Pass {
 }
 
 /// Checks the arguments of `print[ln]!` and `write[ln]!` calls. It will return a tuple of two
-/// options. The first part of the tuple is format_str of the macros. The secund part of the tuple
-/// is in the `write[ln]!` case the expression the format_str should be written to.
+/// options. The first part of the tuple is `format_str` of the macros. The secund part of the tuple
+/// is in the `write[ln]!` case the expression the `format_str` should be written to.
 ///
 /// Example:
 ///

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -258,6 +258,20 @@ impl EarlyLintPass for Pass {
     }
 }
 
+/// Checks the arguments of `print[ln]!` and `write[ln]!` calls. It will return a tuple of two
+/// options. The first part of the tuple is format_str of the macros. The secund part of the tuple
+/// is in the `write[ln]!` case the expression the format_str should be written to.
+///
+/// Example:
+///
+/// Calling this function on
+/// ```rust,ignore
+/// writeln!(buf, "string to write: {}", something)
+/// ```
+/// will return
+/// ```rust,ignore
+/// (Some("string to write: {}"), Some(buf))
+/// ```
 fn check_tts<'a>(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -> (Option<String>, Option<Expr>) {
     use crate::fmt_macros::*;
     let tts = TokenStream::from(tts.clone());

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -8,13 +8,14 @@
 // except according to those terms.
 
 
-use crate::utils::{snippet, span_lint, span_lint_and_sugg};
 use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
-use std::borrow::Cow;
+use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 use crate::syntax::parse::{parser, token};
 use crate::syntax::tokenstream::{ThinTokenStream, TokenStream};
+use crate::utils::{snippet, span_lint, span_lint_and_sugg};
+use std::borrow::Cow;
 
 /// **What it does:** This lint warns when you use `println!("")` to
 /// print a newline.
@@ -199,6 +200,7 @@ impl EarlyLintPass for Pass {
                         "using `println!(\"\")`",
                         "replace it with",
                         "println!()".to_string(),
+                        Applicability::Unspecified,
                     );
                 }
             }
@@ -248,6 +250,7 @@ impl EarlyLintPass for Pass {
                         format!("using `writeln!({}, \"\")`", suggestion).as_str(),
                         "replace it with",
                         format!("writeln!({})", suggestion),
+                        Applicability::Unspecified,
                     );
                 }
             }

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -14,7 +14,7 @@ use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
 use crate::syntax::parse::{parser, token};
 use crate::syntax::tokenstream::{ThinTokenStream, TokenStream};
-use crate::utils::{snippet, span_lint, span_lint_and_sugg};
+use crate::utils::{snippet_with_applicability, span_lint, span_lint_and_sugg};
 use std::borrow::Cow;
 
 /// **What it does:** This lint warns when you use `println!("")` to
@@ -200,7 +200,7 @@ impl EarlyLintPass for Pass {
                         "using `println!(\"\")`",
                         "replace it with",
                         "println!()".to_string(),
-                        Applicability::Unspecified,
+                        Applicability::MachineApplicable,
                     );
                 }
             }
@@ -239,9 +239,14 @@ impl EarlyLintPass for Pass {
             let check_tts = check_tts(cx, &mac.node.tts, true);
             if let Some(fmtstr) = check_tts.0 {
                 if fmtstr == "" {
-                    let suggestion = check_tts
-                        .1
-                        .map_or(Cow::Borrowed("v"), |expr| snippet(cx, expr.span, "v"));
+                    let mut applicability = Applicability::MachineApplicable;
+                    let suggestion = check_tts.1.map_or_else(
+                        move || {
+                            applicability = Applicability::HasPlaceholders;
+                            Cow::Borrowed("v")
+                        },
+                        move |expr| snippet_with_applicability(cx, expr.span, "v", &mut applicability),
+                    );
 
                     span_lint_and_sugg(
                         cx,
@@ -250,7 +255,7 @@ impl EarlyLintPass for Pass {
                         format!("using `writeln!({}, \"\")`", suggestion).as_str(),
                         "replace it with",
                         format!("writeln!({})", suggestion),
-                        Applicability::Unspecified,
+                        applicability,
                     );
                 }
             }

--- a/tests/ui/else_if_without_else.stderr
+++ b/tests/ui/else_if_without_else.stderr
@@ -5,9 +5,10 @@ error: if expression with an `else if`, but without a final `else`
    |  ____________^
 52 | |         println!("else if");
 53 | |     }
-   | |_____^ help: add an `else` block here
+   | |_____^
    |
    = note: `-D clippy::else-if-without-else` implied by `-D warnings`
+   = help: add an `else` block here
 
 error: if expression with an `else if`, but without a final `else`
   --> $DIR/else_if_without_else.rs:59:12
@@ -16,7 +17,9 @@ error: if expression with an `else if`, but without a final `else`
    |  ____________^
 60 | |         println!("else if 2");
 61 | |     }
-   | |_____^ help: add an `else` block here
+   | |_____^
+   |
+   = help: add an `else` block here
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This is #2943 completely redone, so that we finally have applicability levels for our suggestion lints and #2943 can finally be closed.

Resolves #2930 

Implements https://github.com/rust-lang/rust-clippy/pull/2943#discussion_r204080707

Still open: `multispan_sugg` (Should this also be done in this PR?)

PS: Sorry for some unrelated formatting changes, those just slipped in ¯\\\_(ツ)_/¯ 