### PR TITLE
Update labels in template files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Create a bug report for Clippy
-labels: L-bug
+labels: C-bug
 ---
 <!--
 Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,

--- a/.github/ISSUE_TEMPLATE/false_negative.md
+++ b/.github/ISSUE_TEMPLATE/false_negative.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report (False Negative)
 about: Create a bug report about missing warnings from a lint
-labels: L-bug, L-false-negative
+labels: C-bug, I-false-negative
 ---
 <!--
 Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,

--- a/.github/ISSUE_TEMPLATE/false_positive.md
+++ b/.github/ISSUE_TEMPLATE/false_positive.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report (False Positive)
 about: Create a bug report about a wrongly emitted lint warning
-labels: L-bug, L-false-positive
+labels: C-bug, I-false-positive
 ---
 <!--
 Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,

--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -1,7 +1,7 @@
 ---
 name: Internal Compiler Error
 about: Create a report for an internal compiler error in Clippy.
-labels: L-bug, L-crash
+labels: C-bug, I-ICE
 ---
 <!--
 Thank you for finding an Internal Compiler Error! 🧊  If possible, try to provide

--- a/.github/ISSUE_TEMPLATE/new_lint.md
+++ b/.github/ISSUE_TEMPLATE/new_lint.md
@@ -1,7 +1,7 @@
 ---
 name: New lint suggestion
 about: Suggest a new Clippy lint.
-labels: L-lint
+labels: A-lint
 ---
 
 ### What it does


### PR DESCRIPTION
It seems like we forgot to update the GitHub templates when we decided to update the label names. This PR just adjusts the templates to use the new label names :)

Context: [Zulip discussion about renaming the labels](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Label.20cleanup/near/224083870)

---

changelog: none
