### PR TITLE
#4542 remove machine applicable suggestion

### DIFF
--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -140,7 +140,8 @@ fn write_output_string(write_args: &HirVec<Expr>) -> Option<String> {
         if output_args.len() > 0;
         if let ExprKind::AddrOf(_, ref output_string_expr) = output_args[0].node;
         if let ExprKind::Array(ref string_exprs) = output_string_expr.node;
-        if string_exprs.len() > 0;
+        // we only want to provide an automatic suggestion for simple (non-format) strings
+        if string_exprs.len() == 1;
         if let ExprKind::Lit(ref lit) = string_exprs[0].node;
         if let LitKind::Str(ref write_output, _) = lit.node;
         then {

--- a/tests/ui/explicit_write_non_rustfix.rs
+++ b/tests/ui/explicit_write_non_rustfix.rs
@@ -1,0 +1,8 @@
+#![allow(unused_imports, clippy::blacklisted_name)]
+#![warn(clippy::explicit_write)]
+
+fn main() {
+    use std::io::Write;
+    let bar = "bar";
+    writeln!(std::io::stderr(), "foo {}", bar).unwrap();
+}

--- a/tests/ui/explicit_write_non_rustfix.stderr
+++ b/tests/ui/explicit_write_non_rustfix.stderr
@@ -1,0 +1,10 @@
+error: use of `writeln!(stderr(), ...).unwrap()`. Consider using `eprintln!` instead
+  --> $DIR/explicit_write_non_rustfix.rs:7:5
+   |
+LL |     writeln!(std::io::stderr(), "foo {}", bar).unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::explicit-write` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This helps #4542 (but does not completely resolve) by removing the machine applicable suggestion (which was incorrect) for that case.

I would have preferred to fix the machine applicable suggestion to handle format strings, but that's a bit beyond my current understanding of the clippy codebase. I'd be happy to give it a try given some guidance. 

changelog: only produce machine applicable suggestions on `explicit_write` lint