### PR TITLE
Implement issue finder for lint names

### DIFF
--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -12,6 +12,9 @@ regex = "1"
 lazy_static = "1.0"
 shell-escape = "0.1"
 walkdir = "2"
+reqwest = { version = "0.10", features = ["blocking", "json"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
 deny-warnings = []
+issues = ["reqwest", "serde"]

--- a/clippy_dev/src/issues_for_lint.rs
+++ b/clippy_dev/src/issues_for_lint.rs
@@ -1,0 +1,154 @@
+use crate::gather_all;
+use lazy_static::lazy_static;
+use regex::Regex;
+use reqwest::{
+    blocking::{Client, Response},
+    header,
+};
+use serde::Deserialize;
+use std::env;
+
+lazy_static! {
+    static ref NEXT_PAGE_RE: Regex = Regex::new(r#"<(?P<link>[^;]+)>;\srel="next""#).unwrap();
+}
+
+#[derive(Debug, Deserialize)]
+struct Issue {
+    title: String,
+    number: u32,
+    body: String,
+    pull_request: Option<PR>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PR {}
+
+enum Error {
+    Reqwest(reqwest::Error),
+    Env(std::env::VarError),
+    Http(header::InvalidHeaderValue),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Reqwest(err)
+    }
+}
+
+impl From<std::env::VarError> for Error {
+    fn from(err: std::env::VarError) -> Self {
+        Self::Env(err)
+    }
+}
+
+impl From<header::InvalidHeaderValue> for Error {
+    fn from(err: header::InvalidHeaderValue) -> Self {
+        Self::Http(err)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Reqwest(err) => write!(fmt, "reqwest: {}", err),
+            Self::Env(err) => write!(fmt, "env: {}", err),
+            Self::Http(err) => write!(fmt, "http: {}", err),
+        }
+    }
+}
+
+pub fn run(name: &str, filter: &[u32]) {
+    match open_issues() {
+        Ok(issues) => {
+            for (i, issue) in filter_issues(&issues, name, filter).enumerate() {
+                if i == 0 {
+                    println!("### `{}`\n", name);
+                }
+                println!("- [ ] #{} ({})", issue.number, issue.title)
+            }
+        },
+        Err(err) => eprintln!("{}", err),
+    }
+}
+
+pub fn run_all(filter: &[u32]) {
+    match open_issues() {
+        Ok(issues) => {
+            let mut lint_names = gather_all().map(|lint| lint.name).collect::<Vec<_>>();
+            lint_names.sort();
+            for name in lint_names {
+                let mut print_empty_line = false;
+                for (i, issue) in filter_issues(&issues, &name, filter).enumerate() {
+                    if i == 0 {
+                        println!("### `{}`\n", name);
+                        print_empty_line = true;
+                    }
+                    println!("- [ ] #{} ({})", issue.number, issue.title)
+                }
+                if print_empty_line {
+                    println!();
+                }
+            }
+        },
+        Err(err) => eprintln!("{}", err),
+    }
+}
+
+fn open_issues() -> Result<Vec<Issue>, Error> {
+    let github_token = env::var("GITHUB_TOKEN")?;
+
+    let mut headers = header::HeaderMap::new();
+    headers.insert(
+        header::AUTHORIZATION,
+        header::HeaderValue::from_str(&format!("token {}", github_token))?,
+    );
+    headers.insert(header::USER_AGENT, header::HeaderValue::from_static("ghost"));
+    let client = Client::builder().default_headers(headers).build()?;
+
+    let issues_base = "https://api.github.com/repos/rust-lang/rust-clippy/issues";
+
+    let mut issues = vec![];
+    let mut response = client
+        .get(issues_base)
+        .query(&[("per_page", "100"), ("state", "open"), ("direction", "asc")])
+        .send()?;
+    while let Some(link) = next_link(&response) {
+        issues.extend(
+            response
+                .json::<Vec<Issue>>()?
+                .into_iter()
+                .filter(|i| i.pull_request.is_none()),
+        );
+        response = client.get(&link).send()?;
+    }
+
+    Ok(issues)
+}
+
+fn filter_issues<'a>(issues: &'a [Issue], name: &str, filter: &'a [u32]) -> impl Iterator<Item = &'a Issue> {
+    let name = name.to_lowercase();
+    let separated_name = name.chars().map(|c| if c == '_' { ' ' } else { c }).collect::<String>();
+    let dash_separated_name = name.chars().map(|c| if c == '_' { '-' } else { c }).collect::<String>();
+
+    issues.iter().filter(move |i| {
+        let title = i.title.to_lowercase();
+        let body = i.body.to_lowercase();
+        !filter.contains(&i.number)
+            && (title.contains(&name)
+                || title.contains(&separated_name)
+                || title.contains(&dash_separated_name)
+                || body.contains(&name)
+                || body.contains(&separated_name)
+                || body.contains(&dash_separated_name))
+    })
+}
+
+fn next_link(response: &Response) -> Option<String> {
+    if let Some(links) = response.headers().get("Link").and_then(|l| l.to_str().ok()) {
+        if let Some(cap) = NEXT_PAGE_RE.captures_iter(links).next() {
+            return Some(cap["link"].to_string());
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
Since we're going towards 1000 issues and simply don't have enough manpower to triage them properly and therefore the issue tracker gets kind of convoluted, I thought it would be a good idea to have one tracking issue for all lints. In the tracking issue, for every lint a list of issues mentioning this lint in its title or in the issue body would be displayed.

This is what this tool does. This tool is behind a feature, because it requires `reqwest` and `serde`, which would otherwise blow up the `clippy_dev` build.

<details>
<summary>Output</summary>

```bash
GITHUB_TOKEN=*** cargo run --features issues -- issues_for_lint --all --filter "2845,2846"
```
### `absurd_extreme_comparisons`

- [ ] #1802 (Should absurd_extreme_comparisons alert for comparison between usize and u64?)

### `approx_constant`

- [ ] #4612 (Clippy doesn't report error/warnings after cargo check)

### `assign_op_pattern`

- [ ] #2268 (assign_op_pattern misleading on wrongly implemented assign impl.)

### `blacklisted_name`

- [ ] #1624 (Lint for blacklisted-strings, similar to blacklisted-names)
- [ ] #2198 (Allow blacklisted names in tests)
- [ ] #4344 (redundant_pattern_matching fixit suggestion fails to apply)

### `block_in_if_condition_expr`

- [ ] #1078 (Merge some lints together)

### `block_in_if_condition_stmt`

- [ ] #1078 (Merge some lints together)
- [ ] #1141 (block_in_if_condition_stmt: false positive in macros)

### `bool_comparison`

- [ ] #1043 (`bool_comparison` should not fire when testing for false)
- [ ] #3973 (`needless_bool` triggers on `cfg!` comparisons)
- [ ] #4987 (New lint: comparing option to Some(true))

### `borrow_interior_mutable_const`

- [ ] #3825 (borrow_interior_mutable_const interacts poorly with the http crate)
- [ ] #3962 (declare_interior_mutable_const and borrow_interior_mutable_const need to respect enum variants)

### `borrowed_box`

- [ ] #1845 (borrowed_box should not be emitted for mutable boxed trait object)
- [x] #2614 (The github.io links don't work for non-master releases if the Travis release build failed)
- [ ] #2907 (`borrowed_box` incorrectly assumes mutable boxed slice allocation won't change)
- [ ] #3128 (borrowed_box gives syntactically invalid suggestion)
- [ ] #3971 (Clippy incorrectly complains about `borrowed_box` when trait object is boxed)

### `box_vec`

- [ ] #2404 (Reword or even allow-by-default box_vec)

### `boxed_local`

- [ ] #4351 (False positive for boxed local with `wasm_bindgen`)
- [ ] #4642 (FN in boxed_local lint)
- [ ] #4740 (boxed_local false positive for ?Sized)
- [ ] #4804 (False positive for boxed local in default Trait method implementation)

### `cargo_common_metadata`

- [ ] #1798 (Meta issue for Rust API Guidelines)

### `cast_lossless`

- [ ] #3689 (On 32-bit, usize as f64 recommends f64::from(usize))
- [ ] #4864 (Re-enable cast_lossless lint by default)

### `cast_possible_truncation`

- [ ] #3695 (Optionally disable allows unless linked to a justification)

### `cast_ptr_alignment`

- [ ] #2881 (cast_ptr_alignment is acceptable in a narrow set of contexts)
- [ ] #3440 (Cast_ptr_alignment false negative in trait method default impl)
- [ ] #4708 (Extend `cast_ptr_alignment` lint for `pointer::cast` method)
- [ ] #4754 (Extend `cast_ptr_alignment` for type alias)

### `cast_sign_loss`

- [ ] #3089 (cast_sign_loss: value can't be negative if guarded by assert:)

### `clone_on_copy`

- [ ] #1254 (Disable `expl_impl_clone_on_copy` when `Copy` is manually implemented.)
- [ ] #1472 (False positive for `clone_on_copy` when the clone is immediately borrowed)
- [ ] #2870 (Why prefer dereference to clone on Copy types?)
- [ ] #4826 (Make clone_on_copy lint machine applicable)

### `clone_on_ref_ptr`

- [ ] #2076 (clone_on_ref_ptr and macros)

### `cmp_owned`

- [ ] #4874 (cmp_owned false positives - proc_macro Ident)
- [ ] #4909 (False positive in cmp_owned lint)

### `cognitive_complexity`

- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #3793 (Suggestion for new lint: Cognitive Complexity)
- [ ] #3900 (Ignore cognitive complexity in macro expanded code)
- [ ] #4167 (Clippy links to `master` instead of actual version)
- [ ] #4470 (Improve the cognitive_complexity lint to show what lines are causing the complexity)

### `collapsible_if`

- [ ] #812 (improve collapsible if in complex cases with same expressions)
- [ ] #1197 (False positive on collapsible_if with if let)
- [ ] #1401 (collapsible_if shouldn't warn on `else` after multiple `else if`)
- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #2974 (Incorrect indentation in suggestion of collapsible_if)

### `comparison_chain`

- [ ] #1111 (detect if comparison chain that could be a tuple comparison instead)
- [ ] #4725 (should comparison_chain only trigger for "if x >  y {} else if x <y {} else {}" ?)

### `debug_assert_with_mut_call`

- [ ] #4737 (debug_assert_with_mut_call: false positive on immutable method call)

### `declare_interior_mutable_const`

- [ ] #3962 (declare_interior_mutable_const and borrow_interior_mutable_const need to respect enum variants)

### `deprecated_cfg_attr`

- [ ] #3660 (deprecated_cfg_attr lint: Also lint inner attributes once `custom_inner_attributes` is stabilized)

### `derive_hash_xor_eq`

- [ ] #2025 (False positive in derive_hash_xor_eq with multiple `Eq` implementations)

### `doc_markdown`

- [ ] #902 (doc_markdown a bit too eager)
- [ ] #1136 (doc_markdown should ignore things which just contain acronyms)
- [ ] #2481 (off-by-one span in doc_markdown warning on single tick)
- [ ] #2581 ((false positive) doc_markdown should disregard escaped underscores)

### `double_comparisons`

- [ ] #753 (lint double comparisons)

### `double_neg`

- [ ] #1893 (nonminimal_bool lint for meta items)

### `drop_copy`

- [ ] #3939 (FP clippy::drop_copy ?: new() called inside drop())

### `drop_ref`

- [ ] #4461 (clippy::drop_ref will trigger on `&mut T` as well as `&T`)

### `else_if_without_else`

- [ ] #2227 (Lint suggestions based on MISRA 2004)

### `empty_enum`

- [ ] #4905 (Improve empty_enum lint)

### `empty_loop`

- [ ] #3746 (Lint: empty_loop lint on `no_std`)

### `enum_clike_unportable_variant`

- [ ] #816 (False positive on `enum_clike_unportable_variant`)
- [ ] #1134 (False positive for C-like enums involving configuration-dependent constants)
- [ ] #1149 (vet all lints for 16 bit compat)

### `enum_glob_use`

- [ ] #1228 (add lint for prevent global import)

### `enum_variant_names`

- [ ] #4639 (Incomplete postfix detected for `enum_variant_names`)

### `eq_op`

- [ ] #461 (Use const_eval instead of constant for more lints?)
- [ ] #1466 (eq_op false positive)
- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)

### `erasing_op`

- [ ] #2086 (lint useless operands in binary operations)

### `eval_order_dependence`

- [ ] #4637 (eval_order_dependence shouldn't fire for struct initializers)

### `exit`

- [ ] #301 (Stronger macro check for identity-op and type-complexity)
- [ ] #713 (Warn when forgetting to flush stdout before calling std::process::exit.)
- [ ] #743 (Create more than 2 lint groups)
- [ ] #966 (lint on a call to `exit` in tests)
- [ ] #1013 (Type complexity should not be considered when defining an associated type)
- [ ] #1209 (Feature request: flag for non-zero exit status if warnings are present)
- [ ] #1329 (Clean up the error reporting in the `cargo clippy` code)
- [ ] #1330 (clippy subcommand does not work properly when root directory is an executable)
- [ ] #1375 ( Lint generic methods using Into/AsRef/AsMut above very modest complexity)
- [ ] #1422 (0.0.105 doesn't work at all on windows 10/msvc target/rust 1.16.0-nightly 2017-01-03)
- [ ] #1681 (New Lint: Avoid too many static code paths)
- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #2124 (Lint against impl in block expressions when could be outside of block expression)
- [ ] #2227 (Lint suggestions based on MISRA 2004)
- [ ] #2249 (Cyclomatic Complexity should not count code in `debug_assert`)
- [ ] #2306 (Panic in nightly-msvc (cddc4a62d 2017-12-26), "thread 'rustc' panicked at 'failed to create span for type arguments',")
- [ ] #2602 (error: multiple input filenames provided with clippy 0.0.191 and last nightly)
- [ ] #2765 (Doesn't work with custom rustc path)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)
- [ ] #3793 (Suggestion for new lint: Cognitive Complexity)
- [ ] #3900 (Ignore cognitive complexity in macro expanded code)
- [ ] #3939 (FP clippy::drop_copy ?: new() called inside drop())
- [ ] #4167 (Clippy links to `master` instead of actual version)
- [ ] #4193 (Make `find_map` lint be more conservative)
- [ ] #4470 (Improve the cognitive_complexity lint to show what lines are causing the complexity)
- [ ] #4505 (Clippy leaves cargo running in the background on SIGTERM )
- [ ] #4524 (New lint: API complexity)
- [ ] #4844 (New lint: Unnecessarily complex types)
- [ ] #4931 (New Lint: Explicit ranges with `p0 | ... | p_n` => range pat)

### `expect_fun_call`

- [ ] #2928 (`expect_fun_call` recommends code which is not equivalent)

### `expl_impl_clone_on_copy`

- [ ] #1254 (Disable `expl_impl_clone_on_copy` when `Copy` is manually implemented.)

### `explicit_counter_loop`

- [ ] #1670 (explicit_counter_loop improvement suggestion)
- [ ] #4677 (explicit_counter_loop produces incorrect advice)

### `explicit_into_iter_loop`

- [ ] #3063 (Lint suggestions around vector iterations are counterproductive)
- [ ] #3343 (Tracking issue for RFC 2476, Clippy 1.0)

### `explicit_iter_loop`

- [ ] #1518 (explicit_iter_loop should warn &[T].iter())
- [ ] #3063 (Lint suggestions around vector iterations are counterproductive)
- [ ] #3343 (Tracking issue for RFC 2476, Clippy 1.0)

### `explicit_write`

- [ ] #4542 (Revive suggestion on explicit_write)

### `extend_from_slice`

- [ ] #4660 (New lint: vec.extend(&vec![elem; len]) is slow, vec.resize() should be used instead)

### `filter_map`

- [ ] #2241 (lint flat_map into filter_map)
- [ ] #3188 (Make the `filter_map` lint more specific)
- [ ] #3302 (lint `vec.clone().into_iter().stuff().collect()` to suggest `vec.iter().stuff().cloned().collect()`)
- [ ] #3424 (filter_map docs woefully incomplete)
- [ ] #3474 (add a lint for find_map)
- [ ] #3787 (Add utils helper for filtering out type/lifetime parameters on generics)
- [ ] #4193 (Make `find_map` lint be more conservative)
- [ ] #4433 (False positive for unnecessary_filter_map)
- [ ] #4496 (New lint: map to Option followed by flatten)

### `filter_next`

- [ ] #3474 (add a lint for find_map)
- [ ] #4036 (Improvement Idea: the ilter_next should also cover skip_while().next())

### `find_map`

- [ ] #3474 (add a lint for find_map)
- [ ] #4193 (Make `find_map` lint be more conservative)

### `float_arithmetic`

- [ ] #1243 (lint long chains of into/float additions/multiplications)

### `float_cmp`

- [ ] #164 (Findings from running Clippy on Servo)
- [ ] #461 (Use const_eval instead of constant for more lints?)
- [ ] #1683 (Additions to float_cmp check)
- [ ] #1685 (Expand float_cmp to structs with PartialEq)
- [ ] #2834 (float_cmp false positive: catching underflow)
- [ ] #3804 (Allow float comparison with zero)
- [ ] #4557 (Should //run-rustfix tests apply HasPlaceholders suggestions?)

### `float_cmp_const`

- [ ] #4557 (Should //run-rustfix tests apply HasPlaceholders suggestions?)

### `fn_to_numeric_cast`

- [ ] #3896 (fn_to_numeric_cast incorrect suggestion)

### `fn_to_numeric_cast_with_truncation`

- [ ] #3896 (fn_to_numeric_cast incorrect suggestion)

### `for_loop_over_option`

- [ ] #1078 (Merge some lints together)

### `for_loop_over_result`

- [ ] #1078 (Merge some lints together)

### `forget_ref`

- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)

### `get_unwrap`

- [ ] #1725 (False positive?: get_unwrap)

### `identity_conversion`

- [ ] #3106 (lint `identity_conversion` name is misleading)
- [ ] #4750 ([cargo fix] `identity_conversion` removes parenthesis with inner expression, that needs them.)

### `identity_op`

- [ ] #301 (Stronger macro check for identity-op and type-complexity)
- [ ] #461 (Use const_eval instead of constant for more lints?)
- [ ] #1078 (Merge some lints together)
- [ ] #3430 (identity_op warns for bitflag constant)
- [ ] #3866 (Consider excluding Duration's associated constants from identity_op lint)

### `if_let_redundant_pattern_matching`

- [ ] #2353 (Do not suggest replacing simple `if let Some(_) / None` with methods)

### `if_let_some_result`

- [ ] #4991 (Add suggestion to `if_let_some_result` lint)

### `if_same_then_else`

- [ ] #1111 (detect if comparison chain that could be a tuple comparison instead)
- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #3030 (FN implicit if_same_then_else)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)
- [ ] #3770 (if_same_then_else Should not warn for `else if` blocks.)

### `implicit_hasher`

- [ ] #3899 (clippy::implicit_hasher shouldn't warn on From<Thing> for HashMap<K, V>)

### `implicit_return`

- [ ] #3969 (crash ./ui/trivial-bounds/trivial-bounds-inconsistent.rs)

### `indexing_slicing`

- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #2866 (Improve `indexing_slicing` help message)

### `inherent_to_string`

- [ ] #4396 (False positive for inherent_to_string_shadow_display?)

### `inherent_to_string_shadow_display`

- [ ] #4396 (False positive for inherent_to_string_shadow_display?)

### `inline_always`

- [ ] #4288 (Warn if 'nonstandard Clone' used in vec!)

### `integer_arithmetic`

- [ ] #1761 (integer_arithmetic gives unhelpful warnings for const expressions)

### `integer_division`

- [ ] #1196 (Lint std::panic::catch_unwind)
- [ ] #1324 (useless op on lhs of integer division or modulo)

### `into_iter_on_array`

- [ ] #4492 (Calling into_iter on an oversized array only triggers into_iter_on_ref)

### `into_iter_on_ref`

- [ ] #4492 (Calling into_iter on an oversized array only triggers into_iter_on_ref)

### `invalid_atomic_ordering`

- [ ] #5026 (Extend `invalid_atomic_ordering` lint to memory fence calls)

### `invalid_regex`

- [ ] #4170 (Unrecognized escape sequence)

### `invalid_upcast_comparisons`

- [ ] #886 (invalid_upcast_comparisons gives false positive on u8 to i8 wrapping cast)

### `items_after_statements`

- [ ] #578 (also lint on items after statements in macros)

### `large_enum_variant`

- [ ] #2121 (large_enum_variant triggered in error-chain macro has unhelpful help message)
- [ ] #3884 (New lint: large Err(E) variant, as compared with Ok(T), for Result<T, E>)

### `len_without_is_empty`

- [ ] #1562 (len_without_is_empty lints if `len` and `is_empty` are in different `impl` blocks)

### `len_zero`

- [ ] #278 ((Preliminary) Results of building rust with clippy)
- [ ] #3807 (`len_zero` with Range suggests code cannot compile)

### `let_and_return`

- [ ] #420 (Restrict let_and_return if the let binding is large)
- [ ] #1322 (Potential false positive for let_and_return)
- [ ] #1524 (let_and_return mistake)
- [ ] #1642 (let_and_return : false positive)
- [ ] #1669 (let_and_return false positive)
- [ ] #3324 (Possible false positive with `let_and_return`)
- [ ] #3792 (let_and_return false positive)
- [ ] #4182 (let_and_return "known problems")

### `let_underscore_must_use`

- [ ] #4980 (let-underscore-must-use is triggered when Debug is derived)

### `let_unit_value`

- [ ] #164 (Findings from running Clippy on Servo)
- [ ] #1502 (Let_unit_value false positive when return type is type parameter)

### `linkedlist`

- [ ] #1800 (linkedlist false positive)

### `logic_bug`

- [ ] #1916 (Rename `logic_bug`)

### `manual_mul_add`

- [ ] #4726 (manual_mul_add suggests broken code)
- [ ] #4735 (mul_add struggling with long expressions)

### `many_single_char_names`

- [ ] #4086 (many_single_char_names incorrectly triggered if 'single-char-binding-names-threshold = 0')

### `map_entry`

- [ ] #4664 (map_entry false positive when returning before inserting)
- [ ] #4674 (map_entry false positive when map needs to be used while still borrowed by the entry)

### `match_bool`

- [ ] #3713 (Perhaps this match_bool case could be considered idiomatic?)

### `match_ref_pats`

- [ ] #533 (Bikesheds to be done when RfCing clippy)
- [ ] #849 (Possible suggestion improvements on match_ref_pats)
- [ ] #4834 (bad `match_ref_pats` suggestion.)

### `match_same_arms`

- [ ] #860 (False positive on match_same_arms)
- [ ] #1140 (match_same_arms: suppress when reordering arms?)
- [ ] #1218 (Another false positive: `match_same_arms` vs. `&Any`)
- [ ] #1390 (False positive with match_on_same_arms and macros)
- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #2185 (False positive with match_same_arms)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)

### `match_wild_err_arm`

- [ ] #3688 (match_wild_err_arm: Err(_) is not wild)
- [ ] #5024 (`match_wild_err_arm` triggers weirdly)

### `min_max`

- [ ] #461 (Use const_eval instead of constant for more lints?)

### `missing_const_for_fn`

- [ ] #4979 (Wrong suggestion of `const fn` if member of member implements Drop)

### `missing_docs_in_private_items`

- [ ] #1895 (missing_docs_in_private_items does not honor allow statements)

### `missing_inline_in_public_items`

- [ ] #3934 (missing_inline_in_public_items and #[wasm_bindgen(start)])

### `mistyped_literal_suffixes`

- [ ] #4706 (BUG: Incorrect mistyped literal suffix on long floats.)

### `module_name_repetitions`

- [ ] #4288 (Warn if 'nonstandard Clone' used in vec!)

### `modulo_one`

- [ ] #1078 (Merge some lints together)

### `multiple_inherent_impl`

- [ ] #414 (Lint: Multiple inherent impls)

### `must_use_candidate`

- [ ] #4778 (-A --allow should take precedence over -D --deny in CLI)
- [ ] #4779 (must_use_candidate is going mad (false positives?))

### `mut_from_ref`

- [ ] #4281 (Should the `mut_from_ref` lint apply to unsafe functions?)

### `mut_mut`

- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)

### `mutable_key_type`

- [ ] #5020 (False Positive? Mutable key type lint is emitted on HashSets containing associated types)

### `mutex_atomic`

- [ ] #1516 (mutex_atomic and CondVar)
- [ ] #4295 (Consider removing `mutex_atomic`)

### `needless_bool`

- [ ] #3973 (`needless_bool` triggers on `cfg!` comparisons)

### `needless_borrow`

- [ ] #1726 (needless borrow does not trigger on block trailing expression)
- [ ] #2610 (needless_borrow suggests bad code when reference-to-reference is required)
- [ ] #2908 (needless_borrow complains when a type alias with reference is used)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)
- [ ] #3742 (`needless_borrow` was temporarily moved to `nursery` in April 2018)

### `needless_continue`

- [ ] #2336 (Appveyor build is broken)
- [ ] #4077 (Needless continue for match block)

### `needless_doctest_main`

- [ ] #4698 (needless_doctest_main yields false positive with proc macros)
- [ ] #4906 (needless_doctest_main vs. question mark operator)

### `needless_lifetimes`

- [ ] #2944 (Incorrect needless_lifetimes warning for impl Trait based code)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)
- [ ] #4746 (False positive for needless_lifetimes (possibly due to async?))
- [ ] #4829 (Give "corrected" code in examples)

### `needless_pass_by_value`

- [ ] #2434 (needless_pass_by_value and closures)
- [ ] #3031 (Is needless_pass_by_value behaving properly?)
- [ ] #3420 (Unsized rvalues now making this lint inaccurate)

### `needless_range_loop`

- [ ] #398 (Weird warning for needless_range_loop)
- [ ] #878 (Wrong hint about needless_range_loop)
- [ ] #1014 (needless_range_loop suggests using iter on a value that do not have iter method)
- [ ] #1831 (`needless_range_loop` could suggest using `clone_from_slice` in some cases)
- [ ] #1864 (Improve suggestions for `needless_range_loop`)
- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #2072 (A problem with needless_range_loop)
- [ ] #2277 (False Positive: needless_range_loop)
- [ ] #2847 (Structs with non-matching Index and Iter impls cause bad suggestions)
- [ ] #3032 (needless_range_loop disregards multiple indexed variables)

### `needless_return`

- [ ] #2472 (Wrong needless_return suggestion with blocks)
- [ ] #4092 (`cargo clippy --all-targets` issues diagnostics for library crate twice)

### `neg_multiply`

- [ ] #3037 (FN neg_multiply:  x *= -1 ?)

### `new_ret_no_self`

- [ ] #734 (False positive in `new_ret_no_self` if self type carries lifetime annotation?)

### `new_without_default`

- [ ] #1078 (Merge some lints together)
- [ ] #1410 (new-without-default-derive ignores existing derives)
- [ ] #1522 (The useless attribute lint doesn't put the ! in the right place.)
- [ ] #1579 (new_without_default_derive help is confusing)
- [ ] #1798 (Meta issue for Rust API Guidelines)
- [ ] #1878 (Why `new_without_default` is shown for structs with private fields?)
- [ ] #1890 (`new_without_default_derive` triggers on types which cannot `#[derive(Default)]`)
- [ ] #3053 (When `derive` is already applied to struct, suggest extending it, not replacing it)
- [ ] #3697 (clippy::new_without_default_derive triggers and shouldn't)

### `no_effect`

- [ ] #2227 (Lint suggestions based on MISRA 2004)
- [ ] #2722 (no_effect lint should also lint calls to const_fn where the result is unused)

### `non_ascii_literal`

- [ ] #4091 (-A should override -W when it appears later on the command line)

### `nonminimal_bool`

- [ ] #1334 (Lint `!any(==)` and similar)
- [ ] #1893 (nonminimal_bool lint for meta items)
- [ ] #3141 (nonminimal_bool can produce minimal but not human readable expressions)

### `not_unsafe_ptr_arg_deref`

- [ ] #3045 (not_unsafe_ptr_arg_deref false positives)

### `op_ref`

- [ ] #2042 (op_ref false positive)
- [ ] #2597 (op_ref false positive with deref coercions when comparing)
- [ ] #4461 (clippy::drop_ref will trigger on `&mut T` as well as `&T`)

### `option_and_then_some`

- [ ] #4412 (Add `result_and_then_ok` lint)

### `option_map_unit_fn`

- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)

### `option_map_unwrap_or`

- [ ] #1078 (Merge some lints together)
- [ ] #3236 (Why does Clippy not suggest removing an  `Option::map` call with an "identity")

### `option_map_unwrap_or_else`

- [ ] #1078 (Merge some lints together)
- [ ] #3236 (Why does Clippy not suggest removing an  `Option::map` call with an "identity")

### `option_option`

- [ ] #4298 (#[allow(clippy::option_option)] not working when paired with #[serde(deserialize_with)])

### `option_unwrap_used`

- [ ] #1015 (Disable result_unwrap_used / option_unwrap_used in tests)
- [ ] #1078 (Merge some lints together)

### `or_fun_call`

- [ ] #1609 (False positive for `or_fun_call`)
- [ ] #1667 (or_fun_call bad output with vec![])
- [ ] #2186 (Suggested code does not compile with or_fun_call)
- [ ] #2379 (Truncated message)

### `out_of_bounds_indexing`

- [ ] #1668 (out_of_bounds_indexing false positive)
- [ ] #4607 (empty_array.rs test removed because it ICEs on CI)

### `overflow_check_conditional`

- [ ] #2457 (false positive: `a - b > b` is not really an underflow check)

### `panic`

- [ ] #19 (foo.unwrap_or(panic!(…)))
- [ ] #278 ((Preliminary) Results of building rust with clippy)
- [ ] #632 (Rust-dogme)
- [ ] #633 (Suggest named parameters for complex/long format! calls)
- [ ] #668 (lint panics (allow))
- [ ] #849 (Possible suggestion improvements on match_ref_pats)
- [ ] #932 (Will not run and panicks on multiple [[bin]] sections in Cargo.toml without --bin flag)
- [ ] #959 ("this could sometimes panic" lint)
- [ ] #1005 (Lint for Unnecessary Map)
- [ ] #1007 (Documentation/Markdown Lints)
- [ ] #1196 (Lint std::panic::catch_unwind)
- [ ] #1329 (Clean up the error reporting in the `cargo clippy` code)
- [ ] #1456 (Figure out which Common Weakness Enumerations Rust or Clippy eliminates or mitgates)
- [ ] #1517 (Panic when compiling redis-rs with clippy)
- [ ] #1523 (Lint unwrap in drop impls)
- [ ] #1630 (don't panic...)
- [ ] #1726 (needless borrow does not trigger on block trailing expression)
- [ ] #1790 (Rust API Guideline: Function docs include error conditions in "Errors" section)
- [ ] #1791 (Rust API Guideline: Function docs include panic conditions in "Panics" section)
- [ ] #1798 (Meta issue for Rust API Guidelines)
- [ ] #1974 (Optional lint for functions that panic without mentioning panics in rustdoc)
- [ ] #1976 (Lint usages of `tcx.hir.body` without accompaning `tcx.body_tables`)
- [ ] #2001 (Attempting to run clippy on a single file causes it to crash)
- [ ] #2142 (Clippy fails as subcommand on Windows when rustc installed via installer)
- [ ] #2297 (Add a lint for `panic!` being used)
- [ ] #2306 (Panic in nightly-msvc (cddc4a62d 2017-12-26), "thread 'rustc' panicked at 'failed to create span for type arguments',")
- [ ] #2621 (clippy fails on missing eh_personality although panic-strategy is defined in custom target)
- [ ] #2866 (Improve `indexing_slicing` help message)
- [ ] #2928 (`expect_fun_call` recommends code which is not equivalent)
- [ ] #2988 (`Any` pitfalls)
- [ ] #3070 (Lint calls to `#[no_mangle]` functions that don't have `#[inline(never)]`)
- [ ] #3575 (lint assert!(true / false))
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)
- [ ] #3713 (Perhaps this match_bool case could be considered idiomatic?)
- [ ] #3746 (Lint: empty_loop lint on `no_std`)
- [ ] #3969 (crash ./ui/trivial-bounds/trivial-bounds-inconsistent.rs)
- [ ] #4281 (Should the `mut_from_ref` lint apply to unsafe functions?)
- [ ] #4483 (New lint: dangerous use of vec.set_len())
- [ ] #4661 (unit_cmp: special handling of assert_eq!(Option.unwrap(), ());)
- [ ] #4681 (RLS crashes on clippyusing rustc 1.39.0-nightly (eb48d6bde 2019-09-12))
- [ ] #4899 (Lint leaky Drop impls that do nothing but drop items in a loop)
- [ ] #5013 (Should pick up panic!(format!()
- [ ] #5024 (`match_wild_err_arm` triggers weirdly)
- [ ] #5026 (Extend `invalid_atomic_ordering` lint to memory fence calls)

