### PR TITLE
Move some `unreadable_literal` ui tests to correct file

### DIFF
--- a/tests/ui/literals.rs
+++ b/tests/ui/literals.rs
@@ -37,10 +37,6 @@ fn main() {
     let ok16 = 0xFE_BAFE_ABAB_ABCD;
     let ok17 = 0x123_4567_8901_usize;
 
-    let fail9 = 0xabcdef;
-    let fail10 = 0xBAFEBAFE;
-    let fail11 = 0xabcdeff;
-    let fail12 = 0xabcabcabcabcabcabc;
     let fail13 = 0x1_23456_78901_usize;
 
     let fail14 = 2_32;

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -86,34 +86,8 @@ help: if you mean to use an octal constant, use `0o`
 LL |     let fail8 = 0o123;
    |                 ^^^^^
 
-error: long literal lacking separators
-  --> $DIR/literals.rs:40:17
-   |
-LL |     let fail9 = 0xabcdef;
-   |                 ^^^^^^^^ help: consider: `0x00ab_cdef`
-   |
-   = note: `-D clippy::unreadable-literal` implied by `-D warnings`
-
-error: long literal lacking separators
-  --> $DIR/literals.rs:41:18
-   |
-LL |     let fail10 = 0xBAFEBAFE;
-   |                  ^^^^^^^^^^ help: consider: `0xBAFE_BAFE`
-
-error: long literal lacking separators
-  --> $DIR/literals.rs:42:18
-   |
-LL |     let fail11 = 0xabcdeff;
-   |                  ^^^^^^^^^ help: consider: `0x0abc_deff`
-
-error: long literal lacking separators
-  --> $DIR/literals.rs:43:18
-   |
-LL |     let fail12 = 0xabcabcabcabcabcabc;
-   |                  ^^^^^^^^^^^^^^^^^^^^ help: consider: `0x00ab_cabc_abca_bcab_cabc`
-
 error: digit groups should be smaller
-  --> $DIR/literals.rs:44:18
+  --> $DIR/literals.rs:40:18
    |
 LL |     let fail13 = 0x1_23456_78901_usize;
    |                  ^^^^^^^^^^^^^^^^^^^^^ help: consider: `0x0123_4567_8901_usize`
@@ -121,7 +95,7 @@ LL |     let fail13 = 0x1_23456_78901_usize;
    = note: `-D clippy::large-digit-groups` implied by `-D warnings`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:46:18
+  --> $DIR/literals.rs:42:18
    |
 LL |     let fail14 = 2_32;
    |                  ^^^^ help: did you mean to write: `2_i32`
@@ -129,25 +103,25 @@ LL |     let fail14 = 2_32;
    = note: #[deny(clippy::mistyped_literal_suffixes)] on by default
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:47:18
+  --> $DIR/literals.rs:43:18
    |
 LL |     let fail15 = 4_64;
    |                  ^^^^ help: did you mean to write: `4_i64`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:48:18
+  --> $DIR/literals.rs:44:18
    |
 LL |     let fail16 = 7_8;
    |                  ^^^ help: did you mean to write: `7_i8`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:49:18
+  --> $DIR/literals.rs:45:18
    |
 LL |     let fail17 = 23_16;
    |                  ^^^^^ help: did you mean to write: `23_i16`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:51:18
+  --> $DIR/literals.rs:47:18
    |
 LL |     let fail19 = 12_3456_21;
    |                  ^^^^^^^^^^ help: consider: `12_345_621`
@@ -155,64 +129,64 @@ LL |     let fail19 = 12_3456_21;
    = note: `-D clippy::inconsistent-digit-grouping` implied by `-D warnings`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:52:18
+  --> $DIR/literals.rs:48:18
    |
 LL |     let fail20 = 2__8;
    |                  ^^^^ help: did you mean to write: `2_i8`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:53:18
+  --> $DIR/literals.rs:49:18
    |
 LL |     let fail21 = 4___16;
    |                  ^^^^^^ help: did you mean to write: `4_i16`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:54:18
+  --> $DIR/literals.rs:50:18
    |
 LL |     let fail22 = 3__4___23;
    |                  ^^^^^^^^^ help: consider: `3_423`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:55:18
+  --> $DIR/literals.rs:51:18
    |
 LL |     let fail23 = 3__16___23;
    |                  ^^^^^^^^^^ help: consider: `31_623`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:57:18
+  --> $DIR/literals.rs:53:18
    |
 LL |     let fail24 = 12.34_64;
    |                  ^^^^^^^^ help: did you mean to write: `12.34_f64`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:58:18
+  --> $DIR/literals.rs:54:18
    |
 LL |     let fail25 = 1E2_32;
    |                  ^^^^^^ help: did you mean to write: `1E2_f32`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:59:18
+  --> $DIR/literals.rs:55:18
    |
 LL |     let fail26 = 43E7_64;
    |                  ^^^^^^^ help: did you mean to write: `43E7_f64`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:60:18
+  --> $DIR/literals.rs:56:18
    |
 LL |     let fail27 = 243E17_32;
    |                  ^^^^^^^^^ help: did you mean to write: `243E17_f32`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:61:18
+  --> $DIR/literals.rs:57:18
    |
 LL |     let fail28 = 241251235E723_64;
    |                  ^^^^^^^^^^^^^^^^ help: did you mean to write: `241_251_235E723_f64`
 
 error: mistyped literal suffix
-  --> $DIR/literals.rs:62:18
+  --> $DIR/literals.rs:58:18
    |
 LL |     let fail29 = 42279.911_32;
    |                  ^^^^^^^^^^^^ help: did you mean to write: `42_279.911_f32`
 
-error: aborting due to 31 previous errors
+error: aborting due to 27 previous errors
 

--- a/tests/ui/unreadable_literal.fixed
+++ b/tests/ui/unreadable_literal.fixed
@@ -17,4 +17,9 @@ fn main() {
     let bad = (0b11_0110_i64, 0x0123_4567_8901_usize, 123_456_f32, 1.234_567_f32);
     let good_sci = 1.1234e1;
     let bad_sci = 1.123_456e1;
+
+    let fail9 = 0x00ab_cdef;
+    let fail10: u32 = 0xBAFE_BAFE;
+    let fail11 = 0x0abc_deff;
+    let fail12: i128 = 0x00ab_cabc_abca_bcab_cabc;
 }

--- a/tests/ui/unreadable_literal.rs
+++ b/tests/ui/unreadable_literal.rs
@@ -17,4 +17,9 @@ fn main() {
     let bad = (0b110110_i64, 0x12345678901_usize, 123456_f32, 1.234567_f32);
     let good_sci = 1.1234e1;
     let bad_sci = 1.123456e1;
+
+    let fail9 = 0xabcdef;
+    let fail10: u32 = 0xBAFEBAFE;
+    let fail11 = 0xabcdeff;
+    let fail12: i128 = 0xabcabcabcabcabcabc;
 }

--- a/tests/ui/unreadable_literal.stderr
+++ b/tests/ui/unreadable_literal.stderr
@@ -30,5 +30,29 @@ error: long literal lacking separators
 LL |     let bad_sci = 1.123456e1;
    |                   ^^^^^^^^^^ help: consider: `1.123_456e1`
 
-error: aborting due to 5 previous errors
+error: long literal lacking separators
+  --> $DIR/unreadable_literal.rs:21:17
+   |
+LL |     let fail9 = 0xabcdef;
+   |                 ^^^^^^^^ help: consider: `0x00ab_cdef`
+
+error: long literal lacking separators
+  --> $DIR/unreadable_literal.rs:22:23
+   |
+LL |     let fail10: u32 = 0xBAFEBAFE;
+   |                       ^^^^^^^^^^ help: consider: `0xBAFE_BAFE`
+
+error: long literal lacking separators
+  --> $DIR/unreadable_literal.rs:23:18
+   |
+LL |     let fail11 = 0xabcdeff;
+   |                  ^^^^^^^^^ help: consider: `0x0abc_deff`
+
+error: long literal lacking separators
+  --> $DIR/unreadable_literal.rs:24:24
+   |
+LL |     let fail12: i128 = 0xabcabcabcabcabcabc;
+   |                        ^^^^^^^^^^^^^^^^^^^^ help: consider: `0x00ab_cabc_abca_bcab_cabc`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
The moved tests were part of `tests/ui/literals.rs` before. Now they are
placed in `tests/ui/unreadable_literal.rs` which now also runs
`rustfix` on these 4 extra let statements.

cc #3603, #2038