### PR TITLE
trigger string_lit_as_bytes when literal has escapes

### DIFF
--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -15,6 +15,8 @@ fn str_lit_as_bytes() {
     let strify = stringify!(foobar).as_bytes();
 
     let includestr = include_bytes!("entry_unfixable.rs");
+
+    let _ = b"string with newline\t\n";
 }
 
 fn main() {}

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -15,6 +15,8 @@ fn str_lit_as_bytes() {
     let strify = stringify!(foobar).as_bytes();
 
     let includestr = include_str!("entry_unfixable.rs").as_bytes();
+
+    let _ = "string with newline\t\n".as_bytes();
 }
 
 fn main() {}

--- a/tests/ui/string_lit_as_bytes.stderr
+++ b/tests/ui/string_lit_as_bytes.stderr
@@ -18,5 +18,11 @@ error: calling `as_bytes()` on `include_str!(..)`
 LL |     let includestr = include_str!("entry_unfixable.rs").as_bytes();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("entry_unfixable.rs")`
 
-error: aborting due to 3 previous errors
+error: calling `as_bytes()` on a string literal
+  --> $DIR/string_lit_as_bytes.rs:19:13
+   |
+LL |     let _ = "string with newline/t/n".as_bytes();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"string with newline/t/n"`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
---

changelog: fix string_lit_as_bytes false negative

Depends on rust-lang/rust#66349.

Fixes #4796.
