### PR TITLE
identity_op: allow `1 << 0`

### DIFF
--- a/tests/ui/identity_op.rs
+++ b/tests/ui/identity_op.rs
@@ -33,4 +33,9 @@ fn main() {
 
     let u: u8 = 0;
     u & 255;
+
+    1 << 0; // no error, this case is allowed, see issue 3430
+    42 << 0;
+    1 >> 0;
+    42 >> 0;
 }

--- a/tests/ui/identity_op.stderr
+++ b/tests/ui/identity_op.stderr
@@ -48,5 +48,23 @@ error: the operation is ineffective. Consider reducing it to `u`
 LL |     u & 255;
    |     ^^^^^^^
 
-error: aborting due to 8 previous errors
+error: the operation is ineffective. Consider reducing it to `42`
+  --> $DIR/identity_op.rs:38:5
+   |
+LL |     42 << 0;
+   |     ^^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `1`
+  --> $DIR/identity_op.rs:39:5
+   |
+LL |     1 >> 0;
+   |     ^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `42`
+  --> $DIR/identity_op.rs:40:5
+   |
+LL |     42 >> 0;
+   |     ^^^^^^^
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
I went for accepting `1 << 0` verbatim instead of something more general as it seems to be what everyone in the issue thread needed.

changelog: identity_op: allow `1 << 0` as it's a common pattern in bit manipulation code.

Fixes #3430  
