### PR TITLE
Fix FP with empty return for `needless_return` lint

### DIFF
--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -101,6 +101,19 @@ fn test_return_in_macro() {
     needed_return!(0);
 }
 
+mod issue6501 {
+    fn foo(bar: Result<(), ()>) {
+        bar.unwrap_or_else(|_| {})
+    }
+
+    fn test_closure() {
+        let _ = || {
+            
+        };
+        let _ = || {};
+    }
+}
+
 fn main() {
     let _ = test_end_of_fn();
     let _ = test_no_semicolon();

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -101,6 +101,19 @@ fn test_return_in_macro() {
     needed_return!(0);
 }
 
+mod issue6501 {
+    fn foo(bar: Result<(), ()>) {
+        bar.unwrap_or_else(|_| return)
+    }
+
+    fn test_closure() {
+        let _ = || {
+            return;
+        };
+        let _ = || return;
+    }
+}
+
 fn main() {
     let _ = test_end_of_fn();
     let _ = test_no_semicolon();

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -85,19 +85,19 @@ LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `String::new()`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:91:32
+  --> $DIR/needless_return.rs:106:32
    |
 LL |         bar.unwrap_or_else(|_| return)
    |                                ^^^^^^ help: replace `return` with an empty block: `{}`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:96:13
+  --> $DIR/needless_return.rs:111:13
    |
 LL |             return;
    |             ^^^^^^^ help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:98:20
+  --> $DIR/needless_return.rs:113:20
    |
 LL |         let _ = || return;
    |                    ^^^^^^ help: replace `return` with an empty block: `{}`

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -84,5 +84,23 @@ error: unneeded `return` statement
 LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `String::new()`
 
-error: aborting due to 14 previous errors
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:91:32
+   |
+LL |         bar.unwrap_or_else(|_| return)
+   |                                ^^^^^^ help: replace `return` with an empty block: `{}`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:96:13
+   |
+LL |             return;
+   |             ^^^^^^^ help: remove `return`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:98:20
+   |
+LL |         let _ = || return;
+   |                    ^^^^^^ help: replace `return` with an empty block: `{}`
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
This fixes a false positive in `needless_return` lint, when triggered in a closure using `return` statement without value.

Fixes: #6501 

changelog: none
