### PR TITLE
Fix master deployment

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -60,6 +60,7 @@ if git diff --exit-code --quiet; then
     echo "No changes to the output on this push; exiting."
     exit 0
 fi
+cd -
 
 # Get the deploy key by using Travis's stored variables to decrypt deploy_key.enc
 ENCRYPTION_LABEL=e3a2d77100be


### PR DESCRIPTION
It was failing because it could not find `.github/deploy_key.enc` in the
current directory (`./out`). Switching to the previous directory should
fix the deployment and the master build.

Example Travis log: https://travis-ci.com/rust-lang/rust-clippy/jobs/261688169#L1900

changelog: none

cc @lzutao