### PR TITLE
Revert "Merge pull request #3257 from o01eg/remove-sysroot"

### DIFF
--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -26,6 +26,11 @@ cd clippy_lints && cargo test && cd ..
 cd rustc_tools_util && cargo test && cd ..
 cd clippy_dev && cargo test && cd ..
 
+# make sure clippy can be called via ./path/to/cargo-clippy
+cd clippy_workspace_tests
+../target/debug/cargo-clippy
+cd ..
+
 # Perform various checks for lint registration
 ./util/dev update_lints --check
 cargo +nightly fmt --all -- --check

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -23,7 +23,7 @@ use self::rustc_driver::{driver::CompileController, Compilation};
 
 use std::convert::TryInto;
 use std::path::Path;
-use std::process::exit;
+use std::process::{exit, Command};
 
 fn show_version() {
     println!(env!("CARGO_PKG_VERSION"));
@@ -40,22 +40,54 @@ pub fn main() {
                 exit(0);
             }
 
+            let sys_root = option_env!("SYSROOT")
+                .map(String::from)
+                .or_else(|| std::env::var("SYSROOT").ok())
+                .or_else(|| {
+                    let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
+                    let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
+                    home.and_then(|home| toolchain.map(|toolchain| format!("{}/toolchains/{}", home, toolchain)))
+                })
+                .or_else(|| {
+                    Command::new("rustc")
+                        .arg("--print")
+                        .arg("sysroot")
+                        .output()
+                        .ok()
+                        .and_then(|out| String::from_utf8(out.stdout).ok())
+                        .map(|s| s.trim().to_owned())
+                })
+                .expect("need to specify SYSROOT env var during clippy compilation, or use rustup or multirust");
+
             // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
             // We're invoking the compiler programmatically, so we ignore this/
-            let mut args: Vec<String> = env::args().collect();
-            if args.len() <= 1 {
+            let mut orig_args: Vec<String> = env::args().collect();
+            if orig_args.len() <= 1 {
                 std::process::exit(1);
             }
-            if Path::new(&args[1]).file_stem() == Some("rustc".as_ref()) {
+            if Path::new(&orig_args[1]).file_stem() == Some("rustc".as_ref()) {
                 // we still want to be able to invoke it normally though
-                args.remove(1);
+                orig_args.remove(1);
             }
+            // this conditional check for the --sysroot flag is there so users can call
+            // `clippy_driver` directly
+            // without having to pass --sysroot or anything
+            let mut args: Vec<String> = if orig_args.iter().any(|s| s == "--sysroot") {
+                orig_args.clone()
+            } else {
+                orig_args
+                    .clone()
+                    .into_iter()
+                    .chain(Some("--sysroot".to_owned()))
+                    .chain(Some(sys_root))
+                    .collect()
+            };
 
             // this check ensures that dependencies are built but not linted and the final
             // crate is
             // linted but not built
             let clippy_enabled = env::var("CLIPPY_TESTS").ok().map_or(false, |val| val == "true")
-                || args.iter().any(|s| s == "--emit=dep-info,metadata");
+                || orig_args.iter().any(|s| s == "--emit=dep-info,metadata");
 
             if clippy_enabled {
                 args.extend_from_slice(&["--cfg".to_owned(), r#"feature="cargo-clippy""#.to_owned()]);

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -7,31 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::path::PathBuf;
-use std::process::Command;
-
-fn rustc_sysroot_path() -> PathBuf {
-    option_env!("SYSROOT")
-        .map(String::from)
-        .or_else(|| std::env::var("SYSROOT").ok())
-        .or_else(|| {
-            let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
-            let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
-            home.and_then(|home| toolchain.map(|toolchain| format!("{}/toolchains/{}", home, toolchain)))
-        })
-        .or_else(|| {
-            Command::new("rustc")
-                .arg("--print")
-                .arg("sysroot")
-                .output()
-                .ok()
-                .and_then(|out| String::from_utf8(out.stdout).ok())
-                .map(|s| s.trim().to_owned())
-        })
-        .expect("need to specify SYSROOT env var during clippy compilation, or use rustup or multirust")
-        .into()
-}
-
 #[test]
 fn dogfood() {
     if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
@@ -46,7 +21,6 @@ fn dogfood() {
     let output = std::process::Command::new(clippy_cmd)
         .current_dir(root_dir)
         .env("CLIPPY_DOGFOOD", "1")
-        .env("RUSTFLAGS", format!("--sysroot {}", rustc_sysroot_path().display()))
         .arg("clippy")
         .arg("--all-targets")
         .arg("--all-features")
@@ -85,7 +59,6 @@ fn dogfood_tests() {
         let output = std::process::Command::new(&clippy_cmd)
             .current_dir(root_dir.join(d))
             .env("CLIPPY_DOGFOOD", "1")
-            .env("RUSTFLAGS", format!("--sysroot {}", rustc_sysroot_path().display()))
             .arg("clippy")
             .arg("--")
             .args(&["-D", "clippy::all"])


### PR DESCRIPTION
This reverts commit 041c49c1ed11b016d6ab9379643bb1da2adf5bfe, reversing
changes made to 1df5766cbb559aab0ad5c2296d8b768182b5186c.

The PR broke running a cargo-install'd clippy.
The installed clippy would not be able to find a crate for std.

Fixes #3523
Reopens #2874