### PR TITLE
build: use release build of RTIM

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
     - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly --profile=minimal
     - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
     - del rust-toolchain
-    - cargo install -Z install-upgrade rustup-toolchain-install-master --debug || echo "rustup-toolchain-install-master already installed"
+    - cargo install -Z install-upgrade rustup-toolchain-install-master
     - rustup-toolchain-install-master -f -n master
     - rustup component add rustfmt --toolchain nightly & exit 0 # Format test handles missing rustfmt
     - rustup default master

--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -3,14 +3,10 @@
 
 set -e
 
-cd "$(dirname "$0")" || exit
+cd "$(dirname "$0")"
 
-if ! command -v rustup-toolchain-install-master > /dev/null; then
-  cargo install \
-    -Z install-upgrade \
-    rustup-toolchain-install-master \
-    --bin rustup-toolchain-install-master \
-    --debug
+if [[ "$CI" == true ]] || ! command -v rustup-toolchain-install-master > /dev/null; then
+  cargo install -Z install-upgrade rustup-toolchain-install-master --bin rustup-toolchain-install-master
 fi
 
 rustup-toolchain-install-master -f -n master


### PR DESCRIPTION
rustup-toolchain-install-master on Travis Windows builds is
unexpectedly slower compared to when run on other OSes.
This commit tries to use release build of RTIM as a mean to
improve performance there.

changelog: none
