### PR TITLE
Corrects the float_equality_without_abs lint

### DIFF
--- a/tests/ui/float_equality_without_abs.stderr
+++ b/tests/ui/float_equality_without_abs.stderr
@@ -2,7 +2,9 @@ error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:4:5
    |
 LL |     (a - b) < f32::EPSILON
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a - b).abs()`
+   |     -------^^^^^^^^^^^^^^^
+   |     |
+   |     help: add `.abs()`: `(a - b).abs()`
    |
    = note: `-D clippy::float-equality-without-abs` implied by `-D warnings`
 
@@ -10,61 +12,81 @@ error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:13:13
    |
 LL |     let _ = (a - b) < f32::EPSILON;
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a - b).abs()`
+   |             -------^^^^^^^^^^^^^^^
+   |             |
+   |             help: add `.abs()`: `(a - b).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:14:13
    |
 LL |     let _ = a - b < f32::EPSILON;
-   |             ^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a - b).abs()`
+   |             -----^^^^^^^^^^^^^^^
+   |             |
+   |             help: add `.abs()`: `(a - b).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:15:13
    |
 LL |     let _ = a - b.abs() < f32::EPSILON;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a - b.abs()).abs()`
+   |             -----------^^^^^^^^^^^^^^^
+   |             |
+   |             help: add `.abs()`: `(a - b.abs()).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:16:13
    |
 LL |     let _ = (a as f64 - b as f64) < f64::EPSILON;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a as f64 - b as f64).abs()`
+   |             ---------------------^^^^^^^^^^^^^^^
+   |             |
+   |             help: add `.abs()`: `(a as f64 - b as f64).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:17:13
    |
 LL |     let _ = 1.0 - 2.0 < f32::EPSILON;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(1.0 - 2.0).abs()`
+   |             ---------^^^^^^^^^^^^^^^
+   |             |
+   |             help: add `.abs()`: `(1.0 - 2.0).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:19:13
    |
 LL |     let _ = f32::EPSILON > (a - b);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a - b).abs()`
+   |             ^^^^^^^^^^^^^^^-------
+   |                            |
+   |                            help: add `.abs()`: `(a - b).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:20:13
    |
 LL |     let _ = f32::EPSILON > a - b;
-   |             ^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a - b).abs()`
+   |             ^^^^^^^^^^^^^^^-----
+   |                            |
+   |                            help: add `.abs()`: `(a - b).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:21:13
    |
 LL |     let _ = f32::EPSILON > a - b.abs();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a - b.abs()).abs()`
+   |             ^^^^^^^^^^^^^^^-----------
+   |                            |
+   |                            help: add `.abs()`: `(a - b.abs()).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:22:13
    |
 LL |     let _ = f64::EPSILON > (a as f64 - b as f64);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(a as f64 - b as f64).abs()`
+   |             ^^^^^^^^^^^^^^^---------------------
+   |                            |
+   |                            help: add `.abs()`: `(a as f64 - b as f64).abs()`
 
 error: float equality check without `.abs()`
   --> $DIR/float_equality_without_abs.rs:23:13
    |
 LL |     let _ = f32::EPSILON > 1.0 - 2.0;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: add `.abs()`: `(1.0 - 2.0).abs()`
+   |             ^^^^^^^^^^^^^^^---------
+   |                            |
+   |                            help: add `.abs()`: `(1.0 - 2.0).abs()`
 
 error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes an issue in the `float_equality_without_abs` lint. The lint suggestion was configured in a way that it lints the whole error and not just the subtraction part. In the current configuration the lint would suggest to change the expression in a wrong way, e.g.
```rust
let _ = (a - b) < f32::EPSILON; // before
let _ = (a - b).abs(); // after
```
This was dicovered by @flip1995. (See discussion of PR #5952).

Also the suggestion is now formatted via `utils::sugg`.
changelog: none
