### PR TITLE
Deploy time travel

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -77,8 +77,6 @@ jobs:
       run: |
         sudo dpkg --add-architecture i386
         sudo apt-get update
-        # perform system upgrade to work around https://github.com/rust-lang/rust-clippy/issues/5477 , revert as soon as that is fixed
-        sudo apt-get -y upgrade
         sudo apt-get install gcc-multilib libssl-dev:i386 libgit2-dev:i386
       if: matrix.host == 'i686-unknown-linux-gnu'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,12 @@ jobs:
     - name: Set beta to true
       if: github.ref == 'refs/heads/beta'
       run: echo "::set-env name=BETA::true"
+
+    - name: Use scripts and templates from master branch
+      run: |
+        git fetch --no-tags --prune --depth=1 origin master
+        git checkout origin/master -- .github/deploy.sh util/gh-pages/ util/*.py
+
     - name: Deploy
       run: |
         eval "$(ssh-agent -s)"


### PR DESCRIPTION
Since not only commits to the master branch, but also tags and the beta branch are deployed, we have to be cautious which version of the deploy script is used. GHA always runs the workflow that is commited on the `ref`, that gets tested. For tagged commits. this is 6 weeks outdated workflows/scripts. To prevent this, this workflow first checks out the deploy.sh script, the website templates and all python scripts generating files for the website.

changelog: none
