### PR TITLE
Macro check for assertion_on_constants lint

### DIFF
--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -1,3 +1,10 @@
+macro_rules! assert_const {
+    ($len:expr) => {
+        assert!($len > 0);
+        debug_assert!($len < 0);
+    };
+}
+
 fn main() {
     assert!(true);
     assert!(false);
@@ -9,4 +16,8 @@ fn main() {
 
     const C: bool = false;
     assert!(C);
+
+    debug_assert!(true);
+    assert_const!(3);
+    assert_const!(-1);
 }

--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -1,5 +1,5 @@
 error: assert!(true) will be optimized out by the compiler
-  --> $DIR/assertions_on_constants.rs:2:5
+  --> $DIR/assertions_on_constants.rs:9:5
    |
 LL |     assert!(true);
    |     ^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     assert!(true);
    = help: remove it
 
 error: assert!(false) should probably be replaced
-  --> $DIR/assertions_on_constants.rs:3:5
+  --> $DIR/assertions_on_constants.rs:10:5
    |
 LL |     assert!(false);
    |     ^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     assert!(false);
    = help: use panic!() or unreachable!()
 
 error: assert!(true) will be optimized out by the compiler
-  --> $DIR/assertions_on_constants.rs:4:5
+  --> $DIR/assertions_on_constants.rs:11:5
    |
 LL |     assert!(true, "true message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     assert!(true, "true message");
    = help: remove it
 
 error: assert!(false) should probably be replaced
-  --> $DIR/assertions_on_constants.rs:5:5
+  --> $DIR/assertions_on_constants.rs:12:5
    |
 LL |     assert!(false, "false message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     assert!(false, "false message");
    = help: use panic!() or unreachable!()
 
 error: assert!(const: true) will be optimized out by the compiler
-  --> $DIR/assertions_on_constants.rs:8:5
+  --> $DIR/assertions_on_constants.rs:15:5
    |
 LL |     assert!(B);
    |     ^^^^^^^^^^^
@@ -40,12 +40,21 @@ LL |     assert!(B);
    = help: remove it
 
 error: assert!(const: false) should probably be replaced
-  --> $DIR/assertions_on_constants.rs:11:5
+  --> $DIR/assertions_on_constants.rs:18:5
    |
 LL |     assert!(C);
    |     ^^^^^^^^^^^
    |
    = help: use panic!() or unreachable!()
 
-error: aborting due to 6 previous errors
+error: assert!(true) will be optimized out by the compiler
+  --> $DIR/assertions_on_constants.rs:20:5
+   |
+LL |     debug_assert!(true);
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove it
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
The `assertion_on_constants` lint currently has following output for this code [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=6f2c9df6fc50baf847212d3b5136ee97):
```rust
macro_rules! assert_const {
    ($len:expr) => {
        assert!($len > 0);
    }
}

fn main() {
    assert_const!(3);
    assert_const!(-1);
}
```
```
warning: assert!(const: true) will be optimized out by the compiler
 --> src/main.rs:3:9
  |
3 |         assert!($len > 0);
  |         ^^^^^^^^^^^^^^^^^^
...
8 |     assert_const!(3);
  |     ---------------- in this macro invocation
  |
  = note: #[warn(clippy::assertions_on_constants)] on by default
  = help: remove it
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: assert!(const: false) should probably be replaced
 --> src/main.rs:3:9
  |
3 |         assert!($len > 0);
  |         ^^^^^^^^^^^^^^^^^^
...
9 |     assert_const!(-1);
  |     ----------------- in this macro invocation
  |
  = help: use panic!() or unreachable!()
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
```

This is contradictory. This lint should not trigger if the `assert!` is in a macro itself.