### PR TITLE
Escape a single quote in single_char_pattern hint

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2143,7 +2143,8 @@ fn lint_single_char_pattern<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, _expr: &'tcx h
         then {
             let mut applicability = Applicability::MachineApplicable;
             let snip = snippet_with_applicability(cx, arg.span, "..", &mut applicability);
-            let hint = format!("'{}'", &snip[1..snip.len() - 1]);
+            let c = &snip[1..snip.len() - 1];
+            let hint = format!("'{}'", if c == "'" { "\\'" } else { c });
             span_lint_and_sugg(
                 cx,
                 SINGLE_CHAR_PATTERN,

--- a/tests/ui/single_char_pattern.fixed
+++ b/tests/ui/single_char_pattern.fixed
@@ -41,6 +41,8 @@ fn main() {
     x.trim_end_matches('x');
     // Make sure we escape characters correctly.
     x.split('\n');
+    x.split('\'');
+    x.split('\'');
 
     let h = HashSet::<String>::new();
     h.contains("X"); // should not warn

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -41,6 +41,8 @@ fn main() {
     x.trim_end_matches("x");
     // Make sure we escape characters correctly.
     x.split("\n");
+    x.split("'");
+    x.split("\'");
 
     let h = HashSet::<String>::new();
     h.contains("X"); // should not warn

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -109,16 +109,28 @@ LL |     x.split("/n");
    |             ^^^^ help: try using a char instead: `'/n'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:48:31
+  --> $DIR/single_char_pattern.rs:44:13
+   |
+LL |     x.split("'");
+   |             ^^^ help: try using a char instead: `'/''`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:45:13
+   |
+LL |     x.split("/'");
+   |             ^^^^ help: try using a char instead: `'/''`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:50:31
    |
 LL |     x.replace(";", ",").split(","); // issue #2978
    |                               ^^^ help: try using a char instead: `','`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:49:19
+  --> $DIR/single_char_pattern.rs:51:19
    |
 LL |     x.starts_with("/x03"); // issue #2996
    |                   ^^^^^^ help: try using a char instead: `'/x03'`
 
-error: aborting due to 20 previous errors
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
This PR correctly escapes single quotes in the hint for `single_char_pattern`.
For instance, the hint for `x.split("'")` was `'''`, while it should be `'\''`.