### PR TITLE
Only run AppVeyor on r+, try and the master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,11 @@ environment:
         - TARGET: x86_64-pc-windows-msvc
 
 branches:
-    # Don't build these branches
-    except:
-        # Used by bors
-        - trying.tmp
-        - staging.tmp
+    # Only build AppVeyor on r+, try and the master branch
+    only:
+      - auto
+      - try
+      - master
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs/


### PR DESCRIPTION
As it is right now, there is only one worker available in the `rust-lang-libs`
AppVeyor project and there are other repos as well that we share this worker
with. This has been a problem for us because we sometimes hit a bors timeout if there
are too many builds queued up.

To improve the situation, I think we could try to use AppVeyor a bit less
often. The average PR is not going to break windows related things anyway, so
it should be fine to run it on r+/try/master only.

changelog: none