### PR TITLE
Fix single binding closure

### DIFF
--- a/tests/ui/match_single_binding.fixed
+++ b/tests/ui/match_single_binding.fixed
@@ -67,4 +67,14 @@ fn main() {
     // Lint
     let Point { x, y } = coords();
     let product = x * y;
+    // Lint
+    let v = vec![Some(1), Some(2), Some(3), Some(4)];
+    #[allow(clippy::let_and_return)]
+    let _ = v
+        .iter()
+        .map(|i| {
+            let unwrapped = i.unwrap();
+            unwrapped
+        })
+        .collect::<Vec<u8>>();
 }

--- a/tests/ui/match_single_binding.rs
+++ b/tests/ui/match_single_binding.rs
@@ -80,4 +80,13 @@ fn main() {
     let product = match coords() {
         Point { x, y } => x * y,
     };
+    // Lint
+    let v = vec![Some(1), Some(2), Some(3), Some(4)];
+    #[allow(clippy::let_and_return)]
+    let _ = v
+        .iter()
+        .map(|i| match i.unwrap() {
+            unwrapped => unwrapped,
+        })
+        .collect::<Vec<u8>>();
 }

--- a/tests/ui/match_single_binding.stderr
+++ b/tests/ui/match_single_binding.stderr
@@ -150,5 +150,22 @@ LL |     let Point { x, y } = coords();
 LL |     let product = x * y;
    |
 
-error: aborting due to 10 previous errors
+error: this match could be written as a `let` statement
+  --> $DIR/match_single_binding.rs:88:18
+   |
+LL |           .map(|i| match i.unwrap() {
+   |  __________________^
+LL | |             unwrapped => unwrapped,
+LL | |         })
+   | |_________^
+   |
+help: consider using `let` statement
+   |
+LL |         .map(|i| {
+LL |             let unwrapped = i.unwrap();
+LL |             unwrapped
+LL |         })
+   |
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fix the `match_single_binding` lint when triggered inside a closure.

Fixes: #5347 

changelog: Improve suggestion for [`match_single_binding`]