### PR TITLE
Fix the bugs of `manual_memcpy`, simplify the suggestion and refactor it

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -960,8 +960,8 @@ fn detect_manual_memcpy<'a, 'tcx>(
             let print_sum = |arg1: &Offset, arg2: &Offset| -> String {
                 match (&arg1.value[..], arg1.negate, &arg2.value[..], arg2.negate) {
                     ("0", _, "0", _) => "".into(),
-                    ("0", _, x, false) | (x, false, "0", false) => x.into(),
-                    ("0", _, x, true) | (x, false, "0", true) => format!("-{}", x),
+                    ("0", _, x, false) | (x, false, "0", _) => x.into(),
+                    ("0", _, x, true) => format!("-{}", x),
                     (x, false, y, false) => format!("({} + {})", x, y),
                     (x, false, y, true) => {
                         if x == y {

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -958,7 +958,7 @@ fn detect_manual_memcpy<'a, 'tcx>(
     {
         // the var must be a single name
         if let PatKind::Binding(_, canonical_id, _, _) = pat.kind {
-            let print_sum = |arg1: &str, arg2: &Offset| -> String {
+            fn print_sum(arg1: &str, arg2: &Offset) -> String {
                 match (arg1, &arg2.value[..], arg2.sign) {
                     ("0", "0", _) => "0".into(),
                     ("0", x, OffsetSign::Positive) | (x, "0", _) => x.into(),
@@ -972,16 +972,16 @@ fn detect_manual_memcpy<'a, 'tcx>(
                         }
                     },
                 }
-            };
+            }
 
-            let print_offset = |start_str: &str, inline_offset: &Offset| -> String {
+            fn print_offset(start_str: &str, inline_offset: &Offset) -> String {
                 let offset = print_sum(start_str, inline_offset);
                 if offset.as_str() == "0" {
                     "".into()
                 } else {
                     offset
                 }
-            };
+            }
 
             let print_limit = |end: &Expr<'_>, offset: Offset, var_name: &str| {
                 if_chain! {

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -775,10 +775,9 @@ fn same_var<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, expr: &Expr<'_>, var: HirId) -
         if let QPath::Resolved(None, path) = qpath;
         if path.segments.len() == 1;
         if let Res::Local(local_id) = qpath_res(cx, qpath, expr.hir_id);
-        // our variable!
-        if local_id == var;
         then {
-            true
+            // our variable!
+            local_id == var
         } else {
             false
         }
@@ -870,10 +869,8 @@ fn get_offset<'a, 'tcx>(cx: &LateContext<'a, 'tcx>, idx: &Expr<'_>, var: HirId) 
     }
 }
 
-fn get_assignments<'a, 'tcx>(
-    body: &'tcx Expr<'tcx>,
-) -> impl Iterator<Item = Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)>> {
-    fn get_assignment<'a, 'tcx>(e: &'tcx Expr<'tcx>) -> Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)> {
+fn get_assignments<'tcx>(body: &'tcx Expr<'tcx>) -> impl Iterator<Item = Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)>> {
+    fn get_assignment<'tcx>(e: &'tcx Expr<'tcx>) -> Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)> {
         if let ExprKind::Assign(lhs, rhs, _) = e.kind {
             Some((lhs, rhs))
         } else {

--- a/tests/ui/manual_memcpy.rs
+++ b/tests/ui/manual_memcpy.rs
@@ -98,6 +98,11 @@ pub fn manual_copy(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
     for i in from..from + 3 {
         dst[i] = src[i - from];
     }
+
+    // `RangeTo` `for` loop - don't trigger lint
+    for i in 0.. {
+        dst[i] = src[i];
+    }
 }
 
 #[warn(clippy::needless_range_loop, clippy::manual_memcpy)]

--- a/tests/ui/manual_memcpy.rs
+++ b/tests/ui/manual_memcpy.rs
@@ -99,6 +99,16 @@ pub fn manual_copy(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
         dst[i] = src[i - from];
     }
 
+    #[allow(clippy::identity_op)]
+    for i in 0..5 {
+        dst[i - 0] = src[i];
+    }
+
+    #[allow(clippy::reverse_range_loop)]
+    for i in 0..0 {
+        dst[i] = src[i];
+    }
+
     // `RangeTo` `for` loop - don't trigger lint
     for i in 0.. {
         dst[i] = src[i];

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -58,13 +58,13 @@ error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:94:14
    |
 LL |     for i in from..from + src.len() {
-   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + src.len()].clone_from_slice(&src[0..(from + src.len() - from)])`
+   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + src.len()].clone_from_slice(&src[..(from + src.len() - from)])`
 
 error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:98:14
    |
 LL |     for i in from..from + 3 {
-   |              ^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + 3].clone_from_slice(&src[0..(from + 3 - from)])`
+   |              ^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + 3].clone_from_slice(&src[..(from + 3 - from)])`
 
 error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:105:14

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -67,10 +67,22 @@ LL |     for i in from..from + 3 {
    |              ^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + 3].clone_from_slice(&src[..(from + 3 - from)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:110:14
+  --> $DIR/manual_memcpy.rs:103:14
+   |
+LL |     for i in 0..5 {
+   |              ^^^^ help: try replacing the loop by: `dst[..5].clone_from_slice(&src[..5])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:108:14
+   |
+LL |     for i in 0..0 {
+   |              ^^^^ help: try replacing the loop by: `dst[..0].clone_from_slice(&src[..0])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:120:14
    |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..])`
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -67,7 +67,7 @@ LL |     for i in from..from + 3 {
    |              ^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + 3].clone_from_slice(&src[..(from + 3 - from)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:105:14
+  --> $DIR/manual_memcpy.rs:110:14
    |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..])`


### PR DESCRIPTION
While I’m working on the long procrastinated work to expand `manual_memcpy`(#1670), I found a few minor bugs and probably unidiomatic or old coding style. There is a brief explanation of changes to the behaviour this PR will make below. And, I have a questoin: do I need to add tests for the first and second fixed bugs? I thought it might be too rare cases to include the tests for those. I added for the last one though.

* Bug fix
  * It negates resulted offsets (`src/dst_offset`) when `offset` is subtraction by 0. This PR will remove any subtraction by 0 as a part of minification.
  
    ```rust
    for i in 0..5 {
        dst[i - 0] = src[i];
    }
    ```

    ```diff
     warning: it looks like you're manually copying between slices
       --> src/main.rs:2:14
        |
    LL  |     for i in 0..5 {
    -   |              ^^^^ help: try replacing the loop by: `dst[..-5].clone_from_slice(&src[..5])`
    +   |              ^^^^ help: try replacing the loop by: `dst[..5].clone_from_slice(&src[..5])`
        |
    ```
  * It prints `RangeTo` or `RangeFull` when both of `end` and `offset` are 0, which have different meaning. This PR will print 0. I could reject the cases `end` is 0, but I thought I won’t catch other cases `reverse_range_loop` will trigger, and it’s over to catch every such cases.

    ```rust
    for i in 0..0 {
        dst[i] = src[i];
    }
    ```

    ```diff
     warning: it looks like you're manually copying between slices
       --> src/main.rs:2:14
        |
     LL |     for i in 0..0 {
    -   |              ^^^^ help: try replacing the loop by: `dst.clone_from_slice(&src[..])`
    +   |              ^^^^ help: try replacing the loop by: `dst[..0].clone_from_slice(&src[..0])`
        |
    ```
  * it prints four dots when `end` is `None`. This PR will ignore any `for` loops without `end` because a `for` loop that takes `RangeFrom` as its argument and contains indexing without the statements or the expressions that end loops such as `break` will definitely panic, and `manual_memcpy` should ignore the loops with such control flow.
  
    ```rust
    fn manual_copy(src: &[u32], dst: &mut [u32]) {
        for i in 0.. {
            dst[i] = src[i];
        }
    }
    ```

    ```diff
    -warning: it looks like you're manually copying between slices
    -  --> src/main.rs:2:14
    -   |
    -LL |     for i in 0.. {
    -   |              ^^^ help: try replacing the loop by: `dst[....].clone_from_slice(&src[....])`
    -   |
    ```
* Simplification of the suggestion
  
  * It prints 0 when `start` or `end` and `offset` are same (from #3323). This PR will use `RangeTo`

changelog: fixed the bugs of `manual_memcpy` and also simplify the suggestion.
