### PR TITLE
integration tests: check if there are ices with cargo clippy -vvvv

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -37,6 +37,7 @@ fn integration_test() {
         .env("CARGO_TARGET_DIR", target_dir)
         .args(&[
             "clippy",
+            "-vvvvv",
             "--all-targets",
             "--all-features",
             "--",


### PR DESCRIPTION
As far as I understand, clippy only checks root crates in the integration tests at the moment.
This should force clippy to be run on all crates in the dep tree but it also might blow up execution time a bit. I want to give it a try-run.

---

changelog: none
