### PR TITLE
Add check for assert_eq macros to unit_cmp lint

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -487,7 +487,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnitValue {
 }
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for comparisons to unit.
+    /// **What it does:** Checks for comparisons to unit. This includes all binary
+    /// comparisons (like `==` and `<`) and asserts.
     ///
     /// **Why is this bad?** Unit is always equal to itself, and thus is just a
     /// clumsily written constant. Mostly this happens when someone accidentally
@@ -519,6 +520,20 @@ declare_clippy_lint! {
     ///     baz();
     /// }
     /// ```
+    ///
+    /// For asserts:
+    /// ```rust
+    /// # fn foo() {};
+    /// # fn bar() {};
+    /// assert_eq!({ foo(); }, { bar(); });
+    /// ```
+    /// will always succeed
+    /// ```rust
+    /// # fn foo() {};
+    /// # fn bar() {};
+    /// assert_ne!({ foo(); }, { bar(); });
+    /// ```
+    /// will always fail
     pub UNIT_CMP,
     correctness,
     "comparing unit values"

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -528,12 +528,6 @@ declare_clippy_lint! {
     /// assert_eq!({ foo(); }, { bar(); });
     /// ```
     /// will always succeed
-    /// ```rust
-    /// # fn foo() {};
-    /// # fn bar() {};
-    /// assert_ne!({ foo(); }, { bar(); });
-    /// ```
-    /// will always fail
     pub UNIT_CMP,
     correctness,
     "comparing unit values"

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -544,7 +544,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnitCmp {
                                 UNIT_CMP,
                                 expr.span,
                                 &format!(
-                                    "{} of unit values detected. This will always {}",
+                                    "`{}` of unit values detected. This will always {}",
                                     symbol.as_str(),
                                     result
                                 ),

--- a/tests/ui/unit_cmp.rs
+++ b/tests/ui/unit_cmp.rs
@@ -21,9 +21,37 @@ fn main() {
         false;
     } {}
 
-    assert_eq!((), ());
-    debug_assert_eq!((), ());
+    assert_eq!(
+        {
+            true;
+        },
+        {
+            false;
+        }
+    );
+    debug_assert_eq!(
+        {
+            true;
+        },
+        {
+            false;
+        }
+    );
 
-    assert_ne!((), ());
-    debug_assert_ne!((), ());
+    assert_ne!(
+        {
+            true;
+        },
+        {
+            false;
+        }
+    );
+    debug_assert_ne!(
+        {
+            true;
+        },
+        {
+            false;
+        }
+    );
 }

--- a/tests/ui/unit_cmp.rs
+++ b/tests/ui/unit_cmp.rs
@@ -20,4 +20,10 @@ fn main() {
     } > {
         false;
     } {}
+
+    assert_eq!((), ());
+    debug_assert_eq!((), ());
+
+    assert_ne!((), ());
+    debug_assert_ne!((), ());
 }

--- a/tests/ui/unit_cmp.stderr
+++ b/tests/ui/unit_cmp.stderr
@@ -25,32 +25,56 @@ LL | |     } {}
 error: `assert_eq` of unit values detected. This will always succeed
   --> $DIR/unit_cmp.rs:24:5
    |
-LL |     assert_eq!((), ());
-   |     ^^^^^^^^^^^^^^^^^^^
+LL | /     assert_eq!(
+LL | |         {
+LL | |             true;
+LL | |         },
+...  |
+LL | |         }
+LL | |     );
+   | |______^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: `debug_assert_eq` of unit values detected. This will always succeed
-  --> $DIR/unit_cmp.rs:25:5
+  --> $DIR/unit_cmp.rs:32:5
    |
-LL |     debug_assert_eq!((), ());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /     debug_assert_eq!(
+LL | |         {
+LL | |             true;
+LL | |         },
+...  |
+LL | |         }
+LL | |     );
+   | |______^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: `assert_ne` of unit values detected. This will always fail
-  --> $DIR/unit_cmp.rs:27:5
+  --> $DIR/unit_cmp.rs:41:5
    |
