### PR TITLE
Change while_let_loop applicability to HasPlaceholders

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -530,12 +530,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
                                     return;
                                 }
 
-                                // NOTE: we used to make build a body here instead of using
+                                // NOTE: we used to build a body here instead of using
                                 // ellipsis, this was removed because:
                                 // 1) it was ugly with big bodies;
                                 // 2) it was not indented properly;
                                 // 3) it wasn’t very smart (see #675).
-                                let mut applicability = Applicability::MachineApplicable;
+                                let mut applicability = Applicability::HasPlaceholders;
                                 span_lint_and_sugg(
                                     cx,
                                     WHILE_LET_LOOP,


### PR DESCRIPTION
The suggestion has been changed at some point to use `..` in the suggested code.
Due to that we can't make the lint MachineApplicable anymore.

cc #3630