### PR TITLE
write_with_newline now handles \r\n

### DIFF
--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -49,4 +49,8 @@ fn main() {
         r"
 "
     );
+
+    // strings ending with \r\n
+    write!(&mut v, "\r\n"); // 4208
+    write!(&mut v, "foobar123\r\n"); // 4208
 }


### PR DESCRIPTION
fixes #4208
changelog: write_with_newline now handles \r\n

based off of https://github.com/matthiaskrgr/rust-clippy/commit/588dcc8
