### PR TITLE
Use assoc int and float consts instead of module level ones

### DIFF
--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// ```rust
     /// # let foo: u32 = 5;
     /// # let _ =
-    /// foo <= i32::max_value() as u32
+    /// foo <= i32::MAX as u32
     /// # ;
     /// ```
     ///
@@ -179,7 +179,7 @@ impl ConversionType {
     }
 }
 
-/// Check for `expr <= (to_type::max_value() as from_type)`
+/// Check for `expr <= (to_type::MAX as from_type)`
 fn check_upper_bound<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<Conversion<'tcx>> {
     if_chain! {
          if let ExprKind::Binary(ref op, ref left, ref right) = &expr.kind;
@@ -194,7 +194,7 @@ fn check_upper_bound<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<Conversion<'tcx>> {
     }
 }
 
-/// Check for `expr >= 0|(to_type::min_value() as from_type)`
+/// Check for `expr >= 0|(to_type::MIN as from_type)`
 fn check_lower_bound<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<Conversion<'tcx>> {
     fn check_function<'a>(candidate: &'a Expr<'a>, check: &'a Expr<'a>) -> Option<Conversion<'a>> {
         (check_lower_bound_zero(candidate, check)).or_else(|| (check_lower_bound_min(candidate, check)))
@@ -222,7 +222,7 @@ fn check_lower_bound_zero<'a>(candidate: &'a Expr<'_>, check: &'a Expr<'_>) -> O
     }
 }
 
-/// Check for `expr >= (to_type::min_value() as from_type)`
+/// Check for `expr >= (to_type::MIN as from_type)`
 fn check_lower_bound_min<'a>(candidate: &'a Expr<'_>, check: &'a Expr<'_>) -> Option<Conversion<'a>> {
     if let Some((from, to)) = get_types_from_cast(check, MIN_VALUE, SINTS) {
         Conversion::try_new(candidate, from, to)

--- a/clippy_lints/src/float_literal.rs
+++ b/clippy_lints/src/float_literal.rs
@@ -6,7 +6,7 @@ use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use std::{f32, f64, fmt};
+use std::fmt;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for float literals with a precision greater

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1138,8 +1138,8 @@ declare_clippy_lint! {
     /// ```rust
     /// # let y: u32 = 0;
     /// # let x: u32 = 100;
-    /// let add = x.checked_add(y).unwrap_or(u32::max_value());
-    /// let sub = x.checked_sub(y).unwrap_or(u32::min_value());
+    /// let add = x.checked_add(y).unwrap_or(u32::MAX);
+    /// let sub = x.checked_sub(y).unwrap_or(u32::MIN);
     /// ```
     ///
     /// can be written using dedicated methods for saturating addition/subtraction as:

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -388,7 +388,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                             ),
                             Applicability::HasPlaceholders, // snippet
                         );
-                        db.span_note(expr.span, "`std::f32::EPSILON` and `std::f64::EPSILON` are available.");
+                        db.span_note(expr.span, "`f32::EPSILON` and `f64::EPSILON` are available.");
                     });
                 } else if op == BinOpKind::Rem && is_integer_const(cx, right, 1) {
                     span_lint(cx, MODULO_ONE, expr.span, "any number modulo 1 will be 0");

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -57,10 +57,9 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// # use core::f32::NAN;
     /// # let x = 1.0;
     ///
-    /// if x == NAN { }
+    /// if x == f32::NAN { }
     /// ```
     pub CMP_NAN,
     correctness,
@@ -457,7 +456,7 @@ fn check_nan(cx: &LateContext<'_, '_>, expr: &Expr<'_>, cmp_expr: &Expr<'_>) {
                     cx,
                     CMP_NAN,
                     cmp_expr.span,
-                    "doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead",
+                    "doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead",
                 );
             }
         }

