### PR TITLE
Add missing `// run-pass` annotations to ICE tests

### DIFF
--- a/tests/ui/crashes/associated-constant-ice.rs
+++ b/tests/ui/crashes/associated-constant-ice.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 /// Test for https://github.com/rust-lang/rust-clippy/issues/1698
 
 pub trait Trait {

--- a/tests/ui/crashes/cc_seme.rs
+++ b/tests/ui/crashes/cc_seme.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #[allow(dead_code)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/478

--- a/tests/ui/crashes/enum-glob-import-crate.rs
+++ b/tests/ui/crashes/enum-glob-import-crate.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![deny(clippy::all)]
 #![allow(unused_imports)]
 

--- a/tests/ui/crashes/ice-1588.rs
+++ b/tests/ui/crashes/ice-1588.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(clippy::all)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/1588

--- a/tests/ui/crashes/ice-1782.rs
+++ b/tests/ui/crashes/ice-1782.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(dead_code, unused_variables)]
 
 /// Should not trigger an ICE in `SpanlessEq` / `consts::constant`

--- a/tests/ui/crashes/ice-1969.rs
+++ b/tests/ui/crashes/ice-1969.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(clippy::all)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/1969

--- a/tests/ui/crashes/ice-2499.rs
+++ b/tests/ui/crashes/ice-2499.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(dead_code, clippy::char_lit_as_u8, clippy::needless_bool)]
 
 /// Should not trigger an ICE in `SpanlessHash` / `consts::constant`

--- a/tests/ui/crashes/ice-2594.rs
+++ b/tests/ui/crashes/ice-2594.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(dead_code, unused_variables)]
 
 /// Should not trigger an ICE in `SpanlessHash` / `consts::constant`

--- a/tests/ui/crashes/ice-2727.rs
+++ b/tests/ui/crashes/ice-2727.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 /// Test for https://github.com/rust-lang/rust-clippy/issues/2727
 
 pub fn f(new: fn()) {

--- a/tests/ui/crashes/ice-2760.rs
+++ b/tests/ui/crashes/ice-2760.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(
     unused_variables,
     clippy::blacklisted_name,

--- a/tests/ui/crashes/ice-2774.rs
+++ b/tests/ui/crashes/ice-2774.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 use std::collections::HashSet;
 
 // See rust-lang/rust-clippy#2774.

--- a/tests/ui/crashes/ice-2865.rs
+++ b/tests/ui/crashes/ice-2865.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #[allow(dead_code)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/2865

--- a/tests/ui/crashes/ice-3151.rs
+++ b/tests/ui/crashes/ice-3151.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 /// Test for https://github.com/rust-lang/rust-clippy/issues/2865
 
 #[derive(Clone)]

--- a/tests/ui/crashes/ice-3462.rs
+++ b/tests/ui/crashes/ice-3462.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![warn(clippy::all)]
 #![allow(clippy::blacklisted_name)]
 #![allow(unused)]

--- a/tests/ui/crashes/ice-3747.rs
+++ b/tests/ui/crashes/ice-3747.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 /// Test for https://github.com/rust-lang/rust-clippy/issues/3747
 
 macro_rules! a {

--- a/tests/ui/crashes/ice-700.rs
+++ b/tests/ui/crashes/ice-700.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![deny(clippy::all)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/700

--- a/tests/ui/crashes/ice_exacte_size.rs
+++ b/tests/ui/crashes/ice_exacte_size.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![deny(clippy::all)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/1336

--- a/tests/ui/crashes/if_same_then_else.rs
+++ b/tests/ui/crashes/if_same_then_else.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![deny(clippy::if_same_then_else)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/2426

--- a/tests/ui/crashes/issue-2862.rs
+++ b/tests/ui/crashes/issue-2862.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 /// Test for https://github.com/rust-lang/rust-clippy/issues/2826
 
 pub trait FooMap {

--- a/tests/ui/crashes/issue-825.rs
+++ b/tests/ui/crashes/issue-825.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(warnings)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/825

--- a/tests/ui/crashes/issues_loop_mut_cond.rs
+++ b/tests/ui/crashes/issues_loop_mut_cond.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(dead_code)]
 
 /// Issue: https://github.com/rust-lang/rust-clippy/issues/2596

--- a/tests/ui/crashes/match_same_arms_const.rs
+++ b/tests/ui/crashes/match_same_arms_const.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![deny(clippy::match_same_arms)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/2427

--- a/tests/ui/crashes/mut_mut_macro.rs
+++ b/tests/ui/crashes/mut_mut_macro.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![deny(clippy::mut_mut, clippy::zero_ptr, clippy::cmp_nan)]
 #![allow(dead_code)]
 

--- a/tests/ui/crashes/needless_borrow_fp.rs
+++ b/tests/ui/crashes/needless_borrow_fp.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #[deny(clippy::all)]
 #[derive(Debug)]
 pub enum Error {

--- a/tests/ui/crashes/needless_lifetimes_impl_trait.rs
+++ b/tests/ui/crashes/needless_lifetimes_impl_trait.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![deny(clippy::needless_lifetimes)]
 #![allow(dead_code)]
 

--- a/tests/ui/crashes/procedural_macro.rs
+++ b/tests/ui/crashes/procedural_macro.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #[macro_use]
 extern crate clippy_mini_macro_test;
 

--- a/tests/ui/crashes/regressions.rs
+++ b/tests/ui/crashes/regressions.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(clippy::blacklisted_name)]
 
 pub fn foo(bar: *const u8) {

--- a/tests/ui/crashes/returns.rs
+++ b/tests/ui/crashes/returns.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 /// Test for https://github.com/rust-lang/rust-clippy/issues/1346
 
 #[deny(warnings)]

--- a/tests/ui/crashes/single-match-else.rs
+++ b/tests/ui/crashes/single-match-else.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![warn(clippy::single_match_else)]
 
 //! Test for https://github.com/rust-lang/rust-clippy/issues/1588

--- a/tests/ui/crashes/used_underscore_binding_macro.rs
+++ b/tests/ui/crashes/used_underscore_binding_macro.rs
@@ -1,3 +1,5 @@
+// run-pass
+
 #![allow(clippy::useless_attribute)] //issue #2910
 
 #[macro_use]


### PR DESCRIPTION
compiletest UI tests do not fail when encountering panics and ICEs
unless the `// run-pass` flag is used.

(This was forgotten in https://github.com/rust-lang/rust-clippy/pull/3743)