### PR TITLE
No lazy static regex

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -34,8 +34,6 @@ rustc-semver="1.1.0"
 url = { version =  "2.1.0", features = ["serde"] }
 quote = "1"
 syn = { version = "1", features = ["full"] }
-regex = "1.4"
-lazy_static = "1.4"
 
 [features]
 deny-warnings = []

--- a/clippy_lints/src/utils/diagnostics.rs
+++ b/clippy_lints/src/utils/diagnostics.rs
@@ -186,8 +186,6 @@ pub fn span_lint_hir_and_then(
 ///     |
 ///     = note: `-D fold-any` implied by `-D warnings`
 /// ```
-
-#[allow(clippy::unknown_clippy_lints)]
 #[cfg_attr(feature = "internal-lints", allow(clippy::collapsible_span_lint_calls))]
 pub fn span_lint_and_sugg<'a, T: LintContext>(
     cx: &'a T,


### PR DESCRIPTION
r? @llogiq 

#6500 

regex is unnecessary for this lint (https://github.com/rust-lang/rust-clippy/pull/6500#discussion_r558555071)
lazy_static is unnecessary. The std lazy feature should be  used instead.

changelog: none
