### PR TITLE
Fix `implicit_return` false positives.

### DIFF
--- a/tests/ui/implicit_return.rs
+++ b/tests/ui/implicit_return.rs
@@ -26,6 +26,14 @@ fn test_match(x: bool) -> bool {
     }
 }
 
+#[allow(clippy::match_bool, clippy::needless_return)]
+fn test_match_with_unreachable(x: bool) -> bool {
+    match x {
+        true => return false,
+        false => unreachable!(),
+    }
+}
+
 #[allow(clippy::never_loop)]
 fn test_loop() -> bool {
     loop {
@@ -53,6 +61,15 @@ fn test_loop_with_nests() -> bool {
     }
 }
 
+#[allow(clippy::redundant_pattern_matching)]
+fn test_loop_with_if_let() -> bool {
+    loop {
+        if let Some(x) = Some(true) {
+            return x;
+        }
+    }
+}
+
 fn test_closure() {
     #[rustfmt::skip]
     let _ = || { true };
@@ -63,8 +80,10 @@ fn main() {
     let _ = test_end_of_fn();
     let _ = test_if_block();
     let _ = test_match(true);
+    let _ = test_match_with_unreachable(true);
     let _ = test_loop();
     let _ = test_loop_with_block();
     let _ = test_loop_with_nests();
+    let _ = test_loop_with_if_let();
     test_closure();
 }

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -31,31 +31,31 @@ LL |         false => { true },
    |                    ^^^^ help: add `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:32:9
+  --> $DIR/implicit_return.rs:40:9
    |
 LL |         break true;
    |         ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:40:13
+  --> $DIR/implicit_return.rs:48:13
    |
 LL |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:49:13
+  --> $DIR/implicit_return.rs:57:13
    |
 LL |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:58:18
+  --> $DIR/implicit_return.rs:75:18
    |
 LL |     let _ = || { true };
    |                  ^^^^ help: add `return` as shown: `return true`
 
 error: missing return statement
-  --> $DIR/implicit_return.rs:59:16
+  --> $DIR/implicit_return.rs:76:16
    |
 LL |     let _ = || true;
    |                ^^^^ help: add `return` as shown: `return true`


### PR DESCRIPTION
Fixes the following false positives:
- linting on `if let` without `else` in a `loop` even with a present `return`
- linting on `unreachable!()`