### PR TITLE
WiP: Fix wrong_self_convention false positive (#3414)

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2373,8 +2373,7 @@ impl SelfKind {
         generics: &hir::Generics,
     ) -> bool {
         // Self types in the HIR are desugared to explicit self types. So it will
-        // always be `self:
-        // SomeType`,
+        // always be `self: SomeType`,
         // where SomeType can be `Self` or an explicit impl self type (e.g. `Foo` if
         // the impl is on `Foo`)
         // Thus, we only need to test equality against the impl self type or if it is
@@ -2407,7 +2406,7 @@ impl SelfKind {
             }
         } else {
             match self {
-                SelfKind::Value => false,
+                SelfKind::Value => is_actually_self(ty),// accept in case Deref<Target=T> is implemented
                 SelfKind::Ref => is_as_ref_or_mut_trait(ty, self_ty, generics, &paths::ASREF_TRAIT),
                 SelfKind::RefMut => is_as_ref_or_mut_trait(ty, self_ty, generics, &paths::ASMUT_TRAIT),
                 SelfKind::No => true,

--- a/tests/ui/wrong_self_convention.rs
+++ b/tests/ui/wrong_self_convention.rs
@@ -65,3 +65,19 @@ impl Bar {
     fn from_(self) {}
     fn to_mut(&mut self) {}
 }
+
+// test false positive
+struct Wrapper<T>(T);
+
+impl<T> Wrapper<T> {
+    fn into_inner(this: Self) -> T {
+        this.0
+    }
+}
+
+impl<T> std::ops::Deref for Wrapper<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}


### PR DESCRIPTION
The current fix passes tests but is likely too broad:
It is not limited to types with generic `Deref` impls, and modifies `SelfKind.matches()` which is also used for the should_implement_trait lint.

I am a bit stuck on detecting generic Deref impls: I started copying `has_debug_impl()` before realizing that function takes `ty::Ty` instead of `hir::Ty`. I also haven't figured out how to get or check the associated type of a trait impl.

The issue only mentions `into_*` wanting self by value, but could there be similar false positives with phrases for which the lint wants `&self` or `&mut self`?

Related: It doesn't look like there's a lint against inherent methods with `self` on types that deref to an unknown (generic) type. Should I add one?