### PR TITLE
Update pulldown_cmark to 0.5

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -28,7 +28,7 @@ serde = "1.0"
 serde_derive = "1.0"
 toml = "0.4"
 unicode-normalization = "0.1"
-pulldown-cmark = "0.2"
+pulldown-cmark = "0.5.0"
 url = "1.7.0"
 if_chain = "0.1.3"
 smallvec = { version = "0.6.5", features = ["union"] }


### PR DESCRIPTION
We now no longer have to use our own wrapper around `Parser` and can use
the new `OffsetIter`.

changelog: none