### PR TITLE
Avoid single_match lint in macro rules

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -447,6 +447,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Matches {
 #[rustfmt::skip]
 fn check_single_match(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>], expr: &Expr<'_>) {
     if arms.len() == 2 && arms[0].guard.is_none() && arms[1].guard.is_none() {
+        if in_macro(expr.span) {
+            // Don't lint match expressions present in
+            // macro_rules! block
+            return;
+        }
         if let PatKind::Or(..) = arms[0].pat.kind {
             // don't lint for or patterns for now, this makes
             // the lint noisy in unnecessary situations

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -81,4 +81,13 @@ fn single_match_know_enum() {
     }
 }
 
-fn main() {}
+macro_rules! single_match {
+    ($num:literal) => {
+        match $num {
+            15 => println!("15"),
+            _ => (),
+        }
+    };
+}
+
+fn main() {single_match!(5);}

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -90,4 +90,6 @@ macro_rules! single_match {
     };
 }
 
-fn main() {single_match!(5);}
+fn main() {
+    single_match!(5);
+}

--- a/tests/ui/single_match_else.rs
+++ b/tests/ui/single_match_else.rs
@@ -18,4 +18,18 @@ fn unwrap_addr() -> Option<&'static ExprNode> {
     }
 }
 
-fn main() {}
+macro_rules! unwrap_addr {
+    ($expression:expr) => {
+        match $expression {
+            ExprNode::ExprAddrOf => Some(&NODE),
+            _ => {
+                let x = 5;
+                None
+            },
+        }
+    };
+}
+
+fn main() {
+    unwrap_addr!(ExprNode::Unicorns);
+}


### PR DESCRIPTION
changelog: none
fixes #5359 
