### PR TITLE
Ignore macros with `!` operators in `eq_op`

### DIFF
--- a/tests/ui/eq_op.rs
+++ b/tests/ui/eq_op.rs
@@ -73,6 +73,15 @@ macro_rules! check_if_named_foo {
     )
 }
 
+macro_rules! bool_macro {
+    ($expression:expr) => {
+        true
+    };
+}
+
+#[allow(clippy::short_circuit_statement)]
 fn check_ignore_macro() {
     check_if_named_foo!(foo);
+    // checks if the lint ignores macros with `!` operator
+    !bool_macro!(1) && !bool_macro!("");
 }


### PR DESCRIPTION
`SpanlessEq::eq_expr` doesn't ignore macros with `!` operators and I'm not sure we should ignore there, so I ignore in `eq_op` (and `op_ref`).

Fixes #5077

changelog: Fix false positive in `eq_op`
