### PR TITLE
Travis: Add rustc sysroot bin to PATH for windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
     - os: linux
       env: BASE_TESTS=true
     - os: windows
-      env: BASE_TESTS=true
+      env: CARGO_INCREMENTAL=0 BASE_TESTS=true
     - env: INTEGRATION=rust-lang/cargo
       if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=rust-random/rand
@@ -81,7 +81,7 @@ matrix:
       if: repo =~ /^rust-lang\/rust-clippy$/
   allow_failures:
   - os: windows
-    env: BASE_TESTS=true
+    env: CARGO_INCREMENTAL=0 BASE_TESTS=true
 # prevent these jobs with default env vars
   exclude:
     - os: linux

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -28,6 +28,9 @@ cd clippy_dev && cargo test && cd ..
 ./util/dev update_lints --check
 cargo +nightly fmt --all -- --check
 
+# Add bin to PATH for windows
+PATH=$PATH:$(rustc --print sysroot)/bin
+
 CLIPPY="`pwd`/target/debug/cargo-clippy clippy"
 # run clippy on its own codebase...
 ${CLIPPY} --all-targets --all-features -- -D clippy::all -D clippy::internal -Dclippy::pedantic


### PR DESCRIPTION
This won't fix the build as the last remaining issue has to be fixed by Travis
CI, but this means that once Travis fixes their problem, the Travis windows
build should succeed.

https://travis-ci.community/t/choco-install-hangs-forever/307/14

cc #3306 