### PR TITLE
Revert "Turn off two tests broken due to #4108"

### DIFF
--- a/tests/ui/crashes/used_underscore_binding_macro.rs
+++ b/tests/ui/crashes/used_underscore_binding_macro.rs
@@ -1,7 +1,5 @@
 // run-pass
 
-// FIXME(#4108)
-/*
 #![allow(clippy::useless_attribute)] //issue #2910
 
 #[macro_use]
@@ -19,6 +17,5 @@ struct MacroAttributesTest {
 fn macro_attributes_test() {
     let _ = MacroAttributesTest { _foo: 0 };
 }
-*/
 
 fn main() {}

--- a/tests/ui/serde.rs
+++ b/tests/ui/serde.rs
@@ -1,6 +1,3 @@
-// FIXME(#4108)
-
-/*
 #![warn(clippy::serde_api_misuse)]
 #![allow(dead_code)]
 
@@ -46,5 +43,5 @@ impl<'de> serde::de::Visitor<'de> for B {
         unimplemented!()
     }
 }
-*/
+
 fn main() {}

--- a/tests/ui/serde.stderr
+++ b/tests/ui/serde.stderr
@@ -1,0 +1,15 @@
+error: you should not implement `visit_string` without also implementing `visit_str`
+  --> $DIR/serde.rs:39:5
+   |
+LL | /     fn visit_string<E>(self, _v: String) -> Result<Self::Value, E>
+LL | |     where
+LL | |         E: serde::de::Error,
+LL | |     {
+LL | |         unimplemented!()
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::serde-api-misuse` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This reverts commit 568a3ecfc3eebe099c1ffe44c3d9afdc5d445fd2 which is unnecessary after https://github.com/rust-lang/rust-clippy/pull/4115

changelog: none
