### PR TITLE
Rename `span_{help, note}_and_lint` to `span_lint_and_*`

### DIFF
--- a/clippy_lints/src/as_conversions.rs
+++ b/clippy_lints/src/as_conversions.rs
@@ -3,7 +3,7 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use syntax::ast::*;
 
-use crate::utils::span_help_and_lint;
+use crate::utils::span_lint_and_help;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for usage of `as` conversions.
@@ -45,7 +45,7 @@ impl EarlyLintPass for AsConversions {
         }
 
         if let ExprKind::Cast(_, _) = expr.kind {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 AS_CONVERSIONS,
                 expr.span,

--- a/clippy_lints/src/assertions_on_constants.rs
+++ b/clippy_lints/src/assertions_on_constants.rs
@@ -1,6 +1,6 @@
 use crate::consts::{constant, Constant};
 use crate::utils::paths;
-use crate::utils::{is_direct_expn_of, is_expn_of, match_function_call, snippet_opt, span_help_and_lint};
+use crate::utils::{is_direct_expn_of, is_expn_of, match_function_call, snippet_opt, span_lint_and_help};
 use if_chain::if_chain;
 use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass};
@@ -34,7 +34,7 @@ declare_lint_pass!(AssertionsOnConstants => [ASSERTIONS_ON_CONSTANTS]);
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssertionsOnConstants {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, e: &'tcx Expr<'_>) {
         let lint_true = |is_debug: bool| {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 ASSERTIONS_ON_CONSTANTS,
                 e.span,
@@ -47,7 +47,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssertionsOnConstants {
             );
         };
         let lint_false_without_message = || {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 ASSERTIONS_ON_CONSTANTS,
                 e.span,
@@ -56,7 +56,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssertionsOnConstants {
             );
         };
         let lint_false_with_message = |panic_message: String| {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 ASSERTIONS_ON_CONSTANTS,
                 e.span,

--- a/clippy_lints/src/atomic_ordering.rs
+++ b/clippy_lints/src/atomic_ordering.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_def_path, span_help_and_lint};
+use crate::utils::{match_def_path, span_lint_and_help};
 use if_chain::if_chain;
 use rustc::ty;
 use rustc_hir::def_id::DefId;
@@ -80,7 +80,7 @@ fn check_atomic_load_store(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
         then {
             if method == "load" &&
                 match_ordering_def_path(cx, ordering_def_id, &["Release", "AcqRel"]) {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     INVALID_ATOMIC_ORDERING,
                     ordering_arg.span,
@@ -89,7 +89,7 @@ fn check_atomic_load_store(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
                 );
             } else if method == "store" &&
                 match_ordering_def_path(cx, ordering_def_id, &["Acquire", "AcqRel"]) {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     INVALID_ATOMIC_ORDERING,
                     ordering_arg.span,
@@ -113,7 +113,7 @@ fn check_memory_fence(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
         if let Some(ordering_def_id) = cx.tables.qpath_res(ordering_qpath, args[0].hir_id).opt_def_id();
         if match_ordering_def_path(cx, ordering_def_id, &["Relaxed"]);
         then {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 INVALID_ATOMIC_ORDERING,
                 args[0].span,

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -89,7 +89,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BlockInIfCondition {
                             if expr.span.from_expansion() || differing_macro_contexts(expr.span, ex.span) {
                                 return;
                             }
-                            span_help_and_lint(
+                            span_lint_and_help(
                                 cx,
                                 BLOCK_IN_IF_CONDITION_EXPR,
                                 check.span,
@@ -107,7 +107,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BlockInIfCondition {
                             return;
                         }
                         // move block higher
-                        span_help_and_lint(
+                        span_lint_and_help(
                             cx,
                             BLOCK_IN_IF_CONDITION_STMT,
                             check.span,

--- a/clippy_lints/src/cognitive_complexity.rs
+++ b/clippy_lints/src/cognitive_complexity.rs
@@ -9,7 +9,7 @@ use rustc_span::source_map::Span;
 use rustc_span::BytePos;
 use syntax::ast::Attribute;
 
-use crate::utils::{match_type, paths, snippet_opt, span_help_and_lint, LimitStack};
+use crate::utils::{match_type, paths, snippet_opt, span_lint_and_help, LimitStack};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for methods with high cognitive complexity.
@@ -96,7 +96,7 @@ impl CognitiveComplexity {
                 },
             };
 
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 COGNITIVE_COMPLEXITY,
                 fn_span,

--- a/clippy_lints/src/comparison_chain.rs
+++ b/clippy_lints/src/comparison_chain.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    get_trait_def_id, if_sequence, implements_trait, parent_node_is_if_expr, paths, span_help_and_lint, SpanlessEq,
+    get_trait_def_id, if_sequence, implements_trait, parent_node_is_if_expr, paths, span_lint_and_help, SpanlessEq,
 };
 use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass};
@@ -99,7 +99,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ComparisonChain {
                 return;
             }
         }
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             COMPARISON_CHAIN,
             expr.span,

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -1,4 +1,4 @@
-use crate::utils::{get_parent_expr, higher, if_sequence, same_tys, snippet, span_lint_and_then, span_note_and_lint};
+use crate::utils::{get_parent_expr, higher, if_sequence, same_tys, snippet, span_lint_and_note, span_lint_and_then};
 use crate::utils::{SpanlessEq, SpanlessHash};
 use rustc::ty::Ty;
 use rustc_data_structures::fx::FxHashMap;
@@ -178,7 +178,7 @@ fn lint_same_then_else(cx: &LateContext<'_, '_>, blocks: &[&Block<'_>]) {
         &|&lhs, &rhs| -> bool { SpanlessEq::new(cx).eq_block(lhs, rhs) };
 
     if let Some((i, j)) = search_same_sequenced(blocks, eq) {
-        span_note_and_lint(
+        span_lint_and_note(
             cx,
             IF_SAME_THEN_ELSE,
             j.span,
@@ -201,7 +201,7 @@ fn lint_same_cond(cx: &LateContext<'_, '_>, conds: &[&Expr<'_>]) {
         &|&lhs, &rhs| -> bool { SpanlessEq::new(cx).ignore_fn().eq_expr(lhs, rhs) };
 
     for (i, j) in search_same(conds, hash, eq) {
-        span_note_and_lint(
+        span_lint_and_note(
             cx,
             IFS_SAME_COND,
             j.span,
@@ -229,7 +229,7 @@ fn lint_same_fns_in_if_cond(cx: &LateContext<'_, '_>, conds: &[&Expr<'_>]) {
     };
 
     for (i, j) in search_same(conds, hash, eq) {
-        span_note_and_lint(
+        span_lint_and_note(
             cx,
             SAME_FUNCTIONS_IN_IF_CONDITION,
             j.span,

--- a/clippy_lints/src/copy_iterator.rs
+++ b/clippy_lints/src/copy_iterator.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_copy, match_path, paths, span_note_and_lint};
+use crate::utils::{is_copy, match_path, paths, span_lint_and_note};
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -41,7 +41,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CopyIterator {
             let ty = cx.tcx.type_of(cx.tcx.hir().local_def_id(item.hir_id));
 
             if is_copy(cx, ty) && match_path(&trait_ref.path, &paths::ITERATOR) {
-                span_note_and_lint(
+                span_lint_and_note(
                     cx,
                     COPY_ITERATOR,
                     item.span,

--- a/clippy_lints/src/dbg_macro.rs
+++ b/clippy_lints/src/dbg_macro.rs
@@ -1,4 +1,4 @@
-use crate::utils::{snippet_opt, span_help_and_lint, span_lint_and_sugg};
+use crate::utils::{snippet_opt, span_lint_and_help, span_lint_and_sugg};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -43,7 +43,7 @@ impl EarlyLintPass for DbgMacro {
                     Applicability::MaybeIncorrect,
                 );
             } else {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     DBG_MACRO,
                     mac.span(),

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_copy, match_def_path, paths, qpath_res, span_note_and_lint};
+use crate::utils::{is_copy, match_def_path, paths, qpath_res, span_lint_and_note};
 use if_chain::if_chain;
 use rustc::ty;
 use rustc_hir::*;
@@ -131,7 +131,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DropForgetRef {
                     } else {
                         return;
                     }
-                    span_note_and_lint(cx,
+                    span_lint_and_note(cx,
                                        lint,
                                        expr.span,
                                        &msg,
@@ -147,7 +147,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for DropForgetRef {
                     } else {
                         return;
                     }
-                    span_note_and_lint(cx,
+                    span_lint_and_note(cx,
                                        lint,
                                        expr.span,
                                        &msg,

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -5,7 +5,7 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use syntax::ast::*;
 
-use crate::utils::span_help_and_lint;
+use crate::utils::span_lint_and_help;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for usage of if expressions with an `else if` branch,
@@ -56,7 +56,7 @@ impl EarlyLintPass for ElseIfWithoutElse {
 
         while let ExprKind::If(_, _, Some(ref els)) = item.kind {
             if let ExprKind::If(_, _, None) = els.kind {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     ELSE_IF_WITHOUT_ELSE,
                     els.span,

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -1,7 +1,7 @@
 //! lint on enum variants that are prefixed or suffixed by the same characters
 
 use crate::utils::{camel_case, is_present_in_source};
-use crate::utils::{span_help_and_lint, span_lint};
+use crate::utils::{span_lint, span_lint_and_help};
 use rustc_lint::{EarlyContext, EarlyLintPass, Lint};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::source_map::Span;
@@ -201,7 +201,7 @@ fn check_variant(
         (false, _) => ("pre", pre),
         (true, false) => ("post", post),
     };
-    span_help_and_lint(
+    span_lint_and_help(
         cx,
         lint,
         span,

--- a/clippy_lints/src/eval_order_dependence.rs
+++ b/clippy_lints/src/eval_order_dependence.rs
@@ -1,4 +1,4 @@
-use crate::utils::{get_parent_expr, span_lint, span_note_and_lint};
+use crate::utils::{get_parent_expr, span_lint, span_lint_and_note};
 use if_chain::if_chain;
 use rustc::hir::map::Map;
 use rustc::ty;
@@ -307,7 +307,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ReadVisitor<'a, 'tcx> {
                     // Check that this is a read, not a write.
                     if !is_in_assignment_position(self.cx, expr);
                     then {
-                        span_note_and_lint(
+                        span_lint_and_note(
                             self.cx,
                             EVAL_ORDER_DEPENDENCE,
                             expr.span,

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -1,4 +1,4 @@
-use crate::utils::{differing_macro_contexts, snippet_opt, span_help_and_lint, span_note_and_lint};
+use crate::utils::{differing_macro_contexts, snippet_opt, span_lint_and_help, span_note_and_lint};
 use if_chain::if_chain;
 use rustc::lint::in_external_macro;
 use rustc_lint::{EarlyContext, EarlyLintPass};
@@ -178,7 +178,7 @@ fn check_unop(cx: &EarlyContext<'_>, expr: &Expr) {
         then {
             let unop_str = UnOp::to_string(op);
             let eqop_span = lhs.span.between(un_rhs.span);
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 SUSPICIOUS_UNARY_OP_FORMATTING,
                 eqop_span,

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -1,4 +1,4 @@
-use crate::utils::{differing_macro_contexts, snippet_opt, span_lint_and_help, span_note_and_lint};
+use crate::utils::{differing_macro_contexts, snippet_opt, span_lint_and_help, span_lint_and_note};
 use if_chain::if_chain;
 use rustc::lint::in_external_macro;
 use rustc_lint::{EarlyContext, EarlyLintPass};
@@ -140,7 +140,7 @@ fn check_assign(cx: &EarlyContext<'_>, expr: &Expr) {
                     let op = UnOp::to_string(op);
                     let eqop_span = lhs.span.between(sub_rhs.span);
                     if eq_snippet.ends_with('=') {
-                        span_note_and_lint(
+                        span_lint_and_note(
                             cx,
                             SUSPICIOUS_ASSIGNMENT_FORMATTING,
                             eqop_span,
@@ -221,7 +221,7 @@ fn check_else(cx: &EarlyContext<'_>, expr: &Expr) {
         let else_desc = if is_if(else_) { "if" } else { "{..}" };
 
         then {
-            span_note_and_lint(
+            span_lint_and_note(
                 cx,
                 SUSPICIOUS_ELSE_FORMATTING,
                 else_span,
@@ -260,7 +260,7 @@ fn check_array(cx: &EarlyContext<'_>, expr: &Expr) {
                 if space_snippet.contains('\n');
                 if indentation(cx, op.span) <= indentation(cx, lhs.span);
                 then {
-                    span_note_and_lint(
+                    span_lint_and_note(
                         cx,
                         POSSIBLE_MISSING_COMMA,
                         lint_span,
@@ -291,7 +291,7 @@ fn check_missing_else(cx: &EarlyContext<'_>, first: &Expr, second: &Expr) {
                     ("an `else {..}`", "the next block")
                 };
 
-                span_note_and_lint(
+                span_lint_and_note(
                     cx,
                     SUSPICIOUS_ELSE_FORMATTING,
                     else_span,

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     attr_by_name, attrs::is_proc_macro, is_must_use_ty, iter_input_pats, match_def_path, must_use_attr, qpath_res,
-    return_ty, snippet, snippet_opt, span_help_and_lint, span_lint, span_lint_and_then, trait_ref_of_method,
+    return_ty, snippet, snippet_opt, span_lint, span_lint_and_help, span_lint_and_then, trait_ref_of_method,
     type_is_unsafe_function,
 };
 use matches::matches;
@@ -433,7 +433,7 @@ fn check_needless_must_use(
             },
         );
     } else if !attr.is_value_str() && is_must_use_ty(cx, return_ty(cx, item_id)) {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             DOUBLE_MUST_USE,
             fn_header_span,

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -6,7 +6,7 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use syntax::ast::*;
 
-use crate::utils::span_help_and_lint;
+use crate::utils::span_lint_and_help;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for usage of `!` or `!=` in an if condition with an
@@ -56,7 +56,7 @@ impl EarlyLintPass for IfNotElse {
             if let ExprKind::Block(..) = els.kind {
                 match cond.kind {
                     ExprKind::Unary(UnOp::Not, _) => {
-                        span_help_and_lint(
+                        span_lint_and_help(
                             cx,
                             IF_NOT_ELSE,
                             item.span,
@@ -65,7 +65,7 @@ impl EarlyLintPass for IfNotElse {
                         );
                     },
                     ExprKind::Binary(ref kind, _, _) if kind.node == BinOpKind::Ne => {
-                        span_help_and_lint(
+                        span_lint_and_help(
                             cx,
                             IF_NOT_ELSE,
                             item.span,

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -136,7 +136,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IndexingSlicing {
                     (None, None) => return, // [..] is ok.
                 };
 
-                utils::span_help_and_lint(cx, INDEXING_SLICING, expr.span, "slicing may panic.", help_msg);
+                utils::span_lint_and_help(cx, INDEXING_SLICING, expr.span, "slicing may panic.", help_msg);
             } else {
                 // Catchall non-range index, i.e., [n] or [n << m]
                 if let ty::Array(..) = ty.kind {
@@ -147,7 +147,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IndexingSlicing {
                     }
                 }
 
-                utils::span_help_and_lint(
+                utils::span_lint_and_help(
                     cx,
                     INDEXING_SLICING,
                     expr.span,

--- a/clippy_lints/src/inherent_to_string.rs
+++ b/clippy_lints/src/inherent_to_string.rs
@@ -4,7 +4,7 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 use crate::utils::{
-    get_trait_def_id, implements_trait, match_type, paths, return_ty, span_help_and_lint, trait_ref_of_method,
+    get_trait_def_id, implements_trait, match_type, paths, return_ty, span_lint_and_help, trait_ref_of_method,
     walk_ptrs_ty,
 };
 
@@ -130,7 +130,7 @@ fn show_lint(cx: &LateContext<'_, '_>, item: &ImplItem<'_>) {
 
     // Emit either a warning or an error
     if implements_trait(cx, self_type, display_trait_id, &[]) {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             INHERENT_TO_STRING_SHADOW_DISPLAY,
             item.span,
@@ -141,7 +141,7 @@ fn show_lint(cx: &LateContext<'_, '_>, item: &ImplItem<'_>) {
             &format!("remove the inherent method from type `{}`", self_type.to_string())
         );
     } else {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             INHERENT_TO_STRING,
             item.span,

--- a/clippy_lints/src/integer_division.rs
+++ b/clippy_lints/src/integer_division.rs
@@ -1,4 +1,4 @@
-use crate::utils::span_help_and_lint;
+use crate::utils::span_lint_and_help;
 use if_chain::if_chain;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
@@ -30,7 +30,7 @@ declare_lint_pass!(IntegerDivision => [INTEGER_DIVISION]);
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IntegerDivision {
     fn check_expr(&mut self, cx: &LateContext<'a, 'tcx>, expr: &'tcx hir::Expr<'_>) {
         if is_integer_division(cx, expr) {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 INTEGER_DIVISION,
                 expr.span,

--- a/clippy_lints/src/large_stack_arrays.rs
+++ b/clippy_lints/src/large_stack_arrays.rs
@@ -7,7 +7,7 @@ use rustc_session::{declare_tool_lint, impl_lint_pass};
 use if_chain::if_chain;
 
 use crate::rustc_target::abi::LayoutOf;
-use crate::utils::{snippet, span_help_and_lint};
+use crate::utils::{snippet, span_lint_and_help};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for local arrays that may be too large.
@@ -49,7 +49,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeStackArrays {
             if let Ok(element_size) = cx.layout_of(element_type).map(|l| l.size.bytes());
             if self.maximum_allowed_size < element_count * element_size;
             then {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     LARGE_STACK_ARRAYS,
                     expr.span,

--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -4,7 +4,7 @@ use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
-use crate::utils::{is_must_use_func_call, is_must_use_ty, span_help_and_lint};
+use crate::utils::{is_must_use_func_call, is_must_use_ty, span_lint_and_help};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for `let _ = <expr>`
@@ -44,7 +44,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnderscore {
             if let Some(ref init) = local.init;
             then {
                 if is_must_use_ty(cx, cx.tables.expr_ty(init)) {
-                   span_help_and_lint(
+                   span_lint_and_help(
                         cx,
                         LET_UNDERSCORE_MUST_USE,
                         stmt.span,
@@ -52,7 +52,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnderscore {
                         "consider explicitly using expression value"
                     )
                 } else if is_must_use_func_call(cx, init) {
-                    span_help_and_lint(
+                    span_lint_and_help(
                         cx,
                         LET_UNDERSCORE_MUST_USE,
                         stmt.span,

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -5,7 +5,7 @@ use crate::utils::usage::{is_unused, mutated_variables};
 use crate::utils::{
     get_enclosing_block, get_parent_expr, get_trait_def_id, has_iter_method, higher, implements_trait,
     is_integer_const, is_no_std_crate, is_refutable, last_path_segment, match_trait_method, match_type, match_var,
-    multispan_sugg, snippet, snippet_opt, snippet_with_applicability, span_help_and_lint, span_lint,
+    multispan_sugg, snippet, snippet_opt, snippet_with_applicability, span_lint, span_lint_and_help,
     span_lint_and_sugg, span_lint_and_then, SpanlessEq,
 };
 use crate::utils::{is_type_diagnostic_item, qpath_res, same_tys, sext, sugg};
@@ -1390,7 +1390,7 @@ fn check_for_loop_arg(cx: &LateContext<'_, '_>, pat: &Pat<'_>, arg: &Expr<'_>, e
 fn check_arg_type(cx: &LateContext<'_, '_>, pat: &Pat<'_>, arg: &Expr<'_>) {
     let ty = cx.tables.expr_ty(arg);
     if match_type(cx, ty, &paths::OPTION) {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             FOR_LOOP_OVER_OPTION,
             arg.span,
@@ -1406,7 +1406,7 @@ fn check_arg_type(cx: &LateContext<'_, '_>, pat: &Pat<'_>, arg: &Expr<'_>) {
             ),
         );
     } else if match_type(cx, ty, &paths::RESULT) {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             FOR_LOOP_OVER_RESULT,
             arg.span,

--- a/clippy_lints/src/main_recursion.rs
+++ b/clippy_lints/src/main_recursion.rs
@@ -2,7 +2,7 @@ use rustc_hir::{Crate, Expr, ExprKind, QPath};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
-use crate::utils::{is_entrypoint_fn, is_no_std_crate, snippet, span_help_and_lint};
+use crate::utils::{is_entrypoint_fn, is_no_std_crate, snippet, span_lint_and_help};
 use if_chain::if_chain;
 
 declare_clippy_lint! {
@@ -48,7 +48,7 @@ impl LateLintPass<'_, '_> for MainRecursion {
             if let Some(def_id) = path.res.opt_def_id();
             if is_entrypoint_fn(cx, def_id);
             then {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     MAIN_RECURSION,
                     func.span,

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -4,7 +4,7 @@ use crate::utils::sugg::Sugg;
 use crate::utils::usage::is_unused;
 use crate::utils::{
     expr_block, is_allowed, is_expn_of, is_wild, match_qpath, match_type, multispan_sugg, remove_blocks, snippet,
-    snippet_with_applicability, span_lint_and_help, span_lint_and_sugg, span_lint_and_then, span_note_and_lint,
+    snippet_with_applicability, span_lint_and_help, span_lint_and_note, span_lint_and_sugg, span_lint_and_then,
     walk_ptrs_ty,
 };
 use if_chain::if_chain;
@@ -449,7 +449,7 @@ fn check_overlapping_arms<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ex: &'tcx Expr<'
         let type_ranges = type_ranges(&ranges);
         if !type_ranges.is_empty() {
             if let Some((start, end)) = overlapping(&type_ranges) {
-                span_note_and_lint(
+                span_lint_and_note(
                     cx,
                     MATCH_OVERLAPPING_ARM,
                     start.span,
@@ -488,7 +488,7 @@ fn check_wild_err_arm(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>])
                         if is_panic_block(block);
                         then {
                             // `Err(_)` or `Err(_e)` arm with `panic!` found
-                            span_note_and_lint(cx,
+                            span_lint_and_note(cx,
                                 MATCH_WILD_ERR_ARM,
                                 arm.pat.span,
                                 &format!("`Err({})` matches all errors", &ident_bind_name),

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -4,7 +4,7 @@ use crate::utils::sugg::Sugg;
 use crate::utils::usage::is_unused;
 use crate::utils::{
     expr_block, is_allowed, is_expn_of, is_wild, match_qpath, match_type, multispan_sugg, remove_blocks, snippet,
-    snippet_with_applicability, span_help_and_lint, span_lint_and_sugg, span_lint_and_then, span_note_and_lint,
+    snippet_with_applicability, span_lint_and_help, span_lint_and_sugg, span_lint_and_then, span_note_and_lint,
     walk_ptrs_ty,
 };
 use if_chain::if_chain;
@@ -700,7 +700,7 @@ fn check_wild_in_or_pats(cx: &LateContext<'_, '_>, arms: &[Arm<'_>]) {
         if let PatKind::Or(ref fields) = arm.pat.kind {
             // look for multiple fields in this arm that contains at least one Wild pattern
             if fields.len() > 1 && fields.iter().any(is_wild) {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     WILDCARD_IN_OR_PATTERNS,
                     arm.pat.span,

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    in_macro, match_def_path, match_qpath, paths, snippet, snippet_with_applicability, span_help_and_lint,
+    in_macro, match_def_path, match_qpath, paths, snippet, snippet_with_applicability, span_lint_and_help,
     span_lint_and_sugg, span_lint_and_then,
 };
 use if_chain::if_chain;
@@ -142,7 +142,7 @@ fn check_replace_with_uninit(cx: &LateContext<'_, '_>, src: &Expr<'_>, expr_span
             if let Some(repl_def_id) = cx.tables.qpath_res(repl_func_qpath, repl_func.hir_id).opt_def_id();
             then {
                 if match_def_path(cx, repl_def_id, &paths::MEM_UNINITIALIZED) {
-                    span_help_and_lint(
+                    span_lint_and_help(
                         cx,
                         MEM_REPLACE_WITH_UNINIT,
                         expr_span,
@@ -151,7 +151,7 @@ fn check_replace_with_uninit(cx: &LateContext<'_, '_>, src: &Expr<'_>, expr_span
                     );
                 } else if match_def_path(cx, repl_def_id, &paths::MEM_ZEROED) &&
                         !cx.tables.expr_ty(src).is_primitive() {
-                    span_help_and_lint(
+                    span_lint_and_help(
                         cx,
                         MEM_REPLACE_WITH_UNINIT,
                         expr_span,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -28,8 +28,8 @@ use crate::utils::{
     is_ctor_or_promotable_const_function, is_expn_of, is_type_diagnostic_item, iter_input_pats, last_path_segment,
     match_def_path, match_qpath, match_trait_method, match_type, match_var, method_calls, method_chain_args, paths,
     remove_blocks, return_ty, same_tys, single_segment_path, snippet, snippet_with_applicability,
-    snippet_with_macro_callsite, span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then,
-    span_note_and_lint, sugg, walk_ptrs_ty, walk_ptrs_ty_depth, SpanlessEq,
+    snippet_with_macro_callsite, span_lint, span_lint_and_help, span_lint_and_note, span_lint_and_sugg,
+    span_lint_and_then, sugg, walk_ptrs_ty, walk_ptrs_ty_depth, SpanlessEq,
 };
 
 declare_clippy_lint! {
@@ -2422,7 +2422,7 @@ fn lint_map_unwrap_or_else<'a, 'tcx>(
         let multiline = map_snippet.lines().count() > 1 || unwrap_snippet.lines().count() > 1;
         let same_span = map_args[1].span.ctxt() == unwrap_args[1].span.ctxt();
         if same_span && !multiline {
-            span_note_and_lint(
+            span_lint_and_note(
                 cx,
                 if is_option {
                     OPTION_MAP_UNWRAP_OR_ELSE
@@ -2566,7 +2566,7 @@ fn lint_filter_next<'a, 'tcx>(
         let filter_snippet = snippet(cx, filter_args[1].span, "..");
         if filter_snippet.lines().count() <= 1 {
             // add note if not multi-line
-            span_note_and_lint(
+            span_lint_and_note(
                 cx,
                 FILTER_NEXT,
                 expr.span,
@@ -2624,7 +2624,7 @@ fn lint_filter_map_next<'a, 'tcx>(
                    `.find_map(p)` instead.";
         let filter_snippet = snippet(cx, filter_args[1].span, "..");
         if filter_snippet.lines().count() <= 1 {
-            span_note_and_lint(
+            span_lint_and_note(
                 cx,
                 FILTER_MAP_NEXT,
                 expr.span,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -28,7 +28,7 @@ use crate::utils::{
     is_ctor_or_promotable_const_function, is_expn_of, is_type_diagnostic_item, iter_input_pats, last_path_segment,
     match_def_path, match_qpath, match_trait_method, match_type, match_var, method_calls, method_chain_args, paths,
     remove_blocks, return_ty, same_tys, single_segment_path, snippet, snippet_with_applicability,
-    snippet_with_macro_callsite, span_help_and_lint, span_lint, span_lint_and_sugg, span_lint_and_then,
+    snippet_with_macro_callsite, span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then,
     span_note_and_lint, sugg, walk_ptrs_ty, walk_ptrs_ty_depth, SpanlessEq,
 };
 
@@ -2133,7 +2133,7 @@ fn lint_iter_nth<'a, 'tcx>(
         return; // caller is not a type that we want to lint
     };
 
-    span_help_and_lint(
+    span_lint_and_help(
         cx,
         ITER_NTH,
         expr.span,
@@ -2242,7 +2242,7 @@ fn lint_get_unwrap<'a, 'tcx>(
 fn lint_iter_skip_next(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>) {
     // lint if caller of skip is an Iterator
     if match_trait_method(cx, expr, &paths::ITERATOR) {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             ITER_SKIP_NEXT,
             expr.span,
@@ -2303,7 +2303,7 @@ fn lint_unwrap(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, unwrap_args: &[hi
     };
 
     if let Some((lint, kind, none_value)) = mess {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             lint,
             expr.span,
@@ -2330,7 +2330,7 @@ fn lint_expect(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, expect_args: &[hi
     };
 
     if let Some((lint, kind, none_value)) = mess {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             lint,
             expr.span,
@@ -2350,7 +2350,7 @@ fn lint_ok_expect(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, ok_args: &[hir
         if has_debug_impl(error_type, cx);
 
         then {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 OK_EXPECT,
                 expr.span,
@@ -2588,7 +2588,7 @@ fn lint_skip_while_next<'a, 'tcx>(
 ) {
     // lint if caller of `.skip_while().next()` is an Iterator
     if match_trait_method(cx, expr, &paths::ITERATOR) {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             SKIP_WHILE_NEXT,
             expr.span,
@@ -2609,7 +2609,7 @@ fn lint_filter_map<'a, 'tcx>(
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         let msg = "called `filter(p).map(q)` on an `Iterator`";
         let hint = "this is more succinctly expressed by calling `.filter_map(..)` instead";
-        span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
+        span_lint_and_help(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }
 
@@ -2649,7 +2649,7 @@ fn lint_find_map<'a, 'tcx>(
     if match_trait_method(cx, &map_args[0], &paths::ITERATOR) {
         let msg = "called `find(p).map(q)` on an `Iterator`";
         let hint = "this is more succinctly expressed by calling `.find_map(..)` instead";
-        span_help_and_lint(cx, FIND_MAP, expr.span, msg, hint);
+        span_lint_and_help(cx, FIND_MAP, expr.span, msg, hint);
     }
 }
 
@@ -2664,7 +2664,7 @@ fn lint_filter_map_map<'a, 'tcx>(
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         let msg = "called `filter_map(p).map(q)` on an `Iterator`";
         let hint = "this is more succinctly expressed by only calling `.filter_map(..)` instead";
-        span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
+        span_lint_and_help(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }
 
@@ -2680,7 +2680,7 @@ fn lint_filter_flat_map<'a, 'tcx>(
         let msg = "called `filter(p).flat_map(q)` on an `Iterator`";
         let hint = "this is more succinctly expressed by calling `.flat_map(..)` \
             and filtering by returning `iter::empty()`";
-        span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
+        span_lint_and_help(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }
 
@@ -2696,7 +2696,7 @@ fn lint_filter_map_flat_map<'a, 'tcx>(
         let msg = "called `filter_map(p).flat_map(q)` on an `Iterator`";
         let hint = "this is more succinctly expressed by calling `.flat_map(..)` \
             and filtering by returning `iter::empty()`";
-        span_help_and_lint(cx, FILTER_MAP, expr.span, msg, hint);
+        span_lint_and_help(cx, FILTER_MAP, expr.span, msg, hint);
     }
 }
 
@@ -3077,7 +3077,7 @@ fn is_maybe_uninit_ty_valid(cx: &LateContext<'_, '_>, ty: Ty<'_>) -> bool {
 }
 
 fn lint_suspicious_map(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>) {
-    span_help_and_lint(
+    span_lint_and_help(
         cx,
         SUSPICIOUS_MAP,
         expr.span,
@@ -3436,5 +3436,5 @@ fn lint_filetype_is_file(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, args: &
     }
     let lint_msg = format!("`{}FileType::is_file()` only {} regular files", lint_unary, verb);
     let help_msg = format!("use `{}FileType::is_dir()` instead", help_unary);
-    span_help_and_lint(cx, FILETYPE_IS_FILE, span, &lint_msg, &help_msg);
+    span_lint_and_help(cx, FILETYPE_IS_FILE, span, &lint_msg, &help_msg);
 }

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    constants, snippet_opt, snippet_with_applicability, span_help_and_lint, span_lint, span_lint_and_sugg,
+    constants, snippet_opt, snippet_with_applicability, span_lint, span_lint_and_help, span_lint_and_sugg,
     span_lint_and_then,
 };
 use if_chain::if_chain;
@@ -305,7 +305,7 @@ impl EarlyLintPass for MiscEarlyLints {
                 }
             }
             if !pfields.is_empty() && wilds == pfields.len() {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     UNNEEDED_FIELD_PATTERN,
                     pat.span,
@@ -338,7 +338,7 @@ impl EarlyLintPass for MiscEarlyLints {
                                 "You matched a field with a wildcard pattern. Consider using `..` instead",
                             );
                         } else {
-                            span_help_and_lint(
+                            span_lint_and_help(
                                 cx,
                                 UNNEEDED_FIELD_PATTERN,
                                 field.span,

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -39,7 +39,7 @@ use rustc_span::source_map::{original_sp, DUMMY_SP};
 use std::borrow::Cow;
 use syntax::ast;
 
-use crate::utils::{snippet, snippet_block, span_help_and_lint, trim_multiline};
+use crate::utils::{snippet, snippet_block, span_lint_and_help, trim_multiline};
 
 declare_clippy_lint! {
     /// **What it does:** The lint checks for `if`-statements appearing in loops
@@ -300,7 +300,7 @@ fn emit_warning<'a>(ctx: &EarlyContext<'_>, data: &'a LintData<'_>, header: &str
             data.if_expr,
         ),
     };
-    span_help_and_lint(ctx, NEEDLESS_CONTINUE, expr.span, message, &snip);
+    span_lint_and_help(ctx, NEEDLESS_CONTINUE, expr.span, message, &snip);
 }
 
 fn suggestion_snippet_for_continue_inside_if<'a>(

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -1,5 +1,5 @@
 use crate::consts::{constant, Constant};
-use crate::utils::{is_expn_of, match_def_path, match_type, paths, span_help_and_lint, span_lint};
+use crate::utils::{is_expn_of, match_def_path, match_type, paths, span_lint, span_lint_and_help};
 use if_chain::if_chain;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::*;
@@ -208,7 +208,7 @@ fn check_regex<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>, utf8:
             match parser.parse(r) {
                 Ok(r) => {
                     if let Some(repl) = is_trivial_regex(&r) {
-                        span_help_and_lint(cx, TRIVIAL_REGEX, expr.span, "trivial regex", repl);
+                        span_lint_and_help(cx, TRIVIAL_REGEX, expr.span, "trivial regex", repl);
                     }
                 },
                 Err(regex_syntax::Error::Parse(e)) => {
@@ -236,7 +236,7 @@ fn check_regex<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_>, utf8:
         match parser.parse(&r) {
             Ok(r) => {
                 if let Some(repl) = is_trivial_regex(&r) {
-                    span_help_and_lint(cx, TRIVIAL_REGEX, expr.span, "trivial regex", repl);
+                    span_lint_and_help(cx, TRIVIAL_REGEX, expr.span, "trivial regex", repl);
                 }
             },
             Err(regex_syntax::Error::Parse(e)) => {

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -1,4 +1,4 @@
-use crate::utils::{in_macro, snippet, span_help_and_lint, SpanlessHash};
+use crate::utils::{in_macro, snippet, span_lint_and_help, SpanlessHash};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass};
@@ -63,7 +63,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TraitBounds {
                     }
                     hint_string.truncate(hint_string.len() - 2);
                     hint_string.push('`');
-                    span_help_and_lint(
+                    span_lint_and_help(
                         cx,
                         TYPE_REPETITION_IN_BOUNDS,
                         p.span,

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -27,7 +27,7 @@ use crate::utils::paths;
 use crate::utils::{
     clip, comparisons, differing_macro_contexts, higher, in_constant, int_bits, last_path_segment, match_def_path,
     match_path, method_chain_args, multispan_sugg, qpath_res, same_tys, sext, snippet, snippet_opt,
-    snippet_with_applicability, snippet_with_macro_callsite, span_help_and_lint, span_lint, span_lint_and_sugg,
+    snippet_with_applicability, snippet_with_macro_callsite, span_lint, span_lint_and_help, span_lint_and_sugg,
     span_lint_and_then, unsext,
 };
 
@@ -264,7 +264,7 @@ impl Types {
                 if let Some(def_id) = res.opt_def_id() {
                     if Some(def_id) == cx.tcx.lang_items().owned_box() {
                         if match_type_parameter(cx, qpath, &paths::VEC) {
-                            span_help_and_lint(
+                            span_lint_and_help(
                                 cx,
                                 BOX_VEC,
                                 hir_ty.span,
@@ -321,7 +321,7 @@ impl Types {
                             return; // don't recurse into the type
                         }
                     } else if match_def_path(cx, def_id, &paths::LINKED_LIST) {
-                        span_help_and_lint(
+                        span_lint_and_help(
                             cx,
                             LINKEDLIST,
                             hir_ty.span,
@@ -1785,7 +1785,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AbsurdExtremeComparisons {
                         conclusion
                     );
 
-                    span_help_and_lint(cx, ABSURD_EXTREME_COMPARISONS, expr.span, msg, &help);
+                    span_lint_and_help(cx, ABSURD_EXTREME_COMPARISONS, expr.span, msg, &help);
                 }
             }
         }

--- a/clippy_lints/src/unused_self.rs
+++ b/clippy_lints/src/unused_self.rs
@@ -6,7 +6,7 @@ use rustc_hir::{AssocItemKind, HirId, ImplItem, ImplItemKind, ImplItemRef, ItemK
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
-use crate::utils::span_help_and_lint;
+use crate::utils::span_lint_and_help;
 
 declare_clippy_lint! {
     /// **What it does:** Checks methods that contain a `self` argument but don't use it
@@ -71,7 +71,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedSelf {
                         };
                         visitor.visit_body(body);
                         if !visitor.uses_self {
-                            span_help_and_lint(
+                            span_lint_and_help(
                                 cx,
                                 UNUSED_SELF,
                                 self_param.span,

--- a/clippy_lints/src/utils/diagnostics.rs
+++ b/clippy_lints/src/utils/diagnostics.rs
@@ -96,7 +96,7 @@ pub fn span_lint_and_help<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, sp
 /// 10 |     forget(&SomeStruct);
 ///    |            ^^^^^^^^^^^
 /// ```
-pub fn span_note_and_lint<'a, T: LintContext>(
+pub fn span_lint_and_note<'a, T: LintContext>(
     cx: &'a T,
     lint: &'static Lint,
     span: Span,

--- a/clippy_lints/src/utils/diagnostics.rs
+++ b/clippy_lints/src/utils/diagnostics.rs
@@ -69,7 +69,7 @@ pub fn span_lint<T: LintContext>(cx: &T, lint: &'static Lint, sp: impl Into<Mult
 ///    |
 ///    = help: Consider using `std::f64::NAN` if you would like a constant representing NaN
 /// ```
-pub fn span_help_and_lint<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, span: Span, msg: &str, help: &str) {
+pub fn span_lint_and_help<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, span: Span, msg: &str, help: &str) {
     let mut db = DiagnosticWrapper(cx.struct_span_lint(lint, span, msg));
     db.0.help(help);
     db.docs_link(lint);

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    is_expn_of, match_def_path, match_type, method_calls, paths, span_help_and_lint, span_lint, span_lint_and_sugg,
+    is_expn_of, match_def_path, match_type, method_calls, paths, span_lint, span_lint_and_help, span_lint_and_sugg,
     walk_ptrs_ty,
 };
 use if_chain::if_chain;
@@ -319,7 +319,7 @@ impl CompilerLintFunctions {
         map.insert("struct_span_lint", "utils::span_lint");
         map.insert("lint", "utils::span_lint");
         map.insert("span_lint_note", "utils::span_note_and_lint");
-        map.insert("span_lint_help", "utils::span_help_and_lint");
+        map.insert("span_lint_help", "utils::span_lint_and_help");
         Self { map }
     }
 }
@@ -336,7 +336,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CompilerLintFunctions {
             if match_type(cx, ty, &paths::EARLY_CONTEXT)
                 || match_type(cx, ty, &paths::LATE_CONTEXT);
             then {
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     COMPILER_LINT_FUNCTIONS,
                     path.ident.span,

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -318,7 +318,7 @@ impl CompilerLintFunctions {
         map.insert("span_lint", "utils::span_lint");
         map.insert("struct_span_lint", "utils::span_lint");
         map.insert("lint", "utils::span_lint");
-        map.insert("span_lint_note", "utils::span_note_and_lint");
+        map.insert("span_lint_note", "utils::span_lint_and_note");
         map.insert("span_lint_help", "utils::span_lint_and_help");
         Self { map }
     }

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -1,5 +1,5 @@
 use crate::consts::{constant_simple, Constant};
-use crate::utils::span_help_and_lint;
+use crate::utils::span_lint_and_help;
 use if_chain::if_chain;
 use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass};
@@ -45,7 +45,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ZeroDiv {
                     | (_, Constant::F64(_)) => "f64",
                     _ => "f32"
                 };
-                span_help_and_lint(
+                span_lint_and_help(
                     cx,
                     ZERO_DIVIDED_BY_ZERO,
                     expr.span,

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -249,14 +249,14 @@ Depending on how complex we want our lint message to be, we can choose from a
 variety of lint emission functions. They can all be found in
 [`clippy_lints/src/utils/diagnostics.rs`][diagnostics].
 
-`span_help_and_lint` seems most appropriate in this case. It allows us to
+`span_lint_and_help` seems most appropriate in this case. It allows us to
 provide an extra help message and we can't really suggest a better name
 automatically. This is how it looks:
 
 ```rust
 impl EarlyLintPass for FooFunctions {
     fn check_fn(&mut self, cx: &EarlyContext<'_>, _: FnKind<'_>, _: &FnDecl, span: Span, _: NodeId) {
-        span_help_and_lint(
+        span_lint_and_help(
             cx,
             FOO_FUNCTIONS,
             span,
@@ -284,7 +284,7 @@ With that we can expand our `check_fn` method to:
 impl EarlyLintPass for FooFunctions {
     fn check_fn(&mut self, cx: &EarlyContext<'_>, fn_kind: FnKind<'_>, _: &FnDecl, span: Span, _: NodeId) {
         if is_foo_fn(fn_kind) {
-            span_help_and_lint(
+            span_lint_and_help(
                 cx,
                 FOO_FUNCTIONS,
                 span,


### PR DESCRIPTION
`span_*_and_lint` and `span_lint_and_*` make us confused. The order should be the same.

[context](https://github.com/rust-lang/rust-clippy/pull/5084#issuecomment-578411309)

changelog: none
