### PR TITLE
Require the `changelog:` entry in the PR body to be modified

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 Thank you for making Clippy better!
 
 We're collecting our changelog from pull request descriptions.
-If your PR only updates to the latest nightly, you can leave the
-`changelog` entry as `none`. Otherwise, please write a short comment
+If your PR only includes internal changes, you can just write
+`changelog: none`. Otherwise, please write a short comment
 explaining your change.
 
 If your PR fixes an issue, you can add "fixes #issue_number" into this
@@ -28,5 +28,5 @@ Delete this line and everything above before opening your PR.
 
 ---
 
-*Please keep the line below*
-changelog: none
+*Please write a short comment explaining your change (or "none" for internal only changes)*
+changelog:


### PR DESCRIPTION
r? @matthiaskrgr 


changelog: none
