### PR TITLE
Improve release compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,7 @@ rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 [features]
 deny-warnings = []
 integration = ["git2", "tempfile"]
+
+# Reduce build time by setting proc-macro crates non optimized.
+[profile.release.build-override]
+opt-level = 0

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -14,7 +14,3 @@ walkdir = "2"
 
 [features]
 deny-warnings = []
-
-# Reduce build time by setting proc-macro crates non optimized.
-[profile.release.build-override]
-opt-level = 0

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -14,3 +14,7 @@ walkdir = "2"
 
 [features]
 deny-warnings = []
+
+# Reduce build time by setting proc-macro crates non optimized.
+[profile.release.build-override]
+opt-level = 0

--- a/clippy_dummy/Cargo.toml
+++ b/clippy_dummy/Cargo.toml
@@ -15,3 +15,7 @@ categories = ["development-tools", "development-tools::cargo-plugins"]
 
 [build-dependencies]
 term = "0.6"
+
+# Reduce build time by setting proc-macro crates non optimized.
+[profile.release.build-override]
+opt-level = 0


### PR DESCRIPTION
On my test, it reduced release compile time of root project from 62.9s to 54.2s.
cargo-timing files: https://send.firefox.com/download/42c022429ebe714d/#g0unPjM989ED38syPZU3Fg
changelog: none
