### PR TITLE
use value.id and SuggestionStyle::ShowCode to fix build

### DIFF
--- a/clippy_lints/src/cyclomatic_complexity.rs
+++ b/clippy_lints/src/cyclomatic_complexity.rs
@@ -94,7 +94,7 @@ impl CyclomaticComplexity {
                 short_circuits,
                 ret_adjust,
                 span,
-                body.id().node_id,
+                body.value.id,
             );
         } else {
             let mut rust_cc = cc + divergence - match_arms - short_circuits;

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -17,7 +17,7 @@ use rustc::ty::{
     Binder, Ty, TyCtxt,
 };
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::{Applicability, CodeSuggestion, Substitution, SubstitutionPart};
+use rustc_errors::{Applicability, CodeSuggestion, Substitution, SubstitutionPart, SuggestionStyle};
 use std::borrow::Cow;
 use std::env;
 use std::mem;
@@ -745,7 +745,7 @@ where
                 .collect(),
         }],
         msg: help_msg,
-        show_code_when_inline: true,
+        style: SuggestionStyle::ShowCode,
         applicability: Applicability::Unspecified,
     };
     db.suggestions.push(sugg);


### PR DESCRIPTION
I try to fix a rust-clippy issue, but failed ```cargo test```.
I think this error is caused by Rust updates, so I send this PR.