### PR TITLE
Update compiletest_rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
 
 [dev-dependencies]
 cargo_metadata = "0.7.1"
-compiletest_rs = { version = "0.3.21", features = ["tmp"] }
+compiletest_rs = { version = "0.3.22", features = ["tmp"] }
 lazy_static = "1.0"
 serde_derive = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }


### PR DESCRIPTION
This includes a fix that make ICEs appear in UI tests again.