### PR TITLE
Don't trigger use_debug lint in Debug impl

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -330,7 +330,7 @@ mod reexport {
 ///
 /// Used in `./src/driver.rs`.
 pub fn register_pre_expansion_lints(store: &mut rustc_lint::LintStore, conf: &Conf) {
-    store.register_pre_expansion_pass(|| box write::Write);
+    store.register_pre_expansion_pass(|| box write::Write::default());
     store.register_pre_expansion_pass(|| box redundant_field_names::RedundantFieldNames);
     let single_char_binding_names_threshold = conf.single_char_binding_names_threshold;
     store.register_pre_expansion_pass(move || box non_expressive_names::NonExpressiveNames {

--- a/tests/ui/print.stderr
+++ b/tests/ui/print.stderr
@@ -6,12 +6,6 @@ LL |         write!(f, "{:?}", 43.1415)
    |
    = note: `-D clippy::use-debug` implied by `-D warnings`
 
-error: use of `Debug`-based formatting
-  --> $DIR/print.rs:18:19
-   |
-LL |         write!(f, "{:?}", 42.718)
-   |                   ^^^^^^
-
 error: use of `println!`
   --> $DIR/print.rs:23:5
    |
@@ -56,5 +50,5 @@ error: use of `Debug`-based formatting
 LL |     print!("Hello {:#?}", "#orld");
    |            ^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Fixes #5039

changelog: Don't trigger [`use_debug`] lint in Debug impl