### PR TITLE
match_like_matches_macro: strip refs in suggestion

### DIFF
--- a/tests/ui/match_expr_like_matches_macro.fixed
+++ b/tests/ui/match_expr_like_matches_macro.fixed
@@ -99,4 +99,51 @@ fn main() {
             _ => false,
         };
     }
+
+    {
+        // should print "z" in suggestion (#6503)
+        let z = &Some(3);
+        let _z = matches!(z, Some(3));
+    }
+
+    {
+        // this could also print "z" in suggestion..?
+        let z = Some(3);
+        let _z = matches!(&z, Some(3));
+    }
+
+    {
+        enum AnEnum {
+            X,
+            Y,
+        }
+
+        fn foo(_x: AnEnum) {}
+
+        fn main() {
+            let z = AnEnum::X;
+            // we can't remove the reference here!
+            let _ = matches!(&z, AnEnum::X);
+            foo(z);
+        }
+    }
+
+    {
+        struct S(i32);
+
+        fn fun(_val: Option<S>) {}
+        let val = Some(S(42));
+        // we need the reference here because later val is consumed by fun()
+        let _res = matches!(&val, &Some(ref _a));
+        fun(val);
+    }
+
+    {
+        struct S(i32);
+
+        fn fun(_val: Option<S>) {}
+        let val = Some(S(42));
+        let _res = matches!(&val, &Some(ref _a));
+        fun(val);
+    }
 }

--- a/tests/ui/match_expr_like_matches_macro.rs
+++ b/tests/ui/match_expr_like_matches_macro.rs
@@ -119,4 +119,66 @@ fn main() {
             _ => false,
         };
     }
+
+    {
+        // should print "z" in suggestion (#6503)
+        let z = &Some(3);
+        let _z = match &z {
+            Some(3) => true,
+            _ => false,
+        };
+    }
+
+    {
+        // this could also print "z" in suggestion..?
+        let z = Some(3);
+        let _z = match &z {
+            Some(3) => true,
+            _ => false,
+        };
+    }
+
+    {
+        enum AnEnum {
+            X,
+            Y,
+        }
+
+        fn foo(_x: AnEnum) {}
+
+        fn main() {
+            let z = AnEnum::X;
+            // we can't remove the reference here!
+            let _ = match &z {
+                AnEnum::X => true,
+                _ => false,
+            };
+            foo(z);
+        }
+    }
+
+    {
+        struct S(i32);
+
+        fn fun(_val: Option<S>) {}
+        let val = Some(S(42));
+        // we need the reference here because later val is consumed by fun()
+        let _res = match &val {
+            &Some(ref _a) => true,
+            _ => false,
+        };
+        fun(val);
+    }
+
+    {
+        struct S(i32);
+
+        fn fun(_val: Option<S>) {}
+        let val = Some(S(42));
+        let _res = match &val {
+            &Some(ref _a) => true,
+            _ => false,
+        };
+        fun(val);
+    }
 }

--- a/tests/ui/match_expr_like_matches_macro.stderr
+++ b/tests/ui/match_expr_like_matches_macro.stderr
@@ -70,5 +70,88 @@ LL | |             _ => true,
 LL | |         };
    | |_________^ help: try this: `!matches!(x, E::B(_) | E::C)`
 
-error: aborting due to 7 previous errors
+error: match expression looks like `matches!` macro
+  --> $DIR/match_expr_like_matches_macro.rs:126:18
+   |
+LL |           let _z = match &z {
+   |  __________________^
+LL | |             Some(3) => true,
+LL | |             _ => false,
+LL | |         };
+   | |_________^ help: try this: `matches!(z, Some(3))`
+
+error: match expression looks like `matches!` macro
+  --> $DIR/match_expr_like_matches_macro.rs:135:18
+   |
+LL |           let _z = match &z {
+   |  __________________^
+LL | |             Some(3) => true,
+LL | |             _ => false,
+LL | |         };
+   | |_________^ help: try this: `matches!(&z, Some(3))`
+
+error: match expression looks like `matches!` macro
+  --> $DIR/match_expr_like_matches_macro.rs:152:21
+   |
+LL |               let _ = match &z {
+   |  _____________________^
+LL | |                 AnEnum::X => true,
+LL | |                 _ => false,
+LL | |             };
+   | |_____________^ help: try this: `matches!(&z, AnEnum::X)`
+
+error: match expression looks like `matches!` macro
+  --> $DIR/match_expr_like_matches_macro.rs:166:20
+   |
+LL |           let _res = match &val {
+   |  ____________________^
+LL | |             &Some(ref _a) => true,
+LL | |             _ => false,
+LL | |         };
+   | |_________^ help: try this: `matches!(&val, &Some(ref _a))`
+
+error: you don't need to add `&` to both the expression and the patterns
+  --> $DIR/match_expr_like_matches_macro.rs:166:20
+   |
+LL |           let _res = match &val {
+   |  ____________________^
+LL | |             &Some(ref _a) => true,
+LL | |             _ => false,
+LL | |         };
+   | |_________^
+   |
+   = note: `-D clippy::match-ref-pats` implied by `-D warnings`
+help: try
+   |
+LL |         let _res = match val {
+LL |             Some(ref _a) => true,
+   |
+
+error: match expression looks like `matches!` macro
+  --> $DIR/match_expr_like_matches_macro.rs:178:20
+   |
+LL |           let _res = match &val {
+   |  ____________________^
+LL | |             &Some(ref _a) => true,
+LL | |             _ => false,
+LL | |         };
+   | |_________^ help: try this: `matches!(&val, &Some(ref _a))`
+
+error: you don't need to add `&` to both the expression and the patterns
+  --> $DIR/match_expr_like_matches_macro.rs:178:20
+   |
+LL |           let _res = match &val {
+   |  ____________________^
+LL | |             &Some(ref _a) => true,
+LL | |             _ => false,
+LL | |         };
+   | |_________^
+   |
+help: try
+   |
+LL |         let _res = match val {
+LL |             Some(ref _a) => true,
+   |
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
fixes #6503

changelog: match_like_matches_macro: strip refs in suggestion (#6503)
