### PR TITLE
Panic multiple args

### DIFF
--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -96,23 +96,20 @@ impl<'tcx> LateLintPass<'tcx> for PanicUnimplemented {
         if_chain! {
             if let ExprKind::Block(ref block, _) = expr.kind;
             if let Some(ref ex) = block.expr;
-            if let Some(params) = match_function_call(cx, ex, &paths::BEGIN_PANIC);
-            if params.len() == 1;
+            if let Some(params) = match_function_call(cx, ex, &paths::BEGIN_PANIC)
+                .or(match_function_call(cx, ex, &paths::BEGIN_PANIC_FMT));
             then {
+                let span = get_outer_span(expr);
                 if is_expn_of(expr.span, "unimplemented").is_some() {
-                    let span = get_outer_span(expr);
                     span_lint(cx, UNIMPLEMENTED, span,
                               "`unimplemented` should not be present in production code");
                 } else if is_expn_of(expr.span, "todo").is_some() {
-                    let span = get_outer_span(expr);
                     span_lint(cx, TODO, span,
                               "`todo` should not be present in production code");
                 } else if is_expn_of(expr.span, "unreachable").is_some() {
-                    let span = get_outer_span(expr);
                     span_lint(cx, UNREACHABLE, span,
                               "`unreachable` should not be present in production code");
                 } else if is_expn_of(expr.span, "panic").is_some() {
-                    let span = get_outer_span(expr);
                     span_lint(cx, PANIC, span,
                               "`panic` should not be present in production code");
                     match_panic(params, expr, cx);

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -97,7 +97,7 @@ impl<'tcx> LateLintPass<'tcx> for PanicUnimplemented {
             if let ExprKind::Block(ref block, _) = expr.kind;
             if let Some(ref ex) = block.expr;
             if let Some(params) = match_function_call(cx, ex, &paths::BEGIN_PANIC)
-                .or(match_function_call(cx, ex, &paths::BEGIN_PANIC_FMT));
+                .or_else(|| match_function_call(cx, ex, &paths::BEGIN_PANIC_FMT));
             then {
                 let span = get_outer_span(expr);
                 if is_expn_of(expr.span, "unimplemented").is_some() {

--- a/tests/ui/panicking_macros.rs
+++ b/tests/ui/panicking_macros.rs
@@ -4,24 +4,32 @@
 fn panic() {
     let a = 2;
     panic!();
+    panic!("message");
+    panic!("{} {}", "panic with", "multiple arguments");
     let b = a + 2;
 }
 
 fn todo() {
     let a = 2;
     todo!();
+    todo!("message");
+    todo!("{} {}", "panic with", "multiple arguments");
     let b = a + 2;
 }
 
 fn unimplemented() {
     let a = 2;
     unimplemented!();
+    unimplemented!("message");
+    unimplemented!("{} {}", "panic with", "multiple arguments");
     let b = a + 2;
 }
 
 fn unreachable() {
     let a = 2;
     unreachable!();
+    unreachable!("message");
+    unreachable!("{} {}", "panic with", "multiple arguments");
     let b = a + 2;
 }
 

--- a/tests/ui/panicking_macros.stderr
+++ b/tests/ui/panicking_macros.stderr
@@ -6,29 +6,83 @@ LL |     panic!();
    |
    = note: `-D clippy::panic` implied by `-D warnings`
 
+error: `panic` should not be present in production code
+  --> $DIR/panicking_macros.rs:7:5
+   |
+LL |     panic!("message");
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `panic` should not be present in production code
+  --> $DIR/panicking_macros.rs:8:5
+   |
+LL |     panic!("{} {}", "panic with", "multiple arguments");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: `todo` should not be present in production code
-  --> $DIR/panicking_macros.rs:12:5
+  --> $DIR/panicking_macros.rs:14:5
    |
 LL |     todo!();
    |     ^^^^^^^^
    |
    = note: `-D clippy::todo` implied by `-D warnings`
 
+error: `todo` should not be present in production code
+  --> $DIR/panicking_macros.rs:15:5
+   |
+LL |     todo!("message");
+   |     ^^^^^^^^^^^^^^^^^
+
+error: `todo` should not be present in production code
+  --> $DIR/panicking_macros.rs:16:5
+   |
+LL |     todo!("{} {}", "panic with", "multiple arguments");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: `unimplemented` should not be present in production code
-  --> $DIR/panicking_macros.rs:18:5
+  --> $DIR/panicking_macros.rs:22:5
    |
 LL |     unimplemented!();
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unimplemented` implied by `-D warnings`
 
-error: `unreachable` should not be present in production code
+error: `unimplemented` should not be present in production code
+  --> $DIR/panicking_macros.rs:23:5
+   |
+LL |     unimplemented!("message");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:24:5
+   |
+LL |     unimplemented!("{} {}", "panic with", "multiple arguments");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `unreachable` should not be present in production code
+  --> $DIR/panicking_macros.rs:30:5
    |
 LL |     unreachable!();
    |     ^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unreachable` implied by `-D warnings`
 
-error: aborting due to 4 previous errors
+error: `unreachable` should not be present in production code
+  --> $DIR/panicking_macros.rs:31:5
+   |
+LL |     unreachable!("message");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `unreachable` should not be present in production code
+  --> $DIR/panicking_macros.rs:32:5
+   |
+LL |     unreachable!("{} {}", "panic with", "multiple arguments");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
changelog: Fixes bug with `panic` lint reported in #5767. I also did the same changes to the lints for `todo`, `unimplemented` and `unreachable`, so those lints should now also detect calls to those macros with a message.