### PR TITLE
Clean up `span_lint` in `methods/mod.rs`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2138,7 +2138,7 @@ fn lint_iter_nth<'a, 'tcx>(
         ITER_NTH,
         expr.span,
         &format!("called `.iter{0}().nth()` on a {1}", mut_str, caller_type),
-        &format!("Calling `.get{}()` is both faster and more readable", mut_str),
+        &format!("calling `.get{}()` is both faster and more readable", mut_str),
     );
 }
 
@@ -2247,7 +2247,7 @@ fn lint_iter_skip_next(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>) {
             ITER_SKIP_NEXT,
             expr.span,
             "called `skip(x).next()` on an iterator",
-            "This is more succinctly expressed by calling `nth(x)`.",
+            "this is more succinctly expressed by calling `nth(x)`",
         );
     }
 }
@@ -2309,8 +2309,8 @@ fn lint_unwrap(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, unwrap_args: &[hi
             expr.span,
             &format!("used `unwrap()` on `{}` value", kind,),
             &format!(
-                "If you don't want to handle the `{}` case gracefully, consider \
-                using `expect()` to provide a better panic message.",
+                "if you don't want to handle the `{}` case gracefully, consider \
+                using `expect()` to provide a better panic message",
                 none_value,
             ),
         );
@@ -2335,7 +2335,7 @@ fn lint_expect(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, expect_args: &[hi
             lint,
             expr.span,
             &format!("used `expect()` on `{}` value", kind,),
-            &format!("If this value is an `{}`, it will panic.", none_value,),
+            &format!("if this value is an `{}`, it will panic", none_value,),
         );
     }
 }
@@ -2355,7 +2355,7 @@ fn lint_ok_expect(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, ok_args: &[hir
                 OK_EXPECT,
                 expr.span,
                 "called `ok().expect()` on a `Result` value",
-                "You can call `expect()` directly on the `Result`",
+                "you can call `expect()` directly on the `Result`",
             );
         }
     }
@@ -2608,7 +2608,7 @@ fn lint_filter_map<'a, 'tcx>(
     // lint if caller of `.filter().map()` is an Iterator
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         let msg = "called `filter(p).map(q)` on an `Iterator`";
-        let hint = "This is more succinctly expressed by calling `.filter_map(..)` instead.";
+        let hint = "this is more succinctly expressed by calling `.filter_map(..)` instead";
         span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }
@@ -2648,7 +2648,7 @@ fn lint_find_map<'a, 'tcx>(
     // lint if caller of `.filter().map()` is an Iterator
     if match_trait_method(cx, &map_args[0], &paths::ITERATOR) {
         let msg = "called `find(p).map(q)` on an `Iterator`";
-        let hint = "This is more succinctly expressed by calling `.find_map(..)` instead.";
+        let hint = "this is more succinctly expressed by calling `.find_map(..)` instead";
         span_help_and_lint(cx, FIND_MAP, expr.span, msg, hint);
     }
 }
@@ -2663,7 +2663,7 @@ fn lint_filter_map_map<'a, 'tcx>(
     // lint if caller of `.filter().map()` is an Iterator
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         let msg = "called `filter_map(p).map(q)` on an `Iterator`";
-        let hint = "This is more succinctly expressed by only calling `.filter_map(..)` instead.";
+        let hint = "this is more succinctly expressed by only calling `.filter_map(..)` instead";
         span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }
@@ -2678,8 +2678,8 @@ fn lint_filter_flat_map<'a, 'tcx>(
     // lint if caller of `.filter().flat_map()` is an Iterator
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         let msg = "called `filter(p).flat_map(q)` on an `Iterator`";
-        let hint = "This is more succinctly expressed by calling `.flat_map(..)` \
-            and filtering by returning an empty Iterator.";
+        let hint = "this is more succinctly expressed by calling `.flat_map(..)` \
+            and filtering by returning `iter::empty()`";
         span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }
