### PR TITLE
Fix an invalid suggestion in `needless_collect` test

### DIFF
--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -3001,7 +3001,14 @@ impl IterFunction {
             IterFunctionKind::IntoIter => String::new(),
             IterFunctionKind::Len => String::from(".count()"),
             IterFunctionKind::IsEmpty => String::from(".next().is_none()"),
-            IterFunctionKind::Contains(span) => format!(".any(|x| x == {})", snippet(cx, *span, "..")),
+            IterFunctionKind::Contains(span) => {
+                let s = snippet(cx, *span, "..");
+                if let Some(stripped) = s.strip_prefix('&') {
+                    format!(".any(|x| x == {})", stripped)
+                } else {
+                    format!(".any(|x| x == *{})", s)
+                }
+            },
         }
     }
     fn get_suggestion_text(&self) -> &'static str {

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -16,4 +16,10 @@ fn main() {
         .into_iter()
         .map(|x| (*x, *x + 1))
         .collect::<HashMap<_, _>>();
+
+    // #6202
+    let a = "a".to_string();
+    let sample = vec![a.clone(), "b".to_string(), "c".to_string()];
+    let non_copy_contains = sample.into_iter().collect::<Vec<_>>();
+    non_copy_contains.contains(&a);
 }

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -48,7 +48,7 @@ LL | |     indirect_contains.contains(&&5);
 help: Check if the original Iterator contains an element instead of collecting then checking
    |
 LL |     
-LL |     sample.iter().any(|x| x == &&5);
+LL |     sample.iter().any(|x| x == &5);
    |
 
 error: aborting due to 4 previous errors

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -51,5 +51,18 @@ LL |
 LL |     sample.iter().any(|x| x == &5);
    |
 
-error: aborting due to 4 previous errors
+error: avoid using `collect()` when not needed
+  --> $DIR/needless_collect_indirect.rs:23:5
+   |
+LL | /     let non_copy_contains = sample.into_iter().collect::<Vec<_>>();
+LL | |     non_copy_contains.contains(&a);
+   | |____^
+   |
+help: Check if the original Iterator contains an element instead of collecting then checking
+   |
+LL |     
+LL |     sample.into_iter().any(|x| x == a);
+   |
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
A test, https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/needless_collect_indirect.rs#L11-L12, suggests following codes, but the suggested codes don't work. An example is here: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=6947d9f2806a83f41cc5eb8e39b09d0b.
```
error: avoid using `collect()` when not needed
  --> $DIR/needless_collect_indirect.rs:11:5
   |
LL | /     let indirect_contains = sample.iter().collect::<VecDeque<_>>();
LL | |     indirect_contains.contains(&&5);
   | |____^
   |
help: Check if the original Iterator contains an element instead of collecting then checking
   |
LL |     
LL |     sample.iter().any(|x| x == &&5);
```

changelog: none
