### PR TITLE
dont fire `possible_missing_comma` if intendation is present

### DIFF
--- a/tests/ui/formatting.rs
+++ b/tests/ui/formatting.rs
@@ -143,4 +143,15 @@ fn main() {
         true
         | false,
     ];
+
+    // don't lint if the indentation suggests not to
+    let _ = &[
+        1 + 2, 3 
+                - 4, 5
+    ];
+    // lint if it doesnt
+    let _ = &[
+        -1
+        -4,
+    ];
 }

--- a/tests/ui/formatting.stderr
+++ b/tests/ui/formatting.stderr
@@ -115,5 +115,13 @@ LL |         -1, -2, -3 // <= no comma here
    |
    = note: to remove this lint, add a comma or write the expr in a single line
 
-error: aborting due to 13 previous errors
+error: possibly missing a comma here
+  --> $DIR/formatting.rs:154:11
+   |
+LL |         -1
+   |           ^
+   |
+   = note: to remove this lint, add a comma or write the expr in a single line
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Closes #4399 
changelog: dont fire `possible_missing_comma` if intendation is present

I suspect there is already a utils function for indentation (but searching indent didn't yield a function for that), and my solution is certainly not universal, but it's probably the best we can do.
