### PR TITLE
Do not run deploy action on other repos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository == 'rust-lang/rust-clippy'
 
     steps:
     # Setup


### PR DESCRIPTION
Usually, we don't have to run deploy action on other repos, let's ignore there.

changelog: none
