### PR TITLE
Rustup to rustc 1.41.0-nightly (35ef33a8 2019-11-21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,9 @@ matrix:
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=bluss/rust-itertools
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
-    - env: INTEGRATION=serde-rs/serde
-      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
+    # FIXME: rustc ICE on `serde_test_suite`
+    # - env: INTEGRATION=serde-rs/serde
+    #   if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang-nursery/stdsimd
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-random/rand

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,9 @@ matrix:
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=rust-lang/cargo
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
-    - env: INTEGRATION=rust-lang-nursery/chalk
-      if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
+    # FIXME: Output too large
+    # - env: INTEGRATION=rust-lang-nursery/chalk
+    #   if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     - env: INTEGRATION=Geal/nom
       if: repo =~ /^rust-lang\/rust-clippy$/ AND branch IN (auto, try)
     # FIXME blocked on https://github.com/rust-lang/rust-clippy/issues/4727

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 
 [dev-dependencies]
 cargo_metadata = "0.9.0"
-compiletest_rs = { version = "0.3.24", features = ["tmp"] }
+compiletest_rs = { version = "0.4.0", features = ["tmp"] }
+tester = "0.7"
 lazy_static = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }
 serde = { version = "1.0", features = ["derive"] }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![feature(box_syntax)]
 #![feature(box_patterns)]
-#![feature(never_type)]
 #![feature(rustc_private)]
 #![feature(slice_patterns)]
 #![feature(stmt_expr_attributes)]

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -720,7 +720,7 @@ fn never_loop_expr(expr: &Expr, main_loop_id: HirId) -> NeverLoopResult {
         ExprKind::Struct(_, _, None)
         | ExprKind::Yield(_, _)
         | ExprKind::Closure(_, _, _, _, _)
-        | ExprKind::InlineAsm(_, _, _)
+        | ExprKind::InlineAsm(_)
         | ExprKind::Path(_)
         | ExprKind::Lit(_)
         | ExprKind::Err => NeverLoopResult::Otherwise,

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -458,8 +458,8 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
                     println!("Ret(None) = {};", current);
                 }
             },
-            ExprKind::InlineAsm(_, ref _input, ref _output) => {
-                println!("InlineAsm(_, ref input, ref output) = {};", current);
+            ExprKind::InlineAsm(_) => {
+                println!("InlineAsm(_) = {};", current);
                 println!("    // unimplemented: `ExprKind::InlineAsm` is not further destructured at the moment");
             },
             ExprKind::Struct(ref path, ref fields, ref opt_base) => {

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -282,14 +282,16 @@ fn print_expr(cx: &LateContext<'_, '_>, expr: &hir::Expr, indent: usize) {
                 print_expr(cx, e, indent + 1);
             }
         },
-        hir::ExprKind::InlineAsm(_, ref input, ref output) => {
+        hir::ExprKind::InlineAsm(ref asm) => {
+            let inputs = &asm.inputs_exprs;
+            let outputs = &asm.outputs_exprs;
             println!("{}InlineAsm", ind);
             println!("{}inputs:", ind);
-            for e in input {
+            for e in inputs.iter() {
                 print_expr(cx, e, indent + 1);
             }
             println!("{}outputs:", ind);
-            for e in output {
+            for e in outputs.iter() {
                 print_expr(cx, e, indent + 1);
             }
         },

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -75,6 +75,8 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
             clippy_lints::register_pre_expansion_lints(&mut lint_store, &conf);
             clippy_lints::register_renamed(&mut lint_store);
         }));
+
+        config.opts.debugging_opts.mir_opt_level = 0;
     }
 }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -76,6 +76,10 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
             clippy_lints::register_renamed(&mut lint_store);
         }));
 
+        // FIXME: #4825; This is required, because Clippy lints that are based on MIR have to be
+        // run on the unoptimized MIR. On the other hand this results in some false negatives. If
+        // MIR passes can be enabled / disabled separately, we should figure out, what passes to
+        // use for Clippy.
         config.opts.debugging_opts.mir_opt_level = 0;
     }
 }

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
 use compiletest_rs as compiletest;
