### PR TITLE
useless Rc<Rc<T>>, Rc<Box<T>>, Rc<&T>, Box<&T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1433,6 +1433,7 @@ Released 2018-09-13
 [`range_plus_one`]: https://rust-lang.github.io/rust-clippy/master/index.html#range_plus_one
 [`range_step_by_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#range_step_by_zero
 [`range_zip_with_len`]: https://rust-lang.github.io/rust-clippy/master/index.html#range_zip_with_len
+[`redundant_allocation`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation
 [`redundant_clone`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
 [`redundant_closure`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
 [`redundant_closure_call`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_call

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -811,6 +811,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         &types::LET_UNIT_VALUE,
         &types::LINKEDLIST,
         &types::OPTION_OPTION,
+        &types::REDUNDANT_ALLOCATION,
         &types::TYPE_COMPLEXITY,
         &types::UNIT_ARG,
         &types::UNIT_CMP,
@@ -1376,6 +1377,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&types::FN_TO_NUMERIC_CAST_WITH_TRUNCATION),
         LintId::of(&types::IMPLICIT_HASHER),
         LintId::of(&types::LET_UNIT_VALUE),
+        LintId::of(&types::REDUNDANT_ALLOCATION),
         LintId::of(&types::TYPE_COMPLEXITY),
         LintId::of(&types::UNIT_ARG),
         LintId::of(&types::UNIT_CMP),
@@ -1660,6 +1662,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&slow_vector_initialization::SLOW_VECTOR_INITIALIZATION),
         LintId::of(&trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF),
         LintId::of(&types::BOX_VEC),
+        LintId::of(&types::REDUNDANT_ALLOCATION),
         LintId::of(&vec::USELESS_VEC),
     ]);
 

--- a/clippy_lints/src/utils/paths.rs
+++ b/clippy_lints/src/utils/paths.rs
@@ -10,6 +10,7 @@ pub const BEGIN_PANIC: [&str; 3] = ["std", "panicking", "begin_panic"];
 pub const BEGIN_PANIC_FMT: [&str; 3] = ["std", "panicking", "begin_panic_fmt"];
 pub const BINARY_HEAP: [&str; 4] = ["alloc", "collections", "binary_heap", "BinaryHeap"];
 pub const BORROW_TRAIT: [&str; 3] = ["core", "borrow", "Borrow"];
+pub const BOX: [&str; 3] = ["alloc", "boxed", "Box"];
 pub const BTREEMAP: [&str; 5] = ["alloc", "collections", "btree", "map", "BTreeMap"];
 pub const BTREEMAP_ENTRY: [&str; 5] = ["alloc", "collections", "btree", "map", "Entry"];
 pub const BTREESET: [&str; 5] = ["alloc", "collections", "btree", "set", "BTreeSet"];

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1726,6 +1726,13 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
         module: "ranges",
     },
     Lint {
+        name: "redundant_allocation",
+        group: "perf",
+        desc: "redundant allocation",
+        deprecation: None,
+        module: "types",
+    },
+    Lint {
         name: "redundant_clone",
         group: "perf",
         desc: "`clone()` of an owned value that is going to be dropped immediately",

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 #![feature(never_type)]
-#![allow(unused_mut)]
+#![allow(unused_mut, clippy::redundant_allocation)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 #![feature(never_type)]
-#![allow(unused_mut)]
+#![allow(unused_mut, clippy::redundant_allocation)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/tests/ui/redundant_allocation.fixed
+++ b/tests/ui/redundant_allocation.fixed
@@ -1,0 +1,48 @@
+// run-rustfix
+#![warn(clippy::all)]
+#![allow(clippy::boxed_local, clippy::needless_pass_by_value)]
+#![allow(clippy::blacklisted_name, unused_variables, dead_code)]
+
+use std::boxed::Box;
+use std::rc::Rc;
+
+pub struct MyStruct {}
+
+pub struct SubT<T> {
+    foo: T,
+}
+
+pub enum MyEnum {
+    One,
+    Two,
+}
+
+// Rc<&T>
+
+pub fn test1<T>(foo: &T) {}
+
+pub fn test2(foo: &MyStruct) {}
+
+pub fn test3(foo: &MyEnum) {}
+
+pub fn test4_neg(foo: Rc<SubT<&usize>>) {}
+
+// Rc<Rc<T>>
+
+pub fn test5(a: Rc<bool>) {}
+
+// Rc<Box<T>>
+
+pub fn test6(a: Box<bool>) {}
+
+// Box<&T>
+
+pub fn test7<T>(foo: &T) {}
+
+pub fn test8(foo: &MyStruct) {}
+
+pub fn test9(foo: &MyEnum) {}
+
+pub fn test10_neg(foo: Box<SubT<&usize>>) {}
+
+fn main() {}

--- a/tests/ui/redundant_allocation.rs
+++ b/tests/ui/redundant_allocation.rs
@@ -1,0 +1,48 @@
+// run-rustfix
+#![warn(clippy::all)]
+#![allow(clippy::boxed_local, clippy::needless_pass_by_value)]
+#![allow(clippy::blacklisted_name, unused_variables, dead_code)]
+
+use std::boxed::Box;
+use std::rc::Rc;
+
+pub struct MyStruct {}
+
+pub struct SubT<T> {
+    foo: T,
+}
+
+pub enum MyEnum {
+    One,
+    Two,
+}
+
+// Rc<&T>
+
+pub fn test1<T>(foo: Rc<&T>) {}
+
+pub fn test2(foo: Rc<&MyStruct>) {}
+
+pub fn test3(foo: Rc<&MyEnum>) {}
+
+pub fn test4_neg(foo: Rc<SubT<&usize>>) {}
+
+// Rc<Rc<T>>
+
+pub fn test5(a: Rc<Rc<bool>>) {}
+
+// Rc<Box<T>>
+
+pub fn test6(a: Rc<Box<bool>>) {}
+
+// Box<&T>
+
+pub fn test7<T>(foo: Box<&T>) {}
+
+pub fn test8(foo: Box<&MyStruct>) {}
+
+pub fn test9(foo: Box<&MyEnum>) {}
+
+pub fn test10_neg(foo: Box<SubT<&usize>>) {}
+
+fn main() {}

--- a/tests/ui/redundant_allocation.stderr
+++ b/tests/ui/redundant_allocation.stderr
@@ -1,0 +1,52 @@
+error: usage of `Rc<&T>`
+  --> $DIR/redundant_allocation.rs:22:22
+   |
+LL | pub fn test1<T>(foo: Rc<&T>) {}
+   |                      ^^^^^^ help: try: `&T`
+   |
+   = note: `-D clippy::redundant-allocation` implied by `-D warnings`
+
+error: usage of `Rc<&T>`
+  --> $DIR/redundant_allocation.rs:24:19
+   |
+LL | pub fn test2(foo: Rc<&MyStruct>) {}
+   |                   ^^^^^^^^^^^^^ help: try: `&MyStruct`
+
+error: usage of `Rc<&T>`
+  --> $DIR/redundant_allocation.rs:26:19
+   |
+LL | pub fn test3(foo: Rc<&MyEnum>) {}
+   |                   ^^^^^^^^^^^ help: try: `&MyEnum`
+
+error: usage of `Rc<Rc<T>>`
+  --> $DIR/redundant_allocation.rs:32:17
+   |
+LL | pub fn test5(a: Rc<Rc<bool>>) {}
+   |                 ^^^^^^^^^^^^ help: try: `Rc<bool>`
+
+error: usage of `Rc<Box<T>>`
+  --> $DIR/redundant_allocation.rs:36:17
+   |
+LL | pub fn test6(a: Rc<Box<bool>>) {}
+   |                 ^^^^^^^^^^^^^ help: try: `Box<bool>`
+
+error: usage of `Box<&T>`
+  --> $DIR/redundant_allocation.rs:40:22
+   |
+LL | pub fn test7<T>(foo: Box<&T>) {}
+   |                      ^^^^^^^ help: try: `&T`
+
+error: usage of `Box<&T>`
+  --> $DIR/redundant_allocation.rs:42:19
+   |
+LL | pub fn test8(foo: Box<&MyStruct>) {}
+   |                   ^^^^^^^^^^^^^^ help: try: `&MyStruct`
+
+error: usage of `Box<&T>`
+  --> $DIR/redundant_allocation.rs:44:19
+   |
+LL | pub fn test9(foo: Box<&MyEnum>) {}
+   |                   ^^^^^^^^^^^^ help: try: `&MyEnum`
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
refers to  #2394

changelog: Add lints for Rc<Rc<T>> and Rc<Box<T>> and Rc<&T>, Box<&T>

this is based on top of another change #5310 so probably should go after that one.