### PR TITLE
Remove util/dev script

### DIFF
--- a/util/dev
+++ b/util/dev
@@ -1,7 +1,0 @@
-#!/bin/sh
-CARGO_TARGET_DIR=$(pwd)/target/
-export CARGO_TARGET_DIR
-
-echo 'Deprecated! `util/dev` usage is deprecated, please use `cargo dev` instead.'
-
-cd clippy_dev && cargo run -- "$@"


### PR DESCRIPTION
`cargo dev` has been the replacement for a while, so I think we can
remove it now.

cc #5394

changelog: none
