### PR TITLE
Use absolute path to Rust repo in ra_setup

### DIFF
--- a/clippy_dev/src/ra_setup.rs
+++ b/clippy_dev/src/ra_setup.rs
@@ -13,7 +13,9 @@ use std::path::{Path, PathBuf};
 /// Panics if `rustc_path` does not lead to a rustc repo or the files could not be read
 pub fn run(rustc_path: Option<&str>) {
     // we can unwrap here because the arg is required by clap
-    let rustc_path = PathBuf::from(rustc_path.unwrap());
+    let rustc_path = PathBuf::from(rustc_path.unwrap())
+        .canonicalize()
+        .expect("failed to get the absolute repo path");
     assert!(rustc_path.is_dir(), "path is not a directory");
     let rustc_source_basedir = rustc_path.join("compiler");
     assert!(


### PR DESCRIPTION
This will convert the path to the Rust repo to an absolute path. This is
important for the clippy_lints/Cargo.toml file. Otherwise if a relative
path is passed, rst-analyzer won't find the Rust repo, because it starts
the relative path search from the clippy_lints dir, not the
rust-clippy dir where the ra_setup command was run from.


changelog: none
