### PR TITLE
[fix] Minor typo in GH Actions 'clippy_dev'

### DIFF
--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     # Only run on paths, that get checked by the clippy_dev tool
     paths:
-    - 'CAHNGELOG.md'
+    - 'CHANGELOG.md'
     - 'README.md'
     - '**.stderr'
     - '**.rs'


### PR DESCRIPTION
changelog: minor: fixes file name in Github Actions workflow `clippy_dev.yml`

I was looking for something else and ended up on that typo, just thought I would fix it.