### PR TITLE
Update Readme for (arguably) better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,15 @@ Once you have rustup and the latest stable release (at least Rust 1.29) installe
 rustup component add clippy
 ```
 
-Now you can run Clippy by invoking `cargo clippy`.
+#### Step 3: Run Clippy
 
-If it says that it can't find the `clippy` subcommand, please run `rustup self update`
+Now you can run Clippy by invoking the following command:
+
+```terminal
+cargo clippy
+```
+
+If it says that it can't find the `clippy` subcommand, please run `rustup self update`.
 
 ### Running Clippy from the command line without installing it
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Once you have rustup and the latest stable release (at least Rust 1.29) installe
 ```terminal
 rustup component add clippy
 ```
+If it says that it can't find the `clippy` component, please run `rustup self update`.
 
 #### Step 3: Run Clippy
 
@@ -76,8 +77,6 @@ Now you can run Clippy by invoking the following command:
 ```terminal
 cargo clippy
 ```
-
-If it says that it can't find the `clippy` subcommand, please run `rustup self update`.
 
 ### Running Clippy from the command line without installing it
 


### PR DESCRIPTION
Move final instruction to run clippy into a third step in the Readme so it's easier to spot at a quick glance.