### PR TITLE
lintcheck: accept env var to set crates.toml file

### DIFF
--- a/clippy_dev/README.md
+++ b/clippy_dev/README.md
@@ -26,7 +26,8 @@ where `custom.toml` must be a relative path from the repo root.
 
 The results will then be saved to `lintcheck-logs/custom_logs.toml`.
 
-### configuring the crate sources
+### Configuring the Crate Sources
+
 The sources to check are saved in a `toml` file.  
 There are three types of sources.  
 A crates-io source:

--- a/clippy_dev/README.md
+++ b/clippy_dev/README.md
@@ -26,3 +26,26 @@ where `custom.toml` must be a relative path from the repo root.
 
 The results will then be saved to `lintcheck-logs/custom_logs.toml`.
 
+### configuring the crate sources
+The sources to check are saved in a `toml` file.  
+There are three types of sources.  
+A crates-io source:
+````toml
+bitflags = {name = "bitflags", versions = ['1.2.1']}
+````
+Requires a "name" and one or multiple "versions" to be checked.
+
+A git source:
+````toml
+puffin = {name = "puffin", git_url = "https://github.com/EmbarkStudios/puffin", git_hash = "02dd4a3"}
+````
+Requires a name, the url to the repo and unique identifier of a commit,
+branch or tag which is checked out before linting.  
+There is no way to always check `HEAD` because that would lead to changing lint-results as the repo would get updated.  
+If `git_url` or `git_hash` is missing, an error will be thrown.
+
+A local dependency:
+````toml
+ clippy = {name = "clippy", path = "/home/user/clippy"}
+````
+For when you want to add a repository that is not published yet.  

--- a/clippy_dev/README.md
+++ b/clippy_dev/README.md
@@ -21,7 +21,7 @@ cargo dev-lintcheck
 
 By default the logs will be saved into `lintcheck-logs/lintcheck_crates_logs.txt`.
 
-You can set a custom sources.toml by adding `--crates-toml custom.toml`
+You can set a custom sources.toml by adding `--crates-toml custom.toml` or using `LINTCHECK_TOML="custom.toml"`
 where `custom.toml` must be a relative path from the repo root.
 
 The results will then be saved to `lintcheck-logs/custom_logs.toml`.

--- a/clippy_dev/src/lintcheck.rs
+++ b/clippy_dev/src/lintcheck.rs
@@ -11,7 +11,7 @@ use crate::clippy_project_root;
 
 use std::collections::HashMap;
 use std::process::Command;
-use std::{fmt, fs::write, path::PathBuf};
+use std::{env, fmt, fs::write, path::PathBuf};
 
 use clap::ArgMatches;
 use serde::{Deserialize, Serialize};
@@ -227,7 +227,9 @@ fn build_clippy() {
 
 // get a list of CrateSources we want to check from a "lintcheck_crates.toml" file.
 fn read_crates(toml_path: Option<&str>) -> (String, Vec<CrateSource>) {
-    let toml_path = PathBuf::from(toml_path.unwrap_or("clippy_dev/lintcheck_crates.toml"));
+    let toml_path = PathBuf::from(
+        env::var("LINTCHECK_TOML").unwrap_or(toml_path.unwrap_or("clippy_dev/lintcheck_crates.toml").to_string()),
+    );
     // save it so that we can use the name of the sources.toml as name for the logfile later.
     let toml_filename = toml_path.file_stem().unwrap().to_str().unwrap().to_string();
     let toml_content: String =


### PR DESCRIPTION

*Please write a short comment explaining your change (or "none" for internal only changes)*
changelog: lintcheck: accept  LINTCHECK_TOML env var to set list of crates to be checked.