### PR TITLE
README: sort en/disabling section, fix typos, add note

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,33 @@ You can add options to your code to `allow`/`warn`/`deny` Clippy lints:
 
 Note: `deny` produces errors instead of warnings.
 
-If you do not want to include your lint levels in your code, you can globally enable/disable lints by passing extra
-flags to Clippy during the run: `cargo clippy -- -A clippy::lint_name` will run Clippy with `lint_name` disabled and
-`cargo clippy -- -W clippy::lint_name` will run it with that enabled. This also works with lint groups. For example you
-can run Clippy with warnings for all lints enabled: `cargo clippy -- -W clippy::pedantic`
+If you do not want to include your lint levels in your code, you can globally enable/disable lints
+by passing extra flags to Clippy during the run:
+
+To disable `lint_name`, run
+
+```terminal
+cargo clippy -- -A clippy::lint_name
+```
+
+And to enable `lint_name`, run
+
+```terminal
+cargo clippy -- -W clippy::lint_name
+```
+
+This also works with lint groups. For example you
+can run Clippy with warnings for all lints enabled: 
+```terminal
+cargo clippy -- -W clippy::pedantic
+```
+
 If you care only about a single lint, you can allow all others and then explicitly reenable
-the lint(s) you are interested in: `cargo clippy -- -Aclippy::all -Wclippy::useless_format -Wclippy::...`
+the lint(s) you are interested in:
+```terminal
+cargo clippy -- -A clippy::all -W clippy::useless_format -W clippy::...
+```
+Note that if you've run clippy before, this may only take effect after you've modified a file or ran `cargo clean`.
 
 ## Contributing
 


### PR DESCRIPTION
it took me a while to figure out why `cargo clippy -- -Aclippy::pedantic -Wclippy::items-after-statements` still showed me *all* the lints. At first I thought it was due to the missing spaces in the current example and I debugged that until I stumbled across an issue noting that you have to touch a random file or run `cargo clean` when you're running clippy repeatedly on an unchanged codebase. This PR is an attempt to save the next person some time and also structure the "Allowing/denying lints" section a bit more while we're at it.

---
*Please keep the line below*
changelog: none
