### PR TITLE
Remove feature gate bind-by-move

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1,6 +1,5 @@
 // error-pattern:cargo-clippy
 
-#![feature(bind_by_move_pattern_guards)] // proposed to be stabilized in Rust v1.39
 #![feature(box_syntax)]
 #![feature(box_patterns)]
 #![feature(never_type)]


### PR DESCRIPTION
This feature was stabilized in https://github.com/rust-lang/rust/pull/63118
changelog: none
