### PR TITLE
New lint: default_numeric_fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1909,6 +1909,7 @@ Released 2018-09-13
 [`debug_assert_with_mut_call`]: https://rust-lang.github.io/rust-clippy/master/index.html#debug_assert_with_mut_call
 [`decimal_literal_representation`]: https://rust-lang.github.io/rust-clippy/master/index.html#decimal_literal_representation
 [`declare_interior_mutable_const`]: https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const
+[`default_numeric_fallback`]: https://rust-lang.github.io/rust-clippy/master/index.html#default_numeric_fallback
 [`default_trait_access`]: https://rust-lang.github.io/rust-clippy/master/index.html#default_trait_access
 [`deprecated_cfg_attr`]: https://rust-lang.github.io/rust-clippy/master/index.html#deprecated_cfg_attr
 [`deprecated_semver`]: https://rust-lang.github.io/rust-clippy/master/index.html#deprecated_semver

--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// **Why is this bad?** For those who are very careful about types, default numeric fallback
     /// can be a pitfall that cause unexpected runtime behavior.
     ///
-    /// **Known problems:** None.
+    /// **Known problems:** This lint can only be allowed at the function level or above.
     ///
     /// **Example:**
     /// ```rust

--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -1,0 +1,388 @@
+use rustc_ast::ast::{Label, LitFloatType, LitIntType, LitKind};
+use rustc_hir::{
+    self as hir,
+    intravisit::{walk_expr, walk_stmt, walk_ty, FnKind, NestedVisitorMap, Visitor},
+    Body, Expr, ExprKind, FnDecl, FnRetTy, Guard, HirId, Lit, Stmt, StmtKind,
+};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::{
+    hir::map::Map,
+    ty::{self, subst::GenericArgKind, FloatTy, IntTy, Ty, TyCtxt},
+};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::Span;
+use rustc_typeck::hir_ty_to_ty;
+
+use if_chain::if_chain;
+
+use crate::utils::span_lint_and_help;
+
+declare_clippy_lint! {
+    /// **What it does:** Checks for usage of unconstrained numeric literals which may cause default numeric fallback in type
+    /// inference.
+    ///
+    /// Default numeric fallback means that if numeric types have not yet been bound to concrete
+    /// types at the end of type inference, then integer type is bound to `i32`, and similarly
+    /// floating type is bound to `f64`.
+    ///
+    /// See [RFC0212](https://github.com/rust-lang/rfcs/blob/master/text/0212-restore-int-fallback.md) for more information about the fallback.
+    ///
+    /// **Why is this bad?** For those who are very careful about types, default numeric fallback
+    /// can be a pitfall that cause unexpected runtime behavior.
+    ///
+    /// **Known problems:** None.
+    ///
+    /// **Example:**
+    /// ```rust
+    /// let i = 10;
+    /// let f = 1.23;
+    /// ```
+    ///
+    /// Use instead:
+    /// ```rust
+    /// let i = 10i32;
+    /// let f = 1.23f64;
+    /// ```
+    pub DEFAULT_NUMERIC_FALLBACK,
+    restriction,
+    "usage of unconstrained numeric literals which may cause default numeric fallback."
+}
+
+declare_lint_pass!(DefaultNumericFallback => [DEFAULT_NUMERIC_FALLBACK]);
+
+fn enclosing_body_owner_opt(tcx: TyCtxt<'_>, hir_id: HirId) -> Option<HirId> {
+    let hir_map = tcx.hir();
+    for (parent, _) in hir_map.parent_iter(hir_id) {
+        if let Some(body) = hir_map.maybe_body_owned_by(parent) {
+            return Some(hir_map.body_owner(body));
+        }
+    }
+    None
+}
+
+impl LateLintPass<'_> for DefaultNumericFallback {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        fn_decl: &'tcx FnDecl<'_>,
+        body: &'tcx Body<'_>,
+        _: Span,
+        hir_id: HirId,
+    ) {
+        let ret_ty_bound = match fn_decl.output {
+            FnRetTy::DefaultReturn(_) => None,
+            FnRetTy::Return(ty) => Some(ty),
+        }
+        .and_then(|ty| {
+            let mut infer_ty_finder = InferTyFinder::new();
+            infer_ty_finder.visit_ty(ty);
+            if infer_ty_finder.found {
+                None
+            } else if enclosing_body_owner_opt(cx.tcx, hir_id).is_some() {
+                cx.typeck_results().node_type_opt(ty.hir_id)
+            } else {
+                Some(hir_ty_to_ty(cx.tcx, ty))
+            }
+        });
+
+        let mut visitor = NumericFallbackVisitor::new(ret_ty_bound, cx);
+        visitor.visit_body(body);
+    }
+}
+
+struct NumericFallbackVisitor<'a, 'tcx> {
+    /// Stack manages type bound of exprs. The top element holds current expr type.
+    ty_bounds: Vec<Option<Ty<'tcx>>>,
+
+    /// Ret type bound.
+    ret_ty_bound: Option<Ty<'tcx>>,
+
+    /// Break type bounds.
+    break_ty_bounds: Vec<(Option<Label>, Option<Ty<'tcx>>)>,
+
+    cx: &'a LateContext<'tcx>,
+}
+
+impl<'a, 'tcx> NumericFallbackVisitor<'a, 'tcx> {
+    fn new(ret_ty_bound: Option<Ty<'tcx>>, cx: &'a LateContext<'tcx>) -> Self {
+        Self {
+            ty_bounds: vec![ret_ty_bound],
+            ret_ty_bound,
+            break_ty_bounds: vec![],
+            cx,
+        }
+    }
+
+    /// Check whether lit cause fallback or not.
+    fn check_lit(&self, lit: &Lit, lit_ty: Ty<'tcx>) {
+        let ty_bound = self.ty_bounds.last().unwrap();
+
+        let should_lint = match (&lit.node, lit_ty.kind()) {
+            (LitKind::Int(_, LitIntType::Unsuffixed), ty::Int(ty::IntTy::I32)) => {
+                // In case integer literal is explicitly bound to i32, then suppress lint.
+                ty_bound.map_or(true, |ty_bound| !matches!(ty_bound.kind(), ty::Int(IntTy::I32)))
+            },
+
+            (LitKind::Float(_, LitFloatType::Unsuffixed), ty::Float(ty::FloatTy::F64)) => {
+                // In case float literal is explicitly bound to f64, then suppress lint.
+                ty_bound.map_or(true, |ty_bound| !matches!(ty_bound.kind(), ty::Float(FloatTy::F64)))
+            },
+
+            _ => false,
+        };
+
+        if should_lint {
+            span_lint_and_help(
+                self.cx,
+                DEFAULT_NUMERIC_FALLBACK,
+                lit.span,
+                "default numeric fallback might occur",
+                None,
+                "consider adding suffix to avoid default numeric fallback",
+            );
+        }
+    }
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for NumericFallbackVisitor<'a, 'tcx> {
+    type Map = Map<'tcx>;
+
+    #[allow(clippy::too_many_lines)]
+    fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
+        match (&expr.kind, *self.ty_bounds.last().unwrap()) {
+            (ExprKind::Array(_), Some(last_bound)) => {
+                if let ty::Array(ty, _) = last_bound.kind() {
+                    self.ty_bounds.push(Some(ty))
+                } else {
+                    self.ty_bounds.push(None)
+                }
+            },
+
+            (ExprKind::Call(func, args), _) => {
+                if_chain! {
+                    if let ExprKind::Path(ref func_path) = func.kind;
+                    if let Some(def_id) = self.cx.qpath_res(func_path, func.hir_id).opt_def_id();
+                    then {
+                        let fn_sig = self.cx.tcx.fn_sig(def_id).skip_binder();
+                        for (expr, bound) in args.iter().zip(fn_sig.inputs().iter()) {
+                            // Push found arg type, then visit arg.
+                            self.ty_bounds.push(Some(bound));
+                            self.visit_expr(expr);
+                            self.ty_bounds.pop();
+                        }
+                        return;
+                    } else {
+                        self.ty_bounds.push(None)
+                    }
+                }
+            },
+
+            (ExprKind::MethodCall(_, _, args, _), _) => {
+                if let Some(def_id) = self.cx.typeck_results().type_dependent_def_id(expr.hir_id) {
+                    let fn_sig = self.cx.tcx.fn_sig(def_id).skip_binder();
+                    for (expr, bound) in args.iter().zip(fn_sig.inputs().iter()) {
+                        self.ty_bounds.push(Some(bound));
+                        self.visit_expr(expr);
+                        self.ty_bounds.pop();
+                    }
+                    return;
+                }
+
+                self.ty_bounds.push(None)
+            },
+
+            (ExprKind::Tup(exprs), Some(last_bound)) => {
+                if let ty::Tuple(tys) = last_bound.kind() {
+                    for (expr, bound) in exprs.iter().zip(tys.iter()) {
+                        if let GenericArgKind::Type(ty) = bound.unpack() {
+                            self.ty_bounds.push(Some(ty));
+                        } else {
+                            self.ty_bounds.push(None);
+                        }
+
+                        self.visit_expr(expr);
+                        self.ty_bounds.pop();
+                    }
+                    return;
+                }
+
+                self.ty_bounds.push(None)
+            },
+
+            (ExprKind::Lit(lit), _) => {
+                let ty = self.cx.typeck_results().expr_ty(expr);
+                self.check_lit(lit, ty);
+                return;
+            },
+
+            (ExprKind::If(cond, then, else_), last_bound) => {
+                // Cond has no type bound in any situation.
+                self.ty_bounds.push(None);
+                self.visit_expr(cond);
+                self.ty_bounds.pop();
+
+                // Propagate current bound to childs.
+                self.ty_bounds.push(last_bound);
+                self.visit_expr(then);
+                if let Some(else_) = else_ {
+                    self.visit_expr(else_);
+                }
+                self.ty_bounds.pop();
+                return;
+            },
+
+            (ExprKind::Loop(_, label, ..), last_bound) => {
+                self.break_ty_bounds.push((*label, last_bound));
+                walk_expr(self, expr);
+                self.break_ty_bounds.pop();
+                return;
+            },
+
+            (ExprKind::Match(arg, arms, _), last_bound) => {
+                // Match argument has no type bound.
+                self.ty_bounds.push(None);
+                self.visit_expr(arg);
+                for arm in arms.iter() {
+                    self.visit_pat(arm.pat);
+                    if let Some(Guard::If(guard)) = arm.guard {
+                        self.visit_expr(guard);
+                    }
+                }
+                self.ty_bounds.pop();
+
+                // Propagate current bound.
+                self.ty_bounds.push(last_bound);
+                for arm in arms.iter() {
+                    self.visit_expr(arm.body);
+                }
+                self.ty_bounds.pop();
+                return;
+            },
+
+            (ExprKind::Block(..), last_bound) => self.ty_bounds.push(last_bound),
+
+            (ExprKind::Break(destination, _), _) => {
+                let ty = destination.label.map_or_else(
+                    || self.break_ty_bounds.last().unwrap().1,
+                    |dest_label| {
+                        self.break_ty_bounds
+                            .iter()
+                            .rev()
+                            .find_map(|(loop_label, ty)| {
+                                loop_label.map_or(None, |loop_label| {
+                                    if loop_label.ident == dest_label.ident {
+                                        Some(*ty)
+                                    } else {
+                                        None
+                                    }
+                                })
+                            })
+                            .unwrap()
+                    },
+                );
+                self.ty_bounds.push(ty);
+            },
+
+            (ExprKind::Ret(_), _) => self.ty_bounds.push(self.ret_ty_bound),
+
+            (ExprKind::Struct(qpath, fields, base), _) => {
+                if_chain! {
+                    if let Some(def_id) = self.cx.qpath_res(qpath, expr.hir_id).opt_def_id();
+                    let ty = self.cx.tcx.type_of(def_id);
+                    if let Some(adt_def) = ty.ty_adt_def();
+                    if adt_def.is_struct();
+                    if let Some(variant) = adt_def.variants.iter().next();
+                    then {
+                        let fields_def = &variant.fields;
+
+                        // Push field type then visit each field expr.
+                        for field in fields.iter() {
+                            let field_ty =
+                                fields_def
+                                    .iter()
+                                    .find_map(|f_def| {
+                                        if f_def.ident == field.ident
+                                            { Some(self.cx.tcx.type_of(f_def.did)) }
+                                        else { None }
+                                    });
+                            self.ty_bounds.push(field_ty);
+                            self.visit_expr(field.expr);
+                            self.ty_bounds.pop();
+                        }
+
+                        // Visit base with no bound.
+                        if let Some(base) = base {
+                            self.ty_bounds.push(None);
+                            self.visit_expr(base);
+                            self.ty_bounds.pop();
+                        }
+                        return;
+                    }
+                }
+                self.ty_bounds.push(None);
+            },
+
+            _ => self.ty_bounds.push(None),
+        }
+
+        walk_expr(self, expr);
+        self.ty_bounds.pop();
+    }
+
+    fn visit_stmt(&mut self, stmt: &'tcx Stmt<'_>) {
+        match stmt.kind {
+            StmtKind::Local(local) => {
+                let ty = local.ty.and_then(|hir_ty| {
+                    let mut infer_ty_finder = InferTyFinder::new();
+                    infer_ty_finder.visit_ty(hir_ty);
+                    if infer_ty_finder.found {
+                        None
+                    } else {
+                        self.cx.typeck_results().node_type_opt(hir_ty.hir_id)
+                    }
+                });
+                self.ty_bounds.push(ty);
+            },
+
+            _ => self.ty_bounds.push(None),
+        }
+
+        walk_stmt(self, stmt);
+        self.ty_bounds.pop();
+    }
+
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
+        NestedVisitorMap::None
+    }
+}
+
+/// Find `hir::TyKind::Infer` is included in passed typed.
+struct InferTyFinder {
+    found: bool,
+}
+
+impl InferTyFinder {
+    fn new() -> Self {
+        Self { found: false }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for InferTyFinder {
+    type Map = Map<'tcx>;
+
+    fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_>) {
+        match ty.kind {
+            hir::TyKind::Infer => {
+                self.found = true;
+            },
+            _ => {
+                walk_ty(self, ty);
+            },
+        }
+    }
+
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
+        NestedVisitorMap::None
+    }
+}

