### PR TITLE
Add test for `needless_return` lint

### DIFF
--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -112,6 +112,12 @@ mod issue6501 {
         };
         let _ = || {};
     }
+
+    struct Foo;
+    #[allow(clippy::unnecessary_lazy_evaluations)]
+    fn bar(res: Result<Foo, u8>) -> Foo {
+        res.unwrap_or_else(|_| Foo)
+    }
 }
 
 fn main() {

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -112,6 +112,12 @@ mod issue6501 {
         };
         let _ = || return;
     }
+
+    struct Foo;
+    #[allow(clippy::unnecessary_lazy_evaluations)]
+    fn bar(res: Result<Foo, u8>) -> Foo {
+        res.unwrap_or_else(|_| return Foo)
+    }
 }
 
 fn main() {

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -102,5 +102,11 @@ error: unneeded `return` statement
 LL |         let _ = || return;
    |                    ^^^^^^ help: replace `return` with an empty block: `{}`
 
-error: aborting due to 17 previous errors
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:119:32
+   |
+LL |         res.unwrap_or_else(|_| return Foo)
+   |                                ^^^^^^^^^^ help: remove `return`: `Foo`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Just a follow up of #6549 that adds a test for this lint.

changelog: none
