### PR TITLE
Update pulldown-cmark to 0.5.3

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -27,7 +27,7 @@ semver = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 unicode-normalization = "0.1"
-pulldown-cmark = "0.5.2"
+pulldown-cmark = "0.5.3"
 url = "1.7.0"
 if_chain = "1.0.0"
 smallvec = { version = "0.6.5", features = ["union"] }

--- a/tests/ui/doc.rs
+++ b/tests/ui/doc.rs
@@ -178,3 +178,7 @@ fn issue_2210() {}
 /// This should not cause the lint to trigger:
 /// #REQ-data-family.lint_partof_exists
 fn issue_2343() {}
+
+/// This should not cause an ICE:
+/// __|_ _|__||_|
+fn pulldown_cmark_crash() {}


### PR DESCRIPTION
Fixes a couple of crashes of which I added one example to our tests.

changelog: Update `pulldown-cmark` to 0.5.3 to fix potential crashes in `doc_markdown` lint