### PR TITLE
Re-enable len_zero for ranges now that `is_empty` is stable on them

### DIFF
--- a/tests/ui/len_zero.fixed
+++ b/tests/ui/len_zero.fixed
@@ -141,11 +141,3 @@ fn main() {
 fn test_slice(b: &[u8]) {
     if !b.is_empty() {}
 }
-
-mod issue_3807 {
-    // Avoid suggesting changes to ranges if the user did not enable `range_is_empty`.
-    // See https://github.com/rust-lang/rust/issues/48111#issuecomment-445132965
-    fn no_suggestion() {
-        let _ = (0..42).len() == 0;
-    }
-}

--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -141,11 +141,3 @@ fn main() {
 fn test_slice(b: &[u8]) {
     if b.len() != 0 {}
 }
-
-mod issue_3807 {
-    // Avoid suggesting changes to ranges if the user did not enable `range_is_empty`.
-    // See https://github.com/rust-lang/rust/issues/48111#issuecomment-445132965
-    fn no_suggestion() {
-        let _ = (0..42).len() == 0;
-    }
-}

--- a/tests/ui/len_zero_ranges.fixed
+++ b/tests/ui/len_zero_ranges.fixed
@@ -1,14 +1,16 @@
 // run-rustfix
 
-#![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
-#![allow(stable_features)] // TODO: https://github.com/rust-lang/rust-clippy/issues/5956
 
+// Now that `Range(Inclusive)::is_empty` is stable (1.47), we can always suggest this
 mod issue_3807 {
-    // With the feature enabled, `is_empty` should be suggested
-    fn suggestion_is_fine() {
+    fn suggestion_is_fine_range() {
         let _ = (0..42).is_empty();
+    }
+
+    fn suggestion_is_fine_range_inclusive() {
+        let _ = (0_u8..=42).is_empty();
     }
 }
 

--- a/tests/ui/len_zero_ranges.rs
+++ b/tests/ui/len_zero_ranges.rs
@@ -1,14 +1,16 @@
 // run-rustfix
 
-#![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
-#![allow(stable_features)] // TODO: https://github.com/rust-lang/rust-clippy/issues/5956
 
+// Now that `Range(Inclusive)::is_empty` is stable (1.47), we can always suggest this
 mod issue_3807 {
-    // With the feature enabled, `is_empty` should be suggested
-    fn suggestion_is_fine() {
+    fn suggestion_is_fine_range() {
         let _ = (0..42).len() == 0;
+    }
+
+    fn suggestion_is_fine_range_inclusive() {
+        let _ = (0_u8..=42).len() == 0;
     }
 }
 

--- a/tests/ui/len_zero_ranges.stderr
+++ b/tests/ui/len_zero_ranges.stderr
@@ -1,10 +1,16 @@
 error: length comparison to zero
-  --> $DIR/len_zero_ranges.rs:11:17
+  --> $DIR/len_zero_ranges.rs:9:17
    |
 LL |         let _ = (0..42).len() == 0;
    |                 ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `(0..42).is_empty()`
    |
    = note: `-D clippy::len-zero` implied by `-D warnings`
 
-error: aborting due to previous error
+error: length comparison to zero
+  --> $DIR/len_zero_ranges.rs:13:17
+   |
+LL |         let _ = (0_u8..=42).len() == 0;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `(0_u8..=42).is_empty()`
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #5956

Completed stabilization PR: https://github.com/rust-lang/rust/pull/75132

changelog: len_zero: re-enable linting ranges now that range_is_empty is stable
