### PR TITLE
Fix `expect_fun_call` false negative on references

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1595,7 +1595,7 @@ fn lint_expect_fun_call(cx: &LateContext<'_, '_>, expr: &hir::Expr, method_span:
         return;
     }
 
-    let receiver_type = cx.tables.expr_ty(&args[0]);
+    let receiver_type = cx.tables.expr_ty_adjusted(&args[0]);
     let closure_args = if match_type(cx, receiver_type, &paths::OPTION) {
         "||"
     } else if match_type(cx, receiver_type, &paths::RESULT) {

--- a/tests/ui/expect_fun_call.fixed
+++ b/tests/ui/expect_fun_call.fixed
@@ -84,4 +84,11 @@ fn main() {
 
     //Issue #3839
     Some(true).unwrap_or_else(|| panic!("key {}, {}", 1, 2));
+
+    //Issue #4912 - the receiver is a &Option
+    {
+        let opt = Some(1);
+        let opt_ref = &opt;
+        opt_ref.unwrap_or_else(|| panic!("{:?}", opt_ref));
+    }
 }

--- a/tests/ui/expect_fun_call.rs
+++ b/tests/ui/expect_fun_call.rs
@@ -84,4 +84,11 @@ fn main() {
 
     //Issue #3839
     Some(true).expect(&format!("key {}, {}", 1, 2));
+
+    //Issue #4912 - the receiver is a &Option
+    {
+        let opt = Some(1);
+        let opt_ref = &opt;
+        opt_ref.expect(&format!("{:?}", opt_ref));
+    }
 }

--- a/tests/ui/expect_fun_call.stderr
+++ b/tests/ui/expect_fun_call.stderr
@@ -66,5 +66,11 @@ error: use of `expect` followed by a function call
 LL |     Some(true).expect(&format!("key {}, {}", 1, 2));
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("key {}, {}", 1, 2))`
 
-error: aborting due to 11 previous errors
+error: use of `expect` followed by a function call
+  --> $DIR/expect_fun_call.rs:92:17
+   |
+LL |         opt_ref.expect(&format!("{:?}", opt_ref));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("{:?}", opt_ref))`
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Closes #4912

changelog: Fix `expect_fun_call` false negative on references