### PR TITLE
Revert "Workaround cargo bug on Windows"

### DIFF
--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -11,5 +11,3 @@ regex = "1"
 lazy_static = "1.0"
 shell-escape = "0.1"
 walkdir = "2"
-# FIXME: remove this once cargo issue #7475 is fixed
-home = "0.5"

--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -137,13 +137,13 @@ fn cargo_fmt(context: &FmtContext, path: &Path) -> Result<bool, CliError> {
         args.push("--");
         args.push("--check");
     }
-    let success = exec(context, &bin_path("cargo"), path, &args)?;
+    let success = exec(context, "cargo", path, &args)?;
 
     Ok(success)
 }
 
 fn rustfmt_test(context: &FmtContext) -> Result<(), CliError> {
-    let program = bin_path("rustfmt");
+    let program = "rustfmt";
     let dir = std::env::current_dir()?;
     let args = &["+nightly", "--version"];
 
@@ -170,7 +170,7 @@ fn rustfmt(context: &FmtContext, path: &Path) -> Result<bool, CliError> {
     if context.check {
         args.push("--check".as_ref());
     }
-    let success = exec(context, &bin_path("rustfmt"), std::env::current_dir()?, &args)?;
+    let success = exec(context, "rustfmt", std::env::current_dir()?, &args)?;
     if !success {
         eprintln!("rustfmt failed on {}", path.display());
     }
@@ -194,13 +194,4 @@ fn project_root() -> Result<PathBuf, CliError> {
     }
 
     Err(CliError::ProjectRootNotFound)
-}
-
-// Workaround for https://github.com/rust-lang/cargo/issues/7475.
-// FIXME: replace `&bin_path("command")` with `"command"` once the issue is fixed
-fn bin_path(bin: &str) -> String {
-    let mut p = home::cargo_home().unwrap();
-    p.push("bin");
-    p.push(bin);
-    p.display().to_string()
 }


### PR DESCRIPTION
[Cargo is fixed on rust master](https://github.com/rust-lang/rust/pull/65186). This reverts PR #4624.

Fixes #4638

changelog: none