### PR TITLE
Improve the "known problems" section of `interior_mutable_key`

### DIFF
--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -12,8 +12,10 @@ declare_clippy_lint! {
     /// `BtreeSet` rely on either the hash or the order of keys be unchanging,
     /// so having types with interior mutability is a bad idea.
     ///
-    /// **Known problems:** We don't currently account for `Rc` or `Arc`, so
-    /// this may yield false positives.
+    /// **Known problems:** It's correct to use a struct, that contains interior mutability,
+    /// as a key; when its `Hash` implementation doesn't access any these interior mutable types.
+    /// However, this lint is unable to recognise it so cause a false positive.
+    /// `bytes` ctate is a great example of this.
     ///
     /// **Example:**
     /// ```rust


### PR DESCRIPTION
* Remove the mention to `Rc` and `Arc` as these are `Freeze` (despite my intuition) so the lint correctly handles already.
* Instead, explain what could cause a false positive, and mention `bytes` as an example.

---

changelog: Improved the "known problems" section of `interior_mutable_key`
