### PR TITLE
Adds inequality cases to bool comparison (#3438)

### DIFF
--- a/tests/ui/bool_comparison.rs
+++ b/tests/ui/bool_comparison.rs
@@ -18,4 +18,8 @@ fn main() {
     if x == false { "yes" } else { "no" };
     if true == x { "yes" } else { "no" };
     if false == x { "yes" } else { "no" };
+    if x != true { "yes" } else { "no" };
+    if x != false { "yes" } else { "no" };
+    if true != x { "yes" } else { "no" };
+    if false != x { "yes" } else { "no" };
 }

--- a/tests/ui/bool_comparison.stderr
+++ b/tests/ui/bool_comparison.stderr
@@ -24,5 +24,29 @@ error: equality checks against false can be replaced by a negation
 20 |     if false == x { "yes" } else { "no" };
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
-error: aborting due to 4 previous errors
+error: inequality checks against true can be replaced by a negation
+  --> $DIR/bool_comparison.rs:21:8
+   |
+21 |     if x != true { "yes" } else { "no" };
+   |        ^^^^^^^^^ help: try simplifying it as shown: `!x`
+
+error: inequality checks against false are unnecessary
+  --> $DIR/bool_comparison.rs:22:8
+   |
+22 |     if x != false { "yes" } else { "no" };
+   |        ^^^^^^^^^^ help: try simplifying it as shown: `x`
+
+error: inequality checks against true can be replaced by a negation
+  --> $DIR/bool_comparison.rs:23:8
+   |
+23 |     if true != x { "yes" } else { "no" };
+   |        ^^^^^^^^^ help: try simplifying it as shown: `!x`
+
+error: inequality checks against false are unnecessary
+  --> $DIR/bool_comparison.rs:24:8
+   |
+24 |     if false != x { "yes" } else { "no" };
+   |        ^^^^^^^^^^ help: try simplifying it as shown: `x`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
The lint now checks cases like `y != true`, as suggested by the issue #3438.

Other cases talked about in the issue (i.e. `x < y` vs `!x && y`) are **not** implemented by this PR.

I can do so if you prefer that the whole issue is closed at once but I might need a little guidance (I will give it a try meanwhile).

Please let me know of any changes necessary