### PR TITLE
Fix unused_unit false positive

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -277,7 +277,7 @@ impl EarlyLintPass for Return {
         if_chain! {
             if let Some(ref stmt) = block.stmts.last();
             if let ast::StmtKind::Expr(ref expr) = stmt.node;
-            if is_unit_expr(expr) && !expr.span.from_expansion();
+            if is_unit_expr(expr) && !stmt.span.from_expansion();
             then {
                 let sp = expr.span;
                 span_lint_and_then(cx, UNUSED_UNIT, sp, "unneeded unit expression", |db| {

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -10,6 +10,7 @@
 #![rustfmt::skip]
 
 #![deny(clippy::unused_unit)]
+#![allow(dead_code)]
 
 struct Unitter;
 impl Unitter {
@@ -41,4 +42,17 @@ fn main() {
         break;
     }
     return;
+}
+
+// https://github.com/rust-lang/rust-clippy/issues/4076
+fn foo() {
+    macro_rules! foo {
+        (recv($r:expr) -> $res:pat => $body:expr) => {
+            $body
+        }
+    }
+
+    foo! {
+        recv(rx) -> _x => ()
+    }
 }

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -10,6 +10,7 @@
 #![rustfmt::skip]
 
 #![deny(clippy::unused_unit)]
+#![allow(dead_code)]
 
 struct Unitter;
 impl Unitter {
@@ -42,4 +43,17 @@ fn main() {
         break();
     }
     return();
+}
+
+// https://github.com/rust-lang/rust-clippy/issues/4076
+fn foo() {
+    macro_rules! foo {
+        (recv($r:expr) -> $res:pat => $body:expr) => {
+            $body
+        }
+    }
+
+    foo! {
+        recv(rx) -> _x => ()
+    }
 }

--- a/tests/ui/unused_unit.stderr
+++ b/tests/ui/unused_unit.stderr
@@ -1,5 +1,5 @@
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:18:59
+  --> $DIR/unused_unit.rs:19:59
    |
 LL |       pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) ->
    |  ___________________________________________________________^
@@ -13,37 +13,37 @@ LL | #![deny(clippy::unused_unit)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:28:19
+  --> $DIR/unused_unit.rs:29:19
    |
 LL |     fn into(self) -> () {
    |                   ^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
-  --> $DIR/unused_unit.rs:29:9
+  --> $DIR/unused_unit.rs:30:9
    |
 LL |         ()
    |         ^^ help: remove the final `()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:33:18
+  --> $DIR/unused_unit.rs:34:18
    |
 LL | fn return_unit() -> () { () }
    |                  ^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
-  --> $DIR/unused_unit.rs:33:26
+  --> $DIR/unused_unit.rs:34:26
    |
 LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
 
 error: unneeded `()`
-  --> $DIR/unused_unit.rs:42:14
+  --> $DIR/unused_unit.rs:43:14
    |
 LL |         break();
    |              ^^ help: remove the `()`
 
 error: unneeded `()`
-  --> $DIR/unused_unit.rs:44:11
+  --> $DIR/unused_unit.rs:45:11
    |
 LL |     return();
    |           ^^ help: remove the `()`


### PR DESCRIPTION
changelog: Fix `unused_unit` false positive

For some reason the `expr` of `stmt.node` didn't contain the expansion information, but the `stmt.span` does.

Fixes #4076