### PR TITLE
Remove `allow` in `option_option` lint test

### DIFF
--- a/tests/ui/option_option.rs
+++ b/tests/ui/option_option.rs
@@ -72,8 +72,6 @@ mod issue_4298 {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[serde(default)]
         #[serde(borrow)]
-        // FIXME: should not lint here
-        #[allow(clippy::option_option)]
         foo: Option<Option<Cow<'a, str>>>,
     }
 

--- a/tests/ui/option_option.stderr
+++ b/tests/ui/option_option.stderr
@@ -59,7 +59,7 @@ LL |     Struct { x: Option<Option<u8>> },
    |                 ^^^^^^^^^^^^^^^^^^
 
 error: consider using `Option<T>` instead of `Option<Option<T>>` or a custom enum if you need to distinguish all 3 cases
-  --> $DIR/option_option.rs:77:14
+  --> $DIR/option_option.rs:75:14
    |
 LL |         foo: Option<Option<Cow<'a, str>>>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
As it is not triggering locally anymore, I propose to remove `#[allow(clippy::option_option)]` from the test.

The goal is also to see what happens on CI.

closes: #4298 

changelog: none
