### PR TITLE
Resolve FIXME: String::new is now a const fn

### DIFF
--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -25,8 +25,7 @@ fn two() -> i32 {
     abc
 }
 
-// FIXME: This is a false positive in the `is_min_const_fn` function.
-// At least until the `const_string_new` feature is stabilzed.
+// Could be const (since Rust 1.39)
 fn string() -> String {
     String::new()
 }

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -26,7 +26,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:30:1
+  --> $DIR/could_be_const.rs:29:1
    |
 LL | / fn string() -> String {
 LL | |     String::new()
@@ -34,7 +34,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:35:1
+  --> $DIR/could_be_const.rs:34:1
    |
 LL | / unsafe fn four() -> i32 {
 LL | |     4
@@ -42,7 +42,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:40:1
+  --> $DIR/could_be_const.rs:39:1
    |
 LL | / fn generic<T>(t: T) -> T {
 LL | |     t
@@ -50,7 +50,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:44:1
+  --> $DIR/could_be_const.rs:43:1
    |
 LL | / fn sub(x: u32) -> usize {
 LL | |     unsafe { transmute(&x) }
@@ -58,7 +58,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:63:9
+  --> $DIR/could_be_const.rs:62:9
    |
 LL | /         pub fn b(self, a: &A) -> B {
 LL | |             B


### PR DESCRIPTION
`const_string_new` is stable since Rust 1.39

changelog: none
