### PR TITLE
Rename lint `identity_conversion` to `useless_conversion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -805,7 +805,7 @@ Released 2018-09-13
 
 ## 0.0.166
 * Rustup to *rustc 1.22.0-nightly (b7960878b 2017-10-18)*
-* New lints: [`explicit_write`], [`identity_conversion`], [`implicit_hasher`], [`invalid_ref`], [`option_map_or_none`],
+* New lints: [`explicit_write`], `identity_conversion`, [`implicit_hasher`], [`invalid_ref`], [`option_map_or_none`],
   [`range_minus_one`], [`range_plus_one`], [`transmute_int_to_bool`], [`transmute_int_to_char`],
   [`transmute_int_to_float`]
 
@@ -1367,7 +1367,6 @@ Released 2018-09-13
 [`future_not_send`]: https://rust-lang.github.io/rust-clippy/master/index.html#future_not_send
 [`get_last_with_len`]: https://rust-lang.github.io/rust-clippy/master/index.html#get_last_with_len
 [`get_unwrap`]: https://rust-lang.github.io/rust-clippy/master/index.html#get_unwrap
-[`identity_conversion`]: https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
 [`identity_op`]: https://rust-lang.github.io/rust-clippy/master/index.html#identity_op
 [`if_let_mutex`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_let_mutex
 [`if_let_redundant_pattern_matching`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_let_redundant_pattern_matching
@@ -1624,6 +1623,7 @@ Released 2018-09-13
 [`used_underscore_binding`]: https://rust-lang.github.io/rust-clippy/master/index.html#used_underscore_binding
 [`useless_asref`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_asref
 [`useless_attribute`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_attribute
+[`useless_conversion`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
 [`useless_format`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_format
 [`useless_let_if_seq`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_let_if_seq
 [`useless_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_transmute

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -221,7 +221,6 @@ mod formatting;
 mod functions;
 mod future_not_send;
 mod get_last_with_len;
-mod identity_conversion;
 mod identity_op;
 mod if_let_mutex;
 mod if_let_some_result;
@@ -324,6 +323,7 @@ mod unused_io_amount;
 mod unused_self;
 mod unwrap;
 mod use_self;
+mod useless_conversion;
 mod vec;
 mod verbose_file_reads;
 mod wildcard_dependencies;
@@ -577,7 +577,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         &functions::TOO_MANY_LINES,
         &future_not_send::FUTURE_NOT_SEND,
         &get_last_with_len::GET_LAST_WITH_LEN,
-        &identity_conversion::IDENTITY_CONVERSION,
         &identity_op::IDENTITY_OP,
         &if_let_mutex::IF_LET_MUTEX,
         &if_let_some_result::IF_LET_SOME_RESULT,
@@ -843,6 +842,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         &unwrap::PANICKING_UNWRAP,
         &unwrap::UNNECESSARY_UNWRAP,
         &use_self::USE_SELF,
+        &useless_conversion::USELESS_CONVERSION,
         &utils::internal_lints::CLIPPY_LINTS_INTERNAL,
         &utils::internal_lints::COLLAPSIBLE_SPAN_LINT_CALLS,
         &utils::internal_lints::COMPILER_LINT_FUNCTIONS,
@@ -980,7 +980,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box bytecount::ByteCount);
     store.register_late_pass(|| box infinite_iter::InfiniteIter);
     store.register_late_pass(|| box inline_fn_without_body::InlineFnWithoutBody);
-    store.register_late_pass(|| box identity_conversion::IdentityConversion::default());
+    store.register_late_pass(|| box useless_conversion::UselessConversion::default());
     store.register_late_pass(|| box types::ImplicitHasher);
     store.register_late_pass(|| box fallible_impl_from::FallibleImplFrom);
     store.register_late_pass(|| box types::UnitArg);
@@ -1241,7 +1241,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&functions::NOT_UNSAFE_PTR_ARG_DEREF),
         LintId::of(&functions::TOO_MANY_ARGUMENTS),
         LintId::of(&get_last_with_len::GET_LAST_WITH_LEN),
-        LintId::of(&identity_conversion::IDENTITY_CONVERSION),
         LintId::of(&identity_op::IDENTITY_OP),
         LintId::of(&if_let_mutex::IF_LET_MUTEX),
         LintId::of(&if_let_some_result::IF_LET_SOME_RESULT),
@@ -1427,6 +1426,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&unused_io_amount::UNUSED_IO_AMOUNT),
         LintId::of(&unwrap::PANICKING_UNWRAP),
         LintId::of(&unwrap::UNNECESSARY_UNWRAP),
+        LintId::of(&useless_conversion::USELESS_CONVERSION),
         LintId::of(&vec::USELESS_VEC),
         LintId::of(&write::PRINTLN_EMPTY_STRING),
         LintId::of(&write::PRINT_LITERAL),
@@ -1546,7 +1546,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&format::USELESS_FORMAT),
         LintId::of(&functions::TOO_MANY_ARGUMENTS),
         LintId::of(&get_last_with_len::GET_LAST_WITH_LEN),
-        LintId::of(&identity_conversion::IDENTITY_CONVERSION),
         LintId::of(&identity_op::IDENTITY_OP),
         LintId::of(&int_plus_one::INT_PLUS_ONE),
         LintId::of(&lifetimes::EXTRA_UNUSED_LIFETIMES),
