### PR TITLE
Allow allowing of toplevel_ref_arg lint

### DIFF
--- a/tests/ui/toplevel_ref_arg.rs
+++ b/tests/ui/toplevel_ref_arg.rs
@@ -22,4 +22,8 @@ fn main() {
 
     let (ref x, _) = (1, 2); // ok, not top level
     println!("The answer is {}.", x);
+
+    // Make sure that allowing the lint works
+    #[allow(clippy::toplevel_ref_arg)]
+    let ref mut x = 1_234_543;
 }


### PR DESCRIPTION
I'm not sure why some lints need the `HirId` to be able to recognize the
lint level attributes, but this commit makes the lint level attributes
work for `toplevel_ref_arg`.

Fixes #2332

changelog: Allow allowing of `toplevel_ref_arg` lint