### PR TITLE
Fix unnecessary_lazy_eval suggestion applicability

### DIFF
--- a/clippy_lints/src/methods/unnecessary_lazy_eval.rs
+++ b/clippy_lints/src/methods/unnecessary_lazy_eval.rs
@@ -35,7 +35,8 @@ pub(super) fn lint<'tcx>(
                 let applicability = if body
                     .params
                     .iter()
-                    .all(|param| matches!(param.pat.kind, hir::PatKind::Wild))
+                    // bindings are checked to be unused above
+                    .all(|param| matches!(param.pat.kind, hir::PatKind::Binding(..) | hir::PatKind::Wild))
                 {
                     Applicability::MachineApplicable
                 } else {

--- a/clippy_lints/src/methods/unnecessary_lazy_eval.rs
+++ b/clippy_lints/src/methods/unnecessary_lazy_eval.rs
@@ -32,6 +32,16 @@ pub(super) fn lint<'tcx>(
                 } else {
                     "unnecessary closure used to substitute value for `Result::Err`"
                 };
+                let applicability = if body
+                    .params
+                    .iter()
+                    .all(|param| matches!(param.pat.kind, hir::PatKind::Wild))
+                {
+                    Applicability::MachineApplicable
+                } else {
+                    // replacing the lambda may break type inference
+                    Applicability::MaybeIncorrect
+                };
 
                 span_lint_and_sugg(
                     cx,
@@ -45,7 +55,7 @@ pub(super) fn lint<'tcx>(
                         simplify_using,
                         snippet(cx, body_expr.span, ".."),
                     ),
-                    Applicability::MachineApplicable,
+                    applicability,
                 );
             }
         }

--- a/tests/ui/unnecessary_lazy_eval_unfixable.rs
+++ b/tests/ui/unnecessary_lazy_eval_unfixable.rs
@@ -1,0 +1,18 @@
+#![warn(clippy::unnecessary_lazy_evaluations)]
+
+struct Deep(Option<usize>);
+
+#[derive(Copy, Clone)]
+struct SomeStruct {
+    some_field: usize,
+}
+
+fn main() {
+    // fix will break type inference
+    let _ = Ok(1).unwrap_or_else(|()| 2);
+    mod e {
+        pub struct E;
+    }
+    let _ = Ok(1).unwrap_or_else(|e::E| 2);
+    let _ = Ok(1).unwrap_or_else(|SomeStruct { .. }| 2);
+}

--- a/tests/ui/unnecessary_lazy_eval_unfixable.stderr
+++ b/tests/ui/unnecessary_lazy_eval_unfixable.stderr
@@ -1,0 +1,22 @@
+error: unnecessary closure used to substitute value for `Result::Err`
+  --> $DIR/unnecessary_lazy_eval_unfixable.rs:12:13
+   |
+LL |     let _ = Ok(1).unwrap_or_else(|()| 2);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Use `unwrap_or` instead: `Ok(1).unwrap_or(2)`
+   |
+   = note: `-D clippy::unnecessary-lazy-evaluations` implied by `-D warnings`
+
+error: unnecessary closure used to substitute value for `Result::Err`
+  --> $DIR/unnecessary_lazy_eval_unfixable.rs:16:13
+   |
+LL |     let _ = Ok(1).unwrap_or_else(|e::E| 2);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Use `unwrap_or` instead: `Ok(1).unwrap_or(2)`
+
+error: unnecessary closure used to substitute value for `Result::Err`
+  --> $DIR/unnecessary_lazy_eval_unfixable.rs:17:13
+   |
+LL |     let _ = Ok(1).unwrap_or_else(|SomeStruct { .. }| 2);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Use `unwrap_or` instead: `Ok(1).unwrap_or(2)`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
changelog: Fix unnecessary_lazy_eval suggestion applicability when breaking type inference

Fixes #6240
