### PR TITLE
Fix `implicit_return` false positives.

### DIFF
--- a/tests/ui/implicit_return.rs
+++ b/tests/ui/implicit_return.rs
@@ -55,10 +55,10 @@ fn test_loop_with_block() -> bool {
 fn test_loop_with_nests() -> bool {
     loop {
         if true {
-            let _ = true;
+            break true;
         }
         else {
-            break true;
+            let _ = true;
         }
     }
 }

--- a/tests/ui/implicit_return.rs
+++ b/tests/ui/implicit_return.rs
@@ -42,6 +42,27 @@ fn test_loop() -> bool {
     }
 }
 
+#[allow(clippy::never_loop)]
+fn test_loop_with_block() -> bool {
+    loop {
+        {
+            break true;
+        }
+    }
+}
+
+#[allow(clippy::never_loop)]
+fn test_loop_with_nests() -> bool {
+    loop {
+        if true {
+            let _ = true;
+        }
+        else {
+            break true;
+        }
+    }
+}
+
 fn test_closure() {
     #[rustfmt::skip]
     let _ = || { true };
@@ -53,5 +74,7 @@ fn main() {
     let _ = test_if_block();
     let _ = test_match(true);
     let _ = test_loop();
+    let _ = test_loop_with_block();
+    let _ = test_loop_with_nests();
     test_closure();
 }

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -43,9 +43,9 @@ error: missing return statement
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:61:13
+  --> $DIR/implicit_return.rs:58:13
    |
-61 |             break true;
+58 |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing return statement

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -37,16 +37,28 @@ error: missing return statement
    |         ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:47:18
+  --> $DIR/implicit_return.rs:49:13
    |
-47 |     let _ = || { true };
+49 |             break true;
+   |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
+
+error: missing return statement
+  --> $DIR/implicit_return.rs:61:13
+   |
+61 |             break true;
+   |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
+
+error: missing return statement
+  --> $DIR/implicit_return.rs:68:18
+   |
+68 |     let _ = || { true };
    |                  ^^^^ help: add `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:48:16
+  --> $DIR/implicit_return.rs:69:16
    |
-48 |     let _ = || true;
+69 |     let _ = || true;
    |                ^^^^ help: add `return` as shown: `return true`
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Fixing some false positives on the `implicit_return` lint.

Basically it should only check for missing return statements in `block.stmts.last()` if it's a `break`, otherwise it should skip because it would either be an error, or a false positive in the case of a `loop` (which I'm trying to fix with this PR).

**Question:**
- I say "we" inside of comments ([`// make sure it's a break, otherwise we want to skip`](https://github.com/rust-lang/rust-clippy/pull/3555/files#diff-11d233fe8c8414214c2b8732b8c9877aR71)). Any alternatives or is that okay?
- I named a test [`test_loop_with_nests()`](https://github.com/rust-lang/rust-clippy/blob/6870638c3fb66c2abb20633bf40cc09ccc760047/tests/ui/implicit_return.rs#L54-L64), any better suggestions?