### PR TITLE
Remove unnecessary `Lint{Array|Pass}` imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ It's worth noting that the majority of `clippy_lints/src/lib.rs` is autogenerate
 ```rust
 // ./clippy_lints/src/else_if_without_else.rs
 
-use rustc::lint::{EarlyLintPass, LintArray, LintPass};
+use rustc_lint::{EarlyLintPass, EarlyContext};
 
 // ...
 

--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -117,7 +117,7 @@ fn get_lint_file_contents(
     context_import: &str,
 ) -> String {
     format!(
-        "use rustc_lint::{{LintArray, LintPass, {type}, {context_import}}};
+        "use rustc_lint::{{{type}, {context_import}}};
 use rustc_session::{{declare_lint_pass, declare_tool_lint}};
 {pass_import}
 

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -138,7 +138,7 @@ at `clippy_lints/src/foo_functions.rs`. That's the crate where all the
 lint code is. This file has already imported some initial things we will need:
 
 ```rust
-use rustc::lint::{LintArray, LintPass, EarlyLintPass, EarlyContext};
+use rustc_lint::{EarlyLintPass, EarlyContext};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use syntax::ast::*;
 ```

--- a/tests/ui/default_lint.rs
+++ b/tests/ui/default_lint.rs
@@ -6,7 +6,6 @@ extern crate rustc;
 #[macro_use]
 extern crate rustc_session;
 extern crate rustc_lint;
-use rustc_lint::{LintArray, LintPass};
 
 declare_tool_lint! {
     pub clippy::TEST_LINT,

--- a/tests/ui/default_lint.stderr
+++ b/tests/ui/default_lint.stderr
@@ -1,5 +1,5 @@
 error: the lint `TEST_LINT_DEFAULT` has the default lint description
-  --> $DIR/default_lint.rs:18:1
+  --> $DIR/default_lint.rs:17:1
    |
 LL | / declare_tool_lint! {
 LL | |     pub clippy::TEST_LINT_DEFAULT,

--- a/tests/ui/lint_without_lint_pass.rs
+++ b/tests/ui/lint_without_lint_pass.rs
@@ -6,7 +6,7 @@ extern crate rustc;
 #[macro_use]
 extern crate rustc_session;
 extern crate rustc_lint;
-use rustc_lint::{LintArray, LintPass};
+use rustc_lint::LintPass;
 
 declare_tool_lint! {
     pub clippy::TEST_LINT,


### PR DESCRIPTION
changelog: none
