### PR TITLE
UI Tests: Separate suspicious_else_formatting tests

### DIFF
--- a/tests/ui/formatting.rs
+++ b/tests/ui/formatting.rs
@@ -10,91 +10,6 @@ fn foo() -> bool {
 
 #[rustfmt::skip]
 fn main() {
-    // weird `else` formatting:
-    if foo() {
-    } {
-    }
-
-    if foo() {
-    } if foo() {
-    }
-
-    let _ = { // if as the last expression
-        let _ = 0;
-
-        if foo() {
-        } if foo() {
-        }
-        else {
-        }
-    };
-
-    let _ = { // if in the middle of a block
-        if foo() {
-        } if foo() {
-        }
-        else {
-        }
-
-        let _ = 0;
-    };
-
-    if foo() {
-    } else
-    {
-    }
-
-    if foo() {
-    }
-    else
-    {
-    }
-
-    if foo() {
-    } else
-    if foo() { // the span of the above error should continue here
-    }
-
-    if foo() {
-    }
-    else
-    if foo() { // the span of the above error should continue here
-    }
-
-    // those are ok:
-    if foo() {
-    }
-    {
-    }
-
-    if foo() {
-    } else {
-    }
-
-    if foo() {
-    }
-    else {
-    }
-
-    if foo() {
-    }
-    if foo() {
-    }
-
-    if foo() {
-    } else if foo() {
-    }
-
-    if foo() {
-    }
-    else if foo() {
-    }
-
-    if foo() {
-    }
-    else if
-    foo() {}
-
     // weird op_eq formatting:
     let mut a = 42;
     a =- 35;
@@ -146,7 +61,7 @@ fn main() {
 
     // don't lint if the indentation suggests not to
     let _ = &[
-        1 + 2, 3 
+        1 + 2, 3
                 - 4, 5
     ];
     // lint if it doesn't

--- a/tests/ui/formatting.stderr
+++ b/tests/ui/formatting.stderr
@@ -1,80 +1,5 @@
-error: this looks like an `else {..}` but the `else` is missing
-  --> $DIR/formatting.rs:15:6
-   |
-LL |     } {
-   |      ^
-   |
-   = note: `-D clippy::suspicious-else-formatting` implied by `-D warnings`
-   = note: to remove this lint, add the missing `else` or add a new line before the next block
-
-error: this looks like an `else if` but the `else` is missing
-  --> $DIR/formatting.rs:19:6
-   |
-LL |     } if foo() {
-   |      ^
-   |
-   = note: to remove this lint, add the missing `else` or add a new line before the second `if`
-
-error: this looks like an `else if` but the `else` is missing
-  --> $DIR/formatting.rs:26:10
-   |
-LL |         } if foo() {
-   |          ^
-   |
-   = note: to remove this lint, add the missing `else` or add a new line before the second `if`
-
-error: this looks like an `else if` but the `else` is missing
-  --> $DIR/formatting.rs:34:10
-   |
-LL |         } if foo() {
-   |          ^
-   |
-   = note: to remove this lint, add the missing `else` or add a new line before the second `if`
-
-error: this is an `else {..}` but the formatting might hide it
-  --> $DIR/formatting.rs:43:6
-   |
-LL |       } else
-   |  ______^
-LL | |     {
-   | |____^
-   |
-   = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
-
-error: this is an `else {..}` but the formatting might hide it
-  --> $DIR/formatting.rs:48:6
-   |
-LL |       }
-   |  ______^
-LL | |     else
-LL | |     {
-   | |____^
-   |
-   = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
-
-error: this is an `else if` but the formatting might hide it
-  --> $DIR/formatting.rs:54:6
-   |
-LL |       } else
-   |  ______^
-LL | |     if foo() { // the span of the above error should continue here
-   | |____^
-   |
-   = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
-
-error: this is an `else if` but the formatting might hide it
-  --> $DIR/formatting.rs:59:6
-   |
-LL |       }
-   |  ______^
-LL | |     else
-LL | |     if foo() { // the span of the above error should continue here
-   | |____^
-   |
-   = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
-
 error: this looks like you are trying to use `.. -= ..`, but you really are doing `.. = (- ..)`
-  --> $DIR/formatting.rs:100:6
+  --> $DIR/formatting.rs:15:6
    |
 LL |     a =- 35;
    |      ^^^^
@@ -83,7 +8,7 @@ LL |     a =- 35;
    = note: to remove this lint, use either `-=` or `= -`
 
 error: this looks like you are trying to use `.. *= ..`, but you really are doing `.. = (* ..)`
-  --> $DIR/formatting.rs:101:6
+  --> $DIR/formatting.rs:16:6
    |
 LL |     a =* &191;
    |      ^^^^
@@ -91,7 +16,7 @@ LL |     a =* &191;
    = note: to remove this lint, use either `*=` or `= *`
 
 error: this looks like you are trying to use `.. != ..`, but you really are doing `.. = (! ..)`
-  --> $DIR/formatting.rs:104:6
+  --> $DIR/formatting.rs:19:6
    |
 LL |     b =! false;
    |      ^^^^
@@ -99,7 +24,7 @@ LL |     b =! false;
    = note: to remove this lint, use either `!=` or `= !`
 
 error: possibly missing a comma here
-  --> $DIR/formatting.rs:113:19
+  --> $DIR/formatting.rs:28:19
    |
 LL |         -1, -2, -3 // <= no comma here
    |                   ^
@@ -108,7 +33,7 @@ LL |         -1, -2, -3 // <= no comma here
    = note: to remove this lint, add a comma or write the expr in a single line
 
 error: possibly missing a comma here
-  --> $DIR/formatting.rs:117:19
+  --> $DIR/formatting.rs:32:19
    |
 LL |         -1, -2, -3 // <= no comma here
    |                   ^
@@ -116,12 +41,12 @@ LL |         -1, -2, -3 // <= no comma here
    = note: to remove this lint, add a comma or write the expr in a single line
 
 error: possibly missing a comma here
-  --> $DIR/formatting.rs:154:11
+  --> $DIR/formatting.rs:69:11
    |
 LL |         -1
    |           ^
    |
    = note: to remove this lint, add a comma or write the expr in a single line
 
-error: aborting due to 14 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -1,0 +1,79 @@
+#![warn(clippy::suspicious_else_formatting)]
+
+fn foo() -> bool {
+    true
+}
+
+#[rustfmt::skip]
+fn main() {
+    // weird `else` formatting:
+    if foo() {
+    } {
+    }
+
+    if foo() {
+    } if foo() {
+    }
+
+    let _ = { // if as the last expression
+        let _ = 0;
+
+        if foo() {
+        } if foo() {
+        }
+        else {
+        }
+    };
+
+    let _ = { // if in the middle of a block
+        if foo() {
+        } if foo() {
+        }
+        else {
+        }
+
+        let _ = 0;
+    };
+
+    if foo() {
+    } else
+    {
+    }
+
+    if foo() {
+    }
+    else
+    {
+    }
+
+    if foo() {
+    } else
+    if foo() { // the span of the above error should continue here
+    }
+
+    if foo() {
+    }
+    else
+    if foo() { // the span of the above error should continue here
+    }
+
+    // those are ok:
+    if foo() {
+    }
+    {
+    }
+
+    if foo() {
+    } else {
+    }
+
+    if foo() {
+    }
+    else {
+    }
+
+    if foo() {
+    }
+    if foo() {
+    }
+}

--- a/tests/ui/suspicious_else_formatting.stderr
+++ b/tests/ui/suspicious_else_formatting.stderr
@@ -1,0 +1,77 @@
+error: this looks like an `else {..}` but the `else` is missing
+  --> $DIR/suspicious_else_formatting.rs:11:6
+   |
+LL |     } {
+   |      ^
+   |
+   = note: `-D clippy::suspicious-else-formatting` implied by `-D warnings`
+   = note: to remove this lint, add the missing `else` or add a new line before the next block
+
+error: this looks like an `else if` but the `else` is missing
+  --> $DIR/suspicious_else_formatting.rs:15:6
+   |
+LL |     } if foo() {
+   |      ^
+   |
+   = note: to remove this lint, add the missing `else` or add a new line before the second `if`
+
+error: this looks like an `else if` but the `else` is missing
+  --> $DIR/suspicious_else_formatting.rs:22:10
+   |
+LL |         } if foo() {
+   |          ^
+   |
+   = note: to remove this lint, add the missing `else` or add a new line before the second `if`
+
+error: this looks like an `else if` but the `else` is missing
+  --> $DIR/suspicious_else_formatting.rs:30:10
+   |
+LL |         } if foo() {
+   |          ^
+   |
+   = note: to remove this lint, add the missing `else` or add a new line before the second `if`
+
+error: this is an `else {..}` but the formatting might hide it
+  --> $DIR/suspicious_else_formatting.rs:39:6
+   |
+LL |       } else
+   |  ______^
+LL | |     {
+   | |____^
+   |
+   = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
+
+error: this is an `else {..}` but the formatting might hide it
+  --> $DIR/suspicious_else_formatting.rs:44:6
+   |
+LL |       }
+   |  ______^
+LL | |     else
+LL | |     {
+   | |____^
+   |
+   = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
+
+error: this is an `else if` but the formatting might hide it
+  --> $DIR/suspicious_else_formatting.rs:50:6
+   |
+LL |       } else
+   |  ______^
+LL | |     if foo() { // the span of the above error should continue here
+   | |____^
+   |
+   = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
+
+error: this is an `else if` but the formatting might hide it
+  --> $DIR/suspicious_else_formatting.rs:55:6
+   |
+LL |       }
+   |  ______^
+LL | |     else
+LL | |     if foo() { // the span of the above error should continue here
+   | |____^
+   |
+   = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
Was briefly looking into https://github.com/rust-lang/rust-clippy/issues/3864 when I saw that the tests could benefit from being in their own file.

---
changelog: none
