### PR TITLE
[WIP] Extend `uninit_assumed_init` lint to cover more cases

### DIFF
--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -5,7 +5,8 @@
     clippy::redundant_pattern_matching,
     clippy::many_single_char_names,
     clippy::option_option,
-    clippy::redundant_clone
+    clippy::redundant_clone,
+    clippy::uninit_assumed_init
 )]
 
 use std::borrow::Borrow;

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -1,5 +1,5 @@
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:18:23
+  --> $DIR/needless_pass_by_value.rs:19:23
    |
 LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T> {
    |                       ^^^^^^ help: consider changing the type to: `&[T]`
@@ -7,55 +7,55 @@ LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T
    = note: `-D clippy::needless-pass-by-value` implied by `-D warnings`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:32:11
+  --> $DIR/needless_pass_by_value.rs:33:11
    |
 LL | fn bar(x: String, y: Wrapper) {
    |           ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:32:22
+  --> $DIR/needless_pass_by_value.rs:33:22
    |
 LL | fn bar(x: String, y: Wrapper) {
    |                      ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:38:71
+  --> $DIR/needless_pass_by_value.rs:39:71
    |
 LL | fn test_borrow_trait<T: Borrow<str>, U: AsRef<str>, V>(t: T, u: U, v: V) {
    |                                                                       ^ help: consider taking a reference instead: `&V`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:50:18
+  --> $DIR/needless_pass_by_value.rs:51:18
    |
 LL | fn test_match(x: Option<Option<String>>, y: Option<Option<String>>) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&Option<Option<String>>`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:63:24
+  --> $DIR/needless_pass_by_value.rs:64:24
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                        ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:63:36
+  --> $DIR/needless_pass_by_value.rs:64:36
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                                    ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:79:49
+  --> $DIR/needless_pass_by_value.rs:80:49
    |
 LL | fn test_blanket_ref<T: Foo, S: Serialize>(_foo: T, _serializable: S) {}
    |                                                 ^ help: consider taking a reference instead: `&T`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:81:18
+  --> $DIR/needless_pass_by_value.rs:82:18
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                  ^^^^^^ help: consider taking a reference instead: `&String`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:81:29
+  --> $DIR/needless_pass_by_value.rs:82:29
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                             ^^^^^^
@@ -70,13 +70,13 @@ LL |     let _ = t.to_string();
    |             ^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:81:40
+  --> $DIR/needless_pass_by_value.rs:82:40
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                        ^^^^^^^^ help: consider taking a reference instead: `&Vec<i32>`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:81:53
+  --> $DIR/needless_pass_by_value.rs:82:53
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                                     ^^^^^^^^
@@ -91,85 +91,85 @@ LL |     let _ = v.to_owned();
    |             ^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:94:12
+  --> $DIR/needless_pass_by_value.rs:95:12
    |
 LL |         s: String,
    |            ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:95:12
+  --> $DIR/needless_pass_by_value.rs:96:12
    |
 LL |         t: String,
    |            ^^^^^^ help: consider taking a reference instead: `&String`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:104:23
+  --> $DIR/needless_pass_by_value.rs:105:23
    |
 LL |     fn baz(&self, _u: U, _s: Self) {}
    |                       ^ help: consider taking a reference instead: `&U`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:104:30
+  --> $DIR/needless_pass_by_value.rs:105:30
    |
 LL |     fn baz(&self, _u: U, _s: Self) {}
    |                              ^^^^ help: consider taking a reference instead: `&Self`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:126:24
+  --> $DIR/needless_pass_by_value.rs:127:24
    |
 LL | fn bar_copy(x: u32, y: CopyWrapper) {
    |                        ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:124:1
+  --> $DIR/needless_pass_by_value.rs:125:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:132:29
+  --> $DIR/needless_pass_by_value.rs:133:29
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:124:1
+  --> $DIR/needless_pass_by_value.rs:125:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:132:45
+  --> $DIR/needless_pass_by_value.rs:133:45
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:124:1
+  --> $DIR/needless_pass_by_value.rs:125:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:132:61
+  --> $DIR/needless_pass_by_value.rs:133:61
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:124:1
+  --> $DIR/needless_pass_by_value.rs:125:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:144:40
+  --> $DIR/needless_pass_by_value.rs:145:40
    |
 LL | fn some_fun<'b, S: Bar<'b, ()>>(_item: S) {}
    |                                        ^ help: consider taking a reference instead: `&S`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:149:20
+  --> $DIR/needless_pass_by_value.rs:150:20
    |
 LL | fn more_fun(_item: impl Club<'static, i32>) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&impl Club<'static, i32>`

--- a/tests/ui/uninit.rs
+++ b/tests/ui/uninit.rs
@@ -20,4 +20,22 @@ fn main() {
 
     // This is OK, because all constitutent types are uninit-compatible.
     let _: (MaybeUninit<usize>, [MaybeUninit<bool>; 2]) = unsafe { MaybeUninit::uninit().assume_init() };
+
+    let mut x: MaybeUninit<usize> = MaybeUninit::uninit();
+    let _: usize = unsafe { x.assume_init() };
+
+    let mut x: MaybeUninit<[u8; 0]> = MaybeUninit::uninit();
+    let _: [u8; 0] = unsafe { x.assume_init() };
+
+    let mut x: MaybeUninit<()> = MaybeUninit::uninit();
+    let _: () = unsafe { x.assume_init() };
+
+    let x: MaybeUninit<MaybeUninit<usize>> = MaybeUninit::uninit();
+    let _: MaybeUninit<usize> = unsafe { x.assume_init() };
+
+    let x: MaybeUninit<(MaybeUninit<usize>, MaybeUninit<bool>)> = MaybeUninit::uninit();
+    let _: (MaybeUninit<usize>, MaybeUninit<bool>) = unsafe { x.assume_init() };
+
+    let x: MaybeUninit<(MaybeUninit<usize>, [MaybeUninit<bool>; 2])> = MaybeUninit::uninit();
+    let _: (MaybeUninit<usize>, [MaybeUninit<bool>; 2]) = unsafe { x.assume_init() };
 }

--- a/tests/ui/uninit.stderr
+++ b/tests/ui/uninit.stderr
@@ -12,5 +12,17 @@ error: this call for this type may be undefined behavior
 LL |     let _: [u8; 0] = unsafe { MaybeUninit::uninit().assume_init() };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: this call for this type may be undefined behavior
+  --> $DIR/uninit.rs:25:29
+   |
+LL |     let _: usize = unsafe { x.assume_init() };
+   |                             ^^^^^^^^^^^^^^^
+
+error: this call for this type may be undefined behavior
+  --> $DIR/uninit.rs:28:31
+   |
+LL |     let _: [u8; 0] = unsafe { x.assume_init() };
+   |                               ^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Currently `uninit_assumed_init` doesn't lint when `assume_init` is
invoked on a `MaybeUninit<_>` variable so extending it to cover that
case.

Fixes #4765 

changelog: Extend `uninit_assumed_init` to cover more cases
