### PR TITLE
README: mention experimental cargo fix clippy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Now you can run Clippy by invoking the following command:
 cargo clippy
 ```
 
+#### Automatically applying clippy suggestions
+
+Some Clippy lint suggestions can be automatically applied by `cargo fix`.
+Note that this is still experimental and only supported on the nightly channel:
+
+```terminal
+cargo fix -Z unstable-options --clippy
+```
+
 ### Running Clippy from the command line without installing it
 
 To have cargo compile your crate with Clippy without Clippy installation

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Now you can run Clippy by invoking the following command:
 cargo clippy
 ```
 
-#### Automatically applying clippy suggestions
+#### Automatically applying Clippy suggestions
 
 Some Clippy lint suggestions can be automatically applied by `cargo fix`.
 Note that this is still experimental and only supported on the nightly channel:


### PR DESCRIPTION
mention that cargo fix has experimental support for applying some clippy lint suggestions via "cargo fix -Z unstable-options --clippy"


[Rendered](https://github.com/matthiaskrgr/rust-clippy/tree/readme_cargo_fix_clippy#auto-applying-clippy-suggestions)

changelog: none
