### PR TITLE
Add Redundant else lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2023,6 +2023,7 @@ Released 2018-09-13
 [`redundant_closure`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
 [`redundant_closure_call`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_call
 [`redundant_closure_for_method_calls`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_for_method_calls
+[`redundant_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_else
 [`redundant_field_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
 [`redundant_pattern`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern
 [`redundant_pattern_matching`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -405,13 +405,10 @@ impl<'tcx> Functions {
                     break;
                 }
                 if in_comment {
-                    match line.find("*/") {
-                        Some(i) => {
-                            line = &line[i + 2..];
-                            in_comment = false;
-                            continue;
-                        },
-                        None => break,
+                    if let Some(i) = line.find("*/") {
+                        line = &line[i + 2..];
+                        in_comment = false;
+                        continue;
                     }
                 } else {
                     let multi_idx = line.find("/*").unwrap_or_else(|| line.len());
@@ -423,8 +420,8 @@ impl<'tcx> Functions {
                         in_comment = true;
                         continue;
                     }
-                    break;
                 }
+                break;
             }
             if code_in_line {
                 line_count += 1;

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -222,9 +222,8 @@ fn check_impl_items(cx: &LateContext<'_>, item: &Item<'_>, impl_items: &[ImplIte
     let is_empty = if let Some(is_empty) = impl_items.iter().find(|i| is_named_self(cx, i, "is_empty")) {
         if cx.access_levels.is_exported(is_empty.id.hir_id) {
             return;
-        } else {
-            "a private"
         }
+        "a private"
     } else {
         "no corresponding"
     };

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -293,6 +293,7 @@ mod question_mark;
 mod ranges;
 mod redundant_clone;
 mod redundant_closure_call;
+mod redundant_else;
 mod redundant_field_names;
 mod redundant_pub_crate;
 mod redundant_static_lifetimes;
@@ -810,6 +811,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         &ranges::REVERSED_EMPTY_RANGES,
         &redundant_clone::REDUNDANT_CLONE,
         &redundant_closure_call::REDUNDANT_CLOSURE_CALL,
+        &redundant_else::REDUNDANT_ELSE,
         &redundant_field_names::REDUNDANT_FIELD_NAMES,
         &redundant_pub_crate::REDUNDANT_PUB_CRATE,
         &redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES,
@@ -1113,6 +1115,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_early_pass(|| box items_after_statements::ItemsAfterStatements);
     store.register_early_pass(|| box precedence::Precedence);
     store.register_early_pass(|| box needless_continue::NeedlessContinue);
+    store.register_early_pass(|| box redundant_else::RedundantElse);
     store.register_late_pass(|| box create_dir::CreateDir);
     store.register_early_pass(|| box needless_arbitrary_self_type::NeedlessArbitrarySelfType);
     store.register_early_pass(|| box redundant_static_lifetimes::RedundantStaticLifetimes);
@@ -1294,6 +1297,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&pass_by_ref_or_value::TRIVIALLY_COPY_PASS_BY_REF),
         LintId::of(&ranges::RANGE_MINUS_ONE),
         LintId::of(&ranges::RANGE_PLUS_ONE),
+        LintId::of(&redundant_else::REDUNDANT_ELSE),
         LintId::of(&ref_option_ref::REF_OPTION_REF),
         LintId::of(&shadow::SHADOW_UNRELATED),
         LintId::of(&strings::STRING_ADD_ASSIGN),

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -696,10 +696,9 @@ fn check_single_match(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>], exp
             if stmts.len() == 1 && block_expr.is_none() || stmts.is_empty() && block_expr.is_some() {
                 // single statement/expr "else" block, don't lint
                 return;
-            } else {
-                // block with 2+ statements or 1 expr and 1+ statement
-                Some(els)
             }
+            // block with 2+ statements or 1 expr and 1+ statement
+            Some(els)
         } else {
             // not a block, don't lint
             return;

--- a/clippy_lints/src/methods/unnecessary_filter_map.rs
+++ b/clippy_lints/src/methods/unnecessary_filter_map.rs
@@ -69,10 +69,9 @@ fn check_expression<'tcx>(cx: &LateContext<'tcx>, arg_id: hir::HirId, expr: &'tc
                             }
                         }
                         return (true, false);
-                    } else {
-                        // We don't know. It might do anything.
-                        return (true, true);
                     }
+                    // We don't know. It might do anything.
+                    return (true, true);
                 }
             }
             (true, true)

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -409,11 +409,10 @@ fn levenstein_not_1(a_name: &str, b_name: &str) -> bool {
         if let Some(b2) = b_chars.next() {
             // check if there's just one character inserted
             return a != b2 || a_chars.ne(b_chars);
-        } else {
-            // tuple
-            // ntuple
-            return true;
         }
+        // tuple
+        // ntuple
+        return true;
     }
     // for item in items
     true

--- a/clippy_lints/src/redundant_else.rs
+++ b/clippy_lints/src/redundant_else.rs
@@ -1,0 +1,135 @@
+use crate::utils::span_lint_and_help;
+use rustc_ast::ast::{Block, Expr, ExprKind, Stmt, StmtKind};
+use rustc_ast::visit::{walk_expr, Visitor};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_middle::lint::in_external_macro;
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// **What it does:** Checks for `else` blocks that can be removed without changing semantics.
+    ///
+    /// **Why is this bad?** The `else` block adds unnecessary indentation and verbosity.
+    ///
+    /// **Known problems:** Some may prefer to keep the `else` block for clarity.
+    ///
+    /// **Example:**
+    ///
+    /// ```rust
+    /// fn my_func(count: u32) {
+    ///     if count == 0 {
+    ///         print!("Nothing to do");
+    ///         return;
+    ///     } else {
+    ///         print!("Moving on...");
+    ///     }
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// fn my_func(count: u32) {
+    ///     if count == 0 {
+    ///         print!("Nothing to do");
+    ///         return;
+    ///     }
+    ///     print!("Moving on...");
+    /// }
+    /// ```
+    pub REDUNDANT_ELSE,
+    pedantic,
+    "`else` branch that can be removed without changing semantics"
+}
+
+declare_lint_pass!(RedundantElse => [REDUNDANT_ELSE]);
+
+impl EarlyLintPass for RedundantElse {
+    fn check_stmt(&mut self, cx: &EarlyContext<'_>, stmt: &Stmt) {
+        if in_external_macro(cx.sess, stmt.span) {
+            return;
+        }
+        // Only look at expressions that are a whole statement
+        let expr: &Expr = match &stmt.kind {
+            StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr,
+            _ => return,
+        };
+        // if else
+        let (mut then, mut els): (&Block, &Expr) = match &expr.kind {
+            ExprKind::If(_, then, Some(els)) => (then, els),
+            _ => return,
+        };
+        loop {
+            if !BreakVisitor::default().check_block(then) {
+                // then block does not always break
+                return;
+            }
+            match &els.kind {
+                // else if else
+                ExprKind::If(_, next_then, Some(next_els)) => {
+                    then = next_then;
+                    els = next_els;
+                    continue;
+                },
+                // else if without else
+                ExprKind::If(..) => return,
+                // done
+                _ => break,
+            }
+        }
+        span_lint_and_help(
+            cx,
+            REDUNDANT_ELSE,
+            els.span,
+            "redundant else block",
+            None,
+            "remove the `else` block and move the contents out",
+        );
+    }
+}
+
+/// Call `check` functions to check if an expression always breaks control flow
+#[derive(Default)]
+struct BreakVisitor {
+    is_break: bool,
+}
+
+impl<'ast> Visitor<'ast> for BreakVisitor {
+    fn visit_block(&mut self, block: &'ast Block) {
+        self.is_break = match block.stmts.as_slice() {
+            [.., last] => self.check_stmt(last),
+            _ => false,
+        };
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        self.is_break = match expr.kind {
+            ExprKind::Break(..) | ExprKind::Continue(..) | ExprKind::Ret(..) => true,
+            ExprKind::Match(_, ref arms) => arms.iter().all(|arm| self.check_expr(&arm.body)),
+            ExprKind::If(_, ref then, Some(ref els)) => self.check_block(then) && self.check_expr(els),
+            ExprKind::If(_, _, None)
+            // ignore loops for simplicity
+            | ExprKind::While(..) | ExprKind::ForLoop(..) | ExprKind::Loop(..) => false,
+            _ => {
+                walk_expr(self, expr);
+                return;
+            },
+        };
+    }
+}
+
+impl BreakVisitor {
+    fn check<T>(&mut self, item: T, visit: fn(&mut Self, T)) -> bool {
+        visit(self, item);
+        std::mem::replace(&mut self.is_break, false)
+    }
+
+    fn check_block(&mut self, block: &Block) -> bool {
+        self.check(block, Self::visit_block)
+    }
+
+    fn check_expr(&mut self, expr: &Expr) -> bool {
+        self.check(expr, Self::visit_expr)
+    }
+
+    fn check_stmt(&mut self, stmt: &Stmt) -> bool {
+        self.check(stmt, Self::visit_stmt)
+    }
+}

