### PR TITLE
Fix false-positive of redundant_clone and move to clippy::perf

### DIFF
--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -100,10 +100,7 @@ pub fn run(check: bool, verbose: bool) {
 }
 
 fn format_command(program: impl AsRef<OsStr>, dir: impl AsRef<Path>, args: &[impl AsRef<OsStr>]) -> String {
-    let arg_display: Vec<_> = args
-        .iter()
-        .map(|a| escape(a.as_ref().to_string_lossy()).to_owned())
-        .collect();
+    let arg_display: Vec<_> = args.iter().map(|a| escape(a.as_ref().to_string_lossy())).collect();
 
     format!(
         "cd {} && {} {}",

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -343,7 +343,7 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
 
             let stats = terminal_stats(&expr);
             let mut simplified = expr.simplify();
-            for simple in Bool::Not(Box::new(expr.clone())).simplify() {
+            for simple in Bool::Not(Box::new(expr)).simplify() {
                 match simple {
                     Bool::Not(_) | Bool::True | Bool::False => {},
                     _ => simplified.push(Bool::Not(Box::new(simple.clone()))),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -864,6 +864,7 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
         ranges::RANGE_MINUS_ONE,
         ranges::RANGE_PLUS_ONE,
         ranges::RANGE_ZIP_WITH_LEN,
+        redundant_clone::REDUNDANT_CLONE,
         redundant_field_names::REDUNDANT_FIELD_NAMES,
         redundant_pattern_matching::REDUNDANT_PATTERN_MATCHING,
         redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES,
@@ -1169,6 +1170,7 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
         methods::SINGLE_CHAR_PATTERN,
         misc::CMP_OWNED,
         mutex_atomic::MUTEX_ATOMIC,
+        redundant_clone::REDUNDANT_CLONE,
         slow_vector_initialization::SLOW_VECTOR_INITIALIZATION,
         trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
         types::BOX_VEC,
@@ -1188,7 +1190,6 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
         mutex_atomic::MUTEX_INTEGER,
         needless_borrow::NEEDLESS_BORROW,
         path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE,
-        redundant_clone::REDUNDANT_CLONE,
     ]);
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -27,6 +27,8 @@ extern crate rustc_driver;
 #[allow(unused_extern_crates)]
 extern crate rustc_errors;
 #[allow(unused_extern_crates)]
+extern crate rustc_index;
+#[allow(unused_extern_crates)]
 extern crate rustc_mir;
 #[allow(unused_extern_crates)]
 extern crate rustc_target;

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -563,8 +563,7 @@ fn rvalue_locals(rvalue: &mir::Rvalue<'_>, mut visit: impl FnMut(mir::Local)) {
 
 struct PossibleBorrower<'a, 'tcx> {
     map: FxHashMap<mir::Local, HybridBitSet<mir::Local>>,
-    maybe_live:
-        DataflowResultsCursor<'a, 'tcx, MaybeStorageLive<'a, 'tcx>, DataflowResults<'tcx, MaybeStorageLive<'a, 'tcx>>>,
+    maybe_live: DataflowResultsCursor<'a, 'tcx, MaybeStorageLive<'a, 'tcx>>,
     bitset: (BitSet<mir::Local>, BitSet<mir::Local>),
 }
 

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -13,12 +13,9 @@ use rustc::mir::{
 };
 use rustc::ty::{self, fold::TypeVisitor, Ty};
 use rustc::{declare_lint_pass, declare_tool_lint};
-use rustc_data_structures::{
-    bit_set::{BitSet, HybridBitSet},
-    fx::FxHashMap,
-    transitive_relation::TransitiveRelation,
-};
+use rustc_data_structures::{fx::FxHashMap, transitive_relation::TransitiveRelation};
 use rustc_errors::Applicability;
+use rustc_index::bit_set::{BitSet, HybridBitSet};
 use rustc_mir::dataflow::{
     do_dataflow, BitDenotation, BottomValue, DataflowResults, DataflowResultsCursor, DebugFormatted, GenKillSet,
 };

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1542,7 +1542,7 @@ pub const ALL_LINTS: [Lint; 318] = [
     },
     Lint {
         name: "redundant_clone",
-        group: "nursery",
+        group: "perf",
         desc: "`clone()` of an owned value that is going to be dropped immediately",
         deprecation: None,
         module: "redundant_clone",

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -38,8 +38,7 @@ fn config(mode: &str, dir: PathBuf) -> compiletest::Config {
 
     let cfg_mode = mode.parse().expect("Invalid mode");
     if let Ok(name) = var::<&str>("TESTNAME") {
-        let s: String = name.to_owned();
-        config.filter = Some(s)
+        config.filter = Some(name)
     }
 
     if rustc_test_suite().is_some() {

--- a/tests/ui/crashes/auxiliary/proc_macro_crash.rs
+++ b/tests/ui/crashes/auxiliary/proc_macro_crash.rs
@@ -30,7 +30,7 @@ pub fn macro_test(input_stream: TokenStream) -> TokenStream {
                 TokenTree::Ident(Ident::new("true", Span::call_site())),
                 TokenTree::Group(clause.clone()),
                 TokenTree::Ident(Ident::new("else", Span::call_site())),
-                TokenTree::Group(clause.clone()),
+                TokenTree::Group(clause),
             ])
         })),
     ])

--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -1,5 +1,10 @@
 #![feature(box_syntax)]
-#![allow(clippy::borrowed_box, clippy::needless_pass_by_value, clippy::unused_unit)]
+#![allow(
+    clippy::borrowed_box,
+    clippy::needless_pass_by_value,
+    clippy::unused_unit,
+    clippy::redundant_clone
+)]
 #![warn(clippy::boxed_local)]
 
 #[derive(Clone)]

