### PR TITLE
base tests: switch to nightly toolchain before checking formatting of tests with rustfmt

### DIFF
--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -36,22 +36,31 @@ cd ..
 cargo +nightly fmt --all -- --check
 
 
-#avoid loop spam
-set +x
+
+
 # make sure tests are formatted
 
 # some lints are sensitive to formatting, exclude some files
-needs_formatting=false
+tests_need_reformatting=false
 # switch to nightly
 rustup default nightly
-for file in `find tests -not -path "tests/ui/methods.rs" -not -path "tests/ui/format.rs" -not -path "tests/ui/formatting.rs" -not -path "tests/ui/empty_line_after_outer_attribute.rs" -not -path "tests/ui/double_parens.rs" -not -path "tests/ui/doc.rs" -not -path "tests/ui/unused_unit.rs" | grep "\.rs$"` ; do
-rustfmt ${file} --check  || echo "${file} needs reformatting!" ; needs_formatting=true
-done
-# switch back to master
-rustup default master
+# avoid loop spam and allow cmds with exit status != 0
+set +ex
 
-if [ "${needs_reformatting}" = true ] ; then
+for file in `find tests -not -path "tests/ui/methods.rs" -not -path "tests/ui/format.rs" -not -path "tests/ui/formatting.rs" -not -path "tests/ui/empty_line_after_outer_attribute.rs" -not -path "tests/ui/double_parens.rs" -not -path "tests/ui/doc.rs" -not -path "tests/ui/unused_unit.rs" | grep "\.rs$"` ; do
+  rustfmt ${file} --check
+  if [ $? -ne 0 ]; then
+    echo "${file} needs reformatting!"
+    tests_need_reformatting=true
+  fi
+done
+
+set -ex # reset
+
+if [ ${tests_need_reformatting} ] ; then
     echo "Tests need reformatting!"
     exit 2
 fi
-set -x
+
+# switch back to master
+rustup default master

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -42,9 +42,13 @@ set +x
 
 # some lints are sensitive to formatting, exclude some files
 needs_formatting=false
+# switch to nightly
+rustup default nightly
 for file in `find tests -not -path "tests/ui/methods.rs" -not -path "tests/ui/format.rs" -not -path "tests/ui/formatting.rs" -not -path "tests/ui/empty_line_after_outer_attribute.rs" -not -path "tests/ui/double_parens.rs" -not -path "tests/ui/doc.rs" -not -path "tests/ui/unused_unit.rs" | grep "\.rs$"` ; do
 rustfmt ${file} --check  || echo "${file} needs reformatting!" ; needs_formatting=true
 done
+# switch back to master
+rustup default master
 
 if [ "${needs_reformatting}" = true ] ; then
     echo "Tests need reformatting!"

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -35,13 +35,10 @@ cd ..
 ./util/dev update_lints --check
 cargo +nightly fmt --all -- --check
 
-
-
-
 # make sure tests are formatted
 
 # some lints are sensitive to formatting, exclude some files
-tests_need_reformatting=false
+tests_need_reformatting="false"
 # switch to nightly
 rustup default nightly
 # avoid loop spam and allow cmds with exit status != 0
@@ -51,13 +48,13 @@ for file in `find tests -not -path "tests/ui/methods.rs" -not -path "tests/ui/fo
   rustfmt ${file} --check
   if [ $? -ne 0 ]; then
     echo "${file} needs reformatting!"
-    tests_need_reformatting=true
+    tests_need_reformatting="true"
   fi
 done
 
 set -ex # reset
 
-if [ ${tests_need_reformatting} ] ; then
+if [ "${tests_need_reformatting}" == "true" ] ; then
     echo "Tests need reformatting!"
     exit 2
 fi

--- a/tests/ui/cast_alignment.rs
+++ b/tests/ui/cast_alignment.rs
@@ -9,7 +9,6 @@
 
 //! Test casts for alignment issues
 
-
 #![feature(rustc_private)]
 extern crate libc;
 

--- a/tests/ui/cast_alignment.stderr
+++ b/tests/ui/cast_alignment.stderr
@@ -1,15 +1,15 @@
 error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`)
-  --> $DIR/cast_alignment.rs:22:5
+  --> $DIR/cast_alignment.rs:21:5
    |
-22 |     (&1u8 as *const u8) as *const u16;
+21 |     (&1u8 as *const u8) as *const u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::cast-ptr-alignment` implied by `-D warnings`
 
 error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`)
-  --> $DIR/cast_alignment.rs:23:5
+  --> $DIR/cast_alignment.rs:22:5
    |
-23 |     (&mut 1u8 as *mut u8) as *mut u16;
+22 |     (&mut 1u8 as *mut u8) as *mut u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors

