### PR TITLE
Normalize lint messages

### DIFF
--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -209,7 +209,7 @@ fn lint_misrefactored_assign_op(
                 db.span_suggestion(
                     expr.span,
                     &format!(
-                        "Did you mean {} = {} {} {} or {}? Consider replacing it with",
+                        "Did you mean `{} = {} {} {}` or `{}`? Consider replacing it with",
                         snip_a,
                         snip_a,
                         op.node.as_str(),

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -187,7 +187,7 @@ declare_clippy_lint! {
     /// ```
     pub DEPRECATED_CFG_ATTR,
     complexity,
-    "usage of `cfg_attr(rustfmt)` instead of `tool_attributes`"
+    "usage of `cfg_attr(rustfmt)` instead of tool attributes"
 }
 
 declare_lint_pass!(Attributes => [
@@ -520,7 +520,7 @@ impl EarlyLintPass for DeprecatedCfgAttribute {
                     cx,
                     DEPRECATED_CFG_ATTR,
                     attr.span,
-                    "`cfg_attr` is deprecated for rustfmt and got replaced by `tool_attributes`",
+                    "`cfg_attr` is deprecated for rustfmt and got replaced by tool attributes",
                     "use",
                     "#[rustfmt::skip]".to_string(),
                     Applicability::MachineApplicable,

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -449,7 +449,7 @@ fn check_attrs(cx: &LateContext<'_, '_>, span: Span, name: Name, attrs: &[Attrib
                         EMPTY_LINE_AFTER_OUTER_ATTR,
                         begin_of_attr_to_item,
                         "Found an empty line after an outer attribute. \
-                         Perhaps you forgot to add a '!' to make it an inner attribute?",
+                         Perhaps you forgot to add a `!` to make it an inner attribute?",
                     );
                 }
             }
@@ -520,7 +520,7 @@ impl EarlyLintPass for DeprecatedCfgAttribute {
                     cx,
                     DEPRECATED_CFG_ATTR,
                     attr.span,
-                    "`cfg_attr` is deprecated for rustfmt and got replaced by tool_attributes",
+                    "`cfg_attr` is deprecated for rustfmt and got replaced by `tool_attributes`",
                     "use",
                     "#[rustfmt::skip]".to_string(),
                     Applicability::MachineApplicable,

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -68,8 +68,8 @@ impl<'a, 'tcx> Visitor<'tcx> for ExVisitor<'a, 'tcx> {
 }
 
 const BRACED_EXPR_MESSAGE: &str = "omit braces around single expression condition";
-const COMPLEX_BLOCK_MESSAGE: &str = "in an 'if' condition, avoid complex blocks or closures with blocks; \
-                                     instead, move the block or closure higher and bind it with a 'let'";
+const COMPLEX_BLOCK_MESSAGE: &str = "in an `if` condition, avoid complex blocks or closures with blocks; \
+                                     instead, move the block or closure higher and bind it with a `let`";
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BlockInIfCondition {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>) {

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -138,7 +138,7 @@ fn check_collapsible_no_if_let(cx: &EarlyContext<'_>, expr: &ast::Expr, check: &
             if expr.span.ctxt() != inner.span.ctxt() {
                 return;
             }
-            span_lint_and_then(cx, COLLAPSIBLE_IF, expr.span, "this if statement can be collapsed", |db| {
+            span_lint_and_then(cx, COLLAPSIBLE_IF, expr.span, "this `if` statement can be collapsed", |db| {
                 let lhs = Sugg::ast(cx, check, "..");
                 let rhs = Sugg::ast(cx, check_inner, "..");
                 db.span_suggestion(

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     /// ```
     pub IFS_SAME_COND,
     correctness,
-    "consecutive `ifs` with the same condition"
+    "consecutive `if`s with the same condition"
 }
 
 declare_clippy_lint! {
@@ -85,7 +85,7 @@ declare_clippy_lint! {
     /// ```
     pub SAME_FUNCTIONS_IN_IF_CONDITION,
     pedantic,
-    "consecutive `ifs` with the same function call"
+    "consecutive `if`s with the same function call"
 }
 
 declare_clippy_lint! {
@@ -106,7 +106,7 @@ declare_clippy_lint! {
     /// ```
     pub IF_SAME_THEN_ELSE,
     correctness,
-    "if with the same *then* and *else* blocks"
+    "`if` with the same `then` and `else` blocks"
 }
 
 declare_clippy_lint! {
@@ -206,7 +206,7 @@ fn lint_same_cond(cx: &LateContext<'_, '_>, conds: &[&Expr<'_>]) {
             cx,
             IFS_SAME_COND,
             j.span,
-            "this `if` has the same condition as a previous if",
+            "this `if` has the same condition as a previous `if`",
             i.span,
             "same as this",
         );
@@ -234,7 +234,7 @@ fn lint_same_fns_in_if_cond(cx: &LateContext<'_, '_>, conds: &[&Expr<'_>]) {
             cx,
             SAME_FUNCTIONS_IN_IF_CONDITION,
             j.span,
-            "this `if` has the same function call as a previous if",
+            "this `if` has the same function call as a previous `if`",
             i.span,
             "same as this",
         );
@@ -300,7 +300,7 @@ fn lint_match_arms<'tcx>(cx: &LateContext<'_, 'tcx>, expr: &Expr<'_>) {
                         db.span_note(
                             i.body.span,
                             &format!(
-                                "`{}` has the same arm body as the `_` wildcard, consider removing it`",
+                                "`{}` has the same arm body as the `_` wildcard, consider removing it",
                                 lhs
                             ),
                         );

--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```
     pub DEFAULT_TRAIT_ACCESS,
     pedantic,
-    "checks for literal calls to Default::default()"
+    "checks for literal calls to `Default::default()`"
 }
 
 declare_lint_pass!(DefaultTraitAccess => [DEFAULT_TRAIT_ACCESS]);
@@ -62,7 +62,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DefaultTraitAccess {
                                 cx,
                                 DEFAULT_TRAIT_ACCESS,
                                 expr.span,
-                                &format!("Calling {} is more clear than this expression", replacement),
+                                &format!("Calling `{}` is more clear than this expression", replacement),
                                 "try",
                                 replacement,
                                 Applicability::Unspecified, // First resolve the TODO above

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -102,9 +102,9 @@ const DROP_REF_SUMMARY: &str = "calls to `std::mem::drop` with a reference inste
                                 Dropping a reference does nothing.";
 const FORGET_REF_SUMMARY: &str = "calls to `std::mem::forget` with a reference instead of an owned value. \
                                   Forgetting a reference does nothing.";
-const DROP_COPY_SUMMARY: &str = "calls to `std::mem::drop` with a value that implements Copy. \
+const DROP_COPY_SUMMARY: &str = "calls to `std::mem::drop` with a value that implements `Copy`. \
                                  Dropping a copy leaves the original intact.";
-const FORGET_COPY_SUMMARY: &str = "calls to `std::mem::forget` with a value that implements Copy. \
+const FORGET_COPY_SUMMARY: &str = "calls to `std::mem::forget` with a value that implements `Copy`. \
                                    Forgetting a copy leaves the original intact.";
 
 declare_lint_pass!(DropForgetRef => [DROP_REF, FORGET_REF, DROP_COPY, FORGET_COPY]);
@@ -137,7 +137,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DropForgetRef {
                                        expr.span,
                                        &msg,
                                        arg.span,
-                                       &format!("argument has type {}", arg_ty));
+                                       &format!("argument has type `{}`", arg_ty));
                 } else if is_copy(cx, arg_ty) {
                     if match_def_path(cx, def_id, &paths::DROP) {
                         lint = DROP_COPY;

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// ```
     pub ELSE_IF_WITHOUT_ELSE,
     restriction,
-    "if expression with an `else if`, but without a final `else` branch"
+    "`if` expression with an `else if`, but without a final `else` branch"
 }
 
 declare_lint_pass!(ElseIfWithoutElse => [ELSE_IF_WITHOUT_ELSE]);
@@ -60,7 +60,7 @@ impl EarlyLintPass for ElseIfWithoutElse {
                     cx,
                     ELSE_IF_WITHOUT_ELSE,
                     els.span,
-                    "if expression with an `else if`, but without a final `else`",
+                    "`if` expression with an `else if`, but without a final `else`",
                     "add an `else` block here",
                 );
             }

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -46,9 +46,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessFormat {
 
         // Operate on the only argument of `alloc::fmt::format`.
         if let Some(sugg) = on_new_v1(cx, expr) {
-            span_useless_format(cx, span, "consider using .to_string()", sugg);
+            span_useless_format(cx, span, "consider using `.to_string()`", sugg);
         } else if let Some(sugg) = on_new_v1_fmt(cx, expr) {
-            span_useless_format(cx, span, "consider using .to_string()", sugg);
+            span_useless_format(cx, span, "consider using `.to_string()`", sugg);
         }
     }
 }

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -61,7 +61,7 @@ impl EarlyLintPass for IfNotElse {
                             IF_NOT_ELSE,
                             item.span,
                             "Unnecessary boolean `not` operation",
-                            "remove the `!` and swap the blocks of the if/else",
+                            "remove the `!` and swap the blocks of the `if`/`else`",
                         );
                     },
                     ExprKind::Binary(ref kind, _, _) if kind.node == BinOpKind::Ne => {
@@ -70,7 +70,7 @@ impl EarlyLintPass for IfNotElse {
                             IF_NOT_ELSE,
                             item.span,
                             "Unnecessary `!=` operation",
-                            "change to `==` and swap the blocks of the if/else",
+                            "change to `==` and swap the blocks of the `if`/`else`",
                         );
                     },
                     _ => (),

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -51,7 +51,7 @@ fn lint(cx: &LateContext<'_, '_>, outer_span: Span, inner_span: Span, msg: &str)
     let outer_span = outer_span.source_callsite();
     let inner_span = inner_span.source_callsite();
 
-    span_lint_and_then(cx, IMPLICIT_RETURN, outer_span, "missing return statement", |db| {
+    span_lint_and_then(cx, IMPLICIT_RETURN, outer_span, "missing `return` statement", |db| {
         if let Some(snippet) = snippet_opt(cx, inner_span) {
             db.span_suggestion(
                 outer_span,
@@ -102,7 +102,7 @@ fn expr_match(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
                     expr_match(cx, &arm.body);
                 }
             } else {
-                expr_match(cx, &arms.first().expect("if let doesn't have a single arm").body);
+                expr_match(cx, &arms.first().expect("`if let` doesn't have a single arm").body);
             }
         },
         // skip if it already has a return statement

--- a/clippy_lints/src/infallible_destructuring_match.rs
+++ b/clippy_lints/src/infallible_destructuring_match.rs
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     /// ```
     pub INFALLIBLE_DESTRUCTURING_MATCH,
     style,
-    "a match statement with a single infallible arm instead of a `let`"
+    "a `match` statement with a single infallible arm instead of a `let`"
 }
 
 declare_lint_pass!(InfallibleDestructingMatch => [INFALLIBLE_DESTRUCTURING_MATCH]);
@@ -61,7 +61,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InfallibleDestructingMatch {
                     cx,
                     INFALLIBLE_DESTRUCTURING_MATCH,
                     local.span,
-                    "you seem to be trying to use match to destructure a single infallible pattern. \
+                    "you seem to be trying to use `match` to destructure a single infallible pattern. \
                      Consider using `let`",
                     "try this",
                     format!(

--- a/clippy_lints/src/inherent_to_string.rs
+++ b/clippy_lints/src/inherent_to_string.rs
@@ -88,7 +88,7 @@ declare_clippy_lint! {
     /// ```
     pub INHERENT_TO_STRING_SHADOW_DISPLAY,
     correctness,
-    "type implements inherent method `to_string()`, which gets shadowed by the implementation of the `Display` trait "
+    "type implements inherent method `to_string()`, which gets shadowed by the implementation of the `Display` trait"
 }
 
 declare_lint_pass!(InherentToString => [INHERENT_TO_STRING, INHERENT_TO_STRING_SHADOW_DISPLAY]);

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// ```
     pub INT_PLUS_ONE,
     complexity,
-    "instead of using x >= y + 1, use x > y"
+    "instead of using `x >= y + 1`, use `x > y`"
 }
 
 declare_lint_pass!(IntPlusOne => [INT_PLUS_ONE]);

--- a/clippy_lints/src/large_stack_arrays.rs
+++ b/clippy_lints/src/large_stack_arrays.rs
@@ -59,7 +59,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeStackArrays {
                         self.maximum_allowed_size
                     ),
                     &format!(
-                        "consider allocating on the heap with vec!{}.into_boxed_slice()",
+                        "consider allocating on the heap with `vec!{}.into_boxed_slice()`",
                         snippet(cx, expr.span, "[...]")
                     ),
                 );

--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// ```
     pub LET_UNDERSCORE_MUST_USE,
     restriction,
-    "non-binding let on a #[must_use] expression"
+    "non-binding let on a `#[must_use]` expression"
 }
 
 declare_lint_pass!(LetUnderscore => [LET_UNDERSCORE_MUST_USE]);
@@ -44,7 +44,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnderscore {
                         cx,
                         LET_UNDERSCORE_MUST_USE,
                         stmt.span,
-                        "non-binding let on an expression with #[must_use] type",
+                        "non-binding let on an expression with `#[must_use]` type",
                         "consider explicitly using expression value"
                     )
                 } else if is_must_use_func_call(cx, init) {
@@ -52,7 +52,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnderscore {
                         cx,
                         LET_UNDERSCORE_MUST_USE,
                         stmt.span,
-                        "non-binding let on a result of a #[must_use] function",
+                        "non-binding let on a result of a `#[must_use]` function",
                         "consider explicitly using function result"
                     )
                 }

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1353,7 +1353,7 @@ fn check_for_loop_arg(cx: &LateContext<'_, '_>, pat: &Pat<'_>, arg: &Expr<'_>, e
                         EXPLICIT_INTO_ITER_LOOP,
                         arg.span,
                         "it is more concise to loop over containers instead of using explicit \
-                         iteration methods`",
+                         iteration methods",
                         "to write this more concisely, try",
                         object.to_string(),
                         applicability,

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -112,7 +112,7 @@ fn lint_needless_cloning(cx: &LateContext<'_, '_>, root: Span, receiver: Span) {
         MAP_CLONE,
         root.trim_start(receiver).unwrap(),
         "You are needlessly cloning iterator elements",
-        "Remove the map call",
+        "Remove the `map` call",
         String::new(),
         Applicability::MachineApplicable,
     )

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -48,7 +48,7 @@ declare_clippy_lint! {
     /// ```
     pub OPTION_MAP_UNIT_FN,
     complexity,
-    "using `option.map(f)`, where f is a function or closure that returns ()"
+    "using `option.map(f)`, where `f` is a function or closure that returns `()`"
 }
 
 declare_clippy_lint! {
@@ -89,7 +89,7 @@ declare_clippy_lint! {
     /// ```
     pub RESULT_MAP_UNIT_FN,
     complexity,
-    "using `result.map(f)`, where f is a function or closure that returns ()"
+    "using `result.map(f)`, where `f` is a function or closure that returns `()`"
 }
 
 declare_lint_pass!(MapUnit => [OPTION_MAP_UNIT_FN, RESULT_MAP_UNIT_FN]);
@@ -199,7 +199,7 @@ fn let_binding_name(cx: &LateContext<'_, '_>, var_arg: &hir::Expr<'_>) -> String
 #[must_use]
 fn suggestion_msg(function_type: &str, map_type: &str) -> String {
     format!(
-        "called `map(f)` on an {0} value where `f` is a unit {1}",
+        "called `map(f)` on an `{0}` value where `f` is a unit {1}",
         map_type, function_type
     )
 }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     /// ```
     pub SINGLE_MATCH,
     style,
-    "a match statement with a single nontrivial arm (i.e., where the other arm is `_ => {}`) instead of `if let`"
+    "a `match` statement with a single nontrivial arm (i.e., where the other arm is `_ => {}`) instead of `if let`"
 }
 
 declare_clippy_lint! {
@@ -76,7 +76,7 @@ declare_clippy_lint! {
     /// ```
     pub SINGLE_MATCH_ELSE,
     pedantic,
-    "a match statement with two arms where the second arm's pattern is a placeholder instead of a specific match pattern"
+    "a `match` statement with two arms where the second arm's pattern is a placeholder instead of a specific match pattern"
 }
 
 declare_clippy_lint! {
@@ -99,7 +99,7 @@ declare_clippy_lint! {
     /// ```
     pub MATCH_REF_PATS,
     style,
-    "a match or `if let` with all arms prefixed with `&` instead of deref-ing the match expression"
+    "a `match` or `if let` with all arms prefixed with `&` instead of deref-ing the match expression"
 }
 
 declare_clippy_lint! {
@@ -133,7 +133,7 @@ declare_clippy_lint! {
     /// ```
     pub MATCH_BOOL,
     style,
-    "a match on a boolean expression instead of an `if..else` block"
+    "a `match` on a boolean expression instead of an `if..else` block"
 }
 
 declare_clippy_lint! {
@@ -155,7 +155,7 @@ declare_clippy_lint! {
     /// ```
     pub MATCH_OVERLAPPING_ARM,
     style,
-    "a match with overlapping arms"
+    "a `match` with overlapping arms"
 }
 
 declare_clippy_lint! {
@@ -177,7 +177,7 @@ declare_clippy_lint! {
     /// ```
     pub MATCH_WILD_ERR_ARM,
     style,
-    "a match with `Err(_)` arm and take drastic actions"
+    "a `match` with `Err(_)` arm and take drastic actions"
 }
 
 declare_clippy_lint! {
@@ -198,7 +198,7 @@ declare_clippy_lint! {
     /// ```
     pub MATCH_AS_REF,
     complexity,
-    "a match on an Option value instead of using `as_ref()` or `as_mut`"
+    "a `match` on an Option value instead of using `as_ref()` or `as_mut`"
 }
 
 declare_clippy_lint! {
@@ -407,7 +407,7 @@ fn check_match_bool(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>], e
                         if let Some(sugg) = sugg {
                             db.span_suggestion(
                                 expr.span,
-                                "consider using an if/else expression",
+                                "consider using an `if`/`else` expression",
                                 sugg,
                                 Applicability::HasPlaceholders,
                             );
@@ -461,10 +461,10 @@ fn check_wild_err_arm(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>])
                         span_note_and_lint(cx,
                                            MATCH_WILD_ERR_ARM,
                                            arm.pat.span,
-                                           "Err(_) will match all errors, maybe not a good idea",
+                                           "`Err(_)` will match all errors, maybe not a good idea",
                                            arm.pat.span,
                                            "to remove this warning, match each error separately \
-                                            or use unreachable macro");
+                                            or use `unreachable!` macro");
                     }
                 }
             }
@@ -650,7 +650,7 @@ fn check_match_as_ref(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>],
                 cx,
                 MATCH_AS_REF,
                 expr.span,
-                &format!("use {}() instead", suggestion),
+                &format!("use `{}()` instead", suggestion),
                 "try this",
                 format!(
                     "{}.{}(){}",

--- a/clippy_lints/src/mem_discriminant.rs
+++ b/clippy_lints/src/mem_discriminant.rs
@@ -25,7 +25,7 @@ declare_clippy_lint! {
     /// ```
     pub MEM_DISCRIMINANT_NON_ENUM,
     correctness,
-    "calling mem::descriminant on non-enum type"
+    "calling `mem::descriminant` on non-enum type"
 }
 
 declare_lint_pass!(MemDiscriminant => [MEM_DISCRIMINANT_NON_ENUM]);

--- a/clippy_lints/src/mem_forget.rs
+++ b/clippy_lints/src/mem_forget.rs
@@ -35,7 +35,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemForget {
                         let forgot_ty = cx.tables.expr_ty(&args[0]);
 
                         if forgot_ty.ty_adt_def().map_or(false, |def| def.has_dtor(cx.tcx)) {
-                            span_lint(cx, MEM_FORGET, e.span, "usage of mem::forget on Drop type");
+                            span_lint(cx, MEM_FORGET, e.span, "usage of `mem::forget` on `Drop` type");
                         }
                     }
                 }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1828,7 +1828,7 @@ fn lint_clone_on_ref_ptr(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, arg: &h
             cx,
             CLONE_ON_REF_PTR,
             expr.span,
-            "using '.clone()' on a ref-counted pointer",
+            "using `.clone()` on a ref-counted pointer",
             "try this",
             format!(
                 "{}::<{}>::clone(&{})",
@@ -2220,8 +2220,8 @@ fn lint_unwrap(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, unwrap_args: &[hi
             lint,
             expr.span,
             &format!(
-                "used unwrap() on {} value. If you don't want to handle the {} case gracefully, consider \
-                 using expect() to provide a better panic \
+                "used `unwrap()` on `{}` value. If you don't want to handle the `{}` case gracefully, consider \
+                 using `expect()` to provide a better panic \
                  message",
                 kind, none_value
             ),
@@ -2247,7 +2247,7 @@ fn lint_expect(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, expect_args: &[hi
             lint,
             expr.span,
             &format!(
-                "used expect() on {} value. If this value is an {} it will panic",
+                "used `expect()` on `{}` value. If this value is an `{}` it will panic",
                 kind, none_value
             ),
         );
@@ -2268,7 +2268,7 @@ fn lint_ok_expect(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, ok_args: &[hir
                 cx,
                 OK_EXPECT,
                 expr.span,
-                "called `ok().expect()` on a Result value. You can call `expect` directly on the `Result`",
+                "called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`",
             );
         }
     }
@@ -2286,7 +2286,7 @@ fn lint_map_flatten<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr<
         span_lint_and_then(cx, MAP_FLATTEN, expr.span, msg, |db| {
             db.span_suggestion(
                 expr.span,
-                "try using flat_map instead",
+                "try using `flat_map` instead",
                 hint,
                 Applicability::MachineApplicable,
             );
@@ -2320,10 +2320,10 @@ fn lint_map_unwrap_or_else<'a, 'tcx>(
 
         // lint message
         let msg = if is_option {
-            "called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling \
+            "called `map(f).unwrap_or_else(g)` on an `Option` value. This can be done more directly by calling \
              `map_or_else(g, f)` instead"
         } else {
-            "called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling \
+            "called `map(f).unwrap_or_else(g)` on a `Result` value. This can be done more directly by calling \
              `.map_or_else(g, f)` instead"
         };
         // get snippets for args to map() and unwrap_or_else()
@@ -2380,7 +2380,7 @@ fn lint_map_or_none<'a, 'tcx>(
 
         if map_or_arg_is_none {
             // lint message
-            let msg = "called `map_or(None, f)` on an Option value. This can be done more directly by calling \
+            let msg = "called `map_or(None, f)` on an `Option` value. This can be done more directly by calling \
                        `and_then(f)` instead";
             let map_or_self_snippet = snippet(cx, map_or_args[0].span, "..");
             let map_or_func_snippet = snippet(cx, map_or_args[2].span, "..");
@@ -2388,7 +2388,7 @@ fn lint_map_or_none<'a, 'tcx>(
             span_lint_and_then(cx, OPTION_MAP_OR_NONE, expr.span, msg, |db| {
                 db.span_suggestion(
                     expr.span,
-                    "try using and_then instead",
+                    "try using `and_then` instead",
                     hint,
                     Applicability::MachineApplicable, // snippet
                 );
@@ -2860,7 +2860,7 @@ fn lint_single_char_pattern<'a, 'tcx>(
                 SINGLE_CHAR_PATTERN,
                 arg.span,
                 "single-character string constant used as pattern",
-                "try using a char instead",
+                "try using a `char` instead",
                 hint,
                 applicability,
             );
@@ -2928,7 +2928,7 @@ fn lint_into_iter(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, self_ref_ty: T
             INTO_ITER_ON_REF,
             method_span,
             &format!(
-                "this .into_iter() call is equivalent to .{}() and will not move the {}",
+                "this `.into_iter()` call is equivalent to `.{}()` and will not move the `{}`",
                 method_name, kind,
             ),
             "call directly",

--- a/clippy_lints/src/methods/option_map_unwrap_or.rs
+++ b/clippy_lints/src/methods/option_map_unwrap_or.rs
@@ -60,7 +60,7 @@ pub(super) fn lint<'a, 'tcx>(
             "map_or(a, f)"
         };
         let msg = &format!(
-            "called `map(f).unwrap_or({})` on an Option value. \
+            "called `map(f).unwrap_or({})` on an `Option` value. \
              This can be done more directly by calling `{}` instead",
             arg, suggest
         );

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -45,7 +45,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MinMaxPass {
                             cx,
                             MIN_MAX,
                             expr.span,
-                            "this min/max combination leads to constant result",
+                            "this `min`/`max` combination leads to constant result",
                         );
                     },
                 }

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -63,7 +63,7 @@ declare_clippy_lint! {
     /// ```
     pub CMP_NAN,
     correctness,
-    "comparisons to NAN, which will always return false, probably not intended"
+    "comparisons to `NAN`, which will always return false, probably not intended"
 }
 
 declare_clippy_lint! {
@@ -194,7 +194,7 @@ declare_clippy_lint! {
     /// ```
     pub ZERO_PTR,
     style,
-    "using 0 as *{const, mut} T"
+    "using `0 as *{const, mut} T`"
 }
 
 declare_clippy_lint! {
@@ -370,9 +370,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                         }
                     }
                     let (lint, msg) = if is_named_constant(cx, left) || is_named_constant(cx, right) {
-                        (FLOAT_CMP_CONST, "strict comparison of f32 or f64 constant")
+                        (FLOAT_CMP_CONST, "strict comparison of `f32` or `f64` constant")
                     } else {
-                        (FLOAT_CMP, "strict comparison of f32 or f64")
+                        (FLOAT_CMP, "strict comparison of `f32` or `f64`")
                     };
                     span_lint_and_then(cx, lint, expr.span, msg, |db| {
                         let lhs = Sugg::hir(cx, left, "..");
@@ -388,7 +388,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                             ),
                             Applicability::HasPlaceholders, // snippet
                         );
-                        db.span_note(expr.span, "std::f32::EPSILON and std::f64::EPSILON are available.");
+                        db.span_note(expr.span, "`std::f32::EPSILON` and `std::f64::EPSILON` are available.");
                     });
                 } else if op == BinOpKind::Rem && is_integer_const(cx, right, 1) {
                     span_lint(cx, MODULO_ONE, expr.span, "any number modulo 1 will be 0");
@@ -456,7 +456,7 @@ fn check_nan(cx: &LateContext<'_, '_>, expr: &Expr<'_>, cmp_expr: &Expr<'_>) {
                     cx,
                     CMP_NAN,
                     cmp_expr.span,
-                    "doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead",
+                    "doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead",
                 );
             }
         }

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -113,7 +113,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
                 cx.tcx.sess.span_err(span, &err);
             }
         } else {
-            span_lint(cx, MISSING_CONST_FOR_FN, span, "this could be a `const_fn`");
+            span_lint(cx, MISSING_CONST_FOR_FN, span, "this could be a `const fn`");
         }
     }
 }

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -113,7 +113,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingConstForFn {
                 cx.tcx.sess.span_err(span, &err);
             }
         } else {
-            span_lint(cx, MISSING_CONST_FOR_FN, span, "this could be a const_fn");
+            span_lint(cx, MISSING_CONST_FOR_FN, span, "this could be a `const_fn`");
         }
     }
 }

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -54,7 +54,7 @@ declare_clippy_lint! {
     /// ```
     pub MISSING_INLINE_IN_PUBLIC_ITEMS,
     restriction,
-    "detects missing #[inline] attribute for public callables (functions, trait methods, methods...)"
+    "detects missing `#[inline]` attribute for public callables (functions, trait methods, methods...)"
 }
 
 fn check_missing_inline_attrs(cx: &LateContext<'_, '_>, attrs: &[ast::Attribute], sp: Span, desc: &'static str) {

--- a/clippy_lints/src/mul_add.rs
+++ b/clippy_lints/src/mul_add.rs
@@ -75,7 +75,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MulAddCheck {
                             cx,
                             MANUAL_MUL_ADD,
                             expr.span,
-                            "consider using mul_add() for better numerical precision",
+                            "consider using `mul_add()` for better numerical precision",
                             "try",
                             format!(
                                 "{}.mul_add({}, {})",
@@ -94,7 +94,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MulAddCheck {
                             cx,
                             MANUAL_MUL_ADD,
                             expr.span,
-                            "consider using mul_add() for better numerical precision",
+                            "consider using `mul_add()` for better numerical precision",
                             "try",
                             format!(
                                 "{}.mul_add({}, {})",

--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// ```
     pub MUTABLE_KEY_TYPE,
     correctness,
-    "Check for mutable Map/Set key type"
+    "Check for mutable `Map`/`Set` key type"
 }
 
 declare_lint_pass!(MutableKeyType => [ MUTABLE_KEY_TYPE ]);

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -63,8 +63,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Mutex {
                 let mutex_param = subst.type_at(0);
                 if let Some(atomic_name) = get_atomic_name(mutex_param) {
                     let msg = format!(
-                        "Consider using an {} instead of a Mutex here. If you just want the locking \
-                         behaviour and not the internal type, consider using Mutex<()>.",
+                        "Consider using an `{}` instead of a `Mutex` here. If you just want the locking \
+                         behavior and not the internal type, consider using `Mutex<()>`.",
                         atomic_name
                     );
                     match mutex_param.kind {

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -113,7 +113,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBool {
                     _ => (),
                 }
             } else {
-                panic!("IfExpr 'then' node is not an ExprKind::Block");
+                panic!("IfExpr `then` node is not an `ExprKind::Block`");
             }
         }
     }

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -274,15 +274,15 @@ struct LintData<'a> {
     block_stmts: &'a [ast::Stmt],
 }
 
-const MSG_REDUNDANT_ELSE_BLOCK: &str = "This else block is redundant.\n";
+const MSG_REDUNDANT_ELSE_BLOCK: &str = "This `else` block is redundant.\n";
 
 const MSG_ELSE_BLOCK_NOT_NEEDED: &str = "There is no need for an explicit `else` block for this `if` \
                                          expression\n";
 
-const DROP_ELSE_BLOCK_AND_MERGE_MSG: &str = "Consider dropping the else clause and merging the code that \
-                                             follows (in the loop) with the if block, like so:\n";
+const DROP_ELSE_BLOCK_AND_MERGE_MSG: &str = "Consider dropping the `else` clause and merging the code that \
+                                             follows (in the loop) with the `if` block, like so:\n";
 
-const DROP_ELSE_BLOCK_MSG: &str = "Consider dropping the else clause, and moving out the code in the else \
+const DROP_ELSE_BLOCK_MSG: &str = "Consider dropping the `else` clause, and moving out the code in the `else` \
                                    block, like so:\n";
 
 fn emit_warning<'a>(ctx: &EarlyContext<'_>, data: &'a LintData<'_>, header: &str, typ: LintType) {

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -206,7 +206,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                         if let ty::Adt(def, ..) = ty.kind {
                             if let Some(span) = cx.tcx.hir().span_if_local(def.did) {
                                 if cx.param_env.can_type_implement_copy(cx.tcx, ty).is_ok() {
-                                    db.span_help(span, "consider marking this type as Copy");
+                                    db.span_help(span, "consider marking this type as `Copy`");
                                 }
                             }
                         }

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// ```
     pub NEG_MULTIPLY,
     style,
-    "multiplying integers with -1"
+    "multiplying integers with `-1`"
 }
 
 declare_lint_pass!(NegMultiply => [NEG_MULTIPLY]);
@@ -48,7 +48,7 @@ fn check_mul(cx: &LateContext<'_, '_>, span: Span, lit: &Expr<'_>, exp: &Expr<'_
         if let Constant::Int(1) = consts::lit_to_constant(&l.node, cx.tables.expr_ty_opt(lit));
         if cx.tables.expr_ty(exp).is_integral();
         then {
-            span_lint(cx, NEG_MULTIPLY, span, "Negation by multiplying with -1");
+            span_lint(cx, NEG_MULTIPLY, span, "Negation by multiplying with `-1`");
         }
     }
 }

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -49,7 +49,7 @@ declare_clippy_lint! {
     /// ```
     pub DECLARE_INTERIOR_MUTABLE_CONST,
     correctness,
-    "declaring const with interior mutability"
+    "declaring `const` with interior mutability"
 }
 
 declare_clippy_lint! {
@@ -81,7 +81,7 @@ declare_clippy_lint! {
     /// ```
     pub BORROW_INTERIOR_MUTABLE_CONST,
     correctness,
-    "referencing const with interior mutability"
+    "referencing `const` with interior mutability"
 }
 
 #[allow(dead_code)]
@@ -98,12 +98,12 @@ impl Source {
         match self {
             Self::Item { item } | Self::Assoc { item, .. } => (
                 DECLARE_INTERIOR_MUTABLE_CONST,
-                "a const item should never be interior mutable",
+                "a `const` item should never be interior mutable",
                 *item,
             ),
             Self::Expr { expr } => (
                 BORROW_INTERIOR_MUTABLE_CONST,
-                "a const item with interior mutability should not be borrowed",
+                "a `const` item with interior mutability should not be borrowed",
                 *expr,
             ),
         }

--- a/clippy_lints/src/open_options.rs
+++ b/clippy_lints/src/open_options.rs
@@ -123,7 +123,7 @@ fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument
                         cx,
                         NONSENSICAL_OPEN_OPTIONS,
                         span,
-                        "the method \"create\" is called more than once",
+                        "the method `create` is called more than once",
                     );
                 } else {
                     create = true
@@ -136,7 +136,7 @@ fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument
                         cx,
                         NONSENSICAL_OPEN_OPTIONS,
                         span,
-                        "the method \"append\" is called more than once",
+                        "the method `append` is called more than once",
                     );
                 } else {
                     append = true
@@ -149,7 +149,7 @@ fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument
                         cx,
                         NONSENSICAL_OPEN_OPTIONS,
                         span,
-                        "the method \"truncate\" is called more than once",
+                        "the method `truncate` is called more than once",
                     );
                 } else {
                     truncate = true
@@ -162,7 +162,7 @@ fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument
                         cx,
                         NONSENSICAL_OPEN_OPTIONS,
                         span,
-                        "the method \"read\" is called more than once",
+                        "the method `read` is called more than once",
                     );
                 } else {
                     read = true
@@ -175,7 +175,7 @@ fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument
                         cx,
                         NONSENSICAL_OPEN_OPTIONS,
                         span,
-                        "the method \"write\" is called more than once",
+                        "the method `write` is called more than once",
                     );
                 } else {
                     write = true
@@ -190,7 +190,7 @@ fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument
             cx,
             NONSENSICAL_OPEN_OPTIONS,
             span,
-            "file opened with \"truncate\" and \"read\"",
+            "file opened with `truncate` and `read`",
         );
     }
     if append && truncate && append_arg && truncate_arg {
@@ -198,7 +198,7 @@ fn check_open_options(cx: &LateContext<'_, '_>, options: &[(OpenOption, Argument
             cx,
             NONSENSICAL_OPEN_OPTIONS,
             span,
-            "file opened with \"append\" and \"truncate\"",
+            "file opened with `append` and `truncate`",
         );
     }
 }

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -137,7 +137,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Ptr {
                     cx,
                     CMP_NULL,
                     expr.span,
-                    "Comparing with null is better expressed by the .is_null() method",
+                    "Comparing with null is better expressed by the `.is_null()` method",
                 );
             }
         }

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -112,7 +112,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Ranges {
                          span_lint(cx,
                                    RANGE_ZIP_WITH_LEN,
                                    expr.span,
-                                   &format!("It is more idiomatic to use {}.iter().enumerate()",
+                                   &format!("It is more idiomatic to use `{}.iter().enumerate()`",
                                             snippet(cx, iter_args[0].span, "_")));
                     }
                 }

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -154,7 +154,7 @@ impl Return {
                     return;
                 }
 
-                span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded return statement", |db| {
+                span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |db| {
                     if let Some(snippet) = snippet_opt(cx, inner_span) {
                         db.span_suggestion(ret_span, "remove `return`", snippet, Applicability::MachineApplicable);
                     }
@@ -162,7 +162,7 @@ impl Return {
             },
             None => match replacement {
                 RetReplacement::Empty => {
-                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded return statement", |db| {
+                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |db| {
                         db.span_suggestion(
                             ret_span,
                             "remove `return`",
@@ -172,7 +172,7 @@ impl Return {
                     });
                 },
                 RetReplacement::Block => {
-                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded return statement", |db| {
+                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |db| {
                         db.span_suggestion(
                             ret_span,
                             "replace `return` with an empty block",
@@ -211,9 +211,9 @@ impl Return {
                     cx,
                     LET_AND_RETURN,
                     retexpr.span,
-                    "returning the result of a let binding from a block",
+                    "returning the result of a `let` binding from a block",
                     |err| {
-                        err.span_label(local.span, "unnecessary let binding");
+                        err.span_label(local.span, "unnecessary `let` binding");
 
                         if let Some(snippet) = snippet_opt(cx, initexpr.span) {
                             err.multipart_suggestion(

--- a/clippy_lints/src/tabs_in_doc_comments.rs
+++ b/clippy_lints/src/tabs_in_doc_comments.rs
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Will be converted to:
-     /// ```rust
+    /// ```rust
     /// ///
     /// /// Struct to hold two strings:
     /// ///     - first        one

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -141,7 +141,7 @@ declare_clippy_lint! {
     /// ```
     pub LINKEDLIST,
     pedantic,
-    "usage of LinkedList, usually a vector is faster, or a more specialized data structure like a VecDeque"
+    "usage of LinkedList, usually a vector is faster, or a more specialized data structure like a `VecDeque`"
 }
 
 declare_clippy_lint! {
@@ -316,7 +316,7 @@ fn check_ty(cx: &LateContext<'_, '_>, hir_ty: &hir::Ty<'_>, is_local: bool) {
                         LINKEDLIST,
                         hir_ty.span,
                         "I see you're using a LinkedList! Perhaps you meant some other data structure?",
-                        "a VecDeque might work",
+                        "a `VecDeque` might work",
                     );
                     return; // don't recurse into the type
                 }
@@ -464,7 +464,7 @@ declare_clippy_lint! {
     /// ```
     pub LET_UNIT_VALUE,
     style,
-    "creating a let binding to a value of unit type, which usually can't be used afterwards"
+    "creating a `let` binding to a value of unit type, which usually can't be used afterwards"
 }
 
 declare_lint_pass!(LetUnitValue => [LET_UNIT_VALUE]);
@@ -998,7 +998,7 @@ fn span_lossless_lint(cx: &LateContext<'_, '_>, expr: &Expr<'_>, op: &Expr<'_>, 
         CAST_LOSSLESS,
         expr.span,
         &format!(
-            "casting {} to {} may become silently lossy if you later change the type",
+            "casting `{}` to `{}` may become silently lossy if you later change the type",
             cast_from, cast_to
         ),
         "try",
@@ -1053,7 +1053,10 @@ fn check_loss_of_sign(cx: &LateContext<'_, '_>, expr: &Expr<'_>, op: &Expr<'_>, 
         cx,
         CAST_SIGN_LOSS,
         expr.span,
-        &format!("casting {} to {} may lose the sign of the value", cast_from, cast_to),
+        &format!(
+            "casting `{}` to `{}` may lose the sign of the value",
+            cast_from, cast_to
+        ),
     );
 }
 
@@ -1098,7 +1101,7 @@ fn check_truncation_and_wrapping(cx: &LateContext<'_, '_>, expr: &Expr<'_>, cast
             CAST_POSSIBLE_TRUNCATION,
             expr.span,
             &format!(
-                "casting {} to {} may truncate the value{}",
+                "casting `{}` to `{}` may truncate the value{}",
                 cast_from,
                 cast_to,
                 match suffix_truncation {
@@ -1115,7 +1118,7 @@ fn check_truncation_and_wrapping(cx: &LateContext<'_, '_>, expr: &Expr<'_>, cast
             CAST_POSSIBLE_WRAP,
             expr.span,
             &format!(
-                "casting {} to {} may wrap around the value{}",
+                "casting `{}` to `{}` may wrap around the value{}",
                 cast_from,
                 cast_to,
                 match suffix_wrap {
@@ -1194,7 +1197,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Casts {
                                 cx,
                                 UNNECESSARY_CAST,
                                 expr.span,
-                                &format!("casting integer literal to {} is unnecessary", cast_to),
+                                &format!("casting integer literal to `{}` is unnecessary", cast_to),
                                 "try",
                                 format!("{}_{}", n, cast_to),
                                 Applicability::MachineApplicable,
@@ -1256,14 +1259,17 @@ fn lint_numeric_casts<'tcx>(
                 cx,
                 CAST_POSSIBLE_TRUNCATION,
                 expr.span,
-                &format!("casting {} to {} may truncate the value", cast_from, cast_to),
+                &format!("casting `{}` to `{}` may truncate the value", cast_from, cast_to),
             );
             if !cast_to.is_signed() {
                 span_lint(
                     cx,
                     CAST_SIGN_LOSS,
                     expr.span,
-                    &format!("casting {} to {} may lose the sign of the value", cast_from, cast_to),
+                    &format!(
+                        "casting `{}` to `{}` may lose the sign of the value",
+                        cast_from, cast_to
+                    ),
                 );
             }
         },
@@ -1278,7 +1284,7 @@ fn lint_numeric_casts<'tcx>(
                     cx,
                     CAST_POSSIBLE_TRUNCATION,
                     expr.span,
-                    "casting f64 to f32 may truncate the value",
+                    "casting `f64` to `f32` may truncate the value",
                 );
             }
             if let (&ty::Float(FloatTy::F32), &ty::Float(FloatTy::F64)) = (&cast_from.kind, &cast_to.kind) {
@@ -1550,7 +1556,7 @@ declare_clippy_lint! {
     /// ```
     pub CHAR_LIT_AS_U8,
     complexity,
-    "casting a character literal to u8 truncates"
+    "casting a character literal to `u8` truncates"
 }
 
 declare_lint_pass!(CharLitAsU8 => [CHAR_LIT_AS_U8]);
@@ -1742,7 +1748,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AbsurdExtremeComparisons {
                         AlwaysFalse => "this comparison is always false".to_owned(),
                         AlwaysTrue => "this comparison is always true".to_owned(),
                         InequalityImpossible => format!(
-                            "the case where the two sides are not equal never occurs, consider using {} == {} \
+                            "the case where the two sides are not equal never occurs, consider using `{} == {}` \
                              instead",
                             snippet(cx, lhs.span, "lhs"),
                             snippet(cx, rhs.span, "rhs")
@@ -1750,7 +1756,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AbsurdExtremeComparisons {
                     };
 
                     let help = format!(
-                        "because {} is the {} value for this type, {}",
+                        "because `{}` is the {} value for this type, {}",
                         snippet(cx, culprit.expr.span, "x"),
                         match culprit.which {
                             Minimum => "minimum",
@@ -1813,7 +1819,7 @@ impl FullInt {
 impl PartialEq for FullInt {
     #[must_use]
     fn eq(&self, other: &Self) -> bool {
-        self.partial_cmp(other).expect("partial_cmp only returns Some(_)") == Ordering::Equal
+        self.partial_cmp(other).expect("`partial_cmp` only returns `Some(_)`") == Ordering::Equal
     }
 }
 
@@ -1832,7 +1838,7 @@ impl Ord for FullInt {
     #[must_use]
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other)
-            .expect("partial_cmp for FullInt can never return None")
+            .expect("`partial_cmp` for FullInt can never return `None`")
     }
 }
 
@@ -2404,7 +2410,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RefToMut {
                     cx,
                     CAST_REF_TO_MUT,
                     expr.span,
-                    "casting &T to &mut T may cause undefined behaviour, consider instead using an UnsafeCell",
+                    "casting `&T` to `&mut T` may cause undefined behavior, consider instead using an `UnsafeCell`",
                 );
             }
         }

--- a/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/clippy_lints/src/unsafe_removed_from_name.rs
@@ -66,7 +66,7 @@ fn unsafe_to_safe_check(old_name: Ident, new_name: Ident, cx: &EarlyContext<'_>,
             UNSAFE_REMOVED_FROM_NAME,
             span,
             &format!(
-                "removed \"unsafe\" from the name of `{}` in use as `{}`",
+                "removed `unsafe` from the name of `{}` in use as `{}`",
                 old_str, new_str
             ),
         );

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// ```
     pub UNNECESSARY_UNWRAP,
     complexity,
-    "checks for calls of unwrap[_err]() that cannot fail"
+    "checks for calls of `unwrap[_err]()` that cannot fail"
 }
 
 declare_clippy_lint! {
@@ -58,7 +58,7 @@ declare_clippy_lint! {
     /// This code will always panic. The if condition should probably be inverted.
     pub PANICKING_UNWRAP,
     correctness,
-    "checks for calls of unwrap[_err]() that will always fail"
+    "checks for calls of `unwrap[_err]()` that will always fail"
 }
 
 /// Visitor that keeps track of which variables are unwrappable.

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -20,7 +20,7 @@ declare_clippy_lint! {
     /// ```
     pub ZERO_DIVIDED_BY_ZERO,
     complexity,
-    "usage of `0.0 / 0.0` to obtain NaN instead of std::f32::NaN or std::f64::NaN"
+    "usage of `0.0 / 0.0` to obtain NaN instead of `std::f32::NAN` or `std::f64::NAN`"
 }
 
 declare_lint_pass!(ZeroDiv => [ZERO_DIVIDED_BY_ZERO]);
@@ -50,7 +50,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ZeroDiv {
                     cx,
                     ZERO_DIVIDED_BY_ZERO,
                     expr.span,
-                    "constant division of 0.0 with 0.0 will always result in NaN",
+                    "constant division of `0.0` with `0.0` will always result in NaN",
                     &format!(
                         "Consider using `std::{}::NAN` if you would like a constant representing NaN",
                         float_type,

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -318,7 +318,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "deprecated_cfg_attr",
         group: "complexity",
-        desc: "usage of `cfg_attr(rustfmt)` instead of `tool_attributes`",
+        desc: "usage of `cfg_attr(rustfmt)` instead of tool attributes",
         deprecation: None,
         module: "attrs",
     },

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -87,7 +87,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "borrow_interior_mutable_const",
         group: "correctness",
-        desc: "referencing const with interior mutability",
+        desc: "referencing `const` with interior mutability",
         deprecation: None,
         module: "non_copy_const",
     },
@@ -178,7 +178,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "char_lit_as_u8",
         group: "complexity",
-        desc: "casting a character literal to u8 truncates",
+        desc: "casting a character literal to `u8` truncates",
         deprecation: None,
         module: "types",
     },
@@ -227,7 +227,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "cmp_nan",
         group: "correctness",
-        desc: "comparisons to NAN, which will always return false, probably not intended",
+        desc: "comparisons to `NAN`, which will always return false, probably not intended",
         deprecation: None,
         module: "misc",
     },
@@ -304,14 +304,14 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "declare_interior_mutable_const",
         group: "correctness",
-        desc: "declaring const with interior mutability",
+        desc: "declaring `const` with interior mutability",
         deprecation: None,
         module: "non_copy_const",
     },
     Lint {
         name: "default_trait_access",
         group: "pedantic",
-        desc: "checks for literal calls to Default::default()",
+        desc: "checks for literal calls to `Default::default()`",
         deprecation: None,
         module: "default_trait_access",
     },
@@ -423,7 +423,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "else_if_without_else",
         group: "restriction",
-        desc: "if expression with an `else if`, but without a final `else` branch",
+        desc: "`if` expression with an `else if`, but without a final `else` branch",
         deprecation: None,
         module: "else_if_without_else",
     },
@@ -710,14 +710,14 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "if_same_then_else",
         group: "correctness",
-        desc: "if with the same *then* and *else* blocks",
+        desc: "`if` with the same `then` and `else` blocks",
         deprecation: None,
         module: "copies",
     },
     Lint {
         name: "ifs_same_cond",
         group: "correctness",
-        desc: "consecutive `ifs` with the same condition",
+        desc: "consecutive `if`s with the same condition",
         deprecation: None,
         module: "copies",
     },
@@ -766,7 +766,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "infallible_destructuring_match",
         group: "style",
-        desc: "a match statement with a single infallible arm instead of a `let`",
+        desc: "a `match` statement with a single infallible arm instead of a `let`",
         deprecation: None,
         module: "infallible_destructuring_match",
     },
@@ -787,7 +787,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "inherent_to_string_shadow_display",
         group: "correctness",
-        desc: "type implements inherent method `to_string()`, which gets shadowed by the implementation of the `Display` trait ",
+        desc: "type implements inherent method `to_string()`, which gets shadowed by the implementation of the `Display` trait",
         deprecation: None,
         module: "inherent_to_string",
     },
@@ -808,7 +808,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "int_plus_one",
         group: "complexity",
-        desc: "instead of using x >= y + 1, use x > y",
+        desc: "instead of using `x >= y + 1`, use `x > y`",
         deprecation: None,
         module: "int_plus_one",
     },
@@ -955,21 +955,21 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "let_underscore_must_use",
         group: "restriction",
-        desc: "non-binding let on a #[must_use] expression",
+        desc: "non-binding let on a `#[must_use]` expression",
         deprecation: None,
         module: "let_underscore",
     },
     Lint {
         name: "let_unit_value",
         group: "style",
-        desc: "creating a let binding to a value of unit type, which usually can\'t be used afterwards",
+        desc: "creating a `let` binding to a value of unit type, which usually can\'t be used afterwards",
         deprecation: None,
         module: "types",
     },
     Lint {
         name: "linkedlist",
         group: "pedantic",
-        desc: "usage of LinkedList, usually a vector is faster, or a more specialized data structure like a VecDeque",
+        desc: "usage of LinkedList, usually a vector is faster, or a more specialized data structure like a `VecDeque`",
         deprecation: None,
         module: "types",
     },
@@ -1046,28 +1046,28 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "match_as_ref",
         group: "complexity",
-        desc: "a match on an Option value instead of using `as_ref()` or `as_mut`",
+        desc: "a `match` on an Option value instead of using `as_ref()` or `as_mut`",
         deprecation: None,
         module: "matches",
     },
     Lint {
         name: "match_bool",
         group: "style",
-        desc: "a match on a boolean expression instead of an `if..else` block",
+        desc: "a `match` on a boolean expression instead of an `if..else` block",
         deprecation: None,
         module: "matches",
     },
     Lint {
         name: "match_overlapping_arm",
         group: "style",
-        desc: "a match with overlapping arms",
+        desc: "a `match` with overlapping arms",
         deprecation: None,
         module: "matches",
     },
     Lint {
         name: "match_ref_pats",
         group: "style",
-        desc: "a match or `if let` with all arms prefixed with `&` instead of deref-ing the match expression",
+        desc: "a `match` or `if let` with all arms prefixed with `&` instead of deref-ing the match expression",
         deprecation: None,
         module: "matches",
     },
@@ -1081,7 +1081,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "match_wild_err_arm",
         group: "style",
-        desc: "a match with `Err(_)` arm and take drastic actions",
+        desc: "a `match` with `Err(_)` arm and take drastic actions",
         deprecation: None,
         module: "matches",
     },
@@ -1095,7 +1095,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "mem_discriminant_non_enum",
         group: "correctness",
-        desc: "calling mem::descriminant on non-enum type",
+        desc: "calling `mem::descriminant` on non-enum type",
         deprecation: None,
         module: "mem_discriminant",
     },
@@ -1165,7 +1165,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "missing_inline_in_public_items",
         group: "restriction",
-        desc: "detects missing #[inline] attribute for public callables (functions, trait methods, methods...)",
+        desc: "detects missing `#[inline]` attribute for public callables (functions, trait methods, methods...)",
         deprecation: None,
         module: "missing_inline",
     },
@@ -1270,7 +1270,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "mutable_key_type",
         group: "correctness",
-        desc: "Check for mutable Map/Set key type",
+        desc: "Check for mutable `Map`/`Set` key type",
         deprecation: None,
         module: "mut_key",
     },
@@ -1382,7 +1382,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "neg_multiply",
         group: "style",
-        desc: "multiplying integers with -1",
+        desc: "multiplying integers with `-1`",
         deprecation: None,
         module: "neg_multiply",
     },
@@ -1480,7 +1480,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "option_map_unit_fn",
         group: "complexity",
-        desc: "using `option.map(f)`, where f is a function or closure that returns ()",
+        desc: "using `option.map(f)`, where `f` is a function or closure that returns `()`",
         deprecation: None,
         module: "map_unit_fn",
     },
@@ -1550,7 +1550,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "panicking_unwrap",
         group: "correctness",
-        desc: "checks for calls of unwrap[_err]() that will always fail",
+        desc: "checks for calls of `unwrap[_err]()` that will always fail",
         deprecation: None,
         module: "unwrap",
     },
@@ -1746,7 +1746,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "result_map_unit_fn",
         group: "complexity",
-        desc: "using `result.map(f)`, where f is a function or closure that returns ()",
+        desc: "using `result.map(f)`, where `f` is a function or closure that returns `()`",
         deprecation: None,
         module: "map_unit_fn",
     },
@@ -1774,7 +1774,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "same_functions_in_if_condition",
         group: "pedantic",
-        desc: "consecutive `ifs` with the same function call",
+        desc: "consecutive `if`s with the same function call",
         deprecation: None,
         module: "copies",
     },
@@ -1844,14 +1844,14 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "single_match",
         group: "style",
-        desc: "a match statement with a single nontrivial arm (i.e., where the other arm is `_ => {}`) instead of `if let`",
+        desc: "a `match` statement with a single nontrivial arm (i.e., where the other arm is `_ => {}`) instead of `if let`",
         deprecation: None,
         module: "matches",
     },
     Lint {
         name: "single_match_else",
         group: "pedantic",
-        desc: "a match statement with two arms where the second arm\'s pattern is a placeholder instead of a specific match pattern",
+        desc: "a `match` statement with two arms where the second arm\'s pattern is a placeholder instead of a specific match pattern",
         deprecation: None,
         module: "matches",
     },
@@ -2159,7 +2159,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "unnecessary_unwrap",
         group: "complexity",
-        desc: "checks for calls of unwrap[_err]() that cannot fail",
+        desc: "checks for calls of `unwrap[_err]()` that cannot fail",
         deprecation: None,
         module: "unwrap",
     },
@@ -2390,7 +2390,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "zero_divided_by_zero",
         group: "complexity",
-        desc: "usage of `0.0 / 0.0` to obtain NaN instead of std::f32::NaN or std::f64::NaN",
+        desc: "usage of `0.0 / 0.0` to obtain NaN instead of `std::f32::NAN` or `std::f64::NAN`",
         deprecation: None,
         module: "zero_div_zero",
     },
@@ -2404,7 +2404,7 @@ pub const ALL_LINTS: [Lint; 345] = [
     Lint {
         name: "zero_ptr",
         group: "style",
-        desc: "using 0 as *{const, mut} T",
+        desc: "using `0 as *{const, mut} T`",
         deprecation: None,
         module: "misc",
     },

--- a/tests/ui/absurd-extreme-comparisons.stderr
+++ b/tests/ui/absurd-extreme-comparisons.stderr
@@ -5,7 +5,7 @@ LL |     u <= 0;
    |     ^^^^^^
    |
    = note: `-D clippy::absurd-extreme-comparisons` implied by `-D warnings`
-   = help: because 0 is the minimum value for this type, the case where the two sides are not equal never occurs, consider using u == 0 instead
+   = help: because `0` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `u == 0` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:15:5
@@ -13,7 +13,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     u <= Z;
    |     ^^^^^^
    |
-   = help: because Z is the minimum value for this type, the case where the two sides are not equal never occurs, consider using u == Z instead
+   = help: because `Z` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `u == Z` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:16:5
@@ -21,7 +21,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     u < Z;
    |     ^^^^^
    |
-   = help: because Z is the minimum value for this type, this comparison is always false
+   = help: because `Z` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:17:5
@@ -29,7 +29,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     Z >= u;
    |     ^^^^^^
    |
-   = help: because Z is the minimum value for this type, the case where the two sides are not equal never occurs, consider using Z == u instead
+   = help: because `Z` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `Z == u` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:18:5
@@ -37,7 +37,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     Z > u;
    |     ^^^^^
    |
-   = help: because Z is the minimum value for this type, this comparison is always false
+   = help: because `Z` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:19:5
@@ -45,7 +45,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     u > std::u32::MAX;
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: because std::u32::MAX is the maximum value for this type, this comparison is always false
+   = help: because `std::u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:20:5
@@ -53,7 +53,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     u >= std::u32::MAX;
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: because std::u32::MAX is the maximum value for this type, the case where the two sides are not equal never occurs, consider using u == std::u32::MAX instead
+   = help: because `std::u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == std::u32::MAX` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:21:5
@@ -61,7 +61,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     std::u32::MAX < u;
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: because std::u32::MAX is the maximum value for this type, this comparison is always false
+   = help: because `std::u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:22:5
@@ -69,7 +69,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     std::u32::MAX <= u;
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: because std::u32::MAX is the maximum value for this type, the case where the two sides are not equal never occurs, consider using std::u32::MAX == u instead
+   = help: because `std::u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `std::u32::MAX == u` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:23:5
@@ -77,7 +77,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     1-1 > u;
    |     ^^^^^^^
    |
-   = help: because 1-1 is the minimum value for this type, this comparison is always false
+   = help: because `1-1` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:24:5
@@ -85,7 +85,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     u >= !0;
    |     ^^^^^^^
    |
-   = help: because !0 is the maximum value for this type, the case where the two sides are not equal never occurs, consider using u == !0 instead
+   = help: because `!0` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == !0` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:25:5
@@ -93,7 +93,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     u <= 12 - 2*6;
    |     ^^^^^^^^^^^^^
    |
-   = help: because 12 - 2*6 is the minimum value for this type, the case where the two sides are not equal never occurs, consider using u == 12 - 2*6 instead
+   = help: because `12 - 2*6` is the minimum value for this type, the case where the two sides are not equal never occurs, consider using `u == 12 - 2*6` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:27:5
@@ -101,7 +101,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     i < -127 - 1;
    |     ^^^^^^^^^^^^
    |
-   = help: because -127 - 1 is the minimum value for this type, this comparison is always false
+   = help: because `-127 - 1` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:28:5
@@ -109,7 +109,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     std::i8::MAX >= i;
    |     ^^^^^^^^^^^^^^^^^
    |
-   = help: because std::i8::MAX is the maximum value for this type, this comparison is always true
+   = help: because `std::i8::MAX` is the maximum value for this type, this comparison is always true
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:29:5
@@ -117,7 +117,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     3-7 < std::i32::MIN;
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = help: because std::i32::MIN is the minimum value for this type, this comparison is always false
+   = help: because `std::i32::MIN` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:31:5
@@ -125,7 +125,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     b >= true;
    |     ^^^^^^^^^
    |
-   = help: because true is the maximum value for this type, the case where the two sides are not equal never occurs, consider using b == true instead
+   = help: because `true` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `b == true` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:32:5
@@ -133,7 +133,7 @@ error: this comparison involving the minimum or maximum element for this type co
 LL |     false > b;
    |     ^^^^^^^^^
    |
-   = help: because false is the minimum value for this type, this comparison is always false
+   = help: because `false` is the minimum value for this type, this comparison is always false
 
 error: <-comparison of unit values detected. This will always be false
   --> $DIR/absurd-extreme-comparisons.rs:35:5

--- a/tests/ui/assign_ops2.stderr
+++ b/tests/ui/assign_ops2.stderr
@@ -5,7 +5,7 @@ LL |     a += a + 1;
    |     ^^^^^^^^^^
    |
    = note: `-D clippy::misrefactored-assign-op` implied by `-D warnings`
-help: Did you mean a = a + 1 or a = a + a + 1? Consider replacing it with
+help: Did you mean `a = a + 1` or `a = a + a + 1`? Consider replacing it with
    |
 LL |     a += 1;
    |     ^^^^^^
@@ -20,7 +20,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a += 1 + a;
    |     ^^^^^^^^^^
    |
-help: Did you mean a = a + 1 or a = a + 1 + a? Consider replacing it with
+help: Did you mean `a = a + 1` or `a = a + 1 + a`? Consider replacing it with
    |
 LL |     a += 1;
    |     ^^^^^^
@@ -35,7 +35,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a -= a - 1;
    |     ^^^^^^^^^^
    |
-help: Did you mean a = a - 1 or a = a - (a - 1)? Consider replacing it with
+help: Did you mean `a = a - 1` or `a = a - (a - 1)`? Consider replacing it with
    |
 LL |     a -= 1;
    |     ^^^^^^
@@ -50,7 +50,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a *= a * 99;
    |     ^^^^^^^^^^^
    |
-help: Did you mean a = a * 99 or a = a * a * 99? Consider replacing it with
+help: Did you mean `a = a * 99` or `a = a * a * 99`? Consider replacing it with
    |
 LL |     a *= 99;
    |     ^^^^^^^
@@ -65,7 +65,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a *= 42 * a;
    |     ^^^^^^^^^^^
    |
-help: Did you mean a = a * 42 or a = a * 42 * a? Consider replacing it with
+help: Did you mean `a = a * 42` or `a = a * 42 * a`? Consider replacing it with
    |
 LL |     a *= 42;
    |     ^^^^^^^
@@ -80,7 +80,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a /= a / 2;
    |     ^^^^^^^^^^
    |
-help: Did you mean a = a / 2 or a = a / (a / 2)? Consider replacing it with
+help: Did you mean `a = a / 2` or `a = a / (a / 2)`? Consider replacing it with
    |
 LL |     a /= 2;
    |     ^^^^^^
@@ -95,7 +95,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a %= a % 5;
    |     ^^^^^^^^^^
    |
-help: Did you mean a = a % 5 or a = a % (a % 5)? Consider replacing it with
+help: Did you mean `a = a % 5` or `a = a % (a % 5)`? Consider replacing it with
    |
 LL |     a %= 5;
    |     ^^^^^^
@@ -110,7 +110,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a &= a & 1;
    |     ^^^^^^^^^^
    |
-help: Did you mean a = a & 1 or a = a & a & 1? Consider replacing it with
+help: Did you mean `a = a & 1` or `a = a & a & 1`? Consider replacing it with
    |
 LL |     a &= 1;
    |     ^^^^^^
@@ -125,7 +125,7 @@ error: variable appears on both sides of an assignment operation
 LL |     a *= a * a;
    |     ^^^^^^^^^^
    |
-help: Did you mean a = a * a or a = a * a * a? Consider replacing it with
+help: Did you mean `a = a * a` or `a = a * a * a`? Consider replacing it with
    |
 LL |     a *= a;
    |     ^^^^^^

--- a/tests/ui/block_in_if_condition.stderr
+++ b/tests/ui/block_in_if_condition.stderr
@@ -1,4 +1,4 @@
-error: in an 'if' condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a 'let'
+error: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
   --> $DIR/block_in_if_condition.rs:26:8
    |
 LL |       if {
@@ -30,7 +30,7 @@ LL |     if { true } {
                6
            } ... 
 
-error: in an 'if' condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a 'let'
+error: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
   --> $DIR/block_in_if_condition.rs:58:17
    |
 LL |               |x| {
@@ -40,7 +40,7 @@ LL | |                 x == target
 LL | |             },
    | |_____________^
 
-error: in an 'if' condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a 'let'
+error: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
   --> $DIR/block_in_if_condition.rs:67:13
    |
 LL |           |x| {

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -36,7 +36,7 @@ error: casting u64 to f64 causes a loss of precision (u64 is 64 bits wide, but f
 LL |     x3 as f64;
    |     ^^^^^^^^^
 
-error: casting f32 to i32 may truncate the value
+error: casting `f32` to `i32` may truncate the value
   --> $DIR/cast.rs:21:5
    |
 LL |     1f32 as i32;
@@ -44,13 +44,13 @@ LL |     1f32 as i32;
    |
    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
 
-error: casting f32 to u32 may truncate the value
+error: casting `f32` to `u32` may truncate the value
   --> $DIR/cast.rs:22:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
 
-error: casting f32 to u32 may lose the sign of the value
+error: casting `f32` to `u32` may lose the sign of the value
   --> $DIR/cast.rs:22:5
    |
 LL |     1f32 as u32;
@@ -58,43 +58,43 @@ LL |     1f32 as u32;
    |
    = note: `-D clippy::cast-sign-loss` implied by `-D warnings`
 
-error: casting f64 to f32 may truncate the value
+error: casting `f64` to `f32` may truncate the value
   --> $DIR/cast.rs:23:5
    |
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
 
-error: casting i32 to i8 may truncate the value
+error: casting `i32` to `i8` may truncate the value
   --> $DIR/cast.rs:24:5
    |
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
 
-error: casting i32 to u8 may truncate the value
+error: casting `i32` to `u8` may truncate the value
   --> $DIR/cast.rs:25:5
    |
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
 
-error: casting f64 to isize may truncate the value
+error: casting `f64` to `isize` may truncate the value
   --> $DIR/cast.rs:26:5
    |
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting f64 to usize may truncate the value
+error: casting `f64` to `usize` may truncate the value
   --> $DIR/cast.rs:27:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
-error: casting f64 to usize may lose the sign of the value
+error: casting `f64` to `usize` may lose the sign of the value
   --> $DIR/cast.rs:27:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
-error: casting u8 to i8 may wrap around the value
+error: casting `u8` to `i8` may wrap around the value
   --> $DIR/cast.rs:29:5
    |
 LL |     1u8 as i8;
@@ -102,37 +102,37 @@ LL |     1u8 as i8;
    |
    = note: `-D clippy::cast-possible-wrap` implied by `-D warnings`
 
-error: casting u16 to i16 may wrap around the value
+error: casting `u16` to `i16` may wrap around the value
   --> $DIR/cast.rs:30:5
    |
 LL |     1u16 as i16;
    |     ^^^^^^^^^^^
 
-error: casting u32 to i32 may wrap around the value
+error: casting `u32` to `i32` may wrap around the value
   --> $DIR/cast.rs:31:5
    |
 LL |     1u32 as i32;
    |     ^^^^^^^^^^^
 
-error: casting u64 to i64 may wrap around the value
+error: casting `u64` to `i64` may wrap around the value
   --> $DIR/cast.rs:32:5
    |
 LL |     1u64 as i64;
    |     ^^^^^^^^^^^
 
-error: casting usize to isize may wrap around the value
+error: casting `usize` to `isize` may wrap around the value
   --> $DIR/cast.rs:33:5
    |
 LL |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
-error: casting i32 to u32 may lose the sign of the value
+error: casting `i32` to `u32` may lose the sign of the value
   --> $DIR/cast.rs:36:5
    |
 LL |     -1i32 as u32;
    |     ^^^^^^^^^^^^
 
-error: casting isize to usize may lose the sign of the value
+error: casting `isize` to `usize` may lose the sign of the value
   --> $DIR/cast.rs:38:5
    |
 LL |     -1isize as usize;

--- a/tests/ui/cast_lossless_float.stderr
+++ b/tests/ui/cast_lossless_float.stderr
@@ -1,4 +1,4 @@
-error: casting i8 to f32 may become silently lossy if you later change the type
+error: casting `i8` to `f32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:9:5
    |
 LL |     x0 as f32;
@@ -6,61 +6,61 @@ LL |     x0 as f32;
    |
    = note: `-D clippy::cast-lossless` implied by `-D warnings`
 
-error: casting i8 to f64 may become silently lossy if you later change the type
+error: casting `i8` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:10:5
    |
 LL |     x0 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x0)`
 
-error: casting u8 to f32 may become silently lossy if you later change the type
+error: casting `u8` to `f32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:12:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^ help: try: `f32::from(x1)`
 
-error: casting u8 to f64 may become silently lossy if you later change the type
+error: casting `u8` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:13:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x1)`
 
-error: casting i16 to f32 may become silently lossy if you later change the type
+error: casting `i16` to `f32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:15:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^ help: try: `f32::from(x2)`
 
-error: casting i16 to f64 may become silently lossy if you later change the type
+error: casting `i16` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:16:5
    |
 LL |     x2 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x2)`
 
-error: casting u16 to f32 may become silently lossy if you later change the type
+error: casting `u16` to `f32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:18:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^ help: try: `f32::from(x3)`
 
-error: casting u16 to f64 may become silently lossy if you later change the type
+error: casting `u16` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:19:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x3)`
 
-error: casting i32 to f64 may become silently lossy if you later change the type
+error: casting `i32` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:21:5
    |
 LL |     x4 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x4)`
 
-error: casting u32 to f64 may become silently lossy if you later change the type
+error: casting `u32` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:23:5
    |
 LL |     x5 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x5)`
 
-error: casting f32 to f64 may become silently lossy if you later change the type
+error: casting `f32` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_float.rs:26:5
    |
 LL |     1.0f32 as f64;

--- a/tests/ui/cast_lossless_integer.stderr
+++ b/tests/ui/cast_lossless_integer.stderr
@@ -1,4 +1,4 @@
-error: casting i8 to i16 may become silently lossy if you later change the type
+error: casting `i8` to `i16` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:8:5
    |
 LL |     1i8 as i16;
@@ -6,109 +6,109 @@ LL |     1i8 as i16;
    |
    = note: `-D clippy::cast-lossless` implied by `-D warnings`
 
-error: casting i8 to i32 may become silently lossy if you later change the type
+error: casting `i8` to `i32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:9:5
    |
 LL |     1i8 as i32;
    |     ^^^^^^^^^^ help: try: `i32::from(1i8)`
 
-error: casting i8 to i64 may become silently lossy if you later change the type
+error: casting `i8` to `i64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:10:5
    |
 LL |     1i8 as i64;
    |     ^^^^^^^^^^ help: try: `i64::from(1i8)`
 
-error: casting u8 to i16 may become silently lossy if you later change the type
+error: casting `u8` to `i16` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:11:5
    |
 LL |     1u8 as i16;
    |     ^^^^^^^^^^ help: try: `i16::from(1u8)`
 
-error: casting u8 to i32 may become silently lossy if you later change the type
+error: casting `u8` to `i32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:12:5
    |
 LL |     1u8 as i32;
    |     ^^^^^^^^^^ help: try: `i32::from(1u8)`
 
-error: casting u8 to i64 may become silently lossy if you later change the type
+error: casting `u8` to `i64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:13:5
    |
 LL |     1u8 as i64;
    |     ^^^^^^^^^^ help: try: `i64::from(1u8)`
 
-error: casting u8 to u16 may become silently lossy if you later change the type
+error: casting `u8` to `u16` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:14:5
    |
 LL |     1u8 as u16;
    |     ^^^^^^^^^^ help: try: `u16::from(1u8)`
 
-error: casting u8 to u32 may become silently lossy if you later change the type
+error: casting `u8` to `u32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:15:5
    |
 LL |     1u8 as u32;
    |     ^^^^^^^^^^ help: try: `u32::from(1u8)`
 
-error: casting u8 to u64 may become silently lossy if you later change the type
+error: casting `u8` to `u64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:16:5
    |
 LL |     1u8 as u64;
    |     ^^^^^^^^^^ help: try: `u64::from(1u8)`
 
-error: casting i16 to i32 may become silently lossy if you later change the type
+error: casting `i16` to `i32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:17:5
    |
 LL |     1i16 as i32;
    |     ^^^^^^^^^^^ help: try: `i32::from(1i16)`
 
-error: casting i16 to i64 may become silently lossy if you later change the type
+error: casting `i16` to `i64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:18:5
    |
 LL |     1i16 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1i16)`
 
-error: casting u16 to i32 may become silently lossy if you later change the type
+error: casting `u16` to `i32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:19:5
    |
 LL |     1u16 as i32;
    |     ^^^^^^^^^^^ help: try: `i32::from(1u16)`
 
-error: casting u16 to i64 may become silently lossy if you later change the type
+error: casting `u16` to `i64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:20:5
    |
 LL |     1u16 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1u16)`
 
-error: casting u16 to u32 may become silently lossy if you later change the type
+error: casting `u16` to `u32` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:21:5
    |
 LL |     1u16 as u32;
    |     ^^^^^^^^^^^ help: try: `u32::from(1u16)`
 
-error: casting u16 to u64 may become silently lossy if you later change the type
+error: casting `u16` to `u64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:22:5
    |
 LL |     1u16 as u64;
    |     ^^^^^^^^^^^ help: try: `u64::from(1u16)`
 
-error: casting i32 to i64 may become silently lossy if you later change the type
+error: casting `i32` to `i64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:23:5
    |
 LL |     1i32 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1i32)`
 
-error: casting u32 to i64 may become silently lossy if you later change the type
+error: casting `u32` to `i64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:24:5
    |
 LL |     1u32 as i64;
    |     ^^^^^^^^^^^ help: try: `i64::from(1u32)`
 
-error: casting u32 to u64 may become silently lossy if you later change the type
+error: casting `u32` to `u64` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:25:5
    |
 LL |     1u32 as u64;
    |     ^^^^^^^^^^^ help: try: `u64::from(1u32)`
 
-error: casting u8 to u16 may become silently lossy if you later change the type
+error: casting `u8` to `u16` may become silently lossy if you later change the type
   --> $DIR/cast_lossless_integer.rs:28:5
    |
 LL |     (1u8 + 1u8) as u16;

--- a/tests/ui/cast_ref_to_mut.stderr
+++ b/tests/ui/cast_ref_to_mut.stderr
@@ -1,4 +1,4 @@
-error: casting &T to &mut T may cause undefined behaviour, consider instead using an UnsafeCell
+error: casting `&T` to `&mut T` may cause undefined behavior, consider instead using an `UnsafeCell`
   --> $DIR/cast_ref_to_mut.rs:18:9
    |
 LL |         (*(a as *const _ as *mut String)).push_str(" world");
@@ -6,13 +6,13 @@ LL |         (*(a as *const _ as *mut String)).push_str(" world");
    |
    = note: `-D clippy::cast-ref-to-mut` implied by `-D warnings`
 
-error: casting &T to &mut T may cause undefined behaviour, consider instead using an UnsafeCell
+error: casting `&T` to `&mut T` may cause undefined behavior, consider instead using an `UnsafeCell`
   --> $DIR/cast_ref_to_mut.rs:19:9
    |
 LL |         *(a as *const _ as *mut _) = String::from("Replaced");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: casting &T to &mut T may cause undefined behaviour, consider instead using an UnsafeCell
+error: casting `&T` to `&mut T` may cause undefined behavior, consider instead using an `UnsafeCell`
   --> $DIR/cast_ref_to_mut.rs:20:9
    |
 LL |         *(a as *const _ as *mut String) += " world";

--- a/tests/ui/cast_size.stderr
+++ b/tests/ui/cast_size.stderr
@@ -1,4 +1,4 @@
-error: casting isize to i8 may truncate the value
+error: casting `isize` to `i8` may truncate the value
   --> $DIR/cast_size.rs:12:5
    |
 LL |     1isize as i8;
@@ -32,31 +32,31 @@ error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits w
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
-error: casting isize to i32 may truncate the value on targets with 64-bit wide pointers
+error: casting `isize` to `i32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size.rs:19:5
    |
 LL |     1isize as i32;
    |     ^^^^^^^^^^^^^
 
-error: casting isize to u32 may truncate the value on targets with 64-bit wide pointers
+error: casting `isize` to `u32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size.rs:20:5
    |
 LL |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
-error: casting usize to u32 may truncate the value on targets with 64-bit wide pointers
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size.rs:21:5
    |
 LL |     1usize as u32;
    |     ^^^^^^^^^^^^^
 
-error: casting usize to i32 may truncate the value on targets with 64-bit wide pointers
+error: casting `usize` to `i32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size.rs:22:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
-error: casting usize to i32 may wrap around the value on targets with 32-bit wide pointers
+error: casting `usize` to `i32` may wrap around the value on targets with 32-bit wide pointers
   --> $DIR/cast_size.rs:22:5
    |
 LL |     1usize as i32;
@@ -64,37 +64,37 @@ LL |     1usize as i32;
    |
    = note: `-D clippy::cast-possible-wrap` implied by `-D warnings`
 
-error: casting i64 to isize may truncate the value on targets with 32-bit wide pointers
+error: casting `i64` to `isize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size.rs:24:5
    |
 LL |     1i64 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting i64 to usize may truncate the value on targets with 32-bit wide pointers
+error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size.rs:25:5
    |
 LL |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
-error: casting u64 to isize may truncate the value on targets with 32-bit wide pointers
+error: casting `u64` to `isize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size.rs:26:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting u64 to isize may wrap around the value on targets with 64-bit wide pointers
+error: casting `u64` to `isize` may wrap around the value on targets with 64-bit wide pointers
   --> $DIR/cast_size.rs:26:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting u64 to usize may truncate the value on targets with 32-bit wide pointers
+error: casting `u64` to `usize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size.rs:27:5
    |
 LL |     1u64 as usize;
    |     ^^^^^^^^^^^^^
 
-error: casting u32 to isize may wrap around the value on targets with 32-bit wide pointers
+error: casting `u32` to `isize` may wrap around the value on targets with 32-bit wide pointers
   --> $DIR/cast_size.rs:28:5
    |
 LL |     1u32 as isize;

--- a/tests/ui/cast_size_32bit.stderr
+++ b/tests/ui/cast_size_32bit.stderr
@@ -1,4 +1,4 @@
-error: casting isize to i8 may truncate the value
+error: casting `isize` to `i8` may truncate the value
   --> $DIR/cast_size_32bit.rs:12:5
    |
 LL |     1isize as i8;
@@ -14,7 +14,7 @@ LL |     x0 as f64;
    |
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
 
-error: casting isize to f64 may become silently lossy if you later change the type
+error: casting `isize` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_size_32bit.rs:15:5
    |
 LL |     x0 as f64;
@@ -28,7 +28,7 @@ error: casting usize to f64 causes a loss of precision on targets with 64-bit wi
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
-error: casting usize to f64 may become silently lossy if you later change the type
+error: casting `usize` to `f64` may become silently lossy if you later change the type
   --> $DIR/cast_size_32bit.rs:16:5
    |
 LL |     x1 as f64;
@@ -46,31 +46,31 @@ error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits w
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
-error: casting isize to i32 may truncate the value on targets with 64-bit wide pointers
+error: casting `isize` to `i32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size_32bit.rs:19:5
    |
 LL |     1isize as i32;
    |     ^^^^^^^^^^^^^
 
-error: casting isize to u32 may truncate the value on targets with 64-bit wide pointers
+error: casting `isize` to `u32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size_32bit.rs:20:5
    |
 LL |     1isize as u32;
    |     ^^^^^^^^^^^^^
 
-error: casting usize to u32 may truncate the value on targets with 64-bit wide pointers
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size_32bit.rs:21:5
    |
 LL |     1usize as u32;
    |     ^^^^^^^^^^^^^
 
-error: casting usize to i32 may truncate the value on targets with 64-bit wide pointers
+error: casting `usize` to `i32` may truncate the value on targets with 64-bit wide pointers
   --> $DIR/cast_size_32bit.rs:22:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
-error: casting usize to i32 may wrap around the value on targets with 32-bit wide pointers
+error: casting `usize` to `i32` may wrap around the value on targets with 32-bit wide pointers
   --> $DIR/cast_size_32bit.rs:22:5
    |
 LL |     1usize as i32;
@@ -78,37 +78,37 @@ LL |     1usize as i32;
    |
    = note: `-D clippy::cast-possible-wrap` implied by `-D warnings`
 
-error: casting i64 to isize may truncate the value on targets with 32-bit wide pointers
+error: casting `i64` to `isize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size_32bit.rs:24:5
    |
 LL |     1i64 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting i64 to usize may truncate the value on targets with 32-bit wide pointers
+error: casting `i64` to `usize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size_32bit.rs:25:5
    |
 LL |     1i64 as usize;
    |     ^^^^^^^^^^^^^
 
-error: casting u64 to isize may truncate the value on targets with 32-bit wide pointers
+error: casting `u64` to `isize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size_32bit.rs:26:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting u64 to isize may wrap around the value on targets with 64-bit wide pointers
+error: casting `u64` to `isize` may wrap around the value on targets with 64-bit wide pointers
   --> $DIR/cast_size_32bit.rs:26:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting u64 to usize may truncate the value on targets with 32-bit wide pointers
+error: casting `u64` to `usize` may truncate the value on targets with 32-bit wide pointers
   --> $DIR/cast_size_32bit.rs:27:5
    |
 LL |     1u64 as usize;
    |     ^^^^^^^^^^^^^
 
-error: casting u32 to isize may wrap around the value on targets with 32-bit wide pointers
+error: casting `u32` to `isize` may wrap around the value on targets with 32-bit wide pointers
   --> $DIR/cast_size_32bit.rs:28:5
    |
 LL |     1u32 as isize;
@@ -120,7 +120,7 @@ error: casting i32 to f32 causes a loss of precision (i32 is 32 bits wide, but f
 LL |     999_999_999 as f32;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: casting integer literal to f64 is unnecessary
+error: casting integer literal to `f64` is unnecessary
   --> $DIR/cast_size_32bit.rs:34:5
    |
 LL |     3_999_999_999usize as f64;

--- a/tests/ui/cfg_attr_rustfmt.stderr
+++ b/tests/ui/cfg_attr_rustfmt.stderr
@@ -1,4 +1,4 @@
-error: `cfg_attr` is deprecated for rustfmt and got replaced by `tool_attributes`
+error: `cfg_attr` is deprecated for rustfmt and got replaced by tool attributes
   --> $DIR/cfg_attr_rustfmt.rs:18:5
    |
 LL |     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -6,7 +6,7 @@ LL |     #[cfg_attr(rustfmt, rustfmt::skip)]
    |
    = note: `-D clippy::deprecated-cfg-attr` implied by `-D warnings`
 
-error: `cfg_attr` is deprecated for rustfmt and got replaced by `tool_attributes`
+error: `cfg_attr` is deprecated for rustfmt and got replaced by tool attributes
   --> $DIR/cfg_attr_rustfmt.rs:22:1
    |
 LL | #[cfg_attr(rustfmt, rustfmt_skip)]

--- a/tests/ui/cfg_attr_rustfmt.stderr
+++ b/tests/ui/cfg_attr_rustfmt.stderr
@@ -1,4 +1,4 @@
-error: `cfg_attr` is deprecated for rustfmt and got replaced by tool_attributes
+error: `cfg_attr` is deprecated for rustfmt and got replaced by `tool_attributes`
   --> $DIR/cfg_attr_rustfmt.rs:18:5
    |
 LL |     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -6,7 +6,7 @@ LL |     #[cfg_attr(rustfmt, rustfmt::skip)]
    |
    = note: `-D clippy::deprecated-cfg-attr` implied by `-D warnings`
 
-error: `cfg_attr` is deprecated for rustfmt and got replaced by tool_attributes
+error: `cfg_attr` is deprecated for rustfmt and got replaced by `tool_attributes`
   --> $DIR/cfg_attr_rustfmt.rs:22:1
    |
 LL | #[cfg_attr(rustfmt, rustfmt_skip)]

--- a/tests/ui/cmp_nan.stderr
+++ b/tests/ui/cmp_nan.stderr
@@ -1,4 +1,4 @@
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:8:5
    |
 LL |     x == std::f32::NAN;
@@ -6,139 +6,139 @@ LL |     x == std::f32::NAN;
    |
    = note: `-D clippy::cmp-nan` implied by `-D warnings`
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:9:5
    |
 LL |     x != std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:10:5
    |
 LL |     x < std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:11:5
    |
 LL |     x > std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:12:5
    |
 LL |     x <= std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:13:5
    |
 LL |     x >= std::f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:14:5
    |
 LL |     x == NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:15:5
    |
 LL |     x != NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:16:5
    |
 LL |     x < NAN_F32;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:17:5
    |
 LL |     x > NAN_F32;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:18:5
    |
 LL |     x <= NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:19:5
    |
 LL |     x >= NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:22:5
    |
 LL |     y == std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:23:5
    |
 LL |     y != std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:24:5
    |
 LL |     y < std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:25:5
    |
 LL |     y > std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:26:5
    |
 LL |     y <= std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:27:5
    |
 LL |     y >= std::f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:28:5
    |
 LL |     y == NAN_F64;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:29:5
    |
 LL |     y != NAN_F64;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:30:5
    |
 LL |     y < NAN_F64;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:31:5
    |
 LL |     y > NAN_F64;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:32:5
    |
 LL |     y <= NAN_F64;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with NAN, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:33:5
    |
 LL |     y >= NAN_F64;

--- a/tests/ui/cmp_null.stderr
+++ b/tests/ui/cmp_null.stderr
@@ -1,4 +1,4 @@
-error: Comparing with null is better expressed by the .is_null() method
+error: Comparing with null is better expressed by the `.is_null()` method
   --> $DIR/cmp_null.rs:9:8
    |
 LL |     if p == ptr::null() {
@@ -6,7 +6,7 @@ LL |     if p == ptr::null() {
    |
    = note: `-D clippy::cmp-null` implied by `-D warnings`
 
-error: Comparing with null is better expressed by the .is_null() method
+error: Comparing with null is better expressed by the `.is_null()` method
   --> $DIR/cmp_null.rs:14:8
    |
 LL |     if m == ptr::null_mut() {

--- a/tests/ui/collapsible_if.stderr
+++ b/tests/ui/collapsible_if.stderr
@@ -1,4 +1,4 @@
-error: this if statement can be collapsed
+error: this `if` statement can be collapsed
   --> $DIR/collapsible_if.rs:9:5
    |
 LL | /     if x == "hello" {
@@ -16,7 +16,7 @@ LL |     println!("Hello world!");
 LL | }
    |
 
-error: this if statement can be collapsed
+error: this `if` statement can be collapsed
   --> $DIR/collapsible_if.rs:15:5
    |
 LL | /     if x == "hello" || x == "world" {
@@ -33,7 +33,7 @@ LL |     println!("Hello world!");
 LL | }
    |
 
-error: this if statement can be collapsed
+error: this `if` statement can be collapsed
   --> $DIR/collapsible_if.rs:21:5
    |
 LL | /     if x == "hello" && x == "world" {
@@ -50,7 +50,7 @@ LL |     println!("Hello world!");
 LL | }
    |
 
-error: this if statement can be collapsed
+error: this `if` statement can be collapsed
   --> $DIR/collapsible_if.rs:27:5
    |
 LL | /     if x == "hello" || x == "world" {
@@ -67,7 +67,7 @@ LL |     println!("Hello world!");
 LL | }
    |
 
-error: this if statement can be collapsed
+error: this `if` statement can be collapsed
   --> $DIR/collapsible_if.rs:33:5
    |
 LL | /     if x == "hello" && x == "world" {
@@ -84,7 +84,7 @@ LL |     println!("Hello world!");
 LL | }
    |
 
-error: this if statement can be collapsed
+error: this `if` statement can be collapsed
   --> $DIR/collapsible_if.rs:39:5
    |
 LL | /     if 42 == 1337 {
@@ -101,7 +101,7 @@ LL |     println!("world!")
 LL | }
    |
 
-error: this if statement can be collapsed
+error: this `if` statement can be collapsed
   --> $DIR/collapsible_if.rs:95:5
    |
 LL | /     if x == "hello" {

--- a/tests/ui/default_trait_access.stderr
+++ b/tests/ui/default_trait_access.stderr
@@ -1,4 +1,4 @@
-error: Calling std::string::String::default() is more clear than this expression
+error: Calling `std::string::String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:8:22
    |
 LL |     let s1: String = Default::default();
@@ -6,43 +6,43 @@ LL |     let s1: String = Default::default();
    |
    = note: `-D clippy::default-trait-access` implied by `-D warnings`
 
-error: Calling std::string::String::default() is more clear than this expression
+error: Calling `std::string::String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:12:22
    |
 LL |     let s3: String = D2::default();
    |                      ^^^^^^^^^^^^^ help: try: `std::string::String::default()`
 
-error: Calling std::string::String::default() is more clear than this expression
+error: Calling `std::string::String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:14:22
    |
 LL |     let s4: String = std::default::Default::default();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
 
-error: Calling std::string::String::default() is more clear than this expression
+error: Calling `std::string::String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:18:22
    |
 LL |     let s6: String = default::Default::default();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
 
-error: Calling GenericDerivedDefault<std::string::String>::default() is more clear than this expression
+error: Calling `GenericDerivedDefault<std::string::String>::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:28:46
    |
 LL |     let s11: GenericDerivedDefault<String> = Default::default();
    |                                              ^^^^^^^^^^^^^^^^^^ help: try: `GenericDerivedDefault<std::string::String>::default()`
 
-error: Calling TupleDerivedDefault::default() is more clear than this expression
+error: Calling `TupleDerivedDefault::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:34:36
    |
 LL |     let s14: TupleDerivedDefault = Default::default();
    |                                    ^^^^^^^^^^^^^^^^^^ help: try: `TupleDerivedDefault::default()`
 
-error: Calling ArrayDerivedDefault::default() is more clear than this expression
+error: Calling `ArrayDerivedDefault::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:36:36
    |
 LL |     let s15: ArrayDerivedDefault = Default::default();
    |                                    ^^^^^^^^^^^^^^^^^^ help: try: `ArrayDerivedDefault::default()`
 
-error: Calling TupleStructDerivedDefault::default() is more clear than this expression
+error: Calling `TupleStructDerivedDefault::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:40:42
    |
 LL |     let s17: TupleStructDerivedDefault = Default::default();

--- a/tests/ui/dlist.stderr
+++ b/tests/ui/dlist.stderr
@@ -5,7 +5,7 @@ LL |     type Baz = LinkedList<u8>;
    |                ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::linkedlist` implied by `-D warnings`
-   = help: a VecDeque might work
+   = help: a `VecDeque` might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
   --> $DIR/dlist.rs:10:15
@@ -13,7 +13,7 @@ error: I see you're using a LinkedList! Perhaps you meant some other data struct
 LL |     fn foo(_: LinkedList<u8>);
    |               ^^^^^^^^^^^^^^
    |
-   = help: a VecDeque might work
+   = help: a `VecDeque` might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
   --> $DIR/dlist.rs:11:23
@@ -21,7 +21,7 @@ error: I see you're using a LinkedList! Perhaps you meant some other data struct
 LL |     const BAR: Option<LinkedList<u8>>;
    |                       ^^^^^^^^^^^^^^
    |
-   = help: a VecDeque might work
+   = help: a `VecDeque` might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
   --> $DIR/dlist.rs:22:15
@@ -29,7 +29,7 @@ error: I see you're using a LinkedList! Perhaps you meant some other data struct
 LL |     fn foo(_: LinkedList<u8>) {}
    |               ^^^^^^^^^^^^^^
    |
-   = help: a VecDeque might work
+   = help: a `VecDeque` might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
   --> $DIR/dlist.rs:25:39
@@ -37,7 +37,7 @@ error: I see you're using a LinkedList! Perhaps you meant some other data struct
 LL | pub fn test(my_favourite_linked_list: LinkedList<u8>) {
    |                                       ^^^^^^^^^^^^^^
    |
-   = help: a VecDeque might work
+   = help: a `VecDeque` might work
 
 error: I see you're using a LinkedList! Perhaps you meant some other data structure?
   --> $DIR/dlist.rs:29:29
@@ -45,7 +45,7 @@ error: I see you're using a LinkedList! Perhaps you meant some other data struct
 LL | pub fn test_ret() -> Option<LinkedList<u8>> {
    |                             ^^^^^^^^^^^^^^
    |
-   = help: a VecDeque might work
+   = help: a `VecDeque` might work
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/drop_forget_copy.stderr
+++ b/tests/ui/drop_forget_copy.stderr
@@ -1,4 +1,4 @@
-error: calls to `std::mem::drop` with a value that implements Copy. Dropping a copy leaves the original intact.
+error: calls to `std::mem::drop` with a value that implements `Copy`. Dropping a copy leaves the original intact.
   --> $DIR/drop_forget_copy.rs:33:5
    |
 LL |     drop(s1);
@@ -11,7 +11,7 @@ note: argument has type SomeStruct
 LL |     drop(s1);
    |          ^^
 
-error: calls to `std::mem::drop` with a value that implements Copy. Dropping a copy leaves the original intact.
+error: calls to `std::mem::drop` with a value that implements `Copy`. Dropping a copy leaves the original intact.
   --> $DIR/drop_forget_copy.rs:34:5
    |
 LL |     drop(s2);
@@ -23,7 +23,7 @@ note: argument has type SomeStruct
 LL |     drop(s2);
    |          ^^
 
-error: calls to `std::mem::drop` with a value that implements Copy. Dropping a copy leaves the original intact.
+error: calls to `std::mem::drop` with a value that implements `Copy`. Dropping a copy leaves the original intact.
   --> $DIR/drop_forget_copy.rs:36:5
    |
 LL |     drop(s4);
@@ -35,7 +35,7 @@ note: argument has type SomeStruct
 LL |     drop(s4);
    |          ^^
 
-error: calls to `std::mem::forget` with a value that implements Copy. Forgetting a copy leaves the original intact.
+error: calls to `std::mem::forget` with a value that implements `Copy`. Forgetting a copy leaves the original intact.
   --> $DIR/drop_forget_copy.rs:39:5
    |
 LL |     forget(s1);
@@ -48,7 +48,7 @@ note: argument has type SomeStruct
 LL |     forget(s1);
    |            ^^
 
-error: calls to `std::mem::forget` with a value that implements Copy. Forgetting a copy leaves the original intact.
+error: calls to `std::mem::forget` with a value that implements `Copy`. Forgetting a copy leaves the original intact.
   --> $DIR/drop_forget_copy.rs:40:5
    |
 LL |     forget(s2);
@@ -60,7 +60,7 @@ note: argument has type SomeStruct
 LL |     forget(s2);
    |            ^^
 
-error: calls to `std::mem::forget` with a value that implements Copy. Forgetting a copy leaves the original intact.
+error: calls to `std::mem::forget` with a value that implements `Copy`. Forgetting a copy leaves the original intact.
   --> $DIR/drop_forget_copy.rs:42:5
    |
 LL |     forget(s4);

--- a/tests/ui/drop_forget_ref.stderr
+++ b/tests/ui/drop_forget_ref.stderr
@@ -5,7 +5,7 @@ LL |     drop(&SomeStruct);
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::drop-ref` implied by `-D warnings`
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:9:10
    |
 LL |     drop(&SomeStruct);
@@ -18,7 +18,7 @@ LL |     forget(&SomeStruct);
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::forget-ref` implied by `-D warnings`
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:10:12
    |
 LL |     forget(&SomeStruct);
@@ -30,7 +30,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     drop(&owned1);
    |     ^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:13:10
    |
 LL |     drop(&owned1);
@@ -42,7 +42,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     drop(&&owned1);
    |     ^^^^^^^^^^^^^^
    |
-note: argument has type &&SomeStruct
+note: argument has type `&&SomeStruct`
   --> $DIR/drop_forget_ref.rs:14:10
    |
 LL |     drop(&&owned1);
@@ -54,7 +54,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     drop(&mut owned1);
    |     ^^^^^^^^^^^^^^^^^
    |
-note: argument has type &mut SomeStruct
+note: argument has type `&mut SomeStruct`
   --> $DIR/drop_forget_ref.rs:15:10
    |
 LL |     drop(&mut owned1);
@@ -66,7 +66,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     forget(&owned2);
    |     ^^^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:18:12
    |
 LL |     forget(&owned2);
@@ -78,7 +78,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     forget(&&owned2);
    |     ^^^^^^^^^^^^^^^^
    |
-note: argument has type &&SomeStruct
+note: argument has type `&&SomeStruct`
   --> $DIR/drop_forget_ref.rs:19:12
    |
 LL |     forget(&&owned2);
@@ -90,7 +90,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     forget(&mut owned2);
    |     ^^^^^^^^^^^^^^^^^^^
    |
-note: argument has type &mut SomeStruct
+note: argument has type `&mut SomeStruct`
   --> $DIR/drop_forget_ref.rs:20:12
    |
 LL |     forget(&mut owned2);
@@ -102,7 +102,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     drop(reference1);
    |     ^^^^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:24:10
    |
 LL |     drop(reference1);
@@ -114,7 +114,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     forget(&*reference1);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:25:12
    |
 LL |     forget(&*reference1);
@@ -126,7 +126,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     drop(reference2);
    |     ^^^^^^^^^^^^^^^^
    |
-note: argument has type &mut SomeStruct
+note: argument has type `&mut SomeStruct`
   --> $DIR/drop_forget_ref.rs:28:10
    |
 LL |     drop(reference2);
@@ -138,7 +138,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     forget(reference3);
    |     ^^^^^^^^^^^^^^^^^^
    |
-note: argument has type &mut SomeStruct
+note: argument has type `&mut SomeStruct`
   --> $DIR/drop_forget_ref.rs:30:12
    |
 LL |     forget(reference3);
@@ -150,7 +150,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     drop(reference4);
    |     ^^^^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:33:10
    |
 LL |     drop(reference4);
@@ -162,7 +162,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     forget(reference4);
    |     ^^^^^^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:34:12
    |
 LL |     forget(reference4);
@@ -174,7 +174,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     drop(&val);
    |     ^^^^^^^^^^
    |
-note: argument has type &T
+note: argument has type `&T`
   --> $DIR/drop_forget_ref.rs:39:10
    |
 LL |     drop(&val);
@@ -186,7 +186,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     forget(&val);
    |     ^^^^^^^^^^^^
    |
-note: argument has type &T
+note: argument has type `&T`
   --> $DIR/drop_forget_ref.rs:45:12
    |
 LL |     forget(&val);
@@ -198,7 +198,7 @@ error: calls to `std::mem::drop` with a reference instead of an owned value. Dro
 LL |     std::mem::drop(&SomeStruct);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:53:20
    |
 LL |     std::mem::drop(&SomeStruct);
@@ -210,7 +210,7 @@ error: calls to `std::mem::forget` with a reference instead of an owned value. F
 LL |     std::mem::forget(&SomeStruct);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: argument has type &SomeStruct
+note: argument has type `&SomeStruct`
   --> $DIR/drop_forget_ref.rs:56:22
    |
 LL |     std::mem::forget(&SomeStruct);

--- a/tests/ui/else_if_without_else.stderr
+++ b/tests/ui/else_if_without_else.stderr
@@ -1,4 +1,4 @@
-error: if expression with an `else if`, but without a final `else`
+error: `if` expression with an `else if`, but without a final `else`
   --> $DIR/else_if_without_else.rs:45:12
    |
 LL |       } else if bla2() {
@@ -11,7 +11,7 @@ LL | |     }
    = note: `-D clippy::else-if-without-else` implied by `-D warnings`
    = help: add an `else` block here
 
-error: if expression with an `else if`, but without a final `else`
+error: `if` expression with an `else if`, but without a final `else`
   --> $DIR/else_if_without_else.rs:54:12
    |
 LL |       } else if bla3() {

--- a/tests/ui/empty_line_after_outer_attribute.stderr
+++ b/tests/ui/empty_line_after_outer_attribute.stderr
@@ -1,4 +1,4 @@
-error: Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?
+error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
   --> $DIR/empty_line_after_outer_attribute.rs:7:1
    |
 LL | / #[crate_type = "lib"]
@@ -9,7 +9,7 @@ LL | | fn with_one_newline_and_comment() { assert!(true) }
    |
    = note: `-D clippy::empty-line-after-outer-attr` implied by `-D warnings`
 
-error: Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?
+error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
   --> $DIR/empty_line_after_outer_attribute.rs:19:1
    |
 LL | / #[crate_type = "lib"]
@@ -17,7 +17,7 @@ LL | |
 LL | | fn with_one_newline() { assert!(true) }
    | |_
 
-error: Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?
+error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
   --> $DIR/empty_line_after_outer_attribute.rs:24:1
    |
 LL | / #[crate_type = "lib"]
@@ -26,7 +26,7 @@ LL | |
 LL | | fn with_two_newlines() { assert!(true) }
    | |_
 
-error: Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?
+error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
   --> $DIR/empty_line_after_outer_attribute.rs:31:1
    |
 LL | / #[crate_type = "lib"]
@@ -34,7 +34,7 @@ LL | |
 LL | | enum Baz {
    | |_
 
-error: Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?
+error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
   --> $DIR/empty_line_after_outer_attribute.rs:39:1
    |
 LL | / #[crate_type = "lib"]
@@ -42,7 +42,7 @@ LL | |
 LL | | struct Foo {
    | |_
 
-error: Found an empty line after an outer attribute. Perhaps you forgot to add a '!' to make it an inner attribute?
+error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
   --> $DIR/empty_line_after_outer_attribute.rs:47:1
    |
 LL | / #[crate_type = "lib"]

--- a/tests/ui/expect.stderr
+++ b/tests/ui/expect.stderr
@@ -1,4 +1,4 @@
-error: used expect() on an Option value. If this value is an None it will panic
+error: used `expect()` on `an Option` value. If this value is an `None` it will panic
   --> $DIR/expect.rs:5:13
    |
 LL |     let _ = opt.expect("");
@@ -6,7 +6,7 @@ LL |     let _ = opt.expect("");
    |
    = note: `-D clippy::option-expect-used` implied by `-D warnings`
 
-error: used expect() on a Result value. If this value is an Err it will panic
+error: used `expect()` on `a Result` value. If this value is an `Err` it will panic
   --> $DIR/expect.rs:10:13
    |
 LL |     let _ = res.expect("");

--- a/tests/ui/float_cmp.stderr
+++ b/tests/ui/float_cmp.stderr
@@ -1,35 +1,35 @@
-error: strict comparison of f32 or f64
+error: strict comparison of `f32` or `f64`
   --> $DIR/float_cmp.rs:59:5
    |
 LL |     ONE as f64 != 2.0;
    |     ^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(ONE as f64 - 2.0).abs() > error`
    |
    = note: `-D clippy::float-cmp` implied by `-D warnings`
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp.rs:59:5
    |
 LL |     ONE as f64 != 2.0;
    |     ^^^^^^^^^^^^^^^^^
 
-error: strict comparison of f32 or f64
+error: strict comparison of `f32` or `f64`
   --> $DIR/float_cmp.rs:64:5
    |
 LL |     x == 1.0;
    |     ^^^^^^^^ help: consider comparing them within some error: `(x - 1.0).abs() < error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp.rs:64:5
    |
 LL |     x == 1.0;
    |     ^^^^^^^^
 
-error: strict comparison of f32 or f64
+error: strict comparison of `f32` or `f64`
   --> $DIR/float_cmp.rs:67:5
    |
 LL |     twice(x) != twice(ONE as f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(twice(x) - twice(ONE as f64)).abs() > error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp.rs:67:5
    |
 LL |     twice(x) != twice(ONE as f64);

--- a/tests/ui/float_cmp_const.stderr
+++ b/tests/ui/float_cmp_const.stderr
@@ -1,83 +1,83 @@
-error: strict comparison of f32 or f64 constant
+error: strict comparison of `f32` or `f64` constant
   --> $DIR/float_cmp_const.rs:20:5
    |
 LL |     1f32 == ONE;
    |     ^^^^^^^^^^^ help: consider comparing them within some error: `(1f32 - ONE).abs() < error`
    |
    = note: `-D clippy::float-cmp-const` implied by `-D warnings`
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:20:5
    |
 LL |     1f32 == ONE;
    |     ^^^^^^^^^^^
 
-error: strict comparison of f32 or f64 constant
+error: strict comparison of `f32` or `f64` constant
   --> $DIR/float_cmp_const.rs:21:5
    |
 LL |     TWO == ONE;
    |     ^^^^^^^^^^ help: consider comparing them within some error: `(TWO - ONE).abs() < error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:21:5
    |
 LL |     TWO == ONE;
    |     ^^^^^^^^^^
 
-error: strict comparison of f32 or f64 constant
+error: strict comparison of `f32` or `f64` constant
   --> $DIR/float_cmp_const.rs:22:5
    |
 LL |     TWO != ONE;
    |     ^^^^^^^^^^ help: consider comparing them within some error: `(TWO - ONE).abs() > error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:22:5
    |
 LL |     TWO != ONE;
    |     ^^^^^^^^^^
 
-error: strict comparison of f32 or f64 constant
+error: strict comparison of `f32` or `f64` constant
   --> $DIR/float_cmp_const.rs:23:5
    |
 LL |     ONE + ONE == TWO;
    |     ^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(ONE + ONE - TWO).abs() < error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:23:5
    |
 LL |     ONE + ONE == TWO;
    |     ^^^^^^^^^^^^^^^^
 
-error: strict comparison of f32 or f64 constant
+error: strict comparison of `f32` or `f64` constant
   --> $DIR/float_cmp_const.rs:25:5
    |
 LL |     x as f32 == ONE;
    |     ^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(x as f32 - ONE).abs() < error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:25:5
    |
 LL |     x as f32 == ONE;
    |     ^^^^^^^^^^^^^^^
 
-error: strict comparison of f32 or f64 constant
+error: strict comparison of `f32` or `f64` constant
   --> $DIR/float_cmp_const.rs:28:5
    |
 LL |     v == ONE;
    |     ^^^^^^^^ help: consider comparing them within some error: `(v - ONE).abs() < error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:28:5
    |
 LL |     v == ONE;
    |     ^^^^^^^^
 
-error: strict comparison of f32 or f64 constant
+error: strict comparison of `f32` or `f64` constant
   --> $DIR/float_cmp_const.rs:29:5
    |
 LL |     v != ONE;
    |     ^^^^^^^^ help: consider comparing them within some error: `(v - ONE).abs() > error`
    |
-note: std::f32::EPSILON and std::f64::EPSILON are available.
+note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:29:5
    |
 LL |     v != ONE;

--- a/tests/ui/for_loop_fixable.stderr
+++ b/tests/ui/for_loop_fixable.stderr
@@ -68,7 +68,7 @@ error: it is more concise to loop over references to containers instead of using
 LL |     for _v in vec.iter_mut() {}
    |               ^^^^^^^^^^^^^^ help: to write this more concisely, try: `&mut vec`
 
-error: it is more concise to loop over containers instead of using explicit iteration methods`
+error: it is more concise to loop over containers instead of using explicit iteration methods
   --> $DIR/for_loop_fixable.rs:103:15
    |
 LL |     for _v in out_vec.into_iter() {}
@@ -130,7 +130,7 @@ error: it is more concise to loop over references to containers instead of using
 LL |     for _v in bs.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&bs`
 
-error: it is more concise to loop over containers instead of using explicit iteration methods`
+error: it is more concise to loop over containers instead of using explicit iteration methods
   --> $DIR/for_loop_fixable.rs:310:18
    |
 LL |         for i in iterator.into_iter() {
@@ -142,7 +142,7 @@ error: it is more concise to loop over references to containers instead of using
 LL |         for _ in t.into_iter() {}
    |                  ^^^^^^^^^^^^^ help: to write this more concisely, try: `&t`
 
-error: it is more concise to loop over containers instead of using explicit iteration methods`
+error: it is more concise to loop over containers instead of using explicit iteration methods
   --> $DIR/for_loop_fixable.rs:332:18
    |
 LL |         for _ in r.into_iter() {}

--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -2,7 +2,7 @@ error: useless use of `format!`
   --> $DIR/format.rs:13:5
    |
 LL |     format!("foo");
-   |     ^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
    |
    = note: `-D clippy::useless-format` implied by `-D warnings`
 
@@ -10,13 +10,13 @@ error: useless use of `format!`
   --> $DIR/format.rs:14:5
    |
 LL |     format!("{{}}");
-   |     ^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"{}".to_string();`
+   |     ^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{}".to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:15:5
    |
 LL |     format!("{{}} abc {{}}");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"{} abc {}".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{} abc {}".to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:16:5
@@ -25,61 +25,61 @@ LL | /     format!(
 LL | |         r##"foo {{}}
 LL | | " bar"##
 LL | |     );
-   | |______^ help: consider using .to_string(): `"foo {}/n/" bar".to_string();`
+   | |______^ help: consider using `.to_string()`: `"foo {}/n/" bar".to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:21:5
    |
 LL |     format!("{}", "foo");
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:25:5
    |
 LL |     format!("{:+}", "foo"); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:26:5
    |
 LL |     format!("{:<}", "foo"); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `"foo".to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:31:5
    |
 LL |     format!("{}", arg);
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `arg.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:35:5
    |
 LL |     format!("{:+}", arg); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `arg.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:36:5
    |
 LL |     format!("{:<}", arg); // Warn when the format makes no difference.
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `arg.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:63:5
    |
 LL |     format!("{}", 42.to_string());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `42.to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `42.to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:65:5
    |
 LL |     format!("{}", x.display().to_string());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `x.display().to_string();`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.display().to_string();`
 
 error: useless use of `format!`
   --> $DIR/format.rs:69:18
    |
 LL |     let _ = Some(format!("{}", a + "bar"));
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using .to_string(): `a + "bar"`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `a + "bar"`
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/if_not_else.stderr
+++ b/tests/ui/if_not_else.stderr
@@ -9,7 +9,7 @@ LL | |     }
    | |_____^
    |
    = note: `-D clippy::if-not-else` implied by `-D warnings`
-   = help: remove the `!` and swap the blocks of the if/else
+   = help: remove the `!` and swap the blocks of the `if`/`else`
 
 error: Unnecessary `!=` operation
   --> $DIR/if_not_else.rs:14:5
@@ -21,7 +21,7 @@ LL | |         println!("Bunny");
 LL | |     }
    | |_____^
    |
-   = help: change to `==` and swap the blocks of the if/else
+   = help: change to `==` and swap the blocks of the `if`/`else`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/if_same_then_else.stderr
+++ b/tests/ui/if_same_then_else.stderr
@@ -230,7 +230,7 @@ LL | |         return Ok(&foo[0..]);
 LL | |     } else {
    | |_____^
 
-error: this `if` has the same condition as a previous if
+error: this `if` has the same condition as a previous `if`
   --> $DIR/if_same_then_else.rs:241:15
    |
 LL |     } else if true {

--- a/tests/ui/ifs_same_cond.stderr
+++ b/tests/ui/ifs_same_cond.stderr
@@ -1,4 +1,4 @@
-error: this `if` has the same condition as a previous if
+error: this `if` has the same condition as a previous `if`
   --> $DIR/ifs_same_cond.rs:9:15
    |
 LL |     } else if b {
@@ -11,7 +11,7 @@ note: same as this
 LL |     if b {
    |        ^
 
-error: this `if` has the same condition as a previous if
+error: this `if` has the same condition as a previous `if`
   --> $DIR/ifs_same_cond.rs:14:15
    |
 LL |     } else if a == 1 {
@@ -23,7 +23,7 @@ note: same as this
 LL |     if a == 1 {
    |        ^^^^^^
 
-error: this `if` has the same condition as a previous if
+error: this `if` has the same condition as a previous `if`
   --> $DIR/ifs_same_cond.rs:20:15
    |
 LL |     } else if 2 * a == 1 {

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -1,4 +1,4 @@
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:12:5
    |
 LL |     true
@@ -6,61 +6,61 @@ LL |     true
    |
    = note: `-D clippy::implicit-return` implied by `-D warnings`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:18:9
    |
 LL |         true
    |         ^^^^ help: add `return` as shown: `return true`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:20:9
    |
 LL |         false
    |         ^^^^^ help: add `return` as shown: `return false`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:28:17
    |
 LL |         true => false,
    |                 ^^^^^ help: add `return` as shown: `return false`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:29:20
    |
 LL |         false => { true },
    |                    ^^^^ help: add `return` as shown: `return true`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:44:9
    |
 LL |         break true;
    |         ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:52:13
    |
 LL |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:61:13
    |
 LL |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:79:18
    |
 LL |     let _ = || { true };
    |                  ^^^^ help: add `return` as shown: `return true`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:80:16
    |
 LL |     let _ = || true;
    |                ^^^^ help: add `return` as shown: `return true`
 
-error: missing return statement
+error: missing `return` statement
   --> $DIR/implicit_return.rs:88:5
    |
 LL |     format!("test {}", "test")

--- a/tests/ui/infallible_destructuring_match.stderr
+++ b/tests/ui/infallible_destructuring_match.stderr
@@ -1,4 +1,4 @@
-error: you seem to be trying to use match to destructure a single infallible pattern. Consider using `let`
+error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
   --> $DIR/infallible_destructuring_match.rs:18:5
    |
 LL | /     let data = match wrapper {
@@ -8,7 +8,7 @@ LL | |     };
    |
    = note: `-D clippy::infallible-destructuring-match` implied by `-D warnings`
 
-error: you seem to be trying to use match to destructure a single infallible pattern. Consider using `let`
+error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
   --> $DIR/infallible_destructuring_match.rs:39:5
    |
 LL | /     let data = match wrapper {
@@ -16,7 +16,7 @@ LL | |         TupleStruct(i) => i,
 LL | |     };
    | |______^ help: try this: `let TupleStruct(data) = wrapper;`
 
-error: you seem to be trying to use match to destructure a single infallible pattern. Consider using `let`
+error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
   --> $DIR/infallible_destructuring_match.rs:60:5
    |
 LL | /     let data = match wrapper {

--- a/tests/ui/into_iter_on_ref.stderr
+++ b/tests/ui/into_iter_on_ref.stderr
@@ -1,4 +1,4 @@
-error: this .into_iter() call is equivalent to .iter() and will not move the Vec
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `Vec`
   --> $DIR/into_iter_on_ref.rs:14:30
    |
 LL |     let _ = (&vec![1, 2, 3]).into_iter(); //~ WARN equivalent to .iter()
@@ -6,151 +6,151 @@ LL |     let _ = (&vec![1, 2, 3]).into_iter(); //~ WARN equivalent to .iter()
    |
    = note: `-D clippy::into-iter-on-ref` implied by `-D warnings`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the slice
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `slice`
   --> $DIR/into_iter_on_ref.rs:15:46
    |
 LL |     let _ = vec![1, 2, 3].into_boxed_slice().into_iter(); //~ WARN equivalent to .iter()
    |                                              ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the slice
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `slice`
   --> $DIR/into_iter_on_ref.rs:16:41
    |
 LL |     let _ = std::rc::Rc::from(&[X][..]).into_iter(); //~ WARN equivalent to .iter()
    |                                         ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the slice
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `slice`
   --> $DIR/into_iter_on_ref.rs:17:44
    |
 LL |     let _ = std::sync::Arc::from(&[X][..]).into_iter(); //~ WARN equivalent to .iter()
    |                                            ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the array
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `array`
   --> $DIR/into_iter_on_ref.rs:19:32
    |
 LL |     let _ = (&&&&&&&[1, 2, 3]).into_iter(); //~ ERROR equivalent to .iter()
    |                                ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the array
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `array`
   --> $DIR/into_iter_on_ref.rs:20:36
    |
 LL |     let _ = (&&&&mut &&&[1, 2, 3]).into_iter(); //~ ERROR equivalent to .iter()
    |                                    ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the array
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `array`
   --> $DIR/into_iter_on_ref.rs:21:40
    |
 LL |     let _ = (&mut &mut &mut [1, 2, 3]).into_iter(); //~ ERROR equivalent to .iter_mut()
    |                                        ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the Option
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `Option`
   --> $DIR/into_iter_on_ref.rs:23:24
    |
 LL |     let _ = (&Some(4)).into_iter(); //~ WARN equivalent to .iter()
    |                        ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the Option
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `Option`
   --> $DIR/into_iter_on_ref.rs:24:28
    |
 LL |     let _ = (&mut Some(5)).into_iter(); //~ WARN equivalent to .iter_mut()
    |                            ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the Result
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `Result`
   --> $DIR/into_iter_on_ref.rs:25:32
    |
 LL |     let _ = (&Ok::<_, i32>(6)).into_iter(); //~ WARN equivalent to .iter()
    |                                ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the Result
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `Result`
   --> $DIR/into_iter_on_ref.rs:26:37
    |
 LL |     let _ = (&mut Err::<i32, _>(7)).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                     ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the Vec
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `Vec`
   --> $DIR/into_iter_on_ref.rs:27:34
    |
 LL |     let _ = (&Vec::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                  ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the Vec
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `Vec`
   --> $DIR/into_iter_on_ref.rs:28:38
    |
 LL |     let _ = (&mut Vec::<i32>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                      ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the BTreeMap
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `BTreeMap`
   --> $DIR/into_iter_on_ref.rs:29:44
    |
 LL |     let _ = (&BTreeMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                            ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the BTreeMap
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `BTreeMap`
   --> $DIR/into_iter_on_ref.rs:30:48
    |
 LL |     let _ = (&mut BTreeMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                                ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the VecDeque
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `VecDeque`
   --> $DIR/into_iter_on_ref.rs:31:39
    |
 LL |     let _ = (&VecDeque::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                       ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the VecDeque
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `VecDeque`
   --> $DIR/into_iter_on_ref.rs:32:43
    |
 LL |     let _ = (&mut VecDeque::<i32>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                           ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the LinkedList
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `LinkedList`
   --> $DIR/into_iter_on_ref.rs:33:41
    |
 LL |     let _ = (&LinkedList::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                         ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the LinkedList
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `LinkedList`
   --> $DIR/into_iter_on_ref.rs:34:45
    |
 LL |     let _ = (&mut LinkedList::<i32>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                             ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the HashMap
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `HashMap`
   --> $DIR/into_iter_on_ref.rs:35:43
    |
 LL |     let _ = (&HashMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                           ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter_mut() and will not move the HashMap
+error: this `.into_iter()` call is equivalent to `.iter_mut()` and will not move the `HashMap`
   --> $DIR/into_iter_on_ref.rs:36:47
    |
 LL |     let _ = (&mut HashMap::<i32, u64>::new()).into_iter(); //~ WARN equivalent to .iter_mut()
    |                                               ^^^^^^^^^ help: call directly: `iter_mut`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the BTreeSet
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `BTreeSet`
   --> $DIR/into_iter_on_ref.rs:38:39
    |
 LL |     let _ = (&BTreeSet::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                       ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the BinaryHeap
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `BinaryHeap`
   --> $DIR/into_iter_on_ref.rs:39:41
    |
 LL |     let _ = (&BinaryHeap::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                         ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the HashSet
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `HashSet`
   --> $DIR/into_iter_on_ref.rs:40:38
    |
 LL |     let _ = (&HashSet::<i32>::new()).into_iter(); //~ WARN equivalent to .iter()
    |                                      ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the Path
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `Path`
   --> $DIR/into_iter_on_ref.rs:41:43
    |
 LL |     let _ = std::path::Path::new("12/34").into_iter(); //~ WARN equivalent to .iter()
    |                                           ^^^^^^^^^ help: call directly: `iter`
 
-error: this .into_iter() call is equivalent to .iter() and will not move the PathBuf
+error: this `.into_iter()` call is equivalent to `.iter()` and will not move the `PathBuf`
   --> $DIR/into_iter_on_ref.rs:42:47
    |
 LL |     let _ = std::path::PathBuf::from("12/34").into_iter(); //~ ERROR equivalent to .iter()

--- a/tests/ui/large_stack_arrays.stderr
+++ b/tests/ui/large_stack_arrays.stderr
@@ -5,7 +5,7 @@ LL |         [0u32; 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::large-stack-arrays` implied by `-D warnings`
-   = help: consider allocating on the heap with vec![0u32; 20_000_000].into_boxed_slice()
+   = help: consider allocating on the heap with `vec![0u32; 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
   --> $DIR/large_stack_arrays.rs:18:9
@@ -13,7 +13,7 @@ error: allocating a local array larger than 512000 bytes
 LL |         [S { data: [0; 32] }; 5000],
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider allocating on the heap with vec![S { data: [0; 32] }; 5000].into_boxed_slice()
+   = help: consider allocating on the heap with `vec![S { data: [0; 32] }; 5000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
   --> $DIR/large_stack_arrays.rs:19:9
@@ -21,7 +21,7 @@ error: allocating a local array larger than 512000 bytes
 LL |         [Some(""); 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider allocating on the heap with vec![Some(""); 20_000_000].into_boxed_slice()
+   = help: consider allocating on the heap with `vec![Some(""); 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
   --> $DIR/large_stack_arrays.rs:20:9
@@ -29,7 +29,7 @@ error: allocating a local array larger than 512000 bytes
 LL |         [E::T(0); 5000],
    |         ^^^^^^^^^^^^^^^
    |
-   = help: consider allocating on the heap with vec![E::T(0); 5000].into_boxed_slice()
+   = help: consider allocating on the heap with `vec![E::T(0); 5000].into_boxed_slice()`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/let_return.stderr
+++ b/tests/ui/let_return.stderr
@@ -1,8 +1,8 @@
-error: returning the result of a let binding from a block
+error: returning the result of a `let` binding from a block
   --> $DIR/let_return.rs:7:5
    |
 LL |     let x = 5;
-   |     ---------- unnecessary let binding
+   |     ---------- unnecessary `let` binding
 LL |     x
    |     ^
    |
@@ -13,11 +13,11 @@ LL |
 LL |     5
    |
 
-error: returning the result of a let binding from a block
+error: returning the result of a `let` binding from a block
   --> $DIR/let_return.rs:13:9
    |
 LL |         let x = 5;
-   |         ---------- unnecessary let binding
+   |         ---------- unnecessary `let` binding
 LL |         x
    |         ^
    |

--- a/tests/ui/let_underscore.stderr
+++ b/tests/ui/let_underscore.stderr
@@ -1,4 +1,4 @@
-error: non-binding let on a result of a #[must_use] function
+error: non-binding let on a result of a `#[must_use]` function
   --> $DIR/let_underscore.rs:59:5
    |
 LL |     let _ = f();
@@ -7,7 +7,7 @@ LL |     let _ = f();
    = note: `-D clippy::let-underscore-must-use` implied by `-D warnings`
    = help: consider explicitly using function result
 
-error: non-binding let on an expression with #[must_use] type
+error: non-binding let on an expression with `#[must_use]` type
   --> $DIR/let_underscore.rs:60:5
    |
 LL |     let _ = g();
@@ -15,7 +15,7 @@ LL |     let _ = g();
    |
    = help: consider explicitly using expression value
 
-error: non-binding let on a result of a #[must_use] function
+error: non-binding let on a result of a `#[must_use]` function
   --> $DIR/let_underscore.rs:62:5
    |
 LL |     let _ = l(0_u32);
@@ -23,7 +23,7 @@ LL |     let _ = l(0_u32);
    |
    = help: consider explicitly using function result
 
-error: non-binding let on a result of a #[must_use] function
+error: non-binding let on a result of a `#[must_use]` function
   --> $DIR/let_underscore.rs:66:5
    |
 LL |     let _ = s.f();
@@ -31,7 +31,7 @@ LL |     let _ = s.f();
    |
    = help: consider explicitly using function result
 
-error: non-binding let on an expression with #[must_use] type
+error: non-binding let on an expression with `#[must_use]` type
   --> $DIR/let_underscore.rs:67:5
    |
 LL |     let _ = s.g();
@@ -39,7 +39,7 @@ LL |     let _ = s.g();
    |
    = help: consider explicitly using expression value
 
-error: non-binding let on a result of a #[must_use] function
+error: non-binding let on a result of a `#[must_use]` function
   --> $DIR/let_underscore.rs:70:5
    |
 LL |     let _ = S::h();
@@ -47,7 +47,7 @@ LL |     let _ = S::h();
    |
    = help: consider explicitly using function result
 
-error: non-binding let on an expression with #[must_use] type
+error: non-binding let on an expression with `#[must_use]` type
   --> $DIR/let_underscore.rs:71:5
    |
 LL |     let _ = S::p();
@@ -55,7 +55,7 @@ LL |     let _ = S::p();
    |
    = help: consider explicitly using expression value
 
-error: non-binding let on a result of a #[must_use] function
+error: non-binding let on a result of a `#[must_use]` function
   --> $DIR/let_underscore.rs:73:5
    |
 LL |     let _ = S::a();
@@ -63,7 +63,7 @@ LL |     let _ = S::a();
    |
    = help: consider explicitly using function result
 
-error: non-binding let on an expression with #[must_use] type
+error: non-binding let on an expression with `#[must_use]` type
   --> $DIR/let_underscore.rs:75:5
    |
 LL |     let _ = if true { Ok(()) } else { Err(()) };
@@ -71,7 +71,7 @@ LL |     let _ = if true { Ok(()) } else { Err(()) };
    |
    = help: consider explicitly using expression value
 
-error: non-binding let on a result of a #[must_use] function
+error: non-binding let on a result of a `#[must_use]` function
   --> $DIR/let_underscore.rs:79:5
    |
 LL |     let _ = a.is_ok();
@@ -79,7 +79,7 @@ LL |     let _ = a.is_ok();
    |
    = help: consider explicitly using function result
 
-error: non-binding let on an expression with #[must_use] type
+error: non-binding let on an expression with `#[must_use]` type
   --> $DIR/let_underscore.rs:81:5
    |
 LL |     let _ = a.map(|_| ());
@@ -87,7 +87,7 @@ LL |     let _ = a.map(|_| ());
    |
    = help: consider explicitly using expression value
 
-error: non-binding let on an expression with #[must_use] type
+error: non-binding let on an expression with `#[must_use]` type
   --> $DIR/let_underscore.rs:83:5
    |
 LL |     let _ = a;

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -34,7 +34,7 @@ error: You are needlessly cloning iterator elements
   --> $DIR/map_clone.rs:25:29
    |
 LL |     let _ = std::env::args().map(|v| v.clone());
-   |                             ^^^^^^^^^^^^^^^^^^^ help: Remove the map call
+   |                             ^^^^^^^^^^^^^^^^^^^ help: Remove the `map` call
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/map_flatten.stderr
+++ b/tests/ui/map_flatten.stderr
@@ -2,7 +2,7 @@ error: called `map(..).flatten()` on an `Iterator`. This is more succinctly expr
   --> $DIR/map_flatten.rs:7:21
    |
 LL |     let _: Vec<_> = vec![5_i8; 6].into_iter().map(|x| 0..x).flatten().collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using flat_map instead: `vec![5_i8; 6].into_iter().flat_map(|x| 0..x)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using `flat_map` instead: `vec![5_i8; 6].into_iter().flat_map(|x| 0..x)`
    |
    = note: `-D clippy::map-flatten` implied by `-D warnings`
 

--- a/tests/ui/match_as_ref.stderr
+++ b/tests/ui/match_as_ref.stderr
@@ -1,4 +1,4 @@
-error: use as_ref() instead
+error: use `as_ref()` instead
   --> $DIR/match_as_ref.rs:8:33
    |
 LL |       let borrowed: Option<&()> = match owned {
@@ -10,7 +10,7 @@ LL | |     };
    |
    = note: `-D clippy::match-as-ref` implied by `-D warnings`
 
-error: use as_mut() instead
+error: use `as_mut()` instead
   --> $DIR/match_as_ref.rs:14:39
    |
 LL |       let borrow_mut: Option<&mut ()> = match mut_owned {
@@ -20,7 +20,7 @@ LL | |         Some(ref mut v) => Some(v),
 LL | |     };
    | |_____^ help: try this: `mut_owned.as_mut()`
 
-error: use as_ref() instead
+error: use `as_ref()` instead
   --> $DIR/match_as_ref.rs:30:13
    |
 LL | /             match self.source {

--- a/tests/ui/match_bool.stderr
+++ b/tests/ui/match_bool.stderr
@@ -13,7 +13,7 @@ LL | /     match test {
 LL | |         true => 0,
 LL | |         false => 42,
 LL | |     };
-   | |_____^ help: consider using an if/else expression: `if test { 0 } else { 42 }`
+   | |_____^ help: consider using an `if`/`else` expression: `if test { 0 } else { 42 }`
    |
    = note: `-D clippy::match-bool` implied by `-D warnings`
 
@@ -24,7 +24,7 @@ LL | /     match option == 1 {
 LL | |         true => 1,
 LL | |         false => 0,
 LL | |     };
-   | |_____^ help: consider using an if/else expression: `if option == 1 { 1 } else { 0 }`
+   | |_____^ help: consider using an `if`/`else` expression: `if option == 1 { 1 } else { 0 }`
 
 error: you seem to be trying to match on a boolean expression
   --> $DIR/match_bool.rs:15:5
@@ -37,7 +37,7 @@ LL | |         },
 LL | |     };
    | |_____^
    |
-help: consider using an if/else expression
+help: consider using an `if`/`else` expression
    |
 LL |     if !test {
 LL |     println!("Noooo!");
@@ -55,7 +55,7 @@ LL | |         _ => (),
 LL | |     };
    | |_____^
    |
-help: consider using an if/else expression
+help: consider using an `if`/`else` expression
    |
 LL |     if !test {
 LL |     println!("Noooo!");
@@ -73,7 +73,7 @@ LL | |         _ => (),
 LL | |     };
    | |_____^
    |
-help: consider using an if/else expression
+help: consider using an `if`/`else` expression
    |
 LL |     if !(test && test) {
 LL |     println!("Noooo!");
@@ -100,7 +100,7 @@ LL | |         },
 LL | |     };
    | |_____^
    |
-help: consider using an if/else expression
+help: consider using an `if`/`else` expression
    |
 LL |     if test {
 LL |     println!("Yes!");

--- a/tests/ui/match_same_arms.stderr
+++ b/tests/ui/match_same_arms.stderr
@@ -24,7 +24,7 @@ LL | |             if true {
 LL | |             a
 LL | |         },
    | |_________^
-note: `42` has the same arm body as the `_` wildcard, consider removing it`
+note: `42` has the same arm body as the `_` wildcard, consider removing it
   --> $DIR/match_same_arms.rs:28:15
    |
 LL |           42 => {
@@ -48,7 +48,7 @@ note: same as this
    |
 LL |         Abc::A => 0,
    |                   ^
-note: `Abc::A` has the same arm body as the `_` wildcard, consider removing it`
+note: `Abc::A` has the same arm body as the `_` wildcard, consider removing it
   --> $DIR/match_same_arms.rs:50:19
    |
 LL |         Abc::A => 0,

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -1,11 +1,11 @@
-error: Err(_) will match all errors, maybe not a good idea
+error: `Err(_)` will match all errors, maybe not a good idea
   --> $DIR/matches.rs:14:9
    |
 LL |         Err(_) => panic!("err"),
    |         ^^^^^^
    |
    = note: `-D clippy::match-wild-err-arm` implied by `-D warnings`
-   = note: to remove this warning, match each error separately or use unreachable macro
+   = note: to remove this warning, match each error separately or use `unreachable!` macro
 
 error: this `match` has identical arm bodies
   --> $DIR/matches.rs:13:18
@@ -26,13 +26,13 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: Err(_) will match all errors, maybe not a good idea
+error: `Err(_)` will match all errors, maybe not a good idea
   --> $DIR/matches.rs:20:9
    |
 LL |         Err(_) => panic!(),
    |         ^^^^^^
    |
-   = note: to remove this warning, match each error separately or use unreachable macro
+   = note: to remove this warning, match each error separately or use `unreachable!` macro
 
 error: this `match` has identical arm bodies
   --> $DIR/matches.rs:19:18
@@ -52,13 +52,13 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: Err(_) will match all errors, maybe not a good idea
+error: `Err(_)` will match all errors, maybe not a good idea
   --> $DIR/matches.rs:26:9
    |
 LL |         Err(_) => {
    |         ^^^^^^
    |
-   = note: to remove this warning, match each error separately or use unreachable macro
+   = note: to remove this warning, match each error separately or use `unreachable!` macro
 
 error: this `match` has identical arm bodies
   --> $DIR/matches.rs:25:18

--- a/tests/ui/mem_forget.stderr
+++ b/tests/ui/mem_forget.stderr
@@ -1,4 +1,4 @@
-error: usage of mem::forget on Drop type
+error: usage of `mem::forget` on `Drop` type
   --> $DIR/mem_forget.rs:14:5
    |
 LL |     memstuff::forget(six);
@@ -6,13 +6,13 @@ LL |     memstuff::forget(six);
    |
    = note: `-D clippy::mem-forget` implied by `-D warnings`
 
-error: usage of mem::forget on Drop type
+error: usage of `mem::forget` on `Drop` type
   --> $DIR/mem_forget.rs:17:5
    |
 LL |     std::mem::forget(seven);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: usage of mem::forget on Drop type
+error: usage of `mem::forget` on `Drop` type
   --> $DIR/mem_forget.rs:20:5
    |
 LL |     forgetSomething(eight);

--- a/tests/ui/min_max.stderr
+++ b/tests/ui/min_max.stderr
@@ -1,4 +1,4 @@
-error: this min/max combination leads to constant result
+error: this `min`/`max` combination leads to constant result
   --> $DIR/min_max.rs:12:5
    |
 LL |     min(1, max(3, x));
@@ -6,37 +6,37 @@ LL |     min(1, max(3, x));
    |
    = note: `-D clippy::min-max` implied by `-D warnings`
 
-error: this min/max combination leads to constant result
+error: this `min`/`max` combination leads to constant result
   --> $DIR/min_max.rs:13:5
    |
 LL |     min(max(3, x), 1);
    |     ^^^^^^^^^^^^^^^^^
 
-error: this min/max combination leads to constant result
+error: this `min`/`max` combination leads to constant result
   --> $DIR/min_max.rs:14:5
    |
 LL |     max(min(x, 1), 3);
    |     ^^^^^^^^^^^^^^^^^
 
-error: this min/max combination leads to constant result
+error: this `min`/`max` combination leads to constant result
   --> $DIR/min_max.rs:15:5
    |
 LL |     max(3, min(x, 1));
    |     ^^^^^^^^^^^^^^^^^
 
-error: this min/max combination leads to constant result
+error: this `min`/`max` combination leads to constant result
   --> $DIR/min_max.rs:17:5
    |
 LL |     my_max(3, my_min(x, 1));
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: this min/max combination leads to constant result
+error: this `min`/`max` combination leads to constant result
   --> $DIR/min_max.rs:29:5
    |
 LL |     min("Apple", max("Zoo", s));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: this min/max combination leads to constant result
+error: this `min`/`max` combination leads to constant result
   --> $DIR/min_max.rs:30:5
    |
 LL |     max(min(s, "Apple"), "Zoo");

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -1,4 +1,4 @@
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:12:5
    |
 LL | /     pub fn new() -> Self {
@@ -8,7 +8,7 @@ LL | |     }
    |
    = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
 
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:18:1
    |
 LL | / fn one() -> i32 {
@@ -16,7 +16,7 @@ LL | |     1
 LL | | }
    | |_^
 
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:23:1
    |
 LL | / fn two() -> i32 {
@@ -25,7 +25,7 @@ LL | |     abc
 LL | | }
    | |_^
 
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:30:1
    |
 LL | / fn string() -> String {
@@ -33,7 +33,7 @@ LL | |     String::new()
 LL | | }
    | |_^
 
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:35:1
    |
 LL | / unsafe fn four() -> i32 {
@@ -41,7 +41,7 @@ LL | |     4
 LL | | }
    | |_^
 
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:40:1
    |
 LL | / fn generic<T>(t: T) -> T {
@@ -49,7 +49,7 @@ LL | |     t
 LL | | }
    | |_^
 
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:44:1
    |
 LL | / fn sub(x: u32) -> usize {
@@ -57,7 +57,7 @@ LL | |     unsafe { transmute(&x) }
 LL | | }
    | |_^
 
-error: this could be a const_fn
+error: this could be a `const_fn`
   --> $DIR/could_be_const.rs:63:9
    |
 LL | /         pub fn b(self, a: &A) -> B {

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -1,4 +1,4 @@
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:12:5
    |
 LL | /     pub fn new() -> Self {
@@ -8,7 +8,7 @@ LL | |     }
    |
    = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
 
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:18:1
    |
 LL | / fn one() -> i32 {
@@ -16,7 +16,7 @@ LL | |     1
 LL | | }
    | |_^
 
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:23:1
    |
 LL | / fn two() -> i32 {
@@ -25,7 +25,7 @@ LL | |     abc
 LL | | }
    | |_^
 
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:30:1
    |
 LL | / fn string() -> String {
@@ -33,7 +33,7 @@ LL | |     String::new()
 LL | | }
    | |_^
 
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:35:1
    |
 LL | / unsafe fn four() -> i32 {
@@ -41,7 +41,7 @@ LL | |     4
 LL | | }
    | |_^
 
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:40:1
    |
 LL | / fn generic<T>(t: T) -> T {
@@ -49,7 +49,7 @@ LL | |     t
 LL | | }
    | |_^
 
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:44:1
    |
 LL | / fn sub(x: u32) -> usize {
@@ -57,7 +57,7 @@ LL | |     unsafe { transmute(&x) }
 LL | | }
    | |_^
 
-error: this could be a `const_fn`
+error: this could be a `const fn`
   --> $DIR/could_be_const.rs:63:9
    |
 LL | /         pub fn b(self, a: &A) -> B {

--- a/tests/ui/mul_add.stderr
+++ b/tests/ui/mul_add.stderr
@@ -1,4 +1,4 @@
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add.rs:10:17
    |
 LL |     let test1 = (a * b + c) * (c + a * b) + (c + (a * b) + c);
@@ -6,25 +6,25 @@ LL |     let test1 = (a * b + c) * (c + a * b) + (c + (a * b) + c);
    |
    = note: `-D clippy::manual-mul-add` implied by `-D warnings`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add.rs:10:17
    |
 LL |     let test1 = (a * b + c) * (c + a * b) + (c + (a * b) + c);
    |                 ^^^^^^^^^^^ help: try: `a.mul_add(b, c)`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add.rs:10:31
    |
 LL |     let test1 = (a * b + c) * (c + a * b) + (c + (a * b) + c);
    |                               ^^^^^^^^^^^ help: try: `a.mul_add(b, c)`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add.rs:10:46
    |
 LL |     let test1 = (a * b + c) * (c + a * b) + (c + (a * b) + c);
    |                                              ^^^^^^^^^^^ help: try: `a.mul_add(b, c)`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add.rs:11:17
    |
 LL |     let test2 = 1234.567 * 45.67834 + 0.0004;

--- a/tests/ui/mul_add_fixable.stderr
+++ b/tests/ui/mul_add_fixable.stderr
@@ -1,4 +1,4 @@
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add_fixable.rs:12:17
    |
 LL |     let test1 = a * b + c;
@@ -6,31 +6,31 @@ LL |     let test1 = a * b + c;
    |
    = note: `-D clippy::manual-mul-add` implied by `-D warnings`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add_fixable.rs:13:17
    |
 LL |     let test2 = c + a * b;
    |                 ^^^^^^^^^ help: try: `a.mul_add(b, c)`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add_fixable.rs:15:17
    |
 LL |     let test3 = (a * b) + c;
    |                 ^^^^^^^^^^^ help: try: `a.mul_add(b, c)`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add_fixable.rs:16:17
    |
 LL |     let test4 = c + (a * b);
    |                 ^^^^^^^^^^^ help: try: `a.mul_add(b, c)`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add_fixable.rs:18:17
    |
 LL |     let test5 = a.mul_add(b, c) * a.mul_add(b, c) + a.mul_add(b, c) + c;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.mul_add(b, c).mul_add(a.mul_add(b, c), a.mul_add(b, c))`
 
-error: consider using mul_add() for better numerical precision
+error: consider using `mul_add()` for better numerical precision
   --> $DIR/mul_add_fixable.rs:19:17
    |
 LL |     let test6 = 1234.567_f64 * 45.67834_f64 + 0.0004_f64;

--- a/tests/ui/mutex_atomic.stderr
+++ b/tests/ui/mutex_atomic.stderr
@@ -1,4 +1,4 @@
-error: Consider using an AtomicBool instead of a Mutex here. If you just want the locking behaviour and not the internal type, consider using Mutex<()>.
+error: Consider using an `AtomicBool` instead of a `Mutex` here. If you just want the locking behavior and not the internal type, consider using `Mutex<()>`.
   --> $DIR/mutex_atomic.rs:6:5
    |
 LL |     Mutex::new(true);
@@ -6,31 +6,31 @@ LL |     Mutex::new(true);
    |
    = note: `-D clippy::mutex-atomic` implied by `-D warnings`
 
-error: Consider using an AtomicUsize instead of a Mutex here. If you just want the locking behaviour and not the internal type, consider using Mutex<()>.
+error: Consider using an `AtomicUsize` instead of a `Mutex` here. If you just want the locking behavior and not the internal type, consider using `Mutex<()>`.
   --> $DIR/mutex_atomic.rs:7:5
    |
 LL |     Mutex::new(5usize);
    |     ^^^^^^^^^^^^^^^^^^
 
-error: Consider using an AtomicIsize instead of a Mutex here. If you just want the locking behaviour and not the internal type, consider using Mutex<()>.
+error: Consider using an `AtomicIsize` instead of a `Mutex` here. If you just want the locking behavior and not the internal type, consider using `Mutex<()>`.
   --> $DIR/mutex_atomic.rs:8:5
    |
 LL |     Mutex::new(9isize);
    |     ^^^^^^^^^^^^^^^^^^
 
-error: Consider using an AtomicPtr instead of a Mutex here. If you just want the locking behaviour and not the internal type, consider using Mutex<()>.
+error: Consider using an `AtomicPtr` instead of a `Mutex` here. If you just want the locking behavior and not the internal type, consider using `Mutex<()>`.
   --> $DIR/mutex_atomic.rs:10:5
    |
 LL |     Mutex::new(&x as *const u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Consider using an AtomicPtr instead of a Mutex here. If you just want the locking behaviour and not the internal type, consider using Mutex<()>.
+error: Consider using an `AtomicPtr` instead of a `Mutex` here. If you just want the locking behavior and not the internal type, consider using `Mutex<()>`.
   --> $DIR/mutex_atomic.rs:11:5
    |
 LL |     Mutex::new(&mut x as *mut u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Consider using an AtomicUsize instead of a Mutex here. If you just want the locking behaviour and not the internal type, consider using Mutex<()>.
+error: Consider using an `AtomicUsize` instead of a `Mutex` here. If you just want the locking behavior and not the internal type, consider using `Mutex<()>`.
   --> $DIR/mutex_atomic.rs:12:5
    |
 LL |     Mutex::new(0u32);
@@ -38,7 +38,7 @@ LL |     Mutex::new(0u32);
    |
    = note: `-D clippy::mutex-integer` implied by `-D warnings`
 
-error: Consider using an AtomicIsize instead of a Mutex here. If you just want the locking behaviour and not the internal type, consider using Mutex<()>.
+error: Consider using an `AtomicIsize` instead of a `Mutex` here. If you just want the locking behavior and not the internal type, consider using `Mutex<()>`.
   --> $DIR/mutex_atomic.rs:13:5
    |
 LL |     Mutex::new(0i32);

--- a/tests/ui/needless_continue.stderr
+++ b/tests/ui/needless_continue.stderr
@@ -1,4 +1,4 @@
-error: This else block is redundant.
+error: This `else` block is redundant.
 
   --> $DIR/needless_continue.rs:28:16
    |
@@ -9,7 +9,7 @@ LL | |         }
    | |_________^
    |
    = note: `-D clippy::needless-continue` implied by `-D warnings`
-   = help: Consider dropping the else clause and merging the code that follows (in the loop) with the if block, like so:
+   = help: Consider dropping the `else` clause and merging the code that follows (in the loop) with the `if` block, like so:
            if i % 2 == 0 && i % 3 == 0 {
            println!("{}", i);
            println!("{}", i + 1);
@@ -47,7 +47,7 @@ LL | |             println!("Jabber");
 LL | |         }
    | |_________^
    |
-   = help: Consider dropping the else clause, and moving out the code in the else block, like so:
+   = help: Consider dropping the `else` clause, and moving out the code in the `else` block, like so:
            if (zero!(i % 2) || nonzero!(i % 5)) && i % 3 != 0 {
                continue;
            }
@@ -55,7 +55,7 @@ LL | |         }
            println!("Jabber");
            ...
 
-error: This else block is redundant.
+error: This `else` block is redundant.
 
   --> $DIR/needless_continue.rs:100:24
    |
@@ -65,7 +65,7 @@ LL | |                     continue 'inner; // should lint here
 LL | |                 }
    | |_________________^
    |
-   = help: Consider dropping the else clause and merging the code that follows (in the loop) with the if block, like so:
+   = help: Consider dropping the `else` clause and merging the code that follows (in the loop) with the `if` block, like so:
            if condition() {
            println!("bar-3");
            // Merged code follows...println!("bar-4");
@@ -90,7 +90,7 @@ LL | |                     println!("bar-5");
 LL | |                 }
    | |_________________^
    |
-   = help: Consider dropping the else clause, and moving out the code in the else block, like so:
+   = help: Consider dropping the `else` clause, and moving out the code in the `else` block, like so:
            if condition() {
                continue;
            }

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -120,7 +120,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn bar_copy(x: u32, y: CopyWrapper) {
    |                        ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as Copy
+help: consider marking this type as `Copy`
   --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);
@@ -132,7 +132,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as Copy
+help: consider marking this type as `Copy`
   --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);
@@ -144,7 +144,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as Copy
+help: consider marking this type as `Copy`
   --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);
@@ -156,7 +156,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as Copy
+help: consider marking this type as `Copy`
   --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -1,4 +1,4 @@
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:18:5
    |
 LL |     return true;
@@ -6,67 +6,67 @@ LL |     return true;
    |
    = note: `-D clippy::needless-return` implied by `-D warnings`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:22:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^^ help: remove `return`: `true`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:27:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^^ help: remove `return`: `true`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:29:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^^ help: remove `return`: `false`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:35:17
    |
 LL |         true => return false,
    |                 ^^^^^^^^^^^^ help: remove `return`: `false`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:37:13
    |
 LL |             return true;
    |             ^^^^^^^^^^^^ help: remove `return`: `true`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:44:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^^ help: remove `return`: `true`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:46:16
    |
 LL |     let _ = || return true;
    |                ^^^^^^^^^^^ help: remove `return`: `true`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:54:5
    |
 LL |     return;
    |     ^^^^^^^ help: remove `return`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:59:9
    |
 LL |         return;
    |         ^^^^^^^ help: remove `return`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:61:9
    |
 LL |         return;
    |         ^^^^^^^ help: remove `return`
 
-error: unneeded return statement
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:68:14
    |
 LL |         _ => return,

--- a/tests/ui/neg_multiply.stderr
+++ b/tests/ui/neg_multiply.stderr
@@ -1,4 +1,4 @@
-error: Negation by multiplying with -1
+error: Negation by multiplying with `-1`
   --> $DIR/neg_multiply.rs:27:5
    |
 LL |     x * -1;
@@ -6,7 +6,7 @@ LL |     x * -1;
    |
    = note: `-D clippy::neg-multiply` implied by `-D warnings`
 
-error: Negation by multiplying with -1
+error: Negation by multiplying with `-1`
   --> $DIR/neg_multiply.rs:29:5
    |
 LL |     -1 * x;

--- a/tests/ui/non_copy_const.stderr
+++ b/tests/ui/non_copy_const.stderr
@@ -1,4 +1,4 @@
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:9:1
    |
 LL | const ATOMIC: AtomicUsize = AtomicUsize::new(5); //~ ERROR interior mutable
@@ -8,7 +8,7 @@ LL | const ATOMIC: AtomicUsize = AtomicUsize::new(5); //~ ERROR interior mutable
    |
    = note: `#[deny(clippy::declare_interior_mutable_const)]` on by default
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:10:1
    |
 LL | const CELL: Cell<usize> = Cell::new(6); //~ ERROR interior mutable
@@ -16,7 +16,7 @@ LL | const CELL: Cell<usize> = Cell::new(6); //~ ERROR interior mutable
    | |
    | make this a static item (maybe with lazy_static)
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:11:1
    |
 LL | const ATOMIC_TUPLE: ([AtomicUsize; 1], Vec<AtomicUsize>, u8) = ([ATOMIC], Vec::new(), 7);
@@ -24,7 +24,7 @@ LL | const ATOMIC_TUPLE: ([AtomicUsize; 1], Vec<AtomicUsize>, u8) = ([ATOMIC], V
    | |
    | make this a static item (maybe with lazy_static)
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:16:9
    |
 LL |         const $name: $ty = $e;
@@ -33,13 +33,13 @@ LL |         const $name: $ty = $e;
 LL | declare_const!(_ONCE: Once = Once::new()); //~ ERROR interior mutable
    | ------------------------------------------ in this macro invocation
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:40:5
    |
 LL |     const ATOMIC: AtomicUsize; //~ ERROR interior mutable
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:44:5
    |
 LL |     const INPUT: T;
@@ -47,7 +47,7 @@ LL |     const INPUT: T;
    |                  |
    |                  consider requiring `T` to be `Copy`
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:47:5
    |
 LL |     const ASSOC: Self::NonCopyType;
@@ -55,7 +55,7 @@ LL |     const ASSOC: Self::NonCopyType;
    |                  |
    |                  consider requiring `<Self as Trait<T>>::NonCopyType` to be `Copy`
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:51:5
    |
 LL |     const AN_INPUT: T = Self::INPUT;
@@ -63,7 +63,7 @@ LL |     const AN_INPUT: T = Self::INPUT;
    |                     |
    |                     consider requiring `T` to be `Copy`
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:16:9
    |
 LL |         const $name: $ty = $e;
@@ -72,7 +72,7 @@ LL |         const $name: $ty = $e;
 LL |     declare_const!(ANOTHER_INPUT: T = Self::INPUT); //~ ERROR interior mutable
    |     ----------------------------------------------- in this macro invocation
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:60:5
    |
 LL |     const SELF_2: Self;
@@ -80,13 +80,13 @@ LL |     const SELF_2: Self;
    |                   |
    |                   consider requiring `Self` to be `Copy`
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:81:5
    |
 LL |     const ASSOC_3: AtomicUsize = AtomicUsize::new(14); //~ ERROR interior mutable
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:84:5
    |
 LL |     const U_SELF: U = U::SELF_2;
@@ -94,7 +94,7 @@ LL |     const U_SELF: U = U::SELF_2;
    |                   |
    |                   consider requiring `U` to be `Copy`
 
-error: a const item should never be interior mutable
+error: a `const` item should never be interior mutable
   --> $DIR/non_copy_const.rs:87:5
    |
 LL |     const T_ASSOC: T::NonCopyType = T::ASSOC;
@@ -102,7 +102,7 @@ LL |     const T_ASSOC: T::NonCopyType = T::ASSOC;
    |                    |
    |                    consider requiring `<T as Trait<u32>>::NonCopyType` to be `Copy`
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:94:5
    |
 LL |     ATOMIC.store(1, Ordering::SeqCst); //~ ERROR interior mutability
@@ -111,7 +111,7 @@ LL |     ATOMIC.store(1, Ordering::SeqCst); //~ ERROR interior mutability
    = note: `#[deny(clippy::borrow_interior_mutable_const)]` on by default
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:95:16
    |
 LL |     assert_eq!(ATOMIC.load(Ordering::SeqCst), 5); //~ ERROR interior mutability
@@ -119,7 +119,7 @@ LL |     assert_eq!(ATOMIC.load(Ordering::SeqCst), 5); //~ ERROR interior mutabi
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:98:22
    |
 LL |     let _once_ref = &ONCE_INIT; //~ ERROR interior mutability
@@ -127,7 +127,7 @@ LL |     let _once_ref = &ONCE_INIT; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:99:25
    |
 LL |     let _once_ref_2 = &&ONCE_INIT; //~ ERROR interior mutability
@@ -135,7 +135,7 @@ LL |     let _once_ref_2 = &&ONCE_INIT; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:100:27
    |
 LL |     let _once_ref_4 = &&&&ONCE_INIT; //~ ERROR interior mutability
@@ -143,7 +143,7 @@ LL |     let _once_ref_4 = &&&&ONCE_INIT; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:101:26
    |
 LL |     let _once_mut = &mut ONCE_INIT; //~ ERROR interior mutability
@@ -151,7 +151,7 @@ LL |     let _once_mut = &mut ONCE_INIT; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:112:14
    |
 LL |     let _ = &ATOMIC_TUPLE; //~ ERROR interior mutability
@@ -159,7 +159,7 @@ LL |     let _ = &ATOMIC_TUPLE; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:113:14
    |
 LL |     let _ = &ATOMIC_TUPLE.0; //~ ERROR interior mutability
@@ -167,7 +167,7 @@ LL |     let _ = &ATOMIC_TUPLE.0; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:114:19
    |
 LL |     let _ = &(&&&&ATOMIC_TUPLE).0; //~ ERROR interior mutability
@@ -175,7 +175,7 @@ LL |     let _ = &(&&&&ATOMIC_TUPLE).0; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:115:14
    |
 LL |     let _ = &ATOMIC_TUPLE.0[0]; //~ ERROR interior mutability
@@ -183,7 +183,7 @@ LL |     let _ = &ATOMIC_TUPLE.0[0]; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:116:13
    |
 LL |     let _ = ATOMIC_TUPLE.0[0].load(Ordering::SeqCst); //~ ERROR interior mutability
@@ -191,7 +191,7 @@ LL |     let _ = ATOMIC_TUPLE.0[0].load(Ordering::SeqCst); //~ ERROR interior mu
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:122:13
    |
 LL |     let _ = ATOMIC_TUPLE.0[0]; //~ ERROR interior mutability
@@ -199,7 +199,7 @@ LL |     let _ = ATOMIC_TUPLE.0[0]; //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:127:5
    |
 LL |     CELL.set(2); //~ ERROR interior mutability
@@ -207,7 +207,7 @@ LL |     CELL.set(2); //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:128:16
    |
 LL |     assert_eq!(CELL.get(), 6); //~ ERROR interior mutability
@@ -215,7 +215,7 @@ LL |     assert_eq!(CELL.get(), 6); //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:141:5
    |
 LL |     u64::ATOMIC.store(5, Ordering::SeqCst); //~ ERROR interior mutability
@@ -223,7 +223,7 @@ LL |     u64::ATOMIC.store(5, Ordering::SeqCst); //~ ERROR interior mutability
    |
    = help: assign this const to a local or static variable, and use the variable here
 
-error: a const item with interior mutability should not be borrowed
+error: a `const` item with interior mutability should not be borrowed
   --> $DIR/non_copy_const.rs:142:16
    |
 LL |     assert_eq!(u64::ATOMIC.load(Ordering::SeqCst), 9); //~ ERROR interior mutability

--- a/tests/ui/ok_expect.stderr
+++ b/tests/ui/ok_expect.stderr
@@ -1,4 +1,4 @@
-error: called `ok().expect()` on a Result value. You can call `expect` directly on the `Result`
+error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
   --> $DIR/ok_expect.rs:14:5
    |
 LL |     res.ok().expect("disaster!");
@@ -6,25 +6,25 @@ LL |     res.ok().expect("disaster!");
    |
    = note: `-D clippy::ok-expect` implied by `-D warnings`
 
-error: called `ok().expect()` on a Result value. You can call `expect` directly on the `Result`
+error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
   --> $DIR/ok_expect.rs:20:5
    |
 LL |     res3.ok().expect("whoof");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: called `ok().expect()` on a Result value. You can call `expect` directly on the `Result`
+error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
   --> $DIR/ok_expect.rs:22:5
    |
 LL |     res4.ok().expect("argh");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: called `ok().expect()` on a Result value. You can call `expect` directly on the `Result`
+error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
   --> $DIR/ok_expect.rs:24:5
    |
 LL |     res5.ok().expect("oops");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: called `ok().expect()` on a Result value. You can call `expect` directly on the `Result`
+error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
   --> $DIR/ok_expect.rs:26:5
    |
 LL |     res6.ok().expect("meh");

--- a/tests/ui/open_options.stderr
+++ b/tests/ui/open_options.stderr
@@ -1,4 +1,4 @@
-error: file opened with "truncate" and "read"
+error: file opened with `truncate` and `read`
   --> $DIR/open_options.rs:6:5
    |
 LL |     OpenOptions::new().read(true).truncate(true).open("foo.txt");
@@ -6,37 +6,37 @@ LL |     OpenOptions::new().read(true).truncate(true).open("foo.txt");
    |
    = note: `-D clippy::nonsensical-open-options` implied by `-D warnings`
 
-error: file opened with "append" and "truncate"
+error: file opened with `append` and `truncate`
   --> $DIR/open_options.rs:7:5
    |
 LL |     OpenOptions::new().append(true).truncate(true).open("foo.txt");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the method "read" is called more than once
+error: the method `read` is called more than once
   --> $DIR/open_options.rs:9:5
    |
 LL |     OpenOptions::new().read(true).read(false).open("foo.txt");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the method "create" is called more than once
+error: the method `create` is called more than once
   --> $DIR/open_options.rs:10:5
    |
 LL |     OpenOptions::new().create(true).create(false).open("foo.txt");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the method "write" is called more than once
+error: the method `write` is called more than once
   --> $DIR/open_options.rs:11:5
    |
 LL |     OpenOptions::new().write(true).write(false).open("foo.txt");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the method "append" is called more than once
+error: the method `append` is called more than once
   --> $DIR/open_options.rs:12:5
    |
 LL |     OpenOptions::new().append(true).append(false).open("foo.txt");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: the method "truncate" is called more than once
+error: the method `truncate` is called more than once
   --> $DIR/open_options.rs:13:5
    |
 LL |     OpenOptions::new().truncate(true).truncate(false).open("foo.txt");

--- a/tests/ui/option_map_or_none.stderr
+++ b/tests/ui/option_map_or_none.stderr
@@ -1,12 +1,12 @@
-error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
+error: called `map_or(None, f)` on an `Option` value. This can be done more directly by calling `and_then(f)` instead
   --> $DIR/option_map_or_none.rs:10:13
    |
 LL |     let _ = opt.map_or(None, |x| Some(x + 1));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using and_then instead: `opt.and_then(|x| Some(x + 1))`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try using `and_then` instead: `opt.and_then(|x| Some(x + 1))`
    |
    = note: `-D clippy::option-map-or-none` implied by `-D warnings`
 
-error: called `map_or(None, f)` on an Option value. This can be done more directly by calling `and_then(f)` instead
+error: called `map_or(None, f)` on an `Option` value. This can be done more directly by calling `and_then(f)` instead
   --> $DIR/option_map_or_none.rs:13:13
    |
 LL |       let _ = opt.map_or(None, |x| {
@@ -15,7 +15,7 @@ LL | |                         Some(x + 1)
 LL | |                        });
    | |_________________________^
    |
-help: try using and_then instead
+help: try using `and_then` instead
    |
 LL |     let _ = opt.and_then(|x| {
 LL |                         Some(x + 1)

--- a/tests/ui/option_map_unit_fn_fixable.stderr
+++ b/tests/ui/option_map_unit_fn_fixable.stderr
@@ -1,4 +1,4 @@
-error: called `map(f)` on an Option value where `f` is a unit function
+error: called `map(f)` on an `Option` value where `f` is a unit function
   --> $DIR/option_map_unit_fn_fixable.rs:34:5
    |
 LL |     x.field.map(do_nothing);
@@ -8,7 +8,7 @@ LL |     x.field.map(do_nothing);
    |
    = note: `-D clippy::option-map-unit-fn` implied by `-D warnings`
 
-error: called `map(f)` on an Option value where `f` is a unit function
+error: called `map(f)` on an `Option` value where `f` is a unit function
   --> $DIR/option_map_unit_fn_fixable.rs:36:5
    |
 LL |     x.field.map(do_nothing);
@@ -16,7 +16,7 @@ LL |     x.field.map(do_nothing);
    |     |
    |     help: try this: `if let Some(x_field) = x.field { do_nothing(x_field) }`
 
-error: called `map(f)` on an Option value where `f` is a unit function
+error: called `map(f)` on an `Option` value where `f` is a unit function
   --> $DIR/option_map_unit_fn_fixable.rs:38:5
    |
 LL |     x.field.map(diverge);
@@ -24,7 +24,7 @@ LL |     x.field.map(diverge);
    |     |
    |     help: try this: `if let Some(x_field) = x.field { diverge(x_field) }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:44:5
    |
 LL |     x.field.map(|value| x.do_option_nothing(value + captured));
@@ -32,7 +32,7 @@ LL |     x.field.map(|value| x.do_option_nothing(value + captured));
    |     |
    |     help: try this: `if let Some(value) = x.field { x.do_option_nothing(value + captured) }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:46:5
    |
 LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
@@ -40,7 +40,7 @@ LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { x.do_option_plus_one(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:49:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
@@ -48,7 +48,7 @@ LL |     x.field.map(|value| do_nothing(value + captured));
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:51:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
@@ -56,7 +56,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:53:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
@@ -64,7 +64,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:55:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
@@ -72,7 +72,7 @@ LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:58:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
@@ -80,7 +80,7 @@ LL |     x.field.map(|value| diverge(value + captured));
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:60:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
@@ -88,7 +88,7 @@ LL |     x.field.map(|value| { diverge(value + captured) });
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:62:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
@@ -96,7 +96,7 @@ LL |     x.field.map(|value| { diverge(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:64:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
@@ -104,7 +104,7 @@ LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:69:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
@@ -112,7 +112,7 @@ LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { let y = plus_one(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:71:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
@@ -120,7 +120,7 @@ LL |     x.field.map(|value| { plus_one(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:73:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
@@ -128,7 +128,7 @@ LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     |
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an Option value where `f` is a unit closure
+error: called `map(f)` on an `Option` value where `f` is a unit closure
   --> $DIR/option_map_unit_fn_fixable.rs:76:5
    |
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });}

--- a/tests/ui/option_map_unwrap_or.stderr
+++ b/tests/ui/option_map_unwrap_or.stderr
@@ -1,4 +1,4 @@
-error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
+error: called `map(f).unwrap_or(a)` on an `Option` value. This can be done more directly by calling `map_or(a, f)` instead
   --> $DIR/option_map_unwrap_or.rs:20:13
    |
 LL |       let _ = opt.map(|x| x + 1)
@@ -13,7 +13,7 @@ help: use `map_or(a, f)` instead
 LL |     let _ = opt.map_or(0, |x| x + 1);
    |                 ^^^^^^ ^^          --
 
-error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
+error: called `map(f).unwrap_or(a)` on an `Option` value. This can be done more directly by calling `map_or(a, f)` instead
   --> $DIR/option_map_unwrap_or.rs:24:13
    |
 LL |       let _ = opt.map(|x| {
@@ -31,7 +31,7 @@ LL |     }
 LL |     );
    |
 
-error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
+error: called `map(f).unwrap_or(a)` on an `Option` value. This can be done more directly by calling `map_or(a, f)` instead
   --> $DIR/option_map_unwrap_or.rs:28:13
    |
 LL |       let _ = opt.map(|x| x + 1)
@@ -48,7 +48,7 @@ LL |             0
 LL |         }, |x| x + 1);
    |
 
-error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
+error: called `map(f).unwrap_or(None)` on an `Option` value. This can be done more directly by calling `and_then(f)` instead
   --> $DIR/option_map_unwrap_or.rs:33:13
    |
 LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
@@ -59,7 +59,7 @@ help: use `and_then(f)` instead
 LL |     let _ = opt.and_then(|x| Some(x + 1));
    |                 ^^^^^^^^                --
 
-error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
+error: called `map(f).unwrap_or(None)` on an `Option` value. This can be done more directly by calling `and_then(f)` instead
   --> $DIR/option_map_unwrap_or.rs:35:13
    |
 LL |       let _ = opt.map(|x| {
@@ -77,7 +77,7 @@ LL |     }
 LL |     );
    |
 
-error: called `map(f).unwrap_or(None)` on an Option value. This can be done more directly by calling `and_then(f)` instead
+error: called `map(f).unwrap_or(None)` on an `Option` value. This can be done more directly by calling `and_then(f)` instead
   --> $DIR/option_map_unwrap_or.rs:39:13
    |
 LL |       let _ = opt
@@ -91,7 +91,7 @@ help: use `and_then(f)` instead
 LL |         .and_then(|x| Some(x + 1));
    |          ^^^^^^^^                --
 
-error: called `map(f).unwrap_or(a)` on an Option value. This can be done more directly by calling `map_or(a, f)` instead
+error: called `map(f).unwrap_or(a)` on an `Option` value. This can be done more directly by calling `map_or(a, f)` instead
   --> $DIR/option_map_unwrap_or.rs:50:13
    |
 LL |     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
@@ -102,7 +102,7 @@ help: use `map_or(a, f)` instead
 LL |     let _ = Some("prefix").map_or(id, |p| format!("{}.", p));
    |                            ^^^^^^ ^^^                      --
 
-error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on an `Option` value. This can be done more directly by calling `map_or_else(g, f)` instead
   --> $DIR/option_map_unwrap_or.rs:54:13
    |
 LL |       let _ = opt.map(|x| x + 1)
@@ -114,7 +114,7 @@ LL | |         .unwrap_or_else(|| 0);
    = note: `-D clippy::option-map-unwrap-or-else` implied by `-D warnings`
    = note: replace `map(|x| x + 1).unwrap_or_else(|| 0)` with `map_or_else(|| 0, |x| x + 1)`
 
-error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on an `Option` value. This can be done more directly by calling `map_or_else(g, f)` instead
   --> $DIR/option_map_unwrap_or.rs:58:13
    |
 LL |       let _ = opt.map(|x| {
@@ -124,7 +124,7 @@ LL | |     }
 LL | |     ).unwrap_or_else(|| 0);
    | |__________________________^
 
-error: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on an `Option` value. This can be done more directly by calling `map_or_else(g, f)` instead
   --> $DIR/option_map_unwrap_or.rs:62:13
    |
 LL |       let _ = opt.map(|x| x + 1)

--- a/tests/ui/range.stderr
+++ b/tests/ui/range.stderr
@@ -1,4 +1,4 @@
-error: It is more idiomatic to use v1.iter().enumerate()
+error: It is more idiomatic to use `v1.iter().enumerate()`
   --> $DIR/range.rs:5:14
    |
 LL |     let _x = v1.iter().zip(0..v1.len());

--- a/tests/ui/result_map_unit_fn_fixable.stderr
+++ b/tests/ui/result_map_unit_fn_fixable.stderr
@@ -1,4 +1,4 @@
-error: called `map(f)` on an Result value where `f` is a unit function
+error: called `map(f)` on an `Result` value where `f` is a unit function
   --> $DIR/result_map_unit_fn_fixable.rs:35:5
    |
 LL |     x.field.map(do_nothing);
@@ -8,7 +8,7 @@ LL |     x.field.map(do_nothing);
    |
    = note: `-D clippy::result-map-unit-fn` implied by `-D warnings`
 
-error: called `map(f)` on an Result value where `f` is a unit function
+error: called `map(f)` on an `Result` value where `f` is a unit function
   --> $DIR/result_map_unit_fn_fixable.rs:37:5
    |
 LL |     x.field.map(do_nothing);
@@ -16,7 +16,7 @@ LL |     x.field.map(do_nothing);
    |     |
    |     help: try this: `if let Ok(x_field) = x.field { do_nothing(x_field) }`
 
-error: called `map(f)` on an Result value where `f` is a unit function
+error: called `map(f)` on an `Result` value where `f` is a unit function
   --> $DIR/result_map_unit_fn_fixable.rs:39:5
    |
 LL |     x.field.map(diverge);
@@ -24,7 +24,7 @@ LL |     x.field.map(diverge);
    |     |
    |     help: try this: `if let Ok(x_field) = x.field { diverge(x_field) }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:45:5
    |
 LL |     x.field.map(|value| x.do_result_nothing(value + captured));
@@ -32,7 +32,7 @@ LL |     x.field.map(|value| x.do_result_nothing(value + captured));
    |     |
    |     help: try this: `if let Ok(value) = x.field { x.do_result_nothing(value + captured) }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:47:5
    |
 LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
@@ -40,7 +40,7 @@ LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { x.do_result_plus_one(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:50:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
@@ -48,7 +48,7 @@ LL |     x.field.map(|value| do_nothing(value + captured));
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:52:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
@@ -56,7 +56,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:54:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
@@ -64,7 +64,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:56:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
@@ -72,7 +72,7 @@ LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:59:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
@@ -80,7 +80,7 @@ LL |     x.field.map(|value| diverge(value + captured));
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:61:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
@@ -88,7 +88,7 @@ LL |     x.field.map(|value| { diverge(value + captured) });
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:63:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
@@ -96,7 +96,7 @@ LL |     x.field.map(|value| { diverge(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:65:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
@@ -104,7 +104,7 @@ LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:70:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
@@ -112,7 +112,7 @@ LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { let y = plus_one(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:72:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
@@ -120,7 +120,7 @@ LL |     x.field.map(|value| { plus_one(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:74:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
@@ -128,7 +128,7 @@ LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     |
    |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an Result value where `f` is a unit closure
+error: called `map(f)` on an `Result` value where `f` is a unit closure
   --> $DIR/result_map_unit_fn_fixable.rs:77:5
    |
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });

--- a/tests/ui/result_map_unwrap_or_else.stderr
+++ b/tests/ui/result_map_unwrap_or_else.stderr
@@ -1,4 +1,4 @@
-error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `.map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on a `Result` value. This can be done more directly by calling `.map_or_else(g, f)` instead
   --> $DIR/result_map_unwrap_or_else.rs:15:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0); // should lint even though this call is on a separate line
@@ -7,7 +7,7 @@ LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0); // should lint even t
    = note: `-D clippy::result-map-unwrap-or-else` implied by `-D warnings`
    = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `map_or_else(|e| 0, |x| x + 1)`
 
-error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `.map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on a `Result` value. This can be done more directly by calling `.map_or_else(g, f)` instead
   --> $DIR/result_map_unwrap_or_else.rs:17:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0);
@@ -15,7 +15,7 @@ LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0);
    |
    = note: replace `map(|x| x + 1).unwrap_or_else(|e| 0)` with `map_or_else(|e| 0, |x| x + 1)`
 
-error: called `map(f).unwrap_or_else(g)` on a Result value. This can be done more directly by calling `.map_or_else(g, f)` instead
+error: called `map(f).unwrap_or_else(g)` on a `Result` value. This can be done more directly by calling `.map_or_else(g, f)` instead
   --> $DIR/result_map_unwrap_or_else.rs:18:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|e| 0);

--- a/tests/ui/same_functions_in_if_condition.stderr
+++ b/tests/ui/same_functions_in_if_condition.stderr
@@ -1,4 +1,4 @@
-error: this `if` has the same function call as a previous if
+error: this `if` has the same function call as a previous `if`
   --> $DIR/same_functions_in_if_condition.rs:29:15
    |
 LL |     } else if function() {
@@ -11,7 +11,7 @@ note: same as this
 LL |     if function() {
    |        ^^^^^^^^^^
 
-error: this `if` has the same function call as a previous if
+error: this `if` has the same function call as a previous `if`
   --> $DIR/same_functions_in_if_condition.rs:34:15
    |
 LL |     } else if fn_arg(a) {
@@ -23,7 +23,7 @@ note: same as this
 LL |     if fn_arg(a) {
    |        ^^^^^^^^^
 
-error: this `if` has the same function call as a previous if
+error: this `if` has the same function call as a previous `if`
   --> $DIR/same_functions_in_if_condition.rs:39:15
    |
 LL |     } else if obj.method() {
@@ -35,7 +35,7 @@ note: same as this
 LL |     if obj.method() {
    |        ^^^^^^^^^^^^
 
-error: this `if` has the same function call as a previous if
+error: this `if` has the same function call as a previous `if`
   --> $DIR/same_functions_in_if_condition.rs:44:15
    |
 LL |     } else if obj.method_arg(a) {
@@ -47,7 +47,7 @@ note: same as this
 LL |     if obj.method_arg(a) {
    |        ^^^^^^^^^^^^^^^^^
 
-error: this `if` has the same function call as a previous if
+error: this `if` has the same function call as a previous `if`
   --> $DIR/same_functions_in_if_condition.rs:51:15
    |
 LL |     } else if v.pop() == None {
@@ -59,7 +59,7 @@ note: same as this
 LL |     if v.pop() == None {
    |        ^^^^^^^^^^^^^^^
 
-error: this `if` has the same function call as a previous if
+error: this `if` has the same function call as a previous `if`
   --> $DIR/same_functions_in_if_condition.rs:56:15
    |
 LL |     } else if v.len() == 42 {

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -2,7 +2,7 @@ error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:9:13
    |
 LL |     x.split("x");
-   |             ^^^ help: try using a char instead: `'x'`
+   |             ^^^ help: try using a `char` instead: `'x'`
    |
    = note: `-D clippy::single-char-pattern` implied by `-D warnings`
 
@@ -10,157 +10,157 @@ error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:26:16
    |
 LL |     x.contains("x");
-   |                ^^^ help: try using a char instead: `'x'`
+   |                ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:27:19
    |
 LL |     x.starts_with("x");
-   |                   ^^^ help: try using a char instead: `'x'`
+   |                   ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:28:17
    |
 LL |     x.ends_with("x");
-   |                 ^^^ help: try using a char instead: `'x'`
+   |                 ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:29:12
    |
 LL |     x.find("x");
-   |            ^^^ help: try using a char instead: `'x'`
+   |            ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:30:13
    |
 LL |     x.rfind("x");
-   |             ^^^ help: try using a char instead: `'x'`
+   |             ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:31:14
    |
 LL |     x.rsplit("x");
-   |              ^^^ help: try using a char instead: `'x'`
+   |              ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:32:24
    |
 LL |     x.split_terminator("x");
-   |                        ^^^ help: try using a char instead: `'x'`
+   |                        ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:33:25
    |
 LL |     x.rsplit_terminator("x");
-   |                         ^^^ help: try using a char instead: `'x'`
+   |                         ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:34:17
    |
 LL |     x.splitn(0, "x");
-   |                 ^^^ help: try using a char instead: `'x'`
+   |                 ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:35:18
    |
 LL |     x.rsplitn(0, "x");
-   |                  ^^^ help: try using a char instead: `'x'`
+   |                  ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:36:15
    |
 LL |     x.matches("x");
-   |               ^^^ help: try using a char instead: `'x'`
+   |               ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:37:16
    |
 LL |     x.rmatches("x");
-   |                ^^^ help: try using a char instead: `'x'`
+   |                ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:38:21
    |
 LL |     x.match_indices("x");
-   |                     ^^^ help: try using a char instead: `'x'`
+   |                     ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:39:22
    |
 LL |     x.rmatch_indices("x");
-   |                      ^^^ help: try using a char instead: `'x'`
+   |                      ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:40:26
    |
 LL |     x.trim_start_matches("x");
-   |                          ^^^ help: try using a char instead: `'x'`
+   |                          ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:41:24
    |
 LL |     x.trim_end_matches("x");
-   |                        ^^^ help: try using a char instead: `'x'`
+   |                        ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:43:13
    |
 LL |     x.split("/n");
-   |             ^^^^ help: try using a char instead: `'/n'`
+   |             ^^^^ help: try using a `char` instead: `'/n'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:44:13
    |
 LL |     x.split("'");
-   |             ^^^ help: try using a char instead: `'/''`
+   |             ^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:45:13
    |
 LL |     x.split("/'");
-   |             ^^^^ help: try using a char instead: `'/''`
+   |             ^^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:50:31
    |
 LL |     x.replace(";", ",").split(","); // issue #2978
-   |                               ^^^ help: try using a char instead: `','`
+   |                               ^^^ help: try using a `char` instead: `','`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:51:19
    |
 LL |     x.starts_with("/x03"); // issue #2996
-   |                   ^^^^^^ help: try using a char instead: `'/x03'`
+   |                   ^^^^^^ help: try using a `char` instead: `'/x03'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:58:13
    |
 LL |     x.split(r"a");
-   |             ^^^^ help: try using a char instead: `'a'`
+   |             ^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:59:13
    |
 LL |     x.split(r#"a"#);
-   |             ^^^^^^ help: try using a char instead: `'a'`
+   |             ^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:60:13
    |
 LL |     x.split(r###"a"###);
-   |             ^^^^^^^^^^ help: try using a char instead: `'a'`
+   |             ^^^^^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:61:13
    |
 LL |     x.split(r###"'"###);
-   |             ^^^^^^^^^^ help: try using a char instead: `'/''`
+   |             ^^^^^^^^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
   --> $DIR/single_char_pattern.rs:62:13
    |
 LL |     x.split(r###"#"###);
-   |             ^^^^^^^^^^ help: try using a char instead: `'#'`
+   |             ^^^^^^^^^^ help: try using a `char` instead: `'#'`
 
 error: aborting due to 27 previous errors
 

--- a/tests/ui/types.stderr
+++ b/tests/ui/types.stderr
@@ -1,4 +1,4 @@
-error: casting i32 to i64 may become silently lossy if you later change the type
+error: casting `i32` to `i64` may become silently lossy if you later change the type
   --> $DIR/types.rs:14:22
    |
 LL |     let c_i64: i64 = c as i64;

--- a/tests/ui/unnecessary_cast_fixable.stderr
+++ b/tests/ui/unnecessary_cast_fixable.stderr
@@ -1,4 +1,4 @@
-error: casting integer literal to f32 is unnecessary
+error: casting integer literal to `f32` is unnecessary
   --> $DIR/unnecessary_cast_fixable.rs:8:5
    |
 LL |     100 as f32;
@@ -6,13 +6,13 @@ LL |     100 as f32;
    |
    = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
 
-error: casting integer literal to f64 is unnecessary
+error: casting integer literal to `f64` is unnecessary
   --> $DIR/unnecessary_cast_fixable.rs:9:5
    |
 LL |     100 as f64;
    |     ^^^^^^^^^^ help: try: `100_f64`
 
-error: casting integer literal to f64 is unnecessary
+error: casting integer literal to `f64` is unnecessary
   --> $DIR/unnecessary_cast_fixable.rs:10:5
    |
 LL |     100_i32 as f64;

--- a/tests/ui/unnecessary_clone.stderr
+++ b/tests/ui/unnecessary_clone.stderr
@@ -18,7 +18,7 @@ error: using `clone` on a `Copy` type
 LL |     rc.borrow().clone();
    |     ^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*rc.borrow()`
 
-error: using '.clone()' on a ref-counted pointer
+error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:39:5
    |
 LL |     rc.clone();
@@ -26,25 +26,25 @@ LL |     rc.clone();
    |
    = note: `-D clippy::clone-on-ref-ptr` implied by `-D warnings`
 
-error: using '.clone()' on a ref-counted pointer
+error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:42:5
    |
 LL |     arc.clone();
    |     ^^^^^^^^^^^ help: try this: `Arc::<bool>::clone(&arc)`
 
-error: using '.clone()' on a ref-counted pointer
+error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:45:5
    |
 LL |     rcweak.clone();
    |     ^^^^^^^^^^^^^^ help: try this: `Weak::<bool>::clone(&rcweak)`
 
-error: using '.clone()' on a ref-counted pointer
+error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:48:5
    |
 LL |     arc_weak.clone();
    |     ^^^^^^^^^^^^^^^^ help: try this: `Weak::<bool>::clone(&arc_weak)`
 
-error: using '.clone()' on a ref-counted pointer
+error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:52:33
    |
 LL |     let _: Arc<dyn SomeTrait> = x.clone();

--- a/tests/ui/unsafe_removed_from_name.stderr
+++ b/tests/ui/unsafe_removed_from_name.stderr
@@ -1,4 +1,4 @@
-error: removed "unsafe" from the name of `UnsafeCell` in use as `TotallySafeCell`
+error: removed `unsafe` from the name of `UnsafeCell` in use as `TotallySafeCell`
   --> $DIR/unsafe_removed_from_name.rs:5:1
    |
 LL | use std::cell::UnsafeCell as TotallySafeCell;
@@ -6,13 +6,13 @@ LL | use std::cell::UnsafeCell as TotallySafeCell;
    |
    = note: `-D clippy::unsafe-removed-from-name` implied by `-D warnings`
 
-error: removed "unsafe" from the name of `UnsafeCell` in use as `TotallySafeCellAgain`
+error: removed `unsafe` from the name of `UnsafeCell` in use as `TotallySafeCellAgain`
   --> $DIR/unsafe_removed_from_name.rs:7:1
    |
 LL | use std::cell::UnsafeCell as TotallySafeCellAgain;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: removed "unsafe" from the name of `Unsafe` in use as `LieAboutModSafety`
+error: removed `unsafe` from the name of `Unsafe` in use as `LieAboutModSafety`
   --> $DIR/unsafe_removed_from_name.rs:21:1
    |
 LL | use mod_with_some_unsafe_things::Unsafe as LieAboutModSafety;

--- a/tests/ui/unwrap.stderr
+++ b/tests/ui/unwrap.stderr
@@ -1,4 +1,4 @@
-error: used unwrap() on an Option value. If you don't want to handle the None case gracefully, consider using expect() to provide a better panic message
+error: used `unwrap()` on `an Option` value. If you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
   --> $DIR/unwrap.rs:5:13
    |
 LL |     let _ = opt.unwrap();
@@ -6,7 +6,7 @@ LL |     let _ = opt.unwrap();
    |
    = note: `-D clippy::option-unwrap-used` implied by `-D warnings`
 
-error: used unwrap() on a Result value. If you don't want to handle the Err case gracefully, consider using expect() to provide a better panic message
+error: used `unwrap()` on `a Result` value. If you don't want to handle the `Err` case gracefully, consider using `expect()` to provide a better panic message
   --> $DIR/unwrap.rs:10:13
    |
 LL |     let _ = res.unwrap();

--- a/tests/ui/zero_div_zero.stderr
+++ b/tests/ui/zero_div_zero.stderr
@@ -6,7 +6,7 @@ LL |     let nan = 0.0 / 0.0;
    |
    = note: `#[deny(clippy::eq_op)]` on by default
 
-error: constant division of 0.0 with 0.0 will always result in NaN
+error: constant division of `0.0` with `0.0` will always result in NaN
   --> $DIR/zero_div_zero.rs:4:15
    |
 LL |     let nan = 0.0 / 0.0;
@@ -21,7 +21,7 @@ error: equal expressions as operands to `/`
 LL |     let f64_nan = 0.0 / 0.0f64;
    |                   ^^^^^^^^^^^^
 
-error: constant division of 0.0 with 0.0 will always result in NaN
+error: constant division of `0.0` with `0.0` will always result in NaN
   --> $DIR/zero_div_zero.rs:5:19
    |
 LL |     let f64_nan = 0.0 / 0.0f64;
@@ -35,7 +35,7 @@ error: equal expressions as operands to `/`
 LL |     let other_f64_nan = 0.0f64 / 0.0;
    |                         ^^^^^^^^^^^^
 
-error: constant division of 0.0 with 0.0 will always result in NaN
+error: constant division of `0.0` with `0.0` will always result in NaN
   --> $DIR/zero_div_zero.rs:6:25
    |
 LL |     let other_f64_nan = 0.0f64 / 0.0;
@@ -49,7 +49,7 @@ error: equal expressions as operands to `/`
 LL |     let one_more_f64_nan = 0.0f64 / 0.0f64;
    |                            ^^^^^^^^^^^^^^^
 
-error: constant division of 0.0 with 0.0 will always result in NaN
+error: constant division of `0.0` with `0.0` will always result in NaN
   --> $DIR/zero_div_zero.rs:7:28
    |
 LL |     let one_more_f64_nan = 0.0f64 / 0.0f64;


### PR DESCRIPTION
On rustc diagnostics, we prefer to use backticks over `'`,  `"`, or something else. I think we should follow their manner here.
In first commit, normalizes lint messages with backticks.
In second commit, updates all stderrs.
In third commit, updates descriptions on lintlist.

changelog: none
