### PR TITLE
Rustup

### DIFF
--- a/tests/ui/len_zero_ranges.fixed
+++ b/tests/ui/len_zero_ranges.fixed
@@ -3,6 +3,7 @@
 #![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
+#![allow(stable_features)] // TODO: https://github.com/rust-lang/rust-clippy/issues/5956
 
 mod issue_3807 {
     // With the feature enabled, `is_empty` should be suggested

--- a/tests/ui/len_zero_ranges.rs
+++ b/tests/ui/len_zero_ranges.rs
@@ -3,6 +3,7 @@
 #![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
+#![allow(stable_features)] // TODO: https://github.com/rust-lang/rust-clippy/issues/5956
 
 mod issue_3807 {
     // With the feature enabled, `is_empty` should be suggested

--- a/tests/ui/len_zero_ranges.stderr
+++ b/tests/ui/len_zero_ranges.stderr
@@ -1,5 +1,5 @@
 error: length comparison to zero
-  --> $DIR/len_zero_ranges.rs:10:17
+  --> $DIR/len_zero_ranges.rs:11:17
    |
 LL |         let _ = (0..42).len() == 0;
    |                 ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `(0..42).is_empty()`


### PR DESCRIPTION
r? @ghost

changelog: none
