### PR TITLE
Fix false positive in `zero_prefixed_literal`

### DIFF
--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -506,7 +506,11 @@ impl MiscEarlyLints {
                 );
             }
 
-            if lit_snip.starts_with("0x") && maybe_last_sep_idx >= 3 {
+            if lit_snip.starts_with("0x") {
+                if maybe_last_sep_idx <= 2 {
+                    // It's meaningless or causes range error.
+                    return;
+                }
                 let mut seen = (false, false);
                 for ch in lit_snip.as_bytes()[2..=maybe_last_sep_idx].iter() {
                     match ch {

--- a/tests/ui/literals.rs
+++ b/tests/ui/literals.rs
@@ -28,6 +28,7 @@ fn main() {
     let ok15 = 0xab_cabc_abca_bcab_cabc;
     let ok16 = 0xFE_BAFE_ABAB_ABCD;
     let ok17 = 0x123_4567_8901_usize;
+    let ok18 = 0xF;
 
     let fail19 = 12_3456_21;
     let fail22 = 3__4___23;

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -50,7 +50,7 @@ LL |     let fail8 = 0o123;
    |                 ^^^^^
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:32:18
+  --> $DIR/literals.rs:33:18
    |
 LL |     let fail19 = 12_3456_21;
    |                  ^^^^^^^^^^ help: consider: `12_345_621`
@@ -58,13 +58,13 @@ LL |     let fail19 = 12_3456_21;
    = note: `-D clippy::inconsistent-digit-grouping` implied by `-D warnings`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:33:18
+  --> $DIR/literals.rs:34:18
    |
 LL |     let fail22 = 3__4___23;
    |                  ^^^^^^^^^ help: consider: `3_423`
 
 error: digits grouped inconsistently by underscores
-  --> $DIR/literals.rs:34:18
+  --> $DIR/literals.rs:35:18
    |
 LL |     let fail23 = 3__16___23;
    |                  ^^^^^^^^^^ help: consider: `31_623`


### PR DESCRIPTION
Fixes #5169

changelog: Fix false positive in `zero_prefixed_literal`
