### PR TITLE
Split up cmp_owned tests, add run-rustfix

### DIFF
--- a/tests/ui/cmp_owned/with_suggestion.fixed
+++ b/tests/ui/cmp_owned/with_suggestion.fixed
@@ -1,42 +1,38 @@
+// run-rustfix
+
 #[warn(clippy::cmp_owned)]
-#[allow(clippy::unnecessary_operation)]
+#[allow(clippy::unnecessary_operation, clippy::no_effect, unused_must_use, clippy::eq_op)]
 fn main() {
     fn with_to_string(x: &str) {
-        x != "foo".to_string();
+        x != "foo";
 
-        "foo".to_string() != x;
+        "foo" != x;
     }
 
     let x = "oh";
 
     with_to_string(x);
 
-    x != "foo".to_owned();
+    x != "foo";
 
-    x != String::from("foo");
+    x != "foo";
 
     42.to_string() == "42";
 
-    Foo.to_owned() == Foo;
-
-    "abc".chars().filter(|c| c.to_owned() != 'X');
+    Foo == Foo;
 
     "abc".chars().filter(|c| *c != 'X');
 
-    let x = &Baz;
-    let y = &Baz;
-
-    y.to_owned() == *x;
-
-    let x = &&Baz;
-    let y = &Baz;
-
-    y.to_owned() == **x;
+    "abc".chars().filter(|c| *c != 'X');
 }
 
 struct Foo;
 
 impl PartialEq for Foo {
+    // Allow this here, because it emits the lint
+    // without a suggestion. This is tested in
+    // `tests/ui/cmp_owned_without_suggestion.rs`
+    #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &Self) -> bool {
         self.to_owned() == *other
     }