### `partialeq_ne_impl`

- [ ] #2893 (partialeq_ne_impl lint documentation incorrect)

### `possible_missing_comma`

- [ ] #4399 (False positive in possible_missing_comma)

### `precedence`

- [ ] #2227 (Lint suggestions based on MISRA 2004)
- [ ] #3396 ("possibly missing a comma here" conflicts with rustfmt)
- [ ] #3903 (Lint negation "followed" by method call)
- [ ] #4778 (-A --allow should take precedence over -D --deny in CLI)
- [ ] #4892 (precedence should not warn for unary minus before odd function)

### `print_literal`

- [ ] #2768 (False literal with empty format string warning when printing two macros)
- [ ] #2802 (`cargo clippy` does not process build scripts)

### `print_with_newline`

- [ ] #2295 (Print with newline edge cases)

### `ptr_arg`

- [ ] #743 (Create more than 2 lint groups)
- [ ] #846 (Consequences of ptr_arg)
- [ ] #1794 (Rust API Guideline: Functions minimize assumptions about parameters by using generics)
- [ ] #1981 (Typedefs and `ptr_arg` lint)
- [ ] #3045 (not_unsafe_ptr_arg_deref false positives)
- [ ] #3381 (ptr_arg: clarify about original type when newtype is just a Vec<_>)
- [ ] #4504 (Option to disable trivially_copy_pass_by_ref in public functions)

