### PR TITLE
Fix a fp in `transmute_ptr_to_ptr`

### DIFF
--- a/tests/ui/transmute_ptr_to_ptr.rs
+++ b/tests/ui/transmute_ptr_to_ptr.rs
@@ -51,4 +51,12 @@ fn transmute_ptr_to_ptr() {
     let _: &GenericParam<&LifetimeParam<'static>> = unsafe { std::mem::transmute(&GenericParam { t: &lp }) };
 }
 
+// dereferencing raw pointers in const contexts, should not lint as it's unstable (issue 5959)
+const _: &() = {
+    struct ZST;
+    let zst = &ZST;
+
+    unsafe { std::mem::transmute::<&'static ZST, &'static ()>(zst) }
+};
+
 fn main() {}


### PR DESCRIPTION
fixes #5959

changelog: Fix a false positive in `transmute_ptr_to_ptr` that the lint fires when `transmute` is used to cast a reference in const contexts although dereferencing raw pointers in consts is unstable.