### PR TITLE
Fix unicode regexen with bytes::Regex

### DIFF
--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -143,7 +143,7 @@ fn check_set<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, utf8: bool) {
 
 fn check_regex<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, utf8: bool) {
     let mut parser = regex_syntax::ParserBuilder::new()
-        .unicode(utf8)
+        .unicode(true)
         .allow_invalid_utf8(!utf8)
         .build();
 

--- a/tests/ui/regex.rs
+++ b/tests/ui/regex.rs
@@ -71,6 +71,9 @@ fn trivial_regex() {
     let non_trivial_ends_with = Regex::new("foo|bar");
     let non_trivial_binary = BRegex::new("foo|bar");
     let non_trivial_binary_builder = BRegexBuilder::new("foo|bar");
+
+    // #6005: unicode classes in bytes::Regex
+    let a_byte_of_unicode = BRegex::new(r"\p{C}");
 }
 
 fn main() {


### PR DESCRIPTION
fixes #6005

The rationale for this is that since we wrote that lint, `bytes::Regex` was extended to be able to use unicode character classes.

---

changelog: [`invalid_regex`]: allow unicode character classes in bytes regex.
