### PR TITLE
[WIP] Fixes issue 5095

### DIFF
--- a/tests/ui/collapsible_span_lint_calls.rs
+++ b/tests/ui/collapsible_span_lint_calls.rs
@@ -6,11 +6,11 @@ fn lint_something() {
     let note= "specificly note on this thing";
 
     let span = ?;
-    let lint = ?;
+    let lint = Lint.default_fields_for_macro();
     let cx = ?;
 
-    let sugg = ?;
-    let applicability = ?;
+    let sugg = "suggest changes";
+    let applicability = Applicability::MachineApllicable;
 
     span_lint_and_then(cx, lint, span, msg, |db| {
         db.span_help(span, help);

--- a/tests/ui/collapsible_span_lint_calls.rs
+++ b/tests/ui/collapsible_span_lint_calls.rs
@@ -1,0 +1,26 @@
+[warn(clippy::collapsible_span_lint_calls)]
+
+fn lint_something() {
+    let msg = "";
+    let help = "";
+    let note= "";
+
+    let span = ?;
+    let lint = ?;
+    let cx = ?;
+
+    let sugg = ?;
+    let applicability = ?;
+
+    span_lint_and_then(cx, lint, span, msg, |db| {
+        db.span_help(span, help);
+    });
+
+    span_lint_and_then(cx, lint, span, msg, |db| {
+        db.span_note(span, note);
+    });
+
+    span_lint_and_then(cx, lint, span, msg, |db| {
+        db.span_suggestion(span, help, sugg, applicability);
+    });
+}

--- a/tests/ui/collapsible_span_lint_calls.rs
+++ b/tests/ui/collapsible_span_lint_calls.rs
@@ -1,7 +1,7 @@
 [warn(clippy::collapsible_span_lint_calls)]
 
 fn lint_something() {
-    let msg = "";
+    let msg = "warn about something";
     let help = "";
     let note= "";
 

--- a/tests/ui/collapsible_span_lint_calls.rs
+++ b/tests/ui/collapsible_span_lint_calls.rs
@@ -2,8 +2,8 @@
 
 fn lint_something() {
     let msg = "warn about something";
-    let help = "";
-    let note= "";
+    let help = "this would help";
+    let note= "specificly note on this thing";
 
     let span = ?;
     let lint = ?;


### PR DESCRIPTION
Fixes #5095.

Check list:
- [ ] Followed [lint naming conventions][lint_naming]
- [ ] Added passing UI tests (including committed `.stderr` file)
- [ ] `cargo test` passes locally
- [ ] Executed `cargo dev update_lints`
- [ ] Added lint documentation
- [ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

changelog: checking for collapsible `span_lint_and_then` calls.
