### PR TITLE
Rustup to rustc 1.40.0-nightly (50f8aadd 2019-11-07)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 332 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 331 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -3,7 +3,7 @@ use rustc::hir::*;
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 use std::f64::consts as f64;
-use syntax::ast::{FloatTy, LitKind};
+use syntax::ast::{FloatTy, LitFloatType, LitKind};
 use syntax::symbol;
 
 declare_clippy_lint! {
@@ -62,9 +62,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ApproxConstant {
 
 fn check_lit(cx: &LateContext<'_, '_>, lit: &LitKind, e: &Expr) {
     match *lit {
-        LitKind::Float(s, FloatTy::F32) => check_known_consts(cx, e, s, "f32"),
-        LitKind::Float(s, FloatTy::F64) => check_known_consts(cx, e, s, "f64"),
-        LitKind::FloatUnsuffixed(s) => check_known_consts(cx, e, s, "f{32, 64}"),
+        LitKind::Float(s, LitFloatType::Suffixed(fty)) => match fty {
+            FloatTy::F32 => check_known_consts(cx, e, s, "f32"),
+            FloatTy::F64 => check_known_consts(cx, e, s, "f64"),
+        },
+        LitKind::Float(s, LitFloatType::Unsuffixed) => check_known_consts(cx, e, s, "f{32, 64}"),
         _ => (),
     }
 }

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -15,7 +15,7 @@ use rustc::ty;
 use rustc::{declare_lint_pass, declare_tool_lint};
 use rustc_errors::Applicability;
 use semver::Version;
-use syntax::ast::{AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem};
+use syntax::ast::{AttrKind, AttrStyle, Attribute, Lit, LitKind, MetaItemKind, NestedMetaItem};
 use syntax::source_map::Span;
 use syntax_pos::symbol::Symbol;
 
@@ -417,11 +417,14 @@ fn check_attrs(cx: &LateContext<'_, '_>, span: Span, name: Name, attrs: &[Attrib
     }
 
     for attr in attrs {
-        if attr.is_sugared_doc {
-            return;
-        }
+        let attr_item = if let AttrKind::Normal(ref attr) = attr.kind {
+            attr
+        } else {
+            continue;
+        };
+
         if attr.style == AttrStyle::Outer {
-            if attr.tokens.is_empty() || !is_present_in_source(cx, attr.span) {
+            if attr_item.tokens.is_empty() || !is_present_in_source(cx, attr.span) {
                 return;
             }
 

--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -161,9 +161,11 @@ pub fn lit_to_constant(lit: &LitKind, ty: Option<Ty<'_>>) -> Constant {
         LitKind::ByteStr(ref s) => Constant::Binary(Lrc::clone(s)),
         LitKind::Char(c) => Constant::Char(c),
         LitKind::Int(n, _) => Constant::Int(n),
-        LitKind::Float(ref is, FloatTy::F32) => Constant::F32(is.as_str().parse().unwrap()),
-        LitKind::Float(ref is, FloatTy::F64) => Constant::F64(is.as_str().parse().unwrap()),
-        LitKind::FloatUnsuffixed(ref is) => match ty.expect("type of float is known").kind {
+        LitKind::Float(ref is, LitFloatType::Suffixed(fty)) => match fty {
+            FloatTy::F32 => Constant::F32(is.as_str().parse().unwrap()),
+            FloatTy::F64 => Constant::F64(is.as_str().parse().unwrap()),
+        },
+        LitKind::Float(ref is, LitFloatType::Unsuffixed) => match ty.expect("type of float is known").kind {
             ty::Float(FloatTy::F32) => Constant::F32(is.as_str().parse().unwrap()),
             ty::Float(FloatTy::F64) => Constant::F64(is.as_str().parse().unwrap()),
             _ => bug!(),

--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -130,3 +130,12 @@ declare_deprecated_lint! {
     pub UNUSED_COLLECT,
     "`collect` has been marked as #[must_use] in rustc and that covers all cases of this lint"
 }
+
+declare_deprecated_lint! {
+    /// **What it does:** Nothing. This lint has been deprecated.
+    ///
+    /// **Deprecation reason:** This lint has been uplifted to rustc and is now called
+    /// `array_into_iter`.
+    pub INTO_ITER_ON_ARRAY,
+    "this lint has been uplifted to rustc and is now called `array_into_iter`"
+}

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -6,7 +6,7 @@ use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, impl_lint_pass};
 use rustc_data_structures::fx::FxHashSet;
 use std::ops::Range;
-use syntax::ast::Attribute;
+use syntax::ast::{AttrKind, Attribute};
 use syntax::source_map::{BytePos, Span};
 use syntax_pos::Pos;
 use url::Url;
@@ -247,13 +247,11 @@ pub fn check_attrs<'a>(cx: &LateContext<'_, '_>, valid_idents: &FxHashSet<String
     let mut spans = vec![];
 
     for attr in attrs {
-        if attr.is_sugared_doc {
-            if let Some(ref current) = attr.value_str() {
-                let current = current.to_string();
-                let (current, current_spans) = strip_doc_comment_decoration(&current, attr.span);
-                spans.extend_from_slice(&current_spans);
-                doc.push_str(&current);
-            }
+        if let AttrKind::DocComment(ref comment) = attr.kind {
+            let comment = comment.to_string();
+            let (comment, current_spans) = strip_doc_comment_decoration(&comment, attr.span);
+            spans.extend_from_slice(&current_spans);
+            doc.push_str(&comment);
         } else if attr.check_name(sym!(doc)) {
             // ignore mix of sugared and non-sugared doc
             return true; // don't trigger the safety check

--- a/clippy_lints/src/excessive_precision.rs
+++ b/clippy_lints/src/excessive_precision.rs
@@ -43,7 +43,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExcessivePrecision {
             let ty = cx.tables.expr_ty(expr);
             if let ty::Float(fty) = ty.kind;
             if let hir::ExprKind::Lit(ref lit) = expr.kind;
-            if let LitKind::Float(sym, _) | LitKind::FloatUnsuffixed(sym) = lit.node;
+            if let LitKind::Float(sym, _) = lit.node;
             if let Some(sugg) = Self::check(sym, fty);
             then {
                 span_lint_and_sugg(

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -430,6 +430,10 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
         "clippy::unused_collect",
         "`collect` has been marked as #[must_use] in rustc and that covers all cases of this lint",
     );
+    store.register_removed(
+        "clippy::into_iter_on_array",
+        "this lint has been uplifted to rustc and is now called `array_into_iter`",
+    );
     // end deprecated lints, do not remove this comment, it’s used in `update_lints`
 
     // begin register lints, do not remove this comment, it’s used in `update_lints`
@@ -584,7 +588,6 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
         &methods::FLAT_MAP_IDENTITY,
         &methods::GET_UNWRAP,
         &methods::INEFFICIENT_TO_STRING,
-        &methods::INTO_ITER_ON_ARRAY,
         &methods::INTO_ITER_ON_REF,
         &methods::ITER_CLONED_COLLECT,
         &methods::ITER_NTH,
@@ -1142,7 +1145,6 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
         LintId::of(&methods::FILTER_NEXT),
         LintId::of(&methods::FLAT_MAP_IDENTITY),
         LintId::of(&methods::INEFFICIENT_TO_STRING),
-        LintId::of(&methods::INTO_ITER_ON_ARRAY),
         LintId::of(&methods::INTO_ITER_ON_REF),
         LintId::of(&methods::ITER_CLONED_COLLECT),
         LintId::of(&methods::ITER_NTH),
@@ -1481,7 +1483,6 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
         LintId::of(&mem_discriminant::MEM_DISCRIMINANT_NON_ENUM),
         LintId::of(&mem_replace::MEM_REPLACE_WITH_UNINIT),
         LintId::of(&methods::CLONE_DOUBLE_REF),
-        LintId::of(&methods::INTO_ITER_ON_ARRAY),
         LintId::of(&methods::TEMPORARY_CSTRING_AS_PTR),
         LintId::of(&methods::UNINIT_ASSUMED_INIT),
         LintId::of(&minmax::MIN_MAX),

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -373,7 +373,7 @@ impl LiteralDigitGrouping {
                     }
                 }
             },
-            LitKind::Float(..) | LitKind::FloatUnsuffixed(..) => {
+            LitKind::Float(..) => {
                 // Lint floating-point literals.
                 if_chain! {
                     if let Some(src) = snippet_opt(cx, lit.span);

--- a/clippy_lints/src/main_recursion.rs
+++ b/clippy_lints/src/main_recursion.rs
@@ -1,6 +1,7 @@
 use rustc::hir::{Crate, Expr, ExprKind, QPath};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_tool_lint, impl_lint_pass};
+use syntax::ast::AttrKind;
 use syntax::symbol::sym;
 
 use crate::utils::{is_entrypoint_fn, snippet, span_help_and_lint};
@@ -34,7 +35,13 @@ impl_lint_pass!(MainRecursion => [MAIN_RECURSION]);
 
 impl LateLintPass<'_, '_> for MainRecursion {
     fn check_crate(&mut self, _: &LateContext<'_, '_>, krate: &Crate) {
-        self.has_no_std_attr = krate.attrs.iter().any(|attr| attr.path == sym::no_std);
+        self.has_no_std_attr = krate.attrs.iter().any(|attr| {
+            if let AttrKind::Normal(ref attr) = attr.kind {
+                attr.path == sym::no_std
+            } else {
+                false
+            }
+        });
     }
 
     fn check_expr_post(&mut self, cx: &LateContext<'_, '_>, expr: &Expr) {

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -482,8 +482,8 @@ impl MiscEarlyLints {
 
         if let LitKind::Int(value, lit_int_type) = lit.kind {
             let suffix = match lit_int_type {
-                LitIntType::Signed(ty) => ty.ty_to_string(),
-                LitIntType::Unsigned(ty) => ty.ty_to_string(),
+                LitIntType::Signed(ty) => ty.name_str(),
+                LitIntType::Unsigned(ty) => ty.name_str(),
                 LitIntType::Unsuffixed => "",
             };
 
@@ -543,8 +543,8 @@ impl MiscEarlyLints {
                     },
                 );
             }
-        } else if let LitKind::Float(_, float_ty) = lit.kind {
-            let suffix = float_ty.ty_to_string();
+        } else if let LitKind::Float(_, LitFloatType::Suffixed(float_ty)) = lit.kind {
+            let suffix = float_ty.name_str();
             let maybe_last_sep_idx = lit_snip.len() - suffix.len() - 1;
             if lit_snip.as_bytes()[maybe_last_sep_idx] != b'_' {
                 span_lint_and_sugg(

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -90,7 +90,7 @@ impl EarlyLintPass for Precedence {
                 if let Some(slf) = args.first() {
                     if let ExprKind::Lit(ref lit) = slf.kind {
                         match lit.kind {
-                            LitKind::Int(..) | LitKind::Float(..) | LitKind::FloatUnsuffixed(..) => {
+                            LitKind::Int(..) | LitKind::Float(..) => {
                                 let mut applicability = Applicability::MachineApplicable;
                                 span_lint_and_sugg(
                                     cx,

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -390,7 +390,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Transmute {
                             |db| {
                                 let arg = sugg::Sugg::hir(cx, &args[0], "..");
                                 let arg = if let ty::Int(_) = from_ty.kind {
-                                    arg.as_ty(ast::UintTy::U32)
+                                    arg.as_ty(ast::UintTy::U32.name_str())
                                 } else {
                                     arg
                                 };

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -15,7 +15,7 @@ use rustc::{declare_lint_pass, declare_tool_lint, impl_lint_pass};
 use rustc_errors::Applicability;
 use rustc_target::spec::abi::Abi;
 use rustc_typeck::hir_ty_to_ty;
-use syntax::ast::{FloatTy, IntTy, LitIntType, LitKind, UintTy};
+use syntax::ast::{FloatTy, IntTy, LitFloatType, LitIntType, LitKind, UintTy};
 use syntax::errors::DiagnosticBuilder;
 use syntax::source_map::Span;
 use syntax::symbol::{sym, Symbol};
@@ -1186,7 +1186,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Casts {
                     }
                 }
                 match lit.node {
-                    LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::FloatUnsuffixed(_) => {},
+                    LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed) => {},
                     _ => {
                         if cast_from.kind == cast_to.kind && !in_external_macro(cx.sess(), expr.span) {
                             span_lint(

--- a/clippy_lints/src/utils/attrs.rs
+++ b/clippy_lints/src/utils/attrs.rs
@@ -57,6 +57,11 @@ pub fn get_attr<'a>(
     name: &'static str,
 ) -> impl Iterator<Item = &'a ast::Attribute> {
     attrs.iter().filter(move |attr| {
+        let attr = if let ast::AttrKind::Normal(ref attr) = attr.kind {
+            attr
+        } else {
+            return false;
+        };
         let attr_segments = &attr.path.segments;
         if attr_segments.len() == 2 && attr_segments[0].ident.to_string() == "clippy" {
             if let Some(deprecation_status) =

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -9,7 +9,7 @@ use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc::session::Session;
 use rustc::{declare_lint_pass, declare_tool_lint};
 use rustc_data_structures::fx::FxHashMap;
-use syntax::ast::{Attribute, LitKind};
+use syntax::ast::{Attribute, LitFloatType, LitKind};
 
 declare_clippy_lint! {
     /// **What it does:** Generates clippy code that detects the offending pattern
@@ -288,10 +288,14 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
                     LitKind::Byte(b) => println!("    if let LitKind::Byte({}) = {}.node;", b, lit_pat),
                     // FIXME: also check int type
                     LitKind::Int(i, _) => println!("    if let LitKind::Int({}, _) = {}.node;", i, lit_pat),
-                    LitKind::Float(..) => println!("    if let LitKind::Float(..) = {}.node;", lit_pat),
-                    LitKind::FloatUnsuffixed(_) => {
-                        println!("    if let LitKind::FloatUnsuffixed(_) = {}.node;", lit_pat)
-                    },
+                    LitKind::Float(_, LitFloatType::Suffixed(_)) => println!(
+                        "    if let LitKind::Float(_, LitFloatType::Suffixed(_)) = {}.node;",
+                        lit_pat
+                    ),
+                    LitKind::Float(_, LitFloatType::Unsuffixed) => println!(
+                        "    if let LitKind::Float(_, LitFloatType::Unsuffixed) = {}.node;",
+                        lit_pat
+                    ),
                     LitKind::ByteStr(ref vec) => {
                         let vec_pat = self.next("vec");
                         println!("    if let LitKind::ByteStr(ref {}) = {}.node;", vec_pat, lit_pat);

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -6,7 +6,7 @@ pub use lint::Lint;
 pub use lint::LINT_LEVELS;
 
 // begin lint list, do not remove this comment, it’s used in `update_lints`
-pub const ALL_LINTS: [Lint; 332] = [
+pub const ALL_LINTS: [Lint; 331] = [
     Lint {
         name: "absurd_extreme_comparisons",
         group: "correctness",
@@ -811,13 +811,6 @@ pub const ALL_LINTS: [Lint; 332] = [
         desc: "integer division may cause loss of precision",
         deprecation: None,
         module: "integer_division",
-    },
-    Lint {
-        name: "into_iter_on_array",
-        group: "correctness",
-        desc: "using `.into_iter()` on an array",
-        deprecation: None,
-        module: "methods",
     },
     Lint {
         name: "into_iter_on_ref",

--- a/tests/ui/deprecated.rs
+++ b/tests/ui/deprecated.rs
@@ -5,5 +5,6 @@
 #[warn(clippy::misaligned_transmute)]
 #[warn(clippy::unused_collect)]
 #[warn(clippy::invalid_ref)]
+#[warn(clippy::into_iter_on_array)]
 
 fn main() {}

--- a/tests/ui/deprecated.stderr
+++ b/tests/ui/deprecated.stderr
@@ -42,11 +42,17 @@ error: lint `clippy::invalid_ref` has been removed: `superseded by rustc lint `i
 LL | #[warn(clippy::invalid_ref)]
    |        ^^^^^^^^^^^^^^^^^^^
 
+error: lint `clippy::into_iter_on_array` has been removed: `this lint has been uplifted to rustc and is now called `array_into_iter``
+  --> $DIR/deprecated.rs:8:8
+   |
+LL | #[warn(clippy::into_iter_on_array)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: lint `clippy::str_to_string` has been removed: `using `str::to_string` is common even today and specialization will likely happen soon`
   --> $DIR/deprecated.rs:1:8
    |
 LL | #[warn(clippy::str_to_string)]
    |        ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/for_loop_fixable.fixed
+++ b/tests/ui/for_loop_fixable.fixed
@@ -31,7 +31,7 @@ impl Unrelated {
     clippy::cognitive_complexity,
     clippy::similar_names
 )]
-#[allow(clippy::many_single_char_names, unused_variables, clippy::into_iter_on_array)]
+#[allow(clippy::many_single_char_names, unused_variables)]
 fn main() {
     const MAX_LEN: usize = 42;
     let mut vec = vec![1, 2, 3, 4];
@@ -101,9 +101,6 @@ fn main() {
 
     let out_vec = vec![1, 2, 3];
     for _v in out_vec {}
-
-    let array = [1, 2, 3];
-    for _v in &array {}
 
     for _v in &vec {} // these are fine
     for _v in &mut vec {} // these are fine

--- a/tests/ui/for_loop_fixable.rs
+++ b/tests/ui/for_loop_fixable.rs
@@ -31,7 +31,7 @@ impl Unrelated {
     clippy::cognitive_complexity,
     clippy::similar_names
 )]
-#[allow(clippy::many_single_char_names, unused_variables, clippy::into_iter_on_array)]
+#[allow(clippy::many_single_char_names, unused_variables)]
 fn main() {
     const MAX_LEN: usize = 42;
     let mut vec = vec![1, 2, 3, 4];
@@ -101,9 +101,6 @@ fn main() {
 
     let out_vec = vec![1, 2, 3];
     for _v in out_vec.into_iter() {}
-
-    let array = [1, 2, 3];
-    for _v in array.into_iter() {}
 
     for _v in &vec {} // these are fine
     for _v in &mut vec {} // these are fine

--- a/tests/ui/for_loop_fixable.stderr
+++ b/tests/ui/for_loop_fixable.stderr
@@ -77,64 +77,58 @@ LL |     for _v in out_vec.into_iter() {}
    = note: `-D clippy::explicit-into-iter-loop` implied by `-D warnings`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:106:15
-   |
-LL |     for _v in array.into_iter() {}
-   |               ^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&array`
-
-error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:111:15
+  --> $DIR/for_loop_fixable.rs:108:15
    |
 LL |     for _v in [1, 2, 3].iter() {}
    |               ^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&[1, 2, 3]`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:115:15
+  --> $DIR/for_loop_fixable.rs:112:15
    |
 LL |     for _v in [0; 32].iter() {}
    |               ^^^^^^^^^^^^^^ help: to write this more concisely, try: `&[0; 32]`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:120:15
+  --> $DIR/for_loop_fixable.rs:117:15
    |
 LL |     for _v in ll.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&ll`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:123:15
+  --> $DIR/for_loop_fixable.rs:120:15
    |
 LL |     for _v in vd.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&vd`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:126:15
+  --> $DIR/for_loop_fixable.rs:123:15
    |
 LL |     for _v in bh.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&bh`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:129:15
+  --> $DIR/for_loop_fixable.rs:126:15
    |
 LL |     for _v in hm.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&hm`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:132:15
+  --> $DIR/for_loop_fixable.rs:129:15
    |
 LL |     for _v in bt.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&bt`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:135:15
+  --> $DIR/for_loop_fixable.rs:132:15
    |
 LL |     for _v in hs.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&hs`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:138:15
+  --> $DIR/for_loop_fixable.rs:135:15
    |
 LL |     for _v in bs.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&bs`
 
-error: aborting due to 18 previous errors
+error: aborting due to 17 previous errors
 

--- a/tests/ui/for_loop_unfixable.rs
+++ b/tests/ui/for_loop_unfixable.rs
@@ -17,7 +17,7 @@
     unused,
     dead_code
 )]
-#[allow(clippy::many_single_char_names, unused_variables, clippy::into_iter_on_array)]
+#[allow(clippy::many_single_char_names, unused_variables)]
 fn main() {
     for i in 5..5 {
         println!("{}", i);

--- a/tests/ui/into_iter_on_ref.fixed
+++ b/tests/ui/into_iter_on_ref.fixed
@@ -1,7 +1,6 @@
 // run-rustfix
 #![allow(clippy::useless_vec)]
 #![warn(clippy::into_iter_on_ref)]
-#![deny(clippy::into_iter_on_array)]
 
 struct X;
 use std::collections::*;
@@ -10,9 +9,7 @@ fn main() {
     for _ in &[1, 2, 3] {}
     for _ in vec![X, X] {}
     for _ in &vec![X, X] {}
-    for _ in [1, 2, 3].iter() {} //~ ERROR equivalent to .iter()
 
-    let _ = [1, 2, 3].iter(); //~ ERROR equivalent to .iter()
     let _ = vec![1, 2, 3].into_iter();
     let _ = (&vec![1, 2, 3]).iter(); //~ WARN equivalent to .iter()
     let _ = vec![1, 2, 3].into_boxed_slice().iter(); //~ WARN equivalent to .iter()

--- a/tests/ui/into_iter_on_ref.rs
+++ b/tests/ui/into_iter_on_ref.rs
@@ -1,7 +1,6 @@
 // run-rustfix
 #![allow(clippy::useless_vec)]
 #![warn(clippy::into_iter_on_ref)]
-#![deny(clippy::into_iter_on_array)]
 
 struct X;
 use std::collections::*;
@@ -10,9 +9,7 @@ fn main() {
     for _ in &[1, 2, 3] {}
     for _ in vec![X, X] {}
     for _ in &vec![X, X] {}
-    for _ in [1, 2, 3].into_iter() {} //~ ERROR equivalent to .iter()
 
-    let _ = [1, 2, 3].into_iter(); //~ ERROR equivalent to .iter()
     let _ = vec![1, 2, 3].into_iter();
     let _ = (&vec![1, 2, 3]).into_iter(); //~ WARN equivalent to .iter()
     let _ = vec![1, 2, 3].into_boxed_slice().into_iter(); //~ WARN equivalent to .iter()

--- a/tests/ui/into_iter_on_ref.stderr
+++ b/tests/ui/into_iter_on_ref.stderr
@@ -1,23 +1,5 @@
-error: this .into_iter() call is equivalent to .iter() and will not move the array
-  --> $DIR/into_iter_on_ref.rs:13:24
-   |
-LL |     for _ in [1, 2, 3].into_iter() {} //~ ERROR equivalent to .iter()
-   |                        ^^^^^^^^^ help: call directly: `iter`
-   |
-note: lint level defined here
-  --> $DIR/into_iter_on_ref.rs:4:9
-   |
-LL | #![deny(clippy::into_iter_on_array)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: this .into_iter() call is equivalent to .iter() and will not move the array
-  --> $DIR/into_iter_on_ref.rs:15:23
-   |
-LL |     let _ = [1, 2, 3].into_iter(); //~ ERROR equivalent to .iter()
-   |                       ^^^^^^^^^ help: call directly: `iter`
-
 error: this .into_iter() call is equivalent to .iter() and will not move the Vec
-  --> $DIR/into_iter_on_ref.rs:17:30
+  --> $DIR/into_iter_on_ref.rs:14:30
    |
 LL |     let _ = (&vec![1, 2, 3]).into_iter(); //~ WARN equivalent to .iter()
    |                              ^^^^^^^^^ help: call directly: `iter`
@@ -25,154 +7,154 @@ LL |     let _ = (&vec![1, 2, 3]).into_iter(); //~ WARN equivalent to .iter()
    = note: `-D clippy::into-iter-on-ref` implied by `-D warnings`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the slice
-  --> $DIR/into_iter_on_ref.rs:18:46
+  --> $DIR/into_iter_on_ref.rs:15:46
    |
 LL |     let _ = vec![1, 2, 3].into_boxed_slice().into_iter(); //~ WARN equivalent to .iter()
    |                                              ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the slice
-  --> $DIR/into_iter_on_ref.rs:19:41
+  --> $DIR/into_iter_on_ref.rs:16:41
    |
 LL |     let _ = std::rc::Rc::from(&[X][..]).into_iter(); //~ WARN equivalent to .iter()
    |                                         ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the slice
-  --> $DIR/into_iter_on_ref.rs:20:44
+  --> $DIR/into_iter_on_ref.rs:17:44
    |
 LL |     let _ = std::sync::Arc::from(&[X][..]).into_iter(); //~ WARN equivalent to .iter()
    |                                            ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the array
-  --> $DIR/into_iter_on_ref.rs:22:32
+  --> $DIR/into_iter_on_ref.rs:19:32
    |
 LL |     let _ = (&&&&&&&[1, 2, 3]).into_iter(); //~ ERROR equivalent to .iter()
    |                                ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the array
-  --> $DIR/into_iter_on_ref.rs:23:36
+  --> $DIR/into_iter_on_ref.rs:20:36
    |
 LL |     let _ = (&&&&mut &&&[1, 2, 3]).into_iter(); //~ ERROR equivalent to .iter()
    |                                    ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the array
-  --> $DIR/into_iter_on_ref.rs:24:40
+  --> $DIR/into_iter_on_ref.rs:21:40
    |
 LL |     let _ = (&mut &mut &mut [1, 2, 3]).into_iter(); //~ ERROR equivalent to .iter_mut()
    |                                        ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the Option
-  --> $DIR/into_iter_on_ref.rs:26:24
+  --> $DIR/into_iter_on_ref.rs:23:24
    |
 LL |     let _ = (&Some(4)).into_iter(); //~ WARN equivalent to .iter()
    |                        ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the Option
-  --> $DIR/into_iter_on_ref.rs:27:28
+  --> $DIR/into_iter_on_ref.rs:24:28
    |
 LL |     let _ = (&mut Some(5)).into_iter(); //~ WARN equivalent to .iter_mut()
    |                            ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the Result
-  --> $DIR/into_iter_on_ref.rs:28:32
+  --> $DIR/into_iter_on_ref.rs:25:32
    |
 LL |     let _ = (&Ok::<_, i32>(6)).into_iter(); //~ WARN equivalent to .iter()
    |                                ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the Result
-  --> $DIR/into_iter_on_ref.rs:29:37
+  --> $DIR/into_iter_on_ref.rs:26:37
    |
 LL |     let _ = (&mut Err::<i32, _>(7)).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                     ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the Vec
-  --> $DIR/into_iter_on_ref.rs:30:34
+  --> $DIR/into_iter_on_ref.rs:27:34
    |
 LL |     let _ = (&Vec::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                  ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the Vec
-  --> $DIR/into_iter_on_ref.rs:31:38
+  --> $DIR/into_iter_on_ref.rs:28:38
    |
 LL |     let _ = (&mut Vec::<i32>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                      ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the BTreeMap
-  --> $DIR/into_iter_on_ref.rs:32:44
+  --> $DIR/into_iter_on_ref.rs:29:44
    |
 LL |     let _ = (&BTreeMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                            ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the BTreeMap
-  --> $DIR/into_iter_on_ref.rs:33:48
+  --> $DIR/into_iter_on_ref.rs:30:48
    |
 LL |     let _ = (&mut BTreeMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                                ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the VecDeque
-  --> $DIR/into_iter_on_ref.rs:34:39
+  --> $DIR/into_iter_on_ref.rs:31:39
    |
 LL |     let _ = (&VecDeque::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                       ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the VecDeque
-  --> $DIR/into_iter_on_ref.rs:35:43
+  --> $DIR/into_iter_on_ref.rs:32:43
    |
 LL |     let _ = (&mut VecDeque::<i32>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                           ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the LinkedList
-  --> $DIR/into_iter_on_ref.rs:36:41
+  --> $DIR/into_iter_on_ref.rs:33:41
    |
 LL |     let _ = (&LinkedList::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                         ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the LinkedList
-  --> $DIR/into_iter_on_ref.rs:37:45
+  --> $DIR/into_iter_on_ref.rs:34:45
    |
 LL |     let _ = (&mut LinkedList::<i32>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                             ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the HashMap
-  --> $DIR/into_iter_on_ref.rs:38:43
+  --> $DIR/into_iter_on_ref.rs:35:43
    |
 LL |     let _ = (&HashMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                           ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter_mut() and will not move the HashMap
-  --> $DIR/into_iter_on_ref.rs:39:47
+  --> $DIR/into_iter_on_ref.rs:36:47
    |
 LL |     let _ = (&mut HashMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                               ^^^^^^^^^ help: call directly: `iter_mut`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the BTreeSet
-  --> $DIR/into_iter_on_ref.rs:41:39
+  --> $DIR/into_iter_on_ref.rs:38:39
    |
 LL |     let _ = (&BTreeSet::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                       ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the BinaryHeap
-  --> $DIR/into_iter_on_ref.rs:42:41
+  --> $DIR/into_iter_on_ref.rs:39:41
    |
 LL |     let _ = (&BinaryHeap::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                         ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the HashSet
-  --> $DIR/into_iter_on_ref.rs:43:38
+  --> $DIR/into_iter_on_ref.rs:40:38
    |
 LL |     let _ = (&HashSet::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                      ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the Path
-  --> $DIR/into_iter_on_ref.rs:44:43
+  --> $DIR/into_iter_on_ref.rs:41:43
    |
 LL |     let _ = std::path::Path::new("12/34").into_iter(); //~ WARN equivalent to .iter()
    |                                           ^^^^^^^^^ help: call directly: `iter`
 
 error: this .into_iter() call is equivalent to .iter() and will not move the PathBuf
-  --> $DIR/into_iter_on_ref.rs:45:47
+  --> $DIR/into_iter_on_ref.rs:42:47
    |
 LL |     let _ = std::path::PathBuf::from("12/34").into_iter(); //~ ERROR equivalent to .iter()
    |                                               ^^^^^^^^^ help: call directly: `iter`
 
-error: aborting due to 28 previous errors
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
changelog: Deprecate [`into_iter_on_array`] lint

r? @phansch @oli-obk