### PR TITLE
Fix suggestion to add unneeded space in `unused_unit`

### DIFF
--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -123,6 +123,17 @@ fn lint_unneeded_unit_return(cx: &EarlyContext<'_>, ty: &ast::Ty, span: Span) {
         fn_source
             .rfind("->")
             .map_or((ty.span, Applicability::MaybeIncorrect), |rpos| {
+                let mut rpos = rpos;
+                let chars: Vec<char> = fn_source.chars().collect();
+                while rpos > 1 {
+                    if let Some(c) = chars.get(rpos - 1) {
+                        if c.is_whitespace() {
+                            rpos -= 1;
+                            continue;
+                        }
+                    }
+                    break;
+                }
                 (
                     #[allow(clippy::cast_possible_truncation)]
                     ty.span.with_lo(BytePos(span.lo().0 + rpos as u32)),

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -15,35 +15,35 @@
 struct Unitter;
 impl Unitter {
     #[allow(clippy::no_effect)]
-    pub fn get_unit<F: Fn() , G>(&self, f: F, _g: G) 
-    where G: Fn()  {
-        let _y: &dyn Fn()  = &f;
+    pub fn get_unit<F: Fn(), G>(&self, f: F, _g: G)
+    where G: Fn() {
+        let _y: &dyn Fn() = &f;
         (); // this should not lint, as it's not in return type position
     }
 }
 
 impl Into<()> for Unitter {
     #[rustfmt::skip]
-    fn into(self)  {
+    fn into(self) {
         
     }
 }
 
 trait Trait {
-    fn redundant<F: FnOnce() , G, H>(&self, _f: F, _g: G, _h: H)
+    fn redundant<F: FnOnce(), G, H>(&self, _f: F, _g: G, _h: H)
     where
-        G: FnMut() ,
-        H: Fn() ;
+        G: FnMut(),
+        H: Fn();
 }
 
 impl Trait for Unitter {
-    fn redundant<F: FnOnce() , G, H>(&self, _f: F, _g: G, _h: H)
+    fn redundant<F: FnOnce(), G, H>(&self, _f: F, _g: G, _h: H)
     where
-        G: FnMut() ,
-        H: Fn()  {}
+        G: FnMut(),
+        H: Fn() {}
 }
 
-fn return_unit()  {  }
+fn return_unit() {  }
 
 #[allow(clippy::needless_return)]
 #[allow(clippy::never_loop)]
@@ -70,3 +70,12 @@ fn foo() {
         recv(rx) -> _x => ()
     }
 }
+
+#[rustfmt::skip]
+fn test(){}
+
+#[rustfmt::skip]
+fn test2(){}
+
+#[rustfmt::skip]
+fn test3(){}

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -70,3 +70,12 @@ fn foo() {
         recv(rx) -> _x => ()
     }
 }
+
+#[rustfmt::skip]
+fn test()->(){}
+
+#[rustfmt::skip]
+fn test2() ->(){}
+
+#[rustfmt::skip]
+fn test3()-> (){}

--- a/tests/ui/unused_unit.stderr
+++ b/tests/ui/unused_unit.stderr
@@ -1,8 +1,8 @@
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:18:29
+  --> $DIR/unused_unit.rs:18:28
    |
 LL |     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) -> ()
-   |                             ^^^^^ help: remove the `-> ()`
+   |                            ^^^^^^ help: remove the `-> ()`
    |
 note: the lint level is defined here
   --> $DIR/unused_unit.rs:12:9
@@ -11,28 +11,28 @@ LL | #![deny(clippy::unused_unit)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:19:19
+  --> $DIR/unused_unit.rs:19:18
    |
 LL |     where G: Fn() -> () {
-   |                   ^^^^^ help: remove the `-> ()`
+   |                  ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:18:59
+  --> $DIR/unused_unit.rs:18:58
    |
 LL |     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) -> ()
-   |                                                           ^^^^^ help: remove the `-> ()`
+   |                                                          ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:20:27
+  --> $DIR/unused_unit.rs:20:26
    |
 LL |         let _y: &dyn Fn() -> () = &f;
-   |                           ^^^^^ help: remove the `-> ()`
+   |                          ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:27:19
+  --> $DIR/unused_unit.rs:27:18
    |
 LL |     fn into(self) -> () {
-   |                   ^^^^^ help: remove the `-> ()`
+   |                  ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
   --> $DIR/unused_unit.rs:28:9
@@ -41,46 +41,46 @@ LL |         ()
    |         ^^ help: remove the final `()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:33:30
+  --> $DIR/unused_unit.rs:33:29
    |
 LL |     fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
-   |                              ^^^^^ help: remove the `-> ()`
+   |                             ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:35:20
+  --> $DIR/unused_unit.rs:35:19
    |
 LL |         G: FnMut() -> (),
-   |                    ^^^^^ help: remove the `-> ()`
+   |                   ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:36:17
+  --> $DIR/unused_unit.rs:36:16
    |
 LL |         H: Fn() -> ();
-   |                 ^^^^^ help: remove the `-> ()`
+   |                ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:40:30
+  --> $DIR/unused_unit.rs:40:29
    |
 LL |     fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
-   |                              ^^^^^ help: remove the `-> ()`
+   |                             ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:42:20
+  --> $DIR/unused_unit.rs:42:19
    |
 LL |         G: FnMut() -> (),
-   |                    ^^^^^ help: remove the `-> ()`
+   |                   ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:43:17
+  --> $DIR/unused_unit.rs:43:16
    |
 LL |         H: Fn() -> () {}
-   |                 ^^^^^ help: remove the `-> ()`
+   |                ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> $DIR/unused_unit.rs:46:18
+  --> $DIR/unused_unit.rs:46:17
    |
 LL | fn return_unit() -> () { () }
-   |                  ^^^^^ help: remove the `-> ()`
+   |                 ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
   --> $DIR/unused_unit.rs:46:26
@@ -100,5 +100,23 @@ error: unneeded `()`
 LL |     return();
    |           ^^ help: remove the `()`
 
-error: aborting due to 16 previous errors
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:75:10
+   |
+LL | fn test()->(){}
+   |          ^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:78:11
+   |
+LL | fn test2() ->(){}
+   |           ^^^^^ help: remove the `-> ()`
+
+error: unneeded unit return type
+  --> $DIR/unused_unit.rs:81:11
+   |
+LL | fn test3()-> (){}
+   |           ^^^^^ help: remove the `-> ()`
+
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust-clippy/issues/6230

changelog: Fix suggestion to add unneeded space in `unused_unit`
