### PR TITLE
Rename "Associated*" to "Assoc*"

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -326,7 +326,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
 
         let res = self.tables.qpath_res(qpath, id);
         match res {
-            Res::Def(DefKind::Const, def_id) | Res::Def(DefKind::AssociatedConst, def_id) => {
+            Res::Def(DefKind::Const, def_id) | Res::Def(DefKind::AssocConst, def_id) => {
                 let substs = self.tables.node_substs(id);
                 let substs = if self.substs.is_empty() {
                     substs

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -120,7 +120,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LenZero {
 fn check_trait_items(cx: &LateContext<'_, '_>, visited_trait: &Item, trait_items: &[TraitItemRef]) {
     fn is_named_self(cx: &LateContext<'_, '_>, item: &TraitItemRef, name: &str) -> bool {
         item.ident.name.as_str() == name
-            && if let AssociatedItemKind::Method { has_self } = item.kind {
+            && if let AssocItemKind::Method { has_self } = item.kind {
                 has_self && {
                     let did = cx.tcx.hir().local_def_id_from_hir_id(item.id.hir_id);
                     cx.tcx.fn_sig(did).inputs().skip_binder().len() == 1
@@ -148,7 +148,7 @@ fn check_trait_items(cx: &LateContext<'_, '_>, visited_trait: &Item, trait_items
             .iter()
             .flat_map(|&i| cx.tcx.associated_items(i))
             .any(|i| {
-                i.kind == ty::AssociatedKind::Method
+                i.kind == ty::AssocKind::Method
                     && i.method_has_self_argument
                     && i.ident.name == sym!(is_empty)
                     && cx.tcx.fn_sig(i.def_id).inputs().skip_binder().len() == 1
@@ -171,7 +171,7 @@ fn check_trait_items(cx: &LateContext<'_, '_>, visited_trait: &Item, trait_items
 fn check_impl_items(cx: &LateContext<'_, '_>, item: &Item, impl_items: &[ImplItemRef]) {
     fn is_named_self(cx: &LateContext<'_, '_>, item: &ImplItemRef, name: &str) -> bool {
         item.ident.name.as_str() == name
-            && if let AssociatedItemKind::Method { has_self } = item.kind {
+            && if let AssocItemKind::Method { has_self } = item.kind {
                 has_self && {
                     let did = cx.tcx.hir().local_def_id_from_hir_id(item.id.hir_id);
                     cx.tcx.fn_sig(did).inputs().skip_binder().len() == 1
@@ -258,9 +258,9 @@ fn check_len(
 
 /// Checks if this type has an `is_empty` method.
 fn has_is_empty(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
-    /// Gets an `AssociatedItem` and return true if it matches `is_empty(self)`.
-    fn is_is_empty(cx: &LateContext<'_, '_>, item: &ty::AssociatedItem) -> bool {
-        if let ty::AssociatedKind::Method = item.kind {
+    /// Gets an `AssocItem` and return true if it matches `is_empty(self)`.
+    fn is_is_empty(cx: &LateContext<'_, '_>, item: &ty::AssocItem) -> bool {
+        if let ty::AssocKind::Method = item.kind {
             if item.ident.name.as_str() == "is_empty" {
                 let sig = cx.tcx.fn_sig(item.def_id);
                 let ty = sig.skip_binder();

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -95,7 +95,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx hir::Item) {
         if let hir::ItemKind::Impl(_, _, _, _, None, _, ref items) = item.node {
             for assoc_item in items {
-                if let hir::AssociatedItemKind::Method { has_self: false } = assoc_item.kind {
+                if let hir::AssocItemKind::Method { has_self: false } = assoc_item.kind {
                     let impl_item = cx.tcx.hir().impl_item(assoc_item.id);
                     if in_external_macro(cx.sess(), impl_item.span) {
                         return;

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -195,7 +195,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonCopyConst {
 
             // Make sure it is a const item.
             match cx.tables.qpath_res(qpath, expr.hir_id) {
-                Res::Def(DefKind::Const, _) | Res::Def(DefKind::AssociatedConst, _) => {},
+                Res::Def(DefKind::Const, _) | Res::Def(DefKind::AssocConst, _) => {},
                 _ => return,
             };
 

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -130,7 +130,7 @@ impl<'a, 'tcx> TriviallyCopyPassByRef {
 
     fn check_trait_items(&mut self, cx: &LateContext<'_, '_>, trait_items: &[TraitItemRef]) {
         for item in trait_items {
-            if let AssociatedItemKind::Method { .. } = item.kind {
+            if let AssocItemKind::Method { .. } = item.kind {
                 self.check_trait_method(cx, item);
             }
         }

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -119,7 +119,7 @@ fn check_trait_method_impl_decl<'a, 'tcx: 'a>(
         .tcx
         .associated_items(impl_trait_ref.def_id)
         .find(|assoc_item| {
-            assoc_item.kind == ty::AssociatedKind::Method
+            assoc_item.kind == ty::AssocKind::Method
                 && cx
                     .tcx
                     .hygienic_eq(impl_item.ident, assoc_item.ident, impl_trait_ref.def_id)


### PR DESCRIPTION
This is to fix the breakage introduced by rust-lang/rust#60163.

changelog: none
