### PR TITLE
Add a minimal reproducer for the ICE in #6179

### DIFF
--- a/tests/ui/crashes/ice-6179.rs
+++ b/tests/ui/crashes/ice-6179.rs
@@ -1,0 +1,21 @@
+//! This is a minimal reproducer for the ICE in https://github.com/rust-lang/rust-clippy/pull/6179.
+//! The ICE is mainly caused by using `hir_ty_to_ty`. See the discussion in the PR for details.
+
+#![warn(clippy::use_self)]
+#![allow(dead_code)]
+
+struct Foo {}
+
+impl Foo {
+    fn foo() -> Self {
+        impl Foo {
+            fn bar() {}
+        }
+
+        let _: _ = 1;
+
+        Self {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This PR is an auxiliary PR for #6179, just add a minimal reproducer for the ICE discussed in #6179.
See #6179 for more details.

changelog: none