### PR TITLE
default_trait_access: Fix wrong suggestion

### DIFF
--- a/clippy_lints/src/default_trait_access.rs
+++ b/clippy_lints/src/default_trait_access.rs
@@ -55,8 +55,8 @@ impl<'tcx> LateLintPass<'tcx> for DefaultTraitAccess {
                         // TODO: Work out a way to put "whatever the imported way of referencing
                         // this type in this file" rather than a fully-qualified type.
                         let expr_ty = cx.typeck_results().expr_ty(expr);
-                        if let ty::Adt(..) = expr_ty.kind {
-                            let replacement = format!("{}::default()", expr_ty);
+                        if let ty::Adt(def, ..) = expr_ty.kind {
+                            let replacement = format!("{}::default()", cx.tcx.def_path_str(def.did));
                             span_lint_and_sugg(
                                 cx,
                                 DEFAULT_TRAIT_ACCESS,

--- a/tests/ui/default_trait_access.fixed
+++ b/tests/ui/default_trait_access.fixed
@@ -8,17 +8,17 @@ use std::default::Default as D2;
 use std::string;
 
 fn main() {
-    let s1: String = Default::default();
+    let s1: String = std::string::String::default();
 
     let s2 = String::default();
 
-    let s3: String = D2::default();
+    let s3: String = std::string::String::default();
 
-    let s4: String = std::default::Default::default();
+    let s4: String = std::string::String::default();
 
     let s5 = string::String::default();
 
-    let s6: String = default::Default::default();
+    let s6: String = std::string::String::default();
 
     let s7 = std::string::String::default();
 
@@ -28,19 +28,19 @@ fn main() {
 
     let s10 = DerivedDefault::default();
 
-    let s11: GenericDerivedDefault<String> = Default::default();
+    let s11: GenericDerivedDefault<String> = GenericDerivedDefault::default();
 
     let s12 = GenericDerivedDefault::<String>::default();
 
     let s13 = TupleDerivedDefault::default();
 
-    let s14: TupleDerivedDefault = Default::default();
+    let s14: TupleDerivedDefault = TupleDerivedDefault::default();
 
-    let s15: ArrayDerivedDefault = Default::default();
+    let s15: ArrayDerivedDefault = ArrayDerivedDefault::default();
 
     let s16 = ArrayDerivedDefault::default();
 
-    let s17: TupleStructDerivedDefault = Default::default();
+    let s17: TupleStructDerivedDefault = TupleStructDerivedDefault::default();
 
     let s18 = TupleStructDerivedDefault::default();
 

--- a/tests/ui/default_trait_access.stderr
+++ b/tests/ui/default_trait_access.stderr
@@ -1,49 +1,53 @@
 error: calling `std::string::String::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:8:22
+  --> $DIR/default_trait_access.rs:11:22
    |
 LL |     let s1: String = Default::default();
    |                      ^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
    |
-   = note: `-D clippy::default-trait-access` implied by `-D warnings`
+note: the lint level is defined here
+  --> $DIR/default_trait_access.rs:4:9
+   |
+LL | #![deny(clippy::default_trait_access)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: calling `std::string::String::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:12:22
+  --> $DIR/default_trait_access.rs:15:22
    |
 LL |     let s3: String = D2::default();
    |                      ^^^^^^^^^^^^^ help: try: `std::string::String::default()`
 
 error: calling `std::string::String::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:14:22
+  --> $DIR/default_trait_access.rs:17:22
    |
 LL |     let s4: String = std::default::Default::default();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
 
 error: calling `std::string::String::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:18:22
+  --> $DIR/default_trait_access.rs:21:22
    |
 LL |     let s6: String = default::Default::default();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
 
-error: calling `GenericDerivedDefault<std::string::String>::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:28:46
+error: calling `GenericDerivedDefault::default()` is more clear than this expression
+  --> $DIR/default_trait_access.rs:31:46
    |
 LL |     let s11: GenericDerivedDefault<String> = Default::default();
-   |                                              ^^^^^^^^^^^^^^^^^^ help: try: `GenericDerivedDefault<std::string::String>::default()`
+   |                                              ^^^^^^^^^^^^^^^^^^ help: try: `GenericDerivedDefault::default()`
 
 error: calling `TupleDerivedDefault::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:34:36
+  --> $DIR/default_trait_access.rs:37:36
    |
 LL |     let s14: TupleDerivedDefault = Default::default();
    |                                    ^^^^^^^^^^^^^^^^^^ help: try: `TupleDerivedDefault::default()`
 
 error: calling `ArrayDerivedDefault::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:36:36
+  --> $DIR/default_trait_access.rs:39:36
    |
 LL |     let s15: ArrayDerivedDefault = Default::default();
    |                                    ^^^^^^^^^^^^^^^^^^ help: try: `ArrayDerivedDefault::default()`
 
 error: calling `TupleStructDerivedDefault::default()` is more clear than this expression
-  --> $DIR/default_trait_access.rs:40:42
+  --> $DIR/default_trait_access.rs:43:42
    |
 LL |     let s17: TupleStructDerivedDefault = Default::default();
    |                                          ^^^^^^^^^^^^^^^^^^ help: try: `TupleStructDerivedDefault::default()`


### PR DESCRIPTION
https://github.com/rust-lang/rust-clippy/issues/5975#issuecomment-683751131
> I think the underlying problem is clippy suggests code with complete parameters, not clippy triggers this lint even for complex types. AFAIK, If code compiles with `Default::default`, it doesn't need to specify any parameters, as type inference is working. (So, in this case, `default_trait_access` should suggest `RefCell::default`.)

Fixes #5975 Fixes #5990

changelog: `default_trait_access`: fixed wrong suggestion
