### PR TITLE
cargo-ui tests: check that <dir>/src exists before processing test

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -181,8 +181,15 @@ fn run_ui_cargo(config: &mut compiletest::Config) {
                 }
 
                 let src_path = case.path().join("src");
-                env::set_current_dir(&src_path)?;
 
+                // When switching between branches, if the previous branch had a test
+                // that the current branch does not have, the directory is not removed
+                // because an ignored Cargo.lock file exists.
+                if !src_path.exists() {
+                    continue;
+                }
+
+                env::set_current_dir(&src_path)?;
                 for file in fs::read_dir(&src_path)? {
                     let file = file?;
                     if file.file_type()?.is_dir() {


### PR DESCRIPTION
I forgot that I had fixed this in a PR I closed some days ago (#5643).

Before this change, cargo UI tests could fail when switching between branches if the previous branch had a test that the current branch does not have. The directory is not removed when switching because an ignored `Cargo.lock` file exists, and the code was trying to reach `$DIR/src` unconditionally.

This change will just skip a directory that has no `src` subdirectory. 

changelog: none
