### PR TITLE
Add example to needless_range_loop

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -66,6 +66,12 @@ declare_clippy_lint! {
     ///     println!("{}", vec[i]);
     /// }
     /// ```
+    /// Could be written as:
+    /// ```ignore
+    /// for i in vec {
+    ///     println!("{}", i);
+    /// }
+    /// ```
     pub NEEDLESS_RANGE_LOOP,
     style,
     "for-looping over a range of indices where an iterator over items would do"

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -61,13 +61,15 @@ declare_clippy_lint! {
     /// **Known problems:** None.
     ///
     /// **Example:**
-    /// ```ignore
+    /// ```rust
+    /// let vec = vec!['a', 'b', 'c'];
     /// for i in 0..vec.len() {
     ///     println!("{}", vec[i]);
     /// }
     /// ```
     /// Could be written as:
-    /// ```ignore
+    /// ```rust
+    /// let vec = vec!['a', 'b', 'c'];
     /// for i in vec {
     ///     println!("{}", i);
     /// }


### PR DESCRIPTION
adds a "could be written as" example

btw, is it correct that the lint triggers even if the index is used not just for getting the values by index?
So that I have to add `.iter().enumerate()` to still get an index?

changelog: none
