### PR TITLE
ptr_arg: honor `allow` attribute on arguments

### DIFF
--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -530,7 +530,7 @@ pub trait DiagnosticBuilderExt<'a, T: LintContext> {
 
     /// Suggest to add an item before another.
     ///
-    /// The item should not be indented (expect for inner indentation).
+    /// The item should not be indented (except for inner indentation).
     ///
     /// # Example
     ///

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -71,7 +71,6 @@ fn false_positive_capacity_too(x: &String) -> String {
 #[allow(dead_code)]
 fn test_cow_with_ref(c: &Cow<[i32]>) {}
 
-#[allow(dead_code)]
 fn test_cow(c: Cow<[i32]>) {
     let _c = c;
 }
@@ -83,4 +82,35 @@ trait Foo2 {
 // no error for &self references where self is of type String (#2293)
 impl Foo2 for String {
     fn do_string(&self) {}
+}
+
+// Check that the allow attribute on parameters is honored
+mod issue_5644 {
+    use std::borrow::Cow;
+
+    fn allowed(
+        #[allow(clippy::ptr_arg)] _v: &Vec<u32>,
+        #[allow(clippy::ptr_arg)] _s: &String,
+        #[allow(clippy::ptr_arg)] _c: &Cow<[i32]>,
+    ) {
+    }
+
+    struct S {}
+    impl S {
+        fn allowed(
+            #[allow(clippy::ptr_arg)] _v: &Vec<u32>,
+            #[allow(clippy::ptr_arg)] _s: &String,
+            #[allow(clippy::ptr_arg)] _c: &Cow<[i32]>,
+        ) {
+        }
+    }
+
+    trait T {
+        fn allowed(
+            #[allow(clippy::ptr_arg)] _v: &Vec<u32>,
+            #[allow(clippy::ptr_arg)] _s: &String,
+            #[allow(clippy::ptr_arg)] _c: &Cow<[i32]>,
+        ) {
+        }
+    }
 }


### PR DESCRIPTION
The `intravisit::Visitor` impl for `LateContextAndPass` only takes into account the attributes of a function parameter inside the `check_param` method. `ptr_arg` starts its heuristics at `check_item` / `check_impl_item` / `check_trait_item`, so the `allow` is not taken into account automatically.

changelog: ptr_arg: honor `allow` attribute on arguments 

Fixes #5644 