### PR TITLE
collapsible_match: fix lint message capitalization

### DIFF
--- a/clippy_lints/src/collapsible_match.rs
+++ b/clippy_lints/src/collapsible_match.rs
@@ -96,12 +96,12 @@ fn check_arm<'tcx>(arm: &Arm<'tcx>, wild_outer_arm: &Arm<'tcx>, cx: &LateContext
                 cx,
                 COLLAPSIBLE_MATCH,
                 expr.span,
-                "Unnecessary nested match",
+                "unnecessary nested match",
                 |diag| {
                     let mut help_span = MultiSpan::from_spans(vec![binding_span, non_wild_inner_arm.pat.span]);
-                    help_span.push_span_label(binding_span, "Replace this binding".into());
+                    help_span.push_span_label(binding_span, "replace this binding".into());
                     help_span.push_span_label(non_wild_inner_arm.pat.span, "with this pattern".into());
-                    diag.span_help(help_span, "The outer pattern can be modified to include the inner pattern.");
+                    diag.span_help(help_span, "the outer pattern can be modified to include the inner pattern");
                 },
             );
         }

--- a/tests/ui/collapsible_match.stderr
+++ b/tests/ui/collapsible_match.stderr
@@ -1,4 +1,4 @@
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:7:20
    |
 LL |           Ok(val) => match val {
@@ -9,15 +9,15 @@ LL | |         },
    | |_________^
    |
    = note: `-D clippy::collapsible-match` implied by `-D warnings`
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:7:12
    |
 LL |         Ok(val) => match val {
-   |            ^^^ Replace this binding
+   |            ^^^ replace this binding
 LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:16:20
    |
 LL |           Ok(val) => match val {
@@ -27,15 +27,15 @@ LL | |             _ => return,
 LL | |         },
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:16:12
    |
 LL |         Ok(val) => match val {
-   |            ^^^ Replace this binding
+   |            ^^^ replace this binding
 LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:25:9
    |
 LL | /         if let Some(n) = val {
@@ -43,15 +43,15 @@ LL | |             take(n);
 LL | |         }
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:24:15
    |
 LL |     if let Ok(val) = res_opt {
-   |               ^^^ Replace this binding
+   |               ^^^ replace this binding
 LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:32:9
    |
 LL | /         if let Some(n) = val {
@@ -61,15 +61,15 @@ LL | |             return;
 LL | |         }
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:31:15
    |
 LL |     if let Ok(val) = res_opt {
-   |               ^^^ Replace this binding
+   |               ^^^ replace this binding
 LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:43:9
    |
 LL | /         match val {
@@ -78,16 +78,16 @@ LL | |             _ => (),
 LL | |         }
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:42:15
    |
 LL |     if let Ok(val) = res_opt {
-   |               ^^^ Replace this binding
+   |               ^^^ replace this binding
 LL |         match val {
 LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:52:13
    |
 LL | /             if let Some(n) = val {
@@ -95,15 +95,15 @@ LL | |                 take(n);
 LL | |             }
    | |_____________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:51:12
    |
 LL |         Ok(val) => {
-   |            ^^^ Replace this binding
+   |            ^^^ replace this binding
 LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:61:9
    |
 LL | /         match val {
@@ -112,16 +112,16 @@ LL | |             _ => return,
 LL | |         }
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:60:15
    |
 LL |     if let Ok(val) = res_opt {
-   |               ^^^ Replace this binding
+   |               ^^^ replace this binding
 LL |         match val {
 LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:72:13
    |
 LL | /             if let Some(n) = val {
@@ -131,15 +131,15 @@ LL | |                 return;
 LL | |             }
    | |_____________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:71:12
    |
 LL |         Ok(val) => {
-   |            ^^^ Replace this binding
+   |            ^^^ replace this binding
 LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:83:20
    |
 LL |           Ok(val) => match val {
@@ -149,15 +149,15 @@ LL | |             None => return,
 LL | |         },
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:83:12
    |
 LL |         Ok(val) => match val {
-   |            ^^^ Replace this binding
+   |            ^^^ replace this binding
 LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match.rs:92:22
    |
 LL |           Some(val) => match val {
@@ -167,11 +167,11 @@ LL | |             _ => return,
 LL | |         },
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match.rs:92:14
    |
 LL |         Some(val) => match val {
-   |              ^^^ Replace this binding
+   |              ^^^ replace this binding
 LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 

--- a/tests/ui/collapsible_match2.stderr
+++ b/tests/ui/collapsible_match2.stderr
@@ -1,4 +1,4 @@
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match2.rs:8:34
    |
 LL |               Ok(val) if make() => match val {
@@ -9,15 +9,15 @@ LL | |             },
    | |_____________^
    |
    = note: `-D clippy::collapsible-match` implied by `-D warnings`
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match2.rs:8:16
    |
 LL |             Ok(val) if make() => match val {
-   |                ^^^ Replace this binding
+   |                ^^^ replace this binding
 LL |                 Some(n) => foo(n),
    |                 ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match2.rs:15:24
    |
 LL |               Ok(val) => match val {
@@ -27,15 +27,15 @@ LL | |                 _ => return,
 LL | |             },
    | |_____________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match2.rs:15:16
    |
 LL |             Ok(val) => match val {
-   |                ^^^ Replace this binding
+   |                ^^^ replace this binding
 LL |                 Some(n) => foo(n),
    |                 ^^^^^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match2.rs:29:29
    |
 LL |                       $pat => match $e {
@@ -48,16 +48,16 @@ LL | |                     },
 LL |           mac!(res_opt => Ok(val), val => Some(n), foo(n));
    |           ------------------------------------------------- in this macro invocation
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match2.rs:41:28
    |
 LL |         mac!(res_opt => Ok(val), val => Some(n), foo(n));
    |                            ^^^          ^^^^^^^ with this pattern
    |                            |
-   |                            Replace this binding
+   |                            replace this binding
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match2.rs:46:20
    |
 LL |           Some(s) => match *s {
@@ -67,15 +67,15 @@ LL | |             _ => (),
 LL | |         },
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match2.rs:46:14
    |
 LL |         Some(s) => match *s {
-   |              ^ Replace this binding
+   |              ^ replace this binding
 LL |             [n] => foo(n),
    |             ^^^ with this pattern
 
-error: Unnecessary nested match
+error: unnecessary nested match
   --> $DIR/collapsible_match2.rs:55:24
    |
 LL |           Some(ref s) => match &*s {
@@ -85,11 +85,11 @@ LL | |             _ => (),
 LL | |         },
    | |_________^
    |
-help: The outer pattern can be modified to include the inner pattern.
+help: the outer pattern can be modified to include the inner pattern
   --> $DIR/collapsible_match2.rs:55:14
    |
 LL |         Some(ref s) => match &*s {
-   |              ^^^^^ Replace this binding
+   |              ^^^^^ replace this binding
 LL |             [n] => foo(n),
    |             ^^^ with this pattern
 


### PR DESCRIPTION
(see https://rustc-dev-guide.rust-lang.org/diagnostics.html for details)

---

*Please write a short comment explaining your change (or "none" for internal only changes)*
changelog: collapsible_match: fix lint message capitalization
