### PR TITLE
Return early if the method is a default trait impl for `boxed_local`

### DIFF
--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -68,6 +68,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BoxedLocal {
             if let ItemKind::Impl(_, _, _, _, Some(..), _, _) = item.kind {
                 return;
             }
+
+            // Issue 4804 fix: don't warn if the method is a default trait impl
+            if let ItemKind::Trait(_, _, _, _, _) = item.kind {
+                return;
+            }
         }
 
         let mut v = EscapeDelegate {

--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -154,6 +154,15 @@ impl<T> MyTrait for Box<T> {
     fn do_sth(self) {}
 }
 
+/// Fix for #4804
+///
+/// This shouldn't warn for `boxed_local` as traits don't have a know size in compile time
+trait DefaultTraitImplTest {
+    fn default_impl(self: Box<Self>) -> u32 {
+        5
+    }
+}
+
 // Issue #3739 - capture in closures
 mod issue_3739 {
     use super::A;


### PR DESCRIPTION
fixes #4804 
changelog: check for a default trait impl and a corresponding test case
