### PR TITLE
doc: fix the comment above the lint function

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2432,7 +2432,7 @@ fn lint_find_map<'a, 'tcx>(
     }
 }
 
-/// lint use of `filter().map()` for `Iterators`
+/// lint use of `filter_map().map()` for `Iterators`
 fn lint_filter_map_map<'a, 'tcx>(
     cx: &LateContext<'a, 'tcx>,
     expr: &'tcx hir::Expr,


### PR DESCRIPTION
it's a simple comment fix.

---

changelog: none
