### PR TITLE
Add assert message to suggestion in lint assertions_on_constants

### DIFF
--- a/clippy_lints/src/assertions_on_constants.rs
+++ b/clippy_lints/src/assertions_on_constants.rs
@@ -1,9 +1,11 @@
-use rustc::hir::{Expr, ExprKind};
+use crate::consts::{constant, Constant};
+use crate::utils::{is_direct_expn_of, is_expn_of, match_qpath, span_help_and_lint};
+use if_chain::if_chain;
+use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
-
-use crate::consts::{constant, Constant};
-use crate::utils::{is_direct_expn_of, is_expn_of, span_help_and_lint};
+use syntax::ast::LitKind;
+use syntax::source_map::symbol::LocalInternedString;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for `assert!(true)` and `assert!(false)` calls.
@@ -63,7 +65,93 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssertionsOnConstants {
             if assert_span.from_expansion() {
                 return;
             }
-            lint_assert_cb(false);
+            if let Some((panic_message, is_true)) = assert_with_message(&cx, e) {
+                if is_true {
+                    span_help_and_lint(
+                        cx,
+                        ASSERTIONS_ON_CONSTANTS,
+                        e.span,
+                        "`assert!(true)` will be optimized out by the compiler",
+                        "remove it",
+                    );
+                } else if panic_message.starts_with("assertion failed: ") {
+                    span_help_and_lint(
+                        cx,
+                        ASSERTIONS_ON_CONSTANTS,
+                        e.span,
+                        "`assert!(false)` should probably be replaced",
+                        "use `panic!()` or `unreachable!()`",
+                    );
+                } else {
+                    span_help_and_lint(
+                        cx,
+                        ASSERTIONS_ON_CONSTANTS,
+                        e.span,
+                        &format!("`assert!(false, \"{}\")` should probably be replaced", panic_message,),
+                        &format!(
+                            "use `panic!(\"{}\")` or `unreachable!(\"{}\")`",
+                            panic_message, panic_message,
+                        ),
+                    );
+                }
+            }
         }
     }
+}
+
+// fn get_assert_args(snip: String) -> Option<Vec<String>> {
+//
+// }
+
+fn assert_with_message<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Option<(LocalInternedString, bool)> {
+    if_chain! {
+        if let ExprKind::Match(ref expr, ref arms, MatchSource::IfDesugar { contains_else_clause: false }) = expr.kind;
+        // match expr
+        if let ExprKind::DropTemps(ref expr) = expr.kind;
+        if let ExprKind::Unary(UnOp::UnNot, ref expr) = expr.kind;
+        //if let ExprKind::Lit(ref lit) = expr.kind;
+        if let Some((Constant::Bool(is_true), _)) = constant(cx, cx.tables, expr);
+        //if is_true;
+        // match arms
+        // arm 1 pattern
+        if let PatKind::Lit(ref lit_expr) = arms[0].pat.kind;
+        if let ExprKind::Lit(ref lit) = lit_expr.kind;
+        if let LitKind::Bool(true) = lit.node;
+        //if let LitKind::Bool(true) = lit1.node;
+        // arm 1 block
+        if let ExprKind::Block(ref block1, _) = arms[0].body.kind;
+        if let Some(trailing_expr1) = &block1.expr;
+        if block1.stmts.len() == 0;
+        //
+        if let ExprKind::Block(ref actual_block1, _) = trailing_expr1.kind;
+        if let Some(block1_expr) = &actual_block1.expr;
+        // function call
+        if let ExprKind::Call(ref func, ref args) = block1_expr.kind;
+        if let ExprKind::Path(ref path) = func.kind;
+        // ["{{root}}", "std", "rt", "begin_panic"] does not work
+        if match_qpath(path, &["$crate", "rt", "begin_panic"]);
+        // arguments
+        if args.len() == 2;
+        if let ExprKind::Lit(ref lit) = args[0].kind;
+        if let LitKind::Str(ref s, _) = lit.node;
+        let panic_message = s.as_str(); // bind the panic message
+        if let ExprKind::AddrOf(MutImmutable, ref inner) = args[1].kind;
+        if let ExprKind::Tup(ref elements) = inner.kind;
+        if elements.len() == 3;
+        if let ExprKind::Lit(ref lit1) = elements[0].kind;
+        if let LitKind::Str(ref s1, _) = lit1.node;
+        if let ExprKind::Lit(ref lit2) = elements[1].kind;
+        if let LitKind::Int(_, _) = lit2.node;
+        if let ExprKind::Lit(ref lit3) = elements[2].kind;
+        if let LitKind::Int(_, _) = lit3.node;
+        // arm 2 block
+        if let PatKind::Wild = arms[1].pat.kind;
+        if let ExprKind::Block(ref block2, _) = arms[1].body.kind;
+        if let None = &block2.expr;
+        if block2.stmts.len() == 0;
+        then {
+            return Some((panic_message, is_true));
+        }
+    }
+    return None;
 }

