### PR TITLE
Bump cargo metadata

### DIFF
--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Hansch <dev@phansch.net>"]
 edition = "2018"
 
 [dependencies]
-clap = "~2.32"
+clap = "2.33"
 itertools = "0.8"
 regex = "1"
 lazy_static = "1.0"

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.7.1"
+cargo_metadata = "0.8.0"
 itertools = "0.8"
 lazy_static = "1.0.2"
 matches = "0.1.7"


### PR DESCRIPTION
Sorry, I forgot to bump `cargo_metadata` in sub-crates.

changelog: none

r? @matthiaskrgr 