### PR TITLE
Use `checked_sub` to avoid index out of bounds

### DIFF
--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -488,7 +488,11 @@ impl MiscEarlyLints {
                 LitIntType::Unsuffixed => "",
             };
 
-            let maybe_last_sep_idx = lit_snip.len() - suffix.len() - 1;
+            let maybe_last_sep_idx = if let Some(val) = lit_snip.len().checked_sub(suffix.len() + 1) {
+                val
+            } else {
+                return; // It's useless so shouldn't lint.
+            };
             // Do not lint when literal is unsuffixed.
             if !suffix.is_empty() && lit_snip.as_bytes()[maybe_last_sep_idx] != b'_' {
                 span_lint_and_sugg(
@@ -502,7 +506,7 @@ impl MiscEarlyLints {
                 );
             }
 
-            if lit_snip.starts_with("0x") {
+            if lit_snip.starts_with("0x") && maybe_last_sep_idx >= 3 {
                 let mut seen = (false, false);
                 for ch in lit_snip.as_bytes()[2..=maybe_last_sep_idx].iter() {
                     match ch {
@@ -546,7 +550,11 @@ impl MiscEarlyLints {
             }
         } else if let LitKind::Float(_, LitFloatType::Suffixed(float_ty)) = lit.kind {
             let suffix = float_ty.name_str();
-            let maybe_last_sep_idx = lit_snip.len() - suffix.len() - 1;
+            let maybe_last_sep_idx = if let Some(val) = lit_snip.len().checked_sub(suffix.len() + 1) {
+                val
+            } else {
+                return; // It's useless so shouldn't lint.
+            };
             if lit_snip.as_bytes()[maybe_last_sep_idx] != b'_' {
                 span_lint_and_sugg(
                     cx,


### PR DESCRIPTION
(Fixes) #4681 (possibly)

The issue likely occurs due to `lit_snip.len() < suffix.len() + 1`. You can see similar backtrace to change it to `lit_snip.len() - suffix.len() - 1000` or something then run `cargo test --release`.
But I couldn't come up with the test so I'd leave the issue open if we want.

changelog: Fix potential ICE in `misc_early`
