### PR TITLE
Fix ICE #3747

### DIFF
--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -147,7 +147,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Functions {
         }
 
         self.check_raw_ptr(cx, unsafety, decl, body, nodeid);
-        self.check_line_number(cx, span);
+        self.check_line_number(cx, span, body);
     }
 
     fn check_trait_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx hir::TraitItem) {
@@ -178,12 +178,12 @@ impl<'a, 'tcx> Functions {
         }
     }
 
-    fn check_line_number(self, cx: &LateContext<'_, '_>, span: Span) {
+    fn check_line_number(self, cx: &LateContext<'_, '_>, span: Span, body: &'tcx hir::Body) {
         if in_external_macro(cx.sess(), span) {
             return;
         }
 
-        let code_snippet = snippet(cx, span, "..");
+        let code_snippet = snippet(cx, body.value.span, "..");
         let mut line_count: u64 = 0;
         let mut in_comment = false;
         let mut code_in_line;

--- a/tests/ui/crashes/ice-3747.rs
+++ b/tests/ui/crashes/ice-3747.rs
@@ -1,0 +1,17 @@
+/// Test for https://github.com/rust-lang/rust-clippy/issues/3747
+
+macro_rules! a {
+    ( $pub:tt $($attr:tt)* ) => {
+        $($attr)* $pub fn say_hello() {}
+    };
+}
+
+macro_rules! b {
+    () => {
+        a! { pub }
+    };
+}
+
+b! {}
+
+fn main() {}


### PR DESCRIPTION
I'm not sure if this was the correct approach.

I don't know if I put tests/ui/crashses/ice-3747.rs in correct place because the test always passed when I ran it with `cargo test`, even without the fix applied.

If I run that test with `env CLIPPY_TESTS=true cargo run --bin clippy-driver -- -L ./target/debug tests/ui/crashes/ice-3747.rs` then the test correctly fails without the fix applied

fixes #3747