### PR TITLE
Replace some lazy_static usage with once_cell feature

### DIFF
--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -9,7 +9,6 @@ bytecount = "0.6"
 clap = "2.33"
 itertools = "0.9"
 regex = "1"
-lazy_static = "1.0"
 shell-escape = "0.1"
 walkdir = "2"
 

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -1,11 +1,12 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
+#![feature(once_cell)]
 
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use regex::Regex;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;
+use std::lazy::SyncLazy;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -15,28 +16,31 @@ pub mod ra_setup;
 pub mod stderr_length_check;
 pub mod update_lints;
 
-lazy_static! {
-    static ref DEC_CLIPPY_LINT_RE: Regex = Regex::new(
+static DEC_CLIPPY_LINT_RE: SyncLazy<Regex> = SyncLazy::new(|| {
+    Regex::new(
         r#"(?x)
-        declare_clippy_lint!\s*[\{(]
-        (?:\s+///.*)*
-        \s+pub\s+(?P<name>[A-Z_][A-Z_0-9]*)\s*,\s*
-        (?P<cat>[a-z_]+)\s*,\s*
-        "(?P<desc>(?:[^"\\]+|\\(?s).(?-s))*)"\s*[})]
-    "#
+    declare_clippy_lint!\s*[\{(]
+    (?:\s+///.*)*
+    \s+pub\s+(?P<name>[A-Z_][A-Z_0-9]*)\s*,\s*
+    (?P<cat>[a-z_]+)\s*,\s*
+    "(?P<desc>(?:[^"\\]+|\\(?s).(?-s))*)"\s*[})]
+"#,
     )
-    .unwrap();
-    static ref DEC_DEPRECATED_LINT_RE: Regex = Regex::new(
+    .unwrap()
+});
+
+static DEC_DEPRECATED_LINT_RE: SyncLazy<Regex> = SyncLazy::new(|| {
+    Regex::new(
         r#"(?x)
-        declare_deprecated_lint!\s*[{(]\s*
-        (?:\s+///.*)*
-        \s+pub\s+(?P<name>[A-Z_][A-Z_0-9]*)\s*,\s*
-        "(?P<desc>(?:[^"\\]+|\\(?s).(?-s))*)"\s*[})]
-    "#
+    declare_deprecated_lint!\s*[{(]\s*
+    (?:\s+///.*)*
+    \s+pub\s+(?P<name>[A-Z_][A-Z_0-9]*)\s*,\s*
+    "(?P<desc>(?:[^"\\]+|\\(?s).(?-s))*)"\s*[})]
+"#,
     )
-    .unwrap();
-    static ref NL_ESCAPE_RE: Regex = Regex::new(r#"\\\n\s*"#).unwrap();
-}
+    .unwrap()
+});
+static NL_ESCAPE_RE: SyncLazy<Regex> = SyncLazy::new(|| Regex::new(r#"\\\n\s*"#).unwrap());
 
 pub static DOCS_LINK: &str = "https://rust-lang.github.io/rust-clippy/master/index.html";
 

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -20,7 +20,6 @@ edition = "2018"
 cargo_metadata = "0.11.1"
 if_chain = "1.0.0"
 itertools = "0.9"
-lazy_static = "1.0.2"
 pulldown-cmark = { version = "0.8", default-features = false }
 quine-mc_cluskey = "0.2.2"
 regex-syntax = "0.6"

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(drain_filter)]
 #![feature(in_band_lifetimes)]
+#![feature(once_cell)]
 #![feature(or_patterns)]
 #![feature(rustc_private)]
 #![feature(stmt_expr_attributes)]

--- a/clippy_lints/src/macro_use.rs
+++ b/clippy_lints/src/macro_use.rs
@@ -18,9 +18,9 @@ declare_clippy_lint! {
     /// **Known problems:** None.
     ///
     /// **Example:**
-    /// ```rust
+    /// ```rust,ignore
     /// #[macro_use]
-    /// use lazy_static;
+    /// use some_macro;
     /// ```
     pub MACRO_USE_IMPORTS,
     pedantic,

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -2,10 +2,10 @@
 
 #![deny(clippy::missing_docs_in_private_items)]
 
-use lazy_static::lazy_static;
 use rustc_ast::ast::{LitKind, MetaItemKind, NestedMetaItem};
 use rustc_span::source_map;
 use source_map::Span;
+use std::lazy::SyncLazy;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::{env, fmt, fs, io};
@@ -54,9 +54,8 @@ impl From<io::Error> for Error {
     }
 }
 
-lazy_static! {
-    static ref ERRORS: Mutex<Vec<Error>> = Mutex::new(Vec::new());
-}
+/// Vec of errors that might be collected during config toml parsing
+static ERRORS: SyncLazy<Mutex<Vec<Error>>> = SyncLazy::new(|| Mutex::new(Vec::new()));
 
 macro_rules! define_Conf {
     ($(#[$doc:meta] ($config:ident, $config_str:literal: $Ty:ty, $default:expr),)+) => {
@@ -82,6 +81,7 @@ macro_rules! define_Conf {
                     use serde::Deserialize;
                     pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<$Ty, D::Error> {
                         use super::super::{ERRORS, Error};
+
                         Ok(
                             <$Ty>::deserialize(deserializer).unwrap_or_else(|e| {
                                 ERRORS

--- a/tests/cargo/mod.rs
+++ b/tests/cargo/mod.rs
@@ -1,27 +1,24 @@
-use lazy_static::lazy_static;
 use std::env;
+use std::lazy::SyncLazy;
 use std::path::PathBuf;
 
-lazy_static! {
-    pub static ref CARGO_TARGET_DIR: PathBuf = {
-        match env::var_os("CARGO_TARGET_DIR") {
-            Some(v) => v.into(),
-            None => env::current_dir().unwrap().join("target"),
+pub static CARGO_TARGET_DIR: SyncLazy<PathBuf> = SyncLazy::new(|| match env::var_os("CARGO_TARGET_DIR") {
+    Some(v) => v.into(),
+    None => env::current_dir().unwrap().join("target"),
+});
+
+pub static TARGET_LIB: SyncLazy<PathBuf> = SyncLazy::new(|| {
+    if let Some(path) = option_env!("TARGET_LIBS") {
+        path.into()
+    } else {
+        let mut dir = CARGO_TARGET_DIR.clone();
+        if let Some(target) = env::var_os("CARGO_BUILD_TARGET") {
+            dir.push(target);
         }
-    };
-    pub static ref TARGET_LIB: PathBuf = {
-        if let Some(path) = option_env!("TARGET_LIBS") {
-            path.into()
-        } else {
-            let mut dir = CARGO_TARGET_DIR.clone();
-            if let Some(target) = env::var_os("CARGO_BUILD_TARGET") {
-                dir.push(target);
-            }
-            dir.push(env!("PROFILE"));
-            dir
-        }
-    };
-}
+        dir.push(env!("PROFILE"));
+        dir
+    }
+});
 
 #[must_use]
 pub fn is_rustc_test_suite() -> bool {

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -1,4 +1,5 @@
 #![feature(test)] // compiletest_rs requires this attribute
+#![feature(once_cell)]
 
 use compiletest_rs as compiletest;
 use compiletest_rs::common::Mode as TestMode;

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -1,15 +1,14 @@
 // Dogfood cannot run on Windows
 #![cfg(not(windows))]
+#![feature(once_cell)]
 
-use lazy_static::lazy_static;
+use std::lazy::SyncLazy;
 use std::path::PathBuf;
 use std::process::Command;
 
 mod cargo;
 
-lazy_static! {
-    static ref CLIPPY_PATH: PathBuf = cargo::TARGET_LIB.join("cargo-clippy");
-}
+static CLIPPY_PATH: SyncLazy<PathBuf> = SyncLazy::new(|| cargo::TARGET_LIB.join("cargo-clippy"));
 
 #[test]
 fn dogfood_clippy() {


### PR DESCRIPTION
This replaces some `lazy_static` usage with [`SyncLazy`](https://doc.rust-lang.org/nightly/std/lazy/struct.SyncLazy.html) of the unstable `once_cell` feature.

changelog: none
