### PR TITLE
make needless_update ignore non_exhaustive structs

### DIFF
--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -8,6 +8,9 @@ declare_clippy_lint! {
     /// **What it does:** Checks for needlessly including a base struct on update
     /// when all fields are changed anyway.
     ///
+    /// This lint is not applied to structs marked with
+    /// [non_exhaustive](https://doc.rust-lang.org/reference/attributes/type_system.html).
+    ///
     /// **Why is this bad?** This will cost resources (because the base has to be
     /// somewhere), and make the code less readable.
     ///
@@ -21,14 +24,7 @@ declare_clippy_lint! {
     /// #     z: i32,
     /// # }
     /// # let zero_point = Point { x: 0, y: 0, z: 0 };
-    /// #
-    /// # #[non_exhaustive]
-    /// # struct Options {
-    /// #     a: bool,
-    /// #     b: i32,
-    /// # }
-    /// # let default_options = Options { a: false, b: 0 };
-    /// #
+    ///
     /// // Bad
     /// Point {
     ///     x: 1,
@@ -43,14 +39,6 @@ declare_clippy_lint! {
     ///     y: 1,
     ///     ..zero_point
     /// };
-    ///
-    /// // this lint is not applied to structs marked with [non_exhaustive](https://doc.rust-lang.org/reference/attributes/type_system.html)
-    /// // Ok
-    /// Options {
-    ///     a: true,
-    ///     b: 321,
-    ///     ..default_options
-    ///  };
     /// ```
     pub NEEDLESS_UPDATE,
     complexity,

--- a/tests/ui/needless_update.rs
+++ b/tests/ui/needless_update.rs
@@ -6,9 +6,20 @@ struct S {
     pub b: i32,
 }
 
+#[non_exhaustive]
+struct T {
+    pub x: i32,
+    pub y: i32,
+}
+
 fn main() {
     let base = S { a: 0, b: 0 };
     S { ..base }; // no error
     S { a: 1, ..base }; // no error
     S { a: 1, b: 1, ..base };
+
+    let base = T { x: 0, y: 0 };
+    T { ..base }; // no error
+    T { x: 1, ..base }; // no error
+    T { x: 1, y: 1, ..base }; // no error
 }

--- a/tests/ui/needless_update.stderr
+++ b/tests/ui/needless_update.stderr
@@ -1,5 +1,5 @@
 error: struct update has no effect, all the fields in the struct have already been specified
-  --> $DIR/needless_update.rs:13:23
+  --> $DIR/needless_update.rs:19:23
    |
 LL |     S { a: 1, b: 1, ..base };
    |                       ^^^^


### PR DESCRIPTION
changelog: make `needless_update` lint ignore `non_exhaustive` structs

fixes #6323

