### PR TITLE
WIP: Add missing trait implementation lints

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -41,34 +41,34 @@ use toml;
 // as said in the README.md of this repository. If this changes, please update README.md.
 #[macro_export]
 macro_rules! declare_clippy_lint {
-    { pub $name:tt, style, $description:tt } => {
+    { pub $name:tt, style, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Warn, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, correctness, $description:tt } => {
+    { pub $name:tt, correctness, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Deny, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, complexity, $description:tt } => {
+    { pub $name:tt, complexity, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Warn, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, perf, $description:tt } => {
+    { pub $name:tt, perf, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Warn, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, pedantic, $description:tt } => {
+    { pub $name:tt, pedantic, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Allow, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, restriction, $description:tt } => {
+    { pub $name:tt, restriction, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Allow, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, cargo, $description:tt } => {
+    { pub $name:tt, cargo, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Allow, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, nursery, $description:tt } => {
+    { pub $name:tt, nursery, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Allow, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, internal, $description:tt } => {
+    { pub $name:tt, internal, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Allow, $description, report_in_external_macro: true }
     };
-    { pub $name:tt, internal_warn, $description:tt } => {
+    { pub $name:tt, internal_warn, $description:expr } => {
         declare_tool_lint! { pub clippy::$name, Warn, $description, report_in_external_macro: true }
     };
 }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -150,6 +150,7 @@ pub mod misc_early;
 pub mod missing_const_for_fn;
 pub mod missing_doc;
 pub mod missing_inline;
+pub mod missing_traits;
 pub mod multiple_crate_versions;
 pub mod mut_mut;
 pub mod mut_reference;
@@ -493,6 +494,8 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_late_lint_pass(box types::RefToMut);
     reg.register_late_lint_pass(box assertions_on_constants::AssertionsOnConstants);
     reg.register_late_lint_pass(box missing_const_for_fn::MissingConstForFn);
+    reg.register_late_lint_pass(box missing_traits::MissingCopyImplementations::default());
+    reg.register_late_lint_pass(box missing_traits::MissingDebugImplementations::default());
 
     reg.register_lint_group("clippy::restriction", Some("clippy_restriction"), vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -706,6 +709,8 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         misc_early::REDUNDANT_CLOSURE_CALL,
         misc_early::UNNEEDED_FIELD_PATTERN,
         misc_early::ZERO_PREFIXED_LITERAL,
+        missing_traits::MISSING_COPY_IMPLEMENTATIONS,
+        missing_traits::MISSING_DEBUG_IMPLEMENTATIONS,
         mut_reference::UNNECESSARY_MUT_PASSED,
         mutex_atomic::MUTEX_ATOMIC,
         needless_bool::BOOL_COMPARISON,

--- a/clippy_lints/src/missing_traits.rs
+++ b/clippy_lints/src/missing_traits.rs
@@ -1,0 +1,130 @@
+use crate::utils::span_lint;
+use rustc::hir::*;
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc::util::nodemap::NodeSet;
+
+macro_rules! missing_impl {
+    ($trait:ident, $trait_path:path, $lint_constant:ident, $struct_name:ident,
+        $trait_check:ident) => (
+        declare_clippy_lint! {
+            pub $lint_constant,
+            correctness,
+            concat!("detects missing implementations of ", stringify!($trait_path))
+        }
+
+        #[derive(Default)]
+        pub struct $struct_name {
+            impling_types: Option<NodeSet>,
+        }
+
+        impl $struct_name {
+            pub fn new() -> $struct_name {
+                $struct_name { impling_types: None }
+            }
+        }
+
+        impl LintPass for $struct_name {
+            fn name(&self) -> &'static str {
+                stringify!($struct_name)
+            }
+
+            fn get_lints(&self) -> LintArray {
+                lint_array!($lint_constant)
+            }
+        }
+
+        impl<'a, 'tcx> LateLintPass<'a, 'tcx> for $struct_name {
+            fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx Item) {
+                if !cx.access_levels.is_reachable(item.id) {
+                    return;
+                }
+
+                match item.node {
+                    ItemKind::Struct(..) |
+                    ItemKind::Union(..) |
+                    ItemKind::Enum(..) => {}
+                    _ => return,
+                }
+
+                let x = match cx.tcx.lang_items().$trait_check() {
+                    Some(x) => x,
+                    None => return,
+                };
+
+                if self.impling_types.is_none() {
+                    let mut impls = NodeSet::default();
+                    cx.tcx.for_each_impl(x, |d| {
+                        if let Some(ty_def) = cx.tcx.type_of(d).ty_adt_def() {
+                            if let Some(node_id) = cx.tcx.hir().as_local_node_id(ty_def.did) {
+                                impls.insert(node_id);
+                            }
+                        }
+                    });
+
+                    self.impling_types = Some(impls);
+                }
+
+                if !self.impling_types.as_ref().unwrap().contains(&item.id) {
+                    span_lint(
+                        cx,
+                        $lint_constant,
+                        item.span,
+                        concat!("type does not implement `", stringify!($trait_path), "`; \
+                        consider adding #[derive(", stringify!($trait), ")] or a manual \
+                        implementation"))
+                }
+            }
+        }
+    )
+}
+
+/// **What it does:** Checks for `Copy` implementations missing from structs and enums
+///
+/// **Why is this bad?** `Copy` is a core trait that should be implemented for
+/// all types as much as possible.
+///
+/// For more, see the [Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#c-common-traits)
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// // Bad
+/// struct Foo;
+///
+/// // Good
+/// #[derive(Copy)]
+/// struct Bar;
+/// ```
+missing_impl!(
+    Copy,
+    Copy,
+    MISSING_COPY_IMPLEMENTATIONS,
+    MissingCopyImplementations,
+    copy_trait);
+
+/// **What it does:** Checks for `Debug` implementations missing from structs and enums
+///
+/// **Why is this bad?** `Debug` is a core trait that should be implemented for
+/// all types as much as possible.
+///
+/// For more, see the [Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#c-common-traits)
+///
+/// **Known problems:** None.
+///
+/// **Example:**
+/// ```rust
+/// // Bad
+/// struct Foo;
+///
+/// // Good
+/// #[derive(Debug)]
+/// struct Bar;
+/// ```
+missing_impl!(
+    Debug,
+    Debug,
+    MISSING_DEBUG_IMPLEMENTATIONS,
+    MissingDebugImplementations,
+    debug_trait);

--- a/tests/run-pass/ice-2774.rs
+++ b/tests/run-pass/ice-2774.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_copy_implementations)]
 use std::collections::HashSet;
 
 // See https://github.com/rust-lang/rust-clippy/issues/2774

--- a/tests/run-pass/ice-3151.rs
+++ b/tests/run-pass/ice-3151.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::missing_copy_implementations)]
+#![allow(clippy::missing_debug_implementations)]
+
 #[derive(Clone)]
 pub struct HashMap<V, S> {
     hash_builder: S,

--- a/tests/run-pass/needless_borrow_fp.rs
+++ b/tests/run-pass/needless_borrow_fp.rs
@@ -1,4 +1,5 @@
 #[deny(clippy::all)]
+#[allow(clippy::missing_copy_implementations)]
 #[derive(Debug)]
 pub enum Error {
     Type(&'static str),

--- a/tests/ui/missing_traits_copy.rs
+++ b/tests/ui/missing_traits_copy.rs
@@ -1,0 +1,36 @@
+#![feature(untagged_unions)]
+#![allow(dead_code)]
+#![allow(clippy::all)]
+#![warn(clippy::missing_copy_implementations)]
+
+pub enum A {}
+
+#[derive(Clone, Copy)]
+pub enum B {}
+
+pub enum C {}
+
+impl Copy for C {}
+impl Clone for C {
+    fn clone(&self) -> C { *self }
+}
+
+pub struct Foo;
+
+#[derive(Clone, Copy)]
+pub struct Bar;
+
+pub struct Baz;
+
+impl Copy for Baz {}
+impl Clone for Baz {
+    fn clone(&self) -> Baz { *self }
+}
+
+struct PrivateStruct;
+
+enum PrivateEnum {}
+
+struct GenericType<T>(T);
+
+fn main() {}

--- a/tests/ui/missing_traits_copy.stderr
+++ b/tests/ui/missing_traits_copy.stderr
@@ -1,0 +1,16 @@
+error: type does not implement `Copy`; consider adding #[derive(Copy)] or a manual implementation
+  --> $DIR/missing_traits_copy.rs:6:1
+   |
+LL | pub enum A {}
+   | ^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::missing-copy-implementations` implied by `-D warnings`
+
+error: type does not implement `Copy`; consider adding #[derive(Copy)] or a manual implementation
+  --> $DIR/missing_traits_copy.rs:18:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/missing_traits_debug.rs
+++ b/tests/ui/missing_traits_debug.rs
@@ -1,0 +1,38 @@
+#![feature(untagged_unions)]
+#![allow(dead_code)]
+#![allow(clippy::all)]
+#![warn(clippy::missing_debug_implementations)]
+
+pub enum A {}
+
+#[derive(Debug)]
+pub enum B {}
+
+pub enum C {}
+
+impl std::fmt::Debug for C {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("C").finish()
+    }
+}
+
+pub struct Foo;
+
+#[derive(Debug)]
+pub struct Bar;
+
+pub struct Baz;
+
+impl std::fmt::Debug for Baz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Baz").finish()
+    }
+}
+
+struct PrivateStruct;
+
+enum PrivateEnum {}
+
+struct GenericType<T>(T);
+
+fn main() {}

--- a/tests/ui/missing_traits_debug.stderr
+++ b/tests/ui/missing_traits_debug.stderr
@@ -1,0 +1,16 @@
+error: type does not implement `Debug`; consider adding #[derive(Debug)] or a manual implementation
+  --> $DIR/missing_traits_debug.rs:6:1
+   |
+LL | pub enum A {}
+   | ^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::missing-debug-implementations` implied by `-D warnings`
+
+error: type does not implement `Debug`; consider adding #[derive(Debug)] or a manual implementation
+  --> $DIR/missing_traits_debug.rs:19:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Posting this now so I can ensure I'm on the right track here.

This adds lints for if types are missing implementations of:

- [ ] `Clone`
- [ ] `Copy`
- [ ] `Debug`
- [ ] `Default`
- [ ] `Display`
- [ ] `Eq`
- [ ] `Hash`
- [ ] `Ord`
- [ ] `PartialEq`
- [ ] `PartialOrd`

Context here is in implementing [RFC2235](https://github.com/rust-lang/rfcs/blob/master/text/2235-libc-struct-traits.md) we cannot auto-derive all traits. However, we still want the traits to be manually implemented. So we'd like lints to check on them.

I started this work in rust-lang/rust#58070, but it was suggested that these lints shouldn't be in the compiler and instead in Clippy. It was suggested that the existing lints for `Copy` and `Debug` be deprecated as part of this as well.

Additionally these lints are part of #1798.

To fully implement all lints here, rust-lang/rust#58070 will need to be merged (which is still a work in progress) in order to get `Default`, `Display`, and `Hash` added as lang_items so they can be easily checked on types.
