### PR TITLE
Detect usage of invalid atomic ordering in memory fences

### DIFF
--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -836,7 +836,7 @@ pub const ALL_LINTS: [Lint; 346] = [
     Lint {
         name: "invalid_atomic_ordering",
         group: "correctness",
-        desc: "usage of invalid atomic ordering in atomic load/store calls",
+        desc: "usage of invalid atomic ordering in atomic loads/stores and memory fences",
         deprecation: None,
         module: "atomic_ordering",
     },

--- a/tests/ui/atomic_ordering_fence.rs
+++ b/tests/ui/atomic_ordering_fence.rs
@@ -1,0 +1,20 @@
+#![warn(clippy::invalid_atomic_ordering)]
+
+use std::sync::atomic::{compiler_fence, fence, Ordering};
+
+fn main() {
+    // Allowed fence ordering modes
+    fence(Ordering::Acquire);
+    fence(Ordering::Release);
+    fence(Ordering::AcqRel);
+    fence(Ordering::SeqCst);
+
+    // Disallowed fence ordering modes
+    fence(Ordering::Relaxed);
+
+    compiler_fence(Ordering::Acquire);
+    compiler_fence(Ordering::Release);
+    compiler_fence(Ordering::AcqRel);
+    compiler_fence(Ordering::SeqCst);
+    compiler_fence(Ordering::Relaxed);
+}

--- a/tests/ui/atomic_ordering_fence.stderr
+++ b/tests/ui/atomic_ordering_fence.stderr
@@ -1,0 +1,19 @@
+error: memory fences cannot have `Relaxed` ordering
+  --> $DIR/atomic_ordering_fence.rs:13:11
+   |
+LL |     fence(Ordering::Relaxed);
+   |           ^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::invalid-atomic-ordering` implied by `-D warnings`
+   = help: consider using ordering modes `Acquire`, `Release`, `AcqRel` or `SeqCst`
+
+error: memory fences cannot have `Relaxed` ordering
+  --> $DIR/atomic_ordering_fence.rs:19:20
+   |
+LL |     compiler_fence(Ordering::Relaxed);
+   |                    ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using ordering modes `Acquire`, `Release`, `AcqRel` or `SeqCst`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Detect usage of `core::sync::atomic::{fence, compiler_fence}` with `Ordering::Relaxed` and suggest valid alternatives.

changelog: Extend `invalid_atomic_ordering` to lint memory fences

Fixes #5026 