### PR TITLE
Cleanup: Rename 'db' variables to 'diag'

### DIFF
--- a/clippy_lints/src/assign_ops.rs
+++ b/clippy_lints/src/assign_ops.rs
@@ -131,11 +131,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for AssignOps {
                                 ASSIGN_OP_PATTERN,
                                 expr.span,
                                 "manual implementation of an assign operation",
-                                |db| {
+                                |diag| {
                                     if let (Some(snip_a), Some(snip_r)) =
                                         (snippet_opt(cx, assignee.span), snippet_opt(cx, rhs.span))
                                     {
-                                        db.span_suggestion(
+                                        diag.span_suggestion(
                                             expr.span,
                                             "replace it with",
                                             format!("{} {}= {}", snip_a, op.node.as_str(), snip_r),
@@ -199,12 +199,12 @@ fn lint_misrefactored_assign_op(
         MISREFACTORED_ASSIGN_OP,
         expr.span,
         "variable appears on both sides of an assignment operation",
-        |db| {
+        |diag| {
             if let (Some(snip_a), Some(snip_r)) = (snippet_opt(cx, assignee.span), snippet_opt(cx, rhs_other.span)) {
                 let a = &sugg::Sugg::hir(cx, assignee, "..");
                 let r = &sugg::Sugg::hir(cx, rhs, "..");
                 let long = format!("{} = {}", snip_a, sugg::make_binop(higher::binop(op.node), a, r));
-                db.span_suggestion(
+                diag.span_suggestion(
                     expr.span,
                     &format!(
                         "Did you mean `{} = {} {} {}` or `{}`? Consider replacing it with",
@@ -217,7 +217,7 @@ fn lint_misrefactored_assign_op(
                     format!("{} {}= {}", snip_a, op.node.as_str(), snip_r),
                     Applicability::MaybeIncorrect,
                 );
-                db.span_suggestion(
+                diag.span_suggestion(
                     expr.span,
                     "or",
                     long,

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -273,9 +273,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Attributes {
                                                 USELESS_ATTRIBUTE,
                                                 line_span,
                                                 "useless lint attribute",
-                                                |db| {
+                                                |diag| {
                                                     sugg = sugg.replacen("#[", "#![", 1);
-                                                    db.span_suggestion(
+                                                    diag.span_suggestion(
                                                         line_span,
                                                         "if you just forgot a `!`, use",
                                                         sugg,
@@ -329,7 +329,7 @@ fn check_clippy_lint_names(cx: &LateContext<'_, '_>, items: &[NestedMetaItem]) {
                     UNKNOWN_CLIPPY_LINTS,
                     lint.span(),
                     &format!("unknown clippy lint: clippy::{}", name),
-                    |db| {
+                    |diag| {
                         let name_lower = name.as_str().to_lowercase();
                         let symbols = lint_store.get_lints().iter().map(
                             |l| Symbol::intern(&l.name_lower())
@@ -341,14 +341,14 @@ fn check_clippy_lint_names(cx: &LateContext<'_, '_>, items: &[NestedMetaItem]) {
                         );
                         if name.as_str().chars().any(char::is_uppercase)
                             && lint_store.find_lints(&format!("clippy::{}", name_lower)).is_ok() {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 lint.span(),
                                 "lowercase the lint name",
                                 format!("clippy::{}", name_lower),
                                 Applicability::MachineApplicable,
                             );
                         } else if let Some(sugg) = sugg {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 lint.span(),
                                 "did you mean",
                                 sugg.to_string(),

--- a/clippy_lints/src/bit_mask.rs
+++ b/clippy_lints/src/bit_mask.rs
@@ -137,9 +137,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for BitMask {
                                    VERBOSE_BIT_MASK,
                                    e.span,
                                    "bit mask could be simplified with a call to `trailing_zeros`",
-                                   |db| {
+                                   |diag| {
                     let sugg = Sugg::hir(cx, left1, "...").maybe_par();
-                    db.span_suggestion(
+                    diag.span_suggestion(
                         e.span,
                         "try",
                         format!("{}.trailing_zeros() >= {}", sugg, n.count_ones()),

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -376,13 +376,13 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
                             LOGIC_BUG,
                             e.span,
                             "this boolean expression contains a logic bug",
-                            |db| {
-                                db.span_help(
+                            |diag| {
+                                diag.span_help(
                                     h2q.terminals[i].span,
                                     "this expression can be optimized out by applying boolean operations to the \
                                      outer expression",
                                 );
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     e.span,
                                     "it would look like the following",
                                     suggest(self.cx, suggestion, &h2q.terminals),
@@ -411,8 +411,8 @@ impl<'a, 'tcx> NonminimalBoolVisitor<'a, 'tcx> {
                     NONMINIMAL_BOOL,
                     e.span,
                     "this boolean expression can be simplified",
-                    |db| {
-                        db.span_suggestions(
+                    |diag| {
+                        diag.span_suggestions(
                             e.span,
                             "try",
                             suggestions.into_iter(),

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -137,10 +137,10 @@ fn check_collapsible_no_if_let(cx: &EarlyContext<'_>, expr: &ast::Expr, check: &
             if expr.span.ctxt() != inner.span.ctxt() {
                 return;
             }
-            span_lint_and_then(cx, COLLAPSIBLE_IF, expr.span, "this `if` statement can be collapsed", |db| {
+            span_lint_and_then(cx, COLLAPSIBLE_IF, expr.span, "this `if` statement can be collapsed", |diag| {
                 let lhs = Sugg::ast(cx, check, "..");
                 let rhs = Sugg::ast(cx, check_inner, "..");
-                db.span_suggestion(
+                diag.span_suggestion(
                     expr.span,
                     "try",
                     format!(

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -279,8 +279,8 @@ fn lint_match_arms<'tcx>(cx: &LateContext<'_, 'tcx>, expr: &Expr<'_>) {
                 MATCH_SAME_ARMS,
                 j.body.span,
                 "this `match` has identical arm bodies",
-                |db| {
-                    db.span_note(i.body.span, "same as this");
+                |diag| {
+                    diag.span_note(i.body.span, "same as this");
 
                     // Note: this does not use `span_suggestion` on purpose:
                     // there is no clean way
@@ -296,7 +296,7 @@ fn lint_match_arms<'tcx>(cx: &LateContext<'_, 'tcx>, expr: &Expr<'_>) {
                         // if the last arm is _, then i could be integrated into _
                         // note that i.pat cannot be _, because that would mean that we're
                         // hiding all the subsequent arms, and rust won't compile
-                        db.span_note(
+                        diag.span_note(
                             i.body.span,
                             &format!(
                                 "`{}` has the same arm body as the `_` wildcard, consider removing it",
@@ -304,7 +304,7 @@ fn lint_match_arms<'tcx>(cx: &LateContext<'_, 'tcx>, expr: &Expr<'_>) {
                             ),
                         );
                     } else {
-                        db.span_help(i.pat.span, &format!("consider refactoring into `{} | {}`", lhs, rhs));
+                        diag.span_help(i.pat.span, &format!("consider refactoring into `{} | {}`", lhs, rhs));
                     }
                 },
             );

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -119,9 +119,9 @@ fn check_hash_peq<'a, 'tcx>(
                     span_lint_and_then(
                         cx, DERIVE_HASH_XOR_EQ, span,
                         mess,
-                        |db| {
+                        |diag| {
                         if let Some(node_id) = cx.tcx.hir().as_local_hir_id(impl_id) {
-                            db.span_note(
+                            diag.span_note(
                                 cx.tcx.hir().span(node_id),
                                 "`PartialEq` implemented here"
                             );
@@ -168,8 +168,8 @@ fn check_copy_clone<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, item: &Item<'_>, trait
             EXPL_IMPL_CLONE_ON_COPY,
             item.span,
             "you are implementing `Clone` explicitly on a `Copy` type",
-            |db| {
-                db.span_note(item.span, "consider deriving `Clone` or removing `Copy`");
+            |diag| {
+                diag.span_note(item.span, "consider deriving `Clone` or removing `Copy`");
             },
         );
     }

--- a/clippy_lints/src/empty_enum.rs
+++ b/clippy_lints/src/empty_enum.rs
@@ -45,8 +45,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EmptyEnum {
             let ty = cx.tcx.type_of(did);
             let adt = ty.ty_adt_def().expect("already checked whether this is an enum");
             if adt.variants.is_empty() {
-                span_lint_and_then(cx, EMPTY_ENUM, item.span, "enum with no variants", |db| {
-                    db.span_help(
+                span_lint_and_then(cx, EMPTY_ENUM, item.span, "enum with no variants", |diag| {
+                    diag.span_help(
                         item.span,
                         "consider using the uninhabited type `!` (never type) or a wrapper \
                          around it to introduce a type which can't be instantiated",

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -148,7 +148,7 @@ impl<'a, 'tcx, 'b> Visitor<'tcx> for InsertVisitor<'a, 'tcx, 'b> {
             if snippet_opt(self.cx, self.map.span) == snippet_opt(self.cx, params[0].span);
             then {
                 span_lint_and_then(self.cx, MAP_ENTRY, self.span,
-                                   &format!("usage of `contains_key` followed by `insert` on a `{}`", self.ty), |db| {
+                                   &format!("usage of `contains_key` followed by `insert` on a `{}`", self.ty), |diag| {
                     if self.sole_expr {
                         let mut app = Applicability::MachineApplicable;
                         let help = format!("{}.entry({}).or_insert({});",
@@ -156,7 +156,7 @@ impl<'a, 'tcx, 'b> Visitor<'tcx> for InsertVisitor<'a, 'tcx, 'b> {
                                            snippet_with_applicability(self.cx, params[1].span, "..", &mut app),
                                            snippet_with_applicability(self.cx, params[2].span, "..", &mut app));
 
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             self.span,
                             "consider using",
                             help,
@@ -168,7 +168,7 @@ impl<'a, 'tcx, 'b> Visitor<'tcx> for InsertVisitor<'a, 'tcx, 'b> {
                                            snippet(self.cx, self.map.span, "map"),
                                            snippet(self.cx, params[1].span, ".."));
 
-                        db.span_label(
+                        diag.span_label(
                             self.span,
                             &help,
                         );

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -124,15 +124,21 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                             && !rcpy
                             && implements_trait(cx, lty, trait_id, &[cx.tables.expr_ty(right).into()])
                         {
-                            span_lint_and_then(cx, OP_REF, e.span, "needlessly taken reference of left operand", |diag| {
-                                let lsnip = snippet(cx, l.span, "...").to_string();
-                                diag.span_suggestion(
-                                    left.span,
-                                    "use the left value directly",
-                                    lsnip,
-                                    Applicability::MaybeIncorrect, // FIXME #2597
-                                );
-                            })
+                            span_lint_and_then(
+                                cx,
+                                OP_REF,
+                                e.span,
+                                "needlessly taken reference of left operand",
+                                |diag| {
+                                    let lsnip = snippet(cx, l.span, "...").to_string();
+                                    diag.span_suggestion(
+                                        left.span,
+                                        "use the left value directly",
+                                        lsnip,
+                                        Applicability::MaybeIncorrect, // FIXME #2597
+                                    );
+                                },
+                            )
                         } else if !lcpy
                             && rcpy
                             && implements_trait(cx, cx.tables.expr_ty(left), trait_id, &[rty.into()])
@@ -161,15 +167,21 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                         if (requires_ref || lcpy)
                             && implements_trait(cx, lty, trait_id, &[cx.tables.expr_ty(right).into()])
                         {
-                            span_lint_and_then(cx, OP_REF, e.span, "needlessly taken reference of left operand", |diag| {
-                                let lsnip = snippet(cx, l.span, "...").to_string();
-                                diag.span_suggestion(
-                                    left.span,
-                                    "use the left value directly",
-                                    lsnip,
-                                    Applicability::MaybeIncorrect, // FIXME #2597
-                                );
-                            })
+                            span_lint_and_then(
+                                cx,
+                                OP_REF,
+                                e.span,
+                                "needlessly taken reference of left operand",
+                                |diag| {
+                                    let lsnip = snippet(cx, l.span, "...").to_string();
+                                    diag.span_suggestion(
+                                        left.span,
+                                        "use the left value directly",
+                                        lsnip,
+                                        Applicability::MaybeIncorrect, // FIXME #2597
+                                    );
+                                },
+                            )
                         }
                     },
                     // foo == &bar

--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -110,11 +110,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                                 OP_REF,
                                 e.span,
                                 "needlessly taken reference of both operands",
-                                |db| {
+                                |diag| {
                                     let lsnip = snippet(cx, l.span, "...").to_string();
                                     let rsnip = snippet(cx, r.span, "...").to_string();
                                     multispan_sugg(
-                                        db,
+                                        diag,
                                         "use the values directly".to_string(),
                                         vec![(left.span, lsnip), (right.span, rsnip)],
                                     );
@@ -124,9 +124,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                             && !rcpy
                             && implements_trait(cx, lty, trait_id, &[cx.tables.expr_ty(right).into()])
                         {
-                            span_lint_and_then(cx, OP_REF, e.span, "needlessly taken reference of left operand", |db| {
+                            span_lint_and_then(cx, OP_REF, e.span, "needlessly taken reference of left operand", |diag| {
                                 let lsnip = snippet(cx, l.span, "...").to_string();
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     left.span,
                                     "use the left value directly",
                                     lsnip,
@@ -142,9 +142,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                                 OP_REF,
                                 e.span,
                                 "needlessly taken reference of right operand",
-                                |db| {
+                                |diag| {
                                     let rsnip = snippet(cx, r.span, "...").to_string();
-                                    db.span_suggestion(
+                                    diag.span_suggestion(
                                         right.span,
                                         "use the right value directly",
                                         rsnip,
@@ -161,9 +161,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                         if (requires_ref || lcpy)
                             && implements_trait(cx, lty, trait_id, &[cx.tables.expr_ty(right).into()])
                         {
-                            span_lint_and_then(cx, OP_REF, e.span, "needlessly taken reference of left operand", |db| {
+                            span_lint_and_then(cx, OP_REF, e.span, "needlessly taken reference of left operand", |diag| {
                                 let lsnip = snippet(cx, l.span, "...").to_string();
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     left.span,
                                     "use the left value directly",
                                     lsnip,
@@ -179,9 +179,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for EqOp {
                         if (requires_ref || rcpy)
                             && implements_trait(cx, cx.tables.expr_ty(left), trait_id, &[rty.into()])
                         {
-                            span_lint_and_then(cx, OP_REF, e.span, "taken reference of right operand", |db| {
+                            span_lint_and_then(cx, OP_REF, e.span, "taken reference of right operand", |diag| {
                                 let rsnip = snippet(cx, r.span, "...").to_string();
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     right.span,
                                     "use the right value directly",
                                     rsnip,

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -101,9 +101,9 @@ fn check_closure(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
             if compare_inputs(&mut iter_input_pats(decl, body), &mut args.iter());
 
             then {
-                span_lint_and_then(cx, REDUNDANT_CLOSURE, expr.span, "redundant closure found", |db| {
+                span_lint_and_then(cx, REDUNDANT_CLOSURE, expr.span, "redundant closure found", |diag| {
                     if let Some(snippet) = snippet_opt(cx, caller.span) {
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             expr.span,
                             "remove closure as shown",
                             snippet,
@@ -131,8 +131,8 @@ fn check_closure(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
             if let Some(name) = get_ufcs_type_name(cx, method_def_id, &args[0]);
 
             then {
-                span_lint_and_then(cx, REDUNDANT_CLOSURE_FOR_METHOD_CALLS, expr.span, "redundant closure found", |db| {
-                    db.span_suggestion(
+                span_lint_and_then(cx, REDUNDANT_CLOSURE_FOR_METHOD_CALLS, expr.span, "redundant closure found", |diag| {
+                    diag.span_suggestion(
                         expr.span,
                         "remove closure as shown",
                         format!("{}::{}", name, path.ident.name),

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -117,11 +117,11 @@ fn lint_impl_body<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, impl_span: Span, impl_it
                         FALLIBLE_IMPL_FROM,
                         impl_span,
                         "consider implementing `TryFrom` instead",
-                        move |db| {
-                            db.help(
+                        move |diag| {
+                            diag.help(
                                 "`From` is intended for infallible conversions only. \
                                  Use `TryFrom` if there's a possibility for the conversion to fail.");
-                            db.span_note(fpu.result, "potential failure(s)");
+                            diag.span_note(fpu.result, "potential failure(s)");
                         });
                 }
             }

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -61,8 +61,8 @@ fn span_useless_format<T: LintContext>(cx: &T, span: Span, help: &str, mut sugg:
         sugg.push(';');
     }
 
-    span_lint_and_then(cx, USELESS_FORMAT, span, "useless use of `format!`", |db| {
-        db.span_suggestion(
+    span_lint_and_then(cx, USELESS_FORMAT, span, "useless use of `format!`", |diag| {
+        diag.span_suggestion(
             to_replace,
             help,
             sugg,

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -416,8 +416,8 @@ fn check_needless_must_use(
             MUST_USE_UNIT,
             fn_header_span,
             "this unit-returning function has a `#[must_use]` attribute",
-            |db| {
-                db.span_suggestion(
+            |diag| {
+                diag.span_suggestion(
                     attr.span,
                     "remove the attribute",
                     "".into(),
@@ -454,9 +454,9 @@ fn check_must_use_candidate<'a, 'tcx>(
     {
         return;
     }
-    span_lint_and_then(cx, MUST_USE_CANDIDATE, fn_span, msg, |db| {
+    span_lint_and_then(cx, MUST_USE_CANDIDATE, fn_span, msg, |diag| {
         if let Some(snippet) = snippet_opt(cx, fn_span) {
-            db.span_suggestion(
+            diag.span_suggestion(
                 fn_span,
                 "add the attribute",
                 format!("#[must_use] {}", snippet),

--- a/clippy_lints/src/identity_conversion.rs
+++ b/clippy_lints/src/identity_conversion.rs
@@ -58,8 +58,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityConversion {
                     if same_tys(cx, a, b) {
                         let sugg = snippet_with_macro_callsite(cx, args[0].span, "<expr>").to_string();
 
-                        span_lint_and_then(cx, IDENTITY_CONVERSION, e.span, "identical conversion", |db| {
-                            db.span_suggestion(
+                        span_lint_and_then(cx, IDENTITY_CONVERSION, e.span, "identical conversion", |diag| {
+                            diag.span_suggestion(
                                 e.span,
                                 "consider removing `.into()`",
                                 sugg,
@@ -73,8 +73,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityConversion {
                     let b = cx.tables.expr_ty(&args[0]);
                     if same_tys(cx, a, b) {
                         let sugg = snippet(cx, args[0].span, "<expr>").into_owned();
-                        span_lint_and_then(cx, IDENTITY_CONVERSION, e.span, "identical conversion", |db| {
-                            db.span_suggestion(
+                        span_lint_and_then(cx, IDENTITY_CONVERSION, e.span, "identical conversion", |diag| {
+                            diag.span_suggestion(
                                 e.span,
                                 "consider removing `.into_iter()`",
                                 sugg,
@@ -95,8 +95,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for IdentityConversion {
                                 let sugg = snippet(cx, args[0].span.source_callsite(), "<expr>").into_owned();
                                 let sugg_msg =
                                     format!("consider removing `{}()`", snippet(cx, path.span, "From::from"));
-                                span_lint_and_then(cx, IDENTITY_CONVERSION, e.span, "identical conversion", |db| {
-                                    db.span_suggestion(
+                                span_lint_and_then(cx, IDENTITY_CONVERSION, e.span, "identical conversion", |diag| {
+                                    diag.span_suggestion(
                                         e.span,
                                         &sugg_msg,
                                         sugg,

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -48,9 +48,9 @@ fn lint(cx: &LateContext<'_, '_>, outer_span: Span, inner_span: Span, msg: &str)
     let outer_span = outer_span.source_callsite();
     let inner_span = inner_span.source_callsite();
 
-    span_lint_and_then(cx, IMPLICIT_RETURN, outer_span, "missing `return` statement", |db| {
+    span_lint_and_then(cx, IMPLICIT_RETURN, outer_span, "missing `return` statement", |diag| {
         if let Some(snippet) = snippet_opt(cx, inner_span) {
-            db.span_suggestion(
+            diag.span_suggestion(
                 outer_span,
                 msg,
                 format!("return {}", snippet),

--- a/clippy_lints/src/inherent_impl.rs
+++ b/clippy_lints/src/inherent_impl.rs
@@ -82,8 +82,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MultipleInherentImpl {
                             MULTIPLE_INHERENT_IMPL,
                             *additional_span,
                             "Multiple implementations of this structure",
-                            |db| {
-                                db.span_note(*initial_span, "First implementation here");
+                            |diag| {
+                                diag.span_note(*initial_span, "First implementation here");
                             },
                         )
                     })

--- a/clippy_lints/src/inline_fn_without_body.rs
+++ b/clippy_lints/src/inline_fn_without_body.rs
@@ -49,8 +49,8 @@ fn check_attrs(cx: &LateContext<'_, '_>, name: Name, attrs: &[Attribute]) {
             INLINE_FN_WITHOUT_BODY,
             attr.span,
             &format!("use of `#[inline]` on trait method `{}` which has no body", name),
-            |db| {
-                db.suggest_remove_item(cx, attr.span, "remove", Applicability::MachineApplicable);
+            |diag| {
+                diag.suggest_remove_item(cx, attr.span, "remove", Applicability::MachineApplicable);
             },
         );
     }

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -154,8 +154,8 @@ impl IntPlusOne {
             INT_PLUS_ONE,
             block.span,
             "Unnecessary `>= y + 1` or `x - 1 >=`",
-            |db| {
-                db.span_suggestion(
+            |diag| {
+                diag.span_suggestion(
                     block.span,
                     "change it to",
                     recommendation,

--- a/clippy_lints/src/large_const_arrays.rs
+++ b/clippy_lints/src/large_const_arrays.rs
@@ -70,8 +70,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeConstArrays {
                     LARGE_CONST_ARRAYS,
                     item.span,
                     "large array defined as const",
-                    |db| {
-                        db.span_suggestion(
+                    |diag| {
+                        diag.span_suggestion(
                             sugg_span,
                             "make this a static item",
                             "static".to_string(),

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -98,12 +98,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
                         LARGE_ENUM_VARIANT,
                         def.variants[i].span,
                         "large size difference between variants",
-                        |db| {
-                            db.span_label(
+                        |diag| {
+                            diag.span_label(
                                 def.variants[(largest.1).0].span,
                                 &format!("this variant is {} bytes", largest.0),
                             );
-                            db.span_note(
+                            diag.span_note(
                                 def.variants[(second.1).0].span,
                                 &format!("and the second-largest variant is {} bytes:", second.0),
                             );
@@ -115,7 +115,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
                                     VariantData::Unit(..) => unreachable!(),
                                 };
                                 if let Some(snip) = snippet_opt(cx, span) {
-                                    db.span_suggestion(
+                                    diag.span_suggestion(
                                         span,
                                         help_text,
                                         format!("Box<{}>", snip),
@@ -124,7 +124,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LargeEnumVariant {
                                     return;
                                 }
                             }
-                            db.span_help(def.variants[i].span, help_text);
+                            diag.span_help(def.variants[i].span, help_text);
                         },
                     );
                 }

--- a/clippy_lints/src/let_if_seq.rs
+++ b/clippy_lints/src/let_if_seq.rs
@@ -120,15 +120,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetIfSeq {
                                        USELESS_LET_IF_SEQ,
                                        span,
                                        "`if _ { .. } else { .. }` is an expression",
-                                       |db| {
-                                           db.span_suggestion(
+                                       |diag| {
+                                           diag.span_suggestion(
                                                 span,
                                                 "it is more idiomatic to write",
                                                 sug,
                                                 Applicability::HasPlaceholders,
                                             );
                                            if !mutability.is_empty() {
-                                               db.note("you might not need `mut` at all");
+                                               diag.note("you might not need `mut` at all");
                                            }
                                        });
                 }

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -224,13 +224,13 @@ fn lint_map_unit_fn(cx: &LateContext<'_, '_>, stmt: &hir::Stmt<'_>, expr: &hir::
             binding = let_binding_name(cx, var_arg)
         );
 
-        span_lint_and_then(cx, lint, expr.span, &msg, |db| {
-            db.span_suggestion(stmt.span, "try this", suggestion, Applicability::MachineApplicable);
+        span_lint_and_then(cx, lint, expr.span, &msg, |diag| {
+            diag.span_suggestion(stmt.span, "try this", suggestion, Applicability::MachineApplicable);
         });
     } else if let Some((binding, closure_expr)) = unit_closure(cx, fn_arg) {
         let msg = suggestion_msg("closure", map_type);
 
-        span_lint_and_then(cx, lint, expr.span, &msg, |db| {
+        span_lint_and_then(cx, lint, expr.span, &msg, |diag| {
             if let Some(reduced_expr_span) = reduce_unit_expression(cx, closure_expr) {
                 let suggestion = format!(
                     "if let {0}({1}) = {2} {{ {3} }}",
@@ -239,7 +239,7 @@ fn lint_map_unit_fn(cx: &LateContext<'_, '_>, stmt: &hir::Stmt<'_>, expr: &hir::
                     snippet(cx, var_arg.span, "_"),
                     snippet(cx, reduced_expr_span, "_")
                 );
-                db.span_suggestion(
+                diag.span_suggestion(
                     stmt.span,
                     "try this",
                     suggestion,
@@ -252,7 +252,7 @@ fn lint_map_unit_fn(cx: &LateContext<'_, '_>, stmt: &hir::Stmt<'_>, expr: &hir::
                     snippet(cx, binding.pat.span, "_"),
                     snippet(cx, var_arg.span, "_"),
                 );
-                db.span_suggestion(stmt.span, "try this", suggestion, Applicability::HasPlaceholders);
+                diag.span_suggestion(stmt.span, "try this", suggestion, Applicability::HasPlaceholders);
             }
         });
     }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -569,7 +569,7 @@ fn check_match_bool(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>], e
             MATCH_BOOL,
             expr.span,
             "you seem to be trying to match on a boolean expression",
-            move |db| {
+            move |diag| {
                 if arms.len() == 2 {
                     // no guards
                     let exprs = if let PatKind::Lit(ref arm_bool) = arms[0].pat.kind {
@@ -611,7 +611,7 @@ fn check_match_bool(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>], e
                         };
 
                         if let Some(sugg) = sugg {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 expr.span,
                                 "consider using an `if`/`else` expression",
                                 sugg,
@@ -817,9 +817,9 @@ fn check_match_ref_pats(cx: &LateContext<'_, '_>, ex: &Expr<'_>, arms: &[Arm<'_>
             }
         }));
 
-        span_lint_and_then(cx, MATCH_REF_PATS, expr.span, title, |db| {
+        span_lint_and_then(cx, MATCH_REF_PATS, expr.span, title, |diag| {
             if !expr.span.from_expansion() {
-                multispan_sugg(db, msg.to_owned(), suggs);
+                multispan_sugg(diag, msg.to_owned(), suggs);
             }
         });
     }

--- a/clippy_lints/src/mem_discriminant.rs
+++ b/clippy_lints/src/mem_discriminant.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemDiscriminant {
                     MEM_DISCRIMINANT_NON_ENUM,
                     expr.span,
                     &format!("calling `mem::discriminant` on non-enum type `{}`", ty_param),
-                    |db| {
+                    |diag| {
                         // if this is a reference to an enum, suggest dereferencing
                         let (base_ty, ptr_depth) = walk_ptrs_ty_depth(ty_param);
                         if ptr_depth >= 1 && base_ty.is_enum() {
@@ -66,7 +66,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MemDiscriminant {
                             }
 
                             let derefs: String = iter::repeat('*').take(derefs_needed).collect();
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 param.span,
                                 "try dereferencing",
                                 format!("{}{}", derefs, snippet(cx, cur_expr.span, "<param>")),

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -178,11 +178,11 @@ fn check_replace_with_default(cx: &LateContext<'_, '_>, src: &Expr<'_>, dest: &E
                     MEM_REPLACE_WITH_DEFAULT,
                     expr_span,
                     "replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`",
-                    |db| {
+                    |diag| {
                         if !in_macro(expr_span) {
                             let suggestion = format!("std::mem::take({})", snippet(cx, dest.span, ""));
 
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 expr_span,
                                 "consider using",
                                 suggestion,

--- a/clippy_lints/src/methods/inefficient_to_string.rs
+++ b/clippy_lints/src/methods/inefficient_to_string.rs
@@ -22,14 +22,14 @@ pub fn lint<'tcx>(cx: &LateContext<'_, 'tcx>, expr: &hir::Expr<'_>, arg: &hir::E
                 INEFFICIENT_TO_STRING,
                 expr.span,
                 &format!("calling `to_string` on `{}`", arg_ty),
-                |db| {
-                    db.help(&format!(
+                |diag| {
+                    diag.help(&format!(
                         "`{}` implements `ToString` through a slower blanket impl, but `{}` has a fast specialization of `ToString`",
                         self_ty, deref_self_ty
                     ));
                     let mut applicability = Applicability::MachineApplicable;
                     let arg_snippet = snippet_with_applicability(cx, arg.span, "..", &mut applicability);
-                    db.span_suggestion(
+                    diag.span_suggestion(
                         expr.span,
                         "try dereferencing the receiver",
                         format!("({}{}).to_string()", "*".repeat(deref_count), arg_snippet),

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1932,7 +1932,7 @@ fn lint_clone_on_copy(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, arg: &hir:
                 expr.span,
                 "using `clone` on a double-reference; \
                  this will copy the reference instead of cloning the inner type",
-                |db| {
+                |diag| {
                     if let Some(snip) = sugg::Sugg::hir_opt(cx, arg) {
                         let mut ty = innermost;
                         let mut n = 0;
@@ -1943,13 +1943,13 @@ fn lint_clone_on_copy(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, arg: &hir:
                         let refs: String = iter::repeat('&').take(n + 1).collect();
                         let derefs: String = iter::repeat('*').take(n).collect();
                         let explicit = format!("{}{}::clone({})", refs, ty, snip);
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             expr.span,
                             "try dereferencing it",
                             format!("{}({}{}).clone()", refs, derefs, snip.deref()),
                             Applicability::MaybeIncorrect,
                         );
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             expr.span,
                             "or try being explicit about what type to clone",
                             explicit,
@@ -2008,9 +2008,9 @@ fn lint_clone_on_copy(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, arg: &hir:
         } else {
             snip = None;
         }
-        span_lint_and_then(cx, CLONE_ON_COPY, expr.span, "using `clone` on a `Copy` type", |db| {
+        span_lint_and_then(cx, CLONE_ON_COPY, expr.span, "using `clone` on a `Copy` type", |diag| {
             if let Some((text, snip)) = snip {
-                db.span_suggestion(expr.span, text, snip, Applicability::Unspecified);
+                diag.span_suggestion(expr.span, text, snip, Applicability::Unspecified);
             }
         });
     }
@@ -2097,9 +2097,9 @@ fn lint_cstring_as_ptr(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, source: &
                 TEMPORARY_CSTRING_AS_PTR,
                 expr.span,
                 "you are getting the inner pointer of a temporary `CString`",
-                |db| {
-                    db.note("that pointer will be invalid outside this expression");
-                    db.span_help(unwrap.span, "assign the `CString` to a variable to extend its lifetime");
+                |diag| {
+                    diag.note("that pointer will be invalid outside this expression");
+                    diag.span_help(unwrap.span, "assign the `CString` to a variable to extend its lifetime");
                 });
         }
     }

--- a/clippy_lints/src/methods/option_map_unwrap_or.rs
+++ b/clippy_lints/src/methods/option_map_unwrap_or.rs
@@ -66,7 +66,7 @@ pub(super) fn lint<'a, 'tcx>(
             arg, suggest
         );
 
-        span_lint_and_then(cx, OPTION_MAP_UNWRAP_OR, expr.span, msg, |db| {
+        span_lint_and_then(cx, OPTION_MAP_UNWRAP_OR, expr.span, msg, |diag| {
             let map_arg_span = map_args[1].span;
 
             let mut suggestion = vec![
@@ -81,7 +81,7 @@ pub(super) fn lint<'a, 'tcx>(
                 suggestion.push((map_arg_span.with_hi(map_arg_span.lo()), format!("{}, ", unwrap_snippet)));
             }
 
-            db.multipart_suggestion(&format!("use `{}` instead", suggest), suggestion, applicability);
+            diag.multipart_suggestion(&format!("use `{}` instead", suggest), suggestion, applicability);
         });
     }
 }

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -290,8 +290,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                         init.hir_id,
                         local.pat.span,
                         "`ref` on an entire `let` pattern is discouraged, take a reference with `&` instead",
-                        |db| {
-                            db.span_suggestion(
+                        |diag| {
+                            diag.span_suggestion(
                                 stmt.span,
                                 "try",
                                 format!(
@@ -317,9 +317,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                     SHORT_CIRCUIT_STATEMENT,
                     stmt.span,
                     "boolean short circuit operator in statement may be clearer using an explicit test",
-                    |db| {
+                    |diag| {
                         let sugg = if binop.node == BinOpKind::Or { !sugg } else { sugg };
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             stmt.span,
                             "replace it with",
                             format!(
@@ -374,12 +374,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                         is_named_constant(cx, left) || is_named_constant(cx, right),
                         is_comparing_arrays,
                     );
-                    span_lint_and_then(cx, lint, expr.span, msg, |db| {
+                    span_lint_and_then(cx, lint, expr.span, msg, |diag| {
                         let lhs = Sugg::hir(cx, left, "..");
                         let rhs = Sugg::hir(cx, right, "..");
 
                         if !is_comparing_arrays {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 expr.span,
                                 "consider comparing them within some error",
                                 format!(
@@ -390,7 +390,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
                                 Applicability::HasPlaceholders, // snippet
                             );
                         }
-                        db.note("`f32::EPSILON` and `f64::EPSILON` are available for the `error`");
+                        diag.note("`f32::EPSILON` and `f64::EPSILON` are available for the `error`");
                     });
                 } else if op == BinOpKind::Rem && is_integer_const(cx, right, 1) {
                     span_lint(cx, MODULO_ONE, expr.span, "any number modulo 1 will be 0");
@@ -601,10 +601,10 @@ fn check_to_owned(cx: &LateContext<'_, '_>, expr: &Expr<'_>, other: &Expr<'_>) {
         CMP_OWNED,
         lint_span,
         "this creates an owned instance just for comparison",
-        |db| {
+        |diag| {
             // This also catches `PartialEq` implementations that call `to_owned`.
             if other_gets_derefed {
-                db.span_label(lint_span, "try implementing the comparison without allocating");
+                diag.span_label(lint_span, "try implementing the comparison without allocating");
                 return;
             }
 
@@ -616,7 +616,7 @@ fn check_to_owned(cx: &LateContext<'_, '_>, expr: &Expr<'_>, other: &Expr<'_>) {
                 snip.to_string()
             };
 
-            db.span_suggestion(
+            diag.span_suggestion(
                 lint_span,
                 "try",
                 try_hint,

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -425,12 +425,12 @@ impl EarlyLintPass for MiscEarlyLints {
                                 REDUNDANT_CLOSURE_CALL,
                                 expr.span,
                                 "Try not to call a closure in the expression where it is declared.",
-                                |db| {
+                                |diag| {
                                     if decl.inputs.is_empty() {
                                         let mut app = Applicability::MachineApplicable;
                                         let hint =
                                             snippet_with_applicability(cx, block.span, "..", &mut app).into_owned();
-                                        db.span_suggestion(expr.span, "Try doing something like: ", hint, app);
+                                        diag.span_suggestion(expr.span, "Try doing something like: ", hint, app);
                                     }
                                 },
                             );
@@ -546,14 +546,14 @@ impl MiscEarlyLints {
                     ZERO_PREFIXED_LITERAL,
                     lit.span,
                     "this is a decimal constant",
-                    |db| {
-                        db.span_suggestion(
+                    |diag| {
+                        diag.span_suggestion(
                             lit.span,
                             "if you mean to use a decimal constant, remove the `0` to avoid confusion",
                             lit_snip.trim_start_matches(|c| c == '_' || c == '0').to_string(),
                             Applicability::MaybeIncorrect,
                         );
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             lit.span,
                             "if you mean to use an octal constant, use `0o`",
                             format!("0o{}", lit_snip.trim_start_matches(|c| c == '_' || c == '0')),

--- a/clippy_lints/src/modulo_arithmetic.rs
+++ b/clippy_lints/src/modulo_arithmetic.rs
@@ -95,10 +95,10 @@ fn check_const_operands<'a, 'tcx>(
                 lhs_operand.string_representation.as_ref().unwrap(),
                 rhs_operand.string_representation.as_ref().unwrap()
             ),
-            |db| {
-                db.note("double check for expected result especially when interoperating with different languages");
+            |diag| {
+                diag.note("double check for expected result especially when interoperating with different languages");
                 if lhs_operand.is_integral {
-                    db.note("or consider using `rem_euclid` or similar function");
+                    diag.note("or consider using `rem_euclid` or similar function");
                 }
             },
         );
@@ -113,10 +113,10 @@ fn check_non_const_operands<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Ex
             MODULO_ARITHMETIC,
             expr.span,
             "you are using modulo operator on types that might have different signs",
-            |db| {
-                db.note("double check for expected result especially when interoperating with different languages");
+            |diag| {
+                diag.note("double check for expected result especially when interoperating with different languages");
                 if operand_type.is_integral() {
-                    db.note("or consider using `rem_euclid` or similar function");
+                    diag.note("or consider using `rem_euclid` or similar function");
                 }
             },
         );

--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -59,9 +59,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
                             e.span,
                             "this expression borrows a reference that is immediately dereferenced \
                              by the compiler",
-                            |db| {
+                            |diag| {
                                 if let Some(snippet) = snippet_opt(cx, inner.span) {
-                                    db.span_suggestion(
+                                    diag.span_suggestion(
                                         e.span,
                                         "change this to",
                                         snippet,
@@ -92,9 +92,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrow {
                     NEEDLESS_BORROW,
                     pat.span,
                     "this pattern creates a reference to a reference",
-                    |db| {
+                    |diag| {
                         if let Some(snippet) = snippet_opt(cx, name.span) {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 pat.span,
                                 "change this to",
                                 snippet,

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -77,9 +77,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessBorrowedRef {
                 let mut applicability = Applicability::MachineApplicable;
                 span_lint_and_then(cx, NEEDLESS_BORROWED_REFERENCE, pat.span,
                                    "this pattern takes a reference on something that is being de-referenced",
-                                   |db| {
+                                   |diag| {
                                        let hint = snippet_with_applicability(cx, spanned_name.span, "..", &mut applicability).into_owned();
-                                       db.span_suggestion(
+                                       diag.span_suggestion(
                                            pat.span,
                                            "try removing the `&ref` part and just keep",
                                            hint,

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -203,11 +203,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                     }
 
                     // Dereference suggestion
-                    let sugg = |db: &mut DiagnosticBuilder<'_>| {
+                    let sugg = |diag: &mut DiagnosticBuilder<'_>| {
                         if let ty::Adt(def, ..) = ty.kind {
                             if let Some(span) = cx.tcx.hir().span_if_local(def.did) {
                                 if can_type_implement_copy(cx.tcx, cx.param_env, ty).is_ok() {
-                                    db.span_help(span, "consider marking this type as `Copy`");
+                                    diag.span_help(span, "consider marking this type as `Copy`");
                                 }
                             }
                         }
@@ -227,7 +227,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                                 }).unwrap());
                             then {
                                 let slice_ty = format!("&[{}]", snippet(cx, elem_ty.span, "_"));
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     input.span,
                                     "consider changing the type to",
                                     slice_ty,
@@ -235,7 +235,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                                 );
 
                                 for (span, suggestion) in clone_spans {
-                                    db.span_suggestion(
+                                    diag.span_suggestion(
                                         span,
                                         &snippet_opt(cx, span)
                                             .map_or(
@@ -256,7 +256,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                         if match_type(cx, ty, &paths::STRING) {
                             if let Some(clone_spans) =
                                 get_spans(cx, Some(body.id()), idx, &[("clone", ".to_string()"), ("as_str", "")]) {
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     input.span,
                                     "consider changing the type to",
                                     "&str".to_string(),
@@ -264,7 +264,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                                 );
 
                                 for (span, suggestion) in clone_spans {
-                                    db.span_suggestion(
+                                    diag.span_suggestion(
                                         span,
                                         &snippet_opt(cx, span)
                                             .map_or(
@@ -293,7 +293,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NeedlessPassByValue {
                             );
                             spans.sort_by_key(|&(span, _)| span);
                         }
-                        multispan_sugg(db, "consider taking a reference instead".to_string(), spans);
+                        multispan_sugg(diag, "consider taking a reference instead".to_string(), spans);
                     };
 
                     span_lint_and_then(

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -168,8 +168,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
                                                 "you should consider deriving a `Default` implementation for `{}`",
                                                 self_ty
                                             ),
-                                            |db| {
-                                                db.suggest_item_with_attr(
+                                            |diag| {
+                                                diag.suggest_item_with_attr(
                                                     cx,
                                                     sp,
                                                     "try this",
@@ -187,8 +187,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NewWithoutDefault {
                                                 "you should consider adding a `Default` implementation for `{}`",
                                                 self_ty
                                             ),
-                                            |db| {
-                                                db.suggest_prepend_item(
+                                            |diag| {
+                                                diag.suggest_prepend_item(
                                                     cx,
                                                     item.span,
                                                     "try this",

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -118,22 +118,22 @@ fn verify_ty_bound<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, ty: Ty<'tcx>, source: S
     }
 
     let (lint, msg, span) = source.lint();
-    span_lint_and_then(cx, lint, span, msg, |db| {
+    span_lint_and_then(cx, lint, span, msg, |diag| {
         if span.from_expansion() {
             return; // Don't give suggestions into macros.
         }
         match source {
             Source::Item { .. } => {
                 let const_kw_span = span.from_inner(InnerSpan::new(0, 5));
-                db.span_label(const_kw_span, "make this a static item (maybe with lazy_static)");
+                diag.span_label(const_kw_span, "make this a static item (maybe with lazy_static)");
             },
             Source::Assoc { ty: ty_span, .. } => {
                 if ty.flags.intersects(TypeFlags::HAS_FREE_LOCAL_NAMES) {
-                    db.span_label(ty_span, &format!("consider requiring `{}` to be `Copy`", ty));
+                    diag.span_label(ty_span, &format!("consider requiring `{}` to be `Copy`", ty));
                 }
             },
             Source::Expr { .. } => {
-                db.help("assign this const to a local or static variable, and use the variable here");
+                diag.help("assign this const to a local or static variable, and use the variable here");
             },
         }
     });

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -175,9 +175,9 @@ fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl<'_>, fn_id: HirId, opt_body_
                         arg.span,
                         "writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used \
                          with non-Vec-based slices.",
-                        |db| {
+                        |diag| {
                             if let Some(ref snippet) = ty_snippet {
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     arg.span,
                                     "change this to",
                                     format!("&[{}]", snippet),
@@ -185,7 +185,7 @@ fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl<'_>, fn_id: HirId, opt_body_
                                 );
                             }
                             for (clonespan, suggestion) in spans {
-                                db.span_suggestion(
+                                diag.span_suggestion(
                                     clonespan,
                                     &snippet_opt(cx, clonespan).map_or("change the call to".into(), |x| {
                                         Cow::Owned(format!("change `{}` to", x))
@@ -204,10 +204,10 @@ fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl<'_>, fn_id: HirId, opt_body_
                         PTR_ARG,
                         arg.span,
                         "writing `&String` instead of `&str` involves a new object where a slice will do.",
-                        |db| {
-                            db.span_suggestion(arg.span, "change this to", "&str".into(), Applicability::Unspecified);
+                        |diag| {
+                            diag.span_suggestion(arg.span, "change this to", "&str".into(), Applicability::Unspecified);
                             for (clonespan, suggestion) in spans {
-                                db.span_suggestion_short(
+                                diag.span_suggestion_short(
                                     clonespan,
                                     &snippet_opt(cx, clonespan).map_or("change the call to".into(), |x| {
                                         Cow::Owned(format!("change `{}` to", x))
@@ -239,8 +239,8 @@ fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl<'_>, fn_id: HirId, opt_body_
                                 PTR_ARG,
                                 arg.span,
                                 "using a reference to `Cow` is not recommended.",
-                                |db| {
-                                    db.span_suggestion(
+                                |diag| {
+                                    diag.span_suggestion(
                                         arg.span,
                                         "change this to",
                                         "&".to_owned() + &r,
@@ -277,9 +277,9 @@ fn check_fn(cx: &LateContext<'_, '_>, decl: &FnDecl<'_>, fn_id: HirId, opt_body_
                 MUT_FROM_REF,
                 ty.span,
                 "mutable borrow from immutable input(s)",
-                |db| {
+                |diag| {
                     let ms = MultiSpan::from_spans(immutables);
-                    db.span_note(ms, "immutable borrow here");
+                    diag.span_note(ms, "immutable borrow here");
                 },
             );
         }

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -150,19 +150,19 @@ fn check_exclusive_range_plus_one(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
                 RANGE_PLUS_ONE,
                 span,
                 "an inclusive range would be more readable",
-                |db| {
+                |diag| {
                     let start = start.map_or(String::new(), |x| Sugg::hir(cx, x, "x").to_string());
                     let end = Sugg::hir(cx, y, "y");
                     if let Some(is_wrapped) = &snippet_opt(cx, span) {
                         if is_wrapped.starts_with('(') && is_wrapped.ends_with(')') {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 span,
                                 "use",
                                 format!("({}..={})", start, end),
                                 Applicability::MaybeIncorrect,
                             );
                         } else {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 span,
                                 "use",
                                 format!("{}..={}", start, end),
@@ -187,10 +187,10 @@ fn check_inclusive_range_minus_one(cx: &LateContext<'_, '_>, expr: &Expr<'_>) {
                 RANGE_MINUS_ONE,
                 expr.span,
                 "an exclusive range would be more readable",
-                |db| {
+                |diag| {
                     let start = start.map_or(String::new(), |x| Sugg::hir(cx, x, "x").to_string());
                     let end = Sugg::hir(cx, y, "y");
-                    db.span_suggestion(
+                    diag.span_suggestion(
                         expr.span,
                         "use",
                         format!("{}..{}", start, end),

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -243,20 +243,20 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantClone {
                             }
                         }
 
-                        span_lint_hir_and_then(cx, REDUNDANT_CLONE, node, sugg_span, "redundant clone", |db| {
-                            db.span_suggestion(
+                        span_lint_hir_and_then(cx, REDUNDANT_CLONE, node, sugg_span, "redundant clone", |diag| {
+                            diag.span_suggestion(
                                 sugg_span,
                                 "remove this",
                                 String::new(),
                                 app,
                             );
                             if used {
-                                db.span_note(
+                                diag.span_note(
                                     span,
                                     "cloned value is neither consumed nor mutated",
                                 );
                             } else {
-                                db.span_note(
+                                diag.span_note(
                                     span.with_hi(span.lo() + BytePos(u32::try_from(dot).unwrap())),
                                     "this value is dropped without further use",
                                 );

--- a/clippy_lints/src/redundant_pattern_matching.rs
+++ b/clippy_lints/src/redundant_pattern_matching.rs
@@ -93,9 +93,9 @@ fn find_sugg_for_if_let<'a, 'tcx>(
         REDUNDANT_PATTERN_MATCHING,
         arms[0].pat.span,
         &format!("redundant pattern matching, consider using `{}`", good_method),
-        |db| {
+        |diag| {
             let span = expr.span.to(op.span);
-            db.span_suggestion(
+            diag.span_suggestion(
                 span,
                 "try this",
                 format!("{}.{}{}", snippet(cx, op.span, "_"), good_method, maybe_semi),
@@ -155,9 +155,9 @@ fn find_sugg_for_match<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &'tcx Expr<'_
                 REDUNDANT_PATTERN_MATCHING,
                 expr.span,
                 &format!("redundant pattern matching, consider using `{}`", good_method),
-                |db| {
+                |diag| {
                     let span = expr.span.to(op.span);
-                    db.span_suggestion(
+                    diag.span_suggestion(
                         span,
                         "try this",
                         format!("{}.{}", snippet(cx, op.span, "_"), good_method),

--- a/clippy_lints/src/redundant_pub_crate.rs
+++ b/clippy_lints/src/redundant_pub_crate.rs
@@ -50,8 +50,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for RedundantPubCrate {
                         REDUNDANT_PUB_CRATE,
                         span,
                         &format!("pub(crate) {} inside private module", item.kind.descr()),
-                        |db| {
-                            db.span_suggestion(
+                        |diag| {
+                            diag.span_suggestion(
                                 item.vis.span,
                                 "consider using",
                                 "pub".to_string(),

--- a/clippy_lints/src/redundant_static_lifetimes.rs
+++ b/clippy_lints/src/redundant_static_lifetimes.rs
@@ -53,14 +53,20 @@ impl RedundantStaticLifetimes {
                             if lifetime.ident.name == rustc_span::symbol::kw::StaticLifetime {
                                 let snip = snippet(cx, borrow_type.ty.span, "<type>");
                                 let sugg = format!("&{}", snip);
-                                span_lint_and_then(cx, REDUNDANT_STATIC_LIFETIMES, lifetime.ident.span, reason, |diag| {
-                                    diag.span_suggestion(
-                                        ty.span,
-                                        "consider removing `'static`",
-                                        sugg,
-                                        Applicability::MachineApplicable, //snippet
-                                    );
-                                });
+                                span_lint_and_then(
+                                    cx,
+                                    REDUNDANT_STATIC_LIFETIMES,
+                                    lifetime.ident.span,
+                                    reason,
+                                    |diag| {
+                                        diag.span_suggestion(
+                                            ty.span,
+                                            "consider removing `'static`",
+                                            sugg,
+                                            Applicability::MachineApplicable, //snippet
+                                        );
+                                    },
+                                );
                             }
                         },
                         _ => {},

--- a/clippy_lints/src/redundant_static_lifetimes.rs
+++ b/clippy_lints/src/redundant_static_lifetimes.rs
@@ -53,8 +53,8 @@ impl RedundantStaticLifetimes {
                             if lifetime.ident.name == rustc_span::symbol::kw::StaticLifetime {
                                 let snip = snippet(cx, borrow_type.ty.span, "<type>");
                                 let sugg = format!("&{}", snip);
-                                span_lint_and_then(cx, REDUNDANT_STATIC_LIFETIMES, lifetime.ident.span, reason, |db| {
-                                    db.span_suggestion(
+                                span_lint_and_then(cx, REDUNDANT_STATIC_LIFETIMES, lifetime.ident.span, reason, |diag| {
+                                    diag.span_suggestion(
                                         ty.span,
                                         "consider removing `'static`",
                                         sugg,

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -154,16 +154,16 @@ impl Return {
                     return;
                 }
 
-                span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |db| {
+                span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |diag| {
                     if let Some(snippet) = snippet_opt(cx, inner_span) {
-                        db.span_suggestion(ret_span, "remove `return`", snippet, Applicability::MachineApplicable);
+                        diag.span_suggestion(ret_span, "remove `return`", snippet, Applicability::MachineApplicable);
                     }
                 })
             },
             None => match replacement {
                 RetReplacement::Empty => {
-                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |db| {
-                        db.span_suggestion(
+                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |diag| {
+                        diag.span_suggestion(
                             ret_span,
                             "remove `return`",
                             String::new(),
@@ -172,8 +172,8 @@ impl Return {
                     });
                 },
                 RetReplacement::Block => {
-                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |db| {
-                        db.span_suggestion(
+                    span_lint_and_then(cx, NEEDLESS_RETURN, ret_span, "unneeded `return` statement", |diag| {
+                        diag.span_suggestion(
                             ret_span,
                             "replace `return` with an empty block",
                             "{}".to_string(),
@@ -259,8 +259,8 @@ impl EarlyLintPass for Return {
                 } else {
                     (ty.span, Applicability::MaybeIncorrect)
                 };
-                span_lint_and_then(cx, UNUSED_UNIT, rspan, "unneeded unit return type", |db| {
-                    db.span_suggestion(
+                span_lint_and_then(cx, UNUSED_UNIT, rspan, "unneeded unit return type", |diag| {
+                    diag.span_suggestion(
                         rspan,
                         "remove the `-> ()`",
                         String::new(),
@@ -279,8 +279,8 @@ impl EarlyLintPass for Return {
             if is_unit_expr(expr) && !stmt.span.from_expansion();
             then {
                 let sp = expr.span;
-                span_lint_and_then(cx, UNUSED_UNIT, sp, "unneeded unit expression", |db| {
-                    db.span_suggestion(
+                span_lint_and_then(cx, UNUSED_UNIT, sp, "unneeded unit expression", |diag| {
+                    diag.span_suggestion(
                         sp,
                         "remove the final `()`",
                         String::new(),
@@ -295,8 +295,8 @@ impl EarlyLintPass for Return {
         match e.kind {
             ast::ExprKind::Ret(Some(ref expr)) | ast::ExprKind::Break(_, Some(ref expr)) => {
                 if is_unit_expr(expr) && !expr.span.from_expansion() {
-                    span_lint_and_then(cx, UNUSED_UNIT, expr.span, "unneeded `()`", |db| {
-                        db.span_suggestion(
+                    span_lint_and_then(cx, UNUSED_UNIT, expr.span, "unneeded `()`", |diag| {
+                        diag.span_suggestion(
                             expr.span,
                             "remove the `()`",
                             String::new(),

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -268,8 +268,8 @@ fn lint_shadow<'a, 'tcx>(
                     snippet(cx, pattern_span, "_"),
                     snippet(cx, expr.span, "..")
                 ),
-                |db| {
-                    db.span_note(prev_span, "previous binding is here");
+                |diag| {
+                    diag.span_note(prev_span, "previous binding is here");
                 },
             );
         } else if contains_name(name, expr) {
@@ -282,9 +282,9 @@ fn lint_shadow<'a, 'tcx>(
                     snippet(cx, pattern_span, "_"),
                     snippet(cx, expr.span, "..")
                 ),
-                |db| {
-                    db.span_note(expr.span, "initialization happens here");
-                    db.span_note(prev_span, "previous binding is here");
+                |diag| {
+                    diag.span_note(expr.span, "initialization happens here");
+                    diag.span_note(prev_span, "previous binding is here");
                 },
             );
         } else {
@@ -297,9 +297,9 @@ fn lint_shadow<'a, 'tcx>(
                     snippet(cx, pattern_span, "_"),
                     snippet(cx, expr.span, "..")
                 ),
-                |db| {
-                    db.span_note(expr.span, "initialization happens here");
-                    db.span_note(prev_span, "previous binding is here");
+                |diag| {
+                    diag.span_note(expr.span, "initialization happens here");
+                    diag.span_note(prev_span, "previous binding is here");
                 },
             );
         }
@@ -309,8 +309,8 @@ fn lint_shadow<'a, 'tcx>(
             SHADOW_UNRELATED,
             span,
             &format!("`{}` shadows a previous declaration", snippet(cx, pattern_span, "_")),
-            |db| {
-                db.span_note(prev_span, "previous binding is here");
+            |diag| {
+                diag.span_note(prev_span, "previous binding is here");
             },
         );
     }

--- a/clippy_lints/src/slow_vector_initialization.rs
+++ b/clippy_lints/src/slow_vector_initialization.rs
@@ -170,8 +170,8 @@ impl SlowVectorInit {
     ) {
         let len_expr = Sugg::hir(cx, vec_alloc.len_expr, "len");
 
-        span_lint_and_then(cx, lint, slow_fill.span, msg, |db| {
-            db.span_suggestion(
+        span_lint_and_then(cx, lint, slow_fill.span, msg, |diag| {
+            diag.span_suggestion(
                 vec_alloc.allocation_expr.span,
                 "consider replace allocation with",
                 format!("vec![0; {}]", len_expr),

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -140,9 +140,9 @@ fn check_manual_swap(cx: &LateContext<'_, '_>, block: &Block<'_>) {
                     MANUAL_SWAP,
                     span,
                     &format!("this looks like you are swapping{} manually", what),
-                    |db| {
+                    |diag| {
                         if !sugg.is_empty() {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 span,
                                 "try",
                                 sugg,
@@ -150,7 +150,7 @@ fn check_manual_swap(cx: &LateContext<'_, '_>, block: &Block<'_>) {
                             );
 
                             if replace {
-                                db.note("or maybe you should use `std::mem::replace`?");
+                                diag.note("or maybe you should use `std::mem::replace`?");
                             }
                         }
                     }
@@ -242,9 +242,9 @@ fn check_suspicious_swap(cx: &LateContext<'_, '_>, block: &Block<'_>) {
                                    ALMOST_SWAPPED,
                                    span,
                                    &format!("this looks like you are trying to swap{}", what),
-                                   |db| {
+                                   |diag| {
                                        if !what.is_empty() {
-                                           db.span_suggestion(
+                                           diag.span_suggestion(
                                                span,
                                                "try",
                                                format!(
@@ -254,7 +254,7 @@ fn check_suspicious_swap(cx: &LateContext<'_, '_>, block: &Block<'_>) {
                                                ),
                                                Applicability::MaybeIncorrect,
                                            );
-                                           db.note("or maybe you should use `std::mem::replace`?");
+                                           diag.note("or maybe you should use `std::mem::replace`?");
                                        }
                                    });
             }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -608,10 +608,10 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnitValue {
                 if higher::is_from_for_desugar(local) {
                     return;
                 }
-                span_lint_and_then(cx, LET_UNIT_VALUE, stmt.span, "this let-binding has unit value", |db| {
+                span_lint_and_then(cx, LET_UNIT_VALUE, stmt.span, "this let-binding has unit value", |diag| {
                     if let Some(expr) = &local.init {
                         let snip = snippet_with_macro_callsite(cx, expr.span, "()");
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             stmt.span,
                             "omit the `let` binding",
                             format!("{};", snip),
@@ -1712,11 +1712,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for CharLitAsU8 {
                     CHAR_LIT_AS_U8,
                     expr.span,
                     "casting a character literal to `u8` truncates",
-                    |db| {
-                        db.note("`char` is four bytes wide, but `u8` is a single byte");
+                    |diag| {
+                        diag.note("`char` is four bytes wide, but `u8` is a single byte");
 
                         if c.is_ascii() {
-                            db.span_suggestion(
+                            diag.span_suggestion(
                                 expr.span,
                                 "use a byte literal instead",
                                 format!("b{}", snippet),
@@ -2182,7 +2182,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
 
         fn suggestion<'a, 'tcx>(
             cx: &LateContext<'a, 'tcx>,
-            db: &mut DiagnosticBuilder<'_>,
+            diag: &mut DiagnosticBuilder<'_>,
             generics_span: Span,
             generics_suggestion_span: Span,
             target: &ImplicitHasherType<'_>,
@@ -2197,7 +2197,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
             };
 
             multispan_sugg(
-                db,
+                diag,
                 "consider adding a type parameter".to_string(),
                 vec![
                     (
@@ -2222,7 +2222,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
             );
 
             if !vis.suggestions.is_empty() {
-                multispan_sugg(db, "...and use generic constructor".into(), vis.suggestions);
+                multispan_sugg(diag, "...and use generic constructor".into(), vis.suggestions);
             }
         }
 
@@ -2268,8 +2268,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
                             "impl for `{}` should be generalized over different hashers",
                             target.type_name()
                         ),
-                        move |db| {
-                            suggestion(cx, db, generics.span, generics_suggestion_span, target, ctr_vis);
+                        move |diag| {
+                            suggestion(cx, diag, generics.span, generics_suggestion_span, target, ctr_vis);
                         },
                     );
                 }
@@ -2306,8 +2306,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImplicitHasher {
                                 "parameter of type `{}` should be generalized over different hashers",
                                 target.type_name()
                             ),
-                            move |db| {
-                                suggestion(cx, db, generics.span, generics_suggestion_span, target, ctr_vis);
+                            move |diag| {
+                                suggestion(cx, diag, generics.span, generics_suggestion_span, target, ctr_vis);
                             },
                         );
                     }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -608,17 +608,23 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for LetUnitValue {
                 if higher::is_from_for_desugar(local) {
                     return;
                 }
-                span_lint_and_then(cx, LET_UNIT_VALUE, stmt.span, "this let-binding has unit value", |diag| {
-                    if let Some(expr) = &local.init {
-                        let snip = snippet_with_macro_callsite(cx, expr.span, "()");
-                        diag.span_suggestion(
-                            stmt.span,
-                            "omit the `let` binding",
-                            format!("{};", snip),
-                            Applicability::MachineApplicable, // snippet
-                        );
-                    }
-                });
+                span_lint_and_then(
+                    cx,
+                    LET_UNIT_VALUE,
+                    stmt.span,
+                    "this let-binding has unit value",
+                    |diag| {
+                        if let Some(expr) = &local.init {
+                            let snip = snippet_with_macro_callsite(cx, expr.span, "()");
+                            diag.span_suggestion(
+                                stmt.span,
+                                "omit the `let` binding",
+                                format!("{};", snip),
+                                Applicability::MachineApplicable, // snippet
+                            );
+                        }
+                    },
+                );
             }
         }
     }

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -167,7 +167,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnwrappableVariablesVisitor<'a, 'tcx> {
                             &format!("You checked before that `{}()` cannot fail. \
                             Instead of checking and unwrapping, it's better to use `if let` or `match`.",
                             method_name.ident.name),
-                            |db| { db.span_label(unwrappable.check.span, "the check is happening here"); },
+                            |diag| { diag.span_label(unwrappable.check.span, "the check is happening here"); },
                         );
                     } else {
                         span_lint_and_then(
@@ -176,7 +176,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnwrappableVariablesVisitor<'a, 'tcx> {
                             expr.span,
                             &format!("This call to `{}()` will always panic.",
                             method_name.ident.name),
-                            |db| { db.span_label(unwrappable.check.span, "because of this check"); },
+                            |diag| { diag.span_label(unwrappable.check.span, "because of this check"); },
                         );
                     }
                 }

--- a/clippy_lints/src/utils/attrs.rs
+++ b/clippy_lints/src/utils/attrs.rs
@@ -76,24 +76,24 @@ pub fn get_attr<'a>(
                         }
                     })
             {
-                let mut db = sess.struct_span_err(attr_segments[1].ident.span, "Usage of deprecated attribute");
+                let mut diag = sess.struct_span_err(attr_segments[1].ident.span, "Usage of deprecated attribute");
                 match *deprecation_status {
                     DeprecationStatus::Deprecated => {
-                        db.emit();
+                        diag.emit();
                         false
                     },
                     DeprecationStatus::Replaced(new_name) => {
-                        db.span_suggestion(
+                        diag.span_suggestion(
                             attr_segments[1].ident.span,
                             "consider using",
                             new_name.to_string(),
                             Applicability::MachineApplicable,
                         );
-                        db.emit();
+                        diag.emit();
                         false
                     },
                     DeprecationStatus::None => {
-                        db.cancel();
+                        diag.cancel();
                         attr_segments[1].ident.to_string() == name
                     },
                 }

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -515,7 +515,7 @@ pub trait DiagnosticBuilderExt<'a, T: LintContext> {
     /// # Example
     ///
     /// ```rust,ignore
-    /// db.suggest_item_with_attr(cx, item, "#[derive(Default)]");
+    /// diag.suggest_item_with_attr(cx, item, "#[derive(Default)]");
     /// ```
     fn suggest_item_with_attr<D: Display + ?Sized>(
         &mut self,
@@ -533,7 +533,7 @@ pub trait DiagnosticBuilderExt<'a, T: LintContext> {
     /// # Example
     ///
     /// ```rust,ignore
-    /// db.suggest_prepend_item(cx, item,
+    /// diag.suggest_prepend_item(cx, item,
     /// "fn foo() {
     ///     bar();
     /// }");
@@ -549,7 +549,7 @@ pub trait DiagnosticBuilderExt<'a, T: LintContext> {
     /// # Example
     ///
     /// ```rust,ignore
-    /// db.suggest_remove_item(cx, item, "remove this")
+    /// diag.suggest_remove_item(cx, item, "remove this")
     /// ```
     fn suggest_remove_item(&mut self, cx: &T, item: Span, msg: &str, applicability: Applicability);
 }


### PR DESCRIPTION
Did the same in rustc a while ago: https://github.com/rust-lang/rust/pull/65428

changelog: none