-LL |     assert_ne!((), ());
-   |     ^^^^^^^^^^^^^^^^^^^
+LL | /     assert_ne!(
+LL | |         {
+LL | |             true;
+LL | |         },
+...  |
+LL | |         }
+LL | |     );
+   | |______^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: `debug_assert_ne` of unit values detected. This will always fail
-  --> $DIR/unit_cmp.rs:28:5
+  --> $DIR/unit_cmp.rs:49:5
    |
-LL |     debug_assert_ne!((), ());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /     debug_assert_ne!(
+LL | |         {
+LL | |             true;
+LL | |         },
+...  |
+LL | |         }
+LL | |     );
+   | |______^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/tests/ui/unit_cmp.stderr
+++ b/tests/ui/unit_cmp.stderr
@@ -22,5 +22,37 @@ LL | |         false;
 LL | |     } {}
    | |_____^
 
-error: aborting due to 2 previous errors
+error: assert_eq of unit values detected. This will always succeed
+  --> $DIR/unit_cmp.rs:24:5
+   |
+LL |     assert_eq!((), ());
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: debug_assert_eq of unit values detected. This will always succeed
+  --> $DIR/unit_cmp.rs:25:5
+   |
+LL |     debug_assert_eq!((), ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: assert_ne of unit values detected. This will always fail
+  --> $DIR/unit_cmp.rs:27:5
+   |
+LL |     assert_ne!((), ());
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: debug_assert_ne of unit values detected. This will always fail
+  --> $DIR/unit_cmp.rs:28:5
+   |
+LL |     debug_assert_ne!((), ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/unit_cmp.stderr
+++ b/tests/ui/unit_cmp.stderr
@@ -22,7 +22,7 @@ LL | |         false;
 LL | |     } {}
    | |_____^
 
-error: assert_eq of unit values detected. This will always succeed
+error: `assert_eq` of unit values detected. This will always succeed
   --> $DIR/unit_cmp.rs:24:5
    |
 LL |     assert_eq!((), ());
@@ -30,7 +30,7 @@ LL |     assert_eq!((), ());
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: debug_assert_eq of unit values detected. This will always succeed
+error: `debug_assert_eq` of unit values detected. This will always succeed
   --> $DIR/unit_cmp.rs:25:5
    |
 LL |     debug_assert_eq!((), ());
@@ -38,7 +38,7 @@ LL |     debug_assert_eq!((), ());
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: assert_ne of unit values detected. This will always fail
+error: `assert_ne` of unit values detected. This will always fail
   --> $DIR/unit_cmp.rs:27:5
    |
 LL |     assert_ne!((), ());
@@ -46,7 +46,7 @@ LL |     assert_ne!((), ());
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: debug_assert_ne of unit values detected. This will always fail
+error: `debug_assert_ne` of unit values detected. This will always fail
   --> $DIR/unit_cmp.rs:28:5
    |
 LL |     debug_assert_ne!((), ());

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -34,6 +34,7 @@ fn return_unit()  {  }
 
 #[allow(clippy::needless_return)]
 #[allow(clippy::never_loop)]
+#[allow(clippy::unit_cmp)]
 fn main() {
     let u = Unitter;
     assert_eq!(u.get_unit(|| {}, return_unit), u.into());

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -35,6 +35,7 @@ fn return_unit() -> () { () }
 
 #[allow(clippy::needless_return)]
 #[allow(clippy::never_loop)]
+#[allow(clippy::unit_cmp)]
 fn main() {
     let u = Unitter;
     assert_eq!(u.get_unit(|| {}, return_unit), u.into());

--- a/tests/ui/unused_unit.stderr
+++ b/tests/ui/unused_unit.stderr
@@ -37,13 +37,13 @@ LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
 
 error: unneeded `()`
-  --> $DIR/unused_unit.rs:43:14
+  --> $DIR/unused_unit.rs:44:14
    |
 LL |         break();
    |              ^^ help: remove the `()`
 
 error: unneeded `()`
-  --> $DIR/unused_unit.rs:45:11
+  --> $DIR/unused_unit.rs:46:11
    |
 LL |     return();
    |           ^^ help: remove the `()`


### PR DESCRIPTION
changelog: Add check for unit comparisons through `assert_eq!`, `debug_assert_eq!`, `assert_ne!` and `debug_assert_ne!` macros to unit_cmp lint.

fixes #4481
