### PR TITLE
Remove dead link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ All contributors are expected to follow the [Rust Code of Conduct](http://www.ru
   * [Running test suite](#running-test-suite)
   * [Running rustfmt](#running-rustfmt)
   * [Testing manually](#testing-manually)
-  * [Linting Clippy with your local changes](#linting-clippy-with-your-local-changes)
   * [How Clippy works](#how-clippy-works)
   * [Fixing nightly build failures](#fixing-build-failures-caused-by-rust)
 * [Issue and PR Triage](#issue-and-pr-triage)


### PR DESCRIPTION
I don't think there was an issue for this, but this is just removing a dead link in CONTRIBUTING.md. The _Linting Clippy with your local changes_ section seems to have been removed without updating the table of contents. 

I'm not sure if I should have opened an issue, but it seemed like a trivial fix to me.