### PR TITLE
deps: bump rustc_tools_util version from 0.1.0 to 0.1.1 just in case...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ clippy_lints = { version = "0.0.212", path = "clippy_lints" }
 # end automatic update
 regex = "1"
 semver = "0.9"
-rustc_tools_util = { version = "0.1.0", path = "rustc_tools_util"}
+rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
 
 [dev-dependencies]
 clippy_dev = { version = "0.0.1", path = "clippy_dev" }
@@ -61,7 +61,7 @@ derive-new = "0.5"
 rustc-workspace-hack = "1.0.0"
 
 [build-dependencies]
-rustc_tools_util = { version = "0.1.0", path = "rustc_tools_util"}
+rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
 
 [features]
 debugging = []


### PR DESCRIPTION
I'm surprised there is no warning since the root cargo.toml specifies 0.1.0 but the subcrate toml actually states 0.1.1.

I should have noticed this in previous pull request but oh well...