### PR TITLE
Integrate rustfix into Clippy test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,15 @@ Therefore you should use `tests/ui/update-all-references.sh` (after running
 `cargo test`) and check whether the output looks as you expect with `git diff`. Commit all
 `*.stderr` files, too.
 
+If the lint you are working on is making use of structured suggestions, the
+test file should include a `// run-rustfix` comment at the top. This will
+additionally run [rustfix](https://github.com/rust-lang-nursery/rustfix) for
+that test. Rustfix will apply the suggestions from the lint to the code of the
+test file and compare that to the contents of a `.fixed` file.
+
+Use `tests/ui/update-all-references.sh` to automatically generate the
+`.fixed` file after running `cargo test`.
+
 ### Running rustfmt
 
 [Rustfmt](https://github.com/rust-lang/rustfmt) is a tool for formatting Rust code according

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rustc_tools_util = { version = "0.1.0", path = "rustc_tools_util"}
 [dev-dependencies]
 clippy_dev = { version = "0.0.1", path = "clippy_dev" }
 cargo_metadata = "0.6.2"
-compiletest_rs = { git = "https://github.com/phansch/compiletest-rs.git", branch = "add_rustfix_support" }
+compiletest_rs = "0.3.18"
 lazy_static = "1.0"
 serde_derive = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rustc_tools_util = { version = "0.1.0", path = "rustc_tools_util"}
 [dev-dependencies]
 clippy_dev = { version = "0.0.1", path = "clippy_dev" }
 cargo_metadata = "0.6.2"
-compiletest_rs = "0.3.16"
+compiletest_rs = { git = "https://github.com/phansch/compiletest-rs.git", branch = "add_rustfix_support" }
 lazy_static = "1.0"
 serde_derive = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -98,7 +98,7 @@ impl LintPass for DerefPass {
 impl EarlyLintPass for DerefPass {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &Expr) {
         if_chain! {
-            if let ExprKind::Field(ref object, ref field_name) = e.node;
+            if let ExprKind::Field(ref object, _) = e.node;
             if let ExprKind::Paren(ref parened) = object.node;
             if let ExprKind::AddrOf(_, ref inner) = parened.node;
             then {
@@ -109,11 +109,7 @@ impl EarlyLintPass for DerefPass {
                     object.span,
                     "Creating a reference that is immediately dereferenced.",
                     "try this",
-                    format!(
-                        "{}.{}",
-                        snippet_with_applicability(cx, inner.span, "_", &mut applicability),
-                        snippet_with_applicability(cx, field_name.span, "_", &mut applicability)
-                    ),
+                    snippet_with_applicability(cx, inner.span, "_", &mut applicability).to_string(),
                     applicability,
                 );
             }

--- a/tests/ui/unnecessary_ref.fixed
+++ b/tests/ui/unnecessary_ref.fixed
@@ -9,6 +9,7 @@
 
 // run-rustfix
 
+
 #![feature(stmt_expr_attributes)]
 
 struct Outer {
@@ -18,5 +19,5 @@ struct Outer {
 #[deny(clippy::ref_in_deref)]
 fn main() {
     let outer = Outer { inner: 0 };
-    let inner = (&outer).inner;
+    let inner = outer.inner.inner;
 }

--- a/tests/ui/unnecessary_ref.fixed
+++ b/tests/ui/unnecessary_ref.fixed
@@ -9,8 +9,8 @@
 
 // run-rustfix
 
-
 #![feature(stmt_expr_attributes)]
+#![allow(unused_variables)]
 
 struct Outer {
     inner: u32,
@@ -19,5 +19,5 @@ struct Outer {
 #[deny(clippy::ref_in_deref)]
 fn main() {
     let outer = Outer { inner: 0 };
-    let inner = outer.inner.inner;
+    let inner = outer.inner;
 }

--- a/tests/ui/unnecessary_ref.rs
+++ b/tests/ui/unnecessary_ref.rs
@@ -10,6 +10,7 @@
 // run-rustfix
 
 #![feature(stmt_expr_attributes)]
+#![allow(unused_variables)]
 
 struct Outer {
     inner: u32,

--- a/tests/ui/unnecessary_ref.stderr
+++ b/tests/ui/unnecessary_ref.stderr
@@ -1,11 +1,11 @@
 error: Creating a reference that is immediately dereferenced.
-  --> $DIR/unnecessary_ref.rs:20:17
+  --> $DIR/unnecessary_ref.rs:21:17
    |
 LL |     let inner = (&outer).inner;
    |                 ^^^^^^^^ help: try this: `outer.inner`
    |
 note: lint level defined here
-  --> $DIR/unnecessary_ref.rs:17:8
+  --> $DIR/unnecessary_ref.rs:18:8
    |
 LL | #[deny(clippy::ref_in_deref)]
    |        ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unnecessary_ref.stderr
+++ b/tests/ui/unnecessary_ref.stderr
@@ -1,11 +1,11 @@
 error: Creating a reference that is immediately dereferenced.
-  --> $DIR/unnecessary_ref.rs:21:17
+  --> $DIR/unnecessary_ref.rs:22:17
    |
 LL |     let inner = (&outer).inner;
-   |                 ^^^^^^^^ help: try this: `outer.inner`
+   |                 ^^^^^^^^ help: try this: `outer`
    |
 note: lint level defined here
-  --> $DIR/unnecessary_ref.rs:18:8
+  --> $DIR/unnecessary_ref.rs:19:8
    |
 LL | #[deny(clippy::ref_in_deref)]
    |        ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/update-references.sh
+++ b/tests/ui/update-references.sh
@@ -34,6 +34,7 @@ shift
 while [[ "$1" != "" ]]; do
     STDERR_NAME="${1/%.rs/.stderr}"
     STDOUT_NAME="${1/%.rs/.stdout}"
+    FIXED_NAME="${1/%.rs/.fixed}"
     shift
     if [ -f $BUILD_DIR/$STDOUT_NAME ] && \
            ! (diff $BUILD_DIR/$STDOUT_NAME $MYDIR/$STDOUT_NAME >& /dev/null); then
@@ -44,6 +45,11 @@ while [[ "$1" != "" ]]; do
            ! (diff $BUILD_DIR/$STDERR_NAME $MYDIR/$STDERR_NAME >& /dev/null); then
         echo updating $MYDIR/$STDERR_NAME
         cp $BUILD_DIR/$STDERR_NAME $MYDIR/$STDERR_NAME
+    fi
+    if [ -f $BUILD_DIR/$FIXED_NAME ] && \
+           ! (diff $BUILD_DIR/$FIXED_NAME $MYDIR/$FIXED_NAME >& /dev/null); then
+        echo updating $MYDIR/$FIXED_NAME
+        cp $BUILD_DIR/$FIXED_NAME $MYDIR/$FIXED_NAME
     fi
 done
 


### PR DESCRIPTION
Once the [PR to compiletest-rs](https://github.com/laumann/compiletest-rs/pull/151) is reviewed and merged this fixes #2376.

I will create a separate tracking issue for adding `run-rustfix` to all tests.