### PR TITLE
Rustup

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -424,7 +424,7 @@ fn check_attrs(cx: &LateContext<'_, '_>, span: Span, name: Name, attrs: &[Attrib
         };
 
         if attr.style == AttrStyle::Outer {
-            if attr_item.tokens.is_empty() || !is_present_in_source(cx, attr.span) {
+            if attr_item.args.inner_tokens().is_empty() || !is_present_in_source(cx, attr.span) {
                 return;
             }
 

--- a/clippy_lints/src/dbg_macro.rs
+++ b/clippy_lints/src/dbg_macro.rs
@@ -32,11 +32,11 @@ declare_lint_pass!(DbgMacro => [DBG_MACRO]);
 impl EarlyLintPass for DbgMacro {
     fn check_mac(&mut self, cx: &EarlyContext<'_>, mac: &ast::Mac) {
         if mac.path == sym!(dbg) {
-            if let Some(sugg) = tts_span(mac.tts.clone()).and_then(|span| snippet_opt(cx, span)) {
+            if let Some(sugg) = tts_span(mac.args.inner_tokens()).and_then(|span| snippet_opt(cx, span)) {
                 span_lint_and_sugg(
                     cx,
                     DBG_MACRO,
-                    mac.span,
+                    mac.span(),
                     "`dbg!` macro is intended as a debugging tool",
                     "ensure to avoid having uses of it in version control",
                     sugg,
@@ -46,7 +46,7 @@ impl EarlyLintPass for DbgMacro {
                 span_help_and_lint(
                     cx,
                     DBG_MACRO,
-                    mac.span,
+                    mac.span(),
                     "`dbg!` macro is intended as a debugging tool",
                     "ensure to avoid having uses of it in version control",
                 );

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -77,7 +77,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                 BinOpKind::Shr => (cx.tcx.lang_items().shr_trait(), false),
                 BinOpKind::Ne | BinOpKind::Eq => (cx.tcx.lang_items().eq_trait(), true),
                 BinOpKind::Lt | BinOpKind::Le | BinOpKind::Ge | BinOpKind::Gt => {
-                    (cx.tcx.lang_items().ord_trait(), true)
+                    (cx.tcx.lang_items().partial_ord_trait(), true)
                 },
             };
             if let Some(trait_id) = trait_id {

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -155,7 +155,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                                     left.span,
                                     "use the left value directly",
                                     lsnip,
-                                    Applicability::MachineApplicable, // snippet
+                                    Applicability::MaybeIncorrect, // FIXME #2597
                                 );
                             })
                         }
@@ -173,7 +173,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                                     right.span,
                                     "use the right value directly",
                                     rsnip,
-                                    Applicability::MachineApplicable, // snippet
+                                    Applicability::MaybeIncorrect, // FIXME #2597
                                 );
                             })
                         }

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -189,13 +189,13 @@ declare_lint_pass!(Write => [
 impl EarlyLintPass for Write {
     fn check_mac(&mut self, cx: &EarlyContext<'_>, mac: &Mac) {
         if mac.path == sym!(println) {
-            span_lint(cx, PRINT_STDOUT, mac.span, "use of `println!`");
-            if let (Some(fmt_str), _) = check_tts(cx, &mac.tts, false) {
+            span_lint(cx, PRINT_STDOUT, mac.span(), "use of `println!`");
+            if let (Some(fmt_str), _) = check_tts(cx, &mac.args.inner_tokens(), false) {
                 if fmt_str.symbol == Symbol::intern("") {
                     span_lint_and_sugg(
                         cx,
                         PRINTLN_EMPTY_STRING,
-                        mac.span,
+                        mac.span(),
                         "using `println!(\"\")`",
                         "replace it with",
                         "println!()".to_string(),
@@ -204,13 +204,13 @@ impl EarlyLintPass for Write {
                 }
             }
         } else if mac.path == sym!(print) {
-            span_lint(cx, PRINT_STDOUT, mac.span, "use of `print!`");
-            if let (Some(fmt_str), _) = check_tts(cx, &mac.tts, false) {
+            span_lint(cx, PRINT_STDOUT, mac.span(), "use of `print!`");
+            if let (Some(fmt_str), _) = check_tts(cx, &mac.args.inner_tokens(), false) {
                 if check_newlines(&fmt_str) {
                     span_lint_and_then(
                         cx,
                         PRINT_WITH_NEWLINE,
-                        mac.span,
+                        mac.span(),
                         "using `print!()` with a format string that ends in a single newline",
                         |err| {
                             err.multipart_suggestion(
@@ -226,12 +226,12 @@ impl EarlyLintPass for Write {
                 }
             }
         } else if mac.path == sym!(write) {
-            if let (Some(fmt_str), _) = check_tts(cx, &mac.tts, true) {
+            if let (Some(fmt_str), _) = check_tts(cx, &mac.args.inner_tokens(), true) {
                 if check_newlines(&fmt_str) {
                     span_lint_and_then(
                         cx,
                         WRITE_WITH_NEWLINE,
-                        mac.span,
+                        mac.span(),
                         "using `write!()` with a format string that ends in a single newline",
                         |err| {
                             err.multipart_suggestion(
@@ -247,7 +247,7 @@ impl EarlyLintPass for Write {
                 }
             }
         } else if mac.path == sym!(writeln) {
-            if let (Some(fmt_str), expr) = check_tts(cx, &mac.tts, true) {
+            if let (Some(fmt_str), expr) = check_tts(cx, &mac.args.inner_tokens(), true) {
                 if fmt_str.symbol == Symbol::intern("") {
                     let mut applicability = Applicability::MachineApplicable;
                     let suggestion = expr.map_or_else(
@@ -261,7 +261,7 @@ impl EarlyLintPass for Write {
                     span_lint_and_sugg(
                         cx,
                         WRITELN_EMPTY_STRING,
-                        mac.span,
+                        mac.span(),
                         format!("using `writeln!({}, \"\")`", suggestion).as_str(),
                         "replace it with",
                         format!("writeln!({})", suggestion),

--- a/tests/ui/op_ref.stderr
+++ b/tests/ui/op_ref.stderr
@@ -11,14 +11,6 @@ LL |     let foo = 5 - 6;
    |               ^   ^
 
 error: taken reference of right operand
-  --> $DIR/op_ref.rs:20:8
-   |
-LL |     if b < &a {
-   |        ^^^^--
-   |            |
-   |            help: use the right value directly: `a`
-
-error: taken reference of right operand
   --> $DIR/op_ref.rs:57:13
    |
 LL |     let z = x & &y;
@@ -26,5 +18,5 @@ LL |     let z = x & &y;
    |                 |
    |                 help: use the right value directly: `y`
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Included rustups:

- rust-lang/rust#66935 (syntax: Unify macro and attribute arguments in AST)
- rust-lang/rust#66941 (Remove `ord` lang item)

Fixes? #2597 

changelog: none
