### PR TITLE
Use syn in needless_doctest_main lint

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -25,14 +25,13 @@ matches = "0.1.7"
 pulldown-cmark = "0.6.0"
 quine-mc_cluskey = "0.2.2"
 regex-syntax = "0.6"
+semver = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 smallvec = { version = "1", features = ["union"] }
+syn = { version = "1.0", features = ["full"] }
 toml = "0.5.3"
 unicode-normalization = "0.1"
-semver = "0.9.0"
-# NOTE: cargo requires serde feat in its url dep
-# see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
-url = { version =  "2.1.0", features = ["serde"] }
+url = "2.1.0"
 
 [features]
 deny-warnings = []


### PR DESCRIPTION
changelog: none

This fixes #4698 by only linting non-empty `fn main()`s. This is not a perfect solution, but I don't want to omit linting if any macro call or attribute is detected, as that would result in many false negatives.