### PR TITLE
Update README local run command to remove syspath

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To have cargo compile your crate with Clippy without Clippy installation
 in your code, you can use:
 
 ```terminal
-RUSTFLAGS=--sysroot=`rustc --print sysroot` cargo run --bin cargo-clippy --manifest-path=path_to_clippys_Cargo.toml
+cargo run --bin cargo-clippy --manifest-path=path_to_clippys_Cargo.toml
 ```
 
 *[Note](https://github.com/rust-lang/rust-clippy/wiki#a-word-of-warning):*


### PR DESCRIPTION
Since #3257 was reverted, including the sysroot in RUSTFLAGS gives the
error `Option 'sysroot' given more than once`