### PR TITLE
Also fetch rollup merges in fetch_prs_between.sh script

### DIFF
--- a/util/fetch_prs_between.sh
+++ b/util/fetch_prs_between.sh
@@ -11,7 +11,7 @@ last=$2
 
 IFS='
 '
-for pr in $(git log --oneline --grep "Merge #" --grep "Merge pull request" --grep "Auto merge of" "$first...$last" | sort -rn | uniq); do
+for pr in $(git log --oneline --grep "Merge #" --grep "Merge pull request" --grep "Auto merge of" --grep "Rollup merge of" "$first...$last" | sort -rn | uniq); do
   id=$(echo $pr | rg -o '#[0-9]{3,5}' | cut -c 2-)
   commit=$(echo $pr | cut -d' ' -f 1)
   message=$(git --no-pager show --pretty=medium $commit)


### PR DESCRIPTION
Otherwise rolled up PRs won't be included in the changelog, e.g. 236666138fa15fdd48b1c12180b2c9dc936441b4

changelog: none