### `question_mark`

- [ ] #1798 (Meta issue for Rust API Guidelines)
- [ ] #4906 (needless_doctest_main vs. question mark operator)

### `range_plus_one`

- [ ] #2217 (Do not suggest to use the closed interval syntax)
- [ ] #3103 (range_plus_one help suggestion should not remove braces)
- [ ] #3307 (range_plus_one lint wrongly suggests using RangeInclusive when Range is required and the other way around)
- [ ] #3583 (Do not lint range_plus_one inside implementations of Index<RangeInclusive<_>>)

### `redundant_clone`

- [ ] #4982 (redundant_clone in Rc context ?)

### `redundant_closure`

- [ ] #407 (Add option to disable all linting in external macros)
- [ ] #533 (Bikesheds to be done when RfCing clippy)
- [ ] #1553 (redundant_closure_call false positive in macros)
- [ ] #1608 (redundant_closure suggests wrong fix when the function being called is not Copy)
- [ ] #3071 (Redundant closure lint recommends invalid code)
- [ ] #3354 (False redundant_closure_call for a closure that has multiple calls)
- [ ] #3468 (redundant_closure should be in the Perf group)
- [ ] #3942 (False positive with redundant_closure and Deref)
- [ ] #3974 (clippy::redundant_closure suggestion unnecessarily complicated)
- [ ] #4002 (False positive in redundant_closure when closure value's lifetime is constrained)
- [ ] #4354 (False positive with redundant_closure)

