### PR TITLE
Remove crate:: prefixes from crate paths

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::{FloatTy, Lit, LitKind};
-use crate::syntax::symbol;
 use crate::utils::span_lint;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 use std::f64::consts as f64;
+use syntax::ast::{FloatTy, Lit, LitKind};
+use syntax::symbol;
 
 /// **What it does:** Checks for floating point literals that approximate
 /// constants which are defined in

--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::source_map::Span;
 use crate::utils::span_lint;
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for plain integer arithmetic.
 ///

--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast;
 use crate::utils::{get_trait_def_id, implements_trait, snippet_opt, span_lint_and_then, SpanlessEq};
 use crate::utils::{higher, sugg};
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast;
 
 /// **What it does:** Checks for `a = a op b` or `a = b commutative_op a`
 /// patterns.
@@ -240,7 +240,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssignOps {
 }
 
 fn is_commutative(op: hir::BinOpKind) -> bool {
-    use crate::rustc::hir::BinOpKind::*;
+    use rustc::hir::BinOpKind::*;
     match op {
         Add | Mul | And | Or | BitXor | BitAnd | BitOr | Eq | Ne => true,
         Sub | Div | Rem | Shl | Shr | Lt | Le | Ge | Gt => false,

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -10,21 +10,21 @@
 //! checks for attributes
 
 use crate::reexport::*;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{
-    CheckLintNameResult, EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintContext, LintPass,
-};
-use crate::rustc::ty::{self, TyCtxt};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem, NestedMetaItemKind};
-use crate::syntax::source_map::Span;
 use crate::utils::{
     in_macro, last_line_of_span, match_def_path, opt_def_id, paths, snippet_opt, span_lint, span_lint_and_sugg,
     span_lint_and_then, without_block_comments,
 };
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{
+    CheckLintNameResult, EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintContext, LintPass,
+};
+use rustc::ty::{self, TyCtxt};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use semver::Version;
+use syntax::ast::{AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem, NestedMetaItemKind};
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for items annotated with `#[inline(always)]`,
 /// unless the annotated function is empty or simply panics.

--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -8,15 +8,15 @@
 // except according to those terms.
 
 use crate::consts::{constant, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::LitKind;
-use crate::syntax::source_map::Span;
 use crate::utils::sugg::Sugg;
 use crate::utils::{span_lint, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::LitKind;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for incompatible bit masks in comparisons.
 ///

--- a/clippy_lints/src/blacklisted_name.rs
+++ b/clippy_lints/src/blacklisted_name.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::span_lint;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for usage of blacklisted names for variables, such
 /// as `foo`.

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::*;
 use matches::matches;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for `if` conditions that use blocks to contain an
 /// expression.

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -7,17 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::*;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::thin_vec::ThinVec;
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{LitKind, NodeId, DUMMY_NODE_ID};
-use crate::syntax::source_map::{dummy_spanned, Span, DUMMY_SP};
 use crate::utils::{
     get_trait_def_id, implements_trait, in_macro, match_type, paths, snippet_opt, span_lint_and_then, SpanlessEq,
 };
+use rustc::hir::intravisit::*;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::thin_vec::ThinVec;
+use rustc_errors::Applicability;
+use syntax::ast::{LitKind, NodeId, DUMMY_NODE_ID};
+use syntax::source_map::{dummy_spanned, Span, DUMMY_SP};
 
 /// **What it does:** Checks for boolean expressions that can be written more
 /// concisely.

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -7,17 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{Name, UintTy};
 use crate::utils::{
     contains_name, get_pat_name, match_type, paths, single_segment_path, snippet_with_applicability,
     span_lint_and_sugg, walk_ptrs_ty,
 };
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::{Name, UintTy};
 
 /// **What it does:** Checks for naive byte counts
 ///

--- a/clippy_lints/src/cargo_common_metadata.rs
+++ b/clippy_lints/src/cargo_common_metadata.rs
@@ -9,10 +9,10 @@
 
 //! lint on missing cargo common metadata
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::{ast::*, source_map::DUMMY_SP};
 use crate::utils::span_lint;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::{ast::*, source_map::DUMMY_SP};
 
 use cargo_metadata;
 

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -21,14 +21,14 @@
 //!
 //! This lint is **warn** by default
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
 use if_chain::if_chain;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
 
-use crate::rustc_errors::Applicability;
 use crate::utils::sugg::Sugg;
 use crate::utils::{in_macro, snippet_block, snippet_block_with_applicability, span_lint_and_sugg, span_lint_and_then};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for nested `if` statements which can be collapsed
 /// by `&&`-combining their conditions and for `else { if ... }` expressions

--- a/clippy_lints/src/const_static_lifetime.rs
+++ b/clippy_lints/src/const_static_lifetime.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
 use crate::utils::{in_macro, snippet, span_lint_and_then};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::*;
 
 /// **What it does:** Checks for constants with an explicit `'static` lifetime.
 ///

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -10,20 +10,20 @@
 
 #![allow(clippy::float_cmp)]
 
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::*;
-use crate::rustc::lint::LateContext;
-use crate::rustc::ty::subst::{Subst, Substs};
-use crate::rustc::ty::{self, Instance, Ty, TyCtxt};
-use crate::rustc::{bug, span_bug};
-use crate::syntax::ast::{FloatTy, LitKind};
-use crate::syntax::ptr::P;
 use crate::utils::{clip, sext, unsext};
+use rustc::hir::def::Def;
+use rustc::hir::*;
+use rustc::lint::LateContext;
+use rustc::ty::subst::{Subst, Substs};
+use rustc::ty::{self, Instance, Ty, TyCtxt};
+use rustc::{bug, span_bug};
 use std::cmp::Ordering::{self, Equal};
 use std::cmp::PartialOrd;
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
+use syntax::ast::{FloatTy, LitKind};
+use syntax::ptr::P;
 
 /// A `LitKind`-like enum to fold constant `Expr`s into.
 #[derive(Debug, Clone)]
@@ -151,7 +151,7 @@ impl Constant {
 
 /// parse a `LitKind` to a `Constant`
 pub fn lit_to_constant<'tcx>(lit: &LitKind, ty: Ty<'tcx>) -> Constant {
-    use crate::syntax::ast::*;
+    use syntax::ast::*;
 
     match *lit {
         LitKind::Str(ref is, _) => Constant::Str(is.to_string()),
@@ -286,7 +286,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
 
     /// lookup a possibly constant expression from a ExprKind::Path
     fn fetch_path(&mut self, qpath: &QPath, id: HirId) -> Option<Constant> {
-        use crate::rustc::mir::interpret::GlobalId;
+        use rustc::mir::interpret::GlobalId;
 
         let def = self.tables.qpath_def(qpath, id);
         match def {
@@ -430,7 +430,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
 }
 
 pub fn miri_to_const<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, result: &ty::Const<'tcx>) -> Option<Constant> {
-    use crate::rustc::mir::interpret::{ConstValue, Scalar};
+    use rustc::mir::interpret::{ConstValue, Scalar};
     match result.val {
         ConstValue::Scalar(Scalar::Bits { bits: b, .. }) => match result.ty.sty {
             ty::Bool => Some(Constant::Bool(b == 1)),

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -7,17 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::Ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashMap;
-use crate::syntax::symbol::LocalInternedString;
 use crate::utils::{get_parent_expr, in_macro, snippet, span_lint_and_then, span_note_and_lint};
 use crate::utils::{SpanlessEq, SpanlessHash};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty::Ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashMap;
 use smallvec::SmallVec;
 use std::collections::hash_map::Entry;
 use std::hash::BuildHasherDefault;
+use syntax::symbol::LocalInternedString;
 
 /// **What it does:** Checks for consecutive `if`s with the same condition.
 ///

--- a/clippy_lints/src/copy_iterator.rs
+++ b/clippy_lints/src/copy_iterator.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{Item, ItemKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{is_copy, match_path, paths, span_note_and_lint};
+use rustc::hir::{Item, ItemKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for types that implement `Copy` as well as
 /// `Iterator`.

--- a/clippy_lints/src/cyclomatic_complexity.rs
+++ b/clippy_lints/src/cyclomatic_complexity.rs
@@ -9,14 +9,14 @@
 
 //! calculate cyclomatic complexity and warn about overly complex functions
 
-use crate::rustc::cfg::CFG;
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::{Attribute, NodeId};
-use crate::syntax::source_map::Span;
+use rustc::cfg::CFG;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::{Attribute, NodeId};
+use syntax::source_map::Span;
 
 use crate::utils::{in_macro, is_allowed, match_type, paths, span_help_and_lint, LimitStack};
 

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 use crate::utils::{any_parent_is_automatically_derived, match_def_path, opt_def_id, paths, span_lint_and_sugg};
 

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::source_map::Span;
 use crate::utils::paths;
 use crate::utils::{is_automatically_derived, is_copy, match_path, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty::{self, Ty};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for deriving `Hash` but implementing `PartialEq`
 /// explicitly or vice versa.

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
-use crate::syntax::source_map::{BytePos, Span};
-use crate::syntax_pos::Pos;
 use crate::utils::span_lint;
 use itertools::Itertools;
 use pulldown_cmark;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
+use syntax::source_map::{BytePos, Span};
+use syntax_pos::Pos;
 use url::Url;
 
 /// **What it does:** Checks for the presence of `_`, `::` or camel-case words

--- a/clippy_lints/src/double_comparison.rs
+++ b/clippy_lints/src/double_comparison.rs
@@ -9,11 +9,11 @@
 
 //! Lint on unnecessary double comparisons. Some examples:
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::source_map::Span;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::source_map::Span;
 
 use crate::utils::{snippet_with_applicability, span_lint_and_sugg, SpanlessEq};
 

--- a/clippy_lints/src/double_parens.rs
+++ b/clippy_lints/src/double_parens.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
 use crate::utils::{in_macro, span_lint};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::*;
 
 /// **What it does:** Checks for unnecessary double parentheses.
 ///

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{is_copy, match_def_path, opt_def_id, paths, span_note_and_lint};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for calls to `std::mem::drop` with a reference
 /// instead of an owned value.

--- a/clippy_lints/src/duration_subsec.rs
+++ b/clippy_lints/src/duration_subsec.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::source_map::Spanned;
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::source_map::Spanned;
 
 use crate::consts::{constant, Constant};
 use crate::utils::paths;

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -9,9 +9,9 @@
 
 //! lint on if expressions with an else if, but without a final else branch
 
-use crate::rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
+use rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::*;
 
 use crate::utils::span_help_and_lint;
 

--- a/clippy_lints/src/empty_enum.rs
+++ b/clippy_lints/src/empty_enum.rs
@@ -9,10 +9,10 @@
 
 //! lint when there is an enum with no variants
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::span_lint_and_then;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for `enum`s with no variants.
 ///

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::source_map::Span;
 use crate::utils::SpanlessEq;
 use crate::utils::{get_item_name, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty};
 use if_chain::if_chain;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for uses of `contains_key` + `insert` on `HashMap`
 /// or `BTreeMap`.

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -11,15 +11,15 @@
 //! don't fit into an `i32`
 
 use crate::consts::{miri_to_const, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::mir::interpret::GlobalId;
-use crate::rustc::ty;
-use crate::rustc::ty::subst::Substs;
-use crate::rustc::ty::util::IntTypeExt;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::{IntTy, UintTy};
 use crate::utils::span_lint;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::mir::interpret::GlobalId;
+use rustc::ty;
+use rustc::ty::subst::Substs;
+use rustc::ty::util::IntTypeExt;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::{IntTy, UintTy};
 
 /// **What it does:** Checks for C-like enumerations that are
 /// `repr(isize/usize)` and have values that don't fit into an `i32`.

--- a/clippy_lints/src/enum_glob_use.rs
+++ b/clippy_lints/src/enum_glob_use.rs
@@ -9,13 +9,13 @@
 
 //! lint on `use`ing all variants of an enum
 
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::NodeId;
-use crate::syntax::source_map::Span;
 use crate::utils::span_lint;
+use rustc::hir::def::Def;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::NodeId;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for `use Enum::*`.
 ///

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -9,13 +9,13 @@
 
 //! lint on enum variants that are prefixed or suffixed by the same characters
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, Lint, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
-use crate::syntax::source_map::Span;
-use crate::syntax::symbol::LocalInternedString;
 use crate::utils::{camel_case, in_macro};
 use crate::utils::{span_help_and_lint, span_lint};
+use rustc::lint::{EarlyContext, EarlyLintPass, Lint, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::*;
+use syntax::source_map::Span;
+use syntax::symbol::LocalInternedString;
 
 /// **What it does:** Detects enumeration variants that are prefixed or suffixed
 /// by the same characters.

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{
     implements_trait, in_macro, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq,
 };
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for equal operands to comparison, logical and
 /// bitwise, difference and division binary operators (`==`, `>`, etc., `&&`,

--- a/clippy_lints/src/erasing_op.rs
+++ b/clippy_lints/src/erasing_op.rs
@@ -8,11 +8,11 @@
 // except according to those terms.
 
 use crate::consts::{constant_simple, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::source_map::Span;
 use crate::utils::{in_macro, span_lint};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for erasing operations, e.g. `x * 0`.
 ///

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -7,18 +7,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit as visit;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::middle::expr_use_visitor::*;
-use crate::rustc::middle::mem_categorization::{cmt_, Categorization};
-use crate::rustc::ty::layout::LayoutOf;
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::util::nodemap::NodeSet;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::NodeId;
-use crate::syntax::source_map::Span;
 use crate::utils::span_lint;
+use rustc::hir::intravisit as visit;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::middle::expr_use_visitor::*;
+use rustc::middle::mem_categorization::{cmt_, Categorization};
+use rustc::ty::layout::LayoutOf;
+use rustc::ty::{self, Ty};
+use rustc::util::nodemap::NodeSet;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::NodeId;
+use syntax::source_map::Span;
 
 pub struct Pass {
     pub too_large_for_stack: u64,

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{is_adjusted, iter_input_pats, snippet_opt, span_lint_and_then};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 pub struct EtaPass;
 

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
 use crate::utils::{get_parent_expr, span_lint, span_note_and_lint};
 use if_chain::if_chain;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
 
 /// **What it does:** Checks for a read and a write to the same variable where
 /// whether the read occurs before or after the write depends on the evaluation

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -7,18 +7,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
-use crate::syntax_pos::symbol::Symbol;
 use crate::utils::span_lint_and_sugg;
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::f32;
 use std::f64;
 use std::fmt;
+use syntax::ast::*;
+use syntax_pos::symbol::Symbol;
 
 /// **What it does:** Checks for float literals with a precision greater
 /// than that supported by the underlying type

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::LitKind;
 use crate::utils::{is_expn_of, match_def_path, opt_def_id, resolve_node, span_lint, span_lint_and_sugg};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::LitKind;
 
 /// **What it does:** Checks for usage of `write!()` / `writeln()!` which can be
 /// replaced with `(e)print!()` / `(e)println!()`

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax_pos::Span;
 use crate::utils::paths::{BEGIN_PANIC, BEGIN_PANIC_FMT, FROM_TRAIT, OPTION, RESULT};
 use crate::utils::{is_expn_of, match_def_path, method_chain_args, opt_def_id, span_lint_and_then, walk_ptrs_ty};
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use syntax_pos::Span;
 
 /// **What it does:** Checks for impls of `From<..>` that contain `panic!()` or `unwrap()`
 ///
@@ -61,8 +61,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for FallibleImplFrom {
 }
 
 fn lint_impl_body<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, impl_span: Span, impl_items: &hir::HirVec<hir::ImplItemRef>) {
-    use crate::rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
-    use crate::rustc::hir::*;
+    use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
+    use rustc::hir::*;
 
     struct FindPanicUnwrap<'a, 'tcx: 'a> {
         tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -7,18 +7,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::LitKind;
 use crate::utils::paths;
 use crate::utils::{
     in_macro, is_expn_of, last_path_segment, match_def_path, match_type, opt_def_id, resolve_node, snippet,
     span_lint_and_then, walk_ptrs_ty,
 };
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::LitKind;
 
 /// **What it does:** Checks for the use of `format!("string literal with no
 /// argument")` and `format!("{}", foo)` where `foo` is a string.

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
-use crate::syntax::ptr::P;
 use crate::utils::{differing_macro_contexts, in_macro, snippet_opt, span_note_and_lint};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
+use syntax::ptr::P;
 
 /// **What it does:** Checks for use of the non-existent `=*`, `=!` and `=-`
 /// operators.

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -7,18 +7,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::intravisit;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashSet;
-use crate::rustc_target::spec::abi::Abi;
-use crate::syntax::ast;
-use crate::syntax::source_map::Span;
 use crate::utils::{iter_input_pats, span_lint, type_is_unsafe_function};
 use matches::matches;
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::hir::intravisit;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashSet;
+use rustc_target::spec::abi::Abi;
+use syntax::ast;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for functions with too many parameters.
 ///

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::NodeId;
 use crate::utils::{
     in_macro, match_def_path, match_trait_method, same_tys, snippet, snippet_with_macro_callsite, span_lint_and_then,
 };
 use crate::utils::{opt_def_id, paths, resolve_node};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::NodeId;
 
 /// **What it does:** Checks for always-identical `Into`/`From`/`IntoIter` conversions.
 ///

--- a/clippy_lints/src/identity_op.rs
+++ b/clippy_lints/src/identity_op.rs
@@ -8,12 +8,12 @@
 // except according to those terms.
 
 use crate::consts::{constant_simple, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::source_map::Span;
 use crate::utils::{clip, in_macro, snippet, span_lint, unsext};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for identity operations, e.g. `x + 0`.
 ///

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -10,9 +10,9 @@
 //! lint on if branches that could be swapped so no `!` operation is necessary
 //! on the condition
 
-use crate::rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
+use rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::*;
 
 use crate::utils::span_help_and_lint;
 

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{intravisit::FnKind, Body, ExprKind, FnDecl};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::{ast::NodeId, source_map::Span};
 use crate::utils::{in_macro, snippet_opt, span_lint_and_then};
+use rustc::hir::{intravisit::FnKind, Body, ExprKind, FnDecl};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::{ast::NodeId, source_map::Span};
 
 /// **What it does:** Checks for missing return statements at the end of a block.
 ///

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -10,14 +10,14 @@
 //! lint on indexing and slicing operations
 
 use crate::consts::{constant, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::RangeLimits;
 use crate::utils;
 use crate::utils::higher;
 use crate::utils::higher::Range;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::RangeLimits;
 
 /// **What it does:** Checks for out of bounds array indexing with a constant
 /// index.

--- a/clippy_lints/src/infallible_destructuring_match.rs
+++ b/clippy_lints/src/infallible_destructuring_match.rs
@@ -8,11 +8,11 @@
 // except according to those terms.
 
 use super::utils::{get_arg_name, match_var, remove_blocks, snippet_with_applicability, span_lint_and_sugg};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for matches being used to destructure a single-variant enum
 /// or tuple struct where a `let` will suffice.

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{get_trait_def_id, higher, implements_trait, match_qpath, paths, span_lint};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for iteration that is guaranteed to be infinite.
 ///

--- a/clippy_lints/src/inherent_impl.rs
+++ b/clippy_lints/src/inherent_impl.rs
@@ -9,13 +9,13 @@
 
 //! lint on inherent implementations
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashMap;
-use crate::syntax_pos::Span;
 use crate::utils::span_lint_and_then;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashMap;
 use std::default::Default;
+use syntax_pos::Span;
 
 /// **What it does:** Checks for multiple inherent implementations of a struct
 ///

--- a/clippy_lints/src/inline_fn_without_body.rs
+++ b/clippy_lints/src/inline_fn_without_body.rs
@@ -9,13 +9,13 @@
 
 //! checks for `#[inline]` on trait methods without bodies
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{Attribute, Name};
 use crate::utils::span_lint_and_then;
 use crate::utils::sugg::DiagnosticBuilderExt;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::{Attribute, Name};
 
 /// **What it does:** Checks for `#[inline]` on trait methods without bodies
 ///

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -9,10 +9,10 @@
 
 //! lint on blocks unnecessarily using >= with a + 1 or - 1
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::*;
 
 use crate::utils::{snippet_opt, span_lint_and_then};
 

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{match_def_path, opt_def_id, paths, span_help_and_lint};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for creation of references to zeroed or uninitialized memory.
 ///

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -9,11 +9,11 @@
 
 //! lint when items are used after statements
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
 use crate::utils::{in_macro, span_lint};
 use matches::matches;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::*;
 
 /// **What it does:** Checks for items declared after some statement in a block.
 ///

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -9,12 +9,12 @@
 
 //! lint when there is a large size difference between variants on an enum
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::layout::LayoutOf;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{snippet_opt, span_lint_and_then};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty::layout::LayoutOf;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for large size differences between variants on
 /// `enum`s.

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -7,16 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::def_id::DefId;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashSet;
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{Lit, LitKind, Name};
-use crate::syntax::source_map::{Span, Spanned};
 use crate::utils::{get_item_name, in_macro, snippet_with_applicability, span_lint, span_lint_and_sugg, walk_ptrs_ty};
+use rustc::hir::def_id::DefId;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashSet;
+use rustc_errors::Applicability;
+use syntax::ast::{Lit, LitKind, Name};
+use syntax::source_map::{Span, Spanned};
 
 /// **What it does:** Checks for getting the length of something via `.len()`
 /// just to compare to zero, and suggests using `.is_empty()` where applicable.
@@ -148,7 +148,7 @@ fn check_trait_items(cx: &LateContext<'_, '_>, visited_trait: &Item, trait_items
     // fill the set with current and super traits
     fn fill_trait_set(traitt: DefId, set: &mut FxHashSet<DefId>, cx: &LateContext<'_, '_>) {
         if set.insert(traitt) {
-            for supertrait in crate::rustc::traits::supertrait_def_ids(cx.tcx, traitt) {
+            for supertrait in rustc::traits::supertrait_def_ids(cx.tcx, traitt) {
                 fill_trait_set(supertrait, set, cx);
             }
         }

--- a/clippy_lints/src/let_if_seq.rs
+++ b/clippy_lints/src/let_if_seq.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::BindingAnnotation;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast;
 use crate::utils::{snippet, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::hir::BindingAnnotation;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast;
 
 /// **What it does:** Checks for variable declarations immediately followed by a
 /// conditional affectation.

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -212,7 +212,7 @@ pub mod zero_div_zero;
 pub use crate::utils::conf::Conf;
 
 mod reexport {
-    crate use crate::syntax::ast::{Name, NodeId};
+    crate use syntax::ast::{Name, NodeId};
 }
 
 pub fn register_pre_expansion_lints(

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -8,16 +8,16 @@
 // except according to those terms.
 
 use crate::reexport::*;
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::intravisit::*;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use crate::syntax::source_map::Span;
-use crate::syntax::symbol::keywords;
 use crate::utils::{last_path_segment, span_lint};
 use matches::matches;
+use rustc::hir::def::Def;
+use rustc::hir::intravisit::*;
+use rustc::hir::*;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use syntax::source_map::Span;
+use syntax::symbol::keywords;
 
 /// **What it does:** Checks for lifetime annotations which can be removed by
 /// relying on lifetime elision.

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -10,13 +10,13 @@
 //! Lints concerned with the grouping of digits with underscores in integral or
 //! floating-point literal expressions.
 
-use crate::rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
-use crate::syntax_pos;
 use crate::utils::{snippet_opt, span_lint_and_sugg};
 use if_chain::if_chain;
+use rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::*;
+use syntax_pos;
 
 /// **What it does:** Warns if a long integral or floating-point constant does
 /// not contain underscores.

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -8,31 +8,31 @@
 // except according to those terms.
 
 use crate::reexport::*;
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::def_id;
-use crate::rustc::hir::intravisit::{walk_block, walk_decl, walk_expr, walk_pat, walk_stmt, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::middle::region;
-use crate::rustc::{declare_tool_lint, lint_array};
 use if_chain::if_chain;
 use itertools::Itertools;
-// use crate::rustc::middle::region::CodeExtent;
+use rustc::hir::def::Def;
+use rustc::hir::def_id;
+use rustc::hir::intravisit::{walk_block, walk_decl, walk_expr, walk_pat, walk_stmt, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::middle::region;
+use rustc::{declare_tool_lint, lint_array};
+// use rustc::middle::region::CodeExtent;
 use crate::consts::{constant, Constant};
-use crate::rustc::middle::expr_use_visitor::*;
-use crate::rustc::middle::mem_categorization::cmt_;
-use crate::rustc::middle::mem_categorization::Categorization;
-use crate::rustc::ty::subst::Subst;
-use crate::rustc::ty::{self, Ty};
-use crate::rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast;
-use crate::syntax::source_map::Span;
-use crate::syntax_pos::BytePos;
 use crate::utils::usage::mutated_variables;
 use crate::utils::{in_macro, sext, sugg};
+use rustc::middle::expr_use_visitor::*;
+use rustc::middle::mem_categorization::cmt_;
+use rustc::middle::mem_categorization::Categorization;
+use rustc::ty::subst::Subst;
+use rustc::ty::{self, Ty};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::Applicability;
 use std::iter::{once, Iterator};
 use std::mem;
+use syntax::ast;
+use syntax::source_map::Span;
+use syntax_pos::BytePos;
 
 use crate::utils::paths;
 use crate::utils::{

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -7,17 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::Ident;
-use crate::syntax::source_map::Span;
 use crate::utils::paths;
 use crate::utils::{
     in_macro, match_trait_method, match_type, remove_blocks, snippet_with_applicability, span_lint_and_sugg,
 };
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::Ident;
+use syntax::source_map::Span;
 
 #[derive(Clone)]
 pub struct Pass;

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::source_map::Span;
 use crate::utils::paths;
 use crate::utils::{in_macro, iter_input_pats, match_type, method_chain_args, snippet, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::source_map::Span;
 
 #[derive(Clone)]
 pub struct Pass;

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -8,13 +8,6 @@
 // except according to those terms.
 
 use crate::consts::{constant, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::LitKind;
-use crate::syntax::source_map::Span;
 use crate::utils::paths;
 use crate::utils::sugg::Sugg;
 use crate::utils::{
@@ -22,8 +15,15 @@ use crate::utils::{
     snippet_with_applicability, span_lint_and_sugg, span_lint_and_then, span_note_and_lint, walk_ptrs_ty,
 };
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::ty::{self, Ty};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::cmp::Ordering;
 use std::collections::Bound;
+use syntax::ast::LitKind;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for matches with a single arm where an `if let`
 /// will usually suffice.

--- a/clippy_lints/src/mem_discriminant.rs
+++ b/clippy_lints/src/mem_discriminant.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{Expr, ExprKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{match_def_path, opt_def_id, paths, snippet, span_lint_and_then, walk_ptrs_ty_depth};
 use if_chain::if_chain;
+use rustc::hir::{Expr, ExprKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 use std::iter;
 

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{Expr, ExprKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
+use rustc::hir::{Expr, ExprKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for usage of `std::mem::forget(t)` where `t` is
 /// `Drop`.

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{Expr, ExprKind, MutMutable, QPath};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{match_def_path, match_qpath, opt_def_id, paths, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
+use rustc::hir::{Expr, ExprKind, MutMutable, QPath};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for `mem::replace()` on an `Option` with
 /// `None`.

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -7,15 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::def::Def;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, Lint, LintArray, LintContext, LintPass};
-use crate::rustc::ty::{self, Predicate, Ty};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast;
-use crate::syntax::source_map::{BytePos, Span};
-use crate::syntax::symbol::LocalInternedString;
 use crate::utils::paths;
 use crate::utils::sugg;
 use crate::utils::{
@@ -27,9 +18,18 @@ use crate::utils::{
 };
 use if_chain::if_chain;
 use matches::matches;
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, Lint, LintArray, LintContext, LintPass};
+use rustc::ty::{self, Predicate, Ty};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::borrow::Cow;
 use std::fmt;
 use std::iter;
+use syntax::ast;
+use syntax::source_map::{BytePos, Span};
+use syntax::symbol::LocalInternedString;
 
 mod unnecessary_filter_map;
 

--- a/clippy_lints/src/methods/unnecessary_filter_map.rs
+++ b/clippy_lints/src/methods/unnecessary_filter_map.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::lint::LateContext;
-use crate::syntax::ast;
 use crate::utils::paths;
 use crate::utils::usage::mutated_variables;
 use crate::utils::{match_qpath, match_trait_method, span_lint};
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::lint::LateContext;
+use syntax::ast;
 
 use if_chain::if_chain;
 

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -8,10 +8,10 @@
 // except according to those terms.
 
 use crate::consts::{constant_simple, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 use std::cmp::Ordering;
 
 /// **What it does:** Checks for expressions where `std::cmp::min` and `max` are

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -9,14 +9,6 @@
 
 use crate::consts::{constant, Constant};
 use crate::reexport::*;
-use crate::rustc::hir::intravisit::FnKind;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::LitKind;
-use crate::syntax::source_map::{ExpnFormat, Span};
 use crate::utils::sugg::Sugg;
 use crate::utils::{
     get_item_name, get_parent_expr, implements_trait, in_constant, in_macro, is_integer_literal, iter_input_pats,
@@ -25,6 +17,14 @@ use crate::utils::{
 };
 use if_chain::if_chain;
 use matches::matches;
+use rustc::hir::intravisit::FnKind;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::LitKind;
+use syntax::source_map::{ExpnFormat, Span};
 
 /// **What it does:** Checks for function arguments and let bindings denoted as
 /// `ref`.

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -7,16 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashMap;
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
-use crate::syntax::source_map::Span;
-use crate::syntax::visit::{walk_expr, FnKind, Visitor};
 use crate::utils::{constants, snippet, snippet_opt, span_help_and_lint, span_lint, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashMap;
+use rustc_errors::Applicability;
 use std::char;
+use syntax::ast::*;
+use syntax::source_map::Span;
+use syntax::visit::{walk_expr, FnKind, Visitor};
 
 /// **What it does:** Checks for structure field patterns bound to wildcards.
 ///

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -27,14 +27,14 @@
 // [`missing_doc`]: https://github.com/rust-lang/rust/blob/d6d05904697d89099b55da3331155392f1db9c00/src/librustc_lint/builtin.rs#L246
 //
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
-use crate::syntax::attr;
-use crate::syntax::source_map::Span;
 use crate::utils::{in_macro, span_lint};
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
+use syntax::attr;
+use syntax::source_map::Span;
 
 /// **What it does:** Warns if there is missing doc for any documentable item
 /// (public or private).

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -18,12 +18,12 @@
 //   except according to those terms.
 //
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
-use crate::syntax::source_map::Span;
 use crate::utils::span_lint;
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
+use syntax::source_map::Span;
 
 /// **What it does:** it lints if an exported function, method, trait method with default impl,
 /// or trait method impl is not `#[inline]`.
@@ -91,7 +91,7 @@ fn check_missing_inline_attrs(cx: &LateContext<'_, '_>, attrs: &[ast::Attribute]
 }
 
 fn is_executable<'a, 'tcx>(cx: &LateContext<'a, 'tcx>) -> bool {
-    use crate::rustc::session::config::CrateType;
+    use rustc::session::config::CrateType;
 
     cx.tcx.sess.crate_types.get().iter().any(|t: &CrateType| match t {
         CrateType::Executable => true,
@@ -156,7 +156,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingInline {
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx hir::ImplItem) {
-        use crate::rustc::ty::{ImplContainer, TraitContainer};
+        use rustc::ty::{ImplContainer, TraitContainer};
         if is_executable(cx) {
             return;
         }

--- a/clippy_lints/src/multiple_crate_versions.rs
+++ b/clippy_lints/src/multiple_crate_versions.rs
@@ -9,10 +9,10 @@
 
 //! lint on multiple versions of a crate being used
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::{ast::*, source_map::DUMMY_SP};
 use crate::utils::span_lint;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::{ast::*, source_map::DUMMY_SP};
 
 use cargo_metadata;
 use itertools::Itertools;

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::intravisit;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{higher, span_lint};
+use rustc::hir;
+use rustc::hir::intravisit;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for instances of `mut mut` references.
 ///
@@ -47,7 +47,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutMut {
     }
 
     fn check_ty(&mut self, cx: &LateContext<'a, 'tcx>, ty: &'tcx hir::Ty) {
-        use crate::rustc::hir::intravisit::Visitor;
+        use rustc::hir::intravisit::Visitor;
 
         MutVisitor { cx }.visit_ty(ty);
     }

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::subst::Subst;
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::span_lint;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty::subst::Subst;
+use rustc::ty::{self, Ty};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Detects giving a mutable reference to a function that only
 /// requires an immutable reference.

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -11,12 +11,12 @@
 //!
 //! This lint is **warn** by default
 
-use crate::rustc::hir::Expr;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
 use crate::utils::{match_type, paths, span_lint};
+use rustc::hir::Expr;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty::{self, Ty};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
 
 /// **What it does:** Checks for usages of `Mutex<X>` where an atomic will do.
 ///

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -11,14 +11,14 @@
 //!
 //! This lint is **warn** by default
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::LitKind;
-use crate::syntax::source_map::Spanned;
 use crate::utils::sugg::Sugg;
 use crate::utils::{in_macro, span_lint, span_lint_and_sugg};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::LitKind;
+use syntax::source_map::Spanned;
 
 /// **What it does:** Checks for expressions of the form `if c { true } else {
 /// false }`

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -11,15 +11,15 @@
 //!
 //! This lint is **warn** by default
 
-use crate::rustc::hir::{BindingAnnotation, Expr, ExprKind, Item, MutImmutable, Pat, PatKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::ty::adjustment::{Adjust, Adjustment};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::NodeId;
 use crate::utils::{in_macro, snippet_opt, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::hir::{BindingAnnotation, Expr, ExprKind, Item, MutImmutable, Pat, PatKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::ty::adjustment::{Adjust, Adjustment};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::NodeId;
 
 /// **What it does:** Checks for address of operations (`&`) that are going to
 /// be dereferenced immediately by the compiler.

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -11,12 +11,12 @@
 //!
 //! This lint is **warn** by default
 
-use crate::rustc::hir::{BindingAnnotation, MutImmutable, Pat, PatKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{in_macro, snippet, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::hir::{BindingAnnotation, MutImmutable, Pat, PatKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for useless borrowed references.
 ///

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -36,11 +36,11 @@
 //! ```
 //!
 //! This lint is **warn** by default.
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
-use crate::syntax::source_map::{original_sp, DUMMY_SP};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 use std::borrow::Cow;
+use syntax::ast;
+use syntax::source_map::{original_sp, DUMMY_SP};
 
 use crate::utils::{in_macro, snippet, snippet_block, span_help_and_lint, trim_multiline};
 

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -7,20 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::FnKind;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::middle::expr_use_visitor as euv;
-use crate::rustc::middle::mem_categorization as mc;
-use crate::rustc::traits;
-use crate::rustc::ty::{self, RegionKind, TypeFoldable};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use crate::rustc_errors::Applicability;
-use crate::rustc_target::spec::abi::Abi;
-use crate::syntax::ast::NodeId;
-use crate::syntax::errors::DiagnosticBuilder;
-use crate::syntax_pos::Span;
 use crate::utils::ptr::get_spans;
 use crate::utils::{
     get_trait_def_id, implements_trait, in_macro, is_copy, is_self, match_type, multispan_sugg, paths, snippet,
@@ -28,7 +14,21 @@ use crate::utils::{
 };
 use if_chain::if_chain;
 use matches::matches;
+use rustc::hir::intravisit::FnKind;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::middle::expr_use_visitor as euv;
+use rustc::middle::mem_categorization as mc;
+use rustc::traits;
+use rustc::ty::{self, RegionKind, TypeFoldable};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::Applicability;
+use rustc_target::spec::abi::Abi;
 use std::borrow::Cow;
+use syntax::ast::NodeId;
+use syntax::errors::DiagnosticBuilder;
+use syntax_pos::Span;
 
 /// **What it does:** Checks for functions taking arguments by value, but not
 /// consuming them in its

--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{Expr, ExprKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::span_lint;
+use rustc::hir::{Expr, ExprKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for needlessly including a base struct on update
 /// when all fields are changed anyway.

--- a/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
+++ b/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 use crate::utils::{self, paths, span_lint};
 

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::source_map::{Span, Spanned};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::source_map::{Span, Spanned};
 
 use crate::consts::{self, Constant};
 use crate::utils::span_lint;

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -7,18 +7,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::def_id::DefId;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::util::nodemap::NodeSet;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::source_map::Span;
 use crate::utils::paths;
 use crate::utils::sugg::DiagnosticBuilderExt;
 use crate::utils::{get_trait_def_id, implements_trait, return_ty, same_tys, span_lint_node_and_then};
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::hir::def_id::DefId;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::ty::{self, Ty};
+use rustc::util::nodemap::NodeSet;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for types with a `fn new() -> Self` method and no
 /// implementation of

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::{BinOpKind, BlockCheckMode, Expr, ExprKind, Stmt, StmtKind, UnsafeSource};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{has_drop, in_macro, snippet_opt, span_lint, span_lint_and_sugg};
+use rustc::hir::def::Def;
+use rustc::hir::{BinOpKind, BlockCheckMode, Expr, ExprKind, Stmt, StmtKind, UnsafeSource};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::ops::Deref;
 
 /// **What it does:** Checks for statements which have no effect.

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -11,17 +11,17 @@
 //!
 //! This lint is **deny** by default.
 
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, Lint, LintArray, LintPass};
-use crate::rustc::ty::adjustment::Adjust;
-use crate::rustc::ty::{self, TypeFlags};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::rustc_typeck::hir_ty_to_ty;
-use crate::syntax_pos::{Span, DUMMY_SP};
 use crate::utils::{in_constant, in_macro, is_copy, span_lint_and_then};
+use rustc::hir::def::Def;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, Lint, LintArray, LintPass};
+use rustc::ty::adjustment::Adjust;
+use rustc::ty::{self, TypeFlags};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use rustc_typeck::hir_ty_to_ty;
 use std::ptr;
+use syntax_pos::{Span, DUMMY_SP};
 
 /// **What it does:** Checks for declaration of `const` items which is interior
 /// mutable (e.g. contains a `Cell`, `Mutex`, `AtomicXxxx` etc).

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
-use crate::syntax::attr;
-use crate::syntax::source_map::Span;
-use crate::syntax::symbol::LocalInternedString;
-use crate::syntax::visit::{walk_block, walk_expr, walk_pat, Visitor};
 use crate::utils::{span_lint, span_lint_and_then};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::*;
+use syntax::attr;
+use syntax::source_map::Span;
+use syntax::symbol::LocalInternedString;
+use syntax::visit::{walk_block, walk_expr, walk_pat, Visitor};
 
 /// **What it does:** Checks for names that are very similar and thus confusing.
 ///

--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{match_type, method_chain_args, paths, snippet, span_help_and_lint};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:*** Checks for unnecessary `ok()` in if let.
 ///

--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{Expr, ExprKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::LitKind;
-use crate::syntax::source_map::{Span, Spanned};
 use crate::utils::{match_type, paths, span_lint, walk_ptrs_ty};
+use rustc::hir::{Expr, ExprKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::LitKind;
+use syntax::source_map::{Span, Spanned};
 
 /// **What it does:** Checks for duplicate open options as well as combinations
 /// that make no sense.

--- a/clippy_lints/src/overflow_check_conditional.rs
+++ b/clippy_lints/src/overflow_check_conditional.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{span_lint, SpanlessEq};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Detects classic underflow/overflow checks.
 ///

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::LitKind;
-use crate::syntax::ext::quote::rt::Span;
-use crate::syntax::ptr::P;
 use crate::utils::{is_direct_expn_of, is_expn_of, match_def_path, opt_def_id, paths, resolve_node, span_lint};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::LitKind;
+use syntax::ext::quote::rt::Span;
+use syntax::ptr::P;
 
 /// **What it does:** Checks for missing parameters in `panic!`.
 ///

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{is_automatically_derived, span_lint_node};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for manual re-implementations of `PartialEq::ne`.
 ///

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
-use crate::syntax::source_map::Spanned;
 use crate::utils::{in_macro, snippet_with_applicability, span_lint_and_sugg};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::*;
+use syntax::source_map::Spanned;
 
 /// **What it does:** Checks for operations where precedence may be unclear
 /// and suggests to add parentheses. Currently it catches the following:
@@ -138,7 +138,7 @@ fn is_arith_expr(expr: &Expr) -> bool {
 }
 
 fn is_bit_op(op: BinOpKind) -> bool {
-    use crate::syntax::ast::BinOpKind::*;
+    use syntax::ast::BinOpKind::*;
     match op {
         BitXor | BitAnd | BitOr | Shl | Shr => true,
         _ => false,
@@ -146,7 +146,7 @@ fn is_bit_op(op: BinOpKind) -> bool {
 }
 
 fn is_arith_op(op: BinOpKind) -> bool {
-    use crate::syntax::ast::BinOpKind::*;
+    use syntax::ast::BinOpKind::*;
     match op {
         Add | Sub | Mul | Div | Rem => true,
         _ => false,

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -9,19 +9,19 @@
 
 //! Checks for usage of  `&Vec[_]` and `&String`.
 
-use crate::rustc::hir::QPath;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::NodeId;
-use crate::syntax::source_map::Span;
-use crate::syntax_pos::MultiSpan;
 use crate::utils::ptr::get_spans;
 use crate::utils::{match_qpath, match_type, paths, snippet_opt, span_lint, span_lint_and_then, walk_ptrs_hir_ty};
 use if_chain::if_chain;
+use rustc::hir::QPath;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::borrow::Cow;
+use syntax::ast::NodeId;
+use syntax::source_map::Span;
+use syntax_pos::MultiSpan;
 
 /// **What it does:** This lint checks for function arguments of type `&String`
 /// or `&Vec` unless the references are mutable. It will also suggest you

--- a/clippy_lints/src/ptr_offset_with_cast.rs
+++ b/clippy_lints/src/ptr_offset_with_cast.rs
@@ -7,9 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::{declare_tool_lint, hir, lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils;
+use rustc::{declare_tool_lint, hir, lint, lint_array};
+use rustc_errors::Applicability;
 use std::fmt;
 
 /// **What it does:** Checks for usage of the `offset` pointer method with a `usize` casted to an

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -7,17 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ptr::P;
 use crate::utils::sugg::Sugg;
 use if_chain::if_chain;
+use rustc::hir::def::Def;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ptr::P;
 
-use crate::rustc_errors::Applicability;
 use crate::utils::paths::*;
 use crate::utils::{match_def_path, match_type, span_lint_and_then, SpanlessEq};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for expressions that could be replaced by the question mark operator
 ///

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -7,16 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::RangeLimits;
-use crate::syntax::source_map::Spanned;
 use crate::utils::sugg::Sugg;
 use crate::utils::{get_trait_def_id, higher, implements_trait, SpanlessEq};
 use crate::utils::{is_integer_literal, paths, snippet, snippet_opt, span_lint, span_lint_and_then};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::RangeLimits;
+use syntax::source_map::Spanned;
 
 /// **What it does:** Checks for calling `.step_by(0)` on iterators,
 /// which never terminates.

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -7,28 +7,28 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::FnKind;
-use crate::rustc::hir::{def_id, Body, FnDecl};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::mir::{
-    self, traversal,
-    visit::{MutatingUseContext, PlaceContext, Visitor},
-    TerminatorKind,
-};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::{
-    ast::NodeId,
-    source_map::{BytePos, Span},
-};
 use crate::utils::{
     has_drop, in_macro, is_copy, match_def_path, match_type, paths, snippet_opt, span_lint_node,
     span_lint_node_and_then, walk_ptrs_ty_depth,
 };
 use if_chain::if_chain;
 use matches::matches;
+use rustc::hir::intravisit::FnKind;
+use rustc::hir::{def_id, Body, FnDecl};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::mir::{
+    self, traversal,
+    visit::{MutatingUseContext, PlaceContext, Visitor},
+    TerminatorKind,
+};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::convert::TryFrom;
+use syntax::{
+    ast::NodeId,
+    source_map::{BytePos, Span},
+};
 
 macro_rules! unwrap_or_continue {
     ($x:expr) => {

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
 use crate::utils::span_lint_and_sugg;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::*;
 
 /// **What it does:** Checks for fields in struct literals where shorthands
 /// could be used.

--- a/clippy_lints/src/redundant_pattern_matching.rs
+++ b/clippy_lints/src/redundant_pattern_matching.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::LitKind;
-use crate::syntax::ptr::P;
 use crate::utils::{match_qpath, paths, snippet, span_lint_and_then};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::LitKind;
+use syntax::ptr::P;
 
 /// **What it does:** Lint for redundant pattern matching over `Result` or
 /// `Option`

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{Expr, ExprKind, UnOp};
 use crate::utils::{snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::{Expr, ExprKind, UnOp};
 
 /// **What it does:** Checks for usage of `*&` and `*&mut` in expressions.
 ///

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -8,16 +8,16 @@
 // except according to those terms.
 
 use crate::consts::{constant, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashSet;
-use crate::syntax::ast::{LitKind, NodeId, StrStyle};
-use crate::syntax::source_map::{BytePos, Span};
 use crate::utils::{is_expn_of, match_def_path, match_type, opt_def_id, paths, span_help_and_lint, span_lint};
 use if_chain::if_chain;
 use regex_syntax;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashSet;
 use std::convert::TryFrom;
+use syntax::ast::{LitKind, NodeId, StrStyle};
+use syntax::source_map::{BytePos, Span};
 
 /// **What it does:** Checks [regex](https://crates.io/crates/regex) creation
 /// (with `Regex::new`,`RegexBuilder::new` or `RegexSet::new`) for correct

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::def::Def;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::{match_def_path, span_lint_and_sugg};
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for usage of `ATOMIC_X_INIT`, `ONCE_INIT`, and
 /// `uX/iX::MIN/MAX`.

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast;
-use crate::syntax::source_map::Span;
-use crate::syntax::visit::FnKind;
-use crate::syntax_pos::BytePos;
 use crate::utils::{in_macro, match_path_ast, snippet_opt, span_lint_and_then, span_note_and_lint};
 use if_chain::if_chain;
+use rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast;
+use syntax::source_map::Span;
+use syntax::visit::FnKind;
+use syntax_pos::BytePos;
 
 /// **What it does:** Checks for return statements at the end of a block.
 ///

--- a/clippy_lints/src/serde_api.rs
+++ b/clippy_lints/src/serde_api.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{get_trait_def_id, paths, span_lint};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for mis-uses of the serde API.
 ///

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -8,13 +8,13 @@
 // except according to those terms.
 
 use crate::reexport::*;
-use crate::rustc::hir::intravisit::FnKind;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::source_map::Span;
 use crate::utils::{contains_name, higher, iter_input_pats, snippet, span_lint_and_then};
+use rustc::hir::intravisit::FnKind;
+use rustc::hir::*;
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for bindings that shadow other bindings already in
 /// scope, while just changing reference level or mutability.

--- a/clippy_lints/src/slow_vector_initialization.rs
+++ b/clippy_lints/src/slow_vector_initialization.rs
@@ -7,16 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::{walk_block, walk_expr, walk_stmt, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, Lint, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{LitKind, NodeId};
-use crate::syntax_pos::symbol::Symbol;
 use crate::utils::sugg::Sugg;
 use crate::utils::{get_enclosing_block, match_qpath, span_lint_and_then, SpanlessEq};
 use if_chain::if_chain;
+use rustc::hir::intravisit::{walk_block, walk_expr, walk_stmt, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, Lint, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::{LitKind, NodeId};
+use syntax_pos::symbol::Symbol;
 
 /// **What it does:** Checks slow zero-filled vector initialization
 ///

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::source_map::Spanned;
 use crate::utils::SpanlessEq;
 use crate::utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::source_map::Spanned;
 
 /// **What it does:** Checks for string appends of the form `x = x + y` (without
 /// `let`!).
@@ -164,8 +164,8 @@ impl LintPass for StringLitAsBytes {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        use crate::syntax::ast::{LitKind, StrStyle};
         use crate::utils::{in_macro, snippet, snippet_with_applicability};
+        use syntax::ast::{LitKind, StrStyle};
 
         if let ExprKind::MethodCall(ref path, _, ref args) = e.node {
             if path.ident.name == "as_bytes" {

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast;
 use crate::utils::{get_trait_def_id, span_lint};
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast;
 
 /// **What it does:** Lints for suspicious operations in impls of arithmetic operators, e.g.
 /// subtracting elements in an Add impl.

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -7,17 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
 use crate::utils::sugg::Sugg;
 use crate::utils::{
     differing_macro_contexts, match_type, paths, snippet, span_lint_and_then, walk_ptrs_ty, SpanlessEq,
 };
 use if_chain::if_chain;
 use matches::matches;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 
 /// **What it does:** Checks for manual swapping.
 ///

--- a/clippy_lints/src/temporary_assignment.rs
+++ b/clippy_lints/src/temporary_assignment.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::{Expr, ExprKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::is_adjusted;
 use crate::utils::span_lint;
+use rustc::hir::{Expr, ExprKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for construction of a structure or tuple just to
 /// assign a value in it.

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -7,16 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast;
 use crate::utils::{last_path_segment, match_def_path, paths, snippet, span_lint, span_lint_and_then};
 use crate::utils::{opt_def_id, sugg};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty::{self, Ty};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::borrow::Cow;
+use syntax::ast;
 
 /// **What it does:** Checks for transmutes that can't ever be correct on any
 /// architecture.

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -9,21 +9,21 @@
 
 use std::cmp;
 
-use crate::rustc::hir;
-use crate::rustc::hir::intravisit::FnKind;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::session::config::Config as SessionConfig;
-use crate::rustc::ty::{self, FnSig};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::rustc_target::abi::LayoutOf;
-use crate::rustc_target::spec::abi::Abi;
-use crate::syntax::ast::NodeId;
-use crate::syntax_pos::Span;
 use crate::utils::{in_macro, is_copy, is_self_ty, snippet, span_lint_and_sugg};
 use if_chain::if_chain;
 use matches::matches;
+use rustc::hir;
+use rustc::hir::intravisit::FnKind;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::session::config::Config as SessionConfig;
+use rustc::ty::{self, FnSig};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use rustc_target::abi::LayoutOf;
+use rustc_target::spec::abi::Abi;
+use syntax::ast::NodeId;
+use syntax_pos::Span;
 
 /// **What it does:** Checks for functions taking arguments by reference, where
 /// the argument type is `Copy` and small enough to be more efficient to always

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::{LitKind, NodeId};
-use crate::syntax::source_map::Span;
 use crate::utils::{is_allowed, snippet, span_help_and_lint};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::{LitKind, NodeId};
+use syntax::source_map::Span;
 use unicode_normalization::UnicodeNormalization;
 
 /// **What it does:** Checks for the Unicode zero-width space in the code.

--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::*;
-use crate::syntax::source_map::Span;
-use crate::syntax::symbol::LocalInternedString;
 use crate::utils::span_lint;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::*;
+use syntax::source_map::Span;
+use syntax::symbol::LocalInternedString;
 
 /// **What it does:** Checks for imports that remove "unsafe" from an item's
 /// name.

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::{is_try, match_qpath, match_trait_method, paths, span_lint};
+use rustc::hir;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for unused written/read amount.
 ///

--- a/clippy_lints/src/unused_label.rs
+++ b/clippy_lints/src/unused_label.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::intravisit::{walk_expr, walk_fn, FnKind, NestedVisitorMap, Visitor};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashMap;
-use crate::syntax::ast;
-use crate::syntax::source_map::Span;
-use crate::syntax::symbol::LocalInternedString;
 use crate::utils::{in_macro, span_lint};
+use rustc::hir;
+use rustc::hir::intravisit::{walk_expr, walk_fn, FnKind, NestedVisitorMap, Visitor};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashMap;
+use syntax::ast;
+use syntax::source_map::Span;
+use syntax::symbol::LocalInternedString;
 
 /// **What it does:** Checks for unused labels.
 ///

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -7,15 +7,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use if_chain::if_chain;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
-use crate::rustc::hir::intravisit::*;
-use crate::rustc::hir::*;
-use crate::syntax::ast::NodeId;
-use crate::syntax::source_map::Span;
 use crate::utils::{in_macro, match_type, paths, span_lint_and_then, usage::is_potentially_mutated};
+use rustc::hir::intravisit::*;
+use rustc::hir::*;
+use syntax::ast::NodeId;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for calls of `unwrap[_err]()` that cannot fail.
 ///

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -7,16 +7,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::{walk_path, walk_ty, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty;
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::NodeId;
-use crate::syntax_pos::symbol::keywords::SelfUpper;
 use crate::utils::{in_macro, span_lint_and_sugg};
 use if_chain::if_chain;
+use rustc::hir::intravisit::{walk_path, walk_ty, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty;
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::ast::NodeId;
+use syntax_pos::symbol::keywords::SelfUpper;
 
 /// **What it does:** Checks for unnecessary repetition of structure name when a
 /// replacement with `Self` is applicable.

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -10,14 +10,14 @@
 //! A group of attributes that can be attached to Rust code in order
 //! to generate a clippy lint detecting said code automatically.
 
-use crate::rustc::hir;
-use crate::rustc::hir::intravisit::{NestedVisitorMap, Visitor};
-use crate::rustc::hir::{BindingAnnotation, DeclKind, Expr, ExprKind, Pat, PatKind, QPath, Stmt, StmtKind, TyKind};
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::FxHashMap;
-use crate::syntax::ast::{Attribute, LitKind, DUMMY_NODE_ID};
 use crate::utils::get_attr;
+use rustc::hir;
+use rustc::hir::intravisit::{NestedVisitorMap, Visitor};
+use rustc::hir::{BindingAnnotation, DeclKind, Expr, ExprKind, Pat, PatKind, QPath, Stmt, StmtKind, TyKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashMap;
+use syntax::ast::{Attribute, LitKind, DUMMY_NODE_ID};
 
 /// **What it does:** Generates clippy code that detects the offending pattern
 ///

--- a/clippy_lints/src/utils/comparisons.rs
+++ b/clippy_lints/src/utils/comparisons.rs
@@ -11,7 +11,7 @@
 
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::rustc::hir::{BinOpKind, Expr};
+use rustc::hir::{BinOpKind, Expr};
 
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 /// Represent a normalized comparison operator.

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -11,12 +11,12 @@
 
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::syntax::{ast, source_map};
 use lazy_static::lazy_static;
 use std::default::Default;
 use std::io::Read;
 use std::sync::Mutex;
 use std::{env, fmt, fs, io, path};
+use syntax::{ast, source_map};
 use toml;
 
 /// Get the configuration file from arguments.

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -12,11 +12,11 @@
 
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::rustc::lint::LateContext;
-use crate::rustc::{hir, ty};
-use crate::syntax::ast;
 use crate::utils::{is_expn_of, match_def_path, match_qpath, opt_def_id, paths, resolve_node};
 use if_chain::if_chain;
+use rustc::lint::LateContext;
+use rustc::{hir, ty};
+use syntax::ast;
 
 /// Convert a hir binary operator to the corresponding `ast` type.
 pub fn binop(op: hir::BinOpKind) -> ast::BinOpKind {

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -8,14 +8,14 @@
 // except according to those terms.
 
 use crate::consts::{constant_context, constant_simple};
-use crate::rustc::hir::*;
-use crate::rustc::lint::LateContext;
-use crate::rustc::ty::TypeckTables;
-use crate::syntax::ast::Name;
-use crate::syntax::ptr::P;
 use crate::utils::differing_macro_contexts;
+use rustc::hir::*;
+use rustc::lint::LateContext;
+use rustc::ty::TypeckTables;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use syntax::ast::Name;
+use syntax::ptr::P;
 
 /// Type used to check whether two ast are the same. This is different from the
 /// operator

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -9,12 +9,12 @@
 
 //! checks for attributes
 
-use crate::rustc::hir;
-use crate::rustc::hir::print;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::ast::Attribute;
 use crate::utils::get_attr;
+use rustc::hir;
+use rustc::hir::print;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::ast::Attribute;
 
 /// **What it does:** Dumps every ast/hir node which has the `#[clippy::dump]`
 /// attribute

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -7,21 +7,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir;
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::{Crate as AstCrate, Ident, ItemKind, Name};
-use crate::syntax::source_map::Span;
-use crate::syntax::symbol::LocalInternedString;
 use crate::utils::{
     match_def_path, match_type, paths, span_help_and_lint, span_lint, span_lint_and_sugg, walk_ptrs_ty,
 };
 use if_chain::if_chain;
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::Applicability;
+use syntax::ast::{Crate as AstCrate, Ident, ItemKind, Name};
+use syntax::source_map::Span;
+use syntax::symbol::LocalInternedString;
 
 /// **What it does:** Checks for various things we like to keep tidy in clippy.
 ///

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -8,35 +8,35 @@
 // except according to those terms.
 
 use crate::reexport::*;
-use crate::rustc::hir;
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::def_id::{DefId, CRATE_DEF_INDEX};
-use crate::rustc::hir::intravisit::{NestedVisitorMap, Visitor};
-use crate::rustc::hir::Node;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, Level, Lint, LintContext};
-use crate::rustc::session::Session;
-use crate::rustc::traits;
-use crate::rustc::ty::{
+use if_chain::if_chain;
+use matches::matches;
+use rustc::hir;
+use rustc::hir::def::Def;
+use rustc::hir::def_id::{DefId, CRATE_DEF_INDEX};
+use rustc::hir::intravisit::{NestedVisitorMap, Visitor};
+use rustc::hir::Node;
+use rustc::hir::*;
+use rustc::lint::{LateContext, Level, Lint, LintContext};
+use rustc::session::Session;
+use rustc::traits;
+use rustc::ty::{
     self,
     layout::{self, IntegerExt},
     subst::Kind,
     Binder, Ty, TyCtxt,
 };
-use crate::rustc_errors::{Applicability, CodeSuggestion, Substitution, SubstitutionPart};
-use crate::syntax::ast::{self, LitKind};
-use crate::syntax::attr;
-use crate::syntax::errors::DiagnosticBuilder;
-use crate::syntax::source_map::{Span, DUMMY_SP};
-use crate::syntax::symbol;
-use crate::syntax::symbol::{keywords, Symbol};
-use if_chain::if_chain;
-use matches::matches;
+use rustc_errors::{Applicability, CodeSuggestion, Substitution, SubstitutionPart};
 use std::borrow::Cow;
 use std::env;
 use std::mem;
 use std::rc::Rc;
 use std::str::FromStr;
+use syntax::ast::{self, LitKind};
+use syntax::attr;
+use syntax::errors::DiagnosticBuilder;
+use syntax::source_map::{Span, DUMMY_SP};
+use syntax::symbol;
+use syntax::symbol::{keywords, Symbol};
 
 pub mod camel_case;
 

--- a/clippy_lints/src/utils/ptr.rs
+++ b/clippy_lints/src/utils/ptr.rs
@@ -7,13 +7,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use crate::rustc::hir::*;
-use crate::rustc::lint::LateContext;
-use crate::syntax::ast::Name;
-use crate::syntax::source_map::Span;
 use crate::utils::{get_pat_name, match_var, snippet};
+use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
+use rustc::hir::*;
+use rustc::lint::LateContext;
 use std::borrow::Cow;
+use syntax::ast::Name;
+use syntax::source_map::Span;
 
 pub fn get_spans(
     cx: &LateContext<'_, '_>,

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -10,22 +10,22 @@
 //! Contains utility functions to generate suggestions.
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::rustc::hir;
-use crate::rustc::lint::{EarlyContext, LateContext, LintContext};
-use crate::rustc_errors;
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast;
-use crate::syntax::parse::token;
-use crate::syntax::print::pprust::token_to_string;
-use crate::syntax::source_map::{CharPos, Span};
-use crate::syntax::util::parser::AssocOp;
-use crate::syntax_pos::{BytePos, Pos};
 use crate::utils::{higher, in_macro, snippet, snippet_opt};
 use matches::matches;
+use rustc::hir;
+use rustc::lint::{EarlyContext, LateContext, LintContext};
+use rustc_errors;
+use rustc_errors::Applicability;
 use std;
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::fmt::Display;
+use syntax::ast;
+use syntax::parse::token;
+use syntax::print::pprust::token_to_string;
+use syntax::source_map::{CharPos, Span};
+use syntax::util::parser::AssocOp;
+use syntax_pos::{BytePos, Pos};
 
 /// A helper type to build suggestion correctly handling parenthesis.
 pub enum Sugg<'a> {
@@ -122,7 +122,7 @@ impl<'a> Sugg<'a> {
 
     /// Prepare a suggestion from an expression.
     pub fn ast(cx: &EarlyContext<'_>, expr: &ast::Expr, default: &'a str) -> Self {
-        use crate::syntax::ast::RangeLimits;
+        use syntax::ast::RangeLimits;
 
         let snippet = snippet(cx, expr.span, default);
 
@@ -407,7 +407,7 @@ enum Associativity {
 /// they are considered
 /// associative.
 fn associativity(op: &AssocOp) -> Associativity {
-    use crate::syntax::util::parser::AssocOp::*;
+    use syntax::util::parser::AssocOp::*;
 
     match *op {
         ObsoleteInPlace | Assign | AssignOp(_) => Associativity::Right,
@@ -420,7 +420,7 @@ fn associativity(op: &AssocOp) -> Associativity {
 
 /// Convert a `hir::BinOp` to the corresponding assigning binary operator.
 fn hirbinop2assignop(op: hir::BinOp) -> AssocOp {
-    use crate::syntax::parse::token::BinOpToken::*;
+    use syntax::parse::token::BinOpToken::*;
 
     AssocOp::AssignOp(match op.node {
         hir::BinOpKind::Add => Plus,
@@ -447,8 +447,8 @@ fn hirbinop2assignop(op: hir::BinOp) -> AssocOp {
 
 /// Convert an `ast::BinOp` to the corresponding assigning binary operator.
 fn astbinop2assignop(op: ast::BinOp) -> AssocOp {
-    use crate::syntax::ast::BinOpKind::*;
-    use crate::syntax::parse::token::BinOpToken;
+    use syntax::ast::BinOpKind::*;
+    use syntax::parse::token::BinOpToken;
 
     AssocOp::AssignOp(match op.node {
         Add => BinOpToken::Plus,

--- a/clippy_lints/src/utils/usage.rs
+++ b/clippy_lints/src/utils/usage.rs
@@ -7,17 +7,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::LateContext;
+use rustc::lint::LateContext;
 
-use crate::rustc::hir::def::Def;
-use crate::rustc::hir::*;
-use crate::rustc::middle::expr_use_visitor::*;
-use crate::rustc::middle::mem_categorization::cmt_;
-use crate::rustc::middle::mem_categorization::Categorization;
-use crate::rustc::ty;
-use crate::rustc_data_structures::fx::FxHashSet;
-use crate::syntax::ast::NodeId;
-use crate::syntax::source_map::Span;
+use rustc::hir::def::Def;
+use rustc::hir::*;
+use rustc::middle::expr_use_visitor::*;
+use rustc::middle::mem_categorization::cmt_;
+use rustc::middle::mem_categorization::Categorization;
+use rustc::ty;
+use rustc_data_structures::fx::FxHashSet;
+use syntax::ast::NodeId;
+use syntax::source_map::Span;
 
 /// Returns a set of mutated local variable ids or None if mutations could not be determined.
 pub fn mutated_variables<'a, 'tcx: 'a>(expr: &'tcx Expr, cx: &'a LateContext<'a, 'tcx>) -> Option<FxHashSet<NodeId>> {

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -8,14 +8,14 @@
 // except according to those terms.
 
 use crate::consts::constant;
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::ty::{self, Ty};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::source_map::Span;
 use crate::utils::{higher, is_copy, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::ty::{self, Ty};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
+use syntax::source_map::Span;
 
 /// **What it does:** Checks for usage of `&vec![..]` when using `&[..]` would
 /// be possible.

--- a/clippy_lints/src/wildcard_dependencies.rs
+++ b/clippy_lints/src/wildcard_dependencies.rs
@@ -7,10 +7,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::syntax::{ast::*, source_map::DUMMY_SP};
 use crate::utils::span_lint;
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use syntax::{ast::*, source_map::DUMMY_SP};
 
 use cargo_metadata;
 use if_chain::if_chain;

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -7,14 +7,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
-use crate::rustc_errors::Applicability;
-use crate::syntax::ast::*;
-use crate::syntax::parse::{parser, token};
-use crate::syntax::tokenstream::{ThinTokenStream, TokenStream};
 use crate::utils::{snippet_with_applicability, span_lint, span_lint_and_sugg};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_errors::Applicability;
 use std::borrow::Cow;
+use syntax::ast::*;
+use syntax::parse::{parser, token};
+use syntax::tokenstream::{ThinTokenStream, TokenStream};
 
 /// **What it does:** This lint warns when you use `println!("")` to
 /// print a newline.
@@ -271,7 +271,7 @@ impl EarlyLintPass for Pass {
 /// (Some("string to write: {}"), Some(buf))
 /// ```
 fn check_tts<'a>(cx: &EarlyContext<'a>, tts: &ThinTokenStream, is_write: bool) -> (Option<String>, Option<Expr>) {
-    use crate::fmt_macros::*;
+    use fmt_macros::*;
     let tts = TokenStream::from(tts.clone());
     let mut parser = parser::Parser::new(&cx.sess.parse_sess, tts, None, false, false);
     let mut expr: Option<Expr> = None;

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -8,11 +8,11 @@
 // except according to those terms.
 
 use crate::consts::{constant_simple, Constant};
-use crate::rustc::hir::*;
-use crate::rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use crate::rustc::{declare_tool_lint, lint_array};
 use crate::utils::span_help_and_lint;
 use if_chain::if_chain;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
 
 /// **What it does:** Checks for `0.0 / 0.0`.
 ///

--- a/tests/matches.rs
+++ b/tests/matches.rs
@@ -15,8 +15,8 @@ use std::collections::Bound;
 
 #[test]
 fn test_overlapping() {
-    use crate::syntax::source_map::DUMMY_SP;
     use clippy_lints::matches::overlapping;
+    use syntax::source_map::DUMMY_SP;
 
     let sp = |s, e| clippy_lints::matches::SpannedRange {
         span: DUMMY_SP,


### PR DESCRIPTION
This is somewhat misleading, as those are actually external crates,
and don't need a crate:: prefix.