### PR TITLE
Allow let_underscore_must_use to be ignored

### DIFF
--- a/tests/ui/let_underscore_must_use.rs
+++ b/tests/ui/let_underscore_must_use.rs
@@ -88,4 +88,7 @@ fn main() {
     let _ = a.map(|_| ());
 
     let _ = a;
+
+    #[allow(clippy::let_underscore_must_use)]
+    let _ = a;
 }


### PR DESCRIPTION
changelog: none
Fixes #5366 