### `redundant_closure_call`

- [ ] #1553 (redundant_closure_call false positive in macros)
- [ ] #3354 (False redundant_closure_call for a closure that has multiple calls)

### `redundant_field_names`

- [ ] #3422 (FR: redundant_field_names should distinguish between all and some fields matching)

### `redundant_pattern`

- [ ] #2353 (Do not suggest replacing simple `if let Some(_) / None` with methods)
- [ ] #4344 (redundant_pattern_matching fixit suggestion fails to apply)

### `redundant_pattern_matching`

- [ ] #2353 (Do not suggest replacing simple `if let Some(_) / None` with methods)
- [ ] #4344 (redundant_pattern_matching fixit suggestion fails to apply)

### `redundant_static_lifetimes`

- [ ] #4612 (Clippy doesn't report error/warnings after cargo check)

### `regex_macro`

- [ ] #2586 (regex_macro false positive)

### `replace_consts`

- [ ] #2380 (Why is `replace_consts` enabled by default?)

### `result_map_unwrap_or_else`

- [ ] #3730 (result_map_unwrap_or_else suggestion masks error from result.)

### `result_unwrap_used`

- [ ] #1015 (Disable result_unwrap_used / option_unwrap_used in tests)
- [ ] #1078 (Merge some lints together)

### `reverse_range_loop`