--- a/tests/ui/implicit_return.rs
+++ b/tests/ui/implicit_return.rs
@@ -56,8 +56,7 @@ fn test_loop_with_nests() -> bool {
     loop {
         if true {
             break true;
-        }
-        else {
+        } else {
             let _ = true;
         }
     }

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -49,15 +49,15 @@ error: missing return statement
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:68:18
+  --> $DIR/implicit_return.rs:67:18
    |
-68 |     let _ = || { true };
+67 |     let _ = || { true };
    |                  ^^^^ help: add `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:69:16
+  --> $DIR/implicit_return.rs:68:16
    |
-69 |     let _ = || true;
+68 |     let _ = || true;
    |                ^^^^ help: add `return` as shown: `return true`
 
 error: aborting due to 10 previous errors

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -143,14 +143,18 @@ pub struct Allow(Foo);
 
 impl Allow {
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self { unimplemented!() }
+    pub fn new() -> Self {
+        unimplemented!()
+    }
 }
 
 pub struct AllowDerive;
 
 impl AllowDerive {
     #[allow(clippy::new_without_default_derive)]
-    pub fn new() -> Self { unimplemented!() }
+    pub fn new() -> Self {
+        unimplemented!()
+    }
 }
 
 fn main() {}

--- a/tests/ui/partialeq_ne_impl.rs
+++ b/tests/ui/partialeq_ne_impl.rs
@@ -23,9 +23,13 @@ impl PartialEq for Foo {
 struct Bar;
 
 impl PartialEq for Bar {
-    fn eq(&self, _: &Bar) -> bool { true }
+    fn eq(&self, _: &Bar) -> bool {
+        true
+    }
     #[allow(clippy::partialeq_ne_impl)]
-    fn ne(&self, _: &Bar) -> bool { false }
+    fn ne(&self, _: &Bar) -> bool {
+        false
+    }
 }
 
 fn main() {}

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -70,8 +70,7 @@ fn main() {
 }
 
 fn issue_3476() {
-    fn foo<T>() {
-    }
+    fn foo<T>() {}
 
     struct S {
         foo: fn(),

--- a/tests/ui/unused_io_amount.rs
+++ b/tests/ui/unused_io_amount.rs
@@ -12,7 +12,6 @@
 
 use std::io;
 
-
 fn try_macro<T: io::Read + io::Write>(s: &mut T) -> io::Result<()> {
     try!(s.write(b"test"));
     let mut buf = [0u8; 4];

--- a/tests/ui/unused_io_amount.stderr
+++ b/tests/ui/unused_io_amount.stderr
@@ -1,42 +1,42 @@
 error: handle written amount returned or use `Write::write_all` instead
-  --> $DIR/unused_io_amount.rs:17:5
+  --> $DIR/unused_io_amount.rs:16:5
    |
-17 |     try!(s.write(b"test"));
+16 |     try!(s.write(b"test"));
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unused-io-amount` implied by `-D warnings`
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: handle read amount returned or use `Read::read_exact` instead
-  --> $DIR/unused_io_amount.rs:19:5
+  --> $DIR/unused_io_amount.rs:18:5
    |
-19 |     try!(s.read(&mut buf));
+18 |     try!(s.read(&mut buf));
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: handle written amount returned or use `Write::write_all` instead
-  --> $DIR/unused_io_amount.rs:24:5
+  --> $DIR/unused_io_amount.rs:23:5
    |
-24 |     s.write(b"test")?;
+23 |     s.write(b"test")?;
    |     ^^^^^^^^^^^^^^^^^
 
 error: handle read amount returned or use `Read::read_exact` instead
-  --> $DIR/unused_io_amount.rs:26:5
+  --> $DIR/unused_io_amount.rs:25:5
    |
-26 |     s.read(&mut buf)?;
+25 |     s.read(&mut buf)?;
    |     ^^^^^^^^^^^^^^^^^
 
 error: handle written amount returned or use `Write::write_all` instead
-  --> $DIR/unused_io_amount.rs:31:5
+  --> $DIR/unused_io_amount.rs:30:5
    |
-31 |     s.write(b"test").unwrap();
+30 |     s.write(b"test").unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: handle read amount returned or use `Read::read_exact` instead
-  --> $DIR/unused_io_amount.rs:33:5
+  --> $DIR/unused_io_amount.rs:32:5
    |
-33 |     s.read(&mut buf).unwrap();
+32 |     s.read(&mut buf).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors

--- a/tests/ui/vec_box_sized.rs
+++ b/tests/ui/vec_box_sized.rs
@@ -1,17 +1,17 @@
 struct SizedStruct {
-	_a: i32,
+    _a: i32,
 }
 
 struct UnsizedStruct {
-	_a: [i32],
+    _a: [i32],
 }
 
 struct StructWithVecBox {
-	sized_type: Vec<Box<SizedStruct>>,
+    sized_type: Vec<Box<SizedStruct>>,
 }
 
 struct StructWithVecBoxButItsUnsized {
-	unsized_type: Vec<Box<UnsizedStruct>>,
+    unsized_type: Vec<Box<UnsizedStruct>>,
 }
 
 fn main() {}

--- a/tests/ui/vec_box_sized.stderr
+++ b/tests/ui/vec_box_sized.stderr
@@ -1,5 +1,5 @@
 error: `Vec<T>` is already on the heap, the boxing is unnecessary.
-  --> $DIR/vec_box_sized.rs:10:14
+  --> $DIR/vec_box_sized.rs:10:17
    |
 10 |     sized_type: Vec<Box<SizedStruct>>,
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<SizedStruct>`


### PR DESCRIPTION
this errored because rustfmt is not available on the master toolchain