### PR TITLE
Suggest similar lint name on `unknown_clippy_lints`

### DIFF
--- a/tests/ui/unknown_clippy_lints.fixed
+++ b/tests/ui/unknown_clippy_lints.fixed
@@ -2,17 +2,17 @@
 
 #![warn(clippy::pedantic)]
 // Should suggest lowercase
-#![allow(clippy::All)]
-#![warn(clippy::CMP_NAN)]
+#![allow(clippy::all)]
+#![warn(clippy::cmp_nan)]
 
 // Should suggest similar clippy lint name
-#[warn(clippy::if_not_els)]
-#[warn(clippy::UNNecsaRy_cAst)]
-#[warn(clippy::useles_transute)]
+#[warn(clippy::if_not_else)]
+#[warn(clippy::unnecessary_cast)]
+#[warn(clippy::useless_transmute)]
 // Shouldn't suggest rustc lint name(`dead_code`)
-#[warn(clippy::dead_cod)]
+#[warn(clippy::drop_copy)]
 // Shouldn't suggest removed/deprecated clippy lint name(`unused_collect`)
-#[warn(clippy::unused_colle)]
+#[warn(clippy::unused_self)]
 // Shouldn't suggest renamed clippy lint name(`const_static_lifetime`)
-#[warn(clippy::const_static_lifetim)]
+#[warn(clippy::redundant_static_lifetimes)]
 fn main() {}

--- a/tests/ui/unknown_clippy_lints.stderr
+++ b/tests/ui/unknown_clippy_lints.stderr
@@ -1,16 +1,52 @@
 error: unknown clippy lint: clippy::if_not_els
-  --> $DIR/unknown_clippy_lints.rs:4:8
+  --> $DIR/unknown_clippy_lints.rs:9:8
    |
 LL | #[warn(clippy::if_not_els)]
-   |        ^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::if_not_else`
    |
    = note: `-D clippy::unknown-clippy-lints` implied by `-D warnings`
 
+error: unknown clippy lint: clippy::UNNecsaRy_cAst
+  --> $DIR/unknown_clippy_lints.rs:10:8
+   |
+LL | #[warn(clippy::UNNecsaRy_cAst)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::unnecessary_cast`
+
+error: unknown clippy lint: clippy::useles_transute
+  --> $DIR/unknown_clippy_lints.rs:11:8
+   |
+LL | #[warn(clippy::useles_transute)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::useless_transmute`
+
+error: unknown clippy lint: clippy::dead_cod
+  --> $DIR/unknown_clippy_lints.rs:13:8
+   |
+LL | #[warn(clippy::dead_cod)]
+   |        ^^^^^^^^^^^^^^^^ help: did you mean: `clippy::drop_copy`
+
+error: unknown clippy lint: clippy::unused_colle
+  --> $DIR/unknown_clippy_lints.rs:15:8
+   |
+LL | #[warn(clippy::unused_colle)]
+   |        ^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::unused_self`
+
+error: unknown clippy lint: clippy::const_static_lifetim
+  --> $DIR/unknown_clippy_lints.rs:17:8
+   |
+LL | #[warn(clippy::const_static_lifetim)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::redundant_static_lifetimes`
+
 error: unknown clippy lint: clippy::All
-  --> $DIR/unknown_clippy_lints.rs:1:10
+  --> $DIR/unknown_clippy_lints.rs:5:10
    |
 LL | #![allow(clippy::All)]
-   |          ^^^^^^^^^^^ help: lowercase the lint name: `all`
+   |          ^^^^^^^^^^^ help: lowercase the lint name: `clippy::all`
 
-error: aborting due to 2 previous errors
+error: unknown clippy lint: clippy::CMP_NAN
+  --> $DIR/unknown_clippy_lints.rs:6:9
+   |
+LL | #![warn(clippy::CMP_NAN)]
+   |         ^^^^^^^^^^^^^^^ help: lowercase the lint name: `clippy::cmp_nan`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Suggest a similar lint name with Levenshtein distance on `unknown_clippy_lints`.
And lowercase suggestion behavior is also changed.

changelog: Suggest similar lint name on `unknown_clippy_lints`