- [ ] #2477 (Potential improvement to reverse_range_loop)

### `shadow_reuse`

- [ ] #2745 (Clippy doesn't honour #![allow(shadow_reuse)])
- [ ] #3433 (Lint dangerous uses of shadowing)
- [ ] #3979 (clippy does not warn me of shadowing)

### `shadow_same`

- [ ] #3433 (Lint dangerous uses of shadowing)
- [ ] #3979 (clippy does not warn me of shadowing)

### `shadow_unrelated`

- [ ] #533 (Bikesheds to be done when RfCing clippy)
- [ ] #3200 (shadow_unrelated breaks when intermediary bindings are used)
- [ ] #3343 (Tracking issue for RFC 2476, Clippy 1.0)
- [ ] #3433 (Lint dangerous uses of shadowing)
- [ ] #3619 (Incorrect message in shadow_unrelated)
- [ ] #3979 (clippy does not warn me of shadowing)

### `should_assert_eq`

- [ ] #1810 (Extensions to should_assert_eq)

### `should_implement_trait`

- [ ] #1600 ( should_implement_trait should include ToOwned, FromStr)
- [ ] #1731 (should_implement_trait should not be triggered by from_str with explicit type annotation)
- [ ] #1798 (Meta issue for Rust API Guidelines)
- [ ] #4290 (should_implement_trait should not warn async methods)
- [ ] #5004 (should_implement_trait triggers for next() where the return value has lifetimes)

