### PR TITLE
Fix usage of ty::TyKind

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -119,17 +119,12 @@ impl Hash for Constant {
 }
 
 impl Constant {
-    pub fn partial_cmp(
-        tcx: TyCtxt<'_, '_, '_>,
-        cmp_type: &ty::TyKind<'_>,
-        left: &Self,
-        right: &Self,
-    ) -> Option<Ordering> {
+    pub fn partial_cmp(tcx: TyCtxt<'_, '_, '_>, cmp_type: ty::Ty<'_>, left: &Self, right: &Self) -> Option<Ordering> {
         match (left, right) {
             (&Constant::Str(ref ls), &Constant::Str(ref rs)) => Some(ls.cmp(rs)),
             (&Constant::Char(ref l), &Constant::Char(ref r)) => Some(l.cmp(r)),
             (&Constant::Int(l), &Constant::Int(r)) => {
-                if let ty::Int(int_ty) = *cmp_type {
+                if let ty::Int(int_ty) = cmp_type.sty {
                     Some(sext(tcx, l, int_ty).cmp(&sext(tcx, r, int_ty)))
                 } else {
                     Some(l.cmp(&r))

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -9,7 +9,7 @@
 
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::TyKind;
+use crate::rustc::ty;
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use if_chain::if_chain;
@@ -71,7 +71,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DefaultTraitAccess {
                         // TODO: Work out a way to put "whatever the imported way of referencing
                         // this type in this file" rather than a fully-qualified type.
                         let expr_ty = cx.tables.expr_ty(expr);
-                        if let TyKind::Adt(..) = expr_ty.sty {
+                        if let ty::Adt(..) = expr_ty.sty {
                             let replacement = format!("{}::default()", expr_ty);
                             span_lint_and_sugg(
                                 cx,

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -9,7 +9,7 @@
 
 use crate::rustc::hir;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::TyKind;
+use crate::rustc::ty;
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::ast::*;
@@ -56,7 +56,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExcessivePrecision {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr) {
         if_chain! {
             let ty = cx.tables.expr_ty(expr);
-            if let TyKind::Float(fty) = ty.sty;
+            if let ty::Float(fty) = ty.sty;
             if let hir::ExprKind::Lit(ref lit) = expr.node;
             if let LitKind::Float(sym, _) | LitKind::FloatUnsuffixed(sym) = lit.node;
             if let Some(sugg) = self.check(sym, fty);

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1252,7 +1252,7 @@ fn is_end_eq_array_len(cx: &LateContext<'_, '_>, end: &Expr, limits: ast::RangeL
     if_chain! {
         if let ExprKind::Lit(ref lit) = end.node;
         if let ast::LitKind::Int(end_int, _) = lit.node;
-        if let ty::TyKind::Array(_, arr_len_const) = indexed_ty.sty;
+        if let ty::Array(_, arr_len_const) = indexed_ty.sty;
         if let Some(arr_len) = arr_len_const.assert_usize(cx.tcx);
         then {
             return match limits {
@@ -1375,7 +1375,7 @@ fn check_for_loop_arg(cx: &LateContext<'_, '_>, pat: &Pat, arg: &Expr, expr: &Ex
                     match cx.tables.expr_ty(&args[0]).sty {
                         // If the length is greater than 32 no traits are implemented for array and
                         // therefore we cannot use `&`.
-                        ty::TyKind::Array(_, size) if size.assert_usize(cx.tcx).expect("array size") > 32 => (),
+                        ty::Array(_, size) if size.assert_usize(cx.tcx).expect("array size") > 32 => (),
                         _ => lint_iter_method(cx, args, arg, method_name),
                     };
                 } else {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -10,7 +10,7 @@
 use crate::rustc::hir;
 use crate::rustc::hir::def::Def;
 use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, Lint, LintArray, LintContext, LintPass};
-use crate::rustc::ty::{self, Predicate, Ty, TyKind};
+use crate::rustc::ty::{self, Predicate, Ty};
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::ast;
@@ -978,7 +978,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             }
 
             // if return type is impl trait, check the associated types
-            if let TyKind::Opaque(def_id, _) = ret_ty.sty {
+            if let ty::Opaque(def_id, _) = ret_ty.sty {
                 // one of the associated types must be Self
                 for predicate in &cx.tcx.predicates_of(def_id).predicates {
                     match predicate {
@@ -2204,7 +2204,7 @@ fn ty_has_iter_method(
     ];
 
     let (self_ty, mutbl) = match self_ref_ty.sty {
-        ty::TyKind::Ref(_, self_ty, mutbl) => (self_ty, mutbl),
+        ty::Ref(_, self_ty, mutbl) => (self_ty, mutbl),
         _ => unreachable!(),
     };
     let method_name = match mutbl {
@@ -2213,8 +2213,8 @@ fn ty_has_iter_method(
     };
 
     let def_id = match self_ty.sty {
-        ty::TyKind::Array(..) => return Some((INTO_ITER_ON_ARRAY, "array", method_name)),
-        ty::TyKind::Slice(..) => return Some((INTO_ITER_ON_REF, "slice", method_name)),
+        ty::Array(..) => return Some((INTO_ITER_ON_ARRAY, "array", method_name)),
+        ty::Slice(..) => return Some((INTO_ITER_ON_REF, "slice", method_name)),
         ty::Adt(adt, _) => adt.did,
         _ => return None,
     };

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -51,7 +51,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MinMaxPass {
                 }
                 match (
                     outer_max,
-                    Constant::partial_cmp(cx.tcx, &cx.tables.expr_ty(ie).sty, &outer_c, &inner_c),
+                    Constant::partial_cmp(cx.tcx, cx.tables.expr_ty(ie), &outer_c, &inner_c),
                 ) {
                     (_, None) | (MinMax::Max, Some(Ordering::Less)) | (MinMax::Min, Some(Ordering::Greater)) => (),
                     _ => {

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -219,7 +219,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
 
                     // Dereference suggestion
                     let sugg = |db: &mut DiagnosticBuilder<'_>| {
-                        if let ty::TyKind::Adt(def, ..) = ty.sty {
+                        if let ty::Adt(def, ..) = ty.sty {
                             if let Some(span) = cx.tcx.hir.span_if_local(def.did) {
                                 if cx.param_env.can_type_implement_copy(cx.tcx, ty).is_ok() {
                                     db.span_help(span, "consider marking this type as Copy");

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -14,7 +14,7 @@ use crate::rustc::hir::intravisit::FnKind;
 use crate::rustc::hir::*;
 use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::session::config::Config as SessionConfig;
-use crate::rustc::ty::{FnSig, TyKind};
+use crate::rustc::ty::{self, FnSig};
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::rustc_target::abi::LayoutOf;
@@ -99,8 +99,8 @@ impl<'a, 'tcx> TriviallyCopyPassByRef {
         // argument. In that case we can't switch to pass-by-value as the
         // argument will not live long enough.
         let output_lts = match sig.output().sty {
-            TyKind::Ref(output_lt, _, _) => vec![output_lt],
-            TyKind::Adt(_, substs) => substs.regions().collect(),
+            ty::Ref(output_lt, _, _) => vec![output_lt],
+            ty::Adt(_, substs) => substs.regions().collect(),
             _ => vec![],
         };
 
@@ -112,7 +112,7 @@ impl<'a, 'tcx> TriviallyCopyPassByRef {
             }
 
             if_chain! {
-                if let TyKind::Ref(input_lt, ty, Mutability::MutImmutable) = ty.sty;
+                if let ty::Ref(input_lt, ty, Mutability::MutImmutable) = ty.sty;
                 if !output_lts.contains(&input_lt);
                 if is_copy(cx, ty);
                 if let Some(size) = cx.layout_of(ty).ok().map(|l| l.size.bytes());


### PR DESCRIPTION
These are the 2 fixing commits cherry-picked from #3493 

I will implement the actual internal lint in rustc and activate it in here ones it is merged there.