### PR TITLE
Remove `expect()` calls to avoid ICEs in `deref_addrof` lint

### DIFF
--- a/tests/ui/crashes/ice-6332.rs
+++ b/tests/ui/crashes/ice-6332.rs
@@ -1,0 +1,11 @@
+fn cmark_check() {
+    let mut link_err = false;
+    macro_rules! cmark_error {
+        ($bad:expr) => {
+            *$bad = true;
+        };
+    }
+    cmark_error!(&mut link_err);
+}
+
+pub fn main() {}


### PR DESCRIPTION
Fixes: #6332 

changelog: none
