### PR TITLE
Remove in_macro_or_desugar

### DIFF
--- a/clippy_lints/src/assertions_on_constants.rs
+++ b/clippy_lints/src/assertions_on_constants.rs
@@ -3,7 +3,7 @@ use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 
 use crate::consts::{constant, Constant};
-use crate::utils::{in_macro_or_desugar, is_direct_expn_of, is_expn_of, span_help_and_lint};
+use crate::utils::{is_direct_expn_of, is_expn_of, span_help_and_lint};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for `assert!(true)` and `assert!(false)` calls.
@@ -55,12 +55,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssertionsOnConstants {
             }
         };
         if let Some(debug_assert_span) = is_expn_of(e.span, "debug_assert") {
-            if in_macro_or_desugar(debug_assert_span) {
+            if debug_assert_span.from_expansion() {
                 return;
             }
             lint_assert_cb(true);
         } else if let Some(assert_span) = is_direct_expn_of(e.span, "assert") {
-            if in_macro_or_desugar(assert_span) {
+            if assert_span.from_expansion() {
                 return;
             }
             lint_assert_cb(false);

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -2,8 +2,8 @@
 
 use crate::reexport::*;
 use crate::utils::{
-    in_macro_or_desugar, is_present_in_source, last_line_of_span, match_def_path, paths, snippet_opt, span_lint,
-    span_lint_and_sugg, span_lint_and_then, without_block_comments,
+    is_present_in_source, last_line_of_span, match_def_path, paths, snippet_opt, span_lint, span_lint_and_sugg,
+    span_lint_and_then, without_block_comments,
 };
 use if_chain::if_chain;
 use rustc::hir::*;
@@ -412,7 +412,7 @@ fn is_relevant_expr(cx: &LateContext<'_, '_>, tables: &ty::TypeckTables<'_>, exp
 }
 
 fn check_attrs(cx: &LateContext<'_, '_>, span: Span, name: Name, attrs: &[Attribute]) {
-    if in_macro_or_desugar(span) {
+    if span.from_expansion() {
         return;
     }
 

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -54,7 +54,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExVisitor<'a, 'tcx> {
         if let ExprKind::Closure(_, _, eid, _, _) = expr.node {
             let body = self.cx.tcx.hir().body(eid);
             let ex = &body.value;
-            if matches!(ex.node, ExprKind::Block(_, _)) && !in_macro_or_desugar(body.value.span) {
+            if matches!(ex.node, ExprKind::Block(_, _)) && !body.value.span.from_expansion() {
                 self.found_block = Some(ex);
                 return;
             }
@@ -79,7 +79,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BlockInIfCondition {
                         if let Some(ex) = &block.expr {
                             // don't dig into the expression here, just suggest that they remove
                             // the block
-                            if in_macro_or_desugar(expr.span) || differing_macro_contexts(expr.span, ex.span) {
+                            if expr.span.from_expansion() || differing_macro_contexts(expr.span, ex.span) {
                                 return;
                             }
                             span_help_and_lint(
@@ -96,7 +96,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BlockInIfCondition {
                         }
                     } else {
                         let span = block.expr.as_ref().map_or_else(|| block.stmts[0].span, |e| e.span);
-                        if in_macro_or_desugar(span) || differing_macro_contexts(expr.span, span) {
+                        if span.from_expansion() || differing_macro_contexts(expr.span, span) {
                             return;
                         }
                         // move block higher

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -1,6 +1,5 @@
 use crate::utils::{
-    get_trait_def_id, implements_trait, in_macro, in_macro_or_desugar, match_type, paths, snippet_opt,
-    span_lint_and_then, SpanlessEq,
+    get_trait_def_id, implements_trait, in_macro, match_type, paths, snippet_opt, span_lint_and_then, SpanlessEq,
 };
 use if_chain::if_chain;
 use rustc::hir::intravisit::*;
@@ -106,7 +105,7 @@ impl<'a, 'tcx, 'v> Hir2Qmm<'a, 'tcx, 'v> {
         }
 
         // prevent folding of `cfg!` macros and the like
-        if !in_macro_or_desugar(e.span) {
+        if !e.span.from_expansion() {
             match &e.node {
                 ExprKind::Unary(UnNot, inner) => return Ok(Bool::Not(box self.run(inner)?)),
                 ExprKind::Binary(binop, lhs, rhs) => match &binop.node {

--- a/clippy_lints/src/cognitive_complexity.rs
+++ b/clippy_lints/src/cognitive_complexity.rs
@@ -9,7 +9,7 @@ use rustc::{declare_tool_lint, impl_lint_pass};
 use syntax::ast::Attribute;
 use syntax::source_map::Span;
 
-use crate::utils::{in_macro_or_desugar, is_allowed, match_type, paths, span_help_and_lint, LimitStack};
+use crate::utils::{is_allowed, match_type, paths, span_help_and_lint, LimitStack};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for methods with high cognitive complexity.
@@ -42,7 +42,7 @@ impl_lint_pass!(CognitiveComplexity => [COGNITIVE_COMPLEXITY]);
 
 impl CognitiveComplexity {
     fn check<'a, 'tcx>(&mut self, cx: &'a LateContext<'a, 'tcx>, body: &'tcx Body, span: Span) {
-        if in_macro_or_desugar(span) {
+        if span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -18,9 +18,7 @@ use rustc::{declare_lint_pass, declare_tool_lint};
 use syntax::ast;
 
 use crate::utils::sugg::Sugg;
-use crate::utils::{
-    in_macro_or_desugar, snippet_block, snippet_block_with_applicability, span_lint_and_sugg, span_lint_and_then,
-};
+use crate::utils::{snippet_block, snippet_block_with_applicability, span_lint_and_sugg, span_lint_and_then};
 use rustc_errors::Applicability;
 
 declare_clippy_lint! {
@@ -77,7 +75,7 @@ declare_lint_pass!(CollapsibleIf => [COLLAPSIBLE_IF]);
 
 impl EarlyLintPass for CollapsibleIf {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &ast::Expr) {
-        if !in_macro_or_desugar(expr.span) {
+        if !expr.span.from_expansion() {
             check_if(cx, expr)
         }
     }
@@ -108,7 +106,7 @@ fn check_collapsible_maybe_if_let(cx: &EarlyContext<'_>, else_: &ast::Expr) {
         if let ast::ExprKind::Block(ref block, _) = else_.node;
         if !block_starts_with_comment(cx, block);
         if let Some(else_) = expr_block(block);
-        if !in_macro_or_desugar(else_.span);
+        if !else_.span.from_expansion();
         if let ast::ExprKind::If(..) = else_.node;
         then {
             let mut applicability = Applicability::MachineApplicable;

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -1,6 +1,4 @@
-use crate::utils::{
-    get_parent_expr, higher, in_macro_or_desugar, same_tys, snippet, span_lint_and_then, span_note_and_lint,
-};
+use crate::utils::{get_parent_expr, higher, same_tys, snippet, span_lint_and_then, span_note_and_lint};
 use crate::utils::{SpanlessEq, SpanlessHash};
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -109,7 +107,7 @@ declare_lint_pass!(CopyAndPaste => [IFS_SAME_COND, IF_SAME_THEN_ELSE, MATCH_SAME
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CopyAndPaste {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
-        if !in_macro_or_desugar(expr.span) {
+        if !expr.span.from_expansion() {
             // skip ifs directly in else, it will be checked in the parent if
             if let Some(expr) = get_parent_expr(cx, expr) {
                 if let Some((_, _, Some(ref else_expr))) = higher::if_block(&expr) {

--- a/clippy_lints/src/double_parens.rs
+++ b/clippy_lints/src/double_parens.rs
@@ -1,4 +1,4 @@
-use crate::utils::{in_macro_or_desugar, span_lint};
+use crate::utils::span_lint;
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 use syntax::ast::*;
@@ -27,7 +27,7 @@ declare_lint_pass!(DoubleParens => [DOUBLE_PARENS]);
 
 impl EarlyLintPass for DoubleParens {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if in_macro_or_desugar(expr.span) {
+        if expr.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -1,6 +1,6 @@
 //! lint on enum variants that are prefixed or suffixed by the same characters
 
-use crate::utils::{camel_case, in_macro_or_desugar, is_present_in_source};
+use crate::utils::{camel_case, is_present_in_source};
 use crate::utils::{span_help_and_lint, span_lint};
 use rustc::lint::{EarlyContext, EarlyLintPass, Lint, LintArray, LintPass};
 use rustc::{declare_tool_lint, impl_lint_pass};
@@ -248,7 +248,7 @@ impl EarlyLintPass for EnumVariantNames {
         let item_name = item.ident.as_str();
         let item_name_chars = item_name.chars().count();
         let item_camel = to_camel_case(&item_name);
-        if !in_macro_or_desugar(item.span) && is_present_in_source(cx, item.span) {
+        if !item.span.from_expansion() && is_present_in_source(cx, item.span) {
             if let Some(&(ref mod_name, ref mod_camel)) = self.modules.last() {
                 // constants don't have surrounding modules
                 if !mod_camel.is_empty() {

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -1,6 +1,4 @@
-use crate::utils::{
-    implements_trait, in_macro_or_desugar, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq,
-};
+use crate::utils::{implements_trait, is_copy, multispan_sugg, snippet, span_lint, span_lint_and_then, SpanlessEq};
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
@@ -52,7 +50,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
     #[allow(clippy::similar_names, clippy::too_many_lines)]
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
         if let ExprKind::Binary(op, ref left, ref right) = e.node {
-            if in_macro_or_desugar(e.span) {
+            if e.span.from_expansion() {
                 return;
             }
             if is_valid_operator(op) && SpanlessEq::new(cx).ignore_fn().eq_expr(left, right) {

--- a/clippy_lints/src/erasing_op.rs
+++ b/clippy_lints/src/erasing_op.rs
@@ -4,7 +4,7 @@ use rustc::{declare_lint_pass, declare_tool_lint};
 use syntax::source_map::Span;
 
 use crate::consts::{constant_simple, Constant};
-use crate::utils::{in_macro_or_desugar, span_lint};
+use crate::utils::span_lint;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for erasing operations, e.g., `x * 0`.
@@ -31,7 +31,7 @@ declare_lint_pass!(ErasingOp => [ERASING_OP]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ErasingOp {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        if in_macro_or_desugar(e.span) {
+        if e.span.from_expansion() {
             return;
         }
         if let ExprKind::Binary(ref cmp, ref left, ref right) = e.node {

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -1,7 +1,6 @@
 use crate::utils::paths;
 use crate::utils::{
-    in_macro_or_desugar, is_expn_of, last_path_segment, match_def_path, match_type, resolve_node, snippet,
-    span_lint_and_then, walk_ptrs_ty,
+    is_expn_of, last_path_segment, match_def_path, match_type, resolve_node, snippet, span_lint_and_then, walk_ptrs_ty,
 };
 use if_chain::if_chain;
 use rustc::hir::*;
@@ -40,7 +39,7 @@ declare_lint_pass!(UselessFormat => [USELESS_FORMAT]);
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessFormat {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         if let Some(span) = is_expn_of(expr.span, "format") {
-            if in_macro_or_desugar(span) {
+            if span.from_expansion() {
                 return;
             }
             match expr.node {

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -1,6 +1,5 @@
 use crate::utils::{
-    in_macro_or_desugar, match_def_path, match_trait_method, same_tys, snippet, snippet_with_macro_callsite,
-    span_lint_and_then,
+    match_def_path, match_trait_method, same_tys, snippet, snippet_with_macro_callsite, span_lint_and_then,
 };
 use crate::utils::{paths, resolve_node};
 use rustc::hir::*;
@@ -34,7 +33,7 @@ impl_lint_pass!(IdentityConversion => [IDENTITY_CONVERSION]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityConversion {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        if in_macro_or_desugar(e.span) {
+        if e.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/identity_op.rs
+++ b/clippy_lints/src/identity_op.rs
@@ -5,7 +5,7 @@ use rustc::{declare_lint_pass, declare_tool_lint};
 use syntax::source_map::Span;
 
 use crate::consts::{constant_simple, Constant};
-use crate::utils::{clip, in_macro_or_desugar, snippet, span_lint, unsext};
+use crate::utils::{clip, snippet, span_lint, unsext};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for identity operations, e.g., `x + 0`.
@@ -29,7 +29,7 @@ declare_lint_pass!(IdentityOp => [IDENTITY_OP]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityOp {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        if in_macro_or_desugar(e.span) {
+        if e.span.from_expansion() {
             return;
         }
         if let ExprKind::Binary(ref cmp, ref left, ref right) = e.node {

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    in_macro_or_desugar, match_def_path,
+    match_def_path,
     paths::{BEGIN_PANIC, BEGIN_PANIC_FMT},
     resolve_node, snippet_opt, span_lint_and_then,
 };
@@ -138,7 +138,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitReturn {
 
         // checking return type through MIR, HIR is not able to determine inferred closure return types
         // make sure it's not a macro
-        if !mir.return_ty().is_unit() && !in_macro_or_desugar(span) {
+        if !mir.return_ty().is_unit() && !span.from_expansion() {
             expr_match(cx, &body.value);
         }
     }

--- a/clippy_lints/src/inherent_to_string.rs
+++ b/clippy_lints/src/inherent_to_string.rs
@@ -4,8 +4,8 @@ use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 
 use crate::utils::{
-    get_trait_def_id, implements_trait, in_macro_or_desugar, match_type, paths, return_ty, span_help_and_lint,
-    trait_ref_of_method, walk_ptrs_ty,
+    get_trait_def_id, implements_trait, match_type, paths, return_ty, span_help_and_lint, trait_ref_of_method,
+    walk_ptrs_ty,
 };
 
 declare_clippy_lint! {
@@ -94,7 +94,7 @@ declare_lint_pass!(InherentToString => [INHERENT_TO_STRING, INHERENT_TO_STRING_S
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InherentToString {
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, impl_item: &'tcx ImplItem) {
-        if in_macro_or_desugar(impl_item.span) {
+        if impl_item.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -1,6 +1,6 @@
 //! lint when items are used after statements
 
-use crate::utils::{in_macro_or_desugar, span_lint};
+use crate::utils::span_lint;
 use matches::matches;
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
@@ -38,7 +38,7 @@ declare_lint_pass!(ItemsAfterStatements => [ITEMS_AFTER_STATEMENTS]);
 
 impl EarlyLintPass for ItemsAfterStatements {
     fn check_block(&mut self, cx: &EarlyContext<'_>, item: &Block) {
-        if in_macro_or_desugar(item.span) {
+        if item.span.from_expansion() {
             return;
         }
 
@@ -52,7 +52,7 @@ impl EarlyLintPass for ItemsAfterStatements {
         // lint on all further items
         for stmt in stmts {
             if let StmtKind::Item(ref it) = *stmt {
-                if in_macro_or_desugar(it.span) {
+                if it.span.from_expansion() {
                     return;
                 }
                 if let ItemKind::MacroDef(..) = it.node {

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -1,6 +1,4 @@
-use crate::utils::{
-    get_item_name, in_macro_or_desugar, snippet_with_applicability, span_lint, span_lint_and_sugg, walk_ptrs_ty,
-};
+use crate::utils::{get_item_name, snippet_with_applicability, span_lint, span_lint_and_sugg, walk_ptrs_ty};
 use rustc::hir::def_id::DefId;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -75,7 +73,7 @@ declare_lint_pass!(LenZero => [LEN_ZERO, LEN_WITHOUT_IS_EMPTY]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LenZero {
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx Item) {
-        if in_macro_or_desugar(item.span) {
+        if item.span.from_expansion() {
             return;
         }
 
@@ -87,7 +85,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LenZero {
     }
 
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
-        if in_macro_or_desugar(expr.span) {
+        if expr.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -11,7 +11,7 @@ use rustc::{declare_lint_pass, declare_tool_lint};
 // use rustc::middle::region::CodeExtent;
 use crate::consts::{constant, Constant};
 use crate::utils::usage::mutated_variables;
-use crate::utils::{in_macro_or_desugar, sext, sugg};
+use crate::utils::{sext, sugg};
 use rustc::middle::expr_use_visitor::*;
 use rustc::middle::mem_categorization::cmt_;
 use rustc::middle::mem_categorization::Categorization;
@@ -470,7 +470,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Loops {
     #[allow(clippy::too_many_lines)]
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
         // we don't want to check expanded macros
-        if in_macro_or_desugar(expr.span) {
+        if expr.span.from_expansion() {
             return;
         }
 
@@ -1034,7 +1034,7 @@ fn check_for_loop_range<'a, 'tcx>(
     body: &'tcx Expr,
     expr: &'tcx Expr,
 ) {
-    if in_macro_or_desugar(expr.span) {
+    if expr.span.from_expansion() {
         return;
     }
 

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -1,7 +1,6 @@
 use crate::utils::paths;
 use crate::utils::{
-    in_macro_or_desugar, is_copy, match_trait_method, match_type, remove_blocks, snippet_with_applicability,
-    span_lint_and_sugg,
+    is_copy, match_trait_method, match_type, remove_blocks, snippet_with_applicability, span_lint_and_sugg,
 };
 use if_chain::if_chain;
 use rustc::hir;
@@ -44,7 +43,7 @@ declare_lint_pass!(MapClone => [MAP_CLONE]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MapClone {
     fn check_expr(&mut self, cx: &LateContext<'_, '_>, e: &hir::Expr) {
-        if in_macro_or_desugar(e.span) {
+        if e.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -1,5 +1,5 @@
 use crate::utils::paths;
-use crate::utils::{in_macro_or_desugar, iter_input_pats, match_type, method_chain_args, snippet, span_lint_and_then};
+use crate::utils::{iter_input_pats, match_type, method_chain_args, snippet, span_lint_and_then};
 use if_chain::if_chain;
 use rustc::hir;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -257,7 +257,7 @@ fn lint_map_unit_fn(cx: &LateContext<'_, '_>, stmt: &hir::Stmt, expr: &hir::Expr
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MapUnit {
     fn check_stmt(&mut self, cx: &LateContext<'_, '_>, stmt: &hir::Stmt) {
-        if in_macro_or_desugar(stmt.span) {
+        if stmt.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -2,8 +2,8 @@ use crate::consts::{constant, Constant};
 use crate::utils::paths;
 use crate::utils::sugg::Sugg;
 use crate::utils::{
-    expr_block, in_macro_or_desugar, is_allowed, is_expn_of, match_qpath, match_type, multispan_sugg, remove_blocks,
-    snippet, snippet_with_applicability, span_lint_and_sugg, span_lint_and_then, span_note_and_lint, walk_ptrs_ty,
+    expr_block, is_allowed, is_expn_of, match_qpath, match_type, multispan_sugg, remove_blocks, snippet,
+    snippet_with_applicability, span_lint_and_sugg, span_lint_and_then, span_note_and_lint, walk_ptrs_ty,
 };
 use if_chain::if_chain;
 use rustc::hir::def::CtorKind;
@@ -597,7 +597,7 @@ fn check_match_ref_pats(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr:
         }));
 
         span_lint_and_then(cx, MATCH_REF_PATS, expr.span, title, |db| {
-            if !in_macro_or_desugar(expr.span) {
+            if !expr.span.from_expansion() {
                 multispan_sugg(db, msg.to_owned(), suggs);
             }
         });

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -21,11 +21,11 @@ use syntax::symbol::LocalInternedString;
 use crate::utils::sugg;
 use crate::utils::usage::mutated_variables;
 use crate::utils::{
-    get_arg_name, get_parent_expr, get_trait_def_id, has_iter_method, implements_trait, in_macro, in_macro_or_desugar,
-    is_copy, is_ctor_function, is_expn_of, iter_input_pats, last_path_segment, match_def_path, match_qpath,
-    match_trait_method, match_type, match_var, method_calls, method_chain_args, remove_blocks, return_ty, same_tys,
-    single_segment_path, snippet, snippet_with_applicability, snippet_with_macro_callsite, span_lint,
-    span_lint_and_sugg, span_lint_and_then, span_note_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth, SpanlessEq,
+    get_arg_name, get_parent_expr, get_trait_def_id, has_iter_method, implements_trait, in_macro, is_copy,
+    is_ctor_function, is_expn_of, iter_input_pats, last_path_segment, match_def_path, match_qpath, match_trait_method,
+    match_type, match_var, method_calls, method_chain_args, remove_blocks, return_ty, same_tys, single_segment_path,
+    snippet, snippet_with_applicability, snippet_with_macro_callsite, span_lint, span_lint_and_sugg,
+    span_lint_and_then, span_note_and_lint, walk_ptrs_ty, walk_ptrs_ty_depth, SpanlessEq,
 };
 use crate::utils::{paths, span_help_and_lint};
 
@@ -2150,7 +2150,7 @@ fn lint_option_and_then_some(cx: &LateContext<'_, '_>, expr: &hir::Expr, args: &
                         return;
                     }
 
-                    let some_inner_snip = if in_macro_or_desugar(inner_expr.span) {
+                    let some_inner_snip = if inner_expr.span.from_expansion() {
                         snippet_with_macro_callsite(cx, inner_expr.span, "_")
                     } else {
                         snippet(cx, inner_expr.span, "_")

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -48,8 +48,8 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     /// **What it does:** Checks for comparisons to NaN.
     ///
-    /// **Why is this bad?** NaN does not compare meaningfully to anything   not
-    /// even itself   so those comparisons are simply wrong.
+    /// **Why is this bad?** NaN does not compare meaningfully to anything – not
+    /// even itself – so those comparisons are simply wrong.
     ///
     /// **Known problems:** None.
     ///

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -12,8 +12,8 @@ use syntax::source_map::{ExpnKind, Span};
 use crate::consts::{constant, Constant};
 use crate::utils::sugg::Sugg;
 use crate::utils::{
-    get_item_name, get_parent_expr, implements_trait, in_constant, in_macro_or_desugar, is_integer_literal,
-    iter_input_pats, last_path_segment, match_qpath, match_trait_method, paths, snippet, span_lint, span_lint_and_then,
+    get_item_name, get_parent_expr, implements_trait, in_constant, is_integer_literal, iter_input_pats,
+    last_path_segment, match_qpath, match_trait_method, paths, snippet, span_lint, span_lint_and_then,
     span_lint_hir_and_then, walk_ptrs_ty, SpanlessEq,
 };
 
@@ -48,8 +48,8 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     /// **What it does:** Checks for comparisons to NaN.
     ///
-    /// **Why is this bad?** NaN does not compare meaningfully to anything – not
-    /// even itself – so those comparisons are simply wrong.
+    /// **Why is this bad?** NaN does not compare meaningfully to anything   not
+    /// even itself   so those comparisons are simply wrong.
     ///
     /// **Known problems:** None.
     ///
@@ -641,7 +641,7 @@ fn in_attributes_expansion(expr: &Expr) -> bool {
 /// Tests whether `res` is a variable defined outside a macro.
 fn non_macro_local(cx: &LateContext<'_, '_>, res: def::Res) -> bool {
     if let def::Res::Local(id) = res {
-        !in_macro_or_desugar(cx.tcx.hir().span(id))
+        !cx.tcx.hir().span(id).from_expansion()
     } else {
         false
     }

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -5,7 +5,7 @@
 // [`missing_doc`]: https://github.com/rust-lang/rust/blob/d6d05904697d89099b55da3331155392f1db9c00/src/librustc_lint/builtin.rs#L246
 //
 
-use crate::utils::{in_macro_or_desugar, span_lint};
+use crate::utils::span_lint;
 use if_chain::if_chain;
 use rustc::hir;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
@@ -85,7 +85,7 @@ impl MissingDoc {
             return;
         }
 
-        if in_macro_or_desugar(sp) {
+        if sp.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -3,7 +3,7 @@
 //! This lint is **warn** by default
 
 use crate::utils::sugg::Sugg;
-use crate::utils::{higher, in_macro_or_desugar, span_lint, span_lint_and_sugg};
+use crate::utils::{higher, span_lint, span_lint_and_sugg};
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
@@ -129,7 +129,7 @@ declare_lint_pass!(BoolComparison => [BOOL_COMPARISON]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoolComparison {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        if in_macro_or_desugar(e.span) {
+        if e.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -2,7 +2,7 @@
 //!
 //! This lint is **warn** by default
 
-use crate::utils::{in_macro_or_desugar, snippet_opt, span_lint_and_then};
+use crate::utils::{snippet_opt, span_lint_and_then};
 use if_chain::if_chain;
 use rustc::hir::{BindingAnnotation, Expr, ExprKind, HirId, Item, MutImmutable, Pat, PatKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -38,7 +38,7 @@ impl_lint_pass!(NeedlessBorrow => [NEEDLESS_BORROW]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        if in_macro_or_desugar(e.span) || self.derived_item.is_some() {
+        if e.span.from_expansion() || self.derived_item.is_some() {
             return;
         }
         if let ExprKind::AddrOf(MutImmutable, ref inner) = e.node {
@@ -76,7 +76,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
         }
     }
     fn check_pat(&mut self, cx: &LateContext<'a, 'tcx>, pat: &'tcx Pat) {
-        if in_macro_or_desugar(pat.span) || self.derived_item.is_some() {
+        if pat.span.from_expansion() || self.derived_item.is_some() {
             return;
         }
         if_chain! {

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -2,7 +2,7 @@
 //!
 //! This lint is **warn** by default
 
-use crate::utils::{in_macro_or_desugar, snippet, span_lint_and_then};
+use crate::utils::{snippet, span_lint_and_then};
 use if_chain::if_chain;
 use rustc::hir::{BindingAnnotation, MutImmutable, Pat, PatKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -54,7 +54,7 @@ declare_lint_pass!(NeedlessBorrowedRef => [NEEDLESS_BORROWED_REFERENCE]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrowedRef {
     fn check_pat(&mut self, cx: &LateContext<'a, 'tcx>, pat: &'tcx Pat) {
-        if in_macro_or_desugar(pat.span) {
+        if pat.span.from_expansion() {
             // OK, simple enough, lints doesn't check in macro.
             return;
         }

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -39,7 +39,7 @@ use std::borrow::Cow;
 use syntax::ast;
 use syntax::source_map::{original_sp, DUMMY_SP};
 
-use crate::utils::{in_macro_or_desugar, snippet, snippet_block, span_help_and_lint, trim_multiline};
+use crate::utils::{snippet, snippet_block, span_help_and_lint, trim_multiline};
 
 declare_clippy_lint! {
     /// **What it does:** The lint checks for `if`-statements appearing in loops
@@ -120,7 +120,7 @@ declare_lint_pass!(NeedlessContinue => [NEEDLESS_CONTINUE]);
 
 impl EarlyLintPass for NeedlessContinue {
     fn check_expr(&mut self, ctx: &EarlyContext<'_>, expr: &ast::Expr) {
-        if !in_macro_or_desugar(expr.span) {
+        if !expr.span.from_expansion() {
             check_and_warn(ctx, expr);
         }
     }

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -1,7 +1,7 @@
 use crate::utils::ptr::get_spans;
 use crate::utils::{
-    get_trait_def_id, implements_trait, in_macro_or_desugar, is_copy, is_self, match_type, multispan_sugg, paths,
-    snippet, snippet_opt, span_lint_and_then,
+    get_trait_def_id, implements_trait, is_copy, is_self, match_type, multispan_sugg, paths, snippet, snippet_opt,
+    span_lint_and_then,
 };
 use if_chain::if_chain;
 use matches::matches;
@@ -76,7 +76,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
         span: Span,
         hir_id: HirId,
     ) {
-        if in_macro_or_desugar(span) {
+        if span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -1,4 +1,4 @@
-use crate::utils::{has_drop, in_macro_or_desugar, snippet_opt, span_lint, span_lint_and_sugg};
+use crate::utils::{has_drop, snippet_opt, span_lint, span_lint_and_sugg};
 use rustc::hir::def::{DefKind, Res};
 use rustc::hir::{BinOpKind, BlockCheckMode, Expr, ExprKind, Stmt, StmtKind, UnsafeSource};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -43,7 +43,7 @@ declare_clippy_lint! {
 }
 
 fn has_no_effect(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
-    if in_macro_or_desugar(expr.span) {
+    if expr.span.from_expansion() {
         return false;
     }
     match expr.node {
@@ -103,7 +103,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NoEffect {
             } else if let Some(reduced) = reduce_expression(cx, expr) {
                 let mut snippet = String::new();
                 for e in reduced {
-                    if in_macro_or_desugar(e.span) {
+                    if e.span.from_expansion() {
                         return;
                     }
                     if let Some(snip) = snippet_opt(cx, e.span) {
@@ -128,7 +128,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NoEffect {
 }
 
 fn reduce_expression<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<Vec<&'a Expr>> {
-    if in_macro_or_desugar(expr.span) {
+    if expr.span.from_expansion() {
         return None;
     }
     match expr.node {

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -14,7 +14,7 @@ use rustc_errors::Applicability;
 use rustc_typeck::hir_ty_to_ty;
 use syntax_pos::{InnerSpan, Span, DUMMY_SP};
 
-use crate::utils::{in_constant, in_macro_or_desugar, is_copy, span_lint_and_then};
+use crate::utils::{in_constant, is_copy, span_lint_and_then};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for declaration of `const` items which is interior
@@ -119,7 +119,7 @@ fn verify_ty_bound<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>, source: S
 
     let (lint, msg, span) = source.lint();
     span_lint_and_then(cx, lint, span, msg, |db| {
-        if in_macro_or_desugar(span) {
+        if span.from_expansion() {
             return; // Don't give suggestions into macros.
         }
         match source {

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -1,4 +1,4 @@
-use crate::utils::{in_macro_or_desugar, snippet_with_applicability, span_lint_and_sugg};
+use crate::utils::{snippet_with_applicability, span_lint_and_sugg};
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 use rustc_errors::Applicability;
@@ -32,7 +32,7 @@ declare_lint_pass!(Precedence => [PRECEDENCE]);
 
 impl EarlyLintPass for Precedence {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if in_macro_or_desugar(expr.span) {
+        if expr.span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    has_drop, in_macro_or_desugar, is_copy, match_def_path, match_type, paths, snippet_opt, span_lint_hir,
-    span_lint_hir_and_then, walk_ptrs_ty_depth,
+    has_drop, is_copy, match_def_path, match_type, paths, snippet_opt, span_lint_hir, span_lint_hir_and_then,
+    walk_ptrs_ty_depth,
 };
 use if_chain::if_chain;
 use matches::matches;
@@ -91,7 +91,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantClone {
         for (bb, bbdata) in mir.basic_blocks().iter_enumerated() {
             let terminator = bbdata.terminator();
 
-            if in_macro_or_desugar(terminator.source_info.span) {
+            if terminator.source_info.span.from_expansion() {
                 continue;
             }
 

--- a/clippy_lints/src/redundant_static_lifetimes.rs
+++ b/clippy_lints/src/redundant_static_lifetimes.rs
@@ -1,4 +1,4 @@
-use crate::utils::{in_macro_or_desugar, snippet, span_lint_and_then};
+use crate::utils::{snippet, span_lint_and_then};
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 use rustc_errors::Applicability;
@@ -78,7 +78,7 @@ impl RedundantStaticLifetimes {
 
 impl EarlyLintPass for RedundantStaticLifetimes {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
-        if !in_macro_or_desugar(item.span) {
+        if !item.span.from_expansion() {
             if let ItemKind::Const(ref var_type, _) = item.node {
                 self.visit_type(var_type, cx, "Constants have by default a `'static` lifetime");
                 // Don't check associated consts because `'static` cannot be elided on those (issue

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -145,7 +145,7 @@ declare_lint_pass!(StringLitAsBytes => [STRING_LIT_AS_BYTES]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        use crate::utils::{in_macro_or_desugar, snippet, snippet_with_applicability};
+        use crate::utils::{snippet, snippet_with_applicability};
         use syntax::ast::{LitKind, StrStyle};
 
         if let ExprKind::MethodCall(ref path, _, ref args) = e.node {
@@ -177,7 +177,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringLitAsBytes {
                         } else if callsite == expanded
                             && lit_content.as_str().chars().all(|c| c.is_ascii())
                             && lit_content.as_str().len() <= MAX_LENGTH_BYTE_STRING_LIT
-                            && !in_macro_or_desugar(args[0].span)
+                            && !args[0].span.from_expansion()
                         {
                             span_lint_and_sugg(
                                 cx,

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use crate::utils::{in_macro_or_desugar, is_copy, is_self_ty, snippet, span_lint_and_sugg};
+use crate::utils::{is_copy, is_self_ty, snippet, span_lint_and_sugg};
 use if_chain::if_chain;
 use matches::matches;
 use rustc::hir;
@@ -127,7 +127,7 @@ impl_lint_pass!(TriviallyCopyPassByRef => [TRIVIALLY_COPY_PASS_BY_REF]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TriviallyCopyPassByRef {
     fn check_trait_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx hir::TraitItem) {
-        if in_macro_or_desugar(item.span) {
+        if item.span.from_expansion() {
             return;
         }
 
@@ -145,7 +145,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TriviallyCopyPassByRef {
         span: Span,
         hir_id: HirId,
     ) {
-        if in_macro_or_desugar(span) {
+        if span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/try_err.rs
+++ b/clippy_lints/src/try_err.rs
@@ -1,4 +1,4 @@
-use crate::utils::{in_macro_or_desugar, match_qpath, paths, snippet, snippet_with_macro_callsite, span_lint_and_sugg};
+use crate::utils::{match_qpath, paths, snippet, snippet_with_macro_callsite, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -67,7 +67,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TryErr {
 
             then {
                 let err_type = cx.tables.expr_ty(err_arg);
-                let origin_snippet = if in_macro_or_desugar(err_arg.span) {
+                let origin_snippet = if err_arg.span.from_expansion() {
                     snippet_with_macro_callsite(cx, err_arg.span, "_")
                 } else {
                     snippet(cx, err_arg.span, "_")

--- a/clippy_lints/src/unused_label.rs
+++ b/clippy_lints/src/unused_label.rs
@@ -1,4 +1,4 @@
-use crate::utils::{in_macro_or_desugar, span_lint};
+use crate::utils::span_lint;
 use rustc::hir;
 use rustc::hir::intravisit::{walk_expr, walk_fn, FnKind, NestedVisitorMap, Visitor};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -44,7 +44,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedLabel {
         span: Span,
         fn_id: hir::HirId,
     ) {
-        if in_macro_or_desugar(span) {
+        if span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -2,9 +2,7 @@ use if_chain::if_chain;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 
-use crate::utils::{
-    higher::if_block, in_macro_or_desugar, match_type, paths, span_lint_and_then, usage::is_potentially_mutated,
-};
+use crate::utils::{higher::if_block, match_type, paths, span_lint_and_then, usage::is_potentially_mutated};
 use rustc::hir::intravisit::*;
 use rustc::hir::*;
 use syntax::source_map::Span;
@@ -197,7 +195,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Unwrap {
         span: Span,
         fn_id: HirId,
     ) {
-        if in_macro_or_desugar(span) {
+        if span.from_expansion() {
             return;
         }
 

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -1,7 +1,7 @@
 //! Contains utility functions to generate suggestions.
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::utils::{higher, in_macro_or_desugar, snippet, snippet_opt, snippet_with_macro_callsite};
+use crate::utils::{higher, snippet, snippet_opt, snippet_with_macro_callsite};
 use matches::matches;
 use rustc::hir;
 use rustc::lint::{EarlyContext, LateContext, LintContext};
@@ -69,7 +69,7 @@ impl<'a> Sugg<'a> {
         default: &'a str,
         applicability: &mut Applicability,
     ) -> Self {
-        if *applicability != Applicability::Unspecified && in_macro_or_desugar(expr.span) {
+        if *applicability != Applicability::Unspecified && expr.span.from_expansion() {
             *applicability = Applicability::MaybeIncorrect;
         }
         Self::hir_opt(cx, expr).unwrap_or_else(|| {

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -392,7 +392,7 @@ Here are some pointers to things you are likely going to need for every lint:
   is already in here (`implements_trait`, `match_path`, `snippet`, etc)
 * [Clippy diagnostics][diagnostics]
 * [The `if_chain` macro][if_chain]
-* [`in_macro_or_desugar`][in_macro_or_desugar] and [`in_external_macro`][in_external_macro]
+* [`from_expansion`][from_expansion] and [`in_external_macro`][in_external_macro]
 * [`Span`][span]
 * [`Applicability`][applicability]
 * [The rustc guide][rustc_guide] explains a lot of internal compiler concepts
@@ -432,7 +432,7 @@ don't hesitate to ask on Discord, IRC or in the issue/PR.
 [if_chain]: https://docs.rs/if_chain/0.1.2/if_chain/
 [ty]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/sty/index.html
 [ast]: https://doc.rust-lang.org/nightly/nightly-rustc/syntax/ast/index.html
-[in_macro_or_desugar]: https://github.com/rust-lang/rust-clippy/blob/d0717d1f9531a03d154aaeb0cad94c243915a146/clippy_lints/src/utils/mod.rs#L94
+[from_expansion]: https://doc.rust-lang.org/nightly/nightly-rustc/syntax_pos/struct.Span.html#method.from_expansion
 [in_external_macro]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/lint/fn.in_external_macro.html
 [play]: https://play.rust-lang.org
 [author_example]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=f093b986e80ad62f3b67a1f24f5e66e2


### PR DESCRIPTION
`in_macro_or_desugar` is just a wrapper around `Span::from_expansion`, so remove the former and call the latter instead.

changelog: Remove `in_macro_or_desugar`.