### PR TITLE
Add negation to `len_zero` lint to show more explicit message.

### DIFF
--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -244,7 +244,7 @@ fn check_len(
                 LEN_ZERO,
                 span,
                 &format!("length comparison to {}", if compare_to == 0 { "zero" } else { "one" }),
-                "using `is_empty` is clearer and more explicit",
+                &format!("using `{}is_empty` is clearer and more explicit", op),
                 format!(
                     "{}{}.is_empty()",
                     op,

--- a/tests/ui/len_zero.stderr
+++ b/tests/ui/len_zero.stderr
@@ -22,13 +22,13 @@ error: length comparison to zero
   --> $DIR/len_zero.rs:83:8
    |
 LL |     if has_is_empty.len() != 0 {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
 
 error: length comparison to zero
   --> $DIR/len_zero.rs:86:8
    |
 LL |     if has_is_empty.len() > 0 {
-   |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
 
 error: length comparison to one
   --> $DIR/len_zero.rs:89:8
@@ -40,7 +40,7 @@ error: length comparison to one
   --> $DIR/len_zero.rs:92:8
    |
 LL |     if has_is_empty.len() >= 1 {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
 
 error: length comparison to zero
   --> $DIR/len_zero.rs:103:8
@@ -52,19 +52,19 @@ error: length comparison to zero
   --> $DIR/len_zero.rs:106:8
    |
 LL |     if 0 != has_is_empty.len() {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
 
 error: length comparison to zero
   --> $DIR/len_zero.rs:109:8
    |
 LL |     if 0 < has_is_empty.len() {
-   |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
 
 error: length comparison to one
   --> $DIR/len_zero.rs:112:8
    |
 LL |     if 1 <= has_is_empty.len() {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
 
 error: length comparison to one
   --> $DIR/len_zero.rs:115:8
@@ -82,7 +82,7 @@ error: length comparison to zero
   --> $DIR/len_zero.rs:142:8
    |
 LL |     if b.len() != 0 {}
-   |        ^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `!b.is_empty()`
+   |        ^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!b.is_empty()`
 
 error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Fixes #4304 I have updated the `len_zero` to show the required negation in case of like the below case.

```
fn main() {
    let v = vec![1];
    if v.len() > 0 {        
    }
}
```

changelog: Clarify suggestion of `len_zero` lint.

