### PR TITLE
Updated some NITs in the documentation from #6630

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,11 @@ first read the [Basics docs](doc/basics.md).**
 
 ### Finding something to fix/improve
 
-All issues on Clippy are mentored, if you want help with a bug just ask
-@Manishearth, @flip1995, @phansch or @yaahc.
+All issues on Clippy are mentored, if you want help simply ask @Manishearth, @flip1995, @phansch
+or @yaahc directly by mentioning them in the issue or over on [Zulip].
 
-Some issues are easier than others. The [`good-first-issue`] label can be used to find the easy issues.
-If you want to work on an issue, please leave a comment so that we can assign it to you!
+Some issues are easier than others. The [`good-first-issue`] label can be used to find the easy
+issues. You can use `@rustbot claim` to assign the issue to yourself.
 
 There are also some abandoned PRs, marked with [`S-inactive-closed`].
 Pretty often these PRs are nearly completed and just need some extra steps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ first read the [Basics docs](doc/basics.md).**
 ### Finding something to fix/improve
 
 All issues on Clippy are mentored, if you want help simply ask @Manishearth, @flip1995, @phansch
-or @yaahc directly by mentioning them in the issue or over on [Zulip].
+or @llogiq directly by mentioning them in the issue or over on [Zulip]. This list may be out of date.
+All currently active mentors can be found [here](https://github.com/rust-lang/highfive/blob/master/highfive/configs/rust-lang/rust-clippy.json#L3)
 
 Some issues are easier than others. The [`good-first-issue`] label can be used to find the easy
 issues. You can use `@rustbot claim` to assign the issue to yourself.

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -581,15 +581,15 @@ in the following steps:
 3. Passing the configuration value to the lint impl struct:
 
     First find the struct construction in the [clippy_lints lib file](/clippy_lints/src/lib.rs). 
-    Make sure that `clippy dev update_lints` added it beforehand. The configuration value is now 
-    cloned or copied into a local value that is then passed to the impl struct like this:
+    The configuration value is now cloned or copied into a local value that is then passed to the
+    impl struct like this:
     ```rust
     // Default generated registration:
-    store.register_late_pass(|| box module::StructName);
+    store.register_*_pass(|| box module::StructName);
 
     // New registration with configuration value
     let configuration_ident = conf.configuration_ident.clone();
-    store.register_late_pass(move || box module::StructName::new(configuration_ident));
+    store.register_*_pass(move || box module::StructName::new(configuration_ident));
     ```
 
     Congratulations the work is almost done. The configuration value can now be accessed
@@ -599,7 +599,7 @@ in the following steps:
     1. The default configured value can be tested like any normal lint in [`tests/ui`](/tests/ui).
     2. The configuration itself will be tested separately in [`tests/ui-toml`](/tests/ui-toml). 
         Simply add a new subfolder with a fitting name. This folder contains a `clippy.toml` file 
-        with the configuration value and a rust file that should be linted by clippy. The test can 
+        with the configuration value and a rust file that should be linted by Clippy. The test can 
         otherwise be written as usual.
 
 ## Cheatsheet

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -109,7 +109,7 @@ See <https://rustc-dev-guide.rust-lang.org/contributing.html#opening-a-pr>.
 | HIR          | High-Level Intermediate Representation |
 | TCX          | Type context                           |
 
-This is a concise list of abbreviations that can come up during clippy development. An extensive
+This is a concise list of abbreviations that can come up during Clippy development. An extensive
 general list can be found in the [rustc-dev-guide glossary][glossary]. Always feel free to ask if
 an abbreviation or meaning is unclear to you.
 


### PR DESCRIPTION
I've implemented the two suggestions from #6630 that were added after the merge. This PR also changes the example code to use `register_*_pass` instead of `register_late_pass`. I'm not sure if this is better or worse, but it makes it clearer in my opinion. Let me know if I should change it back.

---

changelog: none

r? @flip1995 