### PR TITLE
stable_sort_primitive: print the type that is being sorted in the lint message

### DIFF
--- a/clippy_lints/src/stable_sort_primitive.rs
+++ b/clippy_lints/src/stable_sort_primitive.rs
@@ -86,6 +86,7 @@ struct LintDetection {
     slice_name: String,
     method: SortingKind,
     method_args: String,
+    slice_type: String,
 }
 
 fn detect_stable_sort_primitive(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<LintDetection> {
@@ -93,10 +94,10 @@ fn detect_stable_sort_primitive(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option
         if let ExprKind::MethodCall(method_name, _, args, _) = &expr.kind;
         if let Some(slice) = &args.get(0);
         if let Some(method) = SortingKind::from_stable_name(&method_name.ident.name.as_str());
-        if is_slice_of_primitives(cx, slice);
+        if let Some(slice_type) = is_slice_of_primitives(cx, slice);
         then {
             let args_str = args.iter().skip(1).map(|arg| Sugg::hir(cx, arg, "..").to_string()).collect::<Vec<String>>().join(", ");
-            Some(LintDetection { slice_name: Sugg::hir(cx, slice, "..").to_string(), method, method_args: args_str })
+            Some(LintDetection { slice_name: Sugg::hir(cx, slice, "..").to_string(), method, method_args: args_str, slice_type })
         } else {
             None
         }
@@ -111,9 +112,10 @@ impl LateLintPass<'_> for StableSortPrimitive {
                 STABLE_SORT_PRIMITIVE,
                 expr.span,
                 format!(
-                    "used {} instead of {}",
+                    "used {} instead of {} to sort primitive type `{}`",
                     detection.method.stable_name(),
-                    detection.method.unstable_name()
+                    detection.method.unstable_name(),
+                    detection.slice_type,
                 )
                 .as_str(),
                 "try",

--- a/tests/ui/stable_sort_primitive.stderr
+++ b/tests/ui/stable_sort_primitive.stderr
@@ -1,4 +1,4 @@
-error: used sort instead of sort_unstable
+error: used sort instead of sort_unstable to sort primitive type `i32`
   --> $DIR/stable_sort_primitive.rs:7:5
    |
 LL |     vec.sort();
@@ -6,37 +6,37 @@ LL |     vec.sort();
    |
    = note: `-D clippy::stable-sort-primitive` implied by `-D warnings`
 
-error: used sort instead of sort_unstable
+error: used sort instead of sort_unstable to sort primitive type `bool`
   --> $DIR/stable_sort_primitive.rs:9:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
 
-error: used sort instead of sort_unstable
+error: used sort instead of sort_unstable to sort primitive type `char`
   --> $DIR/stable_sort_primitive.rs:11:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
 
-error: used sort instead of sort_unstable
+error: used sort instead of sort_unstable to sort primitive type `str`
   --> $DIR/stable_sort_primitive.rs:13:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
 
-error: used sort instead of sort_unstable
+error: used sort instead of sort_unstable to sort primitive type `tuple`
   --> $DIR/stable_sort_primitive.rs:15:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
 
-error: used sort instead of sort_unstable
+error: used sort instead of sort_unstable to sort primitive type `array`
   --> $DIR/stable_sort_primitive.rs:17:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
 
-error: used sort instead of sort_unstable
+error: used sort instead of sort_unstable to sort primitive type `i32`
   --> $DIR/stable_sort_primitive.rs:19:5
    |
 LL |     arr.sort();


### PR DESCRIPTION
changelog: stable_sort_primitive: print the type that is being sorted in the lint message
