### PR TITLE
tests: ignore check_that_clippy_has_the_same_major_version_as_rustc()inside the rustc repo

### DIFF
--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -23,6 +23,12 @@ fn check_that_clippy_lints_has_the_same_version_as_clippy() {
 
 #[test]
 fn check_that_clippy_has_the_same_major_version_as_rustc() {
+    // do not run this test inside the upstream rustc repo:
+    // https://github.com/rust-lang/rust-clippy/issues/6683
+    if option_env!("RUSTC_TEST_SUITE").is_some() {
+        return;
+    }
+
     let clippy_version = rustc_tools_util::get_version_info!();
     let clippy_major = clippy_version.major;
     let clippy_minor = clippy_version.minor;


### PR DESCRIPTION

Do not check if clippy version matches rustc version when runnning tests inside the rustc repo.
This makes sure that upstream rustc maintainers do not have to deal with our test failing/mismatching versions
when the rustc version bump is happening.
cc #6683

We already do the "don't run inside the rustc-repo" workaround for the dogfood test:
https://github.com/rust-lang/rust-clippy/blob/a507c27660d05f37307369d30bee9e82ce3a11e1/tests/dogfood.rs#L16

changelog: None
