### PR TITLE
Add workspace to manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ build = "build.rs"
 edition = "2018"
 publish = false
 
+[workspace]
+exclude = ["clippy_dev", "mini-macro"]
+
 [[bin]]
 name = "cargo-clippy"
 test = false


### PR DESCRIPTION
changelog: none

This fixes the dogfood test to include clippy_lints (regression from #6687).

r? @flip1995 