### PR TITLE
Use windows-sdk-10.1 to avoid installation failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
         npm install remark-cli remark-lint
       fi
       if [ "$TRAVIS_OS_NAME" == "windows" ]; then
-        choco install windows-sdk-10.0
+        choco install windows-sdk-10.1
       fi
     fi
 


### PR DESCRIPTION
This fixes installation failure on Windows on Travis but we need to fix rustfmt issue first to pass the CI completely.

changelog: none
