### PR TITLE
[WIP] build(travis): Speed up macOS builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
   include:
     # Builds that are executed for every PR
     - os: osx # run base tests on both platforms
+      osx_image: xcode9.2 # macOS 10.12
       env: BASE_TESTS=true
     - os: linux
       env: BASE_TESTS=true


### PR DESCRIPTION
According to <https://github.com/rust-lang/cargo/pull/6254#issue-228079464>,
macOS 10.12 (xode9.2) run much faster.

changelog: none
