### PR TITLE
Prevent compile parts of rustc when using `cargo dev ra-setup`

### DIFF
--- a/clippy_dev/src/ra_setup.rs
+++ b/clippy_dev/src/ra_setup.rs
@@ -68,10 +68,11 @@ fn inject_deps_into_manifest(
     });
 
     // format a new [dependencies]-block with the new deps we need to inject
-    let mut all_deps = String::from("[dependencies]\n");
+    let mut all_deps = String::from("[target.'cfg(NOT_A_PLATFORM)'.dependencies]\n");
     new_deps.for_each(|dep_line| {
         all_deps.push_str(&dep_line);
     });
+    all_deps.push_str("\n[dependencies]\n");
 
     // replace "[dependencies]" with
     // [dependencies]


### PR DESCRIPTION
Currently after running `cargo dev ra-setup` the following lines are added to `Cargo.toml`:

```toml
[target]
rustc_data_structures = { path = ".../rust/src/librustc_data_structures" }
rustc_driver = { path = ".../rust/src/librustc_driver" }
rustc_errors = { path = ".../rust/src/librustc_errors" }
rustc_interface = { path = ".../rust/src/librustc_interface" }
rustc_middle = { path = ".../rust/src/librustc_middle" }
```

This pull request adds dependencies for `rustc` crates under `cfg(NOT_A_PLATFORM)`, thus preventing them from compiling together with clippy:

```toml
[target.'cfg(NOT_A_PLATFORM)'.dependencies]
rustc_data_structures = { path = ".../rust/src/librustc_data_structures" }
rustc_driver = { path = ".../rust/src/librustc_driver" }
rustc_errors = { path = ".../rust/src/librustc_errors" }
rustc_interface = { path = ".../rust/src/librustc_interface" }
rustc_middle = { path = ".../rust/src/librustc_middle" }
```

---

This approach was [originally proposed for IntelliJ Rust](https://github.com/intellij-rust/intellij-rust/issues/1618#issuecomment-459098749), and looks like it works for rust-analyzer too.

changelog: none
