### PR TITLE
Show line count and max lines in too_many_lines lint message

### DIFF
--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -374,7 +374,12 @@ impl<'tcx> Functions {
         }
 
         if line_count > self.max_lines {
-            span_lint(cx, TOO_MANY_LINES, span, "this function has a large number of lines")
+            span_lint(
+                cx,
+                TOO_MANY_LINES,
+                span,
+                &format!("this function has too many lines ({}/{})", line_count, self.max_lines),
+            )
         }
     }
 

--- a/tests/ui-toml/functions_maxlines/test.stderr
+++ b/tests/ui-toml/functions_maxlines/test.stderr
@@ -1,4 +1,4 @@
-error: this function has a large number of lines
+error: this function has too many lines (2/1)
   --> $DIR/test.rs:18:1
    |
 LL | / fn too_many_lines() {
@@ -9,7 +9,7 @@ LL | | }
    |
    = note: `-D clippy::too-many-lines` implied by `-D warnings`
 
-error: this function has a large number of lines
+error: this function has too many lines (2/1)
   --> $DIR/test.rs:38:1
    |
 LL | / fn comment_before_code() {

--- a/tests/ui/functions_maxlines.stderr
+++ b/tests/ui/functions_maxlines.stderr
@@ -1,4 +1,4 @@
-error: this function has a large number of lines
+error: this function has too many lines (102/100)
   --> $DIR/functions_maxlines.rs:58:1
    |
 LL | / fn bad_lines() {


### PR DESCRIPTION
This PR adds the current amount of lines and the current maximum number of lines in the message for the `too_many_lines` lint, in a similar way as the `too_many_arguments` lint currently does.

changelog: show the line count and the maximum lines in the message for the `too_many_lines` lint.
