### PR TITLE
git attribute macros not allowed in submodules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-[attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
-
 * text=auto eol=lf
-*.rs rust
+*.rs text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
 *.fixed linguist-language=Rust


### PR DESCRIPTION
This change simply moves the `rust` macro definition directly into the
attributes for `*.rs` files.

git commands that recurse from the rust toplevel tree into submodules
produce errors in clippy due to the fact that:

  "Custom macro attributes can be defined only in top-level
  gitattributes files"

For example, from the toplevel `rust` directory in a rustc development
build, try:

  $ git grep "search string" --recurse-submodules

Embedded within the actual results is the error message:

  [attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
   not allowed: src/tools/clippy/.gitattributes:1

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only updates to the latest nightly, you can leave the
`changelog` entry as `none`. Otherwise, please write a short comment
explaining your change.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- [ ] Followed [lint naming conventions][lint_naming]
- [ ] Added passing UI tests (including committed `.stderr` file)
- [ ] `cargo test` passes locally
- [ ] Executed `cargo dev update_lints`
- [ ] Added lint documentation
- [ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

changelog: none
