### PR TITLE
Move unnecessary_wraps to pedantic

### DIFF
--- a/clippy_lints/src/unnecessary_wraps.rs
+++ b/clippy_lints/src/unnecessary_wraps.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     ///
     /// **Why is this bad?** It is not meaningful to wrap values when no `None` or `Err` is returned.
     ///
-    /// **Known problems:** Since this lint changes function type signature, you may need to
+    /// **Known problems:** Since this lint changes function type signature, you will need to
     /// adjust some code at callee side.
     ///
     /// **Example:**
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     pub UNNECESSARY_WRAPS,
-    complexity,
+    pedantic,
     "functions that only return `Ok` or `Some`"
 }
 


### PR DESCRIPTION
There are valid use cases for a function to return an `Option` or `Result` type even if it's only ever `Some` or `Ok`.  This lint should be in the pedantic group, not complexity.