--- a/tests/ui/redundant_else.rs
+++ b/tests/ui/redundant_else.rs
@@ -1,0 +1,154 @@
+#![warn(clippy::redundant_else)]
+#![allow(clippy::needless_return)]
+
+fn main() {
+    loop {
+        // break
+        if foo() {
+            println!("Love your neighbor;");
+            break;
+        } else {
+            println!("yet don't pull down your hedge.");
+        }
+        // continue
+        if foo() {
+            println!("He that lies down with Dogs,");
+            continue;
+        } else {
+            println!("shall rise up with fleas.");
+        }
+        // match block
+        if foo() {
+            match foo() {
+                1 => break,
+                _ => return,
+            }
+        } else {
+            println!("You may delay, but time will not.");
+        }
+    }
+    // else if
+    if foo() {
+        return;
+    } else if foo() {
+        return;
+    } else {
+        println!("A fat kitchen makes a lean will.");
+    }
+    // let binding outside of block
+    let _ = {
+        if foo() {
+            return;
+        } else {
+            1
+        }
+    };
+    // else if with let binding outside of block
+    let _ = {
+        if foo() {
+            return;
+        } else if foo() {
+            return;
+        } else {
+            2
+        }
+    };
+    // inside if let
+    let _ = if let Some(1) = foo() {
+        let _ = 1;
+        if foo() {
+            return;
+        } else {
+            1
+        }
+    } else {
+        1
+    };
+
+    //
+    // non-lint cases
+    //
+
+    // sanity check
+    if foo() {
+        let _ = 1;
+    } else {
+        println!("Who is wise? He that learns from every one.");
+    }
+    // else if without else
+    if foo() {
+        return;
+    } else if foo() {
+        foo()
+    };
+    // nested if return
+    if foo() {
+        if foo() {
+            return;
+        }
+    } else {
+        foo()
+    };
+    // match with non-breaking branch
+    if foo() {
+        match foo() {
+            1 => foo(),
+            _ => return,
+        }
+    } else {
+        println!("Three may keep a secret, if two of them are dead.");
+    }
+    // let binding
+    let _ = if foo() {
+        return;
+    } else {
+        1
+    };
+    // assign
+    let a;
+    a = if foo() {
+        return;
+    } else {
+        1
+    };
+    // assign-op
+    a += if foo() {
+        return;
+    } else {
+        1
+    };
+    // if return else if else
+    if foo() {
+        return;
+    } else if foo() {
+        1
+    } else {
+        2
+    };
+    // if else if return else
+    if foo() {
+        1
+    } else if foo() {
+        return;
+    } else {
+        2
+    };
+    // else if with let binding
+    let _ = if foo() {
+        return;
+    } else if foo() {
+        return;
+    } else {
+        2
+    };
+    // inside function call
+    Box::new(if foo() {
+        return;
+    } else {
+        1
+    });
+}
+
+fn foo<T>() -> T {
+    unimplemented!("I'm not Santa Claus")
+}

