### PR TITLE
Add run-rustfix for match_as_ref lint

### DIFF
--- a/tests/ui/match_as_ref.fixed
+++ b/tests/ui/match_as_ref.fixed
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![allow(unused)]
+#![warn(clippy::match_as_ref)]
+
+fn match_as_ref() {
+    let owned: Option<()> = None;
+    let borrowed: Option<&()> = owned.as_ref();
+
+    let mut mut_owned: Option<()> = None;
+    let borrow_mut: Option<&mut ()> = mut_owned.as_mut();
+}
+
+fn main() {}

--- a/tests/ui/match_as_ref.rs
+++ b/tests/ui/match_as_ref.rs
@@ -1,0 +1,20 @@
+// run-rustfix
+
+#![allow(unused)]
+#![warn(clippy::match_as_ref)]
+
+fn match_as_ref() {
+    let owned: Option<()> = None;
+    let borrowed: Option<&()> = match owned {
+        None => None,
+        Some(ref v) => Some(v),
+    };
+
+    let mut mut_owned: Option<()> = None;
+    let borrow_mut: Option<&mut ()> = match mut_owned {
+        None => None,
+        Some(ref mut v) => Some(v),
+    };
+}
+
+fn main() {}

--- a/tests/ui/match_as_ref.stderr
+++ b/tests/ui/match_as_ref.stderr
@@ -1,0 +1,24 @@
+error: use as_ref() instead
+  --> $DIR/match_as_ref.rs:8:33
+   |
+LL |       let borrowed: Option<&()> = match owned {
+   |  _________________________________^
+LL | |         None => None,
+LL | |         Some(ref v) => Some(v),
+LL | |     };
+   | |_____^ help: try this: `owned.as_ref()`
+   |
+   = note: `-D clippy::match-as-ref` implied by `-D warnings`
+
+error: use as_mut() instead
+  --> $DIR/match_as_ref.rs:14:39
+   |
+LL |       let borrow_mut: Option<&mut ()> = match mut_owned {
+   |  _______________________________________^
+LL | |         None => None,
+LL | |         Some(ref mut v) => Some(v),
+LL | |     };
+   | |_____^ help: try this: `mut_owned.as_mut()`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -136,20 +136,6 @@ fn match_wild_err_arm() {
     }
 }
 
-fn match_as_ref() {
-    let owned: Option<()> = None;
-    let borrowed: Option<&()> = match owned {
-        None => None,
-        Some(ref v) => Some(v),
-    };
-
-    let mut mut_owned: Option<()> = None;
-    let borrow_mut: Option<&mut ()> = match mut_owned {
-        None => None,
-        Some(ref mut v) => Some(v),
-    };
-}
-
 macro_rules! foo_variant(
     ($idx:expr) => (Foo::get($idx).unwrap())
 );

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -256,30 +256,8 @@ LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: use as_ref() instead
-  --> $DIR/matches.rs:141:33
-   |
-LL |       let borrowed: Option<&()> = match owned {
-   |  _________________________________^
-LL | |         None => None,
-LL | |         Some(ref v) => Some(v),
-LL | |     };
-   | |_____^ help: try this: `owned.as_ref()`
-   |
-   = note: `-D clippy::match-as-ref` implied by `-D warnings`
-
-error: use as_mut() instead
-  --> $DIR/matches.rs:147:39
-   |
-LL |       let borrow_mut: Option<&mut ()> = match mut_owned {
-   |  _______________________________________^
-LL | |         None => None,
-LL | |         Some(ref mut v) => Some(v),
-LL | |     };
-   | |_____^ help: try this: `mut_owned.as_mut()`
-
 error: you don't need to add `&` to all patterns
-  --> $DIR/matches.rs:174:5
+  --> $DIR/matches.rs:160:5
    |
 LL | /     match foo_variant!(0) {
 LL | |         &Foo::A => println!("A"),
@@ -292,5 +270,5 @@ LL |     match *foo_variant!(0) {
 LL |         Foo::A => println!("A"),
    |
 
-error: aborting due to 20 previous errors
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
* Extracts `match_as_ref` into separate file
* Adds `// run-rustfix` to `tests/ui/match_as_ref.rs`

cc #3630

changelog: none