### PR TITLE
Fix false positive in derive_hash_xor_eq

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -90,6 +90,7 @@ fn check_hash_peq<'a, 'tcx>(
     if_chain! {
         if match_path(&trait_ref.path, &paths::HASH);
         if let Some(peq_trait_def_id) = cx.tcx.lang_items().eq_trait();
+        if !&trait_ref.trait_def_id().is_local();
         then {
             // Look for the PartialEq implementations for `ty`
             cx.tcx.for_each_relevant_impl(peq_trait_def_id, ty, |impl_id| {

--- a/tests/ui/derive_hash_xor_eq.rs
+++ b/tests/ui/derive_hash_xor_eq.rs
@@ -1,5 +1,3 @@
-use std::hash::{Hash, Hasher};
-
 #[derive(PartialEq, Hash)]
 struct Foo;
 
@@ -30,8 +28,27 @@ impl PartialEq<Baz> for Baz {
 #[derive(PartialEq)]
 struct Bah;
 
-impl Hash for Bah {
-    fn hash<H: Hasher>(&self, _: &mut H) {}
+impl std::hash::Hash for Bah {
+    fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+}
+
+#[derive(PartialEq)]
+struct Foo2;
+
+trait Hash {}
+
+// We don't want to lint on user-defined traits called `Hash`
+impl Hash for Foo2 {}
+
+mod use_hash {
+    use std::hash::{Hash, Hasher};
+
+    #[derive(PartialEq)]
+    struct Foo3;
+
+    impl Hash for Foo3 {
+        fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+    }
 }
 
 fn main() {}

--- a/tests/ui/derive_hash_xor_eq.stderr
+++ b/tests/ui/derive_hash_xor_eq.stderr
@@ -1,12 +1,12 @@
 error: you are deriving `Hash` but have implemented `PartialEq` explicitly
-  --> $DIR/derive_hash_xor_eq.rs:12:10
+  --> $DIR/derive_hash_xor_eq.rs:10:10
    |
 LL | #[derive(Hash)]
    |          ^^^^
    |
    = note: `#[deny(clippy::derive_hash_xor_eq)]` on by default
 note: `PartialEq` implemented here
-  --> $DIR/derive_hash_xor_eq.rs:15:1
+  --> $DIR/derive_hash_xor_eq.rs:13:1
    |
 LL | / impl PartialEq for Bar {
 LL | |     fn eq(&self, _: &Bar) -> bool {
@@ -16,13 +16,13 @@ LL | | }
    | |_^
 
 error: you are deriving `Hash` but have implemented `PartialEq` explicitly
-  --> $DIR/derive_hash_xor_eq.rs:21:10
+  --> $DIR/derive_hash_xor_eq.rs:19:10
    |
 LL | #[derive(Hash)]
    |          ^^^^
    |
 note: `PartialEq` implemented here
-  --> $DIR/derive_hash_xor_eq.rs:24:1
+  --> $DIR/derive_hash_xor_eq.rs:22:1
    |
 LL | / impl PartialEq<Baz> for Baz {
 LL | |     fn eq(&self, _: &Baz) -> bool {
@@ -32,18 +32,32 @@ LL | | }
    | |_^
 
 error: you are implementing `Hash` explicitly but have derived `PartialEq`
-  --> $DIR/derive_hash_xor_eq.rs:33:1
+  --> $DIR/derive_hash_xor_eq.rs:31:1
    |
-LL | / impl Hash for Bah {
-LL | |     fn hash<H: Hasher>(&self, _: &mut H) {}
+LL | / impl std::hash::Hash for Bah {
+LL | |     fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
 LL | | }
    | |_^
    |
 note: `PartialEq` implemented here
-  --> $DIR/derive_hash_xor_eq.rs:30:10
+  --> $DIR/derive_hash_xor_eq.rs:28:10
    |
 LL | #[derive(PartialEq)]
    |          ^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: you are implementing `Hash` explicitly but have derived `PartialEq`
+  --> $DIR/derive_hash_xor_eq.rs:49:5
+   |
+LL | /     impl Hash for Foo3 {
+LL | |         fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
+LL | |     }
+   | |_____^
+   |
+note: `PartialEq` implemented here
+  --> $DIR/derive_hash_xor_eq.rs:46:14
+   |
+LL |     #[derive(PartialEq)]
+   |              ^^^^^^^^^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This fixes a false positive in derive_hash_xor_eq where the lint was
triggering on user-defined traits called `Hash`.

changelog: Fix false positive in `derive_hash_xor_eq`

Fixes #4658