### PR TITLE
Remove negative float literal checks.

### DIFF
--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -92,14 +92,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Arithmetic {
             },
             hir::ExprKind::Unary(hir::UnOp::UnNeg, arg) => {
                 let ty = cx.tables.expr_ty(arg);
-                if ty.is_integral() {
-                    if constant_simple(cx, cx.tables, expr).is_none() {
+                if constant_simple(cx, cx.tables, expr).is_none() {
+                    if ty.is_integral() {
                         span_lint(cx, INTEGER_ARITHMETIC, expr.span, "integer arithmetic detected");
                         self.expr_span = Some(expr.span);
+                    } else if ty.is_floating_point() {
+                        span_lint(cx, FLOAT_ARITHMETIC, expr.span, "floating-point arithmetic detected");
+                        self.expr_span = Some(expr.span);
                     }
-                } else if ty.is_floating_point() {
-                    span_lint(cx, FLOAT_ARITHMETIC, expr.span, "floating-point arithmetic detected");
-                    self.expr_span = Some(expr.span);
                 }
             },
             _ => (),

--- a/tests/ui/arithmetic.rs
+++ b/tests/ui/arithmetic.rs
@@ -55,6 +55,10 @@ fn main() {
     f *= 2.0;
     f /= 2.0;
 
+    // no error, overflows are checked by `overflowing_literals`
+    -1.;
+    -(-1.);
+
     // No errors for the following items because they are constant expressions
     enum Foo {
         Bar = -2,


### PR DESCRIPTION
Fixes #4850.

changelog: Remove negative float literal checks.