### PR TITLE
Do not trigger `let_and_return` lint on macros

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -8,7 +8,7 @@ use rustc_span::BytePos;
 use syntax::ast;
 use syntax::visit::FnKind;
 
-use crate::utils::{match_path_ast, snippet_opt, span_lint_and_then};
+use crate::utils::{in_macro, match_path_ast, snippet_opt, span_lint_and_then};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for return statements at the end of a block.
@@ -205,6 +205,7 @@ impl Return {
             if !in_external_macro(cx.sess(), initexpr.span);
             if !in_external_macro(cx.sess(), retexpr.span);
             if !in_external_macro(cx.sess(), local.span);
+            if !in_macro(local.span);
             then {
                 span_lint_and_then(
                     cx,

--- a/tests/ui/let_return.rs
+++ b/tests/ui/let_return.rs
@@ -45,4 +45,26 @@ fn test_nowarn_5(x: i16) -> u16 {
     x
 }
 
+// False positive example
+trait Decode {
+    fn decode<D: std::io::Read>(d: D) -> Result<Self, ()>
+    where
+        Self: Sized;
+}
+
+macro_rules! tuple_encode {
+    ($($x:ident),*) => (
+        impl<$($x: Decode),*> Decode for ($($x),*) {
+            #[inline]
+            #[allow(non_snake_case)]
+            fn decode<D: std::io::Read>(mut d: D) -> Result<Self, ()> {
+                // Shouldn't trigger lint
+                Ok(($({let $x = Decode::decode(&mut d)?; $x }),*))
+            }
+        }
+    );
+}
+
+tuple_encode!(T0, T1, T2, T3, T4, T5, T6, T7);
+
 fn main() {}


### PR DESCRIPTION
Fixes #4997

changelog: Fix false positive in `let_and_return`
