### PR TITLE
UI Test Cleanup: No wrong_self_convention in methods.rs

### DIFF
--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -12,7 +12,8 @@
     clippy::default_trait_access,
     clippy::use_self,
     clippy::new_ret_no_self,
-    clippy::useless_format
+    clippy::useless_format,
+    clippy::wrong_self_convention
 )]
 
 #[macro_use]

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -1,5 +1,5 @@
 error: defining a method called `add` on this type; consider implementing the `std::ops::Add` trait or choosing a less ambiguous name
-  --> $DIR/methods.rs:35:5
+  --> $DIR/methods.rs:36:5
    |
 LL | /     pub fn add(self, other: T) -> T {
 LL | |         self
@@ -8,28 +8,8 @@ LL | |     }
    |
    = note: `-D clippy::should-implement-trait` implied by `-D warnings`
 
-error: methods called `into_*` usually take self by value; consider choosing a less ambiguous name
-  --> $DIR/methods.rs:70:17
-   |
-LL |     fn into_u16(&self) -> u16 {
-   |                 ^^^^^
-   |
-   = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
-
-error: methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
-  --> $DIR/methods.rs:74:21
-   |
-LL |     fn to_something(self) -> u32 {
-   |                     ^^^^
-
-error: methods called `new` usually take no self; consider choosing a less ambiguous name
-  --> $DIR/methods.rs:78:12
-   |
-LL |     fn new(self) -> Self {
-   |            ^^^^
-
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:157:13
+  --> $DIR/methods.rs:158:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -41,7 +21,7 @@ LL | |                .unwrap_or(0);
    = note: replace `map(|x| x + 1).unwrap_or(0)` with `map_or(0, |x| x + 1)`
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:161:13
+  --> $DIR/methods.rs:162:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -51,7 +31,7 @@ LL | |               ).unwrap_or(0);
    | |____________________________^
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:165:13
+  --> $DIR/methods.rs:166:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -61,7 +41,7 @@ LL | |                 });
    | |__________________^
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:170:13
+  --> $DIR/methods.rs:171:13
    |
 LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +49,7 @@ LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
    = note: replace `map(|x| Some(x + 1)).unwrap_or(None)` with `and_then(|x| Some(x + 1))`
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:172:13
+  --> $DIR/methods.rs:173:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -79,7 +59,7 @@ LL | |     ).unwrap_or(None);
    | |_____________________^
 
 error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
-  --> $DIR/methods.rs:176:13
+  --> $DIR/methods.rs:177:13
    |
 LL |       let _ = opt
    |  _____________^
@@ -90,7 +70,7 @@ LL | |         .unwrap_or(None);
    = note: replace `map(|x| Some(x + 1)).unwrap_or(None)` with `and_then(|x| Some(x + 1))`
 
 error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
-  --> $DIR/methods.rs:187:13
+  --> $DIR/methods.rs:188:13
    |
 LL |     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -98,7 +78,7 @@ LL |     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
    = note: replace `map(|p| format!("{}.", p)).unwrap_or(id)` with `map_or(id, |p| format!("{}.", p))`
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:191:13
+  --> $DIR/methods.rs:192:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -110,7 +90,7 @@ LL | |                .unwrap_or_else(|| 0);
    = note: replace `map(|x| x + 1).unwrap_or_else(|| 0)` with `map_or_else(|| 0, |x| x + 1)`
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:195:13
+  --> $DIR/methods.rs:196:13
    |
 LL |       let _ = opt.map(|x| {
    |  _____________^
@@ -120,7 +100,7 @@ LL | |               ).unwrap_or_else(|| 0);
    | |____________________________________^
 
 error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
-  --> $DIR/methods.rs:199:13
+  --> $DIR/methods.rs:200:13
    |
 LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
@@ -130,7 +110,7 @@ LL | |                 );
    | |_________________^
 
 error: called `filter(p).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(p)` instead.
-  --> $DIR/methods.rs:229:13
+  --> $DIR/methods.rs:230:13
    |
 LL |     let _ = v.iter().filter(|&x| *x < 0).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,7 +119,7 @@ LL |     let _ = v.iter().filter(|&x| *x < 0).next();
    = note: replace `filter(|&x| *x < 0).next()` with `find(|&x| *x < 0)`
 
 error: called `filter(p).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(p)` instead.
-  --> $DIR/methods.rs:232:13
+  --> $DIR/methods.rs:233:13
    |
 LL |       let _ = v.iter().filter(|&x| {
    |  _____________^
@@ -149,7 +129,7 @@ LL | |                    ).next();
    | |___________________________^
 
 error: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:248:13
+  --> $DIR/methods.rs:249:13
    |
 LL |     let _ = v.iter().find(|&x| *x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,7 +138,7 @@ LL |     let _ = v.iter().find(|&x| *x < 0).is_some();
    = note: replace `find(|&x| *x < 0).is_some()` with `any(|x| *x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:251:13
+  --> $DIR/methods.rs:252:13
    |
 LL |       let _ = v.iter().find(|&x| {
    |  _____________^
@@ -168,7 +148,7 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: called `is_some()` after searching an `Iterator` with position. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:257:13
+  --> $DIR/methods.rs:258:13
    |
 LL |     let _ = v.iter().position(|&x| x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +156,7 @@ LL |     let _ = v.iter().position(|&x| x < 0).is_some();
    = note: replace `position(|&x| x < 0).is_some()` with `any(|&x| x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with position. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:260:13
+  --> $DIR/methods.rs:261:13
    |
 LL |       let _ = v.iter().position(|&x| {
    |  _____________^
@@ -186,7 +166,7 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: called `is_some()` after searching an `Iterator` with rposition. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:266:13
+  --> $DIR/methods.rs:267:13
    |
 LL |     let _ = v.iter().rposition(|&x| x < 0).is_some();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,7 +174,7 @@ LL |     let _ = v.iter().rposition(|&x| x < 0).is_some();
    = note: replace `rposition(|&x| x < 0).is_some()` with `any(|&x| x < 0)`
 
 error: called `is_some()` after searching an `Iterator` with rposition. This is more succinctly expressed by calling `any()`.
-  --> $DIR/methods.rs:269:13
+  --> $DIR/methods.rs:270:13
    |
 LL |       let _ = v.iter().rposition(|&x| {
    |  _____________^
@@ -204,12 +184,12 @@ LL | |                    ).is_some();
    | |______________________________^
 
 error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
-  --> $DIR/methods.rs:284:13
+  --> $DIR/methods.rs:285:13
    |
 LL |     let _ = opt.unwrap();
    |             ^^^^^^^^^^^^
    |
    = note: `-D clippy::option-unwrap-used` implied by `-D warnings`
 
-error: aborting due to 23 previous errors
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
These cases are already covered in `tests/ui/wrong_self_convention.rs`.

cc #2038

changelog: none