### PR TITLE
deps: update cargo_metadata from 0.8.0 to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ semver = "0.9"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 
 [dev-dependencies]
-cargo_metadata = "0.8.0"
+cargo_metadata = "0.9.0"
 compiletest_rs = { version = "0.3.24", features = ["tmp"] }
 lazy_static = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.8.0"
+cargo_metadata = "0.9.0"
 itertools = "0.8"
 lazy_static = "1.0.2"
 matches = "0.1.7"

--- a/clippy_lints/src/cargo_common_metadata.rs
+++ b/clippy_lints/src/cargo_common_metadata.rs
@@ -86,7 +86,7 @@ impl EarlyLintPass for CargoCommonMetadata {
                 missing_warning(cx, &package, "package.repository");
             }
 
-            if is_empty_str(&package.readme) {
+            if is_empty_path(&package.readme) {
                 missing_warning(cx, &package, "package.readme");
             }
 


### PR DESCRIPTION
changelog: none
