### PR TITLE
Fix rvm/gpg bug in travis osx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,6 @@ env:
  global:
    - RUST_BACKTRACE=1
 
-before_install:
- - |
-    # work-around for issue https://github.com/travis-ci/travis-ci/issues/6307
-    # might not be necessary in the future
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-     command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-     rvm get stable
-    fi
-
 install:
   - |
     if [ -z ${INTEGRATION} ]; then


### PR DESCRIPTION
Apparently this workaround isn't needed anymore ([travis](https://travis-ci.org/flip1995/rust-clippy/jobs/467027571)) and fixes the latest osx failures: [travis](https://travis-ci.org/rust-lang/rust-clippy/jobs/467013498#L152)