### PR TITLE
Adding try_err lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1134,6 +1134,7 @@ Released 2018-09-13
 [`transmuting_null`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmuting_null
 [`trivial_regex`]: https://rust-lang.github.io/rust-clippy/master/index.html#trivial_regex
 [`trivially_copy_pass_by_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
+[`try_err`]: https://rust-lang.github.io/rust-clippy/master/index.html#try_err
 [`type_complexity`]: https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
 [`unicode_not_nfc`]: https://rust-lang.github.io/rust-clippy/master/index.html#unicode_not_nfc
 [`unimplemented`]: https://rust-lang.github.io/rust-clippy/master/index.html#unimplemented

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 305 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 306 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -263,6 +263,7 @@ pub mod temporary_assignment;
 pub mod transmute;
 pub mod transmuting_null;
 pub mod trivially_copy_pass_by_ref;
+pub mod try_err;
 pub mod types;
 pub mod unicode;
 pub mod unsafe_removed_from_name;
@@ -546,6 +547,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_early_lint_pass(box literal_representation::DecimalLiteralRepresentation::new(
             conf.literal_representation_threshold
     ));
+    reg.register_late_lint_pass(box try_err::TryErr);
     reg.register_late_lint_pass(box use_self::UseSelf);
     reg.register_late_lint_pass(box bytecount::ByteCount);
     reg.register_late_lint_pass(box infinite_iter::InfiniteIter);
@@ -861,6 +863,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         transmute::WRONG_TRANSMUTE,
         transmuting_null::TRANSMUTING_NULL,
         trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
+        try_err::TRY_ERR,
         types::ABSURD_EXTREME_COMPARISONS,
         types::BORROWED_BOX,
         types::BOX_VEC,
@@ -963,6 +966,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         returns::NEEDLESS_RETURN,
         returns::UNUSED_UNIT,
         strings::STRING_LIT_AS_BYTES,
+        try_err::TRY_ERR,
         types::FN_TO_NUMERIC_CAST,
         types::FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
         types::IMPLICIT_HASHER,

--- a/clippy_lints/src/try_err.rs
+++ b/clippy_lints/src/try_err.rs
@@ -80,7 +80,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TryErr {
                     "returning an `Err(_)` with the `?` operator",
                     "try this",
                     suggestion,
-                    Applicability::MaybeIncorrect
+                    Applicability::MachineApplicable
                 );
             }
         }

--- a/clippy_lints/src/utils/paths.rs
+++ b/clippy_lints/src/utils/paths.rs
@@ -107,6 +107,7 @@ pub const TO_OWNED_METHOD: [&str; 4] = ["alloc", "borrow", "ToOwned", "to_owned"
 pub const TO_STRING: [&str; 3] = ["alloc", "string", "ToString"];
 pub const TO_STRING_METHOD: [&str; 4] = ["alloc", "string", "ToString", "to_string"];
 pub const TRANSMUTE: [&str; 4] = ["core", "intrinsics", "", "transmute"];
+pub const TRY_FROM_ERROR: [&str; 4] = ["std", "ops", "Try", "from_error"];
 pub const TRY_INTO_RESULT: [&str; 4] = ["std", "ops", "Try", "into_result"];
 pub const UNINIT: [&str; 4] = ["core", "intrinsics", "", "uninit"];
 pub const VEC: [&str; 3] = ["alloc", "vec", "Vec"];

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -6,7 +6,7 @@ pub use lint::Lint;
 pub use lint::LINT_LEVELS;
 
 // begin lint list, do not remove this comment, it’s used in `update_lints`
-pub const ALL_LINTS: [Lint; 305] = [
+pub const ALL_LINTS: [Lint; 306] = [
     Lint {
         name: "absurd_extreme_comparisons",
         group: "correctness",
@@ -1819,6 +1819,13 @@ pub const ALL_LINTS: [Lint; 305] = [
         desc: "functions taking small copyable arguments by reference",
         deprecation: None,
         module: "trivially_copy_pass_by_ref",
+    },
+    Lint {
+        name: "try_err",
+        group: "style",
+        desc: "TODO",
+        deprecation: None,
+        module: "try_err",
     },
     Lint {
         name: "type_complexity",

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1823,7 +1823,7 @@ pub const ALL_LINTS: [Lint; 306] = [
     Lint {
         name: "try_err",
         group: "style",
-        desc: "TODO",
+        desc: "return errors explicitly rather than hiding them behind a `?`",
         deprecation: None,
         module: "try_err",
     },

--- a/tests/ui/try_err.fixed
+++ b/tests/ui/try_err.fixed
@@ -7,7 +7,7 @@
 pub fn basic_test() -> Result<i32, i32> {
     let err: i32 = 1;
     if true { // To avoid warnings during rustfix
-        Err(err)?;
+        return Err(err);
     }
     Ok(0)
 }
@@ -16,7 +16,7 @@ pub fn basic_test() -> Result<i32, i32> {
 pub fn into_test() -> Result<i32, i32> {
     let err: u8 = 1;
     if true { // To avoid warnings during rustfix
-        Err(err)?;
+        return Err(err.into());
     }
     Ok(0)
 }
@@ -35,7 +35,7 @@ pub fn closure_matches_test() -> Result<i32, i32> {
         .map(|i| {
             let err: i8 = 1;
             if true { // To avoid warnings during rustfix
-                Err(err)?;
+                return Err(err);
             }
             Ok(i)
         })
@@ -52,7 +52,7 @@ pub fn closure_into_test() -> Result<i32, i32> {
         .map(|i| {
             let err: i8 = 1;
             if true { // To avoid warnings during rustfix
-                Err(err)?;
+                return Err(err.into());
             }
             Ok(i)
         })

--- a/tests/ui/try_err.fixed
+++ b/tests/ui/try_err.fixed
@@ -6,7 +6,8 @@
 // Should flag `Err(err)?`
 pub fn basic_test() -> Result<i32, i32> {
     let err: i32 = 1;
-    if true { // To avoid warnings during rustfix
+    // To avoid warnings during rustfix
+    if true {
         return Err(err);
     }
     Ok(0)
@@ -15,7 +16,8 @@ pub fn basic_test() -> Result<i32, i32> {
 // Tests that `.into()` is added when appropriate
 pub fn into_test() -> Result<i32, i32> {
     let err: u8 = 1;
-    if true { // To avoid warnings during rustfix
+    // To avoid warnings during rustfix
+    if true {
         return Err(err.into());
     }
     Ok(0)
@@ -26,15 +28,16 @@ pub fn negative_test() -> Result<i32, i32> {
     Ok(nested_error()? + 1)
 }
 
-
 // Tests that `.into()` isn't added when the error type
 // matches the surrounding closure's return type, even
 // when it doesn't match the surrounding function's.
 pub fn closure_matches_test() -> Result<i32, i32> {
-    let res: Result<i32, i8> = Some(1).into_iter()
+    let res: Result<i32, i8> = Some(1)
+        .into_iter()
         .map(|i| {
             let err: i8 = 1;
-            if true { // To avoid warnings during rustfix
+            // To avoid warnings during rustfix
+            if true {
                 return Err(err);
             }
             Ok(i)
@@ -48,10 +51,12 @@ pub fn closure_matches_test() -> Result<i32, i32> {
 // Tests that `.into()` isn't added when the error type
 // doesn't match the surrounding closure's return type.
 pub fn closure_into_test() -> Result<i32, i32> {
-    let res: Result<i32, i16> = Some(1).into_iter()
+    let res: Result<i32, i16> = Some(1)
+        .into_iter()
         .map(|i| {
             let err: i8 = 1;
-            if true { // To avoid warnings during rustfix
+            // To avoid warnings during rustfix
+            if true {
                 return Err(err.into());
             }
             Ok(i)

--- a/tests/ui/try_err.rs
+++ b/tests/ui/try_err.rs
@@ -6,7 +6,8 @@
 // Should flag `Err(err)?`
 pub fn basic_test() -> Result<i32, i32> {
     let err: i32 = 1;
-    if true { // To avoid warnings during rustfix
+    // To avoid warnings during rustfix
+    if true {
         Err(err)?;
     }
     Ok(0)
@@ -15,7 +16,8 @@ pub fn basic_test() -> Result<i32, i32> {
 // Tests that `.into()` is added when appropriate
 pub fn into_test() -> Result<i32, i32> {
     let err: u8 = 1;
-    if true { // To avoid warnings during rustfix
+    // To avoid warnings during rustfix
+    if true {
         Err(err)?;
     }
     Ok(0)
@@ -26,15 +28,16 @@ pub fn negative_test() -> Result<i32, i32> {
     Ok(nested_error()? + 1)
 }
 
-
 // Tests that `.into()` isn't added when the error type
 // matches the surrounding closure's return type, even
 // when it doesn't match the surrounding function's.
 pub fn closure_matches_test() -> Result<i32, i32> {
-    let res: Result<i32, i8> = Some(1).into_iter()
+    let res: Result<i32, i8> = Some(1)
+        .into_iter()
         .map(|i| {
             let err: i8 = 1;
-            if true { // To avoid warnings during rustfix
+            // To avoid warnings during rustfix
+            if true {
                 Err(err)?;
             }
             Ok(i)
@@ -48,10 +51,12 @@ pub fn closure_matches_test() -> Result<i32, i32> {
 // Tests that `.into()` isn't added when the error type
 // doesn't match the surrounding closure's return type.
 pub fn closure_into_test() -> Result<i32, i32> {
-    let res: Result<i32, i16> = Some(1).into_iter()
+    let res: Result<i32, i16> = Some(1)
+        .into_iter()
         .map(|i| {
             let err: i8 = 1;
-            if true { // To avoid warnings during rustfix
+            // To avoid warnings during rustfix
+            if true {
                 Err(err)?;
             }
             Ok(i)

--- a/tests/ui/try_err.rs
+++ b/tests/ui/try_err.rs
@@ -1,0 +1,65 @@
+#![deny(clippy::try_err)]
+
+// Tests that a simple case works
+// Should flag `Err(err)?`
+pub fn basic_test() -> Result<i32, i32> {
+    let err: i32 = 1;
+    Err(err)?;
+    Ok(0)
+}
+
+// Tests that `.into()` is added when appropriate
+pub fn into_test() -> Result<i32, i32> {
+    let err: u8 = 1;
+    Err(err)?;
+    Ok(0)
+}
+
+// Tests that tries in general don't trigger the error
+pub fn negative_test() -> Result<i32, i32> {
+    Ok(nested_error()? + 1)
+}
+
+
+// Tests that `.into()` isn't added when the error type
+// matches the surrounding closure's return type, even
+// when it doesn't match the surrounding function's.
+pub fn closure_matches_test() -> Result<i32, i32> {
+    let res: Result<i32, i8> = Some(1).into_iter()
+        .map(|i| {
+            let err: i8 = 1;
+            Err(err)?;
+            Ok(i)
+        })
+        .next()
+        .unwrap();
+
+    Ok(res?)
+}
+
+// Tests that `.into()` isn't added when the error type
+// doesn't match the surrounding closure's return type.
+pub fn closure_into_test() -> Result<i32, i32> {
+    let res: Result<i32, i16> = Some(1).into_iter()
+        .map(|i| {
+            let err: i8 = 1;
+            Err(err)?;
+            Ok(i)
+        })
+        .next()
+        .unwrap();
+
+    Ok(res?)
+}
+
+fn nested_error() -> Result<i32, i32> {
+    Ok(1)
+}
+
+fn main() {
+    basic_test().unwrap();
+    into_test().unwrap();
+    negative_test().unwrap();
+    closure_matches_test().unwrap();
+    closure_into_test().unwrap();
+}

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -1,0 +1,32 @@
+error: confusing error return, consider using `return Err(err)`
+  --> $DIR/try_err.rs:7:5
+   |
+LL |     Err(err)?;
+   |     ^^^^^^^^^ help: try this: `return Err(err)`
+   |
+note: lint level defined here
+  --> $DIR/try_err.rs:1:9
+   |
+LL | #![deny(clippy::try_err)]
+   |         ^^^^^^^^^^^^^^^
+
+error: confusing error return, consider using `return Err(err.into())`
+  --> $DIR/try_err.rs:14:5
+   |
+LL |     Err(err)?;
+   |     ^^^^^^^^^ help: try this: `return Err(err.into())`
+
+error: confusing error return, consider using `return Err(err)`
+  --> $DIR/try_err.rs:31:13
+   |
+LL |             Err(err)?;
+   |             ^^^^^^^^^ help: try this: `return Err(err)`
+
+error: confusing error return, consider using `return Err(err.into())`
+  --> $DIR/try_err.rs:46:13
+   |
+LL |             Err(err)?;
+   |             ^^^^^^^^^ help: try this: `return Err(err.into())`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -1,5 +1,5 @@
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:10:9
+  --> $DIR/try_err.rs:11:9
    |
 LL |         Err(err)?;
    |         ^^^^^^^^^ help: try this: `return Err(err)`
@@ -11,19 +11,19 @@ LL | #![deny(clippy::try_err)]
    |         ^^^^^^^^^^^^^^^
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:19:9
+  --> $DIR/try_err.rs:21:9
    |
 LL |         Err(err)?;
    |         ^^^^^^^^^ help: try this: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:38:17
+  --> $DIR/try_err.rs:41:17
    |
 LL |                 Err(err)?;
    |                 ^^^^^^^^^ help: try this: `return Err(err)`
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:55:17
+  --> $DIR/try_err.rs:60:17
    |
 LL |                 Err(err)?;
    |                 ^^^^^^^^^ help: try this: `return Err(err.into())`

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -1,4 +1,4 @@
-error: confusing error return, consider using `return Err(err)`
+error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:7:5
    |
 LL |     Err(err)?;
@@ -10,19 +10,19 @@ note: lint level defined here
 LL | #![deny(clippy::try_err)]
    |         ^^^^^^^^^^^^^^^
 
-error: confusing error return, consider using `return Err(err.into())`
+error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:14:5
    |
 LL |     Err(err)?;
    |     ^^^^^^^^^ help: try this: `return Err(err.into())`
 
-error: confusing error return, consider using `return Err(err)`
+error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:31:13
    |
 LL |             Err(err)?;
    |             ^^^^^^^^^ help: try this: `return Err(err)`
 
-error: confusing error return, consider using `return Err(err.into())`
+error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:46:13
    |
 LL |             Err(err)?;

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -1,32 +1,32 @@
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:7:5
+  --> $DIR/try_err.rs:10:9
    |
-LL |     Err(err)?;
-   |     ^^^^^^^^^ help: try this: `return Err(err)`
+LL |         Err(err)?;
+   |         ^^^^^^^^^ help: try this: `return Err(err)`
    |
 note: lint level defined here
-  --> $DIR/try_err.rs:1:9
+  --> $DIR/try_err.rs:3:9
    |
 LL | #![deny(clippy::try_err)]
    |         ^^^^^^^^^^^^^^^
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:14:5
+  --> $DIR/try_err.rs:19:9
    |
-LL |     Err(err)?;
-   |     ^^^^^^^^^ help: try this: `return Err(err.into())`
+LL |         Err(err)?;
+   |         ^^^^^^^^^ help: try this: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:31:13
+  --> $DIR/try_err.rs:38:17
    |
-LL |             Err(err)?;
-   |             ^^^^^^^^^ help: try this: `return Err(err)`
+LL |                 Err(err)?;
+   |                 ^^^^^^^^^ help: try this: `return Err(err)`
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:46:13
+  --> $DIR/try_err.rs:55:17
    |
-LL |             Err(err)?;
-   |             ^^^^^^^^^ help: try this: `return Err(err.into())`
+LL |                 Err(err)?;
+   |                 ^^^^^^^^^ help: try this: `return Err(err.into())`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
changelog: Adds the "try_err" lint, which catches instances of the following: Err(x)?
fixes #4212 
