### PR TITLE
Travis: Don't run integration tests on every PR commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,10 @@ matrix:
     # Builds that are executed for every PR
     - os: osx # run base tests on both platforms
       env: BASE_TESTS=true
-      if: type = pull_request OR branch IN (auto, try)
     - os: linux
       env: BASE_TESTS=true
-      if: type = pull_request OR branch IN (auto, try)
     - os: windows
       env: CARGO_INCREMENTAL=0 BASE_TESTS=true
-      if: type = pull_request OR branch IN (auto, try)
 
     # Builds that are only executed when a PR is r+ed or a try build is started
     # We don't want to run these always because they go towards

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,40 +39,48 @@ install:
 matrix:
   fast_finish: true
   include:
+    # Builds that are executed for every PR
     - os: osx # run base tests on both platforms
       env: BASE_TESTS=true
+      if: type = pull_request OR branch IN (auto, try)
     - os: linux
       env: BASE_TESTS=true
+      if: type = pull_request OR branch IN (auto, try)
     - os: windows
       env: CARGO_INCREMENTAL=0 BASE_TESTS=true
+      if: type = pull_request OR branch IN (auto, try)
+
+    # Builds that are only executed when a PR is r+ed or a try build is started
+    # We don't want to run these always because they go towards
+    # the build limit within the Travis rust-lang account.
     - env: INTEGRATION=rust-lang/cargo
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-random/rand
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang-nursery/stdsimd
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang/rustfmt
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang-nursery/futures-rs
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang-nursery/failure
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang-nursery/log
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang-nursery/chalk
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang/rls
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=chronotope/chrono
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=serde-rs/serde
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=Geal/nom
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=hyperium/hyper
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=bluss/rust-itertools
-      if: repo =~ /^rust-lang\/rust-clippy$/
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
   allow_failures:
   - os: windows
     env: CARGO_INCREMENTAL=0 BASE_TESTS=true


### PR DESCRIPTION
This does not save Clippy any time but it makes sure that the concurrent
build limit is not reached as quickly for the `rust-lang` Travis
account.

I can't create a permalink to the discussion somehow, so here's an
excerpt from the Infra channel:

```
[11:57 PM] pietroalbini: there is a clippy build (20 jobs) and a packed_simd one (42 builders)  and a rustc one which isn't scheduling atm
[11:58 PM] pietroalbini: I don't think there is a way to prioritize rustc builds in the queue on travis, right?
[12:22 AM] alexcrichton: pietro: I don't think so no
[12:22 AM] alexcrichton: If it's a problem we should cull builds on other projects
[12:22 AM] alexcrichton: The rust repo is the #1 priority
```

Since the integration tests are rarely failing these days, I think it's
fine to not run them on every commit.

If needed, it's also still possible to do a complete test run with `@bors try`.