### PR TITLE
Add run-rustfix for option_map_or_none lint

### DIFF
--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -148,7 +148,6 @@ impl Mul<T> for T {
 /// Checks implementation of the following lints:
 /// * `OPTION_MAP_UNWRAP_OR`
 /// * `OPTION_MAP_UNWRAP_OR_ELSE`
-/// * `OPTION_MAP_OR_NONE`
 #[rustfmt::skip]
 fn option_methods() {
     let opt = Some(1);
@@ -204,15 +203,6 @@ fn option_methods() {
     // Macro case.
     // Should not lint.
     let _ = opt_map!(opt, |x| x + 1).unwrap_or_else(|| 0);
-
-    // Check `OPTION_MAP_OR_NONE`.
-    // Single line case.
-    let _ = opt.map_or(None, |x| Some(x + 1));
-    // Multi-line case.
-    let _ = opt.map_or(None, |x| {
-                        Some(x + 1)
-                       }
-                );
 }
 
 /// Checks implementation of `FILTER_NEXT` lint.

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -29,7 +29,7 @@ LL |     fn new(self) -> Self {
    |            ^^^^
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:158:13
+  --> $DIR/methods.rs:157:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -41,7 +41,7 @@ LL | |                .unwrap_or(0);
    = note: replace `map(|x| x + 1).unwrap_or(0)` with `map_or(0, |x| x + 1)`
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:162:13
+  --> $DIR/methods.rs:161:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -51,7 +51,7 @@ LL | |               ).unwrap_or(0);
    | |____________________________^
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:166:13
+  --> $DIR/methods.rs:165:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -61,7 +61,7 @@ LL | |                 });
    | |__________________^
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:171:13
+  --> $DIR/methods.rs:170:13
    |
 LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
    = note: replace `map(|x| Some(x + 1)).unwrap_or(None)` with `and_then(|x| Some(x + 1))`
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:173:13
+  --> $DIR/methods.rs:172:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -79,7 +79,7 @@ LL | |     ).unwrap_or(None);
    | |_____________________^
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:177:13
+  --> $DIR/methods.rs:176:13
    |
 LL |       let _ = opt
    |  _____________^
@@ -90,7 +90,7 @@ LL | |         .unwrap_or(None);
    = note: replace `map(|x| Some(x + 1)).unwrap_or(None)` with `and_then(|x| Some(x + 1))`
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:188:13
+  --> $DIR/methods.rs:187:13
    |
 LL |     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -98,7 +98,7 @@ LL |     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
    = note: replace `map(|p| format!("{}.", p)).unwrap_or(id)` with `map_or(id, |p| format!("{}.", p))`
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:192:13
+  --> $DIR/methods.rs:191:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -110,7 +110,7 @@ LL | |                .unwrap_or_else(|| 0);
    = note: replace `map(|x| x + 1).unwrap_or_else(|| 0)` with `map_or_else(|| 0, |x| x + 1)`
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:196:13
+  --> $DIR/methods.rs:195:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -120,7 +120,7 @@ LL | |               ).unwrap_or_else(|| 0);
    | |____________________________________^
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:200:13
+  --> $DIR/methods.rs:199:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -129,32 +129,8 @@ LL | |                     0
 LL | |                 );
    | |_________________^
 
-error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:210:13
-   |
-LL |     let _ = opt.map_or(None, |x| Some(x + 1));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using and_then instead: `opt.and_then(|x| Some(x + 1))`
-   |
-   = note: `-D clippy::option-map-or-none` implied by `-D warnings`
-
-error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:212:13
-   |
-LL |       let _ = opt.map_or(None, |x| {
-   |  _____________^
-LL | |                         Some(x + 1)
-LL | |                        }
-LL | |                 );
-   | |_________________^
-help: try using and_then instead
-   |
-LL |     let _ = opt.and_then(|x| {
-LL |                         Some(x + 1)
-LL |                        });
-   |
-
 error: called `filter(p).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(p)` instead.
-  --> $DIR/methods.rs:224:13
+  --> $DIR/methods.rs:214:13
    |
 LL |     let _ = v.iter().filter(|&x| *x < 0).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +139,7 @@ LL |     let _ = v.iter().filter(|&x| *x < 0).next();
    = note: replace `filter(|&x| *x < 0).next()` with `find(|&x| *x < 0)`
 
 error: called `filter(p).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(p)` instead.
