### PR TITLE
unnecessary_sort_by: avoid linting if key borrows

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -1363,6 +1363,21 @@ pub fn fn_has_unsatisfiable_preds(cx: &LateContext<'_>, did: DefId) -> bool {
     )
 }
 
+/// Returns the `DefId` of the callee if the given expression is a function or method call.
+pub fn fn_def_id(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<DefId> {
+    match &expr.kind {
+        ExprKind::MethodCall(..) => cx.tables().type_dependent_def_id(expr.hir_id),
+        ExprKind::Call(
+            Expr {
+                kind: ExprKind::Path(qpath),
+                ..
+            },
+            ..,
+        ) => cx.tables().qpath_res(qpath, expr.hir_id).opt_def_id(),
+        _ => None,
+    }
+}
+
 pub fn run_lints(cx: &LateContext<'_>, lints: &[&'static Lint], id: HirId) -> bool {
     lints.iter().any(|lint| {
         matches!(

--- a/tests/ui/unnecessary_sort_by.fixed
+++ b/tests/ui/unnecessary_sort_by.fixed
@@ -2,11 +2,11 @@
 
 use std::cmp::Reverse;
 
-fn id(x: isize) -> isize {
-    x
-}
+fn unnecessary_sort_by() {
+    fn id(x: isize) -> isize {
+        x
+    }
 
-fn main() {
     let mut vec: Vec<isize> = vec![3, 6, 1, 2, 5];
     // Forward examples
     vec.sort();
@@ -23,4 +23,42 @@ fn main() {
     vec.sort_by(|_, b| b.cmp(&5));
     vec.sort_by(|_, b| b.cmp(c));
     vec.sort_unstable_by(|a, _| a.cmp(c));
+}
+
+// Should not be linted to avoid hitting https://github.com/rust-lang/rust/issues/34162
+mod issue_5754 {
+    struct Test(String);
+
+    #[derive(PartialOrd, Ord, PartialEq, Eq)]
+    struct Wrapper<'a>(&'a str);
+
+    impl Test {
+        fn name(&self) -> &str {
+            &self.0
+        }
+
+        fn wrapped(&self) -> Wrapper<'_> {
+            Wrapper(&self.0)
+        }
+    }
+
+    pub fn test() {
+        let mut args: Vec<Test> = vec![];
+
+        // Forward
+        args.sort_by(|a, b| a.name().cmp(b.name()));
+        args.sort_by(|a, b| a.wrapped().cmp(&b.wrapped()));
+        args.sort_unstable_by(|a, b| a.name().cmp(b.name()));
+        args.sort_unstable_by(|a, b| a.wrapped().cmp(&b.wrapped()));
+        // Reverse
+        args.sort_by(|a, b| b.name().cmp(a.name()));
+        args.sort_by(|a, b| b.wrapped().cmp(&a.wrapped()));
+        args.sort_unstable_by(|a, b| b.name().cmp(a.name()));
+        args.sort_unstable_by(|a, b| b.wrapped().cmp(&a.wrapped()));
+    }
+}
+
+fn main() {
+    unnecessary_sort_by();
+    issue_5754::test();
 }

--- a/tests/ui/unnecessary_sort_by.rs
+++ b/tests/ui/unnecessary_sort_by.rs
@@ -2,11 +2,11 @@
 
 use std::cmp::Reverse;
 
-fn id(x: isize) -> isize {
-    x
-}
+fn unnecessary_sort_by() {
+    fn id(x: isize) -> isize {
+        x
+    }
 
-fn main() {
     let mut vec: Vec<isize> = vec![3, 6, 1, 2, 5];
     // Forward examples
     vec.sort_by(|a, b| a.cmp(b));
@@ -23,4 +23,42 @@ fn main() {
     vec.sort_by(|_, b| b.cmp(&5));
     vec.sort_by(|_, b| b.cmp(c));
     vec.sort_unstable_by(|a, _| a.cmp(c));
+}
+
+// Should not be linted to avoid hitting https://github.com/rust-lang/rust/issues/34162
+mod issue_5754 {
+    struct Test(String);
+
+    #[derive(PartialOrd, Ord, PartialEq, Eq)]
+    struct Wrapper<'a>(&'a str);
+
+    impl Test {
+        fn name(&self) -> &str {
+            &self.0
+        }
+
+        fn wrapped(&self) -> Wrapper<'_> {
+            Wrapper(&self.0)
+        }
+    }
+
+    pub fn test() {
+        let mut args: Vec<Test> = vec![];
+
+        // Forward
+        args.sort_by(|a, b| a.name().cmp(b.name()));
+        args.sort_by(|a, b| a.wrapped().cmp(&b.wrapped()));
+        args.sort_unstable_by(|a, b| a.name().cmp(b.name()));
+        args.sort_unstable_by(|a, b| a.wrapped().cmp(&b.wrapped()));
+        // Reverse
+        args.sort_by(|a, b| b.name().cmp(a.name()));
+        args.sort_by(|a, b| b.wrapped().cmp(&a.wrapped()));
+        args.sort_unstable_by(|a, b| b.name().cmp(a.name()));
+        args.sort_unstable_by(|a, b| b.wrapped().cmp(&a.wrapped()));
+    }
+}
+
+fn main() {
+    unnecessary_sort_by();
+    issue_5754::test();
 }


### PR DESCRIPTION
changelog: Avoid linting if key borrows in [`unnecessary_sort_by`]

Fixes #5754 
Closes #2313