### PR TITLE
Remove `bar` from blacklisted names

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -107,7 +107,7 @@ macro_rules! define_Conf {
 pub use self::helpers::Conf;
 define_Conf! {
     /// Lint: BLACKLISTED_NAME. The list of blacklisted names to lint about
-    (blacklisted_names, "blacklisted_names": Vec<String>, ["foo", "bar", "baz", "quux"].iter().map(ToString::to_string).collect()),
+    (blacklisted_names, "blacklisted_names": Vec<String>, ["foo", "baz", "quux"].iter().map(ToString::to_string).collect()),
     /// Lint: COGNITIVE_COMPLEXITY. The maximum cognitive complexity a function can have
     (cognitive_complexity_threshold, "cognitive_complexity_threshold": u64, 25),
     /// DEPRECATED LINT: CYCLOMATIC_COMPLEXITY. Use the Cognitive Complexity lint instead.

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -106,7 +106,7 @@ macro_rules! define_Conf {
 
 pub use self::helpers::Conf;
 define_Conf! {
-    /// Lint: BLACKLISTED_NAME. The list of blacklisted names to lint about
+    /// Lint: BLACKLISTED_NAME. The list of blacklisted names to lint about. NB: `bar` is not here since it has legitimate uses
     (blacklisted_names, "blacklisted_names": Vec<String>, ["foo", "baz", "quux"].iter().map(ToString::to_string).collect()),
     /// Lint: COGNITIVE_COMPLEXITY. The maximum cognitive complexity a function can have
     (cognitive_complexity_threshold, "cognitive_complexity_threshold": u64, 25),

--- a/tests/ui/blacklisted_name.rs
+++ b/tests/ui/blacklisted_name.rs
@@ -12,29 +12,32 @@ fn test(foo: ()) {}
 
 fn main() {
     let foo = 42;
-    let bar = 42;
     let baz = 42;
+    let quux = 42;
+    // Unlike these others, `bar` is considered an acceptable name to use.
+    // See https://github.com/rust-lang/rust-clippy/issues/5225.
 
-    let barb = 42;
-    let barbaric = 42;
+    let food = 42;
+    let foodstuffs = 42;
+    let bazaar = 42;
 
     match (42, Some(1337), Some(0)) {
-        (foo, Some(bar), baz @ Some(_)) => (),
+        (foo, Some(baz), quux @ Some(_)) => (),
         _ => (),
     }
 }
 
 fn issue_1647(mut foo: u8) {
-    let mut bar = 0;
-    if let Some(mut baz) = Some(42) {}
+    let mut baz = 0;
+    if let Some(mut quux) = Some(42) {}
 }
 
 fn issue_1647_ref() {
-    let ref bar = 0;
-    if let Some(ref baz) = Some(42) {}
+    let ref baz = 0;
+    if let Some(ref quux) = Some(42) {}
 }
 
 fn issue_1647_ref_mut() {
-    let ref mut bar = 0;
-    if let Some(ref mut baz) = Some(42) {}
+    let ref mut baz = 0;
+    if let Some(ref mut quux) = Some(42) {}
 }

--- a/tests/ui/blacklisted_name.rs
+++ b/tests/ui/blacklisted_name.rs
@@ -14,8 +14,10 @@ fn main() {
     let foo = 42;
     let baz = 42;
     let quux = 42;
-    // Unlike these others, `bar` is considered an acceptable name to use.
+    // Unlike these others, `bar` is actually considered an acceptable name.
+    // Among many other legitimate uses, bar commonly refers to a period of time in music.
     // See https://github.com/rust-lang/rust-clippy/issues/5225.
+    let bar = 42;
 
     let food = 42;
     let foodstuffs = 42;

--- a/tests/ui/blacklisted_name.stderr
+++ b/tests/ui/blacklisted_name.stderr
@@ -12,77 +12,77 @@ error: use of a blacklisted/placeholder name `foo`
 LL |     let foo = 42;
    |         ^^^
 
-error: use of a blacklisted/placeholder name `bar`
-  --> $DIR/blacklisted_name.rs:15:9
-   |
-LL |     let bar = 42;
-   |         ^^^
-
 error: use of a blacklisted/placeholder name `baz`
-  --> $DIR/blacklisted_name.rs:16:9
+  --> $DIR/blacklisted_name.rs:15:9
    |
 LL |     let baz = 42;
    |         ^^^
 
-error: use of a blacklisted/placeholder name `foo`
-  --> $DIR/blacklisted_name.rs:22:10
+error: use of a blacklisted/placeholder name `quux`
+  --> $DIR/blacklisted_name.rs:16:9
    |
-LL |         (foo, Some(bar), baz @ Some(_)) => (),
+LL |     let quux = 42;
+   |         ^^^^
+
+error: use of a blacklisted/placeholder name `foo`
+  --> $DIR/blacklisted_name.rs:27:10
+   |
+LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |          ^^^
 
-error: use of a blacklisted/placeholder name `bar`
-  --> $DIR/blacklisted_name.rs:22:20
+error: use of a blacklisted/placeholder name `baz`
+  --> $DIR/blacklisted_name.rs:27:20
    |
-LL |         (foo, Some(bar), baz @ Some(_)) => (),
+LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |                    ^^^
 
-error: use of a blacklisted/placeholder name `baz`
-  --> $DIR/blacklisted_name.rs:22:26
+error: use of a blacklisted/placeholder name `quux`
+  --> $DIR/blacklisted_name.rs:27:26
    |
-LL |         (foo, Some(bar), baz @ Some(_)) => (),
-   |                          ^^^
+LL |         (foo, Some(baz), quux @ Some(_)) => (),
+   |                          ^^^^
 
 error: use of a blacklisted/placeholder name `foo`
-  --> $DIR/blacklisted_name.rs:27:19
+  --> $DIR/blacklisted_name.rs:32:19
    |
 LL | fn issue_1647(mut foo: u8) {
    |                   ^^^
 
-error: use of a blacklisted/placeholder name `bar`
-  --> $DIR/blacklisted_name.rs:28:13
-   |
-LL |     let mut bar = 0;
-   |             ^^^
-
 error: use of a blacklisted/placeholder name `baz`
-  --> $DIR/blacklisted_name.rs:29:21
-   |
-LL |     if let Some(mut baz) = Some(42) {}
-   |                     ^^^
-
-error: use of a blacklisted/placeholder name `bar`
   --> $DIR/blacklisted_name.rs:33:13
    |
-LL |     let ref bar = 0;
+LL |     let mut baz = 0;
    |             ^^^
 
-error: use of a blacklisted/placeholder name `baz`
+error: use of a blacklisted/placeholder name `quux`
   --> $DIR/blacklisted_name.rs:34:21
    |
-LL |     if let Some(ref baz) = Some(42) {}
-   |                     ^^^
-
-error: use of a blacklisted/placeholder name `bar`
-  --> $DIR/blacklisted_name.rs:38:17
-   |
-LL |     let ref mut bar = 0;
-   |                 ^^^
+LL |     if let Some(mut quux) = Some(42) {}
+   |                     ^^^^
 
 error: use of a blacklisted/placeholder name `baz`
-  --> $DIR/blacklisted_name.rs:39:25
+  --> $DIR/blacklisted_name.rs:38:13
    |
-LL |     if let Some(ref mut baz) = Some(42) {}
-   |                         ^^^
+LL |     let ref baz = 0;
+   |             ^^^
+
+error: use of a blacklisted/placeholder name `quux`
+  --> $DIR/blacklisted_name.rs:39:21
+   |
+LL |     if let Some(ref quux) = Some(42) {}
+   |                     ^^^^
+
+error: use of a blacklisted/placeholder name `baz`
+  --> $DIR/blacklisted_name.rs:43:17
+   |
+LL |     let ref mut baz = 0;
+   |                 ^^^
+
+error: use of a blacklisted/placeholder name `quux`
+  --> $DIR/blacklisted_name.rs:44:25
+   |
+LL |     if let Some(ref mut quux) = Some(42) {}
+   |                         ^^^^
 
 error: aborting due to 14 previous errors
 


### PR DESCRIPTION
changelog: Remove `bar` from blacklisted names
fixes #5225