### PR TITLE
Changes to catch_fatal_errors in rustc driver

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -247,8 +247,9 @@ You can use tool lints to allow or deny lints from your code, eg.:
 
 pub fn main() {
     rustc_driver::init_rustc_env_logger();
+    rustc_driver::install_ice_hook();
     exit(
-        rustc_driver::report_ices_to_stderr_if_any(move || {
+        rustc_driver::catch_fatal_errors(move || {
             use std::env;
 
             if std::env::args().any(|a| a == "--version" || a == "-V") {

--- a/tests/ui/ice-4545.rs
+++ b/tests/ui/ice-4545.rs
@@ -1,0 +1,15 @@
+fn repro() {
+    trait Foo {
+        type Bar;
+    }
+
+    #[allow(dead_code)]
+    struct Baz<T: Foo> {
+        field: T::Bar,
+    }
+}
+
+fn main() {
+    repro();
+}
+


### PR DESCRIPTION
A [recent PR](https://github.com/rust-lang/rust/pull/60584/files#diff-707a0eda6b2f1a0537abc3d23133748cL1151) changed the function name from `report_ices_to_stderr_if_any` to `catch_fatal_errors`. This PR changes to using the new function name.

changelog: none
