### PR TITLE
Fixes issue #4892.

### DIFF
--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -5,6 +5,23 @@ use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Spanned;
 
+const ODD_FUNCTIONS_WHITELIST: [&str; 14] = [
+    "asin",
+    "asinh",
+    "atan",
+    "atanh",
+    "cbrt",
+    "fract",
+    "round",
+    "signum",
+    "sin",
+    "sinh",
+    "tan",
+    "tanh",
+    "to_degrees",
+    "to_radians",
+];
+
 declare_clippy_lint! {
     /// **What it does:** Checks for operations where precedence may be unclear
     /// and suggests to add parentheses. Currently it catches the following:
@@ -86,11 +103,16 @@ impl EarlyLintPass for Precedence {
         }
 
         if let ExprKind::Unary(UnOp::Neg, ref rhs) = expr.kind {
-            if let ExprKind::MethodCall(_, ref args) = rhs.kind {
+            if let ExprKind::MethodCall(ref path_segment, ref args) = rhs.kind {
                 if let Some(slf) = args.first() {
                     if let ExprKind::Lit(ref lit) = slf.kind {
                         match lit.kind {
                             LitKind::Int(..) | LitKind::Float(..) => {
+                                for &odd_function in &ODD_FUNCTIONS_WHITELIST {
+                                    if odd_function == &*path_segment.ident.name.as_str() {
+                                        return;
+                                    }
+                                }
                                 let mut applicability = Applicability::MachineApplicable;
                                 span_lint_and_sugg(
                                     cx,

--- a/clippy_lints/src/precedence.rs
+++ b/clippy_lints/src/precedence.rs
@@ -104,14 +104,16 @@ impl EarlyLintPass for Precedence {
 
         if let ExprKind::Unary(UnOp::Neg, ref rhs) = expr.kind {
             if let ExprKind::MethodCall(ref path_segment, ref args) = rhs.kind {
+                let path_segment_str = path_segment.ident.name.as_str();
                 if let Some(slf) = args.first() {
                     if let ExprKind::Lit(ref lit) = slf.kind {
                         match lit.kind {
                             LitKind::Int(..) | LitKind::Float(..) => {
-                                for &odd_function in &ODD_FUNCTIONS_WHITELIST {
-                                    if odd_function == &*path_segment.ident.name.as_str() {
-                                        return;
-                                    }
+                                if ODD_FUNCTIONS_WHITELIST
+                                    .iter()
+                                    .any(|odd_function| **odd_function == *path_segment_str)
+                                {
+                                    return;
                                 }
                                 let mut applicability = Applicability::MachineApplicable;
                                 span_lint_and_sugg(

--- a/tests/ui/precedence.fixed
+++ b/tests/ui/precedence.fixed
@@ -32,6 +32,22 @@ fn main() {
     let _ = -(1i32.abs());
     let _ = -(1f32.abs());
 
+    // Odd functions shoud not trigger an error
+    let _ = -1f64.asin();
+    let _ = -1f64.asinh();
+    let _ = -1f64.atan();
+    let _ = -1f64.atanh();
+    let _ = -1f64.cbrt();
+    let _ = -1f64.fract();
+    let _ = -1f64.round();
+    let _ = -1f64.signum();
+    let _ = -1f64.sin();
+    let _ = -1f64.sinh();
+    let _ = -1f64.tan();
+    let _ = -1f64.tanh();
+    let _ = -1f64.to_degrees();
+    let _ = -1f64.to_radians();
+
     let b = 3;
     trip!(b * 8);
 }

--- a/tests/ui/precedence.rs
+++ b/tests/ui/precedence.rs
@@ -32,6 +32,22 @@ fn main() {
     let _ = -(1i32.abs());
     let _ = -(1f32.abs());
 
+    // Odd functions shoud not trigger an error
+    let _ = -1f64.asin();
+    let _ = -1f64.asinh();
+    let _ = -1f64.atan();
+    let _ = -1f64.atanh();
+    let _ = -1f64.cbrt();
+    let _ = -1f64.fract();
+    let _ = -1f64.round();
+    let _ = -1f64.signum();
+    let _ = -1f64.sin();
+    let _ = -1f64.sinh();
+    let _ = -1f64.tan();
+    let _ = -1f64.tanh();
+    let _ = -1f64.to_degrees();
+    let _ = -1f64.to_radians();
+
     let b = 3;
     trip!(b * 8);
 }


### PR DESCRIPTION
First contribution here 😊 ! Do not hesitate to correct me. 

This PR is related to issue #4892 . 

# Summary 

```rust
-literal.method_call(args)
```
The main idea is to not trigger `clippy::precedence` when the method call is an odd function.

# Example 

```rust
// should trigger lint 
let _ = -1.0_f64.abs() //precedence of method call abs() and neg ('-') is ambiguous

// should not trigger lint
let _ = -1.0_f64.sin() // sin is an odd function => -sin(x) = sin(-x) 
```

# Theory

Rust allows following literals: 
- char
- string
- integers
- floats
- byte
- bool

Only integers/floats implements the relevant `std::ops::Neg`.
Following odd functions are implemented on i[8-128] and/or f[32-64]: 
- `asin`
- `asinh`
- `atan`
- `atanh`
- `cbrt`
- `fract`
- `round`
- `signum`
- `sin`
- `sinh`
- `tan`
- `tanh `
- `to_degrees`
- `to_radians`

# Implementation 

As suggested by `flip1995` in [comment](https://github.com/rust-lang/rust-clippy/issues/4892#issuecomment-568249683), this PR add a whitelist of odd functions and compare method call to the the whitelist before triggering lint. 

changelog: Don't trigger [`clippy::precedence`] on odd functions.