### PR TITLE
Cognitive Complexity PR, re-gitted

### DIFF
--- a/clippy_lints/src/cognitive_complexity.rs
+++ b/clippy_lints/src/cognitive_complexity.rs
@@ -480,11 +480,9 @@ impl<'ast> Visitor<'ast> for CoCHelper {
             // # asm!(), basically, inline assembly
             // ExprKind::InlineAsm(..) => {},
 
-            // Ill formed expressions.
-            ExprKind::Err => {
-                panic!("Found an ExprKind::Err. Is this a compiler bug??");
-            },
-
+            // Ill formed expressions. Just don't lint on them,
+            // otherwise this will raise an ICE.
+            // ExprKind::Err => {},
             _ => {
                 walk_expr(self, ex);
             },

--- a/clippy_lints/src/cognitive_complexity.rs
+++ b/clippy_lints/src/cognitive_complexity.rs
@@ -1,15 +1,13 @@
 //! calculate cognitive complexity and warn about overly complex functions
 
-use rustc::cfg::CFG;
-use rustc::hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
-use rustc::hir::*;
-use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
-use rustc::ty;
+use rustc::lint::{EarlyContext, EarlyLintPass};
+use rustc::lint::{LintArray, LintContext, LintPass};
 use rustc::{declare_tool_lint, impl_lint_pass};
 use syntax::ast::Attribute;
-use syntax::source_map::Span;
+use syntax::ast::*;
+use syntax::visit::{walk_expr, Visitor};
 
-use crate::utils::{is_allowed, match_type, paths, span_help_and_lint, LimitStack};
+use crate::utils::{span_help_and_lint, LimitStack};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for methods with high cognitive complexity.
@@ -20,215 +18,484 @@ declare_clippy_lint! {
     /// **Known problems:** Sometimes it's hard to find a way to reduce the
     /// complexity.
     ///
-    /// **Example:** No. You'll see it when you get the warning.
+    /// **Example:** Sorry. Examples are too big and varied to put in here. For a
+    /// complete explanation of the analysis being made though, you can read this paper:
+    /// https://www.sonarsource.com/docs/CognitiveComplexity.pdf
     pub COGNITIVE_COMPLEXITY,
-    complexity,
+    nursery,
     "functions that should be split up into multiple functions"
 }
 
 pub struct CognitiveComplexity {
     limit: LimitStack,
+    current_enclosing_function: Option<NodeId>,
 }
 
 impl CognitiveComplexity {
     pub fn new(limit: u64) -> Self {
         Self {
             limit: LimitStack::new(limit),
+            current_enclosing_function: None,
         }
     }
 }
 
 impl_lint_pass!(CognitiveComplexity => [COGNITIVE_COMPLEXITY]);
 
-impl CognitiveComplexity {
-    fn check<'a, 'tcx>(&mut self, cx: &'a LateContext<'a, 'tcx>, body: &'tcx Body, span: Span) {
-        if span.from_expansion() {
-            return;
-        }
-
-        let cfg = CFG::new(cx.tcx, body);
-        let expr = &body.value;
-        let n = cfg.graph.len_nodes() as u64;
-        let e = cfg.graph.len_edges() as u64;
-        if e + 2 < n {
-            // the function has unreachable code, other lints should catch this
-            return;
-        }
-        let cc = e + 2 - n;
-        let mut helper = CCHelper {
-            match_arms: 0,
-            divergence: 0,
-            short_circuits: 0,
-            returns: 0,
-            cx,
-        };
-        helper.visit_expr(expr);
-        let CCHelper {
-            match_arms,
-            divergence,
-            short_circuits,
-            returns,
-            ..
-        } = helper;
-        let ret_ty = cx.tables.node_type(expr.hir_id);
-        let ret_adjust = if match_type(cx, ret_ty, &paths::RESULT) {
-            returns
-        } else {
-            #[allow(clippy::integer_division)]
-            (returns / 2)
-        };
-
-        if cc + divergence < match_arms + short_circuits {
-            report_cc_bug(
-                cx,
-                cc,
-                match_arms,
-                divergence,
-                short_circuits,
-                ret_adjust,
-                span,
-                body.id().hir_id,
-            );
-        } else {
-            let mut rust_cc = cc + divergence - match_arms - short_circuits;
-            // prevent degenerate cases where unreachable code contains `return` statements
-            if rust_cc >= ret_adjust {
-                rust_cc -= ret_adjust;
-            }
-            if rust_cc > self.limit.limit() {
-                span_help_and_lint(
-                    cx,
-                    COGNITIVE_COMPLEXITY,
-                    span,
-                    &format!(
-                        "the function has a cognitive complexity of ({}/{})",
-                        rust_cc,
-                        self.limit.limit()
-                    ),
-                    "you could split it up into multiple smaller functions",
-                );
+impl EarlyLintPass for CognitiveComplexity {
+    fn check_item_post(&mut self, _: &EarlyContext<'_>, item: &Item) {
+        // After processing the inner AST of a function, we unrecord its
+        // id, so that other functions can now be recognized and processed.
+        if let Some(fn_id) = self.current_enclosing_function {
+            if item.id == fn_id {
+                self.current_enclosing_function = None;
             }
         }
     }
-}
 
-impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CognitiveComplexity {
-    fn check_fn(
-        &mut self,
-        cx: &LateContext<'a, 'tcx>,
-        _: intravisit::FnKind<'tcx>,
-        _: &'tcx FnDecl,
-        body: &'tcx Body,
-        span: Span,
-        hir_id: HirId,
-    ) {
-        let def_id = cx.tcx.hir().local_def_id(hir_id);
-        if !cx.tcx.has_attr(def_id, sym!(test)) {
-            self.check(cx, body, span);
+    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
+        if let ItemKind::Fn(_, _, _, fn_block) = &item.node {
+            // Before scoring a function, we check that it's not
+            // an inner function. If it was, then we'd be scoring it
+            // twice: once for its parent and once for itself.
+            if let None = self.current_enclosing_function {
+                // Now that we've entered a function, we record it
+                // as the current enclosing one. No functions inside it
+                // will ever be scored now.
+                self.current_enclosing_function = Some(item.id);
+
+                // If the function being explored is marked as "test",
+                // then we skip it.
+                if item.attrs.iter().any(|a| a.check_name(sym!(test))) {
+                    return;
+                }
+
+                let mut helper = CoCHelper::new();
+
+                helper.visit_block(&fn_block);
+
+                let fn_score = helper.score;
+                let score_limit = self.limit.limit();
+
+                if fn_score > score_limit {
+                    span_help_and_lint(
+                        cx,
+                        COGNITIVE_COMPLEXITY,
+                        item.span,
+                        &format!("the function has a cognitive complexity of {}", fn_score),
+                        "you could split it up into multiple smaller functions",
+                    );
+                }
+            }
         }
     }
 
-    fn enter_lint_attrs(&mut self, cx: &LateContext<'a, 'tcx>, attrs: &'tcx [Attribute]) {
+    fn enter_lint_attrs(&mut self, cx: &EarlyContext<'_>, attrs: &[Attribute]) {
         self.limit.push_attrs(cx.sess(), attrs, "cognitive_complexity");
     }
-    fn exit_lint_attrs(&mut self, cx: &LateContext<'a, 'tcx>, attrs: &'tcx [Attribute]) {
+    fn exit_lint_attrs(&mut self, cx: &EarlyContext<'_>, attrs: &[Attribute]) {
         self.limit.pop_attrs(cx.sess(), attrs, "cognitive_complexity");
     }
 }
 
-struct CCHelper<'a, 'tcx> {
-    match_arms: u64,
-    divergence: u64,
-    returns: u64,
-    short_circuits: u64, // && and ||
-    cx: &'a LateContext<'a, 'tcx>,
+/// Helps keep track of the Cognitive Complexity Score
+/// of a function being analyzed.
+struct CoCHelper {
+    /// Current Nesting value
+    current_nesting: u64,
+    /// Current Cognitive Complexity score
+    score: u64,
+    /// Current Nesting of Binary Logical Operations
+    /// (used for proper score calculation)
+    logical_binop_nesting: u64,
 }
 
-impl<'a, 'tcx> Visitor<'tcx> for CCHelper<'a, 'tcx> {
-    fn visit_expr(&mut self, e: &'tcx Expr) {
-        match e.node {
-            ExprKind::Match(_, ref arms, _) => {
-                walk_expr(self, e);
-                let arms_n: u64 = arms.iter().map(|arm| arm.pats.len() as u64).sum();
-                if arms_n > 1 {
-                    self.match_arms += arms_n - 2;
-                }
-            },
-            ExprKind::Call(ref callee, _) => {
-                walk_expr(self, e);
-                let ty = self.cx.tables.node_type(callee.hir_id);
-                match ty.sty {
-                    ty::FnDef(..) | ty::FnPtr(_) => {
-                        let sig = ty.fn_sig(self.cx.tcx);
-                        if sig.skip_binder().output().sty == ty::Never {
-                            self.divergence += 1;
-                        }
-                    },
-                    _ => (),
-                }
-            },
-            ExprKind::Closure(.., _) => (),
-            ExprKind::Binary(op, _, _) => {
-                walk_expr(self, e);
-                match op.node {
-                    BinOpKind::And | BinOpKind::Or => self.short_circuits += 1,
-                    _ => (),
-                }
-            },
-            ExprKind::Ret(_) => self.returns += 1,
-            _ => walk_expr(self, e),
+enum ComplexityLevel {
+    /// Almost no individual score (Paren, Assign, AssignOp)
+    Low,
+    /// Most common score (If, Return, Yield)
+    Normal,
+    // FIXME: delete or populate this case.
+    /// High score (no cases yet?)
+    High,
+    /// Custom score (a catch-all for other cases)
+    Custom(u64),
+}
+
+impl ComplexityLevel {
+    fn get_score(&self) -> u64 {
+        match self {
+            ComplexityLevel::Low => 2,
+            ComplexityLevel::Normal => 10,
+            ComplexityLevel::High => 50,
+            ComplexityLevel::Custom(score) => *score,
         }
     }
-    fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::None
+}
+
+impl CoCHelper {
+    /// Create a clean CoCHelper
+    fn new() -> CoCHelper {
+        CoCHelper {
+            current_nesting: 0,
+            score: 0,
+            logical_binop_nesting: 0,
+        }
+    }
+
+    /// Increment the nesting level by one
+    fn push_nesting(&mut self) {
+        self.current_nesting += 1;
+    }
+
+    /// Decrement the nesting level by one
+    fn pop_nesting(&mut self) {
+        assert!(self.current_nesting > 0);
+        self.current_nesting -= 1;
+    }
+
+    /// Mark a determined amount of score
+    fn add_to_score(&mut self, amount: u64) {
+        self.score += amount;
+    }
+
+    /// Mark score for a Nesting-Dependent Structure
+    fn score_nd_structure(&mut self, level: ComplexityLevel) {
+        self.add_to_score(self.current_nesting * level.get_score());
+        self.score_ni_structure(level);
+    }
+
+    /// Mark score for a Nesting-Independent Structure
+    fn score_ni_structure(&mut self, level: ComplexityLevel) {
+        self.add_to_score(level.get_score());
+    }
+
+    /// Let the helper know that we've entered a Binary Logical Operation
+    fn enter_logical_binop(&mut self) {
+        // We score once every time we enter a *new*
+        // binary logical operation.
+        // That way, the score for chains is
+        // `1 + (number of operator changes in the chain)`
+        if self.logical_binop_nesting == 0 {
+            self.score_ni_structure(ComplexityLevel::Normal);
+        }
+        self.logical_binop_nesting += 1;
+    }
+
+    /// Let the helper know that we've exited a Binary Logical Operation
+    fn exit_logical_binop(&mut self) {
+        self.logical_binop_nesting -= 1;
     }
 }
 
-#[cfg(feature = "debugging")]
-#[allow(clippy::too_many_arguments)]
-fn report_cc_bug(
-    _: &LateContext<'_, '_>,
-    cc: u64,
-    narms: u64,
-    div: u64,
-    shorts: u64,
-    returns: u64,
-    span: Span,
-    _: HirId,
-) {
-    span_bug!(
-        span,
-        "Clippy encountered a bug calculating cognitive complexity: cc = {}, arms = {}, \
-         div = {}, shorts = {}, returns = {}. Please file a bug report.",
-        cc,
-        narms,
-        div,
-        shorts,
-        returns
-    );
-}
-#[cfg(not(feature = "debugging"))]
-#[allow(clippy::too_many_arguments)]
-fn report_cc_bug(
-    cx: &LateContext<'_, '_>,
-    cc: u64,
-    narms: u64,
-    div: u64,
-    shorts: u64,
-    returns: u64,
-    span: Span,
-    id: HirId,
-) {
-    if !is_allowed(cx, COGNITIVE_COMPLEXITY, id) {
-        cx.sess().span_note_without_error(
-            span,
-            &format!(
-                "Clippy encountered a bug calculating cognitive complexity \
-                 (hide this message with `#[allow(cognitive_complexity)]`): \
-                 cc = {}, arms = {}, div = {}, shorts = {}, returns = {}. \
-                 Please file a bug report.",
-                cc, narms, div, shorts, returns
-            ),
-        );
+impl<'ast> Visitor<'ast> for CoCHelper {
+    /*
+    # Implemented here:
+
+    ## Nesting Structures
+        IMPORTANT: ExprKind::Block(..)
+        already covers all cases.
+    ## (Nesting-Dependent) Increments
+        if
+        match
+        for, while, loop
+    ## (Nesting-Independent) Increments
+        break, continue
+        Sequences of binary logical operators
+        Function calls
+        Macro calls
+    */
+
+    fn visit_expr(&mut self, ex: &'ast Expr) {
+        match ex.node {
+            // Nesting-Increasing (the one and only)
+            ExprKind::Block(..) => {
+                self.push_nesting();
+                walk_expr(self, ex);
+                self.pop_nesting();
+            },
+
+            ExprKind::Closure(.., _)
+            | ExprKind::Lit(..)
+            | ExprKind::Try(..) => {
+                // "If Let" and "Try" are free of own increment.
+                // This is because they are language constructs
+                // specifically designed to save on complexity.
+                walk_expr(self, ex);
+            },
+
+            // FIXME (FAR FUTURE): make a separate, documented case, for recursive calls,
+            // such that it's treated differently from function or method calls.
+            ExprKind::Call(..) | ExprKind::MethodCall(..) => {
+                self.score_ni_structure(ComplexityLevel::Normal);
+                walk_expr(self, ex);
+            },
+
+            // Nesting-Dependent
+            ExprKind::If(..)
+            | ExprKind::Match(..)
+            | ExprKind::ForLoop(..)
+            | ExprKind::While(..)
+            | ExprKind::Loop(..) => {
+                // XXXManishearth don't count complexity of `if let`
+                // (For the IF-Case)
+                // Important: this pays for one "if" and one "else".
+                // Every "if" in an "else if" comes here again to pay
+                // for itself and its subsequent else.
+                self.score_nd_structure(ComplexityLevel::Normal);
+                walk_expr(self, ex);
+            },
+
+            // Nesting-Independent
+            ExprKind::Mac(ref mac) => {
+                self.visit_mac(mac);
+            },
+
+            // Nesting-Independent
+            ExprKind::Continue(_) => {
+                self.score_ni_structure(ComplexityLevel::Normal);
+            },
+
+            // Nesting-Independent,
+            // Sometimes Nesting
+            ExprKind::Break(_, ref maybe_inner_ex) => {
+                self.score_ni_structure(ComplexityLevel::Normal);
+                if let Some(ref inner_ex) = maybe_inner_ex {
+                    walk_expr(self, inner_ex);
+                }
+            },
+
+            // (Nesting-Independent) When boolean operators change, we add 1 to the score.
+            ExprKind::Binary(binop, ref l_ex, ref r_ex) => {
+                // Here, we're either looking for the leftmost logical operator on the right side,
+                // or the rightmost logical operator on the left side. It looks like this:
+                //
+                // Let's say our Expr is `(a && b) || ((c ^ d) & e)`, and its AST:
+                //
+                //                          Or
+                //                        /    \
+                //                       /      \
+                //                      /        \
+                //                 Paren          Paren
+                //                  |               |
+                //                 And            BitAnd
+                //                /   \          /      \
+                //               a     b        /        \
+                //                           Paren        e
+                //                             |
+                //                            Xor
+                //                           /   \
+                //                          c     d
+                //
+                // Then, when we call `log_op_at(right_branch, At:LeftMostSide)`,
+                // We're looking for that Xor at the leftmost side of the right branch:
+                //                          Or
+                //                        /    \
+                //                       /      \
+                //                      /        \
+                //                 Paren          Paren
+                //                  |               |
+                //                 And            BitAnd
+                //                /   \          /      \
+                //               a     b        /        \
+                //                           Paren        e
+                //                             |
+                //                            Xor <~ THIS ONE :D
+                //                           /   \
+                //                          c     d
+                //
+                // Doing this, we can effectively mark a score whenever there is a change
+                // in the current chain of logical operators.
+                //
+                // So say for example, that we're scoring `a && b && c || d && e`.
+                // There are 2 changes in the operator chain in this expression,
+                // once at `c || d` (it changes from `&&` to `||`) and once at
+                // `d && e` (it changes from `||` to `&&`).
+                //
+                // In order for us to score this change, regardless of the shape of
+                // the AST, we need to be able to know which operator sits right
+                // next to the current one. If it's then a different operator,
+                // we know there is a change in the chain, and we can score it.
+                //
+                // But what about scoring it twice? Will we see the same change
+                // more than once?
+                // The answer is no: since ASTs are recursive, child operators
+                // can't see their parent operators. Given we're only scoring
+                // a change whenever the operators right next to the current one
+                // are different to it, AND in our subsequent calls the current
+                // operator will not be visible, it's effectively impossible
+                // to score this change in the chain more than once.
+
+                /// A location in the AST.
+                enum At {
+                    LeftMostSide,
+                    RightMostSide,
+                }
+
+                /// A logical operator
+                #[derive(PartialEq)]
+                enum LogOp {
+                    LogAnd, // &&
+                    LogOr,  // ||
+                    BitAnd, // &
+                    BitOr,  // |
+                    BitXor, // ^
+                    None,   // Other
+                }
+
+                /// Translate from a binary operator to a logical operator
+                fn log_op_from_bin_op(bop_kind: BinOpKind) -> LogOp {
+                    match bop_kind {
+                        BinOpKind::And => LogOp::LogAnd,
+                        BinOpKind::Or => LogOp::LogOr,
+                        BinOpKind::BitAnd => LogOp::BitAnd,
+                        BinOpKind::BitOr => LogOp::BitOr,
+                        BinOpKind::BitXor => LogOp::BitXor,
+                        _ => LogOp::None,
+                    }
+                }
+
+                /// Find the rightmost or leftmost logical operator inside of the given `Expr`
+                fn log_op_at(expr: &Expr, at: At) -> LogOp {
+                    match &expr.node {
+                        ExprKind::Binary(binop, ref left_side, ref right_side) => {
+                            let current_operator = log_op_from_bin_op(binop.node);
+
+                            let next_operator = match at {
+                                At::LeftMostSide => log_op_at(left_side, at),
+                                At::RightMostSide => log_op_at(right_side, at),
+                            };
+
+                            match next_operator {
+                                LogOp::None => current_operator,
+                                _ => next_operator,
+                            }
+                        },
+                        ExprKind::Paren(expr) | ExprKind::Unary(_, expr) => log_op_at(&expr, at),
+                        _ => LogOp::None,
+                    }
+                }
+
+                let current_log_op = log_op_from_bin_op(binop.node);
+
+                let is_log_op = current_log_op != LogOp::None;
+
+                if is_log_op {
+                    // Here we separate the left and right branches, and go looking
+                    // for the rightmost and leftmost logical operator in them, respectively
+                    let op_at_left_side = log_op_at(l_ex, At::RightMostSide);
+                    let op_at_right_side = log_op_at(r_ex, At::LeftMostSide);
+
+                    if op_at_left_side != LogOp::None && current_log_op != op_at_left_side {
+                        self.score_ni_structure(ComplexityLevel::Normal);
+                    }
+
+                    if op_at_right_side != LogOp::None && current_log_op != op_at_right_side {
+                        self.score_ni_structure(ComplexityLevel::Normal);
+                    }
+
+                    self.enter_logical_binop();
+                }
+
+                walk_expr(self, ex);
+
+                if is_log_op {
+                    self.exit_logical_binop();
+                }
+            },
+
+            /*
+                Low complexity cases
+            */
+
+            // (...)
+            // ExprKind::Paren(..) => {},
+
+            // # a += bar()
+            // ExprKind::AssignOp(..) => {},
+
+            // # a = foo()
+            // ExprKind::Assign(..) => {},
+
+            // # foo[2]
+            // ExprKind::Index(..) => {},
+
+            // # a.count, or b.0
+            // ExprKind::Field(..) => {},
+
+            // # &a or &mut a
+            // ExprKind::AddrOf(..) => {},
+
+            // !a, *b
+            // ExprKind::Unary(..) => {},
+
+            /*
+                Medium complexity cases
+            */
+
+            // Return and Yield have the same cog. complexity
+            // ExprKind::Ret(..) => {},
+            // ExprKind::Yield(..) => {},
+
+            // # foo as f32
+            // ExprKind::Cast(..) => {},
+
+            // # Struct literal: Foo { (things) }
+            // ExprKind::Struct(..) => {},
+
+            // # (a, b, c)
+            // ExprKind::Tup(..) => {},
+
+            // # [a, b, c, d]
+            // ExprKind::Array(..) => {},
+
+            // # m..n
+            // ExprKind::Range(..) => {},
+
+            /*
+                ### Pending ones (FIXME) ###
+            */
+
+            // # [m; n]
+            // ExprKind::Repeat(..) => {},
+
+            // Haven't used these. Investigate further.
+            // ExprKind::TryBlock(..) => {},
+
+            // # Variable reference??
+            // ExprKind::Path(..) => {},
+
+            // # (unstable) `box a` syntax
+            // ExprKind::Box(..) => {},
+
+            // # FIXME: what is this?
+            // ExprKind::ObsoleteInPlace(..) => {},
+
+            // What is Type Ascription??
+            // ExprKind::Type(..) => {},
+
+            // Unstable, leave it for after the MVP.
+            // ExprKind::Async(..) => {},
+
+            // # asm!(), basically, inline assembly
+            // ExprKind::InlineAsm(..) => {},
+
+            // Ill formed expressions.
+            ExprKind::Err => {
+                panic!("Found an ExprKind::Err. Is this a compiler bug??");
+            },
+
+            _ => {
+                walk_expr(self, ex);
+            },
+        }
+    }
+
+    fn visit_mac(&mut self, _mac: &Mac) {
+        // We override this so that the compiler
+        // doesn't panic. See the original implementation
+        // of `visit_mac` at rustc's src/libsyntax/visit.rs
+        // to know what normally happens.
+        self.score_ni_structure(ComplexityLevel::Normal);
     }
 }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -500,7 +500,7 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
     reg.register_late_lint_pass(box no_effect::NoEffect);
     reg.register_late_lint_pass(box temporary_assignment::TemporaryAssignment);
     reg.register_late_lint_pass(box transmute::Transmute);
-    reg.register_late_lint_pass(
+    reg.register_early_lint_pass(
         box cognitive_complexity::CognitiveComplexity::new(conf.cognitive_complexity_threshold)
     );
     reg.register_late_lint_pass(box escape::BoxedLocal{too_large_for_stack: conf.too_large_for_stack});
@@ -703,7 +703,6 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
         booleans::LOGIC_BUG,
         booleans::NONMINIMAL_BOOL,
         bytecount::NAIVE_BYTECOUNT,
-        cognitive_complexity::COGNITIVE_COMPLEXITY,
         collapsible_if::COLLAPSIBLE_IF,
         copies::IFS_SAME_COND,
         copies::IF_SAME_THEN_ELSE,
@@ -1012,7 +1011,6 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
         assign_ops::MISREFACTORED_ASSIGN_OP,
         attrs::DEPRECATED_CFG_ATTR,
         booleans::NONMINIMAL_BOOL,
-        cognitive_complexity::COGNITIVE_COMPLEXITY,
         double_comparison::DOUBLE_COMPARISONS,
         double_parens::DOUBLE_PARENS,
         duration_subsec::DURATION_SUBSEC,
@@ -1172,6 +1170,7 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
 
     reg.register_lint_group("clippy::nursery", Some("clippy_nursery"), vec![
         attrs::EMPTY_LINE_AFTER_OUTER_ATTR,
+        cognitive_complexity::COGNITIVE_COMPLEXITY,
         fallible_impl_from::FALLIBLE_IMPL_FROM,
         missing_const_for_fn::MISSING_CONST_FOR_FN,
         mutex_atomic::MUTEX_INTEGER,

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -240,7 +240,7 @@ pub const ALL_LINTS: [Lint; 313] = [
     },
     Lint {
         name: "cognitive_complexity",
-        group: "complexity",
+        group: "nursery",
         desc: "functions that should be split up into multiple functions",
         deprecation: None,
         module: "cognitive_complexity",

--- a/tests/ui/cognitive_complexity/legacy.rs
+++ b/tests/ui/cognitive_complexity/legacy.rs
@@ -1,0 +1,288 @@
+#![allow(clippy::all)]
+#![warn(clippy::cognitive_complexity)]
+#![allow(unused)]
+
+fn main() {}
+
+/*
+    These tests must be reviewed and either eliminated or repurposed
+*/
+
+#[clippy::cognitive_complexity = "0"]
+fn kaboom() {
+    let n = 0;
+    'a: for i in 0..20 {
+        'b: for j in i..20 {
+            for k in j..20 {
+                if k == 5 {
+                    break 'b;
+                }
+                if j == 3 && k == 6 {
+                    continue 'a;
+                }
+                if k == j {
+                    continue;
+                }
+                println!("bake");
+            }
+        }
+        println!("cake");
+    }
+}
+
+fn bloo() {
+    match 42 {
+        0 => println!("hi"),
+        1 => println!("hai"),
+        2 => println!("hey"),
+        3 => println!("hallo"),
+        4 => println!("hello"),
+        5 => println!("salut"),
+        6 => println!("good morning"),
+        7 => println!("good evening"),
+        8 => println!("good afternoon"),
+        9 => println!("good night"),
+        10 => println!("bonjour"),
+        11 => println!("hej"),
+        12 => println!("hej hej"),
+        13 => println!("greetings earthling"),
+        14 => println!("take us to you leader"),
+        15 | 17 | 19 | 21 | 23 | 25 | 27 | 29 | 31 | 33 => println!("take us to you leader"),
+        35 | 37 | 39 | 41 | 43 | 45 | 47 | 49 | 51 | 53 => println!("there is no undefined behavior"),
+        55 | 57 | 59 | 61 | 63 | 65 | 67 | 69 | 71 | 73 => println!("I know borrow-fu"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn baa() {
+    let x = || match 99 {
+        0 => 0,
+        1 => 1,
+        2 => 2,
+        4 => 4,
+        6 => 6,
+        9 => 9,
+        _ => 42,
+    };
+    if x() == 42 {
+        println!("x");
+    } else {
+        println!("not x");
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn bar() {
+    match 99 {
+        0 => println!("hi"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn barr() {
+    match 99 {
+        0 => println!("hi"),
+        1 => println!("bla"),
+        2 | 3 => println!("blub"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn barr2() {
+    match 99 {
+        0 => println!("hi"),
+        1 => println!("bla"),
+        2 | 3 => println!("blub"),
+        _ => println!("bye"),
+    }
+    match 99 {
+        0 => println!("hi"),
+        1 => println!("bla"),
+        2 | 3 => println!("blub"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn barrr() {
+    match 99 {
+        0 => println!("hi"),
+        1 => panic!("bla"),
+        2 | 3 => println!("blub"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn barrr2() {
+    match 99 {
+        0 => println!("hi"),
+        1 => panic!("bla"),
+        2 | 3 => println!("blub"),
+        _ => println!("bye"),
+    }
+    match 99 {
+        0 => println!("hi"),
+        1 => panic!("bla"),
+        2 | 3 => println!("blub"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn barrrr() {
+    match 99 {
+        0 => println!("hi"),
+        1 => println!("bla"),
+        2 | 3 => panic!("blub"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn barrrr2() {
+    match 99 {
+        0 => println!("hi"),
+        1 => println!("bla"),
+        2 | 3 => panic!("blub"),
+        _ => println!("bye"),
+    }
+    match 99 {
+        0 => println!("hi"),
+        1 => println!("bla"),
+        2 | 3 => panic!("blub"),
+        _ => println!("bye"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn cake() {
+    if 4 == 5 {
+        println!("yea");
+    } else {
+        panic!("meh");
+    }
+    println!("whee");
+}
+
+#[clippy::cognitive_complexity = "0"]
+pub fn read_file(input_path: &str) -> String {
+    use std::fs::File;
+    use std::io::{Read, Write};
+    use std::path::Path;
+    let mut file = match File::open(&Path::new(input_path)) {
+        Ok(f) => f,
+        Err(err) => {
+            panic!("Can't open {}: {}", input_path, err);
+        },
+    };
+
+    let mut bytes = Vec::new();
+
+    match file.read_to_end(&mut bytes) {
+        Ok(..) => {},
+        Err(_) => {
+            panic!("Can't read {}", input_path);
+        },
+    };
+
+    match String::from_utf8(bytes) {
+        Ok(contents) => contents,
+        Err(_) => {
+            panic!("{} is not UTF-8 encoded", input_path);
+        },
+    }
+}
+
+enum Void {}
+
+#[clippy::cognitive_complexity = "0"]
+fn void(void: Void) {
+    if true {
+        match void {}
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn mcarton_sees_all() {
+    panic!("meh");
+    panic!("möh");
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn try() -> Result<i32, &'static str> {
+    match 5 {
+        5 => Ok(5),
+        _ => return Err("bla"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn try_again() -> Result<i32, &'static str> {
+    let _ = try!(Ok(42));
+    let _ = try!(Ok(43));
+    let _ = try!(Ok(44));
+    let _ = try!(Ok(45));
+    let _ = try!(Ok(46));
+    let _ = try!(Ok(47));
+    let _ = try!(Ok(48));
+    let _ = try!(Ok(49));
+    match 5 {
+        5 => Ok(5),
+        _ => return Err("bla"),
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn early() -> Result<i32, &'static str> {
+    return Ok(5);
+    return Ok(5);
+    return Ok(5);
+    return Ok(5);
+    return Ok(5);
+    return Ok(5);
+    return Ok(5);
+    return Ok(5);
+    return Ok(5);
+}
+
+#[rustfmt::skip]
+#[clippy::cognitive_complexity = "0"]
+fn early_ret() -> i32 {
+    let a = if true { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    let a = if a < 99 { 42 } else { return 0; };
+    match 5 {
+        5 => 5,
+        _ => return 6,
+    }
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn osscilating_logical_chain_1() -> bool {
+    true && false || true && false
+}
+
+// This tests that the only thing that matters 
+// is the change in operator
+#[clippy::cognitive_complexity = "0"]
+fn osscilating_logical_chain_2() -> bool {
+    true && false && true && false || true && false && true && false
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn osscilating_logical_chain_3() -> bool {
+    (true && false) || (true && false)
+}

--- a/tests/ui/cognitive_complexity/legacy.stderr
+++ b/tests/ui/cognitive_complexity/legacy.stderr
@@ -1,20 +1,55 @@
-error: the function has a cognitive complexity of 1350
-  --> $DIR/cognitive_complexity.rs:6:1
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:225:13
    |
-LL | / fn main() {
-LL | |     if true {
-LL | |         println!("a");
-LL | |     }
-...  |
-LL | |     }
-LL | | }
-   | |_^
+LL |     let _ = try!(Ok(42));
+   |             ^^^
    |
-   = note: `-D clippy::cognitive-complexity` implied by `-D warnings`
-   = help: you could split it up into multiple smaller functions
+   = note: `-D deprecated` implied by `-D warnings`
+
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:226:13
+   |
+LL |     let _ = try!(Ok(43));
+   |             ^^^
+
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:227:13
+   |
+LL |     let _ = try!(Ok(44));
+   |             ^^^
+
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:228:13
+   |
+LL |     let _ = try!(Ok(45));
+   |             ^^^
+
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:229:13
+   |
+LL |     let _ = try!(Ok(46));
+   |             ^^^
+
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:230:13
+   |
+LL |     let _ = try!(Ok(47));
+   |             ^^^
+
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:231:13
+   |
+LL |     let _ = try!(Ok(48));
+   |             ^^^
+
+error: use of deprecated item 'try': use the `?` operator instead
+  --> $DIR/legacy.rs:232:13
+   |
+LL |     let _ = try!(Ok(49));
+   |             ^^^
 
 error: the function has a cognitive complexity of 180
-  --> $DIR/cognitive_complexity.rs:91:1
+  --> $DIR/legacy.rs:12:1
    |
 LL | / fn kaboom() {
 LL | |     let n = 0;
@@ -25,10 +60,11 @@ LL | |     }
 LL | | }
    | |_^
    |
+   = note: `-D clippy::cognitive-complexity` implied by `-D warnings`
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 770
-  --> $DIR/cognitive_complexity.rs:112:1
+  --> $DIR/legacy.rs:33:1
    |
 LL | / fn bloo() {
 LL | |     match 42 {
@@ -41,28 +77,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of 10
-  --> $DIR/cognitive_complexity.rs:137:1
-   |
-LL | / fn lots_of_short_circuits() -> bool {
-LL | |     true && false && true && false && true && false && true
-LL | | }
-   | |_^
-   |
-   = help: you could split it up into multiple smaller functions
-
-error: the function has a cognitive complexity of 10
-  --> $DIR/cognitive_complexity.rs:142:1
-   |
-LL | / fn lots_of_short_circuits2() -> bool {
-LL | |     true || false || true || false || true || false || true
-LL | | }
-   | |_^
-   |
-   = help: you could split it up into multiple smaller functions
-
 error: the function has a cognitive complexity of 120
-  --> $DIR/cognitive_complexity.rs:147:1
+  --> $DIR/legacy.rs:58:1
    |
 LL | / fn baa() {
 LL | |     let x = || match 99 {
@@ -76,7 +92,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 90
-  --> $DIR/cognitive_complexity.rs:165:1
+  --> $DIR/legacy.rs:76:1
    |
 LL | / fn bar() {
 LL | |     match 99 {
@@ -89,7 +105,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 170
-  --> $DIR/cognitive_complexity.rs:184:1
+  --> $DIR/legacy.rs:84:1
    |
 LL | / fn barr() {
 LL | |     match 99 {
@@ -103,7 +119,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 340
-  --> $DIR/cognitive_complexity.rs:194:1
+  --> $DIR/legacy.rs:94:1
    |
 LL | / fn barr2() {
 LL | |     match 99 {
@@ -117,7 +133,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 140
-  --> $DIR/cognitive_complexity.rs:210:1
+  --> $DIR/legacy.rs:110:1
    |
 LL | / fn barrr() {
 LL | |     match 99 {
@@ -131,7 +147,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 280
-  --> $DIR/cognitive_complexity.rs:220:1
+  --> $DIR/legacy.rs:120:1
    |
 LL | / fn barrr2() {
 LL | |     match 99 {
@@ -145,7 +161,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 140
-  --> $DIR/cognitive_complexity.rs:236:1
+  --> $DIR/legacy.rs:136:1
    |
 LL | / fn barrrr() {
 LL | |     match 99 {
@@ -159,7 +175,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 280
-  --> $DIR/cognitive_complexity.rs:246:1
+  --> $DIR/legacy.rs:146:1
    |
 LL | / fn barrrr2() {
 LL | |     match 99 {
@@ -173,7 +189,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 100
-  --> $DIR/cognitive_complexity.rs:262:1
+  --> $DIR/legacy.rs:162:1
    |
 LL | / fn cake() {
 LL | |     if 4 == 5 {
@@ -187,7 +203,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 270
-  --> $DIR/cognitive_complexity.rs:272:1
+  --> $DIR/legacy.rs:172:1
    |
 LL | / pub fn read_file(input_path: &str) -> String {
 LL | |     use std::fs::File;
@@ -201,7 +217,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 20
-  --> $DIR/cognitive_complexity.rs:303:1
+  --> $DIR/legacy.rs:203:1
    |
 LL | / fn void(void: Void) {
 LL | |     if true {
@@ -213,7 +229,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 20
-  --> $DIR/cognitive_complexity.rs:310:1
+  --> $DIR/legacy.rs:210:1
    |
 LL | / fn mcarton_sees_all() {
 LL | |     panic!("meh");
@@ -224,9 +240,9 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 30
-  --> $DIR/cognitive_complexity.rs:316:1
+  --> $DIR/legacy.rs:216:1
    |
-LL | / fn try_() -> Result<i32, &'static str> {
+LL | / fn try() -> Result<i32, &'static str> {
 LL | |     match 5 {
 LL | |         5 => Ok(5),
 LL | |         _ => return Err("bla"),
@@ -236,13 +252,13 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of 110
-  --> $DIR/cognitive_complexity.rs:324:1
+error: the function has a cognitive complexity of 350
+  --> $DIR/legacy.rs:224:1
    |
 LL | / fn try_again() -> Result<i32, &'static str> {
-LL | |     let _ = Ok(42)?;
-LL | |     let _ = Ok(43)?;
-LL | |     let _ = Ok(44)?;
+LL | |     let _ = try!(Ok(42));
+LL | |     let _ = try!(Ok(43));
+LL | |     let _ = try!(Ok(44));
 ...  |
 LL | |     }
 LL | | }
@@ -251,7 +267,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 90
-  --> $DIR/cognitive_complexity.rs:340:1
+  --> $DIR/legacy.rs:240:1
    |
 LL | / fn early() -> Result<i32, &'static str> {
 LL | |     return Ok(5);
@@ -265,7 +281,7 @@ LL | | }
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of 130
-  --> $DIR/cognitive_complexity.rs:354:1
+  --> $DIR/legacy.rs:254:1
    |
 LL | / fn early_ret() -> i32 {
 LL | |     let a = if true { 42 } else { return 0; };
@@ -278,5 +294,35 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: aborting due to 21 previous errors
+error: the function has a cognitive complexity of 30
+  --> $DIR/legacy.rs:274:1
+   |
+LL | / fn osscilating_logical_chain_1() -> bool {
+LL | |     true && false || true && false
+LL | | }
+   | |_^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 30
+  --> $DIR/legacy.rs:281:1
+   |
+LL | / fn osscilating_logical_chain_2() -> bool {
+LL | |     true && false && true && false || true && false && true && false
+LL | | }
+   | |_^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 30
+  --> $DIR/legacy.rs:286:1
+   |
+LL | / fn osscilating_logical_chain_3() -> bool {
+LL | |     (true && false) || (true && false)
+LL | | }
+   | |_^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: aborting due to 29 previous errors
 

--- a/tests/ui/cognitive_complexity/nd_structures.rs
+++ b/tests/ui/cognitive_complexity/nd_structures.rs
@@ -1,0 +1,5 @@
+#![allow(clippy::all)]
+#![warn(clippy::cognitive_complexity)]
+#![allow(unused)]
+
+fn main() {}

--- a/tests/ui/cognitive_complexity/ni_structures.rs
+++ b/tests/ui/cognitive_complexity/ni_structures.rs
@@ -1,0 +1,197 @@
+#![allow(clippy::all)]
+#![warn(clippy::cognitive_complexity)]
+#![allow(unused)]
+
+fn main() {}
+
+/*
+    Tests for Nesting-Independent Structures
+*/
+
+#[clippy::cognitive_complexity = "0"]
+fn func_calls() {
+    let _ = Vec::new();
+}
+
+#[clippy::cognitive_complexity = "0"]
+fn macro_calls() {
+    println!("Hello!");
+}
+
+mod loop_change_statements {
+
+    /* 
+        ### We check that their most basic form scores 1 ### 
+    */
+
+    #[clippy::cognitive_complexity = "1"]
+    fn b_reak() {
+        loop {
+            break;
+        }
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn c_ontinue() {
+        loop {
+            continue;
+        }
+    }
+
+    #[clippy::cognitive_complexity = "2"]
+    fn break_plus_ni_expr() -> bool {
+        loop {
+            break {
+                true || false
+            }
+        }
+    }
+
+    #[clippy::cognitive_complexity = "3"]
+    fn break_plus_nd_expr() -> bool {
+        loop {
+            break {
+                if(true) {
+                    println!("Hello");
+                }
+            }
+        }
+    }
+}
+
+mod binary_logic {
+
+    /*
+        ### The base cases should score 1 ###
+    */
+
+    #[clippy::cognitive_complexity = "0"]
+    fn and(a: bool, b: bool) -> bool {
+        a && b
+    }
+
+    #[clippy::cognitive_complexity = "0"]
+    fn or(a: bool, b: bool) -> bool {
+        a || b
+    }
+
+    #[clippy::cognitive_complexity = "0"]
+    fn bit_and(a: bool, b: bool) -> bool {
+        a & b
+    }
+
+    #[clippy::cognitive_complexity = "0"]
+    fn bit_or(a: bool, b: bool) -> bool {
+        a | b
+    }
+
+    #[clippy::cognitive_complexity = "0"]
+    fn bit_xor(a: bool, b: bool) -> bool {
+        a ^ b
+    }
+
+    /* 
+        ### All of these should score 2 ### 
+    */
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_1(a: bool, b: bool, c: bool) -> bool {
+        a && b || c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_2(a: bool, b: bool, c: bool) -> bool {
+        a && b & c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_3(a: bool, b: bool, c: bool) -> bool {
+        a && b | c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_4(a: bool, b: bool, c: bool) -> bool {
+        a && b ^ c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_5(a: bool, b: bool, c: bool) -> bool {
+        a || b & c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_6(a: bool, b: bool, c: bool) -> bool {
+        a || b | c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_7(a: bool, b: bool, c: bool) -> bool {
+        a || b ^ c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_8(a: bool, b: bool, c: bool) -> bool {
+        a & b | c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_9(a: bool, b: bool, c: bool) -> bool {
+        a & b ^ c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn change_one_10(a: bool, b: bool, c: bool) -> bool {
+        a | b ^ c
+    }
+
+    /* 
+        ### These should score 2 as well ### 
+    */
+   
+    #[clippy::cognitive_complexity = "1"]
+    fn one_paren(a: bool, b: bool, c: bool) -> bool {
+        a && (b || c)
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn two_paren(a: bool, b: bool, c: bool) -> bool {
+        a & ((b | c))
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn one_unary(a: bool, b: bool, c: bool) -> bool {
+        a ^ b && !c
+    }
+
+    #[clippy::cognitive_complexity = "1"]
+    fn one_unary_one_paren(a: bool, b: bool, c: bool) -> bool {
+        a || !(b & c)
+    }
+
+    mod complex_patterns {
+
+        /*
+            These patterns are made to test that the 
+            binary logic scoring algorithm recurses correctly
+        */
+
+        #[clippy::cognitive_complexity = "3"]
+        fn right_side_is_a_trap_1(a: bool, b: bool, c: bool, d: bool, e: bool) -> bool {
+            // Here, if the algorithm recurses to the right instead of the left,
+            // it should produce a lower score.
+            (a && b) || ((c ^ d) || e)
+        }
+
+        #[clippy::cognitive_complexity = "3"]
+        fn right_side_is_a_trap_2(a: bool, b: bool, c: bool, d: bool, e: bool) -> bool {
+            // Same as (right_side_is_a_trap_1), this tries to check that
+            // the algorithm's direction is correct
+            (a && b) || (((c ^ d) || e) || c)
+        }
+
+        #[clippy::cognitive_complexity = "0"]
+        fn super_long_chain(a: bool, b: bool, c: bool, d: bool, e: bool) -> bool {
+            a && b && c && d && e
+        }
+    }
+}

--- a/tests/ui/cognitive_complexity/ni_structures.stderr
+++ b/tests/ui/cognitive_complexity/ni_structures.stderr
@@ -1,0 +1,323 @@
+error: the function has a cognitive complexity of 10
+  --> $DIR/ni_structures.rs:12:1
+   |
+LL | / fn func_calls() {
+LL | |     let _ = Vec::new();
+LL | | }
+   | |_^
+   |
+   = note: `-D clippy::cognitive-complexity` implied by `-D warnings`
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 40
+  --> $DIR/ni_structures.rs:17:1
+   |
+LL | / fn macro_calls() {
+LL | |     println!("Hello!");
+LL | | }
+   | |_^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:28:5
+   |
+LL | /     fn b_reak() {
+LL | |         loop {
+LL | |             break;
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:35:5
+   |
+LL | /     fn c_ontinue() {
+LL | |         loop {
+LL | |             continue;
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 30
+  --> $DIR/ni_structures.rs:42:5
+   |
+LL | /     fn break_plus_ni_expr() -> bool {
+LL | |         loop {
+LL | |             break {
+LL | |                 true || false
+LL | |             }
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 70
+  --> $DIR/ni_structures.rs:51:5
+   |
+LL | /     fn break_plus_nd_expr() -> bool {
+LL | |         loop {
+LL | |             break {
+LL | |                 if(true) {
+...  |
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 10
+  --> $DIR/ni_structures.rs:69:5
+   |
+LL | /     fn and(a: bool, b: bool) -> bool {
+LL | |         a && b
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 10
+  --> $DIR/ni_structures.rs:74:5
+   |
+LL | /     fn or(a: bool, b: bool) -> bool {
+LL | |         a || b
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 10
+  --> $DIR/ni_structures.rs:79:5
+   |
+LL | /     fn bit_and(a: bool, b: bool) -> bool {
+LL | |         a & b
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 10
+  --> $DIR/ni_structures.rs:84:5
+   |
+LL | /     fn bit_or(a: bool, b: bool) -> bool {
+LL | |         a | b
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 10
+  --> $DIR/ni_structures.rs:89:5
+   |
+LL | /     fn bit_xor(a: bool, b: bool) -> bool {
+LL | |         a ^ b
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:98:5
+   |
+LL | /     fn change_one_1(a: bool, b: bool, c: bool) -> bool {
+LL | |         a && b || c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:103:5
+   |
+LL | /     fn change_one_2(a: bool, b: bool, c: bool) -> bool {
+LL | |         a && b & c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:108:5
+   |
+LL | /     fn change_one_3(a: bool, b: bool, c: bool) -> bool {
+LL | |         a && b | c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:113:5
+   |
+LL | /     fn change_one_4(a: bool, b: bool, c: bool) -> bool {
+LL | |         a && b ^ c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:118:5
+   |
+LL | /     fn change_one_5(a: bool, b: bool, c: bool) -> bool {
+LL | |         a || b & c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:123:5
+   |
+LL | /     fn change_one_6(a: bool, b: bool, c: bool) -> bool {
+LL | |         a || b | c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:128:5
+   |
+LL | /     fn change_one_7(a: bool, b: bool, c: bool) -> bool {
+LL | |         a || b ^ c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:133:5
+   |
+LL | /     fn change_one_8(a: bool, b: bool, c: bool) -> bool {
+LL | |         a & b | c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:138:5
+   |
+LL | /     fn change_one_9(a: bool, b: bool, c: bool) -> bool {
+LL | |         a & b ^ c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:143:5
+   |
+LL | /     fn change_one_10(a: bool, b: bool, c: bool) -> bool {
+LL | |         a | b ^ c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:152:5
+   |
+LL | /     fn one_paren(a: bool, b: bool, c: bool) -> bool {
+LL | |         a && (b || c)
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:157:5
+   |
+LL | /     fn two_paren(a: bool, b: bool, c: bool) -> bool {
+LL | |         a & ((b | c))
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:162:5
+   |
+LL | /     fn one_unary(a: bool, b: bool, c: bool) -> bool {
+LL | |         a ^ b && !c
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 20
+  --> $DIR/ni_structures.rs:167:5
+   |
+LL | /     fn one_unary_one_paren(a: bool, b: bool, c: bool) -> bool {
+LL | |         a || !(b & c)
+LL | |     }
+   | |_____^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 40
+  --> $DIR/ni_structures.rs:179:9
+   |
+LL | /         fn right_side_is_a_trap_1(a: bool, b: bool, c: bool, d: bool, e: bool) -> bool {
+LL | |             // Here, if the algorithm recurses to the right instead of the left,
+LL | |             // it should produce a lower score.
+LL | |             (a && b) || ((c ^ d) || e)
+LL | |         }
+   | |_________^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 40
+  --> $DIR/ni_structures.rs:186:9
+   |
+LL | /         fn right_side_is_a_trap_2(a: bool, b: bool, c: bool, d: bool, e: bool) -> bool {
+LL | |             // Same as (right_side_is_a_trap_1), this tries to check that
+LL | |             // the algorithm's direction is correct
+LL | |             (a && b) || (((c ^ d) || e) || c)
+LL | |         }
+   | |_________^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 10
+  --> $DIR/ni_structures.rs:193:9
+   |
+LL | /         fn super_long_chain(a: bool, b: bool, c: bool, d: bool, e: bool) -> bool {
+LL | |             a && b && c && d && e
+LL | |         }
+   | |_________^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error[E0308]: mismatched types
+  --> $DIR/ni_structures.rs:54:26
+   |
+LL |                   if(true) {
+   |  __________________________^
+LL | |                     println!("Hello");
+LL | |                 }
+   | |_________________^ expected bool, found ()
+   |
+   = note: expected type `bool`
+              found type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/ni_structures.rs:54:17
+   |
+LL | /                 if(true) {
+LL | |                     println!("Hello");
+LL | |                 }
+   | |_________________^ expected bool, found ()
+   |
+   = note: expected type `bool`
+              found type `()`
+
+error: aborting due to 30 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/cognitive_complexity/no_ops.rs
+++ b/tests/ui/cognitive_complexity/no_ops.rs
@@ -1,0 +1,71 @@
+#![allow(clippy::all)]
+#![warn(clippy::cognitive_complexity)]
+#![allow(unused)]
+
+fn main() {}
+
+/*
+    A collection of functions that should
+    mark no score.
+*/
+
+#[clippy::cognitive_complexity = "1"]
+fn chaining_with_one_block(a: bool, b: bool, c: bool) -> bool {
+    a ^ {b && c}
+}
+
+/*
+    Tests should never be scored
+*/
+
+// This is a normal test function
+
+#[test]
+#[clippy::cognitive_complexity = "0"]
+fn simple_test(n: usize) {
+    for i in range(0, n) {
+        for j in range(0, n) {
+            println!("{}, {}", i, j);        
+        }
+    }
+}
+
+// This is a test function with an inner function.
+// None should be scored
+
+#[test]
+#[clippy::cognitive_complexity = "0"]
+fn test_with_inner_function(n: usize) {
+    fn print_and_exaggerate(n: usize) {
+        println!("{}000", n);
+    }
+
+    for i in range(0, n) {
+        print_and_exaggerate(n);
+    }
+}
+
+/*
+    Macros should not be expanded
+*/
+
+macro_rules! lucas_macro {
+    ($n: expr) => {
+        {
+            fn lucas_number(n: usize) -> usize {
+                match n {
+                    0 => 2,
+                    1 => 1,
+                    _ => lucas_number(n - 1) + lucas_number(n - 2),
+                }
+            }
+
+            lucas_number($n)
+        }
+    }
+}
+
+#[clippy::cognitive_complexity = "1"]
+fn macros_are_not_expanded(n: usize) -> usize {
+    lucas_macro!(n)
+}

--- a/tests/ui/cognitive_complexity/no_ops.stderr
+++ b/tests/ui/cognitive_complexity/no_ops.stderr
@@ -1,0 +1,23 @@
+error: the function has a cognitive complexity of 10
+  --> $DIR/no_ops.rs:13:1
+   |
+LL | / fn chaining_with_one_block(a: bool, b: bool, c: bool) -> bool {
+LL | |     a ^ {b && c}
+LL | | }
+   | |_^
+   |
+   = note: `-D clippy::cognitive-complexity` implied by `-D warnings`
+   = help: you could split it up into multiple smaller functions
+
+error: the function has a cognitive complexity of 50
+  --> $DIR/no_ops.rs:69:1
+   |
+LL | / fn macros_are_not_expanded(n: usize) -> usize {
+LL | |     lucas_macro!(n)
+LL | | }
+   | |_^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/cognitive_complexity/other_cases.rs
+++ b/tests/ui/cognitive_complexity/other_cases.rs
@@ -1,0 +1,21 @@
+#![allow(clippy::all)]
+#![warn(clippy::cognitive_complexity)]
+#![allow(unused)]
+
+fn main() {}
+
+/*
+    Other Tests
+*/
+
+#[clippy::cognitive_complexity = "1"]
+fn nested_functions_are_counted(n: usize) -> usize {
+    fn lucas_number(n: usize) -> usize {
+        match n {
+            0 => 2,
+            1 => 1,
+            _ => lucas_number(n - 1) + lucas_number(n - 2),
+        }
+    }
+    lucas_number(n)
+}

--- a/tests/ui/cognitive_complexity/other_cases.stderr
+++ b/tests/ui/cognitive_complexity/other_cases.stderr
@@ -1,0 +1,17 @@
+error: the function has a cognitive complexity of 40
+  --> $DIR/other_cases.rs:12:1
+   |
+LL | / fn nested_functions_are_counted(n: usize) -> usize {
+LL | |     fn lucas_number(n: usize) -> usize {
+LL | |         match n {
+LL | |             0 => 2,
+...  |
+LL | |     lucas_number(n)
+LL | | }
+   | |_^
+   |
+   = note: `-D clippy::cognitive-complexity` implied by `-D warnings`
+   = help: you could split it up into multiple smaller functions
+
+error: aborting due to previous error
+

--- a/tests/ui/cognitive_complexity/too_complex_by_default.rs
+++ b/tests/ui/cognitive_complexity/too_complex_by_default.rs
@@ -1,0 +1,9 @@
+#![allow(clippy::all)]
+#![warn(clippy::cognitive_complexity)]
+#![allow(unused)]
+
+fn main() {}
+
+/*
+    Tests that trigger the default CoC value.
+*/

--- a/tests/ui/cognitive_complexity_attr_used.stderr
+++ b/tests/ui/cognitive_complexity_attr_used.stderr
@@ -1,4 +1,4 @@
-error: the function has a cognitive complexity of (3/0)
+error: the function has a cognitive complexity of 70
   --> $DIR/cognitive_complexity_attr_used.rs:9:1
    |
 LL | / fn kaboom() {

--- a/tests/ui/issue-3145.stderr
+++ b/tests/ui/issue-3145.stderr
@@ -4,18 +4,5 @@ error: expected token: `,`
 LL |     println!("{}" a); //~ERROR expected token: `,`
    |                   ^ expected `,`
 
-thread 'rustc' panicked at 'Found an ExprKind::Err. Is this a compiler bug??', clippy_lints/src/cognitive_complexity.rs:485:17
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 error: aborting due to previous error
-
-
-error: internal compiler error: unexpected panic
-
-note: the compiler unexpectedly panicked. this is a bug.
-
-note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
-
-note: rustc 1.39.0-nightly (c6e9c76c5 2019-09-04) running on x86_64-unknown-linux-gnu
-
-note: compiler flags: -Z ui-testing -C prefer-dynamic
 

--- a/tests/ui/issue-3145.stderr
+++ b/tests/ui/issue-3145.stderr
@@ -4,5 +4,18 @@ error: expected token: `,`
 LL |     println!("{}" a); //~ERROR expected token: `,`
    |                   ^ expected `,`
 
+thread 'rustc' panicked at 'Found an ExprKind::Err. Is this a compiler bug??', clippy_lints/src/cognitive_complexity.rs:485:17
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 error: aborting due to previous error
+
+
+error: internal compiler error: unexpected panic
+
+note: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
+
+note: rustc 1.39.0-nightly (c6e9c76c5 2019-09-04) running on x86_64-unknown-linux-gnu
+
+note: compiler flags: -Z ui-testing -C prefer-dynamic
 


### PR DESCRIPTION
A continuation of the work done in #3963 due to git conflicts. 

References:
- A significant portion of the conversation surrounding this lint has happened at #3793 as well.
- Previous PR (#3963)
- [The original paper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf)

Overall todo:

- [x] Remove the [ICE described by Manish](https://github.com/rust-lang/rust-clippy/pull/3963#issuecomment-528178183).

- [x] Decide if and how to score the constructs that are not being scored right now at all (most of them were not considered in the paper and so I thought that maybe there could be a default, low value, for non-specified kinds of expressions. **Either do that, or just skip them** for now and expand upon them in later versions).
- [ ] Roll back the implementation of flexible scores (done in one of the last commits of the original PR). This is because we want to keep this PR as simple as possible, and steering too far out of where the paper scores things will make future expansions harder to do in the right direction. For now, **the minimal, the better**.
- [ ] Write the complete specification for what's been implemented (the [Draft](https://github.com/rust-lang/rust-clippy/issues/3793#issuecomment-466160733) should be a good base, and the original paper should be used as a reference). This should end up in the docs directory of Clippy, _I think._
- [ ] Finish writing up test cases and tidy up the test folder for this lint.

Overall already done:

- Implemented the entire spec described in the Draft.
- Changed Lint from _Late_ to _Early_ pass.
- Downgraded Lint to Nursery (in preparation for next step) (thanks Manish!)