### PR TITLE
Restrict `use_self` on nested items

### DIFF
--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -246,7 +246,8 @@ impl<'a, 'tcx> Visitor<'tcx> for UseSelfVisitor<'a, 'tcx> {
             | ItemKind::Static(..)
             | ItemKind::Enum(..)
             | ItemKind::Struct(..)
-            | ItemKind::Union(..) => {
+            | ItemKind::Union(..)
+            | ItemKind::Impl(..) => {
                 // Don't check statements that shadow `Self` or where `Self` can't be used
             },
             _ => walk_item(self, item),

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -10,13 +10,12 @@
 use crate::utils::span_lint_and_sugg;
 use if_chain::if_chain;
 use rustc::hir::def::{CtorKind, Def};
-use rustc::hir::intravisit::{walk_path, walk_ty, NestedVisitorMap, Visitor};
+use rustc::hir::intravisit::{walk_item, walk_path, walk_ty, NestedVisitorMap, Visitor};
 use rustc::hir::*;
 use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc::ty;
 use rustc::{declare_tool_lint, lint_array};
 use rustc_errors::Applicability;
-use syntax::ast::NodeId;
 use syntax_pos::symbol::keywords::SelfUpper;
 
 /// **What it does:** Checks for unnecessary repetition of structure name when a
@@ -242,8 +241,17 @@ impl<'a, 'tcx> Visitor<'tcx> for UseSelfVisitor<'a, 'tcx> {
         walk_path(self, path);
     }
 
-    fn visit_use(&mut self, _path: &'tcx Path, _id: NodeId, _hir_id: HirId) {
-        // Don't check use statements
+    fn visit_item(&mut self, item: &'tcx Item) {
+        match item.node {
+            ItemKind::Use(..)
+            | ItemKind::Static(..)
+            | ItemKind::Enum(..)
+            | ItemKind::Struct(..)
+            | ItemKind::Union(..) => {
+                // Don't check statements that shadow `Self` or where `Self` can't be used
+            },
+            _ => walk_item(self, item),
+        }
     }
 
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -28,7 +28,6 @@ use syntax_pos::symbol::keywords::SelfUpper;
 /// **Known problems:**
 /// - False positive when using associated types (#2843)
 /// - False positives in some situations when using generics (#3410)
-/// - False positive when type from outer function can't be used (#3463)
 ///
 /// **Example:**
 /// ```rust

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -253,9 +253,7 @@ mod nesting {
 
             impl Bar {
                 fn bar() -> Bar {
-                    Bar {
-                        foo: Foo{},
-                    }
+                    Bar { foo: Foo {} }
                 }
             }
         }

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -250,6 +250,14 @@ mod nesting {
             struct Bar {
                 foo: Foo, // Foo != Self
             }
+
+            impl Bar {
+                fn bar() -> Bar {
+                    Bar {
+                        foo: Foo{},
+                    }
+                }
+            }
         }
     }
 
@@ -258,7 +266,7 @@ mod nesting {
     }
     impl Enum {
         fn method() {
-            use self::Enum::*;
+            use self::Enum::*; // Issue 3425
             static STATIC: Enum = Enum::A; // Can't use Self as type
         }
     }

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -242,6 +242,28 @@ mod macros {
     }
 }
 
+mod nesting {
+    struct Foo {}
+    impl Foo {
+        fn foo() {
+            use self::Foo; // Can't use Self here
+            struct Bar {
+                foo: Foo, // Foo != Self
+            }
+        }
+    }
+
+    enum Enum {
+        A,
+    }
+    impl Enum {
+        fn method() {
+            use self::Enum::*;
+            static STATIC: Enum = Enum::A; // Can't use Self as type
+        }
+    }
+}
+
 mod issue3410 {
 
     struct A;
@@ -253,16 +275,5 @@ mod issue3410 {
 
     impl Trait<Vec<A>> for Vec<B> {
         fn a(_: Vec<A>) {}
-    }
-}
-
-mod issue3425 {
-    enum Enum {
-        A,
-    }
-    impl Enum {
-        fn a() {
-            use self::Enum::*;
-        }
     }
 }

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -159,7 +159,7 @@ LL |                 fn bar() -> Bar {
 error: unnecessary structure name repetition
   --> $DIR/use_self.rs:256:21
    |
-LL |                     Bar {
+LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: aborting due to 26 previous errors

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -150,5 +150,17 @@ LL |                 Foo {}
 LL |         use_self_expand!(); // Should lint in local macros
    |         ------------------- in this macro invocation
 
-error: aborting due to 24 previous errors
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:255:29
+   |
+LL |                 fn bar() -> Bar {
+   |                             ^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:256:21
+   |
+LL |                     Bar {
+   |                     ^^^ help: use the applicable keyword: `Self`
+
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
Fixes #3637
Fixes #3463

These changes make it so that nested items aren't visited any more by the `use_self` lint.

I think visiting nested items should be possible (so that it uses a different `item_path` for the nested item), but I'm not sure whether it's viable and what the best approach would be.
- Can `item_path` be changed to a new `Self` path before visiting the item, and then changing it back afterwards?
- Alternatively, could a new visitor be created, re-using `check_trait_method_impl_decl`?