### PR TITLE
Fix automatic suggestion on `use_self`.

### DIFF
--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -60,7 +60,7 @@ fn span_use_self_lint(cx: &LateContext<'_, '_>, path: &Path) {
     let last_path_span = path.segments.last().expect(SEGMENTS_MSG).ident.span;
     // `to()` doesn't shorten span, so we shorten it with `until(..)`
     // and then include it with `to(..)`
-    let span = path.span.until(last_path_span).to(last_path_span);
+    let span = path.span.with_hi(last_path_span.hi());
 
     span_lint_and_sugg(
         cx,

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -58,8 +58,7 @@ const SEGMENTS_MSG: &str = "segments should be composed of at least 1 element";
 fn span_use_self_lint(cx: &LateContext<'_, '_>, path: &Path) {
     // path segments only include actual path, no methods or fields
     let last_path_span = path.segments.last().expect(SEGMENTS_MSG).ident.span;
-    // `to()` doesn't shorten span, so we shorten it with `until(..)`
-    // and then include it with `to(..)`
+    // only take path up to the end of last_path_span
     let span = path.span.with_hi(last_path_span.hi());
 
     span_lint_and_sugg(

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -10,17 +10,17 @@ mod use_self {
     struct Foo {}
 
     impl Foo {
-        fn new() -> Foo {
-            Foo {}
+        fn new() -> Self {
+            Self {}
         }
-        fn test() -> Foo {
-            Foo::new()
+        fn test() -> Self {
+            Self::new()
         }
     }
 
     impl Default for Foo {
-        fn default() -> Foo {
-            Foo::new()
+        fn default() -> Self {
+            Self::new()
         }
     }
 }
@@ -85,29 +85,29 @@ mod traits {
     struct Bad;
 
     impl SelfTrait for Bad {
-        fn refs(p1: &Bad) -> &Bad {
+        fn refs(p1: &Self) -> &Self {
             p1
         }
 
-        fn ref_refs<'a>(p1: &'a &'a Bad) -> &'a &'a Bad {
+        fn ref_refs<'a>(p1: &'a &'a Self) -> &'a &'a Self {
             p1
         }
 
-        fn mut_refs(p1: &mut Bad) -> &mut Bad {
+        fn mut_refs(p1: &mut Self) -> &mut Self {
             p1
         }
 
-        fn nested(_p1: Box<Bad>, _p2: (&u8, &Bad)) {}
+        fn nested(_p1: Box<Self>, _p2: (&u8, &Self)) {}
 
-        fn vals(_: Bad) -> Bad {
-            Bad::default()
+        fn vals(_: Self) -> Self {
+            Self::default()
         }
     }
 
     impl Mul for Bad {
-        type Output = Bad;
+        type Output = Self;
 
-        fn mul(self, rhs: Bad) -> Bad {
+        fn mul(self, rhs: Self) -> Self {
             rhs
         }
     }
@@ -199,7 +199,7 @@ mod existential {
     struct Foo;
 
     impl Foo {
-        fn bad(foos: &[Self]) -> impl Iterator<Item = &Foo> {
+        fn bad(foos: &[Self]) -> impl Iterator<Item = &Self> {
             foos.iter()
         }
 
@@ -214,7 +214,7 @@ mod tuple_structs {
 
     impl TS {
         pub fn ts() -> Self {
-            TS(0)
+            Self(0)
         }
     }
 }
@@ -222,8 +222,8 @@ mod tuple_structs {
 mod macros {
     macro_rules! use_self_expand {
         () => {
-            fn new() -> Foo {
-                Foo {}
+            fn new() -> Self {
+                Self {}
             }
         };
     }
@@ -245,8 +245,8 @@ mod nesting {
             }
 
             impl Bar {
-                fn bar() -> Bar {
-                    Bar { foo: Foo {} }
+                fn bar() -> Self {
+                    Self { foo: Foo {} }
                 }
             }
         }
@@ -290,10 +290,10 @@ mod rustfix {
         fn fun_1() {}
 
         fn fun_2() {
-            nested::A::fun_1();
-            nested::A::A;
+            Self::fun_1();
+            Self::A;
 
-            nested::A {};
+            Self {};
         }
     }
 }

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -274,3 +274,23 @@ mod issue3410 {
         fn a(_: Vec<A>) {}
     }
 }
+
+#[allow(clippy::no_effect)]
+mod rustfix {
+    mod nested {
+        pub struct A {}
+    }
+
+    impl nested::A {
+        const A: bool = true;
+
+        fn fun_1() {}
+
+        fn fun_2() {
+            nested::A::fun_1();
+            nested::A::A;
+
+            nested::A {};
+        }
+    }
+}

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -22,7 +22,7 @@ error: unnecessary structure name repetition
   --> $DIR/use_self.rs:15:13
    |
 LL |             Foo::new()
-   |             ^^^^^^^^ help: use the applicable keyword: `Self`
+   |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
   --> $DIR/use_self.rs:20:25
@@ -34,7 +34,7 @@ error: unnecessary structure name repetition
   --> $DIR/use_self.rs:21:13
    |
 LL |             Foo::new()
-   |             ^^^^^^^^ help: use the applicable keyword: `Self`
+   |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
   --> $DIR/use_self.rs:86:22
@@ -100,7 +100,7 @@ error: unnecessary structure name repetition
   --> $DIR/use_self.rs:101:13
    |
 LL |             Bad::default()
-   |             ^^^^^^^^^^^^ help: use the applicable keyword: `Self`
+   |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
   --> $DIR/use_self.rs:106:23

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -162,5 +162,23 @@ error: unnecessary structure name repetition
 LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
-error: aborting due to 26 previous errors
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:290:13
+   |
+LL |             nested::A::fun_1();
+   |             ^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:291:13
+   |
+LL |             nested::A::A;
+   |             ^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:293:13
+   |
+LL |             nested::A {};
+   |             ^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: aborting due to 29 previous errors
 

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -1,5 +1,5 @@
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:11:21
+  --> $DIR/use_self.rs:13:21
    |
 LL |         fn new() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
@@ -7,133 +7,133 @@ LL |         fn new() -> Foo {
    = note: `-D clippy::use-self` implied by `-D warnings`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:12:13
+  --> $DIR/use_self.rs:14:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:14:22
+  --> $DIR/use_self.rs:16:22
    |
 LL |         fn test() -> Foo {
    |                      ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:15:13
+  --> $DIR/use_self.rs:17:13
    |
 LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:20:25
+  --> $DIR/use_self.rs:22:25
    |
 LL |         fn default() -> Foo {
    |                         ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:21:13
+  --> $DIR/use_self.rs:23:13
    |
 LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:86:22
+  --> $DIR/use_self.rs:88:22
    |
 LL |         fn refs(p1: &Bad) -> &Bad {
    |                      ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:86:31
+  --> $DIR/use_self.rs:88:31
    |
 LL |         fn refs(p1: &Bad) -> &Bad {
    |                               ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:90:37
+  --> $DIR/use_self.rs:92:37
    |
 LL |         fn ref_refs<'a>(p1: &'a &'a Bad) -> &'a &'a Bad {
    |                                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:90:53
+  --> $DIR/use_self.rs:92:53
    |
 LL |         fn ref_refs<'a>(p1: &'a &'a Bad) -> &'a &'a Bad {
    |                                                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:94:30
+  --> $DIR/use_self.rs:96:30
    |
 LL |         fn mut_refs(p1: &mut Bad) -> &mut Bad {
    |                              ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:94:43
+  --> $DIR/use_self.rs:96:43
    |
 LL |         fn mut_refs(p1: &mut Bad) -> &mut Bad {
    |                                           ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:98:28
+  --> $DIR/use_self.rs:100:28
    |
 LL |         fn nested(_p1: Box<Bad>, _p2: (&u8, &Bad)) {}
    |                            ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:98:46
+  --> $DIR/use_self.rs:100:46
    |
 LL |         fn nested(_p1: Box<Bad>, _p2: (&u8, &Bad)) {}
    |                                              ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:100:20
+  --> $DIR/use_self.rs:102:20
    |
 LL |         fn vals(_: Bad) -> Bad {
    |                    ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:100:28
+  --> $DIR/use_self.rs:102:28
    |
 LL |         fn vals(_: Bad) -> Bad {
    |                            ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:101:13
+  --> $DIR/use_self.rs:103:13
    |
 LL |             Bad::default()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:106:23
+  --> $DIR/use_self.rs:108:23
    |
 LL |         type Output = Bad;
    |                       ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:108:27
+  --> $DIR/use_self.rs:110:27
    |
 LL |         fn mul(self, rhs: Bad) -> Bad {
    |                           ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:108:35
+  --> $DIR/use_self.rs:110:35
    |
 LL |         fn mul(self, rhs: Bad) -> Bad {
    |                                   ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:200:56
+  --> $DIR/use_self.rs:202:56
    |
 LL |         fn bad(foos: &[Self]) -> impl Iterator<Item = &Foo> {
    |                                                        ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:215:13
+  --> $DIR/use_self.rs:217:13
    |
 LL |             TS(0)
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:223:25
+  --> $DIR/use_self.rs:225:25
    |
 LL |             fn new() -> Foo {
    |                         ^^^ help: use the applicable keyword: `Self`
@@ -142,7 +142,7 @@ LL |         use_self_expand!(); // Should lint in local macros
    |         ------------------- in this macro invocation
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:224:17
+  --> $DIR/use_self.rs:226:17
    |
 LL |                 Foo {}
    |                 ^^^ help: use the applicable keyword: `Self`
@@ -151,31 +151,31 @@ LL |         use_self_expand!(); // Should lint in local macros
    |         ------------------- in this macro invocation
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:246:29
+  --> $DIR/use_self.rs:248:29
    |
 LL |                 fn bar() -> Bar {
    |                             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:247:21
+  --> $DIR/use_self.rs:249:21
    |
 LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:290:13
+  --> $DIR/use_self.rs:293:13
    |
 LL |             nested::A::fun_1();
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:291:13
+  --> $DIR/use_self.rs:294:13
    |
 LL |             nested::A::A;
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:293:13
+  --> $DIR/use_self.rs:296:13
    |
 LL |             nested::A {};
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`


### PR DESCRIPTION
In an example like this:
```rust
impl Example {
    fn fun_1() { }
    fn fun_2() {
        Example::fun_1();
    }
}
```
Clippy tries to replace `Example::fun_1` with `Self`, loosing `::fun_1` in the process, it should rather try to replace `Example` with `Self`.

**Question**
- There may be other paths that need the same treatment, but I'm not sure I understand them fully:
  - https://github.com/rust-lang/rust-clippy/blob/e648adf0866a1cea7db6ce2d33ea86e442f25377/clippy_lints/src/use_self.rs#L94-L96
  - https://github.com/rust-lang/rust-clippy/blob/e648adf0866a1cea7db6ce2d33ea86e442f25377/clippy_lints/src/use_self.rs#L225-L229