### PR TITLE
Do not drop suffixes on `decimal_literal_representation`

### DIFF
--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -560,7 +560,7 @@ impl DecimalLiteralRepresentation {
             if val >= u128::from(self.threshold);
             then {
                 let hex = format!("{:#X}", val);
-                let num_lit = NumericLiteral::new(&hex, None, false);
+                let num_lit = NumericLiteral::new(&hex, num_lit.suffix, false);
                 let _ = Self::do_lint(num_lit.integer).map_err(|warning_type| {
                     warning_type.display(num_lit.format(), cx, lit.span)
                 });

--- a/tests/ui/decimal_literal_representation.fixed
+++ b/tests/ui/decimal_literal_representation.fixed
@@ -21,5 +21,7 @@ fn main() {
         0x7FFF_FFFF, // 0x7FFF_FFFF
         #[allow(overflowing_literals)]
         0xF0F0_F0F0, // 0xF0F0_F0F0
+        0x8005_usize,   // 0x8005_usize
+        0x7F0F_F00F_isize, // 0x7F0F_F00F_isize
     );
 }

--- a/tests/ui/decimal_literal_representation.rs
+++ b/tests/ui/decimal_literal_representation.rs
@@ -21,5 +21,7 @@ fn main() {
         2_147_483_647, // 0x7FFF_FFFF
         #[allow(overflowing_literals)]
         4_042_322_160, // 0xF0F0_F0F0
+        32_773usize,   // 0x8005_usize
+        2_131_750_927isize, // 0x7F0F_F00F_isize
     );
 }

--- a/tests/ui/decimal_literal_representation.stderr
+++ b/tests/ui/decimal_literal_representation.stderr
@@ -30,5 +30,17 @@ error: integer literal has a better hexadecimal representation
 LL |         4_042_322_160, // 0xF0F0_F0F0
    |         ^^^^^^^^^^^^^ help: consider: `0xF0F0_F0F0`
 
-error: aborting due to 5 previous errors
+error: integer literal has a better hexadecimal representation
+  --> $DIR/decimal_literal_representation.rs:24:9
+   |
+LL |         32_773usize,   // 0x8005_usize
+   |         ^^^^^^^^^^^ help: consider: `0x8005_usize`
+
+error: integer literal has a better hexadecimal representation
+  --> $DIR/decimal_literal_representation.rs:25:9
+   |
+LL |         2_131_750_927isize, // 0x7F0F_F00F_isize
+   |         ^^^^^^^^^^^^^^^^^^ help: consider: `0x7F0F_F00F_isize`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes #4763

changelog: Do not drop type suffixes on `decimal_literal_representation`
