### PR TITLE
Update why transmute_int_to_float is bad

### DIFF
--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -159,7 +159,8 @@ declare_clippy_lint! {
 
 /// **What it does:** Checks for transmutes from an integer to a float.
 ///
-/// **Why is this bad?** Transmutes are dangerous and error-prone, whereas `from_bits` is intuitive and safe.
+/// **Why is this bad?** Transmutes are dangerous and error-prone, whereas `from_bits` is intuitive
+/// and safe.
 ///
 /// **Known problems:** None.
 ///

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -159,7 +159,7 @@ declare_clippy_lint! {
 
 /// **What it does:** Checks for transmutes from an integer to a float.
 ///
-/// **Why is this bad?** This might result in an invalid in-memory representation of a float.
+/// **Why is this bad?** Transmutes are dangerous and error-prone, whereas `from_bits` is intuitive and safe.
 ///
 /// **Known problems:** None.
 ///


### PR DESCRIPTION
As suggested in #3550, this PR changes the reason why using `transmute` from an integer to a float is not recommended. Effectively, `from_bits` uses `transmute` underneath, but the former is preferred.