--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -11,6 +11,9 @@ fn main() {
     assert!(true, "true message");
     assert!(false, "false message");
 
+    let msg = "panic message";
+    assert!(false, msg.to_uppercase());
+
     const B: bool = true;
     assert!(B);
 

--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -16,6 +16,7 @@ fn main() {
 
     const C: bool = false;
     assert!(C);
+    assert!(C, "C message");
 
     debug_assert!(true);
     // Don't lint this, since there is no better way for expressing "Only panic in debug mode".

--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -31,8 +31,16 @@ LL |     assert!(false, "false message");
    |
    = help: use `panic!("false message")` or `unreachable!("false message")`
 
-error: `assert!(true)` will be optimized out by the compiler
+error: `assert!(false, msg.to_uppercase())` should probably be replaced
   --> $DIR/assertions_on_constants.rs:15:5
+   |
+LL |     assert!(false, msg.to_uppercase());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `panic!(msg.to_uppercase())` or `unreachable!(msg.to_uppercase())`
+
+error: `assert!(true)` will be optimized out by the compiler
+  --> $DIR/assertions_on_constants.rs:18:5
    |
 LL |     assert!(B);
    |     ^^^^^^^^^^^
@@ -40,7 +48,7 @@ LL |     assert!(B);
    = help: remove it
 
 error: `assert!(false)` should probably be replaced
-  --> $DIR/assertions_on_constants.rs:18:5
+  --> $DIR/assertions_on_constants.rs:21:5
    |
 LL |     assert!(C);
    |     ^^^^^^^^^^^
@@ -48,7 +56,7 @@ LL |     assert!(C);
    = help: use `panic!()` or `unreachable!()`
 
 error: `assert!(false, "C message")` should probably be replaced
-  --> $DIR/assertions_on_constants.rs:19:5
+  --> $DIR/assertions_on_constants.rs:22:5
    |
 LL |     assert!(C, "C message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +64,7 @@ LL |     assert!(C, "C message");
    = help: use `panic!("C message")` or `unreachable!("C message")`
 
 error: `assert!(true)` will be optimized out by the compiler
-  --> $DIR/assertions_on_constants.rs:21:5
+  --> $DIR/assertions_on_constants.rs:24:5
    |
 LL |     debug_assert!(true);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -64,5 +72,5 @@ LL |     debug_assert!(true);
    = help: remove it
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -23,13 +23,13 @@ LL |     assert!(true, "true message");
    |
    = help: remove it
 
-error: `assert!(false)` should probably be replaced
+error: `assert!(false, "false message")` should probably be replaced
   --> $DIR/assertions_on_constants.rs:12:5
    |
 LL |     assert!(false, "false message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use `panic!()` or `unreachable!()`
+   = help: use `panic!("false message")` or `unreachable!("false message")`
 
 error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:15:5
@@ -47,8 +47,16 @@ LL |     assert!(C);
    |
    = help: use `panic!()` or `unreachable!()`
 
+error: `assert!(false, "C message")` should probably be replaced
+  --> $DIR/assertions_on_constants.rs:19:5
+   |
+LL |     assert!(C, "C message");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `panic!("C message")` or `unreachable!("C message")`
+
 error: `assert!(true)` will be optimized out by the compiler
-  --> $DIR/assertions_on_constants.rs:20:5
+  --> $DIR/assertions_on_constants.rs:21:5
    |
 LL |     debug_assert!(true);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -56,5 +64,5 @@ LL |     debug_assert!(true);
    = help: remove it
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
<!--
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only updates to the latest nightly, you can leave the
`changelog` entry as `none`. Otherwise, please write a short comment
explaining your change.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [ ] `cargo test` passes locally
- [x] Executed `./util/dev update_lints`
- [ ] Added lint documentation
- [ ] Run `./util/dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR -->

- [x] suggest replacing `assert!(false, "msg")` with `panic!("msg")`
- [x] extend to allow ~~variables~~ any expression for `"msg"`
- ~~suggest replacing `assert!(false, "msg {}", "arg")` with `panic!("msg {}", "arg")`~~

changelog: add assert message to suggestion in lint assertions_on_constants

Work towards fixing: #3575 
