### PR TITLE
Filter out PRs with changelog: none

### DIFF
--- a/util/fetch_prs_between.sh
+++ b/util/fetch_prs_between.sh
@@ -14,7 +14,12 @@ IFS='
 for pr in $(git log --oneline --grep "Merge #" --grep "Merge pull request" --grep "Auto merge of" "$first...$last" | sort -rn | uniq); do
   id=$(echo $pr | rg -o '#[0-9]{3,5}' | cut -c 2-)
   commit=$(echo $pr | cut -d' ' -f 1)
+  message=$(git --no-pager show --pretty=medium $commit)
+  if [ ! -z $(echo "$message" | rg "^[\s]{4}changelog: [nN]one\.*$") ]; then
+    continue
+  fi
+
   echo "URL: https://github.com/rust-lang/rust-clippy/pull/$id"
-  echo "$(git --no-pager show --pretty=medium $commit)"
+  echo "$message"
   echo "---------------------------------------------------------\n"
 done


### PR DESCRIPTION
cc #4372 

Filtering out the `changelog: none` merge commits, to unclutter the output.

changelog: none
