### PR TITLE
rustup https://github.com/rust-lang/rust/pull/56092

### DIFF
--- a/tests/ui/cast_alignment.rs
+++ b/tests/ui/cast_alignment.rs
@@ -9,8 +9,8 @@
 
 //! Test casts for alignment issues
 
-#![feature(libc)]
 
+#![feature(rustc_private)]
 extern crate libc;
 
 #[warn(clippy::cast_ptr_alignment)]


### PR DESCRIPTION
fix ui test cast_alignment failure by adding #![feature(rustc_private)]