### PR TITLE
Detect mutating arithmetic in integer_arithmetic restriction lint

### DIFF
--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -64,7 +64,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Arithmetic {
             }
         }
         match &expr.node {
-            hir::ExprKind::Binary(op, l, r) => {
+            hir::ExprKind::Binary(op, l, r) | hir::ExprKind::AssignOp(op, l, r) => {
                 match op.node {
                     hir::BinOpKind::And
                     | hir::BinOpKind::Or

--- a/tests/ui/arithmetic.rs
+++ b/tests/ui/arithmetic.rs
@@ -9,7 +9,7 @@
 
 #[rustfmt::skip]
 fn main() {
-    let i = 1i32;
+    let mut i = 1i32;
     1 + i;
     i * 2;
     1 %
@@ -27,7 +27,20 @@ fn main() {
     i >> 1;
     i << 1;
 
-    let f = 1.0f32;
+    i += 1;
+    i -= 1;
+    i *= 2;
+    i /= 2;
+    i %= 2;
+
+    // no errors
+    i <<= 3;
+    i >>= 2;
+    i |= 1;
+    i &= 1;
+    i ^= i;
+
+    let mut f = 1.0f32;
 
     f * 2.0;
 
@@ -36,6 +49,11 @@ fn main() {
     f / 2.0;
     f - 2.0 * 4.2;
     -f;
+
+    f += 1.0;
+    f -= 1.0;
+    f *= 2.0;
+    f /= 2.0;
 
     // No errors for the following items because they are constant expressions
     enum Foo {

--- a/tests/ui/arithmetic.stderr
+++ b/tests/ui/arithmetic.stderr
@@ -31,8 +31,38 @@ error: integer arithmetic detected
 LL |     -i;
    |     ^^
 
-error: floating-point arithmetic detected
+error: integer arithmetic detected
+  --> $DIR/arithmetic.rs:30:5
+   |
+LL |     i += 1;
+   |     ^^^^^^
+
+error: integer arithmetic detected
+  --> $DIR/arithmetic.rs:31:5
+   |
+LL |     i -= 1;
+   |     ^^^^^^
+
+error: integer arithmetic detected
   --> $DIR/arithmetic.rs:32:5
+   |
+LL |     i *= 2;
+   |     ^^^^^^
+
+error: integer arithmetic detected
+  --> $DIR/arithmetic.rs:33:5
+   |
+LL |     i /= 2;
+   |     ^^^^^^
+
+error: integer arithmetic detected
+  --> $DIR/arithmetic.rs:34:5
+   |
+LL |     i %= 2;
+   |     ^^^^^^
+
+error: floating-point arithmetic detected
+  --> $DIR/arithmetic.rs:45:5
    |
 LL |     f * 2.0;
    |     ^^^^^^^
@@ -40,34 +70,58 @@ LL |     f * 2.0;
    = note: `-D clippy::float-arithmetic` implied by `-D warnings`
 
 error: floating-point arithmetic detected
-  --> $DIR/arithmetic.rs:34:5
+  --> $DIR/arithmetic.rs:47:5
    |
 LL |     1.0 + f;
    |     ^^^^^^^
 
 error: floating-point arithmetic detected
-  --> $DIR/arithmetic.rs:35:5
+  --> $DIR/arithmetic.rs:48:5
    |
 LL |     f * 2.0;
    |     ^^^^^^^
 
 error: floating-point arithmetic detected
-  --> $DIR/arithmetic.rs:36:5
+  --> $DIR/arithmetic.rs:49:5
    |
 LL |     f / 2.0;
    |     ^^^^^^^
 
 error: floating-point arithmetic detected
-  --> $DIR/arithmetic.rs:37:5
+  --> $DIR/arithmetic.rs:50:5
    |
 LL |     f - 2.0 * 4.2;
    |     ^^^^^^^^^^^^^
 
 error: floating-point arithmetic detected
-  --> $DIR/arithmetic.rs:38:5
+  --> $DIR/arithmetic.rs:51:5
    |
 LL |     -f;
    |     ^^
 
-error: aborting due to 11 previous errors
+error: floating-point arithmetic detected
+  --> $DIR/arithmetic.rs:53:5
+   |
+LL |     f += 1.0;
+   |     ^^^^^^^^
+
+error: floating-point arithmetic detected
+  --> $DIR/arithmetic.rs:54:5
+   |
+LL |     f -= 1.0;
+   |     ^^^^^^^^
+
+error: floating-point arithmetic detected
+  --> $DIR/arithmetic.rs:55:5
+   |
+LL |     f *= 2.0;
+   |     ^^^^^^^^
+
+error: floating-point arithmetic detected
+  --> $DIR/arithmetic.rs:56:5
+   |
+LL |     f /= 2.0;
+   |     ^^^^^^^^
+
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
changelog: detect mutating arithmetic (like +=) in `integer_arithmetic` restriction lint
