### PR TITLE
readme: remove paragraph about executing clippy via "cargo run .."

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,6 @@ If you want to run Clippy **only** on the given crate, use the `--no-deps` optio
 cargo clippy -p example -- --no-deps 
 ```
 
-### Running Clippy from the command line without installing it
-
-To have cargo compile your crate with Clippy without Clippy installation
-in your code, you can use:
-
-```terminal
-cargo run --bin cargo-clippy --manifest-path=path_to_clippys_Cargo.toml
-```
-
-*Note:* Be sure that Clippy was compiled with the same version of rustc that cargo invokes here!
-
 ### Travis CI
 
 You can add Clippy to Travis CI in the same way you use it locally:


### PR DESCRIPTION
This most likely no longer works since we are pinning clippy on a specific nightly now.
"cargo run" would try to compile clippy with whatever version the project we want to check demands.

Also building clippy yourself to run it on a project is not really needed anymore since clippy is shipped with official rust releases.

Fixes #6489


changelog: none
