### PR TITLE
deps: bump cargo_metadata and semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ path = "src/driver.rs"
 # begin automatic update
 clippy_lints = { version = "0.0.212", path = "clippy_lints" }
 # end automatic update
-semver = "0.9"
+semver = "0.10"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 tempfile = { version = "3.1.0", optional = true }
 lazy_static = "1.0"
 
 [dev-dependencies]
-cargo_metadata = "0.9.1"
+cargo_metadata = "0.11.1"
 compiletest_rs = { version = "0.5.0", features = ["tmp"] }
 tester = "0.7"
 lazy_static = "1.0"

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.9.1"
+cargo_metadata = "0.11.1"
 if_chain = "1.0.0"
 itertools = "0.9"
 lazy_static = "1.0.2"
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 smallvec = { version = "1", features = ["union"] }
 toml = "0.5.3"
 unicode-normalization = "0.1"
-semver = "0.9.0"
+semver = "0.10.0"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
 url = { version =  "2.1.0", features = ["serde"] }


### PR DESCRIPTION
cargo_metadata 0.9.1 -> 0.11.1
semver 0.9.0 -> 0.10.0

changelog: none
