### PR TITLE
account for doc visibility

### DIFF
--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -57,7 +57,7 @@ impl Lint {
         lints.filter(|l| l.deprecation.is_none() && !l.is_internal())
     }
 
-    /// Returns the lints in a HashMap, grouped by the different lint groups
+    /// Returns the lints in a `HashMap`, grouped by the different lint groups
     pub fn by_lint_group(lints: &[Self]) -> HashMap<String, Vec<Self>> {
         lints
             .iter()

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -324,7 +324,7 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
         vec.iter().map(|elem| self.expr(elem)).collect::<Option<_>>()
     }
 
-    /// Lookup a possibly constant expression from a ExprKind::Path.
+    /// Lookup a possibly constant expression from a `ExprKind::Path`.
     fn fetch_path(&mut self, qpath: &QPath, id: HirId) -> Option<Constant> {
         use rustc::mir::interpret::GlobalId;
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -533,7 +533,7 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
             conf.blacklisted_names.iter().cloned().collect()
     ));
     reg.register_late_lint_pass(box functions::Functions::new(conf.too_many_arguments_threshold, conf.too_many_lines_threshold));
-    reg.register_early_lint_pass(box doc::DocMarkdown::new(conf.doc_valid_idents.iter().cloned().collect()));
+    reg.register_late_lint_pass(box doc::DocMarkdown::new(conf.doc_valid_idents.iter().cloned().collect()));
     reg.register_late_lint_pass(box neg_multiply::NegMultiply);
     reg.register_early_lint_pass(box unsafe_removed_from_name::UnsafeNameRemoval);
     reg.register_late_lint_pass(box mem_discriminant::MemDiscriminant);

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1895,7 +1895,7 @@ fn lint_iter_nth<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &hir::Expr, iter_ar
 }
 
 fn lint_get_unwrap<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &hir::Expr, get_args: &'tcx [hir::Expr], is_mut: bool) {
-    // Note: we don't want to lint `get_mut().unwrap` for HashMap or BTreeMap,
+    // Note: we don't want to lint `get_mut().unwrap` for `HashMap` or `BTreeMap`,
     // because they do not implement `IndexMut`
     let mut applicability = Applicability::MachineApplicable;
     let expr_ty = cx.tables.expr_ty(&get_args[0]);

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1940,7 +1940,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidUpcastComparisons {
 declare_clippy_lint! {
     /// **What it does:** Checks for public `impl` or `fn` missing generalization
     /// over different hashers and implicitly defaulting to the default hashing
-    /// algorithm (SipHash).
+    /// algorithm (`SipHash`).
     ///
     /// **Why is this bad?** `HashMap` or `HashSet` with custom hashers cannot be
     /// used with them.
@@ -2118,7 +2118,7 @@ enum ImplicitHasherType<'tcx> {
 }
 
 impl<'tcx> ImplicitHasherType<'tcx> {
-    /// Checks that `ty` is a target type without a BuildHasher.
+    /// Checks that `ty` is a target type without a `BuildHasher`.
     fn new<'a>(cx: &LateContext<'a, 'tcx>, hir_ty: &hir::Ty) -> Option<Self> {
         if let TyKind::Path(QPath::Resolved(None, ref path)) = hir_ty.kind {
             let params: Vec<_> = path

--- a/tests/ui/doc_unsafe.rs
+++ b/tests/ui/doc_unsafe.rs
@@ -17,9 +17,59 @@ unsafe fn you_dont_see_me() {
     unimplemented!();
 }
 
+mod private_mod {
+    pub unsafe fn only_crate_wide_accessible() {
+        unimplemented!();
+    }
+
+    pub unsafe fn republished() {
+        unimplemented!();
+    }
+}
+
+pub use private_mod::republished;
+
+pub trait UnsafeTrait {
+    unsafe fn woefully_underdocumented(self);
+
+    /// # Safety
+    unsafe fn at_least_somewhat_documented(self);
+}
+
+pub struct Struct;
+
+impl UnsafeTrait for Struct {
+    unsafe fn woefully_underdocumented(self) {
+        // all is well
+    }
+
+    unsafe fn at_least_somewhat_documented(self) {
+        // all is still well
+    }
+}
+
+impl Struct {
+    pub unsafe fn more_undocumented_unsafe() -> Self {
+        unimplemented!();
+    }
+
+    /// # Safety
+    pub unsafe fn somewhat_documented(&self) {
+        unimplemented!();
+    }
+
+    unsafe fn private(&self) {
+        unimplemented!();
+    }
+}
+
+#[allow(clippy::let_unit_value)]
 fn main() {
-    you_dont_see_me();
-    destroy_the_planet();
-    let mut universe = ();
-    apocalypse(&mut universe);
+    unsafe {
+        you_dont_see_me();
+        destroy_the_planet();
+        let mut universe = ();
+        apocalypse(&mut universe);
+        private_mod::only_crate_wide_accessible();
+    }
 }

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -8,5 +8,27 @@ LL | | }
    |
    = note: `-D clippy::missing-safety-doc` implied by `-D warnings`
 
-error: aborting due to previous error
+error: unsafe function's docs miss `# Safety` section
+  --> $DIR/doc_unsafe.rs:25:5
+   |
+LL | /     pub unsafe fn republished() {
+LL | |         unimplemented!();
+LL | |     }
+   | |_____^
+
+error: unsafe function's docs miss `# Safety` section
+  --> $DIR/doc_unsafe.rs:33:5
+   |
+LL |     unsafe fn woefully_underdocumented(self);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsafe function's docs miss `# Safety` section
+  --> $DIR/doc_unsafe.rs:52:5
+   |
+LL | /     pub unsafe fn more_undocumented_unsafe() -> Self {
+LL | |         unimplemented!();
+LL | |     }
+   | |_____^
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/functions.rs
+++ b/tests/ui/functions.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all)]
 #![allow(dead_code)]
-#![allow(unused_unsafe)]
+#![allow(unused_unsafe, clippy::missing_safety_doc)]
 
 // TOO_MANY_ARGUMENTS
 fn good(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f32, _seven: bool) {}

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -1,5 +1,5 @@
 #![feature(const_fn)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::missing_safety_doc)]
 #![warn(clippy::new_without_default)]
 
 pub struct Foo;


### PR DESCRIPTION
This fixes #4608.

Also I noticed that the lint failed to look at trait and impl items. There's a small bit of fallout in the code, too, but not enough to warrant its own commit.

changelog: check docs of trait items and impl items, also make `missing_safety_doc` account for visibility