### PR TITLE
Expand `missing_errors_doc` to also work on async functions

### DIFF
--- a/clippy_lints/src/utils/paths.rs
+++ b/clippy_lints/src/utils/paths.rs
@@ -36,6 +36,7 @@ pub const FMT_ARGUMENTS_NEW_V1_FORMATTED: [&str; 4] = ["core", "fmt", "Arguments
 pub const FMT_ARGUMENTV1_NEW: [&str; 4] = ["core", "fmt", "ArgumentV1", "new"];
 pub const FROM_FROM: [&str; 4] = ["core", "convert", "From", "from"];
 pub const FROM_TRAIT: [&str; 3] = ["core", "convert", "From"];
+pub const FUTURE: [&str; 3] = ["std", "future", "Future"];
 pub const HASH: [&str; 2] = ["hash", "Hash"];
 pub const HASHMAP: [&str; 5] = ["std", "collections", "hash", "map", "HashMap"];
 pub const HASHMAP_ENTRY: [&str; 5] = ["std", "collections", "hash", "map", "Entry"];

--- a/tests/ui/doc_errors.rs
+++ b/tests/ui/doc_errors.rs
@@ -1,3 +1,4 @@
+// compile-flags: --edition 2018
 #![warn(clippy::missing_errors_doc)]
 
 use std::io;
@@ -6,8 +7,17 @@ pub fn pub_fn_missing_errors_header() -> Result<(), ()> {
     unimplemented!();
 }
 
+pub async fn async_pub_fn_missing_errors_header() -> Result<(), ()> {
+    unimplemented!();
+}
+
 /// This is not sufficiently documented.
 pub fn pub_fn_returning_io_result() -> io::Result<()> {
+    unimplemented!();
+}
+
+/// This is not sufficiently documented.
+pub async fn async_pub_fn_returning_io_result() -> io::Result<()> {
     unimplemented!();
 }
 
@@ -17,8 +27,19 @@ pub fn pub_fn_with_errors_header() -> Result<(), ()> {
     unimplemented!();
 }
 
+/// # Errors
+/// A description of the errors goes here.
+pub async fn async_pub_fn_with_errors_header() -> Result<(), ()> {
+    unimplemented!();
+}
+
 /// This function doesn't require the documentation because it is private
 fn priv_fn_missing_errors_header() -> Result<(), ()> {
+    unimplemented!();
+}
+
+/// This function doesn't require the documentation because it is private
+async fn async_priv_fn_missing_errors_header() -> Result<(), ()> {
     unimplemented!();
 }
 
@@ -30,14 +51,30 @@ impl Struct1 {
         unimplemented!();
     }
 
+    /// This is not sufficiently documented.
+    pub async fn async_pub_method_missing_errors_header() -> Result<(), ()> {
+        unimplemented!();
+    }
+
     /// # Errors
     /// A description of the errors goes here.
     pub fn pub_method_with_errors_header() -> Result<(), ()> {
         unimplemented!();
     }
 
+    /// # Errors
+    /// A description of the errors goes here.
+    pub async fn async_pub_method_with_errors_header() -> Result<(), ()> {
+        unimplemented!();
+    }
+
     /// This function doesn't require the documentation because it is private.
     fn priv_method_missing_errors_header() -> Result<(), ()> {
+        unimplemented!();
+    }
+
+    /// This function doesn't require the documentation because it is private.
+    async fn async_priv_method_missing_errors_header() -> Result<(), ()> {
         unimplemented!();
     }
 }

--- a/tests/ui/doc_errors.stderr
+++ b/tests/ui/doc_errors.stderr
@@ -1,5 +1,5 @@
 error: docs for function returning `Result` missing `# Errors` section
-  --> $DIR/doc_errors.rs:5:1
+  --> $DIR/doc_errors.rs:6:1
    |
 LL | / pub fn pub_fn_missing_errors_header() -> Result<(), ()> {
 LL | |     unimplemented!();
@@ -11,13 +11,29 @@ LL | | }
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:10:1
    |
+LL | / pub async fn async_pub_fn_missing_errors_header() -> Result<(), ()> {
+LL | |     unimplemented!();
+LL | | }
+   | |_^
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> $DIR/doc_errors.rs:15:1
+   |
 LL | / pub fn pub_fn_returning_io_result() -> io::Result<()> {
 LL | |     unimplemented!();
 LL | | }
    | |_^
 
 error: docs for function returning `Result` missing `# Errors` section
-  --> $DIR/doc_errors.rs:29:5
+  --> $DIR/doc_errors.rs:20:1
+   |
+LL | / pub async fn async_pub_fn_returning_io_result() -> io::Result<()> {
+LL | |     unimplemented!();
+LL | | }
+   | |_^
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> $DIR/doc_errors.rs:50:5
    |
 LL | /     pub fn pub_method_missing_errors_header() -> Result<(), ()> {
 LL | |         unimplemented!();
@@ -25,10 +41,18 @@ LL | |     }
    | |_____^
 
 error: docs for function returning `Result` missing `# Errors` section
-  --> $DIR/doc_errors.rs:47:5
+  --> $DIR/doc_errors.rs:55:5
+   |
+LL | /     pub async fn async_pub_method_missing_errors_header() -> Result<(), ()> {
+LL | |         unimplemented!();
+LL | |     }
+   | |_____^
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> $DIR/doc_errors.rs:84:5
    |
 LL |     fn trait_method_missing_errors_header() -> Result<(), ()>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This adds the `missing_errors_doc` lint to async functions.

changelog: Make [`missing_errors_doc`] lint also trigger on `async` functions