### PR TITLE
Fix lintcheck by excluding checked crates from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2018"
 publish = false
 
 [workspace]
-exclude = ["clippy_dev", "mini-macro"]
+exclude = ["clippy_dev", "mini-macro", "target/lintcheck/crates"]
 
 [[bin]]
 name = "cargo-clippy"


### PR DESCRIPTION
r? @matthiaskrgr  cc @camsteffen 

So `exclude` doesn't work with glob patterns, but it turns out that it works with `starts_with`.

changelog: none
