### PR TITLE
redundant_pattern: take binding (ref, ref mut) into account in suggestion

### DIFF
--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -5,8 +5,8 @@ use crate::utils::{
 use if_chain::if_chain;
 use rustc::lint::in_external_macro;
 use rustc_ast::ast::{
-    Block, Expr, ExprKind, GenericParamKind, Generics, Lit, LitFloatType, LitIntType, LitKind, NodeId, Pat, PatKind,
-    StmtKind, UnOp,
+    BindingMode, Block, Expr, ExprKind, GenericParamKind, Generics, Lit, LitFloatType, LitIntType, LitKind, Mutability,
+    NodeId, Pat, PatKind, StmtKind, UnOp,
 };
 use rustc_ast::visit::{walk_expr, FnKind, Visitor};
 use rustc_data_structures::fx::FxHashMap;
@@ -355,7 +355,13 @@ impl EarlyLintPass for MiscEarlyLints {
             }
         }
 
-        if let PatKind::Ident(_, ident, Some(ref right)) = pat.kind {
+        if let PatKind::Ident(left, ident, Some(ref right)) = pat.kind {
+            let left_binding = match left {
+                BindingMode::ByRef(Mutability::Mut) => "ref mut ",
+                BindingMode::ByRef(Mutability::Not) => "ref ",
+                _ => "",
+            };
+
             if let PatKind::Wild = right.kind {
                 span_lint_and_sugg(
                     cx,
@@ -366,7 +372,7 @@ impl EarlyLintPass for MiscEarlyLints {
                         ident.name, ident.name,
                     ),
                     "try",
-                    format!("{}", ident.name),
+                    format!("{}{}", left_binding, ident.name),
                     Applicability::MachineApplicable,
                 );
             }

--- a/tests/ui/patterns.fixed
+++ b/tests/ui/patterns.fixed
@@ -17,4 +17,20 @@ fn main() {
         [x, inside @ .., y] => (), // no error
         [..] => (),
     }
+
+    let mut mutv = vec![1, 2, 3];
+
+    // required "ref" left out in suggestion: #5271
+    match mutv {
+        ref mut x => {
+            x.push(4);
+            println!("vec: {:?}", x);
+        },
+        ref y if y == &vec![0] => (),
+    }
+
+    match mutv {
+        ref x => println!("vec: {:?}", x),
+        ref y if y == &vec![0] => (),
+    }
 }

--- a/tests/ui/patterns.rs
+++ b/tests/ui/patterns.rs
@@ -17,4 +17,20 @@ fn main() {
         [x, inside @ .., y] => (), // no error
         [..] => (),
     }
+
+    let mut mutv = vec![1, 2, 3];
+
+    // required "ref" left out in suggestion: #5271
+    match mutv {
+        ref mut x @ _ => {
+            x.push(4);
+            println!("vec: {:?}", x);
+        },
+        ref y if y == &vec![0] => (),
+    }
+
+    match mutv {
+        ref x @ _ => println!("vec: {:?}", x),
+        ref y if y == &vec![0] => (),
+    }
 }

--- a/tests/ui/patterns.stderr
+++ b/tests/ui/patterns.stderr
@@ -6,5 +6,17 @@ LL |         y @ _ => (),
    |
    = note: `-D clippy::redundant-pattern` implied by `-D warnings`
 
-error: aborting due to previous error
+error: the `x @ _` pattern can be written as just `x`
+  --> $DIR/patterns.rs:25:9
+   |
+LL |         ref mut x @ _ => {
+   |         ^^^^^^^^^^^^^ help: try: `ref mut x`
+
+error: the `x @ _` pattern can be written as just `x`
+  --> $DIR/patterns.rs:33:9
+   |
+LL |         ref x @ _ => println!("vec: {:?}", x),
+   |         ^^^^^^^^^ help: try: `ref x`
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
fixes #5271

changelog: redundant_pattern: take binding (ref, ref mut) into account in suggestion (#5271)
