### PR TITLE
Suggest a compatible shell for setup-toolchain.sh

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -46,7 +46,7 @@ this toolchain, you can just use the `setup-toolchain.sh` script or use
 `rustup-toolchain-install-master`:
 
 ```bash
-sh setup-toolchain.sh
+bash setup-toolchain.sh
 # OR
 cargo install rustup-toolchain-install-master
 # For better IDE integration also add `-c rustfmt -c rust-src` (optional)


### PR DESCRIPTION
setup-toolchain.sh uses "[[" which is a bash builtin, but the guide
suggests running it with sh.  On Ubuntu, /bin/sh points to dash and
running the script fails.

---

*Please keep the line below*
changelog: none
