### PR TITLE
Add `fast_finish` to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
 # if: fork = false
 # but this is currently buggy travis-ci/travis-ci#9118
 matrix:
+  fast_finish: true
   include:
     - os: osx # run base tests on both platforms
       env: BASE_TESTS=true


### PR DESCRIPTION
This means we don't have to wait for `allowed_failures` builds to
complete. It should save us ~10 minutes until we remove the windows
build from `allowed_failures`.

cc #3306