### PR TITLE
Revert compiletest hacks, use latest compiletest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
 clippy_dev = { version = "0.0.1", path = "clippy_dev" }
 cargo_metadata = "0.7.1"
 compiletest_rs = { version = "0.3.21" }
-libtest = "0.0.1"
 lazy_static = "1.0"
 serde_derive = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
 [dev-dependencies]
 clippy_dev = { version = "0.0.1", path = "clippy_dev" }
 cargo_metadata = "0.7.1"
-compiletest_rs = { version = "=0.3.19", features = ["tmp", "stable"] }
+compiletest_rs = { version = "0.3.21" }
 libtest = "0.0.1"
 lazy_static = "1.0"
 serde_derive = "1.0"

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -74,6 +74,7 @@ fn run_mode(mode: &str, dir: PathBuf) {
     compiletest::run_tests(&cfg);
 }
 
+#[allow(clippy::identity_conversion)]
 fn run_ui_toml_tests(config: &compiletest::Config, mut tests: Vec<test::TestDescAndFn>) -> Result<bool, io::Error> {
     let mut result = true;
     let opts = compiletest::test_opts(config);

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
 use compiletest_rs as compiletest;
-use libtest::TestDescAndFn;
+extern crate test;
 
 use std::env::{set_var, var};
 use std::ffi::OsStr;
@@ -74,12 +74,15 @@ fn run_mode(mode: &str, dir: PathBuf) {
     compiletest::run_tests(&cfg);
 }
 
-#[warn(clippy::identity_conversion)]
-fn run_ui_toml_tests(config: &compiletest::Config, mut tests: Vec<TestDescAndFn>) -> Result<bool, io::Error> {
+fn run_ui_toml_tests(config: &compiletest::Config, mut tests: Vec<test::TestDescAndFn>) -> Result<bool, io::Error> {
     let mut result = true;
     let opts = compiletest::test_opts(config);
     for dir in fs::read_dir(&config.src_base)? {
-        let dir_path = dir.unwrap().path();
+        let dir = dir?;
+        if !dir.file_type()?.is_dir() {
+            continue;
+        }
+        let dir_path = dir.path();
         set_var("CARGO_MANIFEST_DIR", &dir_path);
         for file in fs::read_dir(&dir_path)? {
             let file = file?;
@@ -98,25 +101,9 @@ fn run_ui_toml_tests(config: &compiletest::Config, mut tests: Vec<TestDescAndFn>
             let test_name = compiletest::make_test_name(&config, &paths);
             let index = tests
                 .iter()
-                .position(|test| test.desc.name.to_string() == test_name.to_string())
+                .position(|test| test.desc.name == test_name)
                 .expect("The test should be in there");
-            let opts = libtest::TestOpts {
-                list: opts.list,
-                filter: opts.filter.clone(),
-                filter_exact: opts.filter_exact,
-                exclude_should_panic: Default::default(),
-                run_ignored: libtest::RunIgnored::No,
-                run_tests: opts.run_tests,
-                bench_benchmarks: opts.bench_benchmarks,
-                logfile: opts.logfile.clone(),
-                nocapture: opts.nocapture,
-                color: libtest::ColorConfig::AutoColor,
-                format: libtest::OutputFormat::Pretty,
-                test_threads: opts.test_threads,
-                skip: opts.skip.clone(),
-                options: libtest::Options::new(),
-            };
-            result &= libtest::run_tests_console(&opts, vec![tests.swap_remove(index)])?;
+            result &= test::run_tests_console(&opts, vec![tests.swap_remove(index)])?;
         }
     }
     Ok(result)
@@ -126,22 +113,6 @@ fn run_ui_toml() {
     let path = PathBuf::from("tests/ui-toml").canonicalize().unwrap();
     let config = config("ui", path);
     let tests = compiletest::make_tests(&config);
-
-    let tests = tests
-        .into_iter()
-        .map(|test| {
-            libtest::TestDescAndFn {
-                desc: libtest::TestDesc {
-                    name: libtest::TestName::DynTestName(test.desc.name.to_string()),
-                    ignore: test.desc.ignore,
-                    allow_fail: test.desc.allow_fail,
-                    should_panic: libtest::ShouldPanic::No,
-                },
-                // oli obk giving up
-                testfn: unsafe { std::mem::transmute(test.testfn) },
-            }
-        })
-        .collect();
 
     let res = run_ui_toml_tests(&config, tests);
     match res {


### PR DESCRIPTION
The libtest changes have been reverted, see https://github.com/rust-lang/rust/pull/59766,  https://github.com/laumann/compiletest-rs/pull/174