### PR TITLE
Transition leftover test libs to Rust 2018

### DIFF
--- a/clippy_workspace_tests/Cargo.toml
+++ b/clippy_workspace_tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "clippy_workspace_tests"
 version = "0.1.0"
+edition = "2018"
 
 [workspace]
 members = ["subcrate"]

--- a/clippy_workspace_tests/src/main.rs
+++ b/clippy_workspace_tests/src/main.rs
@@ -1,2 +1,4 @@
+#![deny(rust_2018_idioms)]
+
 fn main() {
 }

--- a/mini-macro/Cargo.toml
+++ b/mini-macro/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 license = "MPL-2.0"
 description = "A macro to test clippy's procedural macro checks"
 repository = "https://github.com/rust-lang/rust-clippy"
+edition = "2018"
 
 [lib]
 name = "clippy_mini_macro_test"

--- a/mini-macro/src/lib.rs
+++ b/mini-macro/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(proc_macro_quote, proc_macro_hygiene)]
+#![deny(rust_2018_idioms)]
 extern crate proc_macro;
 
 use proc_macro::{TokenStream, quote};


### PR DESCRIPTION
To tick off some checkboxes in https://github.com/rust-lang/rust/issues/58099 =)