### PR TITLE
build: use my RTIM branch because old commit is force-pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
     - os: osx
     - os: windows
 
-script:
+before_script:
   - |
     if [ "$TRAVIS_BRANCH" == "auto" ] || [ "$TRAVIS_BRANCH" == "try" ]; then
       pr=$(echo $TRAVIS_COMMIT_MESSAGE | grep -o "#[0-9]*" | head -1 | sed 's/^#//g')
@@ -109,11 +109,14 @@ script:
   - |
     rm rust-toolchain
     ./setup-toolchain.sh
+  - |
     if [ "$TRAVIS_OS_NAME" == "windows" ]; then
       export PATH=$PATH:$(rustc --print sysroot)/bin
     else
       export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
     fi
+
+script:
   - |
     if [ -z ${INTEGRATION} ]; then
       travis_wait 30 ./ci/base-tests.sh && sleep 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,13 +107,13 @@ script:
       fi
     fi
   - |
-      rm rust-toolchain
-      ./setup-toolchain.sh
-      if [ "$TRAVIS_OS_NAME" == "windows" ]; then
-        export PATH=$PATH:$(rustc --print sysroot)/bin
-      else
-        export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
-      fi
+    rm rust-toolchain
+    ./setup-toolchain.sh
+    if [ "$TRAVIS_OS_NAME" == "windows" ]; then
+      export PATH=$PATH:$(rustc --print sysroot)/bin
+    else
+      export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
+    fi
   - |
     if [ -z ${INTEGRATION} ]; then
       travis_wait 30 ./ci/base-tests.sh && sleep 5
@@ -121,14 +121,14 @@ script:
       ./ci/integration-tests.sh && sleep 5
     fi
 
-after_success: |
-  #!/bin/bash
-  if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    set -ex
-    if [ -z ${INTEGRATION} ]; then
-      ./.github/deploy.sh
-    else
-      echo "Not deploying, because we're in an integration test run"
+after_success:
+  - |
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      set -e
+      if [ -z ${INTEGRATION} ]; then
+        ./.github/deploy.sh
+      else
+        echo "Not deploying, because we're in an integration test run"
+      fi
+      set +e
     fi
-    set +e
-  fi

--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Set up the appropriate rustc toolchain
 
+set -e
+
 cd "$(dirname "$0")" || exit
 
 if ! command -v rustup-toolchain-install-master > /dev/null; then

--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")" || exit
 if ! command -v rustup-toolchain-install-master > /dev/null; then
   cargo install \
     --git https://github.com/lzutao/rustup-toolchain-install-master \
-    --rev c44dbf920b644000ac3ba01184cbb1a01bb91519 \
+    --branch ci-more-oses \
     --bin rustup-toolchain-install-master \
     --debug
 fi


### PR DESCRIPTION
The old commit is gone (because of force-pushing).
Sorry for the inconvenience.

changelog: none
