### PR TITLE
match_wildcard_for_single_variants: remove empty line at start of lint example.

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -270,7 +270,6 @@ declare_clippy_lint! {
     /// ```rust
     /// # enum Foo { A, B, C }
     /// # let x = Foo::B;
-    ///
     /// // Bad
     /// match x {
     ///     Foo::A => {},


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#match_wildcard_for_single_variants

changelog: none

