### PR TITLE
[beta] Backport: Re-enable len_zero for ranges now that `is_empty` is stable on them

### DIFF
--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -1,4 +1,4 @@
-use crate::utils::{get_item_name, higher, snippet_with_applicability, span_lint, span_lint_and_sugg, walk_ptrs_ty};
+use crate::utils::{get_item_name, snippet_with_applicability, span_lint, span_lint_and_sugg, walk_ptrs_ty};
 use rustc_ast::ast::LitKind;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
@@ -260,17 +260,6 @@ fn check_len(
 
 /// Checks if this type has an `is_empty` method.
 fn has_is_empty(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    /// Special case ranges until `range_is_empty` is stabilized. See issue 3807.
-    fn should_skip_range(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-        higher::range(cx, expr).map_or(false, |_| {
-            !cx.tcx
-                .features()
-                .declared_lib_features
-                .iter()
-                .any(|(name, _)| name.as_str() == "range_is_empty")
-        })
-    }
-
     /// Gets an `AssocItem` and return true if it matches `is_empty(self)`.
     fn is_is_empty(cx: &LateContext<'_>, item: &ty::AssocItem) -> bool {
         if let ty::AssocKind::Fn = item.kind {
@@ -294,10 +283,6 @@ fn has_is_empty(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
                 .in_definition_order()
                 .any(|item| is_is_empty(cx, &item))
         })
-    }
-
-    if should_skip_range(cx, expr) {
-        return false;
     }
 
     let ty = &walk_ptrs_ty(cx.typeck_results().expr_ty(expr));

--- a/tests/ui/len_zero.fixed
+++ b/tests/ui/len_zero.fixed
@@ -141,11 +141,3 @@ fn main() {
 fn test_slice(b: &[u8]) {
     if !b.is_empty() {}
 }
-
-mod issue_3807 {
-    // Avoid suggesting changes to ranges if the user did not enable `range_is_empty`.
-    // See https://github.com/rust-lang/rust/issues/48111#issuecomment-445132965
-    fn no_suggestion() {
-        let _ = (0..42).len() == 0;
-    }
-}

--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -141,11 +141,3 @@ fn main() {
 fn test_slice(b: &[u8]) {
     if b.len() != 0 {}
 }
-
-mod issue_3807 {
-    // Avoid suggesting changes to ranges if the user did not enable `range_is_empty`.
-    // See https://github.com/rust-lang/rust/issues/48111#issuecomment-445132965
-    fn no_suggestion() {
-        let _ = (0..42).len() == 0;
-    }
-}

--- a/tests/ui/len_zero_ranges.fixed
+++ b/tests/ui/len_zero_ranges.fixed
@@ -1,13 +1,16 @@
 // run-rustfix
 
-#![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
 
+// Now that `Range(Inclusive)::is_empty` is stable (1.47), we can always suggest this
 mod issue_3807 {
-    // With the feature enabled, `is_empty` should be suggested
-    fn suggestion_is_fine() {
+    fn suggestion_is_fine_range() {
         let _ = (0..42).is_empty();
+    }
+
+    fn suggestion_is_fine_range_inclusive() {
+        let _ = (0_u8..=42).is_empty();
     }
 }
 

--- a/tests/ui/len_zero_ranges.rs
+++ b/tests/ui/len_zero_ranges.rs
@@ -1,13 +1,16 @@
 // run-rustfix
 
-#![feature(range_is_empty)]
 #![warn(clippy::len_zero)]
 #![allow(unused)]
 
+// Now that `Range(Inclusive)::is_empty` is stable (1.47), we can always suggest this
 mod issue_3807 {
-    // With the feature enabled, `is_empty` should be suggested
-    fn suggestion_is_fine() {
+    fn suggestion_is_fine_range() {
         let _ = (0..42).len() == 0;
+    }
+
+    fn suggestion_is_fine_range_inclusive() {
+        let _ = (0_u8..=42).len() == 0;
     }
 }
 

--- a/tests/ui/len_zero_ranges.stderr
+++ b/tests/ui/len_zero_ranges.stderr
@@ -1,10 +1,16 @@
 error: length comparison to zero
-  --> $DIR/len_zero_ranges.rs:10:17
+  --> $DIR/len_zero_ranges.rs:9:17
    |
 LL |         let _ = (0..42).len() == 0;
    |                 ^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `(0..42).is_empty()`
    |
    = note: `-D clippy::len-zero` implied by `-D warnings`
 
-error: aborting due to previous error
+error: length comparison to zero
+  --> $DIR/len_zero_ranges.rs:13:17
+   |
+LL |         let _ = (0_u8..=42).len() == 0;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `(0_u8..=42).is_empty()`
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Backport #5961 

changelog: none
