### PR TITLE
disallowed_methods: Support functions in addition to methods

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -169,7 +169,7 @@ define_Conf! {
     (max_fn_params_bools, "max_fn_params_bools": u64, 3),
     /// Lint: WILDCARD_IMPORTS. Whether to allow certain wildcard imports (prelude, super in tests).
     (warn_on_all_wildcard_imports, "warn_on_all_wildcard_imports": bool, false),
-    /// Lint: DISALLOWED_METHOD. The list of blacklisted methods to lint about. NB: `bar` is not here since it has legitimate uses
+    /// Lint: DISALLOWED_METHOD. The list of disallowed methods, written as fully qualified paths.
     (disallowed_methods, "disallowed_methods": Vec<String>, Vec::<String>::new()),
     /// Lint: UNREADABLE_LITERAL. Should the fraction of a decimal be linted to include separators.
     (unreadable_literal_lint_fractions, "unreadable_literal_lint_fractions": bool, true),

--- a/tests/ui-toml/toml_disallowed_method/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_method/clippy.toml
@@ -1,1 +1,1 @@
-disallowed-methods = ["core::iter::traits::iterator::Iterator::sum", "regex::re_unicode::Regex::is_match"]
+disallowed-methods = ["core::iter::traits::iterator::Iterator::sum", "regex::re_unicode::Regex::is_match", "regex::re_unicode::Regex::new"]

--- a/tests/ui-toml/toml_disallowed_method/conf_disallowed_method.rs
+++ b/tests/ui-toml/toml_disallowed_method/conf_disallowed_method.rs
@@ -4,10 +4,9 @@ extern crate regex;
 use regex::Regex;
 
 fn main() {
-    let a = vec![1, 2, 3, 4];
     let re = Regex::new(r"ab.*c").unwrap();
-
     re.is_match("abc");
 
+    let a = vec![1, 2, 3, 4];
     a.iter().sum::<i32>();
 }

--- a/tests/ui-toml/toml_disallowed_method/conf_disallowed_method.stderr
+++ b/tests/ui-toml/toml_disallowed_method/conf_disallowed_method.stderr
@@ -1,16 +1,22 @@
-error: use of a disallowed method `regex::re_unicode::Regex::is_match`
-  --> $DIR/conf_disallowed_method.rs:10:5
+error: use of a disallowed method `regex::re_unicode::Regex::new`
+  --> $DIR/conf_disallowed_method.rs:7:14
    |
-LL |     re.is_match("abc");
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     let re = Regex::new(r"ab.*c").unwrap();
+   |              ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::disallowed-method` implied by `-D warnings`
 
+error: use of a disallowed method `regex::re_unicode::Regex::is_match`
+  --> $DIR/conf_disallowed_method.rs:8:5
+   |
+LL |     re.is_match("abc");
+   |     ^^^^^^^^^^^^^^^^^^
+
 error: use of a disallowed method `core::iter::traits::iterator::Iterator::sum`
-  --> $DIR/conf_disallowed_method.rs:12:5
+  --> $DIR/conf_disallowed_method.rs:11:5
    |
 LL |     a.iter().sum::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
## Context:

Hey all! I have a particular use case where I'd like to ban certain functions in a code base I work on. For example, I want to ban `Instant::now()` (among others) as we have a time service for mocking time in deterministic simulation tests. Obviously, it doesn't make sense to include a lint like this for all clippy users. Imagine my excitement when I spotted the new `disallowed_methods` lint in clippy--perfect! Unfortunately, after playing around with it for a bit, I was frustrated to realize that it didn't support functions like `Instant::now()`, so I've added support for them in this PR.

It might also make sense to rename the lint from `disallowed_methods` -> `disallowed_functions`, though I've held off from including that rename in this change, since I'm unsure of clippy's breaking change policy.

## Change

Support functions in addition to methods. In other words, support:

`disallowed_methods = ["alloc::vec::Vec::new"]` (a function) in addition to
`disallowed_methods = ["alloc::vec::Vec::leak"]` (a method).

Improve the documentation to clarify that users must specify the full qualified path for each disallowed function, which can be confusing for reexports. Include an example `clippy.toml`.

Simplify the actual lint pass so we can reuse `utils::fn_def_id`.

changelog: disallowed_method: Now supports functions in addition to methods
