### PR TITLE
Suggest .copied() instead of .cloned() in map_clone where applicable

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -1,6 +1,6 @@
 use crate::utils::paths;
 use crate::utils::{
-    in_macro, match_trait_method, match_type, remove_blocks, snippet_with_applicability, span_lint_and_sugg,
+    in_macro, match_trait_method, match_type, remove_blocks, snippet_with_applicability, span_lint_and_sugg, is_copy
 };
 use if_chain::if_chain;
 use rustc::hir;
@@ -88,8 +88,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                                     && match_trait_method(cx, closure_expr, &paths::CLONE_TRAIT) {
 
                                     let obj_ty = cx.tables.expr_ty(&obj[0]);
-                                    if let ty::Ref(..) = obj_ty.sty {
-                                        lint(cx, e.span, args[0].span, false);
+                                    if let ty::Ref(_, ty, _) = obj_ty.sty {
+                                        let copy = is_copy(cx, ty);
+                                        lint(cx, e.span, args[0].span, copy);
                                     } else {
                                         lint_needless_cloning(cx, e.span, args[0].span);
                                     }

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -4,11 +4,12 @@
 #![allow(clippy::clone_on_copy)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure)]
+#![feature(iter_copied)]
 
 fn main() {
-    let _: Vec<i8> = vec![5_i8; 6].iter().cloned().collect();
+    let _: Vec<i8> = vec![5_i8; 6].iter().copied().collect();
     let _: Vec<String> = vec![String::new()].iter().cloned().collect();
-    let _: Vec<u32> = vec![42, 43].iter().cloned().collect();
+    let _: Vec<u32> = vec![42, 43].iter().copied().collect();
     let _: Option<u64> = Some(Box::new(16)).map(|b| *b);
 
     // Don't lint these

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -11,6 +11,7 @@ fn main() {
     let _: Vec<String> = vec![String::new()].iter().cloned().collect();
     let _: Vec<u32> = vec![42, 43].iter().copied().collect();
     let _: Option<u64> = Some(Box::new(16)).map(|b| *b);
+    let _: Vec<u8> = vec![1; 6].iter().copied().collect();
 
     // Don't lint these
     let v = vec![5_i8; 6];

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -4,14 +4,14 @@
 #![allow(clippy::clone_on_copy)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure)]
-#![feature(iter_copied)]
 
 fn main() {
-    let _: Vec<i8> = vec![5_i8; 6].iter().copied().collect();
+    let _: Vec<i8> = vec![5_i8; 6].iter().cloned().collect();
     let _: Vec<String> = vec![String::new()].iter().cloned().collect();
-    let _: Vec<u32> = vec![42, 43].iter().copied().collect();
+    let _: Vec<u32> = vec![42, 43].iter().cloned().collect();
     let _: Option<u64> = Some(Box::new(16)).map(|b| *b);
-    let _: Vec<u8> = vec![1; 6].iter().copied().collect();
+    let _: Option<u64> = Some(&16).copied();
+    let _: Option<u8> = Some(&1).copied();
 
     // Don't lint these
     let v = vec![5_i8; 6];

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -11,6 +11,7 @@ fn main() {
     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
     let _: Option<u64> = Some(Box::new(16)).map(|b| *b);
+    let _: Vec<u8> = vec![1; 6].iter().map(|x| x.clone()).collect();
 
     // Don't lint these
     let v = vec![5_i8; 6];

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -4,14 +4,14 @@
 #![allow(clippy::clone_on_copy)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure)]
-#![feature(iter_copied)]
 
 fn main() {
     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
     let _: Option<u64> = Some(Box::new(16)).map(|b| *b);
-    let _: Vec<u8> = vec![1; 6].iter().map(|x| x.clone()).collect();
+    let _: Option<u64> = Some(&16).map(|b| *b);
+    let _: Option<u8> = Some(&1).map(|x| x.clone());
 
     // Don't lint these
     let v = vec![5_i8; 6];

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::clone_on_copy)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure)]
+#![feature(iter_copied)]
 
 fn main() {
     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -1,25 +1,25 @@
-error: You are using an explicit closure for cloning elements
-  --> $DIR/map_clone.rs:9:22
+error: You are using an explicit closure for copying elements
+  --> $DIR/map_clone.rs:10:22
    |
 LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `vec![5_i8; 6].iter().cloned()`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![5_i8; 6].iter().copied()`
    |
    = note: `-D clippy::map-clone` implied by `-D warnings`
 
 error: You are using an explicit closure for cloning elements
-  --> $DIR/map_clone.rs:10:26
+  --> $DIR/map_clone.rs:11:26
    |
 LL |     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `vec![String::new()].iter().cloned()`
 
-error: You are using an explicit closure for cloning elements
-  --> $DIR/map_clone.rs:11:23
+error: You are using an explicit closure for copying elements
+  --> $DIR/map_clone.rs:12:23
    |
 LL |     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `vec![42, 43].iter().cloned()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![42, 43].iter().copied()`
 
 error: You are needlessly cloning iterator elements
-  --> $DIR/map_clone.rs:23:29
+  --> $DIR/map_clone.rs:24:29
    |
 LL |     let _ = std::env::args().map(|v| v.clone());
    |                             ^^^^^^^^^^^^^^^^^^^ help: Remove the map call

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -18,11 +18,17 @@ error: You are using an explicit closure for copying elements
 LL |     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![42, 43].iter().copied()`
 
+error: You are using an explicit closure for copying elements
+  --> $DIR/map_clone.rs:14:22
+   |
+LL |     let _: Vec<u8> = vec![1; 6].iter().map(|x| x.clone()).collect();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![1; 6].iter().copied()`
+
 error: You are needlessly cloning iterator elements
-  --> $DIR/map_clone.rs:24:29
+  --> $DIR/map_clone.rs:25:29
    |
 LL |     let _ = std::env::args().map(|v| v.clone());
    |                             ^^^^^^^^^^^^^^^^^^^ help: Remove the map call
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -1,28 +1,34 @@
-error: You are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:10:22
+error: You are using an explicit closure for cloning elements
+  --> $DIR/map_clone.rs:9:22
    |
 LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![5_i8; 6].iter().copied()`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `vec![5_i8; 6].iter().cloned()`
    |
    = note: `-D clippy::map-clone` implied by `-D warnings`
 
 error: You are using an explicit closure for cloning elements
-  --> $DIR/map_clone.rs:11:26
+  --> $DIR/map_clone.rs:10:26
    |
 LL |     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `vec![String::new()].iter().cloned()`
 
-error: You are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:12:23
+error: You are using an explicit closure for cloning elements
+  --> $DIR/map_clone.rs:11:23
    |
 LL |     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![42, 43].iter().copied()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `vec![42, 43].iter().cloned()`
 
 error: You are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:14:22
+  --> $DIR/map_clone.rs:13:26
    |
-LL |     let _: Vec<u8> = vec![1; 6].iter().map(|x| x.clone()).collect();
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![1; 6].iter().copied()`
+LL |     let _: Option<u64> = Some(&16).map(|b| *b);
+   |                          ^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `Some(&16).copied()`
+
+error: You are using an explicit closure for copying elements
+  --> $DIR/map_clone.rs:14:25
+   |
+LL |     let _: Option<u8> = Some(&1).map(|x| x.clone());
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `Some(&1).copied()`
 
 error: You are needlessly cloning iterator elements
   --> $DIR/map_clone.rs:25:29
@@ -30,5 +36,5 @@ error: You are needlessly cloning iterator elements
 LL |     let _ = std::env::args().map(|v| v.clone());
    |                             ^^^^^^^^^^^^^^^^^^^ help: Remove the map call
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION


partial fix for https://github.com/rust-lang/rust-clippy/issues/3958

changelog: Improve suggestion in `map_clone` to suggest `.copied()` where applicable