### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -16,7 +16,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// a + 1
+    /// # let a = 0;
+    /// a + 1;
     /// ```
     pub INTEGER_ARITHMETIC,
     restriction,
@@ -33,7 +34,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// a + 1.0
+    /// # let a = 0.0;
+    /// a + 1.0;
     /// ```
     pub FLOAT_ARITHMETIC,
     restriction,

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -113,19 +113,19 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// // Bad
-    /// #[inline(always)]
-    ///
-    /// fn not_quite_good_code(..) { ... }
-    ///
     /// // Good (as inner attribute)
     /// #![inline(always)]
     ///
-    /// fn this_is_fine(..) { ... }
+    /// fn this_is_fine() { }
+    ///
+    /// // Bad
+    /// #[inline(always)]
+    ///
+    /// fn not_quite_good_code() { }
     ///
     /// // Good (as outer attribute)
     /// #[inline(always)]
-    /// fn this_is_fine_too(..) { ... }
+    /// fn this_is_fine_too() { }
     /// ```
     pub EMPTY_LINE_AFTER_OUTER_ATTR,
     nursery,

--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -27,6 +27,8 @@ declare_clippy_lint! {
     /// Could be written:
     ///
     /// ```rust
+    /// # use std::convert::TryFrom;
+    /// # let foo = 1;
     /// # let _ =
     /// i32::try_from(foo).is_ok()
     /// # ;

--- a/clippy_lints/src/copy_iterator.rs
+++ b/clippy_lints/src/copy_iterator.rs
@@ -13,7 +13,7 @@ declare_clippy_lint! {
     /// **Known problems:** None.
     ///
     /// **Example:**
-    /// ```rust
+    /// ```rust,ignore
     /// #[derive(Copy, Clone)]
     /// struct Countdown(u8);
     ///

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -49,12 +49,12 @@ declare_clippy_lint! {
     /// **Known problems:** Bounds of generic types are sometimes wrong: https://github.com/rust-lang/rust/issues/26925
     ///
     /// **Example:**
-    /// ```rust
+    /// ```rust,ignore
     /// #[derive(Copy)]
     /// struct Foo;
     ///
     /// impl Clone for Foo {
-    ///     ..
+    ///     // ..
     /// }
     /// ```
     pub EXPL_IMPL_CLONE_ON_COPY,

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// /// Do something with the foo_bar parameter. See also
     /// /// that::other::module::foo.
     /// // ^ `foo_bar` and `that::other::module::foo` should be ticked.
-    /// fn doit(foo_bar) { .. }
+    /// fn doit(foo_bar: usize) {}
     /// ```
     pub DOC_MARKDOWN,
     pedantic,

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -16,6 +16,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # fn a() {}
+    /// # fn b() {}
+    /// # let x: i32 = 1;
     /// if x.is_positive() {
     ///     a();
     /// } else if x.is_negative() {
@@ -26,6 +29,9 @@ declare_clippy_lint! {
     /// Could be written:
     ///
     /// ```rust
+    /// # fn a() {}
+    /// # fn b() {}
+    /// # let x: i32 = 1;
     /// if x.is_positive() {
     ///     a();
     /// } else if x.is_negative() {

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -17,6 +17,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let v: Vec<usize> = vec![];
+    /// # fn a() {}
+    /// # fn b() {}
     /// if !v.is_empty() {
     ///     a()
     /// } else {
@@ -27,6 +30,9 @@ declare_clippy_lint! {
     /// Could be written:
     ///
     /// ```rust
+    /// # let v: Vec<usize> = vec![];
+    /// # fn a() {}
+    /// # fn b() {}
     /// if v.is_empty() {
     ///     b()
     /// } else {

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// **Known problems:** Hopefully none.
     ///
     /// **Example:**
-    /// ```rust
+    /// ```rust,no_run
     /// // Vector
     /// let x = vec![0; 5];
     ///

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -34,7 +34,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// [0..].iter().zip(infinite_iter.take_while(|x| x > 5))
+    /// let infinite_iter = 0..;
+    /// [0..].iter().zip(infinite_iter.take_while(|x| *x > 5));
     /// ```
     pub MAYBE_INFINITE_ITER,
     pedantic,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -115,7 +115,7 @@ macro_rules! declare_clippy_lint {
     };
     { $(#[$attr:meta])* pub $name:tt, restriction, $description:tt } => {
         declare_tool_lint! {
-            pub clippy::$name, Allow, $description, report_in_external_macro: true
+            $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true
         }
     };
     { $(#[$attr:meta])* pub $name:tt, cargo, $description:tt } => {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -125,7 +125,7 @@ macro_rules! declare_clippy_lint {
     };
     { $(#[$attr:meta])* pub $name:tt, nursery, $description:tt } => {
         declare_tool_lint! {
-            pub clippy::$name, Allow, $description, report_in_external_macro: true
+            $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true
         }
     };
     { $(#[$attr:meta])* pub $name:tt, internal, $description:tt } => {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -110,7 +110,7 @@ macro_rules! declare_clippy_lint {
     };
     { $(#[$attr:meta])* pub $name:tt, pedantic, $description:tt } => {
         declare_tool_lint! {
-            pub clippy::$name, Allow, $description, report_in_external_macro: true
+            $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true
         }
     };
     { $(#[$attr:meta])* pub $name:tt, restriction, $description:tt } => {

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -91,16 +91,18 @@ declare_clippy_lint! {
     /// types.
     ///
     /// **Example:**
-    /// ```ignore
+    /// ```rust
     /// // with `y` a `Vec` or slice:
+    /// # let y = vec![1];
     /// for x in y.iter() {
-    ///     ..
+    ///     // ..
     /// }
     /// ```
     /// can be rewritten to
     /// ```rust
+    /// # let y = vec![1];
     /// for x in &y {
-    ///     ..
+    ///     // ..
     /// }
     /// ```
     pub EXPLICIT_ITER_LOOP,
@@ -117,16 +119,18 @@ declare_clippy_lint! {
     /// **Known problems:** None
     ///
     /// **Example:**
-    /// ```ignore
+    /// ```rust
+    /// # let y = vec![1];
     /// // with `y` a `Vec` or slice:
     /// for x in y.into_iter() {
-    ///     ..
+    ///     // ..
     /// }
     /// ```
     /// can be rewritten to
-    /// ```ignore
+    /// ```rust
+    /// # let y = vec![1];
     /// for x in y {
-    ///     ..
+    ///     // ..
     /// }
     /// ```
     pub EXPLICIT_INTO_ITER_LOOP,

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -53,19 +53,25 @@ declare_clippy_lint! {
     /// Using `match`:
     ///
     /// ```rust
+    /// # fn bar(foo: &usize) {}
+    /// # let other_ref: usize = 1;
+    /// # let x: Option<&usize> = Some(&1);
     /// match x {
     ///     Some(ref foo) => bar(foo),
-    ///     _ => bar(other_ref),
+    ///     _ => bar(&other_ref),
     /// }
     /// ```
     ///
     /// Using `if let` with `else`:
     ///
     /// ```rust
+    /// # fn bar(foo: &usize) {}
+    /// # let other_ref: usize = 1;
+    /// # let x: Option<&usize> = Some(&1);
     /// if let Some(ref foo) = x {
     ///     bar(foo);
     /// } else {
-    ///     bar(other_ref);
+    ///     bar(&other_ref);
     /// }
     /// ```
     pub SINGLE_MATCH_ELSE,

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -211,6 +211,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # enum Foo { A(usize), B(usize) }
+    /// # let x = Foo::B(1);
     /// match x {
     ///     A => {},
     ///     _ => {},

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -14,6 +14,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # use std::mem;
+    /// # use std::rc::Rc;
     /// mem::forget(Rc::new(55))
     /// ```
     pub MEM_FORGET,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -40,8 +40,19 @@ declare_clippy_lint! {
     /// **Known problems:** None.
     ///
     /// **Example:**
+    ///
+    /// Using unwrap on an `Option`:
+    ///
     /// ```rust
-    /// x.unwrap()
+    /// let opt = Some(1);
+    /// opt.unwrap();
+    /// ```
+    ///
+    /// Better:
+    ///
+    /// ```rust
+    /// let opt = Some(1);
+    /// opt.expect("more helpful message");
     /// ```
     pub OPTION_UNWRAP_USED,
     restriction,
@@ -62,8 +73,18 @@ declare_clippy_lint! {
     /// **Known problems:** None.
     ///
     /// **Example:**
+    /// Using unwrap on an `Option`:
+    ///
     /// ```rust
-    /// x.unwrap()
+    /// let res: Result<usize, ()> = Ok(1);
+    /// res.unwrap();
+    /// ```
+    ///
+    /// Better:
+    ///
+    /// ```rust
+    /// let res: Result<usize, ()> = Ok(1);
+    /// res.expect("more helpful message");
     /// ```
     pub RESULT_UNWRAP_USED,
     restriction,
@@ -141,9 +162,10 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// impl X {
-    ///     pub fn as_str(self) -> &str {
-    ///         ..
+    /// # struct X;
+    /// impl<'a> X {
+    ///     pub fn as_str(self) -> &'a str {
+    ///         "foo"
     ///     }
     /// }
     /// ```
@@ -474,7 +496,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// x.clone()
+    /// # use std::rc::Rc;
+    /// let x = Rc::new(1);
+    /// x.clone();
     /// ```
     pub CLONE_ON_REF_PTR,
     restriction,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -179,7 +179,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// x.map(|a| a + 1).unwrap_or(0)
+    /// # let x = Some(1);
+    /// x.map(|a| a + 1).unwrap_or(0);
     /// ```
     pub OPTION_MAP_UNWRAP_OR,
     pedantic,
@@ -196,7 +197,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// x.map(|a| a + 1).unwrap_or_else(some_function)
+    /// # let x = Some(1);
+    /// # fn some_function() -> usize { 1 }
+    /// x.map(|a| a + 1).unwrap_or_else(some_function);
     /// ```
     pub OPTION_MAP_UNWRAP_OR_ELSE,
     pedantic,
@@ -213,7 +216,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// x.map(|a| a + 1).unwrap_or_else(some_function)
+    /// # let x: Result<usize, ()> = Ok(1);
+    /// # fn some_function(foo: ()) -> usize { 1 }
+    /// x.map(|a| a + 1).unwrap_or_else(some_function);
     /// ```
     pub RESULT_MAP_UNWRAP_OR_ELSE,
     pedantic,
@@ -265,7 +270,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// iter.map(|x| x.iter()).flatten()
+    /// let vec = vec![vec![1]];
+    /// vec.iter().map(|x| x.iter()).flatten();
     /// ```
     pub MAP_FLATTEN,
     pedantic,
@@ -284,7 +290,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// iter.filter(|x| x == 0).map(|x| x * 2)
+    /// let vec = vec![1];
+    /// vec.iter().filter(|x| **x == 0).map(|x| *x * 2);
     /// ```
     pub FILTER_MAP,
     pedantic,
@@ -324,7 +331,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    ///  (0..3).find(|x| x == 2).map(|x| x * 2);
+    ///  (0..3).find(|x| *x == 2).map(|x| x * 2);
     /// ```
     /// Can be written as
     /// ```rust

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -226,8 +226,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// const ONE = 1.00f64;
-    /// x == ONE  // where both are floats
+    /// let x: f64 = 1.0;
+    /// const ONE: f64 = 1.00;
+    /// x == ONE;  // where both are floats
     /// ```
     pub FLOAT_CMP_CONST,
     restriction,

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -40,17 +40,27 @@ declare_clippy_lint! {
     /// **Example:**
     ///
     /// ```rust
+    /// # struct Foo {
+    /// #     random_number: usize,
+    /// # }
+    /// # impl Foo {
     /// fn new() -> Self {
     ///     Self { random_number: 42 }
     /// }
+    /// # }
     /// ```
     ///
     /// Could be a const fn:
     ///
     /// ```rust
+    /// # struct Foo {
+    /// #     random_number: usize,
+    /// # }
+    /// # impl Foo {
     /// const fn new() -> Self {
     ///     Self { random_number: 42 }
     /// }
+    /// # }
     /// ```
     pub MISSING_CONST_FOR_FN,
     nursery,

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     ///
     /// struct Baz;
     /// impl Baz {
-    ///    fn priv() {} // ok
+    ///    fn private() {} // ok
     /// }
     ///
     /// impl Bar for Baz {
@@ -42,8 +42,8 @@ declare_clippy_lint! {
     ///
     /// pub struct PubBaz;
     /// impl PubBaz {
-    ///    fn priv() {} // ok
-    ///    pub not_ptriv() {} // missing #[inline]
+    ///    fn private() {} // ok
+    ///    pub fn not_ptrivate() {} // missing #[inline]
     /// }
     ///
     /// impl Bar for PubBaz {

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -16,6 +16,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let mut y = 1;
     /// let x = &mut &mut y;
     /// ```
     pub MUT_MUT,

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -44,6 +44,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # use std::sync::Mutex;
     /// let x = Mutex::new(0usize);
     /// ```
     pub MUTEX_INTEGER,

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -57,6 +57,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # fn condition() -> bool { false }
+    /// # fn update_condition() {}
+    /// # let x = false;
     /// while condition() {
     ///     update_condition();
     ///     if x {
@@ -71,6 +74,9 @@ declare_clippy_lint! {
     /// Could be rewritten as
     ///
     /// ```rust
+    /// # fn condition() -> bool { false }
+    /// # fn update_condition() {}
+    /// # let x = false;
     /// while condition() {
     ///     update_condition();
     ///     if x {
@@ -83,22 +89,26 @@ declare_clippy_lint! {
     /// As another example, the following code
     ///
     /// ```rust
+    /// # fn waiting() -> bool { false }
     /// loop {
     ///     if waiting() {
     ///         continue;
     ///     } else {
     ///         // Do something useful
     ///     }
+    ///     # break;
     /// }
     /// ```
     /// Could be rewritten as
     ///
     /// ```rust
+    /// # fn waiting() -> bool { false }
     /// loop {
     ///     if waiting() {
     ///         continue;
     ///     }
     ///     // Do something useful
+    ///     # break;
     /// }
     /// ```
     pub NEEDLESS_CONTINUE,

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -40,6 +40,9 @@ declare_clippy_lint! {
     /// fn foo(v: Vec<i32>) {
     ///     assert_eq!(v.len(), 42);
     /// }
+    /// ```
+    ///
+    /// ```rust
     /// // should be
     /// fn foo(v: &[i32]) {
     ///     assert_eq!(v.len(), 42);

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -40,6 +40,7 @@ declare_clippy_lint! {
     /// * False-positive if there is a borrow preventing the value from moving out.
     ///
     /// ```rust
+    /// # fn foo(x: String) {}
     /// let x = String::new();
     ///
     /// let y = &x;
@@ -49,15 +50,22 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # use std::path::Path;
+    /// # #[derive(Clone)]
+    /// # struct Foo;
+    /// # impl Foo {
+    /// #     fn new() -> Self { Foo {} }
+    /// # }
+    /// # fn call(x: Foo) {}
     /// {
     ///     let x = Foo::new();
     ///     call(x.clone());
     ///     call(x.clone()); // this can just pass `x`
     /// }
     ///
-    /// ["lorem", "ipsum"].join(" ").to_string()
+    /// ["lorem", "ipsum"].join(" ").to_string();
     ///
-    /// Path::new("/a/b").join("c").to_path_buf()
+    /// Path::new("/a/b").join("c").to_path_buf();
     /// ```
     pub REDUNDANT_CLONE,
     nursery,

--- a/clippy_lints/src/replace_consts.rs
+++ b/clippy_lints/src/replace_consts.rs
@@ -16,12 +16,14 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # use core::sync::atomic::{ATOMIC_ISIZE_INIT, AtomicIsize};
     /// static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
     /// ```
     ///
     /// Could be written:
     ///
     /// ```rust
+    /// # use core::sync::atomic::AtomicIsize;
     /// static FOO: AtomicIsize = AtomicIsize::new(0);
     /// ```
     pub REPLACE_CONSTS,

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -67,6 +67,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let y = 1;
+    /// # let z = 2;
     /// let x = y;
     /// let x = z; // shadows the earlier binding
     /// ```

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -20,6 +20,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let x = 1;
     /// let x = &x;
     /// ```
     pub SHADOW_SAME,
@@ -41,10 +42,12 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// let x = 2;
     /// let x = x + 1;
     /// ```
     /// use different variable name:
     /// ```rust
+    /// let x = 2;
     /// let y = x + 1;
     /// ```
     pub SHADOW_REUSE,

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -48,7 +48,7 @@ declare_clippy_lint! {
     ///
     /// ```rust
     /// let x = "Hello".to_owned();
-    /// x + ", World"
+    /// x + ", World";
     /// ```
     pub STRING_ADD,
     restriction,

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -133,7 +133,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// let x = LinkedList::new();
+    /// # use std::collections::LinkedList;
+    /// let x: LinkedList<usize> = LinkedList::new();
     /// ```
     pub LINKEDLIST,
     pedantic,
@@ -660,8 +661,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// let x = u64::MAX;
-    /// x as f64
+    /// let x = std::u64::MAX;
+    /// x as f64;
     /// ```
     pub CAST_PRECISION_LOSS,
     pedantic,
@@ -682,7 +683,7 @@ declare_clippy_lint! {
     /// **Example:**
     /// ```rust
     /// let y: i8 = -1;
-    /// y as u128 // will return 18446744073709551615
+    /// y as u128; // will return 18446744073709551615
     /// ```
     pub CAST_SIGN_LOSS,
     pedantic,
@@ -727,7 +728,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// u32::MAX as i32 // will yield a value of `-1`
+    /// std::u32::MAX as i32; // will yield a value of `-1`
     /// ```
     pub CAST_POSSIBLE_WRAP,
     pedantic,
@@ -1689,7 +1690,8 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// let x : u8 = ...; (x as u32) > 300
+    /// let x: u8 = 1;
+    /// (x as u32) > 300;
     /// ```
     pub INVALID_UPCAST_COMPARISONS,
     pedantic,

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -77,6 +77,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
+    /// # let foo = "bar";
     /// println!("{:?}", foo);
     /// ```
     pub USE_DEBUG,

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -42,32 +42,4 @@ fn main() {
     i32::max_value() as u32;
     i64::max_value() as u64;
     i128::max_value() as u128;
-    // Extra checks for *size
-    // Test cast_unnecessary
-    1i32 as i32;
-    1f32 as f32;
-    false as bool;
-    &1i32 as &i32;
-    // macro version
-    macro_rules! foo {
-        ($a:ident, $b:ident) => {
-            pub fn $a() -> $b {
-                1 as $b
-            }
-        };
-    }
-    foo!(a, i32);
-    foo!(b, f32);
-    foo!(c, f64);
-
-    // casting integer literal to float is unnecessary
-    100 as f32;
-    100 as f64;
-    100_i32 as f64;
-    // Should not trigger
-    #[rustfmt::skip]
-    let v = vec!(1);
-    &v as &[i32];
-    1.0 as f64;
-    1 as u64;
 }

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -138,43 +138,5 @@ error: casting isize to usize may lose the sign of the value
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
-error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/cast.rs:47:5
-   |
-LL |     1i32 as i32;
-   |     ^^^^^^^^^^^
-   |
-   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
-
-error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/cast.rs:48:5
-   |
-LL |     1f32 as f32;
-   |     ^^^^^^^^^^^
-
-error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/cast.rs:49:5
-   |
-LL |     false as bool;
-   |     ^^^^^^^^^^^^^
-
-error: casting integer literal to f32 is unnecessary
-  --> $DIR/cast.rs:64:5
-   |
-LL |     100 as f32;
-   |     ^^^^^^^^^^ help: try: `100_f32`
-
-error: casting integer literal to f64 is unnecessary
-  --> $DIR/cast.rs:65:5
-   |
-LL |     100 as f64;
-   |     ^^^^^^^^^^ help: try: `100_f64`
-
-error: casting integer literal to f64 is unnecessary
-  --> $DIR/cast.rs:66:5
-   |
-LL |     100_i32 as f64;
-   |     ^^^^^^^^^^^^^^ help: try: `100_f64`
-
-error: aborting due to 28 previous errors
+error: aborting due to 22 previous errors
 

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -1,0 +1,23 @@
+#![warn(clippy::unnecessary_cast)]
+#![allow(clippy::no_effect)]
+
+fn main() {
+    // Test cast_unnecessary
+    1i32 as i32;
+    1f32 as f32;
+    false as bool;
+    &1i32 as &i32;
+
+    // macro version
+    macro_rules! foo {
+        ($a:ident, $b:ident) => {
+            #[allow(unused)]
+            pub fn $a() -> $b {
+                1 as $b
+            }
+        };
+    }
+    foo!(a, i32);
+    foo!(b, f32);
+    foo!(c, f64);
+}

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -1,0 +1,22 @@
+error: casting to the same type is unnecessary (`i32` -> `i32`)
+  --> $DIR/unnecessary_cast.rs:6:5
+   |
+LL |     1i32 as i32;
+   |     ^^^^^^^^^^^
+   |
+   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
+
+error: casting to the same type is unnecessary (`f32` -> `f32`)
+  --> $DIR/unnecessary_cast.rs:7:5
+   |
+LL |     1f32 as f32;
+   |     ^^^^^^^^^^^
+
+error: casting to the same type is unnecessary (`bool` -> `bool`)
+  --> $DIR/unnecessary_cast.rs:8:5
+   |
+LL |     false as bool;
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/unnecessary_cast_fixable.fixed
+++ b/tests/ui/unnecessary_cast_fixable.fixed
@@ -1,0 +1,17 @@
+// run-rustfix
+
+#![warn(clippy::unnecessary_cast)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+
+fn main() {
+    // casting integer literal to float is unnecessary
+    100_f32;
+    100_f64;
+    100_f64;
+    // Should not trigger
+    #[rustfmt::skip]
+    let v = vec!(1);
+    &v as &[i32];
+    1.0 as f64;
+    1 as u64;
+}

--- a/tests/ui/unnecessary_cast_fixable.rs
+++ b/tests/ui/unnecessary_cast_fixable.rs
@@ -1,0 +1,17 @@
+// run-rustfix
+
+#![warn(clippy::unnecessary_cast)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+
+fn main() {
+    // casting integer literal to float is unnecessary
+    100 as f32;
+    100 as f64;
+    100_i32 as f64;
+    // Should not trigger
+    #[rustfmt::skip]
+    let v = vec!(1);
+    &v as &[i32];
+    1.0 as f64;
+    1 as u64;
+}

--- a/tests/ui/unnecessary_cast_fixable.stderr
+++ b/tests/ui/unnecessary_cast_fixable.stderr
@@ -1,0 +1,22 @@
+error: casting integer literal to f32 is unnecessary
+  --> $DIR/unnecessary_cast_fixable.rs:8:5
+   |
+LL |     100 as f32;
+   |     ^^^^^^^^^^ help: try: `100_f32`
+   |
+   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
+
+error: casting integer literal to f64 is unnecessary
+  --> $DIR/unnecessary_cast_fixable.rs:9:5
+   |
+LL |     100 as f64;
+   |     ^^^^^^^^^^ help: try: `100_f64`
+
+error: casting integer literal to f64 is unnecessary
+  --> $DIR/unnecessary_cast_fixable.rs:10:5
+   |
+LL |     100_i32 as f64;
+   |     ^^^^^^^^^^^^^^ help: try: `100_f64`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #4329 (Doctests: Enable running doc tests for pedantic lints)
 - #4330 (Doctests: Enable running doc tests for nursery lints)
 - #4331 (Doctests: Enable running doc tests for restriction lints)
 - #4332 (Split up cast.rs tests, run-rustfix for unnecessary_cast)

Failed merges:


r? @ghost

changelog: none