### PR TITLE
Fix FP in manual_swap lint with slice-like types

### DIFF
--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -111,42 +111,51 @@ fn check_manual_swap(cx: &LateContext<'_, '_>, block: &Block) {
                     return;
                 } else if let Slice::Swappable(slice, idx1, idx2) = slice {
                     if let Some(slice) = Sugg::hir_opt(cx, slice) {
-                        (false,
-                         format!(" elements of `{}`", slice),
-                         format!("{}.swap({}, {})",
-                                 slice.maybe_par(),
-                                 snippet(cx, idx1.span, ".."),
-                                 snippet(cx, idx2.span, "..")))
+                        (
+                            false,
+                            format!(" elements of `{}`", slice),
+                            format!(
+                                "{}.swap({}, {})",
+                                slice.maybe_par(),
+                                snippet(cx, idx1.span, ".."),
+                                snippet(cx, idx2.span, ".."),
+                            ),
+                        )
                     } else {
                         (false, String::new(), String::new())
                     }
                 } else if let (Some(first), Some(second)) = (Sugg::hir_opt(cx, lhs1), Sugg::hir_opt(cx, rhs1)) {
-                    (true, format!(" `{}` and `{}`", first, second),
-                        format!("std::mem::swap({}, {})", first.mut_addr(), second.mut_addr()))
+                    (
+                        true,
+                        format!(" `{}` and `{}`", first, second),
+                        format!("std::mem::swap({}, {})", first.mut_addr(), second.mut_addr()),
+                    )
                 } else {
                     (true, String::new(), String::new())
                 };
 
                 let span = w[0].span.to(second.span);
 
-                span_lint_and_then(cx,
-                                   MANUAL_SWAP,
-                                   span,
-                                   &format!("this looks like you are swapping{} manually", what),
-                                   |db| {
-                                       if !sugg.is_empty() {
-                                           db.span_suggestion(
-                                               span,
-                                               "try",
-                                               sugg,
-                                               Applicability::Unspecified,
-                                           );
+                span_lint_and_then(
+                    cx,
+                    MANUAL_SWAP,
+                    span,
+                    &format!("this looks like you are swapping{} manually", what),
+                    |db| {
+                        if !sugg.is_empty() {
+                            db.span_suggestion(
+                                span,
+                                "try",
+                                sugg,
+                                Applicability::Unspecified,
+                            );
 
-                                           if replace {
-                                               db.note("or maybe you should use `std::mem::replace`?");
-                                           }
-                                       }
-                                   });
+                            if replace {
+                                db.note("or maybe you should use `std::mem::replace`?");
+                            }
+                        }
+                    }
+                );
             }
         }
     }

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -168,6 +168,7 @@ enum Slice<'a> {
     /// ## Example
     ///
     /// ```rust
+    /// # let mut a = vec![0, 1];
     /// let t = a[1];
     /// a[1] = a[0];
     /// a[0] = t;
@@ -180,6 +181,7 @@ enum Slice<'a> {
     /// ## Example
     ///
     /// ```rust
+    /// # let mut a = [vec![1, 2], vec![3, 4]];
     /// let t = a[0][1];
     /// a[0][1] = a[1][0];
     /// a[1][0] = t;

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -32,18 +32,14 @@ fn field() {
 
 fn array() {
     let mut foo = [1, 2];
-    let temp = foo[0];
-    foo[0] = foo[1];
-    foo[1] = temp;
+    foo.swap(0, 1);
 
     foo.swap(0, 1);
 }
 
 fn slice() {
     let foo = &mut [1, 2];
-    let temp = foo[0];
-    foo[0] = foo[1];
-    foo[1] = temp;
+    foo.swap(0, 1);
 
     foo.swap(0, 1);
 }
@@ -59,9 +55,7 @@ fn unswappable_slice() {
 
 fn vec() {
     let mut foo = vec![1, 2];
-    let temp = foo[0];
-    foo[0] = foo[1];
-    foo[1] = temp;
+    foo.swap(0, 1);
 
     foo.swap(0, 1);
 }
@@ -77,19 +71,13 @@ fn main() {
     let mut a = 42;
     let mut b = 1337;
 
-    a = b;
-    b = a;
+    std::mem::swap(&mut a, &mut b);
 
-    ; let t = a;
-    a = b;
-    b = t;
+    ; std::mem::swap(&mut a, &mut b);
 
     let mut c = Foo(42);
 
-    c.0 = a;
-    a = c.0;
+    std::mem::swap(&mut c.0, &mut a);
 
-    ; let t = c.0;
-    c.0 = a;
-    a = t;
+    ; std::mem::swap(&mut c.0, &mut a);
 }

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -46,6 +46,15 @@ fn slice() {
     foo.swap(0, 1);
 }
 
+fn unswappable_slice() {
+    let foo = &mut [vec![1, 2], vec![3, 4]];
+    let temp = foo[0][1];
+    foo[0][1] = foo[1][0];
+    foo[1][0] = temp;
+
+    // swap(foo[0][1], foo[1][0]) would fail
+}
+
 fn vec() {
     let mut foo = vec![1, 2];
     let temp = foo[0];

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -17,7 +17,7 @@ LL | |     foo[1] = temp;
    | |_________________^ help: try: `foo.swap(0, 1)`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:51:5
+  --> $DIR/swap.rs:60:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -25,7 +25,7 @@ LL | |     foo[1] = temp;
    | |_________________^ help: try: `foo.swap(0, 1)`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:71:7
+  --> $DIR/swap.rs:80:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -36,7 +36,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:80:7
+  --> $DIR/swap.rs:89:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -47,7 +47,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:68:5
+  --> $DIR/swap.rs:77:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -57,7 +57,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:77:5
+  --> $DIR/swap.rs:86:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:33:5
+  --> $DIR/swap.rs:35:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -9,7 +9,7 @@ LL | |     foo[1] = temp;
    = note: `-D clippy::manual-swap` implied by `-D warnings`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:42:5
+  --> $DIR/swap.rs:44:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -17,7 +17,7 @@ LL | |     foo[1] = temp;
    | |_________________^ help: try: `foo.swap(0, 1)`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:60:5
+  --> $DIR/swap.rs:62:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -25,7 +25,7 @@ LL | |     foo[1] = temp;
    | |_________________^ help: try: `foo.swap(0, 1)`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:80:7
+  --> $DIR/swap.rs:83:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -36,7 +36,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:89:7
+  --> $DIR/swap.rs:92:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -47,7 +47,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:77:5
+  --> $DIR/swap.rs:80:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -57,7 +57,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:86:5
+  --> $DIR/swap.rs:89:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;


### PR DESCRIPTION
Fixes #4853 

changelog: Fix FP in [`manual_swap`] lint with slice-like types and make it auto applicable
