### PR TITLE
Do not lint when the closure is called using an iterator

### DIFF
--- a/tests/ui/blocks_in_if_conditions_closure.rs
+++ b/tests/ui/blocks_in_if_conditions_closure.rs
@@ -44,4 +44,13 @@ fn macro_in_closure() {
     }
 }
 
-fn main() {}
+#[rustfmt::skip]
+fn main() {
+    let mut range = 0..10;
+    range.all(|i| {i < 10} );
+
+    let v = vec![1, 2, 3];
+    if v.into_iter().any(|x| {x == 4}) {
+        println!("contains 4!");
+    }
+}


### PR DESCRIPTION
Fix FP when the closure is used in an iterator for `blocks_in_if_conditions` lint

FIxes: #1141 

changelog: none