### PR TITLE
Expands `manual_memcpy` to lint ones with loop counters

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -875,7 +875,7 @@ impl std::ops::Sub for &MinifyingSugg<'static> {
     fn sub(self, rhs: &MinifyingSugg<'static>) -> MinifyingSugg<'static> {
         match (self.as_str(), rhs.as_str()) {
             (_, "0") => self.clone(),
-            ("0", _) => MinifyingSugg(sugg::make_unop("-", rhs.0.clone())),
+            ("0", _) => MinifyingSugg(-(rhs.0.clone())),
             (x, y) if x == y => MinifyingSugg::non_paren("0"),
             (_, _) => MinifyingSugg(&self.0 - &rhs.0),
         }
@@ -898,7 +898,7 @@ impl std::ops::Sub<&MinifyingSugg<'static>> for MinifyingSugg<'static> {
     fn sub(self, rhs: &MinifyingSugg<'static>) -> MinifyingSugg<'static> {
         match (self.as_str(), rhs.as_str()) {
             (_, "0") => self,
-            ("0", _) => MinifyingSugg(sugg::make_unop("-", rhs.0.clone())),
+            ("0", _) => MinifyingSugg(-(rhs.0.clone())),
             (x, y) if x == y => MinifyingSugg::non_paren("0"),
             (_, _) => MinifyingSugg(self.0 - &rhs.0),
         }

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -2250,6 +2250,11 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
 
         // If node is the desired variable, see how it's used
         if var_def_id(self.cx, expr) == Some(self.var_id) {
+            if self.past_loop {
+                self.state = VarState::DontWarn;
+                return;
+            }
+
             if let Some(parent) = get_parent_expr(self.cx, expr) {
                 match parent.kind {
                     ExprKind::AssignOp(_, ref lhs, _) if lhs.hir_id == expr.hir_id => {
@@ -2269,10 +2274,6 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
                 }
             }
 
-            if self.past_loop {
-                self.state = VarState::DontWarn;
-                return;
-            }
             walk_expr(self, expr);
         } else if !self.past_loop && is_loop(expr) {
             self.state = VarState::DontWarn;

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -2181,16 +2181,17 @@ impl<'a, 'tcx> Visitor<'tcx> for IncrementVisitor<'a, 'tcx> {
                     _ => (),
                 }
             }
+
+            walk_expr(self, expr);
         } else if is_loop(expr) || is_conditional(expr) {
             self.depth += 1;
             walk_expr(self, expr);
             self.depth -= 1;
-            return;
         } else if let ExprKind::Continue(_) = expr.kind {
             self.done = true;
-            return;
+        } else {
+            walk_expr(self, expr);
         }
-        walk_expr(self, expr);
     }
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
         NestedVisitorMap::None
@@ -2272,16 +2273,16 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
                 self.state = VarState::DontWarn;
                 return;
             }
+            walk_expr(self, expr);
         } else if !self.past_loop && is_loop(expr) {
             self.state = VarState::DontWarn;
-            return;
         } else if is_conditional(expr) {
             self.depth += 1;
             walk_expr(self, expr);
             self.depth -= 1;
-            return;
+        } else {
+            walk_expr(self, expr);
         }
-        walk_expr(self, expr);
     }
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -5,9 +5,8 @@ use crate::utils::usage::{is_unused, mutated_variables};
 use crate::utils::{
     get_enclosing_block, get_parent_expr, get_trait_def_id, has_iter_method, higher, implements_trait,
     is_integer_const, is_no_std_crate, is_refutable, is_type_diagnostic_item, last_path_segment, match_trait_method,
-    match_type, match_var, multispan_sugg, qpath_res, snippet, snippet_opt, snippet_with_applicability,
-    snippet_with_macro_callsite, span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then, sugg,
-    SpanlessEq,
+    match_type, match_var, multispan_sugg, qpath_res, snippet, snippet_with_applicability, snippet_with_macro_callsite,
+    span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then, sugg, SpanlessEq,
 };
 use if_chain::if_chain;
 use rustc_ast::ast;
@@ -1121,8 +1120,8 @@ fn build_manual_memcpy_suggestion<'tcx>(
     let (dst_offset, dst_limit) = print_offset_and_limit(&dst);
     let (src_offset, src_limit) = print_offset_and_limit(&src);
 
-    let dst_base_str = snippet_opt(cx, dst.base.span).unwrap_or_else(|| "???".into());
-    let src_base_str = snippet_opt(cx, src.base.span).unwrap_or_else(|| "???".into());
+    let dst_base_str = snippet(cx, dst.base.span, "???");
+    let src_base_str = snippet(cx, src.base.span, "???");
 
     let dst = if dst_offset.as_str() == "" && dst_limit.as_str() == "" {
         dst_base_str
@@ -1133,6 +1132,7 @@ fn build_manual_memcpy_suggestion<'tcx>(
             dst_offset.maybe_par(),
             dst_limit.maybe_par()
         )
