### PR TITLE
Remove mention of possibility to specify the MSRV with a tilde/caret

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,6 @@ fn main() {
 }
 ```
 
-Tilde/Caret version requirements (like `^1.0` or `~1.2`) can be specified as well.
-
 Note: `custom_inner_attributes` is an unstable feature so it has to be enabled explicitly.
 
 Lints that recognize this configuration option can be found [here](https://rust-lang.github.io/rust-clippy/master/index.html#msrv)

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ cargo clippy -- -W clippy::lint_name
 ```
 
 This also works with lint groups. For example you
-can run Clippy with warnings for all lints enabled: 
+can run Clippy with warnings for all lints enabled:
 ```terminal
 cargo clippy -- -W clippy::pedantic
 ```
@@ -213,6 +213,9 @@ fn main() {
   ...
 }
 ```
+
+You can also omit the patch version when specifying the MSRV, so `msrv = 1.30`
+is equivalent to `msrv = 1.30.0`.
 
 Note: `custom_inner_attributes` is an unstable feature so it has to be enabled explicitly.
 


### PR DESCRIPTION
As @taiki-e explained in https://github.com/rust-lang/rust-clippy/pull/6379#discussion_r530743279, mentioning this might be problematic.

changelog: none
