### PR TITLE
Remove "a" from single_match_else description

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -41,7 +41,7 @@ declare_clippy_lint! {
 }
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for matches with a two arms where an `if let else` will
+    /// **What it does:** Checks for matches with two arms where an `if let else` will
     /// usually suffice.
     ///
     /// **Why is this bad?** Just readability – `if let` nests less than a `match`.
@@ -76,7 +76,7 @@ declare_clippy_lint! {
     /// ```
     pub SINGLE_MATCH_ELSE,
     pedantic,
-    "a match statement with a two arms where the second arm's pattern is a placeholder instead of a specific match pattern"
+    "a match statement with two arms where the second arm's pattern is a placeholder instead of a specific match pattern"
 }
 
 declare_clippy_lint! {

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1676,7 +1676,7 @@ pub const ALL_LINTS: [Lint; 309] = [
     Lint {
         name: "single_match_else",
         group: "pedantic",
-        desc: "a match statement with a two arms where the second arm\'s pattern is a placeholder instead of a specific match pattern",
+        desc: "a match statement with two arms where the second arm\'s pattern is a placeholder instead of a specific match pattern",
         deprecation: None,
         module: "matches",
     },


### PR DESCRIPTION
changelog: none
