### PR TITLE
Run rustfix for string_lit_as_bytes tests

### DIFF
--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -1,0 +1,19 @@
+// run-rustfix
+
+#![allow(dead_code, unused_variables)]
+#![warn(clippy::string_lit_as_bytes)]
+
+fn str_lit_as_bytes() {
+    let bs = b"hello there";
+
+    let bs = br###"raw string with three ### in it and some " ""###;
+
+    // no warning, because this cannot be written as a byte string literal:
+    let ubs = "☃".as_bytes();
+
+    let strify = stringify!(foobar).as_bytes();
+
+    let includestr = include_bytes!("entry.rs");
+}
+
+fn main() {}

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -1,0 +1,19 @@
+// run-rustfix
+
+#![allow(dead_code, unused_variables)]
+#![warn(clippy::string_lit_as_bytes)]
+
+fn str_lit_as_bytes() {
+    let bs = "hello there".as_bytes();
+
+    let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
+
+    // no warning, because this cannot be written as a byte string literal:
+    let ubs = "☃".as_bytes();
+
+    let strify = stringify!(foobar).as_bytes();
+
+    let includestr = include_str!("entry.rs").as_bytes();
+}
+
+fn main() {}

--- a/tests/ui/string_lit_as_bytes.stderr
+++ b/tests/ui/string_lit_as_bytes.stderr
@@ -1,0 +1,22 @@
+error: calling `as_bytes()` on a string literal
+  --> $DIR/string_lit_as_bytes.rs:7:14
+   |
+LL |     let bs = "hello there".as_bytes();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"hello there"`
+   |
+   = note: `-D clippy::string-lit-as-bytes` implied by `-D warnings`
+
+error: calling `as_bytes()` on a string literal
+  --> $DIR/string_lit_as_bytes.rs:9:14
+   |
+LL |     let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with three ### in it and some " ""###`
+
+error: calling `as_bytes()` on `include_str!(..)`
+  --> $DIR/string_lit_as_bytes.rs:16:22
+   |
+LL |     let includestr = include_str!("entry.rs").as_bytes();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("entry.rs")`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/strings.rs
+++ b/tests/ui/strings.rs
@@ -42,21 +42,6 @@ fn both() {
     assert_eq!(&x, &z);
 }
 
-#[allow(dead_code, unused_variables)]
-#[warn(clippy::string_lit_as_bytes)]
-fn str_lit_as_bytes() {
-    let bs = "hello there".as_bytes();
-
-    let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
-
-    // no warning, because this cannot be written as a byte string literal:
-    let ubs = "☃".as_bytes();
-
-    let strify = stringify!(foobar).as_bytes();
-
-    let includestr = include_str!("entry.rs").as_bytes();
-}
-
 #[allow(clippy::assign_op_pattern)]
 fn main() {
     add_only();

--- a/tests/ui/strings.stderr
+++ b/tests/ui/strings.stderr
@@ -52,25 +52,5 @@ error: you added something to a string. Consider using `String::push_str()` inst
 LL |     let z = y + "...";
    |             ^^^^^^^^^
 
-error: calling `as_bytes()` on a string literal
-  --> $DIR/strings.rs:48:14
-   |
-LL |     let bs = "hello there".as_bytes();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"hello there"`
-   |
-   = note: `-D clippy::string-lit-as-bytes` implied by `-D warnings`
-
-error: calling `as_bytes()` on a string literal
-  --> $DIR/strings.rs:50:14
-   |
-LL |     let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with three ### in it and some " ""###`
-
-error: calling `as_bytes()` on `include_str!(..)`
-  --> $DIR/strings.rs:57:22
-   |
-LL |     let includestr = include_str!("entry.rs").as_bytes();
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("entry.rs")`
-
-error: aborting due to 11 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
This moves the `string_lit_as_bytes` tests into a new file and enables
rustfix tests for them.

cc #3603, #2038