### PR TITLE
Fix ICE #3717 in lint implicit_hasher

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -2239,8 +2239,10 @@ impl<'a, 'b, 'tcx: 'a + 'b> ImplicitHasherConstructorVisitor<'a, 'b, 'tcx> {
 
 impl<'a, 'b, 'tcx: 'a + 'b> Visitor<'tcx> for ImplicitHasherConstructorVisitor<'a, 'b, 'tcx> {
     fn visit_body(&mut self, body: &'tcx Body) {
+        let prev_body = self.body;
         self.body = self.cx.tcx.body_tables(body.id());
         walk_body(self, body);
+        self.body = prev_body;
     }
 
     fn visit_expr(&mut self, e: &'tcx Expr) {

--- a/tests/ui/ice-3717.rs
+++ b/tests/ui/ice-3717.rs
@@ -1,0 +1,8 @@
+use std::collections::HashSet;
+
+fn main() {}
+
+pub fn ice_3717(_: &HashSet<usize>) {
+    let _ = [0u8; 0];
+    let _: HashSet<usize> = HashSet::new();
+}

--- a/tests/ui/ice-3717.stderr
+++ b/tests/ui/ice-3717.stderr
@@ -1,0 +1,18 @@
+error: parameter of type `HashSet` should be generalized over different hashers
+  --> $DIR/ice-3717.rs:5:21
+   |
+LL | pub fn ice_3717(_: &HashSet<usize>) {
+   |                     ^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::implicit-hasher` implied by `-D warnings`
+help: consider adding a type parameter
+   |
+LL | pub fn ice_3717<S: ::std::hash::BuildHasher + Default>(_: &HashSet<usize, S>) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^
+help: ...and use generic constructor
+   |
+LL |     let _: HashSet<usize> = HashSet::default();
+   |                             ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #3717 

This fixes the ICE. We lose some information in a very specific case though. But less information if better than an ICE. For an example see the test file.

Does anyone know, if there's another way to get the `ty::Ty` of a `hir::Expr`?