### PR TITLE
do not run clippy for cargo clippy -- -W help 

### DIFF
--- a/clippy_lints/src/consts.rs
+++ b/clippy_lints/src/consts.rs
@@ -155,7 +155,7 @@ pub fn lit_to_constant(lit: &LitKind, ty: Option<Ty<'_>>) -> Constant {
     match *lit {
         LitKind::Str(ref is, _) => Constant::Str(is.to_string()),
         LitKind::Byte(b) => Constant::Int(u128::from(b)),
-        LitKind::ByteStr(ref s) => Constant::Binary(Lrc::from(s.as_slice())),
+        LitKind::ByteStr(ref s) => Constant::Binary(Lrc::from(&s[..])),
         LitKind::Char(c) => Constant::Char(c),
         LitKind::Int(n, _) => Constant::Int(n),
         LitKind::Float(ref is, LitFloatType::Suffixed(fty)) => match fty {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -7,7 +7,6 @@
 
 // FIXME: switch to something more ergonomic here, once available.
 // (Currently there is no way to opt into sysroot crates without `extern crate`.)
-extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_interface;
@@ -24,8 +23,6 @@ use std::ops::Deref;
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
-
-mod lintlist;
 
 /// If a command-line option matches `find_arg`, then apply the predicate `pred` on its value. If
 /// true, then return it. The parameter is assumed to be either `--arg=value` or `--arg value`.
@@ -89,113 +86,6 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
         // use for Clippy.
         config.opts.debugging_opts.mir_opt_level = 0;
     }
-}
-
-#[allow(clippy::find_map, clippy::filter_map)]
-fn describe_lints() {
-    use lintlist::{Level, Lint, ALL_LINTS, LINT_LEVELS};
-    use rustc_data_structures::fx::FxHashSet;
-
-    println!(
-        "
-Available lint options:
-    -W <foo>           Warn about <foo>
-    -A <foo>           Allow <foo>
-    -D <foo>           Deny <foo>
-    -F <foo>           Forbid <foo> (deny <foo> and all attempts to override)
-
-"
-    );
-
-    let lint_level = |lint: &Lint| {
-        LINT_LEVELS
-            .iter()
-            .find(|level_mapping| level_mapping.0 == lint.group)
-            .map(|(_, level)| match level {
-                Level::Allow => "allow",
-                Level::Warn => "warn",
-                Level::Deny => "deny",
-            })
-            .unwrap()
-    };
-
-    let mut lints: Vec<_> = ALL_LINTS.iter().collect();
-    // The sort doesn't case-fold but it's doubtful we care.
-    lints.sort_by_cached_key(|x: &&Lint| (lint_level(x), x.name));
-
-    let max_lint_name_len = lints
-        .iter()
-        .map(|lint| lint.name.len())
-        .map(|len| len + "clippy::".len())
-        .max()
-        .unwrap_or(0);
-
-    let padded = |x: &str| {
-        let mut s = " ".repeat(max_lint_name_len - x.chars().count());
-        s.push_str(x);
-        s
-    };
-
-    let scoped = |x: &str| format!("clippy::{}", x);
-
-    let lint_groups: FxHashSet<_> = lints.iter().map(|lint| lint.group).collect();
-
-    println!("Lint checks provided by clippy:\n");
-    println!("    {}  {:7.7}  meaning", padded("name"), "default");
-    println!("    {}  {:7.7}  -------", padded("----"), "-------");
-
-    let print_lints = |lints: &[&Lint]| {
-        for lint in lints {
-            let name = lint.name.replace("_", "-");
-            println!(
-                "    {}  {:7.7}  {}",
-                padded(&scoped(&name)),
-                lint_level(lint),
-                lint.desc
-            );
-        }
-        println!("\n");
-    };
-
-    print_lints(&lints);
-
-    let max_group_name_len = std::cmp::max(
-        "clippy::all".len(),
-        lint_groups
-            .iter()
-            .map(|group| group.len())
-            .map(|len| len + "clippy::".len())
-            .max()
-            .unwrap_or(0),
-    );
-
-    let padded_group = |x: &str| {
-        let mut s = " ".repeat(max_group_name_len - x.chars().count());
-        s.push_str(x);
-        s
-    };
-
-    println!("Lint groups provided by clippy:\n");
-    println!("    {}  sub-lints", padded_group("name"));
-    println!("    {}  ---------", padded_group("----"));
-    println!("    {}  the set of all clippy lints", padded_group("clippy::all"));
-
-    let print_lint_groups = || {
-        for group in lint_groups {
-            let name = group.to_lowercase().replace("_", "-");
-            let desc = lints
-                .iter()
-                .filter(|&lint| lint.group == group)
-                .map(|lint| lint.name)
-                .map(|name| name.replace("_", "-"))
-                .collect::<Vec<String>>()
-                .join(", ");
-            println!("    {}  {}", padded_group(&scoped(&name)), desc);
-        }
-        println!("\n");
-    };
-
-    print_lint_groups();
 }
 
 fn display_help() {
@@ -377,17 +267,6 @@ pub fn main() {
 
         if !wrapper_mode && (orig_args.iter().any(|a| a == "--help" || a == "-h") || orig_args.len() == 1) {
             display_help();
-            exit(0);
-        }
-
-        let should_describe_lints = || {
-            let args: Vec<_> = env::args().collect();
-            args.windows(2)
-                .any(|args| args[1] == "help" && matches!(args[0].as_str(), "-W" | "-A" | "-D" | "-F"))
-        };
-
-        if !wrapper_mode && should_describe_lints() {
-            describe_lints();
             exit(0);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,12 @@
 #![warn(rust_2018_idioms, unused_lifetimes)]
 
 use rustc_tools_util::VersionInfo;
-use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::{self, Command};
+use std::{collections::HashSet, env, path::Path};
+
+mod lintlist;
 
 const CARGO_CLIPPY_HELP: &str = r#"Checks a package to catch common mistakes and improve your Rust code.
 
@@ -50,6 +52,28 @@ pub fn main() {
 
     if env::args().any(|a| a == "--version" || a == "-V") {
         show_version();
+        return;
+    }
+
+    let mut orig_args: Vec<String> = env::args().collect();
+
+    // Setting RUSTC_WRAPPER causes Cargo to pass 'rustc' as the first argument.
+    // We're invoking the compiler programmatically, so we ignore this/
+    let wrapper_mode = orig_args.get(1).map(Path::new).and_then(Path::file_stem) == Some("rustc".as_ref());
+
+    if wrapper_mode {
+        // we still want to be able to invoke it normally though
+        orig_args.remove(1);
+    }
+
+    let should_describe_lints = || {
+        let args: Vec<_> = env::args().collect();
+        args.windows(2)
+            .any(|args| args[1] == "help" && matches!(args[0].as_str(), "-W" | "-A" | "-D" | "-F"))
+    };
+
+    if !wrapper_mode && should_describe_lints() {
+        describe_lints();
         return;
     }
 
@@ -177,6 +201,112 @@ where
     } else {
         Err(exit_status.code().unwrap_or(-1))
     }
+}
+
+#[allow(clippy::find_map, clippy::filter_map)]
+fn describe_lints() {
+    use lintlist::{Level, Lint, ALL_LINTS, LINT_LEVELS};
+
+    println!(
+        "
+Available lint options:
+    -W <foo>           Warn about <foo>
+    -A <foo>           Allow <foo>
+    -D <foo>           Deny <foo>
+    -F <foo>           Forbid <foo> (deny <foo> and all attempts to override)
+
+"
+    );
+
+    let lint_level = |lint: &Lint| {
+        LINT_LEVELS
+            .iter()
+            .find(|level_mapping| level_mapping.0 == lint.group)
+            .map(|(_, level)| match level {
+                Level::Allow => "allow",
+                Level::Warn => "warn",
+                Level::Deny => "deny",
+            })
+            .unwrap()
+    };
+
+    let mut lints: Vec<_> = ALL_LINTS.iter().collect();
+    // The sort doesn't case-fold but it's doubtful we care.
+    lints.sort_by_cached_key(|x: &&Lint| (lint_level(x), x.name));
+
+    let max_lint_name_len = lints
+        .iter()
+        .map(|lint| lint.name.len())
+        .map(|len| len + "clippy::".len())
+        .max()
+        .unwrap_or(0);
+
+    let padded = |x: &str| {
+        let mut s = " ".repeat(max_lint_name_len - x.chars().count());
+        s.push_str(x);
+        s
+    };
+
+    let scoped = |x: &str| format!("clippy::{}", x);
+
+    let lint_groups: HashSet<_> = lints.iter().map(|lint| lint.group).collect();
+
+    println!("Lint checks provided by clippy:\n");
+    println!("    {}  {:7.7}  meaning", padded("name"), "default");
+    println!("    {}  {:7.7}  -------", padded("----"), "-------");
+
+    let print_lints = |lints: &[&Lint]| {
+        for lint in lints {
+            let name = lint.name.replace("_", "-");
+            println!(
+                "    {}  {:7.7}  {}",
+                padded(&scoped(&name)),
+                lint_level(lint),
+                lint.desc
+            );
+        }
+        println!("\n");
+    };
+
+    print_lints(&lints);
+
+    let max_group_name_len = std::cmp::max(
+        "clippy::all".len(),
+        lint_groups
+            .iter()
+            .map(|group| group.len())
+            .map(|len| len + "clippy::".len())
+            .max()
+            .unwrap_or(0),
+    );
+
+    let padded_group = |x: &str| {
+        let mut s = " ".repeat(max_group_name_len - x.chars().count());
+        s.push_str(x);
+        s
+    };
+
+    println!("Lint groups provided by clippy:\n");
+    println!("    {}  sub-lints", padded_group("name"));
+    println!("    {}  ---------", padded_group("----"));
+    println!("    {}  the set of all clippy lints", padded_group("clippy::all"));
+
+    let print_lint_groups = || {
+        for group in lint_groups {
+            let name = group.to_lowercase().replace("_", "-");
+            let desc = lints
+                .iter()
+                .filter(|&lint| lint.group == group)
+                .map(|lint| lint.name)
+                .map(|name| name.replace("_", "-"))
+                .collect::<Vec<String>>()
+                .join(", ");
+            println!("    {}  {}", padded_group(&scoped(&name)), desc);
+        }
+        println!("\n");
+    };
+
+    print_lint_groups();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
close #6122
Allow cli to display available lints without running the clippy process.

Let me know if the wrapper_mode is still relevant at this location in the source code. 

Thanks for your review :) 
