### PR TITLE
needless_doc_main: only check rust code

### DIFF
--- a/tests/ui/needless_doc_main.rs
+++ b/tests/ui/needless_doc_main.rs
@@ -51,7 +51,7 @@ fn bad_doctests() {}
 /// }
 /// ```
 ///
-/// We should not lint non-rust examples:
+/// We should not lint ignored examples:
 ///
 /// ```rust,ignore
 /// fn main() {

--- a/tests/ui/needless_doc_main.rs
+++ b/tests/ui/needless_doc_main.rs
@@ -8,7 +8,23 @@
 ///     unimplemented!();
 /// }
 /// ```
-fn bad_doctest() {}
+///
+/// This should, too.
+///
+/// ```rust
+/// fn main() {
+///     unimplemented!();
+/// }
+/// ```
+///
+/// This one too.
+///
+/// ```no_run
+/// fn main() {
+///     unimplemented!();
+/// }
+/// ```
+fn bad_doctests() {}
 
 /// # Examples
 ///
@@ -34,9 +50,25 @@ fn bad_doctest() {}
 ///     assert_eq(1u8, test::black_box(1));
 /// }
 /// ```
+///
+/// We should not lint non-rust examples:
+///
+/// ```rust,ignore
+/// fn main() {
+///     unimplemented!();
+/// }
+/// ```
+///
+/// Or even non-rust examples:
+///
+/// ```text
+/// fn main() {
+///     is what starts the program
+/// }
+/// ```
 fn no_false_positives() {}
 
 fn main() {
-    bad_doctest();
+    bad_doctests();
     no_false_positives();
 }

--- a/tests/ui/needless_doc_main.stderr
+++ b/tests/ui/needless_doc_main.stderr
@@ -6,5 +6,17 @@ LL | /// fn main() {
    |
    = note: `-D clippy::needless-doctest-main` implied by `-D warnings`
 
-error: aborting due to previous error
+error: needless `fn main` in doctest
+  --> $DIR/needless_doc_main.rs:15:4
+   |
+LL | /// fn main() {
+   |    ^^^^^^^^^^^^
+
+error: needless `fn main` in doctest
+  --> $DIR/needless_doc_main.rs:23:4
+   |
+LL | /// fn main() {
+   |    ^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This fixes #5280 by checking the language attribute on code blocks.

---

changelog: none
