### PR TITLE
Deny warnings in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,3 @@ rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 
 [features]
 deny-warnings = []
-debugging = []

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,10 +37,10 @@ install:
 build: false
 
 build_script:
-  - cargo build --features debugging
+  - cargo build --features deny-warnings
 
 test_script:
-  - cargo test --features debugging
+  - cargo test --features deny-warnings
 
 notifications:
   - provider: Email

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -15,9 +15,9 @@ fi
 cargo build --features deny-warnings
 cargo test --features deny-warnings
 
-(cd clippy_lints && cargo test)
-(cd rustc_tools_util && cargo test)
-(cd clippy_dev && cargo test)
+(cd clippy_lints && cargo test --features deny-warnings)
+(cd rustc_tools_util && cargo test --features deny-warnings)
+(cd clippy_dev && cargo test --features deny-warnings)
 
 # make sure clippy can be called via ./path/to/cargo-clippy
 (

--- a/ci/base-tests.sh
+++ b/ci/base-tests.sh
@@ -12,8 +12,8 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   remark -f ./*.md -f doc/*.md > /dev/null
 fi
 # build clippy in debug mode and run tests
-cargo build --features "debugging deny-warnings"
-cargo test --features "debugging deny-warnings"
+cargo build --features deny-warnings
+cargo test --features deny-warnings
 
 (cd clippy_lints && cargo test)
 (cd rustc_tools_util && cargo test)

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -11,3 +11,6 @@ regex = "1"
 lazy_static = "1.0"
 shell-escape = "0.1"
 walkdir = "2"
+
+[features]
+deny-warnings = []

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
+
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
+
 extern crate clap;
 extern crate clippy_dev;
 extern crate regex;

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -35,4 +35,4 @@ semver = "0.9.0"
 url = { version =  "2.1.0", features = ["serde"] }
 
 [features]
-debugging = []
+deny-warnings = []

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -9,4 +9,8 @@ license = "MIT OR Apache-2.0"
 keywords = ["rustc", "tool", "git", "version", "hash"]
 categories = ["development-tools"]
 edition = "2018"
+
 [dependencies]
+
+[features]
+deny-warnings = []

--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
+
 use std::env;
 
 #[macro_export]


### PR DESCRIPTION
Removes the `debugging` feature, that wasn't used anymore and adds/enables the `deny-warnings` feature for every sub-crate of Clippy.

changelog: none
