### PR TITLE
UI Test Cleanup: Split up checked_unwrap tests

### DIFF
--- a/tests/ui/checked_unwrap/complex_conditionals.rs
+++ b/tests/ui/checked_unwrap/complex_conditionals.rs
@@ -1,44 +1,6 @@
 #![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
 #![allow(clippy::if_same_then_else)]
 
-fn main() {
-    let x = Some(());
-    if x.is_some() {
-        x.unwrap(); // unnecessary
-    } else {
-        x.unwrap(); // will panic
-    }
-    if x.is_none() {
-        x.unwrap(); // will panic
-    } else {
-        x.unwrap(); // unnecessary
-    }
-    let mut x: Result<(), ()> = Ok(());
-    if x.is_ok() {
-        x.unwrap(); // unnecessary
-        x.unwrap_err(); // will panic
-    } else {
-        x.unwrap(); // will panic
-        x.unwrap_err(); // unnecessary
-    }
-    if x.is_err() {
-        x.unwrap(); // will panic
-        x.unwrap_err(); // unnecessary
-    } else {
-        x.unwrap(); // unnecessary
-        x.unwrap_err(); // will panic
-    }
-    if x.is_ok() {
-        x = Err(());
-        x.unwrap(); // not unnecessary because of mutation of x
-                    // it will always panic but the lint is not smart enough to see this (it only checks if conditions).
-    } else {
-        x = Ok(());
-        x.unwrap_err(); // not unnecessary because of mutation of x
-                        // it will always panic but the lint is not smart enough to see this (it only checks if conditions).
-    }
-}
-
 fn test_complex_conditions() {
     let x: Result<(), ()> = Ok(());
     let y: Result<(), ()> = Ok(());
@@ -99,3 +61,5 @@ fn test_nested() {
         }
     }
 }
+
+fn main() {}

--- a/tests/ui/checked_unwrap/complex_conditionals.stderr
+++ b/tests/ui/checked_unwrap/complex_conditionals.stderr
@@ -1,138 +1,34 @@
 error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:7:9
+  --> $DIR/complex_conditionals.rs:8:9
    |
