### PR TITLE
Improve deployment and documentation

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -8,7 +8,7 @@ rm -rf out/master/ || exit 0
 echo "Making the docs for master"
 mkdir out/master/
 cp util/gh-pages/index.html out/master
-python ./util/export.py out/master/lints.json
+python3 ./util/export.py out/master/lints.json
 
 if [[ -n $TAG_NAME ]]; then
   echo "Save the doc for the current tag ($TAG_NAME) and point current/ to it"
@@ -21,7 +21,7 @@ fi
 cp util/gh-pages/versions.html out/index.html
 
 echo "Making the versions.json file"
-python ./util/versions.py out
+python3 ./util/versions.py out
 
 cd out
 # Now let's go have some fun with the cloned repo

--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -11,10 +11,10 @@ cp util/gh-pages/index.html out/master
 python3 ./util/export.py out/master/lints.json
 
 if [[ -n $TAG_NAME ]]; then
-  echo "Save the doc for the current tag ($TAG_NAME) and point current/ to it"
+  echo "Save the doc for the current tag ($TAG_NAME) and point stable/ to it"
   cp -r out/master "out/$TAG_NAME"
-  rm -f out/current
-  ln -s "$TAG_NAME" out/current
+  rm -f out/stable
+  ln -s "$TAG_NAME" out/stable
 fi
 
 # Generate version index that is shown as root index page

--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -20,14 +20,10 @@ fi
 # Generate version index that is shown as root index page
 cp util/gh-pages/versions.html out/index.html
 
-cd out
-cat <<-EOF | python - > versions.json
-import os, json
-print json.dumps([
-    dir for dir in os.listdir(".") if not dir.startswith(".") and os.path.isdir(dir)
-])
-EOF
+echo "Making the versions.json file"
+python ./util/versions.py out
 
+cd out
 # Now let's go have some fun with the cloned repo
 git config user.name "GHA CI"
 git config user.email "gha@ci.invalid"

--- a/util/gh-pages/versions.html
+++ b/util/gh-pages/versions.html
@@ -64,7 +64,7 @@
 
             $scope.versionOrder = function(v) {
                 if (v === 'master') { return Infinity; }
-                if (v === 'current') { return Number.MAX_VALUE; }
+                if (v === 'stable') { return Number.MAX_VALUE; }
 
                 return $scope.normalizeVersion(v)
                     .split('.')

--- a/util/gh-pages/versions.html
+++ b/util/gh-pages/versions.html
@@ -36,7 +36,7 @@
                 <ul class="list-group">
                     <a class="list-group-item" ng-repeat="version in data | orderBy:versionOrder:true"
                        href="./{{version}}/index.html">
-                        {{normalizeVersion(version)}}
+                        {{normalizeVersionDisplay(version)}}
                     </a>
                 </ul>
             </article>
@@ -54,8 +54,12 @@
         .controller('docVersions', function ($scope, $http) {
             $scope.loading = true;
 
-            $scope.normalizeVersion = function(v) {
+            $scope.normalizeVersionDisplay = function(v) {
                 return v.replace(/^v/, '');
+            };
+
+            $scope.normalizeVersion = function(v) {
+                return v.replace(/^v/, '').replace(/^rust-/, '');
             };
 
             $scope.versionOrder = function(v) {

--- a/util/versions.py
+++ b/util/versions.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+from lintlib import log
+
+
+def key(v):
+    if v == 'master':
+        return float('inf')
+    if v == 'current':
+        return sys.maxsize
+
+    v = v.replace('v', '').replace('rust-', '')
+
+    s = 0
+    for i, val in enumerate(v.split('.')[::-1]):
+        s += int(val) * 100**i
+
+    return s
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Error: specify output directory")
+        return
+
+    outdir = sys.argv[1]
+    versions = [
+        dir for dir in os.listdir(outdir) if not dir.startswith(".") and os.path.isdir(os.path.join(outdir, dir))
+    ]
+    versions.sort(key=key)
+
+    with open(os.path.join(outdir, "versions.json"), "w") as fp:
+        json.dump(versions, fp, indent=2)
+        log.info("wrote JSON for great justice")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/versions.py
+++ b/util/versions.py
@@ -10,7 +10,7 @@ from lintlib import log
 def key(v):
     if v == 'master':
         return float('inf')
-    if v == 'current':
+    if v == 'stable':
         return sys.maxsize
 
     v = v.replace('v', '').replace('rust-', '')


### PR DESCRIPTION
**This should be merged shortly after** #5172

This extracts the python code that generated the `versions.json` file and now sorts the versions. in addition to that it improves the order on the website, respecting the new `rust-*` directories.

The new appearance of the documentation site can be previewed here: https://flip1995.github.io/rust-clippy/

changelog: Add documentation for Clippy stable releases at https://rust-lang.github.io/rust-clippy/