### PR TITLE
Add reference to rustc-dev-guide about lint message

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -295,8 +295,14 @@ impl EarlyLintPass for FooFunctions {
 
 Running our UI test should now produce output that contains the lint message.
 
+According to [the rustc-dev-guide], the text should be matter of fact and avoid
+capitalization and periods, unless multiple sentences are needed.
+When code or an identifier must appear in a message or label, it should be
+surrounded with single acute accents \`.
+
 [check_fn]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/trait.EarlyLintPass.html#method.check_fn
 [diagnostics]: https://github.com/rust-lang/rust-clippy/blob/master/clippy_lints/src/utils/diagnostics.rs
+[the rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/diagnostics.html
 
 ## Adding the lint logic
 


### PR DESCRIPTION
I think it would be better to add lint message convention to documentation. I referred to https://github.com/rust-lang/rust-clippy/pull/5888 and https://github.com/rust-lang/rust-clippy/pull/5893.

changelog: none
