### PR TITLE
Fix `let_and_return` bad suggestion

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -99,7 +99,10 @@ impl<'tcx> LateLintPass<'tcx> for Return {
                     |err| {
                         err.span_label(local.span, "unnecessary `let` binding");
 
-                        if let Some(snippet) = snippet_opt(cx, initexpr.span) {
+                        if let Some(mut snippet) = snippet_opt(cx, initexpr.span) {
+                            if !cx.typeck_results().expr_adjustments(&retexpr).is_empty() {
+                                snippet.push_str(" as _");
+                            }
                             err.multipart_suggestion(
                                 "return the expression directly",
                                 vec![

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -135,4 +135,25 @@ mod no_lint_if_stmt_borrows {
     }
 }
 
+mod issue_5729 {
+    use std::sync::Arc;
+
+    trait Foo {}
+
+    trait FooStorage {
+        fn foo_cloned(&self) -> Arc<dyn Foo>;
+    }
+
+    struct FooStorageImpl<T: Foo> {
+        foo: Arc<T>,
+    }
+
+    impl<T: Foo + 'static> FooStorage for FooStorageImpl<T> {
+        fn foo_cloned(&self) -> Arc<dyn Foo> {
+            let clone = Arc::clone(&self.foo);
+            clone
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.stderr
+++ b/tests/ui/let_and_return.stderr
@@ -27,5 +27,19 @@ LL |
 LL |         5
    |
 
-error: aborting due to 2 previous errors
+error: returning the result of a `let` binding from a block
+  --> $DIR/let_and_return.rs:154:13
+   |
+LL |             let clone = Arc::clone(&self.foo);
+   |             ---------------------------------- unnecessary `let` binding
+LL |             clone
+   |             ^^^^^
+   |
+help: return the expression directly
+   |
+LL |             
+LL |             Arc::clone(&self.foo) as _
+   |
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Add a cast to the suggestion when the return expression has adjustments.
These adjustments are lost when the suggestion is applied.

This is similar to the problem in issue #4437.

Closes #5729

changelog: Fix `let_and_return` bad suggestion
