### PR TITLE
don't warn on CRLF in `with_newline` lints

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -29,6 +29,8 @@ extern crate rustc_errors;
 #[allow(unused_extern_crates)]
 extern crate rustc_index;
 #[allow(unused_extern_crates)]
+extern crate rustc_lexer;
+#[allow(unused_extern_crates)]
 extern crate rustc_mir;
 #[allow(unused_extern_crates)]
 extern crate rustc_parse;

--- a/tests/ui/print_with_newline.rs
+++ b/tests/ui/print_with_newline.rs
@@ -42,4 +42,10 @@ fn main() {
         r"
 "
     );
+
+    // Don't warn on CRLF (#4208)
+    print!("\r\n");
+    print!("foo\r\n");
+    print!("\\r\n"); //~ ERROR
+    print!("foo\rbar\n") // ~ ERROR
 }

--- a/tests/ui/print_with_newline.stderr
+++ b/tests/ui/print_with_newline.stderr
@@ -84,5 +84,27 @@ LL |     println!(
 LL |         r""
    |
 
-error: aborting due to 7 previous errors
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:49:5
+   |
+LL |     print!("/r/n"); //~ ERROR
+   |     ^^^^^^^^^^^^^^^
+   |
+help: use `println!` instead
+   |
+LL |     println!("/r"); //~ ERROR
+   |     ^^^^^^^     --
+
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:50:5
+   |
+LL |     print!("foo/rbar/n") // ~ ERROR
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `println!` instead
+   |
+LL |     println!("foo/rbar") // ~ ERROR
+   |     ^^^^^^^          --
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -49,4 +49,10 @@ fn main() {
         r"
 "
     );
+
+    // Don't warn on CRLF (#4208)
+    write!(&mut v, "\r\n");
+    write!(&mut v, "foo\r\n");
+    write!(&mut v, "\\r\n"); //~ ERROR
+    write!(&mut v, "foo\rbar\n");
 }

--- a/tests/ui/write_with_newline.stderr
+++ b/tests/ui/write_with_newline.stderr
@@ -88,5 +88,27 @@ LL |         &mut v,
 LL |         r""
    |
 
-error: aborting due to 7 previous errors
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:56:5
+   |
+LL |     write!(&mut v, "/r/n"); //~ ERROR
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, "/r"); //~ ERROR
+   |     ^^^^^^^             --
+
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:57:5
+   |
+LL |     write!(&mut v, "foo/rbar/n");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, "foo/rbar");
+   |     ^^^^^^^                  --
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
changelog: don't warn on CRLF in `print_with_newline` and `write_with_newline`
fixes #4208.

This PR also transitions the unescaping logic to use the compiler's lexer.