### PR TITLE
Update clippy for latest rustc changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ You can use [rustup-toolchain-install-master][rtim] to do that:
 
 ```bash
 cargo install rustup-toolchain-install-master
-rustup-toolchain-install-master --force -n master
+rustup-toolchain-install-master --force -n master -c rustc-dev
 rustup override set master
 cargo test
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
     - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
     - del rust-toolchain
     - cargo install -Z install-upgrade rustup-toolchain-install-master
-    - rustup-toolchain-install-master -f -n master
+    - rustup-toolchain-install-master -f -n master -c rustc-dev
     - rustup component add rustfmt --toolchain nightly & exit 0 # Format test handles missing rustfmt
     - rustup default master
     - set PATH=%PATH%;C:\Users\appveyor\.rustup\toolchains\master\bin

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -82,7 +82,7 @@ pub fn gen_lint_group_list(lints: Vec<Lint>) -> Vec<String> {
             if l.is_internal() || l.deprecation.is_some() {
                 None
             } else {
-                Some(format!("        {}::{},", l.module, l.name.to_uppercase()))
+                Some(format!("        LintId::of(&{}::{}),", l.module, l.name.to_uppercase()))
             }
         })
         .sorted()
@@ -141,6 +141,20 @@ pub fn gen_deprecated(lints: &[Lint]) -> Vec<String> {
         })
         .flatten()
         .collect::<Vec<String>>()
+}
+
+pub fn gen_register_lint_list(lints: &[Lint]) -> Vec<String> {
+    let pre = "    store.register_lints(&[".to_string();
+    let post = "    ]);".to_string();
+    let mut inner = lints
+        .iter()
+        .filter(|l| !(l.is_internal() || l.deprecation.is_some()))
+        .map(|l| format!("        &{}::{},", l.module, l.name.to_uppercase()))
+        .sorted()
+        .collect::<Vec<String>>();
+    inner.insert(0, pre);
+    inner.push(post);
+    inner
 }
 
 /// Gathers all files in `src/clippy_lints` and gathers all lints inside
@@ -487,8 +501,8 @@ fn test_gen_lint_group_list() {
         Lint::new("incorrect_internal", "internal_style", "abc", None, "module_name"),
     ];
     let expected = vec![
-        "        module_name::ABC,".to_string(),
-        "        module_name::SHOULD_ASSERT_EQ,".to_string(),
+        "        LintId::of(&module_name::ABC),".to_string(),
+        "        LintId::of(&module_name::SHOULD_ASSERT_EQ),".to_string(),
     ];
     assert_eq!(expected, gen_lint_group_list(lints));
 }

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -143,13 +143,19 @@ pub fn gen_deprecated(lints: &[Lint]) -> Vec<String> {
         .collect::<Vec<String>>()
 }
 
+#[must_use]
 pub fn gen_register_lint_list(lints: &[Lint]) -> Vec<String> {
     let pre = "    store.register_lints(&[".to_string();
     let post = "    ]);".to_string();
     let mut inner = lints
         .iter()
-        .filter(|l| !(l.is_internal() || l.deprecation.is_some()))
-        .map(|l| format!("        &{}::{},", l.module, l.name.to_uppercase()))
+        .filter_map(|l| {
+            if !l.is_internal() && l.deprecation.is_none() {
+                Some(format!("        &{}::{},", l.module, l.name.to_uppercase()))
+            } else {
+                None
+            }
+        })
         .sorted()
         .collect::<Vec<String>>();
     inner.insert(0, pre);

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
     match matches.subcommand() {
         ("fmt", Some(matches)) => {
             fmt::run(matches.is_present("check"), matches.is_present("verbose"));
-        },
+        }
         ("update_lints", Some(matches)) => {
             if matches.is_present("print-only") {
                 print_lints();
@@ -76,8 +76,8 @@ fn main() {
             } else {
                 update_lints(&UpdateMode::Change);
             }
-        },
-        _ => {},
+        }
+        _ => {}
     }
 }
 
@@ -172,6 +172,16 @@ fn update_lints(update_mode: &UpdateMode) {
 
     file_change |= replace_region_in_file(
         "../clippy_lints/src/lib.rs",
+        "begin register lints",
+        "end register lints",
+        false,
+        update_mode == &UpdateMode::Change,
+        || gen_register_lint_list(&lint_list),
+    )
+    .changed;
+
+    file_change |= replace_region_in_file(
+        "../clippy_lints/src/lib.rs",
         "begin lints modules",
         "end lints modules",
         false,
@@ -183,7 +193,7 @@ fn update_lints(update_mode: &UpdateMode) {
     // Generate lists of lints in the clippy::all lint group
     file_change |= replace_region_in_file(
         "../clippy_lints/src/lib.rs",
-        r#"reg.register_lint_group\("clippy::all""#,
+        r#"store.register_group\(true, "clippy::all""#,
         r#"\]\);"#,
         false,
         update_mode == &UpdateMode::Change,
@@ -206,7 +216,7 @@ fn update_lints(update_mode: &UpdateMode) {
     for (lint_group, lints) in Lint::by_lint_group(&usable_lints) {
         file_change |= replace_region_in_file(
             "../clippy_lints/src/lib.rs",
-            &format!("reg.register_lint_group\\(\"clippy::{}\"", lint_group),
+            &format!("store.register_group\\(true, \"clippy::{}\"", lint_group),
             r#"\]\);"#,
             false,
             update_mode == &UpdateMode::Change,

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -109,6 +109,7 @@ fn print_lints() {
     println!("there are {} lints", lint_count);
 }
 
+#[allow(clippy::too_many_lines)]
 fn update_lints(update_mode: &UpdateMode) {
     let lint_list: Vec<Lint> = gather_all().collect();
 

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
     match matches.subcommand() {
         ("fmt", Some(matches)) => {
             fmt::run(matches.is_present("check"), matches.is_present("verbose"));
-        }
+        },
         ("update_lints", Some(matches)) => {
             if matches.is_present("print-only") {
                 print_lints();
@@ -76,8 +76,8 @@ fn main() {
             } else {
                 update_lints(&UpdateMode::Change);
             }
-        }
-        _ => {}
+        },
+        _ => {},
     }
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -914,7 +914,6 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_late_pass(|| box trait_bounds::TraitBounds);
     store.register_late_pass(|| box comparison_chain::ComparisonChain);
     store.register_late_pass(|| box mul_add::MulAddCheck);
-
     store.register_early_pass(|| box reference::DerefAddrOf);
     store.register_early_pass(|| box reference::RefInDeref);
     store.register_early_pass(|| box double_parens::DoubleParens);
@@ -939,6 +938,8 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_early_pass(|| box utils::internal_lints::ClippyLintsInternal);
     let p = conf.enum_variant_name_threshold;
     store.register_early_pass(move || box enum_variants::EnumVariantNames::new(p));
+    store.register_late_pass(|| box unused_self::UnusedSelf);
+    store.register_late_pass(|| box mutable_debug_assertion::DebugAssertWithMutCall);
 
     store.register_group(true, "clippy::restriction", Some("clippy_restriction"), vec![
         LintId::of(&arithmetic::FLOAT_ARITHMETIC),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -309,9 +309,9 @@ mod reexport {
 pub fn register_pre_expansion_lints(store: &mut rustc::lint::LintStore, conf: &Conf) {
     store.register_pre_expansion_pass(|| box write::Write);
     store.register_pre_expansion_pass(|| box redundant_field_names::RedundantFieldNames);
-    let p = conf.single_char_binding_names_threshold;
+    let single_char_binding_names_threshold = conf.single_char_binding_names_threshold;
     store.register_pre_expansion_pass(move || box non_expressive_names::NonExpressiveNames {
-        single_char_binding_names_threshold: p,
+        single_char_binding_names_threshold,
     });
     store.register_pre_expansion_pass(|| box attrs::DeprecatedCfgAttribute);
     store.register_pre_expansion_pass(|| box dbg_macro::DbgMacro);
@@ -783,8 +783,8 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_late_pass(|| box enum_glob_use::EnumGlobUse);
     store.register_late_pass(|| box enum_clike::UnportableVariant);
     store.register_late_pass(|| box excessive_precision::ExcessivePrecision);
-    let p = conf.verbose_bit_mask_threshold;
-    store.register_late_pass(move || box bit_mask::BitMask::new(p));
+    let verbose_bit_mask_threshold = conf.verbose_bit_mask_threshold;
+    store.register_late_pass(move || box bit_mask::BitMask::new(verbose_bit_mask_threshold));
     store.register_late_pass(|| box ptr::Ptr);
     store.register_late_pass(|| box needless_bool::NeedlessBool);
     store.register_late_pass(|| box needless_bool::BoolComparison);
@@ -812,8 +812,8 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_late_pass(|| box entry::HashMapPass);
     store.register_late_pass(|| box ranges::Ranges);
     store.register_late_pass(|| box types::Casts);
-    let p = conf.type_complexity_threshold;
-    store.register_late_pass(move || box types::TypeComplexity::new(p));
+    let type_complexity_threshold = conf.type_complexity_threshold;
+    store.register_late_pass(move || box types::TypeComplexity::new(type_complexity_threshold));
     store.register_late_pass(|| box matches::Matches);
     store.register_late_pass(|| box minmax::MinMaxPass);
     store.register_late_pass(|| box open_options::OpenOptions);
@@ -825,10 +825,10 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_late_pass(|| box no_effect::NoEffect);
     store.register_late_pass(|| box temporary_assignment::TemporaryAssignment);
     store.register_late_pass(|| box transmute::Transmute);
-    let p = conf.cognitive_complexity_threshold;
-    store.register_late_pass(move || box cognitive_complexity::CognitiveComplexity::new(p));
-    let a = conf.too_large_for_stack;
-    store.register_late_pass(move || box escape::BoxedLocal{too_large_for_stack: a});
+    let cognitive_complexity_threshold = conf.cognitive_complexity_threshold;
+    store.register_late_pass(move || box cognitive_complexity::CognitiveComplexity::new(cognitive_complexity_threshold));
+    let too_large_for_stack = conf.too_large_for_stack;
+    store.register_late_pass(move || box escape::BoxedLocal{too_large_for_stack});
     store.register_late_pass(|| box panic_unimplemented::PanicUnimplemented);
     store.register_late_pass(|| box strings::StringLitAsBytes);
     store.register_late_pass(|| box derive::Derive);
@@ -848,13 +848,13 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_late_pass(|| box overflow_check_conditional::OverflowCheckConditional);
     store.register_late_pass(|| box unused_label::UnusedLabel);
     store.register_late_pass(|| box new_without_default::NewWithoutDefault::default());
-    let p = conf.blacklisted_names.iter().cloned().collect::<FxHashSet<_>>();
-    store.register_late_pass(move || box blacklisted_name::BlacklistedName::new(p.clone()));
-    let a1 = conf.too_many_arguments_threshold;
-    let a2 = conf.too_many_lines_threshold;
-    store.register_late_pass(move || box functions::Functions::new(a1, a2));
-    let p = conf.doc_valid_idents.iter().cloned().collect::<FxHashSet<_>>();
-    store.register_late_pass(move || box doc::DocMarkdown::new(p.clone()));
+    let blacklisted_names = conf.blacklisted_names.iter().cloned().collect::<FxHashSet<_>>();
+    store.register_late_pass(move || box blacklisted_name::BlacklistedName::new(blacklisted_names.clone()));
+    let too_many_arguments_threshold1 = conf.too_many_arguments_threshold;
+    let too_many_lines_threshold2 = conf.too_many_lines_threshold;
+    store.register_late_pass(move || box functions::Functions::new(too_many_arguments_threshold1, too_many_lines_threshold2));
+    let doc_valid_idents = conf.doc_valid_idents.iter().cloned().collect::<FxHashSet<_>>();
+    store.register_late_pass(move || box doc::DocMarkdown::new(doc_valid_idents.clone()));
     store.register_late_pass(|| box neg_multiply::NegMultiply);
     store.register_late_pass(|| box mem_discriminant::MemDiscriminant);
     store.register_late_pass(|| box mem_forget::MemForget);
@@ -869,15 +869,15 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_late_pass(|| box redundant_pattern_matching::RedundantPatternMatching);
     store.register_late_pass(|| box partialeq_ne_impl::PartialEqNeImpl);
     store.register_late_pass(|| box unused_io_amount::UnusedIoAmount);
-    let p = conf.enum_variant_size_threshold;
-    store.register_late_pass(move || box large_enum_variant::LargeEnumVariant::new(p));
+    let enum_variant_size_threshold = conf.enum_variant_size_threshold;
+    store.register_late_pass(move || box large_enum_variant::LargeEnumVariant::new(enum_variant_size_threshold));
     store.register_late_pass(|| box explicit_write::ExplicitWrite);
     store.register_late_pass(|| box needless_pass_by_value::NeedlessPassByValue);
-    let p = trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
+    let trivially_copy_pass_by_ref = trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
         conf.trivial_copy_size_limit,
         &sess.target,
     );
-    store.register_late_pass(move || box p);
+    store.register_late_pass(move || box trivially_copy_pass_by_ref);
     store.register_late_pass(|| box try_err::TryErr);
     store.register_late_pass(|| box use_self::UseSelf);
     store.register_late_pass(|| box bytecount::ByteCount);
@@ -933,11 +933,11 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
     store.register_early_pass(|| box multiple_crate_versions::MultipleCrateVersions);
     store.register_early_pass(|| box wildcard_dependencies::WildcardDependencies);
     store.register_early_pass(|| box literal_representation::LiteralDigitGrouping);
-    let p = conf.literal_representation_threshold;
-    store.register_early_pass(move || box literal_representation::DecimalLiteralRepresentation::new(p));
+    let literal_representation_threshold = conf.literal_representation_threshold;
+    store.register_early_pass(move || box literal_representation::DecimalLiteralRepresentation::new(literal_representation_threshold));
     store.register_early_pass(|| box utils::internal_lints::ClippyLintsInternal);
-    let p = conf.enum_variant_name_threshold;
-    store.register_early_pass(move || box enum_variants::EnumVariantNames::new(p));
+    let enum_variant_name_threshold = conf.enum_variant_name_threshold;
+    store.register_early_pass(move || box enum_variants::EnumVariantNames::new(enum_variant_name_threshold));
     store.register_late_pass(|| box unused_self::UnusedSelf);
     store.register_late_pass(|| box mutable_debug_assertion::DebugAssertWithMutCall);
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -332,7 +332,7 @@ pub fn read_conf(args: &[syntax::ast::NestedMetaItem], sess: &Session) -> Conf {
                         sess.struct_err(&format!("error finding Clippy's configuration file: {}", error))
                             .emit();
                         None
-                    }
+                    },
                 }
             };
 
@@ -361,13 +361,13 @@ pub fn read_conf(args: &[syntax::ast::NestedMetaItem], sess: &Session) -> Conf {
             }
 
             conf
-        }
+        },
         Err((err, span)) => {
             sess.struct_span_err(span, err)
                 .span_note(span, "Clippy will use default configuration")
                 .emit();
             toml::from_str("").expect("we never error on empty config files")
-        }
+        },
     }
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -41,6 +41,9 @@ extern crate syntax_expand;
 #[allow(unused_extern_crates)]
 extern crate syntax_pos;
 
+use rustc::lint::{self, LintId};
+use rustc::session::Session;
+use rustc_data_structures::fx::FxHashSet;
 use toml;
 
 /// Macro used to declare a Clippy lint.
@@ -303,33 +306,20 @@ mod reexport {
 /// level (i.e `#![cfg_attr(...)]`) will still be expanded even when using a pre-expansion pass.
 ///
 /// Used in `./src/driver.rs`.
