### PR TITLE
unnecessary-mut-passed: make lint message say if fn is a function or a method

### DIFF
--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -39,6 +39,7 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryMutPassed {
                         arguments,
                         cx.typeck_results().expr_ty(fn_expr),
                         &rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_qpath(path, false)),
+                        "function",
                     );
                 }
             },
@@ -46,14 +47,20 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryMutPassed {
                 let def_id = cx.typeck_results().type_dependent_def_id(e.hir_id).unwrap();
                 let substs = cx.typeck_results().node_substs(e.hir_id);
                 let method_type = cx.tcx.type_of(def_id).subst(cx.tcx, substs);
-                check_arguments(cx, arguments, method_type, &path.ident.as_str())
+                check_arguments(cx, arguments, method_type, &path.ident.as_str(), "method")
             },
             _ => (),
         }
     }
 }
 
-fn check_arguments<'tcx>(cx: &LateContext<'tcx>, arguments: &[Expr<'_>], type_definition: Ty<'tcx>, name: &str) {
+fn check_arguments<'tcx>(
+    cx: &LateContext<'tcx>,
+    arguments: &[Expr<'_>],
+    type_definition: Ty<'tcx>,
+    name: &str,
+    fn_kind: &str,
+) {
     match type_definition.kind {
         ty::FnDef(..) | ty::FnPtr(_) => {
             let parameters = type_definition.fn_sig(cx.tcx).skip_binder().inputs();
@@ -68,7 +75,7 @@ fn check_arguments<'tcx>(cx: &LateContext<'tcx>, arguments: &[Expr<'_>], type_de
                                 cx,
                                 UNNECESSARY_MUT_PASSED,
                                 argument.span,
-                                &format!("The function/method `{}` doesn't need a mutable reference", name),
+                                &format!("the {} `{}` doesn't need a mutable reference", fn_kind, name),
                             );
                         }
                     },

--- a/tests/ui/mut_reference.stderr
+++ b/tests/ui/mut_reference.stderr
@@ -1,4 +1,4 @@
-error: The function/method `takes_an_immutable_reference` doesn't need a mutable reference
+error: the function `takes_an_immutable_reference` doesn't need a mutable reference
   --> $DIR/mut_reference.rs:17:34
    |
 LL |     takes_an_immutable_reference(&mut 42);
@@ -6,13 +6,13 @@ LL |     takes_an_immutable_reference(&mut 42);
    |
    = note: `-D clippy::unnecessary-mut-passed` implied by `-D warnings`
 
-error: The function/method `as_ptr` doesn't need a mutable reference
+error: the function `as_ptr` doesn't need a mutable reference
   --> $DIR/mut_reference.rs:19:12
    |
 LL |     as_ptr(&mut 42);
    |            ^^^^^^^
 
-error: The function/method `takes_an_immutable_reference` doesn't need a mutable reference
+error: the method `takes_an_immutable_reference` doesn't need a mutable reference
   --> $DIR/mut_reference.rs:23:44
    |
 LL |     my_struct.takes_an_immutable_reference(&mut 42);


### PR DESCRIPTION
changelog: refine "unnecessary-mut-passed" lint message
