### PR TITLE
Workaround cargo issue on appveyor

### DIFF
--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -11,3 +11,5 @@ regex = "1"
 lazy_static = "1.0"
 shell-escape = "0.1"
 walkdir = "2"
+# FIXME: remove this once cargo issue #7475 is fixed
+home = "0.5"

--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -140,13 +140,13 @@ fn cargo_fmt(context: &FmtContext, path: &Path) -> Result<bool, CliError> {
         args.push("--");
         args.push("--check");
     }
-    let success = exec(context, "cargo", path, &args)?;
+    let success = exec(context, &bin_path("cargo"), path, &args)?;
 
     Ok(success)
 }
 
 fn rustfmt_test(context: &FmtContext) -> Result<(), CliError> {
-    let program = "rustfmt";
+    let program = bin_path("rustfmt");
     let dir = std::env::current_dir()?;
     let args = &["+nightly", "--version"];
 
@@ -173,7 +173,7 @@ fn rustfmt(context: &FmtContext, path: &Path) -> Result<bool, CliError> {
     if context.check {
         args.push("--check".as_ref());
     }
-    let success = exec(context, "rustfmt", std::env::current_dir()?, &args)?;
+    let success = exec(context, &bin_path("rustfmt"), std::env::current_dir()?, &args)?;
     if !success {
         eprintln!("rustfmt failed on {}", path.display());
     }
@@ -197,4 +197,13 @@ fn project_root() -> Result<PathBuf, CliError> {
     }
 
     Err(CliError::ProjectRootNotFound)
+}
+
+// Workaround for https://github.com/rust-lang/cargo/issues/7475.
+// FIXME: replace `&bin_path("command")` with `"command"` once the issue is fixed
+fn bin_path(bin: &str) -> String {
+    let mut p = PathBuf::from(std::env::var_os("CARGO_HOME").unwrap());
+    p.push("bin");
+    p.push(bin);
+    p.display().to_string()
 }

--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -202,7 +202,7 @@ fn project_root() -> Result<PathBuf, CliError> {
 // Workaround for https://github.com/rust-lang/cargo/issues/7475.
 // FIXME: replace `&bin_path("command")` with `"command"` once the issue is fixed
 fn bin_path(bin: &str) -> String {
-    let mut p = PathBuf::from(std::env::var_os("CARGO_HOME").unwrap());
+    let mut p = home::cargo_home().unwrap();
     p.push("bin");
     p.push(bin);
     p.display().to_string()


### PR DESCRIPTION
Use absolute paths for `cargo` and `rustfmt` to workaround https://github.com/rust-lang/cargo/issues/7475.

Appveyor passed on my fork: https://ci.appveyor.com/project/sinkuu/rust-clippy/builds/27870367

changelog: none