### PR TITLE
Avoid or_fun_call for const_fn with no args

### DIFF
--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -116,4 +116,12 @@ fn f() -> Option<()> {
     Some(())
 }
 
+// Issue 5886 - const fn (with no arguments)
+pub fn skip_const_fn_with_no_args() {
+    const fn foo() -> Option<i32> {
+        Some(42)
+    }
+    let _ = None.or(foo());
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -116,4 +116,12 @@ fn f() -> Option<()> {
     Some(())
 }
 
+// Issue 5886 - const fn (with no arguments)
+pub fn skip_const_fn_with_no_args() {
+    const fn foo() -> Option<i32> {
+        Some(42)
+    }
+    let _ = None.or(foo());
+}
+
 fn main() {}


### PR DESCRIPTION
Based on #5682 by @lzutao 

This avoids a subset of false positives, specifically those related to `const fn`s that take no arguments. 
For the rest, a much more involved fix would be needed, see https://github.com/rust-lang/rust-clippy/pull/5682#issuecomment-638681210. 

So this does *not* solve #5658 

changelog: Avoid triggering [`or_fun_call`] with `const fn`s that take no arguments. 

Fixes #5886 