### PR TITLE
PR template might not be stripped by contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!--
 Thank you for making Clippy better!
 
 We're collecting our changelog from pull request descriptions.
@@ -25,6 +24,8 @@ checked during review or continuous integration.
 Note that you can skip the above if you are just opening a WIP PR in
 order to get feedback.
 
-Delete this line and everything above before opening your PR -->
+Delete this line and everything above before opening your PR.
+
+---
 
 changelog: none


### PR DESCRIPTION
cc d97fbdbb42c28ec9e051b23138d7898bae6836c4

So I think it would be better to make the template visible. 
Also I renamed the template with extension `.md`.

changelog: none
