### PR TITLE
Adapted the website search for better matching

### DIFF
--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -89,7 +89,7 @@
             </div>
 
             <article class="panel panel-default" id="{{lint.id}}"
-                ng-repeat="lint in data | filter:byLevels | filter:byGroups | filter:search | orderBy:'id' track by lint.id" on-finish-render="ngRepeatFinished">
+                ng-repeat="lint in data | filter:byLevels | filter:byGroups | filter:bySearch | orderBy:'id' track by lint.id">
                 <header class="panel-heading" ng-click="open[lint.id] = !open[lint.id]">
                     <h2 class="panel-title">
                         <div class="panel-title-name">
@@ -214,6 +214,46 @@
             $scope.byGroups = function (lint) {
                 return $scope.groups[lint.group];
             };
+
+            $scope.bySearch = function (lint, index, array) {
+                let search_str = $scope.search;
+                // It can be `null` I haven't missed this value 
+                if (search_str == null || search_str.length == 0) {
+                    return true;
+                }
+                search_str = search_str.toLowerCase();
+
+                // Search by id
+                let id_search = search_str.trim().replace(/(\-| )/g, "_");
+                if (lint.id.includes(id_search)) {
+                    return true;
+                }
+
+                // Search the description
+                // The use of `for`-loops instead of `foreach` enables us to return early 
+                let search_lint = (lint, therm) => {
+                    for (const field in lint.docs) {
+                        // Continue if it's not a property
+                        if (!lint.docs.hasOwnProperty(field)) {
+                            continue;
+                        }
+
+                        // Return if not found
+                        if (lint.docs[field].toLowerCase().includes(therm)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+                let therms = search_str.split(" ");
+                for (index = 0; index < therms.length; index++) {
+                    if (!search_lint(lint, therms[index])) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
 
             // Get data
             $scope.open = {};


### PR DESCRIPTION
* This adds the ability to search for ids with dashes and spaces in the name. 
    * Example: `missing-errors-doc` and `missing errors doc` are now valid aliases for lint names
* It also improves the fuzzy search in the description. This search will now match any lint that where all searched words are inside the description.
    * Example: `doc section` finds two lints in our selection

This was suggested/discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Enable.20lint.20search.20with.20dashes/near/220469464)

### Testing
These changes can be tested locally by:
1. Clone this branch
2. Download the current lint index from the [gh-pages branch](https://github.com/rust-lang/rust-clippy/blob/gh-pages/master/lints.json)
3. Put it next to the `util/gh-pages/index.html` and open the html file. Make sure that it can load the lint data. (Browsers can be a bit iffy when opening a loacl html page and loading data)

### Note
I found that searching only a few characters (< 3) seams slow and deleting one even more as almost every lint description contains them. This also happens in our current [lint list](https://rust-lang.github.io/rust-clippy/master/index.html). We could change the search to only be triggered if the search field contains more than 3 letters to slightly improve performance. 

---

changelog: Adapted the website search for better matching 
