### PR TITLE
Macro use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1209,6 +1209,7 @@ Released 2018-09-13
 [`linkedlist`]: https://rust-lang.github.io/rust-clippy/master/index.html#linkedlist
 [`logic_bug`]: https://rust-lang.github.io/rust-clippy/master/index.html#logic_bug
 [`lossy_float_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#lossy_float_literal
+[`macro_use_import`]: https://rust-lang.github.io/rust-clippy/master/index.html#macro_use_import
 [`main_recursion`]: https://rust-lang.github.io/rust-clippy/master/index.html#main_recursion
 [`manual_memcpy`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_memcpy
 [`manual_saturating_arithmetic`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 359 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are 360 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -234,6 +234,7 @@ pub mod let_underscore;
 pub mod lifetimes;
 pub mod literal_representation;
 pub mod loops;
+pub mod macro_use;
 pub mod main_recursion;
 pub mod map_clone;
 pub mod map_unit_fn;
@@ -599,6 +600,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         &loops::WHILE_IMMUTABLE_CONDITION,
         &loops::WHILE_LET_LOOP,
         &loops::WHILE_LET_ON_ITERATOR,
+        &macro_use::MACRO_USE_IMPORT,
         &main_recursion::MAIN_RECURSION,
         &map_clone::MAP_CLONE,
         &map_unit_fn::OPTION_MAP_UNIT_FN,
@@ -1012,6 +1014,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_early_pass(move || box excessive_bools::ExcessiveBools::new(max_struct_bools, max_fn_params_bools));
     store.register_early_pass(|| box option_env_unwrap::OptionEnvUnwrap);
     store.register_late_pass(|| box wildcard_imports::WildcardImports);
+    store.register_early_pass(|| box macro_use::MacroUseImport);
 
     store.register_group(true, "clippy::restriction", Some("clippy_restriction"), vec![
         LintId::of(&arithmetic::FLOAT_ARITHMETIC),
@@ -1079,6 +1082,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&literal_representation::LARGE_DIGIT_GROUPS),
         LintId::of(&loops::EXPLICIT_INTO_ITER_LOOP),
         LintId::of(&loops::EXPLICIT_ITER_LOOP),
+        LintId::of(&macro_use::MACRO_USE_IMPORT),
         LintId::of(&matches::SINGLE_MATCH_ELSE),
         LintId::of(&methods::FILTER_MAP),
         LintId::of(&methods::FILTER_MAP_NEXT),

--- a/clippy_lints/src/macro_use.rs
+++ b/clippy_lints/src/macro_use.rs
@@ -1,0 +1,53 @@
+use crate::utils::{snippet, span_lint_and_sugg};
+use if_chain::if_chain;
+use rustc_ast::ast;
+use rustc_errors::Applicability;
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::edition::Edition;
+
+declare_clippy_lint! {
+    /// **What it does:** Checks for `#[macro_use] use...`.
+    ///
+    /// **Why is this bad?** Since the Rust 2018 edition you can import
+    /// macro's directly, this is considered idiomatic.
+    ///
+    /// **Known problems:** This lint does not generate an auto-applicable suggestion.
+    ///
+    /// **Example:**
+    /// ```rust
+    /// #[macro_use]
+    /// use lazy_static;
+    /// ```
+    pub MACRO_USE_IMPORT,
+    pedantic,
+    "#[macro_use] is no longer needed"
+}
+
+declare_lint_pass!(MacroUseImport => [MACRO_USE_IMPORT]);
+
+impl EarlyLintPass for MacroUseImport {
+    fn check_item(&mut self, ecx: &EarlyContext<'_>, item: &ast::Item) {
+        if_chain! {
+            if ecx.sess.opts.edition == Edition::Edition2018;
+            if let ast::ItemKind::Use(use_tree) = &item.kind;
+            if let Some(mac_attr) = item
+                .attrs
+                .iter()
+                .find(|attr| attr.ident().map(|s| s.to_string()) == Some("macro_use".to_string()));
+            then {
+                let msg = "`macro_use` attributes are no longer needed in the Rust 2018 edition";
+                let help = format!("use {}::<macro name>", snippet(ecx, use_tree.span, "_"));
+                span_lint_and_sugg(
+                    ecx,
+                    MACRO_USE_IMPORT,
+                    mac_attr.span,
+                    msg,
+                    "remove the attribute and import the macro directly, try",
+                    help,
+                    Applicability::HasPlaceholders,
+                );
+            }
+        }
+    }
+}

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -6,7 +6,7 @@ pub use lint::Lint;
 pub use lint::LINT_LEVELS;
 
 // begin lint list, do not remove this comment, it’s used in `update_lints`
-pub const ALL_LINTS: [Lint; 359] = [
+pub const ALL_LINTS: [Lint; 360] = [
     Lint {
         name: "absurd_extreme_comparisons",
         group: "correctness",
@@ -1014,6 +1014,13 @@ pub const ALL_LINTS: [Lint; 359] = [
         desc: "lossy whole number float literals",
         deprecation: None,
         module: "float_literal",
+    },
+    Lint {
+        name: "macro_use_import",
+        group: "pedantic",
+        desc: "#[macro_use] is no longer needed",
+        deprecation: None,
+        module: "macro_use",
     },
     Lint {
         name: "main_recursion",

--- a/tests/ui/macro_use_import.rs
+++ b/tests/ui/macro_use_import.rs
@@ -1,0 +1,11 @@
+// compile-flags: --edition 2018
+#![warn(clippy::macro_use_import)]
+
+use std::collections::HashMap;
+#[macro_use]
+use std::prelude;
+
+fn main() {
+    let _ = HashMap::<u8, u8>::new();
+    println!();
+}

--- a/tests/ui/macro_use_import.stderr
+++ b/tests/ui/macro_use_import.stderr
@@ -1,0 +1,10 @@
+error: `macro_use` attributes are no longer needed in the Rust 2018 edition
+  --> $DIR/macro_use_import.rs:5:1
+   |
+LL | #[macro_use]
+   | ^^^^^^^^^^^^ help: remove the attribute and import the macro directly, try: `use std::prelude::<macro name>`
+   |
+   = note: `-D clippy::macro-use-import` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
---

changelog: This lint enforces Rust 2018 idiom of importing macro's directly without `#[macro_use]` fixes #5179 . 


