### PR TITLE
Remove lazy_static completely and use once_cell feature instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,11 @@ clippy_lints = { version = "0.0.212", path = "clippy_lints" }
 semver = "0.10"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
 tempfile = { version = "3.1.0", optional = true }
-lazy_static = "1.0"
 
 [dev-dependencies]
 cargo_metadata = "0.11.1"
 compiletest_rs = { version = "0.5.0", features = ["tmp"] }
 tester = "0.7"
-lazy_static = "1.0"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }
 serde = { version = "1.0", features = ["derive"] }
 derive-new = "0.5"

--- a/clippy_dev/src/update_lints.rs
+++ b/clippy_dev/src/update_lints.rs
@@ -29,7 +29,7 @@ pub fn run(update_mode: UpdateMode) {
         false,
         update_mode == UpdateMode::Change,
         || {
-            format!("pub static ref ALL_LINTS: Vec<Lint> = vec!{:#?};", sorted_usable_lints)
+            format!("vec!{:#?}", sorted_usable_lints)
                 .lines()
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -18,13 +18,13 @@ use rustc_interface::interface;
 use rustc_middle::ty::TyCtxt;
 use rustc_tools_util::VersionInfo;
 
-use lazy_static::lazy_static;
 use std::borrow::Cow;
 use std::env;
 use std::ops::Deref;
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
+use std::lazy::SyncLazy;
 
 mod lintlist;
 
@@ -231,13 +231,11 @@ You can use tool lints to allow or deny lints from your code, eg.:
 
 const BUG_REPORT_URL: &str = "https://github.com/rust-lang/rust-clippy/issues/new";
 
-lazy_static! {
-    static ref ICE_HOOK: Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static> = {
-        let hook = panic::take_hook();
-        panic::set_hook(Box::new(|info| report_clippy_ice(info, BUG_REPORT_URL)));
-        hook
-    };
-}
+static ICE_HOOK: SyncLazy<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>> = SyncLazy::new(|| {
+    let hook = panic::take_hook();
+    panic::set_hook(Box::new(|info| report_clippy_ice(info, BUG_REPORT_URL)));
+    hook
+});
 
 fn report_clippy_ice(info: &panic::PanicInfo<'_>, bug_report_url: &str) {
     // Invoke our ICE handler, which prints the actual panic message and optionally a backtrace
@@ -296,7 +294,7 @@ fn toolchain_path(home: Option<String>, toolchain: Option<String>) -> Option<Pat
 
 pub fn main() {
     rustc_driver::init_rustc_env_logger();
-    lazy_static::initialize(&ICE_HOOK);
+    SyncLazy::force(&ICE_HOOK);
     exit(rustc_driver::catch_with_exit_code(move || {
         let mut orig_args: Vec<String> = env::args().collect();
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_private)]
+#![feature(once_cell)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 // warn on lints, that are included in `rust-lang/rust`s bootstrap
 #![warn(rust_2018_idioms, unused_lifetimes)]

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -20,11 +20,11 @@ use rustc_tools_util::VersionInfo;
 
 use std::borrow::Cow;
 use std::env;
+use std::lazy::SyncLazy;
 use std::ops::Deref;
 use std::panic;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
-use std::lazy::SyncLazy;
 
 mod lintlist;
 

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -1,15 +1,16 @@
-//! This file is managed by `cargo dev update_lints`. Do not edit.
+//! This file is managed by `cargo dev update_lints`. Do not edit or format this file.
 
-use lazy_static::lazy_static;
+use std::lazy::SyncLazy;
 
 pub mod lint;
 pub use lint::Level;
 pub use lint::Lint;
 pub use lint::LINT_LEVELS;
 
-lazy_static! {
+#[rustfmt::skip]
+pub static ALL_LINTS: SyncLazy<Vec<Lint>> = SyncLazy::new(|| {
 // begin lint list, do not remove this comment, it’s used in `update_lints`
-pub static ref ALL_LINTS: Vec<Lint> = vec![
+vec![
     Lint {
         name: "absurd_extreme_comparisons",
         group: "correctness",
@@ -2831,6 +2832,6 @@ pub static ref ALL_LINTS: Vec<Lint> = vec![
         deprecation: None,
         module: "methods",
     },
-];
+]
 // end lint list, do not remove this comment, it’s used in `update_lints`
-}
+});


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust-clippy/pull/6120

This removes the last remaining `lazy_static` usages and replaces them with `SyncLazy` from the `once_cell` feature.

---

changelog: none
