### PR TITLE
Turn unnecessary_wraps applicability to MaybeIncorrect

### DIFF
--- a/clippy_lints/src/unnecessary_wraps.rs
+++ b/clippy_lints/src/unnecessary_wraps.rs
@@ -135,7 +135,7 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
                     diag.multipart_suggestion(
                         "...and change the returning expressions",
                         suggs,
-                        Applicability::MachineApplicable,
+                        Applicability::MaybeIncorrect,
                     );
                 },
             );


### PR DESCRIPTION
Fixes: #6417 

changelog: Turn [`unnecessary_wraps`] applicability to `MaybeIncorrect`
