### PR TITLE
Cleanup: Use rustc's is_proc_macro_attr

### DIFF
--- a/clippy_lints/src/utils/attrs.rs
+++ b/clippy_lints/src/utils/attrs.rs
@@ -1,4 +1,5 @@
 use rustc_ast::ast;
+use rustc_ast::expand::is_proc_macro_attr;
 use rustc_errors::Applicability;
 use rustc_session::Session;
 use std::str::FromStr;
@@ -123,12 +124,5 @@ fn parse_attrs<F: FnMut(u64)>(sess: &Session, attrs: &[ast::Attribute], name: &'
 /// Return true if the attributes contain any of `proc_macro`,
 /// `proc_macro_derive` or `proc_macro_attribute`, false otherwise
 pub fn is_proc_macro(attrs: &[ast::Attribute]) -> bool {
-    use rustc_span::Symbol;
-
-    let syms = [
-        Symbol::intern("proc_macro"),
-        Symbol::intern("proc_macro_derive"),
-        Symbol::intern("proc_macro_attribute"),
-    ];
-    attrs.iter().any(|attr| syms.iter().any(move |&s| attr.check_name(s)))
+    attrs.iter().any(is_proc_macro_attr)
 }


### PR DESCRIPTION
It's doing exactly the same: https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_ast/expand/mod.rs.html#8-12

changelog: none
