### PR TITLE
travis: Windows build might be stuck as non-supported languages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-language: minimal
+language: bash
 
 os:
   - linux


### PR DESCRIPTION
See <https://docs.travis-ci.com/user/reference/windows/#supported-languages>
for list of Windows supported languages.

I'm sorry for making Travis Windows build stuck.

changelog: none
