### PR TITLE
[DNM] Also install llvm-tools on toolchain setup

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -32,5 +32,5 @@ else
     TOOLCHAIN=()
 fi
 
-rustup-toolchain-install-master -f -n master "${TOOLCHAIN[@]}" -c rustc-dev -- "$RUST_COMMIT"
+rustup-toolchain-install-master -f -n master "${TOOLCHAIN[@]}" -c rustc-dev -c llvm-tools-preview -- "$RUST_COMMIT"
 rustup override set master


### PR DESCRIPTION
Preparation for rust-lang/rust#72000

cc @cuviper @Mark-Simulacrum Is this the correct way to install the llvm-tools with RTIM?

Before merging this, I want to try if llvm-tools are really necessary to compile Clippy. From the rust PR I understood, that it probably will be.

changelog: none
