### PR TITLE
Documentation for adding configuration to a lint and common abbreviations

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -11,6 +11,7 @@ the codebase take a look at [Adding Lints] or [Common Tools].
   - [Get the Code](#get-the-code)
   - [Building and Testing](#building-and-testing)
   - [`cargo dev`](#cargo-dev)
+  - [Common Abbreviations](#common-abbreviations)
   - [PR](#pr)
 
 ## Get the Code
@@ -109,7 +110,7 @@ See <https://rustc-dev-guide.rust-lang.org/contributing.html#opening-a-pr>.
 | TCX          | Type context                           |
 
 This is a concise list of abbreviations that can come up during clippy development. An extensive
-genal list can be found in the [rustc-dev-guide glossary][glossary]. Always feel free to ask if
+general list can be found in the [rustc-dev-guide glossary][glossary]. Always feel free to ask if
 an abbreviation or meaning is unclear to you.
 
 [glossary]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -94,3 +94,22 @@ cargo dev ra_setup
 
 We follow a rustc no merge-commit policy.
 See <https://rustc-dev-guide.rust-lang.org/contributing.html#opening-a-pr>.
+
+## Common Abbreviations
+
+| Abbreviation | Meaning                                |
+| ------------ | -------------------------------------- |
+| UB           | Undefined Behavior                     |
+| FP           | False Positive                         |
+| FN           | False Negative                         |
+| ICE          | Internal Compiler Error                |
+| AST          | Abstract Syntax Tree                   |
+| MIR          | Mid-Level Intermediate Representation  |
+| HIR          | High-Level Intermediate Representation |
+| TCX          | Type context                           |
+
+This is a concise list of abbreviations that can come up during clippy development. An extensive
+genal list can be found in the [rustc-dev-guide glossary][glossary]. Always feel free to ask if
+an abbreviation or meaning is unclear to you.
+
+[glossary]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html


### PR DESCRIPTION
This PR adds some commonly used abbreviations to the `basis.md` file and a guide on how to implement a configuration value for a lint. 

* [Rendered `/doc/basics.md` (Abbreviation list)](https://github.com/xFrednet/rust-clippy/blob/0000-configuration-documentation/doc/basics.md#common-abbreviations)
* [Rendered `/doc/adding_lints.md` (Configuration value guide)](https://github.com/xFrednet/rust-clippy/blob/0000-configuration-documentation/doc/adding_lints.md#adding-configuration-to-a-lint)

I'm not sure if the guide is written in the best way. Style suggestions are appreciated. :upside_down_face: 

 ---

Again a big **thank you** for everyone who helped to collect the abbreviation list over on [zulip]. I had a lot of fun, and it was also very informative. Keep up the good work :upside_down_face: 

[zulip]: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Common.20abbreviations.20in.20basics.2Emd/near/223548065
---

changelog: none