### PR TITLE
clone_on_copy: show the type in the lint message

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2174,11 +2174,17 @@ fn lint_clone_on_copy(cx: &LateContext<'_>, expr: &hir::Expr<'_>, arg: &hir::Exp
         } else {
             snip = None;
         }
-        span_lint_and_then(cx, CLONE_ON_COPY, expr.span, "using `clone` on a `Copy` type", |diag| {
-            if let Some((text, snip)) = snip {
-                diag.span_suggestion(expr.span, text, snip, Applicability::MachineApplicable);
-            }
-        });
+        span_lint_and_then(
+            cx,
+            CLONE_ON_COPY,
+            expr.span,
+            &format!("using `clone` on type `{}` which implements the `Copy` trait", ty),
+            |diag| {
+                if let Some((text, snip)) = snip {
+                    diag.span_suggestion(expr.span, text, snip, Applicability::MachineApplicable);
+                }
+            },
+        );
     }
 }
 

--- a/tests/ui/clone_on_copy.stderr
+++ b/tests/ui/clone_on_copy.stderr
@@ -1,4 +1,4 @@
-error: using `clone` on a `Copy` type
+error: using `clone` on type `i32` which implements the `Copy` trait
   --> $DIR/clone_on_copy.rs:22:5
    |
 LL |     42.clone();
@@ -6,25 +6,25 @@ LL |     42.clone();
    |
    = note: `-D clippy::clone-on-copy` implied by `-D warnings`
 
-error: using `clone` on a `Copy` type
+error: using `clone` on type `i32` which implements the `Copy` trait
   --> $DIR/clone_on_copy.rs:26:5
    |
 LL |     (&42).clone();
    |     ^^^^^^^^^^^^^ help: try dereferencing it: `*(&42)`
 
-error: using `clone` on a `Copy` type
+error: using `clone` on type `i32` which implements the `Copy` trait
   --> $DIR/clone_on_copy.rs:29:5
    |
 LL |     rc.borrow().clone();
    |     ^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*rc.borrow()`
 
-error: using `clone` on a `Copy` type
+error: using `clone` on type `char` which implements the `Copy` trait
   --> $DIR/clone_on_copy.rs:35:14
    |
 LL |     is_ascii('z'.clone());
    |              ^^^^^^^^^^^ help: try removing the `clone` call: `'z'`
 
-error: using `clone` on a `Copy` type
+error: using `clone` on type `i32` which implements the `Copy` trait
   --> $DIR/clone_on_copy.rs:39:14
    |
 LL |     vec.push(42.clone());

--- a/tests/ui/unnecessary_clone.stderr
+++ b/tests/ui/unnecessary_clone.stderr
@@ -30,7 +30,7 @@ error: using `.clone()` on a ref-counted pointer
 LL |     let _: Arc<dyn SomeTrait> = x.clone();
    |                                 ^^^^^^^^^ help: try this: `Arc::<SomeImpl>::clone(&x)`
 
-error: using `clone` on a `Copy` type
+error: using `clone` on type `T` which implements the `Copy` trait
   --> $DIR/unnecessary_clone.rs:40:5
    |
 LL |     t.clone();
@@ -38,7 +38,7 @@ LL |     t.clone();
    |
    = note: `-D clippy::clone-on-copy` implied by `-D warnings`
 
-error: using `clone` on a `Copy` type
+error: using `clone` on type `std::option::Option<T>` which implements the `Copy` trait
   --> $DIR/unnecessary_clone.rs:42:5
    |
 LL |     Some(t).clone();
@@ -60,7 +60,7 @@ help: or try being explicit if you are sure, that you want to clone a reference
 LL |     let z: &Vec<_> = <&std::vec::Vec<i32>>::clone(y);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using `clone` on a `Copy` type
+error: using `clone` on type `many_derefs::E` which implements the `Copy` trait
   --> $DIR/unnecessary_clone.rs:84:20
    |
 LL |         let _: E = a.clone();


### PR DESCRIPTION
changelog: clone_on_copy: show the type in the lint message
