### PR TITLE
Fix redundant_clone lint not working with PathBuf and OsString

### DIFF
--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -307,6 +307,13 @@ fn find_stmt_assigns_to<'tcx>(
         (true, mir::Rvalue::Ref(_, _, place)) | (false, mir::Rvalue::Use(mir::Operand::Copy(place))) => {
             base_local_and_movability(cx, mir, place)
         },
+        (false, mir::Rvalue::Ref(_, _, place)) => {
+            if let [mir::ProjectionElem::Deref] = place.as_ref().projection {
+                base_local_and_movability(cx, mir, place)
+            } else {
+                None
+            }
+        },
         _ => None,
     }
 }

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -18,11 +18,11 @@ fn main() {
 
     let _s = Path::new("/a/b/").join("c");
 
-    let _s = Path::new("/a/b/").join("c").to_path_buf();
+    let _s = Path::new("/a/b/").join("c");
 
     let _s = OsString::new();
 
-    let _s = OsString::new().to_os_string();
+    let _s = OsString::new();
 
     // Check that lint level works
     #[allow(clippy::redundant_clone)]

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -60,6 +60,18 @@ LL |     let _s = Path::new("/a/b/").join("c").to_owned();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
+  --> $DIR/redundant_clone.rs:21:42
+   |
+LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
+   |                                          ^^^^^^^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:21:14
+   |
+LL |     let _s = Path::new("/a/b/").join("c").to_path_buf();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: redundant clone
   --> $DIR/redundant_clone.rs:23:29
    |
 LL |     let _s = OsString::new().to_owned();
@@ -69,6 +81,18 @@ note: this value is dropped without further use
   --> $DIR/redundant_clone.rs:23:14
    |
 LL |     let _s = OsString::new().to_owned();
+   |              ^^^^^^^^^^^^^^^
+
+error: redundant clone
+  --> $DIR/redundant_clone.rs:25:29
+   |
+LL |     let _s = OsString::new().to_os_string();
+   |                             ^^^^^^^^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:25:14
+   |
+LL |     let _s = OsString::new().to_os_string();
    |              ^^^^^^^^^^^^^^^
 
 error: redundant clone
@@ -131,5 +155,5 @@ note: this value is dropped without further use
 LL |         let _f = f.clone();
    |                  ^
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
https://github.com/rust-lang/rust-clippy/pull/4825 diabled MIR optimization in clippy, including `rustc_mir::transform::InstCombine` which reduces `&(*x)` to `x`. This PR tries to unwrap `&*` when looking into `mir::Rvalue`s.

Fixes #5014.

---

changelog: fixed `redundant_clone` lint not working with `PathBuf` and `OsString`