### PR TITLE
Enable rustfix for `useless_asref` lint tests

### DIFF
--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -41,35 +41,35 @@ fn not_ok() {
 
     {
         let rslice: &[i32] = &*mrslice;
-        foo_rstr(rstr.as_ref());
         foo_rstr(rstr);
-        foo_rslice(rslice.as_ref());
+        foo_rstr(rstr);
+        foo_rslice(rslice);
         foo_rslice(rslice);
     }
     {
-        foo_mrslice(mrslice.as_mut());
         foo_mrslice(mrslice);
-        foo_rslice(mrslice.as_ref());
+        foo_mrslice(mrslice);
+        foo_rslice(mrslice);
         foo_rslice(mrslice);
     }
 
     {
         let rrrrrstr = &&&&rstr;
         let rrrrrslice = &&&&&*mrslice;
-        foo_rslice(rrrrrslice.as_ref());
         foo_rslice(rrrrrslice);
-        foo_rstr(rrrrrstr.as_ref());
+        foo_rslice(rrrrrslice);
+        foo_rstr(rrrrrstr);
         foo_rstr(rrrrrstr);
     }
     {
         let mrrrrrslice = &mut &mut &mut &mut mrslice;
-        foo_mrslice(mrrrrrslice.as_mut());
         foo_mrslice(mrrrrrslice);
-        foo_rslice(mrrrrrslice.as_ref());
+        foo_mrslice(mrrrrrslice);
+        foo_rslice(mrrrrrslice);
         foo_rslice(mrrrrrslice);
     }
     #[allow(unused_parens, clippy::double_parens)]
-    foo_rrrrmr((&&&&MoreRef).as_ref());
+    foo_rrrrmr((&&&&MoreRef));
 
     generic_not_ok(mrslice);
     generic_ok(mrslice);
@@ -119,9 +119,9 @@ fn foo_rt<T: Debug + ?Sized>(t: &T) {
 }
 
 fn generic_not_ok<T: AsMut<T> + AsRef<T> + Debug + ?Sized>(mrt: &mut T) {
-    foo_mrt(mrt.as_mut());
     foo_mrt(mrt);
-    foo_rt(mrt.as_ref());
+    foo_mrt(mrt);
+    foo_rt(mrt);
     foo_rt(mrt);
 }
 

--- a/tests/ui/useless_asref.stderr
+++ b/tests/ui/useless_asref.stderr
@@ -1,71 +1,71 @@
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:41:18
+  --> $DIR/useless_asref.rs:44:18
    |
 LL |         foo_rstr(rstr.as_ref());
    |                  ^^^^^^^^^^^^^ help: try this: `rstr`
    |
 note: lint level defined here
-  --> $DIR/useless_asref.rs:1:9
+  --> $DIR/useless_asref.rs:3:9
    |
 LL | #![deny(clippy::useless_asref)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:43:20
+  --> $DIR/useless_asref.rs:46:20
    |
 LL |         foo_rslice(rslice.as_ref());
    |                    ^^^^^^^^^^^^^^^ help: try this: `rslice`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:47:21
+  --> $DIR/useless_asref.rs:50:21
    |
 LL |         foo_mrslice(mrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:49:20
+  --> $DIR/useless_asref.rs:52:20
    |
 LL |         foo_rslice(mrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:56:20
+  --> $DIR/useless_asref.rs:59:20
    |
 LL |         foo_rslice(rrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^ help: try this: `rrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:58:18
+  --> $DIR/useless_asref.rs:61:18
    |
 LL |         foo_rstr(rrrrrstr.as_ref());
    |                  ^^^^^^^^^^^^^^^^^ help: try this: `rrrrrstr`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:63:21
+  --> $DIR/useless_asref.rs:66:21
    |
 LL |         foo_mrslice(mrrrrrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:65:20
+  --> $DIR/useless_asref.rs:68:20
    |
 LL |         foo_rslice(mrrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:68:16
+  --> $DIR/useless_asref.rs:72:16
    |
 LL |     foo_rrrrmr((&&&&MoreRef).as_ref());
    |                ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(&&&&MoreRef)`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:118:13
+  --> $DIR/useless_asref.rs:122:13
    |
 LL |     foo_mrt(mrt.as_mut());
    |             ^^^^^^^^^^^^ help: try this: `mrt`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:120:12
+  --> $DIR/useless_asref.rs:124:12
    |
 LL |     foo_rt(mrt.as_ref());
    |            ^^^^^^^^^^^^ help: try this: `mrt`


### PR DESCRIPTION
cc #3630