### PR TITLE
needless_borrow: print the type in the lint message

### DIFF
--- a/clippy_lints/src/needless_borrow.rs
+++ b/clippy_lints/src/needless_borrow.rs
@@ -47,7 +47,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBorrow {
             return;
         }
         if let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Not, ref inner) = e.kind {
-            if let ty::Ref(..) = cx.typeck_results().expr_ty(inner).kind() {
+            if let ty::Ref(_, ty, _) = cx.typeck_results().expr_ty(inner).kind() {
                 for adj3 in cx.typeck_results().expr_adjustments(e).windows(3) {
                     if let [Adjustment {
                         kind: Adjust::Deref(_), ..
@@ -62,8 +62,11 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessBorrow {
                             cx,
                             NEEDLESS_BORROW,
                             e.span,
-                            "this expression borrows a reference that is immediately dereferenced \
+                            &format!(
+                                "this expression borrows a reference (`&{}`) that is immediately dereferenced \
                              by the compiler",
+                                ty
+                            ),
                             |diag| {
                                 if let Some(snippet) = snippet_opt(cx, inner.span) {
                                     diag.span_suggestion(

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -12,7 +12,7 @@ error: redundant closure found
 LL |     meta(|a| foo(a));
    |          ^^^^^^^^^^ help: remove closure as shown: `foo`
 
-error: this expression borrows a reference that is immediately dereferenced by the compiler
+error: this expression borrows a reference (`&u8`) that is immediately dereferenced by the compiler
   --> $DIR/eta.rs:24:21
    |
 LL |     all(&[1, 2, 3], &&2, |x, y| below(x, y)); //is adjusted

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -1,4 +1,4 @@
-error: this expression borrows a reference that is immediately dereferenced by the compiler
+error: this expression borrows a reference (`&i32`) that is immediately dereferenced by the compiler
   --> $DIR/needless_borrow.rs:14:15
    |
 LL |     let c = x(&&a);
@@ -12,7 +12,7 @@ error: this pattern creates a reference to a reference
 LL |     if let Some(ref cake) = Some(&5) {}
    |                 ^^^^^^^^ help: change this to: `cake`
 
-error: this expression borrows a reference that is immediately dereferenced by the compiler
+error: this expression borrows a reference (`&i32`) that is immediately dereferenced by the compiler
   --> $DIR/needless_borrow.rs:28:15
    |
 LL |         46 => &&a,


### PR DESCRIPTION
changelog: needless_borrow: print type in lint message