--- a/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
+++ b/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
@@ -25,13 +25,13 @@ declare_clippy_lint! {
     ///
     /// // Bad
     /// let a = 1.0;
-    /// let b = std::f64::NAN;
+    /// let b = f64::NAN;
     ///
     /// let _not_less_or_equal = !(a <= b);
     ///
     /// // Good
     /// let a = 1.0;
-    /// let b = std::f64::NAN;
+    /// let b = f64::NAN;
     ///
     /// let _not_less_or_equal = match a.partial_cmp(&b) {
     ///     None | Some(Ordering::Greater) => true,

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -837,7 +837,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// let x = std::u64::MAX;
+    /// let x = u64::MAX;
     /// x as f64;
     /// ```
     pub CAST_PRECISION_LOSS,
@@ -904,7 +904,7 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```rust
-    /// std::u32::MAX as i32; // will yield a value of `-1`
+    /// u32::MAX as i32; // will yield a value of `-1`
     /// ```
     pub CAST_POSSIBLE_WRAP,
     pedantic,
@@ -1752,7 +1752,7 @@ declare_clippy_lint! {
     /// ```rust
     /// let vec: Vec<isize> = Vec::new();
     /// if vec.len() <= 0 {}
-    /// if 100 > std::i32::MAX {}
+    /// if 100 > i32::MAX {}
     /// ```
     pub ABSURD_EXTREME_COMPARISONS,
     correctness,

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -1973,8 +1973,6 @@ impl Ord for FullInt {
 }
 
 fn numeric_cast_precast_bounds<'a>(cx: &LateContext<'_, '_>, expr: &'a Expr<'_>) -> Option<(FullInt, FullInt)> {
-    use std::{i128, i16, i32, i64, i8, isize, u128, u16, u32, u64, u8, usize};
-
     if let ExprKind::Cast(ref cast_exp, _) = expr.kind {
         let pre_cast_ty = cx.tables.expr_ty(cast_exp);
         let cast_ty = cx.tables.expr_ty(expr);

--- a/clippy_lints/src/utils/diagnostics.rs
+++ b/clippy_lints/src/utils/diagnostics.rs
@@ -60,7 +60,7 @@ pub fn span_lint<T: LintContext>(cx: &T, lint: &'static Lint, sp: impl Into<Mult
 /// 6  |     let other_f64_nan = 0.0f64 / 0.0;
 ///    |                         ^^^^^^^^^^^^
 ///    |
-///    = help: Consider using `std::f64::NAN` if you would like a constant representing NaN
+///    = help: Consider using `f64::NAN` if you would like a constant representing NaN
 /// ```
 pub fn span_lint_and_help<'a, T: LintContext>(cx: &'a T, lint: &'static Lint, span: Span, msg: &str, help: &str) {
     cx.struct_span_lint(lint, span, |ldb| {

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -8,8 +8,7 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 declare_clippy_lint! {
     /// **What it does:** Checks for `0.0 / 0.0`.
     ///
-    /// **Why is this bad?** It's less readable than `std::f32::NAN` or
-    /// `std::f64::NAN`.
+    /// **Why is this bad?** It's less readable than `f32::NAN` or `f64::NAN`.
     ///
     /// **Known problems:** None.
     ///
@@ -19,7 +18,7 @@ declare_clippy_lint! {
     /// ```
     pub ZERO_DIVIDED_BY_ZERO,
     complexity,
-    "usage of `0.0 / 0.0` to obtain NaN instead of `std::f32::NAN` or `std::f64::NAN`"
+    "usage of `0.0 / 0.0` to obtain NaN instead of `f32::NAN` or `f64::NAN`"
 }
 
 declare_lint_pass!(ZeroDiv => [ZERO_DIVIDED_BY_ZERO]);
@@ -38,7 +37,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ZeroDiv {
             if Constant::F32(0.0) == lhs_value || Constant::F64(0.0) == lhs_value;
             if Constant::F32(0.0) == rhs_value || Constant::F64(0.0) == rhs_value;
             then {
-                // since we're about to suggest a use of std::f32::NaN or std::f64::NaN,
+                // since we're about to suggest a use of f32::NAN or f64::NAN,
                 // match the precision of the literals that are given.
                 let float_type = match (lhs_value, rhs_value) {
                     (Constant::F64(_), _)
@@ -51,7 +50,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ZeroDiv {
                     expr.span,
                     "constant division of `0.0` with `0.0` will always result in NaN",
                     &format!(
-                        "Consider using `std::{}::NAN` if you would like a constant representing NaN",
+                        "Consider using `{}::NAN` if you would like a constant representing NaN",
                         float_type,
                     ),
                 );

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -2526,7 +2526,7 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
     Lint {
         name: "zero_divided_by_zero",
         group: "complexity",
-        desc: "usage of `0.0 / 0.0` to obtain NaN instead of `std::f32::NAN` or `std::f64::NAN`",
+        desc: "usage of `0.0 / 0.0` to obtain NaN instead of `f32::NAN` or `f64::NAN`",
         deprecation: None,
         module: "zero_div_zero",
     },

--- a/tests/ui/absurd-extreme-comparisons.rs
+++ b/tests/ui/absurd-extreme-comparisons.rs
@@ -16,17 +16,17 @@ fn main() {
     u < Z;
     Z >= u;
     Z > u;
-    u > std::u32::MAX;
-    u >= std::u32::MAX;
-    std::u32::MAX < u;
-    std::u32::MAX <= u;
+    u > u32::MAX;
+    u >= u32::MAX;
+    u32::MAX < u;
+    u32::MAX <= u;
     1-1 > u;
     u >= !0;
     u <= 12 - 2*6;
     let i: i8 = 0;
     i < -127 - 1;
-    std::i8::MAX >= i;
-    3-7 < std::i32::MIN;
+    i8::MAX >= i;
+    3-7 < i32::MIN;
     let b = false;
     b >= true;
     false > b;
@@ -52,10 +52,10 @@ impl PartialOrd<u32> for U {
 }
 
 pub fn foo(val: U) -> bool {
-    val > std::u32::MAX
+    val > u32::MAX
 }
 
 pub fn bar(len: u64) -> bool {
     // This is OK as we are casting from target sized to fixed size
-    len >= std::usize::MAX as u64
+    len >= usize::MAX as u64
 }

--- a/tests/ui/absurd-extreme-comparisons.stderr
+++ b/tests/ui/absurd-extreme-comparisons.stderr
@@ -42,34 +42,34 @@ LL |     Z > u;
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:19:5
    |
-LL |     u > std::u32::MAX;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     u > u32::MAX;
+   |     ^^^^^^^^^^^^
    |
-   = help: because `std::u32::MAX` is the maximum value for this type, this comparison is always false
+   = help: because `u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:20:5
    |
-LL |     u >= std::u32::MAX;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     u >= u32::MAX;
+   |     ^^^^^^^^^^^^^
    |
-   = help: because `std::u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == std::u32::MAX` instead
+   = help: because `u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u == u32::MAX` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:21:5
    |
-LL |     std::u32::MAX < u;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     u32::MAX < u;
+   |     ^^^^^^^^^^^^
    |
-   = help: because `std::u32::MAX` is the maximum value for this type, this comparison is always false
+   = help: because `u32::MAX` is the maximum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:22:5
    |
-LL |     std::u32::MAX <= u;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     u32::MAX <= u;
+   |     ^^^^^^^^^^^^^
    |
-   = help: because `std::u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `std::u32::MAX == u` instead
+   = help: because `u32::MAX` is the maximum value for this type, the case where the two sides are not equal never occurs, consider using `u32::MAX == u` instead
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:23:5
@@ -106,18 +106,18 @@ LL |     i < -127 - 1;
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:28:5
    |
-LL |     std::i8::MAX >= i;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     i8::MAX >= i;
+   |     ^^^^^^^^^^^^
    |
-   = help: because `std::i8::MAX` is the maximum value for this type, this comparison is always true
+   = help: because `i8::MAX` is the maximum value for this type, this comparison is always true
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:29:5
    |
-LL |     3-7 < std::i32::MIN;
-   |     ^^^^^^^^^^^^^^^^^^^
+LL |     3-7 < i32::MIN;
+   |     ^^^^^^^^^^^^^^
    |
-   = help: because `std::i32::MIN` is the minimum value for this type, this comparison is always false
+   = help: because `i32::MIN` is the minimum value for this type, this comparison is always false
 
 error: this comparison involving the minimum or maximum element for this type contains a case that is always true or always false
   --> $DIR/absurd-extreme-comparisons.rs:31:5

--- a/tests/ui/cmp_nan.rs
+++ b/tests/ui/cmp_nan.rs
@@ -1,16 +1,16 @@
-const NAN_F32: f32 = std::f32::NAN;
-const NAN_F64: f64 = std::f64::NAN;
+const NAN_F32: f32 = f32::NAN;
+const NAN_F64: f64 = f64::NAN;
 
 #[warn(clippy::cmp_nan)]
 #[allow(clippy::float_cmp, clippy::no_effect, clippy::unnecessary_operation)]
 fn main() {
     let x = 5f32;
-    x == std::f32::NAN;
-    x != std::f32::NAN;
-    x < std::f32::NAN;
-    x > std::f32::NAN;
-    x <= std::f32::NAN;
-    x >= std::f32::NAN;
+    x == f32::NAN;
+    x != f32::NAN;
+    x < f32::NAN;
+    x > f32::NAN;
+    x <= f32::NAN;
+    x >= f32::NAN;
     x == NAN_F32;
     x != NAN_F32;
     x < NAN_F32;
@@ -19,12 +19,12 @@ fn main() {
     x >= NAN_F32;
 
     let y = 0f64;
-    y == std::f64::NAN;
-    y != std::f64::NAN;
-    y < std::f64::NAN;
-    y > std::f64::NAN;
-    y <= std::f64::NAN;
-    y >= std::f64::NAN;
+    y == f64::NAN;
+    y != f64::NAN;
+    y < f64::NAN;
+    y > f64::NAN;
+    y <= f64::NAN;
+    y >= f64::NAN;
     y == NAN_F64;
     y != NAN_F64;
     y < NAN_F64;

--- a/tests/ui/cmp_nan.stderr
+++ b/tests/ui/cmp_nan.stderr
@@ -1,144 +1,144 @@
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:8:5
    |
-LL |     x == std::f32::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     x == f32::NAN;
+   |     ^^^^^^^^^^^^^
    |
    = note: `-D clippy::cmp-nan` implied by `-D warnings`
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:9:5
    |
-LL |     x != std::f32::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     x != f32::NAN;
+   |     ^^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:10:5
    |
-LL |     x < std::f32::NAN;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     x < f32::NAN;
+   |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:11:5
    |
-LL |     x > std::f32::NAN;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     x > f32::NAN;
+   |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:12:5
    |
-LL |     x <= std::f32::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     x <= f32::NAN;
+   |     ^^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:13:5
    |
-LL |     x >= std::f32::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     x >= f32::NAN;
+   |     ^^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:14:5
    |
 LL |     x == NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:15:5
    |
 LL |     x != NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:16:5
    |
 LL |     x < NAN_F32;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:17:5
    |
 LL |     x > NAN_F32;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:18:5
    |
 LL |     x <= NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:19:5
    |
 LL |     x >= NAN_F32;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:22:5
    |
-LL |     y == std::f64::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     y == f64::NAN;
+   |     ^^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:23:5
    |
-LL |     y != std::f64::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     y != f64::NAN;
+   |     ^^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:24:5
    |
-LL |     y < std::f64::NAN;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     y < f64::NAN;
+   |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:25:5
    |
-LL |     y > std::f64::NAN;
-   |     ^^^^^^^^^^^^^^^^^
+LL |     y > f64::NAN;
+   |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:26:5
    |
-LL |     y <= std::f64::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     y <= f64::NAN;
+   |     ^^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:27:5
    |
-LL |     y >= std::f64::NAN;
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     y >= f64::NAN;
+   |     ^^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:28:5
    |
 LL |     y == NAN_F64;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:29:5
    |
 LL |     y != NAN_F64;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:30:5
    |
 LL |     y < NAN_F64;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:31:5
    |
 LL |     y > NAN_F64;
    |     ^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:32:5
    |
 LL |     y <= NAN_F64;
    |     ^^^^^^^^^^^^
 
-error: doomed comparison with `NAN`, use `std::{f32,f64}::is_nan()` instead
+error: doomed comparison with `NAN`, use `{f32,f64}::is_nan()` instead
   --> $DIR/cmp_nan.rs:33:5
    |
 LL |     y >= NAN_F64;

--- a/tests/ui/crashes/mut_mut_macro.rs
+++ b/tests/ui/crashes/mut_mut_macro.rs
@@ -16,7 +16,7 @@
 const BAA: *const i32 = 0 as *const i32;
 static mut BAR: *const i32 = BAA;
 static mut FOO: *const i32 = 0 as *const i32;
-static mut BUH: bool = 42.0 < std::f32::NAN;
+static mut BUH: bool = 42.0 < f32::NAN;
 
 #[allow(unused_variables, unused_mut)]
 fn main() {
@@ -32,5 +32,5 @@ fn main() {
     assert_eq!(*MUT_COUNT, 1);
     */
     // FIXME: don't lint in array length, requires `check_body`
-    //let _ = [""; (42.0 < std::f32::NAN) as usize];
+    //let _ = [""; (42.0 < f32::NAN) as usize];
 }

--- a/tests/ui/enum_clike_unportable_variant.rs
+++ b/tests/ui/enum_clike_unportable_variant.rs
@@ -24,8 +24,8 @@ enum NonPortableSigned {
     Y = 0x7FFF_FFFF,
     Z = 0xFFFF_FFFF,
     A = 0x1_0000_0000,
-    B = std::i32::MIN as isize,
-    C = (std::i32::MIN as isize) - 1,
+    B = i32::MIN as isize,
+    C = (i32::MIN as isize) - 1,
 }
 
 enum NonPortableSignedNoHint {

--- a/tests/ui/enum_clike_unportable_variant.stderr
+++ b/tests/ui/enum_clike_unportable_variant.stderr
@@ -33,8 +33,8 @@ LL |     A = 0x1_0000_0000,
 error: Clike enum variant discriminant is not portable to 32-bit targets
   --> $DIR/enum_clike_unportable_variant.rs:28:5
    |
-LL |     C = (std::i32::MIN as isize) - 1,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     C = (i32::MIN as isize) - 1,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Clike enum variant discriminant is not portable to 32-bit targets
   --> $DIR/enum_clike_unportable_variant.rs:34:5

--- a/tests/ui/float_cmp.rs
+++ b/tests/ui/float_cmp.rs
@@ -45,8 +45,8 @@ impl PartialEq for X {
 
 fn main() {
     ZERO == 0f32; //no error, comparison with zero is ok
-    1.0f32 != ::std::f32::INFINITY; // also comparison with infinity
-    1.0f32 != ::std::f32::NEG_INFINITY; // and negative infinity
+    1.0f32 != f32::INFINITY; // also comparison with infinity
+    1.0f32 != f32::NEG_INFINITY; // and negative infinity
     ZERO == 0.0; //no error, comparison with zero is ok
     ZERO + ZERO != 1.0; //no error, comparison with zero is ok
 

--- a/tests/ui/float_cmp.stderr
+++ b/tests/ui/float_cmp.stderr
@@ -5,7 +5,7 @@ LL |     ONE as f64 != 2.0;
    |     ^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(ONE as f64 - 2.0).abs() > error`
    |
    = note: `-D clippy::float-cmp` implied by `-D warnings`
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp.rs:59:5
    |
 LL |     ONE as f64 != 2.0;
@@ -17,7 +17,7 @@ error: strict comparison of `f32` or `f64`
 LL |     x == 1.0;
    |     ^^^^^^^^ help: consider comparing them within some error: `(x - 1.0).abs() < error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp.rs:64:5
    |
 LL |     x == 1.0;
@@ -29,7 +29,7 @@ error: strict comparison of `f32` or `f64`
 LL |     twice(x) != twice(ONE as f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(twice(x) - twice(ONE as f64)).abs() > error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp.rs:67:5
    |
 LL |     twice(x) != twice(ONE as f64);

--- a/tests/ui/float_cmp_const.rs
+++ b/tests/ui/float_cmp_const.rs
@@ -37,8 +37,8 @@ fn main() {
     // no errors, zero and infinity values
     ONE != 0f32;
     TWO == 0f32;
-    ONE != ::std::f32::INFINITY;
-    ONE == ::std::f32::NEG_INFINITY;
+    ONE != f32::INFINITY;
+    ONE == f32::NEG_INFINITY;
 
     // no errors, but will warn clippy::float_cmp if '#![allow(float_cmp)]' above is removed
     let w = 1.1;

--- a/tests/ui/float_cmp_const.stderr
+++ b/tests/ui/float_cmp_const.stderr
@@ -5,7 +5,7 @@ LL |     1f32 == ONE;
    |     ^^^^^^^^^^^ help: consider comparing them within some error: `(1f32 - ONE).abs() < error`
    |
    = note: `-D clippy::float-cmp-const` implied by `-D warnings`
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:20:5
    |
 LL |     1f32 == ONE;
@@ -17,7 +17,7 @@ error: strict comparison of `f32` or `f64` constant
 LL |     TWO == ONE;
    |     ^^^^^^^^^^ help: consider comparing them within some error: `(TWO - ONE).abs() < error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:21:5
    |
 LL |     TWO == ONE;
@@ -29,7 +29,7 @@ error: strict comparison of `f32` or `f64` constant
 LL |     TWO != ONE;
    |     ^^^^^^^^^^ help: consider comparing them within some error: `(TWO - ONE).abs() > error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:22:5
    |
 LL |     TWO != ONE;
@@ -41,7 +41,7 @@ error: strict comparison of `f32` or `f64` constant
 LL |     ONE + ONE == TWO;
    |     ^^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(ONE + ONE - TWO).abs() < error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:23:5
    |
 LL |     ONE + ONE == TWO;
@@ -53,7 +53,7 @@ error: strict comparison of `f32` or `f64` constant
 LL |     x as f32 == ONE;
    |     ^^^^^^^^^^^^^^^ help: consider comparing them within some error: `(x as f32 - ONE).abs() < error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:25:5
    |
 LL |     x as f32 == ONE;
@@ -65,7 +65,7 @@ error: strict comparison of `f32` or `f64` constant
 LL |     v == ONE;
    |     ^^^^^^^^ help: consider comparing them within some error: `(v - ONE).abs() < error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:28:5
    |
 LL |     v == ONE;
@@ -77,7 +77,7 @@ error: strict comparison of `f32` or `f64` constant
 LL |     v != ONE;
    |     ^^^^^^^^ help: consider comparing them within some error: `(v - ONE).abs() > error`
    |
-note: `std::f32::EPSILON` and `std::f64::EPSILON` are available.
+note: `f32::EPSILON` and `f64::EPSILON` are available.
   --> $DIR/float_cmp_const.rs:29:5
    |
 LL |     v != ONE;

--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -78,7 +78,7 @@ fn if_same_then_else() {
     let _ = if true { 0.0 } else { -0.0 };
 
     // Different NaNs
-    let _ = if true { 0.0 / 0.0 } else { std::f32::NAN };
+    let _ = if true { 0.0 / 0.0 } else { f32::NAN };
 
     if true {
         foo();

--- a/tests/ui/if_same_then_else2.rs
+++ b/tests/ui/if_same_then_else2.rs
@@ -87,10 +87,10 @@ fn if_same_then_else2() -> Result<&'static str, ()> {
 
     // Same NaNs
     let _ = if true {
-        std::f32::NAN
+        f32::NAN
     } else {
         //~ ERROR same body as `if` block
-        std::f32::NAN
+        f32::NAN
     };
 
     if true {

--- a/tests/ui/if_same_then_else2.stderr
+++ b/tests/ui/if_same_then_else2.stderr
@@ -69,7 +69,7 @@ error: this `if` has identical blocks
 LL |       } else {
    |  ____________^
 LL | |         //~ ERROR same body as `if` block
-LL | |         std::f32::NAN
+LL | |         f32::NAN
 LL | |     };
    | |_____^
    |
@@ -78,7 +78,7 @@ note: same as this
    |
 LL |       let _ = if true {
    |  _____________________^
-LL | |         std::f32::NAN
+LL | |         f32::NAN
 LL | |     } else {
    | |_____^
 

--- a/tests/ui/zero_div_zero.stderr
+++ b/tests/ui/zero_div_zero.stderr
@@ -13,7 +13,7 @@ LL |     let nan = 0.0 / 0.0;
    |               ^^^^^^^^^
    |
    = note: `-D clippy::zero-divided-by-zero` implied by `-D warnings`
-   = help: Consider using `std::f64::NAN` if you would like a constant representing NaN
+   = help: Consider using `f64::NAN` if you would like a constant representing NaN
 
 error: equal expressions as operands to `/`
   --> $DIR/zero_div_zero.rs:5:19
@@ -27,7 +27,7 @@ error: constant division of `0.0` with `0.0` will always result in NaN
 LL |     let f64_nan = 0.0 / 0.0f64;
    |                   ^^^^^^^^^^^^
    |
-   = help: Consider using `std::f64::NAN` if you would like a constant representing NaN
+   = help: Consider using `f64::NAN` if you would like a constant representing NaN
 
 error: equal expressions as operands to `/`
   --> $DIR/zero_div_zero.rs:6:25
@@ -41,7 +41,7 @@ error: constant division of `0.0` with `0.0` will always result in NaN
 LL |     let other_f64_nan = 0.0f64 / 0.0;
    |                         ^^^^^^^^^^^^
    |
-   = help: Consider using `std::f64::NAN` if you would like a constant representing NaN
+   = help: Consider using `f64::NAN` if you would like a constant representing NaN
 
 error: equal expressions as operands to `/`
   --> $DIR/zero_div_zero.rs:7:28
@@ -55,7 +55,7 @@ error: constant division of `0.0` with `0.0` will always result in NaN
 LL |     let one_more_f64_nan = 0.0f64 / 0.0f64;
    |                            ^^^^^^^^^^^^^^^
    |
-   = help: Consider using `std::f64::NAN` if you would like a constant representing NaN
+   = help: Consider using `f64::NAN` if you would like a constant representing NaN
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
changelog: Recommend primitive type associated constants instead of module level constants

In Rust 1.43 integer and float primitive types will have a number of new associated constants. For example `MAX`, `MIN` and a number of constants related to the machine representation of floats. https://github.com/rust-lang/rust/pull/68952

These new constants are preferred over the module level constants in `{core,std}::{f*, u*, i*}`. I have in the last few days made sure that the documentation in the main rust repository uses the new constants in every place I could find (https://github.com/rust-lang/rust/pull/69860, https://github.com/rust-lang/rust/pull/70782). So the next step is naturally to make the linter recommend the new constants as well.

This PR only changes two lints. There are more. But I did not want the PR to be too big. And since I have not contributed to clippy before it felt saner to start with a small PR so I see if there are any quirks. More will come later.