### PR TITLE
fix #3482 and add ui test for it

### DIFF
--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -70,7 +70,7 @@ impl<'a, 'tcx: 'a> Visitor<'tcx> for ExVisitor<'a, 'tcx> {
         if let ExprKind::Closure(_, _, eid, _, _) = expr.node {
             let body = self.cx.tcx.hir.body(eid);
             let ex = &body.value;
-            if matches!(ex.node, ExprKind::Block(_, _)) {
+            if matches!(ex.node, ExprKind::Block(_, _)) && !in_macro(body.value.span) {
                 self.found_block = Some(ex);
                 return;
             }

--- a/tests/ui/block_in_if_condition.rs
+++ b/tests/ui/block_in_if_condition.rs
@@ -98,3 +98,11 @@ fn condition_is_unsafe_block() {
 
 fn main() {
 }
+
+fn macro_in_closure() {
+    let option = Some(true);
+
+    if option.unwrap_or_else(|| unimplemented!()) {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
I wrote a ui test that reproduces the false positive in #3482 and wrote an `in_macro` check to suppress blocks that were created during macro expansion.

Since this is my first contribution to this project, I'm not sure if I solved the issue appropriately. Feedback is highly appreciated.

Thanks in advance 😉 