### PR TITLE
Detect usage of custom floating-point abs implementation 

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -76,12 +76,12 @@ declare_clippy_lint! {
     ///     -a
     /// } else {
     ///     a
-    /// }
+    /// };
     /// let _ = if a < 0.0 {
     ///     a
     /// } else {
     ///     -a
-    /// }
+    /// };
     /// ```
     ///
     /// is better expressed as

--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -422,8 +422,28 @@ fn is_zero(expr: &Expr<'_>) -> bool {
 
 fn check_custom_abs(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
     if let Some((cond, body, Some(else_body))) = higher::if_block(&expr) {
-        if let ExprKind::Block( Block { stmts: [], expr: Some(Expr { kind: ExprKind::Unary(UnOp::UnNeg, else_expr), ..  }), ..  }, _,) = else_body.kind {
-            if let ExprKind::Block( Block { stmts: [], expr: Some(body), ..  }, _,) = &body.kind {
+        if let ExprKind::Block(
+            Block {
+                stmts: [],
+                expr:
+                    Some(Expr {
+                        kind: ExprKind::Unary(UnOp::UnNeg, else_expr),
+                        ..
+                    }),
+                ..
+            },
+            _,
+        ) = else_body.kind
+        {
+            if let ExprKind::Block(
+                Block {
+                    stmts: [],
+                    expr: Some(body),
+                    ..
+                },
+                _,
+            ) = &body.kind
+            {
                 if are_exprs_equal(cx, else_expr, body) {
                     if is_testing_positive(cx, cond, body) {
                         span_lint_and_sugg(
@@ -449,9 +469,28 @@ fn check_custom_abs(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
                 }
             }
         }
-        if let ExprKind::Block( Block { stmts: [], expr: Some(Expr { kind: ExprKind::Unary(UnOp::UnNeg, else_expr), ..  }), ..  }, _,) = &body.kind
+        if let ExprKind::Block(
+            Block {
+                stmts: [],
+                expr:
+                    Some(Expr {
+                        kind: ExprKind::Unary(UnOp::UnNeg, else_expr),
+                        ..
+                    }),
+                ..
+            },
+            _,
+        ) = &body.kind
         {
-            if let ExprKind::Block( Block { stmts: [], expr: Some(body), ..  }, _,) = &else_body.kind {
+            if let ExprKind::Block(
+                Block {
+                    stmts: [],
+                    expr: Some(body),
+                    ..
+                },
+                _,
+            ) = &else_body.kind
+            {
                 if are_exprs_equal(cx, else_expr, body) {
                     if is_testing_negative(cx, cond, body) {
                         span_lint_and_sugg(

--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -420,11 +420,7 @@ fn is_zero(cx: &LateContext<'_, '_>, expr: &Expr<'_>) -> bool {
 /// one of the two expressions
 /// If the two expressions are not negations of each other, then it
 /// returns None.
-fn are_negated<'a>(
-    cx: &LateContext<'_, '_>,
-    expr1: &'a Expr<'a>,
-    expr2: &'a Expr<'a>,
-) -> Option<(bool, &'a Expr<'a>)> {
+fn are_negated<'a>(cx: &LateContext<'_, '_>, expr1: &'a Expr<'a>, expr2: &'a Expr<'a>) -> Option<(bool, &'a Expr<'a>)> {
     if let ExprKind::Unary(UnOp::UnNeg, expr1_negated) = &expr1.kind {
         if are_exprs_equal(cx, expr1_negated, expr2) {
             return Some((false, expr2));

--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -11,11 +11,10 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Spanned;
 
-use rustc_ast::ast;
+use rustc_ast::ast::{self, FloatTy, LitFloatType, LitKind};
 use std::f32::consts as f32_consts;
 use std::f64::consts as f64_consts;
 use sugg::{format_numeric_literal, Sugg};
-use syntax::ast::{self, FloatTy, LitFloatType, LitKind};
 
 declare_clippy_lint! {
     /// **What it does:** Looks for floating-point expressions that

--- a/tests/ui/floating_point_abs.fixed
+++ b/tests/ui/floating_point_abs.fixed
@@ -84,15 +84,15 @@ fn not_fake_abs5(a: A) -> f64 {
 fn main() {
     fake_abs1(5.0);
     fake_abs2(5.0);
-    fake_abs3(A { a: 5.0, b: 5.0 } );
+    fake_abs3(A { a: 5.0, b: 5.0 });
     fake_abs4(5.0);
-    fake_abs5(A { a: 5.0, b: 5.0 } );
+    fake_abs5(A { a: 5.0, b: 5.0 });
     fake_nabs1(5.0);
     fake_nabs2(5.0);
-    fake_nabs3(A { a: 5.0, b: 5.0 } );
+    fake_nabs3(A { a: 5.0, b: 5.0 });
     not_fake_abs1(5.0);
     not_fake_abs2(5.0);
     not_fake_abs3(5.0, 5.0);
-    not_fake_abs4(A { a: 5.0, b: 5.0 } );
-    not_fake_abs5(A { a: 5.0, b: 5.0 } );
+    not_fake_abs4(A { a: 5.0, b: 5.0 });
+    not_fake_abs5(A { a: 5.0, b: 5.0 });
 }

--- a/tests/ui/floating_point_abs.fixed
+++ b/tests/ui/floating_point_abs.fixed
@@ -7,64 +7,36 @@ struct A {
 }
 
 fn fake_abs1(num: f64) -> f64 {
-    if num >= 0.0 {
-        num
-    } else {
-        -num
-    }
+    num.abs()
 }
 
 fn fake_abs2(num: f64) -> f64 {
-    if 0.0 < num {
-        num
-    } else {
-        -num
-    }
+    num.abs()
 }
 
 fn fake_abs3(a: A) -> f64 {
-    if a.a > 0.0 {
-        a.a
-    } else {
-        -a.a
-    }
+    a.a.abs()
 }
 
 fn fake_abs4(num: f64) -> f64 {
-    if 0.0 >= num {
-        -num
-    } else {
-        num
-    }
+    num.abs()
 }
 
 fn fake_abs5(a: A) -> f64 {
-    if a.a < 0.0 {
-        -a.a
-    } else {
-        a.a
-    }
+    a.a.abs()
 }
 
 fn fake_nabs1(num: f64) -> f64 {
-    if num < 0.0 {
-        num
-    } else {
-        -num
-    }
+    -num.abs()
 }
 
 fn fake_nabs2(num: f64) -> f64 {
-    if 0.0 >= num {
-        num
-    } else {
-        -num
-    }
+    -num.abs()
 }
 
 fn fake_nabs3(a: A) -> A {
     A {
-        a: if a.a >= 0.0 { -a.a } else { a.a },
+        a: -a.a.abs(),
         b: a.b,
     }
 }

--- a/tests/ui/floating_point_abs.rs
+++ b/tests/ui/floating_point_abs.rs
@@ -1,4 +1,5 @@
-#[warn(clippy::suboptimal_flops)]
+#![warn(clippy::suboptimal_flops)]
+
 struct A {
     a: f64,
     b: f64
@@ -28,6 +29,22 @@ fn fake_abs3(a: A) -> f64 {
     }
 }
 
+fn fake_abs4(num: f64) -> f64 {
+    if 0.0 >= num {
+        -num
+    } else {
+        num
+    }
+}
+
+fn fake_abs5(a: A) -> f64 {
+    if a.a < 0.0 {
+        -a.a
+    } else {
+        a.a
+    }
+}
+
 fn fake_nabs1(num: f64) -> f64 {
     if num < 0.0 {
         num
@@ -46,9 +63,9 @@ fn fake_nabs2(num: f64) -> f64 {
 
 fn fake_nabs3(a: A) -> A {
     A { a: if a.a >= 0.0 {
-            a.a
-        } else {
             -a.a
+        } else {
+            a.a
         }, b: a.b }
 }
 

--- a/tests/ui/floating_point_abs.rs
+++ b/tests/ui/floating_point_abs.rs
@@ -2,7 +2,7 @@
 
 struct A {
     a: f64,
-    b: f64
+    b: f64,
 }
 
 fn fake_abs1(num: f64) -> f64 {
@@ -62,11 +62,10 @@ fn fake_nabs2(num: f64) -> f64 {
 }
 
 fn fake_nabs3(a: A) -> A {
-    A { a: if a.a >= 0.0 {
-            -a.a
-        } else {
-            a.a
-        }, b: a.b }
+    A {
+        a: if a.a >= 0.0 { -a.a } else { a.a },
+        b: a.b,
+    }
 }
 
 fn not_fake_abs1(num: f64) -> f64 {

--- a/tests/ui/floating_point_abs.rs
+++ b/tests/ui/floating_point_abs.rs
@@ -1,0 +1,59 @@
+#[warn(clippy::suboptimal_flops)]
+
+fn fake_abs1(num: f64) -> f64 {
+    if num >= 0.0 {
+        num
+    } else {
+        -num
+    }
+}
+
+fn fake_abs2(num: f64) -> f64 {
+    if 0.0 < num {
+        num
+    } else {
+        -num
+    }
+}
+
+fn fake_nabs1(num: f64) -> f64 {
+    if num < 0.0 {
+        num
+    } else {
+        -num
+    }
+}
+
+fn fake_nabs2(num: f64) -> f64 {
+    if 0.0 >= num {
+        num
+    } else {
+        -num
+    }
+}
+
+fn not_fake_abs1(num: f64) -> f64 {
+    if num > 0.0 {
+        num
+    } else {
+        -num - 1f64
+    }
+}
+
+fn not_fake_abs2(num: f64) -> f64 {
+    if num > 0.0 {
+        num + 1.0
+    } else {
+        -(num + 1.0)
+    }
+}
+
+fn not_fake_abs3(num1: f64, num2: f64) -> f64 {
+    if num1 > 0.0 {
+        num2
+    } else {
+        -num2
+    }
+}
+
+fn main() {}

--- a/tests/ui/floating_point_abs.rs
+++ b/tests/ui/floating_point_abs.rs
@@ -112,15 +112,15 @@ fn not_fake_abs5(a: A) -> f64 {
 fn main() {
     fake_abs1(5.0);
     fake_abs2(5.0);
-    fake_abs3(A { a: 5.0, b: 5.0 } );
+    fake_abs3(A { a: 5.0, b: 5.0 });
     fake_abs4(5.0);
-    fake_abs5(A { a: 5.0, b: 5.0 } );
+    fake_abs5(A { a: 5.0, b: 5.0 });
     fake_nabs1(5.0);
     fake_nabs2(5.0);
-    fake_nabs3(A { a: 5.0, b: 5.0 } );
+    fake_nabs3(A { a: 5.0, b: 5.0 });
     not_fake_abs1(5.0);
     not_fake_abs2(5.0);
     not_fake_abs3(5.0, 5.0);
-    not_fake_abs4(A { a: 5.0, b: 5.0 } );
-    not_fake_abs5(A { a: 5.0, b: 5.0 } );
+    not_fake_abs4(A { a: 5.0, b: 5.0 });
+    not_fake_abs5(A { a: 5.0, b: 5.0 });
 }

--- a/tests/ui/floating_point_abs.rs
+++ b/tests/ui/floating_point_abs.rs
@@ -1,4 +1,8 @@
 #[warn(clippy::suboptimal_flops)]
+struct A {
+    a: f64,
+    b: f64
+}
 
 fn fake_abs1(num: f64) -> f64 {
     if num >= 0.0 {
@@ -16,6 +20,14 @@ fn fake_abs2(num: f64) -> f64 {
     }
 }
 
+fn fake_abs3(a: A) -> f64 {
+    if a.a > 0.0 {
+        a.a
+    } else {
+        -a.a
+    }
+}
+
 fn fake_nabs1(num: f64) -> f64 {
     if num < 0.0 {
         num
@@ -30,6 +42,14 @@ fn fake_nabs2(num: f64) -> f64 {
     } else {
         -num
     }
+}
+
+fn fake_nabs3(a: A) -> A {
+    A { a: if a.a >= 0.0 {
+            a.a
+        } else {
+            -a.a
+        }, b: a.b }
 }
 
 fn not_fake_abs1(num: f64) -> f64 {
@@ -53,6 +73,22 @@ fn not_fake_abs3(num1: f64, num2: f64) -> f64 {
         num2
     } else {
         -num2
+    }
+}
+
+fn not_fake_abs4(a: A) -> f64 {
+    if a.a > 0.0 {
+        a.b
+    } else {
+        -a.b
+    }
+}
+
+fn not_fake_abs5(a: A) -> f64 {
+    if a.a > 0.0 {
+        a.a
+    } else {
+        -a.b
     }
 }
 

--- a/tests/ui/floating_point_abs.stderr
+++ b/tests/ui/floating_point_abs.stderr
@@ -1,0 +1,14 @@
+error: This looks like you've implemented your own absolute value function
+  --> $DIR/floating_point_abs.rs:4:5
+   |
+LL | /     if num >= 0.0 {
+LL | |         num
+LL | |     } else {
+LL | |         -num
+LL | |     }
+   | |_____^ help: try: `num.abs()`
+   |
+   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/tests/ui/floating_point_abs.stderr
+++ b/tests/ui/floating_point_abs.stderr
@@ -1,5 +1,5 @@
-error: This looks like you've implemented your own absolute value function
-  --> $DIR/floating_point_abs.rs:9:5
+error: manual implementation of `abs` method
+  --> $DIR/floating_point_abs.rs:10:5
    |
 LL | /     if num >= 0.0 {
 LL | |         num
@@ -10,8 +10,8 @@ LL | |     }
    |
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
-error: This looks like you've implemented your own absolute value function
-  --> $DIR/floating_point_abs.rs:17:5
+error: manual implementation of `abs` method
+  --> $DIR/floating_point_abs.rs:18:5
    |
 LL | /     if 0.0 < num {
 LL | |         num
@@ -20,8 +20,8 @@ LL | |         -num
 LL | |     }
    | |_____^ help: try: `num.abs()`
 
-error: This looks like you've implemented your own absolute value function
-  --> $DIR/floating_point_abs.rs:25:5
+error: manual implementation of `abs` method
+  --> $DIR/floating_point_abs.rs:26:5
    |
 LL | /     if a.a > 0.0 {
 LL | |         a.a
@@ -30,8 +30,8 @@ LL | |         -a.a
 LL | |     }
    | |_____^ help: try: `a.a.abs()`
 
-error: This looks like you've implemented your own absolute value function
-  --> $DIR/floating_point_abs.rs:33:5
+error: manual implementation of `abs` method
+  --> $DIR/floating_point_abs.rs:34:5
    |
 LL | /     if 0.0 >= num {
 LL | |         -num
@@ -40,8 +40,8 @@ LL | |         num
 LL | |     }
    | |_____^ help: try: `num.abs()`
 
-error: This looks like you've implemented your own absolute value function
-  --> $DIR/floating_point_abs.rs:41:5
+error: manual implementation of `abs` method
+  --> $DIR/floating_point_abs.rs:42:5
    |
 LL | /     if a.a < 0.0 {
 LL | |         -a.a
@@ -50,8 +50,8 @@ LL | |         a.a
 LL | |     }
    | |_____^ help: try: `a.a.abs()`
 
-error: This looks like you've implemented your own negative absolute value function
-  --> $DIR/floating_point_abs.rs:49:5
+error: manual implementation of negation of `abs` method
+  --> $DIR/floating_point_abs.rs:50:5
    |
 LL | /     if num < 0.0 {
 LL | |         num
@@ -60,8 +60,8 @@ LL | |         -num
 LL | |     }
    | |_____^ help: try: `-num.abs()`
 
-error: This looks like you've implemented your own negative absolute value function
-  --> $DIR/floating_point_abs.rs:57:5
+error: manual implementation of negation of `abs` method
+  --> $DIR/floating_point_abs.rs:58:5
    |
 LL | /     if 0.0 >= num {
 LL | |         num
@@ -70,8 +70,8 @@ LL | |         -num
 LL | |     }
    | |_____^ help: try: `-num.abs()`
 
-error: This looks like you've implemented your own negative absolute value function
-  --> $DIR/floating_point_abs.rs:66:12
+error: manual implementation of negation of `abs` method
+  --> $DIR/floating_point_abs.rs:67:12
    |
 LL |         a: if a.a >= 0.0 { -a.a } else { a.a },
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `-a.a.abs()`

--- a/tests/ui/floating_point_abs.stderr
+++ b/tests/ui/floating_point_abs.stderr
@@ -71,15 +71,10 @@ LL | |     }
    | |_____^ help: try: `-num.abs()`
 
 error: This looks like you've implemented your own negative absolute value function
-  --> $DIR/floating_point_abs.rs:65:12
+  --> $DIR/floating_point_abs.rs:66:12
    |
-LL |       A { a: if a.a >= 0.0 {
-   |  ____________^
-LL | |             -a.a
-LL | |         } else {
-LL | |             a.a
-LL | |         }, b: a.b }
-   | |_________^ help: try: `-a.a.abs()`
+LL |         a: if a.a >= 0.0 { -a.a } else { a.a },
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `-a.a.abs()`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/floating_point_abs.stderr
+++ b/tests/ui/floating_point_abs.stderr
@@ -1,5 +1,5 @@
 error: This looks like you've implemented your own absolute value function
-  --> $DIR/floating_point_abs.rs:4:5
+  --> $DIR/floating_point_abs.rs:9:5
    |
 LL | /     if num >= 0.0 {
 LL | |         num
@@ -10,5 +10,76 @@ LL | |     }
    |
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
-error: aborting due to previous error
+error: This looks like you've implemented your own absolute value function
+  --> $DIR/floating_point_abs.rs:17:5
+   |
+LL | /     if 0.0 < num {
+LL | |         num
+LL | |     } else {
+LL | |         -num
+LL | |     }
+   | |_____^ help: try: `num.abs()`
+
+error: This looks like you've implemented your own absolute value function
+  --> $DIR/floating_point_abs.rs:25:5
+   |
+LL | /     if a.a > 0.0 {
+LL | |         a.a
+LL | |     } else {
+LL | |         -a.a
+LL | |     }
+   | |_____^ help: try: `a.a.abs()`
+
+error: This looks like you've implemented your own absolute value function
+  --> $DIR/floating_point_abs.rs:33:5
+   |
+LL | /     if 0.0 >= num {
+LL | |         -num
+LL | |     } else {
+LL | |         num
+LL | |     }
+   | |_____^ help: try: `num.abs()`
+
+error: This looks like you've implemented your own absolute value function
+  --> $DIR/floating_point_abs.rs:41:5
+   |
+LL | /     if a.a < 0.0 {
+LL | |         -a.a
+LL | |     } else {
+LL | |         a.a
+LL | |     }
+   | |_____^ help: try: `a.a.abs()`
+
+error: This looks like you've implemented your own negative absolute value function
+  --> $DIR/floating_point_abs.rs:49:5
+   |
+LL | /     if num < 0.0 {
+LL | |         num
+LL | |     } else {
+LL | |         -num
+LL | |     }
+   | |_____^ help: try: `-num.abs()`
+
+error: This looks like you've implemented your own negative absolute value function
+  --> $DIR/floating_point_abs.rs:57:5
+   |
+LL | /     if 0.0 >= num {
+LL | |         num
+LL | |     } else {
+LL | |         -num
+LL | |     }
+   | |_____^ help: try: `-num.abs()`
+
+error: This looks like you've implemented your own negative absolute value function
+  --> $DIR/floating_point_abs.rs:65:12
+   |
+LL |       A { a: if a.a >= 0.0 {
+   |  ____________^
+LL | |             -a.a
+LL | |         } else {
+LL | |             a.a
+LL | |         }, b: a.b }
+   | |_________^ help: try: `-a.a.abs()`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Closes #5224  

changelog: Enhance [`suboptimal_flops`] lint to detect manual implementations of the `abs` method