### PR TITLE
Remove rustfmt from rust-toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2021-02-03"
-components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]
+components = ["llvm-tools-preview", "rustc-dev", "rust-src"]


### PR DESCRIPTION
We use latest nightly rustfmt in our tests anyway

r? @matthiaskrgr 

changelog: none
