### PR TITLE
Rustup

### DIFF
--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -43,10 +43,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnportableVariant {
         if cx.tcx.data_layout.pointer_size.bits() != 64 {
             return;
         }
-        if let ItemKind::Enum(ref def, _) = item.node {
+        if let ItemKind::Enum(def, _) = &item.node {
             for var in &def.variants {
-                let variant = &var.node;
-                if let Some(ref anon_const) = variant.disr_expr {
+                if let Some(anon_const) = &var.disr_expr {
                     let param_env = ty::ParamEnv::empty();
                     let def_id = cx.tcx.hir().body_owner_def_id(anon_const.body);
                     let substs = InternalSubsts::identity_for_item(cx.tcx.global_tcx(), def_id);

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -123,7 +123,7 @@ impl_lint_pass!(EnumVariantNames => [
 ]);
 
 fn var2str(var: &Variant) -> LocalInternedString {
-    var.node.ident.as_str()
+    var.ident.as_str()
 }
 
 /// Returns the number of chars that match from the start

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -85,7 +85,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
                         "large size difference between variants",
                         |db| {
                             if variant.fields.len() == 1 {
-                                let span = match def.variants[i].node.data {
+                                let span = match def.variants[i].data {
                                     VariantData::Struct(ref fields, ..) | VariantData::Tuple(ref fields, ..) => {
                                         fields[0].ty.span
                                     },

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -197,6 +197,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
     }
 
     fn check_variant(&mut self, cx: &LateContext<'a, 'tcx>, v: &'tcx hir::Variant, _: &hir::Generics) {
-        self.check_missing_docs_attrs(cx, &v.node.attrs, v.span, "a variant");
+        self.check_missing_docs_attrs(cx, &v.attrs, v.span, "a variant");
     }
 }

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -91,7 +91,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Author {
     }
 
     fn check_variant(&mut self, cx: &LateContext<'a, 'tcx>, var: &'tcx hir::Variant, generics: &hir::Generics) {
-        if !has_attr(cx.sess(), &var.node.attrs) {
+        if !has_attr(cx.sess(), &var.attrs) {
             return;
         }
         prelude();

--- a/tests/ui/author/blocks.rs
+++ b/tests/ui/author/blocks.rs
@@ -1,4 +1,5 @@
 #![feature(stmt_expr_attributes)]
+#![allow(redundant_semicolon)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui/author/blocks.stderr
+++ b/tests/ui/author/blocks.stderr
@@ -1,10 +1,16 @@
 error: statement with no effect
-  --> $DIR/blocks.rs:14:5
+  --> $DIR/blocks.rs:8:9
    |
-LL |     -x;
-   |     ^^^
+LL |         ;;;;
+   |         ^^^^
    |
    = note: `-D clippy::no-effect` implied by `-D warnings`
 
-error: aborting due to previous error
+error: statement with no effect
+  --> $DIR/blocks.rs:15:5
+   |
+LL |     -x;
+   |     ^^^
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/author/blocks.stdout
+++ b/tests/ui/author/blocks.stdout
@@ -1,7 +1,10 @@
 if_chain! {
     if let ExprKind::Block(ref block) = expr.node;
     if let Some(trailing_expr) = &block.expr;
-    if block.stmts.len() == 0;
+    if block.stmts.len() == 1;
+    if let StmtKind::Semi(ref e, _) = block.stmts[0].node
+    if let ExprKind::Tup(ref elements) = e.node;
+    if elements.len() == 0;
     then {
         // report your lint here
     }

--- a/tests/ui/cognitive_complexity.rs
+++ b/tests/ui/cognitive_complexity.rs
@@ -322,14 +322,14 @@ fn try_() -> Result<i32, &'static str> {
 
 #[clippy::cognitive_complexity = "0"]
 fn try_again() -> Result<i32, &'static str> {
-    let _ = r#try!(Ok(42));
-    let _ = r#try!(Ok(43));
-    let _ = r#try!(Ok(44));
-    let _ = r#try!(Ok(45));
-    let _ = r#try!(Ok(46));
-    let _ = r#try!(Ok(47));
-    let _ = r#try!(Ok(48));
-    let _ = r#try!(Ok(49));
+    let _ = Ok(42)?;
+    let _ = Ok(43)?;
+    let _ = Ok(44)?;
+    let _ = Ok(45)?;
+    let _ = Ok(46)?;
+    let _ = Ok(47)?;
+    let _ = Ok(48)?;
+    let _ = Ok(49)?;
     match 5 {
         5 => Ok(5),
         _ => return Err("bla"),

--- a/tests/ui/cognitive_complexity.stderr
+++ b/tests/ui/cognitive_complexity.stderr
@@ -230,9 +230,9 @@ error: the function has a cognitive complexity of 1
   --> $DIR/cognitive_complexity.rs:324:1
    |
 LL | / fn try_again() -> Result<i32, &'static str> {
-LL | |     let _ = r#try!(Ok(42));
-LL | |     let _ = r#try!(Ok(43));
-LL | |     let _ = r#try!(Ok(44));
+LL | |     let _ = Ok(42)?;
+LL | |     let _ = Ok(43)?;
+LL | |     let _ = Ok(44)?;
 ...  |
 LL | |     }
 LL | | }

--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -215,10 +215,10 @@ fn if_same_then_else() -> Result<&'static str, ()> {
     };
 
     if true {
-        r#try!(Ok("foo"));
+        Ok("foo")?;
     } else {
         //~ ERROR same body as `if` block
-        r#try!(Ok("foo"));
+        Ok("foo")?;
     }
 
     if true {

--- a/tests/ui/if_same_then_else.stderr
+++ b/tests/ui/if_same_then_else.stderr
@@ -197,7 +197,7 @@ error: this `if` has identical blocks
 LL |       } else {
    |  ____________^
 LL | |         //~ ERROR same body as `if` block
-LL | |         r#try!(Ok("foo"));
+LL | |         Ok("foo")?;
 LL | |     }
    | |_____^
    |
@@ -206,7 +206,7 @@ note: same as this
    |
 LL |       if true {
    |  _____________^
-LL | |         r#try!(Ok("foo"));
+LL | |         Ok("foo")?;
 LL | |     } else {
    | |_____^
 

--- a/tests/ui/redundant_closure_call.rs
+++ b/tests/ui/redundant_closure_call.rs
@@ -19,5 +19,5 @@ fn main() {
     #[allow(clippy::needless_return)]
     (|| return 2)();
     (|| -> Option<i32> { None? })();
-    (|| -> Result<i32, i32> { r#try!(Err(2)) })();
+    (|| -> Result<i32, i32> { Err(2)? })();
 }

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::all)]
-#![allow(clippy::blacklisted_name, unused_assignments)]
+#![allow(clippy::blacklisted_name, clippy::no_effect, redundant_semicolon, unused_assignments)]
 
 struct Foo(u32);
 

--- a/tests/ui/unused_io_amount.rs
+++ b/tests/ui/unused_io_amount.rs
@@ -3,13 +3,6 @@
 
 use std::io;
 
-fn try_macro<T: io::Read + io::Write>(s: &mut T) -> io::Result<()> {
-    r#try!(s.write(b"test"));
-    let mut buf = [0u8; 4];
-    r#try!(s.read(&mut buf));
-    Ok(())
-}
-
 fn question_mark<T: io::Read + io::Write>(s: &mut T) -> io::Result<()> {
     s.write(b"test")?;
     let mut buf = [0u8; 4];

--- a/tests/ui/unused_io_amount.stderr
+++ b/tests/ui/unused_io_amount.stderr
@@ -1,43 +1,28 @@
 error: handle written amount returned or use `Write::write_all` instead
   --> $DIR/unused_io_amount.rs:7:5
    |
-LL |     r#try!(s.write(b"test"));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     s.write(b"test")?;
+   |     ^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unused-io-amount` implied by `-D warnings`
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: handle read amount returned or use `Read::read_exact` instead
   --> $DIR/unused_io_amount.rs:9:5
-   |
-LL |     r#try!(s.read(&mut buf));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error: handle written amount returned or use `Write::write_all` instead
-  --> $DIR/unused_io_amount.rs:14:5
-   |
-LL |     s.write(b"test")?;
-   |     ^^^^^^^^^^^^^^^^^
-
-error: handle read amount returned or use `Read::read_exact` instead
-  --> $DIR/unused_io_amount.rs:16:5
    |
 LL |     s.read(&mut buf)?;
    |     ^^^^^^^^^^^^^^^^^
 
 error: handle written amount returned or use `Write::write_all` instead
-  --> $DIR/unused_io_amount.rs:21:5
+  --> $DIR/unused_io_amount.rs:14:5
    |
 LL |     s.write(b"test").unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: handle read amount returned or use `Read::read_exact` instead
-  --> $DIR/unused_io_amount.rs:23:5
+  --> $DIR/unused_io_amount.rs:16:5
    |
 LL |     s.read(&mut buf).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Supersedes #4387 and #4385 

This removes tests with the `try!` macro in them completely. There is no need for Clippy to support the `try!` macro, since it is deprecated now.

[`StmtKind`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/hir/enum.StmtKind.html) got a new variant [`Semi`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/hir/enum.StmtKind.html#variant.Semi), which Just Works with the `author` lint. Nice.

changelog: none