--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -1,9 +1,14 @@
-use rustc_ast::{LitFloatType, LitIntType, LitKind};
-use rustc_data_structures::fx::FxHashSet;
-use rustc_hir::{Expr, ExprKind, HirId, Stmt, StmtKind};
+use rustc_ast::ast::{LitFloatType, LitIntType, LitKind};
+use rustc_hir::{
+    intravisit::{walk_expr, walk_stmt, NestedVisitorMap, Visitor},
+    Body, Expr, ExprKind, Lit, Stmt, StmtKind,
+};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty::{self, FloatTy, IntTy};
-use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_middle::{
+    hir::map::Map,
+    ty::{self, FloatTy, IntTy, Ty},
+};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 use if_chain::if_chain;
 
@@ -33,53 +38,141 @@ declare_clippy_lint! {
     /// Use instead:
     /// ```rust
     /// let i = 10i32;
-    /// let f: f64 = 1.23;
+    /// let f = 1.23f64;
     /// ```
     pub DEFAULT_NUMERIC_FALLBACK,
     restriction,
     "usage of unconstrained numeric literals which may cause default numeric fallback."
 }
 
-#[derive(Default)]
-pub struct DefaultNumericFallback {
-    /// Hold `init` in `Local` if `Local` has a type annotation.
-    bounded_inits: FxHashSet<HirId>,
-}
-
-impl_lint_pass!(DefaultNumericFallback => [DEFAULT_NUMERIC_FALLBACK]);
+declare_lint_pass!(DefaultNumericFallback => [DEFAULT_NUMERIC_FALLBACK]);
 
 impl LateLintPass<'_> for DefaultNumericFallback {
