### PR TITLE
Fix ICEs 6792 and 6793

### DIFF
--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -130,10 +130,9 @@ impl<'a, 'tcx> Visitor<'tcx> for NumericFallbackVisitor<'a, 'tcx> {
                 }
             },
 
-            ExprKind::Struct(qpath, fields, base) => {
+            ExprKind::Struct(_, fields, base) => {
                 if_chain! {
-                    if let Some(def_id) = self.cx.qpath_res(qpath, expr.hir_id).opt_def_id();
-                    let ty = self.cx.tcx.type_of(def_id);
+                    let ty = self.cx.typeck_results().expr_ty(expr);
                     if let Some(adt_def) = ty.ty_adt_def();
                     if adt_def.is_struct();
                     if let Some(variant) = adt_def.variants.iter().next();

--- a/clippy_lints/src/inconsistent_struct_constructor.rs
+++ b/clippy_lints/src/inconsistent_struct_constructor.rs
@@ -66,8 +66,7 @@ impl LateLintPass<'_> for InconsistentStructConstructor {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
         if_chain! {
             if let ExprKind::Struct(qpath, fields, base) = expr.kind;
-            if let Some(def_id)  = cx.qpath_res(qpath, expr.hir_id).opt_def_id();
-            let ty = cx.tcx.type_of(def_id);
+            let ty = cx.typeck_results().expr_ty(expr);
             if let Some(adt_def) = ty.ty_adt_def();
             if adt_def.is_struct();
             if let Some(variant) = adt_def.variants.iter().next();

--- a/tests/ui/crashes/ice-6792.rs
+++ b/tests/ui/crashes/ice-6792.rs
@@ -1,0 +1,20 @@
+//! This is a reproducer for the ICE 6792: https://github.com/rust-lang/rust-clippy/issues/6792.
+//! The ICE is caused by using `TyCtxt::type_of(assoc_type_id)`.
+
+trait Trait {
+    type Ty;
+
+    fn broken() -> Self::Ty;
+}
+
+struct Foo {}
+
+impl Trait for Foo {
+    type Ty = Foo;
+
+    fn broken() -> Self::Ty {
+        Self::Ty {}
+    }
+}
+
+fn main() {}

--- a/tests/ui/crashes/ice-6793.rs
+++ b/tests/ui/crashes/ice-6793.rs
@@ -1,0 +1,23 @@
+//! This is a reproducer for the ICE 6793: https://github.com/rust-lang/rust-clippy/issues/6793.
+//! The ICE is caused by using `TyCtxt::type_of(assoc_type_id)`, which is the same as the ICE 6792.
+
+trait Trait {
+    type Ty: 'static + Clone;
+
+    fn broken() -> Self::Ty;
+}
+
+#[derive(Clone)]
+struct MyType {
+    x: i32,
+}
+
+impl Trait for MyType {
+    type Ty = MyType;
+
+    fn broken() -> Self::Ty {
+        Self::Ty { x: 1 }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
fixes #6792, fixes #6793.
r? @matthiaskrgr 

Fixes the ICEs by replacing `TyCtxt::type_of` with `TypeckResults::expr_ty`.

changelog: none
