### PR TITLE
Fix `use_self` false positive on nested functions

### DIFF
--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -248,7 +248,8 @@ impl<'a, 'tcx> Visitor<'tcx> for UseSelfVisitor<'a, 'tcx> {
             | ItemKind::Enum(..)
             | ItemKind::Struct(..)
             | ItemKind::Union(..)
-            | ItemKind::Impl(..) => {
+            | ItemKind::Impl(..)
+            | ItemKind::Fn(..) => {
                 // Don't check statements that shadow `Self` or where `Self` can't be used
             },
             _ => walk_item(self, item),

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -249,6 +249,16 @@ mod nesting {
                     Self { foo: Foo {} }
                 }
             }
+
+            // Can't use Self here
+            fn baz() -> Foo {
+                Foo {}
+            }
+        }
+
+        // Should lint here
+        fn baz() -> Self {
+            Self {}
         }
     }
 

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -249,6 +249,16 @@ mod nesting {
                     Bar { foo: Foo {} }
                 }
             }
+
+            // Can't use Self here
+            fn baz() -> Foo {
+                Foo {}
+            }
+        }
+
+        // Should lint here
+        fn baz() -> Foo {
+            Foo {}
         }
     }
 

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -151,6 +151,18 @@ LL |         use_self_expand!(); // Should lint in local macros
    |         ------------------- in this macro invocation
 
 error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:260:21
+   |
+LL |         fn baz() -> Foo {
+   |                     ^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:261:13
+   |
+LL |             Foo {}
+   |             ^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
   --> $DIR/use_self.rs:248:29
    |
 LL |                 fn bar() -> Bar {
@@ -163,22 +175,22 @@ LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:293:13
+  --> $DIR/use_self.rs:303:13
    |
 LL |             nested::A::fun_1();
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:294:13
+  --> $DIR/use_self.rs:304:13
    |
 LL |             nested::A::A;
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:296:13
+  --> $DIR/use_self.rs:306:13
    |
 LL |             nested::A {};
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
-error: aborting due to 29 previous errors
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Related to https://github.com/rust-lang/rust-clippy/pull/3640

The current `use_self` warns the following code.

```rust
#![warn(clippy::use_self)]
struct Foo {}
impl Foo {
    fn bar() {
        fn baz() -> Foo { //^ warning: unnecessary structure name repetition
            Foo {} //^ warning: unnecessary structure name repetition
         }
    }
}
```
