### PR TITLE
Some more HirId-ification

### DIFF
--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -122,8 +122,7 @@ impl<'a, 'tcx> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
             return;
         }
         if let Categorization::Rvalue(..) = cmt.cat {
-            let id = map.hir_to_node_id(cmt.hir_id);
-            if let Some(Node::Stmt(st)) = map.find(map.get_parent_node(id)) {
+            if let Some(Node::Stmt(st)) = map.find_by_hir_id(map.get_parent_node_by_hir_id(cmt.hir_id)) {
                 if let StmtKind::Local(ref loc) = st.node {
                     if let Some(ref ex) = loc.init {
                         if let ExprKind::Box(..) = ex.node {

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -1,6 +1,6 @@
 use crate::utils::paths;
 use crate::utils::sugg::DiagnosticBuilderExt;
-use crate::utils::{get_trait_def_id, implements_trait, return_ty, same_tys, span_lint_node_and_then};
+use crate::utils::{get_trait_def_id, implements_trait, return_ty, same_tys, span_lint_hir_and_then};
 use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::def_id::DefId;
@@ -163,7 +163,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
                                     }
 
                                     if let Some(sp) = can_derive_default(self_ty, cx, default_trait_id) {
-                                        span_lint_node_and_then(
+                                        span_lint_hir_and_then(
                                             cx,
                                             NEW_WITHOUT_DEFAULT,
                                             id,
@@ -182,7 +182,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
                                                 );
                                             });
                                     } else {
-                                        span_lint_node_and_then(
+                                        span_lint_hir_and_then(
                                             cx,
                                             NEW_WITHOUT_DEFAULT,
                                             id,

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_automatically_derived, span_lint_node};
+use crate::utils::{is_automatically_derived, span_lint_hir};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -51,7 +51,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             then {
                 for impl_item in impl_items {
                     if impl_item.ident.name == "ne" {
-                        span_lint_node(
+                        span_lint_hir(
                             cx,
                             PARTIALEQ_NE_IMPL,
                             impl_item.id.hir_id,

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    has_drop, in_macro, is_copy, match_def_path, match_type, paths, snippet_opt, span_lint_hir,
-    span_lint_hir_and_then, walk_ptrs_ty_depth,
+    has_drop, in_macro, is_copy, match_def_path, match_type, paths, snippet_opt, span_lint_hir, span_lint_hir_and_then,
+    walk_ptrs_ty_depth,
 };
 use if_chain::if_chain;
 use matches::matches;

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    has_drop, in_macro, is_copy, match_def_path, match_type, paths, snippet_opt, span_lint_node,
-    span_lint_node_and_then, walk_ptrs_ty_depth,
+    has_drop, in_macro, is_copy, match_def_path, match_type, paths, snippet_opt, span_lint_hir,
+    span_lint_hir_and_then, walk_ptrs_ty_depth,
 };
 use if_chain::if_chain;
 use matches::matches;
@@ -199,7 +199,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantClone {
                             span.lo() + BytePos(u32::try_from(dot).unwrap())
                         );
 
-                        span_lint_node_and_then(cx, REDUNDANT_CLONE, node, sugg_span, "redundant clone", |db| {
+                        span_lint_hir_and_then(cx, REDUNDANT_CLONE, node, sugg_span, "redundant clone", |db| {
                             db.span_suggestion(
                                 sugg_span,
                                 "remove this",
@@ -212,7 +212,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantClone {
                             );
                         });
                     } else {
-                        span_lint_node(cx, REDUNDANT_CLONE, node, span, "redundant clone");
+                        span_lint_hir(cx, REDUNDANT_CLONE, node, span, "redundant clone");
                     }
                 }
             }

--- a/clippy_lints/src/utils/diagnostics.rs
+++ b/clippy_lints/src/utils/diagnostics.rs
@@ -134,19 +134,19 @@ pub fn span_lint_and_then<'a, 'tcx: 'a, T: LintContext<'tcx>, F>(
     db.docs_link(lint);
 }
 
-pub fn span_lint_node(cx: &LateContext<'_, '_>, lint: &'static Lint, node: HirId, sp: Span, msg: &str) {
-    DiagnosticWrapper(cx.tcx.struct_span_lint_hir(lint, node, sp, msg)).docs_link(lint);
+pub fn span_lint_hir(cx: &LateContext<'_, '_>, lint: &'static Lint, hir_id: HirId, sp: Span, msg: &str) {
+    DiagnosticWrapper(cx.tcx.struct_span_lint_hir(lint, hir_id, sp, msg)).docs_link(lint);
 }
 
-pub fn span_lint_node_and_then(
+pub fn span_lint_hir_and_then(
     cx: &LateContext<'_, '_>,
     lint: &'static Lint,
-    node: HirId,
+    hir_id: HirId,
     sp: Span,
     msg: &str,
     f: impl FnOnce(&mut DiagnosticBuilder<'_>),
 ) {
-    let mut db = DiagnosticWrapper(cx.tcx.struct_span_lint_hir(lint, node, sp, msg));
+    let mut db = DiagnosticWrapper(cx.tcx.struct_span_lint_hir(lint, hir_id, sp, msg));
     f(&mut db.0);
     db.docs_link(lint);
 }


### PR DESCRIPTION
* 8a59f81: Rename span_lint_node* functions to span_lint_hir*
* a457258: Use `HirId` instead of `NodeId` for lookup