### PR TITLE
Fix error E0460 when compiled on Rustc repo

### DIFF
--- a/tests/cargo/mod.rs
+++ b/tests/cargo/mod.rs
@@ -1,75 +1,29 @@
-use cargo_metadata::{Message::CompilerArtifact, MetadataCommand};
+use lazy_static::lazy_static;
 use std::env;
-use std::ffi::OsStr;
-use std::mem;
 use std::path::PathBuf;
-use std::process::Command;
 
-pub struct BuildInfo {
-    cargo_target_dir: PathBuf,
-}
-
-impl BuildInfo {
-    pub fn new() -> Self {
-        let data = MetadataCommand::new().exec().unwrap();
-        Self {
-            cargo_target_dir: data.target_directory,
+lazy_static! {
+    pub static ref CARGO_TARGET_DIR: PathBuf = {
+        match env::var_os("CARGO_TARGET_DIR") {
+            Some(v) => v.into(),
+            None => "target".into(),
         }
-    }
-
-    pub fn host_lib(&self) -> PathBuf {
-        if let Some(path) = option_env!("HOST_LIBS") {
-            PathBuf::from(path)
-        } else {
-            self.cargo_target_dir.join(env!("PROFILE"))
-        }
-    }
-
-    pub fn target_lib(&self) -> PathBuf {
+    };
+    pub static ref TARGET_LIB: PathBuf = {
         if let Some(path) = option_env!("TARGET_LIBS") {
             path.into()
         } else {
-            let mut dir = self.cargo_target_dir.clone();
+            let mut dir = CARGO_TARGET_DIR.clone();
             if let Some(target) = env::var_os("CARGO_BUILD_TARGET") {
                 dir.push(target);
             }
             dir.push(env!("PROFILE"));
             dir
         }
-    }
+    };
+}
 
-    pub fn clippy_driver_path(&self) -> PathBuf {
-        if let Some(path) = option_env!("CLIPPY_DRIVER_PATH") {
-            PathBuf::from(path)
-        } else {
-            self.target_lib().join("clippy-driver")
-        }
-    }
-
-    // When we'll want to use `extern crate ..` for a dependency that is used
-    // both by the crate and the compiler itself, we can't simply pass -L flags
-    // as we'll get a duplicate matching versions. Instead, disambiguate with
-    // `--extern dep=path`.
-    // See https://github.com/rust-lang/rust-clippy/issues/4015.
-    pub fn third_party_crates() -> Vec<(&'static str, PathBuf)> {
-        const THIRD_PARTY_CRATES: [&str; 4] = ["serde", "serde_derive", "regex", "clippy_lints"];
-        let cargo = env::var_os("CARGO");
-        let cargo = cargo.as_deref().unwrap_or_else(|| OsStr::new("cargo"));
-        let output = Command::new(cargo)
-            .arg("build")
-            .arg("--test=compile-test")
-            .arg("--message-format=json")
-            .output()
-            .unwrap();
-
-        let mut crates = Vec::with_capacity(THIRD_PARTY_CRATES.len());
-        for message in cargo_metadata::parse_messages(output.stdout.as_slice()) {
-            if let CompilerArtifact(mut artifact) = message.unwrap() {
-                if let Some(&krate) = THIRD_PARTY_CRATES.iter().find(|&&krate| krate == artifact.target.name) {
-                    crates.push((krate, mem::take(&mut artifact.filenames[0])));
-                }
-            }
-        }
-        crates
-    }
+#[must_use]
+pub fn is_rustc_test_suite() -> bool {
+    option_env!("RUSTC_TEST_SUITE").is_some()
 }

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -1,21 +1,20 @@
+// Dogfood cannot run on Windows
+#![cfg(not(windows))]
+
 use lazy_static::lazy_static;
 use std::path::PathBuf;
 use std::process::Command;
 
-#[allow(dead_code)]
 mod cargo;
 
 lazy_static! {
-    static ref CLIPPY_PATH: PathBuf = {
-        let build_info = cargo::BuildInfo::new();
-        build_info.target_lib().join("cargo-clippy")
-    };
+    static ref CLIPPY_PATH: PathBuf = cargo::TARGET_LIB.join("cargo-clippy");
 }
 
 #[test]
 fn dogfood_clippy() {
     // run clippy on itself and fail the test if lint warnings are reported
-    if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
+    if cargo::is_rustc_test_suite() {
         return;
     }
     let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -44,7 +43,7 @@ fn dogfood_clippy() {
 #[test]
 fn dogfood_subprojects() {
     // run clippy on remaining subprojects and fail the test if lint warnings are reported
-    if option_env!("RUSTC_TEST_SUITE").is_some() || cfg!(windows) {
+    if cargo::is_rustc_test_suite() {
         return;
     }
     let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
Sadly, this mostly reverts  #5121. Now I use HashMap to only store one rlib
per crate. But that would not work when non-compatible version of the same crate show up.

changelog: none
