### PR TITLE
Use {get,match}_def_path from rustc

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -2,7 +2,7 @@
 
 use crate::reexport::*;
 use crate::utils::{
-    in_macro, last_line_of_span, match_def_path, paths, snippet_opt, span_lint, span_lint_and_sugg, span_lint_and_then,
+    in_macro, last_line_of_span, paths, snippet_opt, span_lint, span_lint_and_sugg, span_lint_and_then,
     without_block_comments,
 };
 use if_chain::if_chain;
@@ -11,7 +11,7 @@ use rustc::lint::{
     in_external_macro, CheckLintNameResult, EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintArray,
     LintContext, LintPass,
 };
-use rustc::ty::{self, TyCtxt};
+use rustc::ty;
 use rustc::{declare_tool_lint, lint_array};
 use rustc_errors::Applicability;
 use semver::Version;
@@ -234,7 +234,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AttrPass {
     }
 
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx Item) {
-        if is_relevant_item(cx.tcx, item) {
+        if is_relevant_item(cx, item) {
             check_attrs(cx, item.span, item.ident.name, &item.attrs)
         }
         match item.node {
@@ -302,13 +302,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AttrPass {
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx ImplItem) {
-        if is_relevant_impl(cx.tcx, item) {
+        if is_relevant_impl(cx, item) {
             check_attrs(cx, item.span, item.ident.name, &item.attrs)
         }
     }
 
     fn check_trait_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx TraitItem) {
-        if is_relevant_trait(cx.tcx, item) {
+        if is_relevant_trait(cx, item) {
             check_attrs(cx, item.span, item.ident.name, &item.attrs)
         }
     }
@@ -361,52 +361,52 @@ fn check_clippy_lint_names(cx: &LateContext<'_, '_>, items: &[NestedMetaItem]) {
     }
 }
 
-fn is_relevant_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item: &Item) -> bool {
+fn is_relevant_item(cx: &LateContext<'_, '_>, item: &Item) -> bool {
     if let ItemKind::Fn(_, _, _, eid) = item.node {
-        is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir().body(eid).value)
+        is_relevant_expr(cx, cx.tcx.body_tables(eid), &cx.tcx.hir().body(eid).value)
     } else {
         true
     }
 }
 
-fn is_relevant_impl<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item: &ImplItem) -> bool {
+fn is_relevant_impl(cx: &LateContext<'_, '_>, item: &ImplItem) -> bool {
     match item.node {
-        ImplItemKind::Method(_, eid) => is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir().body(eid).value),
+        ImplItemKind::Method(_, eid) => is_relevant_expr(cx, cx.tcx.body_tables(eid), &cx.tcx.hir().body(eid).value),
         _ => false,
     }
 }
 
-fn is_relevant_trait<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item: &TraitItem) -> bool {
+fn is_relevant_trait(cx: &LateContext<'_, '_>, item: &TraitItem) -> bool {
     match item.node {
         TraitItemKind::Method(_, TraitMethod::Required(_)) => true,
         TraitItemKind::Method(_, TraitMethod::Provided(eid)) => {
-            is_relevant_expr(tcx, tcx.body_tables(eid), &tcx.hir().body(eid).value)
+            is_relevant_expr(cx, cx.tcx.body_tables(eid), &cx.tcx.hir().body(eid).value)
         },
         _ => false,
     }
 }
 
-fn is_relevant_block<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, tables: &ty::TypeckTables<'_>, block: &Block) -> bool {
+fn is_relevant_block(cx: &LateContext<'_, '_>, tables: &ty::TypeckTables<'_>, block: &Block) -> bool {
     if let Some(stmt) = block.stmts.first() {
         match &stmt.node {
             StmtKind::Local(_) => true,
-            StmtKind::Expr(expr) | StmtKind::Semi(expr) => is_relevant_expr(tcx, tables, expr),
+            StmtKind::Expr(expr) | StmtKind::Semi(expr) => is_relevant_expr(cx, tables, expr),
             _ => false,
         }
     } else {
-        block.expr.as_ref().map_or(false, |e| is_relevant_expr(tcx, tables, e))
+        block.expr.as_ref().map_or(false, |e| is_relevant_expr(cx, tables, e))
     }
 }
 
-fn is_relevant_expr<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, tables: &ty::TypeckTables<'_>, expr: &Expr) -> bool {
+fn is_relevant_expr(cx: &LateContext<'_, '_>, tables: &ty::TypeckTables<'_>, expr: &Expr) -> bool {
     match &expr.node {
-        ExprKind::Block(block, _) => is_relevant_block(tcx, tables, block),
-        ExprKind::Ret(Some(e)) => is_relevant_expr(tcx, tables, e),
+        ExprKind::Block(block, _) => is_relevant_block(cx, tables, block),
+        ExprKind::Ret(Some(e)) => is_relevant_expr(cx, tables, e),
         ExprKind::Ret(None) | ExprKind::Break(_, None) => false,
         ExprKind::Call(path_expr, _) => {
             if let ExprKind::Path(qpath) = &path_expr.node {
                 if let Some(fun_id) = tables.qpath_def(qpath, path_expr.hir_id).opt_def_id() {
-                    !match_def_path(tcx, fun_id, &paths::BEGIN_PANIC)
+                    !cx.match_def_path(fun_id, &paths::BEGIN_PANIC)
                 } else {
                     true
                 }

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -5,7 +5,7 @@ use rustc::ty;
 use rustc::{declare_tool_lint, lint_array};
 use rustc_errors::Applicability;
 
-use crate::utils::{any_parent_is_automatically_derived, match_def_path, paths, span_lint_and_sugg};
+use crate::utils::{any_parent_is_automatically_derived, paths, span_lint_and_sugg};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for literal calls to `Default::default()`.
@@ -48,7 +48,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DefaultTraitAccess {
             if !any_parent_is_automatically_derived(cx.tcx, expr.hir_id);
             if let ExprKind::Path(ref qpath) = path.node;
             if let Some(def_id) = cx.tables.qpath_def(qpath, path.hir_id).opt_def_id();
-            if match_def_path(cx.tcx, def_id, &paths::DEFAULT_TRAIT_METHOD);
+            if cx.match_def_path(def_id, &paths::DEFAULT_TRAIT_METHOD);
             then {
                 match qpath {
                     QPath::Resolved(..) => {

--- a/clippy_lints/src/drop_bounds.rs
+++ b/clippy_lints/src/drop_bounds.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, paths, span_lint};
+use crate::utils::{paths, span_lint};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateLintPass, LintArray, LintPass};
@@ -66,7 +66,7 @@ fn lint_bound<'a, 'tcx>(cx: &rustc::lint::LateContext<'a, 'tcx>, bound: &'tcx Ge
     if_chain! {
         if let GenericBound::Trait(t, _) = bound;
         if let Some(def_id) = t.trait_ref.path.def.opt_def_id();
-        if match_def_path(cx.tcx, def_id, &paths::DROP_TRAIT);
+        if cx.match_def_path(def_id, &paths::DROP_TRAIT);
         then {
             span_lint(
                 cx,

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_copy, match_def_path, paths, span_note_and_lint};
+use crate::utils::{is_copy, paths, span_note_and_lint};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -132,10 +132,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                 let arg_ty = cx.tables.expr_ty(arg);
 
                 if let ty::Ref(..) = arg_ty.sty {
-                    if match_def_path(cx.tcx, def_id, &paths::DROP) {
+                    if cx.match_def_path(def_id, &paths::DROP) {
                         lint = DROP_REF;
                         msg = DROP_REF_SUMMARY.to_string();
-                    } else if match_def_path(cx.tcx, def_id, &paths::MEM_FORGET) {
+                    } else if cx.match_def_path(def_id, &paths::MEM_FORGET) {
                         lint = FORGET_REF;
                         msg = FORGET_REF_SUMMARY.to_string();
                     } else {
@@ -148,10 +148,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                                        arg.span,
                                        &format!("argument has type {}", arg_ty));
                 } else if is_copy(cx, arg_ty) {
-                    if match_def_path(cx.tcx, def_id, &paths::DROP) {
+                    if cx.match_def_path(def_id, &paths::DROP) {
                         lint = DROP_COPY;
                         msg = DROP_COPY_SUMMARY.to_string();
-                    } else if match_def_path(cx.tcx, def_id, &paths::MEM_FORGET) {
+                    } else if cx.match_def_path(def_id, &paths::MEM_FORGET) {
                         lint = FORGET_COPY;
                         msg = FORGET_COPY_SUMMARY.to_string();
                     } else {

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_expn_of, match_def_path, resolve_node, span_lint, span_lint_and_sugg};
+use crate::utils::{is_expn_of, resolve_node, span_lint, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -54,9 +54,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let ExprKind::Path(ref qpath) = dest_fun.node;
             if let Some(dest_fun_id) =
                 resolve_node(cx, qpath, dest_fun.hir_id).opt_def_id();
-            if let Some(dest_name) = if match_def_path(cx.tcx, dest_fun_id, &["std", "io", "stdio", "stdout"]) {
+            if let Some(dest_name) = if cx.match_def_path(dest_fun_id, &["std", "io", "stdio", "stdout"]) {
                 Some("stdout")
-            } else if match_def_path(cx.tcx, dest_fun_id, &["std", "io", "stdio", "stderr"]) {
+            } else if cx.match_def_path(dest_fun_id, &["std", "io", "stdio", "stderr"]) {
                 Some("stderr")
             } else {
                 None

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -1,7 +1,6 @@
 use crate::utils::paths;
 use crate::utils::{
-    in_macro, is_expn_of, last_path_segment, match_def_path, match_type, resolve_node, snippet, span_lint_and_then,
-    walk_ptrs_ty,
+    in_macro, is_expn_of, last_path_segment, match_type, resolve_node, snippet, span_lint_and_then, walk_ptrs_ty,
 };
 use if_chain::if_chain;
 use rustc::hir::*;
@@ -59,9 +58,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                     if_chain! {
                         if let ExprKind::Path(ref qpath) = fun.node;
                         if let Some(fun_def_id) = resolve_node(cx, qpath, fun.hir_id).opt_def_id();
-                        let new_v1 = match_def_path(cx.tcx, fun_def_id, &paths::FMT_ARGUMENTS_NEWV1);
-                        let new_v1_fmt = match_def_path(
-                            cx.tcx,
+                        let new_v1 = cx.match_def_path(fun_def_id, &paths::FMT_ARGUMENTS_NEWV1);
+                        let new_v1_fmt = cx.match_def_path(
                             fun_def_id,
                             &paths::FMT_ARGUMENTS_NEWV1FORMATTED
                         );
@@ -162,7 +160,7 @@ fn get_single_string_arg<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option
         if args.len() == 2;
         if let ExprKind::Path(ref qpath) = args[1].node;
         if let Some(fun_def_id) = resolve_node(cx, qpath, args[1].hir_id).opt_def_id();
-        if match_def_path(cx.tcx, fun_def_id, &paths::DISPLAY_FMT_METHOD);
+        if cx.match_def_path(fun_def_id, &paths::DISPLAY_FMT_METHOD);
         then {
             let ty = walk_ptrs_ty(cx.tables.pat_ty(&pat[0]));
             if ty.sty == ty::Str || match_type(cx, ty, &paths::STRING) {

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -1,6 +1,4 @@
-use crate::utils::{
-    in_macro, match_def_path, match_trait_method, same_tys, snippet, snippet_with_macro_callsite, span_lint_and_then,
-};
+use crate::utils::{in_macro, match_trait_method, same_tys, snippet, snippet_with_macro_callsite, span_lint_and_then};
 use crate::utils::{paths, resolve_node};
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -99,7 +97,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityConversion {
             ExprKind::Call(ref path, ref args) => {
                 if let ExprKind::Path(ref qpath) = path.node {
                     if let Some(def_id) = resolve_node(cx, qpath, path.hir_id).opt_def_id() {
-                        if match_def_path(cx.tcx, def_id, &paths::FROM_FROM[..]) {
+                        if cx.match_def_path(def_id, &paths::FROM_FROM[..]) {
                             let a = cx.tables.expr_ty(e);
                             let b = cx.tables.expr_ty(&args[0]);
                             if same_tys(cx, a, b) {

--- a/clippy_lints/src/invalid_ref.rs
+++ b/clippy_lints/src/invalid_ref.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, paths, span_help_and_lint};
+use crate::utils::{paths, span_help_and_lint};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -47,12 +47,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidRef {
             if let ty::Ref(..) = cx.tables.expr_ty(expr).sty;
             if let Some(def_id) = cx.tables.qpath_def(qpath, path.hir_id).opt_def_id();
             then {
-                let msg = if match_def_path(cx.tcx, def_id, &paths::MEM_ZEROED) |
-                             match_def_path(cx.tcx, def_id, &paths::INIT)
+                let msg = if cx.match_def_path(def_id, &paths::MEM_ZEROED) |
+                             cx.match_def_path(def_id, &paths::INIT)
                 {
                     ZERO_REF_SUMMARY
-                } else if match_def_path(cx.tcx, def_id, &paths::MEM_UNINIT) |
-                          match_def_path(cx.tcx, def_id, &paths::UNINIT)
+                } else if cx.match_def_path(def_id, &paths::MEM_UNINIT) |
+                          cx.match_def_path(def_id, &paths::UNINIT)
                 {
                     UNINIT_REF_SUMMARY
                 } else {

--- a/clippy_lints/src/mem_discriminant.rs
+++ b/clippy_lints/src/mem_discriminant.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, paths, snippet, span_lint_and_then, walk_ptrs_ty_depth};
+use crate::utils::{paths, snippet, span_lint_and_then, walk_ptrs_ty_depth};
 use if_chain::if_chain;
 use rustc::hir::{Expr, ExprKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -46,7 +46,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemDiscriminant {
             // is `mem::discriminant`
             if let ExprKind::Path(ref func_qpath) = func.node;
             if let Some(def_id) = cx.tables.qpath_def(func_qpath, func.hir_id).opt_def_id();
-            if match_def_path(cx.tcx, def_id, &paths::MEM_DISCRIMINANT);
+            if cx.match_def_path(def_id, &paths::MEM_DISCRIMINANT);
             // type is non-enum
             let ty_param = cx.tables.node_substs(func.hir_id).type_at(0);
             if !ty_param.is_enum();

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, paths, span_lint};
+use crate::utils::{paths, span_lint};
 use rustc::hir::{Expr, ExprKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
@@ -38,7 +38,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemForget {
         if let ExprKind::Call(ref path_expr, ref args) = e.node {
             if let ExprKind::Path(ref qpath) = path_expr.node {
                 if let Some(def_id) = cx.tables.qpath_def(qpath, path_expr.hir_id).opt_def_id() {
-                    if match_def_path(cx.tcx, def_id, &paths::MEM_FORGET) {
+                    if cx.match_def_path(def_id, &paths::MEM_FORGET) {
                         let forgot_ty = cx.tables.expr_ty(&args[0]);
 
                         if forgot_ty.ty_adt_def().map_or(false, |def| def.has_dtor(cx.tcx)) {

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, match_qpath, paths, snippet_with_applicability, span_lint_and_sugg};
+use crate::utils::{match_qpath, paths, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc::hir::{Expr, ExprKind, MutMutable, QPath};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -52,7 +52,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemReplace {
             if func_args.len() == 2;
             if let ExprKind::Path(ref func_qpath) = func.node;
             if let Some(def_id) = cx.tables.qpath_def(func_qpath, func.hir_id).opt_def_id();
-            if match_def_path(cx.tcx, def_id, &paths::MEM_REPLACE);
+            if cx.match_def_path(def_id, &paths::MEM_REPLACE);
 
             // Check that second argument is `Option::None`
             if let ExprKind::Path(ref replacement_qpath) = func_args[1].node;

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -21,10 +21,10 @@ use crate::utils::paths;
 use crate::utils::sugg;
 use crate::utils::{
     get_arg_name, get_parent_expr, get_trait_def_id, has_iter_method, implements_trait, in_macro, is_copy, is_expn_of,
-    is_self, is_self_ty, iter_input_pats, last_path_segment, match_def_path, match_path, match_qpath,
-    match_trait_method, match_type, match_var, method_calls, method_chain_args, remove_blocks, return_ty, same_tys,
-    single_segment_path, snippet, snippet_with_applicability, snippet_with_macro_callsite, span_lint,
-    span_lint_and_sugg, span_lint_and_then, span_note_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth, SpanlessEq,
+    is_self, is_self_ty, iter_input_pats, last_path_segment, match_path, match_qpath, match_trait_method, match_type,
+    match_var, method_calls, method_chain_args, remove_blocks, return_ty, same_tys, single_segment_path, snippet,
+    snippet_with_applicability, snippet_with_macro_callsite, span_lint, span_lint_and_sugg, span_lint_and_then,
+    span_note_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth, SpanlessEq,
 };
 
 #[derive(Clone)]
@@ -1464,7 +1464,7 @@ fn lint_cstring_as_ptr(cx: &LateContext<'_, '_>, expr: &hir::Expr, new: &hir::Ex
         if args.len() == 1;
         if let hir::ExprKind::Path(ref path) = fun.node;
         if let Def::Method(did) = cx.tables.qpath_def(path, fun.hir_id);
-        if match_def_path(cx.tcx, did, &paths::CSTRING_NEW);
+        if cx.match_def_path(did, &paths::CSTRING_NEW);
         then {
             span_lint_and_then(
                 cx,

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -1,5 +1,5 @@
 use crate::consts::{constant_simple, Constant};
-use crate::utils::{match_def_path, paths, span_lint};
+use crate::utils::{paths, span_lint};
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
@@ -73,9 +73,9 @@ fn min_max<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<(MinMax, Cons
     if let ExprKind::Call(ref path, ref args) = expr.node {
         if let ExprKind::Path(ref qpath) = path.node {
             cx.tables.qpath_def(qpath, path.hir_id).opt_def_id().and_then(|def_id| {
-                if match_def_path(cx.tcx, def_id, &paths::CMP_MIN) {
+                if cx.match_def_path(def_id, &paths::CMP_MIN) {
                     fetch_const(cx, args, MinMax::Min)
-                } else if match_def_path(cx.tcx, def_id, &paths::CMP_MAX) {
+                } else if cx.match_def_path(def_id, &paths::CMP_MAX) {
                     fetch_const(cx, args, MinMax::Max)
                 } else {
                     None

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_direct_expn_of, is_expn_of, match_def_path, paths, resolve_node, span_lint};
+use crate::utils::{is_direct_expn_of, is_expn_of, paths, resolve_node, span_lint};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -62,7 +62,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if let ExprKind::Call(ref fun, ref params) = ex.node;
             if let ExprKind::Path(ref qpath) = fun.node;
             if let Some(fun_def_id) = resolve_node(cx, qpath, fun.hir_id).opt_def_id();
-            if match_def_path(cx.tcx, fun_def_id, &paths::BEGIN_PANIC);
+            if cx.match_def_path(fun_def_id, &paths::BEGIN_PANIC);
             if params.len() == 2;
             then {
                 if is_expn_of(expr.span, "unimplemented").is_some() {

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -8,7 +8,7 @@ use syntax::ptr::P;
 
 use crate::utils::paths::*;
 use crate::utils::sugg::Sugg;
-use crate::utils::{match_def_path, match_type, span_lint_and_then, SpanlessEq};
+use crate::utils::{match_type, span_lint_and_then, SpanlessEq};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for expressions that could be replaced by the question mark operator.
@@ -129,7 +129,7 @@ impl Pass {
             ExprKind::Ret(Some(ref expr)) => Self::expression_returns_none(cx, expr),
             ExprKind::Path(ref qp) => {
                 if let Def::Ctor(def_id, def::CtorOf::Variant, _) = cx.tables.qpath_def(qp, expression.hir_id) {
-                    return match_def_path(cx.tcx, def_id, &OPTION_NONE);
+                    return cx.match_def_path(def_id, &OPTION_NONE);
                 }
 
                 false

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -1,5 +1,5 @@
 use crate::consts::{constant, Constant};
-use crate::utils::{is_expn_of, match_def_path, match_type, paths, span_help_and_lint, span_lint};
+use crate::utils::{is_expn_of, match_type, paths, span_help_and_lint, span_lint};
 use if_chain::if_chain;
 use regex_syntax;
 use rustc::hir::*;
@@ -120,15 +120,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
             if args.len() == 1;
             if let Some(def_id) = cx.tables.qpath_def(qpath, fun.hir_id).opt_def_id();
             then {
-                if match_def_path(cx.tcx, def_id, &paths::REGEX_NEW) ||
-                   match_def_path(cx.tcx, def_id, &paths::REGEX_BUILDER_NEW) {
+                if cx.match_def_path(def_id, &paths::REGEX_NEW) ||
+                   cx.match_def_path(def_id, &paths::REGEX_BUILDER_NEW) {
                     check_regex(cx, &args[0], true);
-                } else if match_def_path(cx.tcx, def_id, &paths::REGEX_BYTES_NEW) ||
-                   match_def_path(cx.tcx, def_id, &paths::REGEX_BYTES_BUILDER_NEW) {
+                } else if cx.match_def_path(def_id, &paths::REGEX_BYTES_NEW) ||
+                   cx.match_def_path(def_id, &paths::REGEX_BYTES_BUILDER_NEW) {
                     check_regex(cx, &args[0], false);
-                } else if match_def_path(cx.tcx, def_id, &paths::REGEX_SET_NEW) {
+                } else if cx.match_def_path(def_id, &paths::REGEX_SET_NEW) {
                     check_set(cx, &args[0], true);
-                } else if match_def_path(cx.tcx, def_id, &paths::REGEX_BYTES_SET_NEW) {
+                } else if cx.match_def_path(def_id, &paths::REGEX_BYTES_SET_NEW) {
                     check_set(cx, &args[0], false);
                 }
             }

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, span_lint_and_sugg};
+use crate::utils::span_lint_and_sugg;
 use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::def::Def;
@@ -48,7 +48,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ReplaceConsts {
             if let Def::Const(def_id) = cx.tables.qpath_def(qp, expr.hir_id);
             then {
                 for &(const_path, repl_snip) in REPLACEMENTS {
-                    if match_def_path(cx.tcx, def_id, const_path) {
+                    if cx.match_def_path(def_id, const_path) {
                         span_lint_and_sugg(
                             cx,
                             REPLACE_CONSTS,

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -1,4 +1,4 @@
-use crate::utils::{last_path_segment, match_def_path, paths, snippet, span_lint, span_lint_and_then, sugg};
+use crate::utils::{last_path_segment, paths, snippet, span_lint, span_lint_and_then, sugg};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -231,7 +231,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Transmute {
         if let ExprKind::Call(ref path_expr, ref args) = e.node {
             if let ExprKind::Path(ref qpath) = path_expr.node {
                 if let Some(def_id) = cx.tables.qpath_def(qpath, path_expr.hir_id).opt_def_id() {
-                    if match_def_path(cx.tcx, def_id, &paths::TRANSMUTE) {
+                    if cx.match_def_path(def_id, &paths::TRANSMUTE) {
                         let from_ty = cx.tables.expr_ty(&args[0]);
                         let to_ty = cx.tables.expr_ty(e);
 

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -3,7 +3,7 @@
 
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::utils::{is_expn_of, match_def_path, match_qpath, paths, resolve_node};
+use crate::utils::{is_expn_of, match_qpath, paths, resolve_node};
 use if_chain::if_chain;
 use rustc::lint::LateContext;
 use rustc::{hir, ty};
@@ -216,11 +216,11 @@ pub fn vec_macro<'e>(cx: &LateContext<'_, '_>, expr: &'e hir::Expr) -> Option<Ve
         if is_expn_of(fun.span, "vec").is_some();
         if let Some(fun_def_id) = resolve_node(cx, path, fun.hir_id).opt_def_id();
         then {
-            return if match_def_path(cx.tcx, fun_def_id, &paths::VEC_FROM_ELEM) && args.len() == 2 {
+            return if cx.match_def_path(fun_def_id, &paths::VEC_FROM_ELEM) && args.len() == 2 {
                 // `vec![elem; size]` case
                 Some(VecArgs::Repeat(&args[0], &args[1]))
             }
-            else if match_def_path(cx.tcx, fun_def_id, &paths::SLICE_INTO_VEC) && args.len() == 1 {
+            else if cx.match_def_path(fun_def_id, &paths::SLICE_INTO_VEC) && args.len() == 1 {
                 // `vec![a, b, c]` case
                 if_chain! {
                     if let hir::ExprKind::Box(ref boxed) = args[0].node;

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, match_type, paths, span_help_and_lint, span_lint, walk_ptrs_ty};
+use crate::utils::{match_type, paths, span_help_and_lint, span_lint, walk_ptrs_ty};
 use if_chain::if_chain;
 use rustc::hir;
 use rustc::hir::def::Def;
@@ -144,7 +144,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LintWithoutLintPass {
             if_chain! {
                 if let hir::TraitRef{path, ..} = trait_ref;
                 if let Def::Trait(def_id) = path.def;
-                if match_def_path(cx.tcx, def_id, &paths::LINT_PASS);
+                if cx.match_def_path(def_id, &paths::LINT_PASS);
                 then {
                     let mut collector = LintCollector {
                         output: &mut self.registered_lints,
@@ -196,7 +196,7 @@ fn is_lint_ref_type<'tcx>(cx: &LateContext<'_, 'tcx>, ty: &Ty) -> bool {
     {
         if let TyKind::Path(ref path) = inner.node {
             if let Def::Struct(def_id) = cx.tables.qpath_def(path, inner.hir_id) {
-                return match_def_path(cx.tcx, def_id, &paths::LINT);
+                return cx.match_def_path(def_id, &paths::LINT);
             }
         }
     }

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -96,7 +96,7 @@ pub fn in_macro(span: Span) -> bool {
 /// Checks if type is struct, enum or union type with the given def path.
 pub fn match_type(cx: &LateContext<'_, '_>, ty: Ty<'_>, path: &[&str]) -> bool {
     match ty.sty {
-        ty::Adt(adt, _) => match_def_path(cx.tcx, adt.did, path),
+        ty::Adt(adt, _) => cx.match_def_path(adt.did, path),
         _ => false,
     }
 }
@@ -106,7 +106,7 @@ pub fn match_trait_method(cx: &LateContext<'_, '_>, expr: &Expr, path: &[&str]) 
     let def_id = cx.tables.type_dependent_def_id(expr.hir_id).unwrap();
     let trt_id = cx.tcx.trait_of_item(def_id);
     if let Some(trt_id) = trt_id {
-        match_def_path(cx.tcx, trt_id, path)
+        cx.match_def_path(trt_id, path)
     } else {
         false
     }
@@ -989,7 +989,7 @@ pub fn has_iter_method(cx: &LateContext<'_, '_>, probably_ref_ty: Ty<'_>) -> Opt
     };
 
     for path in &INTO_ITER_COLLECTIONS {
-        if match_def_path(cx.tcx, def_id, path) {
+        if cx.match_def_path(def_id, path) {
             return Some(path.last().unwrap());
         }
     }

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -24,10 +24,8 @@ use if_chain::if_chain;
 use matches::matches;
 use rustc::hir;
 use rustc::hir::def::Def;
-use rustc::hir::def_id::CrateNum;
 use rustc::hir::def_id::{DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc::hir::intravisit::{NestedVisitorMap, Visitor};
-use rustc::hir::map::{DefPathData, DisambiguatedDefPathData};
 use rustc::hir::Node;
 use rustc::hir::*;
 use rustc::lint::{LateContext, Level, Lint, LintContext};
@@ -43,7 +41,7 @@ use rustc_errors::Applicability;
 use syntax::ast::{self, LitKind};
 use syntax::attr;
 use syntax::source_map::{Span, DUMMY_SP};
-use syntax::symbol::{keywords, LocalInternedString, Symbol};
+use syntax::symbol::{keywords, Symbol};
 
 use crate::reexport::*;
 
@@ -93,135 +91,6 @@ pub fn in_constant(cx: &LateContext<'_, '_>, id: HirId) -> bool {
 /// Returns `true` if this `expn_info` was expanded by any macro.
 pub fn in_macro(span: Span) -> bool {
     span.ctxt().outer().expn_info().is_some()
-}
-
-/// Used to store the absolute path to a type.
-///
-/// See `match_def_path` for usage.
-pub struct AbsolutePathPrinter<'a, 'tcx> {
-    pub tcx: TyCtxt<'a, 'tcx, 'tcx>,
-}
-
-use rustc::ty::print::Printer;
-
-#[allow(clippy::diverging_sub_expression)]
-impl<'tcx> Printer<'tcx, 'tcx> for AbsolutePathPrinter<'_, 'tcx> {
-    type Error = !;
-
-    type Path = Vec<LocalInternedString>;
-    type Region = ();
-    type Type = ();
-    type DynExistential = ();
-
-    fn tcx<'a>(&'a self) -> TyCtxt<'a, 'tcx, 'tcx> {
-        self.tcx
-    }
-
-    fn print_region(self, _region: ty::Region<'_>) -> Result<Self::Region, Self::Error> {
-        Ok(())
-    }
-
-    fn print_type(self, _ty: Ty<'tcx>) -> Result<Self::Type, Self::Error> {
-        Ok(())
-    }
-
-    fn print_dyn_existential(
-        self,
-        _predicates: &'tcx ty::List<ty::ExistentialPredicate<'tcx>>,
-    ) -> Result<Self::DynExistential, Self::Error> {
-        Ok(())
-    }
-
-    fn path_crate(self, cnum: CrateNum) -> Result<Self::Path, Self::Error> {
-        Ok(vec![self.tcx.original_crate_name(cnum).as_str()])
-    }
-
-    fn path_qualified(
-        self,
-        self_ty: Ty<'tcx>,
-        trait_ref: Option<ty::TraitRef<'tcx>>,
-    ) -> Result<Self::Path, Self::Error> {
-        if trait_ref.is_none() {
-            if let ty::Adt(def, substs) = self_ty.sty {
-                return self.print_def_path(def.did, substs);
-            }
-        }
-
-        // This shouldn't ever be needed, but just in case:
-        Ok(vec![match trait_ref {
-            Some(trait_ref) => Symbol::intern(&format!("{:?}", trait_ref)).as_str(),
-            None => Symbol::intern(&format!("<{}>", self_ty)).as_str(),
-        }])
-    }
-
-    fn path_append_impl(
-        self,
-        print_prefix: impl FnOnce(Self) -> Result<Self::Path, Self::Error>,
-        _disambiguated_data: &DisambiguatedDefPathData,
-        self_ty: Ty<'tcx>,
-        trait_ref: Option<ty::TraitRef<'tcx>>,
-    ) -> Result<Self::Path, Self::Error> {
-        let mut path = print_prefix(self)?;
-
-        // This shouldn't ever be needed, but just in case:
-        path.push(match trait_ref {
-            Some(trait_ref) => Symbol::intern(&format!("<impl {} for {}>", trait_ref, self_ty)).as_str(),
-            None => Symbol::intern(&format!("<impl {}>", self_ty)).as_str(),
-        });
-
-        Ok(path)
-    }
-
-    fn path_append(
-        self,
-        print_prefix: impl FnOnce(Self) -> Result<Self::Path, Self::Error>,
-        disambiguated_data: &DisambiguatedDefPathData,
-    ) -> Result<Self::Path, Self::Error> {
-        let mut path = print_prefix(self)?;
-
-        // Skip `::{{constructor}}` on tuple/unit structs.
-        if let DefPathData::Ctor = disambiguated_data.data {
-            return Ok(path);
-        }
-
-        path.push(disambiguated_data.data.as_interned_str().as_str());
-        Ok(path)
-    }
-
-    fn path_generic_args(
-        self,
-        print_prefix: impl FnOnce(Self) -> Result<Self::Path, Self::Error>,
-        _args: &[Kind<'tcx>],
-    ) -> Result<Self::Path, Self::Error> {
-        print_prefix(self)
-    }
-}
-
-/// Checks if a `DefId`'s path matches the given absolute type path usage.
-///
-/// # Examples
-/// ```rust,ignore
-/// match_def_path(cx.tcx, id, &["core", "option", "Option"])
-/// ```
-///
-/// See also the `paths` module.
-pub fn match_def_path<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId, path: &[&str]) -> bool {
-    let names = get_def_path(tcx, def_id);
-
-    names.len() == path.len() && names.into_iter().zip(path.iter()).all(|(a, &b)| *a == *b)
-}
-
-/// Gets the absolute path of `def_id` as a vector of `&str`.
-///
-/// # Examples
-/// ```rust,ignore
-/// let def_path = get_def_path(tcx, def_id);
-/// if let &["core", "option", "Option"] = &def_path[..] {
-///     // The given `def_id` is that of an `Option` type
-/// };
-/// ```
-pub fn get_def_path<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> Vec<LocalInternedString> {
-    AbsolutePathPrinter { tcx }.print_def_path(def_id, &[]).unwrap()
 }
 
 /// Checks if type is struct, enum or union type with the given def path.


### PR DESCRIPTION
This is a follow up of the uplift of `{get,match}_def_path` to rustc.

~~This is blocked on rust-lang/rust#59779~~