-    fn check_stmt(&mut self, _: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
-        if_chain! {
-            if let StmtKind::Local(local) = stmt.kind;
-            if local.ty.is_some();
-            if let Some(init) = local.init;
-            then {
-                self.bounded_inits.insert(init.hir_id);
-            }
+    fn check_body(&mut self, cx: &LateContext<'tcx>, body: &'tcx Body<'_>) {
+        let mut visitor = NumericFallbackVisitor::new(cx);
+        visitor.visit_body(body);
+    }
+}
+
+struct NumericFallbackVisitor<'a, 'tcx> {
+    /// Stack manages type bound of exprs. The top element holds current expr type.
+    ty_bounds: Vec<TyBound<'tcx>>,
+
+    cx: &'a LateContext<'tcx>,
+}
+
+impl<'a, 'tcx> NumericFallbackVisitor<'a, 'tcx> {
+    fn new(cx: &'a LateContext<'tcx>) -> Self {
+        Self {
+            ty_bounds: vec![TyBound::Nothing],
+            cx,
         }
     }
 
-    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        let expr_ty = cx.typeck_results().expr_ty(expr);
-        let hir_id = expr.hir_id;
+    /// Check whether a passed literal has potential to cause fallback or not.
+    fn check_lit(&self, lit: &Lit, lit_ty: Ty<'tcx>) {
+        let ty_bound = self.ty_bounds.last().unwrap();
         if_chain! {
-            if let ExprKind::Lit(ref lit) = expr.kind;
-            if matches!(lit.node,
-                        LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed));
-            if matches!(expr_ty.kind(), ty::Int(IntTy::I32) | ty::Float(FloatTy::F64));
-            if !self.bounded_inits.contains(&hir_id);
-            if !cx.tcx.hir().parent_iter(hir_id).any(|(ref hir_id, _)| self.bounded_inits.contains(hir_id));
-            then {
-                 span_lint_and_help(
-                    cx,
-                    DEFAULT_NUMERIC_FALLBACK,
-                    lit.span,
-                    "default numeric fallback might occur",
-                    None,
-                    "consider adding suffix to avoid default numeric fallback",
-                 )
-            }
+                if matches!(lit.node,
+                            LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed));
+                if matches!(lit_ty.kind(), ty::Int(IntTy::I32) | ty::Float(FloatTy::F64));
+                if !ty_bound.is_integral();
+                then {
+                    span_lint_and_help(
+                        self.cx,
+                        DEFAULT_NUMERIC_FALLBACK,
+                        lit.span,
+                        "default numeric fallback might occur",
+                        None,
+                        "consider adding suffix to avoid default numeric fallback",
+                    );
+                }
+        }
+    }
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for NumericFallbackVisitor<'a, 'tcx> {
+    type Map = Map<'tcx>;
+
+    #[allow(clippy::too_many_lines)]
+    fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
+        match &expr.kind {
+            ExprKind::Call(func, args) => {
+                if_chain! {
+                    if let ExprKind::Path(ref func_path) = func.kind;
+                    if let Some(def_id) = self.cx.qpath_res(func_path, func.hir_id).opt_def_id();
+                    then {
+                        let fn_sig = self.cx.tcx.fn_sig(def_id).skip_binder();
+                        for (expr, bound) in args.iter().zip(fn_sig.inputs().iter()) {
+                            // Push found arg type, then visit arg.
+                            self.ty_bounds.push(TyBound::Ty(bound));
+                            self.visit_expr(expr);
+                            self.ty_bounds.pop();
+                        }
+                        return;
+                    }
+                }
+            },
+
+            ExprKind::MethodCall(_, _, args, _) => {
+                if let Some(def_id) = self.cx.typeck_results().type_dependent_def_id(expr.hir_id) {
+                    let fn_sig = self.cx.tcx.fn_sig(def_id).skip_binder();
+                    for (expr, bound) in args.iter().zip(fn_sig.inputs().iter()) {
+                        self.ty_bounds.push(TyBound::Ty(bound));
+                        self.visit_expr(expr);
+                        self.ty_bounds.pop();
+                    }
+                    return;
+                }
+            },
+
+            ExprKind::Lit(lit) => {
+                let ty = self.cx.typeck_results().expr_ty(expr);
+                self.check_lit(lit, ty);
+                return;
+            },
+
+            _ => {},
+        }
+
+        walk_expr(self, expr);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'tcx Stmt<'_>) {
+        match stmt.kind {
+            StmtKind::Local(local) => {
+                if local.ty.is_some() {
+                    self.ty_bounds.push(TyBound::Any)
+                } else {
+                    self.ty_bounds.push(TyBound::Nothing)
+                }
+            },
+
+            _ => self.ty_bounds.push(TyBound::Nothing),
+        }
+
+        walk_stmt(self, stmt);
+        self.ty_bounds.pop();
+    }
+
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
+        NestedVisitorMap::None
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TyBound<'ctx> {
+    Any,
+    Ty(Ty<'ctx>),
+    Nothing,
+}
+
+impl<'ctx> TyBound<'ctx> {
+    fn is_integral(self) -> bool {
+        match self {
+            TyBound::Any => true,
+            TyBound::Ty(t) => t.is_integral(),
+            TyBound::Nothing => false,
         }
     }
 }

