### PR TITLE
Improve doc about `map_clone`

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -14,8 +14,9 @@ use rustc_span::symbol::Ident;
 use rustc_span::{sym, Span};
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for usage of `iterator.map(|x| x.clone())` and suggests
-    /// `iterator.cloned()` instead
+    /// **What it does:** Checks for usage of `map(|x| x.clone())` or
+    /// dereferencing closures for `Copy` types, on `Iterator` or `Option`,
+    /// and suggests `cloned()` or `copied()` instead
     ///
     /// **Why is this bad?** Readability, this can be written more concisely
     ///


### PR DESCRIPTION
A follow up of https://github.com/rust-lang/rust-clippy/issues/6239#issuecomment-719100677.

`map_clone` works with not only `Iterator` but `Option` although not written in [doc](https://rust-lang.github.io/rust-clippy/master/#map_clone). Also, an example in the doc shows  a usage of dereferencing, but this isn't also written.

changelog: Improve doc about `map_clone`
