### PR TITLE
Fix camel case postfix for `enum_variant_names` lint

### DIFF
--- a/clippy_lints/src/utils/camel_case.rs
+++ b/clippy_lints/src/utils/camel_case.rs
@@ -55,6 +55,8 @@ pub fn from(s: &str) -> usize {
             }
         } else if c.is_lowercase() {
             down = true;
+        } else if c.is_uppercase() {
+            last_i = i;
         } else {
             return last_i;
         }
@@ -70,12 +72,16 @@ mod test {
     fn from_full() {
         assert_eq!(from("AbcDef"), 0);
         assert_eq!(from("Abc"), 0);
+        assert_eq!(from("ABcd"), 0);
+        assert_eq!(from("ABcdEf"), 0);
+        assert_eq!(from("AabABcd"), 0);
     }
 
     #[test]
     fn from_partial() {
         assert_eq!(from("abcDef"), 3);
         assert_eq!(from("aDbc"), 1);
+        assert_eq!(from("aabABcd"), 3);
     }
 
     #[test]

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -133,4 +133,17 @@ pub enum NetworkLayer {
     Layer3,
 }
 
+// should lint suggesting `IData`, not only `Data` (see #4639)
+enum IDataRequest {
+    PutIData(String),
+    GetIData(String),
+    DeleteUnpubIData(String),
+}
+
+enum HIDataRequest {
+    PutHIData(String),
+    GetHIData(String),
+    DeleteUnpubHIData(String),
+}
+
 fn main() {}

--- a/tests/ui/enum_variants.stderr
+++ b/tests/ui/enum_variants.stderr
@@ -97,5 +97,29 @@ LL | | }
    = note: `-D clippy::pub-enum-variant-names` implied by `-D warnings`
    = help: remove the prefixes and use full paths to the variants instead of glob imports
 
-error: aborting due to 10 previous errors
+error: all variants have the same postfix: `IData`
+  --> $DIR/enum_variants.rs:137:1
+   |
+LL | / enum IDataRequest {
+LL | |     PutIData(String),
+LL | |     GetIData(String),
+LL | |     DeleteUnpubIData(String),
+LL | | }
+   | |_^
+   |
+   = help: remove the postfixes and use full paths to the variants instead of glob imports
+
+error: all variants have the same postfix: `HIData`
+  --> $DIR/enum_variants.rs:143:1
+   |
+LL | / enum HIDataRequest {
+LL | |     PutHIData(String),
+LL | |     GetHIData(String),
+LL | |     DeleteUnpubHIData(String),
+LL | | }
+   | |_^
+   |
+   = help: remove the postfixes and use full paths to the variants instead of glob imports
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Fix camel case postfix

Fixes: #4639 

changelog: none
