### PR TITLE
Bump pulldown-cmark v0.8

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -21,7 +21,7 @@ cargo_metadata = "0.11.1"
 if_chain = "1.0.0"
 itertools = "0.9"
 lazy_static = "1.0.2"
-pulldown-cmark = { version = "0.7.1", default-features = false }
+pulldown-cmark = { version = "0.8", default-features = false }
 quine-mc_cluskey = "0.2.2"
 regex-syntax = "0.6"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Closes  #6054

changelog: none
