### PR TITLE
Fix wrong lifetime of TyCtxt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
       export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
   - |
     if [ -z ${INTEGRATION} ]; then
-      ./ci/base-tests.sh && sleep 5
+      travis_wait 30 ./ci/base-tests.sh && sleep 5
     else
       ./ci/integration-tests.sh && sleep 5
     fi

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -121,7 +121,7 @@ impl Hash for Constant {
 }
 
 impl Constant {
-    pub fn partial_cmp(tcx: TyCtxt<'_, '_, '_>, cmp_type: Ty<'_>, left: &Self, right: &Self) -> Option<Ordering> {
+    pub fn partial_cmp(tcx: TyCtxt<'_, '_>, cmp_type: Ty<'_>, left: &Self, right: &Self) -> Option<Ordering> {
         match (left, right) {
             (&Constant::Str(ref ls), &Constant::Str(ref rs)) => Some(ls.cmp(rs)),
             (&Constant::Char(ref l), &Constant::Char(ref r)) => Some(l.cmp(r)),

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -860,7 +860,7 @@ declare_clippy_lint! {
 
 /// Returns the size in bits of an integral type.
 /// Will return 0 if the type is not an int or uint variant
-fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_, '_, '_>) -> u64 {
+fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_, '_>) -> u64 {
     match typ.sty {
         ty::Int(i) => match i {
             IntTy::Isize => tcx.data_layout.pointer_size.bits(),

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -911,7 +911,7 @@ pub fn get_arg_name(pat: &Pat) -> Option<ast::Name> {
     }
 }
 
-pub fn int_bits(tcx: TyCtxt<'_, '_, '_>, ity: ast::IntTy) -> u64 {
+pub fn int_bits(tcx: TyCtxt<'_, '_>, ity: ast::IntTy) -> u64 {
     layout::Integer::from_attr(&tcx, attr::IntType::SignedInt(ity))
         .size()
         .bits()
@@ -919,20 +919,20 @@ pub fn int_bits(tcx: TyCtxt<'_, '_, '_>, ity: ast::IntTy) -> u64 {
 
 #[allow(clippy::cast_possible_wrap)]
 /// Turn a constant int byte representation into an i128
-pub fn sext(tcx: TyCtxt<'_, '_, '_>, u: u128, ity: ast::IntTy) -> i128 {
+pub fn sext(tcx: TyCtxt<'_, '_>, u: u128, ity: ast::IntTy) -> i128 {
     let amt = 128 - int_bits(tcx, ity);
     ((u as i128) << amt) >> amt
 }
 
 #[allow(clippy::cast_sign_loss)]
 /// clip unused bytes
-pub fn unsext(tcx: TyCtxt<'_, '_, '_>, u: i128, ity: ast::IntTy) -> u128 {
+pub fn unsext(tcx: TyCtxt<'_, '_>, u: i128, ity: ast::IntTy) -> u128 {
     let amt = 128 - int_bits(tcx, ity);
     ((u as u128) << amt) >> amt
 }
 
 /// clip unused bytes
-pub fn clip(tcx: TyCtxt<'_, '_, '_>, u: u128, ity: ast::UintTy) -> u128 {
+pub fn clip(tcx: TyCtxt<'_, '_>, u: u128, ity: ast::UintTy) -> u128 {
     let bits = layout::Integer::from_attr(&tcx, attr::IntType::UnsignedInt(ity))
         .size()
         .bits();
@@ -973,7 +973,7 @@ pub fn without_block_comments(lines: Vec<&str>) -> Vec<&str> {
     without
 }
 
-pub fn any_parent_is_automatically_derived(tcx: TyCtxt<'_, '_, '_>, node: HirId) -> bool {
+pub fn any_parent_is_automatically_derived(tcx: TyCtxt<'_, '_>, node: HirId) -> bool {
     let map = &tcx.hir();
     let mut prev_enclosing_node = None;
     let mut enclosing_node = node;


### PR DESCRIPTION
Rustup https://github.com/rust-lang/rust/pull/61722

changelog: none
