### PR TITLE
Prevent `replace_consts` lint within match patterns

### DIFF
--- a/tests/ui/replace_consts.fixed
+++ b/tests/ui/replace_consts.fixed
@@ -76,10 +76,20 @@ fn good() {
     { let foo = u64::max_value(); };
     { let foo = u128::max_value(); };
 
-    let _ = match 42 {
+    let x = 42;
+
+    let _ = match x {
         std::i8::MIN => -1,
         1..=std::i8::MAX => 1,
         _ => 0
+    };
+
+    let _ = if let std::i8::MIN = x {
+        -1
+    } else if let 1..=std::i8::MAX = x {
+        1
+    } else {
+        0
     };
 }
 

--- a/tests/ui/replace_consts.fixed
+++ b/tests/ui/replace_consts.fixed
@@ -75,6 +75,12 @@ fn good() {
     { let foo = u32::max_value(); };
     { let foo = u64::max_value(); };
     { let foo = u128::max_value(); };
+
+    let _ = match 42 {
+        std::i8::MIN => -1,
+        1..=std::i8::MAX => 1,
+        _ => 0
+    };
 }
 
 fn main() {

--- a/tests/ui/replace_consts.rs
+++ b/tests/ui/replace_consts.rs
@@ -76,10 +76,20 @@ fn good() {
     { let foo = u64::max_value(); };
     { let foo = u128::max_value(); };
 
-    let _ = match 42 {
+    let x = 42;
+
+    let _ = match x {
         std::i8::MIN => -1,
         1..=std::i8::MAX => 1,
         _ => 0
+    };
+
+    let _ = if let std::i8::MIN = x {
+        -1
+    } else if let 1..=std::i8::MAX = x {
+        1
+    } else {
+        0
     };
 }
 

--- a/tests/ui/replace_consts.rs
+++ b/tests/ui/replace_consts.rs
@@ -75,6 +75,12 @@ fn good() {
     { let foo = u32::max_value(); };
     { let foo = u64::max_value(); };
     { let foo = u128::max_value(); };
+
+    let _ = match 42 {
+        std::i8::MIN => -1,
+        1..=std::i8::MAX => 1,
+        _ => 0
+    };
 }
 
 fn main() {


### PR DESCRIPTION
Currently `replace_consts` lint applies within match patterns but the suggestion is incorrect as function calls are disallowed in them. To fix this we prevent the lint from firing within patterns.

Fixes #4969 

changelog: Fix false positive in `replace_consts` lint

