### PR TITLE
Remove `except` in suspicious_else_formatting

### DIFF
--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -165,23 +165,23 @@ fn check_else(cx: &EarlyContext<'_>, expr: &ast::Expr) {
             // the snippet should look like " else \n    " with maybe comments anywhere
             // it’s bad when there is a ‘\n’ after the “else”
             if let Some(else_snippet) = snippet_opt(cx, else_span) {
-                let else_pos = else_snippet.find("else").expect("there must be a `else` here");
+                if let Some(else_pos) = else_snippet.find("else") {
+                    if else_snippet[else_pos..].contains('\n') {
+                        let else_desc = if unsugar_if(else_).is_some() { "if" } else { "{..}" };
 
-                if else_snippet[else_pos..].contains('\n') {
-                    let else_desc = if unsugar_if(else_).is_some() { "if" } else { "{..}" };
-
-                    span_note_and_lint(
-                        cx,
-                        SUSPICIOUS_ELSE_FORMATTING,
-                        else_span,
-                        &format!("this is an `else {}` but the formatting might hide it", else_desc),
-                        else_span,
-                        &format!(
-                            "to remove this lint, remove the `else` or remove the new line between \
-                             `else` and `{}`",
-                            else_desc,
-                        ),
-                    );
+                        span_note_and_lint(
+                            cx,
+                            SUSPICIOUS_ELSE_FORMATTING,
+                            else_span,
+                            &format!("this is an `else {}` but the formatting might hide it", else_desc),
+                            else_span,
+                            &format!(
+                                "to remove this lint, remove the `else` or remove the new line between \
+                                 `else` and `{}`",
+                                else_desc,
+                            ),
+                        );
+                    }
                 }
             }
         }

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -1,9 +1,9 @@
 use crate::utils::{differing_macro_contexts, in_macro, snippet_opt, span_note_and_lint};
+use if_chain::if_chain;
 use rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, lint_array};
 use syntax::ast;
 use syntax::ptr::P;
-use if_chain::if_chain;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for use of the non-existent `=*`, `=!` and `=-`
@@ -157,8 +157,7 @@ fn check_else(cx: &EarlyContext<'_>, expr: &ast::Expr) {
         if expr.span.lo().0 != 0 && expr.span.hi().0 != 0;
 
         // this will be a span from the closing ‘}’ of the “then” block (excluding) to
-        // the
-        // “if” of the “else if” block (excluding)
+        // the “if” of the “else if” block (excluding)
         let else_span = then.span.between(else_.span);
 
         // the snippet should look like " else \n    " with maybe comments anywhere


### PR DESCRIPTION
96c34e85 contains the fix:

This was causing two different ICEs in #3741. The first was fixed in #3925.

The second one is fixed with this commit: We just don't `expect` anymore.
If the snippet doesn't contain an `else`, we stop emitting the lint because
it's not a suspiciously formatted else anyway.

Unfortunately I wasn't able to provide a minimal test case, but I think it's
fine since it's just ignoring the `None` case now.

And ad27e3ff cleans up the lint code to use `if_chain`.

Fixes #3741 once more.