### PR TITLE
suspicious_map: accept mutation in `map().count()`

### DIFF
--- a/tests/ui/suspicious_map.rs
+++ b/tests/ui/suspicious_map.rs
@@ -1,5 +1,19 @@
 #![warn(clippy::suspicious_map)]
+#![allow(clippy::redundant_closure)]
 
 fn main() {
     let _ = (0..3).map(|x| x + 2).count();
+
+    // This usage is OK because the `sum` side effect makes the `map` useful.
+    let mut sum = 0;
+    let _ = (0..3).map(|x| sum += x).count();
+
+    // The linter is blind to path-based arguments however.
+    let mut ext_sum = 0;
+    let ext_closure = |x| ext_sum += x;
+    let _ = (0..3).map(ext_closure).count();
+
+    // The linter can see `FnMut` calls however.
+    let mut ext_closure_inner = |x| ext_sum += x;
+    let _ = (0..3).map(|x| ext_closure_inner(x)).count();
 }

--- a/tests/ui/suspicious_map.stderr
+++ b/tests/ui/suspicious_map.stderr
@@ -1,5 +1,5 @@
 error: this call to `map()` won't have an effect on the call to `count()`
-  --> $DIR/suspicious_map.rs:4:13
+  --> $DIR/suspicious_map.rs:5:13
    |
 LL |     let _ = (0..3).map(|x| x + 2).count();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,5 +7,13 @@ LL |     let _ = (0..3).map(|x| x + 2).count();
    = note: `-D clippy::suspicious-map` implied by `-D warnings`
    = help: make sure you did not confuse `map` with `filter` or `for_each`
 
-error: aborting due to previous error
+error: this call to `map()` won't have an effect on the call to `count()`
+  --> $DIR/suspicious_map.rs:14:13
+   |
+LL |     let _ = (0..3).map(ext_closure).count();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: make sure you did not confuse `map` with `filter` or `for_each`
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
If the closure in the `map` call ends up mutating a variable, the call
is assumed to no longer be suspicious.

Given just a function name or path, there's no way to detect that there
is interiour mutability, so the lint still fires in that case. However,
it is now documented as a known problem.

Closes: #5253

---
Cc: @jpospychala @flip1995 @matthiaskrgr 

---

changelog:

```
* `suspicious_map` no longer lints closures in `map()` which modify a variable
```