### PR TITLE
Add test for derives for used_underscore_binding lint

### DIFF
--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -9,7 +9,12 @@ use proc_macro::{quote, TokenStream};
 
 #[proc_macro_derive(DeriveSomething)]
 pub fn derive(_: TokenStream) -> TokenStream {
+    // Shound not trigger `used_underscore_binding`
+    let _inside_derive = 1;
+    assert_eq!(_inside_derive, _inside_derive);
+
     let output = quote! {
+        // Should not trigger `useless_attribute`
         #[allow(dead_code)]
         extern crate clippy_lints;
     };

--- a/tests/ui/used_underscore_binding.rs
+++ b/tests/ui/used_underscore_binding.rs
@@ -1,6 +1,16 @@
+// aux-build:proc_macro_derive.rs
+
 #![warn(clippy::all)]
 #![allow(clippy::blacklisted_name)]
 #![warn(clippy::used_underscore_binding)]
+
+#[macro_use]
+extern crate proc_macro_derive;
+
+// This should not trigger the lint. There's underscore binding inside the external derive that
+// would trigger the `used_underscore_binding` lint.
+#[derive(DeriveSomething)]
+struct Baz;
 
 macro_rules! test_macro {
     () => {{
@@ -51,7 +61,7 @@ fn unused_underscore_complex(mut _foo: u32) -> u32 {
     1
 }
 
-///Test that we do not lint for multiple underscores
+/// Test that we do not lint for multiple underscores
 fn multiple_underscores(__foo: u32) -> u32 {
     __foo + 1
 }

--- a/tests/ui/used_underscore_binding.stderr
+++ b/tests/ui/used_underscore_binding.stderr
@@ -1,5 +1,5 @@
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:14:5
+  --> $DIR/used_underscore_binding.rs:24:5
    |
 LL |     _foo + 1
    |     ^^^^
@@ -7,25 +7,25 @@ LL |     _foo + 1
    = note: `-D clippy::used-underscore-binding` implied by `-D warnings`
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:19:20
+  --> $DIR/used_underscore_binding.rs:29:20
    |
 LL |     println!("{}", _foo);
    |                    ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:20:16
+  --> $DIR/used_underscore_binding.rs:30:16
    |
 LL |     assert_eq!(_foo, _foo);
    |                ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:20:22
+  --> $DIR/used_underscore_binding.rs:30:22
    |
 LL |     assert_eq!(_foo, _foo);
    |                      ^^^^
 
 error: used binding `_underscore_field` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:33:5
+  --> $DIR/used_underscore_binding.rs:43:5
    |
 LL |     s._underscore_field += 1;
    |     ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This closes #852 as I can't reproduce the original issue anymore.

changelog: none