### PR TITLE
Prevent failing to restart setup-toolchain

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -13,7 +13,7 @@ if [[ "$INSTALLED" == false || "$RTIM_PATH" == $CARGO_HOME/bin/rustup-toolchain-
     cargo +nightly install rustup-toolchain-install-master
 else
     VERSION=$(rustup-toolchain-install-master -V | grep -o "[0-9.]*")
-    REMOTE=$(cargo search rustup-toolchain-install-master | grep -o "[0-9.]*")
+    REMOTE=$(cargo +nightly search rustup-toolchain-install-master | grep -o "[0-9.]*")
     echo "info: skipping updating rustup-toolchain-install-master at $RTIM_PATH"
     echo "      current version : $VERSION"
     echo "      remote version  : $REMOTE"


### PR DESCRIPTION
If `rustup-toolchain-install-master` fails to install master
toolchain (in case `rustup update` executes at the same time 
it would remove the tmp directory), `cargo search` (which use 
master toolchain after `rustup override` command) will fail. 
This leads to `setup-toolchain` fails too.

changelog: none
