### PR TITLE
Match wild err arm improvements

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -528,12 +528,13 @@ fn check_wild_err_arm(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>])
                         then {
                             // `Err(_)` or `Err(_e)` arm with `panic!` found
                             span_note_and_lint(cx,
-                                            MATCH_WILD_ERR_ARM,
-                                            arm.pat.span,
-                                            &format!("`Err({})` will match all errors, maybe not a good idea", &ident_bind_name),
-                                            arm.pat.span,
-                                            "to remove this warning, match each error separately \
-                                                or use `unreachable!` macro");
+                                MATCH_WILD_ERR_ARM,
+                                arm.pat.span,
+                                &format!("`Err({})` will match all errors, maybe not a good idea", &ident_bind_name),
+                                arm.pat.span,
+                                "to remove this warning, match each error separately \
+                                    or use `unreachable!` macro"
+                            );
                         }
                     }
                 }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -530,10 +530,9 @@ fn check_wild_err_arm(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>])
                             span_note_and_lint(cx,
                                 MATCH_WILD_ERR_ARM,
                                 arm.pat.span,
-                                &format!("`Err({})` will match all errors, maybe not a good idea", &ident_bind_name),
+                                &format!("`Err({})` matches all errors", &ident_bind_name),
                                 arm.pat.span,
-                                "to remove this warning, match each error separately \
-                                    or use `unreachable!` macro"
+                                "match each error separately or use the error output",
                             );
                         }
                     }

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -127,6 +127,14 @@ pub fn is_present_in_source<T: LintContext>(cx: &T, span: Span) -> bool {
     true
 }
 
+/// Checks if given pattern is a wildcard (`_`)
+pub fn is_wild<'tcx>(pat: &impl std::ops::Deref<Target = Pat<'tcx>>) -> bool {
+    match pat.kind {
+        PatKind::Wild => true,
+        _ => false,
+    }
+}
+
 /// Checks if type is struct, enum or union type with the given def path.
 pub fn match_type(cx: &LateContext<'_, '_>, ty: Ty<'_>, path: &[&str]) -> bool {
     match ty.kind {

--- a/clippy_lints/src/utils/usage.rs
+++ b/clippy_lints/src/utils/usage.rs
@@ -1,9 +1,14 @@
+use crate::utils::match_var;
+use rustc::hir::map::Map;
 use rustc::ty;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def::Res;
+use rustc_hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc_hir::*;
 use rustc_lint::LateContext;
+use rustc_span::symbol::Ident;
 use rustc_typeck::expr_use_visitor::*;
+use syntax::ast;
 
 /// Returns a set of mutated local variable IDs, or `None` if mutations could not be determined.
 pub fn mutated_variables<'a, 'tcx>(expr: &'tcx Expr<'_>, cx: &'a LateContext<'a, 'tcx>) -> Option<FxHashSet<HirId>> {
@@ -69,4 +74,34 @@ impl<'tcx> Delegate<'tcx> for MutVarsDelegate {
     fn mutate(&mut self, cmt: &Place<'tcx>) {
         self.update(&cmt)
     }
+}
+
+pub struct UsedVisitor {
+    pub var: ast::Name, // var to look for
+    pub used: bool,     // has the var been used otherwise?
+}
+
+impl<'tcx> Visitor<'tcx> for UsedVisitor {
+    type Map = Map<'tcx>;
+
+    fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
+        if match_var(expr, self.var) {
+            self.used = true;
+        } else {
+            walk_expr(self, expr);
+        }
+    }
+
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<'_, Self::Map> {
+        NestedVisitorMap::None
+    }
+}
+
+pub fn is_unused<'tcx>(ident: &'tcx Ident, body: &'tcx Expr<'_>) -> bool {
+    let mut visitor = UsedVisitor {
+        var: ident.name,
+        used: false,
+    };
+    walk_expr(&mut visitor, body);
+    !visitor.used
 }

--- a/tests/ui/matches.rs
+++ b/tests/ui/matches.rs
@@ -28,6 +28,19 @@ fn match_wild_err_arm() {
         },
     }
 
