### PR TITLE
Lintcheck and an options for command line options

### DIFF
--- a/clippy_dev/README.md
+++ b/clippy_dev/README.md
@@ -1,41 +1,48 @@
 # Clippy Dev Tool
 
-The Clippy Dev Tool is a tool to ease Clippy development, similar to `rustc`s `x.py`.
+The Clippy Dev Tool is a tool to ease Clippy development, similar to `rustc`s
+`x.py`.
 
 Functionalities (incomplete):
 
 ## `lintcheck`
-Runs clippy on a fixed set of crates read from `clippy_dev/lintcheck_crates.toml`
-and saves logs of the lint warnings into the repo.
-We can then check the diff and spot new or disappearing warnings.
+
+Runs clippy on a fixed set of crates read from
+`clippy_dev/lintcheck_crates.toml` and saves logs of the lint warnings into the
+repo.  We can then check the diff and spot new or disappearing warnings.
 
 From the repo root, run:
-````
+
+```
 cargo run --target-dir clippy_dev/target --package clippy_dev \
 --bin clippy_dev --manifest-path clippy_dev/Cargo.toml --features lintcheck -- lintcheck
-````
+```
+
 or
-````
+
+```
 cargo dev-lintcheck
-````
+```
 
-By default the logs will be saved into `lintcheck-logs/lintcheck_crates_logs.txt`.
+By default the logs will be saved into
+`lintcheck-logs/lintcheck_crates_logs.txt`.
 
-You can set a custom sources.toml by adding `--crates-toml custom.toml` or using `LINTCHECK_TOML="custom.toml"`
-where `custom.toml` must be a relative path from the repo root.
+You can set a custom sources.toml by adding `--crates-toml custom.toml` or using
+`LINTCHECK_TOML="custom.toml"` where `custom.toml` must be a relative path from
+the repo root.
 
 The results will then be saved to `lintcheck-logs/custom_logs.toml`.
 
 ### Configuring the Crate Sources
 
-The sources to check are saved in a `toml` file.
-There are three types of sources.
+The sources to check are saved in a `toml` file. There are three types of
+sources.
 
 1. Crates-io Source
 
-   ````toml
+   ```toml
    bitflags = {name = "bitflags", versions = ['1.2.1']}
-   ````
+   ```
    Requires a "name" and one or multiple "versions" to be checked.
 
 2. `git` Source
@@ -43,14 +50,15 @@ There are three types of sources.
    puffin = {name = "puffin", git_url = "https://github.com/EmbarkStudios/puffin", git_hash = "02dd4a3"}
    ````
    Requires a name, the url to the repo and unique identifier of a commit,
-   branch or tag which is checked out before linting.
-   There is no way to always check `HEAD` because that would lead to changing lint-results as the repo would get updated.
-   If `git_url` or `git_hash` is missing, an error will be thrown.
+   branch or tag which is checked out before linting.  There is no way to always
+   check `HEAD` because that would lead to changing lint-results as the repo
+   would get updated.  If `git_url` or `git_hash` is missing, an error will be
+   thrown.
 
 3. Local Dependency
-   ````toml
-    clippy = {name = "clippy", path = "/home/user/clippy"}
-   ````
+   ```toml
+   clippy = {name = "clippy", path = "/home/user/clippy"}
+   ```
    For when you want to add a repository that is not published yet.
 
 #### Command Line Options (optional)

--- a/clippy_dev/README.md
+++ b/clippy_dev/README.md
@@ -72,3 +72,6 @@ possible to only check a crate for certain lint groups. If no options are
 specified, the lint groups `clippy::all`, `clippy::pedantic`, and
 `clippy::cargo` are checked. If an empty array is specified only `clippy::all`
 is checked.
+
+**Note:** `-Wclippy::all` is always enabled by default, unless `-Aclippy::all`
+is explicitly specified in the options.

--- a/clippy_dev/README.md
+++ b/clippy_dev/README.md
@@ -1,4 +1,4 @@
-# Clippy Dev Tool 
+# Clippy Dev Tool
 
 The Clippy Dev Tool is a tool to ease Clippy development, similar to `rustc`s `x.py`.
 
@@ -28,25 +28,39 @@ The results will then be saved to `lintcheck-logs/custom_logs.toml`.
 
 ### Configuring the Crate Sources
 
-The sources to check are saved in a `toml` file.  
-There are three types of sources.  
-A crates-io source:
-````toml
-bitflags = {name = "bitflags", versions = ['1.2.1']}
-````
-Requires a "name" and one or multiple "versions" to be checked.
+The sources to check are saved in a `toml` file.
+There are three types of sources.
 
-A git source:
-````toml
-puffin = {name = "puffin", git_url = "https://github.com/EmbarkStudios/puffin", git_hash = "02dd4a3"}
-````
-Requires a name, the url to the repo and unique identifier of a commit,
-branch or tag which is checked out before linting.  
-There is no way to always check `HEAD` because that would lead to changing lint-results as the repo would get updated.  
-If `git_url` or `git_hash` is missing, an error will be thrown.
+1. Crates-io Source
 
-A local dependency:
-````toml
- clippy = {name = "clippy", path = "/home/user/clippy"}
-````
-For when you want to add a repository that is not published yet.  
+   ````toml
+   bitflags = {name = "bitflags", versions = ['1.2.1']}
+   ````
+   Requires a "name" and one or multiple "versions" to be checked.
+
+2. `git` Source
+   ````toml
+   puffin = {name = "puffin", git_url = "https://github.com/EmbarkStudios/puffin", git_hash = "02dd4a3"}
+   ````
+   Requires a name, the url to the repo and unique identifier of a commit,
+   branch or tag which is checked out before linting.
+   There is no way to always check `HEAD` because that would lead to changing lint-results as the repo would get updated.
+   If `git_url` or `git_hash` is missing, an error will be thrown.
+
+3. Local Dependency
+   ````toml
+    clippy = {name = "clippy", path = "/home/user/clippy"}
+   ````
+   For when you want to add a repository that is not published yet.
+
+#### Command Line Options (optional)
+
+```toml
+bitflags = {name = "bitflags", versions = ['1.2.1'], options = ['-Wclippy::pedantic', '-Wclippy::cargo']}
+```
+
+It is possible to specify command line options for each crate. This makes it
+possible to only check a crate for certain lint groups. If no options are
+specified, the lint groups `clippy::all`, `clippy::pedantic`, and
+`clippy::cargo` are checked. If an empty array is specified only `clippy::all`
+is checked.


### PR DESCRIPTION
Make it possible to add command line options to the clippy invocation of the lintcheck-tool

changelog: none

r? @matthiaskrgr 

I found that this will be really helpful if we use a separate repository and want to maintain a all-lints-passing list of crates. See my early experimentation here: https://github.com/flip1995/clippy-lintcheck 

```
git submodule update --init
cargo run -- --mode=all
```

Will run the lintcheck tool on all the specified crates in `config/` in that repository.