### PR TITLE
Update 'or_fun_call' to ignore calls to len

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1614,11 +1614,11 @@ fn lint_or_fun_call<'a, 'tcx>(
         or_has_args: bool,
         span: Span,
     ) {
-        if let hir::ExprKind::MethodCall(ref path, _, ref args) = &arg.node {
+        if let hir::ExprKind::MethodCall(ref path, _, ref args) = &arg.kind {
             if path.ident.as_str() == "len" {
                 let ty = walk_ptrs_ty(cx.tables.expr_ty(&args[0]));
 
-                match ty.sty {
+                match ty.kind {
                     ty::Slice(_) | ty::Array(_, _) => return,
                     _ => (),
                 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1614,6 +1614,21 @@ fn lint_or_fun_call<'a, 'tcx>(
         or_has_args: bool,
         span: Span,
     ) {
+        if let hir::ExprKind::MethodCall(ref path, _, ref args) = &arg.node {
+            if path.ident.as_str() == "len" {
+                let ty = walk_ptrs_ty(cx.tables.expr_ty(&args[0]));
+
+                match ty.sty {
+                    ty::Slice(_) | ty::Array(_, _) => return,
+                    _ => (),
+                }
+
+                if match_type(cx, ty, &paths::VEC) {
+                    return;
+                }
+            }
+        }
+
         // (path, fn_has_argument, methods, suffix)
         let know_types: &[(&[_], _, &[_], _)] = &[
             (&paths::BTREEMAP_ENTRY, false, &["or_insert"], "with"),

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -95,6 +95,15 @@ fn test_or_with_ctors() {
     let b = "b".to_string();
     let _ = Some(Bar("a".to_string(), Duration::from_secs(1)))
         .or(Some(Bar(b, Duration::from_secs(2))));
+
+    let vec = vec!["foo"];
+    let _ = opt.ok_or(vec.len());
+
+    let array = ["foo"];
+    let _ = opt.ok_or(array.len());
+
+    let slice = &["foo"][..];
+    let _ = opt.ok_or(slice.len());
 }
 
 // Issue 4514 - early return

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -95,6 +95,15 @@ fn test_or_with_ctors() {
     let b = "b".to_string();
     let _ = Some(Bar("a".to_string(), Duration::from_secs(1)))
         .or(Some(Bar(b, Duration::from_secs(2))));
+
+    let vec = vec!["foo"];
+    let _ = opt.ok_or(vec.len());
+
+    let array = ["foo"];
+    let _ = opt.ok_or(array.len());
+
+    let slice = &["foo"][..];
+    let _ = opt.ok_or(slice.len());
 }
 
 // Issue 4514 - early return


### PR DESCRIPTION
Resolves #1653

changelog: Update `or_fun_call`: Allow calls to `len` for Slice, Array & Vec.
