### PR TITLE
Rustup to https://github.com/rust-lang/rust/pull/61203

### DIFF
--- a/tests/ui/borrow_box.rs
+++ b/tests/ui/borrow_box.rs
@@ -27,46 +27,46 @@ impl<'a> Test4 for Test3<'a> {
 
 use std::any::Any;
 
-pub fn test5(foo: &mut Box<Any>) {
+pub fn test5(foo: &mut Box<dyn Any>) {
     println!("{:?}", foo)
 }
 
 pub fn test6() {
-    let foo: &Box<Any>;
+    let foo: &Box<dyn Any>;
 }
 
 struct Test7<'a> {
-    foo: &'a Box<Any>,
+    foo: &'a Box<dyn Any>,
 }
 
 trait Test8 {
-    fn test8(a: &Box<Any>);
+    fn test8(a: &Box<dyn Any>);
 }
 
 impl<'a> Test8 for Test7<'a> {
-    fn test8(a: &Box<Any>) {
+    fn test8(a: &Box<dyn Any>) {
         unimplemented!();
     }
 }
 
-pub fn test9(foo: &mut Box<Any + Send + Sync>) {
+pub fn test9(foo: &mut Box<dyn Any + Send + Sync>) {
     let _ = foo;
 }
 
 pub fn test10() {
-    let foo: &Box<Any + Send + 'static>;
+    let foo: &Box<dyn Any + Send + 'static>;
 }
 
 struct Test11<'a> {
-    foo: &'a Box<Any + Send>,
+    foo: &'a Box<dyn Any + Send>,
 }
 
 trait Test12 {
-    fn test4(a: &Box<Any + 'static>);
+    fn test4(a: &Box<dyn Any + 'static>);
 }
 
 impl<'a> Test12 for Test11<'a> {
-    fn test4(a: &Box<Any + 'static>) {
+    fn test4(a: &Box<dyn Any + 'static>) {
         unimplemented!();
     }
 }
@@ -74,8 +74,8 @@ impl<'a> Test12 for Test11<'a> {
 fn main() {
     test1(&mut Box::new(false));
     test2();
-    test5(&mut (Box::new(false) as Box<Any>));
+    test5(&mut (Box::new(false) as Box<dyn Any>));
     test6();
-    test9(&mut (Box::new(false) as Box<Any + Send + Sync>));
+    test9(&mut (Box::new(false) as Box<dyn Any + Send + Sync>));
     test10();
 }

--- a/tests/ui/box_vec.rs
+++ b/tests/ui/box_vec.rs
@@ -15,7 +15,7 @@ pub fn test(foo: Box<Vec<bool>>) {
     println!("{:?}", foo.get(0))
 }
 
-pub fn test2(foo: Box<Fn(Vec<u32>)>) {
+pub fn test2(foo: Box<dyn Fn(Vec<u32>)>) {
     // pass if #31 is fixed
     foo(vec![1, 2, 3])
 }

--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -21,7 +21,7 @@ impl Z for A {
 
 fn main() {}
 
-fn ok_box_trait(boxed_trait: &Box<Z>) {
+fn ok_box_trait(boxed_trait: &Box<dyn Z>) {
     let boxed_local = boxed_trait;
     // done
 }

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -32,8 +32,8 @@ fn main() {
     let e = Some(1u8).map(generic);
     let e = Some(1u8).map(generic);
     // See #515
-    let a: Option<Box<::std::ops::Deref<Target = [i32]>>> =
-        Some(vec![1i32, 2]).map(|v| -> Box<::std::ops::Deref<Target = [i32]>> { Box::new(v) });
+    let a: Option<Box<dyn (::std::ops::Deref<Target = [i32]>)>> =
+        Some(vec![1i32, 2]).map(|v| -> Box<dyn (::std::ops::Deref<Target = [i32]>)> { Box::new(v) });
 }
 
 trait TestTrait {
@@ -108,7 +108,7 @@ fn test_redundant_closures_containing_method_calls() {
     let _: Vec<_> = arr.iter().map(|x| x.map_err(some.take().unwrap())).collect();
 }
 
-struct Thunk<T>(Box<FnMut() -> T>);
+struct Thunk<T>(Box<dyn FnMut() -> T>);
 
 impl<T> Thunk<T> {
     fn new<F: 'static + FnOnce() -> T>(f: F) -> Thunk<T> {

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -32,8 +32,8 @@ fn main() {
     let e = Some(1u8).map(|a| generic(a));
     let e = Some(1u8).map(generic);
     // See #515
-    let a: Option<Box<::std::ops::Deref<Target = [i32]>>> =
-        Some(vec![1i32, 2]).map(|v| -> Box<::std::ops::Deref<Target = [i32]>> { Box::new(v) });
+    let a: Option<Box<dyn (::std::ops::Deref<Target = [i32]>)>> =
+        Some(vec![1i32, 2]).map(|v| -> Box<dyn (::std::ops::Deref<Target = [i32]>)> { Box::new(v) });
 }
 
 trait TestTrait {
@@ -108,7 +108,7 @@ fn test_redundant_closures_containing_method_calls() {
     let _: Vec<_> = arr.iter().map(|x| x.map_err(|e| some.take().unwrap()(e))).collect();
 }
 
-struct Thunk<T>(Box<FnMut() -> T>);
+struct Thunk<T>(Box<dyn FnMut() -> T>);
 
 impl<T> Thunk<T> {
     fn new<F: 'static + FnOnce() -> T>(f: F) -> Thunk<T> {

--- a/tests/ui/extra_unused_lifetimes.rs
+++ b/tests/ui/extra_unused_lifetimes.rs
@@ -25,7 +25,7 @@ fn lt_return_only<'a>() -> &'a u8 {
     panic!()
 }
 
-fn unused_lt_blergh<'a>(x: Option<Box<Send + 'a>>) {}
+fn unused_lt_blergh<'a>(x: Option<Box<dyn Send + 'a>>) {}
 
 trait Foo<'a> {
     fn x(&self, a: &'a u8);

--- a/tests/ui/len_zero.fixed
+++ b/tests/ui/len_zero.fixed
@@ -70,7 +70,7 @@ fn main() {
         println!("This should not happen either!");
     }
 
-    let z: &TraitsToo = &y;
+    let z: &dyn TraitsToo = &y;
     if z.len() > 0 {
         // No error; `TraitsToo` has no `.is_empty()` method.
         println!("Nor should this!");
@@ -125,7 +125,7 @@ fn main() {
     }
     assert!(!has_is_empty.is_empty());
 
-    let with_is_empty: &WithIsEmpty = &Wither;
+    let with_is_empty: &dyn WithIsEmpty = &Wither;
     if with_is_empty.is_empty() {
         println!("Or this!");
     }

--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -70,7 +70,7 @@ fn main() {
         println!("This should not happen either!");
     }
 
-    let z: &TraitsToo = &y;
+    let z: &dyn TraitsToo = &y;
     if z.len() > 0 {
         // No error; `TraitsToo` has no `.is_empty()` method.
         println!("Nor should this!");
@@ -125,7 +125,7 @@ fn main() {
     }
     assert!(!has_is_empty.is_empty());
 
-    let with_is_empty: &WithIsEmpty = &Wither;
+    let with_is_empty: &dyn WithIsEmpty = &Wither;
     if with_is_empty.len() == 0 {
         println!("Or this!");
     }

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -41,7 +41,7 @@ trait Trait {}
 
 impl<'a> Trait for &'a str {}
 
-fn h(_: &Trait) {}
+fn h(_: &dyn Trait) {}
 #[warn(clippy::needless_borrow)]
 #[allow(dead_code)]
 fn issue_1432() {

--- a/tests/ui/needless_lifetimes.rs
+++ b/tests/ui/needless_lifetimes.rs
@@ -166,16 +166,16 @@ fn struct_with_lt4<'a, 'b>(_foo: &'a Foo<'b>) -> &'a str {
 
 trait WithLifetime<'a> {}
 
-type WithLifetimeAlias<'a> = WithLifetime<'a>;
+type WithLifetimeAlias<'a> = dyn WithLifetime<'a>;
 
 // Should not warn because it won't build without the lifetime.
-fn trait_obj_elided<'a>(_arg: &'a WithLifetime) -> &'a str {
+fn trait_obj_elided<'a>(_arg: &'a dyn WithLifetime) -> &'a str {
     unimplemented!()
 }
 
 // Should warn because there is no lifetime on `Drop`, so this would be
 // unambiguous if we elided the lifetime.
-fn trait_obj_elided2<'a>(_arg: &'a Drop) -> &'a str {
+fn trait_obj_elided2<'a>(_arg: &'a dyn Drop) -> &'a str {
     unimplemented!()
 }
 
@@ -226,7 +226,7 @@ struct Test {
 }
 
 impl Test {
-    fn iter<'a>(&'a self) -> Box<Iterator<Item = usize> + 'a> {
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = usize> + 'a> {
         unimplemented!()
     }
 }

--- a/tests/ui/needless_lifetimes.stderr
+++ b/tests/ui/needless_lifetimes.stderr
@@ -81,7 +81,7 @@ LL | | }
 error: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
   --> $DIR/needless_lifetimes.rs:178:1
    |
-LL | / fn trait_obj_elided2<'a>(_arg: &'a Drop) -> &'a str {
+LL | / fn trait_obj_elided2<'a>(_arg: &'a dyn Drop) -> &'a str {
 LL | |     unimplemented!()
 LL | | }
    | |_^

--- a/tests/ui/non_copy_const.rs
+++ b/tests/ui/non_copy_const.rs
@@ -27,7 +27,7 @@ const STR: &str = "012345";
 const COW: Cow<str> = Cow::Borrowed("abcdef");
 //^ note: a const item of Cow is used in the `postgres` package.
 
-const NO_ANN: &Display = &70;
+const NO_ANN: &dyn Display = &70;
 
 static STATIC_TUPLE: (AtomicUsize, String) = (ATOMIC, STRING);
 //^ there should be no lints on this line

--- a/tests/ui/unnecessary_clone.rs
+++ b/tests/ui/unnecessary_clone.rs
@@ -44,7 +44,7 @@ fn clone_on_ref_ptr() {
     sync::Weak::clone(&arc_weak);
 
     let x = Arc::new(SomeImpl);
-    let _: Arc<SomeTrait> = x.clone();
+    let _: Arc<dyn SomeTrait> = x.clone();
 }
 
 fn clone_on_copy_generic<T: Copy>(t: T) {

--- a/tests/ui/unnecessary_clone.stderr
+++ b/tests/ui/unnecessary_clone.stderr
@@ -45,10 +45,10 @@ LL |     arc_weak.clone();
    |     ^^^^^^^^^^^^^^^^ help: try this: `Weak::<bool>::clone(&arc_weak)`
 
 error: using '.clone()' on a ref-counted pointer
-  --> $DIR/unnecessary_clone.rs:47:29
+  --> $DIR/unnecessary_clone.rs:47:33
    |
-LL |     let _: Arc<SomeTrait> = x.clone();
-   |                             ^^^^^^^^^ help: try this: `Arc::<SomeImpl>::clone(&x)`
+LL |     let _: Arc<dyn SomeTrait> = x.clone();
+   |                                 ^^^^^^^^^ help: try this: `Arc::<SomeImpl>::clone(&x)`
 
 error: using `clone` on a `Copy` type
   --> $DIR/unnecessary_clone.rs:51:5

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -17,7 +17,7 @@ impl Unitter {
     #[allow(clippy::no_effect)]
     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) 
     where G: Fn() -> () {
-        let _y: &Fn() -> () = &f;
+        let _y: &dyn Fn() -> () = &f;
         (); // this should not lint, as it's not in return type position
     }
 }

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -18,7 +18,7 @@ impl Unitter {
     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) ->
         ()
     where G: Fn() -> () {
-        let _y: &Fn() -> () = &f;
+        let _y: &dyn Fn() -> () = &f;
         (); // this should not lint, as it's not in return type position
     }
 }


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/61203 

Migrates all trait objects to use `dyn` in our ui tests

changelog: none