### PR TITLE
Document how to write tests requiring the 2018 edition

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -10,6 +10,7 @@ because that's clearly a non-descriptive name.
 * [Setup](#Setup)
 * [Testing](#Testing)
 * [Rustfix tests](#Rustfix-tests)
+* [Edition 2018 tests](#Edition-2018-tests)
 * [Lint declaration](#Lint-declaration)
 * [Lint passes](#Lint-passes)
 * [Emitting a lint](#Emitting-a-lint)
@@ -100,6 +101,12 @@ Use `tests/ui/update-all-references.sh` to automatically generate the
 `.fixed` file after running the tests.
 
 With tests in place, let's have a look at implementing our lint now.
+
+### Edition 2018 tests
+
+Some features require the 2018 edition to work (e.g. `async_await`), but
+compile-test tests run on the 2015 edition by default. To change this behavior
+add `// compile-flags: --edition 2018` at the top of the test file.
 
 ### Testing manually
 


### PR DESCRIPTION
[Rendered](https://github.com/flip1995/rust-clippy/blob/doc_edition_2018_tests/doc/adding_lints.md#Edition-2018-tests)

cc #4365 

changelog: none
