### PR TITLE
Account for trait alias when looking for defid

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2781,7 +2781,10 @@ impl SelfKind {
                 hir::Mutability::MutMutable => &paths::ASMUT_TRAIT,
             };
 
-            let trait_def_id = get_trait_def_id(cx, trait_path).expect("trait def id not found");
+            let trait_def_id = match get_trait_def_id(cx, trait_path) {
+                Some(did) => did,
+                None => return false,
+            };
             implements_trait(cx, ty, trait_def_id, &[parent_ty.into()])
         }
 

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -261,6 +261,7 @@ pub fn path_to_res(cx: &LateContext<'_, '_>, path: &[&str]) -> Option<(def::Res)
 }
 
 /// Convenience function to get the `DefId` of a trait by path.
+/// It could be a trait or trait alias.
 pub fn get_trait_def_id(cx: &LateContext<'_, '_>, path: &[&str]) -> Option<DefId> {
     let res = match path_to_res(cx, path) {
         Some(res) => res,
@@ -268,7 +269,8 @@ pub fn get_trait_def_id(cx: &LateContext<'_, '_>, path: &[&str]) -> Option<DefId
     };
 
     match res {
-        def::Res::Def(DefKind::Trait, trait_id) => Some(trait_id),
+        Res::Def(DefKind::Trait, trait_id) | Res::Def(DefKind::TraitAlias, trait_id) => Some(trait_id),
+        Res::Err => unreachable!("this trait resolution is impossible: {:?}", &path),
         _ => None,
     }
 }

--- a/tests/ui/def_id_nocore.rs
+++ b/tests/ui/def_id_nocore.rs
@@ -1,0 +1,29 @@
+// ignore-windows
+// ignore-macos
+
+#![feature(no_core, lang_items, start)]
+#![no_core]
+
+#[link(name = "c")]
+extern "C" {}
+
+#[lang = "sized"]
+pub trait Sized {}
+#[lang = "copy"]
+pub trait Copy {}
+#[lang = "freeze"]
+pub unsafe trait Freeze {}
+
+#[lang = "start"]
+#[start]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+
+pub struct A;
+
+impl A {
+    pub fn as_ref(self) -> &'static str {
+        "A"
+    }
+}

--- a/tests/ui/def_id_nocore.stderr
+++ b/tests/ui/def_id_nocore.stderr
@@ -1,0 +1,10 @@
+error: methods called `as_*` usually take self by reference or self by mutable reference; consider choosing a less ambiguous name
+  --> $DIR/def_id_nocore.rs:26:19
+   |
+LL |     pub fn as_ref(self) -> &'static str {
+   |                   ^^^^
+   |
+   = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
I hit the crash on the `expect` call when running clippy on rustc libcore.
Hopefully this will fix it.
changelog: none
