### PR TITLE
Don't trigger assertions_on_constants on debug_assert!(false)

### DIFF
--- a/clippy_lints/src/assertions_on_constants.rs
+++ b/clippy_lints/src/assertions_on_constants.rs
@@ -47,29 +47,44 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssertionsOnConstants {
                 if let ExprKind::Lit(ref inner) = lit.node {
                     match inner.node {
                         LitKind::Bool(true) => {
-                            span_help_and_lint(cx, ASSERTIONS_ON_CONSTANTS, e.span,
-                                "assert!(true) will be optimized out by the compiler",
-                                "remove it");
+                            span_help_and_lint(
+                                cx,
+                                ASSERTIONS_ON_CONSTANTS,
+                                e.span,
+                                "`assert!(true)` will be optimized out by the compiler",
+                                "remove it"
+                            );
                         },
                         LitKind::Bool(false) if !is_debug_assert => {
                             span_help_and_lint(
-                                cx, ASSERTIONS_ON_CONSTANTS, e.span,
-                                "assert!(false) should probably be replaced",
-                                "use panic!() or unreachable!()");
+                                cx,
+                                ASSERTIONS_ON_CONSTANTS,
+                                e.span,
+                                "`assert!(false)` should probably be replaced",
+                                "use `panic!()` or `unreachable!()`"
+                            );
                         },
                         _ => (),
                     }
                 } else if let Some(bool_const) = constant(cx, cx.tables, lit) {
                     match bool_const.0 {
                         Constant::Bool(true) => {
-                            span_help_and_lint(cx, ASSERTIONS_ON_CONSTANTS, e.span,
-                                "assert!(const: true) will be optimized out by the compiler",
-                                "remove it");
+                            span_help_and_lint(
+                                cx,
+                                ASSERTIONS_ON_CONSTANTS,
+                                e.span,
+                                "`assert!(const: true)` will be optimized out by the compiler",
+                                "remove it"
+                            );
                         },
                         Constant::Bool(false) if !is_debug_assert => {
-                            span_help_and_lint(cx, ASSERTIONS_ON_CONSTANTS, e.span,
-                                "assert!(const: false) should probably be replaced",
-                                "use panic!() or unreachable!()");
+                            span_help_and_lint(
+                                cx,
+                                ASSERTIONS_ON_CONSTANTS,
+                                e.span,
+                                "`assert!(const: false)` should probably be replaced",
+                                "use `panic!()` or `unreachable!()`"
+                            );
                         },
                         _ => (),
                     }

--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -18,6 +18,8 @@ fn main() {
     assert!(C);
 
     debug_assert!(true);
+    // Don't lint this, since there is no better way for expressing "Only panic in debug mode".
+    debug_assert!(false); // #3948
     assert_const!(3);
     assert_const!(-1);
 }

--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -1,4 +1,4 @@
-error: assert!(true) will be optimized out by the compiler
+error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:9:5
    |
 LL |     assert!(true);
@@ -7,15 +7,15 @@ LL |     assert!(true);
    = note: `-D clippy::assertions-on-constants` implied by `-D warnings`
    = help: remove it
 
-error: assert!(false) should probably be replaced
+error: `assert!(false)` should probably be replaced
   --> $DIR/assertions_on_constants.rs:10:5
    |
 LL |     assert!(false);
    |     ^^^^^^^^^^^^^^^
    |
-   = help: use panic!() or unreachable!()
+   = help: use `panic!()` or `unreachable!()`
 
-error: assert!(true) will be optimized out by the compiler
+error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:11:5
    |
 LL |     assert!(true, "true message");
@@ -23,15 +23,15 @@ LL |     assert!(true, "true message");
    |
    = help: remove it
 
-error: assert!(false) should probably be replaced
+error: `assert!(false)` should probably be replaced
   --> $DIR/assertions_on_constants.rs:12:5
    |
 LL |     assert!(false, "false message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use panic!() or unreachable!()
+   = help: use `panic!()` or `unreachable!()`
 
-error: assert!(const: true) will be optimized out by the compiler
+error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:15:5
    |
 LL |     assert!(B);
@@ -39,15 +39,15 @@ LL |     assert!(B);
    |
    = help: remove it
 
-error: assert!(const: false) should probably be replaced
+error: `assert!(false)` should probably be replaced
   --> $DIR/assertions_on_constants.rs:18:5
    |
 LL |     assert!(C);
    |     ^^^^^^^^^^^
    |
-   = help: use panic!() or unreachable!()
+   = help: use `panic!()` or `unreachable!()`
 
-error: assert!(true) will be optimized out by the compiler
+error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:20:5
    |
 LL |     debug_assert!(true);


### PR DESCRIPTION
Fixes #3948 
Fixes #3765 

changelog: Fix `debug_assert!` false positive on `assertions_on_constants` lint
