### PR TITLE
redundant_closure_for_method_calls fixes

### DIFF
--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -184,3 +184,22 @@ fn make_lazy(f: impl Fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
     // called. This changes semantics, so the closure must stay.
     Box::new(move |x| f()(x))
 }
+
+fn call<F: FnOnce(&mut String) -> String>(f: F) -> String {
+    f(&mut "Hello".to_owned())
+}
+fn test_difference_in_mutability() {
+    call(|s| s.clone());
+}
+
+struct Bar;
+impl std::ops::Deref for Bar {
+    type Target = str;
+    fn deref(&self) -> &str {
+        "hi"
+    }
+}
+
+fn test_deref_with_trait_method() {
+    let _ = [Bar].iter().map(|s| s.to_string()).collect::<Vec<_>>();
+}

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -184,3 +184,22 @@ fn make_lazy(f: impl Fn() -> fn(u8) -> u8) -> impl Fn(u8) -> u8 {
     // called. This changes semantics, so the closure must stay.
     Box::new(move |x| f()(x))
 }
+
+fn call<F: FnOnce(&mut String) -> String>(f: F) -> String {
+    f(&mut "Hello".to_owned())
+}
+fn test_difference_in_mutability() {
+    call(|s| s.clone());
+}
+
+struct Bar;
+impl std::ops::Deref for Bar {
+    type Target = str;
+    fn deref(&self) -> &str {
+        "hi"
+    }
+}
+
+fn test_deref_with_trait_method() {
+    let _ = [Bar].iter().map(|s| s.to_string()).collect::<Vec<_>>();
+}


### PR DESCRIPTION
lint does not trigger when there is a difference in mutability
lint does not trigger when the method belongs to a trait which is not implemebted directly (Deref)

<!--
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only updates to the latest nightly, you can leave the
`changelog` entry as `none`. Otherwise, please write a short comment
explaining your change.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- [ ] Followed [lint naming conventions][lint_naming]
- [ ] Added passing UI tests (including committed `.stderr` file)
- [ ] `cargo test` passes locally
- [ ] Executed `util/dev update_lints`
- [ ] Added lint documentation
- [ ] Run `cargo fmt`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR -->

changelog: none
