### PR TITLE
trait bounds lint - repeated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1138,6 +1138,7 @@ Released 2018-09-13
 [`trivially_copy_pass_by_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
 [`try_err`]: https://rust-lang.github.io/rust-clippy/master/index.html#try_err
 [`type_complexity`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
+[`type_repetition_in_bounds`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_repetition_in_bounds
 [`unicode_not_nfc`]: https://rust-lang.github.io/rust-clippy/master/index.html#unicode_not_nfc
 [`unimplemented`]: https://rust-lang.github.io/rust-clippy/master/index.html#unimplemented
 [`unit_arg`]: https://rust-lang.github.io/rust-clippy/master/index.html#unit_arg

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 308 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 309 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -265,6 +265,7 @@ pub mod swap;
 pub mod temporary_assignment;
 pub mod transmute;
 pub mod transmuting_null;
+pub mod trait_bounds;
 pub mod trivially_copy_pass_by_ref;
 pub mod try_err;
 pub mod types;
@@ -588,6 +589,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_late_lint_pass(box checked_conversions::CheckedConversions);
     reg.register_late_lint_pass(box integer_division::IntegerDivision);
     reg.register_late_lint_pass(box inherent_to_string::InherentToString);
+    reg.register_late_lint_pass(box trait_bounds::TraitBounds);
 
     reg.register_lint_group("clippy::restriction", Some("clippy_restriction"), vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -868,6 +870,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         transmute::USELESS_TRANSMUTE,
         transmute::WRONG_TRANSMUTE,
         transmuting_null::TRANSMUTING_NULL,
+        trait_bounds::TYPE_REPETITION_IN_BOUNDS,
         trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
         try_err::TRY_ERR,
         types::ABSURD_EXTREME_COMPARISONS,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -263,9 +263,9 @@ pub mod strings;
 pub mod suspicious_trait_impl;
 pub mod swap;
 pub mod temporary_assignment;
+pub mod trait_bounds;
 pub mod transmute;
 pub mod transmuting_null;
-pub mod trait_bounds;
 pub mod trivially_copy_pass_by_ref;
 pub mod try_err;
 pub mod types;
@@ -860,6 +860,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         swap::ALMOST_SWAPPED,
         swap::MANUAL_SWAP,
         temporary_assignment::TEMPORARY_ASSIGNMENT,
+        trait_bounds::TYPE_REPETITION_IN_BOUNDS,
         transmute::CROSSPOINTER_TRANSMUTE,
         transmute::TRANSMUTE_BYTES_TO_STR,
         transmute::TRANSMUTE_INT_TO_BOOL,
@@ -870,7 +871,6 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         transmute::USELESS_TRANSMUTE,
         transmute::WRONG_TRANSMUTE,
         transmuting_null::TRANSMUTING_NULL,
-        trait_bounds::TYPE_REPETITION_IN_BOUNDS,
         trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
         try_err::TRY_ERR,
         types::ABSURD_EXTREME_COMPARISONS,
@@ -1042,6 +1042,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         reference::REF_IN_DEREF,
         swap::MANUAL_SWAP,
         temporary_assignment::TEMPORARY_ASSIGNMENT,
+        trait_bounds::TYPE_REPETITION_IN_BOUNDS,
         transmute::CROSSPOINTER_TRANSMUTE,
         transmute::TRANSMUTE_BYTES_TO_STR,
         transmute::TRANSMUTE_INT_TO_BOOL,

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -32,10 +32,16 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TraitBounds {
                 if let Some(ref v) = map.insert(h, p.bounds.iter().collect::<Vec<_>>()) {
                     let mut hint_string = format!("consider combining the bounds: `{:?}: ", p.bounded_ty);
                     for b in v.iter() {
-                        hint_string.push_str(&format!("{:?}, ", b));
+                        if let GenericBound::Trait(ref poly_trait_ref, _) = b {
+                            let path = &poly_trait_ref.trait_ref.path;
+                            hint_string.push_str(&format!("{}, ", path));
+                        }
                     }
                     for b in p.bounds.iter() {
-                        hint_string.push_str(&format!("{:?}, ", b));
+                        if let GenericBound::Trait(ref poly_trait_ref, _) = b {
+                            let path = &poly_trait_ref.trait_ref.path;
+                            hint_string.push_str(&format!("{}, ", path));
+                        }
                     }
                     hint_string.truncate(hint_string.len() - 2);
                     hint_string.push('`');

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -28,13 +28,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TraitBounds {
         let mut map = FxHashMap::default();
         for bound in &gen.where_clause.predicates {
             if let WherePredicate::BoundPredicate(ref p) = bound {
-                let h = hash(&p.bounded_ty.node);
+                let h = hash(&p.bounded_ty);
                 if let Some(ref v) = map.insert(h, p.bounds) {
                     let mut hint_string = format!("consider combining the bounds: `{:?}: ", p.bounded_ty);
-                    for &b in v.iter() {
+                    for b in v.iter() {
                         hint_string.push_str(&format!("{:?}, ", b));
                     }
-                    for &b in p.bounds.iter() {
+                    for b in p.bounds.iter() {
                         hint_string.push_str(&format!("{:?}, ", b));
                     }
                     hint_string.truncate(hint_string.len() - 2);

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -1,6 +1,6 @@
 use crate::utils::{in_macro, span_help_and_lint, SpanlessHash};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
-use rustc::{declare_tool_lint, lint_array, impl_lint_pass};
+use rustc::{declare_tool_lint, impl_lint_pass};
 use rustc_data_structures::fx::FxHashMap;
 use rustc::hir::*;
 
@@ -29,7 +29,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TraitBounds {
         for bound in &gen.where_clause.predicates {
             if let WherePredicate::BoundPredicate(ref p) = bound {
                 let h = hash(&p.bounded_ty);
-                if let Some(ref v) = map.insert(h, p.bounds) {
+                if let Some(ref v) = map.insert(h, p.bounds.iter().collect::<Vec<_>>()) {
                     let mut hint_string = format!("consider combining the bounds: `{:?}: ", p.bounded_ty);
                     for b in v.iter() {
                         hint_string.push_str(&format!("{:?}, ", b));

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -1,0 +1,63 @@
+use crate::utils::{in_macro, span_help_and_lint, SpanlessHash};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_tool_lint, lint_array};
+use rustc_data_structures::fx::FxHashMap;
+use rustc::hir::*;
+
+declare_clippy_lint! {
+    pub TYPE_REPETITION_IN_BOUNDS,
+    complexity,
+    "Types are repeated unnecessary in trait bounds use `+` instead of using `T: _, T: _`"
+}
+
+#[derive(Copy, Clone)]
+pub struct TraitBounds;
+
+impl LintPass for TraitBounds {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(TYPE_REPETITION_IN_BOUNDS)
+    }
+
+    fn name(&self) -> &'static str {
+        "TypeRepetitionInBounds"
+    }
+}
+
+
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TraitBounds {
+    fn check_generics(&mut self, cx: &LateContext<'a, 'tcx>, gen: &'tcx Generics) {
+        if in_macro(gen.span) {
+            return;
+        }
+        let hash = | ty | -> u64 {
+            let mut hasher = SpanlessHash::new(cx, cx.tables);
+            hasher.hash_ty(ty);
+            hasher.finish()
+        };
+        let mut map = FxHashMap::default();
+        for bound in &gen.where_clause.predicates {
+            if let WherePredicate::BoundPredicate(ref p) = bound {
+                let h = hash(&p.bounded_ty);
+                if let Some(ref v) = map.insert(h, p.bounds) {
+                    let mut hint_string = format!("consider combining the bounds: `{:?}: ", p.bounded_ty);
+                    for &b in v.iter() {
+                        hint_string.push_str(&format!("{:?}, ", b));
+                    }
+                    for &b in p.bounds.iter() {
+                        hint_string.push_str(&format!("{:?}, ", b));
+                    }
+                    hint_string.truncate(hint_string.len() - 2);
+                    hint_string.push('`');
+                    span_help_and_lint(
+                        cx,
+                        TYPE_REPETITION_IN_BOUNDS,
+                        p.span,
+                        "this type has already been used as a bound predicate",
+                        &hint_string,
+                    );
+                }
+            }
+        }
+    }
+}

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -1,8 +1,8 @@
 use crate::utils::{in_macro, snippet, span_help_and_lint, SpanlessHash};
+use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, impl_lint_pass};
 use rustc_data_structures::fx::FxHashMap;
-use rustc::hir::*;
 
 #[derive(Copy, Clone)]
 pub struct TraitBounds;
@@ -10,11 +10,12 @@ pub struct TraitBounds;
 declare_clippy_lint! {
     /// **What it does:** This lint warns about unnecessary type repetitions in trait bounds
     ///
-    /// **Why is this bad?** Complexity
+    /// **Why is this bad?** Repeating the type for every bound makes the code
+    /// less readable than combining the bounds
     ///
     /// **Example:**
     /// ```rust
-    /// pub fn foo<T>(t: T) where T: Copy, T: Clone 
+    /// pub fn foo<T>(t: T) where T: Copy, T: Clone
     /// ```
     ///
     /// Could be written as:
@@ -34,7 +35,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TraitBounds {
         if in_macro(gen.span) {
             return;
         }
-        let hash = | ty | -> u64 {
+        let hash = |ty| -> u64 {
             let mut hasher = SpanlessHash::new(cx, cx.tables);
             hasher.hash_ty(ty);
             hasher.finish()
@@ -44,17 +45,20 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TraitBounds {
             if let WherePredicate::BoundPredicate(ref p) = bound {
                 let h = hash(&p.bounded_ty);
                 if let Some(ref v) = map.insert(h, p.bounds.iter().collect::<Vec<_>>()) {
-                    let mut hint_string = format!("consider combining the bounds: `{}: ", snippet(cx, p.bounded_ty.span, "_"));
+                    let mut hint_string = format!(
+                        "consider combining the bounds: `{}:",
+                        snippet(cx, p.bounded_ty.span, "_")
+                    );
                     for b in v.iter() {
                         if let GenericBound::Trait(ref poly_trait_ref, _) = b {
                             let path = &poly_trait_ref.trait_ref.path;
-                            hint_string.push_str(&format!("{}, ", path));
+                            hint_string.push_str(&format!(" {} +", path));
                         }
                     }
                     for b in p.bounds.iter() {
                         if let GenericBound::Trait(ref poly_trait_ref, _) = b {
                             let path = &poly_trait_ref.trait_ref.path;
-                            hint_string.push_str(&format!("{}, ", path));
+                            hint_string.push_str(&format!(" {} +", path));
                         }
                     }
                     hint_string.truncate(hint_string.len() - 2);

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -513,18 +513,12 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 }
             },
             ExprKind::Tup(ref tup) => {
-                let c: fn(_) -> _ = ExprKind::Tup;
-                c.hash(&mut self.s);
                 self.hash_exprs(tup);
             },
             ExprKind::Array(ref v) => {
-                let c: fn(_) -> _ = ExprKind::Array;
-                c.hash(&mut self.s);
                 self.hash_exprs(v);
             },
             ExprKind::Type(ref e, ref ty) => {
-                let c: fn(_, _) -> _ = ExprKind::Type;
-                c.hash(&mut self.s);
                 self.hash_expr(e);
                 self.hash_ty(ty);
             },

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -639,23 +639,20 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 for ty in ty_list {
                     self.hash_ty(ty);
                 }
-
             },
-            TyKind::Path(qpath) => {
-                match qpath {
-                    QPath::Resolved(ref maybe_ty, ref path) => {
-                        if let Some(ref ty) = maybe_ty {
-                            self.hash_ty(ty);
-                        }
-                        for segment in &path.segments {
-                            segment.ident.name.hash(&mut self.s);
-                        }
-                    }, 
-                    QPath::TypeRelative(ref ty, ref segment) => {
+            TyKind::Path(qpath) => match qpath {
+                QPath::Resolved(ref maybe_ty, ref path) => {
+                    if let Some(ref ty) = maybe_ty {
                         self.hash_ty(ty);
+                    }
+                    for segment in &path.segments {
                         segment.ident.name.hash(&mut self.s);
-                    },
-                }
+                    }
+                },
+                QPath::TypeRelative(ref ty, ref segment) => {
+                    self.hash_ty(ty);
+                    segment.ident.name.hash(&mut self.s);
+                },
             },
             TyKind::Def(_, arg_list) => {
                 for arg in arg_list {
@@ -670,14 +667,11 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
             },
             TyKind::TraitObject(_, lifetime) => {
                 self.hash_lifetime(lifetime);
-
             },
             TyKind::Typeof(anon_const) => {
                 self.hash_expr(&self.cx.tcx.hir().body(anon_const.body).value);
             },
-            TyKind::CVarArgs(lifetime) => {
-                self.hash_lifetime(lifetime) 
-            },
+            TyKind::CVarArgs(lifetime) => self.hash_lifetime(lifetime),
             TyKind::Err | TyKind::Infer | TyKind::Never => {},
         }
     }

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -584,6 +584,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
 
     pub fn hash_lifetime(&mut self, lifetime: &Lifetime) {
         if let LifetimeName::Param(ref name) = lifetime.name {
+            std::mem::discriminant(&name).hash(&mut self.s);
             match name {
                 ParamName::Plain(ref ident) => {
                     ident.name.hash(&mut self.s);
@@ -591,7 +592,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 ParamName::Fresh(ref size) => {
                     size.hash(&mut self.s);
                 },
-                _ => {},
+                ParamName::Error => {},
             }
         }
     }

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -438,7 +438,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 self.hash_expr(fun);
                 self.hash_exprs(args);
             },
-            ExprKind::Cast(ref e, ref ty) => {
+            ExprKind::Cast(ref e, ref ty) | ExprKind::Type(ref e, ref ty) => {
                 self.hash_expr(e);
                 self.hash_ty(ty);
             },
@@ -518,10 +518,6 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
             ExprKind::Array(ref v) => {
                 self.hash_exprs(v);
             },
-            ExprKind::Type(ref e, ref ty) => {
-                self.hash_expr(e);
-                self.hash_ty(ty);
-            },
             ExprKind::Unary(lop, ref le) => {
                 lop.hash(&mut self.s);
                 self.hash_expr(le);
@@ -585,7 +581,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     pub fn hash_lifetime(&mut self, lifetime: &Lifetime) {
         std::mem::discriminant(&lifetime.name).hash(&mut self.s);
         if let LifetimeName::Param(ref name) = lifetime.name {
-            std::mem::discriminant(&name).hash(&mut self.s);
+            std::mem::discriminant(name).hash(&mut self.s);
             match name {
                 ParamName::Plain(ref ident) => {
                     ident.name.hash(&mut self.s);
@@ -603,7 +599,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     }
 
     pub fn hash_tykind(&mut self, ty: &TyKind) {
-        std::mem::discriminant(&ty).hash(&mut self.s);
+        std::mem::discriminant(ty).hash(&mut self.s);
         match ty {
             TyKind::Slice(ty) => {
                 self.hash_ty(ty);

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -583,6 +583,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     }
 
     pub fn hash_lifetime(&mut self, lifetime: &Lifetime) {
+        std::mem::discriminant(&lifetime.name).hash(&mut self.s);
         if let LifetimeName::Param(ref name) = lifetime.name {
             std::mem::discriminant(&name).hash(&mut self.s);
             match name {

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -258,7 +258,7 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
     }
 
     pub fn eq_ty(&mut self, left: &Ty<'tcx>, right: &Ty<'tcx>) -> bool {
-        self.eq_ty_kind(&left.node, &right.node)
+        self.eq_ty_kind(&left.sty, &right.sty)
     }
 
     #[allow(clippy::similar_names)]
@@ -604,26 +604,26 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
         }
     }
 
-    pub fn hash_ty(&mut self, ty: &Ty<'tcx>) {
+    pub fn hash_ty(&mut self, ty: &TyKind) {
         std::mem::discriminant(&ty.node).hash(&mut self.s);
-        match ty.sty {
-            ty::Slice(ty) => {
+        match ty {
+            TyKind::Slice(ty) => {
                 self.hash_ty(ty);
             },
-            ty::Array(ty, anon_const) => {
+            TyKind::Array(ty, anon_const) => {
                 self.hash_ty(ty);
                 self.hash_expr(&self.cx.tcx.hir().body(anon_const.body).value);
             },
-            ty::Ptr(mut_ty) => {
+            TyKind::Ptr(mut_ty) => {
                 self.hash_ty(&mut_ty.ty);
                 mut_ty.mutbl.hash(&mut self.s);
             },
-            ty::Rptr(lifetime, mut_ty) => {
+            TyKind::Rptr(lifetime, mut_ty) => {
                 self.hash_lifetime(lifetime);
                 self.hash_ty(&mut_ty.ty);
                 mut_ty.mutbl.hash(&mut self.s);
             },
-            ty::BareFn(bfn) => {
+            TyKind::BareFn(bfn) => {
                 bfn.unsafety.hash(&mut self.s);
                 bfn.abi.hash(&mut self.s);
                 for arg in &bfn.decl.inputs {
@@ -639,13 +639,13 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 }
                 bfn.decl.c_variadic.hash(&mut self.s);
             },
-            ty::Tup(ty_list) => {
+            TyKind::Tup(ty_list) => {
                 for ty in ty_list {
                     self.hash_ty(ty);
                 }
 
             },
-            ty::Path(qpath) => {
+            TyKind::Path(qpath) => {
                 match qpath {
                     QPath::Resolved(ref maybe_ty, ref path) => {
                         if let Some(ref ty) = maybe_ty {
@@ -661,7 +661,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                     },
                 }
             },
-            ty::Def(_, arg_list) => {
+            TyKind::Def(_, arg_list) => {
                 for arg in arg_list {
                     match arg {
                         GenericArg::Lifetime(ref l) => self.hash_lifetime(l),
@@ -672,17 +672,17 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                     }
                 }
             },
-            ty::TraitObject(_, lifetime) => {
+            TyKind::TraitObject(_, lifetime) => {
                 self.hash_lifetime(lifetime);
 
             },
-            ty::Typeof(anon_const) => {
+            TyKind::Typeof(anon_const) => {
                 self.hash_expr(&self.cx.tcx.hir().body(anon_const.body).value);
             },
-            ty::CVarArgs(lifetime) => {
-                self.hash_lifetime(lifetime);
+            TyKind::CVarArgs(lifetime) => {
+                self.hash_lifetime(lifetime) 
             },
-            ty::Err | ty::Infer | ty::Never => {},
+            TyKind::Err | TyKind::Infer | TyKind::Never => {},
         }
     }
 }

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -3,7 +3,7 @@ use crate::utils::differing_macro_contexts;
 use rustc::hir::ptr::P;
 use rustc::hir::*;
 use rustc::lint::LateContext;
-use rustc::ty::{self, TypeckTables};
+use rustc::ty::TypeckTables;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use syntax::ast::Name;
@@ -439,8 +439,6 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                 self.hash_exprs(args);
             },
             ExprKind::Cast(ref e, ref ty) => {
-                let c: fn(_, _) -> _ = ExprKind::Cast;
-                c.hash(&mut self.s);
                 self.hash_expr(e);
                 self.hash_ty(ty);
             },

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -6,7 +6,7 @@ pub use lint::Lint;
 pub use lint::LINT_LEVELS;
 
 // begin lint list, do not remove this comment, it’s used in `update_lints`
-pub const ALL_LINTS: [Lint; 308] = [
+pub const ALL_LINTS: [Lint; 309] = [
     Lint {
         name: "absurd_extreme_comparisons",
         group: "correctness",
@@ -1847,6 +1847,13 @@ pub const ALL_LINTS: [Lint; 308] = [
         desc: "usage of very complex types that might be better factored into `type` definitions",
         deprecation: None,
         module: "types",
+    },
+    Lint {
+        name: "type_repetition_in_bounds",
+        group: "complexity",
+        desc: "Types are repeated unnecessary in trait bounds use `+` instead of using `T: _, T: _`",
+        deprecation: None,
+        module: "trait_bounds",
     },
     Lint {
         name: "unicode_not_nfc",

--- a/tests/ui/float_cmp.rs
+++ b/tests/ui/float_cmp.rs
@@ -8,8 +8,7 @@ const ONE: f32 = ZERO + 1.0;
 
 fn twice<T>(x: T) -> T
 where
-    T: Add<T, Output = T>,
-    T: Copy,
+    T: Add<T, Output = T> + Copy,
 {
     x + x
 }

--- a/tests/ui/float_cmp.stderr
+++ b/tests/ui/float_cmp.stderr
@@ -1,3 +1,12 @@
+error: this type has already been used as a bound predicate
+  --> $DIR/float_cmp.rs:12:5
+   |
+LL |     T: Copy,
+   |     ^^^^^^^
+   |
+   = note: `-D clippy::type-repetition-in-bounds` implied by `-D warnings`
+   = help: consider combining the bounds: `T: Add<T, Output = T>, Copy`
+
 error: strict comparison of f32 or f64
   --> $DIR/float_cmp.rs:60:5
    |
@@ -35,5 +44,5 @@ note: std::f32::EPSILON and std::f64::EPSILON are available.
 LL |     twice(x) != twice(ONE as f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/float_cmp.stderr
+++ b/tests/ui/float_cmp.stderr
@@ -1,48 +1,39 @@
-error: this type has already been used as a bound predicate
-  --> $DIR/float_cmp.rs:12:5
-   |
-LL |     T: Copy,
-   |     ^^^^^^^
-   |
-   = note: `-D clippy::type-repetition-in-bounds` implied by `-D warnings`
-   = help: consider combining the bounds: `T: Add<T, Output = T>, Copy`
-
 error: strict comparison of f32 or f64
-  --> $DIR/float_cmp.rs:60:5
+  --> $DIR/float_cmp.rs:59:5
    |
 LL |     ONE as f64 != 2.0;
    |     ^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(ONE as f64 - 2.0).abs() > error`
    |
    = note: `-D clippy::float-cmp` implied by `-D warnings`
 note: std::f32::EPSILON and std::f64::EPSILON are available.
-  --> $DIR/float_cmp.rs:60:5
+  --> $DIR/float_cmp.rs:59:5
    |
 LL |     ONE as f64 != 2.0;
    |     ^^^^^^^^^^^^^^^^^
 
 error: strict comparison of f32 or f64
-  --> $DIR/float_cmp.rs:65:5
+  --> $DIR/float_cmp.rs:64:5
    |
 LL |     x == 1.0;
    |     ^^^^^^^^ help: consider comparing them within some error: `(x - 1.0).abs() < error`
    |
 note: std::f32::EPSILON and std::f64::EPSILON are available.
-  --> $DIR/float_cmp.rs:65:5
+  --> $DIR/float_cmp.rs:64:5
    |
 LL |     x == 1.0;
    |     ^^^^^^^^
 
 error: strict comparison of f32 or f64
-  --> $DIR/float_cmp.rs:68:5
+  --> $DIR/float_cmp.rs:67:5
    |
 LL |     twice(x) != twice(ONE as f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(twice(x) - twice(ONE as f64)).abs() > error`
    |
 note: std::f32::EPSILON and std::f64::EPSILON are available.
-  --> $DIR/float_cmp.rs:68:5
+  --> $DIR/float_cmp.rs:67:5
    |
 LL |     twice(x) != twice(ONE as f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/type_repetition_in_bounds.rs
+++ b/tests/ui/type_repetition_in_bounds.rs
@@ -1,14 +1,19 @@
 #[deny(clippy::type_repetition_in_bounds)]
 
-pub fn foo<T>(_t: T) where T: Copy, T: Clone {
+pub fn foo<T>(_t: T)
+where
+    T: Copy,
+    T: Clone,
+{
     unimplemented!();
 }
 
-pub fn bar<T, U>(_t: T, _u: U) where T: Copy, U: Clone {
+pub fn bar<T, U>(_t: T, _u: U)
+where
+    T: Copy,
+    U: Clone,
+{
     unimplemented!();
 }
 
-
-fn main() {
-
-}
+fn main() {}

--- a/tests/ui/type_repetition_in_bounds.rs
+++ b/tests/ui/type_repetition_in_bounds.rs
@@ -1,0 +1,14 @@
+#[deny(clippy::type_repetition_in_bounds)]
+
+pub fn foo<T>(_t: T) where T: Copy, T: Clone {
+    unimplemented!();
+}
+
+pub fn bar<T, U>(_t: T, _u: U) where T: Copy, U: Clone {
+    unimplemented!();
+}
+
+
+fn main() {
+
+}

--- a/tests/ui/type_repetition_in_bounds.stderr
+++ b/tests/ui/type_repetition_in_bounds.stderr
@@ -1,15 +1,15 @@
 error: this type has already been used as a bound predicate
-  --> $DIR/type_repetition_in_bounds.rs:3:37
+  --> $DIR/type_repetition_in_bounds.rs:6:5
    |
-LL | pub fn foo<T>(_t: T) where T: Copy, T: Clone {
-   |                                     ^^^^^^^^
+LL |     T: Clone,
+   |     ^^^^^^^^
    |
 note: lint level defined here
   --> $DIR/type_repetition_in_bounds.rs:1:8
    |
 LL | #[deny(clippy::type_repetition_in_bounds)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: consider combining the bounds: `T: Copy, Clone`
+   = help: consider combining the bounds: `T: Copy + Clone`
 
 error: aborting due to previous error
 

--- a/tests/ui/type_repetition_in_bounds.stderr
+++ b/tests/ui/type_repetition_in_bounds.stderr
@@ -1,0 +1,15 @@
+error: this type has already been used as a bound predicate
+  --> $DIR/type_repetition_in_bounds.rs:3:37
+   |
+LL | pub fn foo<T>(_t: T) where T: Copy, T: Clone {
+   |                                     ^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/type_repetition_in_bounds.rs:1:8
+   |
+LL | #[deny(clippy::type_repetition_in_bounds)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider combining the bounds: `T: Copy + Clone`
+
+error: aborting due to previous error
+

--- a/tests/ui/type_repetition_in_bounds.stderr
+++ b/tests/ui/type_repetition_in_bounds.stderr
@@ -9,7 +9,7 @@ note: lint level defined here
    |
 LL | #[deny(clippy::type_repetition_in_bounds)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: consider combining the bounds: `T: Copy + Clone`
+   = help: consider combining the bounds: `T: Copy, Clone`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR is to tackle https://github.com/rust-lang/rust-clippy/issues/3764 it's still a WIP and doesn't work but this is an initial stab. It builds though I haven't added any tests as I'm not sure where lint tests should go? 

Unfortunately, it seems id isn't tied to the type itself but I guess where it is in the AST? Looking at https://manishearth.github.io/rust-internals-docs/syntax/ast/struct.Ty.html I can't see any members that would let me tell if a type was repeated in multiple trait bounds.

There may be other issues with how I've implemented this so any assistance is appreciated!

changelog: Add new lint: `type_repetition_in_bounds`