### PR TITLE
Fix typo

### DIFF
--- a/tests/ui/zero_div_zero.rs
+++ b/tests/ui/zero_div_zero.rs
@@ -7,7 +7,7 @@ fn main() {
     let one_more_f64_nan = 0.0f64 / 0.0f64;
     let zero = 0.0;
     let other_zero = 0.0;
-    let other_nan = zero / other_zero; // fine - this lint doesn't propegate constants.
+    let other_nan = zero / other_zero; // fine - this lint doesn't propagate constants.
     let not_nan = 2.0 / 0.0; // not an error: 2/0 = inf
     let also_not_nan = 0.0 / 2.0; // not an error: 0/2 = 0
 }


### PR DESCRIPTION
This patch fixes a typo.

changelog: none
