### PR TITLE
Use article_and_description for missing docs

### DIFF
--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -2,7 +2,7 @@
 // *rustc*'s
 // [`missing_doc`].
 //
-// [`missing_doc`]: https://github.com/rust-lang/rust/blob/d6d05904697d89099b55da3331155392f1db9c00/src/librustc_lint/builtin.rs#L246
+// [`missing_doc`]: https://github.com/rust-lang/rust/blob/cf9cf7c923eb01146971429044f216a3ca905e06/compiler/rustc_lint/src/builtin.rs#L415
 //
 
 use crate::utils::span_lint;
@@ -70,7 +70,14 @@ impl MissingDoc {
         }
     }
 
-    fn check_missing_docs_attrs(&self, cx: &LateContext<'_>, attrs: &[ast::Attribute], sp: Span, desc: &'static str) {
+    fn check_missing_docs_attrs(
+        &self,
+        cx: &LateContext<'_>,
+        attrs: &[ast::Attribute],
+        sp: Span,
+        article: &'static str,
+        desc: &'static str,
+    ) {
         // If we're building a test harness, then warning about
         // documentation is probably not really relevant right now.
         if cx.sess().opts.test {
@@ -94,7 +101,7 @@ impl MissingDoc {
                 cx,
                 MISSING_DOCS_IN_PRIVATE_ITEMS,
                 sp,
-                &format!("missing documentation for {}", desc),
+                &format!("missing documentation for {} {}", article, desc),
             );
         }
     }
@@ -120,13 +127,11 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
     }
 
     fn check_crate(&mut self, cx: &LateContext<'tcx>, krate: &'tcx hir::Crate<'_>) {
-        self.check_missing_docs_attrs(cx, &krate.item.attrs, krate.item.span, "crate");
+        self.check_missing_docs_attrs(cx, &krate.item.attrs, krate.item.span, "the", "crate");
     }
 
     fn check_item(&mut self, cx: &LateContext<'tcx>, it: &'tcx hir::Item<'_>) {
-        let desc = match it.kind {
-            hir::ItemKind::Const(..) => "a constant",
-            hir::ItemKind::Enum(..) => "an enum",
+        match it.kind {
             hir::ItemKind::Fn(..) => {
                 // ignore main()
                 if it.ident.name == sym::main {
@@ -136,16 +141,17 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
                         return;
                     }
                 }
-                "a function"
             },
-            hir::ItemKind::Mod(..) => "a module",
-            hir::ItemKind::Static(..) => "a static",
-            hir::ItemKind::Struct(..) => "a struct",
-            hir::ItemKind::Trait(..) => "a trait",
-            hir::ItemKind::TraitAlias(..) => "a trait alias",
-            hir::ItemKind::TyAlias(..) => "a type alias",
-            hir::ItemKind::Union(..) => "a union",
-            hir::ItemKind::OpaqueTy(..) => "an existential type",
+            hir::ItemKind::Const(..)
+            | hir::ItemKind::Enum(..)
+            | hir::ItemKind::Mod(..)
+            | hir::ItemKind::Static(..)
+            | hir::ItemKind::Struct(..)
+            | hir::ItemKind::Trait(..)
+            | hir::ItemKind::TraitAlias(..)
+            | hir::ItemKind::TyAlias(..)
+            | hir::ItemKind::Union(..)
+            | hir::ItemKind::OpaqueTy(..) => {},
             hir::ItemKind::ExternCrate(..)
             | hir::ItemKind::ForeignMod(..)
             | hir::ItemKind::GlobalAsm(..)
@@ -153,17 +159,17 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
             | hir::ItemKind::Use(..) => return,
         };
 
-        self.check_missing_docs_attrs(cx, &it.attrs, it.span, desc);
+        let def_id = cx.tcx.hir().local_def_id(it.hir_id);
+        let (article, desc) = cx.tcx.article_and_description(def_id.to_def_id());
+
+        self.check_missing_docs_attrs(cx, &it.attrs, it.span, article, desc);
     }
 
     fn check_trait_item(&mut self, cx: &LateContext<'tcx>, trait_item: &'tcx hir::TraitItem<'_>) {
-        let desc = match trait_item.kind {
-            hir::TraitItemKind::Const(..) => "an associated constant",
-            hir::TraitItemKind::Fn(..) => "a trait method",
-            hir::TraitItemKind::Type(..) => "an associated type",
-        };
+        let def_id = cx.tcx.hir().local_def_id(trait_item.hir_id);
+        let (article, desc) = cx.tcx.article_and_description(def_id.to_def_id());
 
-        self.check_missing_docs_attrs(cx, &trait_item.attrs, trait_item.span, desc);
+        self.check_missing_docs_attrs(cx, &trait_item.attrs, trait_item.span, article, desc);
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, impl_item: &'tcx hir::ImplItem<'_>) {
@@ -178,21 +184,17 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
             },
         }
 
