### PR TITLE
Improve the example in `ref_in_deref`

### DIFF
--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -111,6 +111,12 @@ declare_clippy_lint! {
     /// let point = Point(30, 20);
     /// let x = (&point).0;
     /// ```
+    /// Use instead:
+    /// ```rust
+    /// # struct Point(u32, u32);
+    /// # let point = Point(30, 20);
+    /// let x = point.0;
+    /// ```
     pub REF_IN_DEREF,
     complexity,
     "Use of reference in auto dereference expression."


### PR DESCRIPTION
Add a suggested code to the example in doc

changelog: none
