### PR TITLE
Don't nudge people towards toilet closures when producing owl results

### DIFF
--- a/tests/ui/drop_forget_ref.rs
+++ b/tests/ui/drop_forget_ref.rs
@@ -55,3 +55,38 @@ fn test_similarly_named_function() {
     forget(&SomeStruct); //OK; call to unrelated function which happens to have the same name
     std::mem::forget(&SomeStruct);
 }
+
+#[derive(Copy, Clone)]
+pub struct Error;
+fn produce_half_owl_error() -> Result<(), Error> {
+    Ok(())
+}
+
+fn produce_half_owl_ok() -> Result<bool, ()> {
+    Ok(true)
+}
+
+#[allow(dead_code)]
+fn test_owl_result() -> Result<(), ()> {
+    produce_half_owl_error().map_err(|_| ())?;
+    produce_half_owl_ok().map(|_| ())?;
+    // the following should not be linted,
+    // we should not force users to use toilet closures
+    // to produce owl results when drop is more convenient
+    produce_half_owl_error().map_err(drop)?;
+    produce_half_owl_ok().map_err(drop)?;
+    Ok(())
+}
+
+
+#[allow(dead_code)]
+fn test_owl_result_2() -> Result<u8, ()> {
+    produce_half_owl_error().map_err(|_| ())?;
+    produce_half_owl_ok().map(|_| ())?;
+    // the following should not be linted,
+    // we should not force users to use toilet closures
+    // to produce owl results when drop is more convenient
+    produce_half_owl_error().map_err(drop)?;
+    produce_half_owl_ok().map(drop)?;
+    Ok(1)
+}


### PR DESCRIPTION
`.map_err(drop)` should never be linted since sometimes you want to produce `Result<(), ()>` and the alternative is `.map_err(|_| ())`, which can be ugly. We don't seem to, but it's good to specifically test for this.

changelog: none

r? @yaahallo