### PR TITLE
Fix missing_panics_doc warning on `unreachable!`.

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    implements_trait, is_entrypoint_fn, is_type_diagnostic_item, match_panic_def_id, method_chain_args, return_ty,
-    span_lint, span_lint_and_note,
+    implements_trait, is_entrypoint_fn, is_expn_of, is_type_diagnostic_item, match_panic_def_id, method_chain_args,
+    return_ty, span_lint, span_lint_and_note,
 };
 use if_chain::if_chain;
 use itertools::Itertools;
@@ -699,6 +699,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FindPanicUnwrap<'a, 'tcx> {
             if let ExprKind::Path(QPath::Resolved(_, ref path)) = func_expr.kind;
             if let Some(path_def_id) = path.res.opt_def_id();
             if match_panic_def_id(self.cx, path_def_id);
+            if is_expn_of(expr.span, "unreachable").is_none();
             then {
                 self.panic_span = Some(expr.span);
             }

--- a/tests/ui/doc_panics.rs
+++ b/tests/ui/doc_panics.rs
@@ -28,6 +28,15 @@ pub fn inner_body(opt: Option<u32>) {
     });
 }
 
+/// This needs to be documented
+pub fn unreachable_and_panic() {
+    if true {
+        unreachable!()
+    } else {
+        panic!()
+    }
+}
+
 /// This is documented
 ///
 /// # Panics
@@ -67,6 +76,19 @@ pub fn inner_body_documented(opt: Option<u32>) {
 /// We still need to do this part
 pub fn todo_documented() {
     todo!()
+}
+
+/// This is documented
+///
+/// # Panics
+///
+/// We still need to do this part
+pub fn unreachable_amd_panic_documented() {
+    if true {
+        unreachable!()
+    } else {
+        panic!()
+    }
 }
 
 /// This is okay because it is private

--- a/tests/ui/doc_panics.rs
+++ b/tests/ui/doc_panics.rs
@@ -93,3 +93,8 @@ fn inner_body_private(opt: Option<u32>) {
         }
     });
 }
+
+/// This is okay because unreachable
+pub fn unreachable() {
+    unreachable!("This function panics")
+}

--- a/tests/ui/doc_panics.stderr
+++ b/tests/ui/doc_panics.stderr
@@ -63,5 +63,24 @@ LL |             panic!()
    |             ^^^^^^^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 4 previous errors
+error: docs for function which may panic missing `# Panics` section
+  --> $DIR/doc_panics.rs:32:1
+   |
+LL | / pub fn unreachable_and_panic() {
+LL | |     if true {
+LL | |         unreachable!()
+LL | |     } else {
+LL | |         panic!()
+LL | |     }
+LL | | }
+   | |_^
+   |
+note: first possible panic found here
+  --> $DIR/doc_panics.rs:36:9
+   |
+LL |         panic!()
+   |         ^^^^^^^^
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes #6699.

Are there any other test-cases I should cover?

changelog: [`missing_panics_doc`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc): No longer lints on [`unreachable!`](https://doc.rust-lang.org/std/macro.unreachable.html)
