### PR TITLE
[WIP] Add getter prefix name lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -698,6 +698,7 @@ All notable changes to this project will be documented in this file.
 [`forget_copy`]: https://rust-lang.github.io/rust-clippy/master/index.html#forget_copy
 [`forget_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#forget_ref
 [`get_unwrap`]: https://rust-lang.github.io/rust-clippy/master/index.html#get_unwrap
+[`getter_prefix`]: https://rust-lang.github.io/rust-clippy/master/index.html#getter_prefix
 [`identity_conversion`]: https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
 [`identity_op`]: https://rust-lang.github.io/rust-clippy/master/index.html#identity_op
 [`if_let_redundant_pattern_matching`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_let_redundant_pattern_matching

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 290 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 291 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -159,6 +159,7 @@ pub mod multiple_crate_versions;
 pub mod mut_mut;
 pub mod mut_reference;
 pub mod mutex_atomic;
+pub mod naming;
 pub mod needless_bool;
 pub mod needless_borrow;
 pub mod needless_borrowed_ref;
@@ -486,6 +487,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_late_lint_pass(box ptr_offset_with_cast::Pass);
     reg.register_late_lint_pass(box redundant_clone::RedundantClone);
     reg.register_late_lint_pass(box slow_vector_initialization::Pass);
+    reg.register_early_lint_pass(box naming::GetterPrefix);
 
     reg.register_lint_group("clippy::restriction", Some("clippy_restriction"), vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -697,6 +699,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         misc_early::ZERO_PREFIXED_LITERAL,
         mut_reference::UNNECESSARY_MUT_PASSED,
         mutex_atomic::MUTEX_ATOMIC,
+        naming::GETTER_PREFIX,
         needless_bool::BOOL_COMPARISON,
         needless_bool::NEEDLESS_BOOL,
         needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE,
@@ -837,6 +840,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         misc_early::MIXED_CASE_HEX_LITERALS,
         misc_early::UNNEEDED_FIELD_PATTERN,
         mut_reference::UNNECESSARY_MUT_PASSED,
+        naming::GETTER_PREFIX,
         neg_multiply::NEG_MULTIPLY,
         new_without_default::NEW_WITHOUT_DEFAULT,
         non_expressive_names::JUST_UNDERSCORES_AND_DIGITS,

--- a/clippy_lints/src/naming.rs
+++ b/clippy_lints/src/naming.rs
@@ -1,0 +1,95 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
+use crate::rustc::{declare_tool_lint, lint_array};
+use crate::syntax::ast;
+use crate::utils::span_lint;
+
+/// **What it does:** Checks for the `get_` prefix on getters.
+///
+/// **Why is this bad?** The Rust API Guidelines section on naming
+/// [specifies](https://rust-lang-nursery.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter)
+/// that the `get_` prefix is not used for getters in Rust code unless
+/// there is a single and obvious thing that could reasonably be gotten by
+/// a getter.
+///
+/// The exceptions to this naming convention are as follows:
+/// - `get` (such as in
+///   [`std::cell::Cell::get`](https://doc.rust-lang.org/std/cell/struct.Cell.html#method.get))
+/// - `get_mut`
+/// - `get_unchecked`
+/// - `get_unchecked_mut`
+/// - `get_ref`
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+///
+/// ```rust
+/// // Bad
+/// impl B {
+///     fn get_id(&self) -> usize {
+///         ..
+///     }
+/// }
+///
+/// // Good
+/// impl G {
+///     fn id(&self) -> usize {
+///         ..
+///     }
+/// }
+///
+/// // Also allowed
+/// impl A {
+///     fn get(&self) -> usize {
+///         ..
+///     }
+/// }
+/// ```
+declare_clippy_lint! {
+    pub GETTER_PREFIX,
+    style,
+    "prefixing a getter with `get_`, which does not follow convention"
+}
+
+#[derive(Copy, Clone)]
+pub struct GetterPrefix;
+
+#[rustfmt::skip]
+const ALLOWED_METHOD_NAMES: [&'static str; 5] = [
+    "get",
+    "get_mut",
+    "get_unchecked",
+    "get_unchecked_mut",
+    "get_ref"
+];
+
+impl LintPass for GetterPrefix {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(GETTER_PREFIX)
+    }
+}
+
+impl EarlyLintPass for GetterPrefix {
+    fn check_impl_item(&mut self, cx: &EarlyContext<'_>, implitem: &ast::ImplItem) {
+        if let ast::ImplItemKind::Method(..) = implitem.node {
+            let name = implitem.ident.name.as_str().get();
+            if name.starts_with("get_") && !ALLOWED_METHOD_NAMES.contains(&name) {
+                span_lint(
+                    cx,
+                    GETTER_PREFIX,
+                    implitem.span,
+                    "prefixing a getter with `get_` does not follow naming conventions",
+                );
+            }
+        }
+    }
+}

--- a/tests/ui/naming.rs
+++ b/tests/ui/naming.rs
@@ -1,0 +1,48 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct MyStruct {
+    id: usize
+}
+
+impl MyStruct {
+    pub fn get_id(&self) -> usize {
+        self.id
+    }
+
+    pub fn get(&self) -> usize {
+        self.id
+    }
+
+    pub fn get_mut(&mut self) -> usize {
+        self.id
+    }
+
+    pub fn get_unchecked(&self) -> usize {
+        self.id
+    }
+
+    pub fn get_unchecked_mut(&mut self) -> usize {
+        self.id
+    }
+
+    pub fn get_ref(&self) -> usize {
+        self.id
+    }
+}
+
+fn main() {
+   let mut s = MyStruct { id: 42 };
+   s.get_id();
+   s.get();
+   s.get_mut();
+   s.get_unchecked();
+   s.get_unchecked_mut();
+   s.get_ref();
+}

