### PR TITLE
disable let_underscore_must_use in external macros

### DIFF
--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -1,4 +1,5 @@
 use if_chain::if_chain;
+use rustc::lint::in_external_macro;
 use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -33,6 +34,10 @@ declare_lint_pass!(LetUnderscore => [LET_UNDERSCORE_MUST_USE]);
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnderscore {
     fn check_stmt(&mut self, cx: &LateContext<'_, '_>, stmt: &Stmt<'_>) {
+        if in_external_macro(cx.tcx.sess, stmt.span) {
+            return;
+        }
+
         if_chain! {
             if let StmtKind::Local(ref local) = stmt.kind;
             if let PatKind::Wild = local.pat.kind;

--- a/tests/ui/let_underscore.rs
+++ b/tests/ui/let_underscore.rs
@@ -1,5 +1,12 @@
 #![warn(clippy::let_underscore_must_use)]
 
+// Debug implementations can fire this lint,
+// so we shouldn't lint external macros
+#[derive(Debug)]
+struct Foo {
+    field: i32,
+}
+
 #[must_use]
 fn f() -> u32 {
     0

--- a/tests/ui/let_underscore.stderr
+++ b/tests/ui/let_underscore.stderr
@@ -1,5 +1,5 @@
 error: non-binding let on a result of a `#[must_use]` function
-  --> $DIR/let_underscore.rs:59:5
+  --> $DIR/let_underscore.rs:66:5
    |
 LL |     let _ = f();
    |     ^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let _ = f();
    = help: consider explicitly using function result
 
 error: non-binding let on an expression with `#[must_use]` type
-  --> $DIR/let_underscore.rs:60:5
+  --> $DIR/let_underscore.rs:67:5
    |
 LL |     let _ = g();
    |     ^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     let _ = g();
    = help: consider explicitly using expression value
 
 error: non-binding let on a result of a `#[must_use]` function
-  --> $DIR/let_underscore.rs:62:5
+  --> $DIR/let_underscore.rs:69:5
    |
 LL |     let _ = l(0_u32);
    |     ^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     let _ = l(0_u32);
    = help: consider explicitly using function result
 
 error: non-binding let on a result of a `#[must_use]` function
-  --> $DIR/let_underscore.rs:66:5
+  --> $DIR/let_underscore.rs:73:5
    |
 LL |     let _ = s.f();
    |     ^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     let _ = s.f();
    = help: consider explicitly using function result
 
 error: non-binding let on an expression with `#[must_use]` type
-  --> $DIR/let_underscore.rs:67:5
+  --> $DIR/let_underscore.rs:74:5
    |
 LL |     let _ = s.g();
    |     ^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |     let _ = s.g();
    = help: consider explicitly using expression value
 
 error: non-binding let on a result of a `#[must_use]` function
-  --> $DIR/let_underscore.rs:70:5
+  --> $DIR/let_underscore.rs:77:5
    |
 LL |     let _ = S::h();
    |     ^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     let _ = S::h();
    = help: consider explicitly using function result
 
 error: non-binding let on an expression with `#[must_use]` type
-  --> $DIR/let_underscore.rs:71:5
+  --> $DIR/let_underscore.rs:78:5
    |
 LL |     let _ = S::p();
    |     ^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     let _ = S::p();
    = help: consider explicitly using expression value
 
 error: non-binding let on a result of a `#[must_use]` function
-  --> $DIR/let_underscore.rs:73:5
+  --> $DIR/let_underscore.rs:80:5
    |
 LL |     let _ = S::a();
    |     ^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |     let _ = S::a();
    = help: consider explicitly using function result
 
 error: non-binding let on an expression with `#[must_use]` type
-  --> $DIR/let_underscore.rs:75:5
+  --> $DIR/let_underscore.rs:82:5
    |
 LL |     let _ = if true { Ok(()) } else { Err(()) };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     let _ = if true { Ok(()) } else { Err(()) };
    = help: consider explicitly using expression value
 
 error: non-binding let on a result of a `#[must_use]` function
-  --> $DIR/let_underscore.rs:79:5
+  --> $DIR/let_underscore.rs:86:5
    |
 LL |     let _ = a.is_ok();
    |     ^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     let _ = a.is_ok();
    = help: consider explicitly using function result
 
 error: non-binding let on an expression with `#[must_use]` type
-  --> $DIR/let_underscore.rs:81:5
+  --> $DIR/let_underscore.rs:88:5
    |
 LL |     let _ = a.map(|_| ());
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL |     let _ = a.map(|_| ());
    = help: consider explicitly using expression value
 
 error: non-binding let on an expression with `#[must_use]` type
-  --> $DIR/let_underscore.rs:83:5
+  --> $DIR/let_underscore.rs:90:5
    |
 LL |     let _ = a;
    |     ^^^^^^^^^^


### PR DESCRIPTION
changelog: disable let_underscore_must_use in external macros
Closes #4980 
