### PR TITLE
Tweak wording in `assertions_on_constants`

### DIFF
--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -63,7 +63,7 @@ LL |     assert!(C, "C message");
    |
    = help: use `panic!("C message")` or `unreachable!("C message")`
 
-error: `assert!(true)` will be optimized out by the compiler
+error: `debug_assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:24:5
    |
 LL |     debug_assert!(true);


### PR DESCRIPTION
Displays actual macro names

changelog: none
