### PR TITLE
clippy_lints: readme: don't mention crates.io since it is no longer used to publish clippy

### DIFF
--- a/clippy_lints/README.md
+++ b/clippy_lints/README.md
@@ -1,3 +1,1 @@
-This crate contains Clippy lints. For the main crate, check
-[*crates.io*](https://crates.io/crates/clippy) or
-[GitHub](https://github.com/rust-lang/rust-clippy).
+This crate contains Clippy lints. For the main crate, check [GitHub](https://github.com/rust-lang/rust-clippy).


### PR DESCRIPTION
changelog: none
