### PR TITLE
Decrease maximum length for stderr files

### DIFF
--- a/clippy_dev/src/stderr_length_check.rs
+++ b/clippy_dev/src/stderr_length_check.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 // The maximum length allowed for stderr files.
 //
 // We limit this because small files are easier to deal with than bigger files.
-const LIMIT: usize = 320;
+const LIMIT: usize = 275;
 
 pub fn check() {
     let stderr_files = stderr_files();


### PR DESCRIPTION
Now at 275.

changelog: none

cc #2038