### PR TITLE
Add Marwes/combine to integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,8 @@ matrix:
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=bluss/rust-itertools
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
+    - env: INTEGRATION=Marwes/combine
+      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
   allow_failures:
   - os: windows
     env: CARGO_INCREMENTAL=0 BASE_TESTS=true


### PR DESCRIPTION
repo link: https://github.com/Marwes/combine

`combine` uses a lot of macros internally, has been downloaded more than 200_000
times and is also a dependency of [`redis-rs`](https://crates.io/crates/redis).

Clippy also previously ICEd on combine in #3747 so I think it would be
good to have this crate as an integration test.