### PR TITLE
Rustup to rustc 1.40.0-nightly (29b6e0f0a 2019-10-13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 
 [dev-dependencies]
 cargo_metadata = "0.8.0"
-compiletest_rs = { version = "0.3.23", features = ["tmp"] }
+compiletest_rs = { version = "0.3.24", features = ["tmp"] }
 lazy_static = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
changelog: none