### PR TITLE
Move verbose_file_reads to restriction

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1062,6 +1062,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&shadow::SHADOW_REUSE),
         LintId::of(&shadow::SHADOW_SAME),
         LintId::of(&strings::STRING_ADD),
+        LintId::of(&verbose_file_reads::VERBOSE_FILE_READS),
         LintId::of(&write::PRINT_STDOUT),
         LintId::of(&write::USE_DEBUG),
     ]);
@@ -1380,7 +1381,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&unwrap::PANICKING_UNWRAP),
         LintId::of(&unwrap::UNNECESSARY_UNWRAP),
         LintId::of(&vec::USELESS_VEC),
-        LintId::of(&verbose_file_reads::VERBOSE_FILE_READS),
         LintId::of(&write::PRINTLN_EMPTY_STRING),
         LintId::of(&write::PRINT_LITERAL),
         LintId::of(&write::PRINT_WITH_NEWLINE),
@@ -1563,7 +1563,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&types::UNNECESSARY_CAST),
         LintId::of(&types::VEC_BOX),
         LintId::of(&unwrap::UNNECESSARY_UNWRAP),
-        LintId::of(&verbose_file_reads::VERBOSE_FILE_READS),
         LintId::of(&zero_div_zero::ZERO_DIVIDED_BY_ZERO),
     ]);
 

--- a/clippy_lints/src/verbose_file_reads.rs
+++ b/clippy_lints/src/verbose_file_reads.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// let mut bytes = fs::read("foo.txt").unwrap();
     /// ```
     pub VERBOSE_FILE_READS,
-    complexity,
+    restriction,
     "use of `File::read_to_end` or `File::read_to_string`"
 }
 

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -2410,7 +2410,7 @@ pub const ALL_LINTS: [Lint; 362] = [
     },
     Lint {
         name: "verbose_file_reads",
-        group: "complexity",
+        group: "restriction",
         desc: "use of `File::read_to_end` or `File::read_to_string`",
         deprecation: None,
         module: "verbose_file_reads",


### PR DESCRIPTION
cc #5368 

Using `File::read` instead of  `fs::read_to_end` does make sense in multiple cases, so this lint is rather restriction, than complexity

changelog: Move [`verbose_file_reads`] to restriction
