### PR TITLE
Unbreaking the clippy build step

### DIFF
--- a/clippy_lints/src/enum_glob_use.rs
+++ b/clippy_lints/src/enum_glob_use.rs
@@ -39,9 +39,10 @@ impl LintPass for EnumGlobUse {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EnumGlobUse {
     fn check_mod(&mut self, cx: &LateContext<'a, 'tcx>, m: &'tcx Mod, _: Span, _: HirId) {
+        let map = cx.tcx.hir();
         // only check top level `use` statements
         for item in &m.item_ids {
-            self.lint_item(cx, cx.tcx.hir().expect_item(item.id));
+            self.lint_item(cx, map.expect_item(map.hir_to_node_id(item.id)));
         }
     }
 }

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -356,7 +356,8 @@ impl<'a, 'tcx> Visitor<'tcx> for RefVisitor<'a, 'tcx> {
                 self.collect_anonymous_lifetimes(path, ty);
             },
             TyKind::Def(item, _) => {
-                if let ItemKind::Existential(ref exist_ty) = self.cx.tcx.hir().expect_item(item.id).node {
+                let map = self.cx.tcx.hir();
+                if let ItemKind::Existential(ref exist_ty) = map.expect_item(map.hir_to_node_id(item.id)).node {
                     for bound in &exist_ty.bounds {
                         if let GenericBound::Outlives(_) = *bound {
                             self.record(&None);

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -93,7 +93,7 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
             ls.register_early_pass(Some(sess), true, false, pass);
         }
         for pass in late_lint_passes {
-            ls.register_late_pass(Some(sess), true, pass);
+            ls.register_late_pass(Some(sess), true, false, pass);
         }
 
         for (name, (to, deprecated_name)) in lint_groups {


### PR DESCRIPTION
(It still can't pass the dogfeed tests; see #3906 and #3905)

The changes made were as conservative as I thought they could be: I used the direct translation of `HirId` to `NodeId` in two files, and picked the `false` value for the new `per_module` field while registering late lint passes.

@oli-obk now it builds again using the `master` toolchain, but the same nonsensical error we found is still there.