--- a/tests/ui/cmp_owned/with_suggestion.fixed
+++ b/tests/ui/cmp_owned/with_suggestion.fixed
@@ -31,7 +31,7 @@ struct Foo;
 impl PartialEq for Foo {
     // Allow this here, because it emits the lint
     // without a suggestion. This is tested in
-    // `tests/ui/cmp_owned_without_suggestion.rs`
+    // `tests/ui/cmp_owned/without_suggestion.rs`
     #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &Self) -> bool {
         self.to_owned() == *other

--- a/tests/ui/cmp_owned/with_suggestion.rs
+++ b/tests/ui/cmp_owned/with_suggestion.rs
@@ -31,7 +31,7 @@ struct Foo;
 impl PartialEq for Foo {
     // Allow this here, because it emits the lint
     // without a suggestion. This is tested in
-    // `tests/ui/cmp_owned_without_suggestion.rs`
+    // `tests/ui/cmp_owned/without_suggestion.rs`
     #[allow(clippy::cmp_owned)]
     fn eq(&self, other: &Self) -> bool {
         self.to_owned() == *other

--- a/tests/ui/cmp_owned/with_suggestion.rs
+++ b/tests/ui/cmp_owned/with_suggestion.rs
@@ -1,0 +1,72 @@
+// run-rustfix
+
+#[warn(clippy::cmp_owned)]
+#[allow(clippy::unnecessary_operation, clippy::no_effect, unused_must_use, clippy::eq_op)]
+fn main() {
+    fn with_to_string(x: &str) {
+        x != "foo".to_string();
+
+        "foo".to_string() != x;
+    }
+
+    let x = "oh";
+
+    with_to_string(x);
+
+    x != "foo".to_owned();
+
+    x != String::from("foo");
+
+    42.to_string() == "42";
+
+    Foo.to_owned() == Foo;
+
+    "abc".chars().filter(|c| c.to_owned() != 'X');
+
+    "abc".chars().filter(|c| *c != 'X');
+}
+
+struct Foo;
+
+impl PartialEq for Foo {
+    // Allow this here, because it emits the lint
+    // without a suggestion. This is tested in
+    // `tests/ui/cmp_owned_without_suggestion.rs`
+    #[allow(clippy::cmp_owned)]
+    fn eq(&self, other: &Self) -> bool {
+        self.to_owned() == *other
+    }
+}
+
+impl ToOwned for Foo {
+    type Owned = Bar;
+    fn to_owned(&self) -> Bar {
+        Bar
+    }
+}
+
+#[derive(PartialEq)]
+struct Bar;
+
+impl PartialEq<Foo> for Bar {
+    fn eq(&self, _: &Foo) -> bool {
+        true
+    }
+}
+
+impl std::borrow::Borrow<Foo> for Bar {
+    fn borrow(&self) -> &Foo {
+        static FOO: Foo = Foo;
+        &FOO
+    }
+}
+
+#[derive(PartialEq)]
+struct Baz;
+
+impl ToOwned for Baz {
+    type Owned = Baz;
+    fn to_owned(&self) -> Baz {
+        Baz
+    }
+}

--- a/tests/ui/cmp_owned/with_suggestion.stderr
+++ b/tests/ui/cmp_owned/with_suggestion.stderr
@@ -1,5 +1,5 @@
 error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:5:14
+  --> $DIR/with_suggestion.rs:7:14
    |
 LL |         x != "foo".to_string();
    |              ^^^^^^^^^^^^^^^^^ help: try: `"foo"`
@@ -7,52 +7,34 @@ LL |         x != "foo".to_string();
    = note: `-D clippy::cmp-owned` implied by `-D warnings`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:7:9
+  --> $DIR/with_suggestion.rs:9:9
    |
 LL |         "foo".to_string() != x;
    |         ^^^^^^^^^^^^^^^^^ help: try: `"foo"`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:14:10
+  --> $DIR/with_suggestion.rs:16:10
    |
 LL |     x != "foo".to_owned();
    |          ^^^^^^^^^^^^^^^^ help: try: `"foo"`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:16:10
+  --> $DIR/with_suggestion.rs:18:10
    |
 LL |     x != String::from("foo");
    |          ^^^^^^^^^^^^^^^^^^^ help: try: `"foo"`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:20:5
+  --> $DIR/with_suggestion.rs:22:5
    |
 LL |     Foo.to_owned() == Foo;
    |     ^^^^^^^^^^^^^^ help: try: `Foo`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:22:30
+  --> $DIR/with_suggestion.rs:24:30
    |
 LL |     "abc".chars().filter(|c| c.to_owned() != 'X');
    |                              ^^^^^^^^^^^^ help: try: `*c`
 
-error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:29:5
-   |
-LL |     y.to_owned() == *x;
-   |     ^^^^^^^^^^^^^^^^^^ try implementing the comparison without allocating
-
-error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:34:5
-   |
-LL |     y.to_owned() == **x;
-   |     ^^^^^^^^^^^^^^^^^^^ try implementing the comparison without allocating
-
-error: this creates an owned instance just for comparison
-  --> $DIR/cmp_owned.rs:41:9
-   |
-LL |         self.to_owned() == *other
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ try implementing the comparison without allocating
-
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/cmp_owned/without_suggestion.rs
+++ b/tests/ui/cmp_owned/without_suggestion.rs
@@ -1,0 +1,52 @@
+#[allow(clippy::unnecessary_operation)]
+
+fn main() {
+    let x = &Baz;
+    let y = &Baz;
+    y.to_owned() == *x;
+
+    let x = &&Baz;
+    let y = &Baz;
+    y.to_owned() == **x;
+}
+
+struct Foo;
+
+impl PartialEq for Foo {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_owned() == *other
+    }
+}
+
+impl ToOwned for Foo {
+    type Owned = Bar;
+    fn to_owned(&self) -> Bar {
+        Bar
+    }
+}
+
+#[derive(PartialEq)]
+struct Baz;
+
+impl ToOwned for Baz {
+    type Owned = Baz;
+    fn to_owned(&self) -> Baz {
+        Baz
+    }
+}
+
+#[derive(PartialEq)]
+struct Bar;
+
+impl PartialEq<Foo> for Bar {
+    fn eq(&self, _: &Foo) -> bool {
+        true
+    }
+}
+
+impl std::borrow::Borrow<Foo> for Bar {
+    fn borrow(&self) -> &Foo {
+        static FOO: Foo = Foo;
+        &FOO
+    }
+}

--- a/tests/ui/cmp_owned/without_suggestion.stderr
+++ b/tests/ui/cmp_owned/without_suggestion.stderr
@@ -1,0 +1,22 @@
+error: this creates an owned instance just for comparison
+  --> $DIR/without_suggestion.rs:6:5
+   |
+LL |     y.to_owned() == *x;
+   |     ^^^^^^^^^^^^^^^^^^ try implementing the comparison without allocating
+   |
+   = note: `-D clippy::cmp-owned` implied by `-D warnings`
+
+error: this creates an owned instance just for comparison
+  --> $DIR/without_suggestion.rs:10:5
+   |
+LL |     y.to_owned() == **x;
+   |     ^^^^^^^^^^^^^^^^^^^ try implementing the comparison without allocating
+
+error: this creates an owned instance just for comparison
+  --> $DIR/without_suggestion.rs:17:9
+   |
+LL |         self.to_owned() == *other
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ try implementing the comparison without allocating
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Some of the cmp_owned tests emitted non-machine-applicable suggestions,
so I moved them to `tests/ui/cmp_owned/without_suggestion.rs` and added
`// run-rustfix` to the other half.

changelog: none

cc #3630