### PR TITLE
fix suggestion for floating point inequality

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -387,7 +387,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                         db.span_suggestion(
                             expr.span,
                             "consider comparing them within some error",
-                            format!("({}).abs() < error", lhs - rhs),
+                            format!(
+                                "({}).abs() {} error",
+                                lhs - rhs,
+                                if op == BinOpKind::Eq { '<' } else { '>' }
+                            ),
                             Applicability::MachineApplicable, // snippet
                         );
                         db.span_note(expr.span, "std::f32::EPSILON and std::f64::EPSILON are available.");

--- a/tests/ui/float_cmp.stderr
+++ b/tests/ui/float_cmp.stderr
@@ -2,7 +2,7 @@ error: strict comparison of f32 or f64
   --> $DIR/float_cmp.rs:60:5
    |
 LL |     ONE as f64 != 2.0;
-   |     ^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(ONE as f64 - 2.0).abs() < error`
+   |     ^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(ONE as f64 - 2.0).abs() > error`
    |
    = note: `-D clippy::float-cmp` implied by `-D warnings`
 note: std::f32::EPSILON and std::f64::EPSILON are available.
@@ -27,7 +27,7 @@ error: strict comparison of f32 or f64
   --> $DIR/float_cmp.rs:68:5
    |
 LL |     twice(x) != twice(ONE as f64);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(twice(x) - twice(ONE as f64)).abs() < error`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(twice(x) - twice(ONE as f64)).abs() > error`
    |
 note: std::f32::EPSILON and std::f64::EPSILON are available.
   --> $DIR/float_cmp.rs:68:5

--- a/tests/ui/float_cmp_const.stderr
+++ b/tests/ui/float_cmp_const.stderr
@@ -27,7 +27,7 @@ error: strict comparison of f32 or f64 constant
   --> $DIR/float_cmp_const.rs:20:5
    |
 LL |     TWO != ONE;
-   |     ^^^^^^^^^^ help: consider comparing them within some error: `(TWO - ONE).abs() < error`
+   |     ^^^^^^^^^^ help: consider comparing them within some error: `(TWO - ONE).abs() > error`
    |
 note: std::f32::EPSILON and std::f64::EPSILON are available.
   --> $DIR/float_cmp_const.rs:20:5
@@ -75,7 +75,7 @@ error: strict comparison of f32 or f64 constant
   --> $DIR/float_cmp_const.rs:27:5
    |
 LL |     v != ONE;
-   |     ^^^^^^^^ help: consider comparing them within some error: `(v - ONE).abs() < error`
+   |     ^^^^^^^^ help: consider comparing them within some error: `(v - ONE).abs() > error`
    |
 note: std::f32::EPSILON and std::f64::EPSILON are available.
   --> $DIR/float_cmp_const.rs:27:5


### PR DESCRIPTION
It should be of the form `(a - b).abs() > error` whereas it was `(a - b).abs() < error` that is instead what should be used for equality.

fixes #4204.

changelog: fix suggestion for floating point inequality
