### PR TITLE
Link to `rustc_driver` crate in plugin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 // FIXME: switch to something more ergonomic here, once available.
 // (currently there is no way to opt into sysroot crates w/o `extern crate`)
 #[allow(unused_extern_crates)]
+extern crate rustc_driver;
+#[allow(unused_extern_crates)]
 extern crate rustc_plugin;
 use self::rustc_plugin::Registry;
 


### PR DESCRIPTION
This is in anticipation for rust-lang/rust#56987 where the
`rustc_driver` crate being linked in will be required to link correctly
against the compiler. In the meantime it should be harmless otherwise!