### PR TITLE
Move two cast_lossless tests to their correct files

### DIFF
--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -2,8 +2,7 @@
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
-    clippy::cast_possible_wrap,
-    clippy::cast_lossless
+    clippy::cast_possible_wrap
 )]
 #[allow(clippy::no_effect, clippy::unnecessary_operation)]
 fn main() {
@@ -32,10 +31,6 @@ fn main() {
     1u32 as i32;
     1u64 as i64;
     1usize as isize;
-    // Test clippy::cast_lossless with casts from floating-point types
-    1.0f32 as f64;
-    // Test clippy::cast_lossless with an expression wrapped in parens
-    (1u8 + 1u8) as u16;
     // Test clippy::cast_sign_loss
     1i32 as u32;
     -1i32 as u32;

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -1,5 +1,5 @@
 error: casting i32 to f32 causes a loss of precision (i32 is 32 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:12:5
+  --> $DIR/cast.rs:11:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
@@ -7,37 +7,37 @@ LL |     x0 as f32;
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
 
 error: casting i64 to f32 causes a loss of precision (i64 is 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:14:5
+  --> $DIR/cast.rs:13:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
 error: casting i64 to f64 causes a loss of precision (i64 is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:15:5
+  --> $DIR/cast.rs:14:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
 error: casting u32 to f32 causes a loss of precision (u32 is 32 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:17:5
+  --> $DIR/cast.rs:16:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^
 
 error: casting u64 to f32 causes a loss of precision (u64 is 64 bits wide, but f32's mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:19:5
+  --> $DIR/cast.rs:18:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^
 
 error: casting u64 to f64 causes a loss of precision (u64 is 64 bits wide, but f64's mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:20:5
+  --> $DIR/cast.rs:19:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^
 
 error: casting f32 to i32 may truncate the value
-  --> $DIR/cast.rs:22:5
+  --> $DIR/cast.rs:21:5
    |
 LL |     1f32 as i32;
    |     ^^^^^^^^^^^
@@ -45,13 +45,13 @@ LL |     1f32 as i32;
    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
 
 error: casting f32 to u32 may truncate the value
-  --> $DIR/cast.rs:23:5
+  --> $DIR/cast.rs:22:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
 
 error: casting f32 to u32 may lose the sign of the value
-  --> $DIR/cast.rs:23:5
+  --> $DIR/cast.rs:22:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -59,43 +59,43 @@ LL |     1f32 as u32;
    = note: `-D clippy::cast-sign-loss` implied by `-D warnings`
 
 error: casting f64 to f32 may truncate the value
-  --> $DIR/cast.rs:24:5
+  --> $DIR/cast.rs:23:5
    |
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
 
 error: casting i32 to i8 may truncate the value
-  --> $DIR/cast.rs:25:5
+  --> $DIR/cast.rs:24:5
    |
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
 
 error: casting i32 to u8 may truncate the value
-  --> $DIR/cast.rs:26:5
+  --> $DIR/cast.rs:25:5
    |
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
 
 error: casting f64 to isize may truncate the value
-  --> $DIR/cast.rs:27:5
+  --> $DIR/cast.rs:26:5
    |
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting f64 to usize may truncate the value
-  --> $DIR/cast.rs:28:5
+  --> $DIR/cast.rs:27:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting f64 to usize may lose the sign of the value
-  --> $DIR/cast.rs:28:5
+  --> $DIR/cast.rs:27:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting u8 to i8 may wrap around the value
-  --> $DIR/cast.rs:30:5
+  --> $DIR/cast.rs:29:5
    |
 LL |     1u8 as i8;
    |     ^^^^^^^^^
@@ -103,57 +103,43 @@ LL |     1u8 as i8;
    = note: `-D clippy::cast-possible-wrap` implied by `-D warnings`
 
 error: casting u16 to i16 may wrap around the value
-  --> $DIR/cast.rs:31:5
+  --> $DIR/cast.rs:30:5
    |
 LL |     1u16 as i16;
    |     ^^^^^^^^^^^
 
 error: casting u32 to i32 may wrap around the value
-  --> $DIR/cast.rs:32:5
+  --> $DIR/cast.rs:31:5
    |
 LL |     1u32 as i32;
    |     ^^^^^^^^^^^
 
 error: casting u64 to i64 may wrap around the value
-  --> $DIR/cast.rs:33:5
+  --> $DIR/cast.rs:32:5
    |
 LL |     1u64 as i64;
    |     ^^^^^^^^^^^
 
 error: casting usize to isize may wrap around the value
-  --> $DIR/cast.rs:34:5
+  --> $DIR/cast.rs:33:5
    |
 LL |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
-error: casting f32 to f64 may become silently lossy if types change
-  --> $DIR/cast.rs:36:5
-   |
-LL |     1.0f32 as f64;
-   |     ^^^^^^^^^^^^^ help: try: `f64::from(1.0f32)`
-   |
-   = note: `-D clippy::cast-lossless` implied by `-D warnings`
-
-error: casting u8 to u16 may become silently lossy if types change
-  --> $DIR/cast.rs:38:5
-   |
-LL |     (1u8 + 1u8) as u16;
-   |     ^^^^^^^^^^^^^^^^^^ help: try: `u16::from(1u8 + 1u8)`
-
 error: casting i32 to u32 may lose the sign of the value
-  --> $DIR/cast.rs:41:5
+  --> $DIR/cast.rs:36:5
    |
 LL |     -1i32 as u32;
    |     ^^^^^^^^^^^^
 
 error: casting isize to usize may lose the sign of the value
-  --> $DIR/cast.rs:43:5
+  --> $DIR/cast.rs:38:5
    |
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/cast.rs:52:5
+  --> $DIR/cast.rs:47:5
    |
 LL |     1i32 as i32;
    |     ^^^^^^^^^^^
@@ -161,34 +147,34 @@ LL |     1i32 as i32;
    = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/cast.rs:53:5
+  --> $DIR/cast.rs:48:5
    |
 LL |     1f32 as f32;
    |     ^^^^^^^^^^^
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/cast.rs:54:5
+  --> $DIR/cast.rs:49:5
    |
 LL |     false as bool;
    |     ^^^^^^^^^^^^^
 
 error: casting integer literal to f32 is unnecessary
-  --> $DIR/cast.rs:57:5
+  --> $DIR/cast.rs:52:5
    |
 LL |     100 as f32;
    |     ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to f64 is unnecessary
-  --> $DIR/cast.rs:58:5
+  --> $DIR/cast.rs:53:5
    |
 LL |     100 as f64;
    |     ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to f64 is unnecessary
-  --> $DIR/cast.rs:59:5
+  --> $DIR/cast.rs:54:5
    |
 LL |     100_i32 as f64;
    |     ^^^^^^^^^^^^^^ help: try: `100_f64`
 
-error: aborting due to 30 previous errors
+error: aborting due to 28 previous errors
 

--- a/tests/ui/cast_lossless_float.fixed
+++ b/tests/ui/cast_lossless_float.fixed
@@ -21,6 +21,9 @@ fn main() {
     f64::from(x4);
     let x5 = 1u32;
     f64::from(x5);
+
+    // Test with casts from floating-point types
+    f64::from(1.0f32);
 }
 
 // The lint would suggest using `f64::from(input)` here but the `XX::from` function is not const,

--- a/tests/ui/cast_lossless_float.rs
+++ b/tests/ui/cast_lossless_float.rs
@@ -21,6 +21,9 @@ fn main() {
     x4 as f64;
     let x5 = 1u32;
     x5 as f64;
+
+    // Test with casts from floating-point types
+    1.0f32 as f64;
 }
 
 // The lint would suggest using `f64::from(input)` here but the `XX::from` function is not const,

--- a/tests/ui/cast_lossless_float.stderr
+++ b/tests/ui/cast_lossless_float.stderr
@@ -60,5 +60,11 @@ error: casting u32 to f64 may become silently lossy if types change
 LL |     x5 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x5)`
 
-error: aborting due to 10 previous errors
+error: casting f32 to f64 may become silently lossy if types change
+  --> $DIR/cast_lossless_float.rs:26:5
+   |
+LL |     1.0f32 as f64;
+   |     ^^^^^^^^^^^^^ help: try: `f64::from(1.0f32)`
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/cast_lossless_integer.fixed
+++ b/tests/ui/cast_lossless_integer.fixed
@@ -23,6 +23,9 @@ fn main() {
     i64::from(1i32);
     i64::from(1u32);
     u64::from(1u32);
+
+    // Test with an expression wrapped in parens
+    u16::from(1u8 + 1u8);
 }
 
 // The lint would suggest using `f64::from(input)` here but the `XX::from` function is not const,

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -23,6 +23,9 @@ fn main() {
     1i32 as i64;
     1u32 as i64;
     1u32 as u64;
+
+    // Test with an expression wrapped in parens
+    (1u8 + 1u8) as u16;
 }
 
 // The lint would suggest using `f64::from(input)` here but the `XX::from` function is not const,

--- a/tests/ui/cast_lossless_integer.stderr
+++ b/tests/ui/cast_lossless_integer.stderr
@@ -108,5 +108,11 @@ error: casting u32 to u64 may become silently lossy if types change
 LL |     1u32 as u64;
    |     ^^^^^^^^^^^ help: try: `u64::from(1u32)`
 
-error: aborting due to 18 previous errors
+error: casting u8 to u16 may become silently lossy if types change
+  --> $DIR/cast_lossless_integer.rs:28:5
+   |
+LL |     (1u8 + 1u8) as u16;
+   |     ^^^^^^^^^^^^^^^^^^ help: try: `u16::from(1u8 + 1u8)`
+
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
First part of checking off the `tests/ui/cast.rs` checkbox in #3630.