### PR TITLE
fix format does not parse escaped braces error

### DIFF
--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -91,7 +91,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                 ExprKind::Match(ref matchee, _, _) => {
                     if let ExprKind::Tup(ref tup) = matchee.node {
                         if tup.is_empty() {
-                            let sugg = format!("{}.to_string()", snippet(cx, expr.span, "<expr>").into_owned());
+                            let actual_snippet = snippet(cx, expr.span, "<expr>").to_string();
+                            let actual_snippet = actual_snippet.replace("{{}}", "{}");
+                            let sugg = format!("{}.to_string()", actual_snippet);
                             span_useless_format(cx, span, "consider using .to_string()", sugg);
                         }
                     }

--- a/tests/ui/format.fixed
+++ b/tests/ui/format.fixed
@@ -11,6 +11,8 @@ macro_rules! foo {
 
 fn main() {
     "foo".to_string();
+    "{}".to_string();
+    "{} abc {}".to_string();
 
     "foo".to_string();
     format!("{:?}", "foo"); // Don't warn about `Debug`.

--- a/tests/ui/format.rs
+++ b/tests/ui/format.rs
@@ -11,6 +11,8 @@ macro_rules! foo {
 
 fn main() {
     format!("foo");
+    format!("{{}}");
+    format!("{{}} abc {{}}");
 
     format!("{}", "foo");
     format!("{:?}", "foo"); // Don't warn about `Debug`.

--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -7,52 +7,64 @@ LL |     format!("foo");
    = note: `-D clippy::useless-format` implied by `-D warnings`
 
 error: useless use of `format!`
+  --> $DIR/format.rs:14:5
+   |
+LL |     format!("{{}}");
+   |     ^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"{}".to_string();`
+
+error: useless use of `format!`
   --> $DIR/format.rs:15:5
+   |
+LL |     format!("{{}} abc {{}}");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"{} abc {}".to_string();`
+
+error: useless use of `format!`
+  --> $DIR/format.rs:17:5
    |
 LL |     format!("{}", "foo");
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string();`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:19:5
+  --> $DIR/format.rs:21:5
    |
 LL |     format!("{:+}", "foo"); // Warn when the format makes no difference.
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string();`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:20:5
+  --> $DIR/format.rs:22:5
    |
 LL |     format!("{:<}", "foo"); // Warn when the format makes no difference.
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string();`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:25:5
+  --> $DIR/format.rs:27:5
    |
 LL |     format!("{}", arg);
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `arg.to_string();`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:29:5
+  --> $DIR/format.rs:31:5
    |
 LL |     format!("{:+}", arg); // Warn when the format makes no difference.
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `arg.to_string();`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:30:5
+  --> $DIR/format.rs:32:5
    |
 LL |     format!("{:<}", arg); // Warn when the format makes no difference.
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `arg.to_string();`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:57:5
+  --> $DIR/format.rs:59:5
    |
 LL |     format!("{}", 42.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `to_string()` is enough: `42.to_string();`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:59:5
+  --> $DIR/format.rs:61:5
    |
 LL |     format!("{}", x.display().to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `to_string()` is enough: `x.display().to_string();`
 
-error: aborting due to 9 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
related: https://github.com/rust-lang/rust-clippy/issues/3920