### PR TITLE
Convert `clippy_lints` to intra-doc links

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -9,9 +9,9 @@ use std::f64::consts as f64;
 declare_clippy_lint! {
     /// **What it does:** Checks for floating point literals that approximate
     /// constants which are defined in
-    /// [`std::f32::consts`](https://doc.rust-lang.org/stable/std/f32/consts/#constants)
+    /// [`std::f32::consts`](std::f32::consts#constants)
     /// or
-    /// [`std::f64::consts`](https://doc.rust-lang.org/stable/std/f64/consts/#constants),
+    /// [`std::f64::consts`](std::f64::consts#constants),
     /// respectively, suggesting to use the predefined constant.
     ///
     /// **Why is this bad?** Usually, the definition in the standard library is more

--- a/clippy_lints/src/functions.rs
+++ b/clippy_lints/src/functions.rs
@@ -212,7 +212,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Note that there are crates that simplify creating the error type, e.g.
-    /// [`thiserror`](https://docs.rs/thiserror).
+    /// [`thiserror`].
     pub RESULT_UNIT_ERR,
     style,
     "public function returning `Result` with an `Err` type of `()`"

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -304,14 +304,14 @@ declare_clippy_lint! {
     ///   - yield or pause the thread
     ///
     /// For `std` targets, this can be done with
-    /// [`std::thread::sleep`](https://doc.rust-lang.org/std/thread/fn.sleep.html)
-    /// or [`std::thread::yield_now`](https://doc.rust-lang.org/std/thread/fn.yield_now.html).
+    /// [`std::thread::sleep`](std::thread::sleep())
+    /// or [`std::thread::yield_now`](std::thread::yield_now()).
     ///
     /// For `no_std` targets, doing this is more complicated, especially because
     /// `#[panic_handler]`s can't panic. To stop/pause the thread, you will
     /// probably need to invoke some target-specific intrinsic. Examples include:
-    ///   - [`x86_64::instructions::hlt`](https://docs.rs/x86_64/0.12.2/x86_64/instructions/fn.hlt.html)
-    ///   - [`cortex_m::asm::wfi`](https://docs.rs/cortex-m/0.6.3/cortex_m/asm/fn.wfi.html)
+    ///   - [`x86_64::instructions::hlt`](x86_64::instructions::hlt())
+    ///   - [`cortex_m::asm::wfi`](cortex_m::asm::wfi())
     ///
     /// **Known problems:** None.
     ///

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -62,7 +62,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     ///
-    /// The [take_mut] crate offers a sound solution,
+    /// The [`take_mut`](https://docs.rs/take_mut) crate offers a sound solution,
     /// at the cost of either lazily creating a replacement value or aborting
     /// on panic, to ensure that the uninitialized value cannot be observed.
     pub MEM_REPLACE_WITH_UNINIT,

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -62,7 +62,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     ///
-    /// The [take_mut](https://docs.rs/take_mut) crate offers a sound solution,
+    /// The [take_mut] crate offers a sound solution,
     /// at the cost of either lazily creating a replacement value or aborting
     /// on panic, to ensure that the uninitialized value cannot be observed.
     pub MEM_REPLACE_WITH_UNINIT,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1376,7 +1376,7 @@ declare_clippy_lint! {
     /// trait.
     ///
     /// **Why is this bad?** It is recommended style to use collect. See
-    /// [FromIterator documentation](https://doc.rust-lang.org/std/iter/trait.FromIterator.html)
+    /// [FromIterator documentation](std::iter::FromIterator)
     ///
     /// **Known problems:** None.
     ///

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1376,7 +1376,7 @@ declare_clippy_lint! {
     /// trait.
     ///
     /// **Why is this bad?** It is recommended style to use collect. See
-    /// [FromIterator documentation](std::iter::FromIterator)
+    /// [`FromIterator` documentation](std::iter::FromIterator)
     ///
     /// **Known problems:** None.
     ///

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -14,10 +14,10 @@ use rustc_span::sym;
 declare_clippy_lint! {
     /// **What it does:** Checks for types with a `fn new() -> Self` method and no
     /// implementation of
-    /// [`Default`](https://doc.rust-lang.org/std/default/trait.Default.html).
+    /// [`Default`](std::default::Default).
     ///
     /// **Why is this bad?** The user might expect to be able to use
-    /// [`Default`](https://doc.rust-lang.org/std/default/trait.Default.html) as the
+    /// [`Default`](std::default::Default) as the
     /// type can be constructed without arguments.
     ///
     /// **Known problems:** Hopefully none.

--- a/clippy_lints/src/path_buf_push_overwrite.rs
+++ b/clippy_lints/src/path_buf_push_overwrite.rs
@@ -8,7 +8,7 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 use std::path::{Component, Path};
 
 declare_clippy_lint! {
-    /// **What it does:*** Checks for [push](std::path::PathBuf::push())
+    /// **What it does:*** Checks for [`push`](std::path::PathBuf::push())
     /// calls on `PathBuf` that can cause overwrites.
     ///
     /// **Why is this bad?** Calling `push` with a root path at the start can overwrite the

--- a/clippy_lints/src/path_buf_push_overwrite.rs
+++ b/clippy_lints/src/path_buf_push_overwrite.rs
@@ -8,7 +8,7 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 use std::path::{Component, Path};
 
 declare_clippy_lint! {
-    /// **What it does:*** Checks for [push](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.push)
+    /// **What it does:*** Checks for [push](std::path::PathBuf::push())
     /// calls on `PathBuf` that can cause overwrites.
     ///
     /// **Why is this bad?** Calling `push` with a root path at the start can overwrite the

--- a/clippy_lints/src/transmute.rs
+++ b/clippy_lints/src/transmute.rs
@@ -131,8 +131,8 @@ declare_clippy_lint! {
     /// but has a semantically meaningful name.
     /// - You might want to handle `None` returned from [`from_u32`] instead of calling `unwrap`.
     ///
-    /// [`from_u32`]: https://doc.rust-lang.org/std/char/fn.from_u32.html
-    /// [`from_u32_unchecked`]: https://doc.rust-lang.org/std/char/fn.from_u32_unchecked.html
+    /// [`from_u32`]: std::char::from_u32()
+    /// [`from_u32_unchecked`]: std::char::from_u32_unchecked()
     ///
     /// **Example:**
     /// ```rust
@@ -162,8 +162,8 @@ declare_clippy_lint! {
     /// but has a semantically meaningful name.
     /// - You might want to handle errors returned from [`from_utf8`] instead of calling `unwrap`.
     ///
-    /// [`from_utf8`]: https://doc.rust-lang.org/std/str/fn.from_utf8.html
-    /// [`from_utf8_unchecked`]: https://doc.rust-lang.org/std/str/fn.from_utf8_unchecked.html
+    /// [`from_utf8`]: std::str::from_utf8()
+    /// [`from_utf8_unchecked`]: std::str::from_utf8_unchecked()
     ///
     /// **Example:**
     /// ```rust

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -39,7 +39,7 @@ use crate::utils::{
 
 declare_clippy_lint! {
     /// **What it does:** Checks for use of `Box<Vec<_>>` anywhere in the code.
-    /// Check the [Box documentation](https://doc.rust-lang.org/std/boxed/index.html) for more information.
+    /// Check the [Box documentation](std::boxed) for more information.
     ///
     /// **Why is this bad?** `Vec` already keeps its contents in a separate area on
     /// the heap. So if you `Box` it, you just add another level of indirection
@@ -68,7 +68,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// **What it does:** Checks for use of `Vec<Box<T>>` where T: Sized anywhere in the code.
-    /// Check the [Box documentation](https://doc.rust-lang.org/std/boxed/index.html) for more information.
+    /// Check the [Box documentation](std::boxed) for more information.
     ///
     /// **Why is this bad?** `Vec` already keeps its contents in a separate area on
     /// the heap. So if you `Box` its contents, you just add another level of indirection.
@@ -171,7 +171,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// **What it does:** Checks for use of `&Box<T>` anywhere in the code.
-    /// Check the [Box documentation](https://doc.rust-lang.org/std/boxed/index.html) for more information.
+    /// Check the [Box documentation](std::boxed) for more information.
     ///
     /// **Why is this bad?** Any `&Box<T>` can also be a `&T`, which is more
     /// general.

--- a/clippy_lints/src/types.rs
+++ b/clippy_lints/src/types.rs
@@ -39,7 +39,7 @@ use crate::utils::{
 
 declare_clippy_lint! {
     /// **What it does:** Checks for use of `Box<Vec<_>>` anywhere in the code.
-    /// Check the [Box documentation](std::boxed) for more information.
+    /// Check the [`Box` documentation](std::boxed) for more information.
     ///
     /// **Why is this bad?** `Vec` already keeps its contents in a separate area on
     /// the heap. So if you `Box` it, you just add another level of indirection
@@ -68,7 +68,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// **What it does:** Checks for use of `Vec<Box<T>>` where T: Sized anywhere in the code.
-    /// Check the [Box documentation](std::boxed) for more information.
+    /// Check the [`Box` documentation](std::boxed) for more information.
     ///
     /// **Why is this bad?** `Vec` already keeps its contents in a separate area on
     /// the heap. So if you `Box` its contents, you just add another level of indirection.
@@ -171,7 +171,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// **What it does:** Checks for use of `&Box<T>` anywhere in the code.
-    /// Check the [Box documentation](std::boxed) for more information.
+    /// Check the [`Box` documentation](std::boxed) for more information.
     ///
     /// **Why is this bad?** Any `&Box<T>` can also be a `&T`, which is more
     /// general.

--- a/clippy_lints/src/verbose_file_reads.rs
+++ b/clippy_lints/src/verbose_file_reads.rs
@@ -8,7 +8,7 @@ declare_clippy_lint! {
     /// **What it does:** Checks for use of File::read_to_end and File::read_to_string.
     ///
     /// **Why is this bad?** `fs::{read, read_to_string}` provide the same functionality when `buf` is empty with fewer imports and no intermediate values.
-    /// See also: [fs::read docs](https://doc.rust-lang.org/std/fs/fn.read.html), [fs::read_to_string docs](https://doc.rust-lang.org/std/fs/fn.read_to_string.html)
+    /// See also: [fs::read docs](std::fs::read()), [fs::read_to_string docs](std::fs::read_to_string())
     ///
     /// **Known problems:** None.
     ///

--- a/clippy_lints/src/verbose_file_reads.rs
+++ b/clippy_lints/src/verbose_file_reads.rs
@@ -8,7 +8,7 @@ declare_clippy_lint! {
     /// **What it does:** Checks for use of File::read_to_end and File::read_to_string.
     ///
     /// **Why is this bad?** `fs::{read, read_to_string}` provide the same functionality when `buf` is empty with fewer imports and no intermediate values.
-    /// See also: [fs::read docs](std::fs::read()), [fs::read_to_string docs](std::fs::read_to_string())
+    /// See also: [`fs::read` docs](std::fs::read()), [`fs::read_to_string` docs](std::fs::read_to_string())
     ///
     /// **Known problems:** None.
     ///


### PR DESCRIPTION
This commit can (mostly) be replicated with `cargo intraconv`. See https://github.com/rust-lang/rust/issues/75080 for the rationale; it's mostly irrelevant to clippy, but it does make the links easier to read and write which seems worth it in itself.

*Please write a short comment explaining your change (or "none" for internal only changes)*
changelog: none