### PR TITLE
appveyor: on_finish run after saving cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ branches:
 
 cache:
     - '%USERPROFILE%\.cargo'
-on_finish:
+after_test:
     - cargo install -Z install-upgrade cargo-cache --debug
     - cargo cache --autoclean
 


### PR DESCRIPTION
According to <https://www.appveyor.com/docs/build-configuration/#build-pipeline>
on_finish step runs after saving cache step, we should use after_test instead.

changelog: none
