### PR TITLE
Allow everyone to assign labels with rustbot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,7 @@
+[relabel]
+allow-unauthenticated = [
+    "C-*", "A-*", "E-*", "L-*", "M-*", "O-*",
+    "good first issue", "needs test"
+]
+
+[assign]


### PR DESCRIPTION
Also allows people to claim issues even if they aren't part of the org

changelog: none