+        .into()
     };
 
     format!(

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1539,18 +1539,18 @@ fn check_for_loop_explicit_counter<'tcx>(
     expr: &'tcx Expr<'_>,
 ) {
     // Look for variables that are incremented once per loop iteration.
-    let mut visitor = IncrementVisitor::new(cx);
-    walk_expr(&mut visitor, body);
+    let mut increment_visitor = IncrementVisitor::new(cx);
+    walk_expr(&mut increment_visitor, body);
 
     // For each candidate, check the parent block to see if
     // it's initialized to zero at the start of the loop.
     if let Some(block) = get_enclosing_block(&cx, expr.hir_id) {
-        for id in visitor.into_results() {
-            let mut visitor2 = InitializeVisitor::new(cx, expr, id);
-            walk_block(&mut visitor2, block);
+        for id in increment_visitor.into_results() {
+            let mut initialize_visitor = InitializeVisitor::new(cx, expr, id);
+            walk_block(&mut initialize_visitor, block);
 
             if_chain! {
-                if let Some((name, initializer)) = visitor2.get_result();
+                if let Some((name, initializer)) = initialize_visitor.get_result();
                 if is_integer_const(cx, initializer, 0);
                 then {
                     let mut applicability = Applicability::MachineApplicable;

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1069,29 +1069,30 @@ fn build_manual_memcpy_suggestion<'tcx>(
         }
     }
 
-    let print_limit = |end: &Expr<'_>, end_str: &str, base: &Expr<'_>, sugg: MinifyingSugg<'static>| -> MinifyingSugg<'static> {
-        if_chain! {
-            if let ExprKind::MethodCall(method, _, len_args, _) = end.kind;
-            if method.ident.name == sym!(len);
-            if len_args.len() == 1;
-            if let Some(arg) = len_args.get(0);
-            if var_def_id(cx, arg) == var_def_id(cx, base);
-            then {
-                if sugg.as_str() == end_str {
-                    MinifyingSugg::non_paren("")
+    let print_limit =
+        |end: &Expr<'_>, end_str: &str, base: &Expr<'_>, sugg: MinifyingSugg<'static>| -> MinifyingSugg<'static> {
+            if_chain! {
+                if let ExprKind::MethodCall(method, _, len_args, _) = end.kind;
+                if method.ident.name == sym!(len);
+                if len_args.len() == 1;
+                if let Some(arg) = len_args.get(0);
+                if var_def_id(cx, arg) == var_def_id(cx, base);
+                then {
+                    if sugg.as_str() == end_str {
+                        MinifyingSugg::non_paren("")
+                    } else {
+                        sugg
+                    }
                 } else {
-                    sugg
-                }
-            } else {
-                match limits {
-                    ast::RangeLimits::Closed => {
-                        sugg + &MinifyingSugg::non_paren("1")
-                    },
-                    ast::RangeLimits::HalfOpen => sugg,
+                    match limits {
+                        ast::RangeLimits::Closed => {
+                            sugg + &MinifyingSugg::non_paren("1")
+                        },
+                        ast::RangeLimits::HalfOpen => sugg,
+                    }
                 }
             }
-        }
-    };
+        };
 
     let start_str = MinifyingSugg::hir(cx, start, "");
     let end_str = MinifyingSugg::hir(cx, end, "");

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1082,30 +1082,29 @@ fn build_manual_memcpy_suggestion<'tcx>(
         }
     }
 
-    let print_limit =
-        |end: &Expr<'_>, end_str: &str, base: &Expr<'_>, sugg: MinifyingSugg<'static>| -> MinifyingSugg<'static> {
-            if_chain! {
-                if let ExprKind::MethodCall(method, _, len_args, _) = end.kind;
-                if method.ident.name == sym!(len);
-                if len_args.len() == 1;
-                if let Some(arg) = len_args.get(0);
-                if var_def_id(cx, arg) == var_def_id(cx, base);
-                then {
-                    if sugg.as_str() == end_str {
-                        sugg::EMPTY.into()
-                    } else {
-                        sugg
-                    }
+    let print_limit = |end: &Expr<'_>, end_str: &str, base: &Expr<'_>, sugg: MinifyingSugg<'static>| {
+        if_chain! {
+            if let ExprKind::MethodCall(method, _, len_args, _) = end.kind;
+            if method.ident.name == sym!(len);
+            if len_args.len() == 1;
+            if let Some(arg) = len_args.get(0);
+            if var_def_id(cx, arg) == var_def_id(cx, base);
+            then {
+                if sugg.as_str() == end_str {
+                    sugg::EMPTY.into()
                 } else {
-                    match limits {
-                        ast::RangeLimits::Closed => {
-                            sugg + &sugg::ONE.into()
-                        },
-                        ast::RangeLimits::HalfOpen => sugg,
-                    }
+                    sugg
+                }
+            } else {
+                match limits {
+                    ast::RangeLimits::Closed => {
+                        sugg + &sugg::ONE.into()
+                    },
+                    ast::RangeLimits::HalfOpen => sugg,
                 }
             }
-        };
+        }
+    };
 
     let start_str = Sugg::hir(cx, start, "").into();
     let end_str: MinifyingSugg<'_> = Sugg::hir(cx, end, "").into();

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1014,6 +1014,9 @@ fn get_assignments<'a: 'c, 'tcx: 'c, 'c>(
     Block { stmts, expr, .. }: &'tcx Block<'tcx>,
     loop_counters: &'c [Start<'tcx>],
 ) -> impl Iterator<Item = Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)>> + 'c {
+    // As the `filter` and `map` below do different things, I think putting together
+    // just increases complexity. (cc #3188 and #4193)
+    #[allow(clippy::filter_map)]
     stmts
         .iter()
         .filter_map(move |stmt| match stmt.kind {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -707,7 +707,7 @@ fn reindent_multiline_inner(s: &str, ignore_first: bool, indent: Option<usize>, 
 }
 
 /// Gets the parent expression, if any –- this is useful to constrain a lint.
-pub fn get_parent_expr<'c>(cx: &'c LateContext<'_>, e: &Expr<'_>) -> Option<&'c Expr<'c>> {
+pub fn get_parent_expr<'tcx>(cx: &LateContext<'tcx>, e: &Expr<'_>) -> Option<&'tcx Expr<'tcx>> {
     let map = &cx.tcx.hir();
     let hir_id = e.hir_id;
     let parent_id = map.get_parent_node(hir_id);

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -16,6 +16,7 @@ use std::fmt::Display;
 use std::ops::{Add, Neg, Not, Sub};
 
 /// A helper type to build suggestion correctly handling parenthesis.
+#[derive(Clone)]
 pub enum Sugg<'a> {
     /// An expression that never needs parenthesis such as `1337` or `[0; 42]`.
     NonParen(Cow<'a, str>),
@@ -33,46 +34,6 @@ impl Display for Sugg<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match *self {
             Sugg::NonParen(ref s) | Sugg::MaybeParen(ref s) | Sugg::BinOp(_, ref s) => s.fmt(f),
-        }
-    }
-}
-
-// It's impossible to derive Clone due to the lack of the impl Clone for AssocOp
-impl Clone for Sugg<'_> {
-    fn clone(&self) -> Self {
-        /// manually cloning AssocOp
-        fn clone_assoc_op(this: &AssocOp) -> AssocOp {
-            match this {
-                AssocOp::Add => AssocOp::Add,
-                AssocOp::Subtract => AssocOp::Subtract,
-                AssocOp::Multiply => AssocOp::Multiply,
-                AssocOp::Divide => AssocOp::Divide,
-                AssocOp::Modulus => AssocOp::Modulus,
-                AssocOp::LAnd => AssocOp::LAnd,
-                AssocOp::LOr => AssocOp::LOr,
-                AssocOp::BitXor => AssocOp::BitXor,
-                AssocOp::BitAnd => AssocOp::BitAnd,
-                AssocOp::BitOr => AssocOp::BitOr,
-                AssocOp::ShiftLeft => AssocOp::ShiftLeft,
-                AssocOp::ShiftRight => AssocOp::ShiftRight,
-                AssocOp::Equal => AssocOp::Equal,
-                AssocOp::Less => AssocOp::Less,
-                AssocOp::LessEqual => AssocOp::LessEqual,
-                AssocOp::NotEqual => AssocOp::NotEqual,
-                AssocOp::Greater => AssocOp::Greater,
-                AssocOp::GreaterEqual => AssocOp::GreaterEqual,
-                AssocOp::Assign => AssocOp::Assign,
-                AssocOp::AssignOp(t) => AssocOp::AssignOp(*t),
-                AssocOp::As => AssocOp::As,
-                AssocOp::DotDot => AssocOp::DotDot,
-                AssocOp::DotDotEq => AssocOp::DotDotEq,
-                AssocOp::Colon => AssocOp::Colon,
-            }
-        }
-        match self {
-            Sugg::NonParen(x) => Sugg::NonParen(x.clone()),
-            Sugg::MaybeParen(x) => Sugg::MaybeParen(x.clone()),
-            Sugg::BinOp(op, x) => Sugg::BinOp(clone_assoc_op(op), x.clone()),
         }
     }
 }

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -13,7 +13,7 @@ use rustc_span::{BytePos, Pos};
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::fmt::Display;
-use std::ops::{Add, Sub, Not};
+use std::ops::{Add, Not, Sub};
 
 /// A helper type to build suggestion correctly handling parenthesis.
 pub enum Sugg<'a> {
@@ -334,7 +334,7 @@ macro_rules! forward_binop_impls_to_ref {
                 $imp::$method(&self, &other)
             }
         }
-    }
+    };
 }
 
 impl Add for &Sugg<'_> {

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -16,7 +16,7 @@ use std::fmt::Display;
 use std::ops::{Add, Neg, Not, Sub};
 
 /// A helper type to build suggestion correctly handling parenthesis.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum Sugg<'a> {
     /// An expression that never needs parenthesis such as `1337` or `[0; 42]`.
     NonParen(Cow<'a, str>),
@@ -27,8 +27,12 @@ pub enum Sugg<'a> {
     BinOp(AssocOp, Cow<'a, str>),
 }
 
+/// Literal constant `0`, for convenience.
+pub const ZERO: Sugg<'static> = Sugg::NonParen(Cow::Borrowed("0"));
 /// Literal constant `1`, for convenience.
 pub const ONE: Sugg<'static> = Sugg::NonParen(Cow::Borrowed("1"));
+/// a constant represents an empty string, for convenience.
+pub const EMPTY: Sugg<'static> = Sugg::NonParen(Cow::Borrowed(""));
 
 impl Display for Sugg<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -13,7 +13,7 @@ use rustc_span::{BytePos, Pos};
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::fmt::Display;
-use std::ops::{Add, Not, Sub};
+use std::ops::{Add, Neg, Not, Sub};
 
 /// A helper type to build suggestion correctly handling parenthesis.
 pub enum Sugg<'a> {
@@ -353,6 +353,13 @@ impl Sub for &Sugg<'_> {
 
 forward_binop_impls_to_ref!(impl Add, add for Sugg<'_>, type Output = Sugg<'static>);
 forward_binop_impls_to_ref!(impl Sub, sub for Sugg<'_>, type Output = Sugg<'static>);
+
+impl Neg for Sugg<'_> {
+    type Output = Sugg<'static>;
+    fn neg(self) -> Sugg<'static> {
+        make_unop("-", self)
+    }
+}
 
 impl Not for Sugg<'_> {
     type Output = Sugg<'static>;

