### PR TITLE
Fix two missing_const_for_fn false positives

### DIFF
--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -1,4 +1,5 @@
 use crate::utils::{is_entrypoint_fn, span_lint};
+use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::intravisit::FnKind;
 use rustc::hir::{Body, Constness, FnDecl, HirId};
@@ -95,7 +96,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
                 }
             },
             FnKind::Method(_, sig, ..) => {
-                if already_const(sig.header) {
+                if is_trait_method(cx, hir_id) || already_const(sig.header) {
                     return;
                 }
             },
@@ -112,6 +113,18 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
             span_lint(cx, MISSING_CONST_FOR_FN, span, "this could be a const_fn");
         }
     }
+}
+
+fn is_trait_method(cx: &LateContext<'_, '_>, hir_id: HirId) -> bool {
+    // Get the implemented trait for the current function
+    let parent_impl = cx.tcx.hir().get_parent_item(hir_id);
+    if_chain! {
+        if parent_impl != hir::CRATE_HIR_ID;
+        if let hir::Node::Item(item) = cx.tcx.hir().get_by_hir_id(parent_impl);
+        if let hir::ItemKind::Impl(_, _, _, _, Some(_trait_ref), _, _) = &item.node;
+        then { return true; }
+    }
+    false
 }
 
 // We don't have to lint on something that's already `const`

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -2,7 +2,7 @@ use crate::utils::{is_entrypoint_fn, span_lint};
 use rustc::hir;
 use rustc::hir::intravisit::FnKind;
 use rustc::hir::{Body, Constness, FnDecl, HirId};
-use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
 use rustc_mir::transform::qualify_min_const_fn::is_min_const_fn;
 use syntax_pos::Span;
@@ -82,7 +82,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
     ) {
         let def_id = cx.tcx.hir().local_def_id_from_hir_id(hir_id);
 
-        if is_entrypoint_fn(cx, def_id) {
+        if in_external_macro(cx.tcx.sess, span) || is_entrypoint_fn(cx, def_id) {
             return;
         }
 

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -59,3 +59,12 @@ trait Foo {
 // Don't lint in external macros (derive)
 #[derive(PartialEq, Eq)]
 struct Point(isize, isize);
+
+impl std::ops::Add for Point {
+    type Output = Self;
+
+    // Don't lint in trait impls of derived methods
+    fn add(self, other: Self) -> Self {
+        Point(self.0 + other.0, self.1 + other.1)
+    }
+}

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -55,3 +55,7 @@ trait Foo {
         33
     }
 }
+
+// Don't lint in external macros (derive)
+#[derive(PartialEq, Eq)]
+struct Point(isize, isize);


### PR DESCRIPTION
Fixes #3841 

* Fixes false positive in external macros
* Fixes false positive when implement trait methods