### PR TITLE
bump rustc_tools_util to 0.2.0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ clippy_lints = { version = "0.0.212", path = "clippy_lints" }
 # end automatic update
 regex = "1"
 semver = "0.9"
-rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
+rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 
 [dev-dependencies]
 cargo_metadata = "0.7.1"
@@ -58,7 +58,7 @@ derive-new = "0.5"
 rustc-workspace-hack = "1.0.0"
 
 [build-dependencies]
-rustc_tools_util = { version = "0.1.1", path = "rustc_tools_util"}
+rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 
 [features]
 debugging = []

--- a/build.rs
+++ b/build.rs
@@ -12,4 +12,8 @@ fn main() {
         "cargo:rustc-env=COMMIT_DATE={}",
         rustc_tools_util::get_commit_date().unwrap_or_default()
     );
+    println!(
+        "cargo:rustc-env=RUSTC_RELEASE_CHANNEL={}",
+        rustc_tools_util::get_channel().unwrap_or_default()
+    );
 }

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_tools_util"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Matthias Krüger <matthias.krueger@famsik.de>"]
 description = "small helper to generate version information for git packages"
 repository = "https://github.com/rust-lang/rust-clippy"

--- a/rustc_tools_util/README.md
+++ b/rustc_tools_util/README.md
@@ -32,7 +32,7 @@ fn main() {
     );
     println!(
         "cargo:rustc-env=RUSTC_RELEASE_CHANNEL={}",
-        rustc_tools_util::get_channel_from_compiler_output().unwrap_or_default()
+        rustc_tools_util::get_channel().unwrap_or_default()
     );
 }
 

--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -131,8 +131,8 @@ mod test {
     fn test_struct_local() {
         let vi = get_version_info!();
         assert_eq!(vi.major, 0);
-        assert_eq!(vi.minor, 1);
-        assert_eq!(vi.patch, 1);
+        assert_eq!(vi.minor, 2);
+        assert_eq!(vi.patch, 0);
         assert_eq!(vi.crate_name, "rustc_tools_util");
         // hard to make positive tests for these since they will always change
         assert!(vi.commit_hash.is_none());
@@ -142,7 +142,7 @@ mod test {
     #[test]
     fn test_display_local() {
         let vi = get_version_info!();
-        assert_eq!(vi.to_string(), "rustc_tools_util 0.1.1");
+        assert_eq!(vi.to_string(), "rustc_tools_util 0.2.0");
     }
 
     #[test]
@@ -151,7 +151,7 @@ mod test {
         let s = format!("{:?}", vi);
         assert_eq!(
             s,
-            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 1, patch: 1 }"
+            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 2, patch: 0 }"
         );
     }
 


### PR DESCRIPTION
I want to push a new version to crates.io.

changelog: release rustc_tool_utils 0.2.0
