### PR TITLE
Mark `fn_to_numeric_cast` lints as MaybeIncorrect

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1251,7 +1251,7 @@ fn lint_fn_to_numeric_cast(
     }
     match cast_from.sty {
         ty::FnDef(..) | ty::FnPtr(_) => {
-            let mut applicability = Applicability::MachineApplicable;
+            let mut applicability = Applicability::MaybeIncorrect;
             let from_snippet = snippet_with_applicability(cx, cast_expr.span, "x", &mut applicability);
 
             let to_nbits = int_ty_to_nbits(cast_to, cx.tcx);


### PR DESCRIPTION
At least for now so that `cargo fix --clippy` is not causing problems
with this lint. See #3896 for the remaining problems with the suggestions of this lint.

changelog: none

cc #3630, #3896