### PR TITLE
Add run-rustfix for deref_addrof lint

### DIFF
--- a/tests/ui/deref_addrof.fixed
+++ b/tests/ui/deref_addrof.fixed
@@ -1,0 +1,39 @@
+// run-rustfix
+
+fn get_number() -> usize {
+    10
+}
+
+fn get_reference(n: &usize) -> &usize {
+    n
+}
+
+#[allow(clippy::many_single_char_names, clippy::double_parens)]
+#[allow(unused_variables, unused_parens)]
+#[warn(clippy::deref_addrof)]
+fn main() {
+    let a = 10;
+    let aref = &a;
+
+    let b = a;
+
+    let b = get_number();
+
+    let b = *get_reference(&a);
+
+    let bytes: Vec<usize> = vec![1, 2, 3, 4];
+    let b = bytes[1..2][0];
+
+    //This produces a suggestion of 'let b = (a);' which
+    //will trigger the 'unused_parens' lint
+    let b = (a);
+
+    let b = a;
+
+    #[rustfmt::skip]
+    let b = a;
+
+    let b = &a;
+
+    let b = *aref;
+}

--- a/tests/ui/deref_addrof.rs
+++ b/tests/ui/deref_addrof.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 fn get_number() -> usize {
     10
 }
@@ -7,7 +9,7 @@ fn get_reference(n: &usize) -> &usize {
 }
 
 #[allow(clippy::many_single_char_names, clippy::double_parens)]
-#[allow(unused_variables)]
+#[allow(unused_variables, unused_parens)]
 #[warn(clippy::deref_addrof)]
 fn main() {
     let a = 10;
@@ -34,20 +36,4 @@ fn main() {
     let b = *&&a;
 
     let b = **&aref;
-
-    //This produces a suggestion of 'let b = *&a;' which
-    //will trigger the 'clippy::deref_addrof' lint again
-    let b = **&&a;
-
-    {
-        let mut x = 10;
-        let y = *&mut x;
-    }
-
-    {
-        //This produces a suggestion of 'let y = *&mut x' which
-        //will trigger the 'clippy::deref_addrof' lint again
-        let mut x = 10;
-        let y = **&mut &mut x;
-    }
 }

--- a/tests/ui/deref_addrof.stderr
+++ b/tests/ui/deref_addrof.stderr
@@ -1,5 +1,5 @@
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:16:13
+  --> $DIR/deref_addrof.rs:18:13
    |
 LL |     let b = *&a;
    |             ^^^ help: try this: `a`
@@ -7,64 +7,46 @@ LL |     let b = *&a;
    = note: `-D clippy::deref-addrof` implied by `-D warnings`
 
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:18:13
+  --> $DIR/deref_addrof.rs:20:13
    |
 LL |     let b = *&get_number();
    |             ^^^^^^^^^^^^^^ help: try this: `get_number()`
 
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:23:13
+  --> $DIR/deref_addrof.rs:25:13
    |
 LL |     let b = *&bytes[1..2][0];
    |             ^^^^^^^^^^^^^^^^ help: try this: `bytes[1..2][0]`
 
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:27:13
+  --> $DIR/deref_addrof.rs:29:13
    |
 LL |     let b = *&(a);
    |             ^^^^^ help: try this: `(a)`
 
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:29:13
+  --> $DIR/deref_addrof.rs:31:13
    |
 LL |     let b = *(&a);
    |             ^^^^^ help: try this: `a`
 
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:32:13
+  --> $DIR/deref_addrof.rs:34:13
    |
 LL |     let b = *((&a));
    |             ^^^^^^^ help: try this: `a`
 
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:34:13
+  --> $DIR/deref_addrof.rs:36:13
    |
 LL |     let b = *&&a;
    |             ^^^^ help: try this: `&a`
 
 error: immediately dereferencing a reference
-  --> $DIR/reference.rs:36:14
+  --> $DIR/deref_addrof.rs:38:14
    |
 LL |     let b = **&aref;
    |              ^^^^^^ help: try this: `aref`
 
-error: immediately dereferencing a reference
-  --> $DIR/reference.rs:40:14
-   |
-LL |     let b = **&&a;
-   |              ^^^^ help: try this: `&a`
-
-error: immediately dereferencing a reference
-  --> $DIR/reference.rs:44:17
-   |
-LL |         let y = *&mut x;
-   |                 ^^^^^^^ help: try this: `x`
-
-error: immediately dereferencing a reference
-  --> $DIR/reference.rs:51:18
-   |
-LL |         let y = **&mut &mut x;
-   |                  ^^^^^^^^^^^^ help: try this: `&mut x`
-
-error: aborting due to 11 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/deref_addrof_double_trigger.rs
+++ b/tests/ui/deref_addrof_double_trigger.rs
@@ -1,0 +1,21 @@
+#[warn(clippy::deref_addrof)]
+#[allow(unused_variables)]
+fn main() {
+    let a = 10;
+
+    //This produces a suggestion of 'let b = *&a;' which
+    //will trigger the 'clippy::deref_addrof' lint again
+    let b = **&&a;
+
+    {
+        let mut x = 10;
+        let y = *&mut x;
+    }
+
+    {
+        //This produces a suggestion of 'let y = *&mut x' which
+        //will trigger the 'clippy::deref_addrof' lint again
+        let mut x = 10;
+        let y = **&mut &mut x;
+    }
+}

--- a/tests/ui/deref_addrof_double_trigger.stderr
+++ b/tests/ui/deref_addrof_double_trigger.stderr
@@ -1,0 +1,22 @@
+error: immediately dereferencing a reference
+  --> $DIR/deref_addrof_double_trigger.rs:8:14
+   |
+LL |     let b = **&&a;
+   |              ^^^^ help: try this: `&a`
+   |
+   = note: `-D clippy::deref-addrof` implied by `-D warnings`
+
+error: immediately dereferencing a reference
+  --> $DIR/deref_addrof_double_trigger.rs:12:17
+   |
+LL |         let y = *&mut x;
+   |                 ^^^^^^^ help: try this: `x`
+
+error: immediately dereferencing a reference
+  --> $DIR/deref_addrof_double_trigger.rs:19:18
+   |
+LL |         let y = **&mut &mut x;
+   |                  ^^^^^^^^^^^^ help: try this: `&mut x`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
* renames `tests/ui/reference.{rs,stderr}` to
  `tests/ui/deref_addrof.{rs,stderr}
* Moves small part of the testfile to a separate file as the lint
  triggered again on the fixed code (as intended)
* Adds `// run-rustfix` to `tests/ui/deref_addrof.rs`

cc #3630