### PR TITLE
Fix false positive in explicit_counter_loop lint

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -2192,8 +2192,9 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
         }
         walk_expr(self, expr);
     }
+
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
-        NestedVisitorMap::None
+        NestedVisitorMap::OnlyBodies(&self.cx.tcx.hir())
     }
 }
 

--- a/tests/ui/explicit_counter_loop.rs
+++ b/tests/ui/explicit_counter_loop.rs
@@ -132,3 +132,16 @@ mod issue_1670 {
         }
     }
 }
+
+mod issue_4732 {
+    pub fn test() {
+        let slice = &[1, 2, 3];
+        let mut index = 0;
+
+        // should not trigger the lint because the count is used after the loop
+        for _v in slice {
+            index += 1
+        }
+        let _closure = || println!("index: {}", index);
+    }
+}


### PR DESCRIPTION
When the counter was used in a closure after the loop the lint didn't detect the
usage of the counter correctly.

changelog: Fix false positive in `explicit_counter_loop`

Fixes #4732
