### PR TITLE
enable rust-lang/rust#58754

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -906,9 +906,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             return;
         }
         let name = implitem.ident.name;
-        let parent = cx.tcx.hir().get_parent(implitem.id);
-        let item = cx.tcx.hir().expect_item(parent);
-        let def_id = cx.tcx.hir().local_def_id(item.id);
+        let parent = cx.tcx.hir().get_parent_item(implitem.hir_id);
+        let item = cx.tcx.hir().expect_item_by_hir_id(parent);
+        let def_id = cx.tcx.hir().local_def_id_from_hir_id(item.hir_id);
         let ty = cx.tcx.type_of(def_id);
         if_chain! {
             if let hir::ImplItemKind::Method(ref sig, id) = implitem.node;
@@ -916,7 +916,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let Some(first_arg) = iter_input_pats(&sig.decl, cx.tcx.hir().body(id)).next();
             if let hir::ItemKind::Impl(_, _, _, _, None, ref self_ty, _) = item.node;
             then {
-                if cx.access_levels.is_exported(implitem.id) {
+                let node_id = cx.tcx.hir().hir_to_node_id(implitem.hir_id);
+                if cx.access_levels.is_exported(node_id) {
                 // check missing trait implementations
                     for &(method_name, n_args, self_kind, out_type, trait_name) in &TRAIT_METHODS {
                         if name == method_name &&
@@ -963,7 +964,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
         }
 
         if let hir::ImplItemKind::Method(_, _) = implitem.node {
-            let ret_ty = return_ty(cx, implitem.id);
+            let ret_ty = return_ty(cx, implitem.hir_id);
 
             // walk the return type and check for Self (this does not check associated types)
             for inner_type in ret_ty.walk() {

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -162,7 +162,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx hir::ImplItem) {
         // If the method is an impl for a trait, don't doc.
-        let def_id = cx.tcx.hir().local_def_id(impl_item.id);
+        let def_id = cx.tcx.hir().local_def_id_from_hir_id(impl_item.hir_id);
         match cx.tcx.associated_item(def_id).container {
             ty::TraitContainer(_) => return,
             ty::ImplContainer(cid) => {

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -146,7 +146,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingInline {
         }
 
         // If the item being implemented is not exported, then we don't need #[inline]
-        if !cx.access_levels.is_exported(impl_item.id) {
+        let node_id = cx.tcx.hir().hir_to_node_id(impl_item.hir_id);
+        if !cx.access_levels.is_exported(node_id) {
             return;
         }
 
@@ -155,7 +156,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingInline {
             hir::ImplItemKind::Const(..) | hir::ImplItemKind::Type(_) | hir::ImplItemKind::Existential(_) => return,
         };
 
-        let def_id = cx.tcx.hir().local_def_id(impl_item.id);
+        let def_id = cx.tcx.hir().local_def_id_from_hir_id(impl_item.hir_id);
         let trait_def_id = match cx.tcx.associated_item(def_id).container {
             TraitContainer(cid) => Some(cid),
             ImplContainer(cid) => cx.tcx.impl_trait_ref(cid).map(|t| t.def_id),

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -133,7 +133,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
                             let self_did = cx.tcx.hir().local_def_id_from_hir_id(cx.tcx.hir().get_parent_item(id));
                             let self_ty = cx.tcx.type_of(self_did);
                             if_chain! {
-                                if same_tys(cx, self_ty, return_ty(cx, node_id));
+                                if same_tys(cx, self_ty, return_ty(cx, id));
                                 if let Some(default_trait_id) = get_trait_def_id(cx, &paths::DEFAULT_TRAIT);
                                 then {
                                     if self.impling_types.is_none() {

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -177,8 +177,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCopyConst {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx ImplItem) {
         if let ImplItemKind::Const(hir_ty, ..) = &impl_item.node {
-            let item_node_id = cx.tcx.hir().get_parent_node(impl_item.id);
-            let item = cx.tcx.hir().expect_item(item_node_id);
+            let item_hir_id = cx.tcx.hir().get_parent_node_by_hir_id(impl_item.hir_id);
+            let item = cx.tcx.hir().expect_item_by_hir_id(item_hir_id);
             // ensure the impl is an inherent impl.
             if let ItemKind::Impl(_, _, _, _, None, _, _) = item.node {
                 let ty = hir_ty_to_ty(cx.tcx, hir_ty);

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -137,7 +137,7 @@ fn check_trait_method_impl_decl<'a, 'tcx: 'a>(
     let trait_method_sig = cx.tcx.fn_sig(trait_method.def_id);
     let trait_method_sig = cx.tcx.erase_late_bound_regions(&trait_method_sig);
 
-    let impl_method_def_id = cx.tcx.hir().local_def_id(impl_item.id);
+    let impl_method_def_id = cx.tcx.hir().local_def_id_from_hir_id(impl_item.hir_id);
     let impl_method_sig = cx.tcx.fn_sig(impl_method_def_id);
     let impl_method_sig = cx.tcx.erase_late_bound_regions(&impl_method_sig);
 

--- a/clippy_lints/src/utils/diagnostics.rs
+++ b/clippy_lints/src/utils/diagnostics.rs
@@ -135,8 +135,7 @@ pub fn span_lint_and_then<'a, 'tcx: 'a, T: LintContext<'tcx>, F>(
 }
 
 pub fn span_lint_node(cx: &LateContext<'_, '_>, lint: &'static Lint, node: HirId, sp: Span, msg: &str) {
-    let node_id = cx.tcx.hir().hir_to_node_id(node);
-    DiagnosticWrapper(cx.tcx.struct_span_lint_node(lint, node_id, sp, msg)).docs_link(lint);
+    DiagnosticWrapper(cx.tcx.struct_span_lint_hir(lint, node, sp, msg)).docs_link(lint);
 }
 
 pub fn span_lint_node_and_then(
@@ -147,8 +146,7 @@ pub fn span_lint_node_and_then(
     msg: &str,
     f: impl FnOnce(&mut DiagnosticBuilder<'_>),
 ) {
-    let node_id = cx.tcx.hir().hir_to_node_id(node);
-    let mut db = DiagnosticWrapper(cx.tcx.struct_span_lint_node(lint, node_id, sp, msg));
+    let mut db = DiagnosticWrapper(cx.tcx.struct_span_lint_hir(lint, node, sp, msg));
     f(&mut db.0);
     db.docs_link(lint);
 }

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -753,8 +753,8 @@ pub fn is_direct_expn_of(span: Span, name: &str) -> Option<Span> {
 }
 
 /// Convenience function to get the return type of a function
-pub fn return_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, fn_item: NodeId) -> Ty<'tcx> {
-    let fn_def_id = cx.tcx.hir().local_def_id(fn_item);
+pub fn return_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, fn_item: hir::HirId) -> Ty<'tcx> {
+    let fn_def_id = cx.tcx.hir().local_def_id_from_hir_id(fn_item);
     let ret_ty = cx.tcx.fn_sig(fn_def_id).output();
     cx.tcx.erase_late_bound_regions(&ret_ty)
 }
@@ -929,8 +929,7 @@ pub fn is_try(expr: &Expr) -> Option<&Expr> {
 ///
 /// Useful for skipping long running code when it's unnecessary
 pub fn is_allowed(cx: &LateContext<'_, '_>, lint: &'static Lint, id: HirId) -> bool {
-    let node_id = cx.tcx.hir().hir_to_node_id(id);
-    cx.tcx.lint_level_at_node(lint, node_id).0 == Level::Allow
+    cx.tcx.lint_level_at_node(lint, id).0 == Level::Allow
 }
 
 pub fn get_arg_name(pat: &Pat) -> Option<ast::Name> {


### PR DESCRIPTION
Enables the next iteration of HidIdification which also brings recent clippy updates to rust-lang.

As usual, a branch will be most welcome :ok_hand:.