### PR TITLE
Suppress let_and_return if let has attributes

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -157,7 +157,7 @@ impl Return {
             if let ast::StmtKind::Local(ref local) = stmt.node;
             // don't lint in the presence of type inference
             if local.ty.is_none();
-            if !local.attrs.iter().any(attr_is_cfg);
+            if local.attrs.is_empty();
             if let Some(ref initexpr) = local.init;
             if let ast::PatKind::Ident(_, ident, _) = local.pat.node;
             if let ast::ExprKind::Path(_, ref path) = retexpr.node;

--- a/tests/ui/let_return.rs
+++ b/tests/ui/let_return.rs
@@ -39,4 +39,10 @@ fn test_nowarn_4() -> i32 {
     x
 }
 
+fn test_nowarn_5(x: i16) -> u16 {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let x = x as u16;
+    x
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes #3882.

changelog: suppress `let_and_return` if `let` has attributes