### PR TITLE
Fix typo: `which which can be` -> `which can be`

### DIFF
--- a/clippy_lints/src/pass_by_ref_or_value.rs
+++ b/clippy_lints/src/pass_by_ref_or_value.rs
@@ -63,7 +63,7 @@ declare_clippy_lint! {
     ///
     /// **Why is this bad?** Arguments passed by value might result in an unnecessary
     /// shallow copy, taking up more space in the stack and requiring a call to
-    /// `memcpy`, which which can be expensive.
+    /// `memcpy`, which can be expensive.
     ///
     /// **Example:**
     ///


### PR DESCRIPTION
Fixed a typo in the explanation of https://rust-lang.github.io/rust-clippy/master/index.html#large_types_passed_by_value : `which which can be` -> `which can be`

changelog: none
