### PR TITLE
build: do not cache clippy binaries in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
     - $HOME/.cargo
 before_cache:
   - cargo install -Z install-upgrade cargo-cache --debug
-  - cargo cache --autoclean
   - find $HOME/.cargo/bin/ ! -type d -exec strip {} \;
+  - cargo cache --autoclean
 
 env:
  global:

--- a/ci/integration-tests.sh
+++ b/ci/integration-tests.sh
@@ -28,6 +28,7 @@ cargo clippy \
     -W clippy::nursery \
     > clippy_output 2>&1 || true
 
+cargo uninstall clippy
 cat clippy_output
 
 if grep -q "internal compiler error\|query stack during panic\|E0463" clippy_output; then


### PR DESCRIPTION
We rebuild clippy anyway. So caching them is needless

```console
% ls -lF target/debug 
total 628M
drwxr-xr-x 22 lzutao lzutao 4.0K Oct 29 04:02 build/
drwxr-xr-x  2 lzutao lzutao 144K Oct 29 04:03 deps/
drwxr-xr-x  2 lzutao lzutao 4.0K Oct 29 03:57 examples/
drwxr-xr-x 11 lzutao lzutao 4.0K Oct 29 04:03 incremental/
-rwxr-xr-x  2 lzutao lzutao 3.4M Oct 29 04:03 cargo-clippy*
-rw-r--r--  1 lzutao lzutao  11K Oct 29 03:58 cargo-clippy.d
-rwxr-xr-x  2 lzutao lzutao 313M Oct 29 04:03 clippy-driver*
-rw-r--r--  1 lzutao lzutao  11K Oct 29 03:58 clippy-driver.d
-rw-r--r--  1 lzutao lzutao  11K Oct 29 04:03 libclippy.d
-rwxr-xr-x  2 lzutao lzutao 312M Oct 29 04:03 libclippy.so*
```

changelog: none
