### PR TITLE
Curse outdated test output

### DIFF
--- a/clippy_dev/src/bless.rs
+++ b/clippy_dev/src/bless.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 use std::lazy::SyncLazy;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 use crate::clippy_project_root;
@@ -16,7 +16,15 @@ pub static CARGO_TARGET_DIR: SyncLazy<PathBuf> = SyncLazy::new(|| match env::var
     None => env::current_dir().unwrap().join("target"),
 });
 
-pub fn bless() {
+static CLIPPY_BUILD_TIME: SyncLazy<Option<std::time::SystemTime>> = SyncLazy::new(|| {
+    let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
+    let mut path = PathBuf::from(&**CARGO_TARGET_DIR);
+    path.push(profile);
+    path.push("cargo-clippy");
+    fs::metadata(path).ok()?.modified().ok()
+});
+
+pub fn bless(ignore_timestamp: bool) {
     let test_suite_dirs = [
         clippy_project_root().join("tests").join("ui"),
         clippy_project_root().join("tests").join("ui-toml"),
@@ -29,21 +37,29 @@ pub fn bless() {
             .filter(|f| f.path().extension() == Some(OsStr::new("rs")))
             .for_each(|f| {
                 let test_name = f.path().strip_prefix(test_suite_dir).unwrap();
-
-                update_reference_file(f.path().with_extension("stdout"), test_name.with_extension("stdout"));
-                update_reference_file(f.path().with_extension("stderr"), test_name.with_extension("stderr"));
-                update_reference_file(f.path().with_extension("fixed"), test_name.with_extension("fixed"));
+                for &ext in &["stdout", "stderr", "fixed"] {
+                    update_reference_file(
+                        f.path().with_extension(ext),
+                        test_name.with_extension(ext),
+                        ignore_timestamp,
+                    );
+                }
             });
     }
 }
 
-fn update_reference_file(reference_file_path: PathBuf, test_name: PathBuf) {
+fn update_reference_file(reference_file_path: PathBuf, test_name: PathBuf, ignore_timestamp: bool) {
     let test_output_path = build_dir().join(test_name);
     let relative_reference_file_path = reference_file_path.strip_prefix(clippy_project_root()).unwrap();
 
     // If compiletest did not write any changes during the test run,
     // we don't have to update anything
     if !test_output_path.exists() {
+        return;
+    }
+
+    // If the test output was not updated since the last clippy build, it may be outdated
+    if !ignore_timestamp && !updated_since_clippy_build(&test_output_path).unwrap_or(true) {
         return;
     }
 
@@ -64,6 +80,12 @@ fn update_reference_file(reference_file_path: PathBuf, test_name: PathBuf) {
             fs::remove_file(reference_file_path).expect("Could not remove reference file");
         }
     }
+}
+
+fn updated_since_clippy_build(path: &Path) -> Option<bool> {
+    let clippy_build_time = (*CLIPPY_BUILD_TIME)?;
+    let modified = fs::metadata(path).ok()?.modified().ok()?;
+    Some(modified >= clippy_build_time)
 }
 
 fn build_dir() -> PathBuf {

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -7,8 +7,8 @@ fn main() {
     let matches = get_clap_config();
 
     match matches.subcommand() {
-        ("bless", Some(_)) => {
-            bless::bless();
+        ("bless", Some(matches)) => {
+            bless::bless(matches.is_present("ignore-timestamp"));
         },
         ("fmt", Some(matches)) => {
             fmt::run(matches.is_present("check"), matches.is_present("verbose"));
@@ -47,7 +47,15 @@ fn main() {
 
 fn get_clap_config<'a>() -> ArgMatches<'a> {
     App::new("Clippy developer tooling")
-        .subcommand(SubCommand::with_name("bless").about("bless the test output changes"))
+        .subcommand(
+            SubCommand::with_name("bless")
+                .about("bless the test output changes")
+                .arg(
+                    Arg::with_name("ignore-timestamp")
+                        .long("ignore-timestamp")
+                        .help("Include files updated before clippy was built"),
+                ),
+        )
         .subcommand(
             SubCommand::with_name("fmt")
                 .about("Run rustfmt on all projects and tests")


### PR DESCRIPTION
changelog: internal

Change `cargo dev bless` to only include test output that was generated since the last build of clippy. This is especially useful when running tests with `TESTNAME=...`. The feature may be disabled by `cargo dev bless --ignore-timestamp`.