### PR TITLE
Removing RHS snippet from SHADOW_UNRELATED message.

### DIFF
--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -295,11 +295,7 @@ fn lint_shadow<'tcx>(
                 cx,
                 SHADOW_UNRELATED,
                 pattern_span,
-                &format!(
-                    "`{}` is shadowed by `{}`",
-                    snippet(cx, pattern_span, "_"),
-                    snippet(cx, expr.span, "..")
-                ),
+                &format!("`{}` is being shadowed", snippet(cx, pattern_span, "_")),
                 |diag| {
                     diag.span_note(expr.span, "initialization happens here");
                     diag.span_note(prev_span, "previous binding is here");

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -104,7 +104,7 @@ note: previous binding is here
 LL |     let x = (1, x);
    |         ^
 
-error: `x` is shadowed by `y`
+error: `x` is being shadowed
   --> $DIR/shadow.rs:34:9
    |
 LL |     let x = y;


### PR DESCRIPTION
Fixes #5703
  
I am not sure if I reinvented the wheel here, but I could not really find a snippet function that did this truncation, so I created the function. Please tell me if there was a more obvious way to do this, I am new here. :smile:

changelog: Truncates multi-line RHS in shadow_unrelated message if it has more than 5 lines.