### PR TITLE
Reinstate test for forbid(clippy::restriction)

### DIFF
--- a/tests/ui/attrs.rs
+++ b/tests/ui/attrs.rs
@@ -1,8 +1,5 @@
 #![warn(clippy::inline_always, clippy::deprecated_semver)]
 #![allow(clippy::assertions_on_constants)]
-// Test that the whole restriction group is not enabled
-#![warn(clippy::restriction)]
-#![deny(clippy::restriction)]
 #![allow(clippy::missing_docs_in_private_items, clippy::panic, clippy::unreachable)]
 
 #[inline(always)]

--- a/tests/ui/attrs.stderr
+++ b/tests/ui/attrs.stderr
@@ -1,5 +1,5 @@
 error: you have declared `#[inline(always)]` on `test_attr_lint`. This is usually a bad idea
-  --> $DIR/attrs.rs:8:1
+  --> $DIR/attrs.rs:5:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #[inline(always)]
    = note: `-D clippy::inline-always` implied by `-D warnings`
 
 error: the since field must contain a semver-compliant version
-  --> $DIR/attrs.rs:28:14
+  --> $DIR/attrs.rs:25:14
    |
 LL | #[deprecated(since = "forever")]
    |              ^^^^^^^^^^^^^^^^^
@@ -15,27 +15,10 @@ LL | #[deprecated(since = "forever")]
    = note: `-D clippy::deprecated-semver` implied by `-D warnings`
 
 error: the since field must contain a semver-compliant version
-  --> $DIR/attrs.rs:31:14
+  --> $DIR/attrs.rs:28:14
    |
 LL | #[deprecated(since = "1")]
    |              ^^^^^^^^^^^
 
-error: restriction lints are not meant to be all enabled
-  --> $DIR/attrs.rs:4:9
-   |
-LL | #![warn(clippy::restriction)]
-   |         ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `-D clippy::blanket-clippy-restriction-lints` implied by `-D warnings`
-   = help: try enabling only the lints you really need
-
-error: restriction lints are not meant to be all enabled
-  --> $DIR/attrs.rs:5:9
-   |
-LL | #![deny(clippy::restriction)]
-   |         ^^^^^^^^^^^^^^^^^^^
-   |
-   = help: try enabling only the lints you really need
-
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/blanket_clippy_restriction_lints.rs
+++ b/tests/ui/blanket_clippy_restriction_lints.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::blanket_clippy_restriction_lints)]
+
+//! Test that the whole restriction group is not enabled
+#![warn(clippy::restriction)]
+#![deny(clippy::restriction)]
+#![forbid(clippy::restriction)]
+
+fn main() {}

--- a/tests/ui/blanket_clippy_restriction_lints.stderr
+++ b/tests/ui/blanket_clippy_restriction_lints.stderr
@@ -1,0 +1,27 @@
+error: restriction lints are not meant to be all enabled
+  --> $DIR/blanket_clippy_restriction_lints.rs:4:9
+   |
+LL | #![warn(clippy::restriction)]
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::blanket-clippy-restriction-lints` implied by `-D warnings`
+   = help: try enabling only the lints you really need
+
+error: restriction lints are not meant to be all enabled
+  --> $DIR/blanket_clippy_restriction_lints.rs:5:9
+   |
+LL | #![deny(clippy::restriction)]
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try enabling only the lints you really need
+
+error: restriction lints are not meant to be all enabled
+  --> $DIR/blanket_clippy_restriction_lints.rs:6:11
+   |
+LL | #![forbid(clippy::restriction)]
+   |           ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try enabling only the lints you really need
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
In [this commit](https://github.com/rust-lang/rust-clippy/pull/6126/commits/5747c15961da9d2d0b0dd775174d39f3b5961597) coming from rust-lang/rust (#6126) the test for `#![forbid(clippy::restriction)]` was removed because some restriction lints were being allowed after the forbid.

This change reinstates the test for `forbid` by using a separate file.

changelog: none

r? @flip1995 