@@ -1605,6 +1604,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&types::UNNECESSARY_CAST),
         LintId::of(&types::VEC_BOX),
         LintId::of(&unwrap::UNNECESSARY_UNWRAP),
+        LintId::of(&useless_conversion::USELESS_CONVERSION),
         LintId::of(&zero_div_zero::ZERO_DIVIDED_BY_ZERO),
     ]);
 
@@ -1795,6 +1795,7 @@ pub fn register_renamed(ls: &mut rustc_lint::LintStore) {
     ls.register_renamed("clippy::result_expect_used", "clippy::expect_used");
     ls.register_renamed("clippy::for_loop_over_option", "clippy::for_loops_over_fallibles");
     ls.register_renamed("clippy::for_loop_over_result", "clippy::for_loops_over_fallibles");
+    ls.register_renamed("clippy::identity_conversion", "clippy::useless_conversion");
 }
 
 // only exists to let the dogfood integration test works.

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -718,13 +718,6 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
         module: "methods",
     },
     Lint {
-        name: "identity_conversion",
-        group: "complexity",
-        desc: "using always-identical `Into`/`From`/`IntoIter` conversions",
-        deprecation: None,
-        module: "identity_conversion",
-    },
-    Lint {
         name: "identity_op",
         group: "complexity",
         desc: "using identity operations, e.g., `x + 0` or `y / 1`",
@@ -2417,6 +2410,13 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
         desc: "use of lint attributes on `extern crate` items",
         deprecation: None,
         module: "attrs",
+    },
+    Lint {
+        name: "useless_conversion",
+        group: "complexity",
+        desc: "calls to `Into`/`From`/`IntoIter` that performs useless conversions to the same type",
+        deprecation: None,
+        module: "useless_conversion",
     },
     Lint {
         name: "useless_format",

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![deny(clippy::identity_conversion)]
+#![deny(clippy::useless_conversion)]
 
 fn test_generic<T: Copy>(val: T) -> T {
     let _ = val;
@@ -41,7 +41,7 @@ fn main() {
     let _: String = "foo".into();
     let _: String = From::from("foo");
     let _ = String::from("foo");
-    #[allow(clippy::identity_conversion)]
+    #[allow(clippy::useless_conversion)]
     {
         let _: String = "foo".into();
         let _ = String::from("foo");

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![deny(clippy::identity_conversion)]
+#![deny(clippy::useless_conversion)]
 
 fn test_generic<T: Copy>(val: T) -> T {
     let _ = T::from(val);
@@ -41,7 +41,7 @@ fn main() {
     let _: String = "foo".into();
     let _: String = From::from("foo");
     let _ = String::from("foo");
-    #[allow(clippy::identity_conversion)]
+    #[allow(clippy::useless_conversion)]
     {
         let _: String = "foo".into();
         let _ = String::from("foo");

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -1,65 +1,65 @@
-error: identical conversion
-  --> $DIR/identity_conversion.rs:6:13
+error: useless conversion
+  --> $DIR/useless_conversion.rs:6:13
    |
 LL |     let _ = T::from(val);
    |             ^^^^^^^^^^^^ help: consider removing `T::from()`: `val`
    |
 note: the lint level is defined here
-  --> $DIR/identity_conversion.rs:3:9
+  --> $DIR/useless_conversion.rs:3:9
    |
-LL | #![deny(clippy::identity_conversion)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(clippy::useless_conversion)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:7:5
+error: useless conversion
+  --> $DIR/useless_conversion.rs:7:5
    |
 LL |     val.into()
    |     ^^^^^^^^^^ help: consider removing `.into()`: `val`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:19:22
+error: useless conversion
+  --> $DIR/useless_conversion.rs:19:22
    |
 LL |         let _: i32 = 0i32.into();
    |                      ^^^^^^^^^^^ help: consider removing `.into()`: `0i32`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:51:21
+error: useless conversion
+  --> $DIR/useless_conversion.rs:51:21
    |
 LL |     let _: String = "foo".to_string().into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `"foo".to_string()`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:52:21
+error: useless conversion
+  --> $DIR/useless_conversion.rs:52:21
    |
 LL |     let _: String = From::from("foo".to_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `From::from()`: `"foo".to_string()`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:53:13
+error: useless conversion
+  --> $DIR/useless_conversion.rs:53:13
    |
 LL |     let _ = String::from("foo".to_string());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `"foo".to_string()`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:54:13
+error: useless conversion
+  --> $DIR/useless_conversion.rs:54:13
    |
 LL |     let _ = String::from(format!("A: {:04}", 123));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `format!("A: {:04}", 123)`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:55:13
+error: useless conversion
+  --> $DIR/useless_conversion.rs:55:13
    |
 LL |     let _ = "".lines().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `"".lines()`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:56:13
+error: useless conversion
+  --> $DIR/useless_conversion.rs:56:13
    |
 LL |     let _ = vec![1, 2, 3].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2, 3].into_iter()`
 
-error: identical conversion
-  --> $DIR/identity_conversion.rs:57:21
+error: useless conversion
+  --> $DIR/useless_conversion.rs:57:21
    |
 LL |     let _: String = format!("Hello {}", "world").into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `format!("Hello {}", "world")`


### PR DESCRIPTION
Lint name `identity_conversion` was misleading, so this PR renames it to `useless_conversion`.

As decision has not really came up in the issue comments, this PR will probably need discussion.

fixes #3106

changelog: Rename lint `identity_conversion` to `useless_conversion`