### PR TITLE
Improve cast_ptr_alignment lint

### DIFF
--- a/tests/ui/cast_alignment.rs
+++ b/tests/ui/cast_alignment.rs
@@ -22,4 +22,6 @@ fn main() {
     // For c_void, we should trust the user. See #2677
     (&1u32 as *const u32 as *const std::os::raw::c_void) as *const u32;
     (&1u32 as *const u32 as *const libc::c_void) as *const u32;
+    // For ZST, we should trust the user. See #4256
+    (&1u32 as *const u32 as *const ()) as *const u32;
 }

--- a/tests/ui/cast_alignment.stderr
+++ b/tests/ui/cast_alignment.stderr
@@ -1,4 +1,4 @@
-error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`)
+error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
   --> $DIR/cast_alignment.rs:12:5
    |
 LL |     (&1u8 as *const u8) as *const u16;
@@ -6,7 +6,7 @@ LL |     (&1u8 as *const u8) as *const u16;
    |
    = note: `-D clippy::cast-ptr-alignment` implied by `-D warnings`
 
-error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`)
+error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`) (1 < 2 bytes)
   --> $DIR/cast_alignment.rs:13:5
    |
 LL |     (&mut 1u8 as *mut u8) as *mut u16;


### PR DESCRIPTION
<!--
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only updates to the latest nightly, you can leave the
`changelog` entry as `none`. Otherwise, please write a short comment
explaining your change.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [x] `cargo test` passes locally
- [x] Executed `util/dev update_lints`
- [x] Added lint documentation
- [x] Run `cargo fmt`

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR -->

* print alignment in bytes in the lint message
* ignore ZST left-hand types

Fixes #3797 and #4256
changelog:
* `cast_ptr_alignment`: Print alignment in bytes in the lint message
* `cast_ptr_alignment`: Ignore casting from ZST left-hand types