### PR TITLE
Fix clippy build failure

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -12,7 +12,6 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![feature(crate_visibility_modifier)]
 #![feature(concat_idents)]
-#![feature(result_map_or)]
 
 // FIXME: switch to something more ergonomic here, once available.
 // (Currently there is no way to opt into sysroot crates without `extern crate`.)

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![feature(result_map_or)]
 #![feature(rustc_private)]
 
 // FIXME: switch to something more ergonomic here, once available.


### PR DESCRIPTION
Clippy build fails because the feature `result_map_or` has been stabilized in v1.41.0 but we still have an explicit feature attribute for it.

changelog: none
