### PR TITLE
Fix documentation example for unnecessary_filter_map.

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -958,11 +958,11 @@ declare_clippy_lint! {
     /// ```
     ///
     /// ```rust
-    /// let _ = (0..4).filter_map(i32::checked_abs);
+    /// let _ = (0..4).filter_map(|x| Some(x + 1));
     /// ```
     /// As there is no conditional check on the argument this could be written as:
     /// ```rust
-    /// let _ = (0..4).map(i32::checked_abs);
+    /// let _ = (0..4).map(|x| x + 1);
     /// ```
     pub UNNECESSARY_FILTER_MAP,
     complexity,


### PR DESCRIPTION
Fixes #4919.

changelog: none
