### PR TITLE
Add exteranal macros for as_conversions

### DIFF
--- a/tests/ui/as_conversions.rs
+++ b/tests/ui/as_conversions.rs
@@ -1,7 +1,19 @@
-#[warn(clippy::as_conversions)]
+// aux-build:macro_rules.rs
+
+#![warn(clippy::as_conversions)]
+
+#[macro_use]
+extern crate macro_rules;
+
+fn with_external_macro() {
+    as_conv_with_arg!(0u32 as u64);
+    as_conv!();
+}
 
 fn main() {
     let i = 0u32 as u64;
 
     let j = &i as *const u64 as *mut u64;
+
+    with_external_macro();
 }

--- a/tests/ui/as_conversions.stderr
+++ b/tests/ui/as_conversions.stderr
@@ -1,5 +1,5 @@
 error: using a potentially dangerous silent `as` conversion
-  --> $DIR/as_conversions.rs:4:13
+  --> $DIR/as_conversions.rs:14:13
    |
 LL |     let i = 0u32 as u64;
    |             ^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let i = 0u32 as u64;
    = help: consider using a safe wrapper for this conversion
 
 error: using a potentially dangerous silent `as` conversion
-  --> $DIR/as_conversions.rs:6:13
+  --> $DIR/as_conversions.rs:16:13
    |
 LL |     let j = &i as *const u64 as *mut u64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     let j = &i as *const u64 as *mut u64;
    = help: consider using a safe wrapper for this conversion
 
 error: using a potentially dangerous silent `as` conversion
-  --> $DIR/as_conversions.rs:6:13
+  --> $DIR/as_conversions.rs:16:13
    |
 LL |     let j = &i as *const u64 as *mut u64;
    |             ^^^^^^^^^^^^^^^^

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -70,3 +70,17 @@ macro_rules! ref_arg_function {
         fn fun_example(ref _x: usize) {}
     };
 }
+
+#[macro_export]
+macro_rules! as_conv_with_arg {
+    (0u32 as u64) => {
+        ()
+    };
+}
+
+#[macro_export]
+macro_rules! as_conv {
+    () => {
+        0u32 as u64
+    };
+}


### PR DESCRIPTION
Added external macros to this PR https://github.com/rust-lang/rust-clippy/pull/4888.

r? @llogiq 

changelog: none
