### PR TITLE
Removed use of intrinsics::uninit from tests.

### DIFF
--- a/tests/ui/invalid_ref.rs
+++ b/tests/ui/invalid_ref.rs
@@ -1,8 +1,8 @@
-#![allow(unused)]
+#![allow(deprecated, unused)]
 #![feature(core_intrinsics)]
 
 extern crate core;
-use std::intrinsics::{init, uninit};
+use std::intrinsics::init;
 
 fn main() {
     let x = 1;
@@ -12,7 +12,6 @@ fn main() {
         ref_to_zeroed_intr(&x);
         ref_to_uninit_std(&x);
         ref_to_uninit_core(&x);
-        ref_to_uninit_intr(&x);
         some_ref();
         std_zeroed_no_ref();
         core_zeroed_no_ref();
@@ -38,10 +37,6 @@ unsafe fn ref_to_uninit_std<T: ?Sized>(t: &T) {
 
 unsafe fn ref_to_uninit_core<T: ?Sized>(t: &T) {
     let ref_uninit: &T = core::mem::uninitialized(); // warning
-}
-
-unsafe fn ref_to_uninit_intr<T: ?Sized>(t: &T) {
-    let ref_uninit: &T = std::intrinsics::uninit(); // warning
 }
 
 fn some_ref() {

--- a/tests/ui/invalid_ref.stderr
+++ b/tests/ui/invalid_ref.stderr
@@ -1,5 +1,5 @@
 error: reference to zeroed memory
-  --> $DIR/invalid_ref.rs:24:24
+  --> $DIR/invalid_ref.rs:23:24
    |
 LL |     let ref_zero: &T = std::mem::zeroed(); // warning
    |                        ^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let ref_zero: &T = std::mem::zeroed(); // warning
    = help: Creation of a null reference is undefined behavior; see https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 
 error: reference to zeroed memory
-  --> $DIR/invalid_ref.rs:28:24
+  --> $DIR/invalid_ref.rs:27:24
    |
 LL |     let ref_zero: &T = core::mem::zeroed(); // warning
    |                        ^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     let ref_zero: &T = core::mem::zeroed(); // warning
    = help: Creation of a null reference is undefined behavior; see https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 
 error: reference to zeroed memory
-  --> $DIR/invalid_ref.rs:32:24
+  --> $DIR/invalid_ref.rs:31:24
    |
 LL |     let ref_zero: &T = std::intrinsics::init(); // warning
    |                        ^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     let ref_zero: &T = std::intrinsics::init(); // warning
    = help: Creation of a null reference is undefined behavior; see https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 
 error: reference to uninitialized memory
-  --> $DIR/invalid_ref.rs:36:26
+  --> $DIR/invalid_ref.rs:35:26
    |
 LL |     let ref_uninit: &T = std::mem::uninitialized(); // warning
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,20 +32,12 @@ LL |     let ref_uninit: &T = std::mem::uninitialized(); // warning
    = help: Creation of a null reference is undefined behavior; see https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 
 error: reference to uninitialized memory
-  --> $DIR/invalid_ref.rs:40:26
+  --> $DIR/invalid_ref.rs:39:26
    |
 LL |     let ref_uninit: &T = core::mem::uninitialized(); // warning
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: Creation of a null reference is undefined behavior; see https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 
-error: reference to uninitialized memory
-  --> $DIR/invalid_ref.rs:44:26
-   |
-LL |     let ref_uninit: &T = std::intrinsics::uninit(); // warning
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: Creation of a null reference is undefined behavior; see https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This is in preperation for https://github.com/rust-lang/rust/pull/62150

Also allows deprecations in preperations for intrinsics::init being deprecated, which is a planned future step.

changelog: none
