### PR TITLE
Add run-rustfix for needless_bool lint

### DIFF
--- a/tests/ui/needless_bool/fixable.fixed
+++ b/tests/ui/needless_bool/fixable.fixed
@@ -1,0 +1,98 @@
+// run-rustfix
+
+#![warn(clippy::needless_bool)]
+#![allow(
+    unused,
+    dead_code,
+    clippy::no_effect,
+    clippy::if_same_then_else,
+    clippy::needless_return
+)]
+
+use std::cell::Cell;
+
+macro_rules! bool_comparison_trigger {
+    ($($i:ident: $def:expr, $stb:expr );+  $(;)*) => (
+
+        #[derive(Clone)]
+        pub struct Trigger {
+            $($i: (Cell<bool>, bool, bool)),+
+        }
+
+        #[allow(dead_code)]
+        impl Trigger {
+            pub fn trigger(&self, key: &str) -> bool {
+                $(
+                    if let stringify!($i) = key {
+                        return self.$i.1 && self.$i.2 == $def;
+                    }
+                 )+
+                false
+            }
+        }
+    )
+}
+
+fn main() {
+    let x = true;
+    let y = false;
+    x;
+    !x;
+    !(x && y);
+    if x {
+        x
+    } else {
+        false
+    }; // would also be questionable, but we don't catch this yet
+    bool_ret3(x);
+    bool_ret4(x);
+    bool_ret5(x, x);
+    bool_ret6(x, x);
+    needless_bool(x);
+    needless_bool2(x);
+    needless_bool3(x);
+}
+
+fn bool_ret3(x: bool) -> bool {
+    return x;
+}
+
+fn bool_ret4(x: bool) -> bool {
+    return !x;
+}
+
+fn bool_ret5(x: bool, y: bool) -> bool {
+    return x && y;
+}
+
+fn bool_ret6(x: bool, y: bool) -> bool {
+    return !(x && y);
+}
+
+fn needless_bool(x: bool) {
+    if x {};
+}
+
+fn needless_bool2(x: bool) {
+    if !x {};
+}
+
+fn needless_bool3(x: bool) {
+    bool_comparison_trigger! {
+        test_one:   false, false;
+        test_three: false, false;
+        test_two:   true, true;
+    }
+
+    if x {};
+    if !x {};
+}
+
+fn needless_bool_in_the_suggestion_wraps_the_predicate_of_if_else_statement_in_brackets() {
+    let b = false;
+    let returns_bool = || false;
+
+    let x = if b {
+        true
+    } else { !returns_bool() };
+}

--- a/tests/ui/needless_bool/fixable.rs
+++ b/tests/ui/needless_bool/fixable.rs
@@ -1,5 +1,13 @@
+// run-rustfix
+
 #![warn(clippy::needless_bool)]
-#![allow(unused, dead_code, clippy::no_effect)]
+#![allow(
+    unused,
+    dead_code,
+    clippy::no_effect,
+    clippy::if_same_then_else,
+    clippy::needless_return
+)]
 
 use std::cell::Cell;
 
@@ -25,20 +33,9 @@ macro_rules! bool_comparison_trigger {
     )
 }
 
