### PR TITLE
Update to rustc changes

### DIFF
--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -591,7 +591,7 @@ struct PossibleBorrowerMap<'a, 'tcx> {
 impl PossibleBorrowerMap<'_, '_> {
     /// Returns true if the set of borrowers of `borrowed` living at `at` matches with `borrowers`.
     fn only_borrowers(&mut self, borrowers: &[mir::Local], borrowed: mir::Local, at: mir::Location) -> bool {
-        self.maybe_live.seek_after(at);
+        self.maybe_live.seek_after_primary_effect(at);
 
         self.bitset.0.clear();
         let maybe_live = &mut self.maybe_live;

--- a/tests/ui/builtin-type-shadow.stderr
+++ b/tests/ui/builtin-type-shadow.stderr
@@ -18,8 +18,6 @@ LL |     42
    |
    = note: expected type parameter `u32`
                         found type `{integer}`
-   = help: type parameters must be constrained to match other types
-   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
changelog: none

So, turns out `git subtree push` dies in various interesting ways, but the source cause is that the rustc repo looks like

```
--- A --- B --- C ---
     \--- D ---/
```

where `B` is the commit where I added clippy to rustc and `D` is an arbitrary other PR and `C` is the master branch (or an earlier commit in it). When we now do `git subtree push`, it doesn't stop looking for things to merge at `B` as it needs to look at `D`, too, but then the bad thing happens, and it doesn't stop at `A` either, and just goes on looking at the entire history of rustc in a recursive bash script. That recursion then quickly runs into a stack overflow. While we can increase the stack size via `ulimit -s 60000`, that just means I was waiting for 30 minutes looking at `git subtree push` counting up the number of commits it has looked at. I aborted that, as a process that needs 30 mins for a push is not reasonable.

This PR cheats by just doing a `cp -r ../rustc/src/tools/clippy/* .` inside my clippy checkout and committing all changes. I'm working on getting us a better workflow, but until then, this workaround will work nicely. Note that this requires a `git subrepo pull` to have occurred in the `rustc` checkout. It's not necessary to merge that pull in order to update clippy, it's just necessary in order to not revert code in the clippy repo that hasn't been synced yet to the rustc repo.