### PR TITLE
Don't emit enum_variant_names if remainder starts with a numeric

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -160,6 +160,7 @@ fn check_variant(
         let name = var2str(var);
         if partial_match(item_name, &name) == item_name_chars
             && name.chars().nth(item_name_chars).map_or(false, |c| !c.is_lowercase())
+            && name.chars().nth(item_name_chars + 1).map_or(false, |c| !c.is_numeric())
         {
             span_lint(cx, lint, var.span, "Variant name starts with the enum's name");
         }
@@ -178,6 +179,9 @@ fn check_variant(
         let pre_camel = camel_case::until(pre);
         pre = &pre[..pre_camel];
         while let Some((next, last)) = name[pre.len()..].chars().zip(pre.chars().rev()).next() {
+            if next.is_numeric() {
+                return;
+            }
             if next.is_lowercase() {
                 let last = pre.len() - last.len_utf8();
                 let last_camel = camel_case::until(&pre[..last]);

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -1,5 +1,5 @@
 #![feature(non_ascii_idents)]
-#![warn(clippy::all, clippy::pub_enum_variant_names)]
+#![warn(clippy::enum_variant_names, clippy::pub_enum_variant_names)]
 #![allow(non_camel_case_types)]
 
 enum FakeCallType {
@@ -118,6 +118,19 @@ enum N {
     Pos,
     Neg,
     Float,
+}
+
+// should not lint
+enum Peek {
+    Peek1,
+    Peek2,
+    Peek3,
+}
+
+// should not lint
+pub enum NetworkLayer {
+    Layer2,
+    Layer3,
 }
 
 fn main() {}


### PR DESCRIPTION
changelog: Fix false positive in `pub_enum_variant_names` and `enum_variant_names`

As [per the reference](https://doc.rust-lang.org/reference/identifiers.html), identifiers must start with a letter. So we don't suggest a better
variant naming in case the remainder would start with a numeric.

Fixes #739