### PR TITLE
Disable AppVeyor builds on the master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,10 @@ environment:
         - TARGET: x86_64-pc-windows-msvc
 
 branches:
-    # Only build AppVeyor on r+, try and the master branch
+    # Only build AppVeyor on r+ and try branch
     only:
       - auto
       - try
-      - master
 
 install:
     - curl -sSf -o rustup-init.exe https://win.rustup.rs/


### PR DESCRIPTION
AppVeyor is already checked on every merge of a PR, rechecking it
immediately after on the master branch is not necessary.

Resolves #4263 

changelog: none
