### PR TITLE
Add `doc(include = ...)` detection to `missing_docs_in_private_items`

### DIFF
--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -6,11 +6,12 @@
 //
 
 use crate::utils::{in_macro, span_lint};
+use if_chain::if_chain;
 use rustc::hir;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc::ty;
 use rustc::{declare_tool_lint, lint_array};
-use syntax::ast;
+use syntax::ast::{self, MetaItem, MetaItemKind};
 use syntax::attr;
 use syntax::source_map::Span;
 
@@ -52,6 +53,22 @@ impl MissingDoc {
         *self.doc_hidden_stack.last().expect("empty doc_hidden_stack")
     }
 
+    #[allow(clippy::needless_bool)]
+    fn has_include(meta: Option<MetaItem>) -> bool {
+        if_chain! {
+            if let Some(meta) = meta;
+            if let MetaItemKind::List(list) = meta.node;
+            if let Some(meta) = list.get(0);
+            if let Some(name) = meta.name();
+            if name == "include";
+            then {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
     fn check_missing_docs_attrs(
         &self,
         cx: &LateContext<'_, '_>,
@@ -74,7 +91,9 @@ impl MissingDoc {
             return;
         }
 
-        let has_doc = attrs.iter().any(|a| a.is_value_str() && a.name() == "doc");
+        let has_doc = attrs
+            .iter()
+            .any(|a| a.name() == "doc" && (a.is_value_str() || Self::has_include(a.meta())));
         if !has_doc {
             span_lint(
                 cx,

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -53,16 +53,14 @@ impl MissingDoc {
         *self.doc_hidden_stack.last().expect("empty doc_hidden_stack")
     }
 
-    #[allow(clippy::needless_bool)]
     fn has_include(meta: Option<MetaItem>) -> bool {
         if_chain! {
             if let Some(meta) = meta;
             if let MetaItemKind::List(list) = meta.node;
             if let Some(meta) = list.get(0);
             if let Some(name) = meta.name();
-            if name == "include";
             then {
-                true
+                name == "include"
             } else {
                 false
             }

--- a/tests/ui/missing-doc-crate-missing.rs
+++ b/tests/ui/missing-doc-crate-missing.rs
@@ -1,0 +1,3 @@
+#![warn(clippy::missing_docs_in_private_items)]
+
+fn main() {}

--- a/tests/ui/missing-doc-crate-missing.stderr
+++ b/tests/ui/missing-doc-crate-missing.stderr
@@ -1,0 +1,12 @@
+error: missing documentation for crate
+  --> $DIR/missing-doc-crate-missing.rs:1:1
+   |
+LL | / #![warn(clippy::missing_docs_in_private_items)]
+LL | |
+LL | | fn main() {}
+   | |____________^
+   |
+   = note: `-D clippy::missing-docs-in-private-items` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/tests/ui/missing-doc-crate.rs
+++ b/tests/ui/missing-doc-crate.rs
@@ -1,0 +1,5 @@
+#![warn(clippy::missing_docs_in_private_items)]
+#![feature(external_doc)]
+#![doc(include = "../../README.md")]
+
+fn main() {}


### PR DESCRIPTION
The whole `missing documentation in crate` part doesn't have any tests. If I should add test cases tell me.