### PR TITLE
rustc_tools_util: changes in preparation of release on crates.io

### DIFF
--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -2,5 +2,11 @@
 name = "rustc_tools_util"
 version = "0.1.0"
 authors = ["Matthias Krüger <matthias.krueger@famsik.de>"]
+description = "small helper to generate version information for git packages"
+repository = "https://github.com/rust-lang/rust-clippy"
+readme = "README.md"
+license = "MIT/Apache-2.0"
+keywords = ["rustc", "tool", "git", "version", "hash"]
+categories = ["development-tools"]
 edition = "2018"
 [dependencies]

--- a/rustc_tools_util/README.md
+++ b/rustc_tools_util/README.md
@@ -1,0 +1,58 @@
+# rustc_tools_util
+
+A small tool to help you generate version information
+for packages installed from a git repo
+
+## Usage
+
+Add a `build.rs` file to your repo and list it in `Cargo.toml`
+````
+build = "build.rs"
+````
+
+List rustc_tools_util as regular AND build dependency.
+````
+[dependencies]
+rustc_tools_util = "0.1"
+
+[build-dependencies]
+rustc_tools_util = "0.1"
+````
+
+In `build.rs`, generate the data in your `main()`
+````rust
+fn main() {
+    println!(
+        "cargo:rustc-env=GIT_HASH={}",
+        rustc_tools_util::get_commit_hash().unwrap_or_default()
+    );
+    println!(
+        "cargo:rustc-env=COMMIT_DATE={}",
+        rustc_tools_util::get_commit_date().unwrap_or_default()
+    );
+}
+
+````
+
+Use the version information in your main.rs
+````rust
+use rustc_tools_util::*;
+
+fn show_version() {
+    let version_info = rustc_tools_util::get_version_info!();
+    println!("{}", version_info);
+}
+````
+This gives the following output in clippy:
+`clippy 0.0.212 (a416c5e 2018-12-14)`
+
+
+## License
+
+Copyright 2014-2018 The Rust Project Developers
+
+Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+<LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+option. All files in the project carrying such notice may not be
+copied, modified, or distributed except according to those terms.


### PR DESCRIPTION
I want to release my [cargo-cache](https://github.com/matthiaskrgr/cargo-cache) crate on crates.io however it depends on rustc_tools_util, thus I need to publish rustc_tools_util on crates.io first.

This PR expands the Cargo.toml and adds a readme.