### PR TITLE
improve advice in iter_nth_zero

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2349,7 +2349,7 @@ fn lint_iter_nth_zero<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, nth_ar
                 ITER_NTH_ZERO,
                 expr.span,
                 "called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent",
-                "try calling .next() instead of .nth(0)",
+                "try calling `.next()` instead of `.nth(0)`",
                 format!("{}.next()", snippet_with_applicability(cx, nth_args[0].span, "..", &mut applicability)),
                 applicability,
             );

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2348,8 +2348,8 @@ fn lint_iter_nth_zero<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, nth_ar
                 cx,
                 ITER_NTH_ZERO,
                 expr.span,
-                "called `.nth(0)` on a `std::iter::Iterator`",
-                "try calling",
+                "called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent",
+                "try calling .next() instead of .nth(0)",
                 format!("{}.next()", snippet_with_applicability(cx, nth_args[0].span, "..", &mut applicability)),
                 applicability,
             );

--- a/tests/ui/iter_nth_zero.stderr
+++ b/tests/ui/iter_nth_zero.stderr
@@ -2,7 +2,7 @@ error: called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent
   --> $DIR/iter_nth_zero.rs:20:14
    |
 LL |     let _x = s.iter().nth(0);
-   |              ^^^^^^^^^^^^^^^ help: try calling .next() instead of .nth(0): `s.iter().next()`
+   |              ^^^^^^^^^^^^^^^ help: try calling `.next()` instead of `.nth(0)`: `s.iter().next()`
    |
    = note: `-D clippy::iter-nth-zero` implied by `-D warnings`
 
@@ -10,13 +10,13 @@ error: called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent
   --> $DIR/iter_nth_zero.rs:25:14
    |
 LL |     let _y = iter.nth(0);
-   |              ^^^^^^^^^^^ help: try calling .next() instead of .nth(0): `iter.next()`
+   |              ^^^^^^^^^^^ help: try calling `.next()` instead of `.nth(0)`: `iter.next()`
 
 error: called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent
   --> $DIR/iter_nth_zero.rs:30:22
    |
 LL |     let _unwrapped = iter2.nth(0).unwrap();
-   |                      ^^^^^^^^^^^^ help: try calling .next() instead of .nth(0): `iter2.next()`
+   |                      ^^^^^^^^^^^^ help: try calling `.next()` instead of `.nth(0)`: `iter2.next()`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/iter_nth_zero.stderr
+++ b/tests/ui/iter_nth_zero.stderr
@@ -1,22 +1,22 @@
-error: called `.nth(0)` on a `std::iter::Iterator`
+error: called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent
   --> $DIR/iter_nth_zero.rs:20:14
    |
 LL |     let _x = s.iter().nth(0);
-   |              ^^^^^^^^^^^^^^^ help: try calling: `s.iter().next()`
+   |              ^^^^^^^^^^^^^^^ help: try calling .next() instead of .nth(0): `s.iter().next()`
    |
    = note: `-D clippy::iter-nth-zero` implied by `-D warnings`
 
-error: called `.nth(0)` on a `std::iter::Iterator`
+error: called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent
   --> $DIR/iter_nth_zero.rs:25:14
    |
 LL |     let _y = iter.nth(0);
-   |              ^^^^^^^^^^^ help: try calling: `iter.next()`
+   |              ^^^^^^^^^^^ help: try calling .next() instead of .nth(0): `iter.next()`
 
-error: called `.nth(0)` on a `std::iter::Iterator`
+error: called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent
   --> $DIR/iter_nth_zero.rs:30:22
    |
 LL |     let _unwrapped = iter2.nth(0).unwrap();
-   |                      ^^^^^^^^^^^^ help: try calling: `iter2.next()`
+   |                      ^^^^^^^^^^^^ help: try calling .next() instead of .nth(0): `iter2.next()`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
fixes #5783

*Please keep the line below*
changelog:  For iter_nth_zero, the "use .next()" replacement advice is on the last line of the code snippet, where it is vulnerable to truncation. Display that advice at the beginning instead.
