### PR TITLE
Doctests: Enable running doc tests for restriction lints

### DIFF
--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -16,7 +16,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// a + 1
+    /// # let a = 0;
+    /// a + 1;
     /// ```
     pub INTEGER_ARITHMETIC,
     restriction,
@@ -33,7 +34,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// a + 1.0
+    /// # let a = 0.0;
+    /// a + 1.0;
     /// ```
     pub FLOAT_ARITHMETIC,
     restriction,

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -16,6 +16,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # fn a() {}
+    /// # fn b() {}
+    /// # let x: i32 = 1;
     /// if x.is_positive() {
     ///     a();
     /// } else if x.is_negative() {
@@ -26,6 +29,9 @@ declare_clippy_lint! {
     /// Could be written:
     ///
     /// ```rust
+    /// # fn a() {}
+    /// # fn b() {}
+    /// # let x: i32 = 1;
     /// if x.is_positive() {
     ///     a();
     /// } else if x.is_negative() {

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// **Known problems:** Hopefully none.
     ///
     /// **Example:**
-    /// ```rust
+    /// ```rust,no_run
     /// // Vector
     /// let x = vec![0; 5];
     ///

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -115,7 +115,7 @@ macro_rules! declare_clippy_lint {
     };
     { $(#[$attr:meta])* pub $name:tt, restriction, $description:tt } => {
         declare_tool_lint! {
-            pub clippy::$name, Allow, $description, report_in_external_macro: true
+            $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true
         }
     };
     { $(#[$attr:meta])* pub $name:tt, cargo, $description:tt } => {

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -205,6 +205,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # enum Foo { A(usize), B(usize) }
+    /// # let x = Foo::B(1);
     /// match x {
     ///     A => {},
     ///     _ => {},

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -14,6 +14,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # use std::mem;
+    /// # use std::rc::Rc;
     /// mem::forget(Rc::new(55))
     /// ```
     pub MEM_FORGET,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -40,8 +40,19 @@ declare_clippy_lint! {
     /// **Known problems:** None.
     ///
     /// **Example:**
+    ///
+    /// Using unwrap on an `Option`:
+    ///
     /// ```rust
-    /// x.unwrap()
+    /// let opt = Some(1);
+    /// opt.unwrap();
+    /// ```
+    ///
+    /// Better:
+    ///
+    /// ```rust
+    /// let opt = Some(1);
+    /// opt.expect("more helpful message");
     /// ```
     pub OPTION_UNWRAP_USED,
     restriction,
@@ -62,8 +73,18 @@ declare_clippy_lint! {
     /// **Known problems:** None.
     ///
     /// **Example:**
+    /// Using unwrap on an `Option`:
+    ///
     /// ```rust
-    /// x.unwrap()
+    /// let res: Result<usize, ()> = Ok(1);
+    /// res.unwrap();
+    /// ```
+    ///
+    /// Better:
+    ///
+    /// ```rust
+    /// let res: Result<usize, ()> = Ok(1);
+    /// res.expect("more helpful message");
     /// ```
     pub RESULT_UNWRAP_USED,
     restriction,
@@ -141,9 +162,10 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// impl X {
-    ///     pub fn as_str(self) -> &str {
-    ///         ..
+    /// # struct X;
+    /// impl<'a> X {
+    ///     pub fn as_str(self) -> &'a str {
+    ///         "foo"
     ///     }
     /// }
     /// ```
@@ -467,7 +489,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// x.clone()
+    /// # use std::rc::Rc;
+    /// let x = Rc::new(1);
+    /// x.clone();
     /// ```
     pub CLONE_ON_REF_PTR,
     restriction,

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -226,8 +226,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// const ONE = 1.00f64;
-    /// x == ONE  // where both are floats
+    /// let x: f64 = 1.0;
+    /// const ONE: f64 = 1.00;
+    /// x == ONE;  // where both are floats
     /// ```
     pub FLOAT_CMP_CONST,
     restriction,

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     ///
     /// struct Baz;
     /// impl Baz {
-    ///    fn priv() {} // ok
+    ///    fn private() {} // ok
     /// }
     ///
     /// impl Bar for Baz {
@@ -42,8 +42,8 @@ declare_clippy_lint! {
     ///
     /// pub struct PubBaz;
     /// impl PubBaz {
-    ///    fn priv() {} // ok
-    ///    pub not_ptriv() {} // missing #[inline]
+    ///    fn private() {} // ok
+    ///    pub fn not_ptrivate() {} // missing #[inline]
     /// }
     ///
     /// impl Bar for PubBaz {

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -20,6 +20,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let x = 1;
     /// let x = &x;
     /// ```
     pub SHADOW_SAME,
@@ -41,10 +42,12 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// let x = 2;
     /// let x = x + 1;
     /// ```
     /// use different variable name:
     /// ```rust
+    /// let x = 2;
     /// let y = x + 1;
     /// ```
     pub SHADOW_REUSE,

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -48,7 +48,7 @@ declare_clippy_lint! {
     ///
     /// ```rust
     /// let x = "Hello".to_owned();
-    /// x + ", World"
+    /// x + ", World";
     /// ```
     pub STRING_ADD,
     restriction,

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -77,6 +77,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let foo = "bar";
     /// println!("{:?}", foo);
     /// ```
     pub USE_DEBUG,


### PR DESCRIPTION
changelog: Enabled remaining doc tests for lint documentation page

master: 202 passed; 0 failed; 122 ignored; 0 measured; 0 filtered out
this PR: 231 passed; 0 failed; 123 ignored; 0 measured; 0 filtered out

Closes #4319 (assuming this is merged after #4329 and #4330)