### PR TITLE
Add the other overloadable operations to suspicious_arithmetic_impl

### DIFF
--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -86,12 +86,18 @@ impl<'tcx> LateLintPass<'tcx> for SuspiciousImpl {
                 cx,
                 expr,
                 binop.node,
-                &["Add", "Sub", "Mul", "Div"],
+                &["Add", "Sub", "Mul", "Div", "Rem", "BitAnd", "BitOr", "BitXor", "Shl", "Shr"],
                 &[
                     hir::BinOpKind::Add,
                     hir::BinOpKind::Sub,
                     hir::BinOpKind::Mul,
                     hir::BinOpKind::Div,
+                    hir::BinOpKind::Rem,
+                    hir::BinOpKind::BitAnd,
+                    hir::BinOpKind::BitOr,
+                    hir::BinOpKind::BitXor,
+                    hir::BinOpKind::Shl,
+                    hir::BinOpKind::Shr,
                 ],
             ) {
                 span_lint(

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -87,7 +87,7 @@ impl<'tcx> LateLintPass<'tcx> for SuspiciousImpl {
                 expr,
                 binop.node,
                 &[
-                    "Add", "Sub", "Mul", "Div", "Rem", "BitAnd", "BitOr", "BitXor", "Shl", "Shr"
+                    "Add", "Sub", "Mul", "Div", "Rem", "BitAnd", "BitOr", "BitXor", "Shl", "Shr",
                 ],
                 &[
                     hir::BinOpKind::Add,

--- a/clippy_lints/src/suspicious_trait_impl.rs
+++ b/clippy_lints/src/suspicious_trait_impl.rs
@@ -86,7 +86,9 @@ impl<'tcx> LateLintPass<'tcx> for SuspiciousImpl {
                 cx,
                 expr,
                 binop.node,
-                &["Add", "Sub", "Mul", "Div", "Rem", "BitAnd", "BitOr", "BitXor", "Shl", "Shr"],
+                &[
+                    "Add", "Sub", "Mul", "Div", "Rem", "BitAnd", "BitOr", "BitXor", "Shl", "Shr"
+                ],
                 &[
                     hir::BinOpKind::Add,
                     hir::BinOpKind::Sub,

--- a/tests/ui/suspicious_arithmetic_impl.rs
+++ b/tests/ui/suspicious_arithmetic_impl.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::suspicious_arithmetic_impl)]
-use std::ops::{Add, AddAssign, BitOrAssign, Div, DivAssign, Mul, MulAssign, Sub};
+use std::ops::{
+    Add, AddAssign, BitAnd, BitOr, BitOrAssign, BitXor, Div, DivAssign, Mul, MulAssign, Rem, Shl, Shr, Sub,
+};
 
 #[derive(Copy, Clone)]
 struct Foo(u32);
@@ -58,6 +60,54 @@ impl Div for Foo {
 
     fn div(self, other: Self) -> Self {
         Foo(do_nothing(self.0 + other.0) / 42) // OK: BinOpKind::Add part of BiExpr as child node
+    }
+}
+
+impl Rem for Foo {
+    type Output = Foo;
+
+    fn rem(self, other: Self) -> Self {
+        Foo(self.0 / other.0)
+    }
+}
+
+impl BitAnd for Foo {
+    type Output = Foo;
+
+    fn bitand(self, other: Self) -> Self {
+        Foo(self.0 | other.0)
+    }
+}
+
+impl BitOr for Foo {
+    type Output = Foo;
+
+    fn bitor(self, other: Self) -> Self {
+        Foo(self.0 ^ other.0)
+    }
+}
+
+impl BitXor for Foo {
+    type Output = Foo;
+
+    fn bitxor(self, other: Self) -> Self {
+        Foo(self.0 & other.0)
+    }
+}
+
+impl Shl for Foo {
+    type Output = Foo;
+
+    fn shl(self, other: Self) -> Self {
+        Foo(self.0 >> other.0)
+    }
+}
+
+impl Shr for Foo {
+    type Output = Foo;
+
+    fn shr(self, other: Self) -> Self {
+        Foo(self.0 << other.0)
     }
 }
 

--- a/tests/ui/suspicious_arithmetic_impl.stderr
+++ b/tests/ui/suspicious_arithmetic_impl.stderr
@@ -1,5 +1,5 @@
 error: suspicious use of binary operator in `Add` impl
-  --> $DIR/suspicious_arithmetic_impl.rs:11:20
+  --> $DIR/suspicious_arithmetic_impl.rs:13:20
    |
 LL |         Foo(self.0 - other.0)
    |                    ^
@@ -7,7 +7,7 @@ LL |         Foo(self.0 - other.0)
    = note: `-D clippy::suspicious-arithmetic-impl` implied by `-D warnings`
 
 error: suspicious use of binary operator in `AddAssign` impl
-  --> $DIR/suspicious_arithmetic_impl.rs:17:23
+  --> $DIR/suspicious_arithmetic_impl.rs:19:23
    |
 LL |         *self = *self - other;
    |                       ^
@@ -15,10 +15,46 @@ LL |         *self = *self - other;
    = note: `#[deny(clippy::suspicious_op_assign_impl)]` on by default
 
 error: suspicious use of binary operator in `MulAssign` impl
-  --> $DIR/suspicious_arithmetic_impl.rs:30:16
+  --> $DIR/suspicious_arithmetic_impl.rs:32:16
    |
 LL |         self.0 /= other.0;
    |                ^^
 
-error: aborting due to 3 previous errors
+error: suspicious use of binary operator in `Rem` impl
+  --> $DIR/suspicious_arithmetic_impl.rs:70:20
+   |
+LL |         Foo(self.0 / other.0)
+   |                    ^
+
+error: suspicious use of binary operator in `BitAnd` impl
+  --> $DIR/suspicious_arithmetic_impl.rs:78:20
+   |
+LL |         Foo(self.0 | other.0)
+   |                    ^
+
+error: suspicious use of binary operator in `BitOr` impl
+  --> $DIR/suspicious_arithmetic_impl.rs:86:20
+   |
+LL |         Foo(self.0 ^ other.0)
+   |                    ^
+
+error: suspicious use of binary operator in `BitXor` impl
+  --> $DIR/suspicious_arithmetic_impl.rs:94:20
+   |
+LL |         Foo(self.0 & other.0)
+   |                    ^
+
+error: suspicious use of binary operator in `Shl` impl
+  --> $DIR/suspicious_arithmetic_impl.rs:102:20
+   |
+LL |         Foo(self.0 >> other.0)
+   |                    ^^
+
+error: suspicious use of binary operator in `Shr` impl
+  --> $DIR/suspicious_arithmetic_impl.rs:110:20
+   |
+LL |         Foo(self.0 << other.0)
+   |                    ^^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
In #2268 I idly mused that the other user-overloadable operations could be added to this lint. Knowing that the lint was arguably incomplete was gnawing at the back of my mind, so I figured that I might as well make this PR, particularly given the change needed was so small.

changelog: Start warning on suspicious implementations of the `BitAnd`, `BitOr`, `BitXor`, `Rem`, `Shl`, and `Shr` traits.
