### PR TITLE
useless_attribute: Add unreachable_pub to whitelists

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -49,9 +49,9 @@ declare_clippy_lint! {
     /// **What it does:** Checks for `extern crate` and `use` items annotated with
     /// lint attributes.
     ///
-    /// This lint whitelists `#[allow(unused_imports)]` and `#[allow(deprecated)]` on
-    /// `use` items and `#[allow(unused_imports)]` on `extern crate` items with a
-    /// `#[macro_use]` attribute.
+    /// This lint whitelists `#[allow(unused_imports)]`, `#[allow(deprecated)]` and
+    /// `#[allow(unreachable_pub)]` on `use` items and `#[allow(unused_imports)]` on
+    /// `extern crate` items with a `#[macro_use]` attribute.
     ///
     /// **Why is this bad?** Lint attributes have no effect on crate imports. Most
     /// likely a `!` was forgotten.
@@ -239,13 +239,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Attributes {
                         if let Some(ident) = attr.ident() {
                             match &*ident.as_str() {
                                 "allow" | "warn" | "deny" | "forbid" => {
-                                    // whitelist `unused_imports` and `deprecated` for `use` items
+                                    // whitelist `unused_imports`, `deprecated` and `unreachable_pub` for `use` items
                                     // and `unused_imports` for `extern crate` items with `macro_use`
                                     for lint in lint_list {
                                         match item.node {
                                             ItemKind::Use(..) => {
                                                 if is_word(lint, sym!(unused_imports))
                                                     || is_word(lint, sym!(deprecated))
+                                                    || is_word(lint, sym!(unreachable_pub))
                                                 {
                                                     return;
                                                 }

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -1,6 +1,7 @@
 // aux-build:proc_macro_derive.rs
 
 #![warn(clippy::useless_attribute)]
+#![warn(unreachable_pub)]
 
 #[allow(dead_code)]
 #[cfg_attr(feature = "cargo-clippy", allow(dead_code))]
@@ -31,5 +32,17 @@ pub use foo::Bar;
 // that would trigger the useless_attribute lint.
 #[derive(DeriveSomething)]
 struct Baz;
+
+// don't lint on unreachable_pub for `use` items
+mod a {
+    mod b {
+        #[allow(dead_code)]
+        #[allow(unreachable_pub)]
+        pub struct C {}
+    }
+
+    #[allow(unreachable_pub)]
+    pub use self::b::C;
+}
 
 fn main() {}

--- a/tests/ui/useless_attribute.stderr
+++ b/tests/ui/useless_attribute.stderr
@@ -1,5 +1,5 @@
 error: useless lint attribute
-  --> $DIR/useless_attribute.rs:5:1
+  --> $DIR/useless_attribute.rs:6:1
    |
 LL | #[allow(dead_code)]
    | ^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![allow(dead_code)]`
@@ -7,7 +7,7 @@ LL | #[allow(dead_code)]
    = note: `-D clippy::useless-attribute` implied by `-D warnings`
 
 error: useless lint attribute
-  --> $DIR/useless_attribute.rs:6:1
+  --> $DIR/useless_attribute.rs:7:1
    |
 LL | #[cfg_attr(feature = "cargo-clippy", allow(dead_code))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![cfg_attr(feature = "cargo-clippy", allow(dead_code)`


### PR DESCRIPTION
Fixes #4106

changelog: `useless_attribute`: whitelist `unreachable_pub` on `use` items
