### PR TITLE
Fix bool_comparison lint usage with macros

### DIFF
--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -226,6 +226,11 @@ fn check_comparison<'a, 'tcx>(
 
     if let ExprKind::Binary(_, ref left_side, ref right_side) = e.node {
         let (l_ty, r_ty) = (cx.tables.expr_ty(left_side), cx.tables.expr_ty(right_side));
+
+        if in_macro(left_side.span) || in_macro(right_side.span) {
+            return;
+        }
+
         if l_ty.is_bool() && r_ty.is_bool() {
             let mut applicability = Applicability::MachineApplicable;
             match (fetch_bool_expr(left_side), fetch_bool_expr(right_side)) {

--- a/tests/ui/bool_comparison.fixed
+++ b/tests/ui/bool_comparison.fixed
@@ -74,6 +74,7 @@ fn main() {
     } else {
         "no"
     };
+    issue3973();
 }
 
 #[allow(dead_code)]
@@ -110,4 +111,9 @@ fn issue3703() {
     if false != Foo {}
     if Foo < false {}
     if false < Foo {}
+}
+
+fn issue3973() {
+    let abc = false;
+    if abc == cfg!(feature = "debugging") {}
 }

--- a/tests/ui/bool_comparison.rs
+++ b/tests/ui/bool_comparison.rs
@@ -74,6 +74,7 @@ fn main() {
     } else {
         "no"
     };
+    issue3973();
 }
 
 #[allow(dead_code)]
@@ -110,4 +111,9 @@ fn issue3703() {
     if false != Foo {}
     if Foo < false {}
     if false < Foo {}
+}
+
+fn issue3973() {
+    let abc = false;
+    if abc == cfg!(feature = "debugging") {}
 }


### PR DESCRIPTION
Fixes #3973.

Clippy gives wrong suggestions on bool comparisons with results of macros, such as e.g. `bool == cfg!(feature = abc)`. This PR fixes the problem by checking if any side of a binary expresion is expanded from a macro.

There's a similar problem present with `rustfix`, so the `bool_comparison.fixed` file has been changed manually for now.