### PR TITLE
Some accuracy lints for floating point operations

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -665,6 +665,7 @@ fn check_radians(cx: &LateContext<'_>, expr: &Expr<'_>) {
         if let Some((rvalue, _)) = constant(cx, cx.tables(), div_rhs);
         if let Some((lvalue, _)) = constant(cx, cx.tables(), mul_rhs);
         then {
+            // TODO: also check for constant values near PI/180 or 180/PI
             if (F32(f32_consts::PI) == rvalue || F64(f64_consts::PI) == rvalue) &&
                (F32(180_f32) == lvalue || F64(180_f64) == lvalue)
             {

--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -651,7 +651,7 @@ fn check_radians(cx: &LateContext<'_>, expr: &Expr<'_>) {
             {
                 span_lint_and_sugg(
                     cx,
-                    IMPRECISE_FLOPS,
+                    SUBOPTIMAL_FLOPS,
                     expr.span,
                     "conversion to degrees can be done more accurately",
                     "consider using",
@@ -664,7 +664,7 @@ fn check_radians(cx: &LateContext<'_>, expr: &Expr<'_>) {
             {
                 span_lint_and_sugg(
                     cx,
-                    IMPRECISE_FLOPS,
+                    SUBOPTIMAL_FLOPS,
                     expr.span,
                     "conversion to radians can be done more accurately",
                     "consider using",

--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -618,7 +618,7 @@ fn check_log_division(cx: &LateContext<'_>, expr: &Expr<'_>) {
                 cx,
                 SUBOPTIMAL_FLOPS,
                 expr.span,
-                "division of logarithms can be calculated more efficiently and accurately",
+                "log base can be expressed more clearly",
                 "consider using",
                 format!("{}.log({})", Sugg::hir(cx, &largs[0], ".."), Sugg::hir(cx, &rargs[0], ".."),),
                 Applicability::MachineApplicable,

--- a/tests/ui/floating_point_hypot.fixed
+++ b/tests/ui/floating_point_hypot.fixed
@@ -1,0 +1,13 @@
+// run-rustfix
+#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+
+fn main() {
+    let x = 3f32;
+    let y = 4f32;
+    let _ = x.hypot(y);
+    let _ = (x + 1f32).hypot(y);
+    let _ = x.hypot(y);
+    // Cases where the lint shouldn't be applied
+    let _ = x.mul_add(x, y * y).sqrt();
+    let _ = x.mul_add(4f32, y * y).sqrt();
+}

--- a/tests/ui/floating_point_hypot.fixed
+++ b/tests/ui/floating_point_hypot.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+#![warn(clippy::imprecise_flops)]
 
 fn main() {
     let x = 3f32;
@@ -8,6 +8,7 @@ fn main() {
     let _ = (x + 1f32).hypot(y);
     let _ = x.hypot(y);
     // Cases where the lint shouldn't be applied
+    // TODO: linting this adds some complexity, but could be done
     let _ = x.mul_add(x, y * y).sqrt();
-    let _ = x.mul_add(4f32, y * y).sqrt();
+    let _ = (x * 4f32 + y * y).sqrt();
 }

--- a/tests/ui/floating_point_hypot.rs
+++ b/tests/ui/floating_point_hypot.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+#![warn(clippy::imprecise_flops)]
 
 fn main() {
     let x = 3f32;
@@ -8,6 +8,7 @@ fn main() {
     let _ = ((x + 1f32) * (x + 1f32) + y * y).sqrt();
     let _ = (x.powi(2) + y.powi(2)).sqrt();
     // Cases where the lint shouldn't be applied
+    // TODO: linting this adds some complexity, but could be done
     let _ = x.mul_add(x, y * y).sqrt();
     let _ = (x * 4f32 + y * y).sqrt();
 }

--- a/tests/ui/floating_point_hypot.rs
+++ b/tests/ui/floating_point_hypot.rs
@@ -1,0 +1,13 @@
+// run-rustfix
+#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+
+fn main() {
+    let x = 3f32;
+    let y = 4f32;
+    let _ = (x * x + y * y).sqrt();
+    let _ = ((x + 1f32) * (x + 1f32) + y * y).sqrt();
+    let _ = (x.powi(2) + y.powi(2)).sqrt();
+    // Cases where the lint shouldn't be applied
+    let _ = x.mul_add(x, y * y).sqrt();
+    let _ = (x * 4f32 + y * y).sqrt();
+}

--- a/tests/ui/floating_point_hypot.stderr
+++ b/tests/ui/floating_point_hypot.stderr
@@ -1,0 +1,30 @@
+error: hypotenuse can be computed more accurately
+  --> $DIR/floating_point_hypot.rs:7:13
+   |
+LL |     let _ = (x * x + y * y).sqrt();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
+   |
+   = note: `-D clippy::imprecise-flops` implied by `-D warnings`
+
+error: hypotenuse can be computed more accurately
+  --> $DIR/floating_point_hypot.rs:8:13
+   |
+LL |     let _ = ((x + 1f32) * (x + 1f32) + y * y).sqrt();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x + 1f32).hypot(y)`
+
+error: hypotenuse can be computed more accurately
+  --> $DIR/floating_point_hypot.rs:9:13
+   |
+LL |     let _ = (x.powi(2) + y.powi(2)).sqrt();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
+
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_hypot.rs:12:13
+   |
+LL |     let _ = (x * 4f32 + y * y).sqrt();
+   |             ^^^^^^^^^^^^^^^^^^ help: consider using: `x.mul_add(4f32, y * y)`
+   |
+   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/floating_point_hypot.stderr
+++ b/tests/ui/floating_point_hypot.stderr
@@ -18,13 +18,5 @@ error: hypotenuse can be computed more accurately
 LL |     let _ = (x.powi(2) + y.powi(2)).sqrt();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
 
-error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_hypot.rs:12:13
-   |
-LL |     let _ = (x * 4f32 + y * y).sqrt();
-   |             ^^^^^^^^^^^^^^^^^^ help: consider using: `x.mul_add(4f32, y * y)`
-   |
-   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/floating_point_log.fixed
+++ b/tests/ui/floating_point_log.fixed
@@ -25,11 +25,11 @@ fn check_ln1p() {
     let _ = 2.0f32.ln_1p();
     let _ = x.ln_1p();
     let _ = (x / 2.0).ln_1p();
-    let _ = x.powi(2).ln_1p();
-    let _ = (x.powi(2) / 2.0).ln_1p();
+    let _ = x.powi(3).ln_1p();
+    let _ = (x.powi(3) / 2.0).ln_1p();
     let _ = ((std::f32::consts::E - 1.0)).ln_1p();
     let _ = x.ln_1p();
-    let _ = x.powi(2).ln_1p();
+    let _ = x.powi(3).ln_1p();
     let _ = (x + 2.0).ln_1p();
     let _ = (x / 2.0).ln_1p();
     // Cases where the lint shouldn't be applied
@@ -43,9 +43,9 @@ fn check_ln1p() {
     let _ = 2.0f64.ln_1p();
     let _ = x.ln_1p();
     let _ = (x / 2.0).ln_1p();
-    let _ = x.powi(2).ln_1p();
+    let _ = x.powi(3).ln_1p();
     let _ = x.ln_1p();
-    let _ = x.powi(2).ln_1p();
+    let _ = x.powi(3).ln_1p();
     let _ = (x + 2.0).ln_1p();
     let _ = (x / 2.0).ln_1p();
     // Cases where the lint shouldn't be applied

--- a/tests/ui/floating_point_log.rs
+++ b/tests/ui/floating_point_log.rs
@@ -25,11 +25,11 @@ fn check_ln1p() {
     let _ = (1f32 + 2.0).ln();
     let _ = (1.0 + x).ln();
     let _ = (1.0 + x / 2.0).ln();
-    let _ = (1.0 + x.powi(2)).ln();
-    let _ = (1.0 + x.powi(2) / 2.0).ln();
+    let _ = (1.0 + x.powi(3)).ln();
+    let _ = (1.0 + x.powi(3) / 2.0).ln();
     let _ = (1.0 + (std::f32::consts::E - 1.0)).ln();
     let _ = (x + 1.0).ln();
-    let _ = (x.powi(2) + 1.0).ln();
+    let _ = (x.powi(3) + 1.0).ln();
     let _ = (x + 2.0 + 1.0).ln();
     let _ = (x / 2.0 + 1.0).ln();
     // Cases where the lint shouldn't be applied
@@ -43,9 +43,9 @@ fn check_ln1p() {
     let _ = (1f64 + 2.0).ln();
     let _ = (1.0 + x).ln();
     let _ = (1.0 + x / 2.0).ln();
-    let _ = (1.0 + x.powi(2)).ln();
+    let _ = (1.0 + x.powi(3)).ln();
     let _ = (x + 1.0).ln();
-    let _ = (x.powi(2) + 1.0).ln();
+    let _ = (x.powi(3) + 1.0).ln();
     let _ = (x + 2.0 + 1.0).ln();
     let _ = (x / 2.0 + 1.0).ln();
     // Cases where the lint shouldn't be applied

--- a/tests/ui/floating_point_log.stderr
+++ b/tests/ui/floating_point_log.stderr
@@ -77,14 +77,14 @@ LL |     let _ = (1.0 + x / 2.0).ln();
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:28:13
    |
-LL |     let _ = (1.0 + x.powi(2)).ln();
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(2).ln_1p()`
+LL |     let _ = (1.0 + x.powi(3)).ln();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(3).ln_1p()`
 
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:29:13
    |
-LL |     let _ = (1.0 + x.powi(2) / 2.0).ln();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x.powi(2) / 2.0).ln_1p()`
+LL |     let _ = (1.0 + x.powi(3) / 2.0).ln();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x.powi(3) / 2.0).ln_1p()`
 
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:30:13
@@ -101,8 +101,8 @@ LL |     let _ = (x + 1.0).ln();
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:32:13
    |
-LL |     let _ = (x.powi(2) + 1.0).ln();
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(2).ln_1p()`
+LL |     let _ = (x.powi(3) + 1.0).ln();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(3).ln_1p()`
 
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:33:13
@@ -143,8 +143,8 @@ LL |     let _ = (1.0 + x / 2.0).ln();
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:46:13
    |
-LL |     let _ = (1.0 + x.powi(2)).ln();
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(2).ln_1p()`
+LL |     let _ = (1.0 + x.powi(3)).ln();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(3).ln_1p()`
 
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:47:13
@@ -155,8 +155,8 @@ LL |     let _ = (x + 1.0).ln();
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:48:13
    |
-LL |     let _ = (x.powi(2) + 1.0).ln();
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(2).ln_1p()`
+LL |     let _ = (x.powi(3) + 1.0).ln();
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.powi(3).ln_1p()`
 
 error: ln(1 + x) can be computed more accurately
   --> $DIR/floating_point_log.rs:49:13

--- a/tests/ui/floating_point_logbase.fixed
+++ b/tests/ui/floating_point_logbase.fixed
@@ -1,0 +1,16 @@
+// run-rustfix
+#![warn(clippy::suboptimal_flops)]
+
+fn main() {
+    let x = 3f32;
+    let y = 5f32;
+    let _ = x.log(y);
+    let _ = x.log(y);
+    let _ = x.log(y);
+    let _ = x.log(y);
+    // Cases where the lint shouldn't be applied
+    let _ = x.ln() / y.powf(3.2);
+    let _ = x.powf(3.2) / y.powf(3.2);
+    let _ = x.powf(3.2) / y.ln();
+    let _ = x.log(5f32) / y.log(7f32);
+}

--- a/tests/ui/floating_point_logbase.rs
+++ b/tests/ui/floating_point_logbase.rs
@@ -1,0 +1,16 @@
+// run-rustfix
+#![warn(clippy::suboptimal_flops)]
+
+fn main() {
+    let x = 3f32;
+    let y = 5f32;
+    let _ = x.ln() / y.ln();
+    let _ = x.log2() / y.log2();
+    let _ = x.log10() / y.log10();
+    let _ = x.log(5f32) / y.log(5f32);
+    // Cases where the lint shouldn't be applied
+    let _ = x.ln() / y.powf(3.2);
+    let _ = x.powf(3.2) / y.powf(3.2);
+    let _ = x.powf(3.2) / y.ln();
+    let _ = x.log(5f32) / y.log(7f32);
+}

--- a/tests/ui/floating_point_logbase.stderr
+++ b/tests/ui/floating_point_logbase.stderr
@@ -1,0 +1,28 @@
+error: division of logarithms can be calculated more efficiently and accurately
+  --> $DIR/floating_point_logbase.rs:7:13
+   |
+LL |     let _ = x.ln() / y.ln();
+   |             ^^^^^^^^^^^^^^^ help: consider using: `x.log(y)`
+   |
+   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
+
+error: division of logarithms can be calculated more efficiently and accurately
+  --> $DIR/floating_point_logbase.rs:8:13
+   |
+LL |     let _ = x.log2() / y.log2();
+   |             ^^^^^^^^^^^^^^^^^^^ help: consider using: `x.log(y)`
+
+error: division of logarithms can be calculated more efficiently and accurately
+  --> $DIR/floating_point_logbase.rs:9:13
+   |
+LL |     let _ = x.log10() / y.log10();
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.log(y)`
+
+error: division of logarithms can be calculated more efficiently and accurately
+  --> $DIR/floating_point_logbase.rs:10:13
+   |
+LL |     let _ = x.log(5f32) / y.log(5f32);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.log(y)`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/floating_point_logbase.stderr
+++ b/tests/ui/floating_point_logbase.stderr
@@ -1,4 +1,4 @@
-error: division of logarithms can be calculated more efficiently and accurately
+error: log base can be expressed more clearly
   --> $DIR/floating_point_logbase.rs:7:13
    |
 LL |     let _ = x.ln() / y.ln();
@@ -6,19 +6,19 @@ LL |     let _ = x.ln() / y.ln();
    |
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
-error: division of logarithms can be calculated more efficiently and accurately
+error: log base can be expressed more clearly
   --> $DIR/floating_point_logbase.rs:8:13
    |
 LL |     let _ = x.log2() / y.log2();
    |             ^^^^^^^^^^^^^^^^^^^ help: consider using: `x.log(y)`
 
-error: division of logarithms can be calculated more efficiently and accurately
+error: log base can be expressed more clearly
   --> $DIR/floating_point_logbase.rs:9:13
    |
 LL |     let _ = x.log10() / y.log10();
    |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.log(y)`
 
-error: division of logarithms can be calculated more efficiently and accurately
+error: log base can be expressed more clearly
   --> $DIR/floating_point_logbase.rs:10:13
    |
 LL |     let _ = x.log(5f32) / y.log(5f32);

--- a/tests/ui/floating_point_mul_add.fixed
+++ b/tests/ui/floating_point_mul_add.fixed
@@ -18,4 +18,9 @@ fn main() {
 
     let _ = a.mul_add(b, c).mul_add(a.mul_add(b, c), a.mul_add(b, c)) + c;
     let _ = 1234.567_f64.mul_add(45.67834_f64, 0.0004_f64);
+
+    let _ = a.mul_add(a, b).sqrt();
+
+    // Cases where the lint shouldn't be applied
+    let _ = (a * a + b * b).sqrt();
 }

--- a/tests/ui/floating_point_mul_add.rs
+++ b/tests/ui/floating_point_mul_add.rs
@@ -18,4 +18,9 @@ fn main() {
 
     let _ = a.mul_add(b, c) * a.mul_add(b, c) + a.mul_add(b, c) + c;
     let _ = 1234.567_f64 * 45.67834_f64 + 0.0004_f64;
+
+    let _ = (a * a + b).sqrt();
+
+    // Cases where the lint shouldn't be applied
+    let _ = (a * a + b * b).sqrt();
 }

--- a/tests/ui/floating_point_mul_add.stderr
+++ b/tests/ui/floating_point_mul_add.stderr
@@ -54,5 +54,11 @@ error: multiply and add expressions can be calculated more efficiently and accur
 LL |     let _ = 1234.567_f64 * 45.67834_f64 + 0.0004_f64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1234.567_f64.mul_add(45.67834_f64, 0.0004_f64)`
 
-error: aborting due to 9 previous errors
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_mul_add.rs:22:13
+   |
+LL |     let _ = (a * a + b).sqrt();
+   |             ^^^^^^^^^^^ help: consider using: `a.mul_add(a, b)`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/floating_point_powf.fixed
+++ b/tests/ui/floating_point_powf.fixed
@@ -11,7 +11,7 @@ fn main() {
     let _ = (-3.1f32).exp();
     let _ = x.sqrt();
     let _ = x.cbrt();
-    let _ = x.powi(2);
+    let _ = x.powi(3);
     let _ = x.powi(-2);
     let _ = x.powi(16_777_215);
     let _ = x.powi(-16_777_215);
@@ -30,7 +30,7 @@ fn main() {
     let _ = (-3.1f64).exp();
     let _ = x.sqrt();
     let _ = x.cbrt();
-    let _ = x.powi(2);
+    let _ = x.powi(3);
     let _ = x.powi(-2);
     let _ = x.powi(-2_147_483_648);
     let _ = x.powi(2_147_483_647);

--- a/tests/ui/floating_point_powf.rs
+++ b/tests/ui/floating_point_powf.rs
@@ -11,7 +11,7 @@ fn main() {
     let _ = std::f32::consts::E.powf(-3.1);
     let _ = x.powf(1.0 / 2.0);
     let _ = x.powf(1.0 / 3.0);
-    let _ = x.powf(2.0);
+    let _ = x.powf(3.0);
     let _ = x.powf(-2.0);
     let _ = x.powf(16_777_215.0);
     let _ = x.powf(-16_777_215.0);
@@ -30,7 +30,7 @@ fn main() {
     let _ = std::f64::consts::E.powf(-3.1);
     let _ = x.powf(1.0 / 2.0);
     let _ = x.powf(1.0 / 3.0);
-    let _ = x.powf(2.0);
+    let _ = x.powf(3.0);
     let _ = x.powf(-2.0);
     let _ = x.powf(-2_147_483_648.0);
     let _ = x.powf(2_147_483_647.0);

--- a/tests/ui/floating_point_powf.stderr
+++ b/tests/ui/floating_point_powf.stderr
@@ -53,8 +53,8 @@ LL |     let _ = x.powf(1.0 / 3.0);
 error: exponentiation with integer powers can be computed more efficiently
   --> $DIR/floating_point_powf.rs:14:13
    |
-LL |     let _ = x.powf(2.0);
-   |             ^^^^^^^^^^^ help: consider using: `x.powi(2)`
+LL |     let _ = x.powf(3.0);
+   |             ^^^^^^^^^^^ help: consider using: `x.powi(3)`
 
 error: exponentiation with integer powers can be computed more efficiently
   --> $DIR/floating_point_powf.rs:15:13
@@ -125,8 +125,8 @@ LL |     let _ = x.powf(1.0 / 3.0);
 error: exponentiation with integer powers can be computed more efficiently
   --> $DIR/floating_point_powf.rs:33:13
    |
-LL |     let _ = x.powf(2.0);
-   |             ^^^^^^^^^^^ help: consider using: `x.powi(2)`
+LL |     let _ = x.powf(3.0);
+   |             ^^^^^^^^^^^ help: consider using: `x.powi(3)`
 
 error: exponentiation with integer powers can be computed more efficiently
   --> $DIR/floating_point_powf.rs:34:13

--- a/tests/ui/floating_point_powi.fixed
+++ b/tests/ui/floating_point_powi.fixed
@@ -1,12 +1,17 @@
 // run-rustfix
-#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+#![warn(clippy::imprecise_flops)]
 
 fn main() {
     let one = 1;
     let x = 3f32;
     let _ = x * x;
     let _ = x * x;
+
+    let y = 4f32;
+    let _ = (x * x + y).sqrt();
+    let _ = (x + y * y).sqrt();
     // Cases where the lint shouldn't be applied
     let _ = x.powi(3);
     let _ = x.powi(one + 1);
+    let _ = x.hypot(y);
 }

--- a/tests/ui/floating_point_powi.fixed
+++ b/tests/ui/floating_point_powi.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+
+fn main() {
+    let one = 1;
+    let x = 3f32;
+    let _ = x * x;
+    let _ = x * x;
+    // Cases where the lint shouldn't be applied
+    let _ = x.powi(3);
+    let _ = x.powi(one + 1);
+}

--- a/tests/ui/floating_point_powi.fixed
+++ b/tests/ui/floating_point_powi.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![warn(clippy::imprecise_flops)]
+#![warn(clippy::suboptimal_flops)]
 
 fn main() {
     let one = 1;
@@ -8,10 +8,12 @@ fn main() {
     let _ = x * x;
 
     let y = 4f32;
-    let _ = (x * x + y).sqrt();
-    let _ = (x + y * y).sqrt();
+    let _ = x.mul_add(x, y);
+    let _ = y.mul_add(y, x);
+    let _ = x.mul_add(x, y).sqrt();
+    let _ = y.mul_add(y, x).sqrt();
     // Cases where the lint shouldn't be applied
     let _ = x.powi(3);
     let _ = x.powi(one + 1);
-    let _ = x.hypot(y);
+    let _ = (x.powi(2) + y.powi(2)).sqrt();
 }

--- a/tests/ui/floating_point_powi.rs
+++ b/tests/ui/floating_point_powi.rs
@@ -1,12 +1,17 @@
 // run-rustfix
-#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+#![warn(clippy::imprecise_flops)]
 
 fn main() {
     let one = 1;
     let x = 3f32;
     let _ = x.powi(2);
     let _ = x.powi(1 + 1);
+
+    let y = 4f32;
+    let _ = (x.powi(2) + y).sqrt();
+    let _ = (x + y.powi(2)).sqrt();
     // Cases where the lint shouldn't be applied
     let _ = x.powi(3);
     let _ = x.powi(one + 1);
+    let _ = (x.powi(2) + y.powi(2)).sqrt();
 }

--- a/tests/ui/floating_point_powi.rs
+++ b/tests/ui/floating_point_powi.rs
@@ -1,0 +1,12 @@
+// run-rustfix
+#![warn(clippy::suboptimal_flops, clippy::imprecise_flops)]
+
+fn main() {
+    let one = 1;
+    let x = 3f32;
+    let _ = x.powi(2);
+    let _ = x.powi(1 + 1);
+    // Cases where the lint shouldn't be applied
+    let _ = x.powi(3);
+    let _ = x.powi(one + 1);
+}

--- a/tests/ui/floating_point_powi.rs
+++ b/tests/ui/floating_point_powi.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![warn(clippy::imprecise_flops)]
+#![warn(clippy::suboptimal_flops)]
 
 fn main() {
     let one = 1;
@@ -8,6 +8,8 @@ fn main() {
     let _ = x.powi(1 + 1);
 
     let y = 4f32;
+    let _ = x.powi(2) + y;
+    let _ = x + y.powi(2);
     let _ = (x.powi(2) + y).sqrt();
     let _ = (x + y.powi(2)).sqrt();
     // Cases where the lint shouldn't be applied

--- a/tests/ui/floating_point_powi.stderr
+++ b/tests/ui/floating_point_powi.stderr
@@ -12,5 +12,23 @@ error: square can be computed more accurately
 LL |     let _ = x.powi(1 + 1);
    |             ^^^^^^^^^^^^^ help: consider using: `x * x`
 
-error: aborting due to 2 previous errors
+error: square can be computed more accurately
+  --> $DIR/floating_point_powi.rs:11:14
+   |
+LL |     let _ = (x.powi(2) + y).sqrt();
+   |              ^^^^^^^^^ help: consider using: `x * x`
+
+error: square can be computed more accurately
+  --> $DIR/floating_point_powi.rs:12:18
+   |
+LL |     let _ = (x + y.powi(2)).sqrt();
+   |                  ^^^^^^^^^ help: consider using: `y * y`
+
+error: hypotenuse can be computed more accurately
+  --> $DIR/floating_point_powi.rs:16:13
+   |
+LL |     let _ = (x.powi(2) + y.powi(2)).sqrt();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/floating_point_powi.stderr
+++ b/tests/ui/floating_point_powi.stderr
@@ -1,0 +1,16 @@
+error: square can be computed more accurately
+  --> $DIR/floating_point_powi.rs:7:13
+   |
+LL |     let _ = x.powi(2);
+   |             ^^^^^^^^^ help: consider using: `x * x`
+   |
+   = note: `-D clippy::imprecise-flops` implied by `-D warnings`
+
+error: square can be computed more accurately
+  --> $DIR/floating_point_powi.rs:8:13
+   |
+LL |     let _ = x.powi(1 + 1);
+   |             ^^^^^^^^^^^^^ help: consider using: `x * x`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/floating_point_powi.stderr
+++ b/tests/ui/floating_point_powi.stderr
@@ -1,34 +1,40 @@
-error: square can be computed more accurately
+error: square can be computed more efficiently
   --> $DIR/floating_point_powi.rs:7:13
    |
 LL |     let _ = x.powi(2);
    |             ^^^^^^^^^ help: consider using: `x * x`
    |
-   = note: `-D clippy::imprecise-flops` implied by `-D warnings`
+   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
-error: square can be computed more accurately
+error: square can be computed more efficiently
   --> $DIR/floating_point_powi.rs:8:13
    |
 LL |     let _ = x.powi(1 + 1);
    |             ^^^^^^^^^^^^^ help: consider using: `x * x`
 
-error: square can be computed more accurately
-  --> $DIR/floating_point_powi.rs:11:14
+error: square can be computed more efficiently
+  --> $DIR/floating_point_powi.rs:11:13
+   |
+LL |     let _ = x.powi(2) + y;
+   |             ^^^^^^^^^^^^^ help: consider using: `x.mul_add(x, y)`
+
+error: square can be computed more efficiently
+  --> $DIR/floating_point_powi.rs:12:13
+   |
+LL |     let _ = x + y.powi(2);
+   |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(y, x)`
+
+error: square can be computed more efficiently
+  --> $DIR/floating_point_powi.rs:13:13
    |
 LL |     let _ = (x.powi(2) + y).sqrt();
-   |              ^^^^^^^^^ help: consider using: `x * x`
+   |             ^^^^^^^^^^^^^^^ help: consider using: `x.mul_add(x, y)`
 
-error: square can be computed more accurately
-  --> $DIR/floating_point_powi.rs:12:18
+error: square can be computed more efficiently
+  --> $DIR/floating_point_powi.rs:14:13
    |
 LL |     let _ = (x + y.powi(2)).sqrt();
-   |                  ^^^^^^^^^ help: consider using: `y * y`
+   |             ^^^^^^^^^^^^^^^ help: consider using: `y.mul_add(y, x)`
 
-error: hypotenuse can be computed more accurately
-  --> $DIR/floating_point_powi.rs:16:13
-   |
-LL |     let _ = (x.powi(2) + y.powi(2)).sqrt();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.hypot(y)`
-
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/floating_point_rad.fixed
+++ b/tests/ui/floating_point_rad.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![warn(clippy::imprecise_flops)]
+#![warn(clippy::suboptimal_flops)]
 
 fn main() {
     let x = 3f32;

--- a/tests/ui/floating_point_rad.fixed
+++ b/tests/ui/floating_point_rad.fixed
@@ -1,0 +1,13 @@
+// run-rustfix
+#![warn(clippy::imprecise_flops)]
+
+fn main() {
+    let x = 3f32;
+    let _ = x.to_degrees();
+    let _ = x.to_radians();
+    // Cases where the lint shouldn't be applied
+    let _ = x * 90f32 / std::f32::consts::PI;
+    let _ = x * std::f32::consts::PI / 90f32;
+    let _ = x * 180f32 / std::f32::consts::E;
+    let _ = x * std::f32::consts::E / 180f32;
+}

--- a/tests/ui/floating_point_rad.rs
+++ b/tests/ui/floating_point_rad.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![warn(clippy::imprecise_flops)]
+#![warn(clippy::suboptimal_flops)]
 
 fn main() {
     let x = 3f32;

--- a/tests/ui/floating_point_rad.rs
+++ b/tests/ui/floating_point_rad.rs
@@ -1,0 +1,13 @@
+// run-rustfix
+#![warn(clippy::imprecise_flops)]
+
+fn main() {
+    let x = 3f32;
+    let _ = x * 180f32 / std::f32::consts::PI;
+    let _ = x * std::f32::consts::PI / 180f32;
+    // Cases where the lint shouldn't be applied
+    let _ = x * 90f32 / std::f32::consts::PI;
+    let _ = x * std::f32::consts::PI / 90f32;
+    let _ = x * 180f32 / std::f32::consts::E;
+    let _ = x * std::f32::consts::E / 180f32;
+}

--- a/tests/ui/floating_point_rad.stderr
+++ b/tests/ui/floating_point_rad.stderr
@@ -1,0 +1,16 @@
+error: conversion to degrees can be done more accurately
+  --> $DIR/floating_point_rad.rs:6:13
+   |
+LL |     let _ = x * 180f32 / std::f32::consts::PI;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.to_degrees()`
+   |
+   = note: `-D clippy::imprecise-flops` implied by `-D warnings`
+
+error: conversion to radians can be done more accurately
+  --> $DIR/floating_point_rad.rs:7:13
+   |
+LL |     let _ = x * std::f32::consts::PI / 180f32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.to_radians()`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/floating_point_rad.stderr
+++ b/tests/ui/floating_point_rad.stderr
@@ -4,7 +4,7 @@ error: conversion to degrees can be done more accurately
 LL |     let _ = x * 180f32 / std::f32::consts::PI;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.to_degrees()`
    |
-   = note: `-D clippy::imprecise-flops` implied by `-D warnings`
+   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
 error: conversion to radians can be done more accurately
   --> $DIR/floating_point_rad.rs:7:13


### PR DESCRIPTION
This will add some lints for accuracy on floating point operations suggested by @clarfon in #2040 (fixes #2040).

These are the remaining lints:

- [x] x.powi(2) => x * x
- [x] x.logN() / y.logN() => x.logbase(y)
- [x] x.logbase(E) => x.log()
- [x] x.logbase(10) => x.log10()
- [x] x.logbase(2) => x.log2().
- [x] x * PI / 180 => x.to_radians()
- [x] x * 180 / PI => x.to_degrees()
- [x] (x + 1).log() => x.log_1p()
- [x] sqrt(x * x + y * y) => x.hypot(y)

changelog: Included some accuracy lints for floating point operations
