### PR TITLE
Re-add tmp feature to compiletest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
 [dev-dependencies]
 clippy_dev = { version = "0.0.1", path = "clippy_dev" }
 cargo_metadata = "0.7.1"
-compiletest_rs = { version = "0.3.21" }
+compiletest_rs = { version = "0.3.21", features = ["tmp"] }
 lazy_static = "1.0"
 serde_derive = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }


### PR DESCRIPTION
Got accidentally removed in the rustup