### PR TITLE
Don't emit try_err lint in external macros

### DIFF
--- a/clippy_lints/src/try_err.rs
+++ b/clippy_lints/src/try_err.rs
@@ -1,7 +1,7 @@
 use crate::utils::{match_qpath, paths, snippet, snippet_with_macro_callsite, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc::hir::*;
-use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintPass};
 use rustc::ty::Ty;
 use rustc::{declare_lint_pass, declare_tool_lint};
 use rustc_errors::Applicability;
@@ -54,6 +54,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TryErr {
         //         val,
         // };
         if_chain! {
+            if !in_external_macro(cx.tcx.sess, expr.span);
             if let ExprKind::Match(ref match_arg, _, MatchSource::TryDesugar) = expr.kind;
             if let ExprKind::Call(ref match_fun, ref try_args) = match_arg.kind;
             if let ExprKind::Path(ref match_fun_path) = match_fun.kind;

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -16,3 +16,18 @@ macro_rules! must_use_unit {
         fn foo() {}
     };
 }
+
+#[macro_export]
+macro_rules! try_err {
+    () => {
+        pub fn try_err_fn() -> Result<i32, i32> {
+            let err: i32 = 1;
+            // To avoid warnings during rustfix
+            if true {
+                Err(err)?
+            } else {
+                Ok(2)
+            }
+        }
+    };
+}

--- a/tests/ui/try_err.fixed
+++ b/tests/ui/try_err.fixed
@@ -1,6 +1,10 @@
 // run-rustfix
+// aux-build:macro_rules.rs
 
 #![deny(clippy::try_err)]
+
+#[macro_use]
+extern crate macro_rules;
 
 // Tests that a simple case works
 // Should flag `Err(err)?`
@@ -77,6 +81,9 @@ fn main() {
     negative_test().unwrap();
     closure_matches_test().unwrap();
     closure_into_test().unwrap();
+
+    // We don't want to lint in external macros
+    try_err!();
 }
 
 macro_rules! bar {

--- a/tests/ui/try_err.rs
+++ b/tests/ui/try_err.rs
@@ -1,6 +1,10 @@
 // run-rustfix
+// aux-build:macro_rules.rs
 
 #![deny(clippy::try_err)]
+
+#[macro_use]
+extern crate macro_rules;
 
 // Tests that a simple case works
 // Should flag `Err(err)?`
@@ -77,6 +81,9 @@ fn main() {
     negative_test().unwrap();
     closure_matches_test().unwrap();
     closure_into_test().unwrap();
+
+    // We don't want to lint in external macros
+    try_err!();
 }
 
 macro_rules! bar {

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -1,35 +1,35 @@
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:11:9
+  --> $DIR/try_err.rs:15:9
    |
 LL |         Err(err)?;
    |         ^^^^^^^^^ help: try this: `return Err(err)`
    |
 note: lint level defined here
-  --> $DIR/try_err.rs:3:9
+  --> $DIR/try_err.rs:4:9
    |
 LL | #![deny(clippy::try_err)]
    |         ^^^^^^^^^^^^^^^
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:21:9
+  --> $DIR/try_err.rs:25:9
    |
 LL |         Err(err)?;
    |         ^^^^^^^^^ help: try this: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:41:17
+  --> $DIR/try_err.rs:45:17
    |
 LL |                 Err(err)?;
    |                 ^^^^^^^^^ help: try this: `return Err(err)`
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:60:17
+  --> $DIR/try_err.rs:64:17
    |
 LL |                 Err(err)?;
    |                 ^^^^^^^^^ help: try this: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
-  --> $DIR/try_err.rs:96:9
+  --> $DIR/try_err.rs:103:9
    |
 LL |         Err(foo!())?;
    |         ^^^^^^^^^^^^ help: try this: `return Err(foo!())`


### PR DESCRIPTION
changelog: Fix [`try_err`] false positive in external macros

Closes #4709