--- a/tests/ui/naming.stderr
+++ b/tests/ui/naming.stderr
@@ -1,0 +1,12 @@
+error: prefixing a getter with `get_` does not follow naming conventions
+  --> $DIR/naming.rs:15:5
+   |
+LL | /     pub fn get_id(&self) -> usize {
+LL | |         self.id
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::getter-prefix` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -22,7 +22,7 @@
 struct Unitter;
 impl Unitter {
     // try to disorient the lint with multiple unit returns and newlines
-    pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) ->
+    pub fn get<F: Fn() -> (), G>(&self, f: F, _g: G) ->
         ()
     where G: Fn() -> () {
         let _y: &Fn() -> () = &f;
@@ -41,7 +41,7 @@ fn return_unit() -> () { () }
 
 fn main() {
     let u = Unitter;
-    assert_eq!(u.get_unit(|| {}, return_unit), u.into());
+    assert_eq!(u.get(|| {}, return_unit), u.into());
     return_unit();
     loop {
         break();

--- a/tests/ui/unused_unit.stderr
+++ b/tests/ui/unused_unit.stderr
@@ -1,8 +1,8 @@
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:25:59
+  --> $DIR/unused_unit.rs:25:54
    |
-LL |       pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) ->
-   |  ___________________________________________________________^
+LL |       pub fn get<F: Fn() -> (), G>(&self, f: F, _g: G) ->
+   |  ______________________________________________________^
 LL | |         ()
    | |__________^ help: remove the `-> ()`
    |


### PR DESCRIPTION
Add a lint to detect getter methods prefixed with `get_` which do not
follow the Rust convention for getter names as described in the
[naming section][0] of the Rust API Guidelines.

The `get_` prefix is not used unless there is a single and obvious thing
that could be gotten by a getter, including:
- `get`
- `get_mut`
- `get_unchecked`
- `get_unchecked_mut`
- `get_ref`

Closes #1673.

[0]: https://rust-lang-nursery.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter

## TODO:

The basic lint is implemented in this pull request, but there are still a couple things I'd like to add/finalize before I feel this is ready to merge. I wanted to open a pull request as soon as possible to collect and start incorporating feedback though, so this is currently a WIP.

- [ ] finalize lint name and lint span message
- [ ] implement machine-applicable renaming suggestions that would remove the `get_` prefix from the method name (using [`span_lint_and_sugg`](https://github.com/rust-lang/rust-clippy/blob/master/clippy_lints/src/utils/mod.rs#L679)?)

## Questions:

Since this is my first contribution to Clippy, I would really appreciate your feedback! I found the `rustc` documentation to be a bit lacking, so if there are better ways to approach this lint I'm all ears.

I also have a few specific items I would appreciate some guidance on:

1. [`LintPass::get_lints`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/lint/trait.LintPass.html#tymethod.get_lints) and thus [`tests/ui/lint_without_lint_pass.rs`](https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/lint_without_lint_pass.rs) (as well as a few other `rustc` methods like [`rustc_codegen_llvm::callee::get_fn`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_codegen_llvm/callee/fn.get_fn.html) and [`syntax::ext::tt::quoted::TokenTree::get_tt`](https://doc.rust-lang.org/nightly/nightly-rustc/syntax/ext/tt/quoted/enum.TokenTree.html#method.get_tt), for example) will not pass this lint rule in its current form. I'm not sure of the next step with these methods; exceptions can be added to the allowed name list, or is this something that will need to be changed in `rustc` first before this lint can land?
1. I wasn't able to run `target/debug/cargo-clippy clippy --all-targets --all-features -- -D clippy::all -D clippy::internal -D clippy::pedantic` against my local changes, I got the following error:
    ```text
    clippy/target/debug/cargo-clippy clippy --all-targets --all-features -- -D clippy::all -D clippy::internal -D clippy::pedantic
    error: failed to run `rustc` to learn about target-specific information

    Caused by:
    process didn't exit successfully: `clippy/target/debug/clippy-driver rustc - --crate-name ___ --print=file-names --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro` (signal: 6, SIGABRT: process abort signal)
    --- stderr
    dyld: Library not loaded: @rpath/librustc_driver-b630426988dbbdb0.dylib
    Referenced from: clippy/target/debug/clippy-driver
    Reason: image not found
    ```
    Looks like a linker error, I'm not sure what's going on here.
1. I'm not totally sure about the lint organization in Clippy. I created a separate file for this new lint, but should it actually live somewhere like `clippy_lints/src/functions.rs` or another existing file?
1. In #1673 @flip1995 [brought up](https://github.com/rust-lang/rust-clippy/issues/1673#issuecomment-441305773) an interesting point about linting just prefixes (e.g. just `get_unchecked*` instead of `get_unchecked` and `get_unchecked_mut` separately). Are there any opinions on how rigid we want the exceptions? As [I commented on the issue](https://github.com/rust-lang/rust-clippy/issues/1673#issuecomment-441306265), more permissive prefix matching could lead to some methods being missed simply because they start with one of the allowed names.
1. This lint only looks at `impl`s, but what about functions not associated with a type? As far as I can tell they aren't covered by the API guidelines but could be added to this lint as well.
1. The current implementation is naive name comparison, should there be some further inspection to test that a function actually accesses `self` to be considered a 'getter'?