### PR TITLE
Fix match_same_arms to fail late

### DIFF
--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -185,44 +185,48 @@ fn lint_match_arms(cx: &LateContext<'_, '_>, expr: &Expr) {
         };
 
         let indexed_arms: Vec<(usize, &Arm)> = arms.iter().enumerate().collect();
-        if let Some((&(_, i), &(_, j))) = search_same(&indexed_arms, hash, eq) {
-            span_lint_and_then(
-                cx,
-                MATCH_SAME_ARMS,
-                j.body.span,
-                "this `match` has identical arm bodies",
-                |db| {
-                    db.span_note(i.body.span, "same as this");
+        search_same_list(&indexed_arms, hash, eq).map(|item| {
+            for match_expr in item {
+                let (&(_, i), &(_, j)) = match_expr;
 
-                    // Note: this does not use `span_suggestion` on purpose:
-                    // there is no clean way
-                    // to remove the other arm. Building a span and suggest to replace it to ""
-                    // makes an even more confusing error message. Also in order not to make up a
-                    // span for the whole pattern, the suggestion is only shown when there is only
-                    // one pattern. The user should know about `|` if they are already using it…
+                span_lint_and_then(
+                    cx,
+                    MATCH_SAME_ARMS,
+                    j.body.span,
+                    "this `match` has identical arm bodies",
+                    |db| {
+                        db.span_note(i.body.span, "same as this");
 
-                    if i.pats.len() == 1 && j.pats.len() == 1 {
-                        let lhs = snippet(cx, i.pats[0].span, "<pat1>");
-                        let rhs = snippet(cx, j.pats[0].span, "<pat2>");
+                        // Note: this does not use `span_suggestion` on purpose:
+                        // there is no clean way
+                        // to remove the other arm. Building a span and suggest to replace it to ""
+                        // makes an even more confusing error message. Also in order not to make up a
+                        // span for the whole pattern, the suggestion is only shown when there is only
+                        // one pattern. The user should know about `|` if they are already using it…
 
-                        if let PatKind::Wild = j.pats[0].node {
-                            // if the last arm is _, then i could be integrated into _
-                            // note that i.pats[0] cannot be _, because that would mean that we're
-                            // hiding all the subsequent arms, and rust won't compile
-                            db.span_note(
-                                i.body.span,
-                                &format!(
-                                    "`{}` has the same arm body as the `_` wildcard, consider removing it`",
-                                    lhs
-                                ),
-                            );
-                        } else {
-                            db.span_note(i.body.span, &format!("consider refactoring into `{} | {}`", lhs, rhs));
+                        if i.pats.len() == 1 && j.pats.len() == 1 {
+                            let lhs = snippet(cx, i.pats[0].span, "<pat1>");
+                            let rhs = snippet(cx, j.pats[0].span, "<pat2>");
+
+                            if let PatKind::Wild = j.pats[0].node {
+                                // if the last arm is _, then i could be integrated into _
+                                // note that i.pats[0] cannot be _, because that would mean that we're
+                                // hiding all the subsequent arms, and rust won't compile
+                                db.span_note(
+                                    i.body.span,
+                                    &format!(
+                                        "`{}` has the same arm body as the `_` wildcard, consider removing it`",
+                                        lhs
+                                    ),
+                                );
+                            } else {
+                                db.span_note(i.body.span, &format!("consider refactoring into `{} | {}`", lhs, rhs));
+                            }
                         }
-                    }
-                },
-            );
-        }
+                    },
+                );
+            }
+        });
     }
 }
 
@@ -359,4 +363,37 @@ where
     }
 
     None