-LL |     if x.is_some() {
-   |        ----------- the check is happening here
+LL |     if x.is_ok() && y.is_err() {
+   |        --------- the check is happening here
 LL |         x.unwrap(); // unnecessary
    |         ^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/checked_unwrap.rs:1:35
+  --> $DIR/complex_conditionals.rs:1:35
    |
 LL | #![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:9:9
+error: This call to `unwrap_err()` will always panic.
+  --> $DIR/complex_conditionals.rs:9:9
    |
-LL |     if x.is_some() {
-   |        ----------- because of this check
-...
-LL |         x.unwrap(); // will panic
-   |         ^^^^^^^^^^
+LL |     if x.is_ok() && y.is_err() {
+   |        --------- because of this check
+LL |         x.unwrap(); // unnecessary
+LL |         x.unwrap_err(); // will panic
+   |         ^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/checked_unwrap.rs:1:9
+  --> $DIR/complex_conditionals.rs:1:9
    |
 LL | #![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:12:9
-   |
-LL |     if x.is_none() {
-   |        ----------- because of this check
-LL |         x.unwrap(); // will panic
-   |         ^^^^^^^^^^
-
-error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:14:9
-   |
-LL |     if x.is_none() {
-   |        ----------- the check is happening here
-...
-LL |         x.unwrap(); // unnecessary
-   |         ^^^^^^^^^^
-
-error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:18:9
-   |
-LL |     if x.is_ok() {
-   |        --------- the check is happening here
-LL |         x.unwrap(); // unnecessary
-   |         ^^^^^^^^^^
-
-error: This call to `unwrap_err()` will always panic.
-  --> $DIR/checked_unwrap.rs:19:9
-   |
-LL |     if x.is_ok() {
-   |        --------- because of this check
-LL |         x.unwrap(); // unnecessary
-LL |         x.unwrap_err(); // will panic
-   |         ^^^^^^^^^^^^^^
-
-error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:21:9
-   |
-LL |     if x.is_ok() {
-   |        --------- because of this check
-...
-LL |         x.unwrap(); // will panic
-   |         ^^^^^^^^^^
-
-error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:22:9
-   |
-LL |     if x.is_ok() {
-   |        --------- the check is happening here
-...
-LL |         x.unwrap_err(); // unnecessary
-   |         ^^^^^^^^^^^^^^
-
-error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:25:9
-   |
-LL |     if x.is_err() {
-   |        ---------- because of this check
-LL |         x.unwrap(); // will panic
-   |         ^^^^^^^^^^
-
-error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:26:9
-   |
-LL |     if x.is_err() {
-   |        ---------- the check is happening here
-LL |         x.unwrap(); // will panic
-LL |         x.unwrap_err(); // unnecessary
-   |         ^^^^^^^^^^^^^^
-
-error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:28:9
-   |
-LL |     if x.is_err() {
-   |        ---------- the check is happening here
-...
-LL |         x.unwrap(); // unnecessary
-   |         ^^^^^^^^^^
-
-error: This call to `unwrap_err()` will always panic.
-  --> $DIR/checked_unwrap.rs:29:9
-   |
-LL |     if x.is_err() {
-   |        ---------- because of this check
-...
-LL |         x.unwrap_err(); // will panic
-   |         ^^^^^^^^^^^^^^
-
-error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:46:9
-   |
-LL |     if x.is_ok() && y.is_err() {
-   |        --------- the check is happening here
-LL |         x.unwrap(); // unnecessary
-   |         ^^^^^^^^^^
-
-error: This call to `unwrap_err()` will always panic.
-  --> $DIR/checked_unwrap.rs:47:9
-   |
-LL |     if x.is_ok() && y.is_err() {
-   |        --------- because of this check
-LL |         x.unwrap(); // unnecessary
-LL |         x.unwrap_err(); // will panic
-   |         ^^^^^^^^^^^^^^
-
-error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:48:9
+  --> $DIR/complex_conditionals.rs:10:9
    |
 LL |     if x.is_ok() && y.is_err() {
    |                     ---------- because of this check
@@ -141,7 +37,7 @@ LL |         y.unwrap(); // will panic
    |         ^^^^^^^^^^
 
 error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:49:9
+  --> $DIR/complex_conditionals.rs:11:9
    |
 LL |     if x.is_ok() && y.is_err() {
    |                     ---------- the check is happening here
@@ -150,7 +46,7 @@ LL |         y.unwrap_err(); // unnecessary
    |         ^^^^^^^^^^^^^^
 
 error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:63:9
+  --> $DIR/complex_conditionals.rs:25:9
    |
 LL |     if x.is_ok() || y.is_ok() {
    |        --------- because of this check
@@ -159,7 +55,7 @@ LL |         x.unwrap(); // will panic
    |         ^^^^^^^^^^
 
 error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:64:9
+  --> $DIR/complex_conditionals.rs:26:9
    |
 LL |     if x.is_ok() || y.is_ok() {
    |        --------- the check is happening here
@@ -168,7 +64,7 @@ LL |         x.unwrap_err(); // unnecessary
    |         ^^^^^^^^^^^^^^
 
 error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:65:9
+  --> $DIR/complex_conditionals.rs:27:9
    |
 LL |     if x.is_ok() || y.is_ok() {
    |                     --------- because of this check
@@ -177,7 +73,7 @@ LL |         y.unwrap(); // will panic
    |         ^^^^^^^^^^
 
 error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:66:9
+  --> $DIR/complex_conditionals.rs:28:9
    |
 LL |     if x.is_ok() || y.is_ok() {
    |                     --------- the check is happening here
@@ -186,7 +82,7 @@ LL |         y.unwrap_err(); // unnecessary
    |         ^^^^^^^^^^^^^^
 
 error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:70:9
+  --> $DIR/complex_conditionals.rs:32:9
    |
 LL |     if x.is_ok() && !(y.is_ok() || z.is_err()) {
    |        --------- the check is happening here
@@ -194,7 +90,7 @@ LL |         x.unwrap(); // unnecessary
    |         ^^^^^^^^^^
 
 error: This call to `unwrap_err()` will always panic.
-  --> $DIR/checked_unwrap.rs:71:9
+  --> $DIR/complex_conditionals.rs:33:9
    |
 LL |     if x.is_ok() && !(y.is_ok() || z.is_err()) {
    |        --------- because of this check
@@ -203,7 +99,7 @@ LL |         x.unwrap_err(); // will panic
    |         ^^^^^^^^^^^^^^
 
 error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:72:9
+  --> $DIR/complex_conditionals.rs:34:9
    |
 LL |     if x.is_ok() && !(y.is_ok() || z.is_err()) {
    |                       --------- because of this check
@@ -212,7 +108,7 @@ LL |         y.unwrap(); // will panic
    |         ^^^^^^^^^^
 
 error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:73:9
+  --> $DIR/complex_conditionals.rs:35:9
    |
 LL |     if x.is_ok() && !(y.is_ok() || z.is_err()) {
    |                       --------- the check is happening here
@@ -221,7 +117,7 @@ LL |         y.unwrap_err(); // unnecessary
    |         ^^^^^^^^^^^^^^
 
 error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:74:9
+  --> $DIR/complex_conditionals.rs:36:9
    |
 LL |     if x.is_ok() && !(y.is_ok() || z.is_err()) {
    |                                    ---------- the check is happening here
@@ -230,7 +126,7 @@ LL |         z.unwrap(); // unnecessary
    |         ^^^^^^^^^^
 
 error: This call to `unwrap_err()` will always panic.
-  --> $DIR/checked_unwrap.rs:75:9
+  --> $DIR/complex_conditionals.rs:37:9
    |
 LL |     if x.is_ok() && !(y.is_ok() || z.is_err()) {
    |                                    ---------- because of this check
@@ -239,7 +135,7 @@ LL |         z.unwrap_err(); // will panic
    |         ^^^^^^^^^^^^^^
 
 error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:83:9
+  --> $DIR/complex_conditionals.rs:45:9
    |
 LL |     if x.is_ok() || !(y.is_ok() && z.is_err()) {
    |        --------- because of this check
@@ -248,7 +144,7 @@ LL |         x.unwrap(); // will panic
    |         ^^^^^^^^^^
 
 error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:84:9
+  --> $DIR/complex_conditionals.rs:46:9
    |
 LL |     if x.is_ok() || !(y.is_ok() && z.is_err()) {
    |        --------- the check is happening here
@@ -257,7 +153,7 @@ LL |         x.unwrap_err(); // unnecessary
    |         ^^^^^^^^^^^^^^
 
 error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:85:9
+  --> $DIR/complex_conditionals.rs:47:9
    |
 LL |     if x.is_ok() || !(y.is_ok() && z.is_err()) {
    |                       --------- the check is happening here
@@ -266,7 +162,7 @@ LL |         y.unwrap(); // unnecessary
    |         ^^^^^^^^^^
 
 error: This call to `unwrap_err()` will always panic.
-  --> $DIR/checked_unwrap.rs:86:9
+  --> $DIR/complex_conditionals.rs:48:9
    |
 LL |     if x.is_ok() || !(y.is_ok() && z.is_err()) {
    |                       --------- because of this check
@@ -275,7 +171,7 @@ LL |         y.unwrap_err(); // will panic
    |         ^^^^^^^^^^^^^^
 
 error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:87:9
+  --> $DIR/complex_conditionals.rs:49:9
    |
 LL |     if x.is_ok() || !(y.is_ok() && z.is_err()) {
    |                                    ---------- because of this check
@@ -284,7 +180,7 @@ LL |         z.unwrap(); // will panic
    |         ^^^^^^^^^^
 
 error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:88:9
+  --> $DIR/complex_conditionals.rs:50:9
    |
 LL |     if x.is_ok() || !(y.is_ok() && z.is_err()) {
    |                                    ---------- the check is happening here
@@ -293,7 +189,7 @@ LL |         z.unwrap_err(); // unnecessary
    |         ^^^^^^^^^^^^^^
 
 error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
-  --> $DIR/checked_unwrap.rs:96:13
+  --> $DIR/complex_conditionals.rs:58:13
    |
 LL |         if x.is_some() {
    |            ----------- the check is happening here
@@ -301,7 +197,7 @@ LL |             x.unwrap(); // unnecessary
    |             ^^^^^^^^^^
 
 error: This call to `unwrap()` will always panic.
-  --> $DIR/checked_unwrap.rs:98:13
+  --> $DIR/complex_conditionals.rs:60:13
    |
 LL |         if x.is_some() {
    |            ----------- because of this check
@@ -309,5 +205,5 @@ LL |         if x.is_some() {
 LL |             x.unwrap(); // will panic
    |             ^^^^^^^^^^
 
-error: aborting due to 34 previous errors
+error: aborting due to 22 previous errors
 

--- a/tests/ui/checked_unwrap/simple_conditionals.rs
+++ b/tests/ui/checked_unwrap/simple_conditionals.rs
@@ -1,0 +1,40 @@
+#![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
+#![allow(clippy::if_same_then_else)]
+
+fn main() {
+    let x = Some(());
+    if x.is_some() {
+        x.unwrap(); // unnecessary
+    } else {
+        x.unwrap(); // will panic
+    }
+    if x.is_none() {
+        x.unwrap(); // will panic
+    } else {
+        x.unwrap(); // unnecessary
+    }
+    let mut x: Result<(), ()> = Ok(());
+    if x.is_ok() {
+        x.unwrap(); // unnecessary
+        x.unwrap_err(); // will panic
+    } else {
+        x.unwrap(); // will panic
+        x.unwrap_err(); // unnecessary
+    }
+    if x.is_err() {
+        x.unwrap(); // will panic
+        x.unwrap_err(); // unnecessary
+    } else {
+        x.unwrap(); // unnecessary
+        x.unwrap_err(); // will panic
+    }
+    if x.is_ok() {
+        x = Err(());
+        x.unwrap(); // not unnecessary because of mutation of x
+                    // it will always panic but the lint is not smart enough to see this (it only checks if conditions).
+    } else {
+        x = Ok(());
+        x.unwrap_err(); // not unnecessary because of mutation of x
+                        // it will always panic but the lint is not smart enough to see this (it only checks if conditions).
+    }
+}

--- a/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -1,0 +1,118 @@
+error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
+  --> $DIR/simple_conditionals.rs:7:9
+   |
+LL |     if x.is_some() {
+   |        ----------- the check is happening here
+LL |         x.unwrap(); // unnecessary
+   |         ^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/simple_conditionals.rs:1:35
+   |
+LL | #![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: This call to `unwrap()` will always panic.
+  --> $DIR/simple_conditionals.rs:9:9
+   |
+LL |     if x.is_some() {
+   |        ----------- because of this check
+...
+LL |         x.unwrap(); // will panic
+   |         ^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/simple_conditionals.rs:1:9
+   |
+LL | #![deny(clippy::panicking_unwrap, clippy::unnecessary_unwrap)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: This call to `unwrap()` will always panic.
+  --> $DIR/simple_conditionals.rs:12:9
+   |
+LL |     if x.is_none() {
+   |        ----------- because of this check
+LL |         x.unwrap(); // will panic
+   |         ^^^^^^^^^^
+
+error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
+  --> $DIR/simple_conditionals.rs:14:9
+   |
+LL |     if x.is_none() {
+   |        ----------- the check is happening here
+...
+LL |         x.unwrap(); // unnecessary
+   |         ^^^^^^^^^^
+
+error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
+  --> $DIR/simple_conditionals.rs:18:9
+   |
+LL |     if x.is_ok() {
+   |        --------- the check is happening here
+LL |         x.unwrap(); // unnecessary
+   |         ^^^^^^^^^^
+
+error: This call to `unwrap_err()` will always panic.
+  --> $DIR/simple_conditionals.rs:19:9
+   |
+LL |     if x.is_ok() {
+   |        --------- because of this check
+LL |         x.unwrap(); // unnecessary
+LL |         x.unwrap_err(); // will panic
+   |         ^^^^^^^^^^^^^^
+
+error: This call to `unwrap()` will always panic.
+  --> $DIR/simple_conditionals.rs:21:9
+   |
+LL |     if x.is_ok() {
+   |        --------- because of this check
+...
+LL |         x.unwrap(); // will panic
+   |         ^^^^^^^^^^
+
+error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
+  --> $DIR/simple_conditionals.rs:22:9
+   |
+LL |     if x.is_ok() {
+   |        --------- the check is happening here
+...
+LL |         x.unwrap_err(); // unnecessary
+   |         ^^^^^^^^^^^^^^
+
+error: This call to `unwrap()` will always panic.
+  --> $DIR/simple_conditionals.rs:25:9
+   |
+LL |     if x.is_err() {
+   |        ---------- because of this check
+LL |         x.unwrap(); // will panic
+   |         ^^^^^^^^^^
+
+error: You checked before that `unwrap_err()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
+  --> $DIR/simple_conditionals.rs:26:9
+   |
+LL |     if x.is_err() {
+   |        ---------- the check is happening here
+LL |         x.unwrap(); // will panic
+LL |         x.unwrap_err(); // unnecessary
+   |         ^^^^^^^^^^^^^^
+
+error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
+  --> $DIR/simple_conditionals.rs:28:9
+   |
+LL |     if x.is_err() {
+   |        ---------- the check is happening here
+...
+LL |         x.unwrap(); // unnecessary
+   |         ^^^^^^^^^^
+
+error: This call to `unwrap_err()` will always panic.
+  --> $DIR/simple_conditionals.rs:29:9
+   |
+LL |     if x.is_err() {
+   |        ---------- because of this check
+...
+LL |         x.unwrap_err(); // will panic
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+


### PR DESCRIPTION
Let's slowly bring that ticket closer to the finish line :snail: :checkered_flag: 

This splits up `tests/ui/checked_unwrap.rs` into:

 * `tests/ui/checked_unwrap/complex.rs`
 * `tests/ui/checked_unwrap/simple.rs`

Based on the naming of the methods in the tests.

changelog: none

cc #2038