### PR TITLE
or_fun_call: fix suggestion for `or_insert(vec![])`

### DIFF
--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -62,8 +62,14 @@ fn or_fun_call() {
     let mut map = HashMap::<u64, String>::new();
     map.entry(42).or_insert_with(String::new);
 
+    let mut map_vec = HashMap::<u64, Vec<i32>>::new();
+    map_vec.entry(42).or_insert_with(Vec::new);
+
     let mut btree = BTreeMap::<u64, String>::new();
     btree.entry(42).or_insert_with(String::new);
+
+    let mut btree_vec = BTreeMap::<u64, Vec<i32>>::new();
+    btree_vec.entry(42).or_insert_with(Vec::new);
 
     let stringy = Some(String::from(""));
     let _ = stringy.unwrap_or_else(|| "".to_owned());

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -62,8 +62,14 @@ fn or_fun_call() {
     let mut map = HashMap::<u64, String>::new();
     map.entry(42).or_insert(String::new());
 
+    let mut map_vec = HashMap::<u64, Vec<i32>>::new();
+    map_vec.entry(42).or_insert(vec![]);
+
     let mut btree = BTreeMap::<u64, String>::new();
     btree.entry(42).or_insert(String::new());
+
+    let mut btree_vec = BTreeMap::<u64, Vec<i32>>::new();
+    btree_vec.entry(42).or_insert(vec![]);
 
     let stringy = Some(String::from(""));
     let _ = stringy.unwrap_or("".to_owned());

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -67,40 +67,52 @@ LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(String::new)`
 
 error: use of `or_insert` followed by a function call
-  --> $DIR/or_fun_call.rs:66:21
+  --> $DIR/or_fun_call.rs:66:23
+   |
+LL |     map_vec.entry(42).or_insert(vec![]);
+   |                       ^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(Vec::new)`
+
+error: use of `or_insert` followed by a function call
+  --> $DIR/or_fun_call.rs:69:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(String::new)`
 
+error: use of `or_insert` followed by a function call
+  --> $DIR/or_fun_call.rs:72:25
+   |
+LL |     btree_vec.entry(42).or_insert(vec![]);
+   |                         ^^^^^^^^^^^^^^^^^ help: try this: `or_insert_with(Vec::new)`
+
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:69:21
+  --> $DIR/or_fun_call.rs:75:21
    |
 LL |     let _ = stringy.unwrap_or("".to_owned());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| "".to_owned())`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:77:21
+  --> $DIR/or_fun_call.rs:83:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:79:21
+  --> $DIR/or_fun_call.rs:85:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
 
 error: use of `or` followed by a function call
-  --> $DIR/or_fun_call.rs:103:35
+  --> $DIR/or_fun_call.rs:109:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some("b".to_string()))`
 
 error: use of `or` followed by a function call
-  --> $DIR/or_fun_call.rs:107:10
+  --> $DIR/or_fun_call.rs:113:10
    |
 LL |         .or(Some(Bar(b, Duration::from_secs(2))));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some(Bar(b, Duration::from_secs(2))))`
 
-error: aborting due to 17 previous errors
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
fixes #6748 
changelog: or_fun_call: fix suggestion for `or_insert(vec![])` on `std::collections::hash_map::Entry` or `std::collections::btree_map::Entry`
