### PR TITLE
Reduce the span in `from_over_into` to impl header

### DIFF
--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -70,7 +70,7 @@ impl LateLintPass<'_> for FromOverInto {
                 span_lint_and_help(
                     cx,
                     FROM_OVER_INTO,
-                    item.span,
+                    cx.tcx.sess.source_map().guess_head_span(item.span),
                     "an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true",
                     None,
                     "consider to implement `From` instead",

--- a/tests/ui/from_over_into.stderr
+++ b/tests/ui/from_over_into.stderr
@@ -1,12 +1,8 @@
 error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
   --> $DIR/from_over_into.rs:6:1
    |
-LL | / impl Into<StringWrapper> for String {
-LL | |     fn into(self) -> StringWrapper {
-LL | |         StringWrapper(self)
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Into<StringWrapper> for String {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::from-over-into` implied by `-D warnings`
    = help: consider to implement `From` instead


### PR DESCRIPTION
A follow up of https://github.com/rust-lang/rust-clippy/pull/6476#discussion_r546271382
> That item might be quite large. We may want to reduce the span to the `impl` header.

changelog: none
