### PR TITLE
Fix #4033 search_is_some

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1980,7 +1980,8 @@ fn lint_search_is_some<'a, 'tcx>(
                 if search_method == "find";
                 if let hir::ExprKind::Closure(_, _, body_id, ..) = search_args[1].node;
                 let closure_body = cx.tcx.hir().body(body_id);
-                if let hir::PatKind::Ref(..) = closure_body.arguments[0].pat.node;
+                if let Some(closure_arg) = closure_body.arguments.get(0);
+                if let hir::PatKind::Ref(..) = closure_arg.pat.node;
                 then {
                     Some(search_snippet.replacen('&', "", 1))
                 } else {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1976,18 +1976,17 @@ fn lint_search_is_some<'a, 'tcx>(
         let search_snippet = snippet(cx, search_args[1].span, "..");
         if search_snippet.lines().count() <= 1 {
             // suggest `any(|x| ..)` instead of `any(|&x| ..)` for `find(|&x| ..).is_some()`
-            let any_search_snippet =
-                if_chain! {
-                    if search_method == "find";
-                    if let hir::ExprKind::Closure(_, _, body_id, ..) = search_args[1].node;
-                    let closure_body = cx.tcx.hir().body(body_id);
-                    if let hir::PatKind::Ref(..) = closure_body.arguments[0].pat.node;
-                    then {
-                        Some(search_snippet.replacen('&', "", 1))
-                    } else {
-                        None
-                    }
-                };
+            let any_search_snippet = if_chain! {
+                if search_method == "find";
+                if let hir::ExprKind::Closure(_, _, body_id, ..) = search_args[1].node;
+                let closure_body = cx.tcx.hir().body(body_id);
+                if let hir::PatKind::Ref(..) = closure_body.arguments[0].pat.node;
+                then {
+                    Some(search_snippet.replacen('&', "", 1))
+                } else {
+                    None
+                }
+            };
             // add note if not multi-line
             span_note_and_lint(
                 cx,
@@ -1997,7 +1996,8 @@ fn lint_search_is_some<'a, 'tcx>(
                 expr.span,
                 &format!(
                     "replace `{0}({1}).is_some()` with `any({2})`",
-                    search_method, search_snippet,
+                    search_method,
+                    search_snippet,
                     any_search_snippet.as_ref().map_or(&*search_snippet, String::as_str)
                 ),
             );

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -155,7 +155,7 @@ LL |     let _ = v.iter().find(|&x| *x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::search-is-some` implied by `-D warnings`
-   = note: replace `find(|&x| *x < 0).is_some()` with `any(|&x| *x < 0)`
+   = note: replace `find(|&x| *x < 0).is_some()` with `any(|x| *x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
   --> $DIR/methods.rs:236:13


### PR DESCRIPTION
Fixes #4033.

Suggest `any(|x| ..)` instead of `any(|&x| ..)` for `find(|&x| ..).is_some()` (Lint [search_is_some](https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some))

FnDecl of `find`:

```rust
fn find<P>(&mut self, mut p: P) -> Option<Self::Item> where
    P: FnMut(&Self::Item) -> bool
```

FnDecl of `any`:

```rust
fn any<F>(&mut self, mut f: F) -> bool where
    F: FnMut(Self::Item) -> bool
```

If match on `|&_|` in closure of `find`, only use `|_|` in the suggestion.

PS. It's the first time that I have used the `hir` API, please correct me if there is any mistake 😺