### `similar_names`

- [ ] #1854 (Lint request: unnecessary pass-by-reference)

### `single_char_pattern`

- [ ] #871 (Make `SINGLE_CHAR_PATTERN` check for bounds, not `self` type)
- [ ] #3075 (single_char_pattern doesn't recognize scape sequences)
- [ ] #3813 (Slow suggestion of single_char_pattern)
- [ ] #4612 (Clippy doesn't report error/warnings after cargo check)

### `single_match`

- [ ] #164 (Findings from running Clippy on Servo)
- [ ] #173 (single_match should suggest plain `if` when possible)
- [ ] #810 (Invalid suggestion for single_match)
- [ ] #929 (Extend single_match to handle return)
- [ ] #1404 (Wrong suggestion from single_match)
- [ ] #1716 (Lint if lets that could be better worded as equality)
- [ ] #2567 (single_match: recongnize "Ok(_) => {}" or "Err(_bla) => {}" as "_ => {}" )
- [ ] #3489 (FN single_match_else)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)
- [ ] #4311 (Lint idea: Bind if/else returning bool and then using that binding to conditionally do something)
- [ ] #4952 (single_match_else false positive)

### `single_match_else`

- [ ] #1716 (Lint if lets that could be better worded as equality)
- [ ] #3489 (FN single_match_else)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)
- [ ] #4311 (Lint idea: Bind if/else returning bool and then using that binding to conditionally do something)
- [ ] #4952 (single_match_else false positive)

