### PR TITLE
gitattributes: Treat .fixed files as rust files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 
 * text=auto eol=lf
 *.rs rust
+*.fixed linguist-language=Rust


### PR DESCRIPTION
This way GitHub treats them as Rust code :crab: :eyes: 