### PR TITLE
upper_case_acronyms: don't warn on public items

### DIFF
--- a/clippy_lints/src/upper_case_acronyms.rs
+++ b/clippy_lints/src/upper_case_acronyms.rs
@@ -1,7 +1,7 @@
 use crate::utils::span_lint_and_sugg;
 use if_chain::if_chain;
 use itertools::Itertools;
-use rustc_ast::ast::{Item, ItemKind, Variant};
+use rustc_ast::ast::{Item, ItemKind, Variant, VisibilityKind};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
@@ -105,6 +105,8 @@ impl EarlyLintPass for UpperCaseAcronyms {
                 it.kind,
                 ItemKind::TyAlias(..) | ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Trait(..)
             );
+            // do not lint public items
+            if !matches!(it.vis.kind, VisibilityKind::Public);
             then {
                 check_ident(cx, &it.ident, self.upper_case_acronyms_aggressive);
             }

--- a/tests/ui-toml/upper_case_acronyms_aggressive/upper_case_acronyms.rs
+++ b/tests/ui-toml/upper_case_acronyms_aggressive/upper_case_acronyms.rs
@@ -19,4 +19,9 @@ enum Flags {
 struct GCCLLVMSomething; // linted with cfg option, beware that lint suggests `GccllvmSomething` instead of
                          // `GccLlvmSomething`
 
+// don't warn on public items
+pub struct MIXEDCapital;
+
+pub struct FULLCAPITAL;
+
 fn main() {}

--- a/tests/ui/upper_case_acronyms.rs
+++ b/tests/ui/upper_case_acronyms.rs
@@ -19,4 +19,8 @@ enum Flags {
 struct GCCLLVMSomething; // linted with cfg option, beware that lint suggests `GccllvmSomething` instead of
                          // `GccLlvmSomething`
 
+// public items must not be linted
+pub struct NOWARNINGHERE;
+pub struct ALSONoWarningHERE;
+
 fn main() {}


### PR DESCRIPTION
Fixes #6803

changelog: upper_case_acronyms: ignore public items

