### PR TITLE
Typo in literal_representation.rs

### DIFF
--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// **Known problems:**
     /// - Recommends a signed suffix, even though the number might be too big and an unsigned
     ///   suffix is required
-    /// - Does not match on `_128` since that is a valid grouping for decimal and hexadecimal numbers
+    /// - Does not match on `_128` since that is a valid grouping for decimal numbers
     ///
     /// **Example:**
     ///

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// **Known problems:**
     /// - Recommends a signed suffix, even though the number might be too big and an unsigned
     ///   suffix is required
-    /// - Does not match on `_128` since that is a valid grouping for decimal numbers
+    /// - Does not match on `_127` since that is a valid grouping for decimal and octal numbers
     ///
     /// **Example:**
     ///

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// **Known problems:**
     /// - Recommends a signed suffix, even though the number might be too big and an unsigned
     ///   suffix is required
-    /// - Does not match on `_128` since that is a valid grouping for decimal and octal numbers
+    /// - Does not match on `_128` since that is a valid grouping for decimal and hexadecimal numbers
     ///
     /// **Example:**
     ///


### PR DESCRIPTION
Octal numbers can't have 8 in them ;)

changelog: none
