### PR TITLE
Change "if types change" to "if you later change the type"

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -949,7 +949,7 @@ fn span_lossless_lint(cx: &LateContext<'_, '_>, expr: &Expr, op: &Expr, cast_fro
         CAST_LOSSLESS,
         expr.span,
         &format!(
-            "casting {} to {} may become silently lossy if types change",
+            "casting {} to {} may become silently lossy if you later change the type",
             cast_from, cast_to
         ),
         "try",

--- a/tests/ui/cast_lossless_float.stderr
+++ b/tests/ui/cast_lossless_float.stderr
@@ -1,4 +1,4 @@
-error: casting i8 to f32 may become silently lossy if types change
+error: casting i8 to f32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:9:5
    |
 LL |     x0 as f32;
@@ -6,61 +6,61 @@ LL |     x0 as f32;
    |
    = note: `-D clippy::cast-lossless` implied by `-D warnings`
 
-error: casting i8 to f64 may become silently lossy if types change
+error: casting i8 to f64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:10:5
    |
 LL |     x0 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x0)`
 
-error: casting u8 to f32 may become silently lossy if types change
+error: casting u8 to f32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:12:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^ help: try: `f32::from(x1)`
 
-error: casting u8 to f64 may become silently lossy if types change
+error: casting u8 to f64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:13:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x1)`
 
-error: casting i16 to f32 may become silently lossy if types change
+error: casting i16 to f32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:15:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^ help: try: `f32::from(x2)`
 
-error: casting i16 to f64 may become silently lossy if types change
+error: casting i16 to f64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:16:5
    |
 LL |     x2 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x2)`
 
-error: casting u16 to f32 may become silently lossy if types change
+error: casting u16 to f32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:18:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^ help: try: `f32::from(x3)`
 
-error: casting u16 to f64 may become silently lossy if types change
+error: casting u16 to f64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:19:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x3)`
 
-error: casting i32 to f64 may become silently lossy if types change
+error: casting i32 to f64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:21:5
    |
 LL |     x4 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x4)`
 
-error: casting u32 to f64 may become silently lossy if types change
+error: casting u32 to f64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:23:5
    |
 LL |     x5 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x5)`
 
-error: casting f32 to f64 may become silently lossy if types change
+error: casting f32 to f64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:26:5
    |
 LL |     1.0f32 as f64;

--- a/tests/ui/cast_lossless_integer.stderr
+++ b/tests/ui/cast_lossless_integer.stderr
@@ -1,4 +1,4 @@
-error: casting i8 to i16 may become silently lossy if types change
+error: casting i8 to i16 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:8:5
    |
 LL |     1i8 as i16;
@@ -6,109 +6,109 @@ LL |     1i8 as i16;
    |
    = note: `-D clippy::cast-lossless` implied by `-D warnings`
 
-error: casting i8 to i32 may become silently lossy if types change
+error: casting i8 to i32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:9:5
    |
 LL |     1i8 as i32;
    |     ^^^^^^^^^^ help: try: `i32::from(1i8)`
 
-error: casting i8 to i64 may become silently lossy if types change
+error: casting i8 to i64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:10:5
    |
 LL |     1i8 as i64;
    |     ^^^^^^^^^^ help: try: `i64::from(1i8)`
 
-error: casting u8 to i16 may become silently lossy if types change
+error: casting u8 to i16 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:11:5
    |
 LL |     1u8 as i16;
    |     ^^^^^^^^^^ help: try: `i16::from(1u8)`
 
-error: casting u8 to i32 may become silently lossy if types change
+error: casting u8 to i32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:12:5
    |
 LL |     1u8 as i32;
    |     ^^^^^^^^^^ help: try: `i32::from(1u8)`
 
-error: casting u8 to i64 may become silently lossy if types change
+error: casting u8 to i64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:13:5
    |
 LL |     1u8 as i64;
    |     ^^^^^^^^^^ help: try: `i64::from(1u8)`
 
-error: casting u8 to u16 may become silently lossy if types change
+error: casting u8 to u16 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:14:5
    |
 LL |     1u8 as u16;
    |     ^^^^^^^^^^ help: try: `u16::from(1u8)`
 
-error: casting u8 to u32 may become silently lossy if types change
+error: casting u8 to u32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:15:5
    |
 LL |     1u8 as u32;
    |     ^^^^^^^^^^ help: try: `u32::from(1u8)`
 
-error: casting u8 to u64 may become silently lossy if types change
+error: casting u8 to u64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:16:5
    |
 LL |     1u8 as u64;
    |     ^^^^^^^^^^ help: try: `u64::from(1u8)`
 
-error: casting i16 to i32 may become silently lossy if types change
+error: casting i16 to i32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:17:5
    |
 LL |     1i16 as i32;
    |     ^^^^^^^^^^^ help: try: `i32::from(1i16)`
 
-error: casting i16 to i64 may become silently lossy if types change
+error: casting i16 to i64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:18:5
    |
 LL |     1i16 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1i16)`
 
-error: casting u16 to i32 may become silently lossy if types change
+error: casting u16 to i32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:19:5
    |
 LL |     1u16 as i32;
    |     ^^^^^^^^^^^ help: try: `i32::from(1u16)`
 
-error: casting u16 to i64 may become silently lossy if types change
+error: casting u16 to i64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:20:5
    |
 LL |     1u16 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1u16)`
 
-error: casting u16 to u32 may become silently lossy if types change
+error: casting u16 to u32 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:21:5
    |
 LL |     1u16 as u32;
    |     ^^^^^^^^^^^ help: try: `u32::from(1u16)`
 
-error: casting u16 to u64 may become silently lossy if types change
+error: casting u16 to u64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:22:5
    |
 LL |     1u16 as u64;
    |     ^^^^^^^^^^^ help: try: `u64::from(1u16)`
 
-error: casting i32 to i64 may become silently lossy if types change
+error: casting i32 to i64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:23:5
    |
 LL |     1i32 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1i32)`
 
-error: casting u32 to i64 may become silently lossy if types change
+error: casting u32 to i64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:24:5
    |
 LL |     1u32 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1u32)`
 
-error: casting u32 to u64 may become silently lossy if types change
+error: casting u32 to u64 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:25:5
    |
 LL |     1u32 as u64;
    |     ^^^^^^^^^^^ help: try: `u64::from(1u32)`
 
-error: casting u8 to u16 may become silently lossy if types change
+error: casting u8 to u16 may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:28:5
    |
 LL |     (1u8 + 1u8) as u16;

--- a/tests/ui/types.stderr
+++ b/tests/ui/types.stderr
@@ -1,4 +1,4 @@
-error: casting i32 to i64 may become silently lossy if types change
+error: casting i32 to i64 may become silently lossy if you later change the type
   --> $DIR/types.rs:13:22
    |
 LL |     let c_i64: i64 = c as i64;


### PR DESCRIPTION
Fixes #3964.

changelog: change wording of `cast_lossless` message
