### PR TITLE
Similar names ignore underscore prefixed names

### DIFF
--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -199,6 +199,10 @@ impl<'a, 'tcx, 'b> SimilarNamesNameVisitor<'a, 'tcx, 'b> {
             );
             return;
         }
+        if interned_name.starts_with('_') {
+            // these bindings are typically unused or represent an ignored portion of a destructuring pattern
+            return;
+        }
         let count = interned_name.chars().count();
         if count < 3 {
             if count == 1 {

--- a/tests/ui/similar_names.rs
+++ b/tests/ui/similar_names.rs
@@ -101,3 +101,8 @@ pub(crate) struct DirSizes {
     pub(crate) numb_reg_cache_entries: u64,
     pub(crate) numb_reg_src_checkouts: u64,
 }
+
+fn ignore_underscore_prefix() {
+    let hello: ();
+    let _hello: ();
+}


### PR DESCRIPTION
changelog: Ignore underscore-prefixed names for similar_names

IMO, this lint is not very helpful for underscore-prefixed variables. Usually they are unused or are just there to ignore part of a destructuring.