@@ -2694,8 +2694,8 @@ fn lint_filter_map_flat_map<'a, 'tcx>(
     // lint if caller of `.filter_map().flat_map()` is an Iterator
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         let msg = "called `filter_map(p).flat_map(q)` on an `Iterator`";
-        let hint = "This is more succinctly expressed by calling `.flat_map(..)` \
-            and filtering by returning an empty Iterator.";
+        let hint = "this is more succinctly expressed by calling `.flat_map(..)` \
+            and filtering by returning `iter::empty()`";
         span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }

--- a/tests/ui/expect.stderr
+++ b/tests/ui/expect.stderr
@@ -1,18 +1,20 @@
-error: used `expect()` on `an Option` value. If this value is an `None` it will panic
+error: used `expect()` on `an Option` value
   --> $DIR/expect.rs:5:13
    |
 LL |     let _ = opt.expect("");
    |             ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::option-expect-used` implied by `-D warnings`
+   = help: If this value is an `None`, it will panic.
 
-error: used `expect()` on `a Result` value. If this value is an `Err` it will panic
+error: used `expect()` on `a Result` value
   --> $DIR/expect.rs:10:13
    |
 LL |     let _ = res.expect("");
    |             ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::result-expect-used` implied by `-D warnings`
+   = help: If this value is an `Err`, it will panic.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/expect.stderr
+++ b/tests/ui/expect.stderr
@@ -5,7 +5,7 @@ LL |     let _ = opt.expect("");
    |             ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::option-expect-used` implied by `-D warnings`
-   = help: If this value is an `None`, it will panic.
+   = help: if this value is an `None`, it will panic
 
 error: used `expect()` on `a Result` value
   --> $DIR/expect.rs:10:13
@@ -14,7 +14,7 @@ LL |     let _ = res.expect("");
    |             ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::result-expect-used` implied by `-D warnings`
