### PR TITLE
Revert "Pass Clippy args also trough RUSTFLAGS"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ publish = false
 
 [[bin]]
 name = "cargo-clippy"
+test = false
 path = "src/main.rs"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ the lint(s) you are interested in:
 ```terminal
 cargo clippy -- -A clippy::all -W clippy::useless_format -W clippy::...
 ```
+Note that if you've run clippy before, this may only take effect after you've modified a file or ran `cargo clean`.
 
 ### Specifying the minimum supported Rust version
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(bool_to_option)]
-#![feature(command_access)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 // warn on lints, that are included in `rust-lang/rust`s bootstrap
 #![warn(rust_2018_idioms, unused_lifetimes)]
@@ -64,7 +62,7 @@ struct ClippyCmd {
     unstable_options: bool,
     cargo_subcommand: &'static str,
     args: Vec<String>,
-    clippy_args: Option<String>,
+    clippy_args: Vec<String>,
 }
 
 impl ClippyCmd {
@@ -101,17 +99,16 @@ impl ClippyCmd {
             args.insert(0, "+nightly".to_string());
         }
 
-        let mut clippy_args = old_args.collect::<Vec<String>>().join(" ");
-        if cargo_subcommand == "fix" && !clippy_args.contains("--no-deps") {
-            clippy_args = format!("{} --no-deps", clippy_args);
+        let mut clippy_args: Vec<String> = old_args.collect();
+        if cargo_subcommand == "fix" && !clippy_args.iter().any(|arg| arg == "--no-deps") {
+            clippy_args.push("--no-deps".into());
         }
 
-        let has_args = !clippy_args.is_empty();
         ClippyCmd {
             unstable_options,
             cargo_subcommand,
             args,
-            clippy_args: has_args.then_some(clippy_args),
+            clippy_args,
         }
     }
 
@@ -151,23 +148,19 @@ impl ClippyCmd {
             .map(|p| ("CARGO_TARGET_DIR", p))
     }
 
-    fn into_std_cmd(self, rustflags: Option<String>) -> Command {
+    fn into_std_cmd(self) -> Command {
         let mut cmd = Command::new("cargo");
+        let clippy_args: String = self
+            .clippy_args
+            .iter()
+            .map(|arg| format!("{}__CLIPPY_HACKERY__", arg))
+            .collect();
 
         cmd.env(self.path_env(), Self::path())
             .envs(ClippyCmd::target_dir())
+            .env("CLIPPY_ARGS", clippy_args)
             .arg(self.cargo_subcommand)
             .args(&self.args);
-
-        // HACK: pass Clippy args to the driver *also* through RUSTFLAGS.
-        // This guarantees that new builds will be triggered when Clippy flags change.
-        if let Some(clippy_args) = self.clippy_args {
-            cmd.env(
-                "RUSTFLAGS",
-                rustflags.map_or(clippy_args.clone(), |flags| format!("{} {}", clippy_args, flags)),
-            );
-            cmd.env("CLIPPY_ARGS", clippy_args);
-        }
 
         cmd
     }
@@ -179,7 +172,7 @@ where
 {
     let cmd = ClippyCmd::new(old_args);
 
-    let mut cmd = cmd.into_std_cmd(env::var("RUSTFLAGS").ok());
+    let mut cmd = cmd.into_std_cmd();
 
     let exit_status = cmd
         .spawn()
@@ -197,7 +190,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::ClippyCmd;
-    use std::ffi::OsStr;
 
     #[test]
     #[should_panic]
@@ -212,7 +204,6 @@ mod tests {
             .split_whitespace()
             .map(ToString::to_string);
         let cmd = ClippyCmd::new(args);
-
         assert_eq!("fix", cmd.cargo_subcommand);
         assert_eq!("RUSTC_WORKSPACE_WRAPPER", cmd.path_env());
         assert!(cmd.args.iter().any(|arg| arg.ends_with("unstable-options")));
@@ -224,8 +215,7 @@ mod tests {
             .split_whitespace()
             .map(ToString::to_string);
         let cmd = ClippyCmd::new(args);
-
-        assert!(cmd.clippy_args.unwrap().contains("--no-deps"));
+        assert!(cmd.clippy_args.iter().any(|arg| arg == "--no-deps"));
     }
 
     #[test]
@@ -234,15 +224,13 @@ mod tests {
             .split_whitespace()
             .map(ToString::to_string);
         let cmd = ClippyCmd::new(args);
-
-        assert_eq!(1, cmd.clippy_args.unwrap().matches("--no-deps").count());
+        assert_eq!(cmd.clippy_args.iter().filter(|arg| *arg == "--no-deps").count(), 1);
     }
 
     #[test]
     fn check() {
         let args = "cargo clippy".split_whitespace().map(ToString::to_string);
         let cmd = ClippyCmd::new(args);
-
         assert_eq!("check", cmd.cargo_subcommand);
         assert_eq!("RUSTC_WRAPPER", cmd.path_env());
     }
@@ -253,63 +241,7 @@ mod tests {
             .split_whitespace()
             .map(ToString::to_string);
         let cmd = ClippyCmd::new(args);
-
         assert_eq!("check", cmd.cargo_subcommand);
         assert_eq!("RUSTC_WORKSPACE_WRAPPER", cmd.path_env());
-    }
-
-    #[test]
-    fn clippy_args_into_rustflags() {
-        let args = "cargo clippy -- -W clippy::as_conversions"
-            .split_whitespace()
-            .map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-
-        let rustflags = None;
-        let cmd = cmd.into_std_cmd(rustflags);
-
-        assert!(cmd
-            .get_envs()
-            .any(|(key, val)| key == "RUSTFLAGS" && val == Some(OsStr::new("-W clippy::as_conversions"))));
-    }
-
-    #[test]
-    fn clippy_args_respect_existing_rustflags() {
-        let args = "cargo clippy -- -D clippy::await_holding_lock"
-            .split_whitespace()
-            .map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-
-        let rustflags = Some(r#"--cfg feature="some_feat""#.into());
-        let cmd = cmd.into_std_cmd(rustflags);
-
-        assert!(cmd.get_envs().any(|(key, val)| key == "RUSTFLAGS"
-            && val == Some(OsStr::new(r#"-D clippy::await_holding_lock --cfg feature="some_feat""#))));
-    }
-
-    #[test]
-    fn no_env_change_if_no_clippy_args() {
-        let args = "cargo clippy".split_whitespace().map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-
-        let rustflags = Some(r#"--cfg feature="some_feat""#.into());
-        let cmd = cmd.into_std_cmd(rustflags);
-
-        assert!(!cmd
-            .get_envs()
-            .any(|(key, _)| key == "RUSTFLAGS" || key == "CLIPPY_ARGS"));
-    }
-
-    #[test]
-    fn no_env_change_if_no_clippy_args_nor_rustflags() {
-        let args = "cargo clippy".split_whitespace().map(ToString::to_string);
-        let cmd = ClippyCmd::new(args);
-
-        let rustflags = None;
-        let cmd = cmd.into_std_cmd(rustflags);
-
-        assert!(!cmd
-            .get_envs()
-            .any(|(key, _)| key == "RUSTFLAGS" || key == "CLIPPY_ARGS"))
     }
 }

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -23,7 +23,7 @@ fn dogfood_clippy() {
         .current_dir(root_dir)
         .env("CLIPPY_DOGFOOD", "1")
         .env("CARGO_INCREMENTAL", "0")
-        .arg("clippy")
+        .arg("clippy-preview")
         .arg("--all-targets")
         .arg("--all-features")
         .arg("--")


### PR DESCRIPTION
Reverts rust-lang/rust-clippy#6441

r? @ebroto 

changelog: Revert "Pass Clippy args also trough RUSTFLAGS"