### PR TITLE
Fix FP in `print_stdout`

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -235,9 +235,8 @@ impl EarlyLintPass for Write {
     }
 
     fn check_mac(&mut self, cx: &EarlyContext<'_>, mac: &MacCall) {
-        fn is_build_scripts(cx: &EarlyContext<'_>) -> bool {
-            // We could leverage the fact that Cargo sets the crate name
-            // for build scripts to `build_script_build`.
+        fn is_build_script(cx: &EarlyContext<'_>) -> bool {
+            // Cargo sets the crate name for build scripts to `build_script_build`
             cx.sess
                 .opts
                 .crate_name
@@ -246,7 +245,7 @@ impl EarlyLintPass for Write {
         }
 
         if mac.path == sym!(println) {
-            if !is_build_scripts(cx) {
+            if !is_build_script(cx) {
                 span_lint(cx, PRINT_STDOUT, mac.span(), "use of `println!`");
             }
             if let (Some(fmt_str), _) = self.check_tts(cx, mac.args.inner_tokens(), false) {
@@ -263,7 +262,7 @@ impl EarlyLintPass for Write {
                 }
             }
         } else if mac.path == sym!(print) {
-            if !is_build_scripts(cx) {
+            if !is_build_script(cx) {
                 span_lint(cx, PRINT_STDOUT, mac.span(), "use of `print!`");
             }
             if let (Some(fmt_str), _) = self.check_tts(cx, mac.args.inner_tokens(), false) {

--- a/clippy_workspace_tests/build.rs
+++ b/clippy_workspace_tests/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // Test for #6041
+    println!("Hello");
+    print!("Hello");
+}

--- a/clippy_workspace_tests/build.rs
+++ b/clippy_workspace_tests/build.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stdout)]
+
 fn main() {
     // Test for #6041
     println!("Hello");

--- a/tests/ui/build.rs
+++ b/tests/ui/build.rs
@@ -1,0 +1,10 @@
+#![warn(clippy::print_stdout)]
+
+fn main() {
+    // Fix #6041
+    //
+    // The `print_stdout` shouldn't be linted in `build.rs`
+    // as these methods are used for the build script.
+    println!("Hello");
+    print!("Hello");
+}

--- a/tests/ui/print_stdout_build_script.rs
+++ b/tests/ui/print_stdout_build_script.rs
@@ -5,7 +5,7 @@
 fn main() {
     // Fix #6041
     //
-    // The `print_stdout` shouldn't be linted in `build.rs`
+    // The `print_stdout` lint shouldn't emit in `build.rs`
     // as these methods are used for the build script.
     println!("Hello");
     print!("Hello");

--- a/tests/ui/print_stdout_build_script.rs
+++ b/tests/ui/print_stdout_build_script.rs
@@ -1,3 +1,5 @@
+// compile-flags: --crate-name=build_script_build
+
 #![warn(clippy::print_stdout)]
 
 fn main() {


### PR DESCRIPTION
Fix #6041 

This lint shouldn't be emitted in `build.rs` as `println!` and `print!` are used for the build script.

changelog: none
