### PR TITLE
Rustup

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -224,7 +224,7 @@ fn check_hash_peq<'tcx>(
                         mess,
                         |diag| {
                             if let Some(local_def_id) = impl_id.as_local() {
-                                let hir_id = cx.tcx.hir().as_local_hir_id(local_def_id);
+                                let hir_id = cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
                                 diag.span_note(
                                     cx.tcx.hir().span(hir_id),
                                     "`PartialEq` implemented here"
@@ -278,7 +278,7 @@ fn check_ord_partial_ord<'tcx>(
                         mess,
                         |diag| {
                             if let Some(local_def_id) = impl_id.as_local() {
-                                let hir_id = cx.tcx.hir().as_local_hir_id(local_def_id);
+                                let hir_id = cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
                                 diag.span_note(
                                     cx.tcx.hir().span(hir_id),
                                     "`PartialOrd` implemented here"
@@ -341,7 +341,7 @@ fn check_unsafe_derive_deserialize<'tcx>(
     ty: Ty<'tcx>,
 ) {
     fn item_from_def_id<'tcx>(cx: &LateContext<'tcx>, def_id: DefId) -> &'tcx Item<'tcx> {
-        let hir_id = cx.tcx.hir().as_local_hir_id(def_id.expect_local());
+        let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def_id.expect_local());
         cx.tcx.hir().expect_item(hir_id)
     }
 
@@ -355,7 +355,7 @@ fn check_unsafe_derive_deserialize<'tcx>(
         if match_path(&trait_ref.path, &paths::SERDE_DESERIALIZE);
         if let ty::Adt(def, _) = ty.kind;
         if let Some(local_def_id) = def.did.as_local();
-        let adt_hir_id = cx.tcx.hir().as_local_hir_id(local_def_id);
+        let adt_hir_id = cx.tcx.hir().local_def_id_to_hir_id(local_def_id);
         if !is_allowed(cx, UNSAFE_DERIVE_DESERIALIZE, adt_hir_id);
         if cx.tcx.inherent_impls(def.did)
             .iter()

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -103,7 +103,7 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                                         cx.tcx.for_each_impl(default_trait_id, |d| {
                                             if let Some(ty_def) = cx.tcx.type_of(d).ty_adt_def() {
                                                 if let Some(local_def_id) = ty_def.did.as_local() {
-                                                    impls.insert(cx.tcx.hir().as_local_hir_id(local_def_id));
+                                                    impls.insert(cx.tcx.hir().local_def_id_to_hir_id(local_def_id));
                                                 }
                                             }
                                         });


### PR DESCRIPTION
r? @ghost

changelog: none
