### PR TITLE
Fire clippy::op_ref on PartialOrd but !Ord types

### DIFF
--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -77,7 +77,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                 BinOpKind::Shr => (cx.tcx.lang_items().shr_trait(), false),
                 BinOpKind::Ne | BinOpKind::Eq => (cx.tcx.lang_items().eq_trait(), true),
                 BinOpKind::Lt | BinOpKind::Le | BinOpKind::Ge | BinOpKind::Gt => {
-                    (cx.tcx.lang_items().ord_trait(), true)
+                    (cx.tcx.lang_items().partial_ord_trait(), true)
                 },
             };
             if let Some(trait_id) = trait_id {


### PR DESCRIPTION
Some context: this _appears_ to be the only usage of `.ord_trait()` in the compiler. [I've a PR that tries to remove it.](https://github.com/rust-lang/rust/pull/66941) It's definitely not correct here, though! [Example:](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=077496b0d2cceb91405c43d3e084f267)

```rust
#[derive(PartialOrd, PartialEq, Eq, /*Ord*/)]
struct S(u32);

fn main() {
    let a = S(0);
    let b = S(1);
    dbg!(&a < &b);
}
```

On the above snippet, `clippy::op_ref` does not fire unless we also derive `Ord` due to the use of `.ord_trait()` here meaning we gate the lint on implementing `Ord`, rather than just `PartialOrd` which is the trait actually required to use comparison operators.

changelog: Fix: trigger `clippy::op_ref` (needlessly taken reference of both operands) when a comparison operator's operands implement `PartialOrd` but not `Ord`. Previously, the lint only fired if and only if `Ord` was implemented.
