### PR TITLE
Make the docs clearer for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,14 @@ All contributors are expected to follow the [Rust Code of Conduct].
 
 ## Getting started
 
-High level approach:
+**Note: If this is your first time contributing to Clippy, you should
+first read the [Basics docs](doc/basics.md).**
+
+### High level approach
 
 1. Find something to fix/improve
 2. Change code (likely some file in `clippy_lints/src/`)
-3. Follow the instructions in the [Basics docs](doc/basics.md) such as running the `setup-toolchain.sh` script
+3. Follow the instructions in the [Basics docs](doc/basics.md) to get set up
 4. Run `cargo test` in the root directory and wiggle code until it passes
 5. Open a PR (also can be done after 2. if you run into problems)
 

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -53,6 +53,9 @@ rustup-toolchain-install-master -f -n master -c rustc-dev -c llvm-tools
 rustup override set master
 ```
 
+_Note:_ Sometimes you may get compiler errors when building Clippy, even if you
+didn't change anything. Normally those will be fixed by a maintainer in a few hours. 
+
 ## Building and Testing
 
 Once the `master` toolchain is installed, you can build and test Clippy like


### PR DESCRIPTION
It confused me before, so I made it extra obvious that you need to run
a script to set up your toolchain before you can build Clippy.

I also added a note so that new contributors aren't confused when
Clippy doesn't build as a result of a change in rustc's internals.

changelog: make `CONTRIBUTING.md` clearer for new contributors