--- a/clippy_lints/src/utils/sugg.rs
+++ b/clippy_lints/src/utils/sugg.rs
@@ -36,6 +36,46 @@ impl Display for Sugg<'_> {
     }
 }
 
+// It's impossible to derive Clone due to the lack of the impl Clone for AssocOp
+impl Clone for Sugg<'_> {
+    fn clone(&self) -> Self {
+        /// manually cloning AssocOp
+        fn clone_assoc_op(this: &AssocOp) -> AssocOp {
+            match this {
+                AssocOp::Add => AssocOp::Add,
+                AssocOp::Subtract => AssocOp::Subtract,
+                AssocOp::Multiply => AssocOp::Multiply,
+                AssocOp::Divide => AssocOp::Divide,
+                AssocOp::Modulus => AssocOp::Modulus,
+                AssocOp::LAnd => AssocOp::LAnd,
+                AssocOp::LOr => AssocOp::LOr,
+                AssocOp::BitXor => AssocOp::BitXor,
+                AssocOp::BitAnd => AssocOp::BitAnd,
+                AssocOp::BitOr => AssocOp::BitOr,
+                AssocOp::ShiftLeft => AssocOp::ShiftLeft,
+                AssocOp::ShiftRight => AssocOp::ShiftRight,
+                AssocOp::Equal => AssocOp::Equal,
+                AssocOp::Less => AssocOp::Less,
+                AssocOp::LessEqual => AssocOp::LessEqual,
+                AssocOp::NotEqual => AssocOp::NotEqual,
+                AssocOp::Greater => AssocOp::Greater,
+                AssocOp::GreaterEqual => AssocOp::GreaterEqual,
+                AssocOp::Assign => AssocOp::Assign,
+                AssocOp::AssignOp(t) => AssocOp::AssignOp(*t),
+                AssocOp::As => AssocOp::As,
+                AssocOp::DotDot => AssocOp::DotDot,
+                AssocOp::DotDotEq => AssocOp::DotDotEq,
+                AssocOp::Colon => AssocOp::Colon,
+            }
+        }
+        match self {
+            Sugg::NonParen(x) => Sugg::NonParen(x.clone()),
+            Sugg::MaybeParen(x) => Sugg::MaybeParen(x.clone()),
+            Sugg::BinOp(op, x) => Sugg::BinOp(clone_assoc_op(op), x.clone()),
+        }
+    }
+}
+
 #[allow(clippy::wrong_self_convention)] // ok, because of the function `as_ty` method
 impl<'a> Sugg<'a> {
     /// Prepare a suggestion from an expression.
@@ -267,21 +307,49 @@ impl<'a> Sugg<'a> {
     }
 }
 
