### PR TITLE
Fix false positive in write_literal and print_literal (numeric literals)

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -470,10 +470,7 @@ impl Write {
                 ExprKind::Assign(lhs, rhs, _) => {
                     if_chain! {
                         if let ExprKind::Lit(ref lit) = rhs.kind;
-                        if match lit.kind {
-                            LitKind::Int(_, _) | LitKind::Float(_, _) => false,
-                            _ => true,
-                        };
+                        if matches!(lit.kind, LitKind::Int(..) | LitKind::Float(..));
                         if let ExprKind::Path(_, p) = &lhs.kind;
                         then {
                             let mut all_simple = true;

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -461,7 +461,7 @@ impl Write {
                         span_lint(cx, lint, token_expr.span, "literal with an empty format string");
                     }
                     idx += 1;
-                }
+                },
                 ExprKind::Assign(lhs, rhs, _) => {
                     if_chain! {
                         if let ExprKind::Lit(ref lit) = rhs.kind;

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -443,7 +443,7 @@ impl Write {
                 return (Some(fmtstr), None);
             };
             match &token_expr.kind {
-                ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Int(..) | LitKind::Float(..)) => {
+                ExprKind::Lit(lit) if !matches!(lit.kind, LitKind::Int(..) | LitKind::Float(..)) => {
                     let mut all_simple = true;
                     let mut seen = false;
                     for arg in &args {
@@ -465,7 +465,7 @@ impl Write {
                 ExprKind::Assign(lhs, rhs, _) => {
                     if_chain! {
                         if let ExprKind::Lit(ref lit) = rhs.kind;
-                        if matches!(lit.kind, LitKind::Int(..) | LitKind::Float(..));
+                        if !matches!(lit.kind, LitKind::Int(..) | LitKind::Float(..));
                         if let ExprKind::Path(_, p) = &lhs.kind;
                         then {
                             let mut all_simple = true;

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -2,7 +2,8 @@ use std::borrow::Cow;
 use std::ops::Range;
 
 use crate::utils::{snippet_with_applicability, span_lint, span_lint_and_sugg, span_lint_and_then};
-use rustc_ast::ast::{Expr, ExprKind, Item, ItemKind, MacCall, StrLit, StrStyle};
+use if_chain::if_chain;
+use rustc_ast::ast::{Expr, ExprKind, Item, ItemKind, LitKind, MacCall, StrLit, StrStyle};
 use rustc_ast::token;
 use rustc_ast::tokenstream::TokenStream;
 use rustc_errors::Applicability;
@@ -442,7 +443,12 @@ impl Write {
                 return (Some(fmtstr), None);
             };
             match &token_expr.kind {
-                ExprKind::Lit(_) => {
+                ExprKind::Lit(lit)
+                    if match lit.kind {
+                        LitKind::Int(_, _) | LitKind::Float(_, _) => false,
+                        _ => true,
+                    } =>
+                {
                     let mut all_simple = true;
                     let mut seen = false;
                     for arg in &args {
@@ -460,10 +466,16 @@ impl Write {
                         span_lint(cx, lint, token_expr.span, "literal with an empty format string");
                     }
                     idx += 1;
-                },
+                }
                 ExprKind::Assign(lhs, rhs, _) => {
-                    if let ExprKind::Lit(_) = rhs.kind {
-                        if let ExprKind::Path(_, p) = &lhs.kind {
+                    if_chain! {
+                        if let ExprKind::Lit(ref lit) = rhs.kind;
+                        if match lit.kind {
+                            LitKind::Int(_, _) | LitKind::Float(_, _) => false,
+                            _ => true,
+                        };
+                        if let ExprKind::Path(_, p) = &lhs.kind;
+                        then {
                             let mut all_simple = true;
                             let mut seen = false;
                             for arg in &args {

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -443,12 +443,7 @@ impl Write {
                 return (Some(fmtstr), None);
             };
             match &token_expr.kind {
-                ExprKind::Lit(lit)
-                    if match lit.kind {
-                        LitKind::Int(_, _) | LitKind::Float(_, _) => false,
-                        _ => true,
-                    } =>
-                {
+                ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Int(..) | LitKind::Float(..)) => {
                     let mut all_simple = true;
                     let mut seen = false;
                     for arg in &args {

--- a/tests/ui/crashes/ice-3891.stderr
+++ b/tests/ui/crashes/ice-3891.stderr
@@ -1,10 +1,10 @@
-error: invalid suffix `x` for integer literal
+error: invalid suffix `x` for number literal
   --> $DIR/ice-3891.rs:2:5
    |
 LL |     1x;
    |     ^^ invalid suffix `x`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
 error: aborting due to previous error
 

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -19,12 +19,9 @@ fn main() {
     println!("{number:>0width$}", number = 1, width = 6);
 
     // these should throw warnings
-    println!("{} of {:b} people know binary, the other half doesn't", 1, 2);
     print!("Hello {}", "world");
     println!("Hello {} {}", world, "world");
     println!("Hello {}", "world");
-    println!("10 / 4 is {}", 2.5);
-    println!("2 + 1 = {}", 3);
 
     // positional args don't change the fact
     // that we're using a literal -- this should

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -17,6 +17,9 @@ fn main() {
     println!("{bar:8} {foo:>8}", foo = "hello", bar = "world");
     println!("{number:>width$}", number = 1, width = 6);
     println!("{number:>0width$}", number = 1, width = 6);
+    println!("{} of {:b} people know binary, the other half doesn't", 1, 2);
+    println!("10 / 4 is {}", 2.5);
+    println!("2 + 1 = {}", 3);
 
     // these should throw warnings
     print!("Hello {}", "world");

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -1,5 +1,5 @@
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:22:24
+  --> $DIR/print_literal.rs:25:24
    |
 LL |     print!("Hello {}", "world");
    |                        ^^^^^^^
@@ -7,61 +7,61 @@ LL |     print!("Hello {}", "world");
    = note: `-D clippy::print-literal` implied by `-D warnings`
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:23:36
+  --> $DIR/print_literal.rs:26:36
    |
 LL |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:24:26
+  --> $DIR/print_literal.rs:27:26
    |
 LL |     println!("Hello {}", "world");
    |                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:29:25
+  --> $DIR/print_literal.rs:32:25
    |
 LL |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:29:34
+  --> $DIR/print_literal.rs:32:34
    |
 LL |     println!("{0} {1}", "hello", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:30:25
+  --> $DIR/print_literal.rs:33:25
    |
 LL |     println!("{1} {0}", "hello", "world");
    |                         ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:30:34
+  --> $DIR/print_literal.rs:33:34
    |
 LL |     println!("{1} {0}", "hello", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:33:35
+  --> $DIR/print_literal.rs:36:35
    |
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                   ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:33:50
+  --> $DIR/print_literal.rs:36:50
    |
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:34:35
+  --> $DIR/print_literal.rs:37:35
    |
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                   ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:34:50
+  --> $DIR/print_literal.rs:37:50
    |
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -1,88 +1,70 @@
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:22:71
+  --> $DIR/print_literal.rs:22:24
    |
-LL |     println!("{} of {:b} people know binary, the other half doesn't", 1, 2);
-   |                                                                       ^
+LL |     print!("Hello {}", "world");
+   |                        ^^^^^^^
    |
    = note: `-D clippy::print-literal` implied by `-D warnings`
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:23:24
-   |
-LL |     print!("Hello {}", "world");
-   |                        ^^^^^^^
-
-error: literal with an empty format string
-  --> $DIR/print_literal.rs:24:36
+  --> $DIR/print_literal.rs:23:36
    |
 LL |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:25:26
+  --> $DIR/print_literal.rs:24:26
    |
 LL |     println!("Hello {}", "world");
    |                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:26:30
-   |
-LL |     println!("10 / 4 is {}", 2.5);
-   |                              ^^^
-
-error: literal with an empty format string
-  --> $DIR/print_literal.rs:27:28
-   |
-LL |     println!("2 + 1 = {}", 3);
-   |                            ^
-
-error: literal with an empty format string
-  --> $DIR/print_literal.rs:32:25
+  --> $DIR/print_literal.rs:29:25
    |
 LL |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:32:34
+  --> $DIR/print_literal.rs:29:34
    |
 LL |     println!("{0} {1}", "hello", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:33:25
+  --> $DIR/print_literal.rs:30:25
    |
 LL |     println!("{1} {0}", "hello", "world");
    |                         ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:33:34
+  --> $DIR/print_literal.rs:30:34
    |
 LL |     println!("{1} {0}", "hello", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:36:35
+  --> $DIR/print_literal.rs:33:35
    |
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                   ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:36:50
+  --> $DIR/print_literal.rs:33:50
    |
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:37:35
+  --> $DIR/print_literal.rs:34:35
    |
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                   ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:37:50
+  --> $DIR/print_literal.rs:34:50
    |
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^
 
-error: aborting due to 14 previous errors
+error: aborting due to 11 previous errors
 

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -24,12 +24,9 @@ fn main() {
     writeln!(&mut v, "{number:>0width$}", number = 1, width = 6);
 
     // these should throw warnings
-    writeln!(&mut v, "{} of {:b} people know binary, the other half doesn't", 1, 2);
     write!(&mut v, "Hello {}", "world");
     writeln!(&mut v, "Hello {} {}", world, "world");
     writeln!(&mut v, "Hello {}", "world");
-    writeln!(&mut v, "10 / 4 is {}", 2.5);
-    writeln!(&mut v, "2 + 1 = {}", 3);
 
     // positional args don't change the fact
     // that we're using a literal -- this should

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -22,6 +22,9 @@ fn main() {
     writeln!(&mut v, "{bar:8} {foo:>8}", foo = "hello", bar = "world");
     writeln!(&mut v, "{number:>width$}", number = 1, width = 6);
     writeln!(&mut v, "{number:>0width$}", number = 1, width = 6);
+    writeln!(&mut v, "{} of {:b} people know binary, the other half doesn't", 1, 2);
+    writeln!(&mut v, "10 / 4 is {}", 2.5);
+    writeln!(&mut v, "2 + 1 = {}", 3);
 
     // these should throw warnings
     write!(&mut v, "Hello {}", "world");

--- a/tests/ui/write_literal.stderr
+++ b/tests/ui/write_literal.stderr
@@ -1,5 +1,5 @@
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:27:32
+  --> $DIR/write_literal.rs:30:32
    |
 LL |     write!(&mut v, "Hello {}", "world");
    |                                ^^^^^^^
@@ -7,61 +7,61 @@ LL |     write!(&mut v, "Hello {}", "world");
    = note: `-D clippy::write-literal` implied by `-D warnings`
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:28:44
+  --> $DIR/write_literal.rs:31:44
    |
 LL |     writeln!(&mut v, "Hello {} {}", world, "world");
    |                                            ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:29:34
+  --> $DIR/write_literal.rs:32:34
    |
 LL |     writeln!(&mut v, "Hello {}", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:34:33
+  --> $DIR/write_literal.rs:37:33
    |
 LL |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:34:42
+  --> $DIR/write_literal.rs:37:42
    |
 LL |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:35:33
+  --> $DIR/write_literal.rs:38:33
    |
 LL |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:35:42
+  --> $DIR/write_literal.rs:38:42
    |
 LL |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:38:43
+  --> $DIR/write_literal.rs:41:43
    |
 LL |     writeln!(&mut v, "{foo} {bar}", foo = "hello", bar = "world");
    |                                           ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:38:58
+  --> $DIR/write_literal.rs:41:58
    |
 LL |     writeln!(&mut v, "{foo} {bar}", foo = "hello", bar = "world");
    |                                                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:39:43
+  --> $DIR/write_literal.rs:42:43
    |
 LL |     writeln!(&mut v, "{bar} {foo}", foo = "hello", bar = "world");
    |                                           ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:39:58
+  --> $DIR/write_literal.rs:42:58
    |
 LL |     writeln!(&mut v, "{bar} {foo}", foo = "hello", bar = "world");
    |                                                          ^^^^^^^

--- a/tests/ui/write_literal.stderr
+++ b/tests/ui/write_literal.stderr
@@ -1,88 +1,70 @@
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:27:79
+  --> $DIR/write_literal.rs:27:32
    |
-LL |     writeln!(&mut v, "{} of {:b} people know binary, the other half doesn't", 1, 2);
-   |                                                                               ^
+LL |     write!(&mut v, "Hello {}", "world");
+   |                                ^^^^^^^
    |
    = note: `-D clippy::write-literal` implied by `-D warnings`
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:28:32
-   |
-LL |     write!(&mut v, "Hello {}", "world");
-   |                                ^^^^^^^
-
-error: literal with an empty format string
-  --> $DIR/write_literal.rs:29:44
+  --> $DIR/write_literal.rs:28:44
    |
 LL |     writeln!(&mut v, "Hello {} {}", world, "world");
    |                                            ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:30:34
+  --> $DIR/write_literal.rs:29:34
    |
 LL |     writeln!(&mut v, "Hello {}", "world");
    |                                  ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:31:38
-   |
-LL |     writeln!(&mut v, "10 / 4 is {}", 2.5);
-   |                                      ^^^
-
-error: literal with an empty format string
-  --> $DIR/write_literal.rs:32:36
-   |
-LL |     writeln!(&mut v, "2 + 1 = {}", 3);
-   |                                    ^
-
-error: literal with an empty format string
-  --> $DIR/write_literal.rs:37:33
+  --> $DIR/write_literal.rs:34:33
    |
 LL |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:37:42
+  --> $DIR/write_literal.rs:34:42
    |
 LL |     writeln!(&mut v, "{0} {1}", "hello", "world");
    |                                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:38:33
+  --> $DIR/write_literal.rs:35:33
    |
 LL |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                 ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:38:42
+  --> $DIR/write_literal.rs:35:42
    |
 LL |     writeln!(&mut v, "{1} {0}", "hello", "world");
    |                                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:41:43
+  --> $DIR/write_literal.rs:38:43
    |
 LL |     writeln!(&mut v, "{foo} {bar}", foo = "hello", bar = "world");
    |                                           ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:41:58
+  --> $DIR/write_literal.rs:38:58
    |
 LL |     writeln!(&mut v, "{foo} {bar}", foo = "hello", bar = "world");
    |                                                          ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:42:43
+  --> $DIR/write_literal.rs:39:43
    |
 LL |     writeln!(&mut v, "{bar} {foo}", foo = "hello", bar = "world");
    |                                           ^^^^^^^
 
 error: literal with an empty format string
-  --> $DIR/write_literal.rs:42:58
+  --> $DIR/write_literal.rs:39:58
    |
 LL |     writeln!(&mut v, "{bar} {foo}", foo = "hello", bar = "world");
    |                                                          ^^^^^^^
 
-error: aborting due to 14 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
changelog: No longer lint numeric literals in [`write_literal`] and [`print_literal`].

Fixes #6335