### PR TITLE
Set level of identity_conversion FP to warn

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -74,6 +74,7 @@ fn run_mode(mode: &str, dir: PathBuf) {
     compiletest::run_tests(&cfg);
 }
 
+#[warn(clippy::identity_conversion)]
 fn run_ui_toml_tests(config: &compiletest::Config, mut tests: Vec<TestDescAndFn>) -> Result<bool, io::Error> {
     let mut result = true;
     let opts = compiletest::test_opts(config);

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -95,7 +95,7 @@ impl<T: Serialize, U> S<T, U> {
         s.len() + t.capacity()
     }
 
-    fn bar(_t: T // Ok, since `&T: Serialize` too
+    fn bar(_t: T, // Ok, since `&T: Serialize` too
     ) {
     }
 


### PR DESCRIPTION
Preparation for forced rustup. cc #3905 

Let's see if this is enough to get the CI green.