### PR TITLE
Associated types should not trigger a type_complexity message.

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1458,7 +1458,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for TypeComplexity {
 
     fn check_impl_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx ImplItem<'_>) {
         match item.kind {
-            ImplItemKind::Const(ref ty, _) | ImplItemKind::TyAlias(ref ty) => self.check_type(cx, ty),
+            ImplItemKind::Const(ref ty, _) => self.check_type(cx, ty),
             // methods are covered by check_fn
             _ => (),
         }

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -1,0 +1,24 @@
+#![warn(clippy::type_complexity)]
+
+use std::iter::{Filter, Map};
+use std::vec::IntoIter;
+
+struct S;
+
+impl IntoIterator for S {
+    type Item = i128;
+    // Associated types should not trigger a type_complexity message.
+    type IntoIter = Filter<Map<IntoIter<i128>, fn(i128) -> i128>, fn(&i128) -> bool>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        fn m(a: i128) -> i128 {
+            a
+        }
+        fn p(_: &i128) -> bool {
+            true
+        }
+        vec![1i128, 2, 3].into_iter().map(m as fn(_) -> _).filter(p)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This PR fixes #1013 by removing the check entirely. Whether this check is useful could be a point of discussion. But considering that type_complexity isn't applied to the generic types of a trait, I don't think it should be applied to the associated types of a trait either.

Still, A lint for the complexity of associated types could be useful. IMHO, it would be better to add that as a separate lint. (And maybe a different threshold.)

I have not contributed to rust-clippy before and did not dive deeply into this, so I might have missed some things. The fix is simple, but I would appreciate a careful review.

changelog: Don't trigger type_complexity for associated types.