### PR TITLE
Detect comparisons with NAN constants

### DIFF
--- a/tests/ui/cmp_nan.rs
+++ b/tests/ui/cmp_nan.rs
@@ -1,3 +1,6 @@
+const NAN_F32: f32 = std::f32::NAN;
+const NAN_F64: f64 = std::f64::NAN;
+
 #[warn(clippy::cmp_nan)]
 #[allow(clippy::float_cmp, clippy::no_effect, clippy::unnecessary_operation)]
 fn main() {
@@ -8,6 +11,12 @@ fn main() {
     x > std::f32::NAN;
     x <= std::f32::NAN;
     x >= std::f32::NAN;
+    x == NAN_F32;
+    x != NAN_F32;
+    x < NAN_F32;
+    x > NAN_F32;
+    x <= NAN_F32;
+    x >= NAN_F32;
 
     let y = 0f64;
     y == std::f64::NAN;
@@ -16,4 +25,10 @@ fn main() {
     y > std::f64::NAN;
     y <= std::f64::NAN;
     y >= std::f64::NAN;
+    y == NAN_F64;
+    y != NAN_F64;
+    y < NAN_F64;
+    y > NAN_F64;
+    y <= NAN_F64;
+    y >= NAN_F64;
 }

--- a/tests/ui/cmp_nan.stderr
+++ b/tests/ui/cmp_nan.stderr
@@ -1,5 +1,5 @@
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:5:5
+  --> $DIR/cmp_nan.rs:8:5
    |
 LL |     x == std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^
@@ -7,70 +7,142 @@ LL |     x == std::f32::NAN;
    = note: `-D clippy::cmp-nan` implied by `-D warnings`
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:6:5
+  --> $DIR/cmp_nan.rs:9:5
    |
 LL |     x != std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:7:5
+  --> $DIR/cmp_nan.rs:10:5
    |
 LL |     x < std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:8:5
+  --> $DIR/cmp_nan.rs:11:5
    |
 LL |     x > std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:9:5
+  --> $DIR/cmp_nan.rs:12:5
    |
 LL |     x <= std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:10:5
+  --> $DIR/cmp_nan.rs:13:5
    |
 LL |     x >= std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:13:5
+  --> $DIR/cmp_nan.rs:14:5
+   |
+LL |     x == NAN_F32;
+   |     ^^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:15:5
+   |
+LL |     x != NAN_F32;
+   |     ^^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:16:5
+   |
+LL |     x < NAN_F32;
+   |     ^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:17:5
+   |
+LL |     x > NAN_F32;
+   |     ^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:18:5
+   |
+LL |     x <= NAN_F32;
+   |     ^^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:19:5
+   |
+LL |     x >= NAN_F32;
+   |     ^^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:22:5
    |
 LL |     y == std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:14:5
+  --> $DIR/cmp_nan.rs:23:5
    |
 LL |     y != std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:15:5
+  --> $DIR/cmp_nan.rs:24:5
    |
 LL |     y < std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:16:5
+  --> $DIR/cmp_nan.rs:25:5
    |
 LL |     y > std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:17:5
+  --> $DIR/cmp_nan.rs:26:5
    |
 LL |     y <= std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
-  --> $DIR/cmp_nan.rs:18:5
+  --> $DIR/cmp_nan.rs:27:5
    |
 LL |     y >= std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:28:5
+   |
+LL |     y == NAN_F64;
+   |     ^^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:29:5
+   |
+LL |     y != NAN_F64;
+   |     ^^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:30:5
+   |
+LL |     y < NAN_F64;
+   |     ^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:31:5
+   |
+LL |     y > NAN_F64;
+   |     ^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:32:5
+   |
+LL |     y <= NAN_F64;
+   |     ^^^^^^^^^^^^
+
+error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+  --> $DIR/cmp_nan.rs:33:5
+   |
+LL |     y >= NAN_F64;
+   |     ^^^^^^^^^^^^
+
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Currently `cmp_nan` lint doesn't detect comparisons with NaN's if the operands are consts variables so to fix this we evaluate the const variables first before testing for NaN.

changelog: Detect comparisons with NaN constants in `cmp_nan` lint

Fixes #1205