### PR TITLE
Fix failing build  (adding new Hir::Def type ConstParam)

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -997,6 +997,7 @@ pub fn opt_def_id(def: Def) -> Option<DefId> {
         | Def::TyAlias(id)
         | Def::AssociatedTy(id)
         | Def::TyParam(id)
+        | Def::ConstParam(id)
         | Def::ForeignTy(id)
         | Def::Struct(id)
         | Def::StructCtor(id, ..)


### PR DESCRIPTION
solves: #3749

related with:
- https://travis-ci.com/rust-lang/rust-clippy/jobs/176480646
- https://github.com/rust-lang/rust/pull/58191
- https://github.com/rust-lang/rust/commit/29f72063667187f2d281e940209a924730e165b2#diff-c1e317a81486d937bbfc6edca1dee92aR55