### PR TITLE
Lint vectored IO in unused_io_amount lint

### DIFF
--- a/tests/ui/unused_io_amount.rs
+++ b/tests/ui/unused_io_amount.rs
@@ -16,4 +16,10 @@ fn unwrap<T: io::Read + io::Write>(s: &mut T) {
     s.read(&mut buf).unwrap();
 }
 
+fn vectored<T: io::Read + io::Write>(s: &mut T) -> io::Result<()> {
+    s.read_vectored(&mut [io::IoSliceMut::new(&mut [])])?;
+    s.write_vectored(&[io::IoSlice::new(&[])])?;
+    Ok(())
+}
+
 fn main() {}

--- a/tests/ui/unused_io_amount.stderr
+++ b/tests/ui/unused_io_amount.stderr
@@ -1,4 +1,4 @@
-error: handle written amount returned or use `Write::write_all` instead
+error: written amount is not handled. Use `Write::write_all` instead
   --> $DIR/unused_io_amount.rs:7:5
    |
 LL |     s.write(b"test")?;
@@ -6,23 +6,35 @@ LL |     s.write(b"test")?;
    |
    = note: `-D clippy::unused-io-amount` implied by `-D warnings`
 
-error: handle read amount returned or use `Read::read_exact` instead
+error: read amount is not handled. Use `Read::read_exact` instead
   --> $DIR/unused_io_amount.rs:9:5
    |
 LL |     s.read(&mut buf)?;
    |     ^^^^^^^^^^^^^^^^^
 
-error: handle written amount returned or use `Write::write_all` instead
+error: written amount is not handled. Use `Write::write_all` instead
   --> $DIR/unused_io_amount.rs:14:5
    |
 LL |     s.write(b"test").unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: handle read amount returned or use `Read::read_exact` instead
+error: read amount is not handled. Use `Read::read_exact` instead
   --> $DIR/unused_io_amount.rs:16:5
    |
 LL |     s.read(&mut buf).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: read amount is not handled
+  --> $DIR/unused_io_amount.rs:20:5
+   |
+LL |     s.read_vectored(&mut [io::IoSliceMut::new(&mut [])])?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: written amount is not handled
+  --> $DIR/unused_io_amount.rs:21:5
+   |
+LL |     s.write_vectored(&[io::IoSlice::new(&[])])?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
`read_vectored` & `write_vectored` require handling returned value likewise non-vectored methods. https://github.com/rust-lang/rust/issues/68041

---

changelog: lint vectored IO in `unused_io_amount` lint