### PR TITLE
Refactor: Remove utils::opt_def_id

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -2,8 +2,8 @@
 
 use crate::reexport::*;
 use crate::utils::{
-    in_macro, last_line_of_span, match_def_path, opt_def_id, paths, snippet_opt, span_lint, span_lint_and_sugg,
-    span_lint_and_then, without_block_comments,
+    in_macro, last_line_of_span, match_def_path, paths, snippet_opt, span_lint, span_lint_and_sugg, span_lint_and_then,
+    without_block_comments,
 };
 use if_chain::if_chain;
 use rustc::hir::*;
@@ -396,7 +396,7 @@ fn is_relevant_expr(tcx: TyCtxt<'_, '_, '_>, tables: &ty::TypeckTables<'_>, expr
         ExprKind::Ret(None) | ExprKind::Break(_, None) => false,
         ExprKind::Call(path_expr, _) => {
             if let ExprKind::Path(qpath) = &path_expr.node {
-                if let Some(fun_id) = opt_def_id(tables.qpath_def(qpath, path_expr.hir_id)) {
+                if let Some(fun_id) = tables.qpath_def(qpath, path_expr.hir_id).opt_def_id() {
                     !match_def_path(tcx, fun_id, &paths::BEGIN_PANIC)
                 } else {
                     true

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -5,7 +5,7 @@ use rustc::ty;
 use rustc::{declare_tool_lint, lint_array};
 use rustc_errors::Applicability;
 
-use crate::utils::{any_parent_is_automatically_derived, match_def_path, opt_def_id, paths, span_lint_and_sugg};
+use crate::utils::{any_parent_is_automatically_derived, match_def_path, paths, span_lint_and_sugg};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for literal calls to `Default::default()`.
@@ -47,7 +47,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DefaultTraitAccess {
             if let ExprKind::Call(ref path, ..) = expr.node;
             if !any_parent_is_automatically_derived(cx.tcx, expr.hir_id);
             if let ExprKind::Path(ref qpath) = path.node;
-            if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, path.hir_id));
+            if let Some(def_id) = cx.tables.qpath_def(qpath, path.hir_id).opt_def_id();
             if match_def_path(cx.tcx, def_id, &paths::DEFAULT_TRAIT_METHOD);
             then {
                 match qpath {

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_copy, match_def_path, opt_def_id, paths, span_note_and_lint};
+use crate::utils::{is_copy, match_def_path, paths, span_note_and_lint};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -124,7 +124,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let ExprKind::Call(ref path, ref args) = expr.node;
             if let ExprKind::Path(ref qpath) = path.node;
             if args.len() == 1;
-            if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, path.hir_id));
+            if let Some(def_id) = cx.tables.qpath_def(qpath, path.hir_id).opt_def_id();
             then {
                 let lint;
                 let msg;

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_expn_of, match_def_path, opt_def_id, resolve_node, span_lint, span_lint_and_sugg};
+use crate::utils::{is_expn_of, match_def_path, resolve_node, span_lint, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -53,7 +53,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let ExprKind::Call(ref dest_fun, _) = write_args[0].node;
             if let ExprKind::Path(ref qpath) = dest_fun.node;
             if let Some(dest_fun_id) =
-                opt_def_id(resolve_node(cx, qpath, dest_fun.hir_id));
+                resolve_node(cx, qpath, dest_fun.hir_id).opt_def_id();
             if let Some(dest_name) = if match_def_path(cx.tcx, dest_fun_id, &["std", "io", "stdio", "stdout"]) {
                 Some("stdout")
             } else if match_def_path(cx.tcx, dest_fun_id, &["std", "io", "stdio", "stderr"]) {

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -1,5 +1,5 @@
 use crate::utils::paths::{BEGIN_PANIC, BEGIN_PANIC_FMT, FROM_TRAIT, OPTION, RESULT};
-use crate::utils::{is_expn_of, match_def_path, method_chain_args, opt_def_id, span_lint_and_then, walk_ptrs_ty};
+use crate::utils::{is_expn_of, match_def_path, method_chain_args, span_lint_and_then, walk_ptrs_ty};
 use if_chain::if_chain;
 use rustc::hir;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -71,7 +71,7 @@ fn lint_impl_body<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, impl_span: Span, impl_it
             if_chain! {
                 if let ExprKind::Call(ref func_expr, _) = expr.node;
                 if let ExprKind::Path(QPath::Resolved(_, ref path)) = func_expr.node;
-                if let Some(path_def_id) = opt_def_id(path.def);
+                if let Some(path_def_id) = path.def.opt_def_id();
                 if match_def_path(self.tcx, path_def_id, &BEGIN_PANIC) ||
                     match_def_path(self.tcx, path_def_id, &BEGIN_PANIC_FMT);
                 if is_expn_of(expr.span, "unreachable").is_none();

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -1,7 +1,7 @@
 use crate::utils::paths;
 use crate::utils::{
-    in_macro, is_expn_of, last_path_segment, match_def_path, match_type, opt_def_id, resolve_node, snippet,
-    span_lint_and_then, walk_ptrs_ty,
+    in_macro, is_expn_of, last_path_segment, match_def_path, match_type, resolve_node, snippet, span_lint_and_then,
+    walk_ptrs_ty,
 };
 use if_chain::if_chain;
 use rustc::hir::*;
@@ -58,7 +58,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                 ExprKind::Call(ref fun, ref args) => {
                     if_chain! {
                         if let ExprKind::Path(ref qpath) = fun.node;
-                        if let Some(fun_def_id) = opt_def_id(resolve_node(cx, qpath, fun.hir_id));
+                        if let Some(fun_def_id) = resolve_node(cx, qpath, fun.hir_id).opt_def_id();
                         let new_v1 = match_def_path(cx.tcx, fun_def_id, &paths::FMT_ARGUMENTS_NEWV1);
                         let new_v1_fmt = match_def_path(
                             cx.tcx,
@@ -159,7 +159,7 @@ fn get_single_string_arg<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option
         if let ExprKind::Call(_, ref args) = exprs[0].node;
         if args.len() == 2;
         if let ExprKind::Path(ref qpath) = args[1].node;
-        if let Some(fun_def_id) = opt_def_id(resolve_node(cx, qpath, args[1].hir_id));
+        if let Some(fun_def_id) = resolve_node(cx, qpath, args[1].hir_id).opt_def_id();
         if match_def_path(cx.tcx, fun_def_id, &paths::DISPLAY_FMT_METHOD);
         then {
             let ty = walk_ptrs_ty(cx.tables.pat_ty(&pat[0]));

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     in_macro, match_def_path, match_trait_method, same_tys, snippet, snippet_with_macro_callsite, span_lint_and_then,
 };
-use crate::utils::{opt_def_id, paths, resolve_node};
+use crate::utils::{paths, resolve_node};
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
@@ -98,7 +98,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityConversion {
 
             ExprKind::Call(ref path, ref args) => {
                 if let ExprKind::Path(ref qpath) = path.node {
-                    if let Some(def_id) = opt_def_id(resolve_node(cx, qpath, path.hir_id)) {
+                    if let Some(def_id) = resolve_node(cx, qpath, path.hir_id).opt_def_id() {
                         if match_def_path(cx.tcx, def_id, &paths::FROM_FROM[..]) {
                             let a = cx.tables.expr_ty(e);
                             let b = cx.tables.expr_ty(&args[0]);

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, opt_def_id, paths, span_help_and_lint};
+use crate::utils::{match_def_path, paths, span_help_and_lint};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -45,7 +45,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidRef {
             if let ExprKind::Path(ref qpath) = path.node;
             if args.len() == 0;
             if let ty::Ref(..) = cx.tables.expr_ty(expr).sty;
-            if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, path.hir_id));
+            if let Some(def_id) = cx.tables.qpath_def(qpath, path.hir_id).opt_def_id();
             then {
                 let msg = if match_def_path(cx.tcx, def_id, &paths::MEM_ZEROED) |
                              match_def_path(cx.tcx, def_id, &paths::INIT)

--- a/clippy_lints/src/mem_discriminant.rs
+++ b/clippy_lints/src/mem_discriminant.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, opt_def_id, paths, snippet, span_lint_and_then, walk_ptrs_ty_depth};
+use crate::utils::{match_def_path, paths, snippet, span_lint_and_then, walk_ptrs_ty_depth};
 use if_chain::if_chain;
 use rustc::hir::{Expr, ExprKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -45,7 +45,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemDiscriminant {
             if let ExprKind::Call(ref func, ref func_args) = expr.node;
             // is `mem::discriminant`
             if let ExprKind::Path(ref func_qpath) = func.node;
-            if let Some(def_id) = opt_def_id(cx.tables.qpath_def(func_qpath, func.hir_id));
+            if let Some(def_id) = cx.tables.qpath_def(func_qpath, func.hir_id).opt_def_id();
             if match_def_path(cx.tcx, def_id, &paths::MEM_DISCRIMINANT);
             // type is non-enum
             let ty_param = cx.tables.node_substs(func.hir_id).type_at(0);

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
+use crate::utils::{match_def_path, paths, span_lint};
 use rustc::hir::{Expr, ExprKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
@@ -37,7 +37,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemForget {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprKind::Call(ref path_expr, ref args) = e.node {
             if let ExprKind::Path(ref qpath) = path_expr.node {
-                if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, path_expr.hir_id)) {
+                if let Some(def_id) = cx.tables.qpath_def(qpath, path_expr.hir_id).opt_def_id() {
                     if match_def_path(cx.tcx, def_id, &paths::MEM_FORGET) {
                         let forgot_ty = cx.tables.expr_ty(&args[0]);
 

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, match_qpath, opt_def_id, paths, snippet_with_applicability, span_lint_and_sugg};
+use crate::utils::{match_def_path, match_qpath, paths, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc::hir::{Expr, ExprKind, MutMutable, QPath};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -51,7 +51,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemReplace {
             if let ExprKind::Call(ref func, ref func_args) = expr.node;
             if func_args.len() == 2;
             if let ExprKind::Path(ref func_qpath) = func.node;
-            if let Some(def_id) = opt_def_id(cx.tables.qpath_def(func_qpath, func.hir_id));
+            if let Some(def_id) = cx.tables.qpath_def(func_qpath, func.hir_id).opt_def_id();
             if match_def_path(cx.tcx, def_id, &paths::MEM_REPLACE);
 
             // Check that second argument is `Option::None`

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -1,5 +1,5 @@
 use crate::consts::{constant_simple, Constant};
-use crate::utils::{match_def_path, opt_def_id, paths, span_lint};
+use crate::utils::{match_def_path, paths, span_lint};
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
@@ -72,7 +72,7 @@ enum MinMax {
 fn min_max<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<(MinMax, Constant, &'a Expr)> {
     if let ExprKind::Call(ref path, ref args) = expr.node {
         if let ExprKind::Path(ref qpath) = path.node {
-            opt_def_id(cx.tables.qpath_def(qpath, path.hir_id)).and_then(|def_id| {
+            cx.tables.qpath_def(qpath, path.hir_id).opt_def_id().and_then(|def_id| {
                 if match_def_path(cx.tcx, def_id, &paths::CMP_MIN) {
                     fetch_const(cx, args, MinMax::Min)
                 } else if match_def_path(cx.tcx, def_id, &paths::CMP_MAX) {

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_direct_expn_of, is_expn_of, match_def_path, opt_def_id, paths, resolve_node, span_lint};
+use crate::utils::{is_direct_expn_of, is_expn_of, match_def_path, paths, resolve_node, span_lint};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -61,7 +61,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let Some(ref ex) = block.expr;
             if let ExprKind::Call(ref fun, ref params) = ex.node;
             if let ExprKind::Path(ref qpath) = fun.node;
-            if let Some(fun_def_id) = opt_def_id(resolve_node(cx, qpath, fun.hir_id));
+            if let Some(fun_def_id) = resolve_node(cx, qpath, fun.hir_id).opt_def_id();
             if match_def_path(cx.tcx, fun_def_id, &paths::BEGIN_PANIC);
             if params.len() == 2;
             then {

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -1,5 +1,5 @@
 use crate::consts::{constant, Constant};
-use crate::utils::{is_expn_of, match_def_path, match_type, opt_def_id, paths, span_help_and_lint, span_lint};
+use crate::utils::{is_expn_of, match_def_path, match_type, paths, span_help_and_lint, span_lint};
 use if_chain::if_chain;
 use regex_syntax;
 use rustc::hir::*;
@@ -118,7 +118,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let ExprKind::Call(ref fun, ref args) = expr.node;
             if let ExprKind::Path(ref qpath) = fun.node;
             if args.len() == 1;
-            if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, fun.hir_id));
+            if let Some(def_id) = cx.tables.qpath_def(qpath, fun.hir_id).opt_def_id();
             then {
                 if match_def_path(cx.tcx, def_id, &paths::REGEX_NEW) ||
                    match_def_path(cx.tcx, def_id, &paths::REGEX_BUILDER_NEW) {

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -1,5 +1,4 @@
-use crate::utils::{last_path_segment, match_def_path, paths, snippet, span_lint, span_lint_and_then};
-use crate::utils::{opt_def_id, sugg};
+use crate::utils::{last_path_segment, match_def_path, paths, snippet, span_lint, span_lint_and_then, sugg};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -231,7 +230,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Transmute {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprKind::Call(ref path_expr, ref args) = e.node {
             if let ExprKind::Path(ref qpath) = path_expr.node {
-                if let Some(def_id) = opt_def_id(cx.tables.qpath_def(qpath, path_expr.hir_id)) {
+                if let Some(def_id) = cx.tables.qpath_def(qpath, path_expr.hir_id).opt_def_id() {
                     if match_def_path(cx.tcx, def_id, &paths::TRANSMUTE) {
                         let from_ty = cx.tables.expr_ty(&args[0]);
                         let to_ty = cx.tables.expr_ty(e);

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -4,9 +4,8 @@ use crate::consts::{constant, Constant};
 use crate::utils::paths;
 use crate::utils::{
     clip, comparisons, differing_macro_contexts, higher, in_constant, in_macro, int_bits, last_path_segment,
-    match_def_path, match_path, multispan_sugg, opt_def_id, same_tys, sext, snippet, snippet_opt,
-    snippet_with_applicability, span_help_and_lint, span_lint, span_lint_and_sugg, span_lint_and_then, unsext,
-    AbsolutePathBuffer,
+    match_def_path, match_path, multispan_sugg, same_tys, sext, snippet, snippet_opt, snippet_with_applicability,
+    span_help_and_lint, span_lint, span_lint_and_sugg, span_lint_and_then, unsext, AbsolutePathBuffer,
 };
 use if_chain::if_chain;
 use rustc::hir;
@@ -225,7 +224,7 @@ fn match_type_parameter(cx: &LateContext<'_, '_>, qpath: &QPath, path: &[&str]) 
             _ => None,
         });
         if let TyKind::Path(ref qpath) = ty.node;
-        if let Some(did) = opt_def_id(cx.tables.qpath_def(qpath, ty.hir_id));
+        if let Some(did) = cx.tables.qpath_def(qpath, ty.hir_id).opt_def_id();
         if match_def_path(cx.tcx, did, path);
         then {
             return true;
@@ -248,7 +247,7 @@ fn check_ty(cx: &LateContext<'_, '_>, hir_ty: &hir::Ty, is_local: bool) {
         TyKind::Path(ref qpath) if !is_local => {
             let hir_id = hir_ty.hir_id;
             let def = cx.tables.qpath_def(qpath, hir_id);
-            if let Some(def_id) = opt_def_id(def) {
+            if let Some(def_id) = def.opt_def_id() {
                 if Some(def_id) == cx.tcx.lang_items().owned_box() {
                     if match_type_parameter(cx, qpath, &paths::VEC) {
                         span_help_and_lint(
@@ -271,7 +270,7 @@ fn check_ty(cx: &LateContext<'_, '_>, hir_ty: &hir::Ty, is_local: bool) {
                         // ty is now _ at this point
                         if let TyKind::Path(ref ty_qpath) = ty.node;
                         let def = cx.tables.qpath_def(ty_qpath, ty.hir_id);
-                        if let Some(def_id) = opt_def_id(def);
+                        if let Some(def_id) = def.opt_def_id();
                         if Some(def_id) == cx.tcx.lang_items().owned_box();
                         // At this point, we know ty is Box<T>, now get T
                         if let Some(ref last) = last_path_segment(ty_qpath).args;
@@ -378,7 +377,7 @@ fn check_ty_rptr(cx: &LateContext<'_, '_>, hir_ty: &hir::Ty, is_local: bool, lt:
             let hir_id = mut_ty.ty.hir_id;
             let def = cx.tables.qpath_def(qpath, hir_id);
             if_chain! {
-                if let Some(def_id) = opt_def_id(def);
+                if let Some(def_id) = def.opt_def_id();
                 if Some(def_id) == cx.tcx.lang_items().owned_box();
                 if let QPath::Resolved(None, ref path) = *qpath;
                 if let [ref bx] = *path.segments;

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -3,7 +3,7 @@
 
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::utils::{is_expn_of, match_def_path, match_qpath, opt_def_id, paths, resolve_node};
+use crate::utils::{is_expn_of, match_def_path, match_qpath, paths, resolve_node};
 use if_chain::if_chain;
 use rustc::lint::LateContext;
 use rustc::{hir, ty};
@@ -214,7 +214,7 @@ pub fn vec_macro<'e>(cx: &LateContext<'_, '_>, expr: &'e hir::Expr) -> Option<Ve
         if let hir::ExprKind::Call(ref fun, ref args) = expr.node;
         if let hir::ExprKind::Path(ref path) = fun.node;
         if is_expn_of(fun.span, "vec").is_some();
-        if let Some(fun_def_id) = opt_def_id(resolve_node(cx, path, fun.hir_id));
+        if let Some(fun_def_id) = resolve_node(cx, path, fun.hir_id).opt_def_id();
         then {
             return if match_def_path(cx.tcx, fun_def_id, &paths::VEC_FROM_ELEM) && args.len() == 2 {
                 // `vec![elem; size]` case

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -799,10 +799,6 @@ pub fn remove_blocks(expr: &Expr) -> &Expr {
     }
 }
 
-pub fn opt_def_id(def: Def) -> Option<DefId> {
-    def.opt_def_id()
-}
-
 pub fn is_self(slf: &Arg) -> bool {
     if let PatKind::Binding(.., name, _) = slf.pat.node {
         name.name == keywords::SelfLower.name()


### PR DESCRIPTION
This removes some indirection. Probably this method was uplifted to
rustc at some point?