### PR TITLE
Use `(std::)f64::EPSILON` in the examples as suggested in the lints

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -99,7 +99,9 @@ declare_clippy_lint! {
     /// if y != x {} // where both are floats
     ///
     /// // Good
-    /// let error = 0.01f64; // Use an epsilon for comparison
+    /// let error = f64::EPSILON; // Use an epsilon for comparison
+    /// // Or, if Rust <= 1.42, use `std::f64::EPSILON` constant instead.
+    /// // let error = std::f64::EPSILON;
     /// if (y - 1.23f64).abs() < error { }
     /// if (y - x).abs() > error { }
     /// ```
@@ -237,10 +239,12 @@ declare_clippy_lint! {
     /// const ONE: f64 = 1.00;
     ///
     /// // Bad
-    /// if x == ONE { }  // where both are floats
+    /// if x == ONE { } // where both are floats
     ///
     /// // Good
-    /// let error = 0.1f64; // Use an epsilon for comparison
+    /// let error = f64::EPSILON; // Use an epsilon for comparison
+    /// // Or, if Rust <= 1.42, use `std::f64::EPSILON` constant instead.
+    /// // let error = std::f64::EPSILON;
     /// if (x - ONE).abs() < error { }
     /// ```
     pub FLOAT_CMP_CONST,


### PR DESCRIPTION
`float_cmp(_const)` suggests using `{f32|f64}::EPSILON` and it'd be great if the docs mentioned it.

changelog: none
