### PR TITLE
bump pinned nightly from nightly-2020-12-09 to nightly-2020-12-14

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2020-12-09"
+channel = "nightly-2020-12-14"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]


### PR DESCRIPTION
This should hopefully fix incremental compilation ICEs in rustc that I have encountered multiple times while working with the previously pinned nightly.

changelog: none