-  --> $DIR/methods.rs:227:13
+  --> $DIR/methods.rs:217:13
    |
 LL |       let _ = v.iter().filter(|&x| {
    |  _____________^
@@ -173,7 +149,7 @@ LL | |                    ).next();
    | |___________________________^
 
 error: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:243:13
+  --> $DIR/methods.rs:233:13
    |
 LL |     let _ = v.iter().find(|&x| *x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -182,7 +158,7 @@ LL |     let _ = v.iter().find(|&x| *x < 0).is_some();
    = note: replace `find(|&x| *x < 0).is_some()` with `any(|&x| *x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:246:13
+  --> $DIR/methods.rs:236:13
    |
 LL |       let _ = v.iter().find(|&x| {
    |  _____________^
@@ -192,7 +168,7 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: called `is_some()` after searching an `Iterator` with position. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:252:13
+  --> $DIR/methods.rs:242:13
    |
 LL |     let _ = v.iter().position(|&x| x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -200,7 +176,7 @@ LL |     let _ = v.iter().position(|&x| x < 0).is_some();
    = note: replace `position(|&x| x < 0).is_some()` with `any(|&x| x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with position. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:255:13
+  --> $DIR/methods.rs:245:13
    |
 LL |       let _ = v.iter().position(|&x| {
    |  _____________^
@@ -210,7 +186,7 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: called `is_some()` after searching an `Iterator` with rposition. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:261:13
+  --> $DIR/methods.rs:251:13
    |
 LL |     let _ = v.iter().rposition(|&x| x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -218,7 +194,7 @@ LL |     let _ = v.iter().rposition(|&x| x < 0).is_some();
    = note: replace `rposition(|&x| x < 0).is_some()` with `any(|&x| x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with rposition. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:264:13
+  --> $DIR/methods.rs:254:13
    |
 LL |       let _ = v.iter().rposition(|&x| {
    |  _____________^
@@ -228,12 +204,12 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
-  --> $DIR/methods.rs:279:13
+  --> $DIR/methods.rs:269:13
    |
 LL |     let _ = opt.unwrap();
    |             ^^^^^^^^^^^^
    |
    = note: `-D clippy::option-unwrap-used` implied by `-D warnings`
 
-error: aborting due to 25 previous errors
+error: aborting due to 23 previous errors
 

--- a/tests/ui/option_map_or_none.fixed
+++ b/tests/ui/option_map_or_none.fixed
@@ -1,0 +1,14 @@
+// run-rustfix
+
+fn main() {
+    let opt = Some(1);
+
+    // Check `OPTION_MAP_OR_NONE`.
+    // Single line case.
+    let _ = opt.and_then(|x| Some(x + 1));
+    // Multi-line case.
+    #[rustfmt::skip]
+    let _ = opt.and_then(|x| {
+                        Some(x + 1)
+                       });
+}

--- a/tests/ui/option_map_or_none.rs
+++ b/tests/ui/option_map_or_none.rs
@@ -1,0 +1,14 @@
+// run-rustfix
+
+fn main() {
+    let opt = Some(1);
+
+    // Check `OPTION_MAP_OR_NONE`.
+    // Single line case.
+    let _ = opt.map_or(None, |x| Some(x + 1));
+    // Multi-line case.
+    #[rustfmt::skip]
+    let _ = opt.map_or(None, |x| {
+                        Some(x + 1)
+                       });
+}

--- a/tests/ui/option_map_or_none.stderr
+++ b/tests/ui/option_map_or_none.stderr
@@ -1,0 +1,25 @@
+error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
+  --> $DIR/option_map_or_none.rs:8:13
+   |
+LL |     let _ = opt.map_or(None, |x| Some(x + 1));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using and_then instead: `opt.and_then(|x| Some(x + 1))`
+   |
+   = note: `-D clippy::option-map-or-none` implied by `-D warnings`
+
+error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
+  --> $DIR/option_map_or_none.rs:11:13
+   |
+LL |       let _ = opt.map_or(None, |x| {
+   |  _____________^
+LL | |                         Some(x + 1)
+LL | |                        });
+   | |_________________________^
+help: try using and_then instead
+   |
+LL |     let _ = opt.and_then(|x| {
+LL |                         Some(x + 1)
+LL |                        });
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
* Extracts `option_map_or_none` tests into separate file
 * Adds `// run-rustfix` to `tests/ui/option_map_or_none.rs`

cc #3630