### PR TITLE
Do not lint when range is completely included into another one

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1544,7 +1544,17 @@ where
                 }
             },
             (&Kind::End(a, _), &Kind::Start(b, _)) if a != Bound::Included(b) => (),
-            _ => return Some((a.range(), b.range())),
+            _ => {
+                // skip if the range `a` is completely included into the range `b`
+                if let Ordering::Equal | Ordering::Less = a.cmp(&b) {
+                    let kind_a = Kind::End(a.range().node.1, a.range());
+                    let kind_b = Kind::End(b.range().node.1, b.range());
+                    if let Ordering::Equal | Ordering::Greater = kind_a.cmp(&kind_b) {
+                        return None;
+                    }
+                }
+                return Some((a.range(), b.range()));
+            },
         }
     }
 

--- a/tests/ui/match_overlapping_arm.rs
+++ b/tests/ui/match_overlapping_arm.rs
@@ -57,6 +57,18 @@ fn overlapping() {
         _ => (),
     }
 
+    match 42 {
+        5..7 => println!("5 .. 7"),
+        0..10 => println!("0 .. 10"),
+        _ => (),
+    }
+
+    match 42 {
+        5..10 => println!("5 .. 10"),
+        0..=10 => println!("0 ... 10"),
+        _ => (),
+    }
+
     /*
     // FIXME(JohnTitor): uncomment this once rustfmt knows half-open patterns
     match 42 {

--- a/tests/ui/match_overlapping_arm.rs
+++ b/tests/ui/match_overlapping_arm.rs
@@ -69,6 +69,24 @@ fn overlapping() {
         _ => (),
     }
 
+    match 42 {
+        0..14 => println!("0 .. 14"),
+        5..10 => println!("5 .. 10"),
+        _ => (),
+    }
+
+    match 42 {
+        5..14 => println!("5 .. 14"),
+        0..=10 => println!("0 ... 10"),
+        _ => (),
+    }
+
+    match 42 {
+        0..7 => println!("0 .. 7"),
+        0..=10 => println!("0 ... 10"),
+        _ => (),
+    }
+
     /*
     // FIXME(JohnTitor): uncomment this once rustfmt knows half-open patterns
     match 42 {

--- a/tests/ui/match_overlapping_arm.stderr
+++ b/tests/ui/match_overlapping_arm.stderr
@@ -24,30 +24,6 @@ LL |         FOO..=11 => println!("0 ... 11"),
    |         ^^^^^^^^
 
 error: some ranges overlap
-  --> $DIR/match_overlapping_arm.rs:26:9
-   |
-LL |         0..=5 => println!("0 ... 5"),
-   |         ^^^^^
-   |
-note: overlaps with this
-  --> $DIR/match_overlapping_arm.rs:25:9
-   |
-LL |         2 => println!("2"),
-   |         ^
-
-error: some ranges overlap
-  --> $DIR/match_overlapping_arm.rs:32:9
-   |
-LL |         0..=2 => println!("0 ... 2"),
-   |         ^^^^^
-   |
-note: overlaps with this
-  --> $DIR/match_overlapping_arm.rs:31:9
-   |
-LL |         2 => println!("2"),
-   |         ^
-
-error: some ranges overlap
   --> $DIR/match_overlapping_arm.rs:55:9
    |
 LL |         0..11 => println!("0 .. 11"),
@@ -59,5 +35,5 @@ note: overlaps with this
 LL |         0..=11 => println!("0 ... 11"),
    |         ^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/match_overlapping_arm.stderr
+++ b/tests/ui/match_overlapping_arm.stderr
@@ -35,5 +35,29 @@ note: overlaps with this
 LL |         0..=11 => println!("0 ... 11"),
    |         ^^^^^^
 
-error: aborting due to 3 previous errors
+error: some ranges overlap
+  --> $DIR/match_overlapping_arm.rs:80:9
+   |
+LL |         0..=10 => println!("0 ... 10"),
+   |         ^^^^^^
+   |
+note: overlaps with this
+  --> $DIR/match_overlapping_arm.rs:79:9
+   |
+LL |         5..14 => println!("5 .. 14"),
+   |         ^^^^^
+
+error: some ranges overlap
+  --> $DIR/match_overlapping_arm.rs:85:9
+   |
+LL |         0..7 => println!("0 .. 7"),
+   |         ^^^^
+   |
+note: overlaps with this
+  --> $DIR/match_overlapping_arm.rs:86:9
+   |
+LL |         0..=10 => println!("0 ... 10"),
+   |         ^^^^^^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This fix has been developed following this [comment](https://github.com/rust-lang/rust-clippy/issues/5986#issuecomment-703313548).
So this will be linted:
```
|----------|
        |-----------|
```
Now this won't be linted:
```
              |---|
|--------------------|
```
and this will still lint:
```
|--------|
|--------------|
```

Fixes: #5986 

changelog: Fix FPs in match_overlapping_arm, when first arm is completely included in second arm
