### PR TITLE
Preserve raw strs for: format!(s) to s.to_string() lint

### DIFF
--- a/tests/ui/format.fixed
+++ b/tests/ui/format.fixed
@@ -13,7 +13,8 @@ fn main() {
     "foo".to_string();
     "{}".to_string();
     "{} abc {}".to_string();
-    "foo {}\n\" bar".to_string();
+    r##"foo {}
+" bar"##.to_string();
 
     "foo".to_string();
     format!("{:?}", "foo"); // Don't warn about `Debug`.

--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -25,7 +25,13 @@ LL | /     format!(
 LL | |         r##"foo {{}}
 LL | | " bar"##
 LL | |     );
-   | |______^ help: consider using `.to_string()`: `"foo {}/n/" bar".to_string();`
+   | |______^
+   |
+help: consider using `.to_string()`
+   |
+LL |     r##"foo {}
+LL | " bar"##.to_string();
+   |
 
 error: useless use of `format!`
   --> $DIR/format.rs:21:5


### PR DESCRIPTION
fixes #6142 

clippy::useless_format will keep the source's string (after converting {{ and }} to { and }) when suggesting a change from format!() to .to_string() usage. Ie:
|     let s = format!(r#""hello {{}}""#);
|             ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `r#""hello {}""#.to_string()`

changelog: [`useless_format`]: preserve raw string literals when no arguments to `format!()` are provided.
