### PR TITLE
Remove an extra blank line in `shadow_same`

### DIFF
--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -25,7 +25,6 @@ declare_clippy_lint! {
     /// **Example:**
     /// ```rust
     /// # let x = 1;
-    ///
     /// // Bad
     /// let x = &x;
     ///


### PR DESCRIPTION
It seems to be an extra blank line in doc example.

changelog: none

<img width="1143" alt="スクリーンショット 2020-09-15 8 50 30" src="https://user-images.githubusercontent.com/17407489/93149409-369df080-f731-11ea-9a39-d8bbc72b61ee.png">

