### PR TITLE
Add custom ICE message that points to Clippy repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ semver = "0.9"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 git2 = { version = "0.10", optional = true }
 tempfile = { version = "3.1.0", optional = true }
+lazy_static = "1.0"
 
 [dev-dependencies]
 cargo_metadata = "0.9.0"

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -963,6 +963,7 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     let array_size_threshold = conf.array_size_threshold;
     store.register_late_pass(move || box large_stack_arrays::LargeStackArrays::new(array_size_threshold));
     store.register_early_pass(|| box as_conversions::AsConversions);
+    store.register_early_pass(|| box utils::internal_lints::ProduceIce);
 
     store.register_group(true, "clippy::restriction", Some("clippy_restriction"), vec![
         LintId::of(&arithmetic::FLOAT_ARITHMETIC),
@@ -1057,6 +1058,7 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
         LintId::of(&utils::internal_lints::COMPILER_LINT_FUNCTIONS),
         LintId::of(&utils::internal_lints::LINT_WITHOUT_LINT_PASS),
         LintId::of(&utils::internal_lints::OUTER_EXPN_EXPN_DATA),
+        LintId::of(&utils::internal_lints::PRODUCE_ICE),
     ]);
 
     store.register_group(true, "clippy::all", Some("clippy"), vec![

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -14,8 +14,8 @@ use rustc_errors::Applicability;
 use syntax::ast;
 use syntax::ast::{Crate as AstCrate, ItemKind, Name};
 use syntax::source_map::Span;
-use syntax_pos::symbol::SymbolStr;
 use syntax::visit::FnKind;
+use syntax_pos::symbol::SymbolStr;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for various things we like to keep tidy in clippy.

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -336,7 +336,7 @@ impl EarlyLintPass for ProduceIce {
 fn is_trigger_fn(fn_kind: FnKind<'_>) -> bool {
     match fn_kind {
         FnKind::ItemFn(ident, ..) | FnKind::Method(ident, ..) => {
-            ident.name.as_str() == "should_trigger_an_ice_in_clippy"
+            ident.name.as_str() == "it_looks_like_you_are_trying_to_kill_clippy"
         },
         FnKind::Closure(..) => false,
     }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -280,7 +280,7 @@ fn report_clippy_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
     let backtrace = std::env::var_os("RUST_BACKTRACE").map(|x| &x != "0").unwrap_or(false);
 
     if backtrace {
-        TyCtxt::try_print_query_stack();
+        TyCtxt::try_print_query_stack(&handler);
     }
 }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -264,10 +264,12 @@ fn report_clippy_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
         handler.abort_if_errors_and_should_abort();
     }
 
+    let version_info = rustc_tools_util::get_version_info!();
+
     let xs: Vec<Cow<'static, str>> = vec![
         "the compiler unexpectedly panicked. this is a bug.".into(),
         format!("we would appreciate a bug report: {}", bug_report_url).into(),
-        format!("rustc {}", option_env!("CFG_VERSION").unwrap_or("unknown_version")).into(),
+        format!("Clippy version: {}", version_info).into(),
     ];
 
     for note in &xs {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -277,7 +277,7 @@ fn report_clippy_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
     }
 
     // If backtraces are enabled, also print the query stack
-    let backtrace = std::env::var_os("RUST_BACKTRACE").map(|x| &x != "0").unwrap_or(false);
+    let backtrace = std::env::var_os("RUST_BACKTRACE").map_or(false, |x| &x != "0");
 
     if backtrace {
         TyCtxt::try_print_query_stack(&handler);

--- a/tests/ui/custom_ice_message.rs
+++ b/tests/ui/custom_ice_message.rs
@@ -1,6 +1,6 @@
-// exec-env:RUST_BACKTRACE=0
+// rustc-env:RUST_BACKTRACE=0
 // normalize-stderr-test: "Clippy version: .*" -> "Clippy version: foo"
-// normalize-stderr-test: "internal_lints.rs.*" -> "internal_lints.rs:1:1"
+// normalize-stderr-test: "internal_lints.rs:\d*:\d*" -> "internal_lints.rs"
 
 #![deny(clippy::internal)]
 

--- a/tests/ui/custom_ice_message.rs
+++ b/tests/ui/custom_ice_message.rs
@@ -1,0 +1,5 @@
+#![deny(clippy::internal)]
+
+fn should_trigger_an_ice_in_clippy() {}
+
+fn main() {}

--- a/tests/ui/custom_ice_message.rs
+++ b/tests/ui/custom_ice_message.rs
@@ -4,6 +4,6 @@
 
 #![deny(clippy::internal)]
 
-fn should_trigger_an_ice_in_clippy() {}
+fn it_looks_like_you_are_trying_to_kill_clippy() {}
 
 fn main() {}

--- a/tests/ui/custom_ice_message.rs
+++ b/tests/ui/custom_ice_message.rs
@@ -1,3 +1,7 @@
+// exec-env:RUST_BACKTRACE=0
+// normalize-stderr-test: "Clippy version: .*" -> "Clippy version: foo"
+// normalize-stderr-test: "internal_lints.rs.*" -> "internal_lints.rs:1:1"
+
 #![deny(clippy::internal)]
 
 fn should_trigger_an_ice_in_clippy() {}

--- a/tests/ui/custom_ice_message.stderr
+++ b/tests/ui/custom_ice_message.stderr
@@ -7,5 +7,5 @@ note: the compiler unexpectedly panicked. this is a bug.
 
 note: we would appreciate a bug report: https://github.com/rust-lang/rust-clippy/issues/new
 
-note: rustc unknown_version
+note: Clippy version: clippy 0.0.212 (68ff8b19 2019-09-26)
 

--- a/tests/ui/custom_ice_message.stderr
+++ b/tests/ui/custom_ice_message.stderr
@@ -1,0 +1,11 @@
+thread 'rustc' panicked at 'Testing the ICE message', clippy_lints/src/utils/internal_lints.rs:333:13
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+
+error: internal compiler error: unexpected panic
+
+note: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust-clippy/issues/new
+
+note: rustc unknown_version
+

--- a/tests/ui/custom_ice_message.stderr
+++ b/tests/ui/custom_ice_message.stderr
@@ -1,4 +1,4 @@
-thread 'rustc' panicked at 'Testing the ICE message', clippy_lints/src/utils/internal_lints.rs:333:13
+thread 'rustc' panicked at 'Testing the ICE message', clippy_lints/src/utils/internal_lints.rs:1:1
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 error: internal compiler error: unexpected panic
@@ -7,5 +7,5 @@ note: the compiler unexpectedly panicked. this is a bug.
 
 note: we would appreciate a bug report: https://github.com/rust-lang/rust-clippy/issues/new
 
-note: Clippy version: clippy 0.0.212 (68ff8b19 2019-09-26)
+note: Clippy version: foo
 

--- a/tests/ui/custom_ice_message.stderr
+++ b/tests/ui/custom_ice_message.stderr
@@ -1,4 +1,4 @@
-thread 'rustc' panicked at 'Testing the ICE message', clippy_lints/src/utils/internal_lints.rs:1:1
+thread 'rustc' panicked at 'Testing the ICE message', clippy_lints/src/utils/internal_lints.rs
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 error: internal compiler error: unexpected panic


### PR DESCRIPTION
changelog: Link to Clippy issue tracker in ICE messages

This utilizes https://github.com/rust-lang/rust/pull/60584 by setting
our own `panic_hook` and pointing to our own issue tracker instead of
the rustc issue tracker.

This also adds a new internal lint to test the ICE message.

**Potential downsides**

* This essentially copies rustc's `report_ice` function as
  `report_clippy_ice`. I think that's how it's meant to be implemented, but
  maybe @jonas-schievink could have a look as well =)

  The downside of more-or-less copying this function is that we have to
  maintain it as well now.
  The original function can be found [here][original].
* `driver` now depends directly on `rustc` and `rustc_errors`

Closes #2734

[original]: https://github.com/rust-lang/rust/blob/59367b074f1523353dddefa678ffe3cac9fd4e50/src/librustc_driver/lib.rs#L1185