### PR TITLE
Clarify the documentation of the `unnecessary_mut_passed` lint

### DIFF
--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -6,7 +6,7 @@ use rustc_middle::ty::{self, Ty};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
-    /// **What it does:** Detects giving a mutable reference to a function that only
+    /// **What it does:** Detects passing a mutable reference to a function that only
     /// requires an immutable reference.
     ///
     /// **Why is this bad?** The immutable reference rules out all other references


### PR DESCRIPTION
fixes #5433 by replacing "giving" with "passing"

changelog: Clarifies documentation for `unnecessary_mut_passed`
