### PR TITLE
Rustup to https://github.com/rust-lang/rust/pull/59545

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -39,8 +39,8 @@ use rustc::ty::{
     subst::Kind,
     Binder, Ty, TyCtxt,
 };
-use rustc_data_structures::sync::Lrc;
 use rustc_errors::Applicability;
+use smallvec::SmallVec;
 use syntax::ast::{self, LitKind};
 use syntax::attr;
 use syntax::ext::hygiene::ExpnFormat;
@@ -248,7 +248,8 @@ pub fn path_to_res(cx: &LateContext<'_, '_>, path: &[&str]) -> Option<(def::Res)
                 None => return None,
             };
 
-            for item in mem::replace(&mut items, Lrc::new(vec![])).iter() {
+            let result = SmallVec::<[_; 8]>::new();
+            for item in mem::replace(&mut items, cx.tcx.arena.alloc_slice(&result)).iter() {
                 if item.ident.name.as_str() == *segment {
                     if path_it.peek().is_none() {
                         return Some(item.res);

--- a/tests/ui/for_loop.stderr
+++ b/tests/ui/for_loop.stderr
@@ -66,7 +66,7 @@ error: it is more concise to loop over references to containers instead of using
   --> $DIR/for_loop.rs:107:15
    |
 LL |     for _v in vec.iter() {}
-   |               ^^^^^^^^^^
+   |               ^^^^^^^^^^ help: to write this more concisely, try: `&vec`
    |
    = note: `-D clippy::explicit-iter-loop` implied by `-D warnings`
 
@@ -74,13 +74,13 @@ error: it is more concise to loop over references to containers instead of using
   --> $DIR/for_loop.rs:109:15
    |
 LL |     for _v in vec.iter_mut() {}
-   |               ^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^ help: to write this more concisely, try: `&mut vec`
 
 error: it is more concise to loop over containers instead of using explicit iteration methods`
   --> $DIR/for_loop.rs:112:15
    |
 LL |     for _v in out_vec.into_iter() {}
-   |               ^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `out_vec`
    |
    = note: `-D clippy::explicit-into-iter-loop` implied by `-D warnings`
 
@@ -88,61 +88,61 @@ error: it is more concise to loop over references to containers instead of using
   --> $DIR/for_loop.rs:115:15
    |
 LL |     for _v in array.into_iter() {}
-   |               ^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&array`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:120:15
    |
 LL |     for _v in [1, 2, 3].iter() {}
-   |               ^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&[1, 2, 3]`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:124:15
    |
 LL |     for _v in [0; 32].iter() {}
-   |               ^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^ help: to write this more concisely, try: `&[0; 32]`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:129:15
    |
 LL |     for _v in ll.iter() {}
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ help: to write this more concisely, try: `&ll`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:132:15
    |
 LL |     for _v in vd.iter() {}
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ help: to write this more concisely, try: `&vd`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:135:15
    |
 LL |     for _v in bh.iter() {}
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ help: to write this more concisely, try: `&bh`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:138:15
    |
 LL |     for _v in hm.iter() {}
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ help: to write this more concisely, try: `&hm`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:141:15
    |
 LL |     for _v in bt.iter() {}
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ help: to write this more concisely, try: `&bt`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:144:15
    |
 LL |     for _v in hs.iter() {}
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ help: to write this more concisely, try: `&hs`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
   --> $DIR/for_loop.rs:147:15
    |
 LL |     for _v in bs.iter() {}
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ help: to write this more concisely, try: `&bs`
 
 error: you are iterating over `Iterator::next()` which is an Option; this will compile but is probably not what you want
   --> $DIR/for_loop.rs:149:15


### PR DESCRIPTION
Needed due to signature changes of `item_children` in [the PR](https://github.com/rust-lang/rust/pull/59545/files) (just grep for `item_children` to see the changes)

I'm not really sure where the .stderr changes came from.