### PR TITLE
result_map_unwrap_or_else: drop the `.ok()` in the suggestion

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -205,7 +205,7 @@ declare_clippy_lint! {
     /// **What it does:** Checks for usage of `result.map(_).unwrap_or_else(_)`.
     ///
     /// **Why is this bad?** Readability, this can be written more concisely as
-    /// `result.ok().map_or_else(_, _)`.
+    /// `result.map_or_else(_, _)`.
     ///
     /// **Known problems:** None.
     ///
@@ -215,7 +215,7 @@ declare_clippy_lint! {
     /// ```
     pub RESULT_MAP_UNWRAP_OR_ELSE,
     pedantic,
-    "using `Result.map(f).unwrap_or_else(g)`, which is more succinctly expressed as `.ok().map_or_else(g, f)`"
+    "using `Result.map(f).unwrap_or_else(g)`, which is more succinctly expressed as `map_or_else(g, f)`"
 }
 
 declare_clippy_lint! {
@@ -1848,7 +1848,7 @@ fn lint_map_unwrap_or_else<'a, 'tcx>(
              `map_or_else(g, f)` instead"
         } else {
             "called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling \
-             `ok().map_or_else(g, f)` instead"
+             `map_or_else(g, f)` instead"
         };
         // get snippets for args to map() and unwrap_or_else()
         let map_snippet = snippet(cx, map_args[1].span, "..");
@@ -1869,10 +1869,8 @@ fn lint_map_unwrap_or_else<'a, 'tcx>(
                 msg,
                 expr.span,
                 &format!(
-                    "replace `map({0}).unwrap_or_else({1})` with `{2}map_or_else({1}, {0})`",
-                    map_snippet,
-                    unwrap_snippet,
-                    if is_result { "ok()." } else { "" }
+                    "replace `map({0}).unwrap_or_else({1})` with `map_or_else({1}, {0})`",
+                    map_snippet, unwrap_snippet,
                 ),
             );
         } else if same_span && multiline {

--- a/tests/ui/result_map_unwrap_or_else.stderr
+++ b/tests/ui/result_map_unwrap_or_else.stderr
@@ -1,27 +1,27 @@
-error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `ok().map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `map_or_else(g, f)` instead
   --> $DIR/result_map_unwrap_or_else.rs:15:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0); // should lint even though this call is on a separate line
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::result-map-unwrap-or-else` implied by `-D warnings`
-   = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `ok().map_or_else(|e| 0, |x| x + 1)`
+   = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `map_or_else(|e| 0, |x| x + 1)`
 
-error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `ok().map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `map_or_else(g, f)` instead
   --> $DIR/result_map_unwrap_or_else.rs:17:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `ok().map_or_else(|e| 0, |x| x + 1)`
+   = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `map_or_else(|e| 0, |x| x + 1)`
 
-error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `ok().map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `map_or_else(g, f)` instead
   --> $DIR/result_map_unwrap_or_else.rs:18:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `ok().map_or_else(|e| 0, |x| x + 1)`
+   = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `map_or_else(|e| 0, |x| x + 1)`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Adding the `.ok()` changes the semantics since that assumes that `g` was
ignoring its argument. Instead, allow `g` to keep taking its argument
and preserve the isomorphism to the original code in the suggestion.

Fixes #1590

Cc: @gendx @Arnavion 

---

changelog: fix result_map_unwrap_or_else suggestion to preserve isomorphism