### PR TITLE
Fix false positives for `implicit_return` and `empty_loop` on macro expansion.

### DIFF
--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -116,14 +116,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         _: FnKind<'tcx>,
         _: &'tcx FnDecl,
         body: &'tcx Body,
-        _: Span,
+        span: Span,
         _: NodeId,
     ) {
         let def_id = cx.tcx.hir().body_owner_def_id(body.id());
         let mir = cx.tcx.optimized_mir(def_id);
 
         // checking return type through MIR, HIR is not able to determine inferred closure return types
-        if !mir.return_ty().is_unit() {
+        // make sure it's not a macro
+        if !mir.return_ty().is_unit() && span.macro_backtrace().is_empty() {
             Self::expr_match(cx, &body.value);
         }
     }

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -12,7 +12,7 @@ use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::{ast::NodeId, source_map::Span};
-use crate::utils::{snippet_opt, span_lint_and_then, in_macro};
+use crate::utils::{in_macro, snippet_opt, span_lint_and_then};
 
 /// **What it does:** Checks for missing return statements at the end of a block.
 ///

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -12,7 +12,7 @@ use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use crate::rustc::{declare_tool_lint, lint_array};
 use crate::rustc_errors::Applicability;
 use crate::syntax::{ast::NodeId, source_map::Span};
-use crate::utils::{snippet_opt, span_lint_and_then};
+use crate::utils::{snippet_opt, span_lint_and_then, in_macro};
 
 /// **What it does:** Checks for missing return statements at the end of a block.
 ///
@@ -124,7 +124,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 
         // checking return type through MIR, HIR is not able to determine inferred closure return types
         // make sure it's not a macro
-        if !mir.return_ty().is_unit() && span.macro_backtrace().is_empty() {
+        if !mir.return_ty().is_unit() && !in_macro(span) {
             Self::expr_match(cx, &body.value);
         }
     }

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -479,7 +479,7 @@ impl LintPass for Pass {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         // we don't want to check expanded macros
-        if !in_macro(expr.span) {
+        if in_macro(expr.span) {
             return;
         }
 

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -478,6 +478,11 @@ impl LintPass for Pass {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
+        // we don't want to check expanded macros
+        if !expr.span.macro_backtrace().is_empty() {
+            return;
+        }
+
         if let Some((pat, arg, body)) = higher::for_loop(expr) {
             check_for_loop(cx, pat, arg, body, expr);
         }

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -479,7 +479,7 @@ impl LintPass for Pass {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         // we don't want to check expanded macros
-        if !expr.span.macro_backtrace().is_empty() {
+        if !in_macro(expr.span) {
             return;
         }
 


### PR DESCRIPTION
This PR only fixes `implicit_return` and `empty_loop`.
But I suspect this bug may affect a lot of other lints.