### PR TITLE
Fix the ICE 6539

### DIFF
--- a/clippy_lints/src/zero_sized_map_values.rs
+++ b/clippy_lints/src/zero_sized_map_values.rs
@@ -6,7 +6,7 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_target::abi::LayoutOf as _;
 use rustc_typeck::hir_ty_to_ty;
 
-use crate::utils::{is_type_diagnostic_item, match_type, paths, span_lint_and_help};
+use crate::utils::{is_normalizable, is_type_diagnostic_item, match_type, paths, span_lint_and_help};
 
 declare_clippy_lint! {
     /// **What it does:** Checks for maps with zero-sized value types anywhere in the code.
@@ -50,6 +50,8 @@ impl LateLintPass<'_> for ZeroSizedMapValues {
             if is_type_diagnostic_item(cx, ty, sym!(hashmap_type)) || match_type(cx, ty, &paths::BTREEMAP);
             if let Adt(_, ref substs) = ty.kind();
             let ty = substs.type_at(1);
+            // Do this to prevent `layout_of` crashing, being unable to fully normalize `ty`.
+            if is_normalizable(cx, cx.param_env, ty);
             if let Ok(layout) = cx.layout_of(ty);
             if layout.is_zst();
             then {

--- a/tests/ui/crashes/ice-6539.rs
+++ b/tests/ui/crashes/ice-6539.rs
@@ -1,0 +1,16 @@
+// The test for the ICE 6539: https://github.com/rust-lang/rust-clippy/issues/6539.
+// The cause is that `zero_sized_map_values` used `layout_of` with types from type aliases,
+// which is essentially the same as the ICE 4968.
+// Note that only type aliases with associated types caused the crash this time,
+// not others such as trait impls.
+
+use std::collections::{BTreeMap, HashMap};
+
+pub trait Trait {
+    type Assoc;
+}
+
+type TypeAlias<T> = HashMap<(), <T as Trait>::Assoc>;
+type TypeAlias2<T> = BTreeMap<(), <T as Trait>::Assoc>;
+
+fn main() {}


### PR DESCRIPTION
Fixes #6539

It happened because `zero_sized_map_values` used `layout_of` with types from type aliases, which is essentially the same as the ICE 4968.

---

changelog: Fix an ICE in `zero_sized_map_values`
