### PR TITLE
Fix suggestion of `explicit_counter_loop`

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1461,10 +1461,19 @@ fn check_for_loop_explicit_counter<'a, 'tcx>(
             if visitor2.state == VarState::Warn {
                 if let Some(name) = visitor2.name {
                     let mut applicability = Applicability::MachineApplicable;
+
+                    // for some reason this is the only way to get the `Span`
+                    // of the entire `for` loop
+                    let for_span = if let ExprKind::Match(_, arms, _) = &expr.kind {
+                        arms[0].body.span
+                    } else {
+                        unreachable!()
+                    };
+
                     span_lint_and_sugg(
                         cx,
                         EXPLICIT_COUNTER_LOOP,
-                        expr.span,
+                        for_span.with_hi(arg.span.hi()),
                         &format!("the variable `{}` is used as a loop counter.", name),
                         "consider using",
                         format!(

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -46,7 +46,7 @@ impl<'a> Sugg<'a> {
     pub fn hir_opt(cx: &LateContext<'_, '_>, expr: &hir::Expr) -> Option<Self> {
         snippet_opt(cx, expr.span).map(|snippet| {
             let snippet = Cow::Owned(snippet);
-            Self::hir_from_snippet(expr, snippet)
+            Self::hir_from_snippet(cx, expr, snippet)
         })
     }
 
@@ -84,12 +84,20 @@ impl<'a> Sugg<'a> {
     pub fn hir_with_macro_callsite(cx: &LateContext<'_, '_>, expr: &hir::Expr, default: &'a str) -> Self {
         let snippet = snippet_with_macro_callsite(cx, expr.span, default);
 
-        Self::hir_from_snippet(expr, snippet)
+        Self::hir_from_snippet(cx, expr, snippet)
     }
 
     /// Generate a suggestion for an expression with the given snippet. This is used by the `hir_*`
     /// function variants of `Sugg`, since these use different snippet functions.
-    fn hir_from_snippet(expr: &hir::Expr, snippet: Cow<'a, str>) -> Self {
+    fn hir_from_snippet(cx: &LateContext<'_, '_>, expr: &hir::Expr, snippet: Cow<'a, str>) -> Self {
+        if let Some(range) = higher::range(cx, expr) {
+            let op = match range.limits {
+                ast::RangeLimits::HalfOpen => AssocOp::DotDot,
+                ast::RangeLimits::Closed => AssocOp::DotDotEq,
+            };
+            return Sugg::BinOp(op, snippet);
+        }
+
         match expr.kind {
             hir::ExprKind::AddrOf(..)
             | hir::ExprKind::Box(..)

--- a/tests/ui/explicit_counter_loop.rs
+++ b/tests/ui/explicit_counter_loop.rs
@@ -12,6 +12,16 @@ fn main() {
     for _v in &vec {
         _index += 1
     }
+
+    let mut _index = 0;
+    for _v in &mut vec {
+        _index += 1;
+    }
+
+    let mut _index = 0;
+    for _v in vec {
+        _index += 1;
+    }
 }
 
 mod issue_1219 {

--- a/tests/ui/explicit_counter_loop.stderr
+++ b/tests/ui/explicit_counter_loop.stderr
@@ -1,46 +1,46 @@
 error: the variable `_index` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:6:15
+  --> $DIR/explicit_counter_loop.rs:6:5
    |
 LL |     for _v in &vec {
-   |               ^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
+   |     ^^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
    |
    = note: `-D clippy::explicit-counter-loop` implied by `-D warnings`
 
 error: the variable `_index` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:12:15
+  --> $DIR/explicit_counter_loop.rs:12:5
    |
 LL |     for _v in &vec {
-   |               ^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
+   |     ^^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
 
 error: the variable `_index` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:17:15
+  --> $DIR/explicit_counter_loop.rs:17:5
    |
 LL |     for _v in &mut vec {
-   |               ^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter_mut().enumerate()`
+   |     ^^^^^^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter_mut().enumerate()`
 
 error: the variable `_index` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:22:15
+  --> $DIR/explicit_counter_loop.rs:22:5
    |
 LL |     for _v in vec {
-   |               ^^^ help: consider using: `for (_index, _v) in vec.into_iter().enumerate()`
+   |     ^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.into_iter().enumerate()`
 
 error: the variable `count` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:61:19
+  --> $DIR/explicit_counter_loop.rs:61:9
    |
 LL |         for ch in text.chars() {
-   |                   ^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
+   |         ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
 
 error: the variable `count` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:72:19
+  --> $DIR/explicit_counter_loop.rs:72:9
    |
 LL |         for ch in text.chars() {
-   |                   ^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
+   |         ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
 
 error: the variable `count` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:130:19
+  --> $DIR/explicit_counter_loop.rs:130:9
    |
 LL |         for _i in 3..10 {
-   |                   ^^^^^ help: consider using: `for (count, _i) in 3..10.enumerate()`
+   |         ^^^^^^^^^^^^^^^ help: consider using: `for (count, _i) in 3..10.enumerate()`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/explicit_counter_loop.stderr
+++ b/tests/ui/explicit_counter_loop.stderr
@@ -2,7 +2,7 @@ error: the variable `_index` is used as a loop counter.
   --> $DIR/explicit_counter_loop.rs:6:15
    |
 LL |     for _v in &vec {
-   |               ^^^^ help: consider using: `for (_index, _v) in (&vec).enumerate()`
+   |               ^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
    |
    = note: `-D clippy::explicit-counter-loop` implied by `-D warnings`
 
@@ -10,25 +10,37 @@ error: the variable `_index` is used as a loop counter.
   --> $DIR/explicit_counter_loop.rs:12:15
    |
 LL |     for _v in &vec {
-   |               ^^^^ help: consider using: `for (_index, _v) in (&vec).enumerate()`
+   |               ^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
+
+error: the variable `_index` is used as a loop counter.
+  --> $DIR/explicit_counter_loop.rs:17:15
+   |
+LL |     for _v in &mut vec {
+   |               ^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter_mut().enumerate()`
+
+error: the variable `_index` is used as a loop counter.
+  --> $DIR/explicit_counter_loop.rs:22:15
+   |
+LL |     for _v in vec {
+   |               ^^^ help: consider using: `for (_index, _v) in vec.into_iter().enumerate()`
 
 error: the variable `count` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:51:19
+  --> $DIR/explicit_counter_loop.rs:61:19
    |
 LL |         for ch in text.chars() {
    |                   ^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
 
 error: the variable `count` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:62:19
+  --> $DIR/explicit_counter_loop.rs:72:19
    |
 LL |         for ch in text.chars() {
    |                   ^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
 
 error: the variable `count` is used as a loop counter.
-  --> $DIR/explicit_counter_loop.rs:120:19
+  --> $DIR/explicit_counter_loop.rs:130:19
    |
 LL |         for _i in 3..10 {
-   |                   ^^^^^ help: consider using: `for (count, _i) in (3..10).enumerate()`
+   |                   ^^^^^ help: consider using: `for (count, _i) in 3..10.enumerate()`
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/explicit_counter_loop.stderr
+++ b/tests/ui/explicit_counter_loop.stderr
@@ -40,7 +40,7 @@ error: the variable `count` is used as a loop counter.
   --> $DIR/explicit_counter_loop.rs:130:9
    |
 LL |         for _i in 3..10 {
-   |         ^^^^^^^^^^^^^^^ help: consider using: `for (count, _i) in 3..10.enumerate()`
+   |         ^^^^^^^^^^^^^^^ help: consider using: `for (count, _i) in (3..10).enumerate()`
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
changelog: In the suggestion of `explicit_counter_loop`, if the `for` loop argument doesn't implement `Iterator`, then we suggest `x.into_iter().enumerate()` (or `x.iter{_mut}()` as appropriate). Also, the span of the suggestion has been corrected.

Fixes #4678