### PR TITLE
Fix FP in inherent_to_string when the function has generic parameters

### DIFF
--- a/clippy_lints/src/inherent_to_string.rs
+++ b/clippy_lints/src/inherent_to_string.rs
@@ -106,6 +106,7 @@ impl<'tcx> LateLintPass<'tcx> for InherentToString {
             let decl = &signature.decl;
             if decl.implicit_self.has_implicit_self();
             if decl.inputs.len() == 1;
+            if impl_item.generics.params.is_empty();
 
             // Check if return type is String
             if is_type_diagnostic_item(cx, return_ty(cx, impl_item.hir_id), sym::string_type);

--- a/tests/ui/inherent_to_string.rs
+++ b/tests/ui/inherent_to_string.rs
@@ -14,6 +14,7 @@ struct C;
 struct D;
 struct E;
 struct F;
+struct G;
 
 impl A {
     // Should be detected; emit warning
@@ -73,6 +74,13 @@ impl F {
     }
 }
 
+impl G {
+    // Should not be detected, as it does not match the function signature
+    fn to_string<const _N: usize>(&self) -> String {
+        "G.to_string()".to_string()
+    }
+}
+
 fn main() {
     let a = A;
     a.to_string();
@@ -93,4 +101,7 @@ fn main() {
 
     let f = F;
     f.to_string(1);
+
+    let g = G;
+    g.to_string::<1>();
 }

--- a/tests/ui/inherent_to_string.stderr
+++ b/tests/ui/inherent_to_string.stderr
@@ -1,5 +1,5 @@
 error: implementation of inherent method `to_string(&self) -> String` for type `A`
-  --> $DIR/inherent_to_string.rs:20:5
+  --> $DIR/inherent_to_string.rs:21:5
    |
 LL | /     fn to_string(&self) -> String {
 LL | |         "A.to_string()".to_string()
@@ -10,7 +10,7 @@ LL | |     }
    = help: implement trait `Display` for type `A` instead
 
 error: type `C` implements inherent method `to_string(&self) -> String` which shadows the implementation of `Display`
-  --> $DIR/inherent_to_string.rs:44:5
+  --> $DIR/inherent_to_string.rs:45:5
    |
 LL | /     fn to_string(&self) -> String {
 LL | |         "C.to_string()".to_string()


### PR DESCRIPTION
Minimal example of the false positive: 
````
struct G;

impl G {
    fn to_string<const _N: usize>(&self) -> String {
        "G.to_string()".to_string()
    }
}

fn main() {
    let g = G;
    g.to_string::<1>();
}
````
Clippy emits an `inherent_to_string` warning, and suggests that we implement `Display` for `G` instead. However, this is not possible, since the generic parameter _N only exists in this function, not in `G` itself. This particular example uses const generics, which is where the issue is most likely to come up, but this PR skips the lint if the `to_string` function has any kind of generic parameters.

changelog: Fix FP in `inherent_to_string`
