### PR TITLE
Remove use of `try!` from documentation

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -65,7 +65,7 @@ declare_clippy_lint! {
     ///
     /// **Why is this bad?** `result.unwrap()` will let the thread panic on `Err`
     /// values. Normally, you want to implement more sophisticated error handling,
-    /// and propagate errors upwards with `try!`.
+    /// and propagate errors upwards with `?` operator.
     ///
     /// Even if you want to panic on errors, not all `Error`s implement good
     /// messages on display. Therefore, it may be beneficial to look at the places
@@ -127,7 +127,7 @@ declare_clippy_lint! {
     ///
     /// **Why is this bad?** `result.expect()` will let the thread panic on `Err`
     /// values. Normally, you want to implement more sophisticated error handling,
-    /// and propagate errors upwards with `try!`.
+    /// and propagate errors upwards with `?` operator.
     ///
     /// **Known problems:** None.
     ///

--- a/clippy_lints/src/ok_if_let.rs
+++ b/clippy_lints/src/ok_if_let.rs
@@ -15,18 +15,18 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```ignore
-    /// for result in iter {
-    ///     if let Some(bench) = try!(result).parse().ok() {
-    ///         vec.push(bench)
+    /// for i in iter {
+    ///     if let Some(value) = i.parse().ok() {
+    ///         vec.push(value)
     ///     }
     /// }
     /// ```
     /// Could be written:
     ///
     /// ```ignore
-    /// for result in iter {
-    ///     if let Ok(bench) = try!(result).parse() {
-    ///         vec.push(bench)
+    /// for i in iter {
+    ///     if let Ok(value) = i.parse() {
+    ///         vec.push(value)
     ///     }
     /// }
     /// ```


### PR DESCRIPTION
Makes documentation more modern and directer

changelog: none
