### PR TITLE
Add itertools to integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,8 @@ matrix:
       if: repo =~ /^rust-lang\/rust-clippy$/
     - env: INTEGRATION=hyperium/hyper
       if: repo =~ /^rust-lang\/rust-clippy$/
+    - env: INTEGRATION=bluss/rust-itertools
+      if: repo =~ /^rust-lang\/rust-clippy$/
   allow_failures:
   - os: windows
     env: CARGO_INCREMENTAL=0 BASE_TESTS=true


### PR DESCRIPTION
Mainly because it causes an ICE in https://github.com/rust-lang/rust/issues/57298
and it's a good library to test anyway.