### PR TITLE
Move use_self to nursery

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1050,7 +1050,6 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
         LintId::of(&unicode::NON_ASCII_LITERAL),
         LintId::of(&unicode::UNICODE_NOT_NFC),
         LintId::of(&unused_self::UNUSED_SELF),
-        LintId::of(&use_self::USE_SELF),
     ]);
 
     store.register_group(true, "clippy::internal", Some("clippy_internal"), vec![
@@ -1579,6 +1578,7 @@ pub fn register_plugins(store: &mut lint::LintStore, sess: &Session, conf: &Conf
         LintId::of(&mutex_atomic::MUTEX_INTEGER),
         LintId::of(&needless_borrow::NEEDLESS_BORROW),
         LintId::of(&path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE),
+        LintId::of(&use_self::USE_SELF),
     ]);
 }
 

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     pub USE_SELF,
-    pedantic,
+    nursery,
     "Unnecessary structure name repetition whereas `Self` is applicable"
 }
 

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -2193,7 +2193,7 @@ pub const ALL_LINTS: [Lint; 338] = [
     },
     Lint {
         name: "use_self",
-        group: "pedantic",
+        group: "nursery",
         desc: "Unnecessary structure name repetition whereas `Self` is applicable",
         deprecation: None,
         module: "use_self",


### PR DESCRIPTION
Closes #4859

We have a lot of false positives in this lint, so I think it makes sense
to move this to the nursery until they are resolved.

changelog: Move `use_self` lint to nursery, due to many false positives