### PR TITLE
Update tests for revert of never type stabilization

### DIFF
--- a/tests/ui/infallible_destructuring_match.fixed
+++ b/tests/ui/infallible_destructuring_match.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![feature(exhaustive_patterns)]
+#![feature(exhaustive_patterns, never_type)]
 #![allow(dead_code, unreachable_code, unused_variables)]
 #![allow(clippy::let_and_return)]
 

--- a/tests/ui/infallible_destructuring_match.rs
+++ b/tests/ui/infallible_destructuring_match.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![feature(exhaustive_patterns)]
+#![feature(exhaustive_patterns, never_type)]
 #![allow(dead_code, unreachable_code, unused_variables)]
 #![allow(clippy::let_and_return)]
 

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![feature(never_type)]
 #![allow(unused_mut)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![feature(never_type)]
 #![allow(unused_mut)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -1,5 +1,5 @@
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:11:1
+  --> $DIR/must_use_candidates.rs:12:1
    |
 LL | pub fn pure(i: u8) -> u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn pure(i: u8) -> u8`
@@ -7,25 +7,25 @@ LL | pub fn pure(i: u8) -> u8 {
    = note: `-D clippy::must-use-candidate` implied by `-D warnings`
 
 error: this method could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:16:5
+  --> $DIR/must_use_candidates.rs:17:5
    |
 LL |     pub fn inherent_pure(&self) -> u8 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn inherent_pure(&self) -> u8`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:47:1
+  --> $DIR/must_use_candidates.rs:48:1
    |
 LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:59:1
+  --> $DIR/must_use_candidates.rs:60:1
    |
 LL | pub fn rcd(_x: Rc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn rcd(_x: Rc<u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:67:1
+  --> $DIR/must_use_candidates.rs:68:1
    |
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn arcd(_x: Arc<u32>) -> bool`

--- a/tests/ui/result_map_unit_fn_unfixable.rs
+++ b/tests/ui/result_map_unit_fn_unfixable.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::result_map_unit_fn)]
+#![feature(never_type)]
 #![allow(unused)]
 
 fn do_nothing<T>(_: T) {}

--- a/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -1,23 +1,23 @@
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:16:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:17:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
    |     ^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:18:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:19:5
    |
 LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });
    |     ^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:22:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:23:5
    |
 LL |     x.field.map(|value| {
    |     ^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:26:5
+  --> $DIR/result_map_unit_fn_unfixable.rs:27:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value); });
    |     ^ not found in this scope


### PR DESCRIPTION
This semi-reverts 3c308b86c81e38d35dd5b0a062076aa591296735, enough to get tests passing locally (at least those that I could easily run). It should be enough to get https://github.com/rust-lang/rust/pull/67224 able to land.

---

changelog: none
