### PR TITLE
Move useless_transmute to nursery

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1351,7 +1351,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&transmute::TRANSMUTE_PTR_TO_PTR),
         LintId::of(&transmute::TRANSMUTE_PTR_TO_REF),
         LintId::of(&transmute::UNSOUND_COLLECTION_TRANSMUTE),
-        LintId::of(&transmute::USELESS_TRANSMUTE),
         LintId::of(&transmute::WRONG_TRANSMUTE),
         LintId::of(&transmuting_null::TRANSMUTING_NULL),
         LintId::of(&trivially_copy_pass_by_ref::TRIVIALLY_COPY_PASS_BY_REF),
@@ -1553,7 +1552,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&transmute::TRANSMUTE_INT_TO_FLOAT),
         LintId::of(&transmute::TRANSMUTE_PTR_TO_PTR),
         LintId::of(&transmute::TRANSMUTE_PTR_TO_REF),
-        LintId::of(&transmute::USELESS_TRANSMUTE),
         LintId::of(&types::BORROWED_BOX),
         LintId::of(&types::CHAR_LIT_AS_U8),
         LintId::of(&types::OPTION_OPTION),
@@ -1670,6 +1668,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&mutex_atomic::MUTEX_INTEGER),
         LintId::of(&needless_borrow::NEEDLESS_BORROW),
         LintId::of(&path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE),
+        LintId::of(&transmute::USELESS_TRANSMUTE),
         LintId::of(&use_self::USE_SELF),
     ]);
 }

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -28,6 +28,7 @@ declare_clippy_lint! {
     "transmutes that are confusing at best, undefined behaviour at worst and always useless"
 }
 
+// FIXME: Move this to `complexity` again, after #5343 is fixed
 declare_clippy_lint! {
     /// **What it does:** Checks for transmutes to the original type of the object
     /// and transmutes that could be a cast.
@@ -42,7 +43,7 @@ declare_clippy_lint! {
     /// core::intrinsics::transmute(t); // where the result type is the same as `t`'s
     /// ```
     pub USELESS_TRANSMUTE,
-    complexity,
+    nursery,
     "transmutes that have the same to and from types or could be a cast/coercion"
 }
 

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -2375,7 +2375,7 @@ pub const ALL_LINTS: [Lint; 361] = [
     },
     Lint {
         name: "useless_transmute",
-        group: "complexity",
+        group: "nursery",
         desc: "transmutes that have the same to and from types or could be a cast/coercion",
         deprecation: None,
         module: "transmute",

--- a/tests/ui/transmute_ptr_to_ptr.stderr
+++ b/tests/ui/transmute_ptr_to_ptr.stderr
@@ -1,17 +1,3 @@
-error: transmute from a type (`&T`) to itself
-  --> $DIR/transmute_ptr_to_ptr.rs:8:5
-   |
-LL |     std::mem::transmute::<&'a T, &'static T>(t)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `-D clippy::useless-transmute` implied by `-D warnings`
-
-error: transmute from a type (`&T`) to itself
-  --> $DIR/transmute_ptr_to_ptr.rs:13:5
-   |
-LL |     std::mem::transmute::<&'a T, &'b T>(t)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: transmute from a pointer to a pointer
   --> $DIR/transmute_ptr_to_ptr.rs:29:29
    |
@@ -50,17 +36,5 @@ error: transmute from a reference to a reference
 LL |         let _: &GenericParam<f32> = std::mem::transmute(&GenericParam { t: 1u32 });
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(&GenericParam { t: 1u32 } as *const GenericParam<u32> as *const GenericParam<f32>)`
 
-error: transmute from a type (`&LifetimeParam`) to itself
-  --> $DIR/transmute_ptr_to_ptr.rs:50:47
-   |
-LL |     let _: &LifetimeParam<'static> = unsafe { std::mem::transmute(&lp) };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: transmute from a type (`&GenericParam<&LifetimeParam>`) to itself
-  --> $DIR/transmute_ptr_to_ptr.rs:51:62
-   |
-LL |     let _: &GenericParam<&LifetimeParam<'static>> = unsafe { std::mem::transmute(&GenericParam { t: &lp }) };
-   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
cc #5343 

@rust-lang/clippy anyone against moving this to nursery?

changelog: Move [`useless_transmute`] to nursery
