### PR TITLE
make clippy version number correspond to rustc version number.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clippy"
-version = "0.0.212"
+version = "0.1.50"
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
@@ -29,7 +29,7 @@ path = "src/driver.rs"
 
 [dependencies]
 # begin automatic update
-clippy_lints = { version = "0.0.212", path = "clippy_lints" }
+clippy_lints = { version = "0.1.50", path = "clippy_lints" }
 # end automatic update
 semver = "0.11"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util" }

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_lints"
 # begin automatic update
-version = "0.0.212"
+version = "0.1.50"
 # end automatic update
 authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",

--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::single_match_else)]
+use rustc_tools_util::VersionInfo;
+
 #[test]
 fn check_that_clippy_lints_has_the_same_version_as_clippy() {
     let clippy_meta = cargo_metadata::MetadataCommand::new()
@@ -16,4 +19,57 @@ fn check_that_clippy_lints_has_the_same_version_as_clippy() {
             return;
         }
     }
+}
+
+#[test]
+fn check_that_clippy_has_the_same_major_version_as_rustc() {
+    let clippy_version = rustc_tools_util::get_version_info!();
+    let clippy_major = clippy_version.major;
+    let clippy_minor = clippy_version.minor;
+    let clippy_patch = clippy_version.patch;
+
+    // get the rustc version from cargo
+    // this way the rust-toolchain file version is honored
+    let rustc_version = String::from_utf8(
+        std::process::Command::new("cargo")
+            .arg("--version")
+            .output()
+            .expect("failed to run 'cargo --version'")
+            .stdout,
+    )
+    .unwrap();
+    // extract "1 50 0" from "cargo 1.50.0-nightly (a3c2627fb 2020-12-14)"
+    let vsplit: Vec<&str> = rustc_version
+        .split(' ')
+        .nth(1)
+        .unwrap()
+        .split('-')
+        .next()
+        .unwrap()
+        .split('.')
+        .collect();
+    match vsplit.as_slice() {
+        [rustc_major, rustc_minor, _rustc_patch] => {
+            // clippy 0.1.50 should correspond to rustc 1.50.0
+            dbg!(&rustc_version);
+            dbg!(&clippy_version);
+            assert_eq!(clippy_major, 0); // this will probably stay the same for a long time
+            assert_eq!(
+                clippy_minor.to_string(),
+                *rustc_major,
+                "clippy minor version does not equal rustc major version"
+            );
+            assert_eq!(
+                clippy_patch.to_string(),
+                *rustc_minor,
+                "clippy patch version does not equal rustc minor version"
+            );
+            // do not check rustc_patch because when a stable-patch-release is made (like 1.50.2),
+            // we don't want our tests failing suddenly
+        },
+        _ => {
+            dbg!(vsplit);
+            panic!("Failed to parse rustc version");
+        },
+    };
 }


### PR DESCRIPTION
clippy 0.1.50 corresponds to rustc 1.50.x

This bumps the clippy version number from 0.0.212 to 0.1.50

Fixes #6499

Notes:
I used `cargo --version` because that way we can honour the version set in the `rust-toolchain` file.
When we bump the bootstrap compiler from 1.50 to 1.51, the version numbers will have to be changed to 1.51 or the test will fail.

---


changelog: make clippy version number correspond to rustc version number (rust 1.50.0 -> clippy 0.1.50)
