### PR TITLE
unused_unit: lint also in type parameters and where clauses

### DIFF
--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -14,11 +14,10 @@
 
 struct Unitter;
 impl Unitter {
-    // try to disorient the lint with multiple unit returns and newlines
     #[allow(clippy::no_effect)]
-    pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) 
-    where G: Fn() -> () {
-        let _y: &dyn Fn() -> () = &f;
+    pub fn get_unit<F: Fn() , G>(&self, f: F, _g: G) 
+    where G: Fn()  {
+        let _y: &dyn Fn()  = &f;
         (); // this should not lint, as it's not in return type position
     }
 }
@@ -28,6 +27,20 @@ impl Into<()> for Unitter {
     fn into(self)  {
         
     }
+}
+
+trait Trait {
+    fn redundant<F: FnOnce() , G, H>(&self, _f: F, _g: G, _h: H)
+    where
+        G: FnMut() ,
+        H: Fn() ;
+}
+
+impl Trait for Unitter {
+    fn redundant<F: FnOnce() , G, H>(&self, _f: F, _g: G, _h: H)
+    where
+        G: FnMut() ,
+        H: Fn()  {}
 }
 
 fn return_unit()  {  }

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -14,10 +14,8 @@
 
 struct Unitter;
 impl Unitter {
-    // try to disorient the lint with multiple unit returns and newlines
     #[allow(clippy::no_effect)]
-    pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) ->
-        ()
+    pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) -> ()
     where G: Fn() -> () {
         let _y: &dyn Fn() -> () = &f;
         (); // this should not lint, as it's not in return type position
@@ -29,6 +27,20 @@ impl Into<()> for Unitter {
     fn into(self) -> () {
         ()
     }
+}
+
+trait Trait {
+    fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
+    where
+        G: FnMut() -> (),
+        H: Fn() -> ();
+}
+
+impl Trait for Unitter {
+    fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
+    where
+        G: FnMut() -> (),
+        H: Fn() -> () {}
 }
 
 fn return_unit() -> () { () }

--- a/tests/ui/unused_unit.stderr
+++ b/tests/ui/unused_unit.stderr
@@ -1,10 +1,8 @@
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:19:59
+  --> $DIR/unused_unit.rs:18:29
    |
-LL |       pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) ->
-   |  ___________________________________________________________^
-LL | |         ()
-   | |__________^ help: remove the `-> ()`
+LL |     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) -> ()
+   |                             ^^^^^ help: remove the `-> ()`
    |
 note: the lint level is defined here
   --> $DIR/unused_unit.rs:12:9
@@ -13,40 +11,94 @@ LL | #![deny(clippy::unused_unit)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:29:19
+  --> $DIR/unused_unit.rs:19:19
+   |
+LL |     where G: Fn() -> () {
+   |                   ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:18:59
+   |
+LL |     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) -> ()
+   |                                                           ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:20:27
+   |
+LL |         let _y: &dyn Fn() -> () = &f;
+   |                           ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:27:19
    |
 LL |     fn into(self) -> () {
    |                   ^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
-  --> $DIR/unused_unit.rs:30:9
+  --> $DIR/unused_unit.rs:28:9
    |
 LL |         ()
    |         ^^ help: remove the final `()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:34:18
+  --> $DIR/unused_unit.rs:33:30
+   |
+LL |     fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
+   |                              ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:35:20
+   |
+LL |         G: FnMut() -> (),
+   |                    ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:36:17
+   |
+LL |         H: Fn() -> ();
+   |                 ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:40:30
+   |
+LL |     fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
+   |                              ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:42:20
+   |
+LL |         G: FnMut() -> (),
+   |                    ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:43:17
+   |
+LL |         H: Fn() -> () {}
+   |                 ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:46:18
    |
 LL | fn return_unit() -> () { () }
    |                  ^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
-  --> $DIR/unused_unit.rs:34:26
+  --> $DIR/unused_unit.rs:46:26
    |
 LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
 
 error: unneeded `()`
-  --> $DIR/unused_unit.rs:44:14
+  --> $DIR/unused_unit.rs:56:14
    |
 LL |         break();
    |              ^^ help: remove the `()`
 
 error: unneeded `()`
-  --> $DIR/unused_unit.rs:46:11
+  --> $DIR/unused_unit.rs:58:11
    |
 LL |     return();
    |           ^^ help: remove the `()`
 
-error: aborting due to 7 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
changelog: unused_unit now also lints in type parameters and where clauses

Fixes #5585 
