### PR TITLE
Fix dogfood tests on Appveyor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,12 @@ where
         })
         .map(|p| ("CARGO_TARGET_DIR", p));
 
+    // Run the dogfood tests directly on nightly cargo. This is required due
+    // to a bug in rustup.rs when running cargo on custom toolchains. See issue #3118.
+    if std::env::var_os("CLIPPY_DOGFOOD").is_some() && cfg!(windows) {
+        args.insert(0, "+nightly".to_string());
+    }
+
     let exit_status = std::process::Command::new("cargo")
         .args(&args)
         .env("RUSTC_WRAPPER", path)

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -1,6 +1,6 @@
 #[test]
 fn dogfood() {
-    if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
+    if option_env!("RUSTC_TEST_SUITE").is_some() {
         return;
     }
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -30,7 +30,7 @@ fn dogfood() {
 
 #[test]
 fn dogfood_tests() {
-    if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
+    if option_env!("RUSTC_TEST_SUITE").is_some() {
         return;
     }
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
This introduces a work-around for a bug in rustup.rs when excuting
cargo from a custom toolchain. Instead of trusting rustup to
invoke cargo from one of the release channels we just invoke
nightly cargo directly.