### PR TITLE
Prevent `missing_const_for_fn` on functions with const generic params

### DIFF
--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -3,7 +3,8 @@
 //! The .stderr output of this test should be empty. Otherwise it's a bug somewhere.
 
 #![warn(clippy::missing_const_for_fn)]
-#![feature(start)]
+#![allow(incomplete_features)]
+#![feature(start, const_generics)]
 
 struct Game;
 
@@ -89,4 +90,14 @@ mod with_drop {
             B
         }
     }
+}
+
+fn const_generic_params<T, const N: usize>(t: &[T; N]) -> &[T; N] {
+    t
+}
+
+fn const_generic_return<T, const N: usize>(t: &[T]) -> &[T; N] {
+    let p = t.as_ptr() as *const [T; N];
+
+    unsafe { &*p }
 }

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::missing_const_for_fn)]
-#![allow(clippy::let_and_return)]
+#![allow(incomplete_features, clippy::let_and_return)]
+#![feature(const_generics)]
 
 use std::mem::transmute;
 
@@ -11,6 +12,10 @@ impl Game {
     // Could be const
     pub fn new() -> Self {
         Self { guess: 42 }
+    }
+
+    fn const_generic_params<'a, T, const N: usize>(&self, b: &'a [T; N]) -> &'a [T; N] {
+        b
     }
 }
 

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -1,5 +1,5 @@
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:12:5
+  --> $DIR/could_be_const.rs:13:5
    |
 LL | /     pub fn new() -> Self {
 LL | |         Self { guess: 42 }
@@ -9,7 +9,15 @@ LL | |     }
    = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:18:1
+  --> $DIR/could_be_const.rs:17:5
+   |
+LL | /     fn const_generic_params<'a, T, const N: usize>(&self, b: &'a [T; N]) -> &'a [T; N] {
+LL | |         b
+LL | |     }
+   | |_____^
+
+error: this could be a `const fn`
+  --> $DIR/could_be_const.rs:23:1
    |
 LL | / fn one() -> i32 {
 LL | |     1
@@ -17,7 +25,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:23:1
+  --> $DIR/could_be_const.rs:28:1
    |
 LL | / fn two() -> i32 {
 LL | |     let abc = 2;
@@ -26,7 +34,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:29:1
+  --> $DIR/could_be_const.rs:34:1
    |
 LL | / fn string() -> String {
 LL | |     String::new()
@@ -34,7 +42,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:34:1
+  --> $DIR/could_be_const.rs:39:1
    |
 LL | / unsafe fn four() -> i32 {
 LL | |     4
@@ -42,7 +50,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:39:1
+  --> $DIR/could_be_const.rs:44:1
    |
 LL | / fn generic<T>(t: T) -> T {
 LL | |     t
@@ -50,7 +58,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:43:1
+  --> $DIR/could_be_const.rs:48:1
    |
 LL | / fn sub(x: u32) -> usize {
 LL | |     unsafe { transmute(&x) }
@@ -58,12 +66,12 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:62:9
+  --> $DIR/could_be_const.rs:67:9
    |
 LL | /         pub fn b(self, a: &A) -> B {
 LL | |             B
 LL | |         }
    | |_________^
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
`const` functions cannot have const generic parameters so prevent the
`missing_const_for_fn` lint from firing in that case.

changelog: Fix false positive in `missing_const_for_fn`

Fixes #5192 
