### PR TITLE
Document map_clone known problems #498

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -27,7 +27,9 @@ pub struct Pass;
 ///
 /// **Why is this bad?** Readability, this can be written more concisely
 ///
-/// **Known problems:** None.
+/// **Known problems:** Sometimes `.cloned()` requires stricter trait
+/// bound than `.map(|e| e.clone())` (which works because of the coercion).
+/// See [#498](https://github.com/rust-lang-nursery/rust-clippy/issues/498).
 ///
 /// **Example:**
 ///


### PR DESCRIPTION
(cherry picked from commit ada0d2c54831a904a53ff4106e0ebb6a0f06a687)

This was lost in relicensing (057243f16b4f4233).
However, I [acknowledged](https://github.com/rust-lang/rust-clippy/issues/3099#issuecomment-416482309) relicensing so this cherry pick should be fine I guess.