-        let desc = match impl_item.kind {
-            hir::ImplItemKind::Const(..) => "an associated constant",
-            hir::ImplItemKind::Fn(..) => "a method",
-            hir::ImplItemKind::TyAlias(_) => "an associated type",
-        };
-        self.check_missing_docs_attrs(cx, &impl_item.attrs, impl_item.span, desc);
+        let (article, desc) = cx.tcx.article_and_description(def_id.to_def_id());
+        self.check_missing_docs_attrs(cx, &impl_item.attrs, impl_item.span, article, desc);
     }
 
     fn check_struct_field(&mut self, cx: &LateContext<'tcx>, sf: &'tcx hir::StructField<'_>) {
         if !sf.is_positional() {
-            self.check_missing_docs_attrs(cx, &sf.attrs, sf.span, "a struct field");
+            self.check_missing_docs_attrs(cx, &sf.attrs, sf.span, "a", "struct field");
         }
     }
 
     fn check_variant(&mut self, cx: &LateContext<'tcx>, v: &'tcx hir::Variant<'_>) {
-        self.check_missing_docs_attrs(cx, &v.attrs, v.span, "a variant");
+        self.check_missing_docs_attrs(cx, &v.attrs, v.span, "a", "variant");
     }
 }

--- a/tests/ui/missing-doc-crate-missing.stderr
+++ b/tests/ui/missing-doc-crate-missing.stderr
@@ -1,4 +1,4 @@
-error: missing documentation for crate
+error: missing documentation for the crate
   --> $DIR/missing-doc-crate-missing.rs:1:1
    |
 LL | / #![warn(clippy::missing_docs_in_private_items)]

--- a/tests/ui/missing-doc-impl.stderr
+++ b/tests/ui/missing-doc-impl.stderr
@@ -51,13 +51,13 @@ LL | |     fn foo_with_impl(&self) {}
 LL | | }
    | |_^
 
-error: missing documentation for a trait method
+error: missing documentation for an associated function
   --> $DIR/missing-doc-impl.rs:39:5
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
 
-error: missing documentation for a trait method
+error: missing documentation for an associated function
   --> $DIR/missing-doc-impl.rs:40:5
    |
 LL |     fn foo_with_impl(&self) {}
@@ -75,25 +75,25 @@ error: missing documentation for an associated type
 LL |     type AssociatedTypeDef = Self;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: missing documentation for a method
+error: missing documentation for an associated function
   --> $DIR/missing-doc-impl.rs:62:5
    |
 LL |     pub fn foo() {}
    |     ^^^^^^^^^^^^^^^
 
-error: missing documentation for a method
+error: missing documentation for an associated function
   --> $DIR/missing-doc-impl.rs:63:5
    |
 LL |     fn bar() {}
    |     ^^^^^^^^^^^
 
-error: missing documentation for a method
+error: missing documentation for an associated function
   --> $DIR/missing-doc-impl.rs:67:5
    |
 LL |     pub fn foo() {}
    |     ^^^^^^^^^^^^^^^
 
-error: missing documentation for a method
+error: missing documentation for an associated function
   --> $DIR/missing-doc-impl.rs:70:5
    |
 LL |     fn foo2() {}


### PR DESCRIPTION
Moves closer to the current rustc missing_doc lint

changelog: none