### PR TITLE
{print,write}-with-newline: do not suggest empty format string

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -322,10 +322,14 @@ impl EarlyLintPass for Write {
 }
 
 /// Given a format string that ends in a newline and its span, calculates the span of the
-/// newline.
+/// newline, or the format string itself if the format string consists solely of a newline.
 fn newline_span(fmtstr: &StrLit) -> Span {
     let sp = fmtstr.span;
     let contents = &fmtstr.symbol.as_str();
+
+    if *contents == r"\n" {
+        return sp;
+    }
 
     let newline_sp_hi = sp.hi()
         - match fmtstr.style {

--- a/tests/ui/print_with_newline.rs
+++ b/tests/ui/print_with_newline.rs
@@ -9,6 +9,7 @@ fn main() {
     print!("Hello {}\n", "world");
     print!("Hello {} {}\n", "world", "#2");
     print!("{}\n", 1265);
+    print!("\n");
 
     // these are all fine
     print!("");

--- a/tests/ui/print_with_newline.stderr
+++ b/tests/ui/print_with_newline.stderr
@@ -44,7 +44,18 @@ LL |     println!("{}", 1265);
    |     ^^^^^^^    --
 
 error: using `print!()` with a format string that ends in a single newline
-  --> $DIR/print_with_newline.rs:30:5
+  --> $DIR/print_with_newline.rs:12:5
+   |
+LL |     print!("/n");
+   |     ^^^^^^^^^^^^
+   |
+help: use `println!` instead
+   |
+LL |     println!();
+   |     ^^^^^^^ --
+
+error: using `print!()` with a format string that ends in a single newline
+  --> $DIR/print_with_newline.rs:31:5
    |
 LL |     print!("//n"); // should fail
    |     ^^^^^^^^^^^^^^
@@ -55,7 +66,7 @@ LL |     println!("/"); // should fail
    |     ^^^^^^^    --
 
 error: using `print!()` with a format string that ends in a single newline
-  --> $DIR/print_with_newline.rs:37:5
+  --> $DIR/print_with_newline.rs:38:5
    |
 LL | /     print!(
 LL | |         "
@@ -70,7 +81,7 @@ LL |         ""
    |
 
 error: using `print!()` with a format string that ends in a single newline
-  --> $DIR/print_with_newline.rs:41:5
+  --> $DIR/print_with_newline.rs:42:5
    |
 LL | /     print!(
 LL | |         r"
@@ -85,7 +96,7 @@ LL |         r""
    |
 
 error: using `print!()` with a format string that ends in a single newline
-  --> $DIR/print_with_newline.rs:49:5
+  --> $DIR/print_with_newline.rs:50:5
    |
 LL |     print!("/r/n"); //~ ERROR
    |     ^^^^^^^^^^^^^^^
@@ -96,7 +107,7 @@ LL |     println!("/r"); //~ ERROR
    |     ^^^^^^^     --
 
 error: using `print!()` with a format string that ends in a single newline
-  --> $DIR/print_with_newline.rs:50:5
+  --> $DIR/print_with_newline.rs:51:5
    |
 LL |     print!("foo/rbar/n") // ~ ERROR
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -106,5 +117,5 @@ help: use `println!` instead
 LL |     println!("foo/rbar") // ~ ERROR
    |     ^^^^^^^          --
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 

--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -14,6 +14,7 @@ fn main() {
     write!(&mut v, "Hello {}\n", "world");
     write!(&mut v, "Hello {} {}\n", "world", "#2");
     write!(&mut v, "{}\n", 1265);
+    write!(&mut v, "\n");
 
     // These should be fine
     write!(&mut v, "");

--- a/tests/ui/write_with_newline.stderr
+++ b/tests/ui/write_with_newline.stderr
@@ -44,7 +44,18 @@ LL |     writeln!(&mut v, "{}", 1265);
    |     ^^^^^^^            --
 
 error: using `write!()` with a format string that ends in a single newline
-  --> $DIR/write_with_newline.rs:35:5
+  --> $DIR/write_with_newline.rs:17:5
+   |
+LL |     write!(&mut v, "/n");
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `writeln!()` instead
+   |
+LL |     writeln!(&mut v, );
+   |     ^^^^^^^         --
+
+error: using `write!()` with a format string that ends in a single newline
+  --> $DIR/write_with_newline.rs:36:5
    |
 LL |     write!(&mut v, "//n"); // should fail
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +66,7 @@ LL |     writeln!(&mut v, "/"); // should fail
    |     ^^^^^^^            --
 
 error: using `write!()` with a format string that ends in a single newline
-  --> $DIR/write_with_newline.rs:42:5
+  --> $DIR/write_with_newline.rs:43:5
    |
 LL | /     write!(
 LL | |         &mut v,
@@ -72,7 +83,7 @@ LL |         ""
    |
 
 error: using `write!()` with a format string that ends in a single newline
-  --> $DIR/write_with_newline.rs:47:5
+  --> $DIR/write_with_newline.rs:48:5
    |
 LL | /     write!(
 LL | |         &mut v,
@@ -89,7 +100,7 @@ LL |         r""
    |
 
 error: using `write!()` with a format string that ends in a single newline
-  --> $DIR/write_with_newline.rs:56:5
+  --> $DIR/write_with_newline.rs:57:5
    |
 LL |     write!(&mut v, "/r/n"); //~ ERROR
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +111,7 @@ LL |     writeln!(&mut v, "/r"); //~ ERROR
    |     ^^^^^^^             --
 
 error: using `write!()` with a format string that ends in a single newline
-  --> $DIR/write_with_newline.rs:57:5
+  --> $DIR/write_with_newline.rs:58:5
    |
 LL |     write!(&mut v, "foo/rbar/n");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,5 +121,5 @@ help: use `writeln!()` instead
 LL |     writeln!(&mut v, "foo/rbar");
    |     ^^^^^^^                  --
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
changelog: do not suggest empty format strings in `print-with-newline` and `write-with-newline`
