### PR TITLE
add "WebGL" to doc_valid_idents

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -127,6 +127,7 @@ define_Conf! {
         "OAuth", "GraphQL",
         "OCaml",
         "OpenGL", "OpenMP", "OpenSSH", "OpenSSL", "OpenStreetMap",
+        "WebGL",
         "TensorFlow",
         "TrueType",
         "iOS", "macOS",


### PR DESCRIPTION
I added "WebGL" along the lines of the existing "OpenGL" to the whitelist of `doc_markdown` as I found this to be a pretty common term.

changelog: Whitelist "WebGL" in `doc_markdown`.