### PR TITLE
Add autofixable suggestion for unseparated integer literal suffixes

### DIFF
--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -1,4 +1,6 @@
-use crate::utils::{constants, snippet, snippet_opt, span_help_and_lint, span_lint, span_lint_and_then};
+use crate::utils::{
+    constants, snippet, snippet_opt, span_help_and_lint, span_lint, span_lint_and_sugg, span_lint_and_then,
+};
 use if_chain::if_chain;
 use rustc::lint::{in_external_macro, EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
@@ -399,19 +401,14 @@ impl MiscEarlyLints {
                 for (idx, ch) in src.chars().enumerate() {
                     if ch == 'i' || ch == 'u' {
                         if prev != '_' {
-                            span_lint_and_then(
+                            span_lint_and_sugg(
                                 cx,
                                 UNSEPARATED_LITERAL_SUFFIX,
                                 lit.span,
                                 "integer type suffix should be separated by an underscore",
-                                |db| {
-                                    db.span_suggestion(
-                                        lit.span,
-                                        "add an underscore",
-                                        format!("{}_{}", &src[0..idx], &src[idx..]),
-                                        Applicability::MachineApplicable,
-                                    );
-                                },
+                                "add an underscore",
+                                format!("{}_{}", &src[0..idx], &src[idx..]),
+                                Applicability::MachineApplicable,
                             );
                         }
                         break;
@@ -466,19 +463,14 @@ impl MiscEarlyLints {
                 for (idx, ch) in src.chars().enumerate() {
                     if ch == 'f' {
                         if prev != '_' {
-                            span_lint_and_then(
+                            span_lint_and_sugg(
                                 cx,
                                 UNSEPARATED_LITERAL_SUFFIX,
                                 lit.span,
                                 "float type suffix should be separated by an underscore",
-                                |db| {
-                                    db.span_suggestion(
-                                        lit.span,
-                                        "add an underscore",
-                                        format!("{}_{}", &src[0..idx], &src[idx..]),
-                                        Applicability::MachineApplicable,
-                                    );
-                                },
+                                "add an underscore",
+                                format!("{}_{}", &src[0..idx], &src[idx..]),
+                                Applicability::MachineApplicable,
                             );
                         }
                         break;

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -396,11 +396,23 @@ impl MiscEarlyLints {
             if char::to_digit(firstch, 10).is_some();
             then {
                 let mut prev = '\0';
-                for ch in src.chars() {
+                for (idx, ch) in src.chars().enumerate() {
                     if ch == 'i' || ch == 'u' {
                         if prev != '_' {
-                            span_lint(cx, UNSEPARATED_LITERAL_SUFFIX, lit.span,
-                                        "integer type suffix should be separated by an underscore");
+                            span_lint_and_then(
+                                cx,
+                                UNSEPARATED_LITERAL_SUFFIX,
+                                lit.span,
+                                "integer type suffix should be separated by an underscore",
+                                |db| {
+                                    db.span_suggestion(
+                                        lit.span,
+                                        "add an underscore",
+                                        format!("{}_{}", &src[0..idx], &src[idx..]),
+                                        Applicability::MachineApplicable,
+                                    );
+                                },
+                            );
                         }
                         break;
                     }
@@ -451,11 +463,23 @@ impl MiscEarlyLints {
             if char::to_digit(firstch, 10).is_some();
             then {
                 let mut prev = '\0';
-                for ch in src.chars() {
+                for (idx, ch) in src.chars().enumerate() {
                     if ch == 'f' {
                         if prev != '_' {
-                            span_lint(cx, UNSEPARATED_LITERAL_SUFFIX, lit.span,
-                                        "float type suffix should be separated by an underscore");
+                            span_lint_and_then(
+                                cx,
+                                UNSEPARATED_LITERAL_SUFFIX,
+                                lit.span,
+                                "float type suffix should be separated by an underscore",
+                                |db| {
+                                    db.span_suggestion(
+                                        lit.span,
+                                        "add an underscore",
+                                        format!("{}_{}", &src[0..idx], &src[idx..]),
+                                        Applicability::MachineApplicable,
+                                    );
+                                },
+                            );
                         }
                         break;
                     }

--- a/tests/ui/literals.rs
+++ b/tests/ui/literals.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::large_digit_groups)]
 #![warn(clippy::mixed_case_hex_literals)]
-#![warn(clippy::unseparated_literal_suffix)]
 #![warn(clippy::zero_prefixed_literal)]
+#![allow(clippy::unseparated_literal_suffix)]
 #![allow(dead_code)]
 
 fn main() {
@@ -14,15 +14,6 @@ fn main() {
     let fail2 = 0xabCD_u32;
     let fail2 = 0xabCD_isize;
     let fail_multi_zero = 000_123usize;
-
-    let ok6 = 1234_i32;
-    let ok7 = 1234_f32;
-    let ok8 = 1234_isize;
-    let fail3 = 1234i32;
-    let fail4 = 1234u32;
-    let fail5 = 1234isize;
-    let fail6 = 1234usize;
-    let fail7 = 1.5f32;
 
     let ok9 = 0;
     let ok10 = 0_i64;

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -22,7 +22,7 @@ error: integer type suffix should be separated by an underscore
   --> $DIR/literals.rs:16:27
    |
 LL |     let fail_multi_zero = 000_123usize;
-   |                           ^^^^^^^^^^^^
+   |                           ^^^^^^^^^^^^ help: add an underscore: `000_123_usize`
    |
    = note: `-D clippy::unseparated-literal-suffix` implied by `-D warnings`
 
@@ -46,31 +46,31 @@ error: integer type suffix should be separated by an underscore
   --> $DIR/literals.rs:21:17
    |
 LL |     let fail3 = 1234i32;
-   |                 ^^^^^^^
+   |                 ^^^^^^^ help: add an underscore: `1234_i32`
 
 error: integer type suffix should be separated by an underscore
   --> $DIR/literals.rs:22:17
    |
 LL |     let fail4 = 1234u32;
-   |                 ^^^^^^^
+   |                 ^^^^^^^ help: add an underscore: `1234_u32`
 
 error: integer type suffix should be separated by an underscore
   --> $DIR/literals.rs:23:17
    |
 LL |     let fail5 = 1234isize;
-   |                 ^^^^^^^^^
+   |                 ^^^^^^^^^ help: add an underscore: `1234_isize`
 
 error: integer type suffix should be separated by an underscore
   --> $DIR/literals.rs:24:17
    |
 LL |     let fail6 = 1234usize;
-   |                 ^^^^^^^^^
+   |                 ^^^^^^^^^ help: add an underscore: `1234_usize`
 
 error: float type suffix should be separated by an underscore
   --> $DIR/literals.rs:25:17
    |
 LL |     let fail7 = 1.5f32;
-   |                 ^^^^^^
+   |                 ^^^^^^ help: add an underscore: `1.5_f32`
 
 error: this is a decimal constant
   --> $DIR/literals.rs:29:17

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -18,14 +18,6 @@ error: inconsistent casing in hexadecimal literal
 LL |     let fail2 = 0xabCD_isize;
    |                 ^^^^^^^^^^^^
 
-error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:16:27
-   |
-LL |     let fail_multi_zero = 000_123usize;
-   |                           ^^^^^^^^^^^^ help: add an underscore: `000_123_usize`
-   |
-   = note: `-D clippy::unseparated-literal-suffix` implied by `-D warnings`
-
 error: this is a decimal constant
   --> $DIR/literals.rs:16:27
    |
@@ -42,38 +34,8 @@ help: if you mean to use an octal constant, use `0o`
 LL |     let fail_multi_zero = 0o123usize;
    |                           ^^^^^^^^^^
 
-error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:21:17
-   |
-LL |     let fail3 = 1234i32;
-   |                 ^^^^^^^ help: add an underscore: `1234_i32`
-
-error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:22:17
-   |
-LL |     let fail4 = 1234u32;
-   |                 ^^^^^^^ help: add an underscore: `1234_u32`
-
-error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:23:17
-   |
-LL |     let fail5 = 1234isize;
-   |                 ^^^^^^^^^ help: add an underscore: `1234_isize`
-
-error: integer type suffix should be separated by an underscore
-  --> $DIR/literals.rs:24:17
-   |
-LL |     let fail6 = 1234usize;
-   |                 ^^^^^^^^^ help: add an underscore: `1234_usize`
-
-error: float type suffix should be separated by an underscore
-  --> $DIR/literals.rs:25:17
-   |
-LL |     let fail7 = 1.5f32;
-   |                 ^^^^^^ help: add an underscore: `1.5_f32`
-
 error: this is a decimal constant
-  --> $DIR/literals.rs:29:17
+  --> $DIR/literals.rs:20:17
    |
 LL |     let fail8 = 0123;
    |                 ^^^^
@@ -87,7 +49,7 @@ LL |     let fail8 = 0o123;
    |                 ^^^^^
 
 error: digit groups should be smaller
-  --> $DIR/literals.rs:40:18
+  --> $DIR/literals.rs:31:18
    |
 LL |     let fail13 = 0x1_23456_78901_usize;
    |                  ^^^^^^^^^^^^^^^^^^^^^ help: consider: `0x0123_4567_8901_usize`
@@ -95,7 +57,7 @@ LL |     let fail13 = 0x1_23456_78901_usize;
    = note: `-D clippy::large-digit-groups` implied by `-D warnings`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:42:18
+  --> $DIR/literals.rs:33:18
    |
 LL |     let fail19 = 12_3456_21;
    |                  ^^^^^^^^^^ help: consider: `12_345_621`
@@ -103,16 +65,16 @@ LL |     let fail19 = 12_3456_21;
    = note: `-D clippy::inconsistent-digit-grouping` implied by `-D warnings`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:43:18
+  --> $DIR/literals.rs:34:18
    |
 LL |     let fail22 = 3__4___23;
    |                  ^^^^^^^^^ help: consider: `3_423`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:44:18
+  --> $DIR/literals.rs:35:18
    |
 LL |     let fail23 = 3__16___23;
    |                  ^^^^^^^^^^ help: consider: `31_623`
 
-error: aborting due to 15 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/unseparated_prefix_literals.fixed
+++ b/tests/ui/unseparated_prefix_literals.fixed
@@ -1,0 +1,20 @@
+// run-rustfix
+
+#![warn(clippy::unseparated_literal_suffix)]
+#![allow(dead_code)]
+
+fn main() {
+    let _ok1 = 1234_i32;
+    let _ok2 = 1234_isize;
+    let _ok3 = 0x123_isize;
+    let _fail1 = 1234_i32;
+    let _fail2 = 1234_u32;
+    let _fail3 = 1234_isize;
+    let _fail4 = 1234_usize;
+    let _fail5 = 0x123_isize;
+
+    let _okf1 = 1.5_f32;
+    let _okf2 = 1_f32;
+    let _failf1 = 1.5_f32;
+    let _failf2 = 1_f32;
+}

--- a/tests/ui/unseparated_prefix_literals.rs
+++ b/tests/ui/unseparated_prefix_literals.rs
@@ -1,0 +1,20 @@
+// run-rustfix
+
+#![warn(clippy::unseparated_literal_suffix)]
+#![allow(dead_code)]
+
+fn main() {
+    let _ok1 = 1234_i32;
+    let _ok2 = 1234_isize;
+    let _ok3 = 0x123_isize;
+    let _fail1 = 1234i32;
+    let _fail2 = 1234u32;
+    let _fail3 = 1234isize;
+    let _fail4 = 1234usize;
+    let _fail5 = 0x123isize;
+
+    let _okf1 = 1.5_f32;
+    let _okf2 = 1_f32;
+    let _failf1 = 1.5f32;
+    let _failf2 = 1f32;
+}

--- a/tests/ui/unseparated_prefix_literals.stderr
+++ b/tests/ui/unseparated_prefix_literals.stderr
@@ -1,0 +1,46 @@
+error: integer type suffix should be separated by an underscore
+  --> $DIR/unseparated_prefix_literals.rs:10:18
+   |
+LL |     let _fail1 = 1234i32;
+   |                  ^^^^^^^ help: add an underscore: `1234_i32`
+   |
+   = note: `-D clippy::unseparated-literal-suffix` implied by `-D warnings`
+
+error: integer type suffix should be separated by an underscore
+  --> $DIR/unseparated_prefix_literals.rs:11:18
+   |
+LL |     let _fail2 = 1234u32;
+   |                  ^^^^^^^ help: add an underscore: `1234_u32`
+
+error: integer type suffix should be separated by an underscore
+  --> $DIR/unseparated_prefix_literals.rs:12:18
+   |
+LL |     let _fail3 = 1234isize;
+   |                  ^^^^^^^^^ help: add an underscore: `1234_isize`
+
+error: integer type suffix should be separated by an underscore
+  --> $DIR/unseparated_prefix_literals.rs:13:18
+   |
+LL |     let _fail4 = 1234usize;
+   |                  ^^^^^^^^^ help: add an underscore: `1234_usize`
+
+error: integer type suffix should be separated by an underscore
+  --> $DIR/unseparated_prefix_literals.rs:14:18
+   |
+LL |     let _fail5 = 0x123isize;
+   |                  ^^^^^^^^^^ help: add an underscore: `0x123_isize`
+
+error: float type suffix should be separated by an underscore
+  --> $DIR/unseparated_prefix_literals.rs:18:19
+   |
+LL |     let _failf1 = 1.5f32;
+   |                   ^^^^^^ help: add an underscore: `1.5_f32`
+
+error: float type suffix should be separated by an underscore
+  --> $DIR/unseparated_prefix_literals.rs:19:19
+   |
+LL |     let _failf2 = 1f32;
+   |                   ^^^^ help: add an underscore: `1_f32`
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
changelog: Add autofixable suggestion for unseparated integer literal suffixes

Somewhat WIP, since I haven't been able to get this working when adding `// run-rustfix` to `ui/literals.rs`. I think the issue is that there are multiple suggestions operating on one numerical literal, and I'm not sure what the best approach is to work around that.

Thanks