### PR TITLE
Implements lint for order comparisons against bool (#3438)

### DIFF
--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -174,7 +174,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                     )),
                     ignore_case,
                     Some((
-                        |l: Sugg<'_>, r: Sugg<'_>| (!l).and(&r),
+                        |l: Sugg<'_>, r: Sugg<'_>| (!l).bit_and(&r),
                         "order comparisons between booleans can be simplified",
                     )),
                 ),
@@ -189,7 +189,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
                     ignore_case,
                     Some((|h| h, "greater than checks against false are unnecessary")),
                     Some((
-                        |l: Sugg<'_>, r: Sugg<'_>| l.and(&(!r)),
+                        |l: Sugg<'_>, r: Sugg<'_>| l.bit_and(&(!r)),
                         "order comparisons between booleans can be simplified",
                     )),
                 ),

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -174,6 +174,11 @@ impl<'a> Sugg<'a> {
         make_binop(ast::BinOpKind::And, &self, rhs)
     }
 
+    /// Convenience method to create the `<lhs> & <rhs>` suggestion.
+    pub fn bit_and(self, rhs: &Self) -> Sugg<'static> {
+        make_binop(ast::BinOpKind::BitAnd, &self, rhs)
+    }
+
     /// Convenience method to create the `<lhs> as <rhs>` suggestion.
     pub fn as_ty<R: Display>(self, rhs: R) -> Sugg<'static> {
         make_assoc(AssocOp::As, &self, &Sugg::NonParen(rhs.to_string().into()))

--- a/tests/ui/bool_comparison.rs
+++ b/tests/ui/bool_comparison.rs
@@ -50,4 +50,35 @@ fn main() {
     } else {
         "no"
     };
+    if x < true {
+        "yes"
+    } else {
+        "no"
+    };
+    if false < x {
+        "yes"
+    } else {
+        "no"
+    };
+    if x > false {
+        "yes"
+    } else {
+        "no"
+    };
+    if true > x {
+        "yes"
+    } else {
+        "no"
+    };
+    let y = true;
+    if x < y {
+        "yes"
+    } else {
+        "no"
+    };
+    if x > y {
+        "yes"
+    } else {
+        "no"
+    };
 }

--- a/tests/ui/bool_comparison.stderr
+++ b/tests/ui/bool_comparison.stderr
@@ -76,13 +76,13 @@ error: order comparisons between booleans can be simplified
   --> $DIR/bool_comparison.rs:74:8
    |
 74 |     if x < y {
-   |        ^^^^^ help: try simplifying it as shown: `!x && y`
+   |        ^^^^^ help: try simplifying it as shown: `!x & y`
 
 error: order comparisons between booleans can be simplified
   --> $DIR/bool_comparison.rs:79:8
    |
 79 |     if x > y {
-   |        ^^^^^ help: try simplifying it as shown: `x && !y`
+   |        ^^^^^ help: try simplifying it as shown: `x & !y`
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/bool_comparison.stderr
+++ b/tests/ui/bool_comparison.stderr
@@ -48,5 +48,41 @@ error: inequality checks against false are unnecessary
 48 |     if false != x {
    |        ^^^^^^^^^^ help: try simplifying it as shown: `x`
 
-error: aborting due to 8 previous errors
+error: less than comparison against true can be replaced by a negation
+  --> $DIR/bool_comparison.rs:53:8
+   |
+53 |     if x < true {
+   |        ^^^^^^^^ help: try simplifying it as shown: `!x`
+
+error: greater than checks against false are unnecessary
+  --> $DIR/bool_comparison.rs:58:8
+   |
+58 |     if false < x {
+   |        ^^^^^^^^^ help: try simplifying it as shown: `x`
+
+error: greater than checks against false are unnecessary
+  --> $DIR/bool_comparison.rs:63:8
+   |
+63 |     if x > false {
+   |        ^^^^^^^^^ help: try simplifying it as shown: `x`
+
+error: less than comparison against true can be replaced by a negation
+  --> $DIR/bool_comparison.rs:68:8
+   |
+68 |     if true > x {
+   |        ^^^^^^^^ help: try simplifying it as shown: `!x`
+
+error: order comparisons between booleans can be simplified
+  --> $DIR/bool_comparison.rs:74:8
+   |
+74 |     if x < y {
+   |        ^^^^^ help: try simplifying it as shown: `!x && y`
+
+error: order comparisons between booleans can be simplified
+  --> $DIR/bool_comparison.rs:79:8
+   |
+79 |     if x > y {
+   |        ^^^^^ help: try simplifying it as shown: `x && !y`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
As described on issue #3438, this change implements linting for `>` and `<` comparisons against both `boolean` literals and between expressions.