### PR TITLE
Don't trigger toplevel_ref_arg for `for` loops

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -14,7 +14,7 @@ use rustc_span::source_map::{ExpnKind, Span};
 use crate::consts::{constant, Constant};
 use crate::utils::sugg::Sugg;
 use crate::utils::{
-    get_item_name, get_parent_expr, implements_trait, in_constant, is_integer_const, iter_input_pats,
+    get_item_name, get_parent_expr, higher, implements_trait, in_constant, is_integer_const, iter_input_pats,
     last_path_segment, match_qpath, match_trait_method, paths, snippet, snippet_opt, span_lint, span_lint_and_sugg,
     span_lint_and_then, span_lint_hir_and_then, walk_ptrs_ty, SpanlessEq,
 };
@@ -267,6 +267,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
             if let StmtKind::Local(ref local) = stmt.kind;
             if let PatKind::Binding(an, .., name, None) = local.pat.kind;
             if let Some(ref init) = local.init;
+            if !higher::is_from_for_desugar(local);
             then {
                 if an == BindingAnnotation::Ref || an == BindingAnnotation::RefMut {
                     let sugg_init = if init.span.from_expansion() {

--- a/tests/ui/toplevel_ref_arg.fixed
+++ b/tests/ui/toplevel_ref_arg.fixed
@@ -23,4 +23,7 @@ fn main() {
     // Make sure that allowing the lint works
     #[allow(clippy::toplevel_ref_arg)]
     let ref mut _x = 1_234_543;
+
+    // ok
+    for ref _x in 0..10 {}
 }

--- a/tests/ui/toplevel_ref_arg.rs
+++ b/tests/ui/toplevel_ref_arg.rs
@@ -23,4 +23,7 @@ fn main() {
     // Make sure that allowing the lint works
     #[allow(clippy::toplevel_ref_arg)]
     let ref mut _x = 1_234_543;
+
+    // ok
+    for ref _x in 0..10 {}
 }


### PR DESCRIPTION
The lint suggests turning `for ref x in 0..10 {` into `for ref x in let x = &0..10; {`.

---

changelog: none
