### PR TITLE
Also specify patch version of toml crate

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -25,7 +25,7 @@ quine-mc_cluskey = "0.2.2"
 regex-syntax = "0.6"
 semver = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.5"
+toml = "0.5.3"
 unicode-normalization = "0.1"
 pulldown-cmark = "0.5.3"
 url = "2.1.0"


### PR DESCRIPTION
cc rust-lang/rust#63587

The patch update of the toml crate to version 0.5.3 recently broke some tests: #4378. For rustc, we have to define the complete version though.

changelog: none
