### PR TITLE
check for misplaced headers in missing_safety/error_doc

### DIFF
--- a/tests/ui/doc_unsafe.rs
+++ b/tests/ui/doc_unsafe.rs
@@ -88,6 +88,21 @@ very_unsafe!();
 // we don't lint code from external macros
 undocd_unsafe!();
 
+/** This safety section is now recognized.
+
+   # Safety
+
+   No risk, no fun.
+*/
+pub unsafe fn strange_doc_comments() {
+    unimplemented!();
+}
+
+/// This is not a # Safety section.
+pub unsafe fn ceci_n_est_pas_un_titre() {
+    unimplemented!();
+}
+
 fn main() {
     unsafe {
         you_dont_see_me();
@@ -96,5 +111,7 @@ fn main() {
         apocalypse(&mut universe);
         private_mod::only_crate_wide_accessible();
         drive();
+        strange_doc_comments();
+        ceci_n_est_pas_un_titre();
     }
 }

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -43,5 +43,13 @@ LL |   very_unsafe!();
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 5 previous errors
+error: unsafe function's docs miss `# Safety` section
+  --> $DIR/doc_unsafe.rs:102:1
+   |
+LL | / pub unsafe fn ceci_n_est_pas_un_titre() {
+LL | |     unimplemented!();
+LL | | }
+   | |_^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
This fixes #5593.

changelog: none
