### PR TITLE
Trigger `use_self` lint in local macros

### DIFF
--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -7,12 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::utils::{in_macro, span_lint_and_sugg};
+use crate::utils::span_lint_and_sugg;
 use if_chain::if_chain;
 use rustc::hir::def::{CtorKind, Def};
 use rustc::hir::intravisit::{walk_path, walk_ty, NestedVisitorMap, Visitor};
 use rustc::hir::*;
-use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc::ty;
 use rustc::{declare_tool_lint, lint_array};
 use rustc_errors::Applicability;
@@ -172,7 +172,7 @@ fn check_trait_method_impl_decl<'a, 'tcx: 'a>(
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UseSelf {
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx Item) {
-        if in_macro(item.span) {
+        if in_external_macro(cx.sess(), item.span) {
             return;
         }
         if_chain! {

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -226,6 +226,22 @@ mod tuple_structs {
     }
 }
 
+mod macros {
+    macro_rules! use_self_expand {
+        () => {
+            fn new() -> Foo {
+                Foo {}
+            }
+        };
+    }
+
+    struct Foo {}
+
+    impl Foo {
+        use_self_expand!(); // Should lint in local macros
+    }
+}
+
 mod issue3410 {
 
     struct A;

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -132,5 +132,23 @@ error: unnecessary structure name repetition
 LL |             TS(0)
    |             ^^ help: use the applicable keyword: `Self`
 
-error: aborting due to 22 previous errors
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:232:25
+   |
+LL |             fn new() -> Foo {
+   |                         ^^^ help: use the applicable keyword: `Self`
+...
+LL |         use_self_expand!(); // Should lint in local macros
+   |         ------------------- in this macro invocation
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:233:17
+   |
+LL |                 Foo {}
+   |                 ^^^ help: use the applicable keyword: `Self`
+...
+LL |         use_self_expand!(); // Should lint in local macros
+   |         ------------------- in this macro invocation
+
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Closes #2098

The test currently only covers local macros. #2098 suggested this:
> You could add the macro in question into the `mini_macro` subcrate

But that doesn't work for a `macro_rules`:
```
error: cannot export macro_rules! macros from a `proc-macro` crate type currently
```

So I suggest leaving out the test for external macros, as using `in_external_macro` seems straigtforward enough. Alternatives would be to use to add an additional crate (overkill if you ask me), or test with a `proc-macro`.