### PR TITLE
Fix fallout from rust-lang/rust PR 60861

### DIFF
--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -245,7 +245,7 @@ fn is_block(expr: &ast::Expr) -> bool {
     }
 }
 
-/// Match `if` expressions and return the `then` and `else` block.
+/// Match `if` or `if let` expressions and return the `then` and `else` block.
 fn unsugar_if(expr: &ast::Expr) -> Option<(&P<ast::Block>, &Option<P<ast::Expr>>)> {
     match expr.node {
         ast::ExprKind::If(_, ref then, ref else_) => Some((then, else_)),

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -245,12 +245,10 @@ fn is_block(expr: &ast::Expr) -> bool {
     }
 }
 
-/// Match `if` or `if let` expressions and return the `then` and `else` block.
+/// Match `if` expressions and return the `then` and `else` block.
 fn unsugar_if(expr: &ast::Expr) -> Option<(&P<ast::Block>, &Option<P<ast::Expr>>)> {
     match expr.node {
-        ast::ExprKind::If(_, ref then, ref else_) | ast::ExprKind::IfLet(_, _, ref then, ref else_) => {
-            Some((then, else_))
-        },
+        ast::ExprKind::If(_, ref then, ref else_) => Some((then, else_)),
         _ => None,
     }
 }

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -50,8 +50,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityConversion {
                 };
                 if let ExprKind::Call(_, ref args) = e.node {
                     self.try_desugar_arm.push(args[0].hir_id);
-                } else {
-                    return;
                 }
             },
 

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -209,12 +209,12 @@ fn with_loop_block<F>(expr: &ast::Expr, mut func: F)
 where
     F: FnMut(&ast::Block, Option<&ast::Label>),
 {
-    match expr.node {
-        ast::ExprKind::While(_, ref loop_block, ref label)
-        | ast::ExprKind::WhileLet(_, _, ref loop_block, ref label)
-        | ast::ExprKind::ForLoop(_, _, ref loop_block, ref label)
-        | ast::ExprKind::Loop(ref loop_block, ref label) => func(loop_block, label.as_ref()),
-        _ => {},
+    if let ast::ExprKind::While(_, loop_block, label)
+        | ast::ExprKind::ForLoop(_, _, loop_block, label)
+        | ast::ExprKind::Loop(loop_block, label)
+        = &expr.node
+    {
+        func(loop_block, label.as_ref());
     }
 }
 

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -210,9 +210,8 @@ where
     F: FnMut(&ast::Block, Option<&ast::Label>),
 {
     if let ast::ExprKind::While(_, loop_block, label)
-        | ast::ExprKind::ForLoop(_, _, loop_block, label)
-        | ast::ExprKind::Loop(loop_block, label)
-        = &expr.node
+    | ast::ExprKind::ForLoop(_, _, loop_block, label)
+    | ast::ExprKind::Loop(loop_block, label) = &expr.node
     {
         func(loop_block, label.as_ref());
     }

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -135,7 +135,7 @@ impl<'a> Sugg<'a> {
             | ast::ExprKind::Box(..)
             | ast::ExprKind::Closure(..)
             | ast::ExprKind::If(..)
-            | ast::ExprKind::IfLet(..)
+            | ast::ExprKind::Let(..)
             | ast::ExprKind::Unary(..)
             | ast::ExprKind::Match(..) => Sugg::MaybeParen(snippet),
             ast::ExprKind::Async(..)
@@ -162,7 +162,6 @@ impl<'a> Sugg<'a> {
             | ast::ExprKind::Tup(..)
             | ast::ExprKind::Array(..)
             | ast::ExprKind::While(..)
-            | ast::ExprKind::WhileLet(..)
             | ast::ExprKind::Await(..)
             | ast::ExprKind::Err => Sugg::NonParen(snippet),
             ast::ExprKind::Range(.., RangeLimits::HalfOpen) => Sugg::BinOp(AssocOp::DotDot, snippet),

--- a/clippy_lints/src/utils/usage.rs
+++ b/clippy_lints/src/utils/usage.rs
@@ -37,7 +37,7 @@ pub fn is_potentially_mutated<'a, 'tcx>(variable: &'tcx Path, expr: &'tcx Expr, 
     if let Res::Local(id) = variable.res {
         mutated_variables(expr, cx).map_or(true, |mutated| mutated.contains(&id))
     } else {
-        return true;
+        true
     }
 }
 

--- a/tests/ui/collapsible_if.fixed
+++ b/tests/ui/collapsible_if.fixed
@@ -172,4 +172,25 @@ else {
             println!("Hello world!");
         }
     }
+
+    // Test behavior wrt. `let_chains`.
+    // None of the cases below should be collapsed.
+    fn truth() -> bool { true }
+
+    // Prefix:
+    if let 0 = 1 {
+        if truth() {}
+    }
+
+    // Suffix:
+    if truth() {
+        if let 0 = 1 {}
+    }
+
+    // Midfix:
+    if truth() {
+        if let 0 = 1 {
+            if truth() {}
+        }
+    }
 }

--- a/tests/ui/collapsible_if.rs
+++ b/tests/ui/collapsible_if.rs
@@ -200,4 +200,25 @@ fn main() {
             println!("Hello world!");
         }
     }
+
+    // Test behavior wrt. `let_chains`.
+    // None of the cases below should be collapsed.
+    fn truth() -> bool { true }
+
+    // Prefix:
+    if let 0 = 1 {
+        if truth() {}
+    }
+
+    // Suffix:
+    if truth() {
+        if let 0 = 1 {}
+    }
+
+    // Midfix:
+    if truth() {
+        if let 0 = 1 {
+            if truth() {}
+        }
+    }
 }


### PR DESCRIPTION
Fixes incoming breakage for unlanded https://github.com/rust-lang/rust/pull/60861.

Tests are passing locally; the Rust PR now needs to land first.

@Manishearth also says we'll want to split out to a `collapsible_if_let` once we have let-chains working in Rust nightly or something.