### PR TITLE
Merge new_without_default_derive into new_without_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -785,7 +785,6 @@ All notable changes to this project will be documented in this file.
 [`never_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#never_loop
 [`new_ret_no_self`]: https://rust-lang.github.io/rust-clippy/master/index.html#new_ret_no_self
 [`new_without_default`]: https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
-[`new_without_default_derive`]: https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default_derive
 [`no_effect`]: https://rust-lang.github.io/rust-clippy/master/index.html#no_effect
 [`non_ascii_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_ascii_literal
 [`nonminimal_bool`]: https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 291 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 290 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -701,7 +701,6 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         neg_cmp_op_on_partial_ord::NEG_CMP_OP_ON_PARTIAL_ORD,
         neg_multiply::NEG_MULTIPLY,
         new_without_default::NEW_WITHOUT_DEFAULT,
-        new_without_default::NEW_WITHOUT_DEFAULT_DERIVE,
         no_effect::NO_EFFECT,
         no_effect::UNNECESSARY_OPERATION,
         non_copy_const::BORROW_INTERIOR_MUTABLE_CONST,
@@ -837,7 +836,6 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         mut_reference::UNNECESSARY_MUT_PASSED,
         neg_multiply::NEG_MULTIPLY,
         new_without_default::NEW_WITHOUT_DEFAULT,
-        new_without_default::NEW_WITHOUT_DEFAULT_DERIVE,
         non_expressive_names::JUST_UNDERSCORES_AND_DIGITS,
         non_expressive_names::MANY_SINGLE_CHAR_NAMES,
         ok_if_let::IF_LET_SOME_RESULT,
@@ -1032,6 +1030,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
 
 pub fn register_renamed(ls: &mut rustc::lint::LintStore) {
     ls.register_renamed("clippy::stutter", "clippy::module_name_repetitions");
+    ls.register_renamed("clippy::new_without_default_derive", "clippy::new_without_default");
 }
 
 // only exists to let the dogfood integration test works.

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -14,7 +14,6 @@
     clippy::print_stdout,
     clippy::non_ascii_literal,
     clippy::new_without_default,
-    clippy::new_without_default_derive,
     clippy::missing_docs_in_private_items,
     clippy::needless_pass_by_value,
     clippy::default_trait_access,

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -1,5 +1,5 @@
 error: defining a method called `add` on this type; consider implementing the `std::ops::Add` trait or choosing a less ambiguous name
-  --> $DIR/methods.rs:38:5
+  --> $DIR/methods.rs:37:5
    |
 LL |     pub fn add(self, other: T) -> T { self }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     pub fn add(self, other: T) -> T { self }
    = note: `-D clippy::should-implement-trait` implied by `-D warnings`
 
 error: methods called `into_*` usually take self by value; consider choosing a less ambiguous name
-  --> $DIR/methods.rs:49:17
+  --> $DIR/methods.rs:48:17
    |
 LL |     fn into_u16(&self) -> u16 { 0 }
    |                 ^^^^^
@@ -15,19 +15,19 @@ LL |     fn into_u16(&self) -> u16 { 0 }
    = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
 
 error: methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
-  --> $DIR/methods.rs:51:21
+  --> $DIR/methods.rs:50:21
    |
 LL |     fn to_something(self) -> u32 { 0 }
    |                     ^^^^
 
 error: methods called `new` usually take no self; consider choosing a less ambiguous name
-  --> $DIR/methods.rs:53:12
+  --> $DIR/methods.rs:52:12
    |
 LL |     fn new(self) -> Self { unimplemented!(); }
    |            ^^^^
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:121:13
+  --> $DIR/methods.rs:120:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -39,7 +39,7 @@ LL | |                .unwrap_or(0); // should lint even though this call is on 
    = note: replace `map(|x| x + 1).unwrap_or(0)` with `map_or(0, |x| x + 1)`
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:125:13
+  --> $DIR/methods.rs:124:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -49,7 +49,7 @@ LL | |               ).unwrap_or(0);
    | |____________________________^
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:129:13
+  --> $DIR/methods.rs:128:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -59,7 +59,7 @@ LL | |                 });
    | |__________________^
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:134:13
+  --> $DIR/methods.rs:133:13
    |
 LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -67,7 +67,7 @@ LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
    = note: replace `map(|x| Some(x + 1)).unwrap_or(None)` with `and_then(|x| Some(x + 1))`
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:136:13
+  --> $DIR/methods.rs:135:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -77,7 +77,7 @@ LL | |     ).unwrap_or(None);
    | |_____________________^
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:140:13
+  --> $DIR/methods.rs:139:13
    |
 LL |       let _ = opt
    |  _____________^
