### PR TITLE
Fix build at nightly

### DIFF
--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -150,7 +150,7 @@ impl<'a, 'tcx> Delegate<'tcx> for EscapeDelegate<'a, 'tcx> {
                     return;
                 }
 
-                if is_non_trait_box(cmt.place.ty) && !self.is_large_box(cmt.place.ty) {
+                if is_non_trait_box(cmt.place.ty()) && !self.is_large_box(cmt.place.ty()) {
                     self.set.insert(cmt.hir_id);
                 }
                 return;

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -110,7 +110,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
 
         let fn_def_id = cx.tcx.hir().local_def_id(hir_id);
 
-        let preds = traits::elaborate_predicates(cx.tcx, cx.param_env.caller_bounds.iter())
+        let preds = traits::elaborate_predicates(cx.tcx, cx.param_env.caller_bounds().iter())
             .filter(|p| !p.is_global())
             .filter_map(|obligation| {
                 if let ty::PredicateKind::Trait(poly_trait_ref, _) = obligation.predicate.kind() {


### PR DESCRIPTION
changelog: none

The build fails when using the following version of nightly. The error message is the same as https://github.com/rust-lang/rust-clippy/pull/5773/checks?check_run_id=845930061 . 
```
$ rustc -V
rustc 1.46.0-nightly (8ac1525e0 2020-07-07)
```