### PR TITLE
Use the same <title> as <h1> on gh-pages

### DIFF
--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
-    <title>Clippy</title>
+    <title>ALL the Clippy Lints</title>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/github.min.css"/>

--- a/util/gh-pages/versions.html
+++ b/util/gh-pages/versions.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
-    <title>Clippy</title>
+    <title>Clippy lints documentation</title>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css"/>
     <style>


### PR DESCRIPTION
I think this makes the page easier to find using firefox's URL bar - it (afaik) searches based on the page's URL and title so if somebody doesn't have it bookmarked but remembers that the page contained "ALL lints" or something similar it's easy to go to it directly without resorting to a search engine.