### PR TITLE
No lint in macro for `toplevel_ref_arg`

### DIFF
--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -56,3 +56,17 @@ macro_rules! option_env_unwrap_external {
         option_env!($env).expect($message)
     };
 }
+
+#[macro_export]
+macro_rules! ref_arg_binding {
+    () => {
+        let ref _y = 42;
+    };
+}
+
+#[macro_export]
+macro_rules! ref_arg_function {
+    () => {
+        fn fun_example(ref _x: usize) {}
+    };
+}

--- a/tests/ui/toplevel_ref_arg.fixed
+++ b/tests/ui/toplevel_ref_arg.fixed
@@ -1,6 +1,16 @@
 // run-rustfix
+// aux-build:macro_rules.rs
 
 #![warn(clippy::toplevel_ref_arg)]
+
+#[macro_use]
+extern crate macro_rules;
+
+macro_rules! gen_binding {
+    () => {
+        let _y = &42;
+    };
+}
 
 fn main() {
     // Closures should not warn
@@ -26,4 +36,15 @@ fn main() {
 
     // ok
     for ref _x in 0..10 {}
+
+    // lint in macro
+    #[allow(unused)]
+    {
+        gen_binding!();
+    }
+
+    // do not lint in external macro
+    {
+        ref_arg_binding!();
+    }
 }

--- a/tests/ui/toplevel_ref_arg.rs
+++ b/tests/ui/toplevel_ref_arg.rs
@@ -1,6 +1,16 @@
 // run-rustfix
+// aux-build:macro_rules.rs
 
 #![warn(clippy::toplevel_ref_arg)]
+
+#[macro_use]
+extern crate macro_rules;
+
+macro_rules! gen_binding {
+    () => {
+        let ref _y = 42;
+    };
+}
 
 fn main() {
     // Closures should not warn
@@ -26,4 +36,15 @@ fn main() {
 
     // ok
     for ref _x in 0..10 {}
+
+    // lint in macro
+    #[allow(unused)]
+    {
+        gen_binding!();
+    }
+
+    // do not lint in external macro
+    {
+        ref_arg_binding!();
+    }
 }

--- a/tests/ui/toplevel_ref_arg.stderr
+++ b/tests/ui/toplevel_ref_arg.stderr
@@ -1,5 +1,5 @@
 error: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
-  --> $DIR/toplevel_ref_arg.rs:10:9
+  --> $DIR/toplevel_ref_arg.rs:20:9
    |
 LL |     let ref _x = 1;
    |     ----^^^^^^----- help: try: `let _x = &1;`
@@ -7,28 +7,39 @@ LL |     let ref _x = 1;
    = note: `-D clippy::toplevel-ref-arg` implied by `-D warnings`
 
 error: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
-  --> $DIR/toplevel_ref_arg.rs:12:9
+  --> $DIR/toplevel_ref_arg.rs:22:9
    |
 LL |     let ref _y: (&_, u8) = (&1, 2);
    |     ----^^^^^^--------------------- help: try: `let _y: &(&_, u8) = &(&1, 2);`
 
 error: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
-  --> $DIR/toplevel_ref_arg.rs:14:9
+  --> $DIR/toplevel_ref_arg.rs:24:9
    |
 LL |     let ref _z = 1 + 2;
    |     ----^^^^^^--------- help: try: `let _z = &(1 + 2);`
 
 error: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
-  --> $DIR/toplevel_ref_arg.rs:16:9
+  --> $DIR/toplevel_ref_arg.rs:26:9
    |
 LL |     let ref mut _z = 1 + 2;
    |     ----^^^^^^^^^^--------- help: try: `let _z = &mut (1 + 2);`
 
 error: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
-  --> $DIR/toplevel_ref_arg.rs:21:9
+  --> $DIR/toplevel_ref_arg.rs:31:9
    |
 LL |     let ref _x = vec![1, 2, 3];
    |     ----^^^^^^----------------- help: try: `let _x = &vec![1, 2, 3];`
 
-error: aborting due to 5 previous errors
+error: `ref` on an entire `let` pattern is discouraged, take a reference with `&` instead
+  --> $DIR/toplevel_ref_arg.rs:11:13
+   |
+LL |         let ref _y = 42;
+   |         ----^^^^^^------ help: try: `let _y = &42;`
+...
+LL |         gen_binding!();
+   |         --------------- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/toplevel_ref_arg_non_rustfix.rs
+++ b/tests/ui/toplevel_ref_arg_non_rustfix.rs
@@ -1,11 +1,33 @@
+// aux-build:macro_rules.rs
+
 #![warn(clippy::toplevel_ref_arg)]
 #![allow(unused)]
+
+#[macro_use]
+extern crate macro_rules;
 
 fn the_answer(ref mut x: u8) {
     *x = 42;
 }
 
+macro_rules! gen_function {
+    () => {
+        fn fun_example(ref _x: usize) {}
+    };
+}
+
 fn main() {
     let mut x = 0;
     the_answer(x);
+
+    // lint in macro
+    #[allow(unused)]
+    {
+        gen_function!();
+    }
+
+    // do not lint in external macro
+    {
+        ref_arg_function!();
+    }
 }

--- a/tests/ui/toplevel_ref_arg_non_rustfix.stderr
+++ b/tests/ui/toplevel_ref_arg_non_rustfix.stderr
@@ -1,10 +1,21 @@
 error: `ref` directly on a function argument is ignored. Consider using a reference type instead.
-  --> $DIR/toplevel_ref_arg_non_rustfix.rs:4:15
+  --> $DIR/toplevel_ref_arg_non_rustfix.rs:9:15
    |
 LL | fn the_answer(ref mut x: u8) {
    |               ^^^^^^^^^
    |
    = note: `-D clippy::toplevel-ref-arg` implied by `-D warnings`
 
-error: aborting due to previous error
+error: `ref` directly on a function argument is ignored. Consider using a reference type instead.
+  --> $DIR/toplevel_ref_arg_non_rustfix.rs:15:24
+   |
+LL |         fn fun_example(ref _x: usize) {}
+   |                        ^^^^^^
+...
+LL |         gen_function!();
+   |         ---------------- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Do not lint when the span is from a macro.

Question: shouldn't we extend this for external macros also ?

Fixes: #5849 

changelog: none
