### PR TITLE
Fix lint_single_char_pattern on raw string literal

### DIFF
--- a/tests/ui/single_char_pattern.fixed
+++ b/tests/ui/single_char_pattern.fixed
@@ -57,4 +57,7 @@ fn main() {
     // Raw string
     x.split('a');
     x.split('a');
+    x.split('a');
+    x.split('\'');
+    x.split('#');
 }

--- a/tests/ui/single_char_pattern.fixed
+++ b/tests/ui/single_char_pattern.fixed
@@ -53,4 +53,8 @@ fn main() {
     // Issue #3204
     const S: &str = "#";
     x.find(S);
+
+    // Raw string
+    x.split('a');
+    x.split('a');
 }

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -57,4 +57,7 @@ fn main() {
     // Raw string
     x.split(r"a");
     x.split(r#"a"#);
+    x.split(r###"a"###);
+    x.split(r###"'"###);
+    x.split(r###"#"###);
 }

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -53,4 +53,8 @@ fn main() {
     // Issue #3204
     const S: &str = "#";
     x.find(S);
+
+    // Raw string
+    x.split(r"a");
+    x.split(r#"a"#);
 }

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -132,5 +132,17 @@ error: single-character string constant used as pattern
 LL |     x.starts_with("/x03"); // issue #2996
    |                   ^^^^^^ help: try using a char instead: `'/x03'`
 
-error: aborting due to 22 previous errors
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:58:13
+   |
+LL |     x.split(r"a");
+   |             ^^^^ help: try using a char instead: `'a'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:59:13
+   |
+LL |     x.split(r#"a"#);
+   |             ^^^^^^ help: try using a char instead: `'a'`
+
+error: aborting due to 24 previous errors
 

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -144,5 +144,23 @@ error: single-character string constant used as pattern
 LL |     x.split(r#"a"#);
    |             ^^^^^^ help: try using a char instead: `'a'`
 
-error: aborting due to 24 previous errors
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:60:13
+   |
+LL |     x.split(r###"a"###);
+   |             ^^^^^^^^^^ help: try using a char instead: `'a'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:61:13
+   |
+LL |     x.split(r###"'"###);
+   |             ^^^^^^^^^^ help: try using a char instead: `'/''`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:62:13
+   |
+LL |     x.split(r###"#"###);
+   |             ^^^^^^^^^^ help: try using a char instead: `'#'`
+
+error: aborting due to 27 previous errors
 


### PR DESCRIPTION
Closes #4356
changelog: Handle raw string literal on `single_char_literal` lint.
