### PR TITLE
don't ignore expression after first not matched method call in PtrCloneVisitor

### DIFF
--- a/clippy_lints/src/utils/ptr.rs
+++ b/clippy_lints/src/utils/ptr.rs
@@ -72,7 +72,6 @@ impl<'a, 'tcx> Visitor<'tcx> for PtrCloneVisitor<'a, 'tcx> {
                     }
                 }
             }
-            return;
         }
         walk_expr(self, expr);
     }

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -136,3 +136,22 @@ mod issue_5644 {
         }
     }
 }
+
+mod issue6509 {
+    use std::path::PathBuf;
+
+    fn foo_vec(vec: &Vec<u8>) {
+        let _ = vec.clone().pop();
+        let _ = vec.clone().clone();
+    }
+
+    fn foo_path(path: &PathBuf) {
+        let _ = path.clone().pop();
+        let _ = path.clone().clone();
+    }
+
+    fn foo_str(str: &PathBuf) {
+        let _ = str.clone().pop();
+        let _ = str.clone().clone();
+    }
+}

--- a/tests/ui/ptr_arg.stderr
+++ b/tests/ui/ptr_arg.stderr
@@ -114,5 +114,62 @@ error: using a reference to `Cow` is not recommended.
 LL | fn test_cow_with_ref(c: &Cow<[i32]>) {}
    |                         ^^^^^^^^^^^ help: change this to: `&[i32]`
 
-error: aborting due to 9 previous errors
+error: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
+  --> $DIR/ptr_arg.rs:143:21
+   |
+LL |     fn foo_vec(vec: &Vec<u8>) {
+   |                     ^^^^^^^^
+   |
+help: change this to
+   |
+LL |     fn foo_vec(vec: &[u8]) {
+   |                     ^^^^^
+help: change `vec.clone()` to
+   |
+LL |         let _ = vec.to_owned().pop();
+   |                 ^^^^^^^^^^^^^^
+help: change `vec.clone()` to
+   |
+LL |         let _ = vec.to_owned().clone();
+   |                 ^^^^^^^^^^^^^^
+
+error: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do.
+  --> $DIR/ptr_arg.rs:148:23
+   |
+LL |     fn foo_path(path: &PathBuf) {
+   |                       ^^^^^^^^
+   |
+help: change this to
+   |
+LL |     fn foo_path(path: &Path) {
+   |                       ^^^^^
+help: change `path.clone()` to
+   |
+LL |         let _ = path.to_path_buf().pop();
+   |                 ^^^^^^^^^^^^^^^^^^
+help: change `path.clone()` to
+   |
+LL |         let _ = path.to_path_buf().clone();
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do.
+  --> $DIR/ptr_arg.rs:153:21
+   |
+LL |     fn foo_str(str: &PathBuf) {
+   |                     ^^^^^^^^
+   |
+help: change this to
+   |
+LL |     fn foo_str(str: &Path) {
+   |                     ^^^^^
+help: change `str.clone()` to
+   |
+LL |         let _ = str.to_path_buf().pop();
+   |                 ^^^^^^^^^^^^^^^^^
+help: change `str.clone()` to
+   |
+LL |         let _ = str.to_path_buf().clone();
+   |                 ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
fixes #6509 

changelog: none
