### PR TITLE
Remove ui/ from TESTNAME for foo lint example

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -77,7 +77,7 @@ fn main() {
 
 ```
 
-Now we can run the test with `TESTNAME=ui/foo_functions cargo uitest`.
+Now we can run the test with `TESTNAME=foo_functions cargo uitest`.
 Currently this test will fail. If you go through the output you will see that we
 are told that `clippy::foo_functions` is an unknown lint, which is expected.
 


### PR DESCRIPTION
changelog: Remove ui/ from TESTNAME in doc/adding-lints.md

This PR remove the `ui/` from the TESTNAME of the example foo lint in the 'Adding lints' documentation.