### PR TITLE
Implement lint for inherent to_string() method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -973,6 +973,8 @@ Released 2018-09-13
 [`ineffective_bit_mask`]: https://rust-lang.github.io/rust-clippy/master/index.html#ineffective_bit_mask
 [`infallible_destructuring_match`]: https://rust-lang.github.io/rust-clippy/master/index.html#infallible_destructuring_match
 [`infinite_iter`]: https://rust-lang.github.io/rust-clippy/master/index.html#infinite_iter
+[`inherent_to_string`]: https://rust-lang.github.io/rust-clippy/master/index.html#inherent_to_string
+[`inherent_to_string_shadow_display`]: https://rust-lang.github.io/rust-clippy/master/index.html#inherent_to_string_shadow_display
 [`inline_always`]: https://rust-lang.github.io/rust-clippy/master/index.html#inline_always
 [`inline_fn_without_body`]: https://rust-lang.github.io/rust-clippy/master/index.html#inline_fn_without_body
 [`int_plus_one`]: https://rust-lang.github.io/rust-clippy/master/index.html#int_plus_one

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 306 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 308 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/inherent_to_string.rs
+++ b/clippy_lints/src/inherent_to_string.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     ///
     /// ** Example:**
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// // Bad
     /// pub struct A;
     ///
@@ -26,6 +26,9 @@ declare_clippy_lint! {
     ///         "I am A".to_string()
     ///     }
     /// }
+    /// ```
+    ///
+    /// ```rust
     /// // Good
     /// use std::fmt;
     ///
@@ -39,19 +42,19 @@ declare_clippy_lint! {
     /// ```
     pub INHERENT_TO_STRING,
     style,
-    "type implements inherent method 'to_string()', but should instead implement the 'Display' trait"
+    "type implements inherent method `to_string()`, but should instead implement the `Display` trait"
 }
 
 declare_clippy_lint! {
     /// **What id does:** Checks for the definition of inherent methods with a signature of `to_string(&self) -> String` and if the type implementing this method also implements the `Display` trait.
     ///
-    /// **Why is this bad?** This method is also implicitly defined if a type implements the 'Display' trait. The less versatile inherent method will then shadow the implementation introduced by `Display`.
+    /// **Why is this bad?** This method is also implicitly defined if a type implements the `Display` trait. The less versatile inherent method will then shadow the implementation introduced by `Display`.
     ///
-    /// **Known problems:** The inherent method will shadow the implementation by `Display`. If they behave differently, this may lead to confusing situations for users of the respective type.
+    /// **Known problems:** None
     ///
     /// ** Example:**
     ///
-    /// ```rust,ignore
+    /// ```rust
     /// // Bad
     /// use std::fmt;
     ///
@@ -68,6 +71,9 @@ declare_clippy_lint! {
     ///         write!(f, "I am A, too")
     ///     }
     /// }
+    /// ```
+    ///
+    /// ```rust
     /// // Good
     /// use std::fmt;
     ///
@@ -81,7 +87,7 @@ declare_clippy_lint! {
     /// ```
     pub INHERENT_TO_STRING_SHADOW_DISPLAY,
     correctness,
-    "type implements inherent method 'to_string()', which gets shadowed by the implementation of the 'Display' trait "
+    "type implements inherent method `to_string()`, which gets shadowed by the implementation of the `Display` trait "
 }
 
 declare_lint_pass!(InherentToString => [INHERENT_TO_STRING, INHERENT_TO_STRING_SHADOW_DISPLAY]);
@@ -114,7 +120,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InherentToString {
 
 fn show_lint(cx: &LateContext<'_, '_>, item: &ImplItem) {
     let display_trait_id =
-        get_trait_def_id(cx, &["core", "fmt", "Display"]).expect("Failed to get trait ID of 'Display'!");
+        get_trait_def_id(cx, &["core", "fmt", "Display"]).expect("Failed to get trait ID of `Display`!");
 
     // Get the real type of 'self'
     let fn_def_id = cx.tcx.hir().local_def_id(item.hir_id);
@@ -128,10 +134,10 @@ fn show_lint(cx: &LateContext<'_, '_>, item: &ImplItem) {
             INHERENT_TO_STRING_SHADOW_DISPLAY,
             item.span,
             &format!(
-                "type '{}' implements inherent method 'to_string() -> String' which shadows the implementation of 'Display'",
+                "type `{}` implements inherent method `to_string(&self) -> String` which shadows the implementation of `Display`",
                 self_type.to_string()
             ),
-            &format!("remove the inherent method from type '{}'", self_type.to_string())
+            &format!("remove the inherent method from type `{}`", self_type.to_string())
         );
     } else {
         span_help_and_lint(
@@ -139,10 +145,10 @@ fn show_lint(cx: &LateContext<'_, '_>, item: &ImplItem) {
             INHERENT_TO_STRING,
             item.span,
             &format!(
-                "implementation of inherent method 'to_string() -> String' for type '{}'",
+                "implementation of inherent method `to_string(&self) -> String` for type `{}`",
                 self_type.to_string()
             ),
-            &format!("implement trait 'Display' for type '{}' instead", self_type.to_string()),
+            &format!("implement trait `Display` for type `{}` instead", self_type.to_string()),
         );
     }
 }

--- a/clippy_lints/src/inherent_to_string.rs
+++ b/clippy_lints/src/inherent_to_string.rs
@@ -1,0 +1,148 @@
+use if_chain::if_chain;
+use rustc::hir::{ImplItem, ImplItemKind};
+use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::{declare_lint_pass, declare_tool_lint};
+
+use crate::utils::{
+    get_trait_def_id, implements_trait, in_macro_or_desugar, match_type, paths, return_ty, span_help_and_lint,
+    trait_ref_of_method, walk_ptrs_ty,
+};
+
+declare_clippy_lint! {
+    /// **What id does:** Checks for the definition of inherent methods with a signature of `to_string(&self) -> String`.
+    ///
+    /// **Why is this bad?** This method is also implicitly defined if a type implements the `Display` trait. As the functionality of `Display` is much more versatile, it should be preferred.
+    ///
+    /// **Known problems:** None
+    ///
+    /// ** Example:**
+    ///
+    /// ```rust,ignore
+    /// // Bad
+    /// pub struct A;
+    ///
+    /// impl A {
+    ///     pub fn to_string(&self) -> String {
+    ///         "I am A".to_string()
+    ///     }
+    /// }
+    /// // Good
+    /// use std::fmt;
+    ///
+    /// pub struct A;
+    ///
+    /// impl fmt::Display for A {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         write!(f, "I am A")
+    ///     }
+    /// }
+    /// ```
+    pub INHERENT_TO_STRING,
+    style,
+    "type implements inherent method 'to_string()', but should instead implement the 'Display' trait"
+}
+
+declare_clippy_lint! {
+    /// **What id does:** Checks for the definition of inherent methods with a signature of `to_string(&self) -> String` and if the type implementing this method also implements the `Display` trait.
+    ///
+    /// **Why is this bad?** This method is also implicitly defined if a type implements the 'Display' trait. The less versatile inherent method will then shadow the implementation introduced by `Display`.
+    ///
+    /// **Known problems:** The inherent method will shadow the implementation by `Display`. If they behave differently, this may lead to confusing situations for users of the respective type.
+    ///
+    /// ** Example:**
+    ///
+    /// ```rust,ignore
+    /// // Bad
+    /// use std::fmt;
+    ///
+    /// pub struct A;
+    ///
+    /// impl A {
+    ///     pub fn to_string(&self) -> String {
+    ///         "I am A".to_string()
+    ///     }
+    /// }
+    ///
+    /// impl fmt::Display for A {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         write!(f, "I am A, too")
+    ///     }
+    /// }
+    /// // Good
+    /// use std::fmt;
+    ///
+    /// pub struct A;
+    ///
+    /// impl fmt::Display for A {
+    ///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    ///         write!(f, "I am A")
+    ///     }
+    /// }
+    /// ```
+    pub INHERENT_TO_STRING_SHADOW_DISPLAY,
+    correctness,
+    "type implements inherent method 'to_string()', which gets shadowed by the implementation of the 'Display' trait "
+}
+
+declare_lint_pass!(InherentToString => [INHERENT_TO_STRING, INHERENT_TO_STRING_SHADOW_DISPLAY]);
+
+impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InherentToString {
+    fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx ImplItem) {
+        if in_macro_or_desugar(impl_item.span) {
+            return;
+        }
+
+        if_chain! {
+            // Check if item is a method, called to_string and has a parameter 'self'
+            if let ImplItemKind::Method(ref signature, _) = impl_item.node;
+            if impl_item.ident.name.as_str() == "to_string";
+            let decl = &signature.decl;
+            if decl.implicit_self.has_implicit_self();
+
+            // Check if return type is String
+            if match_type(cx, return_ty(cx, impl_item.hir_id), &paths::STRING);
+
+            // Filters instances of to_string which are required by a trait
+            if trait_ref_of_method(cx, impl_item.hir_id).is_none();
+
+            then {
+                show_lint(cx, impl_item);
+            }
+        }
+    }
+}
+
+fn show_lint(cx: &LateContext<'_, '_>, item: &ImplItem) {
+    let display_trait_id =
+        get_trait_def_id(cx, &["core", "fmt", "Display"]).expect("Failed to get trait ID of 'Display'!");
+
+    // Get the real type of 'self'
+    let fn_def_id = cx.tcx.hir().local_def_id(item.hir_id);
+    let self_type = cx.tcx.fn_sig(fn_def_id).input(0);
+    let self_type = walk_ptrs_ty(self_type.skip_binder());
+
+    // Emit either a warning or an error
+    if implements_trait(cx, self_type, display_trait_id, &[]) {
+        span_help_and_lint(
+            cx,
+            INHERENT_TO_STRING_SHADOW_DISPLAY,
+            item.span,
+            &format!(
+                "type '{}' implements inherent method 'to_string() -> String' which shadows the implementation of 'Display'",
+                self_type.to_string()
+            ),
+            &format!("remove the inherent method from type '{}'", self_type.to_string())
+        );
+    } else {
+        span_help_and_lint(
+            cx,
+            INHERENT_TO_STRING,
+            item.span,
+            &format!(
+                "implementation of inherent method 'to_string() -> String' for type '{}'",
+                self_type.to_string()
+            ),
+            &format!("implement trait 'Display' for type '{}' instead", self_type.to_string()),
+        );
+    }
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -195,6 +195,7 @@ pub mod indexing_slicing;
 pub mod infallible_destructuring_match;
 pub mod infinite_iter;
 pub mod inherent_impl;
+pub mod inherent_to_string;
 pub mod inline_fn_without_body;
 pub mod int_plus_one;
 pub mod integer_division;
@@ -585,6 +586,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
     reg.register_late_lint_pass(box path_buf_push_overwrite::PathBufPushOverwrite);
     reg.register_late_lint_pass(box checked_conversions::CheckedConversions);
     reg.register_late_lint_pass(box integer_division::IntegerDivision);
+    reg.register_late_lint_pass(box inherent_to_string::InherentToString);
 
     reg.register_lint_group("clippy::restriction", Some("clippy_restriction"), vec![
         arithmetic::FLOAT_ARITHMETIC,
@@ -725,6 +727,8 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         indexing_slicing::OUT_OF_BOUNDS_INDEXING,
         infallible_destructuring_match::INFALLIBLE_DESTRUCTURING_MATCH,
         infinite_iter::INFINITE_ITER,
+        inherent_to_string::INHERENT_TO_STRING,
+        inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY,
         inline_fn_without_body::INLINE_FN_WITHOUT_BODY,
         int_plus_one::INT_PLUS_ONE,
         invalid_ref::INVALID_REF,
@@ -913,6 +917,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING,
         formatting::SUSPICIOUS_ELSE_FORMATTING,
         infallible_destructuring_match::INFALLIBLE_DESTRUCTURING_MATCH,
+        inherent_to_string::INHERENT_TO_STRING,
         len_zero::LEN_WITHOUT_IS_EMPTY,
         len_zero::LEN_ZERO,
         let_if_seq::USELESS_LET_IF_SEQ,
@@ -1075,6 +1080,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         functions::NOT_UNSAFE_PTR_ARG_DEREF,
         indexing_slicing::OUT_OF_BOUNDS_INDEXING,
         infinite_iter::INFINITE_ITER,
+        inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY,
         inline_fn_without_body::INLINE_FN_WITHOUT_BODY,
         invalid_ref::INVALID_REF,
         literal_representation::MISTYPED_LITERAL_SUFFIXES,

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -731,14 +731,14 @@ pub const ALL_LINTS: [Lint; 308] = [
     Lint {
         name: "inherent_to_string",
         group: "style",
-        desc: "type implements inherent method \'to_string()\', but should instead implement the \'Display\' trait",
+        desc: "type implements inherent method `to_string()`, but should instead implement the `Display` trait",
         deprecation: None,
         module: "inherent_to_string",
     },
     Lint {
         name: "inherent_to_string_shadow_display",
         group: "correctness",
-        desc: "type implements inherent method \'to_string()\', which gets shadowed by the implementation of the \'Display\' trait ",
+        desc: "type implements inherent method `to_string()`, which gets shadowed by the implementation of the `Display` trait ",
         deprecation: None,
         module: "inherent_to_string",
     },

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -6,7 +6,7 @@ pub use lint::Lint;
 pub use lint::LINT_LEVELS;
 
 // begin lint list, do not remove this comment, it’s used in `update_lints`
-pub const ALL_LINTS: [Lint; 306] = [
+pub const ALL_LINTS: [Lint; 308] = [
     Lint {
         name: "absurd_extreme_comparisons",
         group: "correctness",
@@ -727,6 +727,20 @@ pub const ALL_LINTS: [Lint; 306] = [
         desc: "infinite iteration",
         deprecation: None,
         module: "infinite_iter",
+    },
+    Lint {
+        name: "inherent_to_string",
+        group: "style",
+        desc: "type implements inherent method \'to_string()\', but should instead implement the \'Display\' trait",
+        deprecation: None,
+        module: "inherent_to_string",
+    },
+    Lint {
+        name: "inherent_to_string_shadow_display",
+        group: "correctness",
+        desc: "type implements inherent method \'to_string()\', which gets shadowed by the implementation of the \'Display\' trait ",
+        deprecation: None,
+        module: "inherent_to_string",
     },
     Lint {
         name: "inline_always",

--- a/tests/ui/inherent_to_string.rs
+++ b/tests/ui/inherent_to_string.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::inherent_to_string)]
-//#![deny(clippy::inherent_to_string_shadow)]
+#![deny(clippy::inherent_to_string_shadow)]
 
 use std::fmt;
 

--- a/tests/ui/inherent_to_string.rs
+++ b/tests/ui/inherent_to_string.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::inherent_to_string)]
-#![deny(clippy::inherent_to_string_shadow)]
+#![deny(clippy::inherent_to_string_shadow_display)]
 
 use std::fmt;
 

--- a/tests/ui/inherent_to_string.rs
+++ b/tests/ui/inherent_to_string.rs
@@ -1,0 +1,84 @@
+#![warn(clippy::inherent_to_string)]
+//#![deny(clippy::inherent_to_string_shadow)]
+
+use std::fmt;
+
+trait FalsePositive {
+    fn to_string(&self) -> String;
+}
+
+struct A;
+struct B;
+struct C;
+struct D;
+struct E;
+
+impl A {
+    // Should be detected; emit warning
+    fn to_string(&self) -> String {
+        "A.to_string()".to_string()
+    }
+
+    // Should not be detected as it does not match the function signature
+    fn to_str(&self) -> String {
+        "A.to_str()".to_string()
+    }
+}
+
+// Should not be detected as it is a free function
+fn to_string() -> String {
+    "free to_string()".to_string()
+}
+
+impl B {
+    // Should not be detected, wrong return type
+    fn to_string(&self) -> i32 {
+        42
+    }
+}
+
+impl C {
+    // Should be detected and emit error as C also implements Display
+    fn to_string(&self) -> String {
+        "C.to_string()".to_string()
+    }
+}
+
+impl fmt::Display for C {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "impl Display for C")
+    }
+}
+
+impl FalsePositive for D {
+    // Should not be detected, as it is a trait function
+    fn to_string(&self) -> String {
+        "impl FalsePositive for D".to_string()
+    }
+}
+
+impl E {
+    // Should not be detected, as it is not bound to an instance
+    fn to_string() -> String {
+        "E::to_string()".to_string()
+    }
+}
+
+fn main() {
+    let a = A;
+    a.to_string();
+    a.to_str();
+
+    to_string();
+
+    let b = B;
+    b.to_string();
+
+    let c = C;
+    C.to_string();
+
+    let d = D;
+    d.to_string();
+
+    E::to_string();
+}

--- a/tests/ui/inherent_to_string.stderr
+++ b/tests/ui/inherent_to_string.stderr
@@ -1,0 +1,24 @@
+error: implementation of inherent method 'to_string() -> String' for type 'A'
+  --> $DIR/inherent_to_string.rs:18:5
+   |
+LL | /     fn to_string(&self) -> String {
+LL | |         "A.to_string()".to_string()
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::inherent-to-string` implied by `-D warnings`
+   = help: implement trait 'Display' for type 'A' instead
+
+error: type 'C' implements inherent method 'to_string() -> String' which shadows the implementation of 'Display'
+  --> $DIR/inherent_to_string.rs:42:5
+   |
+LL | /     fn to_string(&self) -> String {
+LL | |         "C.to_string()".to_string()
+LL | |     }
+   | |_____^
+   |
+   = note: #[deny(clippy::inherent_to_string_shadow_display)] on by default
+   = help: remove the inherent method from type 'C'
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/inherent_to_string.stderr
+++ b/tests/ui/inherent_to_string.stderr
@@ -1,4 +1,4 @@
-error: implementation of inherent method 'to_string() -> String' for type 'A'
+error: implementation of inherent method `to_string(&self) -> String` for type `A`
   --> $DIR/inherent_to_string.rs:18:5
    |
 LL | /     fn to_string(&self) -> String {
@@ -7,9 +7,9 @@ LL | |     }
    | |_____^
    |
    = note: `-D clippy::inherent-to-string` implied by `-D warnings`
-   = help: implement trait 'Display' for type 'A' instead
+   = help: implement trait `Display` for type `A` instead
 
-error: type 'C' implements inherent method 'to_string() -> String' which shadows the implementation of 'Display'
+error: type `C` implements inherent method `to_string(&self) -> String` which shadows the implementation of `Display`
   --> $DIR/inherent_to_string.rs:42:5
    |
 LL | /     fn to_string(&self) -> String {
@@ -18,7 +18,15 @@ LL | |     }
    | |_____^
    |
    = note: #[deny(clippy::inherent_to_string_shadow_display)] on by default
-   = help: remove the inherent method from type 'C'
+   = help: remove the inherent method from type `C`
 
-error: aborting due to 2 previous errors
+error: unknown clippy lint: clippy::inherent_to_string_shadow
+  --> $DIR/inherent_to_string.rs:2:9
+   |
+LL | #![deny(clippy::inherent_to_string_shadow)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unknown-clippy-lints` implied by `-D warnings`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/inherent_to_string.stderr
+++ b/tests/ui/inherent_to_string.stderr
@@ -17,16 +17,12 @@ LL | |         "C.to_string()".to_string()
 LL | |     }
    | |_____^
    |
-   = note: #[deny(clippy::inherent_to_string_shadow_display)] on by default
-   = help: remove the inherent method from type `C`
-
-error: unknown clippy lint: clippy::inherent_to_string_shadow
+note: lint level defined here
   --> $DIR/inherent_to_string.rs:2:9
    |
-LL | #![deny(clippy::inherent_to_string_shadow)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `-D clippy::unknown-clippy-lints` implied by `-D warnings`
+LL | #![deny(clippy::inherent_to_string_shadow_display)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: remove the inherent method from type `C`
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #4247

changelog: Implement two new lints: `inherent_to_string` and `inherent_to_string_shadow_display`

1) Emits a warning if a type implements an inherent method `to_string(&self) -> String`
2) Emits an error if a type implements an inherent method `to_string(&self) -> String` and also implements the `Display` trait