### PR TITLE
Omit proc macros from `must_use_candidate`

### DIFF
--- a/clippy_lints/src/utils/attrs.rs
+++ b/clippy_lints/src/utils/attrs.rs
@@ -114,3 +114,16 @@ fn parse_attrs<F: FnMut(u64)>(sess: &Session, attrs: &[ast::Attribute], name: &'
         }
     }
 }
+
+/// Return true if the attributes contain any of `proc_macro`,
+/// `proc_macro_derive` or `proc_macro_attribute`, false otherwise
+pub fn is_proc_macro(attrs: &[ast::Attribute]) -> bool {
+    use syntax_pos::Symbol;
+
+    let syms = [
+        Symbol::intern("proc_macro"),
+        Symbol::intern("proc_macro_derive"),
+        Symbol::intern("proc_macro_attribute"),
+    ];
+    attrs.iter().any(|attr| syms.iter().any(move |&s| attr.check_name(s)))
+}

--- a/tests/ui/proc_macro.rs
+++ b/tests/ui/proc_macro.rs
@@ -1,8 +1,26 @@
 //! Check that we correctly lint procedural macros.
-
 #![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
 
 #[allow(dead_code)]
 fn f() {
     let _x = 3.14;
+}
+
+#[proc_macro]
+pub fn mybangmacro(t: TokenStream) -> TokenStream {
+    t
+}
+
+#[proc_macro_derive(MyDerivedTrait)]
+pub fn myderive(t: TokenStream) -> TokenStream {
+    t
+}
+
+#[proc_macro_attribute]
+pub fn myattribute(t: TokenStream, a: TokenStream) -> TokenStream {
+    t
 }

--- a/tests/ui/proc_macro.stderr
+++ b/tests/ui/proc_macro.stderr
@@ -1,5 +1,5 @@
 error: approximate value of `f{32, 64}::consts::PI` found. Consider using it directly
-  --> $DIR/proc_macro.rs:7:14
+  --> $DIR/proc_macro.rs:10:14
    |
 LL |     let _x = 3.14;
    |              ^^^^


### PR DESCRIPTION
This fixes #4684.

changelog: none
