### PR TITLE
Rename `FunctionRetTy` to `FnRetTy`

### DIFF
--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -468,8 +468,8 @@ fn check_must_use_candidate<'a, 'tcx>(
 
 fn returns_unit(decl: &hir::FnDecl<'_>) -> bool {
     match decl.output {
-        hir::FunctionRetTy::DefaultReturn(_) => true,
-        hir::FunctionRetTy::Return(ref ty) => match ty.kind {
+        hir::FnRetTy::DefaultReturn(_) => true,
+        hir::FnRetTy::Return(ref ty) => match ty.kind {
             hir::TyKind::Tup(ref tys) => tys.is_empty(),
             hir::TyKind::Never => true,
             _ => false,

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -4,7 +4,7 @@ use rustc::lint::in_external_macro;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::*;
-use rustc_hir::FunctionRetTy::Return;
+use rustc_hir::FnRetTy::Return;
 use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::{declare_lint_pass, declare_tool_lint};

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3406,14 +3406,14 @@ enum OutType {
 }
 
 impl OutType {
-    fn matches(self, cx: &LateContext<'_, '_>, ty: &hir::FunctionRetTy<'_>) -> bool {
+    fn matches(self, cx: &LateContext<'_, '_>, ty: &hir::FnRetTy<'_>) -> bool {
         let is_unit = |ty: &hir::Ty<'_>| SpanlessEq::new(cx).eq_ty_kind(&ty.kind, &hir::TyKind::Tup(&[]));
         match (self, ty) {
-            (Self::Unit, &hir::FunctionRetTy::DefaultReturn(_)) => true,
-            (Self::Unit, &hir::FunctionRetTy::Return(ref ty)) if is_unit(ty) => true,
-            (Self::Bool, &hir::FunctionRetTy::Return(ref ty)) if is_bool(ty) => true,
-            (Self::Any, &hir::FunctionRetTy::Return(ref ty)) if !is_unit(ty) => true,
-            (Self::Ref, &hir::FunctionRetTy::Return(ref ty)) => matches!(ty.kind, hir::TyKind::Rptr(_, _)),
+            (Self::Unit, &hir::FnRetTy::DefaultReturn(_)) => true,
+            (Self::Unit, &hir::FnRetTy::Return(ref ty)) if is_unit(ty) => true,
+            (Self::Bool, &hir::FnRetTy::Return(ref ty)) if is_bool(ty) => true,
+            (Self::Any, &hir::FnRetTy::Return(ref ty)) if !is_unit(ty) => true,
+            (Self::Ref, &hir::FnRetTy::Return(ref ty)) => matches!(ty.kind, hir::TyKind::Rptr(_, _)),
             _ => false,
         }
     }

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -253,7 +253,7 @@ fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl<'_>, fn_id: HirId, opt_body_
         }
     }
 
-    if let FunctionRetTy::Return(ref ty) = decl.output {
+    if let FnRetTy::Return(ref ty) = decl.output {
         if let Some((out, Mutability::Mut, _)) = get_rptr_lm(ty) {
             let mut immutables = vec![];
             for (_, ref mutbl, ref argspan) in decl

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -242,7 +242,7 @@ impl EarlyLintPass for Return {
             FnKind::Fn(.., None) => {},
         }
         if_chain! {
-            if let ast::FunctionRetTy::Ty(ref ty) = kind.decl().output;
+            if let ast::FnRetTy::Ty(ref ty) = kind.decl().output;
             if let ast::TyKind::Tup(ref vals) = ty.kind;
             if vals.is_empty() && !ty.span.from_expansion() && get_def(span) == get_def(ty.span);
             then {

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -242,7 +242,7 @@ impl Types {
             self.check_ty(cx, input, false);
         }
 
-        if let FunctionRetTy::Return(ref ty) = decl.output {
+        if let FnRetTy::Return(ref ty) = decl.output {
             self.check_ty(cx, ty, false);
         }
     }
@@ -1476,7 +1476,7 @@ impl<'a, 'tcx> TypeComplexity {
         for arg in decl.inputs {
             self.check_type(cx, arg);
         }
-        if let FunctionRetTy::Return(ref ty) = decl.output {
+        if let FnRetTy::Return(ref ty) = decl.output {
             self.check_type(cx, ty);
         }
     }

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -141,7 +141,7 @@ fn check_trait_method_impl_decl<'a, 'tcx>(
     let impl_method_sig = cx.tcx.fn_sig(impl_method_def_id);
     let impl_method_sig = cx.tcx.erase_late_bound_regions(&impl_method_sig);
 
-    let output_ty = if let FunctionRetTy::Return(ty) = &impl_decl.output {
+    let output_ty = if let FnRetTy::Return(ty) = &impl_decl.output {
         Some(&**ty)
     } else {
         None

--- a/clippy_lints/src/utils/hir_utils.rs
+++ b/clippy_lints/src/utils/hir_utils.rs
@@ -633,10 +633,10 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                     self.hash_ty(&arg);
                 }
                 match bfn.decl.output {
-                    FunctionRetTy::DefaultReturn(_) => {
+                    FnRetTy::DefaultReturn(_) => {
                         ().hash(&mut self.s);
                     },
-                    FunctionRetTy::Return(ref ty) => {
+                    FnRetTy::Return(ref ty) => {
                         self.hash_ty(ty);
                     },
                 }


### PR DESCRIPTION
Rustup to rust-lang/rust#69179

changelog: none
