### PR TITLE
remove macro_at_most_once_rep feature attribute since it's stable

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -16,7 +16,6 @@
 #![feature(range_contains)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![recursion_limit = "256"]
-#![feature(macro_at_most_once_rep)]
 #![warn(rust_2018_idioms, trivial_casts, trivial_numeric_casts)]
 #![feature(crate_visibility_modifier)]
 #![feature(try_from)]


### PR DESCRIPTION
Warning was:
warning: the feature `macro_at_most_once_rep` has been stable since 1.32.0 and no longer requires an attribute to enable
  --> clippy_lints/src/lib.rs:19:12
   |
19 | #![feature(macro_at_most_once_rep)]
   |            ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(stable_features)] on by default