-pub fn register_pre_expansion_lints(
-    session: &rustc::session::Session,
-    store: &mut rustc::lint::LintStore,
-    conf: &Conf,
-) {
-    store.register_pre_expansion_pass(Some(session), true, false, box write::Write);
-    store.register_pre_expansion_pass(
-        Some(session),
-        true,
-        false,
-        box redundant_field_names::RedundantFieldNames,
-    );
-    store.register_pre_expansion_pass(
-        Some(session),
-        true,
-        false,
-        box non_expressive_names::NonExpressiveNames {
-            single_char_binding_names_threshold: conf.single_char_binding_names_threshold,
-        },
-    );
-    store.register_pre_expansion_pass(Some(session), true, false, box attrs::DeprecatedCfgAttribute);
-    store.register_pre_expansion_pass(Some(session), true, false, box dbg_macro::DbgMacro);
+pub fn register_pre_expansion_lints(store: &mut rustc::lint::LintStore, conf: &Conf) {
+    store.register_pre_expansion_pass(|| box write::Write);
+    store.register_pre_expansion_pass(|| box redundant_field_names::RedundantFieldNames);
+    let p = conf.single_char_binding_names_threshold;
+    store.register_pre_expansion_pass(move || box non_expressive_names::NonExpressiveNames {
+        single_char_binding_names_threshold: p,
+    });
+    store.register_pre_expansion_pass(|| box attrs::DeprecatedCfgAttribute);
+    store.register_pre_expansion_pass(|| box dbg_macro::DbgMacro);
 }
 
 #[doc(hidden)]
-pub fn read_conf(reg: &rustc_driver::plugin::Registry<'_>) -> Conf {
-    match utils::conf::file_from_args(reg.args()) {
+pub fn read_conf(args: &[syntax::ast::NestedMetaItem], sess: &Session) -> Conf {
+    match utils::conf::file_from_args(args) {
         Ok(file_name) => {
             // if the user specified a file, it must exist, otherwise default to `clippy.toml` but
             // do not require the file to exist
@@ -339,18 +329,16 @@ pub fn read_conf(reg: &rustc_driver::plugin::Registry<'_>) -> Conf {
                 match utils::conf::lookup_conf_file() {
                     Ok(path) => path,
                     Err(error) => {
-                        reg.sess
-                            .struct_err(&format!("error finding Clippy's configuration file: {}", error))
+                        sess.struct_err(&format!("error finding Clippy's configuration file: {}", error))
                             .emit();
                         None
-                    },
+                    }
                 }
             };
 
             let file_name = file_name.map(|file_name| {
                 if file_name.is_relative() {
-                    reg.sess
-                        .local_crate_source_file
+                    sess.local_crate_source_file
                         .as_ref()
                         .and_then(|file| std::path::Path::new(&file).parent().map(std::path::Path::to_path_buf))
                         .unwrap_or_default()
@@ -364,24 +352,22 @@ pub fn read_conf(reg: &rustc_driver::plugin::Registry<'_>) -> Conf {
 
             // all conf errors are non-fatal, we just use the default conf in case of error
             for error in errors {
-                reg.sess
-                    .struct_err(&format!(
-                        "error reading Clippy's configuration file `{}`: {}",
-                        file_name.as_ref().and_then(|p| p.to_str()).unwrap_or(""),
-                        error
-                    ))
-                    .emit();
+                sess.struct_err(&format!(
+                    "error reading Clippy's configuration file `{}`: {}",
+                    file_name.as_ref().and_then(|p| p.to_str()).unwrap_or(""),
+                    error
+                ))
+                .emit();
             }
 
             conf
-        },
+        }
         Err((err, span)) => {
-            reg.sess
-                .struct_span_err(span, err)
+            sess.struct_span_err(span, err)
                 .span_note(span, "Clippy will use default configuration")
                 .emit();
             toml::from_str("").expect("we never error on empty config files")
-        },
+        }
     }
 }
 
@@ -390,9 +376,8 @@ pub fn read_conf(reg: &rustc_driver::plugin::Registry<'_>) -> Conf {
 /// Used in `./src/driver.rs`.
 #[allow(clippy::too_many_lines)]
 #[rustfmt::skip]
-pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Conf) {
-    let mut store = reg.sess.lint_store.borrow_mut();
-    register_removed_non_tool_lints(&mut store);
+pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf) {
+    register_removed_non_tool_lints(store);
 
     // begin deprecated lints, do not remove this comment, it’s used in `update_lints`
     store.register_removed(
@@ -449,778 +434,1120 @@ pub fn register_plugins(reg: &mut rustc_driver::plugin::Registry<'_>, conf: &Con
     );
     // end deprecated lints, do not remove this comment, it’s used in `update_lints`
 
-    reg.register_late_lint_pass(box serde_api::SerdeAPI);
-    reg.register_early_lint_pass(box utils::internal_lints::ClippyLintsInternal);
-    reg.register_late_lint_pass(box utils::internal_lints::CompilerLintFunctions::new());
-    reg.register_late_lint_pass(box utils::internal_lints::LintWithoutLintPass::default());
-    reg.register_late_lint_pass(box utils::internal_lints::OuterExpnDataPass);
-    reg.register_late_lint_pass(box utils::inspector::DeepCodeInspector);
-    reg.register_late_lint_pass(box utils::author::Author);
-    reg.register_late_lint_pass(box types::Types);
-    reg.register_late_lint_pass(box booleans::NonminimalBool);
-    reg.register_late_lint_pass(box eq_op::EqOp);
-    reg.register_early_lint_pass(box enum_variants::EnumVariantNames::new(conf.enum_variant_name_threshold));
-    reg.register_late_lint_pass(box enum_glob_use::EnumGlobUse);
-    reg.register_late_lint_pass(box enum_clike::UnportableVariant);
-    reg.register_late_lint_pass(box excessive_precision::ExcessivePrecision);
-    reg.register_late_lint_pass(box bit_mask::BitMask::new(conf.verbose_bit_mask_threshold));
-    reg.register_late_lint_pass(box ptr::Ptr);
-    reg.register_late_lint_pass(box needless_bool::NeedlessBool);
-    reg.register_late_lint_pass(box needless_bool::BoolComparison);
-    reg.register_late_lint_pass(box approx_const::ApproxConstant);
-    reg.register_late_lint_pass(box misc::MiscLints);
-    reg.register_early_lint_pass(box precedence::Precedence);
-    reg.register_early_lint_pass(box needless_continue::NeedlessContinue);
-    reg.register_late_lint_pass(box eta_reduction::EtaReduction);
-    reg.register_late_lint_pass(box identity_op::IdentityOp);
-    reg.register_late_lint_pass(box erasing_op::ErasingOp);
-    reg.register_early_lint_pass(box items_after_statements::ItemsAfterStatements);
-    reg.register_late_lint_pass(box mut_mut::MutMut);
-    reg.register_late_lint_pass(box mut_reference::UnnecessaryMutPassed);
-    reg.register_late_lint_pass(box len_zero::LenZero);
-    reg.register_late_lint_pass(box attrs::Attributes);
-    reg.register_early_lint_pass(box collapsible_if::CollapsibleIf);
-    reg.register_late_lint_pass(box block_in_if_condition::BlockInIfCondition);
-    reg.register_late_lint_pass(box unicode::Unicode);
-    reg.register_late_lint_pass(box strings::StringAdd);
-    reg.register_early_lint_pass(box returns::Return);
-    reg.register_late_lint_pass(box implicit_return::ImplicitReturn);
-    reg.register_late_lint_pass(box methods::Methods);
-    reg.register_late_lint_pass(box map_clone::MapClone);
-    reg.register_late_lint_pass(box shadow::Shadow);
-    reg.register_late_lint_pass(box types::LetUnitValue);
-    reg.register_late_lint_pass(box types::UnitCmp);
-    reg.register_late_lint_pass(box loops::Loops);
-    reg.register_late_lint_pass(box main_recursion::MainRecursion::default());
-    reg.register_late_lint_pass(box lifetimes::Lifetimes);
-    reg.register_late_lint_pass(box entry::HashMapPass);
-    reg.register_late_lint_pass(box ranges::Ranges);
-    reg.register_late_lint_pass(box types::Casts);
-    reg.register_late_lint_pass(box types::TypeComplexity::new(conf.type_complexity_threshold));
-    reg.register_late_lint_pass(box matches::Matches);
-    reg.register_late_lint_pass(box minmax::MinMaxPass);
-    reg.register_late_lint_pass(box open_options::OpenOptions);
-    reg.register_late_lint_pass(box zero_div_zero::ZeroDiv);
-    reg.register_late_lint_pass(box mutex_atomic::Mutex);
-    reg.register_late_lint_pass(box needless_update::NeedlessUpdate);
-    reg.register_late_lint_pass(box needless_borrow::NeedlessBorrow::default());
-    reg.register_late_lint_pass(box needless_borrowed_ref::NeedlessBorrowedRef);
-    reg.register_late_lint_pass(box no_effect::NoEffect);
-    reg.register_late_lint_pass(box temporary_assignment::TemporaryAssignment);
-    reg.register_late_lint_pass(box transmute::Transmute);
-    reg.register_late_lint_pass(
-        box cognitive_complexity::CognitiveComplexity::new(conf.cognitive_complexity_threshold)
+    // begin register lints, do not remove this comment, it’s used in `update_lints`
+    store.register_lints(&[
+        &approx_const::APPROX_CONSTANT,
+        &arithmetic::FLOAT_ARITHMETIC,
+        &arithmetic::INTEGER_ARITHMETIC,
+        &assertions_on_constants::ASSERTIONS_ON_CONSTANTS,
+        &assign_ops::ASSIGN_OP_PATTERN,
+        &assign_ops::MISREFACTORED_ASSIGN_OP,
+        &attrs::DEPRECATED_CFG_ATTR,
+        &attrs::DEPRECATED_SEMVER,
+        &attrs::EMPTY_LINE_AFTER_OUTER_ATTR,
+        &attrs::INLINE_ALWAYS,
+        &attrs::UNKNOWN_CLIPPY_LINTS,
+        &attrs::USELESS_ATTRIBUTE,
+        &bit_mask::BAD_BIT_MASK,
+        &bit_mask::INEFFECTIVE_BIT_MASK,
+        &bit_mask::VERBOSE_BIT_MASK,
+        &blacklisted_name::BLACKLISTED_NAME,
+        &block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR,
+        &block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT,
+        &booleans::LOGIC_BUG,
+        &booleans::NONMINIMAL_BOOL,
+        &bytecount::NAIVE_BYTECOUNT,
+        &cargo_common_metadata::CARGO_COMMON_METADATA,
+        &checked_conversions::CHECKED_CONVERSIONS,
+        &cognitive_complexity::COGNITIVE_COMPLEXITY,
+        &collapsible_if::COLLAPSIBLE_IF,
+        &comparison_chain::COMPARISON_CHAIN,
+        &copies::IFS_SAME_COND,
+        &copies::IF_SAME_THEN_ELSE,
+        &copies::MATCH_SAME_ARMS,
+        &copy_iterator::COPY_ITERATOR,
+        &dbg_macro::DBG_MACRO,
+        &default_trait_access::DEFAULT_TRAIT_ACCESS,
+        &derive::DERIVE_HASH_XOR_EQ,
+        &derive::EXPL_IMPL_CLONE_ON_COPY,
+        &doc::DOC_MARKDOWN,
+        &doc::MISSING_SAFETY_DOC,
+        &doc::NEEDLESS_DOCTEST_MAIN,
+        &double_comparison::DOUBLE_COMPARISONS,
+        &double_parens::DOUBLE_PARENS,
+        &drop_bounds::DROP_BOUNDS,
+        &drop_forget_ref::DROP_COPY,
+        &drop_forget_ref::DROP_REF,
+        &drop_forget_ref::FORGET_COPY,
+        &drop_forget_ref::FORGET_REF,
+        &duration_subsec::DURATION_SUBSEC,
+        &else_if_without_else::ELSE_IF_WITHOUT_ELSE,
+        &empty_enum::EMPTY_ENUM,
+        &entry::MAP_ENTRY,
+        &enum_clike::ENUM_CLIKE_UNPORTABLE_VARIANT,
+        &enum_glob_use::ENUM_GLOB_USE,
+        &enum_variants::ENUM_VARIANT_NAMES,
+        &enum_variants::MODULE_INCEPTION,
+        &enum_variants::MODULE_NAME_REPETITIONS,
+        &enum_variants::PUB_ENUM_VARIANT_NAMES,
+        &eq_op::EQ_OP,
+        &eq_op::OP_REF,
+        &erasing_op::ERASING_OP,
+        &escape::BOXED_LOCAL,
+        &eta_reduction::REDUNDANT_CLOSURE,
+        &eta_reduction::REDUNDANT_CLOSURE_FOR_METHOD_CALLS,
+        &eval_order_dependence::DIVERGING_SUB_EXPRESSION,
+        &eval_order_dependence::EVAL_ORDER_DEPENDENCE,
+        &excessive_precision::EXCESSIVE_PRECISION,
+        &explicit_write::EXPLICIT_WRITE,
+        &fallible_impl_from::FALLIBLE_IMPL_FROM,
+        &format::USELESS_FORMAT,
+        &formatting::POSSIBLE_MISSING_COMMA,
+        &formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING,
+        &formatting::SUSPICIOUS_ELSE_FORMATTING,
+        &formatting::SUSPICIOUS_UNARY_OP_FORMATTING,
+        &functions::DOUBLE_MUST_USE,
+        &functions::MUST_USE_CANDIDATE,
+        &functions::MUST_USE_UNIT,
+        &functions::NOT_UNSAFE_PTR_ARG_DEREF,
+        &functions::TOO_MANY_ARGUMENTS,
+        &functions::TOO_MANY_LINES,
+        &get_last_with_len::GET_LAST_WITH_LEN,
+        &identity_conversion::IDENTITY_CONVERSION,
+        &identity_op::IDENTITY_OP,
+        &if_not_else::IF_NOT_ELSE,
+        &implicit_return::IMPLICIT_RETURN,
+        &indexing_slicing::INDEXING_SLICING,
+        &indexing_slicing::OUT_OF_BOUNDS_INDEXING,
+        &infallible_destructuring_match::INFALLIBLE_DESTRUCTURING_MATCH,
+        &infinite_iter::INFINITE_ITER,
+        &infinite_iter::MAYBE_INFINITE_ITER,
+        &inherent_impl::MULTIPLE_INHERENT_IMPL,
+        &inherent_to_string::INHERENT_TO_STRING,
+        &inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY,
+        &inline_fn_without_body::INLINE_FN_WITHOUT_BODY,
+        &int_plus_one::INT_PLUS_ONE,
+        &integer_division::INTEGER_DIVISION,
+        &items_after_statements::ITEMS_AFTER_STATEMENTS,
+        &large_enum_variant::LARGE_ENUM_VARIANT,
+        &len_zero::LEN_WITHOUT_IS_EMPTY,
+        &len_zero::LEN_ZERO,
+        &let_if_seq::USELESS_LET_IF_SEQ,
+        &lifetimes::EXTRA_UNUSED_LIFETIMES,
+        &lifetimes::NEEDLESS_LIFETIMES,
+        &literal_representation::DECIMAL_LITERAL_REPRESENTATION,
+        &literal_representation::INCONSISTENT_DIGIT_GROUPING,
+        &literal_representation::LARGE_DIGIT_GROUPS,
+        &literal_representation::MISTYPED_LITERAL_SUFFIXES,
+        &literal_representation::UNREADABLE_LITERAL,
+        &loops::EMPTY_LOOP,
+        &loops::EXPLICIT_COUNTER_LOOP,
+        &loops::EXPLICIT_INTO_ITER_LOOP,
+        &loops::EXPLICIT_ITER_LOOP,
+        &loops::FOR_KV_MAP,
+        &loops::FOR_LOOP_OVER_OPTION,
+        &loops::FOR_LOOP_OVER_RESULT,
+        &loops::ITER_NEXT_LOOP,
+        &loops::MANUAL_MEMCPY,
+        &loops::MUT_RANGE_BOUND,
+        &loops::NEEDLESS_COLLECT,
+        &loops::NEEDLESS_RANGE_LOOP,
+        &loops::NEVER_LOOP,
+        &loops::REVERSE_RANGE_LOOP,
+        &loops::WHILE_IMMUTABLE_CONDITION,
+        &loops::WHILE_LET_LOOP,
+        &loops::WHILE_LET_ON_ITERATOR,
+        &main_recursion::MAIN_RECURSION,
+        &map_clone::MAP_CLONE,
+        &map_unit_fn::OPTION_MAP_UNIT_FN,
+        &map_unit_fn::RESULT_MAP_UNIT_FN,
+        &matches::MATCH_AS_REF,
+        &matches::MATCH_BOOL,
+        &matches::MATCH_OVERLAPPING_ARM,
+        &matches::MATCH_REF_PATS,
+        &matches::MATCH_WILD_ERR_ARM,
+        &matches::SINGLE_MATCH,
+        &matches::SINGLE_MATCH_ELSE,
+        &matches::WILDCARD_ENUM_MATCH_ARM,
+        &mem_discriminant::MEM_DISCRIMINANT_NON_ENUM,
+        &mem_forget::MEM_FORGET,
+        &mem_replace::MEM_REPLACE_OPTION_WITH_NONE,
+        &mem_replace::MEM_REPLACE_WITH_UNINIT,
+        &methods::CHARS_LAST_CMP,
+        &methods::CHARS_NEXT_CMP,
+        &methods::CLONE_DOUBLE_REF,
+        &methods::CLONE_ON_COPY,
+        &methods::CLONE_ON_REF_PTR,
+        &methods::EXPECT_FUN_CALL,
+        &methods::FILTER_MAP,
+        &methods::FILTER_MAP_NEXT,
+        &methods::FILTER_NEXT,
+        &methods::FIND_MAP,
+        &methods::FLAT_MAP_IDENTITY,
+        &methods::GET_UNWRAP,
+        &methods::INEFFICIENT_TO_STRING,
+        &methods::INTO_ITER_ON_ARRAY,
+        &methods::INTO_ITER_ON_REF,
+        &methods::ITER_CLONED_COLLECT,
+        &methods::ITER_NTH,
+        &methods::ITER_SKIP_NEXT,
+        &methods::MANUAL_SATURATING_ARITHMETIC,
+        &methods::MAP_FLATTEN,
+        &methods::NEW_RET_NO_SELF,
+        &methods::OK_EXPECT,
+        &methods::OPTION_AND_THEN_SOME,
+        &methods::OPTION_EXPECT_USED,
+        &methods::OPTION_MAP_OR_NONE,
+        &methods::OPTION_MAP_UNWRAP_OR,
+        &methods::OPTION_MAP_UNWRAP_OR_ELSE,
+        &methods::OPTION_UNWRAP_USED,
+        &methods::OR_FUN_CALL,
+        &methods::RESULT_EXPECT_USED,
+        &methods::RESULT_MAP_UNWRAP_OR_ELSE,
+        &methods::RESULT_UNWRAP_USED,
+        &methods::SEARCH_IS_SOME,
+        &methods::SHOULD_IMPLEMENT_TRAIT,
+        &methods::SINGLE_CHAR_PATTERN,
+        &methods::STRING_EXTEND_CHARS,
+        &methods::SUSPICIOUS_MAP,
+        &methods::TEMPORARY_CSTRING_AS_PTR,
+        &methods::UNINIT_ASSUMED_INIT,
+        &methods::UNNECESSARY_FILTER_MAP,
+        &methods::UNNECESSARY_FOLD,
+        &methods::USELESS_ASREF,
+        &methods::WRONG_PUB_SELF_CONVENTION,
+        &methods::WRONG_SELF_CONVENTION,
+        &minmax::MIN_MAX,
+        &misc::CMP_NAN,
+        &misc::CMP_OWNED,
+        &misc::FLOAT_CMP,
+        &misc::FLOAT_CMP_CONST,
+        &misc::MODULO_ONE,
+        &misc::SHORT_CIRCUIT_STATEMENT,
+        &misc::TOPLEVEL_REF_ARG,
+        &misc::USED_UNDERSCORE_BINDING,
+        &misc::ZERO_PTR,
+        &misc_early::BUILTIN_TYPE_SHADOW,
+        &misc_early::DOUBLE_NEG,
+        &misc_early::DUPLICATE_UNDERSCORE_ARGUMENT,
+        &misc_early::MIXED_CASE_HEX_LITERALS,
+        &misc_early::REDUNDANT_CLOSURE_CALL,
+        &misc_early::REDUNDANT_PATTERN,
+        &misc_early::UNNEEDED_FIELD_PATTERN,
+        &misc_early::UNNEEDED_WILDCARD_PATTERN,
+        &misc_early::UNSEPARATED_LITERAL_SUFFIX,
+        &misc_early::ZERO_PREFIXED_LITERAL,
+        &missing_const_for_fn::MISSING_CONST_FOR_FN,
+        &missing_doc::MISSING_DOCS_IN_PRIVATE_ITEMS,
+        &missing_inline::MISSING_INLINE_IN_PUBLIC_ITEMS,
+        &mul_add::MANUAL_MUL_ADD,
+        &multiple_crate_versions::MULTIPLE_CRATE_VERSIONS,
+        &mut_mut::MUT_MUT,
+        &mut_reference::UNNECESSARY_MUT_PASSED,
+        &mutable_debug_assertion::DEBUG_ASSERT_WITH_MUT_CALL,
+        &mutex_atomic::MUTEX_ATOMIC,
+        &mutex_atomic::MUTEX_INTEGER,
+        &needless_bool::BOOL_COMPARISON,
+        &needless_bool::NEEDLESS_BOOL,
+        &needless_borrow::NEEDLESS_BORROW,
+        &needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE,
+        &needless_continue::NEEDLESS_CONTINUE,
+        &needless_pass_by_value::NEEDLESS_PASS_BY_VALUE,
+        &needless_update::NEEDLESS_UPDATE,
+        &neg_cmp_op_on_partial_ord::NEG_CMP_OP_ON_PARTIAL_ORD,
+        &neg_multiply::NEG_MULTIPLY,
+        &new_without_default::NEW_WITHOUT_DEFAULT,
+        &no_effect::NO_EFFECT,
+        &no_effect::UNNECESSARY_OPERATION,
+        &non_copy_const::BORROW_INTERIOR_MUTABLE_CONST,
+        &non_copy_const::DECLARE_INTERIOR_MUTABLE_CONST,
+        &non_expressive_names::JUST_UNDERSCORES_AND_DIGITS,
+        &non_expressive_names::MANY_SINGLE_CHAR_NAMES,
+        &non_expressive_names::SIMILAR_NAMES,
+        &ok_if_let::IF_LET_SOME_RESULT,
+        &open_options::NONSENSICAL_OPEN_OPTIONS,
+        &overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL,
+        &panic_unimplemented::PANIC,
+        &panic_unimplemented::PANIC_PARAMS,
+        &panic_unimplemented::TODO,
+        &panic_unimplemented::UNIMPLEMENTED,
+        &panic_unimplemented::UNREACHABLE,
+        &partialeq_ne_impl::PARTIALEQ_NE_IMPL,
+        &path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE,
+        &precedence::PRECEDENCE,
+        &ptr::CMP_NULL,
+        &ptr::MUT_FROM_REF,
+        &ptr::PTR_ARG,
+        &ptr_offset_with_cast::PTR_OFFSET_WITH_CAST,
+        &question_mark::QUESTION_MARK,
+        &ranges::ITERATOR_STEP_BY_ZERO,
+        &ranges::RANGE_MINUS_ONE,
+        &ranges::RANGE_PLUS_ONE,
+        &ranges::RANGE_ZIP_WITH_LEN,
+        &redundant_clone::REDUNDANT_CLONE,
+        &redundant_field_names::REDUNDANT_FIELD_NAMES,
+        &redundant_pattern_matching::REDUNDANT_PATTERN_MATCHING,
+        &redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES,
+        &reference::DEREF_ADDROF,
+        &reference::REF_IN_DEREF,
+        &regex::INVALID_REGEX,
+        &regex::REGEX_MACRO,
+        &regex::TRIVIAL_REGEX,
+        &replace_consts::REPLACE_CONSTS,
+        &returns::LET_AND_RETURN,
+        &returns::NEEDLESS_RETURN,
+        &returns::UNUSED_UNIT,
+        &serde_api::SERDE_API_MISUSE,
+        &shadow::SHADOW_REUSE,
+        &shadow::SHADOW_SAME,
+        &shadow::SHADOW_UNRELATED,
+        &slow_vector_initialization::SLOW_VECTOR_INITIALIZATION,
+        &strings::STRING_ADD,
+        &strings::STRING_ADD_ASSIGN,
+        &strings::STRING_LIT_AS_BYTES,
+        &suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL,
+        &suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL,
+        &swap::ALMOST_SWAPPED,
+        &swap::MANUAL_SWAP,
+        &temporary_assignment::TEMPORARY_ASSIGNMENT,
+        &trait_bounds::TYPE_REPETITION_IN_BOUNDS,
+        &transmute::CROSSPOINTER_TRANSMUTE,
+        &transmute::TRANSMUTE_BYTES_TO_STR,
+        &transmute::TRANSMUTE_INT_TO_BOOL,
+        &transmute::TRANSMUTE_INT_TO_CHAR,
+        &transmute::TRANSMUTE_INT_TO_FLOAT,
+        &transmute::TRANSMUTE_PTR_TO_PTR,
+        &transmute::TRANSMUTE_PTR_TO_REF,
+        &transmute::UNSOUND_COLLECTION_TRANSMUTE,
+        &transmute::USELESS_TRANSMUTE,
+        &transmute::WRONG_TRANSMUTE,
+        &transmuting_null::TRANSMUTING_NULL,
+        &trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
+        &try_err::TRY_ERR,
+        &types::ABSURD_EXTREME_COMPARISONS,
+        &types::BORROWED_BOX,
+        &types::BOX_VEC,
+        &types::CAST_LOSSLESS,
+        &types::CAST_POSSIBLE_TRUNCATION,
+        &types::CAST_POSSIBLE_WRAP,
+        &types::CAST_PRECISION_LOSS,
+        &types::CAST_PTR_ALIGNMENT,
+        &types::CAST_REF_TO_MUT,
+        &types::CAST_SIGN_LOSS,
+        &types::CHAR_LIT_AS_U8,
+        &types::FN_TO_NUMERIC_CAST,
+        &types::FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
+        &types::IMPLICIT_HASHER,
+        &types::INVALID_UPCAST_COMPARISONS,
+        &types::LET_UNIT_VALUE,
+        &types::LINKEDLIST,
+        &types::OPTION_OPTION,
+        &types::TYPE_COMPLEXITY,
+        &types::UNIT_ARG,
+        &types::UNIT_CMP,
+        &types::UNNECESSARY_CAST,
+        &types::VEC_BOX,
+        &unicode::NON_ASCII_LITERAL,
+        &unicode::UNICODE_NOT_NFC,
+        &unicode::ZERO_WIDTH_SPACE,
+        &unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME,
+        &unused_io_amount::UNUSED_IO_AMOUNT,
+        &unused_label::UNUSED_LABEL,
+        &unused_self::UNUSED_SELF,
+        &unwrap::PANICKING_UNWRAP,
+        &unwrap::UNNECESSARY_UNWRAP,
+        &use_self::USE_SELF,
+        &vec::USELESS_VEC,
+        &wildcard_dependencies::WILDCARD_DEPENDENCIES,
+        &write::PRINTLN_EMPTY_STRING,
+        &write::PRINT_LITERAL,
+        &write::PRINT_STDOUT,
+        &write::PRINT_WITH_NEWLINE,
+        &write::USE_DEBUG,
+        &write::WRITELN_EMPTY_STRING,
+        &write::WRITE_LITERAL,
+        &write::WRITE_WITH_NEWLINE,
+        &zero_div_zero::ZERO_DIVIDED_BY_ZERO,
+    ]);
+    // end register lints, do not remove this comment, it’s used in `update_lints`
+
+    store.register_late_pass(|| box serde_api::SerdeAPI);
+    store.register_late_pass(|| box utils::internal_lints::CompilerLintFunctions::new());
+    store.register_late_pass(|| box utils::internal_lints::LintWithoutLintPass::default());
+    store.register_late_pass(|| box utils::internal_lints::OuterExpnDataPass);
+    store.register_late_pass(|| box utils::inspector::DeepCodeInspector);
+    store.register_late_pass(|| box utils::author::Author);
+    store.register_late_pass(|| box types::Types);
+    store.register_late_pass(|| box booleans::NonminimalBool);
+    store.register_late_pass(|| box eq_op::EqOp);
+    store.register_late_pass(|| box enum_glob_use::EnumGlobUse);
+    store.register_late_pass(|| box enum_clike::UnportableVariant);
+    store.register_late_pass(|| box excessive_precision::ExcessivePrecision);
+    let p = conf.verbose_bit_mask_threshold;
+    store.register_late_pass(move || box bit_mask::BitMask::new(p));
+    store.register_late_pass(|| box ptr::Ptr);
+    store.register_late_pass(|| box needless_bool::NeedlessBool);
+    store.register_late_pass(|| box needless_bool::BoolComparison);
+    store.register_late_pass(|| box approx_const::ApproxConstant);
+    store.register_late_pass(|| box misc::MiscLints);
+    store.register_late_pass(|| box eta_reduction::EtaReduction);
+    store.register_late_pass(|| box identity_op::IdentityOp);
+    store.register_late_pass(|| box erasing_op::ErasingOp);
+    store.register_late_pass(|| box mut_mut::MutMut);
+    store.register_late_pass(|| box mut_reference::UnnecessaryMutPassed);
+    store.register_late_pass(|| box len_zero::LenZero);
+    store.register_late_pass(|| box attrs::Attributes);
+    store.register_late_pass(|| box block_in_if_condition::BlockInIfCondition);
+    store.register_late_pass(|| box unicode::Unicode);
+    store.register_late_pass(|| box strings::StringAdd);
+    store.register_late_pass(|| box implicit_return::ImplicitReturn);
+    store.register_late_pass(|| box methods::Methods);
+    store.register_late_pass(|| box map_clone::MapClone);
+    store.register_late_pass(|| box shadow::Shadow);
+    store.register_late_pass(|| box types::LetUnitValue);
+    store.register_late_pass(|| box types::UnitCmp);
+    store.register_late_pass(|| box loops::Loops);
+    store.register_late_pass(|| box main_recursion::MainRecursion::default());
+    store.register_late_pass(|| box lifetimes::Lifetimes);
+    store.register_late_pass(|| box entry::HashMapPass);
+    store.register_late_pass(|| box ranges::Ranges);
+    store.register_late_pass(|| box types::Casts);
+    let p = conf.type_complexity_threshold;
+    store.register_late_pass(move || box types::TypeComplexity::new(p));
+    store.register_late_pass(|| box matches::Matches);
+    store.register_late_pass(|| box minmax::MinMaxPass);
+    store.register_late_pass(|| box open_options::OpenOptions);
+    store.register_late_pass(|| box zero_div_zero::ZeroDiv);
+    store.register_late_pass(|| box mutex_atomic::Mutex);
+    store.register_late_pass(|| box needless_update::NeedlessUpdate);
+    store.register_late_pass(|| box needless_borrow::NeedlessBorrow::default());
+    store.register_late_pass(|| box needless_borrowed_ref::NeedlessBorrowedRef);
+    store.register_late_pass(|| box no_effect::NoEffect);
+    store.register_late_pass(|| box temporary_assignment::TemporaryAssignment);
+    store.register_late_pass(|| box transmute::Transmute);
+    let p = conf.cognitive_complexity_threshold;
+    store.register_late_pass(move || box cognitive_complexity::CognitiveComplexity::new(p));
+    let a = conf.too_large_for_stack;
+    store.register_late_pass(move || box escape::BoxedLocal{too_large_for_stack: a});
+    store.register_late_pass(|| box panic_unimplemented::PanicUnimplemented);
+    store.register_late_pass(|| box strings::StringLitAsBytes);
+    store.register_late_pass(|| box derive::Derive);
+    store.register_late_pass(|| box types::CharLitAsU8);
+    store.register_late_pass(|| box vec::UselessVec);
+    store.register_late_pass(|| box drop_bounds::DropBounds);
+    store.register_late_pass(|| box get_last_with_len::GetLastWithLen);
+    store.register_late_pass(|| box drop_forget_ref::DropForgetRef);
+    store.register_late_pass(|| box empty_enum::EmptyEnum);
+    store.register_late_pass(|| box types::AbsurdExtremeComparisons);
+    store.register_late_pass(|| box types::InvalidUpcastComparisons);
+    store.register_late_pass(|| box regex::Regex::default());
+    store.register_late_pass(|| box copies::CopyAndPaste);
+    store.register_late_pass(|| box copy_iterator::CopyIterator);
+    store.register_late_pass(|| box format::UselessFormat);
+    store.register_late_pass(|| box swap::Swap);
+    store.register_late_pass(|| box overflow_check_conditional::OverflowCheckConditional);
+    store.register_late_pass(|| box unused_label::UnusedLabel);
+    store.register_late_pass(|| box new_without_default::NewWithoutDefault::default());
+    let p = conf.blacklisted_names.iter().cloned().collect::<FxHashSet<_>>();
+    store.register_late_pass(move || box blacklisted_name::BlacklistedName::new(p.clone()));
+    let a1 = conf.too_many_arguments_threshold;
+    let a2 = conf.too_many_lines_threshold;
+    store.register_late_pass(move || box functions::Functions::new(a1, a2));
+    let p = conf.doc_valid_idents.iter().cloned().collect::<FxHashSet<_>>();
+    store.register_late_pass(move || box doc::DocMarkdown::new(p.clone()));
+    store.register_late_pass(|| box neg_multiply::NegMultiply);
+    store.register_late_pass(|| box mem_discriminant::MemDiscriminant);
+    store.register_late_pass(|| box mem_forget::MemForget);
+    store.register_late_pass(|| box mem_replace::MemReplace);
+    store.register_late_pass(|| box arithmetic::Arithmetic::default());
+    store.register_late_pass(|| box assign_ops::AssignOps);
+    store.register_late_pass(|| box let_if_seq::LetIfSeq);
+    store.register_late_pass(|| box eval_order_dependence::EvalOrderDependence);
+    store.register_late_pass(|| box missing_doc::MissingDoc::new());
+    store.register_late_pass(|| box missing_inline::MissingInline);
+    store.register_late_pass(|| box ok_if_let::OkIfLet);
+    store.register_late_pass(|| box redundant_pattern_matching::RedundantPatternMatching);
+    store.register_late_pass(|| box partialeq_ne_impl::PartialEqNeImpl);
+    store.register_late_pass(|| box unused_io_amount::UnusedIoAmount);
+    let p = conf.enum_variant_size_threshold;
+    store.register_late_pass(move || box large_enum_variant::LargeEnumVariant::new(p));
+    store.register_late_pass(|| box explicit_write::ExplicitWrite);
+    store.register_late_pass(|| box needless_pass_by_value::NeedlessPassByValue);
+    let p = trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
+        conf.trivial_copy_size_limit,
+        &sess.target,
     );
-    reg.register_late_lint_pass(box escape::BoxedLocal{too_large_for_stack: conf.too_large_for_stack});
-    reg.register_early_lint_pass(box misc_early::MiscEarlyLints);
-    reg.register_late_lint_pass(box panic_unimplemented::PanicUnimplemented);
-    reg.register_late_lint_pass(box strings::StringLitAsBytes);
-    reg.register_late_lint_pass(box derive::Derive);
-    reg.register_late_lint_pass(box types::CharLitAsU8);
-    reg.register_late_lint_pass(box vec::UselessVec);
-    reg.register_late_lint_pass(box drop_bounds::DropBounds);
-    reg.register_late_lint_pass(box get_last_with_len::GetLastWithLen);
-    reg.register_late_lint_pass(box drop_forget_ref::DropForgetRef);
-    reg.register_late_lint_pass(box empty_enum::EmptyEnum);
-    reg.register_late_lint_pass(box types::AbsurdExtremeComparisons);
-    reg.register_late_lint_pass(box types::InvalidUpcastComparisons);
-    reg.register_late_lint_pass(box regex::Regex::default());
-    reg.register_late_lint_pass(box copies::CopyAndPaste);
-    reg.register_late_lint_pass(box copy_iterator::CopyIterator);
-    reg.register_late_lint_pass(box format::UselessFormat);
-    reg.register_early_lint_pass(box formatting::Formatting);
-    reg.register_late_lint_pass(box swap::Swap);
-    reg.register_early_lint_pass(box if_not_else::IfNotElse);
-    reg.register_early_lint_pass(box else_if_without_else::ElseIfWithoutElse);
-    reg.register_early_lint_pass(box int_plus_one::IntPlusOne);
-    reg.register_late_lint_pass(box overflow_check_conditional::OverflowCheckConditional);
-    reg.register_late_lint_pass(box unused_label::UnusedLabel);
-    reg.register_late_lint_pass(box new_without_default::NewWithoutDefault::default());
-    reg.register_late_lint_pass(box blacklisted_name::BlacklistedName::new(
-            conf.blacklisted_names.iter().cloned().collect()
-    ));
-    reg.register_late_lint_pass(box functions::Functions::new(conf.too_many_arguments_threshold, conf.too_many_lines_threshold));
-    reg.register_late_lint_pass(box doc::DocMarkdown::new(conf.doc_valid_idents.iter().cloned().collect()));
-    reg.register_late_lint_pass(box neg_multiply::NegMultiply);
-    reg.register_early_lint_pass(box unsafe_removed_from_name::UnsafeNameRemoval);
-    reg.register_late_lint_pass(box mem_discriminant::MemDiscriminant);
-    reg.register_late_lint_pass(box mem_forget::MemForget);
-    reg.register_late_lint_pass(box mem_replace::MemReplace);
-    reg.register_late_lint_pass(box arithmetic::Arithmetic::default());
-    reg.register_late_lint_pass(box assign_ops::AssignOps);
-    reg.register_late_lint_pass(box let_if_seq::LetIfSeq);
-    reg.register_late_lint_pass(box eval_order_dependence::EvalOrderDependence);
-    reg.register_late_lint_pass(box missing_doc::MissingDoc::new());
-    reg.register_late_lint_pass(box missing_inline::MissingInline);
-    reg.register_late_lint_pass(box ok_if_let::OkIfLet);
-    reg.register_late_lint_pass(box redundant_pattern_matching::RedundantPatternMatching);
-    reg.register_late_lint_pass(box partialeq_ne_impl::PartialEqNeImpl);
-    reg.register_early_lint_pass(box reference::DerefAddrOf);
-    reg.register_early_lint_pass(box reference::RefInDeref);
-    reg.register_early_lint_pass(box double_parens::DoubleParens);
-    reg.register_late_lint_pass(box unused_io_amount::UnusedIoAmount);
-    reg.register_late_lint_pass(box large_enum_variant::LargeEnumVariant::new(conf.enum_variant_size_threshold));
-    reg.register_late_lint_pass(box explicit_write::ExplicitWrite);
-    reg.register_late_lint_pass(box needless_pass_by_value::NeedlessPassByValue);
-    reg.register_late_lint_pass(box trivially_copy_pass_by_ref::TriviallyCopyPassByRef::new(
-            conf.trivial_copy_size_limit,
-            &reg.sess.target,
-    ));
-    reg.register_early_lint_pass(box literal_representation::LiteralDigitGrouping);
-    reg.register_early_lint_pass(box literal_representation::DecimalLiteralRepresentation::new(
-            conf.literal_representation_threshold
-    ));
-    reg.register_late_lint_pass(box try_err::TryErr);
-    reg.register_late_lint_pass(box use_self::UseSelf);
-    reg.register_late_lint_pass(box bytecount::ByteCount);
-    reg.register_late_lint_pass(box infinite_iter::InfiniteIter);
-    reg.register_late_lint_pass(box inline_fn_without_body::InlineFnWithoutBody);
-    reg.register_late_lint_pass(box identity_conversion::IdentityConversion::default());
-    reg.register_late_lint_pass(box types::ImplicitHasher);
-    reg.register_early_lint_pass(box redundant_static_lifetimes::RedundantStaticLifetimes);
-    reg.register_late_lint_pass(box fallible_impl_from::FallibleImplFrom);
-    reg.register_late_lint_pass(box replace_consts::ReplaceConsts);
-    reg.register_late_lint_pass(box types::UnitArg);
-    reg.register_late_lint_pass(box double_comparison::DoubleComparisons);
-    reg.register_late_lint_pass(box question_mark::QuestionMark);
-    reg.register_late_lint_pass(box suspicious_trait_impl::SuspiciousImpl);
-    reg.register_early_lint_pass(box cargo_common_metadata::CargoCommonMetadata);
-    reg.register_early_lint_pass(box multiple_crate_versions::MultipleCrateVersions);
-    reg.register_early_lint_pass(box wildcard_dependencies::WildcardDependencies);
-    reg.register_late_lint_pass(box map_unit_fn::MapUnit);
-    reg.register_late_lint_pass(box infallible_destructuring_match::InfallibleDestructingMatch);
-    reg.register_late_lint_pass(box inherent_impl::MultipleInherentImpl::default());
-    reg.register_late_lint_pass(box neg_cmp_op_on_partial_ord::NoNegCompOpForPartialOrd);
-    reg.register_late_lint_pass(box unwrap::Unwrap);
-    reg.register_late_lint_pass(box duration_subsec::DurationSubsec);
-    reg.register_late_lint_pass(box default_trait_access::DefaultTraitAccess);
-    reg.register_late_lint_pass(box indexing_slicing::IndexingSlicing);
-    reg.register_late_lint_pass(box non_copy_const::NonCopyConst);
-    reg.register_late_lint_pass(box ptr_offset_with_cast::PtrOffsetWithCast);
-    reg.register_late_lint_pass(box redundant_clone::RedundantClone);
-    reg.register_late_lint_pass(box slow_vector_initialization::SlowVectorInit);
-    reg.register_late_lint_pass(box types::RefToMut);
-    reg.register_late_lint_pass(box assertions_on_constants::AssertionsOnConstants);
-    reg.register_late_lint_pass(box missing_const_for_fn::MissingConstForFn);
-    reg.register_late_lint_pass(box transmuting_null::TransmutingNull);
-    reg.register_late_lint_pass(box path_buf_push_overwrite::PathBufPushOverwrite);
-    reg.register_late_lint_pass(box checked_conversions::CheckedConversions);
-    reg.register_late_lint_pass(box integer_division::IntegerDivision);
-    reg.register_late_lint_pass(box inherent_to_string::InherentToString);
-    reg.register_late_lint_pass(box trait_bounds::TraitBounds);
-    reg.register_late_lint_pass(box comparison_chain::ComparisonChain);
-    reg.register_late_lint_pass(box mul_add::MulAddCheck);
-    reg.register_late_lint_pass(box unused_self::UnusedSelf);
-    reg.register_late_lint_pass(box mutable_debug_assertion::DebugAssertWithMutCall);
+    store.register_late_pass(move || box p);
+    store.register_late_pass(|| box try_err::TryErr);
+    store.register_late_pass(|| box use_self::UseSelf);
+    store.register_late_pass(|| box bytecount::ByteCount);
+    store.register_late_pass(|| box infinite_iter::InfiniteIter);
+    store.register_late_pass(|| box inline_fn_without_body::InlineFnWithoutBody);
+    store.register_late_pass(|| box identity_conversion::IdentityConversion::default());
+    store.register_late_pass(|| box types::ImplicitHasher);
+    store.register_late_pass(|| box fallible_impl_from::FallibleImplFrom);
+    store.register_late_pass(|| box replace_consts::ReplaceConsts);
+    store.register_late_pass(|| box types::UnitArg);
+    store.register_late_pass(|| box double_comparison::DoubleComparisons);
+    store.register_late_pass(|| box question_mark::QuestionMark);
+    store.register_late_pass(|| box suspicious_trait_impl::SuspiciousImpl);
+    store.register_late_pass(|| box map_unit_fn::MapUnit);
+    store.register_late_pass(|| box infallible_destructuring_match::InfallibleDestructingMatch);
+    store.register_late_pass(|| box inherent_impl::MultipleInherentImpl::default());
+    store.register_late_pass(|| box neg_cmp_op_on_partial_ord::NoNegCompOpForPartialOrd);
+    store.register_late_pass(|| box unwrap::Unwrap);
+    store.register_late_pass(|| box duration_subsec::DurationSubsec);
+    store.register_late_pass(|| box default_trait_access::DefaultTraitAccess);
+    store.register_late_pass(|| box indexing_slicing::IndexingSlicing);
+    store.register_late_pass(|| box non_copy_const::NonCopyConst);
+    store.register_late_pass(|| box ptr_offset_with_cast::PtrOffsetWithCast);
+    store.register_late_pass(|| box redundant_clone::RedundantClone);
+    store.register_late_pass(|| box slow_vector_initialization::SlowVectorInit);
+    store.register_late_pass(|| box types::RefToMut);
+    store.register_late_pass(|| box assertions_on_constants::AssertionsOnConstants);
+    store.register_late_pass(|| box missing_const_for_fn::MissingConstForFn);
+    store.register_late_pass(|| box transmuting_null::TransmutingNull);
+    store.register_late_pass(|| box path_buf_push_overwrite::PathBufPushOverwrite);
+    store.register_late_pass(|| box checked_conversions::CheckedConversions);
+    store.register_late_pass(|| box integer_division::IntegerDivision);
+    store.register_late_pass(|| box inherent_to_string::InherentToString);
+    store.register_late_pass(|| box trait_bounds::TraitBounds);
+    store.register_late_pass(|| box comparison_chain::ComparisonChain);
+    store.register_late_pass(|| box mul_add::MulAddCheck);
 
-    reg.register_lint_group("clippy::restriction", Some("clippy_restriction"), vec![
-        arithmetic::FLOAT_ARITHMETIC,
-        arithmetic::INTEGER_ARITHMETIC,
-        dbg_macro::DBG_MACRO,
-        else_if_without_else::ELSE_IF_WITHOUT_ELSE,
-        implicit_return::IMPLICIT_RETURN,
-        indexing_slicing::INDEXING_SLICING,
-        inherent_impl::MULTIPLE_INHERENT_IMPL,
-        integer_division::INTEGER_DIVISION,
-        literal_representation::DECIMAL_LITERAL_REPRESENTATION,
-        matches::WILDCARD_ENUM_MATCH_ARM,
-        mem_forget::MEM_FORGET,
-        methods::CLONE_ON_REF_PTR,
-        methods::GET_UNWRAP,
-        methods::OPTION_EXPECT_USED,
-        methods::OPTION_UNWRAP_USED,
-        methods::RESULT_EXPECT_USED,
-        methods::RESULT_UNWRAP_USED,
-        methods::WRONG_PUB_SELF_CONVENTION,
-        misc::FLOAT_CMP_CONST,
-        missing_doc::MISSING_DOCS_IN_PRIVATE_ITEMS,
-        missing_inline::MISSING_INLINE_IN_PUBLIC_ITEMS,
-        panic_unimplemented::PANIC,
-        panic_unimplemented::TODO,
-        panic_unimplemented::UNIMPLEMENTED,
-        panic_unimplemented::UNREACHABLE,
-        shadow::SHADOW_REUSE,
-        shadow::SHADOW_SAME,
-        strings::STRING_ADD,
-        write::PRINT_STDOUT,
-        write::USE_DEBUG,
+    store.register_early_pass(|| box reference::DerefAddrOf);
+    store.register_early_pass(|| box reference::RefInDeref);
+    store.register_early_pass(|| box double_parens::DoubleParens);
+    store.register_early_pass(|| box unsafe_removed_from_name::UnsafeNameRemoval);
+    store.register_early_pass(|| box if_not_else::IfNotElse);
+    store.register_early_pass(|| box else_if_without_else::ElseIfWithoutElse);
+    store.register_early_pass(|| box int_plus_one::IntPlusOne);
+    store.register_early_pass(|| box formatting::Formatting);
+    store.register_early_pass(|| box misc_early::MiscEarlyLints);
+    store.register_early_pass(|| box returns::Return);
+    store.register_early_pass(|| box collapsible_if::CollapsibleIf);
+    store.register_early_pass(|| box items_after_statements::ItemsAfterStatements);
+    store.register_early_pass(|| box precedence::Precedence);
+    store.register_early_pass(|| box needless_continue::NeedlessContinue);
+    store.register_early_pass(|| box redundant_static_lifetimes::RedundantStaticLifetimes);
+    store.register_early_pass(|| box cargo_common_metadata::CargoCommonMetadata);
+    store.register_early_pass(|| box multiple_crate_versions::MultipleCrateVersions);
+    store.register_early_pass(|| box wildcard_dependencies::WildcardDependencies);
+    store.register_early_pass(|| box literal_representation::LiteralDigitGrouping);
+    let p = conf.literal_representation_threshold;
+    store.register_early_pass(move || box literal_representation::DecimalLiteralRepresentation::new(p));
+    store.register_early_pass(|| box utils::internal_lints::ClippyLintsInternal);
+    let p = conf.enum_variant_name_threshold;
+    store.register_early_pass(move || box enum_variants::EnumVariantNames::new(p));
+
+    store.register_group(true, "clippy::restriction", Some("clippy_restriction"), vec![
+        LintId::of(&arithmetic::FLOAT_ARITHMETIC),
+        LintId::of(&arithmetic::INTEGER_ARITHMETIC),
+        LintId::of(&dbg_macro::DBG_MACRO),
+        LintId::of(&else_if_without_else::ELSE_IF_WITHOUT_ELSE),
+        LintId::of(&implicit_return::IMPLICIT_RETURN),
+        LintId::of(&indexing_slicing::INDEXING_SLICING),
+        LintId::of(&inherent_impl::MULTIPLE_INHERENT_IMPL),
+        LintId::of(&integer_division::INTEGER_DIVISION),
+        LintId::of(&literal_representation::DECIMAL_LITERAL_REPRESENTATION),
+        LintId::of(&matches::WILDCARD_ENUM_MATCH_ARM),
+        LintId::of(&mem_forget::MEM_FORGET),
+        LintId::of(&methods::CLONE_ON_REF_PTR),
+        LintId::of(&methods::GET_UNWRAP),
+        LintId::of(&methods::OPTION_EXPECT_USED),
+        LintId::of(&methods::OPTION_UNWRAP_USED),
+        LintId::of(&methods::RESULT_EXPECT_USED),
+        LintId::of(&methods::RESULT_UNWRAP_USED),
+        LintId::of(&methods::WRONG_PUB_SELF_CONVENTION),
+        LintId::of(&misc::FLOAT_CMP_CONST),
+        LintId::of(&missing_doc::MISSING_DOCS_IN_PRIVATE_ITEMS),
+        LintId::of(&missing_inline::MISSING_INLINE_IN_PUBLIC_ITEMS),
+        LintId::of(&panic_unimplemented::PANIC),
+        LintId::of(&panic_unimplemented::TODO),
+        LintId::of(&panic_unimplemented::UNIMPLEMENTED),
+        LintId::of(&panic_unimplemented::UNREACHABLE),
+        LintId::of(&shadow::SHADOW_REUSE),
+        LintId::of(&shadow::SHADOW_SAME),
+        LintId::of(&strings::STRING_ADD),
+        LintId::of(&write::PRINT_STDOUT),
+        LintId::of(&write::USE_DEBUG),
     ]);
 
-    reg.register_lint_group("clippy::pedantic", Some("clippy_pedantic"), vec![
-        attrs::INLINE_ALWAYS,
-        checked_conversions::CHECKED_CONVERSIONS,
-        copies::MATCH_SAME_ARMS,
-        copy_iterator::COPY_ITERATOR,
-        default_trait_access::DEFAULT_TRAIT_ACCESS,
-        derive::EXPL_IMPL_CLONE_ON_COPY,
-        doc::DOC_MARKDOWN,
-        empty_enum::EMPTY_ENUM,
-        enum_glob_use::ENUM_GLOB_USE,
-        enum_variants::MODULE_NAME_REPETITIONS,
-        enum_variants::PUB_ENUM_VARIANT_NAMES,
-        eta_reduction::REDUNDANT_CLOSURE_FOR_METHOD_CALLS,
-        functions::MUST_USE_CANDIDATE,
-        functions::TOO_MANY_LINES,
-        if_not_else::IF_NOT_ELSE,
-        infinite_iter::MAYBE_INFINITE_ITER,
-        items_after_statements::ITEMS_AFTER_STATEMENTS,
-        literal_representation::LARGE_DIGIT_GROUPS,
-        loops::EXPLICIT_INTO_ITER_LOOP,
-        loops::EXPLICIT_ITER_LOOP,
-        matches::SINGLE_MATCH_ELSE,
-        methods::FILTER_MAP,
-        methods::FILTER_MAP_NEXT,
-        methods::FIND_MAP,
-        methods::MAP_FLATTEN,
-        methods::OPTION_MAP_UNWRAP_OR,
-        methods::OPTION_MAP_UNWRAP_OR_ELSE,
-        methods::RESULT_MAP_UNWRAP_OR_ELSE,
-        misc::USED_UNDERSCORE_BINDING,
-        misc_early::UNSEPARATED_LITERAL_SUFFIX,
-        mut_mut::MUT_MUT,
-        needless_continue::NEEDLESS_CONTINUE,
-        needless_pass_by_value::NEEDLESS_PASS_BY_VALUE,
-        non_expressive_names::SIMILAR_NAMES,
-        replace_consts::REPLACE_CONSTS,
-        shadow::SHADOW_UNRELATED,
-        strings::STRING_ADD_ASSIGN,
-        trait_bounds::TYPE_REPETITION_IN_BOUNDS,
-        types::CAST_LOSSLESS,
-        types::CAST_POSSIBLE_TRUNCATION,
-        types::CAST_POSSIBLE_WRAP,
-        types::CAST_PRECISION_LOSS,
-        types::CAST_SIGN_LOSS,
-        types::INVALID_UPCAST_COMPARISONS,
-        types::LINKEDLIST,
-        unicode::NON_ASCII_LITERAL,
-        unicode::UNICODE_NOT_NFC,
-        unused_self::UNUSED_SELF,
-        use_self::USE_SELF,
+    store.register_group(true, "clippy::pedantic", Some("clippy_pedantic"), vec![
+        LintId::of(&attrs::INLINE_ALWAYS),
+        LintId::of(&checked_conversions::CHECKED_CONVERSIONS),
+        LintId::of(&copies::MATCH_SAME_ARMS),
+        LintId::of(&copy_iterator::COPY_ITERATOR),
+        LintId::of(&default_trait_access::DEFAULT_TRAIT_ACCESS),
+        LintId::of(&derive::EXPL_IMPL_CLONE_ON_COPY),
+        LintId::of(&doc::DOC_MARKDOWN),
+        LintId::of(&empty_enum::EMPTY_ENUM),
+        LintId::of(&enum_glob_use::ENUM_GLOB_USE),
+        LintId::of(&enum_variants::MODULE_NAME_REPETITIONS),
+        LintId::of(&enum_variants::PUB_ENUM_VARIANT_NAMES),
+        LintId::of(&eta_reduction::REDUNDANT_CLOSURE_FOR_METHOD_CALLS),
+        LintId::of(&functions::MUST_USE_CANDIDATE),
+        LintId::of(&functions::TOO_MANY_LINES),
+        LintId::of(&if_not_else::IF_NOT_ELSE),
+        LintId::of(&infinite_iter::MAYBE_INFINITE_ITER),
+        LintId::of(&items_after_statements::ITEMS_AFTER_STATEMENTS),
+        LintId::of(&literal_representation::LARGE_DIGIT_GROUPS),
+        LintId::of(&loops::EXPLICIT_INTO_ITER_LOOP),
+        LintId::of(&loops::EXPLICIT_ITER_LOOP),
+        LintId::of(&matches::SINGLE_MATCH_ELSE),
+        LintId::of(&methods::FILTER_MAP),
+        LintId::of(&methods::FILTER_MAP_NEXT),
+        LintId::of(&methods::FIND_MAP),
+        LintId::of(&methods::MAP_FLATTEN),
+        LintId::of(&methods::OPTION_MAP_UNWRAP_OR),
+        LintId::of(&methods::OPTION_MAP_UNWRAP_OR_ELSE),
+        LintId::of(&methods::RESULT_MAP_UNWRAP_OR_ELSE),
+        LintId::of(&misc::USED_UNDERSCORE_BINDING),
+        LintId::of(&misc_early::UNSEPARATED_LITERAL_SUFFIX),
+        LintId::of(&mut_mut::MUT_MUT),
+        LintId::of(&needless_continue::NEEDLESS_CONTINUE),
+        LintId::of(&needless_pass_by_value::NEEDLESS_PASS_BY_VALUE),
+        LintId::of(&non_expressive_names::SIMILAR_NAMES),
+        LintId::of(&replace_consts::REPLACE_CONSTS),
+        LintId::of(&shadow::SHADOW_UNRELATED),
+        LintId::of(&strings::STRING_ADD_ASSIGN),
+        LintId::of(&trait_bounds::TYPE_REPETITION_IN_BOUNDS),
+        LintId::of(&types::CAST_LOSSLESS),
+        LintId::of(&types::CAST_POSSIBLE_TRUNCATION),
+        LintId::of(&types::CAST_POSSIBLE_WRAP),
+        LintId::of(&types::CAST_PRECISION_LOSS),
+        LintId::of(&types::CAST_SIGN_LOSS),
+        LintId::of(&types::INVALID_UPCAST_COMPARISONS),
+        LintId::of(&types::LINKEDLIST),
+        LintId::of(&unicode::NON_ASCII_LITERAL),
+        LintId::of(&unicode::UNICODE_NOT_NFC),
+        LintId::of(&unused_self::UNUSED_SELF),
+        LintId::of(&use_self::USE_SELF),
     ]);
 
-    reg.register_lint_group("clippy::internal", Some("clippy_internal"), vec![
-        utils::internal_lints::CLIPPY_LINTS_INTERNAL,
-        utils::internal_lints::COMPILER_LINT_FUNCTIONS,
-        utils::internal_lints::LINT_WITHOUT_LINT_PASS,
-        utils::internal_lints::OUTER_EXPN_EXPN_DATA,
+    store.register_group(true, "clippy::internal", Some("clippy_internal"), vec![
+        LintId::of(&utils::internal_lints::CLIPPY_LINTS_INTERNAL),
+        LintId::of(&utils::internal_lints::COMPILER_LINT_FUNCTIONS),
+        LintId::of(&utils::internal_lints::LINT_WITHOUT_LINT_PASS),
+        LintId::of(&utils::internal_lints::OUTER_EXPN_EXPN_DATA),
     ]);
 
-    reg.register_lint_group("clippy::all", Some("clippy"), vec![
-        approx_const::APPROX_CONSTANT,
-        assertions_on_constants::ASSERTIONS_ON_CONSTANTS,
-        assign_ops::ASSIGN_OP_PATTERN,
-        assign_ops::MISREFACTORED_ASSIGN_OP,
-        attrs::DEPRECATED_CFG_ATTR,
-        attrs::DEPRECATED_SEMVER,
-        attrs::UNKNOWN_CLIPPY_LINTS,
-        attrs::USELESS_ATTRIBUTE,
-        bit_mask::BAD_BIT_MASK,
-        bit_mask::INEFFECTIVE_BIT_MASK,
-        bit_mask::VERBOSE_BIT_MASK,
-        blacklisted_name::BLACKLISTED_NAME,
-        block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR,
-        block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT,
-        booleans::LOGIC_BUG,
-        booleans::NONMINIMAL_BOOL,
-        bytecount::NAIVE_BYTECOUNT,
-        cognitive_complexity::COGNITIVE_COMPLEXITY,
-        collapsible_if::COLLAPSIBLE_IF,
-        comparison_chain::COMPARISON_CHAIN,
-        copies::IFS_SAME_COND,
-        copies::IF_SAME_THEN_ELSE,
-        derive::DERIVE_HASH_XOR_EQ,
-        doc::MISSING_SAFETY_DOC,
-        doc::NEEDLESS_DOCTEST_MAIN,
-        double_comparison::DOUBLE_COMPARISONS,
-        double_parens::DOUBLE_PARENS,
-        drop_bounds::DROP_BOUNDS,
-        drop_forget_ref::DROP_COPY,
-        drop_forget_ref::DROP_REF,
-        drop_forget_ref::FORGET_COPY,
-        drop_forget_ref::FORGET_REF,
-        duration_subsec::DURATION_SUBSEC,
-        entry::MAP_ENTRY,
-        enum_clike::ENUM_CLIKE_UNPORTABLE_VARIANT,
-        enum_variants::ENUM_VARIANT_NAMES,
-        enum_variants::MODULE_INCEPTION,
-        eq_op::EQ_OP,
-        eq_op::OP_REF,
-        erasing_op::ERASING_OP,
-        escape::BOXED_LOCAL,
-        eta_reduction::REDUNDANT_CLOSURE,
-        eval_order_dependence::DIVERGING_SUB_EXPRESSION,
-        eval_order_dependence::EVAL_ORDER_DEPENDENCE,
-        excessive_precision::EXCESSIVE_PRECISION,
-        explicit_write::EXPLICIT_WRITE,
-        format::USELESS_FORMAT,
-        formatting::POSSIBLE_MISSING_COMMA,
-        formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING,
-        formatting::SUSPICIOUS_ELSE_FORMATTING,
-        formatting::SUSPICIOUS_UNARY_OP_FORMATTING,
-        functions::DOUBLE_MUST_USE,
-        functions::MUST_USE_UNIT,
-        functions::NOT_UNSAFE_PTR_ARG_DEREF,
-        functions::TOO_MANY_ARGUMENTS,
-        get_last_with_len::GET_LAST_WITH_LEN,
-        identity_conversion::IDENTITY_CONVERSION,
-        identity_op::IDENTITY_OP,
-        indexing_slicing::OUT_OF_BOUNDS_INDEXING,
-        infallible_destructuring_match::INFALLIBLE_DESTRUCTURING_MATCH,
-        infinite_iter::INFINITE_ITER,
-        inherent_to_string::INHERENT_TO_STRING,
-        inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY,
-        inline_fn_without_body::INLINE_FN_WITHOUT_BODY,
-        int_plus_one::INT_PLUS_ONE,
-        large_enum_variant::LARGE_ENUM_VARIANT,
-        len_zero::LEN_WITHOUT_IS_EMPTY,
-        len_zero::LEN_ZERO,
-        let_if_seq::USELESS_LET_IF_SEQ,
-        lifetimes::EXTRA_UNUSED_LIFETIMES,
-        lifetimes::NEEDLESS_LIFETIMES,
-        literal_representation::INCONSISTENT_DIGIT_GROUPING,
-        literal_representation::MISTYPED_LITERAL_SUFFIXES,
-        literal_representation::UNREADABLE_LITERAL,
-        loops::EMPTY_LOOP,
-        loops::EXPLICIT_COUNTER_LOOP,
-        loops::FOR_KV_MAP,
-        loops::FOR_LOOP_OVER_OPTION,
-        loops::FOR_LOOP_OVER_RESULT,
-        loops::ITER_NEXT_LOOP,
-        loops::MANUAL_MEMCPY,
-        loops::MUT_RANGE_BOUND,
-        loops::NEEDLESS_COLLECT,
-        loops::NEEDLESS_RANGE_LOOP,
-        loops::NEVER_LOOP,
-        loops::REVERSE_RANGE_LOOP,
-        loops::WHILE_IMMUTABLE_CONDITION,
-        loops::WHILE_LET_LOOP,
-        loops::WHILE_LET_ON_ITERATOR,
-        main_recursion::MAIN_RECURSION,
-        map_clone::MAP_CLONE,
-        map_unit_fn::OPTION_MAP_UNIT_FN,
-        map_unit_fn::RESULT_MAP_UNIT_FN,
-        matches::MATCH_AS_REF,
-        matches::MATCH_BOOL,
-        matches::MATCH_OVERLAPPING_ARM,
-        matches::MATCH_REF_PATS,
-        matches::MATCH_WILD_ERR_ARM,
-        matches::SINGLE_MATCH,
-        mem_discriminant::MEM_DISCRIMINANT_NON_ENUM,
-        mem_replace::MEM_REPLACE_OPTION_WITH_NONE,
-        mem_replace::MEM_REPLACE_WITH_UNINIT,
-        methods::CHARS_LAST_CMP,
-        methods::CHARS_NEXT_CMP,
-        methods::CLONE_DOUBLE_REF,
-        methods::CLONE_ON_COPY,
-        methods::EXPECT_FUN_CALL,
-        methods::FILTER_NEXT,
-        methods::FLAT_MAP_IDENTITY,
-        methods::INEFFICIENT_TO_STRING,
-        methods::INTO_ITER_ON_ARRAY,
-        methods::INTO_ITER_ON_REF,
-        methods::ITER_CLONED_COLLECT,
-        methods::ITER_NTH,
-        methods::ITER_SKIP_NEXT,
-        methods::MANUAL_SATURATING_ARITHMETIC,
-        methods::NEW_RET_NO_SELF,
-        methods::OK_EXPECT,
-        methods::OPTION_AND_THEN_SOME,
-        methods::OPTION_MAP_OR_NONE,
-        methods::OR_FUN_CALL,
-        methods::SEARCH_IS_SOME,
-        methods::SHOULD_IMPLEMENT_TRAIT,
-        methods::SINGLE_CHAR_PATTERN,
-        methods::STRING_EXTEND_CHARS,
-        methods::SUSPICIOUS_MAP,
-        methods::TEMPORARY_CSTRING_AS_PTR,
-        methods::UNINIT_ASSUMED_INIT,
-        methods::UNNECESSARY_FILTER_MAP,
-        methods::UNNECESSARY_FOLD,
-        methods::USELESS_ASREF,
-        methods::WRONG_SELF_CONVENTION,
-        minmax::MIN_MAX,
-        misc::CMP_NAN,
-        misc::CMP_OWNED,
-        misc::FLOAT_CMP,
-        misc::MODULO_ONE,
-        misc::SHORT_CIRCUIT_STATEMENT,
-        misc::TOPLEVEL_REF_ARG,
-        misc::ZERO_PTR,
-        misc_early::BUILTIN_TYPE_SHADOW,
-        misc_early::DOUBLE_NEG,
-        misc_early::DUPLICATE_UNDERSCORE_ARGUMENT,
-        misc_early::MIXED_CASE_HEX_LITERALS,
-        misc_early::REDUNDANT_CLOSURE_CALL,
-        misc_early::REDUNDANT_PATTERN,
-        misc_early::UNNEEDED_FIELD_PATTERN,
-        misc_early::UNNEEDED_WILDCARD_PATTERN,
-        misc_early::ZERO_PREFIXED_LITERAL,
-        mul_add::MANUAL_MUL_ADD,
-        mut_reference::UNNECESSARY_MUT_PASSED,
-        mutable_debug_assertion::DEBUG_ASSERT_WITH_MUT_CALL,
-        mutex_atomic::MUTEX_ATOMIC,
-        needless_bool::BOOL_COMPARISON,
-        needless_bool::NEEDLESS_BOOL,
-        needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE,
-        needless_update::NEEDLESS_UPDATE,
-        neg_cmp_op_on_partial_ord::NEG_CMP_OP_ON_PARTIAL_ORD,
-        neg_multiply::NEG_MULTIPLY,
-        new_without_default::NEW_WITHOUT_DEFAULT,
-        no_effect::NO_EFFECT,
-        no_effect::UNNECESSARY_OPERATION,
-        non_copy_const::BORROW_INTERIOR_MUTABLE_CONST,
-        non_copy_const::DECLARE_INTERIOR_MUTABLE_CONST,
-        non_expressive_names::JUST_UNDERSCORES_AND_DIGITS,
-        non_expressive_names::MANY_SINGLE_CHAR_NAMES,
-        ok_if_let::IF_LET_SOME_RESULT,
-        open_options::NONSENSICAL_OPEN_OPTIONS,
-        overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL,
-        panic_unimplemented::PANIC_PARAMS,
-        partialeq_ne_impl::PARTIALEQ_NE_IMPL,
-        precedence::PRECEDENCE,
-        ptr::CMP_NULL,
-        ptr::MUT_FROM_REF,
-        ptr::PTR_ARG,
-        ptr_offset_with_cast::PTR_OFFSET_WITH_CAST,
-        question_mark::QUESTION_MARK,
-        ranges::ITERATOR_STEP_BY_ZERO,
-        ranges::RANGE_MINUS_ONE,
-        ranges::RANGE_PLUS_ONE,
-        ranges::RANGE_ZIP_WITH_LEN,
-        redundant_clone::REDUNDANT_CLONE,
-        redundant_field_names::REDUNDANT_FIELD_NAMES,
-        redundant_pattern_matching::REDUNDANT_PATTERN_MATCHING,
-        redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES,
-        reference::DEREF_ADDROF,
-        reference::REF_IN_DEREF,
-        regex::INVALID_REGEX,
-        regex::REGEX_MACRO,
-        regex::TRIVIAL_REGEX,
-        returns::LET_AND_RETURN,
-        returns::NEEDLESS_RETURN,
-        returns::UNUSED_UNIT,
-        serde_api::SERDE_API_MISUSE,
-        slow_vector_initialization::SLOW_VECTOR_INITIALIZATION,
-        strings::STRING_LIT_AS_BYTES,
-        suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL,
-        suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL,
-        swap::ALMOST_SWAPPED,
-        swap::MANUAL_SWAP,
-        temporary_assignment::TEMPORARY_ASSIGNMENT,
-        transmute::CROSSPOINTER_TRANSMUTE,
-        transmute::TRANSMUTE_BYTES_TO_STR,
-        transmute::TRANSMUTE_INT_TO_BOOL,
-        transmute::TRANSMUTE_INT_TO_CHAR,
-        transmute::TRANSMUTE_INT_TO_FLOAT,
-        transmute::TRANSMUTE_PTR_TO_PTR,
-        transmute::TRANSMUTE_PTR_TO_REF,
-        transmute::UNSOUND_COLLECTION_TRANSMUTE,
-        transmute::USELESS_TRANSMUTE,
-        transmute::WRONG_TRANSMUTE,
-        transmuting_null::TRANSMUTING_NULL,
-        trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
-        try_err::TRY_ERR,
-        types::ABSURD_EXTREME_COMPARISONS,
-        types::BORROWED_BOX,
-        types::BOX_VEC,
-        types::CAST_PTR_ALIGNMENT,
-        types::CAST_REF_TO_MUT,
-        types::CHAR_LIT_AS_U8,
-        types::FN_TO_NUMERIC_CAST,
-        types::FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
-        types::IMPLICIT_HASHER,
-        types::LET_UNIT_VALUE,
-        types::OPTION_OPTION,
-        types::TYPE_COMPLEXITY,
-        types::UNIT_ARG,
-        types::UNIT_CMP,
-        types::UNNECESSARY_CAST,
-        types::VEC_BOX,
-        unicode::ZERO_WIDTH_SPACE,
-        unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME,
-        unused_io_amount::UNUSED_IO_AMOUNT,
-        unused_label::UNUSED_LABEL,
-        unwrap::PANICKING_UNWRAP,
-        unwrap::UNNECESSARY_UNWRAP,
-        vec::USELESS_VEC,
-        write::PRINTLN_EMPTY_STRING,
-        write::PRINT_LITERAL,
-        write::PRINT_WITH_NEWLINE,
-        write::WRITELN_EMPTY_STRING,
-        write::WRITE_LITERAL,
-        write::WRITE_WITH_NEWLINE,
-        zero_div_zero::ZERO_DIVIDED_BY_ZERO,
+    store.register_group(true, "clippy::all", Some("clippy"), vec![
+        LintId::of(&approx_const::APPROX_CONSTANT),
+        LintId::of(&assertions_on_constants::ASSERTIONS_ON_CONSTANTS),
+        LintId::of(&assign_ops::ASSIGN_OP_PATTERN),
+        LintId::of(&assign_ops::MISREFACTORED_ASSIGN_OP),
+        LintId::of(&attrs::DEPRECATED_CFG_ATTR),
+        LintId::of(&attrs::DEPRECATED_SEMVER),
+        LintId::of(&attrs::UNKNOWN_CLIPPY_LINTS),
+        LintId::of(&attrs::USELESS_ATTRIBUTE),
+        LintId::of(&bit_mask::BAD_BIT_MASK),
+        LintId::of(&bit_mask::INEFFECTIVE_BIT_MASK),
+        LintId::of(&bit_mask::VERBOSE_BIT_MASK),
+        LintId::of(&blacklisted_name::BLACKLISTED_NAME),
+        LintId::of(&block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR),
+        LintId::of(&block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT),
+        LintId::of(&booleans::LOGIC_BUG),
+        LintId::of(&booleans::NONMINIMAL_BOOL),
+        LintId::of(&bytecount::NAIVE_BYTECOUNT),
+        LintId::of(&cognitive_complexity::COGNITIVE_COMPLEXITY),
+        LintId::of(&collapsible_if::COLLAPSIBLE_IF),
+        LintId::of(&comparison_chain::COMPARISON_CHAIN),
+        LintId::of(&copies::IFS_SAME_COND),
+        LintId::of(&copies::IF_SAME_THEN_ELSE),
+        LintId::of(&derive::DERIVE_HASH_XOR_EQ),
+        LintId::of(&doc::MISSING_SAFETY_DOC),
+        LintId::of(&doc::NEEDLESS_DOCTEST_MAIN),
+        LintId::of(&double_comparison::DOUBLE_COMPARISONS),
+        LintId::of(&double_parens::DOUBLE_PARENS),
+        LintId::of(&drop_bounds::DROP_BOUNDS),
+        LintId::of(&drop_forget_ref::DROP_COPY),
+        LintId::of(&drop_forget_ref::DROP_REF),
+        LintId::of(&drop_forget_ref::FORGET_COPY),
+        LintId::of(&drop_forget_ref::FORGET_REF),
+        LintId::of(&duration_subsec::DURATION_SUBSEC),
+        LintId::of(&entry::MAP_ENTRY),
+        LintId::of(&enum_clike::ENUM_CLIKE_UNPORTABLE_VARIANT),
+        LintId::of(&enum_variants::ENUM_VARIANT_NAMES),
+        LintId::of(&enum_variants::MODULE_INCEPTION),
+        LintId::of(&eq_op::EQ_OP),
+        LintId::of(&eq_op::OP_REF),
+        LintId::of(&erasing_op::ERASING_OP),
+        LintId::of(&escape::BOXED_LOCAL),
+        LintId::of(&eta_reduction::REDUNDANT_CLOSURE),
+        LintId::of(&eval_order_dependence::DIVERGING_SUB_EXPRESSION),
+        LintId::of(&eval_order_dependence::EVAL_ORDER_DEPENDENCE),
+        LintId::of(&excessive_precision::EXCESSIVE_PRECISION),
+        LintId::of(&explicit_write::EXPLICIT_WRITE),
+        LintId::of(&format::USELESS_FORMAT),
+        LintId::of(&formatting::POSSIBLE_MISSING_COMMA),
+        LintId::of(&formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING),
+        LintId::of(&formatting::SUSPICIOUS_ELSE_FORMATTING),
+        LintId::of(&formatting::SUSPICIOUS_UNARY_OP_FORMATTING),
+        LintId::of(&functions::DOUBLE_MUST_USE),
+        LintId::of(&functions::MUST_USE_UNIT),
+        LintId::of(&functions::NOT_UNSAFE_PTR_ARG_DEREF),
+        LintId::of(&functions::TOO_MANY_ARGUMENTS),
+        LintId::of(&get_last_with_len::GET_LAST_WITH_LEN),
+        LintId::of(&identity_conversion::IDENTITY_CONVERSION),
+        LintId::of(&identity_op::IDENTITY_OP),
+        LintId::of(&indexing_slicing::OUT_OF_BOUNDS_INDEXING),
+        LintId::of(&infallible_destructuring_match::INFALLIBLE_DESTRUCTURING_MATCH),
+        LintId::of(&infinite_iter::INFINITE_ITER),
+        LintId::of(&inherent_to_string::INHERENT_TO_STRING),
+        LintId::of(&inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY),
+        LintId::of(&inline_fn_without_body::INLINE_FN_WITHOUT_BODY),
+        LintId::of(&int_plus_one::INT_PLUS_ONE),
+        LintId::of(&large_enum_variant::LARGE_ENUM_VARIANT),
+        LintId::of(&len_zero::LEN_WITHOUT_IS_EMPTY),
+        LintId::of(&len_zero::LEN_ZERO),
+        LintId::of(&let_if_seq::USELESS_LET_IF_SEQ),
+        LintId::of(&lifetimes::EXTRA_UNUSED_LIFETIMES),
+        LintId::of(&lifetimes::NEEDLESS_LIFETIMES),
+        LintId::of(&literal_representation::INCONSISTENT_DIGIT_GROUPING),
+        LintId::of(&literal_representation::MISTYPED_LITERAL_SUFFIXES),
+        LintId::of(&literal_representation::UNREADABLE_LITERAL),
+        LintId::of(&loops::EMPTY_LOOP),
+        LintId::of(&loops::EXPLICIT_COUNTER_LOOP),
+        LintId::of(&loops::FOR_KV_MAP),
+        LintId::of(&loops::FOR_LOOP_OVER_OPTION),
+        LintId::of(&loops::FOR_LOOP_OVER_RESULT),
+        LintId::of(&loops::ITER_NEXT_LOOP),
+        LintId::of(&loops::MANUAL_MEMCPY),
+        LintId::of(&loops::MUT_RANGE_BOUND),
+        LintId::of(&loops::NEEDLESS_COLLECT),
+        LintId::of(&loops::NEEDLESS_RANGE_LOOP),
+        LintId::of(&loops::NEVER_LOOP),
+        LintId::of(&loops::REVERSE_RANGE_LOOP),
+        LintId::of(&loops::WHILE_IMMUTABLE_CONDITION),
+        LintId::of(&loops::WHILE_LET_LOOP),
+        LintId::of(&loops::WHILE_LET_ON_ITERATOR),
+        LintId::of(&main_recursion::MAIN_RECURSION),
+        LintId::of(&map_clone::MAP_CLONE),
+        LintId::of(&map_unit_fn::OPTION_MAP_UNIT_FN),
+        LintId::of(&map_unit_fn::RESULT_MAP_UNIT_FN),
+        LintId::of(&matches::MATCH_AS_REF),
+        LintId::of(&matches::MATCH_BOOL),
+        LintId::of(&matches::MATCH_OVERLAPPING_ARM),
+        LintId::of(&matches::MATCH_REF_PATS),
+        LintId::of(&matches::MATCH_WILD_ERR_ARM),
+        LintId::of(&matches::SINGLE_MATCH),
+        LintId::of(&mem_discriminant::MEM_DISCRIMINANT_NON_ENUM),
+        LintId::of(&mem_replace::MEM_REPLACE_OPTION_WITH_NONE),
+        LintId::of(&mem_replace::MEM_REPLACE_WITH_UNINIT),
+        LintId::of(&methods::CHARS_LAST_CMP),
+        LintId::of(&methods::CHARS_NEXT_CMP),
+        LintId::of(&methods::CLONE_DOUBLE_REF),
+        LintId::of(&methods::CLONE_ON_COPY),
+        LintId::of(&methods::EXPECT_FUN_CALL),
+        LintId::of(&methods::FILTER_NEXT),
+        LintId::of(&methods::FLAT_MAP_IDENTITY),
+        LintId::of(&methods::INEFFICIENT_TO_STRING),
+        LintId::of(&methods::INTO_ITER_ON_ARRAY),
+        LintId::of(&methods::INTO_ITER_ON_REF),
+        LintId::of(&methods::ITER_CLONED_COLLECT),
+        LintId::of(&methods::ITER_NTH),
+        LintId::of(&methods::ITER_SKIP_NEXT),
+        LintId::of(&methods::MANUAL_SATURATING_ARITHMETIC),
+        LintId::of(&methods::NEW_RET_NO_SELF),
+        LintId::of(&methods::OK_EXPECT),
+        LintId::of(&methods::OPTION_AND_THEN_SOME),
+        LintId::of(&methods::OPTION_MAP_OR_NONE),
+        LintId::of(&methods::OR_FUN_CALL),
+        LintId::of(&methods::SEARCH_IS_SOME),
+        LintId::of(&methods::SHOULD_IMPLEMENT_TRAIT),
+        LintId::of(&methods::SINGLE_CHAR_PATTERN),
+        LintId::of(&methods::STRING_EXTEND_CHARS),
+        LintId::of(&methods::SUSPICIOUS_MAP),
+        LintId::of(&methods::TEMPORARY_CSTRING_AS_PTR),
+        LintId::of(&methods::UNINIT_ASSUMED_INIT),
+        LintId::of(&methods::UNNECESSARY_FILTER_MAP),
+        LintId::of(&methods::UNNECESSARY_FOLD),
+        LintId::of(&methods::USELESS_ASREF),
+        LintId::of(&methods::WRONG_SELF_CONVENTION),
+        LintId::of(&minmax::MIN_MAX),
+        LintId::of(&misc::CMP_NAN),
+        LintId::of(&misc::CMP_OWNED),
+        LintId::of(&misc::FLOAT_CMP),
+        LintId::of(&misc::MODULO_ONE),
+        LintId::of(&misc::SHORT_CIRCUIT_STATEMENT),
+        LintId::of(&misc::TOPLEVEL_REF_ARG),
+        LintId::of(&misc::ZERO_PTR),
+        LintId::of(&misc_early::BUILTIN_TYPE_SHADOW),
+        LintId::of(&misc_early::DOUBLE_NEG),
+        LintId::of(&misc_early::DUPLICATE_UNDERSCORE_ARGUMENT),
+        LintId::of(&misc_early::MIXED_CASE_HEX_LITERALS),
+        LintId::of(&misc_early::REDUNDANT_CLOSURE_CALL),
+        LintId::of(&misc_early::REDUNDANT_PATTERN),
+        LintId::of(&misc_early::UNNEEDED_FIELD_PATTERN),
+        LintId::of(&misc_early::UNNEEDED_WILDCARD_PATTERN),
+        LintId::of(&misc_early::ZERO_PREFIXED_LITERAL),
+        LintId::of(&mul_add::MANUAL_MUL_ADD),
+        LintId::of(&mut_reference::UNNECESSARY_MUT_PASSED),
+        LintId::of(&mutable_debug_assertion::DEBUG_ASSERT_WITH_MUT_CALL),
+        LintId::of(&mutex_atomic::MUTEX_ATOMIC),
+        LintId::of(&needless_bool::BOOL_COMPARISON),
+        LintId::of(&needless_bool::NEEDLESS_BOOL),
+        LintId::of(&needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE),
+        LintId::of(&needless_update::NEEDLESS_UPDATE),
+        LintId::of(&neg_cmp_op_on_partial_ord::NEG_CMP_OP_ON_PARTIAL_ORD),
+        LintId::of(&neg_multiply::NEG_MULTIPLY),
+        LintId::of(&new_without_default::NEW_WITHOUT_DEFAULT),
+        LintId::of(&no_effect::NO_EFFECT),
+        LintId::of(&no_effect::UNNECESSARY_OPERATION),
+        LintId::of(&non_copy_const::BORROW_INTERIOR_MUTABLE_CONST),
+        LintId::of(&non_copy_const::DECLARE_INTERIOR_MUTABLE_CONST),
+        LintId::of(&non_expressive_names::JUST_UNDERSCORES_AND_DIGITS),
+        LintId::of(&non_expressive_names::MANY_SINGLE_CHAR_NAMES),
+        LintId::of(&ok_if_let::IF_LET_SOME_RESULT),
+        LintId::of(&open_options::NONSENSICAL_OPEN_OPTIONS),
+        LintId::of(&overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL),
+        LintId::of(&panic_unimplemented::PANIC_PARAMS),
+        LintId::of(&partialeq_ne_impl::PARTIALEQ_NE_IMPL),
+        LintId::of(&precedence::PRECEDENCE),
+        LintId::of(&ptr::CMP_NULL),
+        LintId::of(&ptr::MUT_FROM_REF),
+        LintId::of(&ptr::PTR_ARG),
+        LintId::of(&ptr_offset_with_cast::PTR_OFFSET_WITH_CAST),
+        LintId::of(&question_mark::QUESTION_MARK),
+        LintId::of(&ranges::ITERATOR_STEP_BY_ZERO),
+        LintId::of(&ranges::RANGE_MINUS_ONE),
+        LintId::of(&ranges::RANGE_PLUS_ONE),
+        LintId::of(&ranges::RANGE_ZIP_WITH_LEN),
+        LintId::of(&redundant_clone::REDUNDANT_CLONE),
+        LintId::of(&redundant_field_names::REDUNDANT_FIELD_NAMES),
+        LintId::of(&redundant_pattern_matching::REDUNDANT_PATTERN_MATCHING),
+        LintId::of(&redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES),
+        LintId::of(&reference::DEREF_ADDROF),
+        LintId::of(&reference::REF_IN_DEREF),
+        LintId::of(&regex::INVALID_REGEX),
+        LintId::of(&regex::REGEX_MACRO),
+        LintId::of(&regex::TRIVIAL_REGEX),
+        LintId::of(&returns::LET_AND_RETURN),
+        LintId::of(&returns::NEEDLESS_RETURN),
+        LintId::of(&returns::UNUSED_UNIT),
+        LintId::of(&serde_api::SERDE_API_MISUSE),
+        LintId::of(&slow_vector_initialization::SLOW_VECTOR_INITIALIZATION),
+        LintId::of(&strings::STRING_LIT_AS_BYTES),
+        LintId::of(&suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL),
+        LintId::of(&suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL),
+        LintId::of(&swap::ALMOST_SWAPPED),
+        LintId::of(&swap::MANUAL_SWAP),
+        LintId::of(&temporary_assignment::TEMPORARY_ASSIGNMENT),
+        LintId::of(&transmute::CROSSPOINTER_TRANSMUTE),
+        LintId::of(&transmute::TRANSMUTE_BYTES_TO_STR),
+        LintId::of(&transmute::TRANSMUTE_INT_TO_BOOL),
+        LintId::of(&transmute::TRANSMUTE_INT_TO_CHAR),
+        LintId::of(&transmute::TRANSMUTE_INT_TO_FLOAT),
+        LintId::of(&transmute::TRANSMUTE_PTR_TO_PTR),
+        LintId::of(&transmute::TRANSMUTE_PTR_TO_REF),
+        LintId::of(&transmute::UNSOUND_COLLECTION_TRANSMUTE),
+        LintId::of(&transmute::USELESS_TRANSMUTE),
+        LintId::of(&transmute::WRONG_TRANSMUTE),
+        LintId::of(&transmuting_null::TRANSMUTING_NULL),
+        LintId::of(&trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF),
+        LintId::of(&try_err::TRY_ERR),
+        LintId::of(&types::ABSURD_EXTREME_COMPARISONS),
+        LintId::of(&types::BORROWED_BOX),
+        LintId::of(&types::BOX_VEC),
+        LintId::of(&types::CAST_PTR_ALIGNMENT),
+        LintId::of(&types::CAST_REF_TO_MUT),
+        LintId::of(&types::CHAR_LIT_AS_U8),
+        LintId::of(&types::FN_TO_NUMERIC_CAST),
+        LintId::of(&types::FN_TO_NUMERIC_CAST_WITH_TRUNCATION),
+        LintId::of(&types::IMPLICIT_HASHER),
+        LintId::of(&types::LET_UNIT_VALUE),
+        LintId::of(&types::OPTION_OPTION),
+        LintId::of(&types::TYPE_COMPLEXITY),
+        LintId::of(&types::UNIT_ARG),
+        LintId::of(&types::UNIT_CMP),
+        LintId::of(&types::UNNECESSARY_CAST),
+        LintId::of(&types::VEC_BOX),
+        LintId::of(&unicode::ZERO_WIDTH_SPACE),
+        LintId::of(&unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME),
+        LintId::of(&unused_io_amount::UNUSED_IO_AMOUNT),
+        LintId::of(&unused_label::UNUSED_LABEL),
+        LintId::of(&unwrap::PANICKING_UNWRAP),
+        LintId::of(&unwrap::UNNECESSARY_UNWRAP),
+        LintId::of(&vec::USELESS_VEC),
+        LintId::of(&write::PRINTLN_EMPTY_STRING),
+        LintId::of(&write::PRINT_LITERAL),
+        LintId::of(&write::PRINT_WITH_NEWLINE),
+        LintId::of(&write::WRITELN_EMPTY_STRING),
+        LintId::of(&write::WRITE_LITERAL),
+        LintId::of(&write::WRITE_WITH_NEWLINE),
+        LintId::of(&zero_div_zero::ZERO_DIVIDED_BY_ZERO),
     ]);
 
-    reg.register_lint_group("clippy::style", Some("clippy_style"), vec![
-        assertions_on_constants::ASSERTIONS_ON_CONSTANTS,
-        assign_ops::ASSIGN_OP_PATTERN,
-        attrs::UNKNOWN_CLIPPY_LINTS,
-        bit_mask::VERBOSE_BIT_MASK,
-        blacklisted_name::BLACKLISTED_NAME,
-        block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR,
-        block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT,
-        collapsible_if::COLLAPSIBLE_IF,
-        comparison_chain::COMPARISON_CHAIN,
-        doc::MISSING_SAFETY_DOC,
-        doc::NEEDLESS_DOCTEST_MAIN,
-        enum_variants::ENUM_VARIANT_NAMES,
-        enum_variants::MODULE_INCEPTION,
-        eq_op::OP_REF,
-        eta_reduction::REDUNDANT_CLOSURE,
-        excessive_precision::EXCESSIVE_PRECISION,
-        formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING,
-        formatting::SUSPICIOUS_ELSE_FORMATTING,
-        formatting::SUSPICIOUS_UNARY_OP_FORMATTING,
-        functions::DOUBLE_MUST_USE,
-        functions::MUST_USE_UNIT,
-        infallible_destructuring_match::INFALLIBLE_DESTRUCTURING_MATCH,
-        inherent_to_string::INHERENT_TO_STRING,
-        len_zero::LEN_WITHOUT_IS_EMPTY,
-        len_zero::LEN_ZERO,
-        let_if_seq::USELESS_LET_IF_SEQ,
-        literal_representation::INCONSISTENT_DIGIT_GROUPING,
-        literal_representation::UNREADABLE_LITERAL,
-        loops::EMPTY_LOOP,
-        loops::FOR_KV_MAP,
-        loops::NEEDLESS_RANGE_LOOP,
-        loops::WHILE_LET_ON_ITERATOR,
-        main_recursion::MAIN_RECURSION,
-        map_clone::MAP_CLONE,
-        matches::MATCH_BOOL,
-        matches::MATCH_OVERLAPPING_ARM,
-        matches::MATCH_REF_PATS,
-        matches::MATCH_WILD_ERR_ARM,
-        matches::SINGLE_MATCH,
-        mem_replace::MEM_REPLACE_OPTION_WITH_NONE,
-        methods::CHARS_LAST_CMP,
-        methods::INTO_ITER_ON_REF,
-        methods::ITER_CLONED_COLLECT,
-        methods::ITER_SKIP_NEXT,
-        methods::MANUAL_SATURATING_ARITHMETIC,
-        methods::NEW_RET_NO_SELF,
-        methods::OK_EXPECT,
-        methods::OPTION_MAP_OR_NONE,
-        methods::SHOULD_IMPLEMENT_TRAIT,
-        methods::STRING_EXTEND_CHARS,
-        methods::UNNECESSARY_FOLD,
-        methods::WRONG_SELF_CONVENTION,
-        misc::TOPLEVEL_REF_ARG,
-        misc::ZERO_PTR,
-        misc_early::BUILTIN_TYPE_SHADOW,
-        misc_early::DOUBLE_NEG,
-        misc_early::DUPLICATE_UNDERSCORE_ARGUMENT,
-        misc_early::MIXED_CASE_HEX_LITERALS,
-        misc_early::REDUNDANT_PATTERN,
-        misc_early::UNNEEDED_FIELD_PATTERN,
-        mut_reference::UNNECESSARY_MUT_PASSED,
-        neg_multiply::NEG_MULTIPLY,
-        new_without_default::NEW_WITHOUT_DEFAULT,
-        non_expressive_names::JUST_UNDERSCORES_AND_DIGITS,
-        non_expressive_names::MANY_SINGLE_CHAR_NAMES,
-        ok_if_let::IF_LET_SOME_RESULT,
-        panic_unimplemented::PANIC_PARAMS,
-        ptr::CMP_NULL,
-        ptr::PTR_ARG,
-        question_mark::QUESTION_MARK,
-        redundant_field_names::REDUNDANT_FIELD_NAMES,
-        redundant_pattern_matching::REDUNDANT_PATTERN_MATCHING,
-        redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES,
-        regex::REGEX_MACRO,
-        regex::TRIVIAL_REGEX,
-        returns::LET_AND_RETURN,
-        returns::NEEDLESS_RETURN,
-        returns::UNUSED_UNIT,
-        strings::STRING_LIT_AS_BYTES,
-        try_err::TRY_ERR,
-        types::FN_TO_NUMERIC_CAST,
-        types::FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
-        types::IMPLICIT_HASHER,
-        types::LET_UNIT_VALUE,
-        unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME,
-        write::PRINTLN_EMPTY_STRING,
-        write::PRINT_LITERAL,
-        write::PRINT_WITH_NEWLINE,
-        write::WRITELN_EMPTY_STRING,
-        write::WRITE_LITERAL,
-        write::WRITE_WITH_NEWLINE,
+    store.register_group(true, "clippy::style", Some("clippy_style"), vec![
+        LintId::of(&assertions_on_constants::ASSERTIONS_ON_CONSTANTS),
+        LintId::of(&assign_ops::ASSIGN_OP_PATTERN),
+        LintId::of(&attrs::UNKNOWN_CLIPPY_LINTS),
+        LintId::of(&bit_mask::VERBOSE_BIT_MASK),
+        LintId::of(&blacklisted_name::BLACKLISTED_NAME),
+        LintId::of(&block_in_if_condition::BLOCK_IN_IF_CONDITION_EXPR),
+        LintId::of(&block_in_if_condition::BLOCK_IN_IF_CONDITION_STMT),
+        LintId::of(&collapsible_if::COLLAPSIBLE_IF),
+        LintId::of(&comparison_chain::COMPARISON_CHAIN),
+        LintId::of(&doc::MISSING_SAFETY_DOC),
+        LintId::of(&doc::NEEDLESS_DOCTEST_MAIN),
+        LintId::of(&enum_variants::ENUM_VARIANT_NAMES),
+        LintId::of(&enum_variants::MODULE_INCEPTION),
+        LintId::of(&eq_op::OP_REF),
+        LintId::of(&eta_reduction::REDUNDANT_CLOSURE),
+        LintId::of(&excessive_precision::EXCESSIVE_PRECISION),
+        LintId::of(&formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING),
+        LintId::of(&formatting::SUSPICIOUS_ELSE_FORMATTING),
+        LintId::of(&formatting::SUSPICIOUS_UNARY_OP_FORMATTING),
+        LintId::of(&functions::DOUBLE_MUST_USE),
+        LintId::of(&functions::MUST_USE_UNIT),
+        LintId::of(&infallible_destructuring_match::INFALLIBLE_DESTRUCTURING_MATCH),
+        LintId::of(&inherent_to_string::INHERENT_TO_STRING),
+        LintId::of(&len_zero::LEN_WITHOUT_IS_EMPTY),
+        LintId::of(&len_zero::LEN_ZERO),
+        LintId::of(&let_if_seq::USELESS_LET_IF_SEQ),
+        LintId::of(&literal_representation::INCONSISTENT_DIGIT_GROUPING),
+        LintId::of(&literal_representation::UNREADABLE_LITERAL),
+        LintId::of(&loops::EMPTY_LOOP),
+        LintId::of(&loops::FOR_KV_MAP),
+        LintId::of(&loops::NEEDLESS_RANGE_LOOP),
+        LintId::of(&loops::WHILE_LET_ON_ITERATOR),
+        LintId::of(&main_recursion::MAIN_RECURSION),
+        LintId::of(&map_clone::MAP_CLONE),
+        LintId::of(&matches::MATCH_BOOL),
+        LintId::of(&matches::MATCH_OVERLAPPING_ARM),
+        LintId::of(&matches::MATCH_REF_PATS),
+        LintId::of(&matches::MATCH_WILD_ERR_ARM),
+        LintId::of(&matches::SINGLE_MATCH),
+        LintId::of(&mem_replace::MEM_REPLACE_OPTION_WITH_NONE),
+        LintId::of(&methods::CHARS_LAST_CMP),
+        LintId::of(&methods::INTO_ITER_ON_REF),
+        LintId::of(&methods::ITER_CLONED_COLLECT),
+        LintId::of(&methods::ITER_SKIP_NEXT),
+        LintId::of(&methods::MANUAL_SATURATING_ARITHMETIC),
+        LintId::of(&methods::NEW_RET_NO_SELF),
+        LintId::of(&methods::OK_EXPECT),
+        LintId::of(&methods::OPTION_MAP_OR_NONE),
+        LintId::of(&methods::SHOULD_IMPLEMENT_TRAIT),
+        LintId::of(&methods::STRING_EXTEND_CHARS),
+        LintId::of(&methods::UNNECESSARY_FOLD),
+        LintId::of(&methods::WRONG_SELF_CONVENTION),
+        LintId::of(&misc::TOPLEVEL_REF_ARG),
+        LintId::of(&misc::ZERO_PTR),
+        LintId::of(&misc_early::BUILTIN_TYPE_SHADOW),
+        LintId::of(&misc_early::DOUBLE_NEG),
+        LintId::of(&misc_early::DUPLICATE_UNDERSCORE_ARGUMENT),
+        LintId::of(&misc_early::MIXED_CASE_HEX_LITERALS),
+        LintId::of(&misc_early::REDUNDANT_PATTERN),
+        LintId::of(&misc_early::UNNEEDED_FIELD_PATTERN),
+        LintId::of(&mut_reference::UNNECESSARY_MUT_PASSED),
+        LintId::of(&neg_multiply::NEG_MULTIPLY),
+        LintId::of(&new_without_default::NEW_WITHOUT_DEFAULT),
+        LintId::of(&non_expressive_names::JUST_UNDERSCORES_AND_DIGITS),
+        LintId::of(&non_expressive_names::MANY_SINGLE_CHAR_NAMES),
+        LintId::of(&ok_if_let::IF_LET_SOME_RESULT),
+        LintId::of(&panic_unimplemented::PANIC_PARAMS),
+        LintId::of(&ptr::CMP_NULL),
+        LintId::of(&ptr::PTR_ARG),
+        LintId::of(&question_mark::QUESTION_MARK),
+        LintId::of(&redundant_field_names::REDUNDANT_FIELD_NAMES),
+        LintId::of(&redundant_pattern_matching::REDUNDANT_PATTERN_MATCHING),
+        LintId::of(&redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES),
+        LintId::of(&regex::REGEX_MACRO),
+        LintId::of(&regex::TRIVIAL_REGEX),
+        LintId::of(&returns::LET_AND_RETURN),
+        LintId::of(&returns::NEEDLESS_RETURN),
+        LintId::of(&returns::UNUSED_UNIT),
+        LintId::of(&strings::STRING_LIT_AS_BYTES),
+        LintId::of(&try_err::TRY_ERR),
+        LintId::of(&types::FN_TO_NUMERIC_CAST),
+        LintId::of(&types::FN_TO_NUMERIC_CAST_WITH_TRUNCATION),
+        LintId::of(&types::IMPLICIT_HASHER),
+        LintId::of(&types::LET_UNIT_VALUE),
+        LintId::of(&unsafe_removed_from_name::UNSAFE_REMOVED_FROM_NAME),
+        LintId::of(&write::PRINTLN_EMPTY_STRING),
+        LintId::of(&write::PRINT_LITERAL),
+        LintId::of(&write::PRINT_WITH_NEWLINE),
+        LintId::of(&write::WRITELN_EMPTY_STRING),
+        LintId::of(&write::WRITE_LITERAL),
+        LintId::of(&write::WRITE_WITH_NEWLINE),
     ]);
 
-    reg.register_lint_group("clippy::complexity", Some("clippy_complexity"), vec![
-        assign_ops::MISREFACTORED_ASSIGN_OP,
-        attrs::DEPRECATED_CFG_ATTR,
-        booleans::NONMINIMAL_BOOL,
-        cognitive_complexity::COGNITIVE_COMPLEXITY,
-        double_comparison::DOUBLE_COMPARISONS,
-        double_parens::DOUBLE_PARENS,
-        duration_subsec::DURATION_SUBSEC,
-        eval_order_dependence::DIVERGING_SUB_EXPRESSION,
-        eval_order_dependence::EVAL_ORDER_DEPENDENCE,
-        explicit_write::EXPLICIT_WRITE,
-        format::USELESS_FORMAT,
-        functions::TOO_MANY_ARGUMENTS,
-        get_last_with_len::GET_LAST_WITH_LEN,
-        identity_conversion::IDENTITY_CONVERSION,
-        identity_op::IDENTITY_OP,
-        int_plus_one::INT_PLUS_ONE,
-        lifetimes::EXTRA_UNUSED_LIFETIMES,
-        lifetimes::NEEDLESS_LIFETIMES,
-        loops::EXPLICIT_COUNTER_LOOP,
-        loops::MUT_RANGE_BOUND,
-        loops::WHILE_LET_LOOP,
-        map_unit_fn::OPTION_MAP_UNIT_FN,
-        map_unit_fn::RESULT_MAP_UNIT_FN,
-        matches::MATCH_AS_REF,
-        methods::CHARS_NEXT_CMP,
-        methods::CLONE_ON_COPY,
-        methods::FILTER_NEXT,
-        methods::FLAT_MAP_IDENTITY,
-        methods::OPTION_AND_THEN_SOME,
-        methods::SEARCH_IS_SOME,
-        methods::SUSPICIOUS_MAP,
-        methods::UNNECESSARY_FILTER_MAP,
-        methods::USELESS_ASREF,
-        misc::SHORT_CIRCUIT_STATEMENT,
-        misc_early::REDUNDANT_CLOSURE_CALL,
-        misc_early::UNNEEDED_WILDCARD_PATTERN,
-        misc_early::ZERO_PREFIXED_LITERAL,
-        needless_bool::BOOL_COMPARISON,
-        needless_bool::NEEDLESS_BOOL,
-        needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE,
-        needless_update::NEEDLESS_UPDATE,
-        neg_cmp_op_on_partial_ord::NEG_CMP_OP_ON_PARTIAL_ORD,
-        no_effect::NO_EFFECT,
-        no_effect::UNNECESSARY_OPERATION,
-        overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL,
-        partialeq_ne_impl::PARTIALEQ_NE_IMPL,
-        precedence::PRECEDENCE,
-        ptr_offset_with_cast::PTR_OFFSET_WITH_CAST,
-        ranges::RANGE_MINUS_ONE,
-        ranges::RANGE_PLUS_ONE,
-        ranges::RANGE_ZIP_WITH_LEN,
-        reference::DEREF_ADDROF,
-        reference::REF_IN_DEREF,
-        swap::MANUAL_SWAP,
-        temporary_assignment::TEMPORARY_ASSIGNMENT,
-        transmute::CROSSPOINTER_TRANSMUTE,
-        transmute::TRANSMUTE_BYTES_TO_STR,
-        transmute::TRANSMUTE_INT_TO_BOOL,
-        transmute::TRANSMUTE_INT_TO_CHAR,
-        transmute::TRANSMUTE_INT_TO_FLOAT,
-        transmute::TRANSMUTE_PTR_TO_PTR,
-        transmute::TRANSMUTE_PTR_TO_REF,
-        transmute::USELESS_TRANSMUTE,
-        types::BORROWED_BOX,
-        types::CHAR_LIT_AS_U8,
-        types::OPTION_OPTION,
-        types::TYPE_COMPLEXITY,
-        types::UNIT_ARG,
-        types::UNNECESSARY_CAST,
-        types::VEC_BOX,
-        unused_label::UNUSED_LABEL,
-        unwrap::UNNECESSARY_UNWRAP,
-        zero_div_zero::ZERO_DIVIDED_BY_ZERO,
+    store.register_group(true, "clippy::complexity", Some("clippy_complexity"), vec![
+        LintId::of(&assign_ops::MISREFACTORED_ASSIGN_OP),
+        LintId::of(&attrs::DEPRECATED_CFG_ATTR),
+        LintId::of(&booleans::NONMINIMAL_BOOL),
+        LintId::of(&cognitive_complexity::COGNITIVE_COMPLEXITY),
+        LintId::of(&double_comparison::DOUBLE_COMPARISONS),
+        LintId::of(&double_parens::DOUBLE_PARENS),
+        LintId::of(&duration_subsec::DURATION_SUBSEC),
+        LintId::of(&eval_order_dependence::DIVERGING_SUB_EXPRESSION),
+        LintId::of(&eval_order_dependence::EVAL_ORDER_DEPENDENCE),
+        LintId::of(&explicit_write::EXPLICIT_WRITE),
+        LintId::of(&format::USELESS_FORMAT),
+        LintId::of(&functions::TOO_MANY_ARGUMENTS),
+        LintId::of(&get_last_with_len::GET_LAST_WITH_LEN),
+        LintId::of(&identity_conversion::IDENTITY_CONVERSION),
+        LintId::of(&identity_op::IDENTITY_OP),
+        LintId::of(&int_plus_one::INT_PLUS_ONE),
+        LintId::of(&lifetimes::EXTRA_UNUSED_LIFETIMES),
+        LintId::of(&lifetimes::NEEDLESS_LIFETIMES),
+        LintId::of(&loops::EXPLICIT_COUNTER_LOOP),
+        LintId::of(&loops::MUT_RANGE_BOUND),
+        LintId::of(&loops::WHILE_LET_LOOP),
+        LintId::of(&map_unit_fn::OPTION_MAP_UNIT_FN),
+        LintId::of(&map_unit_fn::RESULT_MAP_UNIT_FN),
+        LintId::of(&matches::MATCH_AS_REF),
+        LintId::of(&methods::CHARS_NEXT_CMP),
+        LintId::of(&methods::CLONE_ON_COPY),
+        LintId::of(&methods::FILTER_NEXT),
+        LintId::of(&methods::FLAT_MAP_IDENTITY),
+        LintId::of(&methods::OPTION_AND_THEN_SOME),
+        LintId::of(&methods::SEARCH_IS_SOME),
+        LintId::of(&methods::SUSPICIOUS_MAP),
+        LintId::of(&methods::UNNECESSARY_FILTER_MAP),
+        LintId::of(&methods::USELESS_ASREF),
+        LintId::of(&misc::SHORT_CIRCUIT_STATEMENT),
+        LintId::of(&misc_early::REDUNDANT_CLOSURE_CALL),
+        LintId::of(&misc_early::UNNEEDED_WILDCARD_PATTERN),
+        LintId::of(&misc_early::ZERO_PREFIXED_LITERAL),
+        LintId::of(&needless_bool::BOOL_COMPARISON),
+        LintId::of(&needless_bool::NEEDLESS_BOOL),
+        LintId::of(&needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE),
+        LintId::of(&needless_update::NEEDLESS_UPDATE),
+        LintId::of(&neg_cmp_op_on_partial_ord::NEG_CMP_OP_ON_PARTIAL_ORD),
+        LintId::of(&no_effect::NO_EFFECT),
+        LintId::of(&no_effect::UNNECESSARY_OPERATION),
+        LintId::of(&overflow_check_conditional::OVERFLOW_CHECK_CONDITIONAL),
+        LintId::of(&partialeq_ne_impl::PARTIALEQ_NE_IMPL),
+        LintId::of(&precedence::PRECEDENCE),
+        LintId::of(&ptr_offset_with_cast::PTR_OFFSET_WITH_CAST),
+        LintId::of(&ranges::RANGE_MINUS_ONE),
+        LintId::of(&ranges::RANGE_PLUS_ONE),
+        LintId::of(&ranges::RANGE_ZIP_WITH_LEN),
+        LintId::of(&reference::DEREF_ADDROF),
+        LintId::of(&reference::REF_IN_DEREF),
+        LintId::of(&swap::MANUAL_SWAP),
+        LintId::of(&temporary_assignment::TEMPORARY_ASSIGNMENT),
+        LintId::of(&transmute::CROSSPOINTER_TRANSMUTE),
+        LintId::of(&transmute::TRANSMUTE_BYTES_TO_STR),
+        LintId::of(&transmute::TRANSMUTE_INT_TO_BOOL),
+        LintId::of(&transmute::TRANSMUTE_INT_TO_CHAR),
+        LintId::of(&transmute::TRANSMUTE_INT_TO_FLOAT),
+        LintId::of(&transmute::TRANSMUTE_PTR_TO_PTR),
+        LintId::of(&transmute::TRANSMUTE_PTR_TO_REF),
+        LintId::of(&transmute::USELESS_TRANSMUTE),
+        LintId::of(&types::BORROWED_BOX),
+        LintId::of(&types::CHAR_LIT_AS_U8),
+        LintId::of(&types::OPTION_OPTION),
+        LintId::of(&types::TYPE_COMPLEXITY),
+        LintId::of(&types::UNIT_ARG),
+        LintId::of(&types::UNNECESSARY_CAST),
+        LintId::of(&types::VEC_BOX),
+        LintId::of(&unused_label::UNUSED_LABEL),
+        LintId::of(&unwrap::UNNECESSARY_UNWRAP),
+        LintId::of(&zero_div_zero::ZERO_DIVIDED_BY_ZERO),
     ]);
 
-    reg.register_lint_group("clippy::correctness", Some("clippy_correctness"), vec![
-        approx_const::APPROX_CONSTANT,
-        attrs::DEPRECATED_SEMVER,
-        attrs::USELESS_ATTRIBUTE,
-        bit_mask::BAD_BIT_MASK,
-        bit_mask::INEFFECTIVE_BIT_MASK,
-        booleans::LOGIC_BUG,
-        copies::IFS_SAME_COND,
-        copies::IF_SAME_THEN_ELSE,
-        derive::DERIVE_HASH_XOR_EQ,
-        drop_bounds::DROP_BOUNDS,
-        drop_forget_ref::DROP_COPY,
-        drop_forget_ref::DROP_REF,
-        drop_forget_ref::FORGET_COPY,
-        drop_forget_ref::FORGET_REF,
-        enum_clike::ENUM_CLIKE_UNPORTABLE_VARIANT,
-        eq_op::EQ_OP,
-        erasing_op::ERASING_OP,
-        formatting::POSSIBLE_MISSING_COMMA,
-        functions::NOT_UNSAFE_PTR_ARG_DEREF,
-        indexing_slicing::OUT_OF_BOUNDS_INDEXING,
-        infinite_iter::INFINITE_ITER,
-        inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY,
-        inline_fn_without_body::INLINE_FN_WITHOUT_BODY,
-        literal_representation::MISTYPED_LITERAL_SUFFIXES,
-        loops::FOR_LOOP_OVER_OPTION,
-        loops::FOR_LOOP_OVER_RESULT,
-        loops::ITER_NEXT_LOOP,
-        loops::NEVER_LOOP,
-        loops::REVERSE_RANGE_LOOP,
-        loops::WHILE_IMMUTABLE_CONDITION,
-        mem_discriminant::MEM_DISCRIMINANT_NON_ENUM,
-        mem_replace::MEM_REPLACE_WITH_UNINIT,
-        methods::CLONE_DOUBLE_REF,
-        methods::INTO_ITER_ON_ARRAY,
-        methods::TEMPORARY_CSTRING_AS_PTR,
-        methods::UNINIT_ASSUMED_INIT,
-        minmax::MIN_MAX,
-        misc::CMP_NAN,
-        misc::FLOAT_CMP,
-        misc::MODULO_ONE,
-        mutable_debug_assertion::DEBUG_ASSERT_WITH_MUT_CALL,
-        non_copy_const::BORROW_INTERIOR_MUTABLE_CONST,
-        non_copy_const::DECLARE_INTERIOR_MUTABLE_CONST,
-        open_options::NONSENSICAL_OPEN_OPTIONS,
-        ptr::MUT_FROM_REF,
-        ranges::ITERATOR_STEP_BY_ZERO,
-        regex::INVALID_REGEX,
-        serde_api::SERDE_API_MISUSE,
-        suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL,
-        suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL,
-        swap::ALMOST_SWAPPED,
-        transmute::UNSOUND_COLLECTION_TRANSMUTE,
-        transmute::WRONG_TRANSMUTE,
-        transmuting_null::TRANSMUTING_NULL,
-        types::ABSURD_EXTREME_COMPARISONS,
-        types::CAST_PTR_ALIGNMENT,
-        types::CAST_REF_TO_MUT,
-        types::UNIT_CMP,
-        unicode::ZERO_WIDTH_SPACE,
-        unused_io_amount::UNUSED_IO_AMOUNT,
-        unwrap::PANICKING_UNWRAP,
+    store.register_group(true, "clippy::correctness", Some("clippy_correctness"), vec![
+        LintId::of(&approx_const::APPROX_CONSTANT),
+        LintId::of(&attrs::DEPRECATED_SEMVER),
+        LintId::of(&attrs::USELESS_ATTRIBUTE),
+        LintId::of(&bit_mask::BAD_BIT_MASK),
+        LintId::of(&bit_mask::INEFFECTIVE_BIT_MASK),
+        LintId::of(&booleans::LOGIC_BUG),
+        LintId::of(&copies::IFS_SAME_COND),
+        LintId::of(&copies::IF_SAME_THEN_ELSE),
+        LintId::of(&derive::DERIVE_HASH_XOR_EQ),
+        LintId::of(&drop_bounds::DROP_BOUNDS),
+        LintId::of(&drop_forget_ref::DROP_COPY),
+        LintId::of(&drop_forget_ref::DROP_REF),
+        LintId::of(&drop_forget_ref::FORGET_COPY),
+        LintId::of(&drop_forget_ref::FORGET_REF),
+        LintId::of(&enum_clike::ENUM_CLIKE_UNPORTABLE_VARIANT),
+        LintId::of(&eq_op::EQ_OP),
+        LintId::of(&erasing_op::ERASING_OP),
+        LintId::of(&formatting::POSSIBLE_MISSING_COMMA),
+        LintId::of(&functions::NOT_UNSAFE_PTR_ARG_DEREF),
+        LintId::of(&indexing_slicing::OUT_OF_BOUNDS_INDEXING),
+        LintId::of(&infinite_iter::INFINITE_ITER),
+        LintId::of(&inherent_to_string::INHERENT_TO_STRING_SHADOW_DISPLAY),
+        LintId::of(&inline_fn_without_body::INLINE_FN_WITHOUT_BODY),
+        LintId::of(&literal_representation::MISTYPED_LITERAL_SUFFIXES),
+        LintId::of(&loops::FOR_LOOP_OVER_OPTION),
+        LintId::of(&loops::FOR_LOOP_OVER_RESULT),
+        LintId::of(&loops::ITER_NEXT_LOOP),
+        LintId::of(&loops::NEVER_LOOP),
+        LintId::of(&loops::REVERSE_RANGE_LOOP),
+        LintId::of(&loops::WHILE_IMMUTABLE_CONDITION),
+        LintId::of(&mem_discriminant::MEM_DISCRIMINANT_NON_ENUM),
+        LintId::of(&mem_replace::MEM_REPLACE_WITH_UNINIT),
+        LintId::of(&methods::CLONE_DOUBLE_REF),
+        LintId::of(&methods::INTO_ITER_ON_ARRAY),
+        LintId::of(&methods::TEMPORARY_CSTRING_AS_PTR),
+        LintId::of(&methods::UNINIT_ASSUMED_INIT),
+        LintId::of(&minmax::MIN_MAX),
+        LintId::of(&misc::CMP_NAN),
+        LintId::of(&misc::FLOAT_CMP),
+        LintId::of(&misc::MODULO_ONE),
+        LintId::of(&mutable_debug_assertion::DEBUG_ASSERT_WITH_MUT_CALL),
+        LintId::of(&non_copy_const::BORROW_INTERIOR_MUTABLE_CONST),
+        LintId::of(&non_copy_const::DECLARE_INTERIOR_MUTABLE_CONST),
+        LintId::of(&open_options::NONSENSICAL_OPEN_OPTIONS),
+        LintId::of(&ptr::MUT_FROM_REF),
+        LintId::of(&ranges::ITERATOR_STEP_BY_ZERO),
+        LintId::of(&regex::INVALID_REGEX),
+        LintId::of(&serde_api::SERDE_API_MISUSE),
+        LintId::of(&suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL),
+        LintId::of(&suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL),
+        LintId::of(&swap::ALMOST_SWAPPED),
+        LintId::of(&transmute::UNSOUND_COLLECTION_TRANSMUTE),
+        LintId::of(&transmute::WRONG_TRANSMUTE),
+        LintId::of(&transmuting_null::TRANSMUTING_NULL),
+        LintId::of(&types::ABSURD_EXTREME_COMPARISONS),
+        LintId::of(&types::CAST_PTR_ALIGNMENT),
+        LintId::of(&types::CAST_REF_TO_MUT),
+        LintId::of(&types::UNIT_CMP),
+        LintId::of(&unicode::ZERO_WIDTH_SPACE),
+        LintId::of(&unused_io_amount::UNUSED_IO_AMOUNT),
+        LintId::of(&unwrap::PANICKING_UNWRAP),
     ]);
 
-    reg.register_lint_group("clippy::perf", Some("clippy_perf"), vec![
-        bytecount::NAIVE_BYTECOUNT,
-        entry::MAP_ENTRY,
-        escape::BOXED_LOCAL,
-        large_enum_variant::LARGE_ENUM_VARIANT,
-        loops::MANUAL_MEMCPY,
-        loops::NEEDLESS_COLLECT,
-        methods::EXPECT_FUN_CALL,
-        methods::INEFFICIENT_TO_STRING,
-        methods::ITER_NTH,
-        methods::OR_FUN_CALL,
-        methods::SINGLE_CHAR_PATTERN,
-        misc::CMP_OWNED,
-        mul_add::MANUAL_MUL_ADD,
-        mutex_atomic::MUTEX_ATOMIC,
-        redundant_clone::REDUNDANT_CLONE,
-        slow_vector_initialization::SLOW_VECTOR_INITIALIZATION,
-        trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF,
-        types::BOX_VEC,
-        vec::USELESS_VEC,
+    store.register_group(true, "clippy::perf", Some("clippy_perf"), vec![
+        LintId::of(&bytecount::NAIVE_BYTECOUNT),
+        LintId::of(&entry::MAP_ENTRY),
+        LintId::of(&escape::BOXED_LOCAL),
+        LintId::of(&large_enum_variant::LARGE_ENUM_VARIANT),
+        LintId::of(&loops::MANUAL_MEMCPY),
+        LintId::of(&loops::NEEDLESS_COLLECT),
+        LintId::of(&methods::EXPECT_FUN_CALL),
+        LintId::of(&methods::INEFFICIENT_TO_STRING),
+        LintId::of(&methods::ITER_NTH),
+        LintId::of(&methods::OR_FUN_CALL),
+        LintId::of(&methods::SINGLE_CHAR_PATTERN),
+        LintId::of(&misc::CMP_OWNED),
+        LintId::of(&mul_add::MANUAL_MUL_ADD),
+        LintId::of(&mutex_atomic::MUTEX_ATOMIC),
+        LintId::of(&redundant_clone::REDUNDANT_CLONE),
+        LintId::of(&slow_vector_initialization::SLOW_VECTOR_INITIALIZATION),
+        LintId::of(&trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF),
+        LintId::of(&types::BOX_VEC),
+        LintId::of(&vec::USELESS_VEC),
     ]);
 
-    reg.register_lint_group("clippy::cargo", Some("clippy_cargo"), vec![
-        cargo_common_metadata::CARGO_COMMON_METADATA,
-        multiple_crate_versions::MULTIPLE_CRATE_VERSIONS,
-        wildcard_dependencies::WILDCARD_DEPENDENCIES,
+    store.register_group(true, "clippy::cargo", Some("clippy_cargo"), vec![
+        LintId::of(&cargo_common_metadata::CARGO_COMMON_METADATA),
+        LintId::of(&multiple_crate_versions::MULTIPLE_CRATE_VERSIONS),
+        LintId::of(&wildcard_dependencies::WILDCARD_DEPENDENCIES),
     ]);
 
-    reg.register_lint_group("clippy::nursery", Some("clippy_nursery"), vec![
-        attrs::EMPTY_LINE_AFTER_OUTER_ATTR,
-        fallible_impl_from::FALLIBLE_IMPL_FROM,
-        missing_const_for_fn::MISSING_CONST_FOR_FN,
-        mutex_atomic::MUTEX_INTEGER,
-        needless_borrow::NEEDLESS_BORROW,
-        path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE,
+    store.register_group(true, "clippy::nursery", Some("clippy_nursery"), vec![
+        LintId::of(&attrs::EMPTY_LINE_AFTER_OUTER_ATTR),
+        LintId::of(&fallible_impl_from::FALLIBLE_IMPL_FROM),
+        LintId::of(&missing_const_for_fn::MISSING_CONST_FOR_FN),
+        LintId::of(&mutex_atomic::MUTEX_INTEGER),
+        LintId::of(&needless_borrow::NEEDLESS_BORROW),
+        LintId::of(&path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE),
     ]);
 }
 

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -54,6 +54,7 @@ declare_clippy_lint! {
     "functions taking small copyable arguments by reference"
 }
 
+#[derive(Copy, Clone)]
 pub struct TriviallyCopyPassByRef {
     limit: u64,
 }
@@ -159,7 +160,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TriviallyCopyPassByRef {
                         return;
                     }
                 }
-            },
+            }
             FnKind::Method(..) => (),
             _ => return,
         }

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -160,7 +160,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TriviallyCopyPassByRef {
                         return;
                     }
                 }
-            }
+            },
             FnKind::Method(..) => (),
             _ => return,
         }

--- a/clippy_lints/src/utils/higher.rs
+++ b/clippy_lints/src/utils/higher.rs
@@ -64,13 +64,13 @@ pub fn range<'a, 'b, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'b hir::Expr) -> O
     if def_path.data.len() != 3 {
         return None;
     }
-    if def_path.data.get(0)?.data.as_interned_str().as_symbol() != sym!(ops) {
+    if def_path.data.get(0)?.data.as_symbol() != sym!(ops) {
         return None;
     }
-    if def_path.data.get(1)?.data.as_interned_str().as_symbol() != sym!(range) {
+    if def_path.data.get(1)?.data.as_symbol() != sym!(range) {
         return None;
     }
-    let type_name = def_path.data.get(2)?.data.as_interned_str();
+    let type_name = def_path.data.get(2)?.data.as_symbol();
     let range_types = [
         "RangeFrom",
         "RangeFull",

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -275,9 +275,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CompilerLintFunctions {
     }
 }
 
-pub struct OuterExpnDataPass;
-
-impl_lint_pass!(OuterExpnDataPass => [OUTER_EXPN_EXPN_DATA]);
+declare_lint_pass!(OuterExpnDataPass => [OUTER_EXPN_EXPN_DATA]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for OuterExpnDataPass {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr) {

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    match_def_path, match_type, method_calls, paths, span_help_and_lint, span_lint, span_lint_and_sugg, walk_ptrs_ty,
+    is_expn_of, match_def_path, match_type, method_calls, paths, span_help_and_lint, span_lint, span_lint_and_sugg,
+    walk_ptrs_ty,
 };
 use if_chain::if_chain;
 use rustc::hir;
@@ -148,25 +149,23 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LintWithoutLintPass {
             if is_lint_ref_type(cx, ty) {
                 self.declared_lints.insert(item.ident.name, item.span);
             }
-        } else if let hir::ItemKind::Impl(.., Some(ref trait_ref), _, ref impl_item_refs) = item.kind {
-            if_chain! {
-                if let hir::TraitRef{path, ..} = trait_ref;
-                if let Res::Def(DefKind::Trait, def_id) = path.res;
-                if match_def_path(cx, def_id, &paths::LINT_PASS);
-                then {
-                    let mut collector = LintCollector {
-                        output: &mut self.registered_lints,
-                        cx,
-                    };
-                    let body_id = cx.tcx.hir().body_owned_by(
-                        impl_item_refs
-                            .iter()
-                            .find(|iiref| iiref.ident.as_str() == "get_lints")
-                            .expect("LintPass needs to implement get_lints")
-                            .id.hir_id
-                    );
-                    collector.visit_expr(&cx.tcx.hir().body(body_id).value);
-                }
+        } else if is_expn_of(item.span, "impl_lint_pass").is_some()
+            || is_expn_of(item.span, "declare_lint_pass").is_some()
+        {
+            if let hir::ItemKind::Impl(.., None, _, ref impl_item_refs) = item.kind {
+                let mut collector = LintCollector {
+                    output: &mut self.registered_lints,
+                    cx,
+                };
+                let body_id = cx.tcx.hir().body_owned_by(
+                    impl_item_refs
+                        .iter()
+                        .find(|iiref| iiref.ident.as_str() == "get_lints")
+                        .expect("LintPass needs to implement get_lints")
+                        .id
+                        .hir_id,
+                );
+                collector.visit_expr(&cx.tcx.hir().body(body_id).value);
             }
         }
     }

--- a/clippy_lints/src/utils/paths.rs
+++ b/clippy_lints/src/utils/paths.rs
@@ -46,7 +46,6 @@ pub const ITERATOR: [&str; 5] = ["core", "iter", "traits", "iterator", "Iterator
 pub const LATE_CONTEXT: [&str; 4] = ["rustc", "lint", "context", "LateContext"];
 pub const LINKED_LIST: [&str; 4] = ["alloc", "collections", "linked_list", "LinkedList"];
 pub const LINT: [&str; 3] = ["rustc", "lint", "Lint"];
-pub const LINT_PASS: [&str; 3] = ["rustc", "lint", "LintPass"];
 pub const MEM_DISCRIMINANT: [&str; 3] = ["core", "mem", "discriminant"];
 pub const MEM_FORGET: [&str; 3] = ["core", "mem", "forget"];
 pub const MEM_MAYBEUNINIT: [&str; 4] = ["core", "mem", "maybe_uninit", "MaybeUninit"];

--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -9,5 +9,5 @@ if [[ "$CI" == true ]] || ! command -v rustup-toolchain-install-master > /dev/nu
   cargo install -Z install-upgrade rustup-toolchain-install-master --bin rustup-toolchain-install-master
 fi
 
-rustup-toolchain-install-master -f -n master
+rustup-toolchain-install-master -f -n master -c rustc-dev
 rustup override set master

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,22 +11,20 @@ use self::rustc_driver::plugin::Registry;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry<'_>) {
-    reg.sess.lint_store.with_read_lock(|lint_store| {
-        for (lint, _, _) in lint_store.get_lint_groups() {
-            reg.sess
-                .struct_warn(
-                    "the clippy plugin is being deprecated, please use cargo clippy or rls with the clippy feature",
-                )
-                .emit();
-            if lint == "clippy" {
-                // cargo clippy run on a crate that also uses the plugin
-                return;
-            }
+    for (lint, _, _) in reg.lint_store.get_lint_groups() {
+        reg.sess
+            .struct_warn(
+                "the clippy plugin is being deprecated, please use cargo clippy or rls with the clippy feature",
+            )
+            .emit();
+        if lint == "clippy" {
+            // cargo clippy run on a crate that also uses the plugin
+            return;
         }
-    });
+    }
 
-    let conf = clippy_lints::read_conf(reg);
-    clippy_lints::register_plugins(reg, &conf);
+    let conf = clippy_lints::read_conf(reg.args(), &reg.sess);
+    clippy_lints::register_plugins(&mut reg.lint_store, &reg.sess, &conf);
 }
 
 // only exists to let the dogfood integration test works.

--- a/tests/ui/lint_without_lint_pass.rs
+++ b/tests/ui/lint_without_lint_pass.rs
@@ -22,10 +22,6 @@ declare_clippy_lint! {
 
 pub struct Pass;
 impl LintPass for Pass {
-    fn get_lints(&self) -> LintArray {
-        lint_array!(TEST_LINT_REGISTERED)
-    }
-
     fn name(&self) -> &'static str {
         "TEST_LINT"
     }

--- a/tests/ui/lint_without_lint_pass.rs
+++ b/tests/ui/lint_without_lint_pass.rs
@@ -20,6 +20,12 @@ declare_clippy_lint! {
     ""
 }
 
+declare_clippy_lint! {
+    pub TEST_LINT_REGISTERED_ONLY_IMPL,
+    correctness,
+    ""
+}
+
 pub struct Pass;
 impl LintPass for Pass {
     fn name(&self) -> &'static str {
@@ -30,6 +36,6 @@ impl LintPass for Pass {
 declare_lint_pass!(Pass2 => [TEST_LINT_REGISTERED]);
 
 pub struct Pass3;
-impl_lint_pass!(Pass3 => [TEST_LINT_REGISTERED]);
+impl_lint_pass!(Pass3 => [TEST_LINT_REGISTERED_ONLY_IMPL]);
 
 fn main() {}


### PR DESCRIPTION
Specifically, this revises the clippy integration to utilize a new
callback to register its lints, as the prior editing of lint store in
Session is no longer possible.

---

changelog: none
