### PR TITLE
Upgrade compiletest-rs to 0.6 and tester to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ tempfile = { version = "3.1.0", optional = true }
 
 [dev-dependencies]
 cargo_metadata = "0.12"
-compiletest_rs = { version = "0.5.0", features = ["tmp"] }
-tester = "0.7"
+compiletest_rs = { version = "0.6.0", features = ["tmp"] }
+tester = "0.9"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }
 serde = { version = "1.0", features = ["derive"] }
 derive-new = "0.5"

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -108,6 +108,9 @@ should only commit files changed by `cargo dev bless` for the
 specific lint you are creating/editing. Note that if the generated files are
 empty, they should be removed.
 
+Note that you can run multiple test files by specifying a comma separated list:
+`TESTNAME=foo_functions,test2,test3`.
+
 ### Cargo lints
 
 For cargo lints, the process of testing differs in that we are interested in


### PR DESCRIPTION
These updates allow us to specify multiple testnames for `TESTNAME` by
providing a comma separated list of testnames.

The new version of compiletest-rs also includes `bless` support, but is
not enabled with this PR.

cc #5394 

changelog: none