-impl<'a, 'b> std::ops::Add<Sugg<'b>> for Sugg<'a> {
+impl std::ops::Add for Sugg<'_> {
     type Output = Sugg<'static>;
-    fn add(self, rhs: Sugg<'b>) -> Sugg<'static> {
+    fn add(self, rhs: Sugg<'_>) -> Sugg<'static> {
         make_binop(ast::BinOpKind::Add, &self, &rhs)
     }
 }
 
-impl<'a, 'b> std::ops::Sub<Sugg<'b>> for Sugg<'a> {
+impl std::ops::Sub for Sugg<'_> {
     type Output = Sugg<'static>;
-    fn sub(self, rhs: Sugg<'b>) -> Sugg<'static> {
+    fn sub(self, rhs: Sugg<'_>) -> Sugg<'static> {
         make_binop(ast::BinOpKind::Sub, &self, &rhs)
     }
 }
 
-impl<'a> std::ops::Not for Sugg<'a> {
+impl std::ops::Add<&Sugg<'_>> for Sugg<'_> {
+    type Output = Sugg<'static>;
+    fn add(self, rhs: &Sugg<'_>) -> Sugg<'static> {
+        make_binop(ast::BinOpKind::Add, &self, rhs)
+    }
+}
+
+impl std::ops::Sub<&Sugg<'_>> for Sugg<'_> {
+    type Output = Sugg<'static>;
+    fn sub(self, rhs: &Sugg<'_>) -> Sugg<'static> {
+        make_binop(ast::BinOpKind::Sub, &self, rhs)
+    }
+}
+
+impl std::ops::Add for &Sugg<'_> {
+    type Output = Sugg<'static>;
+    fn add(self, rhs: &Sugg<'_>) -> Sugg<'static> {
+        make_binop(ast::BinOpKind::Add, self, rhs)
+    }
+}
+
+impl std::ops::Sub for &Sugg<'_> {
+    type Output = Sugg<'static>;
+    fn sub(self, rhs: &Sugg<'_>) -> Sugg<'static> {
+        make_binop(ast::BinOpKind::Sub, self, rhs)
+    }
+}
+
+impl std::ops::Not for Sugg<'_> {
     type Output = Sugg<'static>;
     fn not(self) -> Sugg<'static> {
         make_unop("!", self)

--- a/tests/ui/manual_memcpy.rs
+++ b/tests/ui/manual_memcpy.rs
@@ -115,6 +115,60 @@ pub fn manual_copy(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
     }
 }
 
+#[allow(clippy::needless_range_loop, clippy::explicit_counter_loop)]
+pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
+    let mut count = 0;
+    for i in 3..src.len() {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 0;
+    for i in 3..src.len() {
+        dst[count] = src[i];
+        count += 1;
+    }
+
+    let mut count = 3;
+    for i in 0..src.len() {
+        dst[count] = src[i];
+        count += 1;
+    }
+
+    let mut count = 3;
+    for i in 0..src.len() {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 0;
+    for i in 3..(3 + src.len()) {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 3;
+    for i in 5..src.len() {
+        dst[i] = src[count - 2];
+        count += 1;
+    }
+
+    let mut count = 5;
+    for i in 3..10 {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 3;
+    let mut count = 30;
+    for i in 0..src.len() {
+        dst[count] = src[i];
+        dst2[count] = src[i];
+        count += 1;
+        count += 1;
+    }
+}
+
 #[warn(clippy::needless_range_loop, clippy::manual_memcpy)]
 pub fn manual_clone(src: &[String], dst: &mut [String]) {
     for i in 0..src.len() {

--- a/tests/ui/manual_memcpy.rs
+++ b/tests/ui/manual_memcpy.rs
@@ -115,7 +115,6 @@ pub fn manual_copy(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
     }
 }
 
-#[allow(clippy::needless_range_loop, clippy::explicit_counter_loop)]
 pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
     let mut count = 0;
     for i in 3..src.len() {

--- a/tests/ui/manual_memcpy.rs
+++ b/tests/ui/manual_memcpy.rs
@@ -160,12 +160,12 @@ pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32])
     }
 
     let mut count = 3;
-    let mut count = 30;
+    let mut count2 = 30;
     for i in 0..src.len() {
         dst[count] = src[i];
-        dst2[count] = src[i];
+        dst2[count2] = src[i];
         count += 1;
-        count += 1;
+        count2 += 1;
     }
 
     // make sure parentheses are added properly to bitwise operators, which have lower precedence than

--- a/tests/ui/manual_memcpy.rs
+++ b/tests/ui/manual_memcpy.rs
@@ -167,6 +167,14 @@ pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32])
         count += 1;
         count += 1;
     }
+
+    // make sure parentheses are added properly to bitwise operators, which have lower precedence than
+    // arithmetric ones
+    let mut count = 0 << 1;
+    for i in 0..1 << 1 {
+        dst[count] = src[i + 2];
+        count += 1;
+    }
 }
 
 #[warn(clippy::needless_range_loop, clippy::manual_memcpy)]

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -58,13 +58,13 @@ error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:94:14
    |
 LL |     for i in from..from + src.len() {
-   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + src.len()].clone_from_slice(&src[..(from + src.len() - from)])`
+   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..(from + src.len())].clone_from_slice(&src[..(from + src.len() - from)])`
 
 error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:98:14
    |
 LL |     for i in from..from + 3 {
-   |              ^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..from + 3].clone_from_slice(&src[..(from + 3 - from)])`
+   |              ^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..(from + 3)].clone_from_slice(&src[..(from + 3 - from)])`
 
 error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:103:14
@@ -106,7 +106,7 @@ error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:145:14
    |
 LL |     for i in 3..(3 + src.len()) {
-   |              ^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..(3 + src.len())].clone_from_slice(&src[..((3 + src.len()) - 3)])`
+   |              ^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..((3 + src.len()))].clone_from_slice(&src[..((3 + src.len()) - 3)])`
 
 error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:151:14

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -79,49 +79,49 @@ LL |     for i in 0..0 {
    |              ^^^^ help: try replacing the loop by: `dst[..0].clone_from_slice(&src[..0])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:121:14
+  --> $DIR/manual_memcpy.rs:120:14
    |
 LL |     for i in 3..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:127:14
+  --> $DIR/manual_memcpy.rs:126:14
    |
 LL |     for i in 3..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..(src.len() - 3)].clone_from_slice(&src[3..])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:133:14
+  --> $DIR/manual_memcpy.rs:132:14
    |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..(src.len() + 3)].clone_from_slice(&src[..])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:139:14
+  --> $DIR/manual_memcpy.rs:138:14
    |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[3..(src.len() + 3)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:145:14
+  --> $DIR/manual_memcpy.rs:144:14
    |
 LL |     for i in 3..(3 + src.len()) {
    |              ^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..((3 + src.len()))].clone_from_slice(&src[..((3 + src.len()) - 3)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:151:14
+  --> $DIR/manual_memcpy.rs:150:14
    |
 LL |     for i in 5..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[5..src.len()].clone_from_slice(&src[(3 - 2)..((src.len() - 2) + 3 - 5)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:157:14
+  --> $DIR/manual_memcpy.rs:156:14
    |
 LL |     for i in 3..10 {
    |              ^^^^^ help: try replacing the loop by: `dst[3..10].clone_from_slice(&src[5..(10 + 5 - 3)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:164:14
+  --> $DIR/manual_memcpy.rs:163:14
    |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^
@@ -133,13 +133,13 @@ LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]) {
    |
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:174:14
+  --> $DIR/manual_memcpy.rs:173:14
    |
 LL |     for i in 0..1 << 1 {
    |              ^^^^^^^^^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:182:14
+  --> $DIR/manual_memcpy.rs:181:14
    |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..])`

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -1,148 +1,204 @@
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:7:14
+  --> $DIR/manual_memcpy.rs:7:5
    |
-LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..])`
+LL | /     for i in 0..src.len() {
+LL | |         dst[i] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..]);`
    |
    = note: `-D clippy::manual-memcpy` implied by `-D warnings`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:12:14
+  --> $DIR/manual_memcpy.rs:12:5
    |
-LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[10..(src.len() + 10)].clone_from_slice(&src[..])`
+LL | /     for i in 0..src.len() {
+LL | |         dst[i + 10] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[10..(src.len() + 10)].clone_from_slice(&src[..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:17:14
+  --> $DIR/manual_memcpy.rs:17:5
    |
-LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[10..(src.len() + 10)])`
+LL | /     for i in 0..src.len() {
+LL | |         dst[i] = src[i + 10];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[10..(src.len() + 10)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:22:14
+  --> $DIR/manual_memcpy.rs:22:5
    |
-LL |     for i in 11..src.len() {
-   |              ^^^^^^^^^^^^^ help: try replacing the loop by: `dst[11..src.len()].clone_from_slice(&src[(11 - 10)..(src.len() - 10)])`
+LL | /     for i in 11..src.len() {
+LL | |         dst[i] = src[i - 10];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[11..src.len()].clone_from_slice(&src[(11 - 10)..(src.len() - 10)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:27:14
+  --> $DIR/manual_memcpy.rs:27:5
    |
-LL |     for i in 0..dst.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst.clone_from_slice(&src[..dst.len()])`
+LL | /     for i in 0..dst.len() {
+LL | |         dst[i] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst.clone_from_slice(&src[..dst.len()]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:40:14
+  --> $DIR/manual_memcpy.rs:40:5
    |
-LL |     for i in 10..256 {
-   |              ^^^^^^^
+LL | /     for i in 10..256 {
+LL | |         dst[i] = src[i - 5];
+LL | |         dst2[i + 500] = src[i]
+LL | |     }
+   | |_____^
    |
 help: try replacing the loop by
    |
-LL |     for i in dst[10..256].clone_from_slice(&src[(10 - 5)..(256 - 5)])
-LL |     dst2[(10 + 500)..(256 + 500)].clone_from_slice(&src[10..256]) {
+LL |     dst[10..256].clone_from_slice(&src[(10 - 5)..(256 - 5)]);
+LL |     dst2[(10 + 500)..(256 + 500)].clone_from_slice(&src[10..256]);
    |
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:52:14
+  --> $DIR/manual_memcpy.rs:52:5
    |
-LL |     for i in 10..LOOP_OFFSET {
-   |              ^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[(10 + LOOP_OFFSET)..(LOOP_OFFSET + LOOP_OFFSET)].clone_from_slice(&src[(10 - some_var)..(LOOP_OFFSET - some_var)])`
+LL | /     for i in 10..LOOP_OFFSET {
+LL | |         dst[i + LOOP_OFFSET] = src[i - some_var];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[(10 + LOOP_OFFSET)..(LOOP_OFFSET + LOOP_OFFSET)].clone_from_slice(&src[(10 - some_var)..(LOOP_OFFSET - some_var)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:65:14
+  --> $DIR/manual_memcpy.rs:65:5
    |
-LL |     for i in 0..src_vec.len() {
-   |              ^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst_vec[..src_vec.len()].clone_from_slice(&src_vec[..])`
+LL | /     for i in 0..src_vec.len() {
+LL | |         dst_vec[i] = src_vec[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst_vec[..src_vec.len()].clone_from_slice(&src_vec[..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:94:14
+  --> $DIR/manual_memcpy.rs:94:5
    |
-LL |     for i in from..from + src.len() {
-   |              ^^^^^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..(from + src.len())].clone_from_slice(&src[..(from + src.len() - from)])`
+LL | /     for i in from..from + src.len() {
+LL | |         dst[i] = src[i - from];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[from..(from + src.len())].clone_from_slice(&src[..(from + src.len() - from)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:98:14
+  --> $DIR/manual_memcpy.rs:98:5
    |
-LL |     for i in from..from + 3 {
-   |              ^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[from..(from + 3)].clone_from_slice(&src[..(from + 3 - from)])`
+LL | /     for i in from..from + 3 {
+LL | |         dst[i] = src[i - from];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[from..(from + 3)].clone_from_slice(&src[..(from + 3 - from)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:103:14
+  --> $DIR/manual_memcpy.rs:103:5
    |
-LL |     for i in 0..5 {
-   |              ^^^^ help: try replacing the loop by: `dst[..5].clone_from_slice(&src[..5])`
+LL | /     for i in 0..5 {
+LL | |         dst[i - 0] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..5].clone_from_slice(&src[..5]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:108:14
+  --> $DIR/manual_memcpy.rs:108:5
    |
-LL |     for i in 0..0 {
-   |              ^^^^ help: try replacing the loop by: `dst[..0].clone_from_slice(&src[..0])`
+LL | /     for i in 0..0 {
+LL | |         dst[i] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..0].clone_from_slice(&src[..0]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:120:14
+  --> $DIR/manual_memcpy.rs:120:5
    |
-LL |     for i in 3..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)])`
+LL | /     for i in 3..src.len() {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:126:14
+  --> $DIR/manual_memcpy.rs:126:5
    |
-LL |     for i in 3..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..(src.len() - 3)].clone_from_slice(&src[3..])`
+LL | /     for i in 3..src.len() {
+LL | |         dst[count] = src[i];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..(src.len() - 3)].clone_from_slice(&src[3..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:132:14
+  --> $DIR/manual_memcpy.rs:132:5
    |
-LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..(src.len() + 3)].clone_from_slice(&src[..])`
+LL | /     for i in 0..src.len() {
+LL | |         dst[count] = src[i];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..(src.len() + 3)].clone_from_slice(&src[..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:138:14
+  --> $DIR/manual_memcpy.rs:138:5
    |
-LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[3..(src.len() + 3)])`
+LL | /     for i in 0..src.len() {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[3..(src.len() + 3)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:144:14
+  --> $DIR/manual_memcpy.rs:144:5
    |
-LL |     for i in 3..(3 + src.len()) {
-   |              ^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..((3 + src.len()))].clone_from_slice(&src[..((3 + src.len()) - 3)])`
+LL | /     for i in 3..(3 + src.len()) {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..((3 + src.len()))].clone_from_slice(&src[..((3 + src.len()) - 3)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:150:14
+  --> $DIR/manual_memcpy.rs:150:5
    |
-LL |     for i in 5..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[5..src.len()].clone_from_slice(&src[(3 - 2)..((src.len() - 2) + 3 - 5)])`
+LL | /     for i in 5..src.len() {
+LL | |         dst[i] = src[count - 2];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[5..src.len()].clone_from_slice(&src[(3 - 2)..((src.len() - 2) + 3 - 5)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:156:14
+  --> $DIR/manual_memcpy.rs:156:5
    |
-LL |     for i in 3..10 {
-   |              ^^^^^ help: try replacing the loop by: `dst[3..10].clone_from_slice(&src[5..(10 + 5 - 3)])`
+LL | /     for i in 3..10 {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..10].clone_from_slice(&src[5..(10 + 5 - 3)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:163:14
+  --> $DIR/manual_memcpy.rs:163:5
    |
-LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^
+LL | /     for i in 0..src.len() {
+LL | |         dst[count] = src[i];
+LL | |         dst2[count2] = src[i];
+LL | |         count += 1;
+LL | |         count2 += 1;
+LL | |     }
+   | |_____^
    |
 help: try replacing the loop by
    |
-LL |     for i in dst[3..(src.len() + 3)].clone_from_slice(&src[..])
-LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]) {
+LL |     dst[3..(src.len() + 3)].clone_from_slice(&src[..]);
+LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]);
    |
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:173:14
+  --> $DIR/manual_memcpy.rs:173:5
    |
-LL |     for i in 0..1 << 1 {
-   |              ^^^^^^^^^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)])`
+LL | /     for i in 0..1 << 1 {
+LL | |         dst[count] = src[i + 2];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:181:14
+  --> $DIR/manual_memcpy.rs:181:5
    |
-LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..])`
+LL | /     for i in 0..src.len() {
+LL | |         dst[i] = src[i].clone();
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..]);`
 
 error: aborting due to 22 previous errors
 

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -16,7 +16,7 @@ error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:17:14
    |
 LL |     for i in 0..src.len() {
-   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[10..])`
+   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[10..(src.len() + 10)])`
 
 error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:22:14
@@ -79,10 +79,64 @@ LL |     for i in 0..0 {
    |              ^^^^ help: try replacing the loop by: `dst[..0].clone_from_slice(&src[..0])`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:120:14
+  --> $DIR/manual_memcpy.rs:121:14
+   |
+LL |     for i in 3..src.len() {
+   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:127:14
+   |
+LL |     for i in 3..src.len() {
+   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..(src.len() - 3)].clone_from_slice(&src[3..])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:133:14
+   |
+LL |     for i in 0..src.len() {
+   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..(src.len() + 3)].clone_from_slice(&src[..])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:139:14
+   |
+LL |     for i in 0..src.len() {
+   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[3..(src.len() + 3)])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:145:14
+   |
+LL |     for i in 3..(3 + src.len()) {
+   |              ^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..(3 + src.len())].clone_from_slice(&src[..((3 + src.len()) - 3)])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:151:14
+   |
+LL |     for i in 5..src.len() {
+   |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[5..src.len()].clone_from_slice(&src[(3 - 2)..((src.len() - 2) + 3 - 5)])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:157:14
+   |
+LL |     for i in 3..10 {
+   |              ^^^^^ help: try replacing the loop by: `dst[3..10].clone_from_slice(&src[5..(10 + 5 - 3)])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:164:14
+   |
+LL |     for i in 0..src.len() {
+   |              ^^^^^^^^^^^^
+   |
+help: try replacing the loop by
+   |
+LL |     for i in dst[3..(src.len() + 3)].clone_from_slice(&src[..])
+LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]) {
+   |
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:174:14
    |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..])`
 
-error: aborting due to 13 previous errors
+error: aborting due to 21 previous errors
 

--- a/tests/ui/manual_memcpy.stderr
+++ b/tests/ui/manual_memcpy.stderr
@@ -135,8 +135,14 @@ LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]) {
 error: it looks like you're manually copying between slices
   --> $DIR/manual_memcpy.rs:174:14
    |
+LL |     for i in 0..1 << 1 {
+   |              ^^^^^^^^^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)])`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/manual_memcpy.rs:182:14
+   |
 LL |     for i in 0..src.len() {
    |              ^^^^^^^^^^^^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..])`
 
-error: aborting due to 21 previous errors
+error: aborting due to 22 previous errors
 

--- a/tests/ui/manual_memcpy/with_loop_counters.rs
+++ b/tests/ui/manual_memcpy/with_loop_counters.rs
@@ -1,0 +1,64 @@
+#![warn(clippy::needless_range_loop, clippy::manual_memcpy)]
+
+pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
+    let mut count = 0;
+    for i in 3..src.len() {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 0;
+    for i in 3..src.len() {
+        dst[count] = src[i];
+        count += 1;
+    }
+
+    let mut count = 3;
+    for i in 0..src.len() {
+        dst[count] = src[i];
+        count += 1;
+    }
+
+    let mut count = 3;
+    for i in 0..src.len() {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 0;
+    for i in 3..(3 + src.len()) {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 3;
+    for i in 5..src.len() {
+        dst[i] = src[count - 2];
+        count += 1;
+    }
+
+    let mut count = 5;
+    for i in 3..10 {
+        dst[i] = src[count];
+        count += 1;
+    }
+
+    let mut count = 3;
+    let mut count2 = 30;
+    for i in 0..src.len() {
+        dst[count] = src[i];
+        dst2[count2] = src[i];
+        count += 1;
+        count2 += 1;
+    }
+
+    // make sure parentheses are added properly to bitwise operators, which have lower precedence than
+    // arithmetric ones
+    let mut count = 0 << 1;
+    for i in 0..1 << 1 {
+        dst[count] = src[i + 2];
+        count += 1;
+    }
+}
+
+fn main() {}

--- a/tests/ui/manual_memcpy/with_loop_counters.rs
+++ b/tests/ui/manual_memcpy/with_loop_counters.rs
@@ -37,6 +37,12 @@ pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32])
         count += 1;
     }
 
+    let mut count = 2;
+    for i in 0..dst.len() {
+        dst[i] = src[count];
+        count += 1;
+    }
+
     let mut count = 5;
     for i in 3..10 {
         dst[i] = src[count];
@@ -65,6 +71,17 @@ pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32])
     for i in 3..src.len() {
         dst[i] = src[count];
         count += 1
+    }
+
+    // make sure ones where the increment is not at the end of the loop.
+    // As a possible enhancement, one could adjust the offset in the suggestion according to
+    // the position. For example, if the increment is at the top of the loop;
+    // treating the loop counter as if it were initialized 1 greater than the original value.
+    let mut count = 0;
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..src.len() {
+        count += 1;
+        dst[i] = src[count];
     }
 }
 

--- a/tests/ui/manual_memcpy/with_loop_counters.rs
+++ b/tests/ui/manual_memcpy/with_loop_counters.rs
@@ -59,6 +59,13 @@ pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32])
         dst[count] = src[i + 2];
         count += 1;
     }
+
+    // make sure incrementing expressions without semicolons at the end of loops are handled correctly.
+    let mut count = 0;
+    for i in 3..src.len() {
+        dst[i] = src[count];
+        count += 1
+    }
 }
 
 fn main() {}

--- a/tests/ui/manual_memcpy/with_loop_counters.stderr
+++ b/tests/ui/manual_memcpy/with_loop_counters.stderr
@@ -1,0 +1,93 @@
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:5:5
+   |
+LL | /     for i in 3..src.len() {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)]);`
+   |
+   = note: `-D clippy::manual-memcpy` implied by `-D warnings`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:11:5
+   |
+LL | /     for i in 3..src.len() {
+LL | |         dst[count] = src[i];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..(src.len() - 3)].clone_from_slice(&src[3..]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:17:5
+   |
+LL | /     for i in 0..src.len() {
+LL | |         dst[count] = src[i];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..(src.len() + 3)].clone_from_slice(&src[..]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:23:5
+   |
+LL | /     for i in 0..src.len() {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[3..(src.len() + 3)]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:29:5
+   |
+LL | /     for i in 3..(3 + src.len()) {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..((3 + src.len()))].clone_from_slice(&src[..((3 + src.len()) - 3)]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:35:5
+   |
+LL | /     for i in 5..src.len() {
+LL | |         dst[i] = src[count - 2];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[5..src.len()].clone_from_slice(&src[(3 - 2)..((src.len() - 2) + 3 - 5)]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:41:5
+   |
+LL | /     for i in 3..10 {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..10].clone_from_slice(&src[5..(10 + 5 - 3)]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:48:5
+   |
+LL | /     for i in 0..src.len() {
+LL | |         dst[count] = src[i];
+LL | |         dst2[count2] = src[i];
+LL | |         count += 1;
+LL | |         count2 += 1;
+LL | |     }
+   | |_____^
+   |
+help: try replacing the loop by
+   |
+LL |     dst[3..(src.len() + 3)].clone_from_slice(&src[..]);
+LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]);
+   |
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:58:5
+   |
+LL | /     for i in 0..1 << 1 {
+LL | |         dst[count] = src[i + 2];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)]);`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/manual_memcpy/with_loop_counters.stderr
+++ b/tests/ui/manual_memcpy/with_loop_counters.stderr
@@ -89,5 +89,14 @@ LL | |         count += 1;
 LL | |     }
    | |_____^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)]);`
 
-error: aborting due to 9 previous errors
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:65:5
+   |
+LL | /     for i in 3..src.len() {
+LL | |         dst[i] = src[count];
+LL | |         count += 1
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)]);`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/manual_memcpy/with_loop_counters.stderr
+++ b/tests/ui/manual_memcpy/with_loop_counters.stderr
@@ -57,6 +57,15 @@ LL | |     }
 error: it looks like you're manually copying between slices
   --> $DIR/with_loop_counters.rs:41:5
    |
+LL | /     for i in 0..dst.len() {
+LL | |         dst[i] = src[count];
+LL | |         count += 1;
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst.clone_from_slice(&src[2..(dst.len() + 2)]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/with_loop_counters.rs:47:5
+   |
 LL | /     for i in 3..10 {
 LL | |         dst[i] = src[count];
 LL | |         count += 1;
@@ -64,7 +73,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[3..10].clone_from_slice(&src[5..(10 + 5 - 3)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/with_loop_counters.rs:48:5
+  --> $DIR/with_loop_counters.rs:54:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[count] = src[i];
@@ -81,7 +90,7 @@ LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]);
    |
 
 error: it looks like you're manually copying between slices
-  --> $DIR/with_loop_counters.rs:58:5
+  --> $DIR/with_loop_counters.rs:64:5
    |
 LL | /     for i in 0..1 << 1 {
 LL | |         dst[count] = src[i + 2];
@@ -90,7 +99,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/with_loop_counters.rs:65:5
+  --> $DIR/with_loop_counters.rs:71:5
    |
 LL | /     for i in 3..src.len() {
 LL | |         dst[i] = src[count];
@@ -98,5 +107,5 @@ LL | |         count += 1
 LL | |     }
    | |_____^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)]);`
 
-error: aborting due to 10 previous errors
+error: aborting due to 11 previous errors
 

--- a/tests/ui/manual_memcpy/without_loop_counters.rs
+++ b/tests/ui/manual_memcpy/without_loop_counters.rs
@@ -115,67 +115,6 @@ pub fn manual_copy(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
     }
 }
 
-pub fn manual_copy_with_counters(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
-    let mut count = 0;
-    for i in 3..src.len() {
-        dst[i] = src[count];
-        count += 1;
-    }
-
-    let mut count = 0;
-    for i in 3..src.len() {
-        dst[count] = src[i];
-        count += 1;
-    }
-
-    let mut count = 3;
-    for i in 0..src.len() {
-        dst[count] = src[i];
-        count += 1;
-    }
-
-    let mut count = 3;
-    for i in 0..src.len() {
-        dst[i] = src[count];
-        count += 1;
-    }
-
-    let mut count = 0;
-    for i in 3..(3 + src.len()) {
-        dst[i] = src[count];
-        count += 1;
-    }
-
-    let mut count = 3;
-    for i in 5..src.len() {
-        dst[i] = src[count - 2];
-        count += 1;
-    }
-
-    let mut count = 5;
-    for i in 3..10 {
-        dst[i] = src[count];
-        count += 1;
-    }
-
-    let mut count = 3;
-    let mut count2 = 30;
-    for i in 0..src.len() {
-        dst[count] = src[i];
-        dst2[count2] = src[i];
-        count += 1;
-        count2 += 1;
-    }
-
-    // make sure parentheses are added properly to bitwise operators, which have lower precedence than
-    // arithmetric ones
-    let mut count = 0 << 1;
-    for i in 0..1 << 1 {
-        dst[count] = src[i + 2];
-        count += 1;
-    }
-}
-
 #[warn(clippy::needless_range_loop, clippy::manual_memcpy)]
 pub fn manual_clone(src: &[String], dst: &mut [String]) {
     for i in 0..src.len() {

--- a/tests/ui/manual_memcpy/without_loop_counters.stderr
+++ b/tests/ui/manual_memcpy/without_loop_counters.stderr
@@ -1,5 +1,5 @@
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:7:5
+  --> $DIR/without_loop_counters.rs:7:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i] = src[i];
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::manual-memcpy` implied by `-D warnings`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:12:5
+  --> $DIR/without_loop_counters.rs:12:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i + 10] = src[i];
@@ -17,7 +17,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[10..(src.len() + 10)].clone_from_slice(&src[..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:17:5
+  --> $DIR/without_loop_counters.rs:17:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i] = src[i + 10];
@@ -25,7 +25,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[10..(src.len() + 10)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:22:5
+  --> $DIR/without_loop_counters.rs:22:5
    |
 LL | /     for i in 11..src.len() {
 LL | |         dst[i] = src[i - 10];
@@ -33,7 +33,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[11..src.len()].clone_from_slice(&src[(11 - 10)..(src.len() - 10)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:27:5
+  --> $DIR/without_loop_counters.rs:27:5
    |
 LL | /     for i in 0..dst.len() {
 LL | |         dst[i] = src[i];
@@ -41,7 +41,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst.clone_from_slice(&src[..dst.len()]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:40:5
+  --> $DIR/without_loop_counters.rs:40:5
    |
 LL | /     for i in 10..256 {
 LL | |         dst[i] = src[i - 5];
@@ -56,7 +56,7 @@ LL |     dst2[(10 + 500)..(256 + 500)].clone_from_slice(&src[10..256]);
    |
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:52:5
+  --> $DIR/without_loop_counters.rs:52:5
    |
 LL | /     for i in 10..LOOP_OFFSET {
 LL | |         dst[i + LOOP_OFFSET] = src[i - some_var];
@@ -64,7 +64,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[(10 + LOOP_OFFSET)..(LOOP_OFFSET + LOOP_OFFSET)].clone_from_slice(&src[(10 - some_var)..(LOOP_OFFSET - some_var)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:65:5
+  --> $DIR/without_loop_counters.rs:65:5
    |
 LL | /     for i in 0..src_vec.len() {
 LL | |         dst_vec[i] = src_vec[i];
@@ -72,7 +72,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst_vec[..src_vec.len()].clone_from_slice(&src_vec[..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:94:5
+  --> $DIR/without_loop_counters.rs:94:5
    |
 LL | /     for i in from..from + src.len() {
 LL | |         dst[i] = src[i - from];
@@ -80,7 +80,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[from..(from + src.len())].clone_from_slice(&src[..(from + src.len() - from)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:98:5
+  --> $DIR/without_loop_counters.rs:98:5
    |
 LL | /     for i in from..from + 3 {
 LL | |         dst[i] = src[i - from];
@@ -88,7 +88,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[from..(from + 3)].clone_from_slice(&src[..(from + 3 - from)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:103:5
+  --> $DIR/without_loop_counters.rs:103:5
    |
 LL | /     for i in 0..5 {
 LL | |         dst[i - 0] = src[i];
@@ -96,7 +96,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..5].clone_from_slice(&src[..5]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:108:5
+  --> $DIR/without_loop_counters.rs:108:5
    |
 LL | /     for i in 0..0 {
 LL | |         dst[i] = src[i];
@@ -104,101 +104,12 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..0].clone_from_slice(&src[..0]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:120:5
-   |
-LL | /     for i in 3..src.len() {
-LL | |         dst[i] = src[count];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[3..src.len()].clone_from_slice(&src[..(src.len() - 3)]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:126:5
-   |
-LL | /     for i in 3..src.len() {
-LL | |         dst[count] = src[i];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[..(src.len() - 3)].clone_from_slice(&src[3..]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:132:5
-   |
-LL | /     for i in 0..src.len() {
-LL | |         dst[count] = src[i];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[3..(src.len() + 3)].clone_from_slice(&src[..]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:138:5
-   |
-LL | /     for i in 0..src.len() {
-LL | |         dst[i] = src[count];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[3..(src.len() + 3)]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:144:5
-   |
-LL | /     for i in 3..(3 + src.len()) {
-LL | |         dst[i] = src[count];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[3..((3 + src.len()))].clone_from_slice(&src[..((3 + src.len()) - 3)]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:150:5
-   |
-LL | /     for i in 5..src.len() {
-LL | |         dst[i] = src[count - 2];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[5..src.len()].clone_from_slice(&src[(3 - 2)..((src.len() - 2) + 3 - 5)]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:156:5
-   |
-LL | /     for i in 3..10 {
-LL | |         dst[i] = src[count];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[3..10].clone_from_slice(&src[5..(10 + 5 - 3)]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:163:5
-   |
-LL | /     for i in 0..src.len() {
-LL | |         dst[count] = src[i];
-LL | |         dst2[count2] = src[i];
-LL | |         count += 1;
-LL | |         count2 += 1;
-LL | |     }
-   | |_____^
-   |
-help: try replacing the loop by
-   |
-LL |     dst[3..(src.len() + 3)].clone_from_slice(&src[..]);
-LL |     dst2[30..(src.len() + 30)].clone_from_slice(&src[..]);
-   |
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:173:5
-   |
-LL | /     for i in 0..1 << 1 {
-LL | |         dst[count] = src[i + 2];
-LL | |         count += 1;
-LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[(0 << 1)..((1 << 1) + (0 << 1))].clone_from_slice(&src[2..((1 << 1) + 2)]);`
-
-error: it looks like you're manually copying between slices
-  --> $DIR/manual_memcpy.rs:181:5
+  --> $DIR/without_loop_counters.rs:120:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i] = src[i].clone();
 LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..]);`
 
-error: aborting due to 22 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Closes #1670

This PR expands `manual_memcpy` to lint ones with loop counters as described in https://github.com/rust-lang/rust-clippy/issues/1670#issuecomment-293280204

Although the current code is working, I have a couple of questions and concerns.

~~Firstly, I manually implemented `Clone` for `Sugg` because `AssocOp` lacks `Clone`. As `AssocOp` only holds an enum, which is `Copy`, as a value, it seems `AssocOp` can be `Clone`; but, I was not sure where to ask it. Should I make a PR to `rustc`?~~ The [PR]( https://github.com/rust-lang/rust/pull/73629) was made.

Secondly, manual copying with loop counters are likely to trigger `needless_range_loop` and `explicit_counter_loop` along with `manual_memcpy`; in fact, I explicitly allowed them in the tests. Is there any way to disable these two lints when a code triggers `manual_memcpy`?

And, another thing I'd like to note is that `Sugg` adds unnecessary parentheses when expressions with parentheses passed to its `hir` function, as seen here:

```
error: it looks like you're manually copying between slices
  --> $DIR/manual_memcpy.rs:145:14
   |
LL |     for i in 3..(3 + src.len()) {
   |              ^^^^^^^^^^^^^^^^^^ help: try replacing the loop by: `dst[3..((3 + src.len()))].clone_from_slice(&src[..((3 + src.len()) - 3)])
```

However, using the `hir` function is needed to prevent the suggestion causing  errors when users use bitwise operations; and also this have already existed, for example: `verbose_bit_mask`. Thus, I think this is fine.

changelog: Expands `manual_memcpy` to lint ones with loop counters
