### PR TITLE
reversed_empty_ranges: add suggestion for &slice[N..N]

### DIFF
--- a/tests/ui/reversed_empty_ranges_fixable.fixed
+++ b/tests/ui/reversed_empty_ranges_fixable.fixed
@@ -4,18 +4,23 @@
 const ANSWER: i32 = 42;
 
 fn main() {
+    let arr = [1, 2, 3, 4, 5];
+
+    // These should be linted:
+
     (21..=42).rev().for_each(|x| println!("{}", x));
     let _ = (21..ANSWER).rev().filter(|x| x % 2 == 0).take(10).collect::<Vec<_>>();
 
     for _ in (-42..=-21).rev() {}
     for _ in (21u32..42u32).rev() {}
 
+    let _ = &[] as &[i32];
+
     // These should be ignored as they are not empty ranges:
 
     (21..=42).for_each(|x| println!("{}", x));
     (21..42).for_each(|x| println!("{}", x));
 
-    let arr = [1, 2, 3, 4, 5];
     let _ = &arr[1..=3];
     let _ = &arr[1..3];
 

--- a/tests/ui/reversed_empty_ranges_fixable.rs
+++ b/tests/ui/reversed_empty_ranges_fixable.rs
@@ -4,18 +4,23 @@
 const ANSWER: i32 = 42;
 
 fn main() {
+    let arr = [1, 2, 3, 4, 5];
+
+    // These should be linted:
+
     (42..=21).for_each(|x| println!("{}", x));
     let _ = (ANSWER..21).filter(|x| x % 2 == 0).take(10).collect::<Vec<_>>();
 
     for _ in -21..=-42 {}
     for _ in 42u32..21u32 {}
 
+    let _ = &arr[3..3];
+
     // These should be ignored as they are not empty ranges:
 
     (21..=42).for_each(|x| println!("{}", x));
     (21..42).for_each(|x| println!("{}", x));
 
-    let arr = [1, 2, 3, 4, 5];
     let _ = &arr[1..=3];
     let _ = &arr[1..3];
 

--- a/tests/ui/reversed_empty_ranges_fixable.stderr
+++ b/tests/ui/reversed_empty_ranges_fixable.stderr
@@ -1,5 +1,5 @@
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:7:5
+  --> $DIR/reversed_empty_ranges_fixable.rs:11:5
    |
 LL |     (42..=21).for_each(|x| println!("{}", x));
    |     ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     (21..=42).rev().for_each(|x| println!("{}", x));
    |     ^^^^^^^^^^^^^^^
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:8:13
+  --> $DIR/reversed_empty_ranges_fixable.rs:12:13
    |
 LL |     let _ = (ANSWER..21).filter(|x| x % 2 == 0).take(10).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |     let _ = (21..ANSWER).rev().filter(|x| x % 2 == 0).take(10).collect::<Ve
    |             ^^^^^^^^^^^^^^^^^^
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:10:14
+  --> $DIR/reversed_empty_ranges_fixable.rs:14:14
    |
 LL |     for _ in -21..=-42 {}
    |              ^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     for _ in (-42..=-21).rev() {}
    |              ^^^^^^^^^^^^^^^^^
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:11:14
+  --> $DIR/reversed_empty_ranges_fixable.rs:15:14
    |
 LL |     for _ in 42u32..21u32 {}
    |              ^^^^^^^^^^^^
@@ -43,5 +43,11 @@ help: consider using the following if you are attempting to iterate over this ra
 LL |     for _ in (21u32..42u32).rev() {}
    |              ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: this range is empty and using it to index a slice will always yield an empty slice
+  --> $DIR/reversed_empty_ranges_fixable.rs:17:18
+   |
+LL |     let _ = &arr[3..3];
+   |              ----^^^^- help: if you want an empty slice, use: `[] as &[i32]`
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/reversed_empty_ranges_unfixable.rs
+++ b/tests/ui/reversed_empty_ranges_unfixable.rs
@@ -9,7 +9,6 @@ fn main() {
     let arr = [1, 2, 3, 4, 5];
     let _ = &arr[3usize..=1usize];
     let _ = &arr[SOME_NUM..1];
-    let _ = &arr[3..3];
 
     for _ in ANSWER..ANSWER {}
 }

--- a/tests/ui/reversed_empty_ranges_unfixable.stderr
+++ b/tests/ui/reversed_empty_ranges_unfixable.stderr
@@ -18,17 +18,11 @@ error: this range is reversed and using it to index a slice will panic at run-ti
 LL |     let _ = &arr[SOME_NUM..1];
    |                  ^^^^^^^^^^^
 
-error: this range is empty and using it to index a slice will always yield an empty slice
-  --> $DIR/reversed_empty_ranges_unfixable.rs:12:18
-   |
-LL |     let _ = &arr[3..3];
-   |                  ^^^^
-
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_unfixable.rs:14:14
+  --> $DIR/reversed_empty_ranges_unfixable.rs:13:14
    |
 LL |     for _ in ANSWER..ANSWER {}
    |              ^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
As discussed in the issue thread, the user accepted this solution. Let me know if this is what we want, or if changing the way we lint the N..N case is prefered.

changelog: reversed_empty_ranges: add suggestion for &slice[N..N]

Closes #5628 