### PR TITLE
Missing docs: don't require documenting Global Asm items.

### DIFF
--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -133,12 +133,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
             hir::ItemKind::Struct(..) => "a struct",
             hir::ItemKind::Trait(..) => "a trait",
             hir::ItemKind::TraitAlias(..) => "a trait alias",
-            hir::ItemKind::GlobalAsm(..) => "an assembly blob",
             hir::ItemKind::Ty(..) => "a type alias",
             hir::ItemKind::Union(..) => "a union",
             hir::ItemKind::Existential(..) => "an existential type",
             hir::ItemKind::ExternCrate(..)
             | hir::ItemKind::ForeignMod(..)
+            | hir::ItemKind::GlobalAsm(..)
             | hir::ItemKind::Impl(..)
             | hir::ItemKind::Use(..) => return,
         };

--- a/tests/ui/missing-doc.rs
+++ b/tests/ui/missing-doc.rs
@@ -2,7 +2,7 @@
 // When denying at the crate level, be sure to not get random warnings from the
 // injected intrinsics by the compiler.
 #![allow(dead_code)]
-#![feature(associated_type_defaults)]
+#![feature(associated_type_defaults, global_asm)]
 
 //! Some garbage docs for the crate here
 #![doc = "More garbage"]
@@ -176,3 +176,6 @@ pub mod public_interface {
 }
 
 fn main() {}
+
+// Ensure global asm doesn't require documentation.
+global_asm! { "" }


### PR DESCRIPTION
global_asm! items cannot be documented, the lint still gets triggered after adding documentation to the macro invocation. Furthermore, even if we could add documentation to the AST node, rustdoc doesn't render it anyways.

Playground example: https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=5182df182f0ffbbab4c3107e43368ac3