### PR TITLE
Update rustc-guide to rustc-dev-guide

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -419,7 +419,7 @@ Here are some pointers to things you are likely going to need for every lint:
 * [`from_expansion`][from_expansion] and [`in_external_macro`][in_external_macro]
 * [`Span`][span]
 * [`Applicability`][applicability]
-* [The rustc guide][rustc_guide] explains a lot of internal compiler concepts
+* [The rustc-dev-guide][rustc-dev-guide] explains a lot of internal compiler concepts
 * [The nightly rustc docs][nightly_docs] which has been linked to throughout
   this guide
 
@@ -459,5 +459,5 @@ don't hesitate to ask on Discord, IRC or in the issue/PR.
 [in_external_macro]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/lint/fn.in_external_macro.html
 [play]: https://play.rust-lang.org
 [author_example]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=f093b986e80ad62f3b67a1f24f5e66e2
-[rustc_guide]: https://rust-lang.github.io/rustc-guide/
+[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
 [nightly_docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -459,5 +459,5 @@ don't hesitate to ask on Discord, IRC or in the issue/PR.
 [in_external_macro]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/lint/fn.in_external_macro.html
 [play]: https://play.rust-lang.org
 [author_example]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=f093b986e80ad62f3b67a1f24f5e66e2
-[rustc-dev-guide]: https://rust-lang.github.io/rustc-dev-guide/
+[rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
 [nightly_docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/


### PR DESCRIPTION
The rustc-guide is being renamed to the rustc-dev-guide. The discussion is in rust-lang/rustc-guide#470.

This PR revises rustc-guide to rustc-dev-guide in the Readme Markdown file.

Transition tracker: rust-lang/rustc-guide#602

changelog: none