### PR TITLE
Update documentation for new_ret_no_self

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -730,7 +730,7 @@ declare_clippy_lint! {
 }
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for `new` not returning `Self`.
+    /// **What it does:** Checks for `new` not returning a type that contains `Self`.
     ///
     /// **Why is this bad?** As a convention, `new` methods are used to make a new
     /// instance of a type.
@@ -747,9 +747,31 @@ declare_clippy_lint! {
     ///     }
     /// }
     /// ```
+    ///
+    /// ```rust
+    /// # struct Foo;
+    /// # struct FooError;
+    /// impl Foo {
+    ///     // Good. Return type contains `Self`
+    ///     fn new() -> Result<Foo, FooError> {
+    ///         # Ok(Foo)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```rust
+    /// # struct Foo;
+    /// struct Bar(Foo);
+    /// impl Foo {
+    ///     // Bad. The type name must contain `Self`.
+    ///     fn new() -> Bar {
+    ///         # Bar(Foo)
+    ///     }
+    /// }
+    /// ```
     pub NEW_RET_NO_SELF,
     style,
-    "not returning `Self` in a `new` method"
+    "not returning type containing `Self` in a `new` method"
 }
 
 declare_clippy_lint! {

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1448,7 +1448,7 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
     Lint {
         name: "new_ret_no_self",
         group: "style",
-        desc: "not returning `Self` in a `new` method",
+        desc: "not returning type containing `Self` in a `new` method",
         deprecation: None,
         module: "methods",
     },


### PR DESCRIPTION
changelog: Update documentation for lint new_ret_no_self to reflect that the return type must only contain `Self`, not be `Self`

The lint was changed to be more lenient than the documentation implies in PR #3338 (Related issue #3313)
