### PR TITLE
Add `LOG2_10` and `LOG10_2` to `approx_const` lint

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -37,7 +37,7 @@ declare_clippy_lint! {
 }
 
 // Tuples are of the form (constant, name, min_digits)
-const KNOWN_CONSTS: [(f64, &str, usize); 16] = [
+const KNOWN_CONSTS: [(f64, &str, usize); 18] = [
     (f64::E, "E", 4),
     (f64::FRAC_1_PI, "FRAC_1_PI", 4),
     (f64::FRAC_1_SQRT_2, "FRAC_1_SQRT_2", 5),
@@ -52,6 +52,8 @@ const KNOWN_CONSTS: [(f64, &str, usize); 16] = [
     (f64::LN_2, "LN_2", 5),
     (f64::LOG10_E, "LOG10_E", 5),
     (f64::LOG2_E, "LOG2_E", 5),
+    (f64::LOG2_10, "LOG2_10", 5),
+    (f64::LOG10_2, "LOG10_2", 5),
     (f64::PI, "PI", 3),
     (f64::SQRT_2, "SQRT_2", 5),
 ];

--- a/tests/ui/approx_const.rs
+++ b/tests/ui/approx_const.rs
@@ -45,6 +45,12 @@ fn main() {
     let my_log2_e = 1.4426950408889634;
     let no_log2_e = 1.442;
 
+    let log2_10 = 3.321928094887362;
+    let no_log2_10 = 3.321;
+
+    let log10_2 = 0.301029995663981;
+    let no_log10_2 = 0.301;
+
     let my_pi = 3.1415;
     let almost_pi = 3.14;
     let no_pi = 3.15;

--- a/tests/ui/approx_const.stderr
+++ b/tests/ui/approx_const.stderr
@@ -96,23 +96,35 @@ error: approximate value of `f{32, 64}::consts::LOG2_E` found. Consider using it
 LL |     let my_log2_e = 1.4426950408889634;
    |                     ^^^^^^^^^^^^^^^^^^
 
+error: approximate value of `f{32, 64}::consts::LOG2_10` found. Consider using it directly
+  --> $DIR/approx_const.rs:48:19
+   |
+LL |     let log2_10 = 3.321928094887362;
+   |                   ^^^^^^^^^^^^^^^^^
+
+error: approximate value of `f{32, 64}::consts::LOG10_2` found. Consider using it directly
+  --> $DIR/approx_const.rs:51:19
+   |
+LL |     let log10_2 = 0.301029995663981;
+   |                   ^^^^^^^^^^^^^^^^^
+
 error: approximate value of `f{32, 64}::consts::PI` found. Consider using it directly
-  --> $DIR/approx_const.rs:48:17
+  --> $DIR/approx_const.rs:54:17
    |
 LL |     let my_pi = 3.1415;
    |                 ^^^^^^
 
 error: approximate value of `f{32, 64}::consts::PI` found. Consider using it directly
-  --> $DIR/approx_const.rs:49:21
+  --> $DIR/approx_const.rs:55:21
    |
 LL |     let almost_pi = 3.14;
    |                     ^^^^
 
 error: approximate value of `f{32, 64}::consts::SQRT_2` found. Consider using it directly
-  --> $DIR/approx_const.rs:52:18
+  --> $DIR/approx_const.rs:58:18
    |
 LL |     let my_sq2 = 1.4142;
    |                  ^^^^^^
 
-error: aborting due to 19 previous errors
+error: aborting due to 21 previous errors
 


### PR DESCRIPTION
changelog: Add constants `LOG2_10` and `LOG10_2` to `approx_const` lint
