### PR TITLE
fix crash on issue-69020-assoc-const-arith-overflow.rs

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -351,9 +351,9 @@ impl<'c, 'cc> ConstEvalLateContext<'c, 'cc> {
         let index = self.expr(index);
 
         match (lhs, index) {
-            (Some(Constant::Vec(vec)), Some(Constant::Int(index))) => match vec[index as usize] {
-                Constant::F32(x) => Some(Constant::F32(x)),
-                Constant::F64(x) => Some(Constant::F64(x)),
+            (Some(Constant::Vec(vec)), Some(Constant::Int(index))) => match vec.get(index as usize) {
+                Some(Constant::F32(x)) => Some(Constant::F32(*x)),
+                Some(Constant::F64(x)) => Some(Constant::F64(*x)),
                 _ => None,
             },
             (Some(Constant::Vec(vec)), _) => {

--- a/tests/ui/crashes/ice-5497.rs
+++ b/tests/ui/crashes/ice-5497.rs
@@ -1,0 +1,11 @@
+// reduced from rustc issue-69020-assoc-const-arith-overflow.rs
+pub fn main() {}
+
+pub trait Foo {
+    const OOB: i32;
+}
+
+impl<T: Foo> Foo for Vec<T> {
+    const OOB: i32 = [1][1] + T::OOB;
+    //~^ ERROR operation will panic
+}


### PR DESCRIPTION
Fixes #5497

changelog: fix crash on rustc test issue-69020-assoc-const-arith-overflow.rs
