### PR TITLE
Fix false positive in `string_add`.

### DIFF
--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -8,7 +8,9 @@ use syntax::source_map::Spanned;
 use if_chain::if_chain;
 
 use crate::utils::SpanlessEq;
-use crate::utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty};
+use crate::utils::{
+    get_parent_expr, in_macro, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty,
+};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for string appends of the form `x = x + y` (without
@@ -80,6 +82,10 @@ declare_lint_pass!(StringAdd => [STRING_ADD, STRING_ADD_ASSIGN]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringAdd {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
+        if in_macro(e.span) {
+            return;
+        }
+
         if let ExprKind::Binary(
             Spanned {
                 node: BinOpKind::Add, ..

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -1,6 +1,6 @@
 use rustc::declare_lint_pass;
 use rustc::hir::*;
-use rustc::lint::{LateContext, LateLintPass, LintArray, LintPass};
+use rustc::lint::{in_external_macro, LateContext, LateLintPass, LintArray, LintContext, LintPass};
 use rustc_errors::Applicability;
 use rustc_session::declare_tool_lint;
 use syntax::source_map::Spanned;
@@ -8,9 +8,7 @@ use syntax::source_map::Spanned;
 use if_chain::if_chain;
 
 use crate::utils::SpanlessEq;
-use crate::utils::{
-    get_parent_expr, in_macro, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty,
-};
+use crate::utils::{get_parent_expr, is_allowed, match_type, paths, span_lint, span_lint_and_sugg, walk_ptrs_ty};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for string appends of the form `x = x + y` (without
@@ -82,7 +80,7 @@ declare_lint_pass!(StringAdd => [STRING_ADD, STRING_ADD_ASSIGN]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for StringAdd {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr) {
-        if in_macro(e.span) {
+        if in_external_macro(cx.sess(), e.span) {
             return;
         }
 

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -31,3 +31,11 @@ macro_rules! try_err {
         }
     };
 }
+
+#[macro_export]
+macro_rules! string_add {
+    () => {
+        let y = "".to_owned();
+        let z = y + "...";
+    };
+}

--- a/tests/ui/string_add.rs
+++ b/tests/ui/string_add.rs
@@ -16,4 +16,13 @@ fn main() {
     let mut x = 1;
     x = x + 1;
     assert_eq!(2, x);
+
+    macro_rules! mac {
+        () => {
+            let y = "".to_owned();
+            let z = y + "...";
+        };
+    }
+
+    mac!();
 }

--- a/tests/ui/string_add.rs
+++ b/tests/ui/string_add.rs
@@ -1,3 +1,8 @@
+// aux-build:macro_rules.rs
+
+#[macro_use]
+extern crate macro_rules;
+
 #[warn(clippy::string_add)]
 #[allow(clippy::string_add_assign, unused)]
 fn main() {
@@ -17,12 +22,5 @@ fn main() {
     x = x + 1;
     assert_eq!(2, x);
 
-    macro_rules! mac {
-        () => {
-            let y = "".to_owned();
-            let z = y + "...";
-        };
-    }
-
-    mac!();
+    string_add!();
 }

--- a/tests/ui/string_add.stderr
+++ b/tests/ui/string_add.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of an assign operation
-  --> $DIR/string_add.rs:8:9
+  --> $DIR/string_add.rs:13:9
    |
 LL |         x = x + ".";
    |         ^^^^^^^^^^^ help: replace it with: `x += "."`
@@ -7,7 +7,7 @@ LL |         x = x + ".";
    = note: `-D clippy::assign-op-pattern` implied by `-D warnings`
 
 error: you added something to a string. Consider using `String::push_str()` instead
-  --> $DIR/string_add.rs:8:13
+  --> $DIR/string_add.rs:13:13
    |
 LL |         x = x + ".";
    |             ^^^^^^^
@@ -15,13 +15,13 @@ LL |         x = x + ".";
    = note: `-D clippy::string-add` implied by `-D warnings`
 
 error: you added something to a string. Consider using `String::push_str()` instead
-  --> $DIR/string_add.rs:12:13
+  --> $DIR/string_add.rs:17:13
    |
 LL |     let z = y + "...";
    |             ^^^^^^^^^
 
 error: manual implementation of an assign operation
-  --> $DIR/string_add.rs:17:5
+  --> $DIR/string_add.rs:22:5
    |
 LL |     x = x + 1;
    |     ^^^^^^^^^ help: replace it with: `x += 1`


### PR DESCRIPTION
`clippy::string_add` was popping up in macros.
I'm not sure what clippy's general direction is in these matters, but I can change it to be external macros only too.

---

changelog: Fix false positives for `string_add` in macro expansions.