### PR TITLE
Improve a suggestion in `needless_collect` with many comments

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -2893,14 +2893,12 @@ fn check_needless_collect_indirect_usage<'tcx>(expr: &'tcx Expr<'_>, cx: &LateCo
                         NEEDLESS_COLLECT_MSG,
                         |diag| {
                             let iter_replacement = format!("{}{}", Sugg::hir(cx, iter_source, ".."), iter_call.get_iter_method(cx));
-                            diag.multipart_suggestion(
+                            diag.span_suggestion(
+                                stmt.span.to(iter_call.span),
                                 iter_call.get_suggestion_text(),
-                                vec![
-                                    (stmt.span, String::new()),
-                                    (iter_call.span, iter_replacement)
-                                ],
-                                Applicability::MachineApplicable,// MaybeIncorrect,
-                            ).emit();
+                                iter_replacement,
+                                Applicability::MaybeIncorrect,
+                            );
                         },
                     );
                 }

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -16,4 +16,14 @@ fn main() {
         .into_iter()
         .map(|x| (*x, *x + 1))
         .collect::<HashMap<_, _>>();
+
+    // Partially fix #6164
+    let indirect_contains_with_comments = sample.iter().collect::<VecDeque<_>>();
+    // This is some stuff,
+    // to pretend that we have some more
+    // code present here
+    // like we did
+    // in the real
+    // deal.
+    indirect_contains_with_comments.contains(&&5);
 }

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -8,9 +8,8 @@ LL | |     indirect_iter.into_iter().map(|x| (x, x + 1)).collect::<HashMap<_, _>
    = note: `-D clippy::needless-collect` implied by `-D warnings`
 help: Use the original Iterator instead of collecting it and then producing a new one
    |
-LL |     
 LL |     sample.iter().map(|x| (x, x + 1)).collect::<HashMap<_, _>>();
-   |
+   |     ^^^^^^^^^^^^^
 
 error: avoid using `collect()` when not needed
   --> $DIR/needless_collect_indirect.rs:7:5
@@ -21,9 +20,8 @@ LL | |     indirect_len.len();
    |
 help: Take the original Iterator's count instead of collecting it and finding the length
    |
-LL |     
 LL |     sample.iter().count();
-   |
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: avoid using `collect()` when not needed
   --> $DIR/needless_collect_indirect.rs:9:5
@@ -34,9 +32,8 @@ LL | |     indirect_empty.is_empty();
    |
 help: Check if the original Iterator has anything instead of collecting it and seeing if it's empty
    |
-LL |     
 LL |     sample.iter().next().is_none();
-   |
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: avoid using `collect()` when not needed
   --> $DIR/needless_collect_indirect.rs:11:5
@@ -47,9 +44,25 @@ LL | |     indirect_contains.contains(&&5);
    |
 help: Check if the original Iterator contains an element instead of collecting then checking
    |
-LL |     
 LL |     sample.iter().any(|x| x == &&5);
-   |
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: avoid using `collect()` when not needed
+  --> $DIR/needless_collect_indirect.rs:21:5
+   |
+LL | /     let indirect_contains_with_comments = sample.iter().collect::<VecDeque<_>>();
+LL | |     // This is some stuff,
+LL | |     // to pretend that we have some more
+LL | |     // code present here
+...  |
+LL | |     // deal.
+LL | |     indirect_contains_with_comments.contains(&&5);
+   | |____^
+   |
+help: Check if the original Iterator contains an element instead of collecting then checking
+   |
+LL |     sample.iter().any(|x| x == &&5);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Partially improve #6164

It looks like that using `multipart_suggestion` with `String::new()` isn't needed, so I just used `span_suggestion`. Also, this lint doesn't have a `.fixed` file and have some suggestion errors, so, I replaced `MachineApplicable` with `MaybeIncorrect`.

changelog: Improve a suggestion in `needless_collect` with many comments
