### PR TITLE
Remove the generated files by `update-references.sh` if they are empty

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -104,7 +104,8 @@ every time before running `tests/ui/update-all-references.sh`.
 Running `TESTNAME=foo_functions cargo uitest` should pass then. When we commit
 our lint, we need to commit the generated `.stderr` files, too. In general, you
 should only commit files changed by `tests/ui/update-all-references.sh` for the
-specific lint you are creating/editing.
+specific lint you are creating/editing. Note that if the generated files are
+empty, they should be removed.
 
 ### Cargo lints
 

--- a/tests/ui-cargo/update-references.sh
+++ b/tests/ui-cargo/update-references.sh
@@ -29,10 +29,18 @@ while [[ "$1" != "" ]]; do
            ! (cmp -s -- "$BUILD_DIR"/"$STDOUT_NAME" "$MYDIR"/"$STDOUT_NAME"); then
         echo updating "$MYDIR"/"$STDOUT_NAME"
         cp "$BUILD_DIR"/"$STDOUT_NAME" "$MYDIR"/"$STDOUT_NAME"
+        if [[ ! -s "$MYDIR"/"$STDOUT_NAME" ]]; then
+            echo removing "$MYDIR"/"$STDOUT_NAME"
+            rm "$MYDIR"/"$STDOUT_NAME"
+        fi
     fi
     if [[ -f "$BUILD_DIR"/"$STDERR_NAME" ]] && \
            ! (cmp -s -- "$BUILD_DIR"/"$STDERR_NAME" "$MYDIR"/"$STDERR_NAME"); then
         echo updating "$MYDIR"/"$STDERR_NAME"
         cp "$BUILD_DIR"/"$STDERR_NAME" "$MYDIR"/"$STDERR_NAME"
+        if [[ ! -s "$MYDIR"/"$STDERR_NAME" ]]; then
+            echo removing "$MYDIR"/"$STDERR_NAME"
+            rm "$MYDIR"/"$STDERR_NAME"
+        fi
     fi
 done

--- a/tests/ui-toml/update-references.sh
+++ b/tests/ui-toml/update-references.sh
@@ -29,10 +29,18 @@ while [[ "$1" != "" ]]; do
            ! (cmp -s -- "$BUILD_DIR"/"$STDOUT_NAME" "$MYDIR"/"$STDOUT_NAME"); then
         echo updating "$MYDIR"/"$STDOUT_NAME"
         cp "$BUILD_DIR"/"$STDOUT_NAME" "$MYDIR"/"$STDOUT_NAME"
+        if [[ ! -s "$MYDIR"/"$STDOUT_NAME" ]]; then
+            echo removing "$MYDIR"/"$STDOUT_NAME"
+            rm "$MYDIR"/"$STDOUT_NAME"
+        fi
     fi
     if [[ -f "$BUILD_DIR"/"$STDERR_NAME" ]] && \
            ! (cmp -s -- "$BUILD_DIR"/"$STDERR_NAME" "$MYDIR"/"$STDERR_NAME"); then
         echo updating "$MYDIR"/"$STDERR_NAME"
         cp "$BUILD_DIR"/"$STDERR_NAME" "$MYDIR"/"$STDERR_NAME"
+        if [[ ! -s "$MYDIR"/"$STDERR_NAME" ]]; then
+            echo removing "$MYDIR"/"$STDERR_NAME"
+            rm "$MYDIR"/"$STDERR_NAME"
+        fi
     fi
 done

--- a/tests/ui/update-references.sh
+++ b/tests/ui/update-references.sh
@@ -30,15 +30,27 @@ while [[ "$1" != "" ]]; do
            ! (cmp -s -- "$BUILD_DIR"/"$STDOUT_NAME" "$MYDIR"/"$STDOUT_NAME"); then
         echo updating "$MYDIR"/"$STDOUT_NAME"
         cp "$BUILD_DIR"/"$STDOUT_NAME" "$MYDIR"/"$STDOUT_NAME"
+        if [[ ! -s "$MYDIR"/"$STDOUT_NAME" ]]; then
+            echo removing "$MYDIR"/"$STDOUT_NAME"
+            rm "$MYDIR"/"$STDOUT_NAME"
+        fi
     fi
     if [[ -f "$BUILD_DIR"/"$STDERR_NAME" ]] && \
            ! (cmp -s -- "$BUILD_DIR"/"$STDERR_NAME" "$MYDIR"/"$STDERR_NAME"); then
         echo updating "$MYDIR"/"$STDERR_NAME"
         cp "$BUILD_DIR"/"$STDERR_NAME" "$MYDIR"/"$STDERR_NAME"
+        if [[ ! -s "$MYDIR"/"$STDERR_NAME" ]]; then
+            echo removing "$MYDIR"/"$STDERR_NAME"
+            rm "$MYDIR"/"$STDERR_NAME"
+        fi
     fi
     if [[ -f "$BUILD_DIR"/"$FIXED_NAME" ]] && \
            ! (cmp -s -- "$BUILD_DIR"/"$FIXED_NAME" "$MYDIR"/"$FIXED_NAME"); then
         echo updating "$MYDIR"/"$FIXED_NAME"
         cp "$BUILD_DIR"/"$FIXED_NAME" "$MYDIR"/"$FIXED_NAME"
+        if [[ ! -s "$MYDIR"/"$FIXED_NAME" ]]; then
+            echo removing "$MYDIR"/"$FIXED_NAME"
+            rm "$MYDIR"/"$FIXED_NAME"
+        fi
     fi
 done


### PR DESCRIPTION
An empty file may be generated by `update-references.sh` and committed as is when creating a patch like https://github.com/rust-lang/rust-clippy/pull/6101#issuecomment-702076508 and https://github.com/rust-lang/rust-clippy/pull/6079#pullrequestreview-496502721. So, I think it would be helpful to add documentation, and automatically remove the generated file if it's empty.

changelog: none
