### PR TITLE
Add license symlink

### DIFF
--- a/rustc_tools_util/LICENSE-APACHE
+++ b/rustc_tools_util/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/rustc_tools_util/LICENSE-MIT
+++ b/rustc_tools_util/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
To make it easier for Linux distributions to ship the licenses text within the rustc_tools_util crate directory.

changelog: none
