### PR TITLE
Change naive_bytecount applicability to MaybeIncorrect

### DIFF
--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ByteCount {
                         } else {
                             &filter_args[0]
                         };
-                        let mut applicability = Applicability::MachineApplicable;
+                        let mut applicability = Applicability::MaybeIncorrect;
                         span_lint_and_sugg(
                             cx,
                             NAIVE_BYTECOUNT,


### PR DESCRIPTION
We can't use `MachineApplicable` here as applying the fix will cause
another error because `bytecount` would first have to be added to the
Cargo.toml.

Example:

```
error: You appear to be counting bytes the naive way
  --> $DIR/bytecount.rs:5:13
   |
LL |     let _ = x.iter().filter(|&&a| a == 0).count(); // naive byte count
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider using the bytecount crate: `bytecount::count(x, 0)`
```

Just replacing it with the suggestion is not enough.

cc #3630 