### PR TITLE
chore(cargo/dependencies/cargo-metadata): Upgrade to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
 
 [dev-dependencies]
 clippy_dev = { version = "0.0.1", path = "clippy_dev" }
-cargo_metadata = "0.6.2"
+cargo_metadata = "0.7.1"
 compiletest_rs = "0.3.18"
 lazy_static = "1.0"
 serde_derive = "1.0"

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.6.2"
+cargo_metadata = "0.7.1"
 itertools = "0.8"
 lazy_static = "1.0.2"
 matches = "0.1.7"

--- a/clippy_lints/src/cargo_common_metadata.rs
+++ b/clippy_lints/src/cargo_common_metadata.rs
@@ -66,7 +66,7 @@ impl LintPass for Pass {
 
 impl EarlyLintPass for Pass {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, _: &Crate) {
-        let metadata = if let Ok(metadata) = cargo_metadata::metadata_deps(None, true) {
+        let metadata = if let Ok(metadata) = cargo_metadata::MetadataCommand::new().no_deps().exec() {
             metadata
         } else {
             warning(cx, "could not read cargo metadata");

--- a/clippy_lints/src/multiple_crate_versions.rs
+++ b/clippy_lints/src/multiple_crate_versions.rs
@@ -41,7 +41,7 @@ impl LintPass for Pass {
 
 impl EarlyLintPass for Pass {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, _: &Crate) {
-        let metadata = if let Ok(metadata) = cargo_metadata::metadata_deps(None, true) {
+        let metadata = if let Ok(metadata) = cargo_metadata::MetadataCommand::new().exec() {
             metadata
         } else {
             span_lint(cx, MULTIPLE_CRATE_VERSIONS, DUMMY_SP, "could not read cargo metadata");

--- a/clippy_lints/src/wildcard_dependencies.rs
+++ b/clippy_lints/src/wildcard_dependencies.rs
@@ -37,7 +37,7 @@ impl LintPass for Pass {
 
 impl EarlyLintPass for Pass {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, _: &Crate) {
-        let metadata = if let Ok(metadata) = cargo_metadata::metadata(None) {
+        let metadata = if let Ok(metadata) = cargo_metadata::MetadataCommand::new().no_deps().exec() {
             metadata
         } else {
             span_lint(cx, WILDCARD_DEPENDENCIES, DUMMY_SP, "could not read cargo metadata");

--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -1,10 +1,12 @@
 #[test]
 fn check_that_clippy_lints_has_the_same_version_as_clippy() {
     let clippy_meta = cargo_metadata::MetadataCommand::new()
+        .no_deps()
         .exec()
         .expect("could not obtain cargo metadata");
     std::env::set_current_dir(std::env::current_dir().unwrap().join("clippy_lints")).unwrap();
     let clippy_lints_meta = cargo_metadata::MetadataCommand::new()
+        .no_deps()
         .exec()
         .expect("could not obtain cargo metadata");
     assert_eq!(clippy_lints_meta.packages[0].version, clippy_meta.packages[0].version);

--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -1,17 +1,16 @@
-use semver::VersionReq;
-
 #[test]
 fn check_that_clippy_lints_has_the_same_version_as_clippy() {
-    let clippy_meta = cargo_metadata::metadata(None).expect("could not obtain cargo metadata");
+    let clippy_meta = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("could not obtain cargo metadata");
     std::env::set_current_dir(std::env::current_dir().unwrap().join("clippy_lints")).unwrap();
-    let clippy_lints_meta = cargo_metadata::metadata(None).expect("could not obtain cargo metadata");
+    let clippy_lints_meta = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("could not obtain cargo metadata");
     assert_eq!(clippy_lints_meta.packages[0].version, clippy_meta.packages[0].version);
     for package in &clippy_meta.packages[0].dependencies {
         if package.name == "clippy_lints" {
-            assert_eq!(
-                VersionReq::parse(&clippy_lints_meta.packages[0].version).unwrap(),
-                package.req
-            );
+            assert!(package.req.matches(&clippy_lints_meta.packages[0].version));
             return;
         }
     }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-clippy/issues/3692.