### PR TITLE
print the unit type `()` in related lint messages.

### DIFF
--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -9,7 +9,7 @@ use rustc_span::source_map::Span;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for usage of `option.map(f)` where f is a function
-    /// or closure that returns the unit type.
+    /// or closure that returns the unit type `()`.
     ///
     /// **Why is this bad?** Readability, this can be written more clearly with
     /// an if let statement
@@ -51,7 +51,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// **What it does:** Checks for usage of `result.map(f)` where f is a function
-    /// or closure that returns the unit type.
+    /// or closure that returns the unit type `()`.
     ///
     /// **Why is this bad?** Readability, this can be written more clearly with
     /// an if let statement
@@ -197,7 +197,7 @@ fn let_binding_name(cx: &LateContext<'_>, var_arg: &hir::Expr<'_>) -> String {
 #[must_use]
 fn suggestion_msg(function_type: &str, map_type: &str) -> String {
     format!(
-        "called `map(f)` on an `{0}` value where `f` is a {1} that returns the unit type",
+        "called `map(f)` on an `{0}` value where `f` is a {1} that returns the unit type `()`",
         map_type, function_type
     )
 }

--- a/tests/ui/option_map_unit_fn_fixable.stderr
+++ b/tests/ui/option_map_unit_fn_fixable.stderr
@@ -1,4 +1,4 @@
-error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:38:5
    |
 LL |     x.field.map(do_nothing);
@@ -8,7 +8,7 @@ LL |     x.field.map(do_nothing);
    |
    = note: `-D clippy::option-map-unit-fn` implied by `-D warnings`
 
-error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:40:5
    |
 LL |     x.field.map(do_nothing);
@@ -16,7 +16,7 @@ LL |     x.field.map(do_nothing);
    |     |
    |     help: try this: `if let Some(x_field) = x.field { do_nothing(x_field) }`
 
-error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:42:5
    |
 LL |     x.field.map(diverge);
@@ -24,7 +24,7 @@ LL |     x.field.map(diverge);
    |     |
    |     help: try this: `if let Some(x_field) = x.field { diverge(x_field) }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:48:5
    |
 LL |     x.field.map(|value| x.do_option_nothing(value + captured));
@@ -32,7 +32,7 @@ LL |     x.field.map(|value| x.do_option_nothing(value + captured));
    |     |
    |     help: try this: `if let Some(value) = x.field { x.do_option_nothing(value + captured) }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:50:5
    |
 LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
@@ -40,7 +40,7 @@ LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { x.do_option_plus_one(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:53:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
@@ -48,7 +48,7 @@ LL |     x.field.map(|value| do_nothing(value + captured));
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:55:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
@@ -56,7 +56,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:57:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
@@ -64,7 +64,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:59:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
@@ -72,7 +72,7 @@ LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     |
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:62:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
@@ -80,7 +80,7 @@ LL |     x.field.map(|value| diverge(value + captured));
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:64:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
@@ -88,7 +88,7 @@ LL |     x.field.map(|value| { diverge(value + captured) });
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:66:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
@@ -96,7 +96,7 @@ LL |     x.field.map(|value| { diverge(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:68:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
@@ -104,7 +104,7 @@ LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     |
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:73:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
@@ -112,7 +112,7 @@ LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { let y = plus_one(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:75:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
@@ -120,7 +120,7 @@ LL |     x.field.map(|value| { plus_one(value + captured); });
    |     |
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:77:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
@@ -128,7 +128,7 @@ LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     |
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:80:5
    |
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });
@@ -136,7 +136,7 @@ LL |     x.field.map(|ref value| { do_nothing(value + captured) });
    |     |
    |     help: try this: `if let Some(ref value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:82:5
    |
 LL |     option().map(do_nothing);}

--- a/tests/ui/result_map_unit_fn_fixable.stderr
+++ b/tests/ui/result_map_unit_fn_fixable.stderr
@@ -1,4 +1,4 @@
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:35:5
    |
 LL |     x.field.map(do_nothing);
@@ -8,7 +8,7 @@ LL |     x.field.map(do_nothing);
    |
    = note: `-D clippy::result-map-unit-fn` implied by `-D warnings`
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:37:5
    |
 LL |     x.field.map(do_nothing);
@@ -16,7 +16,7 @@ LL |     x.field.map(do_nothing);
    |     |
    |     help: try this: `if let Ok(x_field) = x.field { do_nothing(x_field) }`
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:39:5
    |
 LL |     x.field.map(diverge);
@@ -24,7 +24,7 @@ LL |     x.field.map(diverge);
    |     |
    |     help: try this: `if let Ok(x_field) = x.field { diverge(x_field) }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:45:5
    |
 LL |     x.field.map(|value| x.do_result_nothing(value + captured));
@@ -32,7 +32,7 @@ LL |     x.field.map(|value| x.do_result_nothing(value + captured));
    |     |
    |     help: try this: `if let Ok(value) = x.field { x.do_result_nothing(value + captured) }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:47:5
    |
 LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
@@ -40,7 +40,7 @@ LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { x.do_result_plus_one(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:50:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
@@ -48,7 +48,7 @@ LL |     x.field.map(|value| do_nothing(value + captured));
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:52:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
@@ -56,7 +56,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:54:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
@@ -64,7 +64,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:56:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
@@ -72,7 +72,7 @@ LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     |
    |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:59:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
@@ -80,7 +80,7 @@ LL |     x.field.map(|value| diverge(value + captured));
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:61:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
@@ -88,7 +88,7 @@ LL |     x.field.map(|value| { diverge(value + captured) });
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:63:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
@@ -96,7 +96,7 @@ LL |     x.field.map(|value| { diverge(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:65:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
@@ -104,7 +104,7 @@ LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     |
    |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:70:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
@@ -112,7 +112,7 @@ LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { let y = plus_one(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:72:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
@@ -120,7 +120,7 @@ LL |     x.field.map(|value| { plus_one(value + captured); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:74:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
@@ -128,7 +128,7 @@ LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     |
    |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:77:5
    |
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });

--- a/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -1,4 +1,4 @@
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:23:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
@@ -8,7 +8,7 @@ LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
    |
    = note: `-D clippy::result-map-unit-fn` implied by `-D warnings`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:25:5
    |
 LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });
@@ -16,7 +16,7 @@ LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value)
    |     |
    |     help: try this: `if let Ok(value) = x.field { ... }`
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:29:5
    |
 LL |        x.field.map(|value| {
@@ -30,7 +30,7 @@ LL | ||     });
    | |_______|
    | 
 
-error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:33:5
    |
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value); });
@@ -38,7 +38,7 @@ LL |     x.field.map(|value| { do_nothing(value); do_nothing(value); });
    |     |
    |     help: try this: `if let Ok(value) = x.field { ... }`
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:37:5
    |
 LL |     "12".parse::<i32>().map(diverge);
@@ -46,7 +46,7 @@ LL |     "12".parse::<i32>().map(diverge);
    |     |
    |     help: try this: `if let Ok(a) = "12".parse::<i32>() { diverge(a) }`
 
-error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type
+error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:43:5
    |
 LL |     y.map(do_nothing);


### PR DESCRIPTION
changelog: print the unit type `()` in related lint messages
