### PR TITLE
rustup rust-lang/rust#52994

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -116,7 +116,7 @@ fn check_if(cx: &EarlyContext<'_>, expr: &ast::Expr) {
 fn block_starts_with_comment(cx: &EarlyContext<'_>, expr: &ast::Block) -> bool {
     // We trim all opening braces and whitespaces and then check if the next string is a comment.
     let trimmed_block_text = snippet_block(cx, expr.span, "..")
-        .trim_left_matches(|c: char| c.is_whitespace() || c == '{')
+        .trim_start_matches(|c: char| c.is_whitespace() || c == '{')
         .to_owned();
     trimmed_block_text.starts_with("//") || trimmed_block_text.starts_with("/*")
 }

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -116,7 +116,7 @@ pub fn strip_doc_comment_decoration(comment: &str, span: Span) -> (String, Vec<(
         for line in doc.lines() {
             let offset = line.as_ptr() as usize - comment.as_ptr() as usize;
             debug_assert_eq!(offset as u32 as usize, offset);
-            contains_initial_stars |= line.trim_left().starts_with('*');
+            contains_initial_stars |= line.trim_start().starts_with('*');
             // +1 for the newline
             sizes.push((line.len() + 1, span.with_lo(span.lo() + BytePos(offset as u32))));
         }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2350,8 +2350,8 @@ const PATTERN_METHODS: [(&str, usize); 17] = [
     ("rmatches", 1),
     ("match_indices", 1),
     ("rmatch_indices", 1),
-    ("trim_left_matches", 1),
-    ("trim_right_matches", 1),
+    ("trim_start_matches", 1),
+    ("trim_end_matches", 1),
 ];
 
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -446,13 +446,13 @@ impl MiscEarly {
                         db.span_suggestion_with_applicability(
                             lit.span,
                             "if you mean to use a decimal constant, remove the `0` to remove confusion",
-                            src.trim_left_matches(|c| c == '_' || c == '0').to_string(),
+                            src.trim_start_matches(|c| c == '_' || c == '0').to_string(),
                             Applicability::MaybeIncorrect,
                         );
                         db.span_suggestion_with_applicability(
                             lit.span,
                             "if you mean to use an octal constant, use `0o`",
-                            format!("0o{}", src.trim_left_matches(|c| c == '_' || c == '0')),
+                            format!("0o{}", src.trim_start_matches(|c| c == '_' || c == '0')),
                             Applicability::MaybeIncorrect,
                         );
                     });

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -42,8 +42,8 @@ fn main() {
     x.rmatches("x");
     x.match_indices("x");
     x.rmatch_indices("x");
-    x.trim_left_matches("x");
-    x.trim_right_matches("x");
+    x.trim_start_matches("x");
+    x.trim_end_matches("x");
     // Make sure we escape characters correctly.
     x.split("\n");
 

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -91,16 +91,16 @@ error: single-character string constant used as pattern
    |                      ^^^ help: try using a char instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:45:25
+  --> $DIR/single_char_pattern.rs:45:26
    |
-45 |     x.trim_left_matches("x");
-   |                         ^^^ help: try using a char instead: `'x'`
+45 |     x.trim_start_matches("x");
+   |                          ^^^ help: try using a char instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:46:26
+  --> $DIR/single_char_pattern.rs:46:24
    |
-46 |     x.trim_right_matches("x");
-   |                          ^^^ help: try using a char instead: `'x'`
+46 |     x.trim_end_matches("x");
+   |                        ^^^ help: try using a char instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:48:13


### PR DESCRIPTION
`trim_left*` and `trim_right*` are deprecated as of 1.33.0.

`s/trim_left/trim_start/`
`s/trim_right/trim_end/`