### PR TITLE
Try to fix Travis Windows build flakiness

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -8,5 +8,5 @@ if ! command -v rustup-toolchain-install-master > /dev/null; then
 fi
 
 RUSTC_HASH=$(git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}')
-rustup-toolchain-install-master -f -n master "$RUSTC_HASH"
+rustup-toolchain-install-master -f -n master "$RUSTC_HASH" -c cargo
 rustup override set master


### PR DESCRIPTION
Use cargo master so that we don't have to rely on faulty rustup
fallback.

changelog: none
