### PR TITLE
Don't lint `single_component_path_imports` in macros

### DIFF
--- a/clippy_lints/src/single_component_path_imports.rs
+++ b/clippy_lints/src/single_component_path_imports.rs
@@ -1,4 +1,4 @@
-use crate::utils::span_lint_and_sugg;
+use crate::utils::{in_macro, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
@@ -39,6 +39,7 @@ declare_lint_pass!(SingleComponentPathImports => [SINGLE_COMPONENT_PATH_IMPORTS]
 impl EarlyLintPass for SingleComponentPathImports {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if_chain! {
+            if !in_macro(item.span);
             if cx.sess.opts.edition == Edition::Edition2018;
             if !item.vis.node.is_pub();
             if let ItemKind::Use(use_tree) = &item.kind;

--- a/tests/ui/single_component_path_imports.fixed
+++ b/tests/ui/single_component_path_imports.fixed
@@ -7,6 +7,15 @@
 use serde as edres;
 pub use serde;
 
+macro_rules! m {
+    () => {
+        use regex;
+    };
+}
+
 fn main() {
     regex::Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
+
+    // False positive #5154, shouldn't trigger lint.
+    m!();
 }

--- a/tests/ui/single_component_path_imports.rs
+++ b/tests/ui/single_component_path_imports.rs
@@ -7,6 +7,15 @@ use regex;
 use serde as edres;
 pub use serde;
 
+macro_rules! m {
+    () => {
+        use regex;
+    };
+}
+
 fn main() {
     regex::Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
+
+    // False positive #5154, shouldn't trigger lint.
+    m!();
 }


### PR DESCRIPTION
Fixes #5154

changelog: Fix false positive in `single_component_path_imports`
