### PR TITLE
Changed more `Vec` paths to diagnostic_items

### DIFF
--- a/clippy_lints/src/get_last_with_len.rs
+++ b/clippy_lints/src/get_last_with_len.rs
@@ -1,6 +1,6 @@
 //! lint on using `x.get(x.len() - 1)` instead of `x.last()`
 
-use crate::utils::{match_type, paths, snippet_with_applicability, span_lint_and_sugg, SpanlessEq};
+use crate::utils::{is_type_diagnostic_item, snippet_with_applicability, span_lint_and_sugg, SpanlessEq};
 use if_chain::if_chain;
 use rustc::hir::{BinOpKind, Expr, ExprKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
@@ -56,7 +56,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for GetLastWithLen {
             // Argument 0 (the struct we're calling the method on) is a vector
             if let Some(struct_calling_on) = args.get(0);
             let struct_ty = cx.tables.expr_ty(struct_calling_on);
-            if match_type(cx, struct_ty, &paths::VEC);
+            if is_type_diagnostic_item(cx, struct_ty, Symbol::intern("vec_type"));
 
             // Argument to "get" is a subtraction
             if let Some(get_index_arg) = args.get(1);

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -2399,7 +2399,7 @@ fn check_needless_collect<'a, 'tcx>(expr: &'tcx Expr, cx: &LateContext<'a, 'tcx>
         if let Some(GenericArg::Type(ref ty)) = generic_args.args.get(0);
         then {
             let ty = cx.tables.node_type(ty.hir_id);
-            if match_type(cx, ty, &paths::VEC) ||
+            if is_type_diagnostic_item(cx, ty, Symbol::intern("vec_type")) ||
                 match_type(cx, ty, &paths::VEC_DEQUE) ||
                 match_type(cx, ty, &paths::BTREEMAP) ||
                 match_type(cx, ty, &paths::HASHMAP) {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1987,7 +1987,7 @@ fn derefs_to_slice<'a, 'tcx>(
         match ty.sty {
             ty::Slice(_) => true,
             ty::Adt(def, _) if def.is_box() => may_slice(cx, ty.boxed_ty()),
-            ty::Adt(..) => match_type(cx, ty, &paths::VEC),
+            ty::Adt(..) => is_type_diagnostic_item(cx, ty, Symbol::intern("vec_type")),
             ty::Array(_, size) => size.eval_usize(cx.tcx, cx.param_env) < 32,
             ty::Ref(_, inner, _) => may_slice(cx, inner),
             _ => false,


### PR DESCRIPTION
In #4519, I missed a few instances of path matching for `Vec`, so here they are.

r? @oli-obk 

changelog: none
