### PR TITLE
Downgrade the await holding lints from correctness

### DIFF
--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -45,7 +45,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     pub AWAIT_HOLDING_LOCK,
-    correctness,
+    pedantic,
     "Inside an async function, holding a MutexGuard while calling await"
 }
 
@@ -84,7 +84,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     pub AWAIT_HOLDING_REFCELL_REF,
-    correctness,
+    pedantic,
     "Inside an async function, holding a RefCell ref while calling await"
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1224,6 +1224,8 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
 
     store.register_group(true, "clippy::pedantic", Some("clippy_pedantic"), vec![
         LintId::of(&attrs::INLINE_ALWAYS),
+        LintId::of(&await_holding_invalid::AWAIT_HOLDING_LOCK),
+        LintId::of(&await_holding_invalid::AWAIT_HOLDING_REFCELL_REF),
         LintId::of(&bit_mask::VERBOSE_BIT_MASK),
         LintId::of(&checked_conversions::CHECKED_CONVERSIONS),
         LintId::of(&copies::SAME_FUNCTIONS_IN_IF_CONDITION),
@@ -1327,8 +1329,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&attrs::MISMATCHED_TARGET_OS),
         LintId::of(&attrs::UNKNOWN_CLIPPY_LINTS),
         LintId::of(&attrs::USELESS_ATTRIBUTE),
-        LintId::of(&await_holding_invalid::AWAIT_HOLDING_LOCK),
-        LintId::of(&await_holding_invalid::AWAIT_HOLDING_REFCELL_REF),
         LintId::of(&bit_mask::BAD_BIT_MASK),
         LintId::of(&bit_mask::INEFFECTIVE_BIT_MASK),
         LintId::of(&blacklisted_name::BLACKLISTED_NAME),
@@ -1793,8 +1793,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&attrs::DEPRECATED_SEMVER),
         LintId::of(&attrs::MISMATCHED_TARGET_OS),
         LintId::of(&attrs::USELESS_ATTRIBUTE),
-        LintId::of(&await_holding_invalid::AWAIT_HOLDING_LOCK),
-        LintId::of(&await_holding_invalid::AWAIT_HOLDING_REFCELL_REF),
         LintId::of(&bit_mask::BAD_BIT_MASK),
         LintId::of(&bit_mask::INEFFECTIVE_BIT_MASK),
         LintId::of(&booleans::LOGIC_BUG),

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -62,14 +62,14 @@ vec![
     },
     Lint {
         name: "await_holding_lock",
-        group: "correctness",
+        group: "pedantic",
         desc: "Inside an async function, holding a MutexGuard while calling await",
         deprecation: None,
         module: "await_holding_invalid",
     },
     Lint {
         name: "await_holding_refcell_ref",
-        group: "correctness",
+        group: "pedantic",
         desc: "Inside an async function, holding a RefCell ref while calling await",
         deprecation: None,
         module: "await_holding_invalid",


### PR DESCRIPTION
We found a false positive in these lints (see https://github.com/rust-lang/rust-clippy/issues/6353 for more details). As a short-term mitigation, this downgrades the lints from correctness to limit the noise.

changelog: downgrade AWAIT_HOLDING_REFCELL_REF and AWAIT_HOLDING_LOCK to pedantic. From rustup earlier, where I forgot the changlog: deprecate [`panic_params`] (uplifted)