### PR TITLE
Remove `extern crate clippy_lints` from tests

### DIFF
--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -16,7 +16,7 @@ pub fn derive(_: TokenStream) -> TokenStream {
     let output = quote! {
         // Should not trigger `useless_attribute`
         #[allow(dead_code)]
-        extern crate clippy_lints;
+        extern crate rustc;
     };
     output
 }

--- a/tests/ui/lint_without_lint_pass.rs
+++ b/tests/ui/lint_without_lint_pass.rs
@@ -5,25 +5,25 @@
 extern crate rustc;
 use rustc::lint::{LintArray, LintPass};
 
-#[macro_use]
-extern crate clippy_lints;
-
-declare_clippy_lint! {
-    pub TEST_LINT,
-    correctness,
-    ""
+declare_tool_lint! {
+    pub clippy::TEST_LINT,
+    Warn,
+    "",
+    report_in_external_macro: true
 }
 
-declare_clippy_lint! {
-    pub TEST_LINT_REGISTERED,
-    correctness,
-    ""
+declare_tool_lint! {
+    pub clippy::TEST_LINT_REGISTERED,
+    Warn,
+    "",
+    report_in_external_macro: true
 }
 
-declare_clippy_lint! {
-    pub TEST_LINT_REGISTERED_ONLY_IMPL,
-    correctness,
-    ""
+declare_tool_lint! {
+    pub clippy::TEST_LINT_REGISTERED_ONLY_IMPL,
+    Warn,
+    "",
+    report_in_external_macro: true
 }
 
 pub struct Pass;

--- a/tests/ui/lint_without_lint_pass.stderr
+++ b/tests/ui/lint_without_lint_pass.stderr
@@ -1,10 +1,11 @@
 error: the lint `TEST_LINT` is not added to any `LintPass`
-  --> $DIR/lint_without_lint_pass.rs:11:1
+  --> $DIR/lint_without_lint_pass.rs:8:1
    |
-LL | / declare_clippy_lint! {
-LL | |     pub TEST_LINT,
-LL | |     correctness,
-LL | |     ""
+LL | / declare_tool_lint! {
+LL | |     pub clippy::TEST_LINT,
+LL | |     Warn,
+LL | |     "",
+LL | |     report_in_external_macro: true
 LL | | }
    | |_^
    |

--- a/tests/ui/used_underscore_binding.rs
+++ b/tests/ui/used_underscore_binding.rs
@@ -1,5 +1,6 @@
 // aux-build:proc_macro_derive.rs
 
+#![feature(rustc_private)]
 #![warn(clippy::all)]
 #![allow(clippy::blacklisted_name)]
 #![warn(clippy::used_underscore_binding)]

--- a/tests/ui/used_underscore_binding.stderr
+++ b/tests/ui/used_underscore_binding.stderr
@@ -1,5 +1,5 @@
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:24:5
+  --> $DIR/used_underscore_binding.rs:25:5
    |
 LL |     _foo + 1
    |     ^^^^
@@ -7,25 +7,25 @@ LL |     _foo + 1
    = note: `-D clippy::used-underscore-binding` implied by `-D warnings`
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:29:20
+  --> $DIR/used_underscore_binding.rs:30:20
    |
 LL |     println!("{}", _foo);
    |                    ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:30:16
+  --> $DIR/used_underscore_binding.rs:31:16
    |
 LL |     assert_eq!(_foo, _foo);
    |                ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:30:22
+  --> $DIR/used_underscore_binding.rs:31:22
    |
 LL |     assert_eq!(_foo, _foo);
    |                      ^^^^
 
 error: used binding `_underscore_field` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:43:5
+  --> $DIR/used_underscore_binding.rs:44:5
    |
 LL |     s._underscore_field += 1;
    |     ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -2,16 +2,15 @@
 
 #![warn(clippy::useless_attribute)]
 #![warn(unreachable_pub)]
+#![feature(rustc_private)]
 
 #[allow(dead_code)]
 #[cfg_attr(feature = "cargo-clippy", allow(dead_code))]
 #[rustfmt::skip]
-#[cfg_attr(feature = "cargo-clippy",
-           allow(dead_code))]
 #[allow(unused_imports)]
 #[allow(unused_extern_crates)]
 #[macro_use]
-extern crate clippy_lints;
+extern crate rustc;
 
 #[macro_use]
 extern crate proc_macro_derive;

--- a/tests/ui/useless_attribute.stderr
+++ b/tests/ui/useless_attribute.stderr
@@ -1,5 +1,5 @@
 error: useless lint attribute
-  --> $DIR/useless_attribute.rs:6:1
+  --> $DIR/useless_attribute.rs:7:1
    |
 LL | #[allow(dead_code)]
    | ^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![allow(dead_code)]`
@@ -7,7 +7,7 @@ LL | #[allow(dead_code)]
    = note: `-D clippy::useless-attribute` implied by `-D warnings`
 
 error: useless lint attribute
-  --> $DIR/useless_attribute.rs:7:1
+  --> $DIR/useless_attribute.rs:8:1
    |
 LL | #[cfg_attr(feature = "cargo-clippy", allow(dead_code))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![cfg_attr(feature = "cargo-clippy", allow(dead_code)`


### PR DESCRIPTION
This causes rustc's build system to fail because it still tries to load the crate as a plugin: https://github.com/rust-lang/rust/pull/66158#issuecomment-550415160 . I'm not sure _why_ this happens, but for a short term fix we should remove these.


In one case it was just a convenient crate to use so i picked a different test. In another it was load-bearing, I had to delete the test. Idk if there's a better way around this.


changelog: none