### PR TITLE
`unused_self` false positive

### DIFF
--- a/tests/ui/unused_self.rs
+++ b/tests/ui/unused_self.rs
@@ -42,6 +42,17 @@ mod unused_self_allow {
     impl B {
         fn unused_self_move(self) {}
     }
+
+    struct C {}
+
+    #[allow(clippy::unused_self)]
+    impl C {
+        #[warn(clippy::unused_self)]
+        fn some_fn((): ()) {}
+
+        // shouldn't trigger
+        fn unused_self_move(self) {}
+    }
 }
 
 mod used_self {


### PR DESCRIPTION
fixes #5351

Remove the for loop in `unused_self` so that lint enabled for one method doesn't trigger on another method.

changelog: Fix false positive in `unused_self` around lint gates on impl items