### PR TITLE
Fail bors on missing changelog

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -312,7 +312,7 @@ jobs:
     name: bors test finished
     if: github.event.pusher.name == 'bors' && success()
     runs-on: ubuntu-latest
-    needs: [base, integration]
+    needs: [changelog, base, integration_build, integration]
 
     steps:
       - name: Mark the job as successful
@@ -322,7 +322,7 @@ jobs:
     name: bors test finished
     if: github.event.pusher.name == 'bors' && (failure() || cancelled())
     runs-on: ubuntu-latest
-    needs: [base, integration]
+    needs: [changelog, base, integration_build, integration]
 
     steps:
       - name: Mark the job as a failure


### PR DESCRIPTION
Bors stopped failed if the changelog was missing. Instead it waited 2h (?) and then timed out.

changelog: none