### PR TITLE
clippy_lints: Do not warn against Box parameter in C FFI

### DIFF
--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -68,7 +68,7 @@ impl<'tcx> LateLintPass<'tcx> for BoxedLocal {
         hir_id: HirId,
     ) {
         if let Some(header) = fn_kind.header() {
-            if header.abi == Abi::Cdecl {
+            if header.abi == Abi::C {
                 return;
             }
         }

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -6,6 +6,7 @@ use rustc_middle::ty::{self, Ty};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::source_map::Span;
 use rustc_target::abi::LayoutOf;
+use rustc_target::spec::abi::Abi;
 use rustc_typeck::expr_use_visitor::{ConsumeMode, Delegate, ExprUseVisitor, PlaceBase, PlaceWithHirId};
 
 use crate::utils::span_lint;
@@ -60,12 +61,18 @@ impl<'tcx> LateLintPass<'tcx> for BoxedLocal {
     fn check_fn(
         &mut self,
         cx: &LateContext<'tcx>,
-        _: intravisit::FnKind<'tcx>,
+        fn_kind: intravisit::FnKind<'tcx>,
         _: &'tcx FnDecl<'_>,
         body: &'tcx Body<'_>,
         _: Span,
         hir_id: HirId,
     ) {
+        if let Some(header) = fn_kind.header() {
+            if header.abi == Abi::Cdecl {
+                return;
+            }
+        }
+
         // If the method is an impl for a trait, don't warn.
         let parent_id = cx.tcx.hir().get_parent_item(hir_id);
         let parent_node = cx.tcx.hir().find(parent_id);

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -68,7 +68,7 @@ impl<'tcx> LateLintPass<'tcx> for BoxedLocal {
         hir_id: HirId,
     ) {
         if let Some(header) = fn_kind.header() {
-            if header.abi == Abi::C {
+            if header.abi != Abi::Rust {
                 return;
             }
         }

--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -179,3 +179,6 @@ mod issue_3739 {
 ///
 /// This shouldn't warn for `boxed_local` as it is intended to called from non-Rust code.
 pub extern "C" fn do_not_warn_me(_c_pointer: Box<String>) -> () {}
+
+#[rustfmt::skip] // Forces rustfmt to not add ABI
+pub extern fn do_not_warn_me_no_abi(_c_pointer: Box<String>) -> () {}

--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -177,5 +177,5 @@ mod issue_3739 {
 
 /// Issue #5542
 ///
-/// This shouldn't warn for `boxed_local` as it is a function to be used in C.
+/// This shouldn't warn for `boxed_local` as it is intended to called from non-Rust code.
 pub extern "C" fn do_not_warn_me(_c_pointer: Box<String>) -> () {}

--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -177,5 +177,5 @@ mod issue_3739 {
 
 /// Issue #5542
 ///
-/// This shouldn't warn for `boxed_local` as it is a function implemented in C.
-pub extern "C" fn do_now_warn_me(_c_pointer: Box<String>) -> () {}
+/// This shouldn't warn for `boxed_local` as it is a function to be used in C.
+pub extern "C" fn do_not_warn_me(_c_pointer: Box<String>) -> () {}

--- a/tests/ui/escape_analysis.rs
+++ b/tests/ui/escape_analysis.rs
@@ -174,3 +174,8 @@ mod issue_3739 {
         };
     }
 }
+
+/// Issue #5542
+///
+/// This shouldn't warn for `boxed_local` as it is a function implemented in C.
+pub extern "C" fn do_now_warn_me(_c_pointer: Box<String>) -> () {}


### PR DESCRIPTION
changelog: [`boxed_local`]: don't lint in `extern fn` arguments

Fixes #5542.

When using C FFI, to handle pointers in parameters it is needed to
declare them as `Box` in its Rust-side signature. However, the current
linter warns against the usage of Box stating that "local variable
doesn't need to be boxed here".

This commit fixes it by ignoring functions whose Abi is C.