### PR TITLE
unit_arg suggestion is not really machine-applicable

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -786,7 +786,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnitArg {
                             "passing a unit value to a function",
                             "if you intended to pass a unit value, use a unit literal instead",
                             "()".to_string(),
-                            Applicability::MachineApplicable,
+                            Applicability::MaybeIncorrect,
                         );
                     }
                 }


### PR DESCRIPTION
This lint suggests replacing any code returining `()`-type with `()` literal, which can change the behavior. e.g. `Ok(do_something())` -> `OK(())`.

---

changelog: none