@@ -88,7 +88,7 @@ LL | |         .unwrap_or(None);
    = note: replace `map(|x| Some(x + 1)).unwrap_or(None)` with `and_then(|x| Some(x + 1))`
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:148:13
+  --> $DIR/methods.rs:147:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -100,7 +100,7 @@ LL | |                .unwrap_or_else(|| 0); // should lint even though this cal
    = note: replace `map(|x| x + 1).unwrap_or_else(|| 0)` with `map_or_else(|| 0, |x| x + 1)`
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:152:13
+  --> $DIR/methods.rs:151:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -110,7 +110,7 @@ LL | |               ).unwrap_or_else(|| 0);
    | |____________________________________^
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:156:13
+  --> $DIR/methods.rs:155:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -120,7 +120,7 @@ LL | |                 );
    | |_________________^
 
 error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:165:13
+  --> $DIR/methods.rs:164:13
    |
 LL |     let _ = opt.map_or(None, |x| Some(x + 1));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using and_then instead: `opt.and_then(|x| Some(x + 1))`
@@ -128,7 +128,7 @@ LL |     let _ = opt.map_or(None, |x| Some(x + 1));
    = note: `-D clippy::option-map-or-none` implied by `-D warnings`
 
 error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:167:13
+  --> $DIR/methods.rs:166:13
    |
 LL |       let _ = opt.map_or(None, |x| {
    |  _____________^
@@ -144,7 +144,7 @@ LL |                        });
    |
 
 error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `ok().map_or_else(g, f)` instead
-  --> $DIR/methods.rs:180:13
+  --> $DIR/methods.rs:179:13
    |
 LL |       let _ = res.map(|x| x + 1)
    |  _____________^
@@ -156,7 +156,7 @@ LL | |                .unwrap_or_else(|e| 0); // should lint even though this ca
    = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `ok().map_or_else(|e| 0, |x| x + 1)`
 
 error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `ok().map_or_else(g, f)` instead
-  --> $DIR/methods.rs:184:13
+  --> $DIR/methods.rs:183:13
    |
 LL |       let _ = res.map(|x| {
    |  _____________^
@@ -166,7 +166,7 @@ LL | |               ).unwrap_or_else(|e| 0);
    | |_____________________________________^
 
 error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `ok().map_or_else(g, f)` instead
-  --> $DIR/methods.rs:188:13
+  --> $DIR/methods.rs:187:13
    |
 LL |       let _ = res.map(|x| x + 1)
    |  _____________^
@@ -176,7 +176,7 @@ LL | |                 );
    | |_________________^
 
 error: called `filter(p).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(p)` instead.
-  --> $DIR/methods.rs:251:13
+  --> $DIR/methods.rs:250:13
    |
 LL |     let _ = v.iter().filter(|&x| *x < 0).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL |     let _ = v.iter().filter(|&x| *x < 0).next();
    = note: replace `filter(|&x| *x < 0).next()` with `find(|&x| *x < 0)`
 
 error: called `filter(p).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(p)` instead.
