### PR TITLE
Bump version of clippy_dummy

### DIFF
--- a/clippy_dummy/Cargo.toml
+++ b/clippy_dummy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy_dummy" # rename to clippy before publishing
-version = "0.0.302"
+version = "0.0.303"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
 readme = "crates-readme.md"

--- a/clippy_dummy/build.rs
+++ b/clippy_dummy/build.rs
@@ -3,7 +3,7 @@ extern crate term;
 fn main() {
     if let Err(_) = foo() {
         eprintln!("error: Clippy is no longer available via crates.io\n");
-        eprintln!("help: please run `rustup component add clippy-preview` instead");
+        eprintln!("help: please run `rustup component add clippy` instead");
     }
     std::process::exit(1);
 }
@@ -31,7 +31,7 @@ fn foo() -> Result<(), ()> {
     write!(t, "please run `").map_err(|_| ())?;
 
     t.attr(term::Attr::Bold).map_err(|_| ())?;
-    write!(t, "rustup component add clippy-preview").map_err(|_| ())?;
+    write!(t, "rustup component add clippy").map_err(|_| ())?;
 
     t.reset().map_err(|_| ())?;
     t.fg(term::color::WHITE).map_err(|_| ())?;

--- a/clippy_dummy/crates-readme.md
+++ b/clippy_dummy/crates-readme.md
@@ -1,7 +1,7 @@
 Installing clippy via crates.io is deprecated. Please use the following:
 
 ```terminal
-rustup component add clippy-preview
+rustup component add clippy
 ```
 
 on a Rust version 1.29 or later. You may need to run `rustup self update` if it complains about a missing clippy binary.


### PR DESCRIPTION
The crates.io page of clippy still suggest to install `clippy-preview`
instead of `clippy` I think it's time to change this.

Thanks to the Stuttgart Meetup for discovering this!

r? @Manishearth could you also publish this after merging?

changelog: none
