### PR TITLE
Whitelist unused attribute for use items.

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -248,6 +248,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Attributes {
                                                 if is_word(lint, sym!(unused_imports))
                                                     || is_word(lint, sym!(deprecated))
                                                     || is_word(lint, sym!(unreachable_pub))
+                                                    || is_word(lint, sym!(unused))
                                                 {
                                                     return;
                                                 }

--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -20,6 +20,10 @@ extern crate proc_macro_derive;
 #[allow(unused_imports)]
 use std::collections;
 
+// don't lint on unused for `use` items
+#[allow(unused)]
+use std::option;
+
 // don't lint on deprecated for `use` items
 mod foo {
     #[deprecated]

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -20,6 +20,10 @@ extern crate proc_macro_derive;
 #[allow(unused_imports)]
 use std::collections;
 
+// don't lint on unused for `use` items
+#[allow(unused)]
+use std::option;
+
 // don't lint on deprecated for `use` items
 mod foo {
     #[deprecated]

--- a/tests/ui/useless_attribute.stderr
+++ b/tests/ui/useless_attribute.stderr
@@ -13,7 +13,7 @@ LL | #[cfg_attr(feature = "cargo-clippy", allow(dead_code))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![cfg_attr(feature = "cargo-clippy", allow(dead_code)`
 
 error: useless lint attribute
-  --> $DIR/useless_attribute.rs:49:5
+  --> $DIR/useless_attribute.rs:53:5
    |
 LL |     #[allow(clippy::almost_swapped)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![allow(clippy::almost_swapped)]`


### PR DESCRIPTION
This PR whitelists the `unused` attribute with `use` items and adds a corresponding test case.

Fixes: #5229
changelog: none