+    match x {
+        Ok(3) => println!("ok"),
+        Ok(_) => println!("ok"),
+        Err(_e) => panic!(),
+    }
+
+    // Allowed when used in `panic!`.
+    match x {
+        Ok(3) => println!("ok"),
+        Ok(_) => println!("ok"),
+        Err(_e) => panic!("{}", _e),
+    }
+
     // Allowed when not with `panic!` block.
     match x {
         Ok(3) => println!("ok"),

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -78,7 +78,7 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: `Err(_)` will match all errors, maybe not a good idea
+error: `Err(_e)` will match all errors, maybe not a good idea
   --> $DIR/matches.rs:34:9
    |
 LL |         Err(_e) => panic!(),

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -1,11 +1,11 @@
-error: `Err(_)` will match all errors, maybe not a good idea
+error: `Err(_)` matches all errors
   --> $DIR/matches.rs:14:9
    |
 LL |         Err(_) => panic!("err"),
    |         ^^^^^^
    |
    = note: `-D clippy::match-wild-err-arm` implied by `-D warnings`
-   = note: to remove this warning, match each error separately or use `unreachable!` macro
+   = note: match each error separately or use the error output
 
 error: this `match` has identical arm bodies
   --> $DIR/matches.rs:13:18
@@ -26,13 +26,13 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: `Err(_)` will match all errors, maybe not a good idea
+error: `Err(_)` matches all errors
   --> $DIR/matches.rs:20:9
    |
 LL |         Err(_) => panic!(),
    |         ^^^^^^
    |
-   = note: to remove this warning, match each error separately or use `unreachable!` macro
+   = note: match each error separately or use the error output
 
 error: this `match` has identical arm bodies
   --> $DIR/matches.rs:19:18
@@ -52,13 +52,13 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: `Err(_)` will match all errors, maybe not a good idea
+error: `Err(_)` matches all errors
   --> $DIR/matches.rs:26:9
    |
 LL |         Err(_) => {
    |         ^^^^^^
    |
-   = note: to remove this warning, match each error separately or use `unreachable!` macro
+   = note: match each error separately or use the error output
 
 error: this `match` has identical arm bodies
   --> $DIR/matches.rs:25:18
@@ -78,13 +78,13 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: `Err(_e)` will match all errors, maybe not a good idea
+error: `Err(_e)` matches all errors
   --> $DIR/matches.rs:34:9
    |
 LL |         Err(_e) => panic!(),
    |         ^^^^^^^
    |
-   = note: to remove this warning, match each error separately or use `unreachable!` macro
+   = note: match each error separately or use the error output
 
 error: this `match` has identical arm bodies
   --> $DIR/matches.rs:33:18

--- a/tests/ui/matches.stderr
+++ b/tests/ui/matches.stderr
@@ -78,37 +78,45 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
+error: `Err(_)` will match all errors, maybe not a good idea
+  --> $DIR/matches.rs:34:9
+   |
+LL |         Err(_e) => panic!(),
+   |         ^^^^^^^
+   |
+   = note: to remove this warning, match each error separately or use `unreachable!` macro
+
 error: this `match` has identical arm bodies
-  --> $DIR/matches.rs:34:18
+  --> $DIR/matches.rs:33:18
    |
 LL |         Ok(_) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/matches.rs:33:18
+  --> $DIR/matches.rs:32:18
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
 help: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:33:9
+  --> $DIR/matches.rs:32:9
    |
 LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-  --> $DIR/matches.rs:41:18
+  --> $DIR/matches.rs:40:18
    |
 LL |         Ok(_) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/matches.rs:40:18
+  --> $DIR/matches.rs:39:18
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
 help: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:40:9
+  --> $DIR/matches.rs:39:9
    |
 LL |         Ok(3) => println!("ok"),
    |         ^^^^^
@@ -133,58 +141,94 @@ LL |         Ok(3) => println!("ok"),
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-  --> $DIR/matches.rs:53:18
+  --> $DIR/matches.rs:54:18
    |
 LL |         Ok(_) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/matches.rs:52:18
+  --> $DIR/matches.rs:53:18
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
 help: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:52:9
+  --> $DIR/matches.rs:53:9
    |
 LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-  --> $DIR/matches.rs:76:29
+  --> $DIR/matches.rs:60:18
+   |
+LL |         Ok(_) => println!("ok"),
+   |                  ^^^^^^^^^^^^^^
+   |
+note: same as this
+  --> $DIR/matches.rs:59:18
+   |
+LL |         Ok(3) => println!("ok"),
+   |                  ^^^^^^^^^^^^^^
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:59:9
+   |
+LL |         Ok(3) => println!("ok"),
+   |         ^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: this `match` has identical arm bodies
+  --> $DIR/matches.rs:66:18
+   |
+LL |         Ok(_) => println!("ok"),
+   |                  ^^^^^^^^^^^^^^
+   |
+note: same as this
+  --> $DIR/matches.rs:65:18
+   |
+LL |         Ok(3) => println!("ok"),
+   |                  ^^^^^^^^^^^^^^
+help: consider refactoring into `Ok(3) | Ok(_)`
+  --> $DIR/matches.rs:65:9
+   |
+LL |         Ok(3) => println!("ok"),
+   |         ^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: this `match` has identical arm bodies
+  --> $DIR/matches.rs:89:29
    |
 LL |         (Ok(_), Some(x)) => println!("ok {}", x),
    |                             ^^^^^^^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/matches.rs:75:29
+  --> $DIR/matches.rs:88:29
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
    |                             ^^^^^^^^^^^^^^^^^^^^
 help: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
-  --> $DIR/matches.rs:75:9
+  --> $DIR/matches.rs:88:9
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
    |         ^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
-  --> $DIR/matches.rs:91:18
+  --> $DIR/matches.rs:104:18
    |
 LL |         Ok(_) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/matches.rs:90:18
+  --> $DIR/matches.rs:103:18
    |
 LL |         Ok(3) => println!("ok"),
    |                  ^^^^^^^^^^^^^^
 help: consider refactoring into `Ok(3) | Ok(_)`
-  --> $DIR/matches.rs:90:9
+  --> $DIR/matches.rs:103:9
    |
 LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
-error: aborting due to 12 previous errors
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
This lint should trigger on other identifiers which have `_` prefix (such as `_e`) and only if they are unused in the panic block.

_Note_: the `is_unused` function is greatly inspired from `pat_is_wild` function in [loops lints](https://github.com/rust-lang/rust-clippy/blob/43ac9416d935942d6c7d2b2e0c876c551652c4ec/clippy_lints/src/loops.rs#L1689).
I've been considering doing some refactoring, maybe in utils. Maybe this PR or a new one. What do you think ?

fixes #5024

changelog: none
