### PR TITLE
Remove unneeded blank lines from doc

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -147,7 +147,6 @@ declare_clippy_lint! {
     /// ```rust
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
-    ///
     /// // Bad
     /// writeln!(buf, "");
     ///
@@ -174,7 +173,6 @@ declare_clippy_lint! {
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
     /// # let name = "World";
-    ///
     /// // Bad
     /// write!(buf, "Hello {}!\n", name);
     ///
@@ -200,7 +198,6 @@ declare_clippy_lint! {
     /// ```rust
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
-    ///
     /// // Bad
     /// writeln!(buf, "{}", "foo");
     ///


### PR DESCRIPTION
Remove unneeded blank lines like below.
<img width="1142" alt="スクリーンショット 2021-02-22 23 01 17" src="https://user-images.githubusercontent.com/17407489/108719295-bb9ff800-7562-11eb-9338-8f2571e61c56.png">

changelog: none