+}
+
+fn search_same_list<T, Hash, Eq>(exprs: &[T], hash: Hash, eq: Eq) -> Option<Vec<(&T, &T)>>
+where
+    Hash: Fn(&T) -> u64,
+    Eq: Fn(&T, &T) -> bool,
+{
+    let mut match_expr_list: Vec<(&T, &T)> = Vec::new();
+
+    let mut map: FxHashMap<_, Vec<&_>> =
+        FxHashMap::with_capacity_and_hasher(exprs.len(), BuildHasherDefault::default());
+
+    for expr in exprs {
+        match map.entry(hash(expr)) {
+            Entry::Occupied(mut o) => {
+                for o in o.get() {
+                    if eq(o, expr) {
+                        match_expr_list.push((o, expr));
+                    }
+                }
+                o.get_mut().push(expr);
+            },
+            Entry::Vacant(v) => {
+                v.insert(vec![expr]);
+            },
+        }
+    }
+
+    if match_expr_list.is_empty() {
+        None
+    } else {
+        Some(match_expr_list)
+    }
 }

--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -232,6 +232,20 @@ fn if_same_then_else() -> Result<&'static str, ()> {
         return Ok(&foo[0..]);
     }
 
+    if true {
+        let foo = "";
+        return Ok(&foo[0..]);
+    } else if false {
+        let foo = "bar";
+        return Ok(&foo[0..]);
+    } else if true {
+        let foo = "";
+        return Ok(&foo[0..]);
+    } else {
+        let foo = "";
+        return Ok(&foo[0..]);
+    }
+
     // False positive `if_same_then_else`: `let (x, y)` vs. `let (y, x)`; see issue #3559.
     if true {
         let foo = "";

--- a/tests/ui/if_same_then_else.stderr
+++ b/tests/ui/if_same_then_else.stderr
@@ -210,5 +210,38 @@ LL | |         try!(Ok("foo"));
 LL | |     } else {
    | |_____^
 
-error: aborting due to 10 previous errors
+error: this `if` has identical blocks
+  --> $DIR/if_same_then_else.rs:244:12
+   |
+LL |       } else {
+   |  ____________^
+LL | |         let foo = "";
+LL | |         return Ok(&foo[0..]);
+LL | |     }
+   | |_____^
+   |
+note: same as this
+  --> $DIR/if_same_then_else.rs:241:20
+   |
+LL |       } else if true {
+   |  ____________________^
+LL | |         let foo = "";
+LL | |         return Ok(&foo[0..]);
+LL | |     } else {
+   | |_____^
+
+error: this `if` has the same condition as a previous if
+  --> $DIR/if_same_then_else.rs:241:15
+   |
+LL |     } else if true {
+   |               ^^^^
+   |
+   = note: #[deny(clippy::ifs_same_cond)] on by default
+note: same as this
+  --> $DIR/if_same_then_else.rs:235:8
+   |
+LL |     if true {
+   |        ^^^^
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui/match_same_arms.rs
+++ b/tests/ui/match_same_arms.rs
@@ -116,6 +116,14 @@ fn match_same_arms() {
         52 => 2, //~ ERROR match arms have same body
         _ => 0,
     };
+
+    let _ = match 42 {
+        1 => 2,
+        2 => 2, //~ ERROR 2rd matched arms have same body
+        3 => 2, //~ ERROR 3rd matched arms have same body
+        4 => 3,
+        _ => 0,
+    };
 }
 
 fn main() {}

--- a/tests/ui/match_same_arms.rs
+++ b/tests/ui/match_same_arms.rs
@@ -108,6 +108,14 @@ fn match_same_arms() {
         (None, Some(a)) => bar(a), // bindings have different types
         _ => (),
     }
+
+    let _ = match 42 {
+        42 => 1,
+        51 => 1, //~ ERROR match arms have same body
+        41 => 2,
+        52 => 2, //~ ERROR match arms have same body
+        _ => 0,
+    };
 }
 
 fn main() {}

