### PR TITLE
Rustup?

### DIFF
--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -58,12 +58,12 @@ impl EarlyLintPass for ItemsAfterStatements {
             return;
         }
 
-        // skip initial items
+        // skip initial items and trailing semicolons
         let stmts = item
             .stmts
             .iter()
             .map(|stmt| &stmt.kind)
-            .skip_while(|s| matches!(**s, StmtKind::Item(..)));
+            .skip_while(|s| matches!(**s, StmtKind::Item(..) | StmtKind::Empty));
 
         // lint on all further items
         for stmt in stmts {

--- a/clippy_lints/src/redundant_closure_call.rs
+++ b/clippy_lints/src/redundant_closure_call.rs
@@ -104,7 +104,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClosureCall {
                 cx: &'a LateContext<'tcx>,
                 path: &'tcx hir::Path<'tcx>,
                 count: usize,
-            };
+            }
             impl<'a, 'tcx> hir_visit::Visitor<'tcx> for ClosureUsageCount<'a, 'tcx> {
                 type Map = Map<'tcx>;
 
@@ -124,7 +124,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClosureCall {
                 fn nested_visit_map(&mut self) -> hir_visit::NestedVisitorMap<Self::Map> {
                     hir_visit::NestedVisitorMap::OnlyBodies(self.cx.tcx.hir())
                 }
-            };
+            }
             let mut closure_usage_count = ClosureUsageCount { cx, path, count: 0 };
             closure_usage_count.visit_block(block);
             closure_usage_count.count

--- a/tests/ui/item_after_statement.rs
+++ b/tests/ui/item_after_statement.rs
@@ -37,3 +37,16 @@ fn mac() {
     b!();
     println!("{}", a);
 }
+
+fn semicolon() {
+    struct S {
+        a: u32,
+    };
+    impl S {
+        fn new(a: u32) -> Self {
+            Self { a }
+        }
+    }
+
+    let _ = S::new(3);
+}


### PR DESCRIPTION
Basically a rustup from an unknown source. I added a regression test (and slightly changed the lint), so this'll need a review.

changelog: Fix bug in [`items_after_statements`] wher it triggered, if items were separated by trailing semicolons.