### `str_to_string`

- [ ] #278 ((Preliminary) Results of building rust with clippy)
- [ ] #317 (idea: Combination of str_to_string and needless_closure)
- [ ] #2824 (new lint for &str to String conversion)

### `string_add`

- [ ] #1078 (Merge some lints together)

### `string_add_assign`

- [ ] #1078 (Merge some lints together)

### `string_lit_as_bytes`

- [ ] #1402 (string_lit_as_bytes doesn't work correctly)
- [ ] #4494 (Incorrect suggestion of `string_lit_as_bytes` lint)

### `string_to_string`

- [ ] #2259 (Lint unnecessary conversion of OsString or CString to String)

### `suspicious_arithmetic_impl`

- [ ] #3215 (spurious suspicious_arithmetic_impl)

### `suspicious_else_formatting`

- [ ] #3864 (allman style brace formatting triggers suspicious_else_formatting)

### `suspicious_map`

- [ ] #4793 (Improve documentation for `suspicious_map`)

### `temporary_cstring_as_ptr`

- [ ] #2637 (vec as_ptr/as_mut_ptr should have a deny lint)

### `todo`

- [ ] #2158 (Allow some way of marking lints as TODO)
- [ ] #2371 (Don't suggest eta-reducible replacements in UNNECESSARY_FOLD lint)
- [ ] #2521 (Suggestion: Single `if let` instead of nested `if let { if let`)

### `too_many_arguments`

- [ ] #1576 (`too_many_arguments` should ignore functions called `new`)
- [ ] #2488 (Improve too_many_arguments: only highlight function arguments instead of entire function)

### `toplevel_ref_arg`

- [ ] #406 (Suggest changing *x to x in toplevel_ref_arg)
- [ ] #1882 (Wrong code example for the "`ref` on an entire `let` pattern is discouraged" lint)
- [ ] #3110 (Suggestions for toplevel_ref_arg should not move `mut` to the right-hand side)

### `transmute_ptr_to_ptr`

- [ ] #2906 (False positives when using `transmute()` with raw trait object pointers to change trait object lifetimes)

### `transmute_ptr_to_ref`

- [ ] #1076 (Suggestion: Don't lose trailing semicolons (and other context-relevant stuff))
- [ ] #1754 (transmute_ptr_to_ref suggestion doesn't with some outer expression types)
- [ ] #1966 (extend transmute_ptr_to_ref to detect transmuting newtypes around ptrs)
- [ ] #2906 (False positives when using `transmute()` with raw trait object pointers to change trait object lifetimes)

### `trivial_regex`

- [ ] #1943 (`trivial_regex` false positive and/or incorrect hint for `replace`?)
- [ ] #3647 (Incorrect hints from trivial_regex for bytes regexes )

### `trivially_copy_pass_by_ref`

- [ ] #2961 (False positive with trivially_copy_pass_by_ref)
- [ ] #4504 (Option to disable trivially_copy_pass_by_ref in public functions)

### `type_complexity`

- [ ] #301 (Stronger macro check for identity-op and type-complexity)
- [ ] #743 (Create more than 2 lint groups)
- [ ] #1013 (Type complexity should not be considered when defining an associated type)
- [ ] #4844 (New lint: Unnecessarily complex types)

### `type_repetition_in_bounds`

- [ ] #4323 (False positive with type_repetition_in_bounds and generics)
- [ ] #4326 (type_repetition_in_bounds should not trigger on macro-generated code)
- [ ] #4380 (type_repetition_in_bounds not always helps)

### `unimplemented`

- [ ] #638 (unnecessary `..` binding in struct)
- [ ] #1058 (lint assigning to fields of an uninitialized struct)
- [ ] #2529 (Warn about `Result`s only used in println!())
- [ ] #3410 (False positive with use_self and generics)
- [ ] #3528 (clippy::unimplemented doesn't detect unimplemented!() with message)
- [ ] #4290 (should_implement_trait should not warn async methods)
- [ ] #4740 (boxed_local false positive for ?Sized)

### `uninit_assumed_init`

- [ ] #4765 (uninit_assumed_init lint does not recognize trivial misuse)

### `unit_arg`

- [ ] #3759 (catch-22 with try block, clippy::unit_arg and clippy::unused_unit)
- [ ] #4741 ([cargo fix] `unit_arg` removes calls to functions with side-effects)

### `unit_cmp`

- [ ] #4661 (unit_cmp: special handling of assert_eq!(Option.unwrap(), ());)

### `unnecessary_filter_map`

- [ ] #4433 (False positive for unnecessary_filter_map)

### `unnecessary_fold`

- [ ] #2371 (Don't suggest eta-reducible replacements in UNNECESSARY_FOLD lint)
- [ ] #2401 (Suggest replacing simple loops with specialized folds)
- [ ] #3351 (unnecessary_fold: .any and .all may not always be safe replacements of .fold)

### `unnecessary_mut_passed`

- [ ] #2373 (False positives selecting system allocator)
- [ ] #3455 (have different docs for nightly/beta/stable channels)

### `unnecessary_unwrap`

- [ ] #4530 (unnecessary_unwrap: should not trigger if the `is_some` is just part of the conditional)

### `unneeded_field_pattern`

- [ ] #1741 (unneeded_field_pattern )

