### PR TITLE
Renamed the good first issue label for rustbot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,7 +1,7 @@
 [relabel]
 allow-unauthenticated = [
     "A-*", "C-*", "E-*", "L-*", "M-*", "O-*", "P-*", "S-*", "T-*",
-    "good first issue"
+    "good-first-issue"
 ]
 
 [assign]


### PR DESCRIPTION
The `good first issue` label got renamed to `good-first-issue`. See [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Rename.20the.20.22good.20first.20issue.22.20label.20for.20bot.20usage/near/220428379) to enable the assignment with rustbot.

changelog: None

r? @flip1995 