### PR TITLE
add suggestions for print/write with newline lint

### DIFF
--- a/tests/ui/print_with_newline.rs
+++ b/tests/ui/print_with_newline.rs
@@ -1,3 +1,6 @@
+// FIXME: Ideally these suggestions would be fixed via rustfix. Blocked by rust-lang/rust#53934
+// // run-rustfix
+
 #![allow(clippy::print_literal)]
 #![warn(clippy::print_with_newline)]
 

--- a/tests/ui/print_with_newline.stderr
+++ b/tests/ui/print_with_newline.stderr
@@ -1,52 +1,82 @@
-error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
-  --> $DIR/print_with_newline.rs:5:5
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:8:5
    |
 LL |     print!("Hello/n");
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::print-with-newline` implied by `-D warnings`
+help: use `println!` instead
+   |
+LL |     println!("Hello");
+   |     ^^^^^^^       --
 
-error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
-  --> $DIR/print_with_newline.rs:6:5
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:9:5
    |
 LL |     print!("Hello {}/n", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use `println!` instead
+   |
+LL |     println!("Hello {}", "world");
+   |     ^^^^^^^          --
 
-error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
-  --> $DIR/print_with_newline.rs:7:5
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:10:5
    |
 LL |     print!("Hello {} {}/n", "world", "#2");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use `println!` instead
+   |
+LL |     println!("Hello {} {}", "world", "#2");
+   |     ^^^^^^^             --
 
-error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
-  --> $DIR/print_with_newline.rs:8:5
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:11:5
    |
 LL |     print!("{}/n", 1265);
    |     ^^^^^^^^^^^^^^^^^^^^
+help: use `println!` instead
+   |
+LL |     println!("{}", 1265);
+   |     ^^^^^^^    --
 
-error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
-  --> $DIR/print_with_newline.rs:27:5
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:30:5
    |
 LL |     print!("//n"); // should fail
    |     ^^^^^^^^^^^^^^
+help: use `println!` instead
+   |
+LL |     println!("/"); // should fail
+   |     ^^^^^^^    --
 
-error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
-  --> $DIR/print_with_newline.rs:34:5
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:37:5
    |
 LL | /     print!(
 LL | |         "
 LL | | "
 LL | |     );
    | |_____^
+help: use `println!` instead
+   |
+LL |     println!(
+LL |         ""
+   |
 
-error: using `print!()` with a format string that ends in a single newline, consider using `println!()` instead
-  --> $DIR/print_with_newline.rs:38:5
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:41:5
    |
 LL | /     print!(
 LL | |         r"
 LL | | "
 LL | |     );
    | |_____^
+help: use `println!` instead
+   |
+LL |     println!(
+LL |         r""
+   |
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -1,3 +1,6 @@
+// FIXME: Ideally these suggestions would be fixed via rustfix. Blocked by rust-lang/rust#53934
+// // run-rustfix
+
 #![allow(clippy::write_literal)]
 #![warn(clippy::write_with_newline)]
 

--- a/tests/ui/write_with_newline.stderr
+++ b/tests/ui/write_with_newline.stderr
@@ -1,37 +1,57 @@
-error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
-  --> $DIR/write_with_newline.rs:10:5
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:13:5
    |
 LL |     write!(&mut v, "Hello/n");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::write-with-newline` implied by `-D warnings`
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, "Hello");
+   |     ^^^^^^^               --
 
-error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
-  --> $DIR/write_with_newline.rs:11:5
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:14:5
    |
 LL |     write!(&mut v, "Hello {}/n", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, "Hello {}", "world");
+   |     ^^^^^^^                  --
 
-error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
-  --> $DIR/write_with_newline.rs:12:5
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:15:5
    |
 LL |     write!(&mut v, "Hello {} {}/n", "world", "#2");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, "Hello {} {}", "world", "#2");
+   |     ^^^^^^^                     --
 
-error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
-  --> $DIR/write_with_newline.rs:13:5
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:16:5
    |
 LL |     write!(&mut v, "{}/n", 1265);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, "{}", 1265);
+   |     ^^^^^^^            --
 
-error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
-  --> $DIR/write_with_newline.rs:32:5
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:35:5
    |
 LL |     write!(&mut v, "//n"); // should fail
    |     ^^^^^^^^^^^^^^^^^^^^^^
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, "/"); // should fail
+   |     ^^^^^^^            --
 
-error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
-  --> $DIR/write_with_newline.rs:39:5
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:42:5
    |
 LL | /     write!(
 LL | |         &mut v,
@@ -39,9 +59,15 @@ LL | |         "
 LL | | "
 LL | |     );
    | |_____^
+help: use `writeln!()` instead
+   |
+LL |     writeln!(
+LL |         &mut v,
+LL |         ""
+   |
 
-error: using `write!()` with a format string that ends in a single newline, consider using `writeln!()` instead
-  --> $DIR/write_with_newline.rs:44:5
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:47:5
    |
 LL | /     write!(
 LL | |         &mut v,
@@ -49,6 +75,12 @@ LL | |         r"
 LL | | "
 LL | |     );
    | |_____^
+help: use `writeln!()` instead
+   |
+LL |     writeln!(
+LL |         &mut v,
+LL |         r""
+   |
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION

changelog: Add machine-applicable suggestions for `print!`/`write!` with newline lints.
