### PR TITLE
Fix false positives on procedural macros of `missing_inline_in_public_items` lint

### DIFF
--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -69,21 +69,21 @@ fn check_missing_inline_attrs(cx: &LateContext<'_>, attrs: &[ast::Attribute], sp
     }
 }
 
-fn is_executable(cx: &LateContext<'_>) -> bool {
+fn is_executable_or_proc_macro(cx: &LateContext<'_>) -> bool {
     use rustc_session::config::CrateType;
 
     cx.tcx
         .sess
         .crate_types()
         .iter()
-        .any(|t: &CrateType| matches!(t, CrateType::Executable))
+        .any(|t: &CrateType| matches!(t, CrateType::Executable | CrateType::ProcMacro))
 }
 
 declare_lint_pass!(MissingInline => [MISSING_INLINE_IN_PUBLIC_ITEMS]);
 
 impl<'tcx> LateLintPass<'tcx> for MissingInline {
     fn check_item(&mut self, cx: &LateContext<'tcx>, it: &'tcx hir::Item<'_>) {
-        if rustc_middle::lint::in_external_macro(cx.sess(), it.span) || is_executable(cx) {
+        if rustc_middle::lint::in_external_macro(cx.sess(), it.span) || is_executable_or_proc_macro(cx) {
             return;
         }
 
@@ -133,7 +133,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingInline {
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, impl_item: &'tcx hir::ImplItem<'_>) {
         use rustc_middle::ty::{ImplContainer, TraitContainer};
-        if rustc_middle::lint::in_external_macro(cx.sess(), impl_item.span) || is_executable(cx) {
+        if rustc_middle::lint::in_external_macro(cx.sess(), impl_item.span) || is_executable_or_proc_macro(cx) {
             return;
         }
 

--- a/tests/ui/missing_inline_executable.rs
+++ b/tests/ui/missing_inline_executable.rs
@@ -1,0 +1,5 @@
+#![warn(clippy::missing_inline_in_public_items)]
+
+pub fn foo() {}
+
+fn main() {}

--- a/tests/ui/missing_inline_proc_macro.rs
+++ b/tests/ui/missing_inline_proc_macro.rs
@@ -1,0 +1,23 @@
+#![warn(clippy::missing_inline_in_public_items)]
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+fn _foo() {}
+
+#[proc_macro]
+pub fn function_like(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+#[proc_macro_attribute]
+pub fn attribute(_: TokenStream, _: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+#[proc_macro_derive(Derive)]
+pub fn derive(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}


### PR DESCRIPTION
Fixes #6486.

changelog: Fix false positives on procedural macros of `missing_inline_in_public_items` lint.