### PR TITLE
Check for results files missing tests

### DIFF
--- a/tests/missing-test-files.rs
+++ b/tests/missing-test-files.rs
@@ -1,10 +1,22 @@
 use std::fs::{self, DirEntry};
-use std::io;
 use std::path::Path;
 
 #[test]
 fn test_missing_tests() {
-    explore_directory(Path::new("./tests")).unwrap();
+    let missing_files = explore_directory(Path::new("./tests"));
+    if missing_files.len() > 0 {
+        assert!(
+            false,
+            format!(
+                "Didn't see a test file for the following files:\n\n{}\n",
+                missing_files
+                    .iter()
+                    .map(|s| format!("\t{}", s))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        );
+    }
 }
 
 /*
@@ -14,14 +26,15 @@ Since rs files are alphabetically before stderr/stdout, we can sort by the full 
 and iter in that order. If we've seen the file stem for the first time and it's not
 a rust file, it means the rust file has to be missing.
 */
-fn explore_directory(dir: &Path) -> io::Result<()> {
+fn explore_directory(dir: &Path) -> Vec<String> {
+    let mut missing_files: Vec<String> = Vec::new();
     let mut current_file = String::new();
-    let mut files: Vec<DirEntry> = fs::read_dir(dir)?.filter_map(Result::ok).collect();
+    let mut files: Vec<DirEntry> = fs::read_dir(dir).unwrap().filter_map(Result::ok).collect();
     files.sort_by_key(|e| e.path());
     for entry in files.iter() {
         let path = entry.path();
         if path.is_dir() {
-            explore_directory(&path)?;
+            missing_files.extend(explore_directory(&path));
         } else {
             let file_stem = path.file_stem().unwrap().to_str().unwrap().to_string();
             match path.extension() {
@@ -29,12 +42,9 @@ fn explore_directory(dir: &Path) -> io::Result<()> {
                     match ext.to_str().unwrap() {
                         "rs" => current_file = file_stem.clone(),
                         "stderr" | "stdout" => {
-                            assert_eq!(
-                                file_stem,
-                                current_file,
-                                "{}",
-                                format!("Didn't see a test file for {:}", path.to_str().unwrap())
-                            );
+                            if file_stem != current_file {
+                                missing_files.push(path.to_str().unwrap().to_string());
+                            }
                         },
                         _ => continue,
                     };
@@ -43,5 +53,5 @@ fn explore_directory(dir: &Path) -> io::Result<()> {
             }
         }
     }
-    Ok(())
+    missing_files
 }

--- a/tests/missing-test-files.rs
+++ b/tests/missing-test-files.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 #[test]
 fn test_missing_tests() {
     let missing_files = explore_directory(Path::new("./tests"));
-    if missing_files.len() > 0 {
+    if !missing_files.is_empty() {
         assert!(
             false,
             format!(
@@ -31,25 +31,22 @@ fn explore_directory(dir: &Path) -> Vec<String> {
     let mut current_file = String::new();
     let mut files: Vec<DirEntry> = fs::read_dir(dir).unwrap().filter_map(Result::ok).collect();
     files.sort_by_key(|e| e.path());
-    for entry in files.iter() {
+    for entry in &files {
         let path = entry.path();
         if path.is_dir() {
             missing_files.extend(explore_directory(&path));
         } else {
             let file_stem = path.file_stem().unwrap().to_str().unwrap().to_string();
-            match path.extension() {
-                Some(ext) => {
-                    match ext.to_str().unwrap() {
-                        "rs" => current_file = file_stem.clone(),
-                        "stderr" | "stdout" => {
-                            if file_stem != current_file {
-                                missing_files.push(path.to_str().unwrap().to_string());
-                            }
-                        },
-                        _ => continue,
-                    };
-                },
-                None => {},
+            if let Some(ext) = path.extension() {
+                match ext.to_str().unwrap() {
+                    "rs" => current_file = file_stem.clone(),
+                    "stderr" | "stdout" => {
+                        if file_stem != current_file {
+                            missing_files.push(path.to_str().unwrap().to_string());
+                        }
+                    },
+                    _ => continue,
+                };
             }
         }
     }


### PR DESCRIPTION
Addresses #3572.

Basically iterates over all the files, and if it sees any files that don't have a matching rs file, it throws an error.