### PR TITLE
Upgrade compiletest-rs to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tempfile = { version = "3.1.0", optional = true }
 
 [dev-dependencies]
 cargo_metadata = "0.12"
-compiletest_rs = { version = "0.5.0", features = ["tmp"] }
+compiletest_rs = { version = "0.6.0", features = ["tmp"] }
 tester = "0.7"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This version includes `bless` support, but is not enabled with this PR.

cc #5394 