### PR TITLE
Fixing eta with respect to lazy evaluation.

### DIFF
--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -82,6 +82,8 @@ fn check_closure(cx: &LateContext<'_, '_>, expr: &Expr) {
         if_chain!(
             if let ExprKind::Call(ref caller, ref args) = ex.node;
 
+            if let ExprKind::Path(_) = caller.node;
+
             // Not the same number of arguments, there is no way the closure is the same as the function return;
             if args.len() == decl.inputs.len();
 

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 fn main() {
     let a = Some(1u8).map(foo);
     meta(foo);
-    let c = Some(1u8).map({1+2; foo});
+    let c = Some(1u8).map(|a| {1+2; foo}(a));
     let d = Some(1u8).map(|a| foo((|b| foo2(b))(a))); //is adjusted?
     all(&[1, 2, 3], &2, |x, y| below(x, y)); //is adjusted
     unsafe {
@@ -105,7 +105,7 @@ fn test_redundant_closures_containing_method_calls() {
 
     let mut some = Some(|x| x * x);
     let arr = [Ok(1), Err(2)];
-    let _: Vec<_> = arr.iter().map(|x| x.map_err(some.take().unwrap())).collect();
+    let _: Vec<_> = arr.iter().map(|x| x.map_err(|e| some.take().unwrap()(e))).collect();
 }
 
 struct Thunk<T>(Box<dyn FnMut() -> T>);
@@ -176,4 +176,11 @@ fn test_redundant_closure_with_function_pointer() {
 fn test_redundant_closure_with_another_closure() {
     let closure = |a| println!("{}", a);
     let a = Some(1u8).map(closure);
+}
+
+fn make_lazy(f: fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
+    // Currently f is called when result of make_lazy is called.
+    // If the closure is removed, f will be called when make_lazy itself is
+    // called. This changes semantics, so the closure must stay.
+    Box::new(move |x| f()(x))
 }

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -178,7 +178,7 @@ fn test_redundant_closure_with_another_closure() {
     let a = Some(1u8).map(closure);
 }
 
-fn make_lazy(f: fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
+fn make_lazy(f: impl Fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
     // Currently f is called when result of make_lazy is called.
     // If the closure is removed, f will be called when make_lazy itself is
     // called. This changes semantics, so the closure must stay.

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -178,7 +178,7 @@ fn test_redundant_closure_with_another_closure() {
     let a = Some(1u8).map(|a| closure(a));
 }
 
-fn make_lazy(f: fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
+fn make_lazy(f: impl Fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
     // Currently f is called when result of make_lazy is called.
     // If the closure is removed, f will be called when make_lazy itself is
     // called. This changes semantics, so the closure must stay.

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -177,3 +177,10 @@ fn test_redundant_closure_with_another_closure() {
     let closure = |a| println!("{}", a);
     let a = Some(1u8).map(|a| closure(a));
 }
+
+fn make_lazy(f: fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
+    // Currently f is called when result of make_lazy is called.
+    // If the closure is removed, f will be called when make_lazy itself is
+    // called. This changes semantics, so the closure must stay.
+    Box::new(move |x| f()(x))
+}

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -12,12 +12,6 @@ error: redundant closure found
 LL |     meta(|a| foo(a));
    |          ^^^^^^^^^^ help: remove closure as shown: `foo`
 
-error: redundant closure found
-  --> $DIR/eta.rs:23:27
-   |
-LL |     let c = Some(1u8).map(|a| {1+2; foo}(a));
-   |                           ^^^^^^^^^^^^^^^^^ help: remove closure as shown: `{1+2; foo}`
-
 error: this expression borrows a reference that is immediately dereferenced by the compiler
   --> $DIR/eta.rs:25:21
    |
@@ -71,12 +65,6 @@ LL |     let e: std::vec::Vec<char> = vec!['a', 'b', 'c'].iter().map(|c| c.to_as
    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove closure as shown: `char::to_ascii_uppercase`
 
 error: redundant closure found
-  --> $DIR/eta.rs:108:50
-   |
-LL |     let _: Vec<_> = arr.iter().map(|x| x.map_err(|e| some.take().unwrap()(e))).collect();
-   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove closure as shown: `some.take().unwrap()`
-
-error: redundant closure found
   --> $DIR/eta.rs:173:27
    |
 LL |     let a = Some(1u8).map(|a| foo_ptr(a));
@@ -88,5 +76,5 @@ error: redundant closure found
 LL |     let a = Some(1u8).map(|a| closure(a));
    |                           ^^^^^^^^^^^^^^ help: remove closure as shown: `closure`
 
-error: aborting due to 14 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
This fixes #4187

changelog: `redundant_closure`: stop linting on expressions returning a function, which is then directly used by the closure
