### PR TITLE
Rustup to rustc 1.41.0-nightly (e87a205c2 2019-11-27)

### DIFF
--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -101,7 +101,7 @@ fn check_arg(name: Name, arg: Name, needle: &Expr) -> bool {
 
 fn get_path_name(expr: &Expr) -> Option<Name> {
     match expr.kind {
-        ExprKind::Box(ref e) | ExprKind::AddrOf(_, ref e) | ExprKind::Unary(UnOp::UnDeref, ref e) => get_path_name(e),
+        ExprKind::Box(ref e) | ExprKind::AddrOf(_, _, ref e) | ExprKind::Unary(UnOp::UnDeref, ref e) => get_path_name(e),
         ExprKind::Block(ref b, _) => {
             if b.stmts.is_empty() {
                 b.expr.as_ref().and_then(|p| get_path_name(p))

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -101,7 +101,7 @@ fn check_arg(name: Name, arg: Name, needle: &Expr) -> bool {
 
 fn get_path_name(expr: &Expr) -> Option<Name> {
     match expr.kind {
-        ExprKind::Box(ref e) | ExprKind::AddrOf(_, _, ref e) | ExprKind::Unary(UnOp::UnDeref, ref e) => {
+        ExprKind::Box(ref e) | ExprKind::AddrOf(BorrowKind::Ref, _, ref e) | ExprKind::Unary(UnOp::UnDeref, ref e) => {
             get_path_name(e)
         },
         ExprKind::Block(ref b, _) => {

--- a/clippy_lints/src/bytecount.rs
+++ b/clippy_lints/src/bytecount.rs
@@ -101,7 +101,9 @@ fn check_arg(name: Name, arg: Name, needle: &Expr) -> bool {
 
 fn get_path_name(expr: &Expr) -> Option<Name> {
     match expr.kind {
-        ExprKind::Box(ref e) | ExprKind::AddrOf(_, _, ref e) | ExprKind::Unary(UnOp::UnDeref, ref e) => get_path_name(e),
+        ExprKind::Box(ref e) | ExprKind::AddrOf(_, _, ref e) | ExprKind::Unary(UnOp::UnDeref, ref e) => {
+            get_path_name(e)
+        },
         ExprKind::Block(ref b, _) => {
             if b.stmts.is_empty() {
                 b.expr.as_ref().and_then(|p| get_path_name(p))

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -105,7 +105,7 @@ fn check_cond<'a, 'tcx, 'b>(
         if let ExprKind::MethodCall(ref path, _, ref params) = check.kind;
         if params.len() >= 2;
         if path.ident.name == sym!(contains_key);
-        if let ExprKind::AddrOf(_, ref key) = params[1].kind;
+        if let ExprKind::AddrOf(_, _, ref key) = params[1].kind;
         then {
             let map = &params[0];
             let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(map));

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -105,7 +105,7 @@ fn check_cond<'a, 'tcx, 'b>(
         if let ExprKind::MethodCall(ref path, _, ref params) = check.kind;
         if params.len() >= 2;
         if path.ident.name == sym!(contains_key);
-        if let ExprKind::AddrOf(_, _, ref key) = params[1].kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref key) = params[1].kind;
         then {
             let map = &params[0];
             let obj_ty = walk_ptrs_ty(cx.tables.expr_ty(map));

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                     // do not suggest to dereference literals
                     (&ExprKind::Lit(..), _) | (_, &ExprKind::Lit(..)) => {},
                     // &foo == &bar
-                    (&ExprKind::AddrOf(_, ref l), &ExprKind::AddrOf(_, ref r)) => {
+                    (&ExprKind::AddrOf(_, _, ref l), &ExprKind::AddrOf(_, _, ref r)) => {
                         let lty = cx.tables.expr_ty(l);
                         let rty = cx.tables.expr_ty(r);
                         let lcpy = is_copy(cx, lty);
@@ -143,7 +143,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                         }
                     },
                     // &foo == bar
-                    (&ExprKind::AddrOf(_, ref l), _) => {
+                    (&ExprKind::AddrOf(_, _, ref l), _) => {
                         let lty = cx.tables.expr_ty(l);
                         let lcpy = is_copy(cx, lty);
                         if (requires_ref || lcpy)
@@ -161,7 +161,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                         }
                     },
                     // foo == &bar
-                    (_, &ExprKind::AddrOf(_, ref r)) => {
+                    (_, &ExprKind::AddrOf(_, _, ref r)) => {
                         let rty = cx.tables.expr_ty(r);
                         let rcpy = is_copy(cx, rty);
                         if (requires_ref || rcpy)

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                     // do not suggest to dereference literals
                     (&ExprKind::Lit(..), _) | (_, &ExprKind::Lit(..)) => {},
                     // &foo == &bar
-                    (&ExprKind::AddrOf(_, _, ref l), &ExprKind::AddrOf(_, _, ref r)) => {
+                    (&ExprKind::AddrOf(BorrowKind::Ref, _, ref l), &ExprKind::AddrOf(BorrowKind::Ref, _, ref r)) => {
                         let lty = cx.tables.expr_ty(l);
                         let rty = cx.tables.expr_ty(r);
                         let lcpy = is_copy(cx, lty);
@@ -143,7 +143,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                         }
                     },
                     // &foo == bar
-                    (&ExprKind::AddrOf(_, _, ref l), _) => {
+                    (&ExprKind::AddrOf(BorrowKind::Ref, _, ref l), _) => {
                         let lty = cx.tables.expr_ty(l);
                         let lcpy = is_copy(cx, lty);
                         if (requires_ref || lcpy)
@@ -161,7 +161,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                         }
                     },
                     // foo == &bar
-                    (_, &ExprKind::AddrOf(_, _, ref r)) => {
+                    (_, &ExprKind::AddrOf(BorrowKind::Ref, _, ref r)) => {
                         let rty = cx.tables.expr_ty(r);
                         let rcpy = is_copy(cx, rty);
                         if (requires_ref || rcpy)

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -328,7 +328,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ReadVisitor<'a, 'tcx> {
             // ```
             //
             // TODO: fix this
-            ExprKind::AddrOf(_, _, _) => {
+            ExprKind::AddrOf(BorrowKind::Ref, _, _) => {
                 return;
             }
             _ => {}

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -328,7 +328,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ReadVisitor<'a, 'tcx> {
             // ```
             //
             // TODO: fix this
-            ExprKind::AddrOf(BorrowKind::Ref, _, _) => {
+            ExprKind::AddrOf(_, _, _) => {
                 return;
             }
             _ => {}

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -328,7 +328,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ReadVisitor<'a, 'tcx> {
             // ```
             //
             // TODO: fix this
-            ExprKind::AddrOf(_, _) => {
+            ExprKind::AddrOf(_, _, _) => {
                 return;
             }
             _ => {}

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -135,7 +135,7 @@ fn write_output_string(write_args: &HirVec<Expr>) -> Option<String> {
         if write_args.len() > 1;
         if let ExprKind::Call(_, ref output_args) = write_args[1].kind;
         if output_args.len() > 0;
-        if let ExprKind::AddrOf(_, ref output_string_expr) = output_args[0].kind;
+        if let ExprKind::AddrOf(_, _, ref output_string_expr) = output_args[0].kind;
         if let ExprKind::Array(ref string_exprs) = output_string_expr.kind;
         // we only want to provide an automatic suggestion for simple (non-format) strings
         if string_exprs.len() == 1;

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -135,7 +135,7 @@ fn write_output_string(write_args: &HirVec<Expr>) -> Option<String> {
         if write_args.len() > 1;
         if let ExprKind::Call(_, ref output_args) = write_args[1].kind;
         if output_args.len() > 0;
-        if let ExprKind::AddrOf(_, _, ref output_string_expr) = output_args[0].kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref output_string_expr) = output_args[0].kind;
         if let ExprKind::Array(ref string_exprs) = output_string_expr.kind;
         // we only want to provide an automatic suggestion for simple (non-format) strings
         if string_exprs.len() == 1;

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -73,7 +73,7 @@ fn span_useless_format<T: LintContext>(cx: &T, span: Span, help: &str, mut sugg:
 
 fn on_argumentv1_new<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, arms: &'tcx [Arm]) -> Option<String> {
     if_chain! {
-        if let ExprKind::AddrOf(_, ref format_args) = expr.kind;
+        if let ExprKind::AddrOf(_, _, ref format_args) = expr.kind;
         if let ExprKind::Array(ref elems) = arms[0].body.kind;
         if elems.len() == 1;
         if let Some(args) = match_function_call(cx, &elems[0], &paths::FMT_ARGUMENTV1_NEW);
@@ -115,13 +115,13 @@ fn on_new_v1<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Option<S
         if let Some(args) = match_function_call(cx, expr, &paths::FMT_ARGUMENTS_NEW_V1);
         if args.len() == 2;
         // Argument 1 in `new_v1()`
-        if let ExprKind::AddrOf(_, ref arr) = args[0].kind;
+        if let ExprKind::AddrOf(_, _, ref arr) = args[0].kind;
         if let ExprKind::Array(ref pieces) = arr.kind;
         if pieces.len() == 1;
         if let ExprKind::Lit(ref lit) = pieces[0].kind;
         if let LitKind::Str(ref s, _) = lit.node;
         // Argument 2 in `new_v1()`
-        if let ExprKind::AddrOf(_, ref arg1) = args[1].kind;
+        if let ExprKind::AddrOf(_, _, ref arg1) = args[1].kind;
         if let ExprKind::Match(ref matchee, ref arms, MatchSource::Normal) = arg1.kind;
         if arms.len() == 1;
         if let ExprKind::Tup(ref tup) = matchee.kind;
@@ -143,13 +143,13 @@ fn on_new_v1_fmt<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Opti
         if args.len() == 3;
         if check_unformatted(&args[2]);
         // Argument 1 in `new_v1_formatted()`
-        if let ExprKind::AddrOf(_, ref arr) = args[0].kind;
+        if let ExprKind::AddrOf(_, _, ref arr) = args[0].kind;
         if let ExprKind::Array(ref pieces) = arr.kind;
         if pieces.len() == 1;
         if let ExprKind::Lit(ref lit) = pieces[0].kind;
         if let LitKind::Str(..) = lit.node;
         // Argument 2 in `new_v1_formatted()`
-        if let ExprKind::AddrOf(_, ref arg1) = args[1].kind;
+        if let ExprKind::AddrOf(_, _, ref arg1) = args[1].kind;
         if let ExprKind::Match(ref matchee, ref arms, MatchSource::Normal) = arg1.kind;
         if arms.len() == 1;
         if let ExprKind::Tup(ref tup) = matchee.kind;
@@ -173,7 +173,7 @@ fn on_new_v1_fmt<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Opti
 /// ```
 fn check_unformatted(expr: &Expr) -> bool {
     if_chain! {
-        if let ExprKind::AddrOf(_, ref expr) = expr.kind;
+        if let ExprKind::AddrOf(_, _, ref expr) = expr.kind;
         if let ExprKind::Array(ref exprs) = expr.kind;
         if exprs.len() == 1;
         // struct `core::fmt::rt::v1::Argument`

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -73,7 +73,7 @@ fn span_useless_format<T: LintContext>(cx: &T, span: Span, help: &str, mut sugg:
 
 fn on_argumentv1_new<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, arms: &'tcx [Arm]) -> Option<String> {
     if_chain! {
-        if let ExprKind::AddrOf(_, _, ref format_args) = expr.kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref format_args) = expr.kind;
         if let ExprKind::Array(ref elems) = arms[0].body.kind;
         if elems.len() == 1;
         if let Some(args) = match_function_call(cx, &elems[0], &paths::FMT_ARGUMENTV1_NEW);
@@ -115,13 +115,13 @@ fn on_new_v1<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Option<S
         if let Some(args) = match_function_call(cx, expr, &paths::FMT_ARGUMENTS_NEW_V1);
         if args.len() == 2;
         // Argument 1 in `new_v1()`
-        if let ExprKind::AddrOf(_, _, ref arr) = args[0].kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref arr) = args[0].kind;
         if let ExprKind::Array(ref pieces) = arr.kind;
         if pieces.len() == 1;
         if let ExprKind::Lit(ref lit) = pieces[0].kind;
         if let LitKind::Str(ref s, _) = lit.node;
         // Argument 2 in `new_v1()`
-        if let ExprKind::AddrOf(_, _, ref arg1) = args[1].kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref arg1) = args[1].kind;
         if let ExprKind::Match(ref matchee, ref arms, MatchSource::Normal) = arg1.kind;
         if arms.len() == 1;
         if let ExprKind::Tup(ref tup) = matchee.kind;
@@ -143,13 +143,13 @@ fn on_new_v1_fmt<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Opti
         if args.len() == 3;
         if check_unformatted(&args[2]);
         // Argument 1 in `new_v1_formatted()`
-        if let ExprKind::AddrOf(_, _, ref arr) = args[0].kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref arr) = args[0].kind;
         if let ExprKind::Array(ref pieces) = arr.kind;
         if pieces.len() == 1;
         if let ExprKind::Lit(ref lit) = pieces[0].kind;
         if let LitKind::Str(..) = lit.node;
         // Argument 2 in `new_v1_formatted()`
-        if let ExprKind::AddrOf(_, _, ref arg1) = args[1].kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref arg1) = args[1].kind;
         if let ExprKind::Match(ref matchee, ref arms, MatchSource::Normal) = arg1.kind;
         if arms.len() == 1;
         if let ExprKind::Tup(ref tup) = matchee.kind;
@@ -173,7 +173,7 @@ fn on_new_v1_fmt<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr) -> Opti
 /// ```
 fn check_unformatted(expr: &Expr) -> bool {
     if_chain! {
-        if let ExprKind::AddrOf(_, _, ref expr) = expr.kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref expr) = expr.kind;
         if let ExprKind::Array(ref exprs) = expr.kind;
         if exprs.len() == 1;
         // struct `core::fmt::rt::v1::Argument`

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -656,7 +656,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for StaticMutVisitor<'a, 'tcx> {
                     tys.clear();
                 }
             },
-            Assign(ref target, _) | AssignOp(_, ref target, _) | AddrOf(_, hir::Mutability::Mutable, ref target) => {
+            Assign(ref target, _) | AssignOp(_, ref target, _) | AddrOf(BorrowKind::Ref, hir::Mutability::Mutable, ref target) => {
                 self.mutates_static |= is_mutated_static(self.cx, target)
             },
             _ => {},

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -656,7 +656,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for StaticMutVisitor<'a, 'tcx> {
                     tys.clear();
                 }
             },
-            Assign(ref target, _) | AssignOp(_, ref target, _) | AddrOf(hir::Mutability::Mutable, ref target) => {
+            Assign(ref target, _) | AssignOp(_, ref target, _) | AddrOf(_, hir::Mutability::Mutable, ref target) => {
                 self.mutates_static |= is_mutated_static(self.cx, target)
             },
             _ => {},

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -656,7 +656,7 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for StaticMutVisitor<'a, 'tcx> {
                     tys.clear();
                 }
             },
-            Assign(ref target, _) | AssignOp(_, ref target, _) | AddrOf(BorrowKind::Ref, hir::Mutability::Mutable, ref target) => {
+            Assign(ref target, _) | AssignOp(_, ref target, _) | AddrOf(_, hir::Mutability::Mutable, ref target) => {
                 self.mutates_static |= is_mutated_static(self.cx, target)
             },
             _ => {},

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -163,7 +163,7 @@ fn is_infinite(cx: &LateContext<'_, '_>, expr: &Expr) -> Finiteness {
             Finite
         },
         ExprKind::Block(ref block, _) => block.expr.as_ref().map_or(Finite, |e| is_infinite(cx, e)),
-        ExprKind::Box(ref e) | ExprKind::AddrOf(_, ref e) => is_infinite(cx, e),
+        ExprKind::Box(ref e) | ExprKind::AddrOf(_, _, ref e) => is_infinite(cx, e),
         ExprKind::Call(ref path, _) => {
             if let ExprKind::Path(ref qpath) = path.kind {
                 match_qpath(qpath, &paths::REPEAT).into()

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -163,7 +163,7 @@ fn is_infinite(cx: &LateContext<'_, '_>, expr: &Expr) -> Finiteness {
             Finite
         },
         ExprKind::Block(ref block, _) => block.expr.as_ref().map_or(Finite, |e| is_infinite(cx, e)),
-        ExprKind::Box(ref e) | ExprKind::AddrOf(_, _, ref e) => is_infinite(cx, e),
+        ExprKind::Box(ref e) | ExprKind::AddrOf(BorrowKind::Ref, _, ref e) => is_infinite(cx, e),
         ExprKind::Call(ref path, _) => {
             if let ExprKind::Path(ref qpath) = path.kind {
                 match_qpath(qpath, &paths::REPEAT).into()

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -674,7 +674,7 @@ fn never_loop_expr(expr: &Expr, main_loop_id: HirId) -> NeverLoopResult {
         | ExprKind::Cast(ref e, _)
         | ExprKind::Type(ref e, _)
         | ExprKind::Field(ref e, _)
-        | ExprKind::AddrOf(BorrowKind::Ref, _, ref e)
+        | ExprKind::AddrOf(_, _, ref e)
         | ExprKind::Struct(_, _, Some(ref e))
         | ExprKind::Repeat(ref e, _)
         | ExprKind::DropTemps(ref e) => never_loop_expr(e, main_loop_id),

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -674,7 +674,7 @@ fn never_loop_expr(expr: &Expr, main_loop_id: HirId) -> NeverLoopResult {
         | ExprKind::Cast(ref e, _)
         | ExprKind::Type(ref e, _)
         | ExprKind::Field(ref e, _)
-        | ExprKind::AddrOf(_, _, ref e)
+        | ExprKind::AddrOf(BorrowKind::Ref, _, ref e)
         | ExprKind::Struct(_, _, Some(ref e))
         | ExprKind::Repeat(ref e, _)
         | ExprKind::DropTemps(ref e) => never_loop_expr(e, main_loop_id),
@@ -1504,7 +1504,7 @@ fn make_iterator_snippet(cx: &LateContext<'_, '_>, arg: &Expr, applic_ref: &mut 
         // (&x).into_iter() ==> x.iter()
         // (&mut x).into_iter() ==> x.iter_mut()
         match &arg.kind {
-            ExprKind::AddrOf(_, mutability, arg_inner)
+            ExprKind::AddrOf(BorrowKind::Ref, mutability, arg_inner)
                 if has_iter_method(cx, cx.tables.expr_ty(&arg_inner)).is_some() =>
             {
                 let meth_name = match mutability {
@@ -1551,7 +1551,7 @@ fn check_for_loop_over_map_kv<'a, 'tcx>(
                 Mutability::Mutable => "_mut",
             };
             let arg = match arg.kind {
-                ExprKind::AddrOf(_, _, ref expr) => &**expr,
+                ExprKind::AddrOf(BorrowKind::Ref, _, ref expr) => &**expr,
                 _ => arg,
             };
 
@@ -1875,7 +1875,7 @@ impl<'a, 'tcx> Visitor<'tcx> for VarVisitor<'a, 'tcx> {
                 self.prefer_mutable = false;
                 self.visit_expr(rhs);
             },
-            ExprKind::AddrOf(_, mutbl, ref expr) => {
+            ExprKind::AddrOf(BorrowKind::Ref, mutbl, ref expr) => {
                 if mutbl == Mutability::Mutable {
                     self.prefer_mutable = true;
                 }
@@ -2092,7 +2092,7 @@ impl<'a, 'tcx> Visitor<'tcx> for IncrementVisitor<'a, 'tcx> {
                         }
                     },
                     ExprKind::Assign(ref lhs, _) if lhs.hir_id == expr.hir_id => *state = VarState::DontWarn,
-                    ExprKind::AddrOf(_, mutability, _) if mutability == Mutability::Mutable => {
+                    ExprKind::AddrOf(BorrowKind::Ref, mutability, _) if mutability == Mutability::Mutable => {
                         *state = VarState::DontWarn
                     },
                     _ => (),
@@ -2176,7 +2176,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
                             VarState::DontWarn
                         }
                     },
-                    ExprKind::AddrOf(_, mutability, _) if mutability == Mutability::Mutable => {
+                    ExprKind::AddrOf(BorrowKind::Ref, mutability, _) if mutability == Mutability::Mutable => {
                         self.state = VarState::DontWarn
                     },
                     _ => (),

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1504,7 +1504,9 @@ fn make_iterator_snippet(cx: &LateContext<'_, '_>, arg: &Expr, applic_ref: &mut 
         // (&x).into_iter() ==> x.iter()
         // (&mut x).into_iter() ==> x.iter_mut()
         match &arg.kind {
-            ExprKind::AddrOf(_, mutability, arg_inner) if has_iter_method(cx, cx.tables.expr_ty(&arg_inner)).is_some() => {
+            ExprKind::AddrOf(_, mutability, arg_inner)
+                if has_iter_method(cx, cx.tables.expr_ty(&arg_inner)).is_some() =>
+            {
                 let meth_name = match mutability {
                     Mutability::Mutable => "iter_mut",
                     Mutability::Immutable => "iter",
@@ -1514,7 +1516,7 @@ fn make_iterator_snippet(cx: &LateContext<'_, '_>, arg: &Expr, applic_ref: &mut 
                     sugg::Sugg::hir_with_applicability(cx, &arg_inner, "_", applic_ref).maybe_par(),
                     meth_name,
                 )
-            },
+            }
             _ => format!(
                 "{}.into_iter()",
                 sugg::Sugg::hir_with_applicability(cx, arg, "_", applic_ref).maybe_par()
@@ -2090,7 +2092,9 @@ impl<'a, 'tcx> Visitor<'tcx> for IncrementVisitor<'a, 'tcx> {
                         }
                     },
                     ExprKind::Assign(ref lhs, _) if lhs.hir_id == expr.hir_id => *state = VarState::DontWarn,
-                    ExprKind::AddrOf(_, mutability, _) if mutability == Mutability::Mutable => *state = VarState::DontWarn,
+                    ExprKind::AddrOf(_, mutability, _) if mutability == Mutability::Mutable => {
+                        *state = VarState::DontWarn
+                    },
                     _ => (),
                 }
             }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -570,7 +570,7 @@ fn is_panic_block(block: &Block) -> bool {
 fn check_match_ref_pats(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr) {
     if has_only_ref_pats(arms) {
         let mut suggs = Vec::new();
-        let (title, msg) = if let ExprKind::AddrOf(_, Mutability::Immutable, ref inner) = ex.kind {
+        let (title, msg) = if let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Immutable, ref inner) = ex.kind {
             let span = ex.span.source_callsite();
             suggs.push((span, Sugg::hir_with_macro_callsite(cx, inner, "..").to_string()));
             (

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -570,7 +570,7 @@ fn is_panic_block(block: &Block) -> bool {
 fn check_match_ref_pats(cx: &LateContext<'_, '_>, ex: &Expr, arms: &[Arm], expr: &Expr) {
     if has_only_ref_pats(arms) {
         let mut suggs = Vec::new();
-        let (title, msg) = if let ExprKind::AddrOf(Mutability::Immutable, ref inner) = ex.kind {
+        let (title, msg) = if let ExprKind::AddrOf(_, Mutability::Immutable, ref inner) = ex.kind {
             let span = ex.span.source_callsite();
             suggs.push((span, Sugg::hir_with_macro_callsite(cx, inner, "..").to_string()));
             (

--- a/clippy_lints/src/mem_discriminant.rs
+++ b/clippy_lints/src/mem_discriminant.rs
@@ -57,7 +57,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemDiscriminant {
                             let mut derefs_needed = ptr_depth;
                             let mut cur_expr = param;
                             while derefs_needed > 0  {
-                                if let ExprKind::AddrOf(_, ref inner_expr) = cur_expr.kind {
+                                if let ExprKind::AddrOf(_, _, ref inner_expr) = cur_expr.kind {
                                     derefs_needed -= 1;
                                     cur_expr = inner_expr;
                                 } else {

--- a/clippy_lints/src/mem_discriminant.rs
+++ b/clippy_lints/src/mem_discriminant.rs
@@ -1,6 +1,6 @@
 use crate::utils::{match_def_path, paths, snippet, span_lint_and_then, walk_ptrs_ty_depth};
 use if_chain::if_chain;
-use rustc::hir::{Expr, ExprKind};
+use rustc::hir::{BorrowKind, Expr, ExprKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 use rustc_errors::Applicability;
@@ -57,7 +57,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemDiscriminant {
                             let mut derefs_needed = ptr_depth;
                             let mut cur_expr = param;
                             while derefs_needed > 0  {
-                                if let ExprKind::AddrOf(_, _, ref inner_expr) = cur_expr.kind {
+                                if let ExprKind::AddrOf(BorrowKind::Ref, _, ref inner_expr) = cur_expr.kind {
                                     derefs_needed -= 1;
                                     cur_expr = inner_expr;
                                 } else {

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -90,7 +90,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemReplace {
                         // argument's type. All that's left is to get
                         // replacee's path.
                         let replaced_path = match func_args[0].kind {
-                            ExprKind::AddrOf(Mutability::Mutable, ref replaced) => {
+                            ExprKind::AddrOf(_, Mutability::Mutable, ref replaced) => {
                                 if let ExprKind::Path(QPath::Resolved(None, ref replaced_path)) = replaced.kind {
                                     replaced_path
                                 } else {

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -2,7 +2,7 @@ use crate::utils::{
     match_def_path, match_qpath, paths, snippet_with_applicability, span_help_and_lint, span_lint_and_sugg,
 };
 use if_chain::if_chain;
-use rustc::hir::{Expr, ExprKind, Mutability, QPath};
+use rustc::hir::{BorrowKind, Expr, ExprKind, Mutability, QPath};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::{declare_lint_pass, declare_tool_lint};
 use rustc_errors::Applicability;
@@ -90,7 +90,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemReplace {
                         // argument's type. All that's left is to get
                         // replacee's path.
                         let replaced_path = match func_args[0].kind {
-                            ExprKind::AddrOf(_, Mutability::Mutable, ref replaced) => {
+                            ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mutable, ref replaced) => {
                                 if let ExprKind::Path(QPath::Resolved(None, ref replaced_path)) = replaced.kind {
                                     replaced_path
                                 } else {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1519,7 +1519,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
         let mut arg_root = arg;
         loop {
             arg_root = match &arg_root.kind {
-                hir::ExprKind::AddrOf(_, _, expr) => expr,
+                hir::ExprKind::AddrOf(hir::BorrowKind::Ref, _, expr) => expr,
                 hir::ExprKind::MethodCall(method_name, _, call_args) => {
                     if call_args.len() == 1
                         && (method_name.ident.name == sym!(as_str) || method_name.ident.name == sym!(as_ref))
@@ -1561,7 +1561,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
         applicability: &mut Applicability,
     ) -> Vec<String> {
         if_chain! {
-            if let hir::ExprKind::AddrOf(_, _, ref format_arg) = a.kind;
+            if let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, _, ref format_arg) = a.kind;
             if let hir::ExprKind::Match(ref format_arg_expr, _, _) = format_arg.kind;
             if let hir::ExprKind::Tup(ref format_arg_expr_tup) = format_arg_expr.kind;
 
@@ -1578,7 +1578,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
 
     fn is_call(node: &hir::ExprKind) -> bool {
         match node {
-            hir::ExprKind::AddrOf(_, _, expr) => {
+            hir::ExprKind::AddrOf(hir::BorrowKind::Ref, _, expr) => {
                 is_call(&expr.kind)
             },
             hir::ExprKind::Call(..)

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1610,30 +1610,35 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
     let mut applicability = Applicability::MachineApplicable;
 
     //Special handling for `format!` as arg_root
-    if let hir::ExprKind::Call(ref inner_fun, ref inner_args) = arg_root.kind {
-        if is_expn_of(inner_fun.span, "format").is_some() && inner_args.len() == 1 {
-            if let hir::ExprKind::Call(_, format_args) = &inner_args[0].kind {
-                let fmt_spec = &format_args[0];
-                let fmt_args = &format_args[1];
+    if_chain! {
+        if let hir::ExprKind::Block(block, None) = &arg_root.kind;
+        if block.stmts.len() == 1;
+        if let hir::StmtKind::Local(local) = &block.stmts[0].kind;
+        if let Some(arg_root) = &local.init;
+        if let hir::ExprKind::Call(ref inner_fun, ref inner_args) = arg_root.kind;
+        if is_expn_of(inner_fun.span, "format").is_some() && inner_args.len() == 1;
+        if let hir::ExprKind::Call(_, format_args) = &inner_args[0].kind;
+        then {
+            let fmt_spec = &format_args[0];
+            let fmt_args = &format_args[1];
 
-                let mut args = vec![snippet(cx, fmt_spec.span, "..").into_owned()];
+            let mut args = vec![snippet(cx, fmt_spec.span, "..").into_owned()];
 
-                args.extend(generate_format_arg_snippet(cx, fmt_args, &mut applicability));
+            args.extend(generate_format_arg_snippet(cx, fmt_args, &mut applicability));
 
-                let sugg = args.join(", ");
+            let sugg = args.join(", ");
 
-                span_lint_and_sugg(
-                    cx,
-                    EXPECT_FUN_CALL,
-                    span_replace_word,
-                    &format!("use of `{}` followed by a function call", name),
-                    "try this",
-                    format!("unwrap_or_else({} panic!({}))", closure_args, sugg),
-                    applicability,
-                );
+            span_lint_and_sugg(
+                cx,
+                EXPECT_FUN_CALL,
+                span_replace_word,
+                &format!("use of `{}` followed by a function call", name),
+                "try this",
+                format!("unwrap_or_else({} panic!({}))", closure_args, sugg),
+                applicability,
+            );
 
-                return;
-            }
+            return;
         }
     }
 

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1519,7 +1519,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
         let mut arg_root = arg;
         loop {
             arg_root = match &arg_root.kind {
-                hir::ExprKind::AddrOf(_, expr) => expr,
+                hir::ExprKind::AddrOf(_, _, expr) => expr,
                 hir::ExprKind::MethodCall(method_name, _, call_args) => {
                     if call_args.len() == 1
                         && (method_name.ident.name == sym!(as_str) || method_name.ident.name == sym!(as_ref))
@@ -1561,7 +1561,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
         applicability: &mut Applicability,
     ) -> Vec<String> {
         if_chain! {
-            if let hir::ExprKind::AddrOf(_, ref format_arg) = a.kind;
+            if let hir::ExprKind::AddrOf(_, _, ref format_arg) = a.kind;
             if let hir::ExprKind::Match(ref format_arg_expr, _, _) = format_arg.kind;
             if let hir::ExprKind::Tup(ref format_arg_expr_tup) = format_arg_expr.kind;
 
@@ -1578,7 +1578,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
 
     fn is_call(node: &hir::ExprKind) -> bool {
         match node {
-            hir::ExprKind::AddrOf(_, expr) => {
+            hir::ExprKind::AddrOf(_, _, expr) => {
                 is_call(&expr.kind)
             },
             hir::ExprKind::Call(..)

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -57,8 +57,8 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for MutVisitor<'a, 'tcx> {
             // Let's ignore the generated code.
             intravisit::walk_expr(self, arg);
             intravisit::walk_expr(self, body);
-        } else if let hir::ExprKind::AddrOf(_, hir::Mutability::Mutable, ref e) = expr.kind {
-            if let hir::ExprKind::AddrOf(_, hir::Mutability::Mutable, _) = e.kind {
+        } else if let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Mutable, ref e) = expr.kind {
+            if let hir::ExprKind::AddrOf(hir::BorrowKind::Ref, hir::Mutability::Mutable, _) = e.kind {
                 span_lint(
                     self.cx,
                     MUT_MUT,

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -57,8 +57,8 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for MutVisitor<'a, 'tcx> {
             // Let's ignore the generated code.
             intravisit::walk_expr(self, arg);
             intravisit::walk_expr(self, body);
-        } else if let hir::ExprKind::AddrOf(hir::Mutability::Mutable, ref e) = expr.kind {
-            if let hir::ExprKind::AddrOf(hir::Mutability::Mutable, _) = e.kind {
+        } else if let hir::ExprKind::AddrOf(_, hir::Mutability::Mutable, ref e) = expr.kind {
+            if let hir::ExprKind::AddrOf(_, hir::Mutability::Mutable, _) = e.kind {
                 span_lint(
                     self.cx,
                     MUT_MUT,

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -60,7 +60,7 @@ fn check_arguments<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, arguments: &[Expr], typ
                         mutbl: Mutability::Immutable,
                         ..
                     }) => {
-                        if let ExprKind::AddrOf(Mutability::Mutable, _) = argument.kind {
+                        if let ExprKind::AddrOf(_, Mutability::Mutable, _) = argument.kind {
                             span_lint(
                                 cx,
                                 UNNECESSARY_MUT_PASSED,

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -60,7 +60,7 @@ fn check_arguments<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, arguments: &[Expr], typ
                         mutbl: Mutability::Immutable,
                         ..
                     }) => {
-                        if let ExprKind::AddrOf(_, Mutability::Mutable, _) = argument.kind {
+                        if let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mutable, _) = argument.kind {
                             span_lint(
                                 cx,
                                 UNNECESSARY_MUT_PASSED,

--- a/clippy_lints/src/mutable_debug_assertion.rs
+++ b/clippy_lints/src/mutable_debug_assertion.rs
@@ -77,14 +77,14 @@ fn extract_call<'a, 'tcx>(cx: &'a LateContext<'a, 'tcx>, e: &'tcx Expr) -> Optio
                         if let ExprKind::Tup(ref conditions) = headerexpr.kind;
                         if conditions.len() == 2;
                         then {
-                            if let ExprKind::AddrOf(_, ref lhs) = conditions[0].kind {
+                            if let ExprKind::AddrOf(_, _, ref lhs) = conditions[0].kind {
                                 let mut visitor = MutArgVisitor::new(cx);
                                 visitor.visit_expr(lhs);
                                 if let Some(span) = visitor.expr_span() {
                                     return Some(span);
                                 }
                             }
-                            if let ExprKind::AddrOf(_, ref rhs) = conditions[1].kind {
+                            if let ExprKind::AddrOf(_, _, ref rhs) = conditions[1].kind {
                                 let mut visitor = MutArgVisitor::new(cx);
                                 visitor.visit_expr(rhs);
                                 if let Some(span) = visitor.expr_span() {
@@ -128,7 +128,7 @@ impl<'a, 'tcx> MutArgVisitor<'a, 'tcx> {
 impl<'a, 'tcx> Visitor<'tcx> for MutArgVisitor<'a, 'tcx> {
     fn visit_expr(&mut self, expr: &'tcx Expr) {
         match expr.kind {
-            ExprKind::AddrOf(Mutability::Mutable, _) => {
+            ExprKind::AddrOf(_, Mutability::Mutable, _) => {
                 self.found = true;
                 return;
             },

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -4,7 +4,7 @@
 
 use crate::utils::{snippet_opt, span_lint_and_then};
 use if_chain::if_chain;
-use rustc::hir::{BindingAnnotation, Expr, ExprKind, HirId, Item, Mutability, Pat, PatKind};
+use rustc::hir::{BindingAnnotation, BorrowKind, Expr, ExprKind, HirId, Item, Mutability, Pat, PatKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
 use rustc::ty;
 use rustc::ty::adjustment::{Adjust, Adjustment};
@@ -41,7 +41,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
         if e.span.from_expansion() || self.derived_item.is_some() {
             return;
         }
-        if let ExprKind::AddrOf(_, Mutability::Immutable, ref inner) = e.kind {
+        if let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Immutable, ref inner) = e.kind {
             if let ty::Ref(..) = cx.tables.expr_ty(inner).kind {
                 for adj3 in cx.tables.expr_adjustments(e).windows(3) {
                     if let [Adjustment {

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -41,7 +41,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
         if e.span.from_expansion() || self.derived_item.is_some() {
             return;
         }
-        if let ExprKind::AddrOf(Mutability::Immutable, ref inner) = e.kind {
+        if let ExprKind::AddrOf(_, Mutability::Immutable, ref inner) = e.kind {
             if let ty::Ref(..) = cx.tables.expr_ty(inner).kind {
                 for adj3 in cx.tables.expr_adjustments(e).windows(3) {
                     if let [Adjustment {

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -58,7 +58,7 @@ fn has_no_effect(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
         | ExprKind::Type(ref inner, _)
         | ExprKind::Unary(_, ref inner)
         | ExprKind::Field(ref inner, _)
-        | ExprKind::AddrOf(BorrowKind::Ref, _, ref inner)
+        | ExprKind::AddrOf(_, _, ref inner)
         | ExprKind::Box(ref inner) => has_no_effect(cx, inner),
         ExprKind::Struct(_, ref fields, ref base) => {
             !has_drop(cx, cx.tables.expr_ty(expr))
@@ -134,7 +134,7 @@ fn reduce_expression<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<Vec
         | ExprKind::Type(ref inner, _)
         | ExprKind::Unary(_, ref inner)
         | ExprKind::Field(ref inner, _)
-        | ExprKind::AddrOf(BorrowKind::Ref, _, ref inner)
+        | ExprKind::AddrOf(_, _, ref inner)
         | ExprKind::Box(ref inner) => reduce_expression(cx, inner).or_else(|| Some(vec![inner])),
         ExprKind::Struct(_, ref fields, ref base) => {
             if has_drop(cx, cx.tables.expr_ty(expr)) {

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -58,7 +58,7 @@ fn has_no_effect(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
         | ExprKind::Type(ref inner, _)
         | ExprKind::Unary(_, ref inner)
         | ExprKind::Field(ref inner, _)
-        | ExprKind::AddrOf(_, ref inner)
+        | ExprKind::AddrOf(_, _, ref inner)
         | ExprKind::Box(ref inner) => has_no_effect(cx, inner),
         ExprKind::Struct(_, ref fields, ref base) => {
             !has_drop(cx, cx.tables.expr_ty(expr))
@@ -134,7 +134,7 @@ fn reduce_expression<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<Vec
         | ExprKind::Type(ref inner, _)
         | ExprKind::Unary(_, ref inner)
         | ExprKind::Field(ref inner, _)
-        | ExprKind::AddrOf(_, ref inner)
+        | ExprKind::AddrOf(_, _, ref inner)
         | ExprKind::Box(ref inner) => reduce_expression(cx, inner).or_else(|| Some(vec![inner])),
         ExprKind::Struct(_, ref fields, ref base) => {
             if has_drop(cx, cx.tables.expr_ty(expr)) {

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -58,7 +58,7 @@ fn has_no_effect(cx: &LateContext<'_, '_>, expr: &Expr) -> bool {
         | ExprKind::Type(ref inner, _)
         | ExprKind::Unary(_, ref inner)
         | ExprKind::Field(ref inner, _)
-        | ExprKind::AddrOf(_, _, ref inner)
+        | ExprKind::AddrOf(BorrowKind::Ref, _, ref inner)
         | ExprKind::Box(ref inner) => has_no_effect(cx, inner),
         ExprKind::Struct(_, ref fields, ref base) => {
             !has_drop(cx, cx.tables.expr_ty(expr))
@@ -134,7 +134,7 @@ fn reduce_expression<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr) -> Option<Vec
         | ExprKind::Type(ref inner, _)
         | ExprKind::Unary(_, ref inner)
         | ExprKind::Field(ref inner, _)
-        | ExprKind::AddrOf(_, _, ref inner)
+        | ExprKind::AddrOf(BorrowKind::Ref, _, ref inner)
         | ExprKind::Box(ref inner) => reduce_expression(cx, inner).or_else(|| Some(vec![inner])),
         ExprKind::Struct(_, ref fields, ref base) => {
             if has_drop(cx, cx.tables.expr_ty(expr)) {

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -37,7 +37,7 @@ impl EarlyLintPass for DerefAddrOf {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &Expr) {
         if_chain! {
             if let ExprKind::Unary(UnOp::Deref, ref deref_target) = e.kind;
-            if let ExprKind::AddrOf(_, ref addrof_target) = without_parens(deref_target).kind;
+            if let ExprKind::AddrOf(_, _, ref addrof_target) = without_parens(deref_target).kind;
             if !in_macro(addrof_target.span);
             then {
                 let mut applicability = Applicability::MachineApplicable;
@@ -80,7 +80,7 @@ impl EarlyLintPass for RefInDeref {
         if_chain! {
             if let ExprKind::Field(ref object, _) = e.kind;
             if let ExprKind::Paren(ref parened) = object.kind;
-            if let ExprKind::AddrOf(_, ref inner) = parened.kind;
+            if let ExprKind::AddrOf(_, _, ref inner) = parened.kind;
             then {
                 let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -37,7 +37,7 @@ impl EarlyLintPass for DerefAddrOf {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &Expr) {
         if_chain! {
             if let ExprKind::Unary(UnOp::Deref, ref deref_target) = e.kind;
-            if let ExprKind::AddrOf(BorrowKind::Ref, _, ref addrof_target) = without_parens(deref_target).kind;
+            if let ExprKind::AddrOf(_, _, ref addrof_target) = without_parens(deref_target).kind;
             if !in_macro(addrof_target.span);
             then {
                 let mut applicability = Applicability::MachineApplicable;
@@ -80,7 +80,7 @@ impl EarlyLintPass for RefInDeref {
         if_chain! {
             if let ExprKind::Field(ref object, _) = e.kind;
             if let ExprKind::Paren(ref parened) = object.kind;
-            if let ExprKind::AddrOf(BorrowKind::Ref, _, ref inner) = parened.kind;
+            if let ExprKind::AddrOf(_, _, ref inner) = parened.kind;
             then {
                 let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -37,7 +37,7 @@ impl EarlyLintPass for DerefAddrOf {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &Expr) {
         if_chain! {
             if let ExprKind::Unary(UnOp::Deref, ref deref_target) = e.kind;
-            if let ExprKind::AddrOf(_, _, ref addrof_target) = without_parens(deref_target).kind;
+            if let ExprKind::AddrOf(BorrowKind::Ref, _, ref addrof_target) = without_parens(deref_target).kind;
             if !in_macro(addrof_target.span);
             then {
                 let mut applicability = Applicability::MachineApplicable;
@@ -80,7 +80,7 @@ impl EarlyLintPass for RefInDeref {
         if_chain! {
             if let ExprKind::Field(ref object, _) = e.kind;
             if let ExprKind::Paren(ref parened) = object.kind;
-            if let ExprKind::AddrOf(_, _, ref inner) = parened.kind;
+            if let ExprKind::AddrOf(BorrowKind::Ref, _, ref inner) = parened.kind;
             then {
                 let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_sugg(

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -186,7 +186,7 @@ fn is_trivial_regex(s: &regex_syntax::hir::Hir) -> Option<&'static str> {
 
 fn check_set<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, utf8: bool) {
     if_chain! {
-        if let ExprKind::AddrOf(_, ref expr) = expr.kind;
+        if let ExprKind::AddrOf(_, _, ref expr) = expr.kind;
         if let ExprKind::Array(ref exprs) = expr.kind;
         then {
             for expr in exprs {

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -186,7 +186,7 @@ fn is_trivial_regex(s: &regex_syntax::hir::Hir) -> Option<&'static str> {
 
 fn check_set<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, utf8: bool) {
     if_chain! {
-        if let ExprKind::AddrOf(_, _, ref expr) = expr.kind;
+        if let ExprKind::AddrOf(BorrowKind::Ref, _, ref expr) = expr.kind;
         if let ExprKind::Array(ref exprs) = expr.kind;
         then {
             for expr in exprs {

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -313,7 +313,7 @@ fn check_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, bindings: 
         return;
     }
     match expr.kind {
-        ExprKind::Unary(_, ref e) | ExprKind::Field(ref e, _) | ExprKind::AddrOf(_, ref e) | ExprKind::Box(ref e) => {
+        ExprKind::Unary(_, ref e) | ExprKind::Field(ref e, _) | ExprKind::AddrOf(_, _, ref e) | ExprKind::Box(ref e) => {
             check_expr(cx, e, bindings)
         },
         ExprKind::Block(ref block, _) | ExprKind::Loop(ref block, _, _) => check_block(cx, block, bindings),
@@ -365,7 +365,7 @@ fn check_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: &'tcx Ty, bindings: &mut V
 
 fn is_self_shadow(name: Name, expr: &Expr) -> bool {
     match expr.kind {
-        ExprKind::Box(ref inner) | ExprKind::AddrOf(_, ref inner) => is_self_shadow(name, inner),
+        ExprKind::Box(ref inner) | ExprKind::AddrOf(_, _, ref inner) => is_self_shadow(name, inner),
         ExprKind::Block(ref block, _) => {
             block.stmts.is_empty() && block.expr.as_ref().map_or(false, |e| is_self_shadow(name, e))
         },

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -313,9 +313,10 @@ fn check_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, bindings: 
         return;
     }
     match expr.kind {
-        ExprKind::Unary(_, ref e) | ExprKind::Field(ref e, _) | ExprKind::AddrOf(_, _, ref e) | ExprKind::Box(ref e) => {
-            check_expr(cx, e, bindings)
-        },
+        ExprKind::Unary(_, ref e)
+        | ExprKind::Field(ref e, _)
+        | ExprKind::AddrOf(_, _, ref e)
+        | ExprKind::Box(ref e) => check_expr(cx, e, bindings),
         ExprKind::Block(ref block, _) | ExprKind::Loop(ref block, _, _) => check_block(cx, block, bindings),
         // ExprKind::Call
         // ExprKind::MethodCall

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -315,7 +315,7 @@ fn check_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, bindings: 
     match expr.kind {
         ExprKind::Unary(_, ref e)
         | ExprKind::Field(ref e, _)
-        | ExprKind::AddrOf(BorrowKind::Ref, _, ref e)
+        | ExprKind::AddrOf(_, _, ref e)
         | ExprKind::Box(ref e) => check_expr(cx, e, bindings),
         ExprKind::Block(ref block, _) | ExprKind::Loop(ref block, _, _) => check_block(cx, block, bindings),
         // ExprKind::Call
@@ -366,7 +366,7 @@ fn check_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: &'tcx Ty, bindings: &mut V
 
 fn is_self_shadow(name: Name, expr: &Expr) -> bool {
     match expr.kind {
-        ExprKind::Box(ref inner) | ExprKind::AddrOf(BorrowKind::Ref, _, ref inner) => is_self_shadow(name, inner),
+        ExprKind::Box(ref inner) | ExprKind::AddrOf(_, _, ref inner) => is_self_shadow(name, inner),
         ExprKind::Block(ref block, _) => {
             block.stmts.is_empty() && block.expr.as_ref().map_or(false, |e| is_self_shadow(name, e))
         },

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -315,7 +315,7 @@ fn check_expr<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr, bindings: 
     match expr.kind {
         ExprKind::Unary(_, ref e)
         | ExprKind::Field(ref e, _)
-        | ExprKind::AddrOf(_, _, ref e)
+        | ExprKind::AddrOf(BorrowKind::Ref, _, ref e)
         | ExprKind::Box(ref e) => check_expr(cx, e, bindings),
         ExprKind::Block(ref block, _) | ExprKind::Loop(ref block, _, _) => check_block(cx, block, bindings),
         // ExprKind::Call
@@ -366,7 +366,7 @@ fn check_ty<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: &'tcx Ty, bindings: &mut V
 
 fn is_self_shadow(name: Name, expr: &Expr) -> bool {
     match expr.kind {
-        ExprKind::Box(ref inner) | ExprKind::AddrOf(_, _, ref inner) => is_self_shadow(name, inner),
+        ExprKind::Box(ref inner) | ExprKind::AddrOf(BorrowKind::Ref, _, ref inner) => is_self_shadow(name, inner),
         ExprKind::Block(ref block, _) => {
             block.stmts.is_empty() && block.expr.as_ref().map_or(false, |e| is_self_shadow(name, e))
         },

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -62,7 +62,7 @@ pub struct TriviallyCopyPassByRef {
 impl<'a, 'tcx> TriviallyCopyPassByRef {
     pub fn new(limit: Option<u64>, target: &SessionConfig) -> Self {
         let limit = limit.unwrap_or_else(|| {
-            let bit_width = target.usize_ty.bit_width().expect("usize should have a width") as u64;
+            let bit_width = u64::from(target.ptr_width);
             // Cap the calculated bit width at 32-bits to reduce
             // portability problems between 32 and 64-bit targets
             let bit_width = cmp::min(bit_width, 32);

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -4,7 +4,7 @@
 use crate::utils::{get_attr, higher};
 use rustc::hir;
 use rustc::hir::intravisit::{NestedVisitorMap, Visitor};
-use rustc::hir::{BindingAnnotation, Block, Expr, ExprKind, Pat, PatKind, QPath, Stmt, StmtKind, TyKind};
+use rustc::hir::{BindingAnnotation, Block, BorrowKind, Expr, ExprKind, Pat, PatKind, QPath, Stmt, StmtKind, TyKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc::session::Session;
 use rustc::{declare_lint_pass, declare_tool_lint};
@@ -425,10 +425,10 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
                 self.current = path_pat;
                 self.print_qpath(path);
             },
-            ExprKind::AddrOf(_, mutability, ref inner) => {
+            ExprKind::AddrOf(BorrowKind::Ref, mutability, ref inner) => {
                 let inner_pat = self.next("inner");
                 println!(
-                    "AddrOf(_, Mutability::{:?}, ref {}) = {};",
+                    "AddrOf(BorrowKind::Ref, Mutability::{:?}, ref {}) = {};",
                     mutability, inner_pat, current
                 );
                 self.current = inner_pat;

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -427,7 +427,10 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
             },
             ExprKind::AddrOf(_, mutability, ref inner) => {
                 let inner_pat = self.next("inner");
-                println!("AddrOf(_, Mutability::{:?}, ref {}) = {};", mutability, inner_pat, current);
+                println!(
+                    "AddrOf(_, Mutability::{:?}, ref {}) = {};",
+                    mutability, inner_pat, current
+                );
                 self.current = inner_pat;
                 self.visit_expr(inner);
             },

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -4,7 +4,7 @@
 use crate::utils::{get_attr, higher};
 use rustc::hir;
 use rustc::hir::intravisit::{NestedVisitorMap, Visitor};
-use rustc::hir::{BindingAnnotation, Block, BorrowKind, Expr, ExprKind, Pat, PatKind, QPath, Stmt, StmtKind, TyKind};
+use rustc::hir::{BindingAnnotation, Block, Expr, ExprKind, Pat, PatKind, QPath, Stmt, StmtKind, TyKind};
 use rustc::lint::{LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc::session::Session;
 use rustc::{declare_lint_pass, declare_tool_lint};
@@ -425,11 +425,11 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
                 self.current = path_pat;
                 self.print_qpath(path);
             },
-            ExprKind::AddrOf(BorrowKind::Ref, mutability, ref inner) => {
+            ExprKind::AddrOf(kind, mutability, ref inner) => {
                 let inner_pat = self.next("inner");
                 println!(
-                    "AddrOf(BorrowKind::Ref, Mutability::{:?}, ref {}) = {};",
-                    mutability, inner_pat, current
+                    "AddrOf(BorrowKind::{:?}, Mutability::{:?}, ref {}) = {};",
+                    kind, mutability, inner_pat, current
                 );
                 self.current = inner_pat;
                 self.visit_expr(inner);

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -425,9 +425,9 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
                 self.current = path_pat;
                 self.print_qpath(path);
             },
-            ExprKind::AddrOf(mutability, ref inner) => {
+            ExprKind::AddrOf(_, mutability, ref inner) => {
                 let inner_pat = self.next("inner");
-                println!("AddrOf(Mutability::{:?}, ref {}) = {};", mutability, inner_pat, current);
+                println!("AddrOf(_, Mutability::{:?}, ref {}) = {};", mutability, inner_pat, current);
                 self.current = inner_pat;
                 self.visit_expr(inner);
             },

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -78,7 +78,7 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
         }
 
         match (&left.kind, &right.kind) {
-            (&ExprKind::AddrOf(_, l_mut, ref le), &ExprKind::AddrOf(_, r_mut, ref re)) => {
+            (&ExprKind::AddrOf(BorrowKind::Ref, l_mut, ref le), &ExprKind::AddrOf(BorrowKind::Ref, r_mut, ref re)) => {
                 l_mut == r_mut && self.eq_expr(le, re)
             },
             (&ExprKind::Continue(li), &ExprKind::Continue(ri)) => {
@@ -398,7 +398,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
         std::mem::discriminant(&e.kind).hash(&mut self.s);
 
         match e.kind {
-            ExprKind::AddrOf(_, m, ref e) => {
+            ExprKind::AddrOf(BorrowKind::Ref, m, ref e) => {
                 m.hash(&mut self.s);
                 self.hash_expr(e);
             },

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -78,8 +78,8 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
         }
 
         match (&left.kind, &right.kind) {
-            (&ExprKind::AddrOf(BorrowKind::Ref, l_mut, ref le), &ExprKind::AddrOf(BorrowKind::Ref, r_mut, ref re)) => {
-                l_mut == r_mut && self.eq_expr(le, re)
+            (&ExprKind::AddrOf(lb, l_mut, ref le), &ExprKind::AddrOf(rb, r_mut, ref re)) => {
+                lb == rb && l_mut == r_mut && self.eq_expr(le, re)
             },
             (&ExprKind::Continue(li), &ExprKind::Continue(ri)) => {
                 both(&li.label, &ri.label, |l, r| l.ident.as_str() == r.ident.as_str())
@@ -398,7 +398,12 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
         std::mem::discriminant(&e.kind).hash(&mut self.s);
 
         match e.kind {
-            ExprKind::AddrOf(BorrowKind::Ref, m, ref e) => {
+            ExprKind::AddrOf(kind, m, ref e) => {
+                match kind {
+                    BorrowKind::Ref => 0,
+                    BorrowKind::Raw => 1,
+                }
+                .hash(&mut self.s);
                 m.hash(&mut self.s);
                 self.hash_expr(e);
             },

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -78,7 +78,7 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
         }
 
         match (&left.kind, &right.kind) {
-            (&ExprKind::AddrOf(l_mut, ref le), &ExprKind::AddrOf(r_mut, ref re)) => {
+            (&ExprKind::AddrOf(_, l_mut, ref le), &ExprKind::AddrOf(_, r_mut, ref re)) => {
                 l_mut == r_mut && self.eq_expr(le, re)
             },
             (&ExprKind::Continue(li), &ExprKind::Continue(ri)) => {
@@ -398,7 +398,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
         std::mem::discriminant(&e.kind).hash(&mut self.s);
 
         match e.kind {
-            ExprKind::AddrOf(m, ref e) => {
+            ExprKind::AddrOf(_, m, ref e) => {
                 m.hash(&mut self.s);
                 self.hash_expr(e);
             },

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -264,8 +264,9 @@ fn print_expr(cx: &LateContext<'_, '_>, expr: &hir::Expr, indent: usize) {
             println!("{}Relative Path, {:?}", ind, ty);
             println!("{}seg: {:?}", ind, seg);
         },
-        hir::ExprKind::AddrOf(BorrowKind::Ref, ref muta, ref e) => {
+        hir::ExprKind::AddrOf(kind, ref muta, ref e) => {
             println!("{}AddrOf", ind);
+            println!("kind: {:?}", kind);
             println!("mutability: {:?}", muta);
             print_expr(cx, e, indent + 1);
         },

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -264,7 +264,7 @@ fn print_expr(cx: &LateContext<'_, '_>, expr: &hir::Expr, indent: usize) {
             println!("{}Relative Path, {:?}", ind, ty);
             println!("{}seg: {:?}", ind, seg);
         },
-        hir::ExprKind::AddrOf(ref muta, ref e) => {
+        hir::ExprKind::AddrOf(_, ref muta, ref e) => {
             println!("{}AddrOf", ind);
             println!("mutability: {:?}", muta);
             print_expr(cx, e, indent + 1);

--- a/clippy_lints/src/utils/inspector.rs
+++ b/clippy_lints/src/utils/inspector.rs
@@ -264,7 +264,7 @@ fn print_expr(cx: &LateContext<'_, '_>, expr: &hir::Expr, indent: usize) {
             println!("{}Relative Path, {:?}", ind, ty);
             println!("{}seg: {:?}", ind, seg);
         },
-        hir::ExprKind::AddrOf(_, ref muta, ref e) => {
+        hir::ExprKind::AddrOf(BorrowKind::Ref, ref muta, ref e) => {
             println!("{}AddrOf", ind);
             println!("mutability: {:?}", muta);
             print_expr(cx, e, indent + 1);

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -33,7 +33,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessVec {
         if_chain! {
             if let ty::Ref(_, ty, _) = cx.tables.expr_ty_adjusted(expr).kind;
             if let ty::Slice(..) = ty.kind;
-            if let ExprKind::AddrOf(_, _, ref addressee) = expr.kind;
+            if let ExprKind::AddrOf(BorrowKind::Ref, _, ref addressee) = expr.kind;
             if let Some(vec_args) = higher::vec_macro(cx, addressee);
             then {
                 check_vec_macro(cx, &vec_args, expr.span);

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -33,7 +33,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessVec {
         if_chain! {
             if let ty::Ref(_, ty, _) = cx.tables.expr_ty_adjusted(expr).kind;
             if let ty::Slice(..) = ty.kind;
-            if let ExprKind::AddrOf(_, ref addressee) = expr.kind;
+            if let ExprKind::AddrOf(_, _, ref addressee) = expr.kind;
             if let Some(vec_args) = higher::vec_macro(cx, addressee);
             then {
                 check_vec_macro(cx, &vec_args, expr.span);

--- a/tests/ui/author/for_loop.stdout
+++ b/tests/ui/author/for_loop.stdout
@@ -22,7 +22,7 @@ if_chain! {
     if let ExprKind::Path(ref path2) = func1.kind;
     if match_qpath(path2, &["{{root}}", "std", "iter", "Iterator", "next"]);
     if args1.len() == 1;
-    if let ExprKind::AddrOf(_, Mutability::Mutable, ref inner) = args1[0].kind;
+    if let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mutable, ref inner) = args1[0].kind;
     if let ExprKind::Path(ref path3) = inner.kind;
     if match_qpath(path3, &["iter"]);
     if arms1.len() == 2;

--- a/tests/ui/author/for_loop.stdout
+++ b/tests/ui/author/for_loop.stdout
@@ -22,7 +22,7 @@ if_chain! {
     if let ExprKind::Path(ref path2) = func1.kind;
     if match_qpath(path2, &["{{root}}", "std", "iter", "Iterator", "next"]);
     if args1.len() == 1;
-    if let ExprKind::AddrOf(Mutability::Mutable, ref inner) = args1[0].kind;
+    if let ExprKind::AddrOf(_, Mutability::Mutable, ref inner) = args1[0].kind;
     if let ExprKind::Path(ref path3) = inner.kind;
     if match_qpath(path3, &["iter"]);
     if arms1.len() == 2;

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -71,7 +71,7 @@ fn or_fun_call() {
 
     let opt = Some(1);
     let hello = "Hello";
-    let _ = opt.ok_or_else(|| format!("{} world.", hello));
+    let _ = opt.ok_or(format!("{} world.", hello));
 }
 
 struct Foo(u8);

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -72,17 +72,11 @@ error: use of `unwrap_or` followed by a function call
 LL |     let _ = stringy.unwrap_or("".to_owned());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| "".to_owned())`
 
-error: use of `ok_or` followed by a function call
-  --> $DIR/or_fun_call.rs:74:17
-   |
-LL |     let _ = opt.ok_or(format!("{} world.", hello));
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `ok_or_else(|| format!("{} world.", hello))`
-
 error: use of `or` followed by a function call
   --> $DIR/or_fun_call.rs:95:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some("b".to_string()))`
 
-error: aborting due to 14 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Rustups:

- rust-lang/rust#66671 (Ast address-of)
- rust-lang/rust#64856 (Scope format! temporaries)
 - http://github.com/rust-lang/rust/pull/66719

changelog: none
