### PR TITLE
Require `or_patterns` to suggest nesting them

### DIFF
--- a/clippy_lints/src/unnested_or_patterns.rs
+++ b/clippy_lints/src/unnested_or_patterns.rs
@@ -72,8 +72,8 @@ impl EarlyLintPass for UnnestedOrPatterns {
 }
 
 fn lint_unnested_or_patterns(cx: &EarlyContext<'_>, pat: &Pat) {
-    if !cx.sess.opts.unstable_features.is_nightly_build() {
-        // User cannot do `#![feature(or_patterns)]`, so bail.
+    if !cx.sess.features_untracked().or_patterns {
+        // Do not suggest nesting the patterns if the feature `or_patterns` is not enabled.
         return;
     }
 

--- a/tests/ui/unnested_or_patterns3.rs
+++ b/tests/ui/unnested_or_patterns3.rs
@@ -1,0 +1,6 @@
+#![warn(clippy::unnested_or_patterns)]
+
+// Test that `unnested_or_patterns` does not trigger without enabling `or_patterns`
+fn main() {
+    if let (0, 1) | (0, 2) | (0, 3) = (0, 0) {}
+}


### PR DESCRIPTION
changelog: Require `#![feature(or_patterns)]` to trigger [`unnested_or_patterns`]

Fixes #5704 
