### PR TITLE
Fix Deprecated lints don't expand

### DIFF
--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -4,85 +4,85 @@ macro_rules! declare_deprecated_lint {
     }
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This used to check for `assert!(a == b)` and recommend
 /// replacement with `assert_eq!(a, b)`, but this is no longer needed after RFC 2011.
-declare_deprecated_lint! {
     pub SHOULD_ASSERT_EQ,
     "`assert!()` will be more flexible with RFC 2011"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This used to check for `Vec::extend`, which was slower than
 /// `Vec::extend_from_slice`. Thanks to specialization, this is no longer true.
-declare_deprecated_lint! {
     pub EXTEND_FROM_SLICE,
     "`.extend_from_slice(_)` is a faster way to extend a Vec by a slice"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** `Range::step_by(0)` used to be linted since it's
 /// an infinite iterator, which is better expressed by `iter::repeat`,
 /// but the method has been removed for `Iterator::step_by` which panics
 /// if given a zero
-declare_deprecated_lint! {
     pub RANGE_STEP_BY_ZERO,
     "`iterator.step_by(0)` panics nowadays"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This used to check for `Vec::as_slice`, which was unstable with good
 /// stable alternatives. `Vec::as_slice` has now been stabilized.
-declare_deprecated_lint! {
     pub UNSTABLE_AS_SLICE,
     "`Vec::as_slice` has been stabilized in 1.7"
 }
 
-
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This used to check for `Vec::as_mut_slice`, which was unstable with good
 /// stable alternatives. `Vec::as_mut_slice` has now been stabilized.
-declare_deprecated_lint! {
     pub UNSTABLE_AS_MUT_SLICE,
     "`Vec::as_mut_slice` has been stabilized in 1.7"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This used to check for `.to_string()` method calls on values
 /// of type `&str`. This is not unidiomatic and with specialization coming, `to_string` could be
 /// specialized to be as efficient as `to_owned`.
-declare_deprecated_lint! {
     pub STR_TO_STRING,
     "using `str::to_string` is common even today and specialization will likely happen soon"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This used to check for `.to_string()` method calls on values
 /// of type `String`. This is not unidiomatic and with specialization coming, `to_string` could be
 /// specialized to be as efficient as `clone`.
-declare_deprecated_lint! {
     pub STRING_TO_STRING,
     "using `string::to_string` is common even today and specialization will likely happen soon"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This lint should never have applied to non-pointer types, as transmuting
 /// between non-pointer types of differing alignment is well-defined behavior (it's semantically
 /// equivalent to a memcpy). This lint has thus been refactored into two separate lints:
 /// cast_ptr_alignment and transmute_ptr_to_ptr.
-declare_deprecated_lint! {
     pub MISALIGNED_TRANSMUTE,
     "this lint has been split into cast_ptr_alignment and transmute_ptr_to_ptr"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This lint is too subjective, not having a good reason for being in clippy.
@@ -93,40 +93,40 @@ declare_deprecated_lint! {
     "using compound assignment operators (e.g., `+=`) is harmless"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** The original rule will only lint for `if let`. After
 /// making it support to lint `match`, naming as `if let` is not suitable for it.
 /// So, this lint is deprecated.
-declare_deprecated_lint! {
     pub IF_LET_REDUNDANT_PATTERN_MATCHING,
     "this lint has been changed to redundant_pattern_matching"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This lint used to suggest replacing `let mut vec =
 /// Vec::with_capacity(n); vec.set_len(n);` with `let vec = vec![0; n];`. The
 /// replacement has very different performance characteristics so the lint is
 /// deprecated.
-declare_deprecated_lint! {
     pub UNSAFE_VECTOR_INITIALIZATION,
     "the replacement suggested by this lint had substantially different behavior"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This lint has been superseded by the warn-by-default
 /// `invalid_value` rustc lint.
-declare_deprecated_lint! {
     pub INVALID_REF,
     "superseded by rustc lint `invalid_value`"
 }
 
+declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This lint has been superseded by #[must_use] in rustc.
-declare_deprecated_lint! {
     pub UNUSED_COLLECT,
     "`collect` has been marked as #[must_use] in rustc and that covers all cases of this lint"
 }

--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -5,79 +5,79 @@ macro_rules! declare_deprecated_lint {
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This used to check for `assert!(a == b)` and recommend
-/// replacement with `assert_eq!(a, b)`, but this is no longer needed after RFC 2011.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This used to check for `assert!(a == b)` and recommend
+    /// replacement with `assert_eq!(a, b)`, but this is no longer needed after RFC 2011.
     pub SHOULD_ASSERT_EQ,
     "`assert!()` will be more flexible with RFC 2011"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This used to check for `Vec::extend`, which was slower than
-/// `Vec::extend_from_slice`. Thanks to specialization, this is no longer true.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This used to check for `Vec::extend`, which was slower than
+    /// `Vec::extend_from_slice`. Thanks to specialization, this is no longer true.
     pub EXTEND_FROM_SLICE,
     "`.extend_from_slice(_)` is a faster way to extend a Vec by a slice"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** `Range::step_by(0)` used to be linted since it's
-/// an infinite iterator, which is better expressed by `iter::repeat`,
-/// but the method has been removed for `Iterator::step_by` which panics
-/// if given a zero
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** `Range::step_by(0)` used to be linted since it's
+    /// an infinite iterator, which is better expressed by `iter::repeat`,
+    /// but the method has been removed for `Iterator::step_by` which panics
+    /// if given a zero
     pub RANGE_STEP_BY_ZERO,
     "`iterator.step_by(0)` panics nowadays"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This used to check for `Vec::as_slice`, which was unstable with good
-/// stable alternatives. `Vec::as_slice` has now been stabilized.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This used to check for `Vec::as_slice`, which was unstable with good
+    /// stable alternatives. `Vec::as_slice` has now been stabilized.
     pub UNSTABLE_AS_SLICE,
     "`Vec::as_slice` has been stabilized in 1.7"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This used to check for `Vec::as_mut_slice`, which was unstable with good
-/// stable alternatives. `Vec::as_mut_slice` has now been stabilized.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This used to check for `Vec::as_mut_slice`, which was unstable with good
+    /// stable alternatives. `Vec::as_mut_slice` has now been stabilized.
     pub UNSTABLE_AS_MUT_SLICE,
     "`Vec::as_mut_slice` has been stabilized in 1.7"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This used to check for `.to_string()` method calls on values
-/// of type `&str`. This is not unidiomatic and with specialization coming, `to_string` could be
-/// specialized to be as efficient as `to_owned`.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This used to check for `.to_string()` method calls on values
+    /// of type `&str`. This is not unidiomatic and with specialization coming, `to_string` could be
+    /// specialized to be as efficient as `to_owned`.
     pub STR_TO_STRING,
     "using `str::to_string` is common even today and specialization will likely happen soon"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This used to check for `.to_string()` method calls on values
-/// of type `String`. This is not unidiomatic and with specialization coming, `to_string` could be
-/// specialized to be as efficient as `clone`.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This used to check for `.to_string()` method calls on values
+    /// of type `String`. This is not unidiomatic and with specialization coming, `to_string` could be
+    /// specialized to be as efficient as `clone`.
     pub STRING_TO_STRING,
     "using `string::to_string` is common even today and specialization will likely happen soon"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This lint should never have applied to non-pointer types, as transmuting
-/// between non-pointer types of differing alignment is well-defined behavior (it's semantically
-/// equivalent to a memcpy). This lint has thus been refactored into two separate lints:
-/// cast_ptr_alignment and transmute_ptr_to_ptr.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This lint should never have applied to non-pointer types, as transmuting
+    /// between non-pointer types of differing alignment is well-defined behavior (it's semantically
+    /// equivalent to a memcpy). This lint has thus been refactored into two separate lints:
+    /// cast_ptr_alignment and transmute_ptr_to_ptr.
     pub MISALIGNED_TRANSMUTE,
     "this lint has been split into cast_ptr_alignment and transmute_ptr_to_ptr"
 }
@@ -93,39 +93,39 @@ declare_deprecated_lint! {
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** The original rule will only lint for `if let`. After
-/// making it support to lint `match`, naming as `if let` is not suitable for it.
-/// So, this lint is deprecated.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** The original rule will only lint for `if let`. After
+    /// making it support to lint `match`, naming as `if let` is not suitable for it.
+    /// So, this lint is deprecated.
     pub IF_LET_REDUNDANT_PATTERN_MATCHING,
     "this lint has been changed to redundant_pattern_matching"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This lint used to suggest replacing `let mut vec =
-/// Vec::with_capacity(n); vec.set_len(n);` with `let vec = vec![0; n];`. The
-/// replacement has very different performance characteristics so the lint is
-/// deprecated.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This lint used to suggest replacing `let mut vec =
+    /// Vec::with_capacity(n); vec.set_len(n);` with `let vec = vec![0; n];`. The
+    /// replacement has very different performance characteristics so the lint is
+    /// deprecated.
     pub UNSAFE_VECTOR_INITIALIZATION,
     "the replacement suggested by this lint had substantially different behavior"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This lint has been superseded by the warn-by-default
-/// `invalid_value` rustc lint.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This lint has been superseded by the warn-by-default
+    /// `invalid_value` rustc lint.
     pub INVALID_REF,
     "superseded by rustc lint `invalid_value`"
 }
 
 declare_deprecated_lint! {
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This lint has been superseded by #[must_use] in rustc.
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This lint has been superseded by #[must_use] in rustc.
     pub UNUSED_COLLECT,
     "`collect` has been marked as #[must_use] in rustc and that covers all cases of this lint"
 }

--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -82,7 +82,6 @@ declare_deprecated_lint! {
     "this lint has been split into cast_ptr_alignment and transmute_ptr_to_ptr"
 }
 
-declare_deprecated_lint! {
 /// **What it does:** Nothing. This lint has been deprecated.
 ///
 /// **Deprecation reason:** This lint is too subjective, not having a good reason for being in clippy.

--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -82,12 +82,12 @@ declare_deprecated_lint! {
     "this lint has been split into cast_ptr_alignment and transmute_ptr_to_ptr"
 }
 
-/// **What it does:** Nothing. This lint has been deprecated.
-///
-/// **Deprecation reason:** This lint is too subjective, not having a good reason for being in clippy.
-/// Additionally, compound assignment operators may be overloaded separately from their non-assigning
-/// counterparts, so this lint may suggest a change in behavior or the code may not compile.
 declare_deprecated_lint! {
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This lint is too subjective, not having a good reason for being in clippy.
+    /// Additionally, compound assignment operators may be overloaded separately from their non-assigning
+    /// counterparts, so this lint may suggest a change in behavior or the code may not compile.
     pub ASSIGN_OPS,
     "using compound assignment operators (e.g., `+=`) is harmless"
 }


### PR DESCRIPTION
### Move doc comments inside of declare_deprecated_lint macros so that they are picked up by lintlib.py

### fixes #4748

Unable to `cargo test` locally (I'm on NixOS, and keep getting errors that are similar to those #4714 might solve) but I have verified that all deprecated lints can now be expanded like other lints.

![2019-10-30_21:06:28](https://user-images.githubusercontent.com/1847524/67910501-5815de00-fb59-11e9-9fa2-91fe6a8b9bb9.png)

changelog: Show deprecated lints in lint documentation again
