### PR TITLE
Do not install rustup-toolchain if it is in PATH

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Set up the appropriate rustc toolchain
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
-cargo install rustup-toolchain-install-master --debug || echo "rustup-toolchain-install-master already installed"
+if ! command -v rustup-toolchain-install-master > /dev/null; then
+  cargo install rustup-toolchain-install-master --debug
+fi
+
 RUSTC_HASH=$(git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}')
-rustup-toolchain-install-master -f -n master $RUSTC_HASH
+rustup-toolchain-install-master -f -n master "$RUSTC_HASH"
 rustup override set master


### PR DESCRIPTION
I find it quiet annoying because I manually build `rustup-toolchain-install-master`
and install it in `PATH` other than in `~/.cargo/bin`. So everytime I run the script,
it always reinstall `rustup-toolchain-install-master` for me.

changelog: none