-   = help: If this value is an `Err`, it will panic.
+   = help: if this value is an `Err`, it will panic
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/filter_methods.stderr
+++ b/tests/ui/filter_methods.stderr
@@ -5,7 +5,7 @@ LL |     let _: Vec<_> = vec![5; 6].into_iter().filter(|&x| x == 0).map(|x| x * 
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::filter-map` implied by `-D warnings`
-   = help: This is more succinctly expressed by calling `.filter_map(..)` instead.
+   = help: this is more succinctly expressed by calling `.filter_map(..)` instead
 
 error: called `filter(p).flat_map(q)` on an `Iterator`
   --> $DIR/filter_methods.rs:7:21
@@ -17,7 +17,7 @@ LL | |         .filter(|&x| x == 0)
 LL | |         .flat_map(|x| x.checked_mul(2))
    | |_______________________________________^
    |
-   = help: This is more succinctly expressed by calling `.flat_map(..)` and filtering by returning an empty Iterator.
+   = help: this is more succinctly expressed by calling `.flat_map(..)` and filtering by returning `iter::empty()`
 
 error: called `filter_map(p).flat_map(q)` on an `Iterator`
   --> $DIR/filter_methods.rs:13:21
@@ -29,7 +29,7 @@ LL | |         .filter_map(|x| x.checked_mul(2))
 LL | |         .flat_map(|x| x.checked_mul(2))
    | |_______________________________________^
    |
-   = help: This is more succinctly expressed by calling `.flat_map(..)` and filtering by returning an empty Iterator.
+   = help: this is more succinctly expressed by calling `.flat_map(..)` and filtering by returning `iter::empty()`
 
 error: called `filter_map(p).map(q)` on an `Iterator`
   --> $DIR/filter_methods.rs:19:21
@@ -41,7 +41,7 @@ LL | |         .filter_map(|x| x.checked_mul(2))
 LL | |         .map(|x| x.checked_mul(2))
    | |__________________________________^
    |
-   = help: This is more succinctly expressed by only calling `.filter_map(..)` instead.
+   = help: this is more succinctly expressed by only calling `.filter_map(..)` instead
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/filter_methods.stderr
+++ b/tests/ui/filter_methods.stderr
@@ -1,12 +1,13 @@
-error: called `filter(p).map(q)` on an `Iterator`. This is more succinctly expressed by calling `.filter_map(..)` instead.
+error: called `filter(p).map(q)` on an `Iterator`
   --> $DIR/filter_methods.rs:5:21
    |
 LL |     let _: Vec<_> = vec![5; 6].into_iter().filter(|&x| x == 0).map(|x| x * 2).collect();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::filter-map` implied by `-D warnings`
+   = help: This is more succinctly expressed by calling `.filter_map(..)` instead.
 
-error: called `filter(p).flat_map(q)` on an `Iterator`. This is more succinctly expressed by calling `.flat_map(..)` and filtering by returning an empty Iterator.
+error: called `filter(p).flat_map(q)` on an `Iterator`
   --> $DIR/filter_methods.rs:7:21
    |
 LL |       let _: Vec<_> = vec![5_i8; 6]
@@ -15,8 +16,10 @@ LL | |         .into_iter()
 LL | |         .filter(|&x| x == 0)
 LL | |         .flat_map(|x| x.checked_mul(2))
    | |_______________________________________^
+   |
+   = help: This is more succinctly expressed by calling `.flat_map(..)` and filtering by returning an empty Iterator.
 
-error: called `filter_map(p).flat_map(q)` on an `Iterator`. This is more succinctly expressed by calling `.flat_map(..)` and filtering by returning an empty Iterator.
+error: called `filter_map(p).flat_map(q)` on an `Iterator`
   --> $DIR/filter_methods.rs:13:21
    |
 LL |       let _: Vec<_> = vec![5_i8; 6]
@@ -25,8 +28,10 @@ LL | |         .into_iter()
 LL | |         .filter_map(|x| x.checked_mul(2))
 LL | |         .flat_map(|x| x.checked_mul(2))
    | |_______________________________________^
+   |
+   = help: This is more succinctly expressed by calling `.flat_map(..)` and filtering by returning an empty Iterator.
 
-error: called `filter_map(p).map(q)` on an `Iterator`. This is more succinctly expressed by only calling `.filter_map(..)` instead.
+error: called `filter_map(p).map(q)` on an `Iterator`
   --> $DIR/filter_methods.rs:19:21
    |
 LL |       let _: Vec<_> = vec![5_i8; 6]
@@ -35,6 +40,8 @@ LL | |         .into_iter()
 LL | |         .filter_map(|x| x.checked_mul(2))
 LL | |         .map(|x| x.checked_mul(2))
    | |__________________________________^
+   |
+   = help: This is more succinctly expressed by only calling `.filter_map(..)` instead.
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/find_map.stderr
+++ b/tests/ui/find_map.stderr
@@ -5,7 +5,7 @@ LL |     let _: Option<i32> = a.iter().find(|s| s.parse::<i32>().is_ok()).map(|s
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::find-map` implied by `-D warnings`
-   = help: This is more succinctly expressed by calling `.find_map(..)` instead.
+   = help: this is more succinctly expressed by calling `.find_map(..)` instead
 
 error: called `find(p).map(q)` on an `Iterator`
   --> $DIR/find_map.rs:22:29
@@ -20,7 +20,7 @@ LL | |             _ => unreachable!(),
 LL | |         });
    | |__________^
    |
-   = help: This is more succinctly expressed by calling `.find_map(..)` instead.
+   = help: this is more succinctly expressed by calling `.find_map(..)` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/find_map.stderr
+++ b/tests/ui/find_map.stderr
@@ -1,12 +1,13 @@
-error: called `find(p).map(q)` on an `Iterator`. This is more succinctly expressed by calling `.find_map(..)` instead.
+error: called `find(p).map(q)` on an `Iterator`
   --> $DIR/find_map.rs:20:26
    |
 LL |     let _: Option<i32> = a.iter().find(|s| s.parse::<i32>().is_ok()).map(|s| s.parse().unwrap());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::find-map` implied by `-D warnings`
+   = help: This is more succinctly expressed by calling `.find_map(..)` instead.
 
-error: called `find(p).map(q)` on an `Iterator`. This is more succinctly expressed by calling `.find_map(..)` instead.
+error: called `find(p).map(q)` on an `Iterator`
   --> $DIR/find_map.rs:22:29
    |
 LL |       let _: Option<Flavor> = desserts_of_the_week
@@ -18,6 +19,8 @@ LL | |             Dessert::Cake(_) => true,
 LL | |             _ => unreachable!(),
 LL | |         });
    | |__________^
