### PR TITLE
Fix false positive in missing_const_for_fn

### DIFF
--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -89,4 +89,29 @@ mod with_drop {
             B
         }
     }
+
+    struct CustomDrop {
+        field: i32,
+    }
+
+    impl Drop for CustomDrop {
+        fn drop(&mut self) {}
+    }
+
+    struct Bar {
+        field: CustomDrop,
+    }
+
+    impl Bar {
+        fn take(self) -> CustomDrop {
+            self.field
+        }
+    }
+
+    fn take() -> CustomDrop {
+        let x = Bar {
+            field: CustomDrop { field: 1 },
+        };
+        x.field
+    }
 }


### PR DESCRIPTION
This fixes some additional false positives with functions or methods
that return types which implement drop. Since `drop` can't be
const-evaluated, these cases can't be made const.

changelog: Fix false positive in [`missing_const_for_fn`]

Fixes #4979