### PR TITLE
Temporarily disable rustfmt integration test

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -234,7 +234,8 @@ jobs:
         - 'rust-lang/cargo'
         - 'rust-lang/rls'
         - 'rust-lang/chalk'
-        - 'rust-lang/rustfmt'
+        # FIXME: Disabled until https://github.com/rust-lang/rust/issues/71077 is fixed
+        # - 'rust-lang/rustfmt'
         - 'Marwes/combine'
         - 'Geal/nom'
         - 'rust-lang/stdarch'

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -64,6 +64,9 @@ fn integration_test() {
     } else if stderr.contains("query stack during panic") {
         panic!("query stack during panic in the output");
     } else if stderr.contains("E0463") {
+        // Encountering E0463 (can't find crate for `x`) did _not_ cause the build to fail in the
+        // past. Even though it should have. That's why we explicitly panic here.
+        // See PR #3552 and issue #3523 for more background.
         panic!("error: E0463");
     } else if stderr.contains("E0514") {
         panic!("incompatible crate versions");


### PR DESCRIPTION
Running rustfmt from master is currently broken and [fails our bors build](https://github.com/rust-lang/rust-clippy/runs/582066368#step:10:19):
https://github.com/rust-lang/rust/issues/71077

changelog: none
