### PR TITLE
Revive rls integration test

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -231,8 +231,7 @@ jobs:
       matrix:
         integration:
         - 'rust-lang/cargo'
-        # FIXME: Re-enable once we can test with rls again.
-        # - 'rust-lang/rls'
+        - 'rust-lang/rls'
         - 'rust-lang/chalk'
         - 'rust-lang/rustfmt'
         - 'Marwes/combine'


### PR DESCRIPTION
RLS updated their dependencies in rust-lang/rls#1646 so we can revive the integration test. I confirm it passed on my local.

changelog: none
