### PR TITLE
Split up `indexing_slicing` ui test

### DIFF
--- a/clippy_dev/src/stderr_length_check.rs
+++ b/clippy_dev/src/stderr_length_check.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 // The maximum length allowed for stderr files.
 //
 // We limit this because small files are easier to deal with than bigger files.
-const LIMIT: usize = 220;
+const LIMIT: usize = 200;
 
 pub fn check() {
     let stderr_files = stderr_files();

--- a/tests/ui/indexing_slicing_index.rs
+++ b/tests/ui/indexing_slicing_index.rs
@@ -1,4 +1,3 @@
-#![feature(plugin)]
 #![warn(clippy::indexing_slicing)]
 // We also check the out_of_bounds_indexing lint here, because it lints similar things and
 // we want to avoid false positives.
@@ -8,42 +7,20 @@
 fn main() {
     let x = [1, 2, 3, 4];
     let index: usize = 1;
-    let index_from: usize = 2;
-    let index_to: usize = 3;
     x[index];
-    &x[index..];
-    &x[..index];
-    &x[index_from..index_to];
-    &x[index_from..][..index_to]; // Two lint reports, one for [index_from..] and another for [..index_to].
     x[4]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
     x[1 << 3]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
-    &x[5..][..10]; // Two lint reports, one for out of bounds [5..] and another for slicing [..10].
-    &x[0..][..3];
-    &x[1..][..5];
 
-    &x[0..].get(..3); // Ok, should not produce stderr.
     x[0]; // Ok, should not produce stderr.
     x[3]; // Ok, should not produce stderr.
-    &x[0..3]; // Ok, should not produce stderr.
 
     let y = &x;
     y[0];
-    &y[1..2];
-    &y[0..=4];
-    &y[..=4];
-
-    &y[..]; // Ok, should not produce stderr.
 
     let v = vec![0; 5];
     v[0];
     v[10];
     v[1 << 3];
-    &v[10..100];
-    &x[10..][..100]; // Two lint reports, one for [10..] and another for [..100].
-    &v[10..];
-    &v[..100];
-
-    &v[..]; // Ok, should not produce stderr.
 
     //
     // Continue tests at end function to minimize the changes to this file's corresponding stderr.

--- a/tests/ui/indexing_slicing_index.rs
+++ b/tests/ui/indexing_slicing_index.rs
@@ -22,10 +22,6 @@ fn main() {
     v[10];
     v[1 << 3];
 
-    //
-    // Continue tests at end function to minimize the changes to this file's corresponding stderr.
-    //
-
     const N: usize = 15; // Out of bounds
     const M: usize = 3; // In bounds
     x[N]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.

--- a/tests/ui/indexing_slicing_index.stderr
+++ b/tests/ui/indexing_slicing_index.stderr
@@ -1,0 +1,79 @@
+error: index out of bounds: the len is 4 but the index is 4
+  --> $DIR/indexing_slicing_index.rs:11:5
+   |
+LL |     x[4]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
+   |     ^^^^
+   |
+   = note: `#[deny(const_err)]` on by default
+
+error: index out of bounds: the len is 4 but the index is 8
+  --> $DIR/indexing_slicing_index.rs:12:5
+   |
+LL |     x[1 << 3]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
+   |     ^^^^^^^^^
+
+error: index out of bounds: the len is 4 but the index is 15
+  --> $DIR/indexing_slicing_index.rs:31:5
+   |
+LL |     x[N]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
+   |     ^^^^
+
+error: indexing may panic.
+  --> $DIR/indexing_slicing_index.rs:10:5
+   |
+LL |     x[index];
+   |     ^^^^^^^^
+   |
+   = note: `-D clippy::indexing-slicing` implied by `-D warnings`
+   = help: Consider using `.get(n)` or `.get_mut(n)` instead
+
+error: indexing may panic.
+  --> $DIR/indexing_slicing_index.rs:18:5
+   |
+LL |     y[0];
+   |     ^^^^
+   |
+   = help: Consider using `.get(n)` or `.get_mut(n)` instead
+
+error: indexing may panic.
+  --> $DIR/indexing_slicing_index.rs:21:5
+   |
+LL |     v[0];
+   |     ^^^^
+   |
+   = help: Consider using `.get(n)` or `.get_mut(n)` instead
+
+error: indexing may panic.
+  --> $DIR/indexing_slicing_index.rs:22:5
+   |
+LL |     v[10];
+   |     ^^^^^
+   |
+   = help: Consider using `.get(n)` or `.get_mut(n)` instead
+
+error: indexing may panic.
+  --> $DIR/indexing_slicing_index.rs:23:5
+   |
+LL |     v[1 << 3];
+   |     ^^^^^^^^^
+   |
+   = help: Consider using `.get(n)` or `.get_mut(n)` instead
+
+error: indexing may panic.
+  --> $DIR/indexing_slicing_index.rs:33:5
+   |
+LL |     v[N];
+   |     ^^^^
+   |
+   = help: Consider using `.get(n)` or `.get_mut(n)` instead
+
+error: indexing may panic.
+  --> $DIR/indexing_slicing_index.rs:34:5
+   |
+LL |     v[M];
+   |     ^^^^
+   |
+   = help: Consider using `.get(n)` or `.get_mut(n)` instead
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/indexing_slicing_index.stderr
+++ b/tests/ui/indexing_slicing_index.stderr
@@ -13,7 +13,7 @@ LL |     x[1 << 3]; // Ok, let rustc's `const_err` lint handle `usize` indexing 
    |     ^^^^^^^^^
 
 error: index out of bounds: the len is 4 but the index is 15
-  --> $DIR/indexing_slicing_index.rs:31:5
+  --> $DIR/indexing_slicing_index.rs:27:5
    |
 LL |     x[N]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
    |     ^^^^
@@ -60,7 +60,7 @@ LL |     v[1 << 3];
    = help: Consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic.
-  --> $DIR/indexing_slicing_index.rs:33:5
+  --> $DIR/indexing_slicing_index.rs:29:5
    |
 LL |     v[N];
    |     ^^^^
@@ -68,7 +68,7 @@ LL |     v[N];
    = help: Consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic.
-  --> $DIR/indexing_slicing_index.rs:34:5
+  --> $DIR/indexing_slicing_index.rs:30:5
    |
 LL |     v[M];
    |     ^^^^

--- a/tests/ui/indexing_slicing_slice.rs
+++ b/tests/ui/indexing_slicing_slice.rs
@@ -1,0 +1,37 @@
+#![warn(clippy::indexing_slicing)]
+// We also check the out_of_bounds_indexing lint here, because it lints similar things and
+// we want to avoid false positives.
+#![warn(clippy::out_of_bounds_indexing)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+
+fn main() {
+    let x = [1, 2, 3, 4];
+    let index: usize = 1;
+    let index_from: usize = 2;
+    let index_to: usize = 3;
+    &x[index..];
+    &x[..index];
+    &x[index_from..index_to];
+    &x[index_from..][..index_to]; // Two lint reports, one for [index_from..] and another for [..index_to].
+    &x[5..][..10]; // Two lint reports, one for out of bounds [5..] and another for slicing [..10].
+    &x[0..][..3];
+    &x[1..][..5];
+
+    &x[0..].get(..3); // Ok, should not produce stderr.
+    &x[0..3]; // Ok, should not produce stderr.
+
+    let y = &x;
+    &y[1..2];
+    &y[0..=4];
+    &y[..=4];
+
+    &y[..]; // Ok, should not produce stderr.
+
+    let v = vec![0; 5];
+    &v[10..100];
+    &x[10..][..100]; // Two lint reports, one for [10..] and another for [..100].
+    &v[10..];
+    &v[..100];
+
+    &v[..]; // Ok, should not produce stderr.
+}

--- a/tests/ui/indexing_slicing_slice.stderr
+++ b/tests/ui/indexing_slicing_slice.stderr
@@ -1,42 +1,14 @@
-error: index out of bounds: the len is 4 but the index is 4
-  --> $DIR/indexing_slicing.rs:18:5
-   |
-LL |     x[4]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
-   |     ^^^^
-   |
-   = note: `#[deny(const_err)]` on by default
-
-error: index out of bounds: the len is 4 but the index is 8
-  --> $DIR/indexing_slicing.rs:19:5
-   |
-LL |     x[1 << 3]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
-   |     ^^^^^^^^^
-
-error: index out of bounds: the len is 4 but the index is 15
-  --> $DIR/indexing_slicing.rs:54:5
-   |
-LL |     x[N]; // Ok, let rustc's `const_err` lint handle `usize` indexing on arrays.
-   |     ^^^^
-
-error: indexing may panic.
-  --> $DIR/indexing_slicing.rs:13:5
-   |
-LL |     x[index];
-   |     ^^^^^^^^
-   |
-   = note: `-D clippy::indexing-slicing` implied by `-D warnings`
-   = help: Consider using `.get(n)` or `.get_mut(n)` instead
-
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:14:6
+  --> $DIR/indexing_slicing_slice.rs:12:6
    |
 LL |     &x[index..];
    |      ^^^^^^^^^^
    |
+   = note: `-D clippy::indexing-slicing` implied by `-D warnings`
    = help: Consider using `.get(n..)` or .get_mut(n..)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:15:6
+  --> $DIR/indexing_slicing_slice.rs:13:6
    |
 LL |     &x[..index];
    |      ^^^^^^^^^^
@@ -44,7 +16,7 @@ LL |     &x[..index];
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:16:6
+  --> $DIR/indexing_slicing_slice.rs:14:6
    |
 LL |     &x[index_from..index_to];
    |      ^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +24,7 @@ LL |     &x[index_from..index_to];
    = help: Consider using `.get(n..m)` or `.get_mut(n..m)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:17:6
+  --> $DIR/indexing_slicing_slice.rs:15:6
    |
 LL |     &x[index_from..][..index_to]; // Two lint reports, one for [index_from..] and another for [..index_to].
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +32,7 @@ LL |     &x[index_from..][..index_to]; // Two lint reports, one for [index_from.
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:17:6
+  --> $DIR/indexing_slicing_slice.rs:15:6
    |
 LL |     &x[index_from..][..index_to]; // Two lint reports, one for [index_from..] and another for [..index_to].
    |      ^^^^^^^^^^^^^^^
@@ -68,7 +40,7 @@ LL |     &x[index_from..][..index_to]; // Two lint reports, one for [index_from.
    = help: Consider using `.get(n..)` or .get_mut(n..)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:20:6
+  --> $DIR/indexing_slicing_slice.rs:16:6
    |
 LL |     &x[5..][..10]; // Two lint reports, one for out of bounds [5..] and another for slicing [..10].
    |      ^^^^^^^^^^^^
@@ -76,7 +48,7 @@ LL |     &x[5..][..10]; // Two lint reports, one for out of bounds [5..] and ano
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
 error: range is out of bounds
-  --> $DIR/indexing_slicing.rs:20:8
+  --> $DIR/indexing_slicing_slice.rs:16:8
    |
 LL |     &x[5..][..10]; // Two lint reports, one for out of bounds [5..] and another for slicing [..10].
    |        ^
@@ -84,7 +56,7 @@ LL |     &x[5..][..10]; // Two lint reports, one for out of bounds [5..] and ano
    = note: `-D clippy::out-of-bounds-indexing` implied by `-D warnings`
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:21:6
+  --> $DIR/indexing_slicing_slice.rs:17:6
    |
 LL |     &x[0..][..3];
    |      ^^^^^^^^^^^
@@ -92,23 +64,15 @@ LL |     &x[0..][..3];
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:22:6
+  --> $DIR/indexing_slicing_slice.rs:18:6
    |
 LL |     &x[1..][..5];
    |      ^^^^^^^^^^^
    |
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
-error: indexing may panic.
-  --> $DIR/indexing_slicing.rs:30:5
-   |
-LL |     y[0];
-   |     ^^^^
-   |
-   = help: Consider using `.get(n)` or `.get_mut(n)` instead
-
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:31:6
+  --> $DIR/indexing_slicing_slice.rs:24:6
    |
 LL |     &y[1..2];
    |      ^^^^^^^
@@ -116,7 +80,7 @@ LL |     &y[1..2];
    = help: Consider using `.get(n..m)` or `.get_mut(n..m)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:32:6
+  --> $DIR/indexing_slicing_slice.rs:25:6
    |
 LL |     &y[0..=4];
    |      ^^^^^^^^
@@ -124,39 +88,15 @@ LL |     &y[0..=4];
    = help: Consider using `.get(n..m)` or `.get_mut(n..m)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:33:6
+  --> $DIR/indexing_slicing_slice.rs:26:6
    |
 LL |     &y[..=4];
    |      ^^^^^^^
    |
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
-error: indexing may panic.
-  --> $DIR/indexing_slicing.rs:38:5
-   |
-LL |     v[0];
-   |     ^^^^
-   |
-   = help: Consider using `.get(n)` or `.get_mut(n)` instead
-
-error: indexing may panic.
-  --> $DIR/indexing_slicing.rs:39:5
-   |
-LL |     v[10];
-   |     ^^^^^
-   |
-   = help: Consider using `.get(n)` or `.get_mut(n)` instead
-
-error: indexing may panic.
-  --> $DIR/indexing_slicing.rs:40:5
-   |
-LL |     v[1 << 3];
-   |     ^^^^^^^^^
-   |
-   = help: Consider using `.get(n)` or `.get_mut(n)` instead
-
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:41:6
+  --> $DIR/indexing_slicing_slice.rs:31:6
    |
 LL |     &v[10..100];
    |      ^^^^^^^^^^
@@ -164,7 +104,7 @@ LL |     &v[10..100];
    = help: Consider using `.get(n..m)` or `.get_mut(n..m)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:42:6
+  --> $DIR/indexing_slicing_slice.rs:32:6
    |
 LL |     &x[10..][..100]; // Two lint reports, one for [10..] and another for [..100].
    |      ^^^^^^^^^^^^^^
@@ -172,13 +112,13 @@ LL |     &x[10..][..100]; // Two lint reports, one for [10..] and another for [.
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
 error: range is out of bounds
-  --> $DIR/indexing_slicing.rs:42:8
+  --> $DIR/indexing_slicing_slice.rs:32:8
    |
 LL |     &x[10..][..100]; // Two lint reports, one for [10..] and another for [..100].
    |        ^^
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:43:6
+  --> $DIR/indexing_slicing_slice.rs:33:6
    |
 LL |     &v[10..];
    |      ^^^^^^^
@@ -186,28 +126,12 @@ LL |     &v[10..];
    = help: Consider using `.get(n..)` or .get_mut(n..)` instead
 
 error: slicing may panic.
-  --> $DIR/indexing_slicing.rs:44:6
+  --> $DIR/indexing_slicing_slice.rs:34:6
    |
 LL |     &v[..100];
    |      ^^^^^^^^
    |
    = help: Consider using `.get(..n)`or `.get_mut(..n)` instead
 
-error: indexing may panic.
-  --> $DIR/indexing_slicing.rs:56:5
-   |
-LL |     v[N];
-   |     ^^^^
-   |
-   = help: Consider using `.get(n)` or `.get_mut(n)` instead
-
-error: indexing may panic.
-  --> $DIR/indexing_slicing.rs:57:5
-   |
-LL |     v[M];
-   |     ^^^^
-   |
-   = help: Consider using `.get(n)` or `.get_mut(n)` instead
-
-error: aborting due to 27 previous errors
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
Closes #2038

Now all the stderrs are less than 200 lines :tada: 

changelog: none
