### PR TITLE
Improve placeholder in map_unit_fn

### DIFF
--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -186,12 +186,12 @@ fn unit_closure<'a, 'tcx>(
 /// `x.field` => `x_field`
 /// `y` => `_y`
 ///
-/// Anything else will return `_`.
+/// Anything else will return `a`.
 fn let_binding_name(cx: &LateContext<'_, '_>, var_arg: &hir::Expr<'_>) -> String {
     match &var_arg.kind {
         hir::ExprKind::Field(_, _) => snippet(cx, var_arg.span, "_").replace(".", "_"),
         hir::ExprKind::Path(_) => format!("_{}", snippet(cx, var_arg.span, "")),
-        _ => "_".to_string(),
+        _ => "a".to_string(),
     }
 }
 

--- a/tests/ui/option_map_unit_fn_fixable.fixed
+++ b/tests/ui/option_map_unit_fn_fixable.fixed
@@ -13,6 +13,10 @@ fn plus_one(value: usize) -> usize {
     value + 1
 }
 
+fn option() -> Option<usize> {
+    Some(10)
+}
+
 struct HasOption {
     field: Option<usize>,
 }
@@ -73,6 +77,8 @@ fn option_map_unit_fn() {
     if let Some(value) = x.field { plus_one(value + captured); }
 
 
-    if let Some(ref value) = x.field { do_nothing(value + captured) }}
+    if let Some(ref value) = x.field { do_nothing(value + captured) }
+
+    if let Some(a) = option() { do_nothing(a) }}
 
 fn main() {}

--- a/tests/ui/option_map_unit_fn_fixable.rs
+++ b/tests/ui/option_map_unit_fn_fixable.rs
@@ -13,6 +13,10 @@ fn plus_one(value: usize) -> usize {
     value + 1
 }
 
+fn option() -> Option<usize> {
+    Some(10)
+}
+
 struct HasOption {
     field: Option<usize>,
 }
@@ -73,6 +77,8 @@ fn option_map_unit_fn() {
     x.field.map(|value| { { plus_one(value + captured); } });
 
 
-    x.field.map(|ref value| { do_nothing(value + captured) });}
+    x.field.map(|ref value| { do_nothing(value + captured) });
+
+    option().map(do_nothing);}
 
 fn main() {}

--- a/tests/ui/option_map_unit_fn_fixable.stderr
+++ b/tests/ui/option_map_unit_fn_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:34:5
+  --> $DIR/option_map_unit_fn_fixable.rs:38:5
    |
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
@@ -9,7 +9,7 @@ LL |     x.field.map(do_nothing);
    = note: `-D clippy::option-map-unit-fn` implied by `-D warnings`
 
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:36:5
+  --> $DIR/option_map_unit_fn_fixable.rs:40:5
    |
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
@@ -17,7 +17,7 @@ LL |     x.field.map(do_nothing);
    |     help: try this: `if let Some(x_field) = x.field { do_nothing(x_field) }`
 
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:38:5
+  --> $DIR/option_map_unit_fn_fixable.rs:42:5
    |
 LL |     x.field.map(diverge);
    |     ^^^^^^^^^^^^^^^^^^^^-
@@ -25,7 +25,7 @@ LL |     x.field.map(diverge);
    |     help: try this: `if let Some(x_field) = x.field { diverge(x_field) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:44:5
+  --> $DIR/option_map_unit_fn_fixable.rs:48:5
    |
 LL |     x.field.map(|value| x.do_option_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -33,7 +33,7 @@ LL |     x.field.map(|value| x.do_option_nothing(value + captured));
    |     help: try this: `if let Some(value) = x.field { x.do_option_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:46:5
+  --> $DIR/option_map_unit_fn_fixable.rs:50:5
    |
 LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -41,7 +41,7 @@ LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
    |     help: try this: `if let Some(value) = x.field { x.do_option_plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:49:5
+  --> $DIR/option_map_unit_fn_fixable.rs:53:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -49,7 +49,7 @@ LL |     x.field.map(|value| do_nothing(value + captured));
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:51:5
+  --> $DIR/option_map_unit_fn_fixable.rs:55:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -57,7 +57,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:53:5
+  --> $DIR/option_map_unit_fn_fixable.rs:57:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -65,7 +65,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:55:5
+  --> $DIR/option_map_unit_fn_fixable.rs:59:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -73,7 +73,7 @@ LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:58:5
+  --> $DIR/option_map_unit_fn_fixable.rs:62:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -81,7 +81,7 @@ LL |     x.field.map(|value| diverge(value + captured));
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:60:5
+  --> $DIR/option_map_unit_fn_fixable.rs:64:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -89,7 +89,7 @@ LL |     x.field.map(|value| { diverge(value + captured) });
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:62:5
+  --> $DIR/option_map_unit_fn_fixable.rs:66:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -97,7 +97,7 @@ LL |     x.field.map(|value| { diverge(value + captured); });
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:64:5
+  --> $DIR/option_map_unit_fn_fixable.rs:68:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -105,7 +105,7 @@ LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:69:5
+  --> $DIR/option_map_unit_fn_fixable.rs:73:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -113,7 +113,7 @@ LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     help: try this: `if let Some(value) = x.field { let y = plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:71:5
+  --> $DIR/option_map_unit_fn_fixable.rs:75:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -121,7 +121,7 @@ LL |     x.field.map(|value| { plus_one(value + captured); });
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:73:5
+  --> $DIR/option_map_unit_fn_fixable.rs:77:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -129,12 +129,20 @@ LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
-  --> $DIR/option_map_unit_fn_fixable.rs:76:5
+  --> $DIR/option_map_unit_fn_fixable.rs:80:5
    |
-LL |     x.field.map(|ref value| { do_nothing(value + captured) });}
+LL |     x.field.map(|ref value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
    |     help: try this: `if let Some(ref value) = x.field { do_nothing(value + captured) }`
 
-error: aborting due to 17 previous errors
+error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
+  --> $DIR/option_map_unit_fn_fixable.rs:82:5
+   |
+LL |     option().map(do_nothing);}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-
+   |     |
+   |     help: try this: `if let Some(a) = option() { do_nothing(a) }`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Instead of using `_` as a default placeholder use `a`.

fixes #5180 
changelog: Improve default placeholder in map_unit_fn
