### PR TITLE
Return early if generator_drop.is_some()

### DIFF
--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -82,6 +82,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantClone {
         let mir = cx.tcx.optimized_mir(def_id);
         let mir_read_only = mir.unwrap_read_only();
 
+        if mir.generator_drop.is_some() {
+            return;
+        }
+
         let maybe_storage_live_result = MaybeStorageLive
             .into_engine(cx.tcx, mir, def_id)
             .iterate_to_fixpoint()

--- a/tests/ui/crashes/ice-5238.rs
+++ b/tests/ui/crashes/ice-5238.rs
@@ -1,0 +1,9 @@
+// Regression test for #5238
+
+#![feature(generators, generator_trait)]
+
+fn main() {
+    let _ = || {
+        yield;
+    };
+}


### PR DESCRIPTION
It can be an avoidance for the clippy ICEs caused by rust-lang/rust#68528 but I'm not sure it's an actual fix.

changelog: Fix ICE in `redundant_clone`