+   |
+   = help: This is more succinctly expressed by calling `.find_map(..)` instead.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/iter_nth.stderr
+++ b/tests/ui/iter_nth.stderr
@@ -1,46 +1,59 @@
-error: called `.iter().nth()` on a Vec. Calling `.get()` is both faster and more readable
+error: called `.iter().nth()` on a Vec
   --> $DIR/iter_nth.rs:33:23
    |
 LL |         let bad_vec = some_vec.iter().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::iter-nth` implied by `-D warnings`
+   = help: Calling `.get()` is both faster and more readable
 
-error: called `.iter().nth()` on a slice. Calling `.get()` is both faster and more readable
+error: called `.iter().nth()` on a slice
   --> $DIR/iter_nth.rs:34:26
    |
 LL |         let bad_slice = &some_vec[..].iter().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Calling `.get()` is both faster and more readable
 
-error: called `.iter().nth()` on a slice. Calling `.get()` is both faster and more readable
+error: called `.iter().nth()` on a slice
   --> $DIR/iter_nth.rs:35:31
    |
 LL |         let bad_boxed_slice = boxed_slice.iter().nth(3);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Calling `.get()` is both faster and more readable
 
-error: called `.iter().nth()` on a VecDeque. Calling `.get()` is both faster and more readable
+error: called `.iter().nth()` on a VecDeque
   --> $DIR/iter_nth.rs:36:29
    |
 LL |         let bad_vec_deque = some_vec_deque.iter().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Calling `.get()` is both faster and more readable
 
-error: called `.iter_mut().nth()` on a Vec. Calling `.get_mut()` is both faster and more readable
+error: called `.iter_mut().nth()` on a Vec
   --> $DIR/iter_nth.rs:41:23
    |
 LL |         let bad_vec = some_vec.iter_mut().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Calling `.get_mut()` is both faster and more readable
 
-error: called `.iter_mut().nth()` on a slice. Calling `.get_mut()` is both faster and more readable
+error: called `.iter_mut().nth()` on a slice
   --> $DIR/iter_nth.rs:44:26
    |
 LL |         let bad_slice = &some_vec[..].iter_mut().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Calling `.get_mut()` is both faster and more readable
 
-error: called `.iter_mut().nth()` on a VecDeque. Calling `.get_mut()` is both faster and more readable
+error: called `.iter_mut().nth()` on a VecDeque
   --> $DIR/iter_nth.rs:47:29
    |
 LL |         let bad_vec_deque = some_vec_deque.iter_mut().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: Calling `.get_mut()` is both faster and more readable
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/iter_nth.stderr
+++ b/tests/ui/iter_nth.stderr
@@ -5,7 +5,7 @@ LL |         let bad_vec = some_vec.iter().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::iter-nth` implied by `-D warnings`
-   = help: Calling `.get()` is both faster and more readable
+   = help: calling `.get()` is both faster and more readable
 
 error: called `.iter().nth()` on a slice
   --> $DIR/iter_nth.rs:34:26
@@ -13,7 +13,7 @@ error: called `.iter().nth()` on a slice
 LL |         let bad_slice = &some_vec[..].iter().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: Calling `.get()` is both faster and more readable
+   = help: calling `.get()` is both faster and more readable
 
 error: called `.iter().nth()` on a slice
   --> $DIR/iter_nth.rs:35:31
@@ -21,7 +21,7 @@ error: called `.iter().nth()` on a slice
 LL |         let bad_boxed_slice = boxed_slice.iter().nth(3);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: Calling `.get()` is both faster and more readable
+   = help: calling `.get()` is both faster and more readable
 
 error: called `.iter().nth()` on a VecDeque
   --> $DIR/iter_nth.rs:36:29
@@ -29,7 +29,7 @@ error: called `.iter().nth()` on a VecDeque
 LL |         let bad_vec_deque = some_vec_deque.iter().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: Calling `.get()` is both faster and more readable
+   = help: calling `.get()` is both faster and more readable
 
 error: called `.iter_mut().nth()` on a Vec
   --> $DIR/iter_nth.rs:41:23
