### PR TITLE
travis: Wait at most 30 minutes for base test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
       export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
   - |
     if [ -z ${INTEGRATION} ]; then
-      ./ci/base-tests.sh && sleep 5
+      travis_wait 30 ./ci/base-tests.sh && sleep 5
     else
       ./ci/integration-tests.sh && sleep 5
     fi


### PR DESCRIPTION
Sometimes travis gets slow and make the builds spurious failure because
of no output in 10 minutes. This PR makes travis wait at most 30 minutes
before timing out.

changelog: none
