### PR TITLE
Extend useless conversion

### DIFF
--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -71,7 +71,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessConversion {
                             cx,
                             USELESS_CONVERSION,
                             e.span,
-                            "Useless conversion to the same type",
+                            "useless conversion to the same type",
                             "consider removing `.into()`",
                             sugg,
                             Applicability::MachineApplicable, // snippet
@@ -87,7 +87,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessConversion {
                             cx,
                             USELESS_CONVERSION,
                             e.span,
-                            "Useless conversion to the same type",
+                            "useless conversion to the same type",
                             "consider removing `.into_iter()`",
                             sugg,
                             Applicability::MachineApplicable, // snippet
@@ -108,7 +108,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessConversion {
                                 cx,
                                 USELESS_CONVERSION,
                                 e.span,
-                                "Useless conversion to the same type",
+                                "useless conversion to the same type",
                                 None,
                                 "consider removing `.try_into()`",
                             );
@@ -139,7 +139,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessConversion {
                                     cx,
                                     USELESS_CONVERSION,
                                     e.span,
-                                    "Useless conversion to the same type",
+                                    "useless conversion to the same type",
                                     None,
                                     &hint,
                                 );
@@ -158,7 +158,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UselessConversion {
                                     cx,
                                     USELESS_CONVERSION,
                                     e.span,
-                                    "Useless conversion to the same type",
+                                    "useless conversion to the same type",
                                     &sugg_msg,
                                     sugg,
                                     Applicability::MachineApplicable, // snippet

--- a/clippy_lints/src/utils/paths.rs
+++ b/clippy_lints/src/utils/paths.rs
@@ -131,6 +131,7 @@ pub const TRANSMUTE: [&str; 4] = ["core", "intrinsics", "", "transmute"];
 pub const TRY_FROM: [&str; 4] = ["core", "convert", "TryFrom", "try_from"];
 pub const TRY_FROM_ERROR: [&str; 4] = ["std", "ops", "Try", "from_error"];
 pub const TRY_INTO_RESULT: [&str; 4] = ["std", "ops", "Try", "into_result"];
+pub const TRY_INTO_TRAIT: [&str; 3] = ["core", "convert", "TryInto"];
 pub const VEC: [&str; 3] = ["alloc", "vec", "Vec"];
 pub const VEC_AS_MUT_SLICE: [&str; 4] = ["alloc", "vec", "Vec", "as_mut_slice"];
 pub const VEC_AS_SLICE: [&str; 4] = ["alloc", "vec", "Vec", "as_slice"];

--- a/clippy_lints/src/utils/paths.rs
+++ b/clippy_lints/src/utils/paths.rs
@@ -128,6 +128,7 @@ pub const TO_OWNED_METHOD: [&str; 4] = ["alloc", "borrow", "ToOwned", "to_owned"
 pub const TO_STRING: [&str; 3] = ["alloc", "string", "ToString"];
 pub const TO_STRING_METHOD: [&str; 4] = ["alloc", "string", "ToString", "to_string"];
 pub const TRANSMUTE: [&str; 4] = ["core", "intrinsics", "", "transmute"];
+pub const TRY_FROM: [&str; 4] = ["core", "convert", "TryFrom", "try_from"];
 pub const TRY_FROM_ERROR: [&str; 4] = ["std", "ops", "Try", "from_error"];
 pub const TRY_INTO_RESULT: [&str; 4] = ["std", "ops", "Try", "into_result"];
 pub const VEC: [&str; 3] = ["alloc", "vec", "Vec"];

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -2421,7 +2421,7 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
     Lint {
         name: "useless_conversion",
         group: "complexity",
-        desc: "calls to `Into`/`From`/`IntoIter` that performs useless conversions to the same type",
+        desc: "calls to `Into`, `TryInto`, `From`, `TryFrom`, `IntoIter` that performs useless conversions to the same type",
         deprecation: None,
         module: "useless_conversion",
     },

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -1,4 +1,4 @@
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:6:13
    |
 LL |     let _ = T::from(val);
@@ -10,55 +10,55 @@ note: the lint level is defined here
 LL | #![deny(clippy::useless_conversion)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:7:5
    |
 LL |     val.into()
    |     ^^^^^^^^^^ help: consider removing `.into()`: `val`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:19:22
    |
 LL |         let _: i32 = 0i32.into();
    |                      ^^^^^^^^^^^ help: consider removing `.into()`: `0i32`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:51:21
    |
 LL |     let _: String = "foo".to_string().into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `"foo".to_string()`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:52:21
    |
 LL |     let _: String = From::from("foo".to_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `From::from()`: `"foo".to_string()`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:53:13
    |
 LL |     let _ = String::from("foo".to_string());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `"foo".to_string()`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:54:13
    |
 LL |     let _ = String::from(format!("A: {:04}", 123));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `format!("A: {:04}", 123)`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:55:13
    |
 LL |     let _ = "".lines().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `"".lines()`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:56:13
    |
 LL |     let _ = vec![1, 2, 3].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2, 3].into_iter()`
 
-error: useless conversion
+error: Useless conversion to the same type
   --> $DIR/useless_conversion.rs:57:21
    |
 LL |     let _: String = format!("Hello {}", "world").into();

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -1,4 +1,4 @@
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:6:13
    |
 LL |     let _ = T::from(val);
@@ -10,55 +10,55 @@ note: the lint level is defined here
 LL | #![deny(clippy::useless_conversion)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:7:5
    |
 LL |     val.into()
    |     ^^^^^^^^^^ help: consider removing `.into()`: `val`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:19:22
    |
 LL |         let _: i32 = 0i32.into();
    |                      ^^^^^^^^^^^ help: consider removing `.into()`: `0i32`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:51:21
    |
 LL |     let _: String = "foo".to_string().into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `"foo".to_string()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:52:21
    |
 LL |     let _: String = From::from("foo".to_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `From::from()`: `"foo".to_string()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:53:13
    |
 LL |     let _ = String::from("foo".to_string());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `"foo".to_string()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:54:13
    |
 LL |     let _ = String::from(format!("A: {:04}", 123));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `format!("A: {:04}", 123)`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:55:13
    |
 LL |     let _ = "".lines().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `"".lines()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:56:13
    |
 LL |     let _ = vec![1, 2, 3].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2, 3].into_iter()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion.rs:57:21
    |
 LL |     let _: String = format!("Hello {}", "world").into();

--- a/tests/ui/useless_conversion_try.rs
+++ b/tests/ui/useless_conversion_try.rs
@@ -1,0 +1,25 @@
+#![deny(clippy::useless_conversion)]
+
+use std::convert::TryFrom;
+
+fn test_generic<T: Copy>(val: T) -> T {
+    T::try_from(val).unwrap()
+}
+
+fn test_generic2<T: Copy + Into<i32> + Into<U>, U: From<T>>(val: T) {
+    let _ = U::try_from(val).unwrap();
+}
+
+fn main() {
+    test_generic(10i32);
+    test_generic2::<i32, i32>(10i32);
+
+    let _: String = TryFrom::try_from("foo").unwrap();
+    let _ = String::try_from("foo").unwrap();
+    #[allow(clippy::useless_conversion)]
+    let _ = String::try_from("foo").unwrap();
+
+    let _: String = TryFrom::try_from("foo".to_string()).unwrap();
+    let _ = String::try_from("foo".to_string()).unwrap();
+    let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
+}

--- a/tests/ui/useless_conversion_try.rs
+++ b/tests/ui/useless_conversion_try.rs
@@ -31,4 +31,12 @@ fn main() {
     let _ = String::try_from("foo".to_string()).unwrap();
     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
     let _: String = format!("Hello {}", "world").try_into().unwrap();
+    let _: String = "".to_owned().try_into().unwrap();
+    let _: String = match String::from("_").try_into() {
+        Ok(a) => a,
+        Err(_) => "".into(),
+    };
+    // FIXME this is a false negative
+    #[allow(clippy::cmp_owned)]
+    if String::from("a") == TryInto::<String>::try_into(String::from("a")).unwrap() {}
 }

--- a/tests/ui/useless_conversion_try.rs
+++ b/tests/ui/useless_conversion_try.rs
@@ -1,12 +1,16 @@
 #![deny(clippy::useless_conversion)]
 
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 fn test_generic<T: Copy>(val: T) -> T {
-    T::try_from(val).unwrap()
+    let _ = T::try_from(val).unwrap();
+    val.try_into().unwrap()
 }
 
 fn test_generic2<T: Copy + Into<i32> + Into<U>, U: From<T>>(val: T) {
+    // ok
+    let _: i32 = val.try_into().unwrap();
+    let _: U = val.try_into().unwrap();
     let _ = U::try_from(val).unwrap();
 }
 
@@ -14,12 +18,17 @@ fn main() {
     test_generic(10i32);
     test_generic2::<i32, i32>(10i32);
 
+    let _: String = "foo".try_into().unwrap();
     let _: String = TryFrom::try_from("foo").unwrap();
     let _ = String::try_from("foo").unwrap();
     #[allow(clippy::useless_conversion)]
-    let _ = String::try_from("foo").unwrap();
-
+    {
+        let _ = String::try_from("foo").unwrap();
+        let _: String = "foo".try_into().unwrap();
+    }
+    let _: String = "foo".to_string().try_into().unwrap();
     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
     let _ = String::try_from("foo".to_string()).unwrap();
     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
+    let _: String = format!("Hello {}", "world").try_into().unwrap();
 }

--- a/tests/ui/useless_conversion_try.stderr
+++ b/tests/ui/useless_conversion_try.stderr
@@ -1,0 +1,39 @@
+error: Useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:6:5
+   |
+LL |     T::try_from(val).unwrap()
+   |     ^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/useless_conversion_try.rs:1:9
+   |
+LL | #![deny(clippy::useless_conversion)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider removing `T::try_from()`
+
+error: Useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:22:21
+   |
+LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing `TryFrom::try_from()`
+
+error: Useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:23:13
+   |
+LL |     let _ = String::try_from("foo".to_string()).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing `String::try_from()`
+
+error: Useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:24:13
+   |
+LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing `String::try_from()`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/useless_conversion_try.stderr
+++ b/tests/ui/useless_conversion_try.stderr
@@ -1,4 +1,4 @@
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion_try.rs:6:13
    |
 LL |     let _ = T::try_from(val).unwrap();
@@ -11,7 +11,7 @@ LL | #![deny(clippy::useless_conversion)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: consider removing `T::try_from()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion_try.rs:7:5
    |
 LL |     val.try_into().unwrap()
@@ -19,7 +19,7 @@ LL |     val.try_into().unwrap()
    |
    = help: consider removing `.try_into()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion_try.rs:29:21
    |
 LL |     let _: String = "foo".to_string().try_into().unwrap();
@@ -27,7 +27,7 @@ LL |     let _: String = "foo".to_string().try_into().unwrap();
    |
    = help: consider removing `.try_into()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion_try.rs:30:21
    |
 LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
@@ -35,7 +35,7 @@ LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
    |
    = help: consider removing `TryFrom::try_from()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion_try.rs:31:13
    |
 LL |     let _ = String::try_from("foo".to_string()).unwrap();
@@ -43,7 +43,7 @@ LL |     let _ = String::try_from("foo".to_string()).unwrap();
    |
    = help: consider removing `String::try_from()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion_try.rs:32:13
    |
 LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
@@ -51,7 +51,7 @@ LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
    |
    = help: consider removing `String::try_from()`
 
-error: Useless conversion to the same type
+error: useless conversion to the same type
   --> $DIR/useless_conversion_try.rs:33:21
    |
 LL |     let _: String = format!("Hello {}", "world").try_into().unwrap();
@@ -59,5 +59,21 @@ LL |     let _: String = format!("Hello {}", "world").try_into().unwrap();
    |
    = help: consider removing `.try_into()`
 
-error: aborting due to 7 previous errors
+error: useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:34:21
+   |
+LL |     let _: String = "".to_owned().try_into().unwrap();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing `.try_into()`
+
+error: useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:35:27
+   |
+LL |     let _: String = match String::from("_").try_into() {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing `.try_into()`
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/useless_conversion_try.stderr
+++ b/tests/ui/useless_conversion_try.stderr
@@ -1,8 +1,8 @@
 error: Useless conversion to the same type
-  --> $DIR/useless_conversion_try.rs:6:5
+  --> $DIR/useless_conversion_try.rs:6:13
    |
-LL |     T::try_from(val).unwrap()
-   |     ^^^^^^^^^^^^^^^^
+LL |     let _ = T::try_from(val).unwrap();
+   |             ^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/useless_conversion_try.rs:1:9
@@ -12,7 +12,23 @@ LL | #![deny(clippy::useless_conversion)]
    = help: consider removing `T::try_from()`
 
 error: Useless conversion to the same type
-  --> $DIR/useless_conversion_try.rs:22:21
+  --> $DIR/useless_conversion_try.rs:7:5
+   |
+LL |     val.try_into().unwrap()
+   |     ^^^^^^^^^^^^^^
+   |
+   = help: consider removing `.try_into()`
+
+error: Useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:29:21
+   |
+LL |     let _: String = "foo".to_string().try_into().unwrap();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing `.try_into()`
+
+error: Useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:30:21
    |
 LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +36,7 @@ LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
    = help: consider removing `TryFrom::try_from()`
 
 error: Useless conversion to the same type
-  --> $DIR/useless_conversion_try.rs:23:13
+  --> $DIR/useless_conversion_try.rs:31:13
    |
 LL |     let _ = String::try_from("foo".to_string()).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,12 +44,20 @@ LL |     let _ = String::try_from("foo".to_string()).unwrap();
    = help: consider removing `String::try_from()`
 
 error: Useless conversion to the same type
-  --> $DIR/useless_conversion_try.rs:24:13
+  --> $DIR/useless_conversion_try.rs:32:13
    |
 LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider removing `String::try_from()`
 
-error: aborting due to 4 previous errors
+error: Useless conversion to the same type
+  --> $DIR/useless_conversion_try.rs:33:21
+   |
+LL |     let _: String = format!("Hello {}", "world").try_into().unwrap();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing `.try_into()`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This PR extends `useless_conversion` lint with `TryFrom` and `TryInto`

fixes: #5344 

changelog: Extend `useless_conversion` with `TryFrom` and `TryInto`
