### PR TITLE
Split up cast.rs tests, run-rustfix for unnecessary_cast

### DIFF
--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -42,32 +42,4 @@ fn main() {
     i32::max_value() as u32;
     i64::max_value() as u64;
     i128::max_value() as u128;
-    // Extra checks for *size
-    // Test cast_unnecessary
-    1i32 as i32;
-    1f32 as f32;
-    false as bool;
-    &1i32 as &i32;
-    // macro version
-    macro_rules! foo {
-        ($a:ident, $b:ident) => {
-            pub fn $a() -> $b {
-                1 as $b
-            }
-        };
-    }
-    foo!(a, i32);
-    foo!(b, f32);
-    foo!(c, f64);
-
-    // casting integer literal to float is unnecessary
-    100 as f32;
-    100 as f64;
-    100_i32 as f64;
-    // Should not trigger
-    #[rustfmt::skip]
-    let v = vec!(1);
-    &v as &[i32];
-    1.0 as f64;
-    1 as u64;
 }

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -138,43 +138,5 @@ error: casting isize to usize may lose the sign of the value
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
-error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/cast.rs:47:5
-   |
-LL |     1i32 as i32;
-   |     ^^^^^^^^^^^
-   |
-   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
-
-error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/cast.rs:48:5
-   |
-LL |     1f32 as f32;
-   |     ^^^^^^^^^^^
-
-error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/cast.rs:49:5
-   |
-LL |     false as bool;
-   |     ^^^^^^^^^^^^^
-
-error: casting integer literal to f32 is unnecessary
-  --> $DIR/cast.rs:64:5
-   |
-LL |     100 as f32;
-   |     ^^^^^^^^^^ help: try: `100_f32`
-
-error: casting integer literal to f64 is unnecessary
-  --> $DIR/cast.rs:65:5
-   |
-LL |     100 as f64;
-   |     ^^^^^^^^^^ help: try: `100_f64`
-
-error: casting integer literal to f64 is unnecessary
-  --> $DIR/cast.rs:66:5
-   |
-LL |     100_i32 as f64;
-   |     ^^^^^^^^^^^^^^ help: try: `100_f64`
-
-error: aborting due to 28 previous errors
+error: aborting due to 22 previous errors
 

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -1,0 +1,23 @@
+#![warn(clippy::unnecessary_cast)]
+#![allow(clippy::no_effect)]
+
+fn main() {
+    // Test cast_unnecessary
+    1i32 as i32;
+    1f32 as f32;
+    false as bool;
+    &1i32 as &i32;
+
+    // macro version
+    macro_rules! foo {
+        ($a:ident, $b:ident) => {
+            #[allow(unused)]
+            pub fn $a() -> $b {
+                1 as $b
+            }
+        };
+    }
+    foo!(a, i32);
+    foo!(b, f32);
+    foo!(c, f64);
+}

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -1,0 +1,22 @@
+error: casting to the same type is unnecessary (`i32` -> `i32`)
+  --> $DIR/unnecessary_cast.rs:6:5
+   |
+LL |     1i32 as i32;
+   |     ^^^^^^^^^^^
+   |
+   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
+
+error: casting to the same type is unnecessary (`f32` -> `f32`)
+  --> $DIR/unnecessary_cast.rs:7:5
+   |
+LL |     1f32 as f32;
+   |     ^^^^^^^^^^^
+
+error: casting to the same type is unnecessary (`bool` -> `bool`)
+  --> $DIR/unnecessary_cast.rs:8:5
+   |
+LL |     false as bool;
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/unnecessary_cast_fixable.fixed
+++ b/tests/ui/unnecessary_cast_fixable.fixed
@@ -1,0 +1,17 @@
+// run-rustfix
+
+#![warn(clippy::unnecessary_cast)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+
+fn main() {
+    // casting integer literal to float is unnecessary
+    100_f32;
+    100_f64;
+    100_f64;
+    // Should not trigger
+    #[rustfmt::skip]
+    let v = vec!(1);
+    &v as &[i32];
+    1.0 as f64;
+    1 as u64;
+}

--- a/tests/ui/unnecessary_cast_fixable.rs
+++ b/tests/ui/unnecessary_cast_fixable.rs
@@ -1,0 +1,17 @@
+// run-rustfix
+
+#![warn(clippy::unnecessary_cast)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+
+fn main() {
+    // casting integer literal to float is unnecessary
+    100 as f32;
+    100 as f64;
+    100_i32 as f64;
+    // Should not trigger
+    #[rustfmt::skip]
+    let v = vec!(1);
+    &v as &[i32];
+    1.0 as f64;
+    1 as u64;
+}

--- a/tests/ui/unnecessary_cast_fixable.stderr
+++ b/tests/ui/unnecessary_cast_fixable.stderr
@@ -1,0 +1,22 @@
+error: casting integer literal to f32 is unnecessary
+  --> $DIR/unnecessary_cast_fixable.rs:8:5
+   |
+LL |     100 as f32;
+   |     ^^^^^^^^^^ help: try: `100_f32`
+   |
+   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
+
+error: casting integer literal to f64 is unnecessary
+  --> $DIR/unnecessary_cast_fixable.rs:9:5
+   |
+LL |     100 as f64;
+   |     ^^^^^^^^^^ help: try: `100_f64`
+
+error: casting integer literal to f64 is unnecessary
+  --> $DIR/unnecessary_cast_fixable.rs:10:5
+   |
+LL |     100_i32 as f64;
+   |     ^^^^^^^^^^^^^^ help: try: `100_f64`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This splits up the cast.rs tests and enables rustfix tests for the part
of the `unnecessary_cast` lint that emits `MachineApplicable`
suggestions.

changelog: none

cc #3630