### PR TITLE
Fix path_to_res for enum inherent items

### DIFF
--- a/tests/ui-internal/invalid_paths.rs
+++ b/tests/ui-internal/invalid_paths.rs
@@ -18,6 +18,9 @@ mod paths {
 
     // Path with bad module
     pub const BAD_MOD_PATH: [&str; 2] = ["std", "xxx"];
+
+    // Path to method on an enum inherent impl
+    pub const OPTION_IS_SOME: [&str; 4] = ["core", "option", "Option", "is_some"];
 }
 
 fn main() {}


### PR DESCRIPTION
changelog: none

I tried to add `Option::is_some` to the paths but got a false positive from the invalid paths lint. Turns out the `path_to_res` function does not find inherent impls for enums. I fixed this and took the liberty to do some additional cleanup in the method.