@@ -37,7 +37,7 @@ error: called `.iter_mut().nth()` on a Vec
 LL |         let bad_vec = some_vec.iter_mut().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: Calling `.get_mut()` is both faster and more readable
+   = help: calling `.get_mut()` is both faster and more readable
 
 error: called `.iter_mut().nth()` on a slice
   --> $DIR/iter_nth.rs:44:26
@@ -45,7 +45,7 @@ error: called `.iter_mut().nth()` on a slice
 LL |         let bad_slice = &some_vec[..].iter_mut().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: Calling `.get_mut()` is both faster and more readable
+   = help: calling `.get_mut()` is both faster and more readable
 
 error: called `.iter_mut().nth()` on a VecDeque
   --> $DIR/iter_nth.rs:47:29
@@ -53,7 +53,7 @@ error: called `.iter_mut().nth()` on a VecDeque
 LL |         let bad_vec_deque = some_vec_deque.iter_mut().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: Calling `.get_mut()` is both faster and more readable
+   = help: calling `.get_mut()` is both faster and more readable
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/iter_skip_next.stderr
+++ b/tests/ui/iter_skip_next.stderr
@@ -5,7 +5,7 @@ LL |     let _ = some_vec.iter().skip(42).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::iter-skip-next` implied by `-D warnings`
-   = help: This is more succinctly expressed by calling `nth(x)`.
+   = help: this is more succinctly expressed by calling `nth(x)`
 
 error: called `skip(x).next()` on an iterator
   --> $DIR/iter_skip_next.rs:14:13
@@ -13,7 +13,7 @@ error: called `skip(x).next()` on an iterator
 LL |     let _ = some_vec.iter().cycle().skip(42).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: This is more succinctly expressed by calling `nth(x)`.
+   = help: this is more succinctly expressed by calling `nth(x)`
 
 error: called `skip(x).next()` on an iterator
   --> $DIR/iter_skip_next.rs:15:13
@@ -21,7 +21,7 @@ error: called `skip(x).next()` on an iterator
 LL |     let _ = (1..10).skip(10).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: This is more succinctly expressed by calling `nth(x)`.
+   = help: this is more succinctly expressed by calling `nth(x)`
 
 error: called `skip(x).next()` on an iterator
   --> $DIR/iter_skip_next.rs:16:14
@@ -29,7 +29,7 @@ error: called `skip(x).next()` on an iterator
 LL |     let _ = &some_vec[..].iter().skip(3).next();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: This is more succinctly expressed by calling `nth(x)`.
+   = help: this is more succinctly expressed by calling `nth(x)`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/iter_skip_next.stderr
+++ b/tests/ui/iter_skip_next.stderr
@@ -1,28 +1,35 @@
-error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
+error: called `skip(x).next()` on an iterator
   --> $DIR/iter_skip_next.rs:13:13
    |
 LL |     let _ = some_vec.iter().skip(42).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::iter-skip-next` implied by `-D warnings`
+   = help: This is more succinctly expressed by calling `nth(x)`.
 
-error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
+error: called `skip(x).next()` on an iterator
   --> $DIR/iter_skip_next.rs:14:13
    |
 LL |     let _ = some_vec.iter().cycle().skip(42).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: This is more succinctly expressed by calling `nth(x)`.
 
-error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
+error: called `skip(x).next()` on an iterator
   --> $DIR/iter_skip_next.rs:15:13
    |
 LL |     let _ = (1..10).skip(10).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: This is more succinctly expressed by calling `nth(x)`.
 
