### PR TITLE
Prefer 2 spaces as indent size over 4 on yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
We use 2 spaces as an indent on YAML like `.travis.yml` now but `.editorconfig` tells my editor that indent size is 4, not 2. It makes my editor confused.

changelog: none
