### PR TITLE
Fix FP of `manual_range_contains` in `const fn`

### DIFF
--- a/tests/ui/range_contains.fixed
+++ b/tests/ui/range_contains.fixed
@@ -44,3 +44,8 @@ fn main() {
     (0. ..1.).contains(&y);
     !(0. ..=1.).contains(&y);
 }
+
+// Fix #6373
+pub const fn in_range(a: i32) -> bool {
+    3 <= a && a <= 20
+}

--- a/tests/ui/range_contains.rs
+++ b/tests/ui/range_contains.rs
@@ -44,3 +44,8 @@ fn main() {
     y >= 0. && y < 1.;
     y < 0. || y > 1.;
 }
+
+// Fix #6373
+pub const fn in_range(a: i32) -> bool {
+    3 <= a && a <= 20
+}


### PR DESCRIPTION
Fix #6373.

changelog: Fix FP of `manual_range_contains` in `const fn`
