### PR TITLE
Fix documentation for `slow_vector_initialization`

### DIFF
--- a/clippy_lints/src/slow_vector_initialization.rs
+++ b/clippy_lints/src/slow_vector_initialization.rs
@@ -11,8 +11,8 @@ use syntax_pos::symbol::Symbol;
 
 /// **What it does:** Checks slow zero-filled vector initialization
 ///
-/// **Why is this bad?** This structures are non-idiomatic and less efficient than simply using
-/// `vec![len; 0]`.
+/// **Why is this bad?** These structures are non-idiomatic and less efficient than simply using
+/// `vec![0; len]`.
 ///
 /// **Known problems:** None.
 ///


### PR DESCRIPTION
This PR fixes the documentation for the lint `slow_vector_initialization`. The documentation recommended writing `vec![len; 0]` but the correct solution is `vec![0; len]`.