### PR TITLE
Explicitly document false positives

### DIFF
--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// other solution is to ensure the mutex is unlocked before calling await,
     /// either by introducing a scope or an explicit call to Drop::drop.
     ///
-    /// **Known problems:** None.
+    /// **Known problems:** Will report false positive for explicitly dropped guards ([#6446](https://github.com/rust-lang/rust-clippy/issues/6446)).
     ///
     /// **Example:**
     ///
@@ -57,7 +57,7 @@ declare_clippy_lint! {
     /// at runtime. Holding onto a `RefCell` ref across an `await` suspension point
     /// risks panics from a mutable ref shared while other refs are outstanding.
     ///
-    /// **Known problems:** None.
+    /// **Known problems:** Will report false positive for explicitly dropped refs ([#6353](https://github.com/rust-lang/rust-clippy/issues/6353)).
     ///
     /// **Example:**
     ///


### PR DESCRIPTION
Adds documentation for known false positives for the `await_holding*` lints.

Issues:

https://github.com/rust-lang/rust-clippy/issues/6353
https://github.com/rust-lang/rust-clippy/issues/6446

changelog: document FPs for the ``await_holding_*`` lints