-extern crate test;
+extern crate tester as test;
 
 use std::env::{set_var, var};
 use std::ffi::OsStr;

--- a/tests/ui/builtin-type-shadow.stderr
+++ b/tests/ui/builtin-type-shadow.stderr
@@ -16,8 +16,8 @@ LL | fn foo<u32>(a: u32) -> u32 {
 LL |     42
    |     ^^ expected type parameter `u32`, found integer
    |
-   = note: expected type `u32`
-              found type `{integer}`
+   = note: expected type parameter `u32`
+                        found type `{integer}`
    = help: type parameters must be constrained to match other types
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 

--- a/tests/ui/diverging_sub_expression.rs
+++ b/tests/ui/diverging_sub_expression.rs
@@ -1,4 +1,3 @@
-#![feature(never_type)]
 #![warn(clippy::diverging_sub_expression)]
 #![allow(clippy::match_same_arms, clippy::logic_bug)]
 

--- a/tests/ui/diverging_sub_expression.stderr
+++ b/tests/ui/diverging_sub_expression.stderr
@@ -1,5 +1,5 @@
 error: sub-expression diverges
-  --> $DIR/diverging_sub_expression.rs:21:10
+  --> $DIR/diverging_sub_expression.rs:20:10
    |
 LL |     b || diverge();
    |          ^^^^^^^^^
@@ -7,31 +7,31 @@ LL |     b || diverge();
    = note: `-D clippy::diverging-sub-expression` implied by `-D warnings`
 
 error: sub-expression diverges
-  --> $DIR/diverging_sub_expression.rs:22:10
+  --> $DIR/diverging_sub_expression.rs:21:10
    |
 LL |     b || A.foo();
    |          ^^^^^^^
 
 error: sub-expression diverges
-  --> $DIR/diverging_sub_expression.rs:31:26
+  --> $DIR/diverging_sub_expression.rs:30:26
    |
 LL |             6 => true || return,
    |                          ^^^^^^
 
 error: sub-expression diverges
-  --> $DIR/diverging_sub_expression.rs:32:26
+  --> $DIR/diverging_sub_expression.rs:31:26
    |
 LL |             7 => true || continue,
    |                          ^^^^^^^^
 
 error: sub-expression diverges
-  --> $DIR/diverging_sub_expression.rs:35:26
+  --> $DIR/diverging_sub_expression.rs:34:26
    |
 LL |             3 => true || diverge(),
    |                          ^^^^^^^^^
 
 error: sub-expression diverges
-  --> $DIR/diverging_sub_expression.rs:40:26
+  --> $DIR/diverging_sub_expression.rs:39:26
    |
 LL |             _ => true || break,
    |                          ^^^^^

--- a/tests/ui/indexing_slicing.stderr
+++ b/tests/ui/indexing_slicing.stderr
@@ -1,23 +1,3 @@
-error: index out of bounds: the len is 4 but the index is 4
-  --> $DIR/indexing_slicing.rs:18:5
-   |
-LL |     x[4]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
-   |     ^^^^
-   |
-   = note: `#[deny(const_err)]` on by default
-
-error: index out of bounds: the len is 4 but the index is 8
-  --> $DIR/indexing_slicing.rs:19:5
-   |
-LL |     x[1 << 3]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
-   |     ^^^^^^^^^
-
-error: index out of bounds: the len is 4 but the index is 15
-  --> $DIR/indexing_slicing.rs:54:5
-   |
-LL |     x[N]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
-   |     ^^^^
-
 error: indexing may panic.
   --> $DIR/indexing_slicing.rs:13:5
    |
@@ -209,5 +189,5 @@ LL |     v[M];
    |
    = help: Consider using `.get(n)` or `.get_mut(n)` instead
 
-error: aborting due to 27 previous errors
+error: aborting due to 24 previous errors
 

--- a/tests/ui/infallible_destructuring_match.fixed
+++ b/tests/ui/infallible_destructuring_match.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![feature(exhaustive_patterns, never_type)]
+#![feature(exhaustive_patterns)]
 #![allow(dead_code, unreachable_code, unused_variables)]
 #![allow(clippy::let_and_return)]
 

--- a/tests/ui/infallible_destructuring_match.rs
+++ b/tests/ui/infallible_destructuring_match.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![feature(exhaustive_patterns, never_type)]
+#![feature(exhaustive_patterns)]
 #![allow(dead_code, unreachable_code, unused_variables)]
 #![allow(clippy::let_and_return)]
 

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -32,8 +32,11 @@ fn random_caller() -> u32 {
 
 static Y: u32 = 0;
 
+// We should not suggest to make this function `const` because const functions are not allowed to
+// refer to a static variable
 fn get_y() -> u32 {
     Y
+    //~^ ERROR E0013
 }
 
 // Don't lint entrypoint functions

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -32,11 +32,8 @@ fn random_caller() -> u32 {
 
 static Y: u32 = 0;
 
-// We should not suggest to make this function `const` because const functions are not allowed to
-// refer to a static variable
 fn get_y() -> u32 {
     Y
-    //~^ ERROR E0013
 }
 
 // Don't lint entrypoint functions

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -1,5 +1,4 @@
 // run-rustfix
-#![feature(never_type)]
 #![allow(unused_mut)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -1,5 +1,4 @@
 // run-rustfix
-#![feature(never_type)]
 #![allow(unused_mut)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -1,5 +1,5 @@
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:12:1
+  --> $DIR/must_use_candidates.rs:11:1
    |
 LL | pub fn pure(i: u8) -> u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn pure(i: u8) -> u8`
@@ -7,25 +7,25 @@ LL | pub fn pure(i: u8) -> u8 {
    = note: `-D clippy::must-use-candidate` implied by `-D warnings`
 
 error: this method could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:17:5
+  --> $DIR/must_use_candidates.rs:16:5
    |
 LL |     pub fn inherent_pure(&self) -> u8 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn inherent_pure(&self) -> u8`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:48:1
+  --> $DIR/must_use_candidates.rs:47:1
    |
 LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:60:1
+  --> $DIR/must_use_candidates.rs:59:1
    |
 LL | pub fn rcd(_x: Rc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn rcd(_x: Rc<u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:68:1
+  --> $DIR/must_use_candidates.rs:67:1
    |
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn arcd(_x: Arc<u32>) -> bool`

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 // rustfix-only-machine-applicable
+
 use std::ffi::OsString;
 use std::path::Path;
 

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -18,11 +18,11 @@ fn main() {
 
     let _s = Path::new("/a/b/").join("c");
 
-    let _s = Path::new("/a/b/").join("c");
+    let _s = Path::new("/a/b/").join("c").to_path_buf();
 
     let _s = OsString::new();
 
-    let _s = OsString::new();
+    let _s = OsString::new().to_os_string();
 
     // Check that lint level works
     #[allow(clippy::redundant_clone)]
@@ -47,6 +47,7 @@ fn main() {
     let _ = Some(String::new()).unwrap_or_else(|| x.0.clone()); // ok; closure borrows `x`
 
     with_branch(Alpha, true);
+    cannot_double_move(Alpha);
     cannot_move_from_type_with_drop();
     borrower_propagation();
 }
@@ -59,6 +60,10 @@ fn with_branch(a: Alpha, b: bool) -> (Alpha, Alpha) {
     } else {
         (Alpha, a)
     }
+}
+
+fn cannot_double_move(a: Alpha) -> (Alpha, Alpha) {
+    (a.clone(), a)
 }
 
 struct TypeWithDrop {

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 // rustfix-only-machine-applicable
+
 use std::ffi::OsString;
 use std::path::Path;
 

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -47,6 +47,7 @@ fn main() {
     let _ = Some(String::new()).unwrap_or_else(|| x.0.clone()); // ok; closure borrows `x`
 
     with_branch(Alpha, true);
+    cannot_double_move(Alpha);
     cannot_move_from_type_with_drop();
     borrower_propagation();
 }
@@ -59,6 +60,10 @@ fn with_branch(a: Alpha, b: bool) -> (Alpha, Alpha) {
     } else {
         (Alpha, a)
     }
+}
+
+fn cannot_double_move(a: Alpha) -> (Alpha, Alpha) {
+    (a.clone(), a)
 }
 
 struct TypeWithDrop {

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -1,156 +1,156 @@
 error: redundant clone
-  --> $DIR/redundant_clone.rs:7:42
+  --> $DIR/redundant_clone.rs:8:42
    |
 LL |     let _s = ["lorem", "ipsum"].join(" ").to_string();
    |                                          ^^^^^^^^^^^^ help: remove this
    |
    = note: `-D clippy::redundant-clone` implied by `-D warnings`
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:7:14
+  --> $DIR/redundant_clone.rs:8:14
    |
 LL |     let _s = ["lorem", "ipsum"].join(" ").to_string();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:10:15
+  --> $DIR/redundant_clone.rs:11:15
    |
 LL |     let _s = s.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:10:14
+  --> $DIR/redundant_clone.rs:11:14
    |
 LL |     let _s = s.clone();
    |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:13:15
+  --> $DIR/redundant_clone.rs:14:15
    |
 LL |     let _s = s.to_string();
    |               ^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:13:14
+  --> $DIR/redundant_clone.rs:14:14
    |
 LL |     let _s = s.to_string();
    |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:16:15
+  --> $DIR/redundant_clone.rs:17:15
    |
 LL |     let _s = s.to_owned();
    |               ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:16:14
+  --> $DIR/redundant_clone.rs:17:14
    |
 LL |     let _s = s.to_owned();
    |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:18:42
+  --> $DIR/redundant_clone.rs:19:42
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_owned();
    |                                          ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:18:14
+  --> $DIR/redundant_clone.rs:19:14
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_owned();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:20:42
+  --> $DIR/redundant_clone.rs:21:42
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
    |                                          ^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:20:14
+  --> $DIR/redundant_clone.rs:21:14
    |
 LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:22:29
+  --> $DIR/redundant_clone.rs:23:29
    |
 LL |     let _s = OsString::new().to_owned();
    |                             ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:22:14
+  --> $DIR/redundant_clone.rs:23:14
    |
 LL |     let _s = OsString::new().to_owned();
    |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:24:29
+  --> $DIR/redundant_clone.rs:25:29
    |
 LL |     let _s = OsString::new().to_os_string();
    |                             ^^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:24:14
+  --> $DIR/redundant_clone.rs:25:14
    |
 LL |     let _s = OsString::new().to_os_string();
    |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:31:19
+  --> $DIR/redundant_clone.rs:32:19
    |
 LL |     let _t = tup.0.clone();
    |                   ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:31:14
+  --> $DIR/redundant_clone.rs:32:14
    |
 LL |     let _t = tup.0.clone();
    |              ^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:57:22
+  --> $DIR/redundant_clone.rs:58:22
    |
 LL |         (a.clone(), a.clone())
    |                      ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:57:21
+  --> $DIR/redundant_clone.rs:58:21
    |
 LL |         (a.clone(), a.clone())
    |                     ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:113:15
-   |
-LL |     let _s = s.clone();
-   |               ^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:113:14
-   |
-LL |     let _s = s.clone();
-   |              ^
-
-error: redundant clone
   --> $DIR/redundant_clone.rs:114:15
    |
-LL |     let _t = t.clone();
+LL |     let _s = s.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
   --> $DIR/redundant_clone.rs:114:14
    |
+LL |     let _s = s.clone();
+   |              ^
+
+error: redundant clone
+  --> $DIR/redundant_clone.rs:115:15
+   |
+LL |     let _t = t.clone();
+   |               ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:115:14
+   |
 LL |     let _t = t.clone();
    |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:124:19
+  --> $DIR/redundant_clone.rs:125:19
    |
 LL |         let _f = f.clone();
    |                   ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:124:18
+  --> $DIR/redundant_clone.rs:125:18
    |
 LL |         let _f = f.clone();
    |                  ^

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -60,18 +60,6 @@ LL |     let _s = Path::new("/a/b/").join("c").to_owned();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:21:42
-   |
-LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
-   |                                          ^^^^^^^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:21:14
-   |
-LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: redundant clone
   --> $DIR/redundant_clone.rs:23:29
    |
 LL |     let _s = OsString::new().to_owned();
@@ -81,18 +69,6 @@ note: this value is dropped without further use
   --> $DIR/redundant_clone.rs:23:14
    |
 LL |     let _s = OsString::new().to_owned();
-   |              ^^^^^^^^^^^^^^^
-
-error: redundant clone
-  --> $DIR/redundant_clone.rs:25:29
-   |
-LL |     let _s = OsString::new().to_os_string();
-   |                             ^^^^^^^^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:25:14
-   |
-LL |     let _s = OsString::new().to_os_string();
    |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
@@ -108,52 +84,52 @@ LL |     let _t = tup.0.clone();
    |              ^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:58:22
+  --> $DIR/redundant_clone.rs:59:22
    |
 LL |         (a.clone(), a.clone())
    |                      ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:58:21
+  --> $DIR/redundant_clone.rs:59:21
    |
 LL |         (a.clone(), a.clone())
    |                     ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:114:15
+  --> $DIR/redundant_clone.rs:119:15
    |
 LL |     let _s = s.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:114:14
+  --> $DIR/redundant_clone.rs:119:14
    |
 LL |     let _s = s.clone();
    |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:115:15
+  --> $DIR/redundant_clone.rs:120:15
    |
 LL |     let _t = t.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:115:14
+  --> $DIR/redundant_clone.rs:120:14
    |
 LL |     let _t = t.clone();
    |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:125:19
+  --> $DIR/redundant_clone.rs:130:19
    |
 LL |         let _f = f.clone();
    |                   ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:125:18
+  --> $DIR/redundant_clone.rs:130:18
    |
 LL |         let _f = f.clone();
    |                  ^
 
-error: aborting due to 13 previous errors
+error: aborting due to 11 previous errors
 

--- a/tests/ui/result_map_unit_fn_fixable.fixed
+++ b/tests/ui/result_map_unit_fn_fixable.fixed
@@ -1,6 +1,5 @@
 // run-rustfix
 
-#![feature(never_type)]
 #![warn(clippy::result_map_unit_fn)]
 #![allow(unused)]
 

--- a/tests/ui/result_map_unit_fn_fixable.rs
+++ b/tests/ui/result_map_unit_fn_fixable.rs
@@ -1,6 +1,5 @@
 // run-rustfix
 
-#![feature(never_type)]
 #![warn(clippy::result_map_unit_fn)]
 #![allow(unused)]
 

--- a/tests/ui/result_map_unit_fn_fixable.stderr
+++ b/tests/ui/result_map_unit_fn_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `map(f)` on an Result value where `f` is a unit function
-  --> $DIR/result_map_unit_fn_fixable.rs:36:5
+  --> $DIR/result_map_unit_fn_fixable.rs:35:5
    |
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
@@ -9,7 +9,7 @@ LL |     x.field.map(do_nothing);
    = note: `-D clippy::result-map-unit-fn` implied by `-D warnings`
 
 error: called `map(f)` on an Result value where `f` is a unit function
-  --> $DIR/result_map_unit_fn_fixable.rs:38:5
+  --> $DIR/result_map_unit_fn_fixable.rs:37:5
    |
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
@@ -17,7 +17,7 @@ LL |     x.field.map(do_nothing);
    |     help: try this: `if let Ok(x_field) = x.field { do_nothing(x_field) }`
 
 error: called `map(f)` on an Result value where `f` is a unit function
-  --> $DIR/result_map_unit_fn_fixable.rs:40:5
+  --> $DIR/result_map_unit_fn_fixable.rs:39:5
    |
 LL |     x.field.map(diverge);
    |     ^^^^^^^^^^^^^^^^^^^^-
@@ -25,7 +25,7 @@ LL |     x.field.map(diverge);
    |     help: try this: `if let Ok(x_field) = x.field { diverge(x_field) }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:46:5
+  --> $DIR/result_map_unit_fn_fixable.rs:45:5
    |
 LL |     x.field.map(|value| x.do_result_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -33,7 +33,7 @@ LL |     x.field.map(|value| x.do_result_nothing(value + captured));
    |     help: try this: `if let Ok(value) = x.field { x.do_result_nothing(value + captured) }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:48:5
+  --> $DIR/result_map_unit_fn_fixable.rs:47:5
    |
 LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -41,7 +41,7 @@ LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
    |     help: try this: `if let Ok(value) = x.field { x.do_result_plus_one(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:51:5
+  --> $DIR/result_map_unit_fn_fixable.rs:50:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -49,7 +49,7 @@ LL |     x.field.map(|value| do_nothing(value + captured));
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:53:5
+  --> $DIR/result_map_unit_fn_fixable.rs:52:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -57,7 +57,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:55:5
+  --> $DIR/result_map_unit_fn_fixable.rs:54:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -65,7 +65,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:57:5
+  --> $DIR/result_map_unit_fn_fixable.rs:56:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -73,7 +73,7 @@ LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:60:5
+  --> $DIR/result_map_unit_fn_fixable.rs:59:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -81,7 +81,7 @@ LL |     x.field.map(|value| diverge(value + captured));
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:62:5
+  --> $DIR/result_map_unit_fn_fixable.rs:61:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -89,7 +89,7 @@ LL |     x.field.map(|value| { diverge(value + captured) });
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:64:5
+  --> $DIR/result_map_unit_fn_fixable.rs:63:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -97,7 +97,7 @@ LL |     x.field.map(|value| { diverge(value + captured); });
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:66:5
+  --> $DIR/result_map_unit_fn_fixable.rs:65:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -105,7 +105,7 @@ LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:71:5
+  --> $DIR/result_map_unit_fn_fixable.rs:70:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -113,7 +113,7 @@ LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     help: try this: `if let Ok(value) = x.field { let y = plus_one(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:73:5
+  --> $DIR/result_map_unit_fn_fixable.rs:72:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -121,7 +121,7 @@ LL |     x.field.map(|value| { plus_one(value + captured); });
    |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:75:5
+  --> $DIR/result_map_unit_fn_fixable.rs:74:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -129,7 +129,7 @@ LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an Result value where `f` is a unit closure
-  --> $DIR/result_map_unit_fn_fixable.rs:78:5
+  --> $DIR/result_map_unit_fn_fixable.rs:77:5
    |
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-

--- a/tests/ui/result_map_unit_fn_unfixable.rs
+++ b/tests/ui/result_map_unit_fn_unfixable.rs
@@ -1,4 +1,3 @@
-#![feature(never_type)]
 #![warn(clippy::result_map_unit_fn)]
 #![allow(unused)]
 

--- a/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -1,23 +1,23 @@
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:17:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:16:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
    |     ^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:19:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:18:5
    |
 LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });
    |     ^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:23:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:22:5
    |
 LL |     x.field.map(|value| {
    |     ^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:27:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:26:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value); });
    |     ^ not found in this scope


### PR DESCRIPTION
I don't have the right fix for the fmtstr tests, and I'm also hitting problems caused by https://github.com/messense/rustc-test/issues/3

List of rustups:
- rust-lang/rust#66271 (syntax: Keep string literals in ABIs and `asm!` more precisely)
- rust-lang/rust#65355 (Stabilize `!` in Rust 1.41.0)
- rust-lang/rust#66515 (Reduce size of `hir::Expr` by boxing more of `hir::InlineAsm`)
- rust-lang/rust#66389 (Specific labels when referring to "expected" and "found" types)
- rust-lang/rust#66074 ([mir-opt] Turn on the `ConstProp` pass by default)

changelog: none