### PR TITLE
ci: test cargo clippy --fix -Zunstable-options

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -57,6 +57,10 @@ jobs:
       run: cargo test --features deny-warnings,internal-lints
       working-directory: clippy_lints
 
+    - name: Test --fix -Zunstable-options
+      run: cargo run --bin cargo-clippy -- clippy --fix -Zunstable-options
+      working-directory: clippy_lints
+
     - name: Test rustc_tools_util
       run: cargo test --features deny-warnings
       working-directory: rustc_tools_util


### PR DESCRIPTION
Make sure we catch cases like https://github.com/rust-lang/rust-clippy/issues/6487 in CI in the future.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*
changelog: none