### PR TITLE
clippy-driver: pass all args to rustc if --rustc is present

### DIFF
--- a/.github/driver.sh
+++ b/.github/driver.sh
@@ -31,9 +31,11 @@ diff normalized.stderr tests/ui/cstring.stderr
 SYSROOT=`rustc --print sysroot`
 diff <(LD_LIBRARY_PATH=${SYSROOT}/lib ./target/debug/clippy-driver --rustc --version --verbose) <(rustc --version --verbose)
 
+
+echo "fn main() {}" > target/driver_test.rs
 # we can't run 2 rustcs on the same file at the same time
-CLIPPY=`LD_LIBRARY_PATH=${SYSROOT}/lib ./target/debug/clippy-driver tests/driver/main.rs`
-RUSTC=`rustc tests/driver/main.rs`
+CLIPPY=`LD_LIBRARY_PATH=${SYSROOT}/lib ./target/debug/clippy-driver ./target/driver_test.rs --rustc`
+RUSTC=`rustc ./target/driver_test.rs`
 diff <($CLIPPY) <($RUSTC)
 
 # TODO: CLIPPY_CONF_DIR / CARGO_MANIFEST_DIR

--- a/.github/driver.sh
+++ b/.github/driver.sh
@@ -26,4 +26,9 @@ unset CARGO_MANIFEST_DIR
 sed -e "s,tests/ui,\$DIR," -e "/= help/d" cstring.stderr > normalized.stderr
 diff normalized.stderr tests/ui/cstring.stderr
 
+
+# make sure "clippy-driver --rustc --arg" and "rustc --arg" behave the same
+SYSROOT=`rustc --print sysroot`
+diff <(LD_LIBRARY_PATH=${SYSROOT}/lib ./target/debug/clippy-driver --rustc --version --verbose) <(rustc --version --verbose)
+
 # TODO: CLIPPY_CONF_DIR / CARGO_MANIFEST_DIR

--- a/.github/driver.sh
+++ b/.github/driver.sh
@@ -31,4 +31,9 @@ diff normalized.stderr tests/ui/cstring.stderr
 SYSROOT=`rustc --print sysroot`
 diff <(LD_LIBRARY_PATH=${SYSROOT}/lib ./target/debug/clippy-driver --rustc --version --verbose) <(rustc --version --verbose)
 
+# we can't run 2 rustcs on the same file at the same time
+CLIPPY=`LD_LIBRARY_PATH=${SYSROOT}/lib ./target/debug/clippy-driver tests/driver/main.rs`
+RUSTC=`rustc tests/driver/main.rs`
+diff <($CLIPPY) <($RUSTC)
+
 # TODO: CLIPPY_CONF_DIR / CARGO_MANIFEST_DIR

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -207,6 +207,7 @@ Usage:
 
 Common options:
     -h, --help               Print this message
+        --rustc              Pass all args to rustc
     -V, --version            Print version info and exit
 
 Other options are the same as `cargo check`.

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -355,7 +355,6 @@ pub fn main() {
                 args.extend(vec!["--sysroot".into(), sys_root]);
             };
 
-            println!("args: {:?}", args);
             return rustc_driver::run_compiler(&args, &mut DefaultCallbacks, None, None);
         }
 


### PR DESCRIPTION
changelog: clippy-driver: pass all args to rustc if --rustc is present
