### PR TITLE
used_underscore_binding: do not lint on `await` desugaring

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -9,6 +9,7 @@ use rustc_hir::{
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::hygiene::DesugaringKind;
 use rustc_span::source_map::{ExpnKind, Span};
 
 use crate::consts::{constant, Constant};
@@ -399,8 +400,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MiscLints {
             },
             _ => {},
         }
-        if in_attributes_expansion(expr) {
-            // Don't lint things expanded by #[derive(...)], etc
+        if in_attributes_expansion(expr) || expr.span.is_desugaring(DesugaringKind::Await) {
+            // Don't lint things expanded by #[derive(...)], etc or `await` desugaring
             return;
         }
         let binding = match expr.kind {

--- a/tests/ui/used_underscore_binding.rs
+++ b/tests/ui/used_underscore_binding.rs
@@ -1,3 +1,4 @@
+// edition:2018
 // aux-build:proc_macro_derive.rs
 
 #![feature(rustc_private)]
@@ -86,6 +87,12 @@ fn non_variables() {
     let f = _fn_test;
     f();
 }
+// Tests that we do not lint if the binding comes from await desugaring.
+// See issue 5360.
+async fn await_desugaring() {
+    async fn foo() {}
+    foo().await;
+}
 
 fn main() {
     let foo = 0u32;
@@ -99,4 +106,5 @@ fn main() {
     let _ = unused_underscore_complex(foo);
     let _ = multiple_underscores(foo);
     non_variables();
+    await_desugaring();
 }

--- a/tests/ui/used_underscore_binding.rs
+++ b/tests/ui/used_underscore_binding.rs
@@ -87,11 +87,20 @@ fn non_variables() {
     let f = _fn_test;
     f();
 }
-// Tests that we do not lint if the binding comes from await desugaring.
-// See issue 5360.
+
+// Tests that we do not lint if the binding comes from await desugaring,
+// but we do lint the awaited expression. See issue 5360.
 async fn await_desugaring() {
     async fn foo() {}
+    fn uses_i(_i: i32) {}
+
     foo().await;
+    ({
+        let _i = 5;
+        uses_i(_i);
+        foo()
+    })
+    .await
 }
 
 fn main() {

--- a/tests/ui/used_underscore_binding.stderr
+++ b/tests/ui/used_underscore_binding.stderr
@@ -1,5 +1,5 @@
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:25:5
+  --> $DIR/used_underscore_binding.rs:26:5
    |
 LL |     _foo + 1
    |     ^^^^
@@ -7,25 +7,25 @@ LL |     _foo + 1
    = note: `-D clippy::used-underscore-binding` implied by `-D warnings`
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:30:20
+  --> $DIR/used_underscore_binding.rs:31:20
    |
 LL |     println!("{}", _foo);
    |                    ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:31:16
+  --> $DIR/used_underscore_binding.rs:32:16
    |
 LL |     assert_eq!(_foo, _foo);
    |                ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:31:22
+  --> $DIR/used_underscore_binding.rs:32:22
    |
 LL |     assert_eq!(_foo, _foo);
    |                      ^^^^
 
 error: used binding `_underscore_field` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
-  --> $DIR/used_underscore_binding.rs:44:5
+  --> $DIR/used_underscore_binding.rs:45:5
    |
 LL |     s._underscore_field += 1;
    |     ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/used_underscore_binding.stderr
+++ b/tests/ui/used_underscore_binding.stderr
@@ -30,5 +30,11 @@ error: used binding `_underscore_field` which is prefixed with an underscore. A 
 LL |     s._underscore_field += 1;
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: used binding `_i` which is prefixed with an underscore. A leading underscore signals that a binding will not be used.
+  --> $DIR/used_underscore_binding.rs:100:16
+   |
+LL |         uses_i(_i);
+   |                ^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
changelog: used_underscore_binding: do not lint on `await` desugaring

Fixes #5360 