### PR TITLE
Allow casts from the result of `abs` to unsigned

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -986,6 +986,17 @@ fn check_loss_of_sign(cx: &LateContext<'_, '_>, expr: &Expr, op: &Expr, cast_fro
         }
     }
 
+    // don't lint for the result of `abs`
+    // `abs` is an inherent impl of `i{N}`, so a method call with ident `abs` will always
+    // resolve to that spesific method
+    if_chain! {
+        if let ExprKind::MethodCall(ref path, _, _) = op.kind;
+        if path.ident.name.as_str() == "abs";
+        then {
+            return
+        }
+    }
+
     span_lint(
         cx,
         CAST_SIGN_LOSS,

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -42,4 +42,9 @@ fn main() {
     i32::max_value() as u32;
     i64::max_value() as u64;
     i128::max_value() as u128;
+    (-1i8).abs() as u8;
+    (-1i16).abs() as u16;
+    (-1i32).abs() as u32;
+    (-1i64).abs() as u64;
+    (-1isize).abs() as usize;
 }


### PR DESCRIPTION
changelog: Allow casts from the result of `abs` to unsigned in `cast_sign_loss`

Fixes #4605