--- a/tests/ui/match_same_arms.rs
+++ b/tests/ui/match_same_arms.rs
@@ -119,7 +119,7 @@ fn match_same_arms() {
 
     let _ = match 42 {
         1 => 2,
-        2 => 2, //~ ERROR 2rd matched arms have same body
+        2 => 2, //~ ERROR 2nd matched arms have same body
         3 => 2, //~ ERROR 3rd matched arms have same body
         4 => 3,
         _ => 0,

--- a/tests/ui/match_same_arms.stderr
+++ b/tests/ui/match_same_arms.stderr
@@ -176,7 +176,7 @@ LL |         41 => 2,
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:122:14
    |
-LL |         2 => 2, //~ ERROR 2rd matched arms have same body
+LL |         2 => 2, //~ ERROR 2nd matched arms have same body
    |              ^
    |
 note: same as this
@@ -216,12 +216,12 @@ LL |         3 => 2, //~ ERROR 3rd matched arms have same body
 note: same as this
   --> $DIR/match_same_arms.rs:122:14
    |
-LL |         2 => 2, //~ ERROR 2rd matched arms have same body
+LL |         2 => 2, //~ ERROR 2nd matched arms have same body
    |              ^
 help: consider refactoring into `2 | 3`
   --> $DIR/match_same_arms.rs:122:9
    |
-LL |         2 => 2, //~ ERROR 2rd matched arms have same body
+LL |         2 => 2, //~ ERROR 2nd matched arms have same body
    |         ^
 
 error: aborting due to 12 previous errors

--- a/tests/ui/match_same_arms.stderr
+++ b/tests/ui/match_same_arms.stderr
@@ -1,10 +1,48 @@
 error: this `match` has identical arm bodies
+  --> $DIR/match_same_arms.rs:37:14
+   |
+LL |           _ => {
+   |  ______________^
+LL | |             //~ ERROR match arms have same body
+LL | |             foo();
+LL | |             let mut a = 42 + [23].len() as i32;
+...  |
+LL | |             a
+LL | |         },
+   | |_________^
+   |
+   = note: `-D clippy::match-same-arms` implied by `-D warnings`
+note: same as this
+  --> $DIR/match_same_arms.rs:28:15
+   |
+LL |           42 => {
+   |  _______________^
+LL | |             foo();
+LL | |             let mut a = 42 + [23].len() as i32;
+LL | |             if true {
+...  |
+LL | |             a
+LL | |         },
+   | |_________^
+note: `42` has the same arm body as the `_` wildcard, consider removing it`
+  --> $DIR/match_same_arms.rs:28:15
+   |
+LL |           42 => {
+   |  _______________^
+LL | |             foo();
+LL | |             let mut a = 42 + [23].len() as i32;
+LL | |             if true {
+...  |
+LL | |             a
+LL | |         },
+   | |_________^
+
+error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:52:14
    |
 LL |         _ => 0, //~ ERROR match arms have same body
    |              ^
    |
-   = note: `-D clippy::match-same-arms` implied by `-D warnings`
 note: same as this
   --> $DIR/match_same_arms.rs:50:19
    |
@@ -27,11 +65,11 @@ note: same as this
    |
 LL |         42 => foo(),
    |               ^^^^^
-note: consider refactoring into `42 | 51`
-  --> $DIR/match_same_arms.rs:56:15
+help: consider refactoring into `42 | 51`
+  --> $DIR/match_same_arms.rs:56:9
    |
 LL |         42 => foo(),
-   |               ^^^^^
+   |         ^^
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:63:17
@@ -44,11 +82,11 @@ note: same as this
    |
 LL |         Some(_) => 24,
    |                    ^^
-note: consider refactoring into `Some(_) | None`
-  --> $DIR/match_same_arms.rs:62:20
+help: consider refactoring into `Some(_) | None`
+  --> $DIR/match_same_arms.rs:62:9
    |
 LL |         Some(_) => 24,
-   |                    ^^
+   |         ^^^^^^^
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:85:28
@@ -61,11 +99,11 @@ note: same as this
    |
 LL |         (Some(a), None) => bar(a),
    |                            ^^^^^^
-note: consider refactoring into `(Some(a), None) | (None, Some(a))`
-  --> $DIR/match_same_arms.rs:84:28
+help: consider refactoring into `(Some(a), None) | (None, Some(a))`
+  --> $DIR/match_same_arms.rs:84:9
    |
 LL |         (Some(a), None) => bar(a),
-   |                            ^^^^^^
+   |         ^^^^^^^^^^^^^^^
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:91:26
@@ -78,11 +116,11 @@ note: same as this
    |
 LL |         (Some(a), ..) => bar(a),
    |                          ^^^^^^
-note: consider refactoring into `(Some(a), ..) | (.., Some(a))`
-  --> $DIR/match_same_arms.rs:90:26
+help: consider refactoring into `(Some(a), ..) | (.., Some(a))`
+  --> $DIR/match_same_arms.rs:90:9
    |
 LL |         (Some(a), ..) => bar(a),
-   |                          ^^^^^^
+   |         ^^^^^^^^^^^^^
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:97:20
@@ -95,11 +133,11 @@ note: same as this
    |
 LL |         (1, .., 3) => 42,
    |                       ^^
-note: consider refactoring into `(1, .., 3) | (.., 3)`
-  --> $DIR/match_same_arms.rs:96:23
+help: consider refactoring into `(1, .., 3) | (.., 3)`
+  --> $DIR/match_same_arms.rs:96:9
    |
 LL |         (1, .., 3) => 42,
-   |                       ^^
+   |         ^^^^^^^^^^
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:114:15
@@ -112,11 +150,11 @@ note: same as this
    |
 LL |         42 => 1,
    |               ^
-note: consider refactoring into `42 | 51`
-  --> $DIR/match_same_arms.rs:113:15
+help: consider refactoring into `42 | 51`
+  --> $DIR/match_same_arms.rs:113:9
    |
 LL |         42 => 1,
-   |               ^
+   |         ^^
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:116:15
@@ -129,11 +167,62 @@ note: same as this
    |
 LL |         41 => 2,
    |               ^
-note: consider refactoring into `41 | 52`
-  --> $DIR/match_same_arms.rs:115:15
+help: consider refactoring into `41 | 52`
+  --> $DIR/match_same_arms.rs:115:9
    |
 LL |         41 => 2,
-   |               ^
+   |         ^^
 
-error: aborting due to 8 previous errors
+error: this `match` has identical arm bodies
+  --> $DIR/match_same_arms.rs:122:14
+   |
+LL |         2 => 2, //~ ERROR 2rd matched arms have same body
+   |              ^
+   |
+note: same as this
+  --> $DIR/match_same_arms.rs:121:14
+   |
+LL |         1 => 2,
+   |              ^
+help: consider refactoring into `1 | 2`
+  --> $DIR/match_same_arms.rs:121:9
+   |
+LL |         1 => 2,
+   |         ^
+
+error: this `match` has identical arm bodies
+  --> $DIR/match_same_arms.rs:123:14
+   |
+LL |         3 => 2, //~ ERROR 3rd matched arms have same body
+   |              ^
+   |
+note: same as this
+  --> $DIR/match_same_arms.rs:121:14
+   |
+LL |         1 => 2,
+   |              ^
+help: consider refactoring into `1 | 3`
+  --> $DIR/match_same_arms.rs:121:9
+   |
+LL |         1 => 2,
+   |         ^
+
+error: this `match` has identical arm bodies
+  --> $DIR/match_same_arms.rs:123:14
+   |
+LL |         3 => 2, //~ ERROR 3rd matched arms have same body
+   |              ^
+   |
+note: same as this
+  --> $DIR/match_same_arms.rs:122:14
+   |
+LL |         2 => 2, //~ ERROR 2rd matched arms have same body
+   |              ^
+help: consider refactoring into `2 | 3`
+  --> $DIR/match_same_arms.rs:122:9
+   |
+LL |         2 => 2, //~ ERROR 2rd matched arms have same body
+   |         ^
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui/match_same_arms.stderr
+++ b/tests/ui/match_same_arms.stderr
@@ -1,48 +1,10 @@
 error: this `match` has identical arm bodies
-  --> $DIR/match_same_arms.rs:37:14
-   |
-LL |           _ => {
-   |  ______________^
-LL | |             //~ ERROR match arms have same body
-LL | |             foo();
-LL | |             let mut a = 42 + [23].len() as i32;
-...  |
-LL | |             a
-LL | |         },
-   | |_________^
-   |
-   = note: `-D clippy::match-same-arms` implied by `-D warnings`
-note: same as this
-  --> $DIR/match_same_arms.rs:28:15
-   |
-LL |           42 => {
-   |  _______________^
-LL | |             foo();
-LL | |             let mut a = 42 + [23].len() as i32;
-LL | |             if true {
-...  |
-LL | |             a
-LL | |         },
-   | |_________^
-note: `42` has the same arm body as the `_` wildcard, consider removing it`
-  --> $DIR/match_same_arms.rs:28:15
-   |
-LL |           42 => {
-   |  _______________^
-LL | |             foo();
-LL | |             let mut a = 42 + [23].len() as i32;
-LL | |             if true {
-...  |
-LL | |             a
-LL | |         },
-   | |_________^
-
-error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:52:14
    |
 LL |         _ => 0, //~ ERROR match arms have same body
    |              ^
    |
+   = note: `-D clippy::match-same-arms` implied by `-D warnings`
 note: same as this
   --> $DIR/match_same_arms.rs:50:19
    |
@@ -139,5 +101,39 @@ note: consider refactoring into `(1, .., 3) | (.., 3)`
 LL |         (1, .., 3) => 42,
    |                       ^^
 
-error: aborting due to 7 previous errors
+error: this `match` has identical arm bodies
+  --> $DIR/match_same_arms.rs:114:15
+   |
+LL |         51 => 1, //~ ERROR match arms have same body
+   |               ^
+   |
+note: same as this
+  --> $DIR/match_same_arms.rs:113:15
+   |
+LL |         42 => 1,
+   |               ^
+note: consider refactoring into `42 | 51`
+  --> $DIR/match_same_arms.rs:113:15
+   |
+LL |         42 => 1,
+   |               ^
+
+error: this `match` has identical arm bodies
+  --> $DIR/match_same_arms.rs:116:15
+   |
+LL |         52 => 2, //~ ERROR match arms have same body
+   |               ^
+   |
+note: same as this
+  --> $DIR/match_same_arms.rs:115:15
+   |
+LL |         41 => 2,
+   |               ^
+note: consider refactoring into `41 | 52`
+  --> $DIR/match_same_arms.rs:115:15
+   |
+LL |         41 => 2,
+   |               ^
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -89,11 +89,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:53:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:53:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: Err(_) will match all errors, maybe not a good idea
@@ -115,11 +115,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:59:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:59:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: Err(_) will match all errors, maybe not a good idea
@@ -141,11 +141,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:65:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:65:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -159,11 +159,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:74:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:74:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -177,11 +177,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:81:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:81:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -195,11 +195,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:87:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:87:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -213,11 +213,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:93:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:93:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -231,11 +231,11 @@ note: same as this
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
    |                             ^^^^^^^^^^^^^^^^^^^^
-note: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
-  --> $DIR/matches.rs:116:29
+help: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
+  --> $DIR/matches.rs:116:9
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
-   |                             ^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -249,11 +249,11 @@ note: same as this
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
-note: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:131:18
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:131:9
    |
 LL |         Ok(3) => println!("ok"),
-   |                  ^^^^^^^^^^^^^^
+   |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: you don't need to add `&` to all patterns


### PR DESCRIPTION
Changes:
- Add a function search_same_list which return a list of matched expressions
- Change the match_same_arms implementation behavior. It will lint each same arms found.

fixes #4096 

changelog: none
