### PR TITLE
useless_let_if_seq handle interior mutability

### DIFF
--- a/clippy_lints/src/let_if_seq.rs
+++ b/clippy_lints/src/let_if_seq.rs
@@ -71,6 +71,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetIfSeq {
                 then {
                     let span = stmt.span.to(if_.span);
 
+                    let has_interior_mutability = !cx.tables.node_type(canonical_id).is_freeze(
+                        cx.tcx,
+                        cx.param_env,
+                        span
+                    );
+                    if has_interior_mutability { return; }
+
                     let (default_multi_stmts, default) = if let Some(ref else_) = *else_ {
                         if let hir::ExprKind::Block(ref else_, _) = else_.node {
                             if let Some(default) = check_assign(cx, canonical_id, else_) {

--- a/tests/ui/let_if_seq.rs
+++ b/tests/ui/let_if_seq.rs
@@ -108,4 +108,13 @@ fn main() {
     }
 
     baz = 1337;
+
+    // issue 3043 - types with interior mutability should not trigger this lint
+    use std::cell::Cell;
+    let mut val = Cell::new(1);
+    if true {
+        val = Cell::new(2);
+    }
+    println!("{}", val.get());
+
 }

--- a/tests/ui/let_if_seq.rs
+++ b/tests/ui/let_if_seq.rs
@@ -116,5 +116,4 @@ fn main() {
         val = Cell::new(2);
     }
     println!("{}", val.get());
-
 }


### PR DESCRIPTION
fixes #3043 

This passes all tests, including a new one specifically dealing with a type with interior mutability. The main thing I'm unsure of is whether the span I used in the call to `is_freeze` is the most appropriate span to use, or if it matters. 
