### PR TITLE
Update the existing arithmetic lint

### DIFF
--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -90,12 +90,7 @@ impl<'tcx> LateLintPass<'tcx> for Arithmetic {
                 if l_ty.peel_refs().is_integral() && r_ty.peel_refs().is_integral() {
                     match op.node {
                         hir::BinOpKind::Div | hir::BinOpKind::Rem => match &r.kind {
-                            hir::ExprKind::Lit(lit) => {
-                                if let rustc_ast::ast::LitKind::Int(0, _) = lit.node {
-                                    span_lint(cx, INTEGER_ARITHMETIC, expr.span, "integer arithmetic detected");
-                                    self.expr_span = Some(expr.span);
-                                }
-                            },
+                            hir::ExprKind::Lit(_lit) => (),
                             hir::ExprKind::Unary(hir::UnOp::UnNeg, expr) => {
                                 if let hir::ExprKind::Lit(lit) = &expr.kind {
                                     if let rustc_ast::ast::LitKind::Int(1, _) = lit.node {

--- a/clippy_lints/src/arithmetic.rs
+++ b/clippy_lints/src/arithmetic.rs
@@ -88,9 +88,33 @@ impl<'tcx> LateLintPass<'tcx> for Arithmetic {
 
                 let (l_ty, r_ty) = (cx.typeck_results().expr_ty(l), cx.typeck_results().expr_ty(r));
                 if l_ty.peel_refs().is_integral() && r_ty.peel_refs().is_integral() {
-                    span_lint(cx, INTEGER_ARITHMETIC, expr.span, "integer arithmetic detected");
-                    self.expr_span = Some(expr.span);
-                } else if l_ty.peel_refs().is_floating_point() && r_ty.peel_refs().is_floating_point() {
+                    match op.node {
+                        hir::BinOpKind::Div | hir::BinOpKind::Rem => match &r.kind {
+                            hir::ExprKind::Lit(lit) => {
+                                if let rustc_ast::ast::LitKind::Int(0, _) = lit.node {
+                                    span_lint(cx, INTEGER_ARITHMETIC, expr.span, "integer arithmetic detected");
+                                    self.expr_span = Some(expr.span);
+                                }
+                            },
+                            hir::ExprKind::Unary(hir::UnOp::UnNeg, expr) => {
+                                if let hir::ExprKind::Lit(lit) = &expr.kind {
+                                    if let rustc_ast::ast::LitKind::Int(1, _) = lit.node {
+                                        span_lint(cx, INTEGER_ARITHMETIC, expr.span, "integer arithmetic detected");
+                                        self.expr_span = Some(expr.span);
+                                    }
+                                }
+                            },
+                            _ => {
+                                span_lint(cx, INTEGER_ARITHMETIC, expr.span, "integer arithmetic detected");
+                                self.expr_span = Some(expr.span);
+                            },
+                        },
+                        _ => {
+                            span_lint(cx, INTEGER_ARITHMETIC, expr.span, "integer arithmetic detected");
+                            self.expr_span = Some(expr.span);
+                        },
+                    }
+                } else if r_ty.peel_refs().is_floating_point() && r_ty.peel_refs().is_floating_point() {
                     span_lint(cx, FLOAT_ARITHMETIC, expr.span, "floating-point arithmetic detected");
                     self.expr_span = Some(expr.span);
                 }

--- a/tests/ui/integer_arithmetic.rs
+++ b/tests/ui/integer_arithmetic.rs
@@ -11,6 +11,8 @@
 #[rustfmt::skip]
 fn main() {
     let mut i = 1i32;
+    let mut var1 = 0i32;
+    let mut var2 = -1i32;
     1 + i;
     i * 2;
     1 %
@@ -32,7 +34,15 @@ fn main() {
     i -= 1;
     i *= 2;
     i /= 2;
+    i /= 0;
+    i /= -1;
+    i /= var1;
+    i /= var2;
     i %= 2;
+    i %= 0;
+    i %= -1;
+    i %= var1;
+    i %= var2;
     i <<= 3;
     i >>= 2;
 

--- a/tests/ui/integer_arithmetic.stderr
+++ b/tests/ui/integer_arithmetic.stderr
@@ -1,5 +1,19 @@
+error: this operation will panic at runtime
+  --> $DIR/integer_arithmetic.rs:37:5
+   |
+LL |     i /= 0;
+   |     ^^^^^^ attempt to divide `_` by zero
+   |
+   = note: `#[deny(unconditional_panic)]` on by default
+
+error: this operation will panic at runtime
+  --> $DIR/integer_arithmetic.rs:42:5
+   |
+LL |     i %= 0;
+   |     ^^^^^^ attempt to calculate the remainder of `_` with a divisor of zero
+
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:14:5
+  --> $DIR/integer_arithmetic.rs:16:5
    |
 LL |     1 + i;
    |     ^^^^^
@@ -7,125 +21,161 @@ LL |     1 + i;
    = note: `-D clippy::integer-arithmetic` implied by `-D warnings`
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:15:5
+  --> $DIR/integer_arithmetic.rs:17:5
    |
 LL |     i * 2;
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:16:5
+  --> $DIR/integer_arithmetic.rs:18:5
    |
 LL | /     1 %
 LL | |     i / 2; // no error, this is part of the expression in the preceding line
-   | |_________^
+   | |_____^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:18:5
+  --> $DIR/integer_arithmetic.rs:20:5
    |
 LL |     i - 2 + 2 - i;
    |     ^^^^^^^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:19:5
+  --> $DIR/integer_arithmetic.rs:21:5
    |
 LL |     -i;
    |     ^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:20:5
+  --> $DIR/integer_arithmetic.rs:22:5
    |
 LL |     i >> 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:21:5
+  --> $DIR/integer_arithmetic.rs:23:5
    |
 LL |     i << 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:31:5
+  --> $DIR/integer_arithmetic.rs:33:5
    |
 LL |     i += 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:32:5
+  --> $DIR/integer_arithmetic.rs:34:5
    |
 LL |     i -= 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:33:5
+  --> $DIR/integer_arithmetic.rs:35:5
    |
 LL |     i *= 2;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:34:5
+  --> $DIR/integer_arithmetic.rs:37:5
    |
-LL |     i /= 2;
+LL |     i /= 0;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:35:5
+  --> $DIR/integer_arithmetic.rs:38:11
    |
-LL |     i %= 2;
+LL |     i /= -1;
+   |           ^
+
+error: integer arithmetic detected
+  --> $DIR/integer_arithmetic.rs:39:5
+   |
+LL |     i /= var1;
+   |     ^^^^^^^^^
+
+error: integer arithmetic detected
+  --> $DIR/integer_arithmetic.rs:40:5
+   |
+LL |     i /= var2;
+   |     ^^^^^^^^^
+
+error: integer arithmetic detected
+  --> $DIR/integer_arithmetic.rs:42:5
+   |
+LL |     i %= 0;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:36:5
+  --> $DIR/integer_arithmetic.rs:43:11
+   |
+LL |     i %= -1;
+   |           ^
+
+error: integer arithmetic detected
+  --> $DIR/integer_arithmetic.rs:44:5
+   |
+LL |     i %= var1;
+   |     ^^^^^^^^^
+
+error: integer arithmetic detected
+  --> $DIR/integer_arithmetic.rs:45:5
+   |
+LL |     i %= var2;
+   |     ^^^^^^^^^
+
+error: integer arithmetic detected
+  --> $DIR/integer_arithmetic.rs:46:5
    |
 LL |     i <<= 3;
    |     ^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:37:5
+  --> $DIR/integer_arithmetic.rs:47:5
    |
 LL |     i >>= 2;
    |     ^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:79:5
+  --> $DIR/integer_arithmetic.rs:89:5
    |
 LL |     3 + &1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:80:5
+  --> $DIR/integer_arithmetic.rs:90:5
    |
 LL |     &3 + 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:81:5
+  --> $DIR/integer_arithmetic.rs:91:5
    |
 LL |     &3 + &1;
    |     ^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:86:5
+  --> $DIR/integer_arithmetic.rs:96:5
    |
 LL |     a + x
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:90:5
+  --> $DIR/integer_arithmetic.rs:100:5
    |
 LL |     x + y
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:94:5
+  --> $DIR/integer_arithmetic.rs:104:5
    |
 LL |     x + y
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:98:5
+  --> $DIR/integer_arithmetic.rs:108:5
    |
 LL |     (&x + &y)
    |     ^^^^^^^^^
 
-error: aborting due to 21 previous errors
+error: aborting due to 29 previous errors
 

--- a/tests/ui/integer_arithmetic.stderr
+++ b/tests/ui/integer_arithmetic.stderr
@@ -76,12 +76,6 @@ LL |     i *= 2;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:37:5
-   |
-LL |     i /= 0;
-   |     ^^^^^^
-
-error: integer arithmetic detected
   --> $DIR/integer_arithmetic.rs:38:11
    |
 LL |     i /= -1;
@@ -98,12 +92,6 @@ error: integer arithmetic detected
    |
 LL |     i /= var2;
    |     ^^^^^^^^^
-
-error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:42:5
-   |
-LL |     i %= 0;
-   |     ^^^^^^
 
 error: integer arithmetic detected
   --> $DIR/integer_arithmetic.rs:43:11
@@ -177,5 +165,5 @@ error: integer arithmetic detected
 LL |     (&x + &y)
    |     ^^^^^^^^^
 
-error: aborting due to 29 previous errors
+error: aborting due to 27 previous errors
 


### PR DESCRIPTION
re: #6209 

Updates the lint to not the error message if RHS of binary operation `/` of `%` is a literal/constant that is not `0` or `-1`, as suggested [here](https://github.com/rust-lang/rust-clippy/issues/6209#issuecomment-715624354)

changelog: Expand [`integer_arithmetic`] to work with RHS literals and constants