### `unreachable`

- [ ] #668 (lint panics (allow))
- [ ] #1632 (Lint for unconditional unreachable!())
- [ ] #2227 (Lint suggestions based on MISRA 2004)
- [ ] #3528 (clippy::unimplemented doesn't detect unimplemented!() with message)
- [ ] #4644 (Suggest using `!`/`Infallibe` in trait implementations with a result type.)

### `unreadable_literal`

- [ ] #2842 (unreadable_literal is annoying for hex numbers)
- [ ] #3455 (have different docs for nightly/beta/stable channels)
- [ ] #4176 (unreadable_literal for floating-point numbers)
- [ ] #4706 (BUG: Incorrect mistyped literal suffix on long floats.)

### `unused_io_amount`

- [ ] #4836 (Clippy errors and says to use `Read::read_exact` inside implementations of `Read::read_exact` that don't directly use the output of `Read::read`)

### `unused_label`

- [ ] #1850 (Add automatically applicable suggestion to unused_label)

### `unused_self`

- [ ] #4928 (FP: `unused_self` triggers if only the lifetime of `self` is used)

### `unused_unit`

- [ ] #3759 (catch-22 with try block, clippy::unit_arg and clippy::unused_unit)

### `use_debug`

- [ ] #1713 (Lint for Debug formatting in Display implementations)
- [ ] #2132 (`use_debug` lint should not trigger on `debug!()` log macro calls)

### `use_self`

- [ ] #2038 (Tracking Issue: Split up our UI-tests into smaller parts)
- [ ] #2843 (False positive for `use_self` when using an associated type instead of the type itself.)
- [ ] #3410 (False positive with use_self and generics)
- [ ] #3618 (New Lint: Unnameable type in public API)
- [ ] #3859 (use_self lint suggests changing code to use outer type parameters breaking build)
- [ ] #3881 (use_self lint false positive in macros)
- [ ] #3909 (use_self false positive on derive)
- [ ] #4140 (Suggestion does not compile: use self with associated types)
- [ ] #4143 (Suggestion does not compile: use self with when implementing a trait for a generic type)
- [ ] #4305 (Suggestion does not compile: use self with when implementing `From` conversion for the `Box<dyn Trait>`.)
- [ ] #4734 (False positive for `use_self` when using core::mem::transmute in From impl)
- [ ] #4887 (use_self lint fires on code expanded from a macro)

### `used_underscore_binding`

- [ ] #947 (Fix `used_underscore_binding`)
- [ ] #3643 ("multiple matching crates for `serde_derive`" in test `used_underscore_binding_macro`)

### `useless_attribute`

- [ ] #1522 (The useless attribute lint doesn't put the ! in the right place.)
- [ ] #4467 (Incorrect suggestion in `useless_attribute` lint)

### `useless_format`

- [ ] #3021 (FN: useless format: formatting PathBuf.display())
- [ ] #3122 (lint unused (clippy) allow attributes)
- [ ] #3155 (FN useless_format: write!(f,"{}",format!()))
- [ ] #3156 (FN useless format: struct with fmt::Display and format!() ? )
- [ ] #3361 (useless_format: .to_string() suggested where format! could be omitted)
- [ ] #3753 (Extend `useless_format` to lint values other than `&str` and `String`)

### `useless_let_if_seq`

- [ ] #1081 (What about placeholders?)
- [ ] #2176 (False positive on 'useless_let_if_seq')
- [ ] #2749 (useless_let_if_seq should not emit a warning if multiple assignments happen)
- [ ] #2918 (Incorrect suggestion by `useless_let_if_seq` lint)
- [ ] #3043 (Clippy suggests optimizing volatile operations away; Shoudln't do so?)
- [ ] #3769 (useless_let_if_seq should not warn when variable is set from multiple places.)
- [ ] #4124 (Bad suggestion of `useless_let_if_seq` when having side effects.)
- [ ] #4448 (Suggest binding to a tuple if possible in the `useless_let_if_seq` lint)

### `useless_transmute`

- [ ] #546 ([lint idea] dangerous transmutes)
- [ ] #1545 (useless_transmute being raised when it's doing multiple casts)
- [ ] #2906 (False positives when using `transmute()` with raw trait object pointers to change trait object lifetimes)
- [ ] #3340 (False positive useless_transmute?)

### `useless_vec`

- [ ] #2256 (useless_vec doesn't suggest a necessary &)

### `vec_box`

- [ ] #3547 (Make VEC_BOX lint configurable over the size of T)

### `while_immutable_condition`

- [ ] #3548 (while_immutable_condition false positive with mut pointers)

### `while_let_loop`

- [ ] #278 ((Preliminary) Results of building rust with clippy)
- [ ] #362 (`while_let_loop` fails to account for lifetimes)
- [ ] #1693 (while_let_loop false positive)

### `while_let_on_iterator`

- [ ] #600 (False positive on while_let_on_iterator with nested while let)
- [ ] #1033 (Wrong suggestion on while_let_on_iterator)
- [ ] #1654 (while_let_on_iterator false positive)
- [ ] #1924 (incorrect suggestion for while_let_on_iterator)
- [ ] #3780 (Bad `while_let_on_iterator` suggestion when pattern is refutable)

### `wrong_pub_self_convention`

- [ ] #320 (Suggest using Cow on mixture of &'static str + Strings)
- [ ] #743 (Create more than 2 lint groups)

### `wrong_self_convention`

- [ ] #3414 (`wrong_self_convention` does not recognize `this: Self`)
- [ ] #3858 (wrong_self_convention fails for libstd RawEntryBuilderMut::from_key)
- [ ] #4037 (wrong_self_convention false positive for async fn `into_*`)
- [ ] #4546 (Pin<&mut self> triggers "wrong_self_convention")

### `zero_prefixed_literal`

- [ ] #1274 (decimal constant error)

### `zero_ptr`

- [ ] #1580 (zero_ptr lint detected for any lazy_static code)
- [ ] #2177 (Lint casting integers to pointers)
- [ ] #2373 (False positives selecting system allocator)
</details>

I'm pretty satisfied with the output. Some lint names that are too generic, like `panic` or `exit`, need some extra work though.

---

Usage:
```
Prints all issues where the specified lint is mentioned either in the title or in the description

USAGE:
    clippy_dev issues_for_lint [FLAGS] [OPTIONS] --name <name>

FLAGS:
        --all        Create a list for all lints
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --filter <filter>    Comma separated list of issue numbers, that should be filtered out
    -n, --name <name>        The name of the lint
```

---

Your thoughts about having such a tracking issue?

changelog: none
