### PR TITLE
Add heuristic to filter_map and find_map

### DIFF
--- a/clippy_dev/src/ra_setup.rs
+++ b/clippy_dev/src/ra_setup.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::filter_map)]
-
 use std::fs;
 use std::fs::File;
 use std::io::prelude::*;

--- a/clippy_lints/src/loops.rs
+++ b/clippy_lints/src/loops.rs
@@ -1061,7 +1061,6 @@ fn get_assignments<'a: 'c, 'tcx: 'c, 'c>(
 ) -> impl Iterator<Item = Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>)>> + 'c {
     // As the `filter` and `map` below do different things, I think putting together
     // just increases complexity. (cc #3188 and #4193)
-    #[allow(clippy::filter_map)]
     stmts
         .iter()
         .filter_map(move |stmt| match stmt.kind {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2994,7 +2994,7 @@ fn lint_filter_map_map<'tcx>(
     _filter_args: &'tcx [hir::Expr<'_>],
     _map_args: &'tcx [hir::Expr<'_>],
 ) {
-    // lint if caller of `.filter().map()` is an Iterator
+    // lint if caller of `.filter_map().map()` is an Iterator
     if match_trait_method(cx, expr, &paths::ITERATOR) {
         let msg = "called `filter_map(..).map(..)` on an `Iterator`";
         let hint = "this is more succinctly expressed by only calling `.filter_map(..)` instead";

--- a/clippy_lints/src/multiple_crate_versions.rs
+++ b/clippy_lints/src/multiple_crate_versions.rs
@@ -51,7 +51,8 @@ impl LateLintPass<'_> for MultipleCrateVersions {
             if let Some(resolve) = &metadata.resolve;
             if let Some(local_id) = packages
                 .iter()
-                .find_map(|p| if p.name == *local_name { Some(&p.id) } else { None });
+                .find(|p| p.name == *local_name)
+                .map(|p| &p.id);
             then {
                 for (name, group) in &packages.iter().group_by(|p| p.name.clone()) {
                     let group: Vec<&Package> = group.collect();

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -203,9 +203,7 @@ fn check_pat<'tcx>(
                 if let ExprKind::Struct(_, ref efields, _) = init_struct.kind {
                     for field in pfields {
                         let name = field.ident.name;
-                        let efield = efields
-                            .iter()
-                            .find_map(|f| if f.ident.name == name { Some(&*f.expr) } else { None });
+                        let efield = efields.iter().find(|f| f.ident.name == name).map(|f| f.expr);
                         check_pat(cx, &field.pat, efield, span, bindings);
                     }
                 } else {

--- a/clippy_lints/src/suspicious_operation_groupings.rs
+++ b/clippy_lints/src/suspicious_operation_groupings.rs
@@ -688,6 +688,5 @@ fn skip_index<A, Iter>(iter: Iter, index: usize) -> impl Iterator<Item = A>
 where
     Iter: Iterator<Item = A>,
 {
-    iter.enumerate()
-        .filter_map(move |(i, a)| if i == index { None } else { Some(a) })
+    iter.enumerate().filter(move |&(i, _)| i != index).map(|(_, a)| a)
 }

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -356,8 +356,6 @@ pub fn path_to_res(cx: &LateContext<'_>, path: &[&str]) -> Option<def::Res> {
                 let item_def_id = current_item.res.def_id();
                 if cx.tcx.def_kind(item_def_id) == DefKind::Struct;
                 then {
-                    // Bad `find_map` suggestion. See #4193.
-                    #[allow(clippy::find_map)]
                     return cx.tcx.inherent_impls(item_def_id).iter()
                         .flat_map(|&impl_def_id| cx.tcx.item_children(impl_def_id))
                         .find(|item| item.ident.name.as_str() == *segment)

--- a/tests/ui/filter_methods.rs
+++ b/tests/ui/filter_methods.rs
@@ -3,8 +3,6 @@
 #![allow(clippy::missing_docs_in_private_items)]
 
 fn main() {
-    let _: Vec<_> = vec![5; 6].into_iter().filter(|&x| x == 0).map(|x| x * 2).collect();
-
     let _: Vec<_> = vec![5_i8; 6]
         .into_iter()
         .filter(|&x| x == 0)
@@ -22,4 +20,8 @@ fn main() {
         .filter_map(|x| x.checked_mul(2))
         .map(|x| x.checked_mul(2))
         .collect();
+}
+
+fn no_lint() {
+    let _: Vec<_> = vec![5; 6].into_iter().filter(|&x| x == 0).map(|x| x * 2).collect();
 }

--- a/tests/ui/filter_methods.stderr
+++ b/tests/ui/filter_methods.stderr
@@ -1,14 +1,5 @@
-error: called `filter(..).map(..)` on an `Iterator`
-  --> $DIR/filter_methods.rs:6:21
-   |
-LL |     let _: Vec<_> = vec![5; 6].into_iter().filter(|&x| x == 0).map(|x| x * 2).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `-D clippy::filter-map` implied by `-D warnings`
-   = help: this is more succinctly expressed by calling `.filter_map(..)` instead
-
 error: called `filter(..).flat_map(..)` on an `Iterator`
-  --> $DIR/filter_methods.rs:8:21
+  --> $DIR/filter_methods.rs:6:21
    |
 LL |       let _: Vec<_> = vec![5_i8; 6]
    |  _____________________^
@@ -17,10 +8,11 @@ LL | |         .filter(|&x| x == 0)
 LL | |         .flat_map(|x| x.checked_mul(2))
    | |_______________________________________^
    |
+   = note: `-D clippy::filter-map` implied by `-D warnings`
    = help: this is more succinctly expressed by calling `.flat_map(..)` and filtering by returning `iter::empty()`
 
 error: called `filter_map(..).flat_map(..)` on an `Iterator`
-  --> $DIR/filter_methods.rs:14:21
+  --> $DIR/filter_methods.rs:12:21
    |
 LL |       let _: Vec<_> = vec![5_i8; 6]
    |  _____________________^
@@ -32,7 +24,7 @@ LL | |         .flat_map(|x| x.checked_mul(2))
    = help: this is more succinctly expressed by calling `.flat_map(..)` and filtering by returning `iter::empty()`
 
 error: called `filter_map(..).map(..)` on an `Iterator`
-  --> $DIR/filter_methods.rs:20:21
+  --> $DIR/filter_methods.rs:18:21
    |
 LL |       let _: Vec<_> = vec![5_i8; 6]
    |  _____________________^
@@ -43,5 +35,5 @@ LL | |         .map(|x| x.checked_mul(2))
    |
    = help: this is more succinctly expressed by only calling `.filter_map(..)` instead
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/find_map.rs
+++ b/tests/ui/find_map.rs
@@ -18,16 +18,8 @@ fn main() {
     let a = ["lol", "NaN", "2", "5", "Xunda"];
 
     let _: Option<i32> = a.iter().find(|s| s.parse::<i32>().is_ok()).map(|s| s.parse().unwrap());
+}
 
-    #[allow(clippy::match_like_matches_macro)]
-    let _: Option<Flavor> = desserts_of_the_week
-        .iter()
-        .find(|dessert| match *dessert {
-            Dessert::Cake(_) => true,
-            _ => false,
-        })
-        .map(|dessert| match *dessert {
-            Dessert::Cake(ref flavor) => *flavor,
-            _ => unreachable!(),
-        });
+fn no_lint() {
+    let _ = vec![1].into_iter().find(|n| *n > 5).map(|n| n + 7);
 }

--- a/tests/ui/find_map.stderr
+++ b/tests/ui/find_map.stderr
@@ -7,20 +7,5 @@ LL |     let _: Option<i32> = a.iter().find(|s| s.parse::<i32>().is_ok()).map(|s
    = note: `-D clippy::find-map` implied by `-D warnings`
    = help: this is more succinctly expressed by calling `.find_map(..)` instead
 
-error: called `find(..).map(..)` on an `Iterator`
-  --> $DIR/find_map.rs:23:29
-   |
-LL |       let _: Option<Flavor> = desserts_of_the_week
-   |  _____________________________^
-LL | |         .iter()
-LL | |         .find(|dessert| match *dessert {
-LL | |             Dessert::Cake(_) => true,
-...  |
-LL | |             _ => unreachable!(),
-LL | |         });
-   | |__________^
-   |
-   = help: this is more succinctly expressed by calling `.find_map(..)` instead
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 


### PR DESCRIPTION
changelog: Reduce false positives for filter_map and find_map

Fixes #3188
Fixes #4193

Simply check if `filter(..)` contains a closure that uses `Option` or `Result` anywhere in any way (using `ExprUseVisitor`). The assumption is: if the `filter` does not use `Option` or `Result` at all, it is perfectly fine as it is and turning it into `filter_map` would make the code more complex. And the very same thing applies to `find_map`.

The heuristic could probably be improved or made more specific down the road. But my goal here is remove false positives without losing any positive cases. I think this is a big improvement.

To anticipate a potential concern, there is one "category" of cases for these lints that will no longer be detected: where the code in `filter` and `map` are redundant, doing the same transformation on the value (e.g. `filter(|n| n + 1 > 5).map(|n| n + 1)`. But I think this is an acceptable loss because 1) there is no logic in these lints that actually recognizes redundant code and 2) this could be a separate lint (e.g. `repetitive_iterator`) - such a lint could apply to a wider variety of Iterator methods (e.g. `iter.inspect(|n| println!("{}", n+1)).fold(0, |s, n| s += n + 1)`).