-  --> $DIR/methods.rs:254:13
+  --> $DIR/methods.rs:253:13
    |
 LL |       let _ = v.iter().filter(|&x| {
    |  _____________^
@@ -195,7 +195,7 @@ LL | |                    ).next();
    | |___________________________^
 
 error: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:269:13
+  --> $DIR/methods.rs:268:13
    |
 LL |     let _ = v.iter().find(|&x| *x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL |     let _ = v.iter().find(|&x| *x < 0).is_some();
    = note: replace `find(|&x| *x < 0).is_some()` with `any(|&x| *x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:272:13
+  --> $DIR/methods.rs:271:13
    |
 LL |       let _ = v.iter().find(|&x| {
    |  _____________^
@@ -214,7 +214,7 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: called `is_some()` after searching an `Iterator` with position. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:278:13
+  --> $DIR/methods.rs:277:13
    |
 LL |     let _ = v.iter().position(|&x| x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -222,7 +222,7 @@ LL |     let _ = v.iter().position(|&x| x < 0).is_some();
    = note: replace `position(|&x| x < 0).is_some()` with `any(|&x| x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with position. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:281:13
+  --> $DIR/methods.rs:280:13
    |
 LL |       let _ = v.iter().position(|&x| {
    |  _____________^
@@ -232,7 +232,7 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: called `is_some()` after searching an `Iterator` with rposition. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:287:13
+  --> $DIR/methods.rs:286:13
    |
 LL |     let _ = v.iter().rposition(|&x| x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -240,7 +240,7 @@ LL |     let _ = v.iter().rposition(|&x| x < 0).is_some();
    = note: replace `rposition(|&x| x < 0).is_some()` with `any(|&x| x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with rposition. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:290:13
+  --> $DIR/methods.rs:289:13
    |
 LL |       let _ = v.iter().rposition(|&x| {
    |  _____________^
@@ -250,7 +250,7 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/methods.rs:325:22
+  --> $DIR/methods.rs:324:22
    |
 LL |     with_constructor.unwrap_or(make());
    |                      ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(make)`
@@ -258,73 +258,73 @@ LL |     with_constructor.unwrap_or(make());
    = note: `-D clippy::or-fun-call` implied by `-D warnings`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/methods.rs:328:5
+  --> $DIR/methods.rs:327:5
    |
 LL |     with_new.unwrap_or(Vec::new());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `with_new.unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/methods.rs:331:21
+  --> $DIR/methods.rs:330:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/methods.rs:334:14
+  --> $DIR/methods.rs:333:14
    |
 LL |     with_err.unwrap_or(make());
    |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| make())`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/methods.rs:337:19
+  --> $DIR/methods.rs:336:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/methods.rs:340:5
+  --> $DIR/methods.rs:339:5
    |
 LL |     with_default_trait.unwrap_or(Default::default());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `with_default_trait.unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/methods.rs:343:5
+  --> $DIR/methods.rs:342:5
    |
 LL |     with_default_type.unwrap_or(u64::default());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `with_default_type.unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/methods.rs:346:14
+  --> $DIR/methods.rs:345:14
    |
 LL |     with_vec.unwrap_or(vec![]);
    |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| vec![])`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/methods.rs:351:21
+  --> $DIR/methods.rs:350:21
    |
 LL |     without_default.unwrap_or(Foo::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` followed by a function call
-  --> $DIR/methods.rs:354:19
+  --> $DIR/methods.rs:353:19
    |
 LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(String::new)`
 
 error: use of `or_insert` followed by a function call
-  --> $DIR/methods.rs:357:21
+  --> $DIR/methods.rs:356:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(String::new)`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/methods.rs:360:21
+  --> $DIR/methods.rs:359:21
    |
 LL |     let _ = stringy.unwrap_or("".to_owned());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| "".to_owned())`
 
 error: called `.iter().nth()` on a Vec. Calling `.get()` is both faster and more readable
-  --> $DIR/methods.rs:371:23
+  --> $DIR/methods.rs:370:23
    |
 LL |         let bad_vec = some_vec.iter().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^
@@ -332,43 +332,43 @@ LL |         let bad_vec = some_vec.iter().nth(3);
    = note: `-D clippy::iter-nth` implied by `-D warnings`
 
 error: called `.iter().nth()` on a slice. Calling `.get()` is both faster and more readable
-  --> $DIR/methods.rs:372:26
+  --> $DIR/methods.rs:371:26
    |
 LL |         let bad_slice = &some_vec[..].iter().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `.iter().nth()` on a slice. Calling `.get()` is both faster and more readable
-  --> $DIR/methods.rs:373:31
+  --> $DIR/methods.rs:372:31
    |
 LL |         let bad_boxed_slice = boxed_slice.iter().nth(3);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `.iter().nth()` on a VecDeque. Calling `.get()` is both faster and more readable
-  --> $DIR/methods.rs:374:29
+  --> $DIR/methods.rs:373:29
    |
 LL |         let bad_vec_deque = some_vec_deque.iter().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `.iter_mut().nth()` on a Vec. Calling `.get_mut()` is both faster and more readable
-  --> $DIR/methods.rs:379:23
+  --> $DIR/methods.rs:378:23
    |
 LL |         let bad_vec = some_vec.iter_mut().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `.iter_mut().nth()` on a slice. Calling `.get_mut()` is both faster and more readable
-  --> $DIR/methods.rs:382:26
+  --> $DIR/methods.rs:381:26
    |
 LL |         let bad_slice = &some_vec[..].iter_mut().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `.iter_mut().nth()` on a VecDeque. Calling `.get_mut()` is both faster and more readable
-  --> $DIR/methods.rs:385:29
+  --> $DIR/methods.rs:384:29
    |
 LL |         let bad_vec_deque = some_vec_deque.iter_mut().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
-  --> $DIR/methods.rs:397:13
+  --> $DIR/methods.rs:396:13
    |
 LL |     let _ = some_vec.iter().skip(42).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -376,25 +376,25 @@ LL |     let _ = some_vec.iter().skip(42).next();
    = note: `-D clippy::iter-skip-next` implied by `-D warnings`
 
 error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
-  --> $DIR/methods.rs:398:13
+  --> $DIR/methods.rs:397:13
    |
 LL |     let _ = some_vec.iter().cycle().skip(42).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
-  --> $DIR/methods.rs:399:13
+  --> $DIR/methods.rs:398:13
    |
 LL |     let _ = (1..10).skip(10).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
-  --> $DIR/methods.rs:400:14
+  --> $DIR/methods.rs:399:14
    |
 LL |     let _ = &some_vec[..].iter().skip(3).next();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
-  --> $DIR/methods.rs:409:13
+  --> $DIR/methods.rs:408:13
    |
 LL |     let _ = opt.unwrap();
    |             ^^^^^^^^^^^^

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -9,7 +9,7 @@
 
 #![feature(const_fn)]
 #![allow(dead_code)]
-#![warn(clippy::new_without_default, clippy::new_without_default_derive)]
+#![warn(clippy::new_without_default)]
 
 pub struct Foo;
 
@@ -151,7 +151,7 @@ impl Allow {
 pub struct AllowDerive;
 
 impl AllowDerive {
-    #[allow(clippy::new_without_default_derive)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         unimplemented!()
     }

--- a/tests/ui/new_without_default.stderr
+++ b/tests/ui/new_without_default.stderr
@@ -6,7 +6,7 @@ LL | |         Foo
 LL | |     }
    | |_____^
    |
-   = note: `-D clippy::new-without-default-derive` implied by `-D warnings`
+   = note: `-D clippy::new-without-default` implied by `-D warnings`
 help: try this
    |
 LL | #[derive(Default)]
@@ -31,8 +31,6 @@ LL | /     pub fn new() -> LtKo<'c> {
 LL | |         unimplemented!()
 LL | |     }
    | |_____^
-   |
-   = note: `-D clippy::new-without-default` implied by `-D warnings`
 help: try this
    |
 LL | impl Default for LtKo<'c> {

--- a/tests/ui/rename.rs
+++ b/tests/ui/rename.rs
@@ -11,3 +11,12 @@
 
 #[warn(clippy::stutter)]
 fn main() {}
+
+#[warn(clippy::new_without_default_derive)]
+struct Foo;
+
+impl Foo {
+    fn new() -> Self {
+        Foo
+    }
+}

--- a/tests/ui/rename.stderr
+++ b/tests/ui/rename.stderr
@@ -14,5 +14,11 @@ LL | #[warn(clippy::stutter)]
    |
    = note: `-D renamed-and-removed-lints` implied by `-D warnings`
 
-error: aborting due to 2 previous errors
+error: lint `clippy::new_without_default_derive` has been renamed to `clippy::new_without_default`
+  --> $DIR/rename.rs:15:8
+   |
+LL | #[warn(clippy::new_without_default_derive)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `clippy::new_without_default`
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Closes #3525, deprecating new_without_default_derive and moving both lints into new_without_default.

