### PR TITLE
Small grammar, punctuation, and code style improvements to docs

### DIFF
--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -69,7 +69,7 @@ declare_clippy_lint! {
 }
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for comparing to an empty slice such as "" or [],`
+    /// **What it does:** Checks for comparing to an empty slice such as `""` or `[]`,
     /// and suggests using `.is_empty()` where applicable.
     ///
     /// **Why is this bad?** Some structures can answer `.is_empty()` much faster

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1351,7 +1351,7 @@ declare_clippy_lint! {
 }
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for usage of `_.map(_).collect::<Result<(),_>()`.
+    /// **What it does:** Checks for usage of `_.map(_).collect::<Result<(), _>()`.
     ///
     /// **Why is this bad?** Using `try_for_each` instead is more readable and idiomatic.
     ///

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 
 declare_clippy_lint! {
     /// **What it does:** Checks [regex](https://crates.io/crates/regex) creation
-    /// (with `Regex::new`,`RegexBuilder::new` or `RegexSet::new`) for correct
+    /// (with `Regex::new`, `RegexBuilder::new`, or `RegexSet::new`) for correct
     /// regex syntax.
     ///
     /// **Why is this bad?** This will lead to a runtime panic.
@@ -29,7 +29,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// **What it does:** Checks for trivial [regex](https://crates.io/crates/regex)
-    /// creation (with `Regex::new`, `RegexBuilder::new` or `RegexSet::new`).
+    /// creation (with `Regex::new`, `RegexBuilder::new`, or `RegexSet::new`).
     ///
     /// **Why is this bad?** Matching the regex can likely be replaced by `==` or
     /// `str::starts_with`, `str::ends_with` or `std::contains` or other `str`

--- a/clippy_lints/src/unit_return_expecting_ord.rs
+++ b/clippy_lints/src/unit_return_expecting_ord.rs
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// **Example:**
     ///
     /// ```rust
-    /// let mut twins = vec!((1,1), (2,2));
+    /// let mut twins = vec!((1, 1), (2, 2));
     /// twins.sort_by_key(|x| { x.1; });
     /// ```
     pub UNIT_RETURN_EXPECTING_ORD,

--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -12,8 +12,8 @@ use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::sym;
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for `Into`, `TryInto`, `From`, `TryFrom`,`IntoIter` calls
-    /// that useless converts to the same type as caller.
+    /// **What it does:** Checks for `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` calls
+    /// that uselessly convert to the same type.
     ///
     /// **Why is this bad?** Redundant code.
     ///
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     pub USELESS_CONVERSION,
     complexity,
-    "calls to `Into`, `TryInto`, `From`, `TryFrom`, `IntoIter` that performs useless conversions to the same type"
+    "calls to `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` that perform useless conversions to the same type"
 }
 
 #[derive(Default)]

--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -13,7 +13,7 @@ use rustc_span::sym;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` calls
-    /// that uselessly convert to the same type.
+    /// which uselessly convert to the same type.
     ///
     /// **Why is this bad?** Redundant code.
     ///
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     pub USELESS_CONVERSION,
     complexity,
-    "calls to `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` that perform useless conversions to the same type"
+    "calls to `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` which perform useless conversions to the same type"
 }
 
 #[derive(Default)]

--- a/src/lintlist/mod.rs
+++ b/src/lintlist/mod.rs
@@ -2751,7 +2751,7 @@ vec![
     Lint {
         name: "useless_conversion",
         group: "complexity",
-        desc: "calls to `Into`, `TryInto`, `From`, `TryFrom`, `IntoIter` that performs useless conversions to the same type",
+        desc: "calls to `Into`, `TryInto`, `From`, `TryFrom`, or `IntoIter` which perform useless conversions to the same type",
         deprecation: None,
         module: "useless_conversion",
     },


### PR DESCRIPTION
changelog: Made small grammar, punctuation, and code style improvements to docs

I recently found some places in rust-lang/rust that had lists without spaces after commas, which led me to look for more places, which led me over here to find:

- Some similar lists in code examples that could use spaces after commas to be idiomatic Rust style
- Some lists in documentation text that didn't have spaces after commas, needed an Oxford comma (fight me), or were otherwise misformatted
- Some other grammar improvements in the area of the other changes

These changes should only be in user-facing documentation or output.