### PR TITLE
Allow block_in_if_{stmt,expr} in external macro

### DIFF
--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -2,7 +2,7 @@ use crate::utils::*;
 use matches::matches;
 use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc::hir::*;
-use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
@@ -72,6 +72,9 @@ const COMPLEX_BLOCK_MESSAGE: &str = "in an 'if' condition, avoid complex blocks 
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BlockInIfCondition {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) {
+        if in_external_macro(cx.sess(), expr.span) {
+            return;
+        }
         if let Some((check, then, _)) = higher::if_block(&expr) {
             if let ExprKind::Block(block, _) = &check.node {
                 if block.rules == DefaultBlock {

--- a/tests/ui/block_in_if_condition.rs
+++ b/tests/ui/block_in_if_condition.rs
@@ -103,3 +103,15 @@ fn macro_in_closure() {
         unimplemented!()
     }
 }
+
+fn block_in_assert() {
+    let opt = Some(42);
+    assert!(opt
+        .as_ref()
+        .and_then(|val| {
+            let mut v = val * 2;
+            v -= 1;
+            Some(v * 3)
+        })
+        .is_some());
+}


### PR DESCRIPTION
I found this by running `cargo fix --clippy` on quite a big codebase.

You could refactor this assert to 
```rust
let block_expr = _;
assert!(block_expr);
```

but,
1. it doesn't increase the readability IMO
2. That isn't possible in a `debug_assert!`

I'm not sure though, if we should allow this for macros in general or just for external macros.

changelog: Allow `block_in_if_{stmt,expr}` in external macros
