### PR TITLE
Rename collapsable_if fix suggestion to "collapse nested if block"

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -115,7 +115,7 @@ fn check_collapsible_maybe_if_let(cx: &EarlyContext<'_>, else_: &ast::Expr) {
                 COLLAPSIBLE_IF,
                 block.span,
                 "this `else { if .. }` block can be collapsed",
-                "try",
+                "collapse nested if block",
                 snippet_block_with_applicability(cx, else_.span, "..", Some(block.span), &mut applicability).into_owned(),
                 applicability,
             );
@@ -142,7 +142,7 @@ fn check_collapsible_no_if_let(cx: &EarlyContext<'_>, expr: &ast::Expr, check: &
                 let rhs = Sugg::ast(cx, check_inner, "..");
                 diag.span_suggestion(
                     expr.span,
-                    "try",
+                    "collapse nested if block",
                     format!(
                         "if {} {}",
                         lhs.and(&rhs),

--- a/tests/ui/collapsible_else_if.stderr
+++ b/tests/ui/collapsible_else_if.stderr
@@ -10,7 +10,7 @@ LL | |     }
    | |_____^
    |
    = note: `-D clippy::collapsible-if` implied by `-D warnings`
-help: try
+help: collapse nested if block
    |
 LL |     } else if y == "world" {
 LL |         println!("world!")
@@ -28,7 +28,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     } else if let Some(42) = Some(42) {
 LL |         println!("world!")
@@ -48,7 +48,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     } else if y == "world" {
 LL |         println!("world")
@@ -71,7 +71,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     } else if let Some(42) = Some(42) {
 LL |         println!("world")
@@ -94,7 +94,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     } else if let Some(42) = Some(42) {
 LL |         println!("world")
@@ -117,7 +117,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     } else if x == "hello" {
 LL |         println!("world")
@@ -140,7 +140,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     } else if let Some(42) = Some(42) {
 LL |         println!("world")

--- a/tests/ui/collapsible_if.stderr
+++ b/tests/ui/collapsible_if.stderr
@@ -9,7 +9,7 @@ LL | |     }
    | |_____^
    |
    = note: `-D clippy::collapsible-if` implied by `-D warnings`
-help: try
+help: collapse nested if block
    |
 LL |     if x == "hello" && y == "world" {
 LL |         println!("Hello world!");
@@ -26,7 +26,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     if (x == "hello" || x == "world") && (y == "world" || y == "hello") {
 LL |         println!("Hello world!");
@@ -43,7 +43,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     if x == "hello" && x == "world" && (y == "world" || y == "hello") {
 LL |         println!("Hello world!");
@@ -60,7 +60,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     if (x == "hello" || x == "world") && y == "world" && y == "hello" {
 LL |         println!("Hello world!");
@@ -77,7 +77,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     if x == "hello" && x == "world" && y == "world" && y == "hello" {
 LL |         println!("Hello world!");
@@ -94,7 +94,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     if 42 == 1337 && 'a' != 'A' {
 LL |         println!("world!")
@@ -111,7 +111,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try
+help: collapse nested if block
    |
 LL |     if x == "hello" && y == "world" { // Collapsible
 LL |         println!("Hello world!");


### PR DESCRIPTION
The name "try" is confusing when shown as quick fix by rust-analyzer

changelog: Rename `collapsable_if` fix suggestion to "collapse nested if block"
