### PR TITLE
Add regression test for `string_lit_as_bytes` issue

### DIFF
--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -14,6 +14,8 @@ fn str_lit_as_bytes() {
 
     let strify = stringify!(foobar).as_bytes();
 
+    let current_version = env!("CARGO_PKG_VERSION").as_bytes();
+
     let includestr = include_bytes!("entry_unfixable.rs");
 
     let _ = b"string with newline\t\n";

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -14,6 +14,8 @@ fn str_lit_as_bytes() {
 
     let strify = stringify!(foobar).as_bytes();
 
+    let current_version = env!("CARGO_PKG_VERSION").as_bytes();
+
     let includestr = include_str!("entry_unfixable.rs").as_bytes();
 
     let _ = "string with newline\t\n".as_bytes();

--- a/tests/ui/string_lit_as_bytes.stderr
+++ b/tests/ui/string_lit_as_bytes.stderr
@@ -13,13 +13,13 @@ LL |     let bs = r###"raw string with 3# plus " ""###.as_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with 3# plus " ""###`
 
 error: calling `as_bytes()` on `include_str!(..)`
-  --> $DIR/string_lit_as_bytes.rs:17:22
+  --> $DIR/string_lit_as_bytes.rs:19:22
    |
 LL |     let includestr = include_str!("entry_unfixable.rs").as_bytes();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("entry_unfixable.rs")`
 
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:19:13
+  --> $DIR/string_lit_as_bytes.rs:21:13
    |
 LL |     let _ = "string with newline/t/n".as_bytes();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"string with newline/t/n"`


### PR DESCRIPTION
Closes #5619

Before the fix in https://github.com/rust-lang/rust/pull/72637, `string_lit_as_bytes` was incorrectly triggering on the `env!` macro. With the fix merged, this test makes sure that the lint is not triggering anymore.

changelog: none
