### PR TITLE
result_map_unit_fn: Fix incorrect UI tests

### DIFF
--- a/tests/ui/result_map_unit_fn_unfixable.rs
+++ b/tests/ui/result_map_unit_fn_unfixable.rs
@@ -2,6 +2,10 @@
 #![feature(never_type)]
 #![allow(unused)]
 
+struct HasResult {
+    field: Result<usize, usize>,
+}
+
 fn do_nothing<T>(_: T) {}
 
 fn diverge<T>(_: T) -> ! {
@@ -14,6 +18,8 @@ fn plus_one(value: usize) -> usize {
 
 #[rustfmt::skip]
 fn result_map_unit_fn() {
+    let x = HasResult { field: Ok(10) };
+
     x.field.map(|value| { do_nothing(value); do_nothing(value) });
 
     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });

--- a/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -1,27 +1,58 @@
-error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:17:5
-   |
-LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
-   |     ^ not found in this scope
-
-error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:19:5
-   |
-LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });
-   |     ^ not found in this scope
-
-error[E0425]: cannot find value `x` in this scope
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
   --> $DIR/result_map_unit_fn_unfixable.rs:23:5
    |
-LL |     x.field.map(|value| {
-   |     ^ not found in this scope
+LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |     |
+   |     help: try this: `if let Ok(value) = x.field { ... }`
+   |
+   = note: `-D clippy::result-map-unit-fn` implied by `-D warnings`
 
-error[E0425]: cannot find value `x` in this scope
-  --> $DIR/result_map_unit_fn_unfixable.rs:27:5
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+  --> $DIR/result_map_unit_fn_unfixable.rs:25:5
+   |
+LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |     |
+   |     help: try this: `if let Ok(value) = x.field { ... }`
+
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+  --> $DIR/result_map_unit_fn_unfixable.rs:29:5
+   |
+LL |        x.field.map(|value| {
+   |   _____^
+   |  |_____|
+   | ||
+LL | ||         do_nothing(value);
+LL | ||         do_nothing(value)
+LL | ||     });
+   | ||______^- help: try this: `if let Ok(value) = x.field { ... }`
+   | |_______|
+   | 
+
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+  --> $DIR/result_map_unit_fn_unfixable.rs:33:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value); });
-   |     ^ not found in this scope
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |     |
+   |     help: try this: `if let Ok(value) = x.field { ... }`
 
-error: aborting due to 4 previous errors
+error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type
+  --> $DIR/result_map_unit_fn_unfixable.rs:37:5
+   |
+LL |     "12".parse::<i32>().map(diverge);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |     |
+   |     help: try this: `if let Ok(a) = "12".parse::<i32>() { diverge(a) }`
 
-For more information about this error, try `rustc --explain E0425`.
+error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type
+  --> $DIR/result_map_unit_fn_unfixable.rs:43:5
+   |
+LL |     y.map(do_nothing);
+   |     ^^^^^^^^^^^^^^^^^-
+   |     |
+   |     help: try this: `if let Ok(_y) = y { do_nothing(_y) }`
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
`x` and the `HasResult` struct were missing in this file.

changelog: none
