### PR TITLE
Website issue tracker link and better search performance

### DIFF
--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -77,7 +77,7 @@
                     <div class="col-md-12 form-horizontal">
                         <div class="input-group">
                             <label class="input-group-addon" id="filter-label" for="filter-input">Filter:</label>
-                            <input type="text" class="form-control" placeholder="Keywords or search string" id="filter-input" ng-model="search" />
+                            <input type="text" class="form-control" placeholder="Keywords or search string" id="filter-input" ng-model="search" ng-model-options="{debounce: 50}"/>
                             <span class="input-group-btn">
                                 <button class="btn btn-default" type="button" ng-click="search = ''">
                                     Clear
@@ -119,6 +119,7 @@
                             {{title}}
                         </h4>
                         <div class="list-group-item-text" ng-bind-html="text | markdown"></div>
+                        <a ng-if="title == 'Known problems'" href="https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+is%3Aopen+{{lint.id}}">Search on GitHub</a>
                     </li>
                 </ul>
             </article>
@@ -180,6 +181,22 @@
             }
         }
 
+        function searchLint(lint, therm) {
+            for (const field in lint.docs) {
+                // Continue if it's not a property
+                if (!lint.docs.hasOwnProperty(field)) {
+                    continue;
+                }
+
+                // Return if not found
+                if (lint.docs[field].toLowerCase().indexOf(therm) !== -1) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         angular.module("clippy", [])
         .filter('markdown', function ($sce) {
             return function (text) {
@@ -216,40 +233,31 @@
             };
 
             $scope.bySearch = function (lint, index, array) {
-                let search_str = $scope.search;
+                let searchStr = $scope.search;
                 // It can be `null` I haven't missed this value 
-                if (search_str == null || search_str.length == 0) {
+                if (searchStr == null || searchStr.length < 3) {
                     return true;
                 }
-                search_str = search_str.toLowerCase();
+                searchStr = searchStr.toLowerCase();
 
                 // Search by id
-                let id_search = search_str.trim().replace(/(\-| )/g, "_");
-                if (lint.id.includes(id_search)) {
+                if (lint.id.indexOf(searchStr.replace("-", "_")) !== -1) {
                     return true;
                 }
 
                 // Search the description
                 // The use of `for`-loops instead of `foreach` enables us to return early 
-                let search_lint = (lint, therm) => {
-                    for (const field in lint.docs) {
-                        // Continue if it's not a property
-                        if (!lint.docs.hasOwnProperty(field)) {
-                            continue;
-                        }
-
-                        // Return if not found
-                        if (lint.docs[field].toLowerCase().includes(therm)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                };
-                let therms = search_str.split(" ");
+                let therms = searchStr.split(" ");
                 for (index = 0; index < therms.length; index++) {
-                    if (!search_lint(lint, therms[index])) {
-                        return false;
+                    if (lint.id.indexOf(therms[index]) !== -1) {
+                        continue;
                     }
+
+                    if (searchLint(lint, therms[index])) {
+                        continue;
+                    }
+
+                    return false;
                 }
 
                 return true;

--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -181,7 +181,7 @@
             }
         }
 
-        function searchLint(lint, therm) {
+        function searchLint(lint, term) {
             for (const field in lint.docs) {
                 // Continue if it's not a property
                 if (!lint.docs.hasOwnProperty(field)) {
@@ -189,7 +189,7 @@
                 }
 
                 // Return if not found
-                if (lint.docs[field].toLowerCase().indexOf(therm) !== -1) {
+                if (lint.docs[field].toLowerCase().indexOf(term) !== -1) {
                     return true;
                 }
             }
@@ -247,13 +247,13 @@
 
                 // Search the description
                 // The use of `for`-loops instead of `foreach` enables us to return early 
-                let therms = searchStr.split(" ");
-                for (index = 0; index < therms.length; index++) {
-                    if (lint.id.indexOf(therms[index]) !== -1) {
+                let terms = searchStr.split(" ");
+                for (index = 0; index < terms.length; index++) {
+                    if (lint.id.indexOf(terms[index]) !== -1) {
                         continue;
                     }
 
-                    if (searchLint(lint, therms[index])) {
+                    if (searchLint(lint, terms[index])) {
                         continue;
                     }
 


### PR DESCRIPTION
This PR implements some improvements to the website:
1. Added a "Search on Github" link to the "Known problems" section (Closes #5386)
    ![example_3](https://user-images.githubusercontent.com/17087237/102718215-e9f12500-42de-11eb-8c1b-487f8184aaf7.png)
    <details>
    <summary>Another mock up I created with the GitHub logo</summary>

    
    ![example_2](https://user-images.githubusercontent.com/17087237/102718281-3472a180-42df-11eb-99b8-7f6d76da2b55.png)

    
    </details>


2. Only starting the search after three letters and improving the search performance in general. (Followup #6477)

### Testing
These changes can be tested locally by:
1. Clone this branch
2. Download the current lint index from the [gh-pages branch](https://github.com/rust-lang/rust-clippy/blob/gh-pages/master/lints.json)
3. Put it next to the `util/gh-pages/index.html` and open the html file. Make sure that it can load the lint data. (Browsers can be a bit iffy when opening a local html page and loading data)

### Sources for search performance:
1. [A stackoverflow about angular filter performance](https://stackoverflow.com/questions/26876514/optimize-angular-filter-performance)
    * I selected a search debounce of 50ms that's fast enough to catch fast deletion and typing but responsive enough to not bother the user
2. [A stackoverflow about string comparison speeds](https://stackoverflow.com/questions/5296268/fastest-way-to-check-a-string-contain-another-substring-in-javascript)
3. [JS benchmarks for string search performance (`indexOf` seams to be the best)](https://jsben.ch/9cwLJ)

Note: The performance is still a bit poor when going from a specific lint to no search filter. I suspect that angular is recreating all lint items when the filter is cleared causing a major lag spike. The filter functions is at least optimized for little to no search. 

---

changelog: Added a "Search on GitHub" link to the website