### PR TITLE
Do not lint float fractions in `mistyped_literal_suffixes`

### DIFF
--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -264,13 +264,10 @@ impl LiteralDigitGrouping {
 
         let (part, mistyped_suffixes, missing_char) = if let Some((_, exponent)) = &mut num_lit.exponent {
             (exponent, &["32", "64"][..], 'f')
+        } else if num_lit.fraction.is_some() {
+            (&mut num_lit.integer, &["32", "64"][..], 'f')
         } else {
-            num_lit
-                .fraction
-                .as_mut()
-                .map_or((&mut num_lit.integer, &["8", "16", "32", "64"][..], 'i'), |fraction| {
-                    (fraction, &["32", "64"][..], 'f')
-                })
+            (&mut num_lit.integer, &["8", "16", "32", "64"][..], 'i')
         };
 
         let mut split = part.rsplit('_');

--- a/tests/ui/mistyped_literal_suffix.fixed
+++ b/tests/ui/mistyped_literal_suffix.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![allow(dead_code, unused_variables, clippy::excessive_precision)]
+#![allow(dead_code, unused_variables, clippy::excessive_precision, clippy::inconsistent_digit_grouping)]
 
 fn main() {
     let fail14 = 2_i32;
@@ -12,13 +12,13 @@ fn main() {
     let fail20 = 2_i8; //
     let fail21 = 4_i16; //
 
-    let fail24 = 12.34_f64;
+    let ok24 = 12.34_64;
     let fail25 = 1E2_f32;
     let fail26 = 43E7_f64;
     let fail27 = 243E17_f32;
     #[allow(overflowing_literals)]
     let fail28 = 241_251_235E723_f64;
-    let fail29 = 42_279.911_f32;
+    let ok29 = 42279.911_32;
 
     let _ = 1.123_45E1_f32;
 }

--- a/tests/ui/mistyped_literal_suffix.fixed
+++ b/tests/ui/mistyped_literal_suffix.fixed
@@ -1,6 +1,11 @@
 // run-rustfix
 
-#![allow(dead_code, unused_variables, clippy::excessive_precision, clippy::inconsistent_digit_grouping)]
+#![allow(
+    dead_code,
+    unused_variables,
+    clippy::excessive_precision,
+    clippy::inconsistent_digit_grouping
+)]
 
 fn main() {
     let fail14 = 2_i32;

--- a/tests/ui/mistyped_literal_suffix.rs
+++ b/tests/ui/mistyped_literal_suffix.rs
@@ -1,6 +1,11 @@
 // run-rustfix
 
-#![allow(dead_code, unused_variables, clippy::excessive_precision, clippy::inconsistent_digit_grouping)]
+#![allow(
+    dead_code,
+    unused_variables,
+    clippy::excessive_precision,
+    clippy::inconsistent_digit_grouping
+)]
 
 fn main() {
     let fail14 = 2_32;

--- a/tests/ui/mistyped_literal_suffix.rs
+++ b/tests/ui/mistyped_literal_suffix.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![allow(dead_code, unused_variables, clippy::excessive_precision)]
+#![allow(dead_code, unused_variables, clippy::excessive_precision, clippy::inconsistent_digit_grouping)]
 
 fn main() {
     let fail14 = 2_32;
@@ -12,13 +12,13 @@ fn main() {
     let fail20 = 2__8; //
     let fail21 = 4___16; //
 
-    let fail24 = 12.34_64;
+    let ok24 = 12.34_64;
     let fail25 = 1E2_32;
     let fail26 = 43E7_64;
     let fail27 = 243E17_32;
     #[allow(overflowing_literals)]
     let fail28 = 241251235E723_64;
-    let fail29 = 42279.911_32;
+    let ok29 = 42279.911_32;
 
     let _ = 1.12345E1_32;
 }

--- a/tests/ui/mistyped_literal_suffix.stderr
+++ b/tests/ui/mistyped_literal_suffix.stderr
@@ -37,12 +37,6 @@ LL |     let fail21 = 4___16; //
    |                  ^^^^^^ help: did you mean to write: `4_i16`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:15:18
-   |
-LL |     let fail24 = 12.34_64;
-   |                  ^^^^^^^^ help: did you mean to write: `12.34_f64`
-
-error: mistyped literal suffix
   --> $DIR/mistyped_literal_suffix.rs:16:18
    |
 LL |     let fail25 = 1E2_32;
@@ -67,16 +61,10 @@ LL |     let fail28 = 241251235E723_64;
    |                  ^^^^^^^^^^^^^^^^ help: did you mean to write: `241_251_235E723_f64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:21:18
-   |
-LL |     let fail29 = 42279.911_32;
-   |                  ^^^^^^^^^^^^ help: did you mean to write: `42_279.911_f32`
-
-error: mistyped literal suffix
   --> $DIR/mistyped_literal_suffix.rs:23:13
    |
 LL |     let _ = 1.12345E1_32;
    |             ^^^^^^^^^^^^ help: did you mean to write: `1.123_45E1_f32`
 
-error: aborting due to 13 previous errors
+error: aborting due to 11 previous errors
 

--- a/tests/ui/mistyped_literal_suffix.stderr
+++ b/tests/ui/mistyped_literal_suffix.stderr
@@ -1,5 +1,5 @@
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:6:18
+  --> $DIR/mistyped_literal_suffix.rs:11:18
    |
 LL |     let fail14 = 2_32;
    |                  ^^^^ help: did you mean to write: `2_i32`
@@ -7,61 +7,61 @@ LL |     let fail14 = 2_32;
    = note: `#[deny(clippy::mistyped_literal_suffixes)]` on by default
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:7:18
+  --> $DIR/mistyped_literal_suffix.rs:12:18
    |
 LL |     let fail15 = 4_64;
    |                  ^^^^ help: did you mean to write: `4_i64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:8:18
+  --> $DIR/mistyped_literal_suffix.rs:13:18
    |
 LL |     let fail16 = 7_8; //
    |                  ^^^ help: did you mean to write: `7_i8`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:9:18
+  --> $DIR/mistyped_literal_suffix.rs:14:18
    |
 LL |     let fail17 = 23_16; //
    |                  ^^^^^ help: did you mean to write: `23_i16`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:12:18
+  --> $DIR/mistyped_literal_suffix.rs:17:18
    |
 LL |     let fail20 = 2__8; //
    |                  ^^^^ help: did you mean to write: `2_i8`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:13:18
+  --> $DIR/mistyped_literal_suffix.rs:18:18
    |
 LL |     let fail21 = 4___16; //
    |                  ^^^^^^ help: did you mean to write: `4_i16`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:16:18
+  --> $DIR/mistyped_literal_suffix.rs:21:18
    |
 LL |     let fail25 = 1E2_32;
    |                  ^^^^^^ help: did you mean to write: `1E2_f32`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:17:18
+  --> $DIR/mistyped_literal_suffix.rs:22:18
    |
 LL |     let fail26 = 43E7_64;
    |                  ^^^^^^^ help: did you mean to write: `43E7_f64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:18:18
+  --> $DIR/mistyped_literal_suffix.rs:23:18
    |
 LL |     let fail27 = 243E17_32;
    |                  ^^^^^^^^^ help: did you mean to write: `243E17_f32`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:20:18
+  --> $DIR/mistyped_literal_suffix.rs:25:18
    |
 LL |     let fail28 = 241251235E723_64;
    |                  ^^^^^^^^^^^^^^^^ help: did you mean to write: `241_251_235E723_f64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:23:13
+  --> $DIR/mistyped_literal_suffix.rs:28:13
    |
 LL |     let _ = 1.12345E1_32;
    |             ^^^^^^^^^^^^ help: did you mean to write: `1.123_45E1_f32`


### PR DESCRIPTION
As suggested in https://github.com/rust-lang/rust-clippy/issues/4706#issuecomment-544797928, the fractional part is now ignored (the integer part is checked instead).

Fixes: #4706

changelog: `mistyped_literal_suffixes` no longer warns on the fractional part of a float (e.g. 713.23_64)