### PR TITLE
Remove Option from `path_to_res` return type

### DIFF
--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -760,7 +760,7 @@ impl<'tcx> LateLintPass<'tcx> for MatchTypeOnDiagItem {
             // Extract the path to the matched type
             if let Some(segments) = path_to_matched_type(cx, ty_path);
             let segments: Vec<&str> = segments.iter().map(|sym| &**sym).collect();
-            if let Some(ty_did) = path_to_res(cx, &segments[..]).and_then(|res| res.opt_def_id());
+            if let Some(ty_did) = path_to_res(cx, &segments[..]).opt_def_id();
             // Check if the matched type is a diagnostic item
             let diag_items = cx.tcx.diagnostic_items(ty_did.krate);
             if let Some(item_name) = diag_items.iter().find_map(|(k, v)| if *v == ty_did { Some(k) } else { None });
@@ -833,7 +833,7 @@ fn path_to_matched_type(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> Option<Ve
 // This is not a complete resolver for paths. It works on all the paths currently used in the paths
 // module.  That's all it does and all it needs to do.
 pub fn check_path(cx: &LateContext<'_>, path: &[&str]) -> bool {
-    if path_to_res(cx, path).is_some() {
+    if path_to_res(cx, path) != Res::Err {
         return true;
     }
 
@@ -906,7 +906,7 @@ impl<'tcx> LateLintPass<'tcx> for InterningDefinedSymbol {
         }
 
         for &module in &[&paths::KW_MODULE, &paths::SYM_MODULE] {
-            if let Some(Res::Def(_, def_id)) = path_to_res(cx, module) {
+            if let Some(def_id) = path_to_res(cx, module).opt_def_id() {
                 for item in cx.tcx.item_children(def_id).iter() {
                     if_chain! {
                         if let Res::Def(DefKind::Const, item_def_id) = item.res;

--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -309,7 +309,15 @@ pub fn match_path_ast(path: &ast::Path, segments: &[&str]) -> bool {
 
 /// Gets the definition associated to a path.
 #[allow(clippy::shadow_unrelated)] // false positive #6563
-pub fn path_to_res(cx: &LateContext<'_>, path: &[&str]) -> Option<Res> {
+pub fn path_to_res(cx: &LateContext<'_>, path: &[&str]) -> Res {
+    macro_rules! try_res {
+        ($e:expr) => {
+            match $e {
+                Some(e) => e,
+                None => return Res::Err,
+            }
+        };
+    }
     fn item_child_by_name<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, name: &str) -> Option<&'tcx Export<HirId>> {
         tcx.item_children(def_id)
             .iter()
@@ -318,12 +326,12 @@ pub fn path_to_res(cx: &LateContext<'_>, path: &[&str]) -> Option<Res> {
 
     let (krate, first, path) = match *path {
         [krate, first, ref path @ ..] => (krate, first, path),
-        _ => return None,
+        _ => return Res::Err,
     };
     let tcx = cx.tcx;
     let crates = tcx.crates();
-    let krate = crates.iter().find(|&&num| tcx.crate_name(num).as_str() == krate)?;
-    let first = item_child_by_name(tcx, krate.as_def_id(), first)?;
+    let krate = try_res!(crates.iter().find(|&&num| tcx.crate_name(num).as_str() == krate));
+    let first = try_res!(item_child_by_name(tcx, krate.as_def_id(), first));
     let last = path
         .iter()
         .copied()
@@ -343,21 +351,15 @@ pub fn path_to_res(cx: &LateContext<'_>, path: &[&str]) -> Option<Res> {
             } else {
                 None
             }
-        })?;
-    Some(last.res)
+        });
+    try_res!(last).res
 }
 
 /// Convenience function to get the `DefId` of a trait by path.
 /// It could be a trait or trait alias.
 pub fn get_trait_def_id(cx: &LateContext<'_>, path: &[&str]) -> Option<DefId> {
-    let res = match path_to_res(cx, path) {
-        Some(res) => res,
-        None => return None,
-    };
-
-    match res {
+    match path_to_res(cx, path) {
         Res::Def(DefKind::Trait | DefKind::TraitAlias, trait_id) => Some(trait_id),
-        Res::Err => unreachable!("this trait resolution is impossible: {:?}", &path),
         _ => None,
     }
 }


### PR DESCRIPTION
changelog: none

Tiny cleanup for `path_to_res` to return `Res` instead of `Option<Res>`.
