### PR TITLE
fix clippy_dev exit status and make regex match again

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are 362 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are over 350 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 We have a bunch of lint categories to allow you to choose how much Clippy is supposed to ~~annoy~~ help you:
 

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -291,10 +291,11 @@ where
     }
 
     if !found {
-        // This happens if the provided regex in `clippy_dev/src/main.rs` is not found in the
+        // This happens if the provided regex in `clippy_dev/src/main.rs` does not match in the
         // given text or file. Most likely this is an error on the programmer's side and the Regex
         // is incorrect.
-        eprintln!("error: regex `{:?}` not found. You may have to update it.", start);
+        eprintln!("error: regex \n{:?}\ndoesn't match. You may have to update it.", start);
+        std::process::exit(1);
     }
 
     let mut new_lines = new_lines.join("\n");


### PR DESCRIPTION
changelog: none

Fixes #5510

r? @phansch 