### PR TITLE
Mention that -D warnings will deny ALL warnings, not just clippy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ before_script:
 Note that adding `-D warnings` will cause your build to fail if **any** warnings are found in your code.
 That includes warnings found by rustc (e.g. `dead_code`, etc.). If you want to avoid this and only cause
 an error for clippy warnings, use `#![deny(clippy::all)]` in your code or `-D clippy::all` on the command
-line. (You can swap `clippy::all` with the specific lint category you are targetting.)
+line. (You can swap `clippy::all` with the specific lint category you are targeting.)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ before_script:
    # etc
 ```
 
+Note that adding `-D warnings` will cause your build to fail if **any** warnings are found in your code.
+That includes warnings found by rustc (e.g. `dead_code`, etc.). If you want to avoid this and only cause
+an error for clippy warnings, use `#![deny(clippy::all)]` in your code or `-D clippy::all` on the command
+line. (You can swap `clippy::all` with the specific lint category you are targetting.)
+
 ## Configuration
 
 Some lints can be configured in a TOML file named `clippy.toml` or `.clippy.toml`. It contains a basic `variable = value` mapping eg.


### PR DESCRIPTION
If we pass `-D warnings` to clippy, it causes the build to fail if there are *any* warnings, even the ones not generated by clippy. This isn't immediately obvious when you're looking at this as someone just setting up clippy, so people might not expect this nor know how to fix it. I've added a few sentences in the README to help anyone who runs into this.

These docs are useful for anyone setting up clippy warnings to be denied during CI, but still otherwise want rustc warnings to be allowed.

I could have also changed `-D warnings` to `-D clippy::all` in the Travis configurations themselves, but I wasn't sure what you would prefer to have people use as the default.