--- a/tests/ui/escape_analysis.stderr
+++ b/tests/ui/escape_analysis.stderr
@@ -1,5 +1,5 @@
 error: local variable doesn't need to be boxed here
-  --> $DIR/escape_analysis.rs:34:13
+  --> $DIR/escape_analysis.rs:39:13
    |
 LL | fn warn_arg(x: Box<A>) {
    |             ^
@@ -7,13 +7,13 @@ LL | fn warn_arg(x: Box<A>) {
    = note: `-D clippy::boxed-local` implied by `-D warnings`
 
 error: local variable doesn't need to be boxed here
-  --> $DIR/escape_analysis.rs:125:12
+  --> $DIR/escape_analysis.rs:130:12
    |
 LL | pub fn new(_needs_name: Box<PeekableSeekable<&()>>) -> () {}
    |            ^^^^^^^^^^^
 
 error: local variable doesn't need to be boxed here
-  --> $DIR/escape_analysis.rs:165:23
+  --> $DIR/escape_analysis.rs:170:23
    |
 LL |     fn closure_borrow(x: Box<A>) {
    |                       ^

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::iter_cloned_collect)]
-#![allow(clippy::clone_on_copy)]
+#![allow(clippy::clone_on_copy, clippy::redundant_clone)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure_for_method_calls)]
 

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::iter_cloned_collect)]
-#![allow(clippy::clone_on_copy)]
+#![allow(clippy::clone_on_copy, clippy::redundant_clone)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure_for_method_calls)]
 

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -4,7 +4,8 @@
     clippy::single_match,
     clippy::redundant_pattern_matching,
     clippy::many_single_char_names,
