### PR TITLE
Remove an extra blank line in doc examples

### DIFF
--- a/clippy_lints/src/blocks_in_if_conditions.rs
+++ b/clippy_lints/src/blocks_in_if_conditions.rs
@@ -28,7 +28,6 @@ declare_clippy_lint! {
     ///
     /// ```rust
     /// # fn somefunc() -> bool { true };
-    ///
     /// // Bad
     /// if { let x = somefunc(); x } { /* ... */ }
     ///

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -29,7 +29,6 @@ declare_clippy_lint! {
     /// **Example:**
     /// ```rust
     /// # fn foo(bar: usize) {}
-    ///
     /// // Bad
     /// let x = Box::new(1);
     /// foo(*x);

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -36,7 +36,6 @@ declare_clippy_lint! {
     /// ```rust
     /// # fn bar(stool: &str) {}
     /// # let x = Some("abc");
-    ///
     /// // Bad
     /// match x {
     ///     Some(ref foo) => bar(foo),
@@ -239,7 +238,6 @@ declare_clippy_lint! {
     /// ```rust
     /// # enum Foo { A(usize), B(usize) }
     /// # let x = Foo::B(1);
-    ///
     /// // Bad
     /// match x {
     ///     Foo::A(_) => {},

--- a/clippy_lints/src/misc_early.rs
+++ b/clippy_lints/src/misc_early.rs
@@ -231,7 +231,6 @@ declare_clippy_lint! {
     /// ```rust
     /// # struct TupleStruct(u32, u32, u32);
     /// # let t = TupleStruct(1, 2, 3);
-    ///
     /// // Bad
     /// match t {
     ///     TupleStruct(0, .., _) => (),


### PR DESCRIPTION
It seems to be an extra blank line in doc example.

changelog: none

<img width="1141" alt="スクリーンショット 2020-10-19 10 32 21" src="https://user-images.githubusercontent.com/17407489/96392372-d0583200-11f6-11eb-9aab-f7e8f87eb04e.png">
