### PR TITLE
Allow UUID style formatting for `inconsistent_digit_grouping` lint

### DIFF
--- a/tests/ui/inconsistent_digit_grouping.fixed
+++ b/tests/ui/inconsistent_digit_grouping.fixed
@@ -34,6 +34,9 @@ fn main() {
     // Test suggestion when fraction has no digits
     let _: f32 = 123_456.;
 
+    // Test UUID formatted literal
+    let _: u128 = 0x12345678_1234_1234_1234_123456789012;
+
     // Ignore literals in macros
     let _ = mac1!();
     let _ = mac2!();

--- a/tests/ui/inconsistent_digit_grouping.rs
+++ b/tests/ui/inconsistent_digit_grouping.rs
@@ -34,6 +34,9 @@ fn main() {
     // Test suggestion when fraction has no digits
     let _: f32 = 1_23_456.;
 
+    // Test UUID formatted literal
+    let _: u128 = 0x12345678_1234_1234_1234_123456789012;
+
     // Ignore literals in macros
     let _ = mac1!();
     let _ = mac2!();


### PR DESCRIPTION
This change adds a check to the `inconsistent_digit_grouping` to add a check for
NumericLiterals that follow the UUID format of 8-4-4-4-12.

If the NumericLiteral matches the UUID format, no further inconsistent grouping checks
will be performed.

Closes #5431

changelog: Allow UUID style formatting for `inconsistent_digit_grouping` lint
