### PR TITLE
Remove deprecated set-env from GHA

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Set LD_LIBRARY_PATH (Linux)
       run: |
         SYSROOT=$(rustc --print sysroot)
-        echo "::set-env name=LD_LIBRARY_PATH::${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
+        echo "LD_LIBRARY_PATH=${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
 
     - name: Build
       run: cargo build --features deny-warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -36,14 +36,14 @@ jobs:
         github_token: "${{ secrets.github_token }}"
 
     - name: rust-toolchain
-      uses: actions-rs/toolchain@v1.0.3
+      uses: actions-rs/toolchain@v1.0.6
       with:
         toolchain: nightly
         target: x86_64-unknown-linux-gnu
         profile: minimal
 
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
 
     - name: Run cargo update
       run: cargo update

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         github_token: "${{ secrets.github_token }}"
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
       with:
         ref: ${{ github.ref }}
 
@@ -81,14 +81,14 @@ jobs:
       if: matrix.host == 'i686-unknown-linux-gnu'
 
     - name: rust-toolchain
-      uses: actions-rs/toolchain@v1.0.3
+      uses: actions-rs/toolchain@v1.0.6
       with:
         toolchain: nightly
         target: ${{ matrix.host }}
         profile: minimal
 
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
 
     - name: Run cargo update
       run: cargo update
@@ -177,14 +177,14 @@ jobs:
         github_token: "${{ secrets.github_token }}"
 
     - name: rust-toolchain
-      uses: actions-rs/toolchain@v1.0.3
+      uses: actions-rs/toolchain@v1.0.6
       with:
         toolchain: nightly
         target: x86_64-unknown-linux-gnu
         profile: minimal
 
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
 
     - name: Run cargo update
       run: cargo update
@@ -258,14 +258,14 @@ jobs:
         github_token: "${{ secrets.github_token }}"
 
     - name: rust-toolchain
-      uses: actions-rs/toolchain@v1.0.3
+      uses: actions-rs/toolchain@v1.0.6
       with:
         toolchain: nightly
         target: x86_64-unknown-linux-gnu
         profile: minimal
 
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
 
     - name: Run cargo update
       run: cargo update

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -11,6 +11,10 @@ env:
   CARGO_TARGET_DIR: '${{ github.workspace }}/target'
   NO_FMT_TEST: 1
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   changelog:
     runs-on: ubuntu-latest
@@ -105,7 +109,6 @@ jobs:
       run: bash setup-toolchain.sh
       env:
         HOST_TOOLCHAIN: ${{ matrix.host }}
-      shell: bash
 
     # Run
     - name: Set LD_LIBRARY_PATH (Linux)
@@ -124,39 +127,31 @@ jobs:
       run: |
         SYSROOT=$(rustc --print sysroot)
         echo "$SYSROOT/bin" >> $GITHUB_PATH
-      shell: bash
 
     - name: Build
       run: cargo build --features deny-warnings
-      shell: bash
 
     - name: Test
       run: cargo test --features deny-warnings
-      shell: bash
 
     - name: Test clippy_lints
       run: cargo test --features deny-warnings
-      shell: bash
       working-directory: clippy_lints
 
     - name: Test rustc_tools_util
       run: cargo test --features deny-warnings
-      shell: bash
       working-directory: rustc_tools_util
 
     - name: Test clippy_dev
       run: cargo test --features deny-warnings
-      shell: bash
       working-directory: clippy_dev
 
     - name: Test cargo-clippy
       run: ../target/debug/cargo-clippy
-      shell: bash
       working-directory: clippy_workspace_tests
 
     - name: Test clippy-driver
       run: bash .github/driver.sh
-      shell: bash
       env:
         OS: ${{ runner.os }}
 
@@ -165,7 +160,7 @@ jobs:
       run: |
         cargo +nightly install cargo-cache --no-default-features --features ci-autoclean cargo-cache
         cargo cache
-      shell: bash
+
   integration_build:
     needs: changelog
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -112,7 +112,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         SYSROOT=$(rustc --print sysroot)
-        echo "::set-env name=LD_LIBRARY_PATH::${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
+        echo "LD_LIBRARY_PATH=${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
     - name: Link rustc dylib (MacOS)
       if: runner.os == 'macOS'
       run: |
@@ -122,9 +122,9 @@ jobs:
     - name: Set PATH (Windows)
       if: runner.os == 'Windows'
       run: |
-        $sysroot = rustc --print sysroot
-        $env:PATH += ';' + $sysroot + '\bin'
-        echo "::set-env name=PATH::$env:PATH"
+        SYSROOT=$(rustc --print sysroot)
+        echo "$SYSROOT/bin" >> $GITHUB_PATH
+      shell: bash
 
     - name: Build
       run: cargo build --features deny-warnings

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     # Setup
     - name: rust-toolchain
-      uses: actions-rs/toolchain@v1.0.3
+      uses: actions-rs/toolchain@v1.0.6
       with:
         toolchain: nightly
         target: x86_64-unknown-linux-gnu
@@ -31,7 +31,7 @@ jobs:
         components: rustfmt
 
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
 
     # Run
     - name: Build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
     # Setup
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
 
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
       with:
         ref: ${{ env.TARGET_BRANCH }}
         path: 'out'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,10 +34,10 @@ jobs:
       if: startswith(github.ref, 'refs/tags/')
       run: |
         TAG=$(basename ${{ github.ref }})
-        echo "::set-env name=TAG_NAME::$TAG"
+        echo "TAG_NAME=$TAG" >> $GITHUB_ENV
     - name: Set beta to true
       if: github.ref == 'refs/heads/beta'
-      run: echo "::set-env name=BETA::true"
+      run: echo "BETA=true" >> $GITHUB_ENV
 
     - name: Use scripts and templates from master branch
       run: |

--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     # Setup
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v2.3.3
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1.1.0
+      uses: actions/setup-node@v1.4.4
 
     - name: Install remark
       run: npm install remark-cli remark-lint remark-lint-maximum-line-length remark-preset-lint-recommended


### PR DESCRIPTION
This updates all of our action dependencies and removes every usage of `set-env`. `set-env` and `add-path` has been deprecated: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

changelog: none
