### PR TITLE
Cleanup: `node_id` -> `hir_id`

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -120,9 +120,9 @@ fn check_hash_peq<'a, 'tcx>(
                         cx, DERIVE_HASH_XOR_EQ, span,
                         mess,
                         |diag| {
-                        if let Some(node_id) = cx.tcx.hir().as_local_hir_id(impl_id) {
+                        if let Some(hir_id) = cx.tcx.hir().as_local_hir_id(impl_id) {
                             diag.span_note(
-                                cx.tcx.hir().span(node_id),
+                                cx.tcx.hir().span(hir_id),
                                 "`PartialEq` implemented here"
                             );
                         }

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1652,14 +1652,14 @@ fn check_for_mutability(cx: &LateContext<'_, '_>, bound: &Expr<'_>) -> Option<Hi
         if let QPath::Resolved(None, _) = *qpath;
         then {
             let res = qpath_res(cx, qpath, bound.hir_id);
-            if let Res::Local(node_id) = res {
-                let node_str = cx.tcx.hir().get(node_id);
+            if let Res::Local(hir_id) = res {
+                let node_str = cx.tcx.hir().get(hir_id);
                 if_chain! {
                     if let Node::Binding(pat) = node_str;
                     if let PatKind::Binding(bind_ann, ..) = pat.kind;
                     if let BindingAnnotation::Mutable = bind_ann;
                     then {
-                        return Some(node_id);
+                        return Some(hir_id);
                     }
                 }
             }
@@ -2184,8 +2184,8 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
 fn var_def_id(cx: &LateContext<'_, '_>, expr: &Expr<'_>) -> Option<HirId> {
     if let ExprKind::Path(ref qpath) = expr.kind {
         let path_res = qpath_res(cx, qpath, expr.hir_id);
-        if let Res::Local(node_id) = path_res {
-            return Some(node_id);
+        if let Res::Local(hir_id) = path_res {
+            return Some(hir_id);
         }
     }
     None
@@ -2422,8 +2422,8 @@ impl<'a, 'tcx> VarCollectorVisitor<'a, 'tcx> {
             let res = qpath_res(self.cx, qpath, ex.hir_id);
             then {
                 match res {
-                    Res::Local(node_id) => {
-                        self.ids.insert(node_id);
+                    Res::Local(hir_id) => {
+                        self.ids.insert(hir_id);
                     },
                     Res::Def(DefKind::Static, def_id) => {
                         let mutable = self.cx.tcx.is_mutable_static(def_id);

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -152,8 +152,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingInline {
         };
 
         if let Some(trait_def_id) = trait_def_id {
-            if cx.tcx.hir().as_local_node_id(trait_def_id).is_some() && !cx.access_levels.is_exported(impl_item.hir_id)
-            {
+            if cx.tcx.hir().as_local_hir_id(trait_def_id).is_some() && !cx.access_levels.is_exported(impl_item.hir_id) {
                 // If a trait is being implemented for an item, and the
                 // trait is not exported, we don't need #[inline]
                 return;


### PR DESCRIPTION
This removes some more `node_id` terminology from Clippy and replaces one occurrence of `as_local_node_id` with `as_local_hir_id`, which should be doing the same for that particular case. 

changelog: none
