### PR TITLE
just a typo

### DIFF
--- a/tests/ui/manual_ok_or.rs
+++ b/tests/ui/manual_ok_or.rs
@@ -32,7 +32,7 @@ fn main() {
     // not applicable, or side isn't `Result::Err`
     foo.map_or(Ok::<i32, &str>(1), |v| Ok(v));
 
-    // not applicatble, expr is not a `Result` value
+    // not applicable, expr is not a `Result` value
     foo.map_or(42, |v| v);
 
     // TODO patterns not covered yet


### PR DESCRIPTION
changelog: none