### PR TITLE
Fix deploy script for tag deploys

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -33,7 +33,17 @@ if git diff --exit-code --quiet; then
   exit 0
 fi
 
-git add .
-git commit -m "Automatic deploy to GitHub Pages: ${SHA}"
+if [[ -n $TAG_NAME ]]; then
+  # Add the new dir
+  git add $TAG_NAME
+  # Update the symlink
+  git add stable
+  # Update versions file
+  git add versions.json
+  git commit -m "Add documentation for ${TAG_NAME} release: ${SHA}"
+else
+  git add .
+  git commit -m "Automatic deploy to GitHub Pages: ${SHA}"
+fi
 
 git push "$SSH_REPO" "$TARGET_BRANCH"


### PR DESCRIPTION
By hand updating the documentation for the `rust-1.41.1` release, I found, that the deploy script was buggy for tag deploys. Luckily we weren't affected yet (will only run if the commit of the tag already has the workflow config, so probably ~`rust-1.43.0`)

The bug:

When a tag was deployed, until now it also updated the master documentation to the state of the tag. This was because the `git add .` not only updated the files created or modified by the tag commit, but also the master lints.json file.

changelog: none
