### PR TITLE
Extend `use_self` to check constructor

### DIFF
--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -1,6 +1,6 @@
 use if_chain::if_chain;
 use rustc::hir;
-use rustc::hir::def::{CtorKind, DefKind, Res};
+use rustc::hir::def::{DefKind, Res};
 use rustc::hir::intravisit::{walk_item, walk_path, walk_ty, NestedVisitorMap, Visitor};
 use rustc::hir::*;
 use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
@@ -239,7 +239,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UseSelfVisitor<'a, 'tcx> {
         if path.segments.last().expect(SEGMENTS_MSG).ident.name != kw::SelfUpper {
             if self.item_path.res == path.res {
                 span_use_self_lint(self.cx, path, None);
-            } else if let Res::Def(DefKind::Ctor(def::CtorOf::Struct, CtorKind::Fn), ctor_def_id) = path.res {
+            } else if let Res::Def(DefKind::Ctor(def::CtorOf::Struct, _), ctor_def_id) = path.res {
                 if self.item_path.res.opt_def_id() == self.cx.tcx.parent(ctor_def_id) {
                     span_use_self_lint(self.cx, path, None);
                 }

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -112,6 +112,12 @@ mod traits {
         }
     }
 
+    impl Clone for Bad {
+        fn clone(&self) -> Self {
+            Self
+        }
+    }
+
     #[derive(Default)]
     struct Good;
 
@@ -169,15 +175,6 @@ mod traits {
 
         fn vals(_: Self) -> Self {
             Self::default()
-        }
-    }
-
-    // Check that self arg isn't linted
-    impl Clone for Good {
-        fn clone(&self) -> Self {
-            // Note: Not linted and it wouldn't be valid
-            // because "can't use `Self` as a constructor`"
-            Good
         }
     }
 }

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -112,6 +112,12 @@ mod traits {
         }
     }
 
+    impl Clone for Bad {
+        fn clone(&self) -> Self {
+            Bad
+        }
+    }
+
     #[derive(Default)]
     struct Good;
 
@@ -169,15 +175,6 @@ mod traits {
 
         fn vals(_: Self) -> Self {
             Self::default()
-        }
-    }
-
-    // Check that self arg isn't linted
-    impl Clone for Good {
-        fn clone(&self) -> Self {
-            // Note: Not linted and it wouldn't be valid
-            // because "can't use `Self` as a constructor`"
-            Good
         }
     }
 }

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -121,19 +121,25 @@ LL |         fn mul(self, rhs: Bad) -> Bad {
    |                                   ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:202:56
+  --> $DIR/use_self.rs:117:13
+   |
+LL |             Bad
+   |             ^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:199:56
    |
 LL |         fn bad(foos: &[Self]) -> impl Iterator<Item = &Foo> {
    |                                                        ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:217:13
+  --> $DIR/use_self.rs:214:13
    |
 LL |             TS(0)
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:225:25
+  --> $DIR/use_self.rs:222:25
    |
 LL |             fn new() -> Foo {
    |                         ^^^ help: use the applicable keyword: `Self`
@@ -142,7 +148,7 @@ LL |         use_self_expand!(); // Should lint in local macros
    |         ------------------- in this macro invocation
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:226:17
+  --> $DIR/use_self.rs:223:17
    |
 LL |                 Foo {}
    |                 ^^^ help: use the applicable keyword: `Self`
@@ -151,64 +157,64 @@ LL |         use_self_expand!(); // Should lint in local macros
    |         ------------------- in this macro invocation
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:261:21
+  --> $DIR/use_self.rs:258:21
    |
 LL |         fn baz() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:262:13
+  --> $DIR/use_self.rs:259:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:249:29
+  --> $DIR/use_self.rs:246:29
    |
 LL |                 fn bar() -> Bar {
    |                             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:250:21
+  --> $DIR/use_self.rs:247:21
    |
 LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:279:21
+  --> $DIR/use_self.rs:276:21
    |
 LL |             let _ = Enum::B(42);
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:280:21
+  --> $DIR/use_self.rs:277:21
    |
 LL |             let _ = Enum::C { field: true };
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:281:21
+  --> $DIR/use_self.rs:278:21
    |
 LL |             let _ = Enum::A;
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:312:13
+  --> $DIR/use_self.rs:309:13
    |
 LL |             nested::A::fun_1();
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:313:13
+  --> $DIR/use_self.rs:310:13
    |
 LL |             nested::A::A;
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:315:13
+  --> $DIR/use_self.rs:312:13
    |
 LL |             nested::A {};
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
-error: aborting due to 34 previous errors
+error: aborting due to 35 previous errors
 


### PR DESCRIPTION
Rust did not allow this before.

changelog: Extend `use_self` to check constructor
