### PR TITLE
Avoid reporting string_lit_as_bytes for long strings

### DIFF
--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -138,6 +138,9 @@ fn is_add(cx: &LateContext<'_, '_>, src: &Expr, target: &Expr) -> bool {
     }
 }
 
+// Max length a b"foo" string can take
+const MAX_LENGTH_BYTE_STRING_LIT: usize = 32;
+
 declare_lint_pass!(StringLitAsBytes => [STRING_LIT_AS_BYTES]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
@@ -173,7 +176,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
                             );
                         } else if callsite == expanded
                             && lit_content.as_str().chars().all(|c| c.is_ascii())
-                            && lit_content.as_str().len() <= 32
+                            && lit_content.as_str().len() <= MAX_LENGTH_BYTE_STRING_LIT
                             && !in_macro_or_desugar(args[0].span)
                         {
                             span_lint_and_sugg(

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -173,6 +173,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
                             );
                         } else if callsite == expanded
                             && lit_content.as_str().chars().all(|c| c.is_ascii())
+                            && lit_content.as_str().len() <= 32
                             && !in_macro_or_desugar(args[0].span)
                         {
                             span_lint_and_sugg(

--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -6,10 +6,11 @@
 fn str_lit_as_bytes() {
     let bs = b"hello there";
 
-    let bs = br###"raw string with three ### in it and some " ""###;
+    let bs = br###"raw string with 3# plus " ""###;
 
-    // no warning, because this cannot be written as a byte string literal:
+    // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();
+    let ubs = "hello there! this is a very long string".as_bytes();
 
     let strify = stringify!(foobar).as_bytes();
 

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -6,10 +6,11 @@
 fn str_lit_as_bytes() {
     let bs = "hello there".as_bytes();
 
-    let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
+    let bs = r###"raw string with 3# plus " ""###.as_bytes();
 
-    // no warning, because this cannot be written as a byte string literal:
+    // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();
+    let ubs = "hello there! this is a very long string".as_bytes();
 
     let strify = stringify!(foobar).as_bytes();
 

--- a/tests/ui/string_lit_as_bytes.stderr
+++ b/tests/ui/string_lit_as_bytes.stderr
@@ -9,11 +9,11 @@ LL |     let bs = "hello there".as_bytes();
 error: calling `as_bytes()` on a string literal
   --> $DIR/string_lit_as_bytes.rs:9:14
    |
-LL |     let bs = r###"raw string with three ### in it and some " ""###.as_bytes();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with three ### in it and some " ""###`
+LL |     let bs = r###"raw string with 3# plus " ""###.as_bytes();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with 3# plus " ""###`
 
 error: calling `as_bytes()` on `include_str!(..)`
-  --> $DIR/string_lit_as_bytes.rs:16:22
+  --> $DIR/string_lit_as_bytes.rs:17:22
    |
 LL |     let includestr = include_str!("entry.rs").as_bytes();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("entry.rs")`


### PR DESCRIPTION
Port of @jens1o code ([b76f939][jens1o_commit])

Fixes #1208

[jens1o_commit]: https://github.com/jens1o/rust-clippy/commit/b76f939ac2efcfe24900c286b3b7713d972d9088

<!--
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only updates to the latest nightly, you can leave the
`changelog` entry as `none`. Otherwise, please write a short comment
explaining your change.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- [ ] Followed [lint naming conventions][lint_naming]
- [ ] Added passing UI tests (including committed `.stderr` file)
- [ ] `cargo test` passes locally
- [ ] Executed `util/dev update_lints`
- [ ] Added lint documentation
- [ ] Run `cargo fmt`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR -->

changelog: bugfix for long strings as bytes
