### PR TITLE
Remove dependency on `matches` crate

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -21,7 +21,6 @@ cargo_metadata = "0.9.0"
 if_chain = "1.0.0"
 itertools = "0.9"
 lazy_static = "1.0.2"
-matches = "0.1.7"
 pulldown-cmark = { version = "0.7", default-features = false }
 quine-mc_cluskey = "0.2.2"
 regex-syntax = "0.6"

--- a/clippy_lints/src/block_in_if_condition.rs
+++ b/clippy_lints/src/block_in_if_condition.rs
@@ -1,5 +1,4 @@
 use crate::utils::{differing_macro_contexts, higher, snippet_block_with_applicability, span_lint, span_lint_and_sugg};
-use matches::matches;
 use rustc::hir::map::Map;
 use rustc::lint::in_external_macro;
 use rustc_errors::Applicability;

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -1,5 +1,4 @@
 use if_chain::if_chain;
-use matches::matches;
 use rustc::lint::in_external_macro;
 use rustc::ty::{self, Ty};
 use rustc_errors::Applicability;

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -1,7 +1,6 @@
 //! lint when items are used after statements
 
 use crate::utils::span_lint;
-use matches::matches;
 use rustc_ast::ast::{Block, ItemKind, StmtKind};
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -1,4 +1,3 @@
-use matches::matches;
 use rustc::hir::map::Map;
 use rustc::lint::in_external_macro;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -8,7 +8,6 @@ use std::fmt;
 use std::iter;
 
 use if_chain::if_chain;
-use matches::matches;
 use rustc::hir::map::Map;
 use rustc::lint::in_external_macro;
 use rustc::ty::{self, Predicate, Ty};

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -1,5 +1,4 @@
 use if_chain::if_chain;
-use matches::matches;
 use rustc::ty;
 use rustc_ast::ast::LitKind;
 use rustc_errors::Applicability;

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -8,7 +8,6 @@ use rustc_mir::transform::qualify_min_const_fn::is_min_const_fn;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
 use rustc_typeck::hir_ty_to_ty;
-use std::matches;
 
 declare_clippy_lint! {
     /// **What it does:**

--- a/clippy_lints/src/mutable_debug_assertion.rs
+++ b/clippy_lints/src/mutable_debug_assertion.rs
@@ -1,6 +1,5 @@
 use crate::utils::{is_direct_expn_of, span_lint};
 use if_chain::if_chain;
-use matches::matches;
 use rustc::hir::map::Map;
 use rustc::ty;
 use rustc_hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -4,7 +4,6 @@ use crate::utils::{
     snippet, snippet_opt, span_lint_and_then,
 };
 use if_chain::if_chain;
-use matches::matches;
 use rustc::ty::{self, TypeFoldable};
 use rustc_ast::ast::Attribute;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -3,7 +3,6 @@ use crate::utils::{
     span_lint_hir_and_then, walk_ptrs_ty_depth,
 };
 use if_chain::if_chain;
-use matches::matches;
 use rustc::mir::{
     self, traversal,
     visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor as _},

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -4,7 +4,6 @@ use crate::utils::{
     span_lint_and_then, walk_ptrs_ty, SpanlessEq,
 };
 use if_chain::if_chain;
-use matches::matches;
 use rustc::ty;
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, ExprKind, PatKind, QPath, StmtKind};

--- a/clippy_lints/src/trivially_copy_pass_by_ref.rs
+++ b/clippy_lints/src/trivially_copy_pass_by_ref.rs
@@ -2,7 +2,6 @@ use std::cmp;
 
 use crate::utils::{is_copy, is_self_ty, snippet, span_lint_and_sugg};
 use if_chain::if_chain;
-use matches::matches;
 use rustc::ty;
 use rustc_errors::Applicability;
 use rustc_hir as hir;

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -25,7 +25,6 @@ use std::borrow::Cow;
 use std::mem;
 
 use if_chain::if_chain;
-use matches::matches;
 use rustc::hir::map::Map;
 use rustc::traits;
 use rustc::ty::{

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -2,7 +2,6 @@
 #![deny(clippy::missing_docs_in_private_items)]
 
 use crate::utils::{higher, snippet, snippet_opt, snippet_with_macro_callsite};
-use matches::matches;
 use rustc_ast::util::parser::AssocOp;
 use rustc_ast::{ast, token};
 use rustc_ast_pretty::pprust::token_kind_to_string;


### PR DESCRIPTION
The std equivalent works exactly the same.

changelog: none
