### PR TITLE
Fixed incorrect suggestion of `clone_double_ref` lint

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1942,7 +1942,7 @@ fn lint_clone_on_copy(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, arg: &hir:
                         }
                         let refs: String = iter::repeat('&').take(n + 1).collect();
                         let derefs: String = iter::repeat('*').take(n).collect();
-                        let explicit = format!("{}{}::clone({})", refs, ty, snip);
+                        let explicit = format!("<{}{}>::clone({})", refs, ty, snip);
                         diag.span_suggestion(
                             expr.span,
                             "try dereferencing it",
@@ -1951,7 +1951,7 @@ fn lint_clone_on_copy(cx: &LateContext<'_, '_>, expr: &hir::Expr<'_>, arg: &hir:
                         );
                         diag.span_suggestion(
                             expr.span,
-                            "or try being explicit about what type to clone",
+                            "or try being explicit if you are sure, that you want to clone a reference",
                             explicit,
                             Applicability::MaybeIncorrect,
                         );

--- a/tests/ui/unnecessary_clone.rs
+++ b/tests/ui/unnecessary_clone.rs
@@ -109,4 +109,9 @@ mod many_derefs {
         let _: E = a.clone();
         let _: E = *****a;
     }
+
+    fn check(mut encoded: &[u8]) {
+        let _ = &mut encoded.clone();
+        let _ = &encoded.clone();
+    }
 }

--- a/tests/ui/unnecessary_clone.stderr
+++ b/tests/ui/unnecessary_clone.stderr
@@ -85,10 +85,10 @@ help: try dereferencing it
    |
 LL |     let z: &Vec<_> = &(*y).clone();
    |                      ^^^^^^^^^^^^^
-help: or try being explicit about what type to clone
+help: or try being explicit if you are sure, that you want to clone a reference
    |
-LL |     let z: &Vec<_> = &std::vec::Vec<i32>::clone(y);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let z: &Vec<_> = <&std::vec::Vec<i32>>::clone(y);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: using `clone` on a `Copy` type
   --> $DIR/unnecessary_clone.rs:109:20
@@ -96,5 +96,35 @@ error: using `clone` on a `Copy` type
 LL |         let _: E = a.clone();
    |                    ^^^^^^^^^ help: try dereferencing it: `*****a`
 
-error: aborting due to 14 previous errors
+error: using `clone` on a double-reference; this will copy the reference instead of cloning the inner type
+  --> $DIR/unnecessary_clone.rs:114:22
+   |
+LL |         let _ = &mut encoded.clone();
+   |                      ^^^^^^^^^^^^^^^
+   |
+help: try dereferencing it
+   |
+LL |         let _ = &mut &(*encoded).clone();
+   |                      ^^^^^^^^^^^^^^^^^^^
+help: or try being explicit if you are sure, that you want to clone a reference
+   |
+LL |         let _ = &mut <&[u8]>::clone(encoded);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: using `clone` on a double-reference; this will copy the reference instead of cloning the inner type
+  --> $DIR/unnecessary_clone.rs:115:18
+   |
+LL |         let _ = &encoded.clone();
+   |                  ^^^^^^^^^^^^^^^
+   |
+help: try dereferencing it
+   |
+LL |         let _ = &&(*encoded).clone();
+   |                  ^^^^^^^^^^^^^^^^^^^
+help: or try being explicit if you are sure, that you want to clone a reference
+   |
+LL |         let _ = &<&[u8]>::clone(encoded);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
- Added `<_>` to suggestion
- Changed help message
- Added new tests
Closes #5494 

changelog: Improve suggestion of [`clone_double_ref`]
