### PR TITLE
Change Rc<Box<T>> recommendation to be Rc<T> instead of Box<T>

### DIFF
--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -353,14 +353,25 @@ impl Types {
                             );
                             return; // don't recurse into the type
                         }
-                        if let Some(span) = match_type_parameter(cx, qpath, &paths::BOX) {
+                        if match_type_parameter(cx, qpath, &paths::BOX).is_some() {
+                            let box_ty = match &last_path_segment(qpath).args.unwrap().args[0] {
+                                GenericArg::Type(ty) => match &ty.kind {
+                                    TyKind::Path(qpath) => qpath,
+                                    _ => panic!("Box that isn't a type"),
+                                },
+                                _ => panic!("Rc without type argument"),
+                            };
+                            let inner_span = match &last_path_segment(&box_ty).args.unwrap().args[0] {
+                                GenericArg::Type(ty) => ty.span,
+                                _ => panic!("Box without type argument"),
+                            };
                             span_lint_and_sugg(
                                 cx,
                                 REDUNDANT_ALLOCATION,
                                 hir_ty.span,
                                 "usage of `Rc<Box<T>>`",
                                 "try",
-                                snippet(cx, span, "..").to_string(),
+                                format!("Rc<{}>", snippet(cx, inner_span, "..")),
                                 Applicability::MachineApplicable,
                             );
                             return; // don't recurse into the type

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -357,13 +357,13 @@ impl Types {
                             let box_ty = match &last_path_segment(qpath).args.unwrap().args[0] {
                                 GenericArg::Type(ty) => match &ty.kind {
                                     TyKind::Path(qpath) => qpath,
-                                    _ => panic!("Box that isn't a type"),
+                                    _ => return,
                                 },
-                                _ => panic!("Rc without type argument"),
+                                _ => return,
                             };
                             let inner_span = match &last_path_segment(&box_ty).args.unwrap().args[0] {
                                 GenericArg::Type(ty) => ty.span,
-                                _ => panic!("Box without type argument"),
+                                _ => return,
                             };
                             span_lint_and_sugg(
                                 cx,

--- a/tests/ui/redundant_allocation.fixed
+++ b/tests/ui/redundant_allocation.fixed
@@ -33,7 +33,7 @@ pub fn test5(a: Rc<bool>) {}
 
 // Rc<Box<T>>
 
-pub fn test6(a: Box<bool>) {}
+pub fn test6(a: Rc<bool>) {}
 
 // Box<&T>
 

--- a/tests/ui/redundant_allocation.stderr
+++ b/tests/ui/redundant_allocation.stderr
@@ -28,7 +28,7 @@ error: usage of `Rc<Box<T>>`
   --> $DIR/redundant_allocation.rs:36:17
    |
 LL | pub fn test6(a: Rc<Box<bool>>) {}
-   |                 ^^^^^^^^^^^^^ help: try: `Box<bool>`
+   |                 ^^^^^^^^^^^^^ help: try: `Rc<bool>`
 
 error: usage of `Box<&T>`
   --> $DIR/redundant_allocation.rs:40:22


### PR DESCRIPTION
Fixes #5722

changelog: Suggest `Rc<Box<T>>` -> `Rc<T>` in [`redundant_allocation`] lint