### PR TITLE
Add initial version of const_fn lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -878,6 +878,7 @@ All notable changes to this project will be documented in this file.
 [`min_max`]: https://rust-lang.github.io/rust-clippy/master/index.html#min_max
 [`misaligned_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#misaligned_transmute
 [`misrefactored_assign_op`]: https://rust-lang.github.io/rust-clippy/master/index.html#misrefactored_assign_op
+[`missing_const_for_fn`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn
 [`missing_docs_in_private_items`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_docs_in_private_items
 [`missing_inline_in_public_items`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_inline_in_public_items
 [`mistyped_literal_suffixes`]: https://rust-lang.github.io/rust-clippy/master/index.html#mistyped_literal_suffixes

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 292 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 293 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -23,6 +23,8 @@ extern crate rustc_data_structures;
 #[allow(unused_extern_crates)]
 extern crate rustc_errors;
 #[allow(unused_extern_crates)]
+extern crate rustc_mir;
+#[allow(unused_extern_crates)]
 extern crate rustc_plugin;
 #[allow(unused_extern_crates)]
 extern crate rustc_target;
@@ -144,6 +146,7 @@ pub mod methods;
 pub mod minmax;
 pub mod misc;
 pub mod misc_early;
+pub mod missing_const_for_fn;
 pub mod missing_doc;
 pub mod missing_inline;
 pub mod multiple_crate_versions;
@@ -486,6 +489,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_late_lint_pass(box slow_vector_initialization::Pass);
     reg.register_late_lint_pass(box types::RefToMut);
     reg.register_late_lint_pass(box assertions_on_constants::AssertionsOnConstants);
+    reg.register_late_lint_pass(box missing_const_for_fn::MissingConstForFn);
 
     reg.register_lint_group("clippy::restriction", Some("clippy_restriction"), vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -1027,6 +1031,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_lint_group("clippy::nursery", Some("clippy_nursery"), vec![
         attrs::EMPTY_LINE_AFTER_OUTER_ATTR,
         fallible_impl_from::FALLIBLE_IMPL_FROM,
+        missing_const_for_fn::MISSING_CONST_FOR_FN,
         mutex_atomic::MUTEX_INTEGER,
         needless_borrow::NEEDLESS_BORROW,
         redundant_clone::REDUNDANT_CLONE,

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -1,8 +1,7 @@
+use crate::utils::{is_entrypoint_fn, span_lint};
 use rustc::hir;
 use rustc::hir::intravisit::FnKind;
 use rustc::hir::{Body, Constness, FnDecl};
-// use rustc::mir::*;
-use crate::utils::{is_entrypoint_fn, span_lint};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
 use rustc_mir::transform::qualify_min_const_fn::is_min_const_fn;

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -11,11 +11,11 @@ use syntax_pos::Span;
 
 /// **What it does:**
 ///
-/// Suggests the use of `const` in functions and methods where possible
+/// Suggests the use of `const` in functions and methods where possible.
 ///
 /// **Why is this bad?**
-/// Not using `const` is a missed optimization. Instead of having the function execute at runtime,
-/// when using `const`, it's evaluated at compiletime.
+///
+/// Not having the function const prevents callers of the function from being const as well.
 ///
 /// **Known problems:**
 ///

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -1,0 +1,115 @@
+use rustc::hir;
+use rustc::hir::{Body, FnDecl, Constness};
+use rustc::hir::intravisit::FnKind;
+// use rustc::mir::*;
+use syntax::ast::{NodeId, Attribute};
+use syntax_pos::Span;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_mir::transform::qualify_min_const_fn::is_min_const_fn;
+use crate::utils::{span_lint, is_entrypoint_fn};
+
+/// **What it does:**
+///
+/// Suggests the use of `const` in functions and methods where possible
+///
+/// **Why is this bad?**
+/// Not using `const` is a missed optimization. Instead of having the function execute at runtime,
+/// when using `const`, it's evaluated at compiletime.
+///
+/// **Known problems:**
+///
+/// Const functions are currently still being worked on, with some features only being available
+/// on nightly. This lint does not consider all edge cases currently and the suggestions may be
+/// incorrect if you are using this lint on stable.
+///
+/// Also, the lint only runs one pass over the code. Consider these two non-const functions:
+///
+/// ```rust
+/// fn a() -> i32 { 0 }
+/// fn b() -> i32 { a() }
+/// ```
+///
+/// When running Clippy, the lint will only suggest to make `a` const, because `b` at this time
+/// can't be const as it calls a non-const function. Making `a` const and running Clippy again,
+/// will suggest to make `b` const, too.
+///
+/// **Example:**
+///
+/// ```rust
+/// fn new() -> Self {
+///     Self {
+///         random_number: 42
+///     }
+/// }
+/// ```
+///
+/// Could be a const fn:
+///
+/// ```rust
+/// const fn new() -> Self {
+///     Self {
+///         random_number: 42
+///     }
+/// }
+/// ```
+declare_clippy_lint! {
+    pub MISSING_CONST_FOR_FN,
+    nursery,
+    "Lint functions definitions that could be made `const fn`"
+}
+
+#[derive(Clone)]
+pub struct MissingConstForFn;
+
+impl LintPass for MissingConstForFn {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(MISSING_CONST_FOR_FN)
+    }
+
+    fn name(&self) -> &'static str {
+        "MissingConstForFn"
+    }
+}
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'_, '_>,
+        kind: FnKind<'_>,
+        _: &FnDecl,
+        _: &Body,
+        span: Span,
+        node_id: NodeId
+    ) {
+        let def_id = cx.tcx.hir().local_def_id(node_id);
+        let mir = cx.tcx.optimized_mir(def_id);
+        if let Ok(_) = is_min_const_fn(cx.tcx, def_id, &mir) {
+            match kind {
+                FnKind::ItemFn(name, _generics, header, _vis, attrs) => {
+                    if !can_be_const_fn(&name.as_str(), header, attrs) {
+                        return;
+                    }
+                },
+                FnKind::Method(ident, sig, _vis, attrs) => {
+                    let header = sig.header;
+                    let name = ident.name.as_str();
+                    if !can_be_const_fn(&name, header, attrs) {
+                        return;
+                    }
+                },
+                _ => return
+            }
+            span_lint(cx, MISSING_CONST_FOR_FN, span, "this could be a const_fn");
+        }
+    }
+}
+
+fn can_be_const_fn(name: &str, header: hir::FnHeader, attrs: &[Attribute]) -> bool {
+    // Main and custom entrypoints can't be `const`
+    if is_entrypoint_fn(name, attrs) { return false }
+
+    // We don't have to lint on something that's already `const`
+    if header.constness == Constness::Const { return false }
+    true
+}

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -84,7 +84,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
     ) {
         let def_id = cx.tcx.hir().local_def_id(node_id);
         let mir = cx.tcx.optimized_mir(def_id);
-        if let Ok(_) = is_min_const_fn(cx.tcx, def_id, &mir) {
+        if let Err((span, err) = is_min_const_fn(cx.tcx, def_id, &mir) {
+            cx.tcx.sess.span_err(span, &err);
+        } else {
             match kind {
                 FnKind::ItemFn(name, _generics, header, _vis, attrs) => {
                     if !can_be_const_fn(&name.as_str(), header, attrs) {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -350,6 +350,19 @@ pub fn method_chain_args<'a>(expr: &'a Expr, methods: &[&str]) -> Option<Vec<&'a
     Some(matched)
 }
 
+/// Returns true if the function is an entrypoint to a program
+///
+/// This is either the usual `main` function or a custom function with the `#[start]` attribute.
+pub fn is_entrypoint_fn(fn_name: &str, attrs: &[ast::Attribute]) -> bool {
+
+    let is_custom_entrypoint = attrs.iter().any(|attr| {
+        attr.path.segments.len() == 1
+            && attr.path.segments[0].ident.to_string() == "start"
+    });
+
+    is_custom_entrypoint || fn_name == "main"
+}
+
 /// Get the name of the item the expression is in, if available.
 pub fn get_item_name(cx: &LateContext<'_, '_>, expr: &Expr) -> Option<Name> {
     let parent_id = cx.tcx.hir().get_parent(expr.id);

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -3,7 +3,7 @@ use if_chain::if_chain;
 use matches::matches;
 use rustc::hir;
 use rustc::hir::def::Def;
-use rustc::hir::def_id::{DefId, LOCAL_CRATE, CRATE_DEF_INDEX};
+use rustc::hir::def_id::{DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc::hir::intravisit::{NestedVisitorMap, Visitor};
 use rustc::hir::Node;
 use rustc::hir::*;
@@ -353,7 +353,7 @@ pub fn method_chain_args<'a>(expr: &'a Expr, methods: &[&str]) -> Option<Vec<&'a
 /// Returns true if the provided `def_id` is an entrypoint to a program
 pub fn is_entrypoint_fn(cx: &LateContext<'_, '_>, def_id: DefId) -> bool {
     if let Some((entry_fn_def_id, _)) = cx.tcx.entry_fn(LOCAL_CRATE) {
-        return def_id == entry_fn_def_id
+        return def_id == entry_fn_def_id;
     }
     false
 }

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -354,11 +354,9 @@ pub fn method_chain_args<'a>(expr: &'a Expr, methods: &[&str]) -> Option<Vec<&'a
 ///
 /// This is either the usual `main` function or a custom function with the `#[start]` attribute.
 pub fn is_entrypoint_fn(fn_name: &str, attrs: &[ast::Attribute]) -> bool {
-
-    let is_custom_entrypoint = attrs.iter().any(|attr| {
-        attr.path.segments.len() == 1
-            && attr.path.segments[0].ident.to_string() == "start"
-    });
+    let is_custom_entrypoint = attrs
+        .iter()
+        .any(|attr| attr.path.segments.len() == 1 && attr.path.segments[0].ident.to_string() == "start");
 
     is_custom_entrypoint || fn_name == "main"
 }

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -39,10 +39,10 @@ fn get_y() -> u32 {
     //~^ ERROR E0013
 }
 
-// Also main should not be suggested to be made const
-fn main() {
-    // We should also be sure to not lint on closures
-    let add_one_v2 = |x: u32| -> u32 { x + 1 };
+// Don't lint entrypoint functions
+#[start]
+fn init(num: isize, something: *const *const u8) -> isize {
+    1
 }
 
 trait Foo {
@@ -54,10 +54,4 @@ trait Foo {
     fn g() -> u32 {
         33
     }
-}
-
-// Don't lint custom entrypoints either
-#[start]
-fn init(num: isize, something: *const *const u8) -> isize {
-    1
 }

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -8,16 +8,22 @@
 struct Game;
 
 // This should not be linted because it's already const
-const fn already_const() -> i32 { 32 }
+const fn already_const() -> i32 {
+    32
+}
 
 impl Game {
     // This should not be linted because it's already const
-    pub const fn already_const() -> i32 { 32 }
+    pub const fn already_const() -> i32 {
+        32
+    }
 }
 
 // Allowing on this function, because it would lint, which we don't want in this case.
 #[allow(clippy::missing_const_for_fn)]
-fn random() -> u32 { 42 }
+fn random() -> u32 {
+    42
+}
 
 // We should not suggest to make this function `const` because `random()` is non-const
 fn random_caller() -> u32 {
@@ -30,7 +36,7 @@ static Y: u32 = 0;
 // refer to a static variable
 fn get_y() -> u32 {
     Y
-        //~^ ERROR E0013
+    //~^ ERROR E0013
 }
 
 // Also main should not be suggested to be made const
@@ -52,4 +58,6 @@ trait Foo {
 
 // Don't lint custom entrypoints either
 #[start]
-fn init(num: isize, something: *const *const u8) -> isize { 1 }
+fn init(num: isize, something: *const *const u8) -> isize {
+    1
+}

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -1,0 +1,50 @@
+//! False-positive tests to ensure we don't suggest `const` for things where it would cause a
+//! compilation error.
+//! The .stderr output of this test should be empty. Otherwise it's a bug somewhere.
+
+#![warn(clippy::missing_const_for_fn)]
+#![feature(start)]
+
+struct Game;
+
+// This should not be linted because it's already const
+const fn already_const() -> i32 { 32 }
+
+impl Game {
+    // This should not be linted because it's already const
+    pub const fn already_const() -> i32 { 32 }
+}
+
+// Allowing on this function, because it would lint, which we don't want in this case.
+#[allow(clippy::missing_const_for_fn)]
+fn random() -> u32 { 42 }
+
+// We should not suggest to make this function `const` because `random()` is non-const
+fn random_caller() -> u32 {
+    random()
+}
+
+static Y: u32 = 0;
+
+// We should not suggest to make this function `const` because const functions are not allowed to
+// refer to a static variable
+fn get_y() -> u32 {
+    Y
+        //~^ ERROR E0013
+}
+
+// Also main should not be suggested to be made const
+fn main() {
+    // We should also be sure to not lint on closures
+    let add_one_v2 = |x: u32| -> u32 { x + 1 };
+}
+
+trait Foo {
+    // This should not be suggested to be made const
+    // (rustc restriction)
+    fn f() -> u32;
+}
+
+// Don't lint custom entrypoints either
+#[start]
+fn init(num: isize, something: *const *const u8) -> isize { 1 }

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -41,8 +41,13 @@ fn main() {
 
 trait Foo {
     // This should not be suggested to be made const
-    // (rustc restriction)
+    // (rustc doesn't allow const trait methods)
     fn f() -> u32;
+
+    // This should not be suggested to be made const either
+    fn g() -> u32 {
+        33
+    }
 }
 
 // Don't lint custom entrypoints either

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -25,8 +25,8 @@ fn two() -> i32 {
     abc
 }
 
-// TODO: Why can this be const? because it's a zero sized type?
-// There is the `const_string_new` feature, but it seems that this already works in const fns?
+// FIXME: This is a false positive in the `is_min_const_fn` function.
+// At least until the `const_string_new` feature is stabilzed.
 fn string() -> String {
     String::new()
 }
@@ -41,12 +41,14 @@ fn generic<T>(t: T) -> T {
     t
 }
 
-// FIXME: This could be const but is currently not linted
+// FIXME: Depends on the `const_transmute` and `const_fn` feature gates.
+// In the future Clippy should be able to suggest this as const, too.
 fn sub(x: u32) -> usize {
     unsafe { transmute(&x) }
 }
 
-// FIXME: This could be const but is currently not linted
+// NOTE: This is currently not yet allowed to be const
+// Once implemented, Clippy should be able to suggest this as const, too.
 fn generic_arr<T: Copy>(t: [T; 1]) -> T {
     t[0]
 }

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -1,0 +1,53 @@
+#![warn(clippy::missing_const_for_fn)]
+#![allow(clippy::let_and_return)]
+
+use std::mem::transmute;
+
+struct Game {
+    guess: i32,
+}
+
+impl Game {
+    // Could be const
+    pub fn new() -> Self {
+        Self {
+            guess: 42,
+        }
+    }
+}
+
+// Could be const
+fn one() -> i32 { 1 }
+
+// Could also be const
+fn two() -> i32 {
+    let abc = 2;
+    abc
+}
+
+// TODO: Why can this be const? because it's a zero sized type?
+// There is the `const_string_new` feature, but it seems that this already works in const fns?
+fn string() -> String {
+    String::new()
+}
+
+// Could be const
+unsafe fn four() -> i32 { 4 }
+
+// Could also be const
+fn generic<T>(t: T) -> T {
+    t
+}
+
+// FIXME: This could be const but is currently not linted
+fn sub(x: u32) -> usize {
+    unsafe { transmute(&x) }
+}
+
+// FIXME: This could be const but is currently not linted
+fn generic_arr<T: Copy>(t: [T; 1]) -> T {
+    t[0]
+}
+
+// Should not be const
+fn main() {}

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -10,14 +10,14 @@ struct Game {
 impl Game {
     // Could be const
     pub fn new() -> Self {
-        Self {
-            guess: 42,
-        }
+        Self { guess: 42 }
     }
 }
 
 // Could be const
-fn one() -> i32 { 1 }
+fn one() -> i32 {
+    1
+}
 
 // Could also be const
 fn two() -> i32 {
@@ -32,7 +32,9 @@ fn string() -> String {
 }
 
 // Could be const
-unsafe fn four() -> i32 { 4 }
+unsafe fn four() -> i32 {
+    4
+}
 
 // Could also be const
 fn generic<T>(t: T) -> T {

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -1,0 +1,42 @@
+error: this could be a const_fn
+  --> $DIR/could_be_const.rs:12:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |         Self {
+LL | |             guess: 42,
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
+
+error: this could be a const_fn
+  --> $DIR/could_be_const.rs:20:1
+   |
+LL | fn one() -> i32 { 1 }
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: this could be a const_fn
+  --> $DIR/could_be_const.rs:30:1
+   |
+LL | / fn string() -> String {
+LL | |     String::new()
+LL | | }
+   | |_^
+
+error: this could be a const_fn
+  --> $DIR/could_be_const.rs:35:1
+   |
+LL | unsafe fn four() -> i32 { 4 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: this could be a const_fn
+  --> $DIR/could_be_const.rs:38:1
+   |
+LL | / fn generic<T>(t: T) -> T {
+LL | |     t
+LL | | }
+   | |_^
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -2,19 +2,19 @@ error: this could be a const_fn
   --> $DIR/could_be_const.rs:12:5
    |
 LL | /     pub fn new() -> Self {
-LL | |         Self {
-LL | |             guess: 42,
-LL | |         }
+LL | |         Self { guess: 42 }
 LL | |     }
    | |_____^
    |
    = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
 
 error: this could be a const_fn
-  --> $DIR/could_be_const.rs:20:1
+  --> $DIR/could_be_const.rs:18:1
    |
-LL | fn one() -> i32 { 1 }
-   | ^^^^^^^^^^^^^^^^^^^^^
+LL | / fn one() -> i32 {
+LL | |     1
+LL | | }
+   | |_^
 
 error: this could be a const_fn
   --> $DIR/could_be_const.rs:23:1
@@ -36,11 +36,13 @@ LL | | }
 error: this could be a const_fn
   --> $DIR/could_be_const.rs:35:1
    |
-LL | unsafe fn four() -> i32 { 4 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / unsafe fn four() -> i32 {
+LL | |     4
+LL | | }
+   | |_^
 
 error: this could be a const_fn
-  --> $DIR/could_be_const.rs:38:1
+  --> $DIR/could_be_const.rs:40:1
    |
 LL | / fn generic<T>(t: T) -> T {
 LL | |     t

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -17,6 +17,15 @@ LL | fn one() -> i32 { 1 }
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error: this could be a const_fn
+  --> $DIR/could_be_const.rs:23:1
+   |
+LL | / fn two() -> i32 {
+LL | |     let abc = 2;
+LL | |     abc
+LL | | }
+   | |_^
+
+error: this could be a const_fn
   --> $DIR/could_be_const.rs:30:1
    |
 LL | / fn string() -> String {
@@ -38,5 +47,5 @@ LL | |     t
 LL | | }
    | |_^
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
This adds an initial version of a lint that can tell if a function could be `const`.

TODO: 

- [x] Finish up the docs
- [x] Fix the ICE

cc #2440