-#[allow(clippy::if_same_then_else)]
 fn main() {
     let x = true;
     let y = false;
-    if x {
-        true
-    } else {
-        true
-    };
-    if x {
-        false
-    } else {
-        false
-    };
     if x {
         true
     } else {
@@ -59,36 +56,15 @@ fn main() {
     } else {
         false
     }; // would also be questionable, but we don't catch this yet
-    bool_ret(x);
-    bool_ret2(x);
     bool_ret3(x);
-    bool_ret5(x, x);
     bool_ret4(x);
+    bool_ret5(x, x);
     bool_ret6(x, x);
     needless_bool(x);
     needless_bool2(x);
     needless_bool3(x);
 }
 
-#[allow(clippy::if_same_then_else, clippy::needless_return)]
-fn bool_ret(x: bool) -> bool {
-    if x {
-        return true;
-    } else {
-        return true;
-    };
-}
-
-#[allow(clippy::if_same_then_else, clippy::needless_return)]
-fn bool_ret2(x: bool) -> bool {
-    if x {
-        return false;
-    } else {
-        return false;
-    };
-}
-
-#[allow(clippy::needless_return)]
 fn bool_ret3(x: bool) -> bool {
     if x {
         return true;
@@ -97,16 +73,6 @@ fn bool_ret3(x: bool) -> bool {
     };
 }
 
-#[allow(clippy::needless_return)]
-fn bool_ret5(x: bool, y: bool) -> bool {
-    if x && y {
-        return true;
-    } else {
-        return false;
-    };
-}
-
-#[allow(clippy::needless_return)]
 fn bool_ret4(x: bool) -> bool {
     if x {
         return false;
@@ -115,7 +81,14 @@ fn bool_ret4(x: bool) -> bool {
     };
 }
 
-#[allow(clippy::needless_return)]
+fn bool_ret5(x: bool, y: bool) -> bool {
+    if x && y {
+        return true;
+    } else {
+        return false;
+    };
+}
+
 fn bool_ret6(x: bool, y: bool) -> bool {
     if x && y {
         return false;

--- a/tests/ui/needless_bool/fixable.stderr
+++ b/tests/ui/needless_bool/fixable.stderr
@@ -1,27 +1,5 @@
-error: this if-then-else expression will always return true
-  --> $DIR/needless_bool.rs:32:5
-   |
-LL | /     if x {
-LL | |         true
-LL | |     } else {
-LL | |         true
-LL | |     };
-   | |_____^
-   |
-   = note: `-D clippy::needless-bool` implied by `-D warnings`
-
-error: this if-then-else expression will always return false
-  --> $DIR/needless_bool.rs:37:5
-   |
-LL | /     if x {
-LL | |         false
-LL | |     } else {
-LL | |         false
-LL | |     };
-   | |_____^
-
 error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:42:5
+  --> $DIR/fixable.rs:39:5
    |
 LL | /     if x {
 LL | |         true
@@ -29,9 +7,11 @@ LL | |     } else {
 LL | |         false
 LL | |     };
    | |_____^ help: you can reduce it to: `x`
+   |
+   = note: `-D clippy::needless-bool` implied by `-D warnings`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:47:5
+  --> $DIR/fixable.rs:44:5
    |
 LL | /     if x {
 LL | |         false
@@ -41,7 +21,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `!x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:52:5
+  --> $DIR/fixable.rs:49:5
    |
 LL | /     if x && y {
 LL | |         false
@@ -50,28 +30,8 @@ LL | |         true
 LL | |     };
    | |_____^ help: you can reduce it to: `!(x && y)`
 
-error: this if-then-else expression will always return true
-  --> $DIR/needless_bool.rs:75:5
-   |
-LL | /     if x {
-LL | |         return true;
-LL | |     } else {
-LL | |         return true;
-LL | |     };
-   | |_____^
-
-error: this if-then-else expression will always return false
-  --> $DIR/needless_bool.rs:84:5
-   |
-LL | /     if x {
-LL | |         return false;
-LL | |     } else {
-LL | |         return false;
-LL | |     };
-   | |_____^
-
 error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:93:5
+  --> $DIR/fixable.rs:69:5
    |
 LL | /     if x {
 LL | |         return true;
@@ -81,17 +41,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:102:5
-   |
-LL | /     if x && y {
-LL | |         return true;
-LL | |     } else {
-LL | |         return false;
-LL | |     };
-   | |_____^ help: you can reduce it to: `return x && y`
-
-error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:111:5
+  --> $DIR/fixable.rs:77:5
    |
 LL | /     if x {
 LL | |         return false;
@@ -101,7 +51,17 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return !x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:120:5
+  --> $DIR/fixable.rs:85:5
+   |
+LL | /     if x && y {
+LL | |         return true;
+LL | |     } else {
+LL | |         return false;
+LL | |     };
+   | |_____^ help: you can reduce it to: `return x && y`
+
+error: this if-then-else expression returns a bool literal
+  --> $DIR/fixable.rs:93:5
    |
 LL | /     if x && y {
 LL | |         return false;
@@ -111,7 +71,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return !(x && y)`
 
 error: equality checks against true are unnecessary
-  --> $DIR/needless_bool.rs:128:8
+  --> $DIR/fixable.rs:101:8
    |
 LL |     if x == true {};
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
@@ -119,25 +79,25 @@ LL |     if x == true {};
    = note: `-D clippy::bool-comparison` implied by `-D warnings`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/needless_bool.rs:132:8
+  --> $DIR/fixable.rs:105:8
    |
 LL |     if x == false {};
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: equality checks against true are unnecessary
-  --> $DIR/needless_bool.rs:142:8
+  --> $DIR/fixable.rs:115:8
    |
 LL |     if x == true {};
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/needless_bool.rs:143:8
+  --> $DIR/fixable.rs:116:8
    |
 LL |     if x == false {};
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/needless_bool.rs:152:12
+  --> $DIR/fixable.rs:125:12
    |
 LL |       } else if returns_bool() {
    |  ____________^
@@ -147,5 +107,5 @@ LL | |         true
 LL | |     };
    | |_____^ help: you can reduce it to: `{ !returns_bool() }`
 
-error: aborting due to 16 previous errors
+error: aborting due to 12 previous errors
 

--- a/tests/ui/needless_bool/simple.rs
+++ b/tests/ui/needless_bool/simple.rs
@@ -1,0 +1,46 @@
+#![warn(clippy::needless_bool)]
+#![allow(
+    unused,
+    dead_code,
+    clippy::no_effect,
+    clippy::if_same_then_else,
+    clippy::needless_return
+)]
+
+fn main() {
+    let x = true;
+    let y = false;
+    if x {
+        true
+    } else {
+        true
+    };
+    if x {
+        false
+    } else {
+        false
+    };
+    if x {
+        x
+    } else {
+        false
+    }; // would also be questionable, but we don't catch this yet
+    bool_ret(x);
+    bool_ret2(x);
+}
+
+fn bool_ret(x: bool) -> bool {
+    if x {
+        return true;
+    } else {
+        return true;
+    };
+}
+
+fn bool_ret2(x: bool) -> bool {
+    if x {
+        return false;
+    } else {
+        return false;
+    };
+}

--- a/tests/ui/needless_bool/simple.stderr
+++ b/tests/ui/needless_bool/simple.stderr
@@ -1,0 +1,44 @@
+error: this if-then-else expression will always return true
+  --> $DIR/simple.rs:13:5
+   |
+LL | /     if x {
+LL | |         true
+LL | |     } else {
+LL | |         true
+LL | |     };
+   | |_____^
+   |
+   = note: `-D clippy::needless-bool` implied by `-D warnings`
+
+error: this if-then-else expression will always return false
+  --> $DIR/simple.rs:18:5
+   |
+LL | /     if x {
+LL | |         false
+LL | |     } else {
+LL | |         false
+LL | |     };
+   | |_____^
+
+error: this if-then-else expression will always return true
+  --> $DIR/simple.rs:33:5
+   |
+LL | /     if x {
+LL | |         return true;
+LL | |     } else {
+LL | |         return true;
+LL | |     };
+   | |_____^
+
+error: this if-then-else expression will always return false
+  --> $DIR/simple.rs:41:5
+   |
+LL | /     if x {
+LL | |         return false;
+LL | |     } else {
+LL | |         return false;
+LL | |     };
+   | |_____^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This splits up the needless_bool tests into `fixable.rs` and
`simple.rs`. `simple.rs` contains the code that triggers the lint
diagnostic without a suggestion.

changelog: none

cc #3630