### PR TITLE
Fix ICE in vec_box lint and add run-rustfix

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -289,7 +289,7 @@ fn check_ty(cx: &LateContext<'_, '_>, hir_ty: &hir::Ty, is_local: bool) {
                                     "`Vec<T>` is already on the heap, the boxing is unnecessary.",
                                     "try",
                                     format!("Vec<{}>", ty_ty),
-                                    Applicability::MaybeIncorrect,
+                                    Applicability::MachineApplicable,
                                 );
                                 return; // don't recurse into the type
                             }

--- a/tests/ui/complex_types.rs
+++ b/tests/ui/complex_types.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::all)]
-#![allow(unused, clippy::needless_pass_by_value)]
+#![allow(unused, clippy::needless_pass_by_value, clippy::vec_box)]
 #![feature(associated_type_defaults)]
 
 type Alias = Vec<Vec<Box<(u32, u32, u32, u32)>>>; // no warning here

--- a/tests/ui/vec_box_sized.fixed
+++ b/tests/ui/vec_box_sized.fixed
@@ -10,11 +10,11 @@ mod should_trigger {
     use super::SizedStruct;
 
     struct StructWithVecBox {
-        sized_type: Vec<Box<SizedStruct>>,
+        sized_type: Vec<SizedStruct>,
     }
 
-    struct A(Vec<Box<SizedStruct>>);
-    struct B(Vec<Vec<Box<(u32)>>>);
+    struct A(Vec<SizedStruct>);
+    struct B(Vec<Vec<u32>>);
 }
 
 /// The following should not trigger the lint

--- a/tests/ui/vec_box_sized.stderr
+++ b/tests/ui/vec_box_sized.stderr
@@ -1,10 +1,22 @@
 error: `Vec<T>` is already on the heap, the boxing is unnecessary.
-  --> $DIR/vec_box_sized.rs:10:17
+  --> $DIR/vec_box_sized.rs:13:21
    |
-LL |     sized_type: Vec<Box<SizedStruct>>,
-   |                 ^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<SizedStruct>`
+LL |         sized_type: Vec<Box<SizedStruct>>,
+   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<SizedStruct>`
    |
    = note: `-D clippy::vec-box` implied by `-D warnings`
 
-error: aborting due to previous error
+error: `Vec<T>` is already on the heap, the boxing is unnecessary.
+  --> $DIR/vec_box_sized.rs:16:14
+   |
+LL |     struct A(Vec<Box<SizedStruct>>);
+   |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<SizedStruct>`
+
+error: `Vec<T>` is already on the heap, the boxing is unnecessary.
+  --> $DIR/vec_box_sized.rs:17:18
+   |
+LL |     struct B(Vec<Vec<Box<(u32)>>>);
+   |                  ^^^^^^^^^^^^^^^ help: try: `Vec<u32>`
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Includes https://github.com/rust-lang/rust-clippy/pull/3726

`hir::Ty` doesn't seem to know anything about type bounds and
`cx.tcx.type_of(def_id)` caused an ICE when it was passed a generic type
with a bound:

```
src/librustc_typeck/collect.rs:1311: unexpected non-type Node::GenericParam: Type { default: None, synthetic: None }
```

Converting it to a proper `Ty` fixes the ICE and catches a few more places
where the lint applies.

Fixes #3720