### PR TITLE
tweak `let_and_return` diagnostic

### DIFF
--- a/tests/ui/author/matches.stderr
+++ b/tests/ui/author/matches.stderr
@@ -1,15 +1,17 @@
-error: returning the result of a let binding from a block. Consider returning the expression directly.
+error: returning the result of a let binding from a block
   --> $DIR/matches.rs:9:13
    |
+LL |             let x = 3;
+   |             ---------- unnecessary let binding
 LL |             x
    |             ^
    |
    = note: `-D clippy::let-and-return` implied by `-D warnings`
-note: this expression can be directly returned
-  --> $DIR/matches.rs:8:21
+help: return the expression directly
    |
-LL |             let x = 3;
-   |                     ^
+LL |             
+LL |             3
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/let_return.stderr
+++ b/tests/ui/let_return.stderr
@@ -1,27 +1,30 @@
-error: returning the result of a let binding from a block. Consider returning the expression directly.
+error: returning the result of a let binding from a block
   --> $DIR/let_return.rs:7:5
    |
+LL |     let x = 5;
+   |     ---------- unnecessary let binding
 LL |     x
    |     ^
    |
    = note: `-D clippy::let-and-return` implied by `-D warnings`
-note: this expression can be directly returned
-  --> $DIR/let_return.rs:6:13
+help: return the expression directly
    |
-LL |     let x = 5;
-   |             ^
+LL |     
+LL |     5
+   |
 
-error: returning the result of a let binding from a block. Consider returning the expression directly.
+error: returning the result of a let binding from a block
   --> $DIR/let_return.rs:13:9
    |
+LL |         let x = 5;
+   |         ---------- unnecessary let binding
 LL |         x
    |         ^
+help: return the expression directly
    |
-note: this expression can be directly returned
-  --> $DIR/let_return.rs:12:17
+LL |         
+LL |         5
    |
-LL |         let x = 5;
-   |                 ^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION

changelog: `let_and_return`: label the unnecessary let binding and convert the note to a structured
suggestion
