### PR TITLE
Update pulldown_cmark to 0.5.2

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -27,7 +27,7 @@ semver = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 unicode-normalization = "0.1"
-pulldown-cmark = "0.5.0"
+pulldown-cmark = "0.5.2"
 url = "1.7.0"
 if_chain = "1.0.0"
 smallvec = { version = "0.6.5", features = ["union"] }


### PR DESCRIPTION
Includes various parsing fixes. Most notably [this PR][pr]

changelog: none

[pr]: https://github.com/raphlinus/pulldown-cmark/pull/325