### PR TITLE
Improve lint message in `to_string_in_display`

### DIFF
--- a/clippy_lints/src/to_string_in_display.rs
+++ b/clippy_lints/src/to_string_in_display.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// ```
     pub TO_STRING_IN_DISPLAY,
     correctness,
-    "to_string method used while implementing Display trait"
+    "`to_string` method used while implementing `Display` trait"
 }
 
 #[derive(Default)]
@@ -80,7 +80,7 @@ impl LateLintPass<'_> for ToStringInDisplay {
                     cx,
                     TO_STRING_IN_DISPLAY,
                     expr.span,
-                    "Using to_string in fmt::Display implementation might lead to infinite recursion",
+                    "using `to_string` in `fmt::Display` implementation might lead to infinite recursion",
                 );
             }
         }

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -2183,7 +2183,7 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
     Lint {
         name: "to_string_in_display",
         group: "correctness",
-        desc: "to_string method used while implementing Display trait",
+        desc: "`to_string` method used while implementing `Display` trait",
         deprecation: None,
         module: "to_string_in_display",
     },

--- a/tests/ui/to_string_in_display.stderr
+++ b/tests/ui/to_string_in_display.stderr
@@ -1,4 +1,4 @@
-error: Using to_string in fmt::Display implementation might lead to infinite recursion
+error: using `to_string` in `fmt::Display` implementation might lead to infinite recursion
   --> $DIR/to_string_in_display.rs:25:25
    |
 LL |         write!(f, "{}", self.to_string())


### PR DESCRIPTION
This is a follow-up of https://github.com/rust-lang/rust-clippy/pull/5831.

changelog: none
