### PR TITLE
Autogenerate new lints

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1090,6 +1090,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&utils::internal_lints::LINT_WITHOUT_LINT_PASS),
         LintId::of(&utils::internal_lints::OUTER_EXPN_EXPN_DATA),
         LintId::of(&utils::internal_lints::PRODUCE_ICE),
+        LintId::of(&utils::internal_lints::DEFAULT_LINT),
     ]);
 
     store.register_group(true, "clippy::all", Some("clippy"), vec![

--- a/tests/ui/default_lint.rs
+++ b/tests/ui/default_lint.rs
@@ -1,0 +1,28 @@
+#![deny(clippy::internal)]
+#![feature(rustc_private)]
+
+#[macro_use]
+extern crate rustc;
+#[macro_use]
+extern crate rustc_session;
+extern crate rustc_lint;
+use rustc_lint::{LintArray, LintPass};
+
+declare_tool_lint! {
+    pub clippy::TEST_LINT,
+    Warn,
+    "",
+    report_in_external_macro: true
+}
+
+declare_tool_lint! {
+    pub clippy::TEST_LINT_DEFAULT,
+    Warn,
+    "default lint description",
+    report_in_external_macro: true
+}
+
+declare_lint_pass!(Pass => [TEST_LINT]);
+declare_lint_pass!(Pass2 => [TEST_LINT_DEFAULT]);
+
+fn main() {}

--- a/tests/ui/default_lint.stderr
+++ b/tests/ui/default_lint.stderr
@@ -1,0 +1,21 @@
+error: the lint `TEST_LINT_DEFAULT` has the default lint description
+  --> $DIR/default_lint.rs:18:1
+   |
+LL | / declare_tool_lint! {
+LL | |     pub clippy::TEST_LINT_DEFAULT,
+LL | |     Warn,
+LL | |     "default lint description",
+LL | |     report_in_external_macro: true
+LL | | }
+   | |_^
+   |
+note: lint level defined here
+  --> $DIR/default_lint.rs:1:9
+   |
+LL | #![deny(clippy::internal)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: `#[deny(clippy::default_lint)]` implied by `#[deny(clippy::internal)]`
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Add option in clippy_dev to automatically generate boilerplate code for adding new lints

example: 

`./util/dev new_lint --name=iter_nth_zero --type=late`

Fixes #4942 

changelog: none