### PR TITLE
readme: fix urls in the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ If you want to contribute to Clippy, you can find more information in [CONTRIBUT
 Copyright 2014-2019 The Rust Project Developers
 
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-<LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)> or the MIT license
+<LICENSE-MIT or [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)>, at your
 option. All files in the project carrying such notice may not be
 copied, modified, or distributed except according to those terms.


### PR DESCRIPTION
The ">" at the end was detected as part of the url and caused it to 404.

changelog: none
