### PR TITLE
rustc_tools_util: try to handle case of not having CFG_RELEASE_CHANNEL better when getting compiler channel.

### DIFF
--- a/rustc_tools_util/README.md
+++ b/rustc_tools_util/README.md
@@ -30,6 +30,10 @@ fn main() {
         "cargo:rustc-env=COMMIT_DATE={}",
         rustc_tools_util::get_commit_date().unwrap_or_default()
     );
+    println!(
+        "cargo:rustc-env=RUSTC_RELEASE_CHANNEL={}",
+        rustc_tools_util::get_channel_from_compiler_output().unwrap_or_default()
+    );
 }
 
 ````


### PR DESCRIPTION
changelog: rustc_tools_util: try to handle case of not having CFG_RELEASE_CHANNEL better when getting compiler channel.
