### PR TITLE
Fix `map_clone` false positive

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -69,8 +69,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MapClone {
                     hir::PatKind::Binding(hir::BindingAnnotation::Unannotated, .., name, None) => {
                         match closure_expr.kind {
                             hir::ExprKind::Unary(hir::UnOp::UnDeref, ref inner) => {
-                                if ident_eq(name, inner) && !cx.tables.expr_ty(inner).is_box() {
-                                    lint(cx, e.span, args[0].span, true);
+                                if ident_eq(name, inner) {
+                                    if let ty::Ref(..) = cx.tables.expr_ty(inner).kind {
+                                        lint(cx, e.span, args[0].span, true);
+                                    }
                                 }
                             },
                             hir::ExprKind::MethodCall(ref method, _, ref obj) => {

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -23,4 +23,14 @@ fn main() {
 
     // Issue #498
     let _ = std::env::args();
+
+    // Issue #4824 item types that aren't references
+    {
+        use std::rc::Rc;
+
+        let o: Option<Rc<u32>> = Some(Rc::new(0_u32));
+        let _: Option<u32> = o.map(|x| *x);
+        let v: Vec<Rc<u32>> = vec![Rc::new(0_u32)];
+        let _: Vec<u32> = v.into_iter().map(|x| *x).collect();
+    }
 }

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -23,4 +23,14 @@ fn main() {
 
     // Issue #498
     let _ = std::env::args().map(|v| v.clone());
+
+    // Issue #4824 item types that aren't references
+    {
+        use std::rc::Rc;
+
+        let o: Option<Rc<u32>> = Some(Rc::new(0_u32));
+        let _: Option<u32> = o.map(|x| *x);
+        let v: Vec<Rc<u32>> = vec![Rc::new(0_u32)];
+        let _: Vec<u32> = v.into_iter().map(|x| *x).collect();
+    }
 }


### PR DESCRIPTION
Don't lint when the item type is not a reference. `copied` only applies to references.

changelog: Fix `map_clone` false positive