### PR TITLE
add tests for using macros in `as_conversions_lint`

### DIFF
--- a/tests/ui/as_conversions.rs
+++ b/tests/ui/as_conversions.rs
@@ -1,7 +1,23 @@
-#[warn(clippy::as_conversions)]
+#![warn(clippy::as_conversions)]
+
+macro_rules! mcr1 {
+    (0_u32 as u64) => {
+        ()
+    };
+}
+
+macro_rules! mcr2 {
+    () => {
+        0_u32 as u64
+    };
+}
 
 fn main() {
     let i = 0u32 as u64;
 
     let j = &i as *const u64 as *mut u64;
+
+    let k = mcr1!(0_u32 as u64);
+
+    let p = mcr2!();
 }

--- a/tests/ui/as_conversions.stderr
+++ b/tests/ui/as_conversions.stderr
@@ -1,5 +1,5 @@
 error: using a potentially dangerous silent `as` conversion
-  --> $DIR/as_conversions.rs:4:13
+  --> $DIR/as_conversions.rs:16:13
    |
 LL |     let i = 0u32 as u64;
    |             ^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let i = 0u32 as u64;
    = help: consider using a safe wrapper for this conversion
 
 error: using a potentially dangerous silent `as` conversion
-  --> $DIR/as_conversions.rs:6:13
+  --> $DIR/as_conversions.rs:18:13
    |
 LL |     let j = &i as *const u64 as *mut u64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,12 +16,23 @@ LL |     let j = &i as *const u64 as *mut u64;
    = help: consider using a safe wrapper for this conversion
 
 error: using a potentially dangerous silent `as` conversion
-  --> $DIR/as_conversions.rs:6:13
+  --> $DIR/as_conversions.rs:18:13
    |
 LL |     let j = &i as *const u64 as *mut u64;
    |             ^^^^^^^^^^^^^^^^
    |
    = help: consider using a safe wrapper for this conversion
 
-error: aborting due to 3 previous errors
+error: using a potentially dangerous silent `as` conversion
+  --> $DIR/as_conversions.rs:11:9
+   |
+LL |         0_u32 as u64
+   |         ^^^^^^^^^^^^
+...
+LL |     let p = mcr2!();
+   |             ------- in this macro invocation
+   |
+   = help: consider using a safe wrapper for this conversion
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
As somebody noted in the original pr (unfortunately only after it was closed), `as_conversions` lint needs macro interaction tests. Also I am not sure whether or not we should lint in the local macro invocations (currently we are linting in them).