### PR TITLE
Add regression test for endless loop / update `pulldown_cmark`

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -21,7 +21,7 @@ cargo_metadata = "0.9.1"
 if_chain = "1.0.0"
 itertools = "0.9"
 lazy_static = "1.0.2"
-pulldown-cmark = { version = "0.7", default-features = false }
+pulldown-cmark = { version = "0.7.1", default-features = false }
 quine-mc_cluskey = "0.2.2"
 regex-syntax = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/tests/ui/crashes/regressions.rs
+++ b/tests/ui/crashes/regressions.rs
@@ -6,4 +6,8 @@ pub fn foo(bar: *const u8) {
     println!("{:#p}", bar);
 }
 
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/4917
+/// <foo
+struct A {}
+
 fn main() {}


### PR DESCRIPTION
Closes #4917

This was fixed in pulldown_cmark 0.7.1, specifically raphlinus/pulldown-cmark#438

changelog: none
