### PR TITLE
[comparison_chain] #4827 Check `core::cmp::Ord` is implemented

### DIFF
--- a/tests/ui/comparison_chain.rs
+++ b/tests/ui/comparison_chain.rs
@@ -76,4 +76,65 @@ fn f(x: u8, y: u8, z: u8) {
     }
 }
 
+#[allow(clippy::float_cmp)]
+fn g(x: f64, y: f64, z: f64) {
+    // Ignored: f64 doesn't implement Ord
+    if x > y {
+        a()
+    } else if x < y {
+        b()
+    }
+
+    // Ignored: f64 doesn't implement Ord
+    if x > y {
+        a()
+    } else if x < y {
+        b()
+    } else {
+        c()
+    }
+
+    // Ignored: f64 doesn't implement Ord
+    if x > y {
+        a()
+    } else if y > x {
+        b()
+    } else {
+        c()
+    }
+
+    // Ignored: f64 doesn't implement Ord
+    if x > 1.0 {
+        a()
+    } else if x < 1.0 {
+        b()
+    } else if x == 1.0 {
+        c()
+    }
+}
+
+fn h<T: Ord>(x: T, y: T, z: T) {
+    if x > y {
+        a()
+    } else if x < y {
+        b()
+    }
+
+    if x > y {
+        a()
+    } else if x < y {
+        b()
+    } else {
+        c()
+    }
+
+    if x > y {
+        a()
+    } else if y > x {
+        b()
+    } else {
+        c()
+    }
+}
+
 fn main() {}

--- a/tests/ui/comparison_chain.stderr
+++ b/tests/ui/comparison_chain.stderr
@@ -53,5 +53,45 @@ LL | |     }
    |
    = help: Consider rewriting the `if` chain to use `cmp` and `match`.
 
-error: aborting due to 4 previous errors
+error: `if` chain can be rewritten with `match`
+  --> $DIR/comparison_chain.rs:117:5
+   |
+LL | /     if x > y {
+LL | |         a()
+LL | |     } else if x < y {
+LL | |         b()
+LL | |     }
+   | |_____^
+   |
+   = help: Consider rewriting the `if` chain to use `cmp` and `match`.
+
+error: `if` chain can be rewritten with `match`
+  --> $DIR/comparison_chain.rs:123:5
+   |
+LL | /     if x > y {
+LL | |         a()
+LL | |     } else if x < y {
+LL | |         b()
+LL | |     } else {
+LL | |         c()
+LL | |     }
+   | |_____^
+   |
+   = help: Consider rewriting the `if` chain to use `cmp` and `match`.
+
+error: `if` chain can be rewritten with `match`
+  --> $DIR/comparison_chain.rs:131:5
+   |
+LL | /     if x > y {
+LL | |         a()
+LL | |     } else if y > x {
+LL | |         b()
+LL | |     } else {
+LL | |         c()
+LL | |     }
+   | |_____^
+   |
+   = help: Consider rewriting the `if` chain to use `cmp` and `match`.
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Only emit `comparison_chain` lint, if `cmp` is actually available on the type being compared. Don't emit lint in cases where only `PartialOrd` is implemented.

I haven't yet fully understood [Adjustments](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/adjustment/struct.Adjustment.html). I would appreciate, if someone could double check whether my usage of [expr_ty](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/struct.TypeckTables.html#method.expr_ty) in `clippy_lints/src/comparison_chain.rs:91` is correct or if there are cases where using [expr_ty_adjusted](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/struct.TypeckTables.html#method.expr_ty_adjusted) would lead to a different result when used with `utils::implements_trait`.

---

fixes #4827
changelog: [comparison_chain] Check `core::cmp::Ord` is implemented
