### PR TITLE
Fix blessing of test output in subdirectories

### DIFF
--- a/clippy_dev/src/bless.rs
+++ b/clippy_dev/src/bless.rs
@@ -17,18 +17,18 @@ pub static CARGO_TARGET_DIR: SyncLazy<PathBuf> = SyncLazy::new(|| match env::var
 });
 
 pub fn bless() {
-    let test_dirs = [
+    let test_suite_dirs = [
         clippy_project_root().join("tests").join("ui"),
         clippy_project_root().join("tests").join("ui-toml"),
         clippy_project_root().join("tests").join("ui-cargo"),
     ];
-    for test_dir in &test_dirs {
-        WalkDir::new(test_dir)
+    for test_suite_dir in &test_suite_dirs {
+        WalkDir::new(test_suite_dir)
             .into_iter()
             .filter_map(Result::ok)
             .filter(|f| f.path().extension() == Some(OsStr::new("rs")))
             .for_each(|f| {
-                let test_name = f.path().strip_prefix(test_dir).unwrap();
+                let test_name = f.path().strip_prefix(test_suite_dir).unwrap();
 
                 update_reference_file(f.path().with_extension("stdout"), test_name.with_extension("stdout"));
                 update_reference_file(f.path().with_extension("stderr"), test_name.with_extension("stderr"));

--- a/clippy_dev/src/bless.rs
+++ b/clippy_dev/src/bless.rs
@@ -28,15 +28,17 @@ pub fn bless() {
             .filter_map(Result::ok)
             .filter(|f| f.path().extension() == Some(OsStr::new("rs")))
             .for_each(|f| {
-                update_reference_file(f.path().with_extension("stdout"));
-                update_reference_file(f.path().with_extension("stderr"));
-                update_reference_file(f.path().with_extension("fixed"));
+                let test_name = f.path().strip_prefix(test_dir).unwrap();
+
+                update_reference_file(f.path().with_extension("stdout"), test_name.with_extension("stdout"));
+                update_reference_file(f.path().with_extension("stderr"), test_name.with_extension("stderr"));
+                update_reference_file(f.path().with_extension("fixed"), test_name.with_extension("fixed"));
             });
     }
 }
 
-fn update_reference_file(reference_file_path: PathBuf) {
-    let test_output_path = build_dir().join(PathBuf::from(reference_file_path.file_name().unwrap()));
+fn update_reference_file(reference_file_path: PathBuf, test_name: PathBuf) {
+    let test_output_path = build_dir().join(test_name);
     let relative_reference_file_path = reference_file_path.strip_prefix(clippy_project_root()).unwrap();
 
     // If compiletest did not write any changes during the test run,


### PR DESCRIPTION
The core issue was the usage of `reference_file_path.file_name()`, which
provided a non-existent path if the file to be updated was in a
subdirectory.

Instead we have to provide the whole path after 'tests/ui/' as the
'filename'. This part of the path is called `test_name` in the code now.

changelog: none
