### PR TITLE
Doctests: Enable running doc tests for nursery lints

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -113,19 +113,19 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// // Bad
-    /// #[inline(always)]
-    ///
-    /// fn not_quite_good_code(..) { ... }
-    ///
     /// // Good (as inner attribute)
     /// #![inline(always)]
     ///
-    /// fn this_is_fine(..) { ... }
+    /// fn this_is_fine() { }
+    ///
+    /// // Bad
+    /// #[inline(always)]
+    ///
+    /// fn not_quite_good_code() { }
     ///
     /// // Good (as outer attribute)
     /// #[inline(always)]
-    /// fn this_is_fine_too(..) { ... }
+    /// fn this_is_fine_too() { }
     /// ```
     pub EMPTY_LINE_AFTER_OUTER_ATTR,
     nursery,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -125,7 +125,7 @@ macro_rules! declare_clippy_lint {
     };
     { $(#[$attr:meta])* pub $name:tt, nursery, $description:tt } => {
         declare_tool_lint! {
-            pub clippy::$name, Allow, $description, report_in_external_macro: true
+            $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true
         }
     };
     { $(#[$attr:meta])* pub $name:tt, internal, $description:tt } => {

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -40,17 +40,27 @@ declare_clippy_lint! {
     /// **Example:**
     ///
     /// ```rust
+    /// # struct Foo {
+    /// #     random_number: usize,
+    /// # }
+    /// # impl Foo {
     /// fn new() -> Self {
     ///     Self { random_number: 42 }
     /// }
+    /// # }
     /// ```
     ///
     /// Could be a const fn:
     ///
     /// ```rust
+    /// # struct Foo {
+    /// #     random_number: usize,
+    /// # }
+    /// # impl Foo {
     /// const fn new() -> Self {
     ///     Self { random_number: 42 }
     /// }
+    /// # }
     /// ```
     pub MISSING_CONST_FOR_FN,
     nursery,

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -44,6 +44,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # use std::sync::Mutex;
     /// let x = Mutex::new(0usize);
     /// ```
     pub MUTEX_INTEGER,

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -40,6 +40,7 @@ declare_clippy_lint! {
     /// * False-positive if there is a borrow preventing the value from moving out.
     ///
     /// ```rust
+    /// # fn foo(x: String) {}
     /// let x = String::new();
     ///
     /// let y = &x;
@@ -49,15 +50,22 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # use std::path::Path;
+    /// # #[derive(Clone)]
+    /// # struct Foo;
+    /// # impl Foo {
+    /// #     fn new() -> Self { Foo {} }
+    /// # }
+    /// # fn call(x: Foo) {}
     /// {
     ///     let x = Foo::new();
     ///     call(x.clone());
     ///     call(x.clone()); // this can just pass `x`
     /// }
     ///
-    /// ["lorem", "ipsum"].join(" ").to_string()
+    /// ["lorem", "ipsum"].join(" ").to_string();
     ///
-    /// Path::new("/a/b").join("c").to_path_buf()
+    /// Path::new("/a/b").join("c").to_path_buf();
     /// ```
     pub REDUNDANT_CLONE,
     nursery,


### PR DESCRIPTION
changelog: none

master: 202 passed; 0 failed; 122 ignored; 0 measured; 0 filtered out
this PR: 213 passed; 0 failed; 122 ignored; 0 measured; 0 filtered out

cc #4319