### PR TITLE
Fixes #5405: redundant clone false positive with arrays

### DIFF
--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -51,6 +51,7 @@ fn main() {
     cannot_move_from_type_with_drop();
     borrower_propagation();
     not_consumed();
+    issue_5405();
 }
 
 #[derive(Clone)]
@@ -159,4 +160,13 @@ fn not_consumed() {
     if let Some(x) = t {
         println!("{}", x);
     }
+}
+
+#[allow(clippy::clone_on_copy)]
+fn issue_5405() {
+    let a: [String; 1] = [String::from("foo")];
+    let _b: String = a[0].clone();
+
+    let c: [usize; 2] = [2, 3];
+    let _d: usize = c[1].clone();
 }

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -51,6 +51,7 @@ fn main() {
     cannot_move_from_type_with_drop();
     borrower_propagation();
     not_consumed();
+    issue_5405();
 }
 
 #[derive(Clone)]
@@ -159,4 +160,13 @@ fn not_consumed() {
     if let Some(x) = t {
         println!("{}", x);
     }
+}
+
+#[allow(clippy::clone_on_copy)]
+fn issue_5405() {
+    let a: [String; 1] = [String::from("foo")];
+    let _b: String = a[0].clone();
+
+    let c: [usize; 2] = [2, 3];
+    let _d: usize = c[1].clone();
 }

--- a/tests/ui/redundant_clone.stderr
+++ b/tests/ui/redundant_clone.stderr
@@ -108,61 +108,61 @@ LL |     let _t = tup.0.clone();
    |              ^^^^^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:60:22
+  --> $DIR/redundant_clone.rs:61:22
    |
 LL |         (a.clone(), a.clone())
    |                      ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:60:21
+  --> $DIR/redundant_clone.rs:61:21
    |
 LL |         (a.clone(), a.clone())
    |                     ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:120:15
-   |
-LL |     let _s = s.clone();
-   |               ^^^^^^^^ help: remove this
-   |
-note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:120:14
-   |
-LL |     let _s = s.clone();
-   |              ^
-
-error: redundant clone
   --> $DIR/redundant_clone.rs:121:15
    |
-LL |     let _t = t.clone();
+LL |     let _s = s.clone();
    |               ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
   --> $DIR/redundant_clone.rs:121:14
    |
+LL |     let _s = s.clone();
+   |              ^
+
+error: redundant clone
+  --> $DIR/redundant_clone.rs:122:15
+   |
+LL |     let _t = t.clone();
+   |               ^^^^^^^^ help: remove this
+   |
+note: this value is dropped without further use
+  --> $DIR/redundant_clone.rs:122:14
+   |
 LL |     let _t = t.clone();
    |              ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:131:19
+  --> $DIR/redundant_clone.rs:132:19
    |
 LL |         let _f = f.clone();
    |                   ^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> $DIR/redundant_clone.rs:131:18
+  --> $DIR/redundant_clone.rs:132:18
    |
 LL |         let _f = f.clone();
    |                  ^
 
 error: redundant clone
-  --> $DIR/redundant_clone.rs:143:14
+  --> $DIR/redundant_clone.rs:144:14
    |
 LL |     let y = x.clone().join("matthias");
    |              ^^^^^^^^ help: remove this
    |
 note: cloned value is neither consumed nor mutated
-  --> $DIR/redundant_clone.rs:143:13
+  --> $DIR/redundant_clone.rs:144:13
    |
 LL |     let y = x.clone().join("matthias");
    |             ^^^^^^^^^


### PR DESCRIPTION
Check whether slice elements implement Copy before suggesting to drop
the clone method

changelog: add a check for slice indexing on redundant_clone lint
