### PR TITLE
Remove bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,0 @@
-status = [
-  "continuous-integration/travis-ci/push",
-  "continuous-integration/appveyor/branch"
-]


### PR DESCRIPTION
This file was only needed for bors-ng, but now we use the default
rust-lang bors fork.