### PR TITLE
Avoid mut_key on types of unknown layout

### DIFF
--- a/tests/ui/mut_key.rs
+++ b/tests/ui/mut_key.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::implicit_hasher)]
+
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
@@ -29,9 +31,27 @@ fn should_not_take_this_arg(m: &mut HashMap<Key, usize>, _n: usize) -> HashSet<K
     m.keys().cloned().collect()
 }
 
-fn this_is_ok(m: &mut HashMap<usize, Key>) {}
+fn this_is_ok(_m: &mut HashMap<usize, Key>) {}
+
+#[allow(unused)]
+trait Trait {
+    type AssociatedType;
+
+    fn trait_fn(&self, set: std::collections::HashSet<Self::AssociatedType>);
+}
+
+fn generics_are_ok_too<K>(_m: &mut HashSet<K>) {
+    // nothing to see here, move along
+}
+
+fn tuples<U>(_m: &mut HashMap<((), U), ()>) {}
+
+fn tuples_bad<U>(_m: &mut HashMap<(Key, U), bool>) {}
 
 fn main() {
     let _ = should_not_take_this_arg(&mut HashMap::new(), 1);
     this_is_ok(&mut HashMap::new());
+    tuples::<Key>(&mut HashMap::new());
+    tuples::<()>(&mut HashMap::new());
+    tuples_bad::<()>(&mut HashMap::new());
 }

--- a/tests/ui/mut_key.stderr
+++ b/tests/ui/mut_key.stderr
@@ -1,5 +1,5 @@
 error: mutable key type
-  --> $DIR/mut_key.rs:27:32
+  --> $DIR/mut_key.rs:29:32
    |
 LL | fn should_not_take_this_arg(m: &mut HashMap<Key, usize>, _n: usize) -> HashSet<Key> {
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,16 +7,22 @@ LL | fn should_not_take_this_arg(m: &mut HashMap<Key, usize>, _n: usize) -> Hash
    = note: `#[deny(clippy::mutable_key_type)]` on by default
 
 error: mutable key type
-  --> $DIR/mut_key.rs:27:72
+  --> $DIR/mut_key.rs:29:72
    |
 LL | fn should_not_take_this_arg(m: &mut HashMap<Key, usize>, _n: usize) -> HashSet<Key> {
    |                                                                        ^^^^^^^^^^^^
 
 error: mutable key type
-  --> $DIR/mut_key.rs:28:5
+  --> $DIR/mut_key.rs:30:5
    |
 LL |     let _other: HashMap<Key, bool> = HashMap::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: mutable key type
+  --> $DIR/mut_key.rs:49:22
+   |
+LL | fn tuples_bad<U>(_m: &mut HashMap<(Key, U), bool>) {}
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This fixes #5020 by requiring a known layout for the key type before linting. Edit: This fixes #5043, too.

changelog: none
