### PR TITLE
lintcheck: add a cmdline option --crates-toml <TOML PATH> to override crate sources file to use.

### DIFF
--- a/clippy_dev/src/lintcheck.rs
+++ b/clippy_dev/src/lintcheck.rs
@@ -192,8 +192,8 @@ fn build_clippy() {
 }
 
 // get a list of CrateSources we want to check from a "lintcheck_crates.toml" file.
-fn read_crates() -> Vec<CrateSource> {
-    let toml_path = PathBuf::from("clippy_dev/lintcheck_crates.toml");
+fn read_crates(toml_path: Option<&str>) -> Vec<CrateSource> {
+    let toml_path = PathBuf::from(toml_path.unwrap_or("clippy_dev/lintcheck_crates.toml"));
     let toml_content: String =
         std::fs::read_to_string(&toml_path).unwrap_or_else(|_| panic!("Failed to read {}", toml_path.display()));
     let crate_list: CrateList =
@@ -288,7 +288,7 @@ pub fn run(clap_config: &ArgMatches) {
     // download and extract the crates, then run clippy on them and collect clippys warnings
     // flatten into one big list of warnings
 
-    let crates = read_crates();
+    let crates = read_crates(clap_config.value_of("crates-toml"));
 
     let clippy_warnings: Vec<ClippyWarning> = if let Some(only_one_crate) = clap_config.value_of("only") {
         // if we don't have the specified crate in the .toml, throw an error

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -62,6 +62,13 @@ fn get_clap_config<'a>() -> ArgMatches<'a> {
                 .value_name("CRATE")
                 .long("only")
                 .help("only process a single crate of the list"),
+        )
+        .arg(
+            Arg::with_name("crates-toml")
+                .takes_value(true)
+                .value_name("CRATES-SOURCES-TOML-PATH")
+                .long("crates-toml")
+                .help("set the path for a crates.toml where lintcheck should read the sources from"),
         );
 
     let app = App::new("Clippy developer tooling")


### PR DESCRIPTION
Fixes #6691

changelog: lintcheck: add --crates-toml  cmdline option to override default crates.toml file.
