### PR TITLE
Fix: keep parenthesis for suggestion in `useless_conversion` lint

### DIFF
--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -1,3 +1,4 @@
+use crate::utils::sugg::Sugg;
 use crate::utils::{
     get_parent_expr, is_type_diagnostic_item, match_def_path, match_trait_method, paths, snippet,
     snippet_with_macro_callsite, span_lint_and_help, span_lint_and_sugg,
@@ -158,7 +159,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                             if TyS::same_type(a, b);
 
                             then {
-                                let sugg = snippet(cx, args[0].span.source_callsite(), "<expr>").into_owned();
+                                let sugg = Sugg::hir_with_macro_callsite(cx, &args[0], "<expr>").maybe_par();
                                 let sugg_msg =
                                     format!("consider removing `{}()`", snippet(cx, path.span, "From::from"));
                                 span_lint_and_sugg(
@@ -167,7 +168,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                                     e.span,
                                     "useless conversion to the same type",
                                     &sugg_msg,
-                                    sugg,
+                                    sugg.to_string(),
                                     Applicability::MachineApplicable, // snippet
                                 );
                             }

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -64,4 +64,9 @@ fn main() {
     let _ = "".lines();
     let _ = vec![1, 2, 3].into_iter();
     let _: String = format!("Hello {}", "world");
+
+    // keep parenthesis around `a + b` for suggestion (see #4750)
+    let a: i32 = 1;
+    let b: i32 = 1;
+    let _ = (a + b) * 3;
 }

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -64,4 +64,9 @@ fn main() {
     let _ = "".lines().into_iter();
     let _ = vec![1, 2, 3].into_iter().into_iter();
     let _: String = format!("Hello {}", "world").into();
+
+    // keep parenthesis around `a + b` for suggestion (see #4750)
+    let a: i32 = 1;
+    let b: i32 = 1;
+    let _ = i32::from(a + b) * 3;
 }

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -64,5 +64,11 @@ error: useless conversion to the same type
 LL |     let _: String = format!("Hello {}", "world").into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `format!("Hello {}", "world")`
 
-error: aborting due to 10 previous errors
+error: useless conversion to the same type
+  --> $DIR/useless_conversion.rs:71:13
+   |
+LL |     let _ = i32::from(a + b) * 3;
+   |             ^^^^^^^^^^^^^^^^ help: consider removing `i32::from()`: `(a + b)`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Note: this lint was previously named `identity_conversion`.

fixes: #4750

changelog: fix parenthesis for `useless_conversion` lint suggestion
