### PR TITLE
Don't run integration tests in forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ install:
       fi
     fi
 
+# disabling the integration tests in forks should be done with
+# if: fork = false
+# but this is currently buggy travis-ci/travis-ci#9118
 matrix:
   include:
     - os: osx # run base tests on both platforms
@@ -48,23 +51,36 @@ matrix:
     - os: linux
       env: BASE_TESTS=true
     - os: windows
-      env: BASE_TEST=true
+      env: BASE_TESTS=true
     - env: INTEGRATION=rust-lang/cargo
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-random/rand
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-lang-nursery/stdsimd
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-lang/rustfmt
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-lang-nursery/futures-rs
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-lang-nursery/failure
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-lang-nursery/log
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-lang-nursery/chalk
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-lang/rls
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=chronotope/chrono
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=serde-rs/serde
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=Geal/nom
+      if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=hyperium/hyper
+      if: repo =~ /^rust-lang\/rust-clippy$/
   allow_failures:
   - os: windows
-    env: BASE_TEST=true
+    env: BASE_TESTS=true
 # prevent these jobs with default env vars
   exclude:
     - os: linux


### PR DESCRIPTION
Normal users only have 5 concurrent jobs in travis. So running the integration tests inside of forks bloats travis for users who enabled it on their fork.