### PR TITLE
Fix two ICEs caused by ty.is_{sized,freeze}

### DIFF
--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -1,6 +1,7 @@
 use crate::utils::{match_def_path, paths, span_lint, trait_ref_of_method};
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TypeFoldable;
 use rustc_middle::ty::{Adt, Array, RawPtr, Ref, Slice, Tuple, Ty, TypeAndMut};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Span;
@@ -120,7 +121,11 @@ fn is_mutable_type<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, span: Span) -> bo
             size.try_eval_usize(cx.tcx, cx.param_env).map_or(true, |u| u != 0) && is_mutable_type(cx, inner_ty, span)
         },
         Tuple(..) => ty.tuple_fields().any(|ty| is_mutable_type(cx, ty, span)),
-        Adt(..) => cx.tcx.layout_of(cx.param_env.and(ty)).is_ok() && !ty.is_freeze(cx.tcx.at(span), cx.param_env),
+        Adt(..) => {
+            cx.tcx.layout_of(cx.param_env.and(ty)).is_ok()
+                && !ty.has_escaping_bound_vars()
+                && !ty.is_freeze(cx.tcx.at(span), cx.param_env)
+        },
         _ => false,
     }
 }

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -17,6 +17,7 @@ use rustc_hir::{
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::hir::map::Map;
 use rustc_middle::lint::in_external_macro;
+use rustc_middle::ty::TypeFoldable;
 use rustc_middle::ty::{self, InferTy, Ty, TyCtxt, TyS, TypeckResults};
 use rustc_session::{declare_lint_pass, declare_tool_lint, impl_lint_pass};
 use rustc_span::hygiene::{ExpnKind, MacroKind};
@@ -541,11 +542,7 @@ impl Types {
                                 _ => None,
                             });
                             let ty_ty = hir_ty_to_ty(cx.tcx, boxed_ty);
-                            // HACK(flip1995): This is a fix for an ICE occuring when `ty_ty` is a
-                            // trait object with a lifetime, e.g. `dyn T<'_>`. Since trait objects
-                            // don't have a known size, this shouldn't introduce FNs. But there
-                            // should be a better solution.
-                            if !matches!(ty_ty.kind(), ty::Dynamic(..));
+                            if !ty_ty.has_escaping_bound_vars();
                             if ty_ty.is_sized(cx.tcx.at(ty.span), cx.param_env);
                             if let Ok(ty_ty_size) = cx.layout_of(ty_ty).map(|l| l.size.bytes());
                             if ty_ty_size <= self.vec_box_size_threshold;

--- a/tests/ui/crashes/ice-6153.rs
+++ b/tests/ui/crashes/ice-6153.rs
@@ -1,0 +1,9 @@
+pub struct S<'a, 'e>(&'a str, &'e str);
+
+pub type T<'a, 'e> = std::collections::HashMap<S<'a, 'e>, ()>;
+
+impl<'e, 'a: 'e> S<'a, 'e> {
+    pub fn foo(_a: &str, _b: &str, _map: &T) {}
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #6153 
Properly fixes #6139 

The test case in #6153 is kind of weird. Even removing one of the arguments of the `foo` function prevented the ICE. I think this test case is actually minimal.

changelog: none
