### PR TITLE
Update release documentation

### DIFF
--- a/doc/release.md
+++ b/doc/release.md
@@ -68,7 +68,7 @@ be updated.
 ```bash
 # Assuming the current directory corresponds to the Clippy repository
 $ git checkout beta
-$ git rebase $BETA_SHA
+$ git reset --hard $BETA_SHA
 $ git push upstream beta
 ```
 


### PR DESCRIPTION
When updating the beta branch, we want to reset, instead of rebase. Otherwise we might produce again new commits on the beta branch, that aren't on the master branch.

changelog: none