--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -1,17 +1,9 @@
-use rustc_ast::ast::{Label, LitFloatType, LitIntType, LitKind};
-use rustc_hir::{
-    self as hir,
-    intravisit::{walk_expr, walk_stmt, walk_ty, FnKind, NestedVisitorMap, Visitor},
-    Body, BodyId, Expr, ExprKind, FnDecl, FnRetTy, Guard, HirId, Lit, Stmt, StmtKind,
-};
+use rustc_ast::{LitFloatType, LitIntType, LitKind};
+use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::{Expr, ExprKind, HirId, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::{
-    hir::map::Map,
-    ty::{self, subst::GenericArgKind, FloatTy, IntTy, Ty, TyCtxt},
-};
-use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::Span;
-use rustc_typeck::hir_ty_to_ty;
+use rustc_middle::ty::{self, FloatTy, IntTy};
+use rustc_session::{declare_tool_lint, impl_lint_pass};
 
 use if_chain::if_chain;
 
@@ -41,363 +33,53 @@ declare_clippy_lint! {
     /// Use instead:
     /// ```rust
     /// let i = 10i32;
-    /// let f = 1.23f64;
+    /// let f: f64 = 1.23;
     /// ```
     pub DEFAULT_NUMERIC_FALLBACK,
     restriction,
     "usage of unconstrained numeric literals which may cause default numeric fallback."
 }
 
-declare_lint_pass!(DefaultNumericFallback => [DEFAULT_NUMERIC_FALLBACK]);
-
-/// Return the body that includes passed `hir_id` if exists.
-fn enclosing_body_opt(tcx: TyCtxt<'_>, hir_id: HirId) -> Option<BodyId> {
-    let hir_map = tcx.hir();
-    let mut trace = vec![(hir_id)];
-
-    for (parent, _) in hir_map.parent_iter(hir_id) {
-        trace.push(parent);
-        if let Some(body) = hir_map.maybe_body_owned_by(parent) {
-            if trace.iter().any(|hir_id| *hir_id == body.hir_id) {
-                return Some(body);
-            }
-        }
-    }
-
-    None
+#[derive(Default)]
+pub struct DefaultNumericFallback {
+    /// Hold `init` in `Local` if `Local` has a type annotation.
+    bounded_inits: FxHashSet<HirId>,
 }
 
-fn ty_from_hir_ty<'tcx>(cx: &LateContext<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Option<Ty<'tcx>> {
-    if enclosing_body_opt(cx.tcx, hir_ty.hir_id).is_some() {
-        cx.typeck_results().node_type_opt(hir_ty.hir_id)
-    } else {
-        Some(hir_ty_to_ty(cx.tcx, hir_ty))
-    }
-}
+impl_lint_pass!(DefaultNumericFallback => [DEFAULT_NUMERIC_FALLBACK]);
 
 impl LateLintPass<'_> for DefaultNumericFallback {
-    fn check_fn(
-        &mut self,
-        cx: &LateContext<'tcx>,
-        _: FnKind<'tcx>,
-        fn_decl: &'tcx FnDecl<'_>,
-        body: &'tcx Body<'_>,
-        _: Span,
-        _: HirId,
-    ) {
-        let ret_ty_bound = match fn_decl.output {
-            FnRetTy::DefaultReturn(_) => None,
-            FnRetTy::Return(ty) => Some(ty),
-        }
-        .and_then(|ty| {
-            if is_infer_included(ty) {
-                None
-            } else {
-                ty_from_hir_ty(cx, ty)
+    fn check_stmt(&mut self, _: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
+        if_chain! {
+            if let StmtKind::Local(local) = stmt.kind;
+            if local.ty.is_some();
+            if let Some(init) = local.init;
+            then {
+                self.bounded_inits.insert(init.hir_id);
             }
-        });
-
-        let mut visitor = NumericFallbackVisitor::new(ret_ty_bound, cx);
-        visitor.visit_body(body);
-    }
-}
-
-struct NumericFallbackVisitor<'a, 'tcx> {
-    /// Stack manages type bound of exprs. The top element holds current expr type.
-    ty_bounds: Vec<Option<Ty<'tcx>>>,
-
-    /// Ret type bound.
-    ret_ty_bound: Option<Ty<'tcx>>,
-
-    /// Break type bounds.
-    break_ty_bounds: Vec<(Option<Label>, Option<Ty<'tcx>>)>,
-
-    cx: &'a LateContext<'tcx>,
-}
-
-impl<'a, 'tcx> NumericFallbackVisitor<'a, 'tcx> {
-    fn new(ret_ty_bound: Option<Ty<'tcx>>, cx: &'a LateContext<'tcx>) -> Self {
-        Self {
-            ty_bounds: vec![ret_ty_bound],
-            ret_ty_bound,
-            break_ty_bounds: vec![],
-            cx,
         }
     }
 
-    /// Check whether a passed literal has potential to cause fallback or not.
-    fn check_lit(&self, lit: &Lit, lit_ty: Ty<'tcx>) {
-        let ty_bound = self.ty_bounds.last().unwrap();
-
-        let should_lint = match (&lit.node, lit_ty.kind()) {
-            (LitKind::Int(_, LitIntType::Unsuffixed), ty::Int(ty::IntTy::I32)) => {
-                // In case integer literal is explicitly bound to i32, then suppress lint.
-                ty_bound.map_or(true, |ty_bound| !matches!(ty_bound.kind(), ty::Int(IntTy::I32)))
-            },
-
-            (LitKind::Float(_, LitFloatType::Unsuffixed), ty::Float(ty::FloatTy::F64)) => {
-                // In case float literal is explicitly bound to f64, then suppress lint.
-                ty_bound.map_or(true, |ty_bound| !matches!(ty_bound.kind(), ty::Float(FloatTy::F64)))
-            },
-
-            _ => false,
-        };
-
-        if should_lint {
-            span_lint_and_help(
-                self.cx,
-                DEFAULT_NUMERIC_FALLBACK,
-                lit.span,
-                "default numeric fallback might occur",
-                None,
-                "consider adding suffix to avoid default numeric fallback",
-            );
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        let expr_ty = cx.typeck_results().expr_ty(expr);
+        let hir_id = expr.hir_id;
+        if_chain! {
+            if let ExprKind::Lit(ref lit) = expr.kind;
+            if matches!(lit.node,
+                        LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed));
+            if matches!(expr_ty.kind(), ty::Int(IntTy::I32) | ty::Float(FloatTy::F64));
+            if !self.bounded_inits.contains(&hir_id);
+            if !cx.tcx.hir().parent_iter(hir_id).any(|(ref hir_id, _)| self.bounded_inits.contains(hir_id));
+            then {
+                 span_lint_and_help(
+                    cx,
+                    DEFAULT_NUMERIC_FALLBACK,
+                    lit.span,
+                    "default numeric fallback might occur",
+                    None,
+                    "consider adding suffix to avoid default numeric fallback",
+                 )
+            }
         }
-    }
-}
-
-impl<'a, 'tcx> Visitor<'tcx> for NumericFallbackVisitor<'a, 'tcx> {
-    type Map = Map<'tcx>;
-
-    #[allow(clippy::too_many_lines)]
-    fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
-        match (&expr.kind, *self.ty_bounds.last().unwrap()) {
-            (ExprKind::Array(_), Some(last_bound)) => {
-                if let ty::Array(ty, _) = last_bound.kind() {
-                    self.ty_bounds.push(Some(ty))
-                } else {
-                    self.ty_bounds.push(None)
-                }
-            },
-
-            (ExprKind::Call(func, args), _) => {
-                if_chain! {
-                    if let ExprKind::Path(ref func_path) = func.kind;
-                    if let Some(def_id) = self.cx.qpath_res(func_path, func.hir_id).opt_def_id();
-                    then {
-                        let fn_sig = self.cx.tcx.fn_sig(def_id).skip_binder();
-                        for (expr, bound) in args.iter().zip(fn_sig.inputs().iter()) {
-                            // Push found arg type, then visit arg.
-                            self.ty_bounds.push(Some(bound));
-                            self.visit_expr(expr);
-                            self.ty_bounds.pop();
-                        }
-                        return;
-                    } else {
-                        self.ty_bounds.push(None)
-                    }
-                }
-            },
-
-            (ExprKind::MethodCall(_, _, args, _), _) => {
-                if let Some(def_id) = self.cx.typeck_results().type_dependent_def_id(expr.hir_id) {
-                    let fn_sig = self.cx.tcx.fn_sig(def_id).skip_binder();
-                    for (expr, bound) in args.iter().zip(fn_sig.inputs().iter()) {
-                        self.ty_bounds.push(Some(bound));
-                        self.visit_expr(expr);
-                        self.ty_bounds.pop();
-                    }
-                    return;
-                }
-
-                self.ty_bounds.push(None)
-            },
-
-            (ExprKind::Tup(exprs), Some(last_bound)) => {
-                if let ty::Tuple(tys) = last_bound.kind() {
-                    for (expr, bound) in exprs.iter().zip(tys.iter()) {
-                        if let GenericArgKind::Type(ty) = bound.unpack() {
-                            self.ty_bounds.push(Some(ty));
-                        } else {
-                            self.ty_bounds.push(None);
-                        }
-
-                        self.visit_expr(expr);
-                        self.ty_bounds.pop();
-                    }
-                    return;
-                }
-
-                self.ty_bounds.push(None)
-            },
-
-            (ExprKind::Lit(lit), _) => {
-                let ty = self.cx.typeck_results().expr_ty(expr);
-                self.check_lit(lit, ty);
-                return;
-            },
-
-            (ExprKind::If(cond, then, else_), last_bound) => {
-                // Cond has no type bound in any situation.
-                self.ty_bounds.push(None);
-                self.visit_expr(cond);
-                self.ty_bounds.pop();
-
-                // Propagate current bound to childs.
-                self.ty_bounds.push(last_bound);
-                self.visit_expr(then);
-                if let Some(else_) = else_ {
-                    self.visit_expr(else_);
-                }
-                self.ty_bounds.pop();
-                return;
-            },
-
-            (ExprKind::Loop(_, label, ..), last_bound) => {
-                self.break_ty_bounds.push((*label, last_bound));
-                walk_expr(self, expr);
-                self.break_ty_bounds.pop();
-                return;
-            },
-
-            (ExprKind::Match(arg, arms, _), last_bound) => {
-                // Match argument has no type bound.
-                self.ty_bounds.push(None);
-                self.visit_expr(arg);
-                for arm in arms.iter() {
-                    self.visit_pat(arm.pat);
-                    if let Some(Guard::If(guard)) = arm.guard {
-                        self.visit_expr(guard);
-                    }
-                }
-                self.ty_bounds.pop();
-
-                // Propagate current bound.
-                self.ty_bounds.push(last_bound);
-                for arm in arms.iter() {
-                    self.visit_expr(arm.body);
-                }
-                self.ty_bounds.pop();
-                return;
-            },
-
-            (ExprKind::Block(..), last_bound) => self.ty_bounds.push(last_bound),
-
-            (ExprKind::Break(destination, _), _) => {
-                let ty = destination.label.map_or_else(
-                    || self.break_ty_bounds.last().unwrap().1,
-                    |dest_label| {
-                        self.break_ty_bounds
-                            .iter()
-                            .rev()
-                            .find_map(|(loop_label, ty)| {
-                                loop_label.map_or(None, |loop_label| {
-                                    if loop_label.ident == dest_label.ident {
-                                        Some(*ty)
-                                    } else {
-                                        None
-                                    }
-                                })
-                            })
-                            .unwrap()
-                    },
-                );
-                self.ty_bounds.push(ty);
-            },
-
-            (ExprKind::Ret(_), _) => self.ty_bounds.push(self.ret_ty_bound),
-
-            (ExprKind::Struct(qpath, fields, base), _) => {
-                if_chain! {
-                    if let Some(def_id) = self.cx.qpath_res(qpath, expr.hir_id).opt_def_id();
-                    let ty = self.cx.tcx.type_of(def_id);
-                    if let Some(adt_def) = ty.ty_adt_def();
-                    if adt_def.is_struct();
-                    if let Some(variant) = adt_def.variants.iter().next();
-                    then {
-                        let fields_def = &variant.fields;
-
-                        // Push field type then visit each field expr.
-                        for field in fields.iter() {
-                            let field_ty =
-                                fields_def
-                                    .iter()
-                                    .find_map(|f_def| {
-                                        if f_def.ident == field.ident
-                                            { Some(self.cx.tcx.type_of(f_def.did)) }
-                                        else { None }
-                                    });
-                            self.ty_bounds.push(field_ty);
-                            self.visit_expr(field.expr);
-                            self.ty_bounds.pop();
-                        }
-
-                        // Visit base with no bound.
-                        if let Some(base) = base {
-                            self.ty_bounds.push(None);
-                            self.visit_expr(base);
-                            self.ty_bounds.pop();
-                        }
-                        return;
-                    }
-                }
-                self.ty_bounds.push(None);
-            },
-
-            _ => self.ty_bounds.push(None),
-        }
-
-        walk_expr(self, expr);
-        self.ty_bounds.pop();
-    }
-
-    fn visit_stmt(&mut self, stmt: &'tcx Stmt<'_>) {
-        match stmt.kind {
-            StmtKind::Local(local) => {
-                let ty = local.ty.and_then(|hir_ty| {
-                    if is_infer_included(hir_ty) {
-                        None
-                    } else {
-                        ty_from_hir_ty(self.cx, hir_ty)
-                    }
-                });
-                self.ty_bounds.push(ty);
-            },
-
-            _ => self.ty_bounds.push(None),
-        }
-
-        walk_stmt(self, stmt);
-        self.ty_bounds.pop();
-    }
-
-    fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
-        NestedVisitorMap::None
-    }
-}
-
-/// Return true if a given ty includes `hir::TyKind::Infer`.
-fn is_infer_included(ty: &hir::Ty<'_>) -> bool {
-    let mut infer_ty_finder = InferTyFinder::new();
-    infer_ty_finder.visit_ty(ty);
-    infer_ty_finder.found
-}
-
-struct InferTyFinder {
-    found: bool,
-}
-
-impl InferTyFinder {
-    fn new() -> Self {
-        Self { found: false }
-    }
-}
-
-impl<'tcx> Visitor<'tcx> for InferTyFinder {
-    type Map = Map<'tcx>;
-
-    fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_>) {
-        match ty.kind {
-            hir::TyKind::Infer => {
-                self.found = true;
-            },
-            _ => {
-                walk_ty(self, ty);
-            },
-        }
-    }
-
-    fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
-        NestedVisitorMap::None
     }
 }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1028,7 +1028,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box strings::StringAdd);
     store.register_late_pass(|| box implicit_return::ImplicitReturn);
     store.register_late_pass(|| box implicit_saturating_sub::ImplicitSaturatingSub);
