### PR TITLE
Use `edition:2018` flag more widely

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ and resolved paths.
 [`T-AST`] issues will generally need you to match against a predefined syntax structure.
 To figure out how this syntax structure is encoded in the AST, it is recommended to run
 `rustc -Z ast-json` on an example of the structure and compare with the [nodes in the AST docs].
-Usually the lint will end up to be a nested series of matches and ifs, [like so].
+Usually the lint will end up to be a nested series of matches and ifs, [like so][deep-nesting].
+But we can make it nest-less by using [if_chain] macro, [like this][nest-less].
 
 [`E-medium`] issues are generally pretty easy too, though it's recommended you work on an E-easy issue first.
 They are mostly classified as [`E-medium`], since they might be somewhat involved code wise,
@@ -71,7 +72,9 @@ an AST expression). `match_def_path()` in Clippy's `utils` module can also be us
 [`E-medium`]: https://github.com/rust-lang/rust-clippy/labels/E-medium
 [`ty`]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty
 [nodes in the AST docs]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/ast/
-[like so]: https://github.com/rust-lang/rust-clippy/blob/de5ccdfab68a5e37689f3c950ed1532ba9d652a0/src/misc.rs#L34
+[deep-nesting]: https://github.com/rust-lang/rust-clippy/blob/557f6848bd5b7183f55c1e1522a326e9e1df6030/clippy_lints/src/mem_forget.rs#L29-L43
+[if_chain]: https://docs.rs/if_chain/*/if_chain
+[nest-less]: https://github.com/rust-lang/rust-clippy/blob/557f6848bd5b7183f55c1e1522a326e9e1df6030/clippy_lints/src/bit_mask.rs#L124-L150
 
 ## Writing code
 

--- a/tests/ui/doc_errors.rs
+++ b/tests/ui/doc_errors.rs
@@ -1,4 +1,4 @@
-// compile-flags: --edition 2018
+// edition:2018
 #![warn(clippy::missing_errors_doc)]
 
 use std::io;

--- a/tests/ui/issue_4266.rs
+++ b/tests/ui/issue_4266.rs
@@ -1,4 +1,4 @@
-// compile-flags: --edition 2018
+// edition:2018
 #![allow(dead_code)]
 
 async fn sink1<'a>(_: &'a str) {} // lint

--- a/tests/ui/macro_use_imports.rs
+++ b/tests/ui/macro_use_imports.rs
@@ -1,4 +1,4 @@
-// compile-flags: --edition 2018
+// edition:2018
 #![warn(clippy::macro_use_imports)]
 
 use std::collections::HashMap;

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -1,5 +1,5 @@
 // aux-build:option_helpers.rs
-// compile-flags: --edition 2018
+// edition:2018
 
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(

--- a/tests/ui/single_component_path_imports.fixed
+++ b/tests/ui/single_component_path_imports.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 #![warn(clippy::single_component_path_imports)]
 #![allow(unused_imports)]
 

--- a/tests/ui/single_component_path_imports.rs
+++ b/tests/ui/single_component_path_imports.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 #![warn(clippy::single_component_path_imports)]
 #![allow(unused_imports)]
 

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 
 #![warn(clippy::use_self)]
 #![allow(dead_code)]

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-// compile-flags: --edition 2018
+// edition:2018
 
 #![warn(clippy::use_self)]
 #![allow(dead_code)]


### PR DESCRIPTION
Now we recommend using `// edition:2018`, so let's use it more widely.
Also replace a too old example with new one in the docs.

changelog: none
