### PR TITLE
do not trigger map_clone in the case of &mut

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -80,9 +80,11 @@ impl<'tcx> LateLintPass<'tcx> for MapClone {
                                     && match_trait_method(cx, closure_expr, &paths::CLONE_TRAIT) {
 
                                     let obj_ty = cx.typeck_results().expr_ty(&obj[0]);
-                                    if let ty::Ref(_, ty, _) = obj_ty.kind() {
-                                        let copy = is_copy(cx, ty);
-                                        lint(cx, e.span, args[0].span, copy);
+                                    if let ty::Ref(_, ty, mutability) = obj_ty.kind() {
+                                        if matches!(mutability, Mutability::Not) {
+                                            let copy = is_copy(cx, ty);
+                                            lint(cx, e.span, args[0].span, copy);
+                                        }
                                     } else {
                                         lint_needless_cloning(cx, e.span, args[0].span);
                                     }

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -44,4 +44,12 @@ fn main() {
         let v = vec![&mut d];
         let _: Vec<u32> = v.into_iter().map(|&mut x| x).collect();
     }
+
+    // Issue #6299
+    {
+        let mut aa = 5;
+        let mut bb = 3;
+        let items = vec![&mut aa, &mut bb];
+        let _: Vec<_> = items.into_iter().map(|x| x.clone()).collect();
+    }
 }

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -44,4 +44,12 @@ fn main() {
         let v = vec![&mut d];
         let _: Vec<u32> = v.into_iter().map(|&mut x| x).collect();
     }
+
+    // Issue #6299
+    {
+        let mut aa = 5;
+        let mut bb = 3;
+        let items = vec![&mut aa, &mut bb];
+        let _: Vec<_> = items.into_iter().map(|x| x.clone()).collect();
+    }
 }


### PR DESCRIPTION
fixes #6299 
changelog: do not trigger map_clone in the case of &mut