--- a/tests/ui/redundant_else.stderr
+++ b/tests/ui/redundant_else.stderr
@@ -1,0 +1,80 @@
+error: redundant else block
+  --> $DIR/redundant_else.rs:10:16
+   |
+LL |           } else {
+   |  ________________^
+LL | |             println!("yet don't pull down your hedge.");
+LL | |         }
+   | |_________^
+   |
+   = note: `-D clippy::redundant-else` implied by `-D warnings`
+   = help: remove the `else` block and move the contents out
+
+error: redundant else block
+  --> $DIR/redundant_else.rs:17:16
+   |
+LL |           } else {
+   |  ________________^
+LL | |             println!("shall rise up with fleas.");
+LL | |         }
+   | |_________^
+   |
+   = help: remove the `else` block and move the contents out
+
+error: redundant else block
+  --> $DIR/redundant_else.rs:26:16
+   |
+LL |           } else {
+   |  ________________^
+LL | |             println!("You may delay, but time will not.");
+LL | |         }
+   | |_________^
+   |
+   = help: remove the `else` block and move the contents out
+
+error: redundant else block
+  --> $DIR/redundant_else.rs:35:12
+   |
+LL |       } else {
+   |  ____________^
+LL | |         println!("A fat kitchen makes a lean will.");
+LL | |     }
+   | |_____^
+   |
+   = help: remove the `else` block and move the contents out
+
+error: redundant else block
+  --> $DIR/redundant_else.rs:42:16
+   |
+LL |           } else {
+   |  ________________^
+LL | |             1
+LL | |         }
+   | |_________^
+   |
+   = help: remove the `else` block and move the contents out
+
+error: redundant else block
+  --> $DIR/redundant_else.rs:52:16
+   |
+LL |           } else {
+   |  ________________^
+LL | |             2
+LL | |         }
+   | |_________^
+   |
+   = help: remove the `else` block and move the contents out
+
+error: redundant else block
+  --> $DIR/redundant_else.rs:61:16
+   |
+LL |           } else {
+   |  ________________^
+LL | |             1
+LL | |         }
+   | |_________^
+   |
+   = help: remove the `else` block and move the contents out
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
changelog: Add redundant_else lint

It seemed appropriate for "pedantic".

Closes #112 \*blows off dust*