### PR TITLE
Disable rustfmt running on AppVeyor for now

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
     - del rust-toolchain
     - cargo install rustup-toolchain-install-master --debug || echo "rustup-toolchain-install-master already installed"
     - rustup-toolchain-install-master %RUSTC_HASH% -f -n master
-    - rustup component add rustfmt --toolchain nightly & exit 0 # Format test handles missing rustfmt
+    # - rustup component add rustfmt --toolchain nightly & exit 0 # Format test handles missing rustfmt
     - rustup default master
     - set PATH=%PATH%;C:\Users\appveyor\.rustup\toolchains\master\bin
     - rustc -V


### PR DESCRIPTION
rustfmt doesn't seem to execute correctly right now, causing some
backlog of PRs. It's not critical that it runs on Windows, so I've
disabled it for now.

changelog: none