### PR TITLE
Allow `Box<[JsValue]>` parameter type

### DIFF
--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -109,6 +109,14 @@ fn nowarn_large_array() {
     }
 }
 
+fn nowarn_non_sized() {
+    let x: Box<[u32]> = box [1; 10000];
+    match &x {
+        // not moved
+        ref y => (),
+    }
+}
+
 /// ICE regression test
 pub trait Foo {
     type Item;

--- a/tests/ui/escape_analysis.stderr
+++ b/tests/ui/escape_analysis.stderr
@@ -7,13 +7,13 @@ LL | fn warn_arg(x: Box<A>) {
    = note: `-D clippy::boxed-local` implied by `-D warnings`
 
 error: local variable doesn't need to be boxed here
-  --> $DIR/escape_analysis.rs:125:12
+  --> $DIR/escape_analysis.rs:133:12
    |
 LL | pub fn new(_needs_name: Box<PeekableSeekable<&()>>) -> () {}
    |            ^^^^^^^^^^^
 
 error: local variable doesn't need to be boxed here
-  --> $DIR/escape_analysis.rs:165:23
+  --> $DIR/escape_analysis.rs:173:23
    |
 LL |     fn closure_borrow(x: Box<A>) {
    |                       ^


### PR DESCRIPTION
changelog: Don't warn boxed_local for unsized
fixes #4351 
