### PR TITLE
tests: used_underscore_binding_macro: disable random_state lint.

### DIFF
--- a/tests/run-pass/used_underscore_binding_macro.rs
+++ b/tests/run-pass/used_underscore_binding_macro.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 #![allow(clippy::useless_attribute)] //issue #2910
+#![allow(clippy::random_state)] // issue #3628
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Trying to work around a crash (see https://github.com/rust-lang/rust-clippy/issues/3628) in
https://github.com/rust-lang/rust/pull/57303