### PR TITLE
only run eta_reduction on calls w/ ExprPath callee

### DIFF
--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 fn main() {
     let a = Some(1u8).map(foo);
     meta(foo);
-    let c = Some(1u8).map({1+2; foo});
+    let c = Some(1u8).map(|a| {1+2; foo}(a));
     let d = Some(1u8).map(|a| foo((|b| foo2(b))(a))); //is adjusted?
     all(&[1, 2, 3], &2, |x, y| below(x, y)); //is adjusted
     unsafe {
@@ -105,7 +105,7 @@ fn test_redundant_closures_containing_method_calls() {
 
     let mut some = Some(|x| x * x);
     let arr = [Ok(1), Err(2)];
-    let _: Vec<_> = arr.iter().map(|x| x.map_err(some.take().unwrap())).collect();
+    let _: Vec<_> = arr.iter().map(|x| x.map_err(|e| some.take().unwrap()(e))).collect();
 }
 
 struct Thunk<T>(Box<dyn FnMut() -> T>);

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -12,12 +12,6 @@ error: redundant closure found
 LL |     meta(|a| foo(a));
    |          ^^^^^^^^^^ help: remove closure as shown: `foo`
 
-error: redundant closure found
-  --> $DIR/eta.rs:23:27
-   |
-LL |     let c = Some(1u8).map(|a| {1+2; foo}(a));
-   |                           ^^^^^^^^^^^^^^^^^ help: remove closure as shown: `{1+2; foo}`
-
 error: this expression borrows a reference that is immediately dereferenced by the compiler
   --> $DIR/eta.rs:25:21
    |
@@ -71,12 +65,6 @@ LL |     let e: std::vec::Vec<char> = vec!['a', 'b', 'c'].iter().map(|c| c.to_as
    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove closure as shown: `char::to_ascii_uppercase`
 
 error: redundant closure found
-  --> $DIR/eta.rs:108:50
-   |
-LL |     let _: Vec<_> = arr.iter().map(|x| x.map_err(|e| some.take().unwrap()(e))).collect();
-   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove closure as shown: `some.take().unwrap()`
-
-error: redundant closure found
   --> $DIR/eta.rs:173:27
    |
 LL |     let a = Some(1u8).map(|a| foo_ptr(a));
@@ -88,5 +76,5 @@ error: redundant closure found
 LL |     let a = Some(1u8).map(|a| closure(a));
    |                           ^^^^^^^^^^^^^^ help: remove closure as shown: `closure`
 
-error: aborting due to 14 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
This fixes #4187


<!--
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only updates to the latest nightly, you can leave the
`changelog` entry as `none`. Otherwise, please write a short comment
explaining your change.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- [ ] Followed [lint naming conventions][lint_naming]
- [ ] Added passing UI tests (including committed `.stderr` file)
- [ ] `cargo test` passes locally
- [ ] Executed `util/dev update_lints`
- [ ] Added lint documentation
- [ ] Run `cargo fmt`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR -->

changelog: none