### PR TITLE
Fix two occurences of TESTNAME=ui/foo_functions

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -86,9 +86,9 @@ test. That allows us to check if the output is turning into what we want.
 
 Once we are satisfied with the output, we need to run
 `tests/ui/update-all-references.sh` to update the `.stderr` file for our lint.
-Please note that, we should run `TESTNAME=ui/foo_functions cargo uitest`
+Please note that, we should run `TESTNAME=foo_functions cargo uitest`
 every time before running `tests/ui/update-all-references.sh`.
-Running `TESTNAME=ui/foo_functions cargo uitest` should pass then. When we
+Running `TESTNAME=foo_functions cargo uitest` should pass then. When we
 commit our lint, we need to commit the generated `.stderr` files, too.
 
 ### Rustfix tests


### PR DESCRIPTION
changelog: Fix two occurrences of the wrong path to the foo_functions test in doc/adding_lints.md

This PR fixes the other two wrong paths to the example test. I already created a PR yesterday but only changed one. The old command was `TESTNAME=ui/foo_functions cargo uitest` and is now `TESTNAME=foo_functions cargo uitest`.
