### PR TITLE
Improve non ascii literal

### DIFF
--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -34,7 +34,11 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// let x = "Hä?"
+    /// let x = String::from("€");
+    /// ```
+    /// Could be written as:
+    /// ```rust
+    /// let x = String::from("\u{20ac}");
     /// ```
     pub NON_ASCII_LITERAL,
     pedantic,

--- a/tests/ui/unicode.stderr
+++ b/tests/ui/unicode.stderr
@@ -5,8 +5,6 @@ LL |     print!("Here >​< is a ZWS, and ​another");
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::zero-width-space` implied by `-D warnings`
-   = help: Consider replacing the string with:
-           ""Here >/u{200B}< is a ZWS, and /u{200B}another""
 
 error: non-nfc unicode sequence detected
   --> $DIR/unicode.rs:9:12
@@ -15,8 +13,6 @@ LL |     print!("̀àh?");
    |            ^^^^^
    |
    = note: `-D clippy::unicode-not-nfc` implied by `-D warnings`
-   = help: Consider replacing the string with:
-           ""̀àh?""
 
 error: literal non-ASCII character detected
   --> $DIR/unicode.rs:15:12
@@ -25,8 +21,6 @@ LL |     print!("Üben!");
    |            ^^^^^^^
    |
    = note: `-D clippy::non-ascii-literal` implied by `-D warnings`
-   = help: Consider replacing the string with:
-           ""/u{dc}ben!""
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This PR improves the example of the [non_ascii_literal](https://rust-lang.github.io/rust-clippy/master/index.html#non_ascii_literal) lint.
It also makes it auto-fixable.

Please review. This is my first PR to this project.
(Thanks @flip1995 for the help :)

changelog: none
fixes #4117
