### PR TITLE
Make empty_line_after_outer_attr an early lint

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -33,5 +33,9 @@ semver = "0.9.0"
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
 url = { version =  "2.1.0", features = ["serde"] }
 
+[dev-dependencies]
+quote = "*"
+syn = { version = "*", features = ["full"] }
+
 [features]
 deny-warnings = []

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -32,8 +32,6 @@ semver = "0.9.0"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
 url = { version =  "2.1.0", features = ["serde"] }
-
-[dev-dependencies]
 quote = "1.0.2"
 syn = { version = "1.0.11", features = ["full"] }
 

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -32,8 +32,8 @@ semver = "0.9.0"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
 url = { version =  "2.1.0", features = ["serde"] }
-quote = "1.0.2"
-syn = { version = "1.0.11", features = ["full"] }
+quote = "1"
+syn = { version = "1", features = ["full"] }
 
 [features]
 deny-warnings = []

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -34,8 +34,8 @@ semver = "0.9.0"
 url = { version =  "2.1.0", features = ["serde"] }
 
 [dev-dependencies]
-quote = "*"
-syn = { version = "*", features = ["full"] }
+quote = "1.0.2"
+syn = { version = "1.0.11", features = ["full"] }
 
 [features]
 deny-warnings = []

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -38,7 +38,7 @@ fn clippy_driver_path() -> PathBuf {
 //        as what we manually pass to `cargo` invocation
 fn third_party_crates() -> String {
     use std::collections::HashMap;
-    static CRATES: &[&str] = &["serde", "serde_derive", "regex", "clippy_lints"];
+    static CRATES: &[&str] = &["serde", "serde_derive", "regex", "clippy_lints", "syn", "quote"];
     let dep_dir = cargo::TARGET_LIB.join("deps");
     let mut crates: HashMap<&str, PathBuf> = HashMap::with_capacity(CRATES.len());
     for entry in fs::read_dir(dep_dir).unwrap() {

--- a/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/tests/ui/auxiliary/proc_macro_attr.rs
@@ -1,0 +1,37 @@
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(repr128, proc_macro_hygiene, proc_macro_quote)]
+#![allow(clippy::useless_conversion)]
+
+extern crate proc_macro;
+extern crate quote;
+extern crate syn;
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::parse_macro_input;
+use syn::{parse_quote, ItemTrait, TraitItem};
+
+#[proc_macro_attribute]
+pub fn fake_async_trait(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut item = parse_macro_input!(input as ItemTrait);
+    for inner in &mut item.items {
+        if let TraitItem::Method(method) = inner {
+            let sig = &method.sig;
+            let block = &mut method.default;
+            if let Some(block) = block {
+                let brace = block.brace_token;
+
+                let my_block = quote_spanned!( brace.span => {
+                    // Should not trigger `empty_line_after_outer_attr`
+                    #[crate_type = "lib"]
+                    #sig #block
+                    Vec::new()
+                });
+                *block = parse_quote!(#my_block);
+            }
+        }
+    }
+    TokenStream::from(quote!(#item))
+}

--- a/tests/ui/empty_line_after_outer_attribute.rs
+++ b/tests/ui/empty_line_after_outer_attribute.rs
@@ -1,7 +1,11 @@
+// aux-build:proc_macro_attr.rs
 #![warn(clippy::empty_line_after_outer_attr)]
 #![allow(clippy::assertions_on_constants)]
 #![feature(custom_inner_attributes)]
 #![rustfmt::skip]
+
+#[macro_use]
+extern crate proc_macro_attr;
 
 // This should produce a warning
 #[crate_type = "lib"]
@@ -93,4 +97,17 @@ pub struct S;
 /* test */
 pub struct T;
 
-fn main() { }
+// This should not produce a warning
+// See https://github.com/rust-lang/rust-clippy/issues/5567
+#[fake_async_trait]
+pub trait Bazz {
+    fn foo() -> Vec<u8> {
+        let _i = "";
+
+
+
+        vec![]
+    }
+}
+
+fn main() {}

--- a/tests/ui/empty_line_after_outer_attribute.stderr
+++ b/tests/ui/empty_line_after_outer_attribute.stderr
@@ -1,5 +1,5 @@
 error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
-  --> $DIR/empty_line_after_outer_attribute.rs:7:1
+  --> $DIR/empty_line_after_outer_attribute.rs:11:1
    |
 LL | / #[crate_type = "lib"]
 LL | |
@@ -10,7 +10,7 @@ LL | | fn with_one_newline_and_comment() { assert!(true) }
    = note: `-D clippy::empty-line-after-outer-attr` implied by `-D warnings`
 
 error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
-  --> $DIR/empty_line_after_outer_attribute.rs:19:1
+  --> $DIR/empty_line_after_outer_attribute.rs:23:1
    |
 LL | / #[crate_type = "lib"]
 LL | |
@@ -18,7 +18,7 @@ LL | | fn with_one_newline() { assert!(true) }
    | |_
 
 error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
-  --> $DIR/empty_line_after_outer_attribute.rs:24:1
+  --> $DIR/empty_line_after_outer_attribute.rs:28:1
    |
 LL | / #[crate_type = "lib"]
 LL | |
@@ -27,7 +27,7 @@ LL | | fn with_two_newlines() { assert!(true) }
    | |_
 
 error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
-  --> $DIR/empty_line_after_outer_attribute.rs:31:1
+  --> $DIR/empty_line_after_outer_attribute.rs:35:1
    |
 LL | / #[crate_type = "lib"]
 LL | |
@@ -35,7 +35,7 @@ LL | | enum Baz {
    | |_
 
 error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
-  --> $DIR/empty_line_after_outer_attribute.rs:39:1
+  --> $DIR/empty_line_after_outer_attribute.rs:43:1
    |
 LL | / #[crate_type = "lib"]
 LL | |
@@ -43,7 +43,7 @@ LL | | struct Foo {
    | |_
 
 error: Found an empty line after an outer attribute. Perhaps you forgot to add a `!` to make it an inner attribute?
-  --> $DIR/empty_line_after_outer_attribute.rs:47:1
+  --> $DIR/empty_line_after_outer_attribute.rs:51:1
    |
 LL | / #[crate_type = "lib"]
 LL | |


### PR DESCRIPTION
Fixes #5567

Unfortunately I couldn't find a way to reproduce the issue without syn/quote. Considering that most real-world macros use syn and/or quote, I think it's okay to pull them in anyway.

changelog: Fix false positive in [`empty_line_after_outer_attr`]