### PR TITLE
switch Version/VersionReq usages to RustcVersion 

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -28,7 +28,7 @@ smallvec = { version = "1", features = ["union"] }
 toml = "0.5.3"
 unicode-normalization = "0.1"
 semver = "0.11"
-rustc-semver="1.0.0"
+rustc-semver="1.1.0"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
 url = { version =  "2.1.0", features = ["serde"] }

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -28,6 +28,7 @@ smallvec = { version = "1", features = ["union"] }
 toml = "0.5.3"
 unicode-normalization = "0.1"
 semver = "0.11"
+rustc-semver="1.0.0"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
 url = { version =  "2.1.0", features = ["serde"] }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -966,22 +966,17 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box implicit_return::ImplicitReturn);
     store.register_late_pass(|| box implicit_saturating_sub::ImplicitSaturatingSub);
 
-    let parsed_msrv = conf.msrv.as_ref().and_then(|s| {
+    let msrv = conf.msrv.as_ref().and_then(|s| {
         parse_msrv(s, None, None).or_else(|| {
             sess.err(&format!("error reading Clippy's configuration file. `{}` is not a valid Rust version", s));
             None
         })
     });
 
-    let msrv = parsed_msrv.clone();
-    store.register_late_pass(move || box methods::Methods::new(msrv.clone()));
-    let msrv = parsed_msrv.clone();
-    store.register_late_pass(move || box matches::Matches::new(msrv.clone()));
-    let msrv = parsed_msrv.clone();
-    store.register_early_pass(move || box manual_non_exhaustive::ManualNonExhaustive::new(msrv.clone()));
-    let msrv = parsed_msrv;
-    store.register_late_pass(move || box manual_strip::ManualStrip::new(msrv.clone()));
-
+    store.register_late_pass(move || box methods::Methods::new(msrv));
+    store.register_late_pass(move || box matches::Matches::new(msrv));
+    store.register_early_pass(move || box manual_non_exhaustive::ManualNonExhaustive::new(msrv));
+    store.register_late_pass(move || box manual_strip::ManualStrip::new(msrv));
     store.register_late_pass(|| box map_clone::MapClone);
     store.register_late_pass(|| box map_err_ignore::MapErrIgnore);
     store.register_late_pass(|| box shadow::Shadow);

--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -4,17 +4,11 @@ use rustc_ast::ast::{Attribute, Item, ItemKind, StructField, Variant, VariantDat
 use rustc_attr as attr;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_semver::RustcVersion;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::{sym, Span};
-use semver::{Version, VersionReq};
 
-const MANUAL_NON_EXHAUSTIVE_MSRV: Version = Version {
-    major: 1,
-    minor: 40,
-    patch: 0,
-    pre: Vec::new(),
-    build: Vec::new(),
-};
+const MANUAL_NON_EXHAUSTIVE_MSRV: RustcVersion = RustcVersion::new(1, 40, 0);
 
 declare_clippy_lint! {
     /// **What it does:** Checks for manual implementations of the non-exhaustive pattern.
@@ -66,12 +60,12 @@ declare_clippy_lint! {
 
 #[derive(Clone)]
 pub struct ManualNonExhaustive {
-    msrv: Option<VersionReq>,
+    msrv: Option<RustcVersion>,
 }
 
 impl ManualNonExhaustive {
     #[must_use]
-    pub fn new(msrv: Option<VersionReq>) -> Self {
+    pub fn new(msrv: Option<RustcVersion>) -> Self {
         Self { msrv }
     }
 }

--- a/clippy_lints/src/manual_strip.rs
+++ b/clippy_lints/src/manual_strip.rs
@@ -13,18 +13,12 @@ use rustc_hir::{BorrowKind, Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::hir::map::Map;
 use rustc_middle::ty;
+use rustc_semver::RustcVersion;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::source_map::Spanned;
 use rustc_span::Span;
-use semver::{Version, VersionReq};
 
-const MANUAL_STRIP_MSRV: Version = Version {
-    major: 1,
-    minor: 45,
-    patch: 0,
-    pre: Vec::new(),
-    build: Vec::new(),
-};
+const MANUAL_STRIP_MSRV: RustcVersion = RustcVersion::new(1, 45, 0);
 
 declare_clippy_lint! {
     /// **What it does:**
@@ -61,12 +55,12 @@ declare_clippy_lint! {
 }
 
 pub struct ManualStrip {
-    msrv: Option<VersionReq>,
+    msrv: Option<RustcVersion>,
 }
 
 impl ManualStrip {
     #[must_use]
-    pub fn new(msrv: Option<VersionReq>) -> Self {
+    pub fn new(msrv: Option<RustcVersion>) -> Self {
         Self { msrv }
     }
 }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -20,10 +20,10 @@ use rustc_hir::{
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::{self, Ty, TyS};
+use rustc_semver::RustcVersion;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::source_map::{Span, Spanned};
 use rustc_span::{sym, Symbol};
-use semver::{Version, VersionReq};
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::Bound;
@@ -535,13 +535,13 @@ declare_clippy_lint! {
 
 #[derive(Default)]
 pub struct Matches {
-    msrv: Option<VersionReq>,
+    msrv: Option<RustcVersion>,
     infallible_destructuring_match_linted: bool,
 }
 
 impl Matches {
     #[must_use]
-    pub fn new(msrv: Option<VersionReq>) -> Self {
+    pub fn new(msrv: Option<RustcVersion>) -> Self {
         Self {
             msrv,
             ..Matches::default()
@@ -568,13 +568,7 @@ impl_lint_pass!(Matches => [
     MATCH_SAME_ARMS,
 ]);
 
-const MATCH_LIKE_MATCHES_MACRO_MSRV: Version = Version {
-    major: 1,
-    minor: 42,
-    patch: 0,
-    pre: Vec::new(),
-    build: Vec::new(),
-};
+const MATCH_LIKE_MATCHES_MACRO_MSRV: RustcVersion = RustcVersion::new(1, 42, 0);
 
 impl<'tcx> LateLintPass<'tcx> for Matches {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -18,6 +18,7 @@ use rustc_hir::{TraitItem, TraitItemKind};
 use rustc_lint::{LateContext, LateLintPass, Lint, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::{self, TraitRef, Ty, TyS};
+use rustc_semver::RustcVersion;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::source_map::Span;
 use rustc_span::symbol::{sym, SymbolStr};
@@ -33,7 +34,6 @@ use crate::utils::{
     snippet_with_macro_callsite, span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then, sugg,
     walk_ptrs_ty_depth, SpanlessEq,
 };
-use semver::{Version, VersionReq};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for `.unwrap()` calls on `Option`s and on `Result`s.
@@ -1405,12 +1405,12 @@ declare_clippy_lint! {
 }
 
 pub struct Methods {
-    msrv: Option<VersionReq>,
+    msrv: Option<RustcVersion>,
 }
 
 impl Methods {
     #[must_use]
-    pub fn new(msrv: Option<VersionReq>) -> Self {
+    pub fn new(msrv: Option<RustcVersion>) -> Self {
         Self { msrv }
     }
 }
@@ -3470,13 +3470,7 @@ fn lint_suspicious_map(cx: &LateContext<'_>, expr: &hir::Expr<'_>) {
     );
 }
 
-const OPTION_AS_REF_DEREF_MSRV: Version = Version {
-    major: 1,
-    minor: 40,
-    patch: 0,
-    pre: Vec::new(),
-    build: Vec::new(),
-};
+const OPTION_AS_REF_DEREF_MSRV: RustcVersion = RustcVersion::new(1, 40, 0);
 
 /// lint use of `_.as_ref().map(Deref::deref)` for `Option`s
 fn lint_option_as_ref_deref<'tcx>(
@@ -3485,7 +3479,7 @@ fn lint_option_as_ref_deref<'tcx>(
     as_ref_args: &[hir::Expr<'_>],
     map_args: &[hir::Expr<'_>],
     is_mut: bool,
-    msrv: Option<&VersionReq>,
+    msrv: Option<&RustcVersion>,
 ) {
     if !meets_msrv(msrv, &OPTION_AS_REF_DEREF_MSRV) {
         return;

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -51,6 +51,7 @@ use rustc_lint::{LateContext, Level, Lint, LintContext};
 use rustc_middle::hir::map::Map;
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind};
 use rustc_middle::ty::{self, layout::IntegerExt, Ty, TyCtxt, TypeFoldable};
+use rustc_semver::RustcVersion;
 use rustc_session::Session;
 use rustc_span::hygiene::{ExpnKind, MacroKind};
 use rustc_span::source_map::original_sp;
@@ -59,13 +60,12 @@ use rustc_span::symbol::{self, kw, Symbol};
 use rustc_span::{BytePos, Pos, Span, DUMMY_SP};
 use rustc_target::abi::Integer;
 use rustc_trait_selection::traits::query::normalize::AtExt;
-use semver::{Version, VersionReq};
 use smallvec::SmallVec;
 
 use crate::consts::{constant, Constant};
 
-pub fn parse_msrv(msrv: &str, sess: Option<&Session>, span: Option<Span>) -> Option<VersionReq> {
-    if let Ok(version) = VersionReq::parse(msrv) {
+pub fn parse_msrv(msrv: &str, sess: Option<&Session>, span: Option<Span>) -> Option<RustcVersion> {
+    if let Ok(version) = RustcVersion::parse(msrv) {
         return Some(version);
     } else if let Some(sess) = sess {
         if let Some(span) = span {
@@ -75,8 +75,8 @@ pub fn parse_msrv(msrv: &str, sess: Option<&Session>, span: Option<Span>) -> Opt
     None
 }
 
-pub fn meets_msrv(msrv: Option<&VersionReq>, lint_msrv: &Version) -> bool {
-    msrv.map_or(true, |msrv| !msrv.matches(lint_msrv))
+pub fn meets_msrv(msrv: Option<&RustcVersion>, lint_msrv: &RustcVersion) -> bool {
+    msrv.map_or(true, |msrv| msrv > lint_msrv)
 }
 
 macro_rules! extract_msrv_attr {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -76,7 +76,7 @@ pub fn parse_msrv(msrv: &str, sess: Option<&Session>, span: Option<Span>) -> Opt
 }
 
 pub fn meets_msrv(msrv: Option<&RustcVersion>, lint_msrv: &RustcVersion) -> bool {
-    msrv.map_or(true, |msrv| msrv > lint_msrv)
+    msrv.map_or(true, |msrv| msrv >= lint_msrv)
 }
 
 macro_rules! extract_msrv_attr {

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -76,7 +76,7 @@ pub fn parse_msrv(msrv: &str, sess: Option<&Session>, span: Option<Span>) -> Opt
 }
 
 pub fn meets_msrv(msrv: Option<&RustcVersion>, lint_msrv: &RustcVersion) -> bool {
-    msrv.map_or(true, |msrv| msrv >= lint_msrv)
+    msrv.map_or(true, |msrv| msrv.meets(*lint_msrv))
 }
 
 macro_rules! extract_msrv_attr {

--- a/tests/ui/min_rust_version_attr.rs
+++ b/tests/ui/min_rust_version_attr.rs
@@ -35,7 +35,7 @@ fn match_same_arms2() {
     };
 }
 
-fn manual_strip_msrv() {
+pub fn manual_strip_msrv() {
     let s = "hello, world!";
     if s.starts_with("hello, ") {
         assert_eq!(s["hello, ".len()..].to_uppercase(), "WORLD!");
@@ -48,4 +48,40 @@ fn main() {
     match_same_arms();
     match_same_arms2();
     manual_strip_msrv();
+}
+
+mod meets_msrv {
+    #![feature(custom_inner_attributes)]
+    #![clippy::msrv = "1.45.0"]
+
+    fn main() {
+        let s = "hello, world!";
+        if s.starts_with("hello, ") {
+            assert_eq!(s["hello, ".len()..].to_uppercase(), "WORLD!");
+        }
+    }
+}
+
+mod just_under_msrv {
+    #![feature(custom_inner_attributes)]
+    #![clippy::msrv = "1.46.0"]
+
+    fn main() {
+        let s = "hello, world!";
+        if s.starts_with("hello, ") {
+            assert_eq!(s["hello, ".len()..].to_uppercase(), "WORLD!");
+        }
+    }
+}
+
+mod just_above_msrv {
+    #![feature(custom_inner_attributes)]
+    #![clippy::msrv = "1.44.0"]
+
+    fn main() {
+        let s = "hello, world!";
+        if s.starts_with("hello, ") {
+            assert_eq!(s["hello, ".len()..].to_uppercase(), "WORLD!");
+        }
+    }
 }

--- a/tests/ui/min_rust_version_attr.stderr
+++ b/tests/ui/min_rust_version_attr.stderr
@@ -1,0 +1,37 @@
+error: stripping a prefix manually
+  --> $DIR/min_rust_version_attr.rs:60:24
+   |
+LL |             assert_eq!(s["hello, ".len()..].to_uppercase(), "WORLD!");
+   |                        ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::manual-strip` implied by `-D warnings`
+note: the prefix was tested here
+  --> $DIR/min_rust_version_attr.rs:59:9
+   |
+LL |         if s.starts_with("hello, ") {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: try using the `strip_prefix` method
+   |
+LL |         if let Some(<stripped>) = s.strip_prefix("hello, ") {
+LL |             assert_eq!(<stripped>.to_uppercase(), "WORLD!");
+   |
+
+error: stripping a prefix manually
+  --> $DIR/min_rust_version_attr.rs:72:24
+   |
+LL |             assert_eq!(s["hello, ".len()..].to_uppercase(), "WORLD!");
+   |                        ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the prefix was tested here
+  --> $DIR/min_rust_version_attr.rs:71:9
+   |
+LL |         if s.starts_with("hello, ") {
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: try using the `strip_prefix` method
+   |
+LL |         if let Some(<stripped>) = s.strip_prefix("hello, ") {
+LL |             assert_eq!(<stripped>.to_uppercase(), "WORLD!");
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/min_rust_version_no_patch.rs
+++ b/tests/ui/min_rust_version_no_patch.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_clone)]
 #![feature(custom_inner_attributes)]
-#![clippy::msrv = "^1.0"]
+#![clippy::msrv = "1.0"]
 
 fn manual_strip_msrv() {
     let s = "hello, world!";


### PR DESCRIPTION
add `rustc-semver` to dependencies
switch `Version/VersionReq` usages to `RustcVersion`
changelog: none
