### PR TITLE
Fix run-pass tests when CARGO_TARGET_DIR is not set

### DIFF
--- a/tests/cargo/mod.rs
+++ b/tests/cargo/mod.rs
@@ -1,4 +1,3 @@
-use cargo_metadata::MetadataCommand;
 use lazy_static::lazy_static;
 use std::env;
 use std::path::PathBuf;
@@ -7,7 +6,7 @@ lazy_static! {
     pub static ref CARGO_TARGET_DIR: PathBuf = {
         match env::var_os("CARGO_TARGET_DIR") {
             Some(v) => v.into(),
-            None => MetadataCommand::new().exec().unwrap().target_directory,
+            None => env::current_dir().unwrap().join("target"),
         }
     };
     pub static ref TARGET_LIB: PathBuf = {

--- a/tests/cargo/mod.rs
+++ b/tests/cargo/mod.rs
@@ -1,3 +1,4 @@
+use cargo_metadata::MetadataCommand;
 use lazy_static::lazy_static;
 use std::env;
 use std::path::PathBuf;
@@ -6,7 +7,7 @@ lazy_static! {
     pub static ref CARGO_TARGET_DIR: PathBuf = {
         match env::var_os("CARGO_TARGET_DIR") {
             Some(v) => v.into(),
-            None => "target".into(),
+            None => MetadataCommand::new().exec().unwrap().target_directory,
         }
     };
     pub static ref TARGET_LIB: PathBuf = {


### PR DESCRIPTION
r? @lzutao 

I got 

```
thread '[ui] ui/crashes/ice-1969.rs' panicked at 'failed to exec `"target/debug/test_build_base/crashes/ice-1969.stage-id"`: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /home/pkrones/.cargo/registry/src/github.com-1ecc6299db9ec823/compiletest_rs-0.4.0/src/runtest.rs:1350:25
```

on tests with `// run-pass` locally. The reason for this is, that I haven't set `CARGO_TARGET_DIR` and then `"target"` was used as the `CARGO_TARGET_DIR`. It seems, that `compiletest-rs` cannot deal with relative paths for `// run-pass` tests.

changelog: none
