### PR TITLE
Revert "Add `rustfmt::skip` as a work around"

### DIFF
--- a/tests/ui/cast_ref_to_mut.rs
+++ b/tests/ui/cast_ref_to_mut.rs
@@ -2,10 +2,6 @@
 #![allow(clippy::no_effect)]
 
 extern "C" {
-    #[rustfmt::skip]
-    // TODO: This `rustfmt::skip` is a work around of #6336 because
-    // the following comments are checked by rustfmt for some reason.
-    //
     // N.B., mutability can be easily incorrect in FFI calls -- as
     // in C, the default is mutable pointers.
     fn ffi(c: *mut u8);

--- a/tests/ui/cast_ref_to_mut.stderr
+++ b/tests/ui/cast_ref_to_mut.stderr
@@ -1,5 +1,5 @@
 error: casting `&T` to `&mut T` may cause undefined behavior, consider instead using an `UnsafeCell`
-  --> $DIR/cast_ref_to_mut.rs:22:9
+  --> $DIR/cast_ref_to_mut.rs:18:9
    |
 LL |         (*(a as *const _ as *mut String)).push_str(" world");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL |         (*(a as *const _ as *mut String)).push_str(" world");
    = note: `-D clippy::cast-ref-to-mut` implied by `-D warnings`
 
 error: casting `&T` to `&mut T` may cause undefined behavior, consider instead using an `UnsafeCell`
-  --> $DIR/cast_ref_to_mut.rs:23:9
+  --> $DIR/cast_ref_to_mut.rs:19:9
    |
 LL |         *(a as *const _ as *mut _) = String::from("Replaced");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `&T` to `&mut T` may cause undefined behavior, consider instead using an `UnsafeCell`
-  --> $DIR/cast_ref_to_mut.rs:24:9
+  --> $DIR/cast_ref_to_mut.rs:20:9
    |
 LL |         *(a as *const _ as *mut String) += " world";
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This reverts commit 0e803417f997ba35c0045704dd347e64c2a1786c.

Fixed by rustfmt v1.4.27 available in the latest nightly (2020-11-18). Refer to https://github.com/rust-lang/rustfmt/issues/4528.

changelog: none
