### PR TITLE
git: Enforce LF lineendings for everything

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+[attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
+
+* text=auto eol=lf
+*.rs rust


### PR DESCRIPTION
Someone on Discord reported issues with UI tests.

This should make sure that git never automatically converts lineendings
for text files to `CRLF`. They should always be `LF` now.

Probably this means that we can stop using dos2unix for #3306, too.

Taken from [Rust's .gitattributes file](https://github.com/rust-lang/rust/blob/master/.gitattributes).