-    store.register_late_pass(|| box default_numeric_fallback::DefaultNumericFallback::default());
+    store.register_late_pass(|| box default_numeric_fallback::DefaultNumericFallback);
 
     let msrv = conf.msrv.as_ref().and_then(|s| {
         parse_msrv(s, None, None).or_else(|| {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -181,6 +181,7 @@ mod copy_iterator;
 mod create_dir;
 mod dbg_macro;
 mod default;
+mod default_numeric_fallback;
 mod dereference;
 mod derive;
 mod disallowed_method;
@@ -584,6 +585,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         &dbg_macro::DBG_MACRO,
         &default::DEFAULT_TRAIT_ACCESS,
         &default::FIELD_REASSIGN_WITH_DEFAULT,
+        &default_numeric_fallback::DEFAULT_NUMERIC_FALLBACK,
         &dereference::EXPLICIT_DEREF_METHODS,
         &derive::DERIVE_HASH_XOR_EQ,
         &derive::DERIVE_ORD_XOR_PARTIAL_ORD,
@@ -1026,6 +1028,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box strings::StringAdd);
     store.register_late_pass(|| box implicit_return::ImplicitReturn);
     store.register_late_pass(|| box implicit_saturating_sub::ImplicitSaturatingSub);
+    store.register_late_pass(|| box default_numeric_fallback::DefaultNumericFallback);
 
     let msrv = conf.msrv.as_ref().and_then(|s| {
         parse_msrv(s, None, None).or_else(|| {
@@ -1258,6 +1261,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(&asm_syntax::INLINE_ASM_X86_INTEL_SYNTAX),
         LintId::of(&create_dir::CREATE_DIR),
         LintId::of(&dbg_macro::DBG_MACRO),
+        LintId::of(&default_numeric_fallback::DEFAULT_NUMERIC_FALLBACK),
         LintId::of(&else_if_without_else::ELSE_IF_WITHOUT_ELSE),
         LintId::of(&exhaustive_items::EXHAUSTIVE_ENUMS),
         LintId::of(&exhaustive_items::EXHAUSTIVE_STRUCTS),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1028,7 +1028,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box strings::StringAdd);
     store.register_late_pass(|| box implicit_return::ImplicitReturn);
     store.register_late_pass(|| box implicit_saturating_sub::ImplicitSaturatingSub);
-    store.register_late_pass(|| box default_numeric_fallback::DefaultNumericFallback);
+    store.register_late_pass(|| box default_numeric_fallback::DefaultNumericFallback::default());
 
     let msrv = conf.msrv.as_ref().and_then(|s| {
         parse_msrv(s, None, None).or_else(|| {

--- a/tests/ui/default_numeric_fallback.rs
+++ b/tests/ui/default_numeric_fallback.rs
@@ -39,6 +39,20 @@ mod nested_local {
             // Should NOT lint this because this literal is bound to `_` of outer `Local`.
             1
         };
+
+        let x: _ = if true {
+            // Should lint this because this literal is not bound to any types.
+            let y = 1;
+
+            // Should NOT lint this because this literal is bound to `_` of outer `Local`.
+            1
+        } else {
+            // Should lint this because this literal is not bound to any types.
+            let y = 1;
+
+            // Should NOT lint this because this literal is bound to `_` of outer `Local`.
+            2
+        };
     }
 }
 
@@ -46,7 +60,7 @@ mod function_def {
     fn ret_i32() -> i32 {
         // Even though the output type is specified,
         // this unsuffixed literal is linted to reduce heuristics and keep codebase simple.
-        23
+        1
     }
 
     fn test() {
@@ -74,6 +88,27 @@ mod function_calls {
 
         // Should lint this because the argument type is inferred to `i32` and NOT bound to a concrete type.
         let x: _ = generic_arg(1);
+    }
+}
+
+mod struct_ctor {
+    struct ConcreteStruct {
+        x: i32,
+    }
+
+    struct GenericStruct<T> {
+        x: T,
+    }
+
+    fn test() {
+        // Should NOT lint this because the field type is bound to a concrete type.
+        ConcreteStruct { x: 1 };
+
+        // Should lint this because the field type is inferred to `i32` and NOT bound to a concrete type.
+        GenericStruct { x: 1 };
+
+        // Should lint this because the field type is inferred to `i32` and NOT bound to a concrete type.
+        let _ = GenericStruct { x: 1 };
     }
 }
 

--- a/tests/ui/default_numeric_fallback.rs
+++ b/tests/ui/default_numeric_fallback.rs
@@ -1,11 +1,45 @@
 #![warn(clippy::default_numeric_fallback)]
 #![allow(unused)]
+#![allow(clippy::never_loop)]
+#![allow(clippy::no_effect)]
+#![allow(clippy::unnecessary_operation)]
+
+fn concrete_arg(x: i32) {}
+
+fn generic_arg<T>(t: T) {}
+
+struct ConcreteStruct {
+    x: i32,
+}
+
+struct StructForMethodCallTest {
+    x: i32,
+}
+
+impl StructForMethodCallTest {
+    fn concrete_arg(&self, x: i32) {}
+
+    fn generic_arg<T>(&self, t: T) {}
+}
 
 fn main() {
+    let s = StructForMethodCallTest { x: 10_i32 };
+
     // Bad.
     let x = 1;
     let x = 0.1;
+
     let x = if true { 1 } else { 2 };
+
+    let x: _ = {
+        let y = 1;
+        1
+    };
+
+    generic_arg(10);
+    s.generic_arg(10);
+    let x: _ = generic_arg(10);
+    let x: _ = s.generic_arg(10);
 
     // Good.
     let x = 1_i32;
@@ -14,5 +48,11 @@ fn main() {
     let x = 0.1_f64;
     let x: f64 = 0.1;
     let x: _ = 0.1;
+
     let x: _ = if true { 1 } else { 2 };
+
+    concrete_arg(10);
+    s.concrete_arg(10);
+    let x = concrete_arg(10);
+    let x = s.concrete_arg(10);
 }

--- a/tests/ui/default_numeric_fallback.rs
+++ b/tests/ui/default_numeric_fallback.rs
@@ -1,99 +1,18 @@
 #![warn(clippy::default_numeric_fallback)]
 #![allow(unused)]
-#![allow(clippy::never_loop)]
-#![allow(clippy::no_effect)]
-#![allow(clippy::unnecessary_operation)]
-
-fn ret_i31() -> i32 {
-    23
-}
-
-fn concrete_arg(x: i32) {}
-
-fn generic_arg<T>(t: T) {}
-
-struct ConcreteStruct {
-    x: i32,
-}
-
-struct GenericStruct<T> {
-    x: T,
-}
-
-struct StructForMethodCallTest {
-    x: i32,
-}
-
-impl StructForMethodCallTest {
-    fn concrete_arg(&self, x: i32) {}
-
-    fn generic_arg<T>(&self, t: T) {}
-}
 
 fn main() {
-    let s = StructForMethodCallTest { x: 10_i32 };
-
     // Bad.
-    let x = 22;
-    let x = 0.12;
-    let x: _ = 13;
-    let x: [_; 3] = [1, 2, 3];
-    let x: (_, i32) = (1, 2);
-
-    let x = if true { (1, 2) } else { (3, 4) };
-
-    let x = match 1 {
-        1 => 1,
-        _ => 2,
-    };
-
-    let x = loop {
-        break 1;
-    };
-
-    let x = 'outer0: loop {
-        {
-            'inner0: loop {
-                break 3;
-            }
-        };
-        break 2;
-    };
-
-    let x = GenericStruct { x: 1 };
-
-    generic_arg(10);
-    s.generic_arg(10);
-    let f = || -> _ { 1 };
+    let x = 1;
+    let x = 0.1;
+    let x = if true { 1 } else { 2 };
 
     // Good.
-    let x = 22_i32;
-    let x: f64 = 0.12;
-    let x = 0.12_f64;
-    let x: i32 = 13;
-    let x: [i32; 3] = [1, 2, 3];
-    let x: (i32, i32) = (1, 2);
-
-    let x: (i32, i32) = if true { (1, 2) } else { (3, 4) };
-
-    let x: i32 = match true {
-        true => 1,
-        _ => 2,
-    };
-
-    let x: i32 = loop {
-        break 1;
-    };
-
-    let x: i32 = 'outer1: loop {
-        'inner1: loop {
-            break 'outer1 3;
-        }
-    };
-
-    let x = ConcreteStruct { x: 1 };
-
-    concrete_arg(10);
-    s.concrete_arg(10);
-    let f = || -> i32 { 1 };
+    let x = 1_i32;
+    let x: i32 = 1;
+    let x: _ = 1;
+    let x = 0.1_f64;
+    let x: f64 = 0.1;
+    let x: _ = 0.1;
+    let x: _ = if true { 1 } else { 2 };
 }

--- a/tests/ui/default_numeric_fallback.rs
+++ b/tests/ui/default_numeric_fallback.rs
@@ -1,0 +1,99 @@
+#![warn(clippy::default_numeric_fallback)]
+#![allow(unused)]
+#![allow(clippy::never_loop)]
+#![allow(clippy::no_effect)]
+#![allow(clippy::unnecessary_operation)]
+
+fn ret_i31() -> i32 {
+    23
+}
+
+fn concrete_arg(x: i32) {}
+
+fn generic_arg<T>(t: T) {}
+
+struct ConcreteStruct {
+    x: i32,
+}
+
+struct GenericStruct<T> {
+    x: T,
+}
+
+struct StructForMethodCallTest {
+    x: i32,
+}
+
+impl StructForMethodCallTest {
+    fn concrete_arg(&self, x: i32) {}
+
+    fn generic_arg<T>(&self, t: T) {}
+}
+
+fn main() {
+    let s = StructForMethodCallTest { x: 10_i32 };
+
+    // Bad.
+    let x = 22;
+    let x = 0.12;
+    let x: _ = 13;
+    let x: [_; 3] = [1, 2, 3];
+    let x: (_, i32) = (1, 2);
+
+    let x = if true { (1, 2) } else { (3, 4) };
+
+    let x = match 1 {
+        1 => 1,
+        _ => 2,
+    };
+
+    let x = loop {
+        break 1;
+    };
+
+    let x = 'outer0: loop {
+        {
+            'inner0: loop {
+                break 3;
+            }
+        };
+        break 2;
+    };
+
+    let x = GenericStruct { x: 1 };
+
+    generic_arg(10);
+    s.generic_arg(10);
+    let f = || -> _ { 1 };
+
+    // Good.
+    let x = 22_i32;
+    let x: f64 = 0.12;
+    let x = 0.12_f64;
+    let x: i32 = 13;
+    let x: [i32; 3] = [1, 2, 3];
+    let x: (i32, i32) = (1, 2);
+
+    let x: (i32, i32) = if true { (1, 2) } else { (3, 4) };
+
+    let x: i32 = match true {
+        true => 1,
+        _ => 2,
+    };
+
+    let x: i32 = loop {
+        break 1;
+    };
+
+    let x: i32 = 'outer1: loop {
+        'inner1: loop {
+            break 'outer1 3;
+        }
+    };
+
+    let x = ConcreteStruct { x: 1 };
+
+    concrete_arg(10);
+    s.concrete_arg(10);
+    let f = || -> i32 { 1 };
+}

--- a/tests/ui/default_numeric_fallback.stderr
+++ b/tests/ui/default_numeric_fallback.stderr
@@ -1,5 +1,5 @@
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:6:13
+  --> $DIR/default_numeric_fallback.rs:29:13
    |
 LL |     let x = 1;
    |             ^
@@ -8,7 +8,7 @@ LL |     let x = 1;
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:7:13
+  --> $DIR/default_numeric_fallback.rs:30:13
    |
 LL |     let x = 0.1;
    |             ^^^
@@ -16,7 +16,7 @@ LL |     let x = 0.1;
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:8:23
+  --> $DIR/default_numeric_fallback.rs:32:23
    |
 LL |     let x = if true { 1 } else { 2 };
    |                       ^
@@ -24,12 +24,52 @@ LL |     let x = if true { 1 } else { 2 };
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:8:34
+  --> $DIR/default_numeric_fallback.rs:32:34
    |
 LL |     let x = if true { 1 } else { 2 };
    |                                  ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
-error: aborting due to 4 previous errors
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:35:17
+   |
+LL |         let y = 1;
+   |                 ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:39:17
+   |
+LL |     generic_arg(10);
+   |                 ^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:40:19
+   |
+LL |     s.generic_arg(10);
+   |                   ^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:41:28
+   |
+LL |     let x: _ = generic_arg(10);
+   |                            ^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:42:30
+   |
+LL |     let x: _ = s.generic_arg(10);
+   |                              ^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/default_numeric_fallback.stderr
+++ b/tests/ui/default_numeric_fallback.stderr
@@ -1,75 +1,139 @@
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:29:13
+  --> $DIR/default_numeric_fallback.rs:10:17
    |
-LL |     let x = 1;
-   |             ^
+LL |         let x = 22;
+   |                 ^^
    |
    = note: `-D clippy::default-numeric-fallback` implied by `-D warnings`
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:30:13
+  --> $DIR/default_numeric_fallback.rs:11:18
    |
-LL |     let x = 0.1;
-   |             ^^^
+LL |         let x = [1, 2, 3];
+   |                  ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:32:23
+  --> $DIR/default_numeric_fallback.rs:11:21
    |
-LL |     let x = if true { 1 } else { 2 };
+LL |         let x = [1, 2, 3];
+   |                     ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:11:24
+   |
+LL |         let x = [1, 2, 3];
+   |                        ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:12:28
+   |
+LL |         let x = if true { (1, 2) } else { (3, 4) };
+   |                            ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:12:31
+   |
+LL |         let x = if true { (1, 2) } else { (3, 4) };
+   |                               ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:12:44
+   |
+LL |         let x = if true { (1, 2) } else { (3, 4) };
+   |                                            ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:12:47
+   |
+LL |         let x = if true { (1, 2) } else { (3, 4) };
+   |                                               ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:13:23
+   |
+LL |         let x = match 1 {
    |                       ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:32:34
+  --> $DIR/default_numeric_fallback.rs:14:13
    |
-LL |     let x = if true { 1 } else { 2 };
-   |                                  ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:35:17
-   |
-LL |         let y = 1;
-   |                 ^
+LL |             1 => 1,
+   |             ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:39:17
+  --> $DIR/default_numeric_fallback.rs:14:18
    |
-LL |     generic_arg(10);
-   |                 ^^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:40:19
-   |
-LL |     s.generic_arg(10);
-   |                   ^^
+LL |             1 => 1,
+   |                  ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:41:28
+  --> $DIR/default_numeric_fallback.rs:15:18
    |
-LL |     let x: _ = generic_arg(10);
-   |                            ^^
+LL |             _ => 2,
+   |                  ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:42:30
+  --> $DIR/default_numeric_fallback.rs:19:17
    |
-LL |     let x: _ = s.generic_arg(10);
-   |                              ^^
+LL |         let x = 0.12;
+   |                 ^^^^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
-error: aborting due to 9 previous errors
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:37:21
+   |
+LL |             let y = 1;
+   |                     ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:73:21
+   |
+LL |         generic_arg(1);
+   |                     ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:76:32
+   |
+LL |         let x: _ = generic_arg(1);
+   |                                ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:96:23
+   |
+LL |         s.generic_arg(1);
+   |                       ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: aborting due to 17 previous errors
 

--- a/tests/ui/default_numeric_fallback.stderr
+++ b/tests/ui/default_numeric_fallback.stderr
@@ -112,7 +112,47 @@ LL |             let y = 1;
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:73:21
+  --> $DIR/default_numeric_fallback.rs:45:21
+   |
+LL |             let y = 1;
+   |                     ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:51:21
+   |
+LL |             let y = 1;
+   |                     ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:63:9
+   |
+LL |         1
+   |         ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:69:27
+   |
+LL |         let f = || -> _ { 1 };
+   |                           ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:73:29
+   |
+LL |         let f = || -> i32 { 1 };
+   |                             ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:87:21
    |
 LL |         generic_arg(1);
    |                     ^
@@ -120,7 +160,7 @@ LL |         generic_arg(1);
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:76:32
+  --> $DIR/default_numeric_fallback.rs:90:32
    |
 LL |         let x: _ = generic_arg(1);
    |                                ^
@@ -128,12 +168,28 @@ LL |         let x: _ = generic_arg(1);
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:96:23
+  --> $DIR/default_numeric_fallback.rs:108:28
+   |
+LL |         GenericStruct { x: 1 };
+   |                            ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:111:36
+   |
+LL |         let _ = GenericStruct { x: 1 };
+   |                                    ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:131:23
    |
 LL |         s.generic_arg(1);
    |                       ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
-error: aborting due to 17 previous errors
+error: aborting due to 24 previous errors
 

--- a/tests/ui/default_numeric_fallback.stderr
+++ b/tests/ui/default_numeric_fallback.stderr
@@ -2,194 +2,147 @@ error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:10:17
    |
 LL |         let x = 22;
-   |                 ^^
+   |                 ^^ help: consider adding suffix: `22_i32`
    |
    = note: `-D clippy::default-numeric-fallback` implied by `-D warnings`
-   = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:11:18
    |
 LL |         let x = [1, 2, 3];
-   |                  ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                  ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:11:21
    |
 LL |         let x = [1, 2, 3];
-   |                     ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                     ^ help: consider adding suffix: `2_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:11:24
    |
 LL |         let x = [1, 2, 3];
-   |                        ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                        ^ help: consider adding suffix: `3_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:12:28
    |
 LL |         let x = if true { (1, 2) } else { (3, 4) };
-   |                            ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                            ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:12:31
    |
 LL |         let x = if true { (1, 2) } else { (3, 4) };
-   |                               ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                               ^ help: consider adding suffix: `2_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:12:44
    |
 LL |         let x = if true { (1, 2) } else { (3, 4) };
-   |                                            ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                                            ^ help: consider adding suffix: `3_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:12:47
    |
 LL |         let x = if true { (1, 2) } else { (3, 4) };
-   |                                               ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                                               ^ help: consider adding suffix: `4_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:13:23
    |
 LL |         let x = match 1 {
-   |                       ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                       ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:14:13
    |
 LL |             1 => 1,
-   |             ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |             ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:14:18
    |
 LL |             1 => 1,
-   |                  ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                  ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:15:18
    |
 LL |             _ => 2,
-   |                  ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                  ^ help: consider adding suffix: `2_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:19:17
    |
 LL |         let x = 0.12;
-   |                 ^^^^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                 ^^^^ help: consider adding suffix: `0.12_f64`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:37:21
    |
 LL |             let y = 1;
-   |                     ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                     ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:45:21
    |
 LL |             let y = 1;
-   |                     ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                     ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:51:21
    |
 LL |             let y = 1;
-   |                     ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                     ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:63:9
    |
 LL |         1
-   |         ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |         ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:69:27
    |
 LL |         let f = || -> _ { 1 };
-   |                           ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                           ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:73:29
    |
 LL |         let f = || -> i32 { 1 };
-   |                             ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                             ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:87:21
    |
 LL |         generic_arg(1);
-   |                     ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                     ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:90:32
    |
 LL |         let x: _ = generic_arg(1);
-   |                                ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                                ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:108:28
    |
 LL |         GenericStruct { x: 1 };
-   |                            ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                            ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:111:36
    |
 LL |         let _ = GenericStruct { x: 1 };
-   |                                    ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                                    ^ help: consider adding suffix: `1_i32`
 
 error: default numeric fallback might occur
   --> $DIR/default_numeric_fallback.rs:131:23
    |
 LL |         s.generic_arg(1);
-   |                       ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
+   |                       ^ help: consider adding suffix: `1_i32`
 
 error: aborting due to 24 previous errors
 

--- a/tests/ui/default_numeric_fallback.stderr
+++ b/tests/ui/default_numeric_fallback.stderr
@@ -1,0 +1,187 @@
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:37:13
+   |
+LL |     let x = 22;
+   |             ^^
+   |
+   = note: `-D clippy::default-numeric-fallback` implied by `-D warnings`
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:38:13
+   |
+LL |     let x = 0.12;
+   |             ^^^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:39:16
+   |
+LL |     let x: _ = 13;
+   |                ^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:40:22
+   |
+LL |     let x: [_; 3] = [1, 2, 3];
+   |                      ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:40:25
+   |
+LL |     let x: [_; 3] = [1, 2, 3];
+   |                         ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:40:28
+   |
+LL |     let x: [_; 3] = [1, 2, 3];
+   |                            ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:41:24
+   |
+LL |     let x: (_, i32) = (1, 2);
+   |                        ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:41:27
+   |
+LL |     let x: (_, i32) = (1, 2);
+   |                           ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:43:24
+   |
+LL |     let x = if true { (1, 2) } else { (3, 4) };
+   |                        ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:43:27
+   |
+LL |     let x = if true { (1, 2) } else { (3, 4) };
+   |                           ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:43:40
+   |
+LL |     let x = if true { (1, 2) } else { (3, 4) };
+   |                                        ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:43:43
+   |
+LL |     let x = if true { (1, 2) } else { (3, 4) };
+   |                                           ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:45:19
+   |
+LL |     let x = match 1 {
+   |                   ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:46:9
+   |
+LL |         1 => 1,
+   |         ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:46:14
+   |
+LL |         1 => 1,
+   |              ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:47:14
+   |
+LL |         _ => 2,
+   |              ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:51:15
+   |
+LL |         break 1;
+   |               ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:57:23
+   |
+LL |                 break 3;
+   |                       ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:60:15
+   |
+LL |         break 2;
+   |               ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:63:32
+   |
+LL |     let x = GenericStruct { x: 1 };
+   |                                ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:65:17
+   |
+LL |     generic_arg(10);
+   |                 ^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:66:19
+   |
+LL |     s.generic_arg(10);
+   |                   ^^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: default numeric fallback might occur
+  --> $DIR/default_numeric_fallback.rs:67:23
+   |
+LL |     let f = || -> _ { 1 };
+   |                       ^
+   |
+   = help: consider adding suffix to avoid default numeric fallback
+
+error: aborting due to 23 previous errors
+

--- a/tests/ui/default_numeric_fallback.stderr
+++ b/tests/ui/default_numeric_fallback.stderr
@@ -1,187 +1,35 @@
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:37:13
+  --> $DIR/default_numeric_fallback.rs:6:13
    |
-LL |     let x = 22;
-   |             ^^
+LL |     let x = 1;
+   |             ^
    |
    = note: `-D clippy::default-numeric-fallback` implied by `-D warnings`
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:38:13
+  --> $DIR/default_numeric_fallback.rs:7:13
    |
-LL |     let x = 0.12;
-   |             ^^^^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:39:16
-   |
-LL |     let x: _ = 13;
-   |                ^^
+LL |     let x = 0.1;
+   |             ^^^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:40:22
+  --> $DIR/default_numeric_fallback.rs:8:23
    |
-LL |     let x: [_; 3] = [1, 2, 3];
-   |                      ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:40:25
-   |
-LL |     let x: [_; 3] = [1, 2, 3];
-   |                         ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:40:28
-   |
-LL |     let x: [_; 3] = [1, 2, 3];
-   |                            ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:41:24
-   |
-LL |     let x: (_, i32) = (1, 2);
-   |                        ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:41:27
-   |
-LL |     let x: (_, i32) = (1, 2);
-   |                           ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:43:24
-   |
-LL |     let x = if true { (1, 2) } else { (3, 4) };
-   |                        ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:43:27
-   |
-LL |     let x = if true { (1, 2) } else { (3, 4) };
-   |                           ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:43:40
-   |
-LL |     let x = if true { (1, 2) } else { (3, 4) };
-   |                                        ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:43:43
-   |
-LL |     let x = if true { (1, 2) } else { (3, 4) };
-   |                                           ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:45:19
-   |
-LL |     let x = match 1 {
-   |                   ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:46:9
-   |
-LL |         1 => 1,
-   |         ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:46:14
-   |
-LL |         1 => 1,
-   |              ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:47:14
-   |
-LL |         _ => 2,
-   |              ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:51:15
-   |
-LL |         break 1;
-   |               ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:57:23
-   |
-LL |                 break 3;
+LL |     let x = if true { 1 } else { 2 };
    |                       ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
 error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:60:15
+  --> $DIR/default_numeric_fallback.rs:8:34
    |
-LL |         break 2;
-   |               ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:63:32
-   |
-LL |     let x = GenericStruct { x: 1 };
-   |                                ^
+LL |     let x = if true { 1 } else { 2 };
+   |                                  ^
    |
    = help: consider adding suffix to avoid default numeric fallback
 
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:65:17
-   |
-LL |     generic_arg(10);
-   |                 ^^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:66:19
-   |
-LL |     s.generic_arg(10);
-   |                   ^^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: default numeric fallback might occur
-  --> $DIR/default_numeric_fallback.rs:67:23
-   |
-LL |     let f = || -> _ { 1 };
-   |                       ^
-   |
-   = help: consider adding suffix to avoid default numeric fallback
-
-error: aborting due to 23 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
fixes #6064 
r? @flip1995 

As we discussed in [here](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Issue.20.236064/near/224647188) and [here](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Issue.20clippy.236064/near/224746333),   I start implementing this lint from the strictest version.
In this PR, I'll allow the below two cases to pass the lint to reduce FPs.
 
1. Appearances of unsuffixed numeric literals in `Local` if `Local` has a type annotation, for example:
```rust
// Good.
let x: i32 = 1;

// Also good.
let x: (i32, i32) = if cond {
   (1, 2)
} else {
   (2, 3)
};
```

2. Appearances of unsuffixed numeric literals in args of `Call` or `MethodCall`  if corresponding arguments of their signature have concrete types, for example:
```rust
fn foo_mono(x: i32) -> i32 {
    x
}

fn foo_poly<T>(t: T) -> t {
    t
}

// Good.
let x = foo_mono(13);

// Still bad.
let x: i32 = foo_poly(13);
```



changelog: Added restriction lint: `default_numeric_fallback`