### PR TITLE
[experimental] ci: bootstrap from beta instead of nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 
-rust: nightly
+rust: beta
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ branches:
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-    - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly
+    - rustup-init.exe -y --default-host %TARGET% --default-toolchain beta
     - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
     - git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}' >rustc-hash.txt
     - set /p RUSTC_HASH=<rustc-hash.txt

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -33,14 +33,14 @@ cd ..
 
 # Perform various checks for lint registration
 ./util/dev update_lints --check
-cargo +nightly fmt --all -- --check
+cargo +beta fmt --all -- --check
 
 # make sure tests are formatted
 
 # some lints are sensitive to formatting, exclude some files
 tests_need_reformatting="false"
 # switch to nightly
-rustup default nightly
+rustup default beta
 # avoid loop spam and allow cmds with exit status != 0
 set +ex
 


### PR DESCRIPTION
A lot of nighties have been missing lately, so I hope this is a bit more stable?

Let's see how this works out.

Currently we rely on rustfmt nightly for formatting, this would make us switch to beta I supposed (maybe we can work around?)