### PR TITLE
Fix cast_lossless false positive in impl const fn

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -88,6 +88,10 @@ pub fn in_constant(cx: &LateContext<'_, '_>, id: HirId) -> bool {
             node: ItemKind::Fn(_, header, ..),
             ..
         }) => header.constness == Constness::Const,
+        Node::ImplItem(&ImplItem {
+            node: ImplItemKind::Method(ref sig, _),
+            ..
+        }) => sig.header.constness == Constness::Const,
         _ => false,
     }
 }

--- a/tests/ui/cast_lossless_float.fixed
+++ b/tests/ui/cast_lossless_float.fixed
@@ -32,3 +32,14 @@ fn main() {
 const fn abc(input: f32) -> f64 {
     input as f64
 }
+
+// Same as the above issue. We can't suggest `::from` in const fns in impls
+mod cast_lossless_in_impl {
+    struct A;
+
+    impl A {
+        pub const fn convert(x: f32) -> f64 {
+            x as f64
+        }
+    }
+}

--- a/tests/ui/cast_lossless_float.rs
+++ b/tests/ui/cast_lossless_float.rs
@@ -32,3 +32,14 @@ fn main() {
 const fn abc(input: f32) -> f64 {
     input as f64
 }
+
+// Same as the above issue. We can't suggest `::from` in const fns in impls
+mod cast_lossless_in_impl {
+    struct A;
+
+    impl A {
+        pub const fn convert(x: f32) -> f64 {
+            x as f64
+        }
+    }
+}

--- a/tests/ui/cast_lossless_integer.fixed
+++ b/tests/ui/cast_lossless_integer.fixed
@@ -34,3 +34,14 @@ fn main() {
 const fn abc(input: u16) -> u32 {
     input as u32
 }
+
+// Same as the above issue. We can't suggest `::from` in const fns in impls
+mod cast_lossless_in_impl {
+    struct A;
+
+    impl A {
+        pub const fn convert(x: u32) -> u64 {
+            x as u64
+        }
+    }
+}

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -34,3 +34,14 @@ fn main() {
 const fn abc(input: u16) -> u32 {
     input as u32
 }
+
+// Same as the above issue. We can't suggest `::from` in const fns in impls
+mod cast_lossless_in_impl {
+    struct A;
+
+    impl A {
+        pub const fn convert(x: u32) -> u64 {
+            x as u64
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/3656#issuecomment-526387382

changelog: Fix false positive in `cast_lossless`