### PR TITLE
map_clone: avoid suggesting `copied()` for &mut

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -7,6 +7,7 @@ use rustc_ast::ast::Ident;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::mir::Mutability;
 use rustc_middle::ty;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Span;
@@ -58,7 +59,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MapClone {
             let closure_expr = remove_blocks(&closure_body.value);
             then {
                 match closure_body.params[0].pat.kind {
-                    hir::PatKind::Ref(ref inner, _) => if let hir::PatKind::Binding(
+                    hir::PatKind::Ref(ref inner, hir::Mutability::Not) => if let hir::PatKind::Binding(
                         hir::BindingAnnotation::Unannotated, .., name, None
                     ) = inner.kind {
                         if ident_eq(name, closure_expr) {
@@ -69,7 +70,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MapClone {
                         match closure_expr.kind {
                             hir::ExprKind::Unary(hir::UnOp::UnDeref, ref inner) => {
                                 if ident_eq(name, inner) {
-                                    if let ty::Ref(..) = cx.tables.expr_ty(inner).kind {
+                                    if let ty::Ref(.., Mutability::Not) = cx.tables.expr_ty(inner).kind {
                                         lint(cx, e.span, args[0].span, true);
                                     }
                                 }

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -4,6 +4,7 @@
 #![allow(clippy::clone_on_copy, clippy::redundant_clone)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure_for_method_calls)]
+#![allow(clippy::many_single_char_names)]
 
 fn main() {
     let _: Vec<i8> = vec![5_i8; 6].iter().copied().collect();
@@ -32,5 +33,15 @@ fn main() {
         let _: Option<u32> = o.map(|x| *x);
         let v: Vec<Rc<u32>> = vec![Rc::new(0_u32)];
         let _: Vec<u32> = v.into_iter().map(|x| *x).collect();
+    }
+
+    // Issue #5524 mutable references
+    {
+        let mut c = 42;
+        let v = vec![&mut c];
+        let _: Vec<u32> = v.into_iter().map(|x| *x).collect();
+        let mut d = 21;
+        let v = vec![&mut d];
+        let _: Vec<u32> = v.into_iter().map(|&mut x| x).collect();
     }
 }

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::clone_on_copy, clippy::redundant_clone)]
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::redundant_closure_for_method_calls)]
+#![allow(clippy::many_single_char_names)]
 
 fn main() {
     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
@@ -32,5 +33,15 @@ fn main() {
         let _: Option<u32> = o.map(|x| *x);
         let v: Vec<Rc<u32>> = vec![Rc::new(0_u32)];
         let _: Vec<u32> = v.into_iter().map(|x| *x).collect();
+    }
+
+    // Issue #5524 mutable references
+    {
+        let mut c = 42;
+        let v = vec![&mut c];
+        let _: Vec<u32> = v.into_iter().map(|x| *x).collect();
+        let mut d = 21;
+        let v = vec![&mut d];
+        let _: Vec<u32> = v.into_iter().map(|&mut x| x).collect();
     }
 }

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -1,5 +1,5 @@
 error: You are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:9:22
+  --> $DIR/map_clone.rs:10:22
    |
 LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![5_i8; 6].iter().copied()`
@@ -7,31 +7,31 @@ LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
    = note: `-D clippy::map-clone` implied by `-D warnings`
 
 error: You are using an explicit closure for cloning elements
-  --> $DIR/map_clone.rs:10:26
+  --> $DIR/map_clone.rs:11:26
    |
 LL |     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `cloned` method: `vec![String::new()].iter().cloned()`
 
 error: You are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:11:23
+  --> $DIR/map_clone.rs:12:23
    |
 LL |     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `vec![42, 43].iter().copied()`
 
 error: You are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:13:26
+  --> $DIR/map_clone.rs:14:26
    |
 LL |     let _: Option<u64> = Some(&16).map(|b| *b);
    |                          ^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `Some(&16).copied()`
 
 error: You are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:14:25
+  --> $DIR/map_clone.rs:15:25
    |
 LL |     let _: Option<u8> = Some(&1).map(|x| x.clone());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Consider calling the dedicated `copied` method: `Some(&1).copied()`
 
 error: You are needlessly cloning iterator elements
-  --> $DIR/map_clone.rs:25:29
+  --> $DIR/map_clone.rs:26:29
    |
 LL |     let _ = std::env::args().map(|v| v.clone());
    |                             ^^^^^^^^^^^^^^^^^^^ help: Remove the `map` call


### PR DESCRIPTION
changelog: map_clone: avoid suggesting `copied()` for &mut 

Fixes #5524 