### PR TITLE
Fix deploy script for beta deployment

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -19,7 +19,7 @@ fi
 
 if [[ $BETA = "true" ]]; then
   echo "Update documentation for the beta release"
-  cp -r out/master out/beta
+  cp -r out/master/* out/beta
 fi
 
 # Generate version index that is shown as root index page
@@ -33,12 +33,11 @@ cd out
 git config user.name "GHA CI"
 git config user.email "gha@ci.invalid"
 
-if git diff --exit-code --quiet; then
-  echo "No changes to the output on this push; exiting."
-  exit 0
-fi
-
 if [[ -n $TAG_NAME ]]; then
+  if git diff --exit-code --quiet -- $TAG_NAME/; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+  fi
   # Add the new dir
   git add "$TAG_NAME"
   # Update the symlink
@@ -47,9 +46,17 @@ if [[ -n $TAG_NAME ]]; then
   git add versions.json
   git commit -m "Add documentation for ${TAG_NAME} release: ${SHA}"
 elif [[ $BETA = "true" ]]; then
+  if git diff --exit-code --quiet -- beta/; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+  fi
   git add beta
   git commit -m "Automatic deploy to GitHub Pages (beta): ${SHA}"
 else
+  if git diff --exit-code --quiet; then
+    echo "No changes to the output on this push; exiting."
+    exit 0
+  fi
   git add .
   git commit -m "Automatic deploy to GitHub Pages: ${SHA}"
 fi

--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -34,6 +34,8 @@ git config user.name "GHA CI"
 git config user.email "gha@ci.invalid"
 
 if [[ -n $TAG_NAME ]]; then
+  # track files, so that the following check works
+  git add --intent-to-add "$TAG_NAME"
   if git diff --exit-code --quiet -- $TAG_NAME/; then
     echo "No changes to the output on this push; exiting."
     exit 0


### PR DESCRIPTION
Since the `beta/` directory already exists, we can't copy the complete `master` dir

changelog: none
