### PR TITLE
Rename macro_use_import -> macro_use_imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1209,7 +1209,7 @@ Released 2018-09-13
 [`linkedlist`]: https://rust-lang.github.io/rust-clippy/master/index.html#linkedlist
 [`logic_bug`]: https://rust-lang.github.io/rust-clippy/master/index.html#logic_bug
 [`lossy_float_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#lossy_float_literal
-[`macro_use_import`]: https://rust-lang.github.io/rust-clippy/master/index.html#macro_use_import
+[`macro_use_imports`]: https://rust-lang.github.io/rust-clippy/master/index.html#macro_use_imports
 [`main_recursion`]: https://rust-lang.github.io/rust-clippy/master/index.html#main_recursion
 [`manual_memcpy`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_memcpy
 [`manual_saturating_arithmetic`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -600,7 +600,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         &loops::WHILE_IMMUTABLE_CONDITION,
         &loops::WHILE_LET_LOOP,
         &loops::WHILE_LET_ON_ITERATOR,
-        &macro_use::MACRO_USE_IMPORT,
+        &macro_use::MACRO_USE_IMPORTS,
         &main_recursion::MAIN_RECURSION,
         &map_clone::MAP_CLONE,
         &map_unit_fn::OPTION_MAP_UNIT_FN,
@@ -1014,7 +1014,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_early_pass(move || box excessive_bools::ExcessiveBools::new(max_struct_bools, max_fn_params_bools));
     store.register_early_pass(|| box option_env_unwrap::OptionEnvUnwrap);
     store.register_late_pass(|| box wildcard_imports::WildcardImports);
-    store.register_early_pass(|| box macro_use::MacroUseImport);
+    store.register_early_pass(|| box macro_use::MacroUseImports);
 
     store.register_group(true, "clippy::restriction", Some("clippy_restriction"), vec![
         LintId::of(&arithmetic::FLOAT_ARITHMETIC),
@@ -1082,7 +1082,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&literal_representation::LARGE_DIGIT_GROUPS),
         LintId::of(&loops::EXPLICIT_INTO_ITER_LOOP),
         LintId::of(&loops::EXPLICIT_ITER_LOOP),
-        LintId::of(&macro_use::MACRO_USE_IMPORT),
+        LintId::of(&macro_use::MACRO_USE_IMPORTS),
         LintId::of(&matches::SINGLE_MATCH_ELSE),
         LintId::of(&methods::FILTER_MAP),
         LintId::of(&methods::FILTER_MAP_NEXT),

--- a/clippy_lints/src/macro_use.rs
+++ b/clippy_lints/src/macro_use.rs
@@ -19,14 +19,14 @@ declare_clippy_lint! {
     /// #[macro_use]
     /// use lazy_static;
     /// ```
-    pub MACRO_USE_IMPORT,
+    pub MACRO_USE_IMPORTS,
     pedantic,
     "#[macro_use] is no longer needed"
 }
 
-declare_lint_pass!(MacroUseImport => [MACRO_USE_IMPORT]);
+declare_lint_pass!(MacroUseImports => [MACRO_USE_IMPORTS]);
 
-impl EarlyLintPass for MacroUseImport {
+impl EarlyLintPass for MacroUseImports {
     fn check_item(&mut self, ecx: &EarlyContext<'_>, item: &ast::Item) {
         if_chain! {
             if ecx.sess.opts.edition == Edition::Edition2018;
@@ -40,7 +40,7 @@ impl EarlyLintPass for MacroUseImport {
                 let help = format!("use {}::<macro name>", snippet(ecx, use_tree.span, "_"));
                 span_lint_and_sugg(
                     ecx,
-                    MACRO_USE_IMPORT,
+                    MACRO_USE_IMPORTS,
                     mac_attr.span,
                     msg,
                     "remove the attribute and import the macro directly, try",

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1016,7 +1016,7 @@ pub const ALL_LINTS: [Lint; 360] = [
         module: "float_literal",
     },
     Lint {
-        name: "macro_use_import",
+        name: "macro_use_imports",
         group: "pedantic",
         desc: "#[macro_use] is no longer needed",
         deprecation: None,

--- a/tests/ui/macro_use_imports.rs
+++ b/tests/ui/macro_use_imports.rs
@@ -1,5 +1,5 @@
 // compile-flags: --edition 2018
-#![warn(clippy::macro_use_import)]
+#![warn(clippy::macro_use_imports)]
 
 use std::collections::HashMap;
 #[macro_use]

--- a/tests/ui/macro_use_imports.stderr
+++ b/tests/ui/macro_use_imports.stderr
@@ -1,10 +1,10 @@
 error: `macro_use` attributes are no longer needed in the Rust 2018 edition
-  --> $DIR/macro_use_import.rs:5:1
+  --> $DIR/macro_use_imports.rs:5:1
    |
 LL | #[macro_use]
    | ^^^^^^^^^^^^ help: remove the attribute and import the macro directly, try: `use std::prelude::<macro name>`
    |
-   = note: `-D clippy::macro-use-import` implied by `-D warnings`
+   = note: `-D clippy::macro-use-imports` implied by `-D warnings`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
I missed this during review of #5230. We can just do this, without deprecating the old name, since this lint didn't hit nightly rustc yet.

changelog: none
