### PR TITLE
Don't check across macro boundary in `deref_addrof`

### DIFF
--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -1,4 +1,4 @@
-use crate::utils::{snippet_with_applicability, span_lint_and_sugg};
+use crate::utils::{in_macro, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
@@ -38,6 +38,7 @@ impl EarlyLintPass for DerefAddrOf {
         if_chain! {
             if let ExprKind::Unary(UnOp::Deref, ref deref_target) = e.node;
             if let ExprKind::AddrOf(_, ref addrof_target) = without_parens(deref_target).node;
+            if !in_macro(addrof_target.span);
             then {
                 let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(

--- a/tests/ui/deref_addrof_macro.rs
+++ b/tests/ui/deref_addrof_macro.rs
@@ -1,0 +1,10 @@
+macro_rules! m {
+    ($($x:tt),*) => { &[$(($x, stringify!(x)),)*] };
+}
+
+#[warn(clippy::deref_addrof)]
+fn f() -> [(i32, &'static str); 3] {
+    *m![1, 2, 3] // should be fine
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #4289

changelog: Allow `deref_addrof` in macros
