### PR TITLE
Increase cargo_metadata version to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tempfile = { version = "3.1.0", optional = true }
 lazy_static = "1.0"
 
 [dev-dependencies]
-cargo_metadata = "0.9.0"
+cargo_metadata = "0.9.1"
 compiletest_rs = { version = "0.5.0", features = ["tmp"] }
 tester = "0.7"
 lazy_static = "1.0"

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.9.0"
+cargo_metadata = "0.9.1"
 if_chain = "1.0.0"
 itertools = "0.9"
 lazy_static = "1.0.2"


### PR DESCRIPTION
`clippy_lints` makes use of `dep_kinds` on `NodeDep` but this was only
added in versoin 0.9.1. Compiling with 0.9.0 will fail because of this.

changelog: none