### PR TITLE
Stop using the HIR CFG

### DIFF
--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -136,6 +136,9 @@ impl<'a, 'tcx, 'b> Visitor<'tcx> for SimilarNamesNameVisitor<'a, 'tcx, 'b> {
                     }
                 }
             },
+            // just go through the first pattern, as either all patterns
+            // bind the same bindings or rustc would have errored much earlier
+            PatKind::Or(ref pats) => self.visit_pat(&pats[0]),
             _ => walk_pat(self, pat),
         }
     }
@@ -325,8 +328,6 @@ impl<'a, 'tcx> Visitor<'tcx> for SimilarNamesLocalVisitor<'a, 'tcx> {
         self.single_char_names.push(vec![]);
 
         self.apply(|this| {
-            // just go through the first pattern, as either all patterns
-            // bind the same bindings or rustc would have errored much earlier
             SimilarNamesNameVisitor(this).visit_pat(&arm.pat);
             this.apply(|this| walk_expr(this, &arm.body));
         });

--- a/tests/ui/cognitive_complexity.rs
+++ b/tests/ui/cognitive_complexity.rs
@@ -87,7 +87,7 @@ fn main() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn kaboom() {
     let n = 0;
     'a: for i in 0..20 {
@@ -133,17 +133,19 @@ fn bloo() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+// Short circuiting operations don't increase the complexity of a function.
+// Note that the minimum complexity of a function is 1.
+#[clippy::cognitive_complexity = "1"]
 fn lots_of_short_circuits() -> bool {
     true && false && true && false && true && false && true
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn lots_of_short_circuits2() -> bool {
     true || false || true || false || true || false || true
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn baa() {
     let x = || match 99 {
         0 => 0,
@@ -161,7 +163,7 @@ fn baa() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn bar() {
     match 99 {
         0 => println!("hi"),
@@ -170,7 +172,7 @@ fn bar() {
 }
 
 #[test]
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 /// Tests are usually complex but simple at the same time. `clippy::cognitive_complexity` used to
 /// give lots of false-positives in tests.
 fn dont_warn_on_tests() {
@@ -180,7 +182,7 @@ fn dont_warn_on_tests() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn barr() {
     match 99 {
         0 => println!("hi"),
@@ -190,7 +192,7 @@ fn barr() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn barr2() {
     match 99 {
         0 => println!("hi"),
@@ -206,7 +208,7 @@ fn barr2() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn barrr() {
     match 99 {
         0 => println!("hi"),
@@ -216,7 +218,7 @@ fn barrr() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn barrr2() {
     match 99 {
         0 => println!("hi"),
@@ -232,7 +234,7 @@ fn barrr2() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn barrrr() {
     match 99 {
         0 => println!("hi"),
@@ -242,7 +244,7 @@ fn barrrr() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn barrrr2() {
     match 99 {
         0 => println!("hi"),
@@ -258,7 +260,7 @@ fn barrrr2() {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn cake() {
     if 4 == 5 {
         println!("yea");
@@ -268,7 +270,7 @@ fn cake() {
     println!("whee");
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 pub fn read_file(input_path: &str) -> String {
     use std::fs::File;
     use std::io::{Read, Write};
@@ -299,20 +301,20 @@ pub fn read_file(input_path: &str) -> String {
 
 enum Void {}
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn void(void: Void) {
     if true {
         match void {}
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn mcarton_sees_all() {
     panic!("meh");
     panic!("möh");
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn try_() -> Result<i32, &'static str> {
     match 5 {
         5 => Ok(5),
@@ -320,7 +322,7 @@ fn try_() -> Result<i32, &'static str> {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn try_again() -> Result<i32, &'static str> {
     let _ = Ok(42)?;
     let _ = Ok(43)?;
@@ -336,7 +338,7 @@ fn try_again() -> Result<i32, &'static str> {
     }
 }
 
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn early() -> Result<i32, &'static str> {
     return Ok(5);
     return Ok(5);
@@ -350,7 +352,7 @@ fn early() -> Result<i32, &'static str> {
 }
 
 #[rustfmt::skip]
-#[clippy::cognitive_complexity = "0"]
+#[clippy::cognitive_complexity = "1"]
 fn early_ret() -> i32 {
     let a = if true { 42 } else { return 0; };
     let a = if a < 99 { 42 } else { return 0; };

--- a/tests/ui/cognitive_complexity.stderr
+++ b/tests/ui/cognitive_complexity.stderr
@@ -13,7 +13,7 @@ LL | | }
    = note: `-D clippy::cognitive-complexity` implied by `-D warnings`
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (7/0)
+error: the function has a cognitive complexity of (7/1)
   --> $DIR/cognitive_complexity.rs:91:1
    |
 LL | / fn kaboom() {
@@ -27,28 +27,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (1/0)
-  --> $DIR/cognitive_complexity.rs:137:1
-   |
-LL | / fn lots_of_short_circuits() -> bool {
-LL | |     true && false && true && false && true && false && true
-LL | | }
-   | |_^
-   |
-   = help: you could split it up into multiple smaller functions
-
-error: the function has a cognitive complexity of (1/0)
-  --> $DIR/cognitive_complexity.rs:142:1
-   |
-LL | / fn lots_of_short_circuits2() -> bool {
-LL | |     true || false || true || false || true || false || true
-LL | | }
-   | |_^
-   |
-   = help: you could split it up into multiple smaller functions
-
-error: the function has a cognitive complexity of (2/0)
-  --> $DIR/cognitive_complexity.rs:147:1
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:149:1
    |
 LL | / fn baa() {
 LL | |     let x = || match 99 {
@@ -61,8 +41,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (2/0)
-  --> $DIR/cognitive_complexity.rs:148:13
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:150:13
    |
 LL |       let x = || match 99 {
    |  _____________^
@@ -76,8 +56,8 @@ LL | |     };
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (2/0)
-  --> $DIR/cognitive_complexity.rs:165:1
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:167:1
    |
 LL | / fn bar() {
 LL | |     match 99 {
@@ -89,8 +69,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (2/0)
-  --> $DIR/cognitive_complexity.rs:184:1
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:186:1
    |
 LL | / fn barr() {
 LL | |     match 99 {
@@ -103,8 +83,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (3/0)
-  --> $DIR/cognitive_complexity.rs:194:1
+error: the function has a cognitive complexity of (3/1)
+  --> $DIR/cognitive_complexity.rs:196:1
    |
 LL | / fn barr2() {
 LL | |     match 99 {
@@ -117,8 +97,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (2/0)
-  --> $DIR/cognitive_complexity.rs:210:1
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:212:1
    |
 LL | / fn barrr() {
 LL | |     match 99 {
@@ -131,8 +111,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (3/0)
-  --> $DIR/cognitive_complexity.rs:220:1
+error: the function has a cognitive complexity of (3/1)
+  --> $DIR/cognitive_complexity.rs:222:1
    |
 LL | / fn barrr2() {
 LL | |     match 99 {
@@ -145,8 +125,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (2/0)
-  --> $DIR/cognitive_complexity.rs:236:1
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:238:1
    |
 LL | / fn barrrr() {
 LL | |     match 99 {
@@ -159,8 +139,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (3/0)
-  --> $DIR/cognitive_complexity.rs:246:1
+error: the function has a cognitive complexity of (3/1)
+  --> $DIR/cognitive_complexity.rs:248:1
    |
 LL | / fn barrrr2() {
 LL | |     match 99 {
@@ -173,8 +153,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (2/0)
-  --> $DIR/cognitive_complexity.rs:262:1
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:264:1
    |
 LL | / fn cake() {
 LL | |     if 4 == 5 {
@@ -187,8 +167,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (4/0)
-  --> $DIR/cognitive_complexity.rs:272:1
+error: the function has a cognitive complexity of (4/1)
+  --> $DIR/cognitive_complexity.rs:274:1
    |
 LL | / pub fn read_file(input_path: &str) -> String {
 LL | |     use std::fs::File;
@@ -201,8 +181,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (1/0)
-  --> $DIR/cognitive_complexity.rs:303:1
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:305:1
    |
 LL | / fn void(void: Void) {
 LL | |     if true {
@@ -213,49 +193,8 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: the function has a cognitive complexity of (1/0)
-  --> $DIR/cognitive_complexity.rs:316:1
-   |
-LL | / fn try_() -> Result<i32, &'static str> {
-LL | |     match 5 {
-LL | |         5 => Ok(5),
-LL | |         _ => return Err("bla"),
-LL | |     }
-LL | | }
-   | |_^
-   |
-   = help: you could split it up into multiple smaller functions
-
-error: the function has a cognitive complexity of (1/0)
-  --> $DIR/cognitive_complexity.rs:324:1
-   |
-LL | / fn try_again() -> Result<i32, &'static str> {
-LL | |     let _ = Ok(42)?;
-LL | |     let _ = Ok(43)?;
-LL | |     let _ = Ok(44)?;
-...  |
-LL | |     }
-LL | | }
-   | |_^
-   |
-   = help: you could split it up into multiple smaller functions
-
-error: the function has a cognitive complexity of (1/0)
-  --> $DIR/cognitive_complexity.rs:340:1
-   |
-LL | / fn early() -> Result<i32, &'static str> {
-LL | |     return Ok(5);
-LL | |     return Ok(5);
-LL | |     return Ok(5);
-...  |
-LL | |     return Ok(5);
-LL | | }
-   | |_^
-   |
-   = help: you could split it up into multiple smaller functions
-
-error: the function has a cognitive complexity of (8/0)
-  --> $DIR/cognitive_complexity.rs:354:1
+error: the function has a cognitive complexity of (8/1)
+  --> $DIR/cognitive_complexity.rs:356:1
    |
 LL | / fn early_ret() -> i32 {
 LL | |     let a = if true { 42 } else { return 0; };
@@ -268,5 +207,5 @@ LL | | }
    |
    = help: you could split it up into multiple smaller functions
 
-error: aborting due to 20 previous errors
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
This does slightly change the behavior:

* Functions with unreachable code don't end up being ignored
* `match` guards are counted as +1 for each guard, rather than +1 for each pattern with a guard
* Or patterns don't add to the complexity

changelog: none
