### PR TITLE
Remove git2 dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ clippy_lints = { version = "0.0.212", path = "clippy_lints" }
 regex = "1"
 semver = "0.9"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
-git2 = { version = "0.12", optional = true }
 tempfile = { version = "3.1.0", optional = true }
 lazy_static = "1.0"
 
@@ -60,4 +59,4 @@ rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 
 [features]
 deny-warnings = []
-integration = ["git2", "tempfile"]
+integration = ["tempfile"]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -20,7 +20,7 @@ fn integration_test() {
     let st = Command::new("git")
         .args(&["clone", "--depth=1", &repo_url, repo_dir.to_str().unwrap()])
         .status()
-        .expect("unstable to run git");
+        .expect("unable to run git");
     assert!(st.success());
 
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "integration")]
 
-use git2::Repository;
-
 use std::env;
 use std::process::Command;
 
@@ -19,7 +17,11 @@ fn integration_test() {
         .path()
         .join(crate_name);
 
-    Repository::clone(&repo_url, &repo_dir).expect("clone of repo failed");
+    let st = Command::new("git")
+        .args(&["clone", "--depth=1", &repo_url, repo_dir.to_str().unwrap()])
+        .status()
+        .expect("unstable to run git");
+    assert!(st.success());
 
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let target_dir = std::path::Path::new(&root_dir).join("target");


### PR DESCRIPTION
This removes the `git2` dependency (used in the integration test).  Updating git2 is awkward because both cargo and clippy have to be updated in sync, so this removes that requirement. It didn't look like it was using the git2 library for any particular reason, so this just launches the `git` executable, which should be available more or less everywhere.

This unblocks updating Cargo.

changelog: none
