### PR TITLE
appreciative too_large_for_stack in useless `vec!`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -930,11 +930,11 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(move || box cognitive_complexity::CognitiveComplexity::new(cognitive_complexity_threshold));
     let too_large_for_stack = conf.too_large_for_stack;
     store.register_late_pass(move || box escape::BoxedLocal{too_large_for_stack});
+    store.register_late_pass(move || box vec::UselessVec{too_large_for_stack});
     store.register_late_pass(|| box panic_unimplemented::PanicUnimplemented);
     store.register_late_pass(|| box strings::StringLitAsBytes);
     store.register_late_pass(|| box derive::Derive);
     store.register_late_pass(|| box types::CharLitAsU8);
-    store.register_late_pass(|| box vec::UselessVec);
     store.register_late_pass(|| box drop_bounds::DropBounds);
     store.register_late_pass(|| box get_last_with_len::GetLastWithLen);
     store.register_late_pass(|| box drop_forget_ref::DropForgetRef);

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -138,7 +138,7 @@ define_Conf! {
     (type_complexity_threshold, "type_complexity_threshold": u64, 250),
     /// Lint: MANY_SINGLE_CHAR_NAMES. The maximum number of single char bindings a scope may have
     (single_char_binding_names_threshold, "single_char_binding_names_threshold": u64, 4),
-    /// Lint: BOXED_LOCAL. The maximum size of objects (in bytes) that will be linted. Larger objects are ok on the heap
+    /// Lint: BOXED_LOCAL, USELESS_VEC. The maximum size of objects (in bytes) that will be linted. Larger objects are ok on the heap
     (too_large_for_stack, "too_large_for_stack": u64, 200),
     /// Lint: ENUM_VARIANT_NAMES. The minimum number of enum variants for the lints about variant names to trigger
     (enum_variant_name_threshold, "enum_variant_name_threshold": u64, 3),

--- a/tests/ui/vec.fixed
+++ b/tests/ui/vec.fixed
@@ -52,4 +52,11 @@ fn main() {
     for a in vec![NonCopy, NonCopy] {
         println!("{:?}", a);
     }
+
+    on_vec(&vec![1; 201]); // Ok, size of `vec` higher than `too_large_for_stack`
+
+    // Ok
+    for a in vec![1; 201] {
+        println!("{:?}", a);
+    }
 }

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -52,4 +52,11 @@ fn main() {
     for a in vec![NonCopy, NonCopy] {
         println!("{:?}", a);
     }
+
+    on_vec(&vec![1; 201]); // Ok, size of `vec` higher than `too_large_for_stack`
+
+    // Ok
+    for a in vec![1; 201] {
+        println!("{:?}", a);
+    }
 }


### PR DESCRIPTION
Fixes: #5847 
changelog: Add `too_large_for_stack ` configuration option for `USELESS_VEC`