-    clippy::option_option
+    clippy::option_option,
+    clippy::redundant_clone
 )]
 
 use std::borrow::Borrow;

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -1,5 +1,5 @@
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:16:23
+  --> $DIR/needless_pass_by_value.rs:17:23
    |
 LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T> {
    |                       ^^^^^^ help: consider changing the type to: `&[T]`
@@ -7,25 +7,25 @@ LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T
    = note: `-D clippy::needless-pass-by-value` implied by `-D warnings`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:30:11
+  --> $DIR/needless_pass_by_value.rs:31:11
    |
 LL | fn bar(x: String, y: Wrapper) {
    |           ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:30:22
+  --> $DIR/needless_pass_by_value.rs:31:22
    |
 LL | fn bar(x: String, y: Wrapper) {
    |                      ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:36:71
+  --> $DIR/needless_pass_by_value.rs:37:71
    |
 LL | fn test_borrow_trait<T: Borrow<str>, U: AsRef<str>, V>(t: T, u: U, v: V) {
    |                                                                       ^ help: consider taking a reference instead: `&V`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:48:18
+  --> $DIR/needless_pass_by_value.rs:49:18
    |
 LL | fn test_match(x: Option<Option<String>>, y: Option<Option<String>>) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^
@@ -36,13 +36,13 @@ LL |     match *x {
    |
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:61:24
+  --> $DIR/needless_pass_by_value.rs:62:24
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                        ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:61:36
+  --> $DIR/needless_pass_by_value.rs:62:36
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                                    ^^^^^^^
@@ -55,19 +55,19 @@ LL |     let Wrapper(_) = *y; // still not moved
    |
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:77:49
+  --> $DIR/needless_pass_by_value.rs:78:49
    |
 LL | fn test_blanket_ref<T: Foo, S: Serialize>(_foo: T, _serializable: S) {}
    |                                                 ^ help: consider taking a reference instead: `&T`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:79:18
+  --> $DIR/needless_pass_by_value.rs:80:18
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                  ^^^^^^ help: consider taking a reference instead: `&String`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:79:29
+  --> $DIR/needless_pass_by_value.rs:80:29
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                             ^^^^^^
@@ -81,13 +81,13 @@ LL |     let _ = t.to_string();
    |             ^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:79:40
+  --> $DIR/needless_pass_by_value.rs:80:40
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                        ^^^^^^^^ help: consider taking a reference instead: `&Vec<i32>`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:79:53
+  --> $DIR/needless_pass_by_value.rs:80:53
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                                     ^^^^^^^^
@@ -101,61 +101,61 @@ LL |     let _ = v.to_owned();
    |             ^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:92:12
+  --> $DIR/needless_pass_by_value.rs:93:12
    |
 LL |         s: String,
    |            ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:93:12
+  --> $DIR/needless_pass_by_value.rs:94:12
    |
 LL |         t: String,
    |            ^^^^^^ help: consider taking a reference instead: `&String`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:102:23
+  --> $DIR/needless_pass_by_value.rs:103:23
    |
 LL |     fn baz(&self, _u: U, _s: Self) {}
    |                       ^ help: consider taking a reference instead: `&U`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:102:30
+  --> $DIR/needless_pass_by_value.rs:103:30
    |
 LL |     fn baz(&self, _u: U, _s: Self) {}
    |                              ^^^^ help: consider taking a reference instead: `&Self`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:124:24
+  --> $DIR/needless_pass_by_value.rs:125:24
    |
 LL | fn bar_copy(x: u32, y: CopyWrapper) {
    |                        ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as Copy
-  --> $DIR/needless_pass_by_value.rs:122:1
+  --> $DIR/needless_pass_by_value.rs:123:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:130:29
+  --> $DIR/needless_pass_by_value.rs:131:29
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as Copy
-  --> $DIR/needless_pass_by_value.rs:122:1
+  --> $DIR/needless_pass_by_value.rs:123:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:130:45
+  --> $DIR/needless_pass_by_value.rs:131:45
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                             ^^^^^^^^^^^
    |
 help: consider marking this type as Copy
-  --> $DIR/needless_pass_by_value.rs:122:1
+  --> $DIR/needless_pass_by_value.rs:123:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -168,13 +168,13 @@ LL |     let CopyWrapper(_) = *y; // still not moved
    |
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:130:61
+  --> $DIR/needless_pass_by_value.rs:131:61
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                                             ^^^^^^^^^^^
    |
 help: consider marking this type as Copy
-  --> $DIR/needless_pass_by_value.rs:122:1
+  --> $DIR/needless_pass_by_value.rs:123:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,13 +185,13 @@ LL |     let CopyWrapper(s) = *z; // moved
    |
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:142:40
+  --> $DIR/needless_pass_by_value.rs:143:40
    |
 LL | fn some_fun<'b, S: Bar<'b, ()>>(_item: S) {}
    |                                        ^ help: consider taking a reference instead: `&S`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:147:20
+  --> $DIR/needless_pass_by_value.rs:148:20
    |
 LL | fn more_fun(_item: impl Club<'static, i32>) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&impl Club<'static, i32>`

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::many_single_char_names)]
+#![allow(unused, clippy::many_single_char_names, clippy::redundant_clone)]
 #![warn(clippy::ptr_arg)]
 
 use std::borrow::Cow;

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -104,7 +104,7 @@ fn main() {
     };
     move_struct.ref_func();
     move_struct.clone().mov_func_reuse();
-    move_struct.clone().mov_func_no_use();
+    move_struct.mov_func_no_use();
 
     let so = SeemsOption::Some(45);
     returns_something_similar_to_option(so);

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -4,31 +4,31 @@ use std::ffi::OsString;
 use std::path::Path;
 
 fn main() {
-    let _s = ["lorem", "ipsum"].join(" ").to_string();
+    let _s = ["lorem", "ipsum"].join(" ");
 
     let s = String::from("foo");
-    let _s = s.clone();
+    let _s = s;
 
     let s = String::from("foo");
-    let _s = s.to_string();
+    let _s = s;
 
     let s = String::from("foo");
-    let _s = s.to_owned();
+    let _s = s;
 
-    let _s = Path::new("/a/b/").join("c").to_owned();
+    let _s = Path::new("/a/b/").join("c");
 
-    let _s = Path::new("/a/b/").join("c").to_path_buf();
+    let _s = Path::new("/a/b/").join("c");
 
-    let _s = OsString::new().to_owned();
+    let _s = OsString::new();
 
-    let _s = OsString::new().to_os_string();
+    let _s = OsString::new();
 
     // Check that lint level works
     #[allow(clippy::redundant_clone)]
     let _s = String::new().to_string();
 
     let tup = (String::from("foo"),);
-    let _t = tup.0.clone();
+    let _t = tup.0;
 
     let tup_ref = &(String::from("foo"),);
     let _s = tup_ref.0.clone(); // this `.clone()` cannot be removed
@@ -54,7 +54,7 @@ fn main() {
 struct Alpha;
 fn with_branch(a: Alpha, b: bool) -> (Alpha, Alpha) {
     if b {
-        (a.clone(), a.clone())
+        (a.clone(), a)
     } else {
         (Alpha, a)
     }
@@ -110,8 +110,8 @@ fn borrower_propagation() {
         let _s = s.clone(); // ok, `u` borrows `s`
     }
 
-    let _s = s.clone();
-    let _t = t.clone();
+    let _s = s;
+    let _t = t;
 
     #[derive(Clone)]
     struct Foo {
@@ -121,7 +121,7 @@ fn borrower_propagation() {
     {
         let f = Foo { x: 123 };
         let _x = Some(f.x);
-        let _f = f.clone();
+        let _f = f;
     }
 
     {

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -108,16 +108,52 @@ LL |     let _ = tup.0.clone();
    |             ^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:41:22
+  --> $DIR/redundant_clone.rs:53:22
    |
 LL |         (a.clone(), a.clone())
    |                      ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:41:21
+  --> $DIR/redundant_clone.rs:53:21
    |
 LL |         (a.clone(), a.clone())
    |                     ^
 
-error: aborting due to 10 previous errors
+error: redundant clone
+  --> $DIR/redundant_clone.rs:109:14
+   |
+LL |     let _ = s.clone();
+   |              ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:109:13
+   |
+LL |     let _ = s.clone();
+   |             ^
+
+error: redundant clone
+  --> $DIR/redundant_clone.rs:110:14
+   |
+LL |     let _ = t.clone();
+   |              ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:110:13
+   |
+LL |     let _ = t.clone();
+   |             ^
+
+error: redundant clone
+  --> $DIR/redundant_clone.rs:120:19
+   |
+LL |         let _f = f.clone();
+   |                   ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:120:18
+   |
+LL |         let _f = f.clone();
+   |                  ^
+
+error: aborting due to 13 previous errors
 

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -1,156 +1,156 @@
 error: redundant clone
-  --> $DIR/redundant_clone.rs:7:41
+  --> $DIR/redundant_clone.rs:7:42
    |
-LL |     let _ = ["lorem", "ipsum"].join(" ").to_string();
-   |                                         ^^^^^^^^^^^^ help: remove this
+LL |     let _s = ["lorem", "ipsum"].join(" ").to_string();
+   |                                          ^^^^^^^^^^^^ help: remove this
    |
    = note: `-D clippy::redundant-clone` implied by `-D warnings`
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:7:13
+  --> $DIR/redundant_clone.rs:7:14
    |
-LL |     let _ = ["lorem", "ipsum"].join(" ").to_string();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _s = ["lorem", "ipsum"].join(" ").to_string();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
+  --> $DIR/redundant_clone.rs:10:15
+   |
+LL |     let _s = s.clone();
+   |               ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
   --> $DIR/redundant_clone.rs:10:14
    |
-LL |     let _ = s.clone();
-   |              ^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:10:13
-   |
-LL |     let _ = s.clone();
-   |             ^
+LL |     let _s = s.clone();
+   |              ^
 
 error: redundant clone
+  --> $DIR/redundant_clone.rs:13:15
+   |
+LL |     let _s = s.to_string();
+   |               ^^^^^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
   --> $DIR/redundant_clone.rs:13:14
    |
-LL |     let _ = s.to_string();
-   |              ^^^^^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:13:13
-   |
-LL |     let _ = s.to_string();
-   |             ^
+LL |     let _s = s.to_string();
+   |              ^
 
 error: redundant clone
+  --> $DIR/redundant_clone.rs:16:15
+   |
+LL |     let _s = s.to_owned();
+   |               ^^^^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
   --> $DIR/redundant_clone.rs:16:14
    |
-LL |     let _ = s.to_owned();
-   |              ^^^^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:16:13
-   |
-LL |     let _ = s.to_owned();
-   |             ^
+LL |     let _s = s.to_owned();
+   |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:18:41
+  --> $DIR/redundant_clone.rs:18:42
    |
-LL |     let _ = Path::new("/a/b/").join("c").to_owned();
-   |                                         ^^^^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:18:13
-   |
-LL |     let _ = Path::new("/a/b/").join("c").to_owned();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: redundant clone
-  --> $DIR/redundant_clone.rs:20:41
-   |
-LL |     let _ = Path::new("/a/b/").join("c").to_path_buf();
-   |                                         ^^^^^^^^^^^^^^ help: remove this
+LL |     let _s = Path::new("/a/b/").join("c").to_owned();
+   |                                          ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:20:13
+  --> $DIR/redundant_clone.rs:18:14
    |
-LL |     let _ = Path::new("/a/b/").join("c").to_path_buf();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _s = Path::new("/a/b/").join("c").to_owned();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:22:28
+  --> $DIR/redundant_clone.rs:20:42
    |
-LL |     let _ = OsString::new().to_owned();
-   |                            ^^^^^^^^^^^ help: remove this
+LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
+   |                                          ^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:22:13
+  --> $DIR/redundant_clone.rs:20:14
    |
-LL |     let _ = OsString::new().to_owned();
-   |             ^^^^^^^^^^^^^^^
+LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:24:28
+  --> $DIR/redundant_clone.rs:22:29
    |
-LL |     let _ = OsString::new().to_os_string();
-   |                            ^^^^^^^^^^^^^^^ help: remove this
+LL |     let _s = OsString::new().to_owned();
+   |                             ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:24:13
+  --> $DIR/redundant_clone.rs:22:14
    |
-LL |     let _ = OsString::new().to_os_string();
-   |             ^^^^^^^^^^^^^^^
+LL |     let _s = OsString::new().to_owned();
+   |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:31:18
+  --> $DIR/redundant_clone.rs:24:29
    |
-LL |     let _ = tup.0.clone();
-   |                  ^^^^^^^^ help: remove this
+LL |     let _s = OsString::new().to_os_string();
+   |                             ^^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:31:13
+  --> $DIR/redundant_clone.rs:24:14
    |
-LL |     let _ = tup.0.clone();
-   |             ^^^^^
+LL |     let _s = OsString::new().to_os_string();
+   |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:53:22
+  --> $DIR/redundant_clone.rs:31:19
+   |
+LL |     let _t = tup.0.clone();
+   |                   ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:31:14
+   |
+LL |     let _t = tup.0.clone();
+   |              ^^^^^
+
+error: redundant clone
+  --> $DIR/redundant_clone.rs:57:22
    |
 LL |         (a.clone(), a.clone())
    |                      ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:53:21
+  --> $DIR/redundant_clone.rs:57:21
    |
 LL |         (a.clone(), a.clone())
    |                     ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:109:14
+  --> $DIR/redundant_clone.rs:113:15
    |
-LL |     let _ = s.clone();
-   |              ^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:109:13
-   |
-LL |     let _ = s.clone();
-   |             ^
-
-error: redundant clone
-  --> $DIR/redundant_clone.rs:110:14
-   |
-LL |     let _ = t.clone();
-   |              ^^^^^^^^ help: remove this
+LL |     let _s = s.clone();
+   |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:110:13
+  --> $DIR/redundant_clone.rs:113:14
    |
-LL |     let _ = t.clone();
-   |             ^
+LL |     let _s = s.clone();
+   |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:120:19
+  --> $DIR/redundant_clone.rs:114:15
+   |
+LL |     let _t = t.clone();
+   |               ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:114:14
+   |
+LL |     let _t = t.clone();
+   |              ^
+
+error: redundant clone
+  --> $DIR/redundant_clone.rs:124:19
    |
 LL |         let _f = f.clone();
    |                   ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:120:18
+  --> $DIR/redundant_clone.rs:124:18
    |
 LL |         let _f = f.clone();
    |                  ^

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -1,5 +1,11 @@
 #![warn(clippy::all)]
-#![allow(clippy::blacklisted_name, clippy::no_effect, redundant_semicolon, unused_assignments)]
+#![allow(
+    clippy::blacklisted_name,
+    clippy::no_effect,
+    clippy::redundant_clone,
+    redundant_semicolon,
+    unused_assignments
+)]
 
 struct Foo(u32);
 

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:27:5
+  --> $DIR/swap.rs:33:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -9,7 +9,7 @@ LL | |     foo[1] = temp;
    = note: `-D clippy::manual-swap` implied by `-D warnings`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:36:5
+  --> $DIR/swap.rs:42:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -17,7 +17,7 @@ LL | |     foo[1] = temp;
    | |_________________^ help: try: `foo.swap(0, 1)`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:45:5
+  --> $DIR/swap.rs:51:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -25,7 +25,7 @@ LL | |     foo[1] = temp;
    | |_________________^ help: try: `foo.swap(0, 1)`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:65:7
+  --> $DIR/swap.rs:71:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -36,7 +36,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:74:7
+  --> $DIR/swap.rs:80:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -47,7 +47,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:62:5
+  --> $DIR/swap.rs:68:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -57,7 +57,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:71:5
+  --> $DIR/swap.rs:77:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;

--- a/tests/ui/unnecessary_clone.rs
+++ b/tests/ui/unnecessary_clone.rs
@@ -1,7 +1,7 @@
 // does not test any rustfixable lints
 
 #![warn(clippy::clone_on_ref_ptr)]
-#![allow(unused)]
+#![allow(unused, clippy::redundant_clone)]
 
 use std::cell::RefCell;
 use std::rc::{self, Rc};


### PR DESCRIPTION
This PR introduces dataflow analysis to `redundant_clone` lint to filter out borrowed variables, which had been incorrectly detected.

Depends on https://github.com/rust-lang/rust/pull/64207.

changelog: Moved `redundant_clone` lint to `perf` group

# What this lint catches

## `clone`/`to_owned`

```rust
let s = String::new();
let t = s.clone();
```

```rust
// MIR
_1 = String::new();
_2 = &_1;
_3 = clone(_2); // (*)
```

We can turn this `clone` call into a move if

1. `_2` is the sole borrow of `_1` at the statement `(*)`
2. `_1` is not used hereafter

## `Deref` + type-specific `to_owned` method

```rust
let s = std::path::PathBuf::new();
let t = s.to_path_buf();
```

```rust
// MIR
_1 = PathBuf::new();
_2 = &1;
_3 = call deref(_2);
_4 = _3;                         // Copies borrow
StorageDead(_2);
_5 = Path::to_path_buf(_4); // (*)
```

We can turn this `to_path_buf` call into a move if

1. `_3` `_4` are the sole borrow of `_1` at `(*)`
2. `_1` is not used hereafter

# What this PR introduces

1. `MaybeStorageLive` that determines whether a local lives at a particular location
2. `PossibleBorrowerVisitor` that constructs [`TransitiveRelation`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_data_structures/transitive_relation/struct.TransitiveRelation.html) of possible borrows, e.g. visiting `_2 = &1; _3 = &_2:` will result in `_3 -> _2 -> _1` relation. Then `_3` and `_2` will be counted as possible borrowers of `_1` in the sole-borrow analysis above.