### PR TITLE
Filter out proc_macro and proc_macro_attribute

### DIFF
--- a/tests/ui/needless_pass_by_value_proc_macro.rs
+++ b/tests/ui/needless_pass_by_value_proc_macro.rs
@@ -9,3 +9,13 @@ use proc_macro::TokenStream;
 pub fn foo(_input: TokenStream) -> TokenStream {
     unimplemented!()
 }
+
+#[proc_macro]
+pub fn bar(_input: TokenStream) -> TokenStream {
+    unimplemented!()
+}
+
+#[proc_macro_attribute]
+pub fn baz(_args: TokenStream, _input: TokenStream) -> TokenStream {
+    unimplemented!()
+}


### PR DESCRIPTION
Related to https://github.com/rust-lang/rust-clippy/pull/1617

Fixes https://github.com/rust-lang/rust-clippy/issues/3067 (this issue has already been closed, but in fact the false positive in `#[proc_macro]` and `#[proc_macro_attribute]` has not been fixed yet)