### PR TITLE
Normalize lint messages in cast_precision_loss

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -953,8 +953,8 @@ fn span_precision_loss_lint(cx: &LateContext<'_, '_>, expr: &Expr<'_>, cast_from
         CAST_PRECISION_LOSS,
         expr.span,
         &format!(
-            "casting {0} to {1} causes a loss of precision {2}({0} is {3} bits wide, but {1}'s mantissa \
-             is only {4} bits wide)",
+            "casting `{0}` to `{1}` causes a loss of precision {2}(`{0}` is {3} bits wide, \
+             but `{1}`'s mantissa is only {4} bits wide)",
             cast_from,
             if cast_to_f64 { "f64" } else { "f32" },
             if arch_dependent { arch_dependent_str } else { "" },

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -1,4 +1,4 @@
-error: casting i32 to f32 causes a loss of precision (i32 is 32 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast.rs:11:5
    |
 LL |     x0 as f32;
@@ -6,31 +6,31 @@ LL |     x0 as f32;
    |
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
 
-error: casting i64 to f32 causes a loss of precision (i64 is 64 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `i64` to `f32` causes a loss of precision (`i64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast.rs:13:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
-error: casting i64 to f64 causes a loss of precision (i64 is 64 bits wide, but f64's mantissa is only 52 bits wide)
+error: casting `i64` to `f64` causes a loss of precision (`i64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast.rs:14:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
-error: casting u32 to f32 causes a loss of precision (u32 is 32 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `u32` to `f32` causes a loss of precision (`u32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast.rs:16:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^
 
-error: casting u64 to f32 causes a loss of precision (u64 is 64 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `u64` to `f32` causes a loss of precision (`u64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast.rs:18:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^
 
-error: casting u64 to f64 causes a loss of precision (u64 is 64 bits wide, but f64's mantissa is only 52 bits wide)
+error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast.rs:19:5
    |
 LL |     x3 as f64;

--- a/tests/ui/cast_size.stderr
+++ b/tests/ui/cast_size.stderr
@@ -6,7 +6,7 @@ LL |     1isize as i8;
    |
    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
 
-error: casting isize to f64 causes a loss of precision on targets with 64-bit wide pointers (isize is 64 bits wide, but f64's mantissa is only 52 bits wide)
+error: casting `isize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`isize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast_size.rs:15:5
    |
 LL |     x0 as f64;
@@ -14,19 +14,19 @@ LL |     x0 as f64;
    |
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
 
-error: casting usize to f64 causes a loss of precision on targets with 64-bit wide pointers (usize is 64 bits wide, but f64's mantissa is only 52 bits wide)
+error: casting `usize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`usize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast_size.rs:16:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
-error: casting isize to f32 causes a loss of precision (isize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `isize` to `f32` causes a loss of precision (`isize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast_size.rs:17:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
 
-error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `usize` to `f32` causes a loss of precision (`usize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast_size.rs:18:5
    |
 LL |     x1 as f32;
@@ -100,13 +100,13 @@ error: casting `u32` to `isize` may wrap around the value on targets with 32-bit
 LL |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting i32 to f32 causes a loss of precision (i32 is 32 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast_size.rs:33:5
    |
 LL |     999_999_999 as f32;
    |     ^^^^^^^^^^^^^^^^^^
 
-error: casting usize to f64 causes a loss of precision on targets with 64-bit wide pointers (usize is 64 bits wide, but f64's mantissa is only 52 bits wide)
+error: casting `usize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`usize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast_size.rs:34:5
    |
 LL |     9_999_999_999_999_999usize as f64;

--- a/tests/ui/cast_size_32bit.stderr
+++ b/tests/ui/cast_size_32bit.stderr
@@ -6,7 +6,7 @@ LL |     1isize as i8;
    |
    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
 
-error: casting isize to f64 causes a loss of precision on targets with 64-bit wide pointers (isize is 64 bits wide, but f64's mantissa is only 52 bits wide)
+error: casting `isize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`isize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast_size_32bit.rs:15:5
    |
 LL |     x0 as f64;
@@ -22,7 +22,7 @@ LL |     x0 as f64;
    |
    = note: `-D clippy::cast-lossless` implied by `-D warnings`
 
-error: casting usize to f64 causes a loss of precision on targets with 64-bit wide pointers (usize is 64 bits wide, but f64's mantissa is only 52 bits wide)
+error: casting `usize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`usize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast_size_32bit.rs:16:5
    |
 LL |     x1 as f64;
@@ -34,13 +34,13 @@ error: casting `usize` to `f64` may become silently lossy if you later change th
 LL |     x1 as f64;
    |     ^^^^^^^^^ help: try: `f64::from(x1)`
 
-error: casting isize to f32 causes a loss of precision (isize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `isize` to `f32` causes a loss of precision (`isize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast_size_32bit.rs:17:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
 
-error: casting usize to f32 causes a loss of precision (usize is 32 or 64 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `usize` to `f32` causes a loss of precision (`usize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast_size_32bit.rs:18:5
    |
 LL |     x1 as f32;
@@ -114,7 +114,7 @@ error: casting `u32` to `isize` may wrap around the value on targets with 32-bit
 LL |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
-error: casting i32 to f32 causes a loss of precision (i32 is 32 bits wide, but f32's mantissa is only 23 bits wide)
+error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast_size_32bit.rs:33:5
    |
 LL |     999_999_999 as f32;


### PR DESCRIPTION
Follow-up of #5000

changelog: none
