### PR TITLE
Unconditionally run cargo install RTIM

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -5,9 +5,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-if [[ "$CI" == true ]] || ! command -v rustup-toolchain-install-master > /dev/null; then
-    cargo install -Z install-upgrade rustup-toolchain-install-master --bin rustup-toolchain-install-master
-fi
+cargo install -Z install-upgrade rustup-toolchain-install-master --bin rustup-toolchain-install-master
 
 RUST_COMMIT=$(git ls-remote https://github.com/rust-lang/rust master | awk '{print $1}')
 


### PR DESCRIPTION
Since we're using `-Z install-upgrade` I think we can run `cargo install` unconditionally. This also solves this problem: https://github.com/rust-lang/rust-clippy/pull/4697#issuecomment-546272487

r? @lzutao 

changelog: none
