### PR TITLE
no more must-use-candidate impls

### DIFF
--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     attrs::is_proc_macro, iter_input_pats, match_def_path, qpath_res, return_ty, snippet, snippet_opt,
-    span_help_and_lint, span_lint, span_lint_and_then, type_is_unsafe_function,
+    span_help_and_lint, span_lint, span_lint_and_then, trait_ref_of_method, type_is_unsafe_function,
 };
 use matches::matches;
 use rustc::hir::{self, def::Res, def_id::DefId, intravisit};
@@ -254,7 +254,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Functions {
             if let Some(attr) = attr {
                 let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
                 check_needless_must_use(cx, &sig.decl, item.hir_id, item.span, fn_header_span, attr);
-            } else if cx.access_levels.is_exported(item.hir_id) && !is_proc_macro(&item.attrs) {
+            } else if cx.access_levels.is_exported(item.hir_id)
+                && !is_proc_macro(&item.attrs)
+                && trait_ref_of_method(cx, item.hir_id).is_none()
+            {
                 check_must_use_candidate(
                     cx,
                     &sig.decl,

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -28,7 +28,7 @@ pub trait MyPureTrait {
 }
 
 impl MyPureTrait for MyPure {
-    #[must_use] fn trait_impl_pure(&self, i: u32) -> u32 {
+    fn trait_impl_pure(&self, i: u32) -> u32 {
         i
     }
 }

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -12,12 +12,6 @@ error: this method could have a `#[must_use]` attribute
 LL |     pub fn inherent_pure(&self) -> u8 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn inherent_pure(&self) -> u8`
 
-error: this method could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:31:5
-   |
-LL |     fn trait_impl_pure(&self, i: u32) -> u32 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] fn trait_impl_pure(&self, i: u32) -> u32`
-
 error: this function could have a `#[must_use]` attribute
   --> $DIR/must_use_candidates.rs:48:1
    |
@@ -36,5 +30,5 @@ error: this function could have a `#[must_use]` attribute
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn arcd(_x: Arc<u32>) -> bool`
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This should help with #4779.

changelog: don't trigger [`must_use_candidate`] on trait impls