### PR TITLE
Fix rustc breaking change: convert to Place's new boxed slice projection

### DIFF
--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -252,13 +252,13 @@ fn find_stmt_assigns_to<'a, 'tcx: 'a>(
     stmts
         .rev()
         .find_map(|stmt| {
-            if let mir::StatementKind::Assign(
+            if let mir::StatementKind::Assign(box (
                 mir::Place {
                     base: mir::PlaceBase::Local(local),
                     ..
                 },
                 v,
-            ) = &stmt.kind
+            )) = &stmt.kind
             {
                 if *local == to {
                     return Some(v);
@@ -269,10 +269,10 @@ fn find_stmt_assigns_to<'a, 'tcx: 'a>(
         })
         .and_then(|v| {
             if by_ref {
-                if let mir::Rvalue::Ref(_, _, ref place) = **v {
+                if let mir::Rvalue::Ref(_, _, ref place) = v {
                     return base_local_and_movability(cx, mir, place);
                 }
-            } else if let mir::Rvalue::Use(mir::Operand::Copy(ref place)) = **v {
+            } else if let mir::Rvalue::Use(mir::Operand::Copy(ref place)) = v {
                 return base_local_and_movability(cx, mir, place);
             }
             None
@@ -291,7 +291,6 @@ fn base_local_and_movability<'tcx>(
     use rustc::mir::Place;
     use rustc::mir::PlaceBase;
     use rustc::mir::PlaceRef;
-    use rustc::mir::Projection;
 
     // Dereference. You cannot move things out from a borrowed value.
     let mut deref = false;
@@ -303,7 +302,7 @@ fn base_local_and_movability<'tcx>(
         mut projection,
     } = place.as_ref();
     if let PlaceBase::Local(local) = place_base {
-        while let Some(box Projection { base, elem }) = projection {
+        while let [base @ .., elem] = projection {
             projection = base;
             deref = matches!(elem, mir::ProjectionElem::Deref);
             field = !field


### PR DESCRIPTION
Addressed breaking changes from rust-lang PR https://github.com/rust-lang/rust/pull/63420/

I'm not entirely sure the semantics are preserved as I don't have much knowledge about MIR yet. So this code was largely reverse-engineered from the PR above. I wouldn't be surprised if I did something wrong :).

I followed the instructions to pull latest rustc from master and verified the build break I was seeing in my PR for cast-lossless in Travis CI. With these changes, it compiles again and all tests pass.

Fixes https://github.com/rust-lang/rust/issues/64440 

changelog: none
