### PR TITLE
Fix ui-cargo tests in CI

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -3,7 +3,7 @@
 use compiletest_rs as compiletest;
 use compiletest_rs::common::Mode as TestMode;
 
-use std::env::{self, set_var};
+use std::env::{self, set_var, var};
 use std::ffi::OsStr;
 use std::fs;
 use std::io;
@@ -136,7 +136,9 @@ fn run_ui_toml(config: &mut compiletest::Config) {
 
     let tests = compiletest::make_tests(&config);
 
+    let manifest_dir = var("CARGO_MANIFEST_DIR").unwrap_or_default();
     let res = run_tests(&config, tests);
+    set_var("CARGO_MANIFEST_DIR", &manifest_dir);
     match res {
         Ok(true) => {},
         Ok(false) => panic!("Some tests failed"),


### PR DESCRIPTION
r? @ebroto 

The `ui-toml` tests set the `CARGO_MANIFEST_DIR` var, but never reset it, so the `ui-cargo` tests used it also and then found a faulty `clippy.toml` file

changelog: none
