### PR TITLE
Move {unnecessary,panicking}_unwrap out of nursery

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -894,6 +894,8 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME,
         unused_io_amount::UNUSED_IO_AMOUNT,
         unused_label::UNUSED_LABEL,
+        unwrap::PANICKING_UNWRAP,
+        unwrap::UNNECESSARY_UNWRAP,
         vec::USELESS_VEC,
         write::PRINTLN_EMPTY_STRING,
         write::PRINT_LITERAL,
@@ -1060,6 +1062,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         types::UNNECESSARY_CAST,
         types::VEC_BOX,
         unused_label::UNUSED_LABEL,
+        unwrap::UNNECESSARY_UNWRAP,
         zero_div_zero::ZERO_DIVIDED_BY_ZERO,
     ]);
 
@@ -1121,6 +1124,7 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         types::UNIT_CMP,
         unicode::ZERO_WIDTH_SPACE,
         unused_io_amount::UNUSED_IO_AMOUNT,
+        unwrap::PANICKING_UNWRAP,
     ]);
 
     reg.register_lint_group("clippy::perf", Some("clippy_perf"), vec![
@@ -1157,8 +1161,6 @@ pub fn register_plugins(reg: &mut rustc_plugin::Registry<'_>, conf: &Conf) {
         needless_borrow::NEEDLESS_BORROW,
         path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE,
         redundant_clone::REDUNDANT_CLONE,
-        unwrap::PANICKING_UNWRAP,
-        unwrap::UNNECESSARY_UNWRAP,
     ]);
 }
 

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     pub UNNECESSARY_UNWRAP,
-    nursery,
+    complexity,
     "checks for calls of unwrap[_err]() that cannot fail"
 }
 
@@ -52,7 +52,7 @@ declare_clippy_lint! {
     ///
     /// This code will always panic. The if condition should probably be inverted.
     pub PANICKING_UNWRAP,
-    nursery,
+    correctness,
     "checks for calls of unwrap[_err]() that will always fail"
 }
 

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -18,6 +18,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let option = Some(0);
+    /// # fn do_something_with(_x: usize) {}
     /// if option.is_some() {
     ///     do_something_with(option.unwrap())
     /// }
@@ -26,6 +28,8 @@ declare_clippy_lint! {
     /// Could be written:
     ///
     /// ```rust
+    /// # let option = Some(0);
+    /// # fn do_something_with(_x: usize) {}
     /// if let Some(value) = option {
     ///     do_something_with(value)
     /// }
@@ -45,6 +49,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let option = Some(0);
+    /// # fn do_something_with(_x: usize) {}
     /// if option.is_none() {
     ///     do_something_with(option.unwrap())
     /// }

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     ///
     /// **Why is this bad?** Using `if let` or `match` is more idiomatic.
     ///
-    /// **Known problems:** Limitations of the borrow checker might make unwrap() necessary sometimes?
+    /// **Known problems:** None
     ///
     /// **Example:**
     /// ```rust

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1381,7 +1381,7 @@ pub const ALL_LINTS: [Lint; 309] = [
     },
     Lint {
         name: "panicking_unwrap",
-        group: "nursery",
+        group: "correctness",
         desc: "checks for calls of unwrap[_err]() that will always fail",
         deprecation: None,
         module: "unwrap",
@@ -1927,7 +1927,7 @@ pub const ALL_LINTS: [Lint; 309] = [
     },
     Lint {
         name: "unnecessary_unwrap",
-        group: "nursery",
+        group: "complexity",
         desc: "checks for calls of unwrap[_err]() that cannot fail",
         deprecation: None,
         module: "unwrap",


### PR DESCRIPTION
Resolves #2437

changelog: Move `{unnnecessary,panicking}_unwrap` out of nursery