-error: called `skip(x).next()` on an iterator. This is more succinctly expressed by calling `nth(x)`
+error: called `skip(x).next()` on an iterator
   --> $DIR/iter_skip_next.rs:16:14
    |
 LL |     let _ = &some_vec[..].iter().skip(3).next();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: This is more succinctly expressed by calling `nth(x)`.
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/ok_expect.stderr
+++ b/tests/ui/ok_expect.stderr
@@ -1,34 +1,43 @@
-error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
+error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:14:5
    |
 LL |     res.ok().expect("disaster!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::ok-expect` implied by `-D warnings`
+   = help: You can call `expect()` directly on the `Result`
 
-error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
+error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:20:5
    |
 LL |     res3.ok().expect("whoof");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: You can call `expect()` directly on the `Result`
 
-error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
+error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:22:5
    |
 LL |     res4.ok().expect("argh");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: You can call `expect()` directly on the `Result`
 
-error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
+error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:24:5
    |
 LL |     res5.ok().expect("oops");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: You can call `expect()` directly on the `Result`
 
-error: called `ok().expect()` on a `Result` value. You can call `expect()` directly on the `Result`
+error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:26:5
    |
 LL |     res6.ok().expect("meh");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: You can call `expect()` directly on the `Result`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/ok_expect.stderr
+++ b/tests/ui/ok_expect.stderr
@@ -5,7 +5,7 @@ LL |     res.ok().expect("disaster!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::ok-expect` implied by `-D warnings`
-   = help: You can call `expect()` directly on the `Result`
+   = help: you can call `expect()` directly on the `Result`
 
 error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:20:5
@@ -13,7 +13,7 @@ error: called `ok().expect()` on a `Result` value
 LL |     res3.ok().expect("whoof");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: You can call `expect()` directly on the `Result`
+   = help: you can call `expect()` directly on the `Result`
 
 error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:22:5
@@ -21,7 +21,7 @@ error: called `ok().expect()` on a `Result` value
 LL |     res4.ok().expect("argh");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: You can call `expect()` directly on the `Result`
+   = help: you can call `expect()` directly on the `Result`
 
 error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:24:5
@@ -29,7 +29,7 @@ error: called `ok().expect()` on a `Result` value
 LL |     res5.ok().expect("oops");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: You can call `expect()` directly on the `Result`
+   = help: you can call `expect()` directly on the `Result`
 
 error: called `ok().expect()` on a `Result` value
   --> $DIR/ok_expect.rs:26:5
@@ -37,7 +37,7 @@ error: called `ok().expect()` on a `Result` value
 LL |     res6.ok().expect("meh");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: You can call `expect()` directly on the `Result`
+   = help: you can call `expect()` directly on the `Result`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/unwrap.stderr
+++ b/tests/ui/unwrap.stderr
@@ -1,18 +1,20 @@
-error: used `unwrap()` on `an Option` value. If you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+error: used `unwrap()` on `an Option` value
   --> $DIR/unwrap.rs:5:13
    |
 LL |     let _ = opt.unwrap();
    |             ^^^^^^^^^^^^
    |
    = note: `-D clippy::option-unwrap-used` implied by `-D warnings`
+   = help: If you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message.
 
-error: used `unwrap()` on `a Result` value. If you don't want to handle the `Err` case gracefully, consider using `expect()` to provide a better panic message
+error: used `unwrap()` on `a Result` value
   --> $DIR/unwrap.rs:10:13
    |
 LL |     let _ = res.unwrap();
    |             ^^^^^^^^^^^^
    |
    = note: `-D clippy::result-unwrap-used` implied by `-D warnings`
+   = help: If you don't want to handle the `Err` case gracefully, consider using `expect()` to provide a better panic message.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unwrap.stderr
+++ b/tests/ui/unwrap.stderr
@@ -5,7 +5,7 @@ LL |     let _ = opt.unwrap();
    |             ^^^^^^^^^^^^
    |
    = note: `-D clippy::option-unwrap-used` implied by `-D warnings`
-   = help: If you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message.
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: used `unwrap()` on `a Result` value
   --> $DIR/unwrap.rs:10:13
@@ -14,7 +14,7 @@ LL |     let _ = res.unwrap();
    |             ^^^^^^^^^^^^
    |
    = note: `-D clippy::result-unwrap-used` implied by `-D warnings`
-   = help: If you don't want to handle the `Err` case gracefully, consider using `expect()` to provide a better panic message.
+   = help: if you don't want to handle the `Err` case gracefully, consider using `expect()` to provide a better panic message
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Uses `span_help_and_lint` instead of `span_lint` and `span_lint_and_sugg` instead of `span_lint_and_then`.

changelog: none
