### PR TITLE
lintcheck: clippy fixes, test on ci

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -27,6 +27,7 @@ env:
 
 jobs:
   base:
+    # NOTE: If you modify this job, make sure you copy the changes to clippy_bors.yml
     runs-on: ubuntu-latest
 
     steps:
@@ -64,8 +65,8 @@ jobs:
       run: cargo test --features deny-warnings
       working-directory: rustc_tools_util
 
-    - name: Test clippy_dev
-      run: cargo test --features deny-warnings
+    - name: Test clippy_dev and lintcheck
+      run: cargo test --features lintcheck,deny-warnings
       working-directory: clippy_dev
 
     - name: Test cargo-clippy

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -62,6 +62,12 @@ jobs:
         run: cargo test --features deny-warnings
         working-directory: rustc_tools_util
 
+      # This test was moved here from clippy_dev.yml because it requires to build clippy
+      # and we do that there anyway
+      - name: Test clippy_dev (lintcheck)
+        run: cargo test lintcheck  --features lintcheck,deny-warnings
+        working-directory: clippy_dev
+
       - name: Test clippy_dev
         run: cargo test --features deny-warnings
         working-directory: clippy_dev

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,21 +8,21 @@ on:
       - try
     # Don't run Clippy tests, when only textfiles were modified
     paths-ignore:
-    - 'COPYRIGHT'
-    - 'LICENSE-*'
-    - '**.md'
-    - '**.txt'
+      - "COPYRIGHT"
+      - "LICENSE-*"
+      - "**.md"
+      - "**.txt"
   pull_request:
     # Don't run Clippy tests, when only textfiles were modified
     paths-ignore:
-    - 'COPYRIGHT'
-    - 'LICENSE-*'
-    - '**.md'
-    - '**.txt'
+      - "COPYRIGHT"
+      - "LICENSE-*"
+      - "**.md"
+      - "**.txt"
 
 env:
   RUST_BACKTRACE: 1
-  CARGO_TARGET_DIR: '${{ github.workspace }}/target'
+  CARGO_TARGET_DIR: "${{ github.workspace }}/target"
   NO_FMT_TEST: 1
 
 jobs:
@@ -31,57 +31,57 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
+      # Setup
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+        with:
+          github_token: "${{ secrets.github_token }}"
 
-    - name: Checkout
-      uses: actions/checkout@v2.3.3
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
 
-    - name: Install toolchain
-      run: rustup show active-toolchain
+      - name: Install toolchain
+        run: rustup show active-toolchain
 
-    # Run
-    - name: Set LD_LIBRARY_PATH (Linux)
-      run: |
-        SYSROOT=$(rustc --print sysroot)
-        echo "LD_LIBRARY_PATH=${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
+      # Run
+      - name: Set LD_LIBRARY_PATH (Linux)
+        run: |
+          SYSROOT=$(rustc --print sysroot)
+          echo "LD_LIBRARY_PATH=${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
 
-    - name: Build
-      run: cargo build --features deny-warnings,internal-lints
+      - name: Build
+        run: cargo build --features deny-warnings,internal-lints
 
-    - name: Test
-      run: cargo test --features deny-warnings,internal-lints
+      - name: Test
+        run: cargo test --features deny-warnings,internal-lints
 
-    - name: Test clippy_lints
-      run: cargo test --features deny-warnings,internal-lints
-      working-directory: clippy_lints
+      - name: Test clippy_lints
+        run: cargo test --features deny-warnings,internal-lints
+        working-directory: clippy_lints
 
-    - name: Test rustc_tools_util
-      run: cargo test --features deny-warnings
-      working-directory: rustc_tools_util
+      - name: Test rustc_tools_util
+        run: cargo test --features deny-warnings
+        working-directory: rustc_tools_util
 
-    - name: Test clippy_dev
-      run: cargo test --features deny-warnings
-      working-directory: clippy_dev
+      - name: Test clippy_dev
+        run: cargo test --features deny-warnings
+        working-directory: clippy_dev
 
-    - name: Test cargo-clippy
-      run: ../target/debug/cargo-clippy
-      working-directory: clippy_workspace_tests
+      - name: Test cargo-clippy
+        run: ../target/debug/cargo-clippy
+        working-directory: clippy_workspace_tests
 
-    - name: Test cargo-clippy --fix
-      run: ../target/debug/cargo-clippy clippy --fix -Zunstable-options
-      working-directory: clippy_workspace_tests
+      - name: Test cargo-clippy --fix
+        run: ../target/debug/cargo-clippy clippy --fix -Zunstable-options
+        working-directory: clippy_workspace_tests
 
-    - name: Test clippy-driver
-      run: bash .github/driver.sh
-      env:
-        OS: ${{ runner.os }}
+      - name: Test clippy-driver
+        run: bash .github/driver.sh
+        env:
+          OS: ${{ runner.os }}
 
-    - name: Test cargo dev new lint
-      run: |
-        cargo dev new_lint --name new_early_pass --pass early
-        cargo dev new_lint --name new_late_pass --pass late
-        cargo check
-        git reset --hard HEAD
+      - name: Test cargo dev new lint
+        run: |
+          cargo dev new_lint --name new_early_pass --pass early
+          cargo dev new_lint --name new_late_pass --pass late
+          cargo check
+          git reset --hard HEAD

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -51,9 +51,6 @@ jobs:
     - name: Build
       run: cargo build --features deny-warnings,internal-lints
 
-    - name: Test "--fix -Zunstable-options"
-      run: cargo run --features deny-warnings,internal-lints --bin cargo-clippy -- clippy --fix -Zunstable-options
-
     - name: Test
       run: cargo test --features deny-warnings,internal-lints
 
@@ -71,6 +68,10 @@ jobs:
 
     - name: Test cargo-clippy
       run: ../target/debug/cargo-clippy
+      working-directory: clippy_workspace_tests
+
+    - name: Test cargo-clippy --fix
+      run: ../target/debug/cargo-clippy clippy -- --fix
       working-directory: clippy_workspace_tests
 
     - name: Test clippy-driver

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -71,7 +71,7 @@ jobs:
       working-directory: clippy_workspace_tests
 
     - name: Test cargo-clippy --fix
-      run: ../target/debug/cargo-clippy clippy -- --fix
+      run: ../target/debug/cargo-clippy clippy --fix -Zunstable-options
       working-directory: clippy_workspace_tests
 
     - name: Test clippy-driver

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -62,8 +62,8 @@ jobs:
       run: cargo test --features deny-warnings
       working-directory: rustc_tools_util
 
-    - name: Test clippy_dev and lintcheck
-      run: cargo test --features lintcheck,deny-warnings
+    - name: Test clippy_dev
+      run: cargo test --features deny-warnings
       working-directory: clippy_dev
 
     - name: Test cargo-clippy

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -130,6 +130,12 @@ jobs:
         run: cargo test --features deny-warnings
         working-directory: rustc_tools_util
 
+      # This test was moved here from clippy_dev.yml because it requires to build clippy
+      # and we do that there anyway
+      - name: Test clippy_dev (lintcheck)
+        run: cargo test lintcheck --features lintcheck,deny-warnings
+        working-directory: clippy_dev
+
       - name: Test clippy_dev
         run: cargo test --features deny-warnings
         working-directory: clippy_dev

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -133,7 +133,7 @@ jobs:
       working-directory: clippy_workspace_tests
 
     - name: Test cargo-clippy --fix
-      run: ../target/debug/cargo-clippy clippy -- --fix
+      run: ../target/debug/cargo-clippy clippy --fix -Zunstable-options
       working-directory: clippy_workspace_tests
 
     - name: Test clippy-driver

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -124,8 +124,8 @@ jobs:
       run: cargo test --features deny-warnings
       working-directory: rustc_tools_util
 
-    - name: Test clippy_dev and lintcheck
-      run: cargo test --features lintcheck,deny-warnings
+    - name: Test clippy_dev
+      run: cargo test --features deny-warnings
       working-directory: clippy_dev
 
     - name: Test cargo-clippy

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  CARGO_TARGET_DIR: '${{ github.workspace }}/target'
+  CARGO_TARGET_DIR: "${{ github.workspace }}/target"
   NO_FMT_TEST: 1
 
 defaults:
@@ -20,168 +20,174 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+        with:
+          github_token: "${{ secrets.github_token }}"
 
-    - name: Checkout
-      uses: actions/checkout@v2.3.3
-      with:
-        ref: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+        with:
+          ref: ${{ github.ref }}
 
-    # Run
-    - name: Check Changelog
-      run: |
-        MESSAGE=$(git log --format=%B -n 1)
-        PR=$(echo "$MESSAGE" | grep -o "#[0-9]*" | head -1 | sed -e 's/^#//')
-        output=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/rust-lang/rust-clippy/pulls/$PR" | \
-          python -c "import sys, json; print(json.load(sys.stdin)['body'])" | \
-          grep "^changelog: " | \
-          sed "s/changelog: //g")
-        if [[ -z "$output" ]]; then
-          echo "ERROR: PR body must contain 'changelog: ...'"
-          exit 1
-        elif [[ "$output" = "none" ]]; then
-          echo "WARNING: changelog is 'none'"
-        fi
-      env:
-        PYTHONIOENCODING: 'utf-8'
+      # Run
+      - name: Check Changelog
+        run: |
+          MESSAGE=$(git log --format=%B -n 1)
+          PR=$(echo "$MESSAGE" | grep -o "#[0-9]*" | head -1 | sed -e 's/^#//')
+          output=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/rust-lang/rust-clippy/pulls/$PR" | \
+            python -c "import sys, json; print(json.load(sys.stdin)['body'])" | \
+            grep "^changelog: " | \
+            sed "s/changelog: //g")
+          if [[ -z "$output" ]]; then
+            echo "ERROR: PR body must contain 'changelog: ...'"
+            exit 1
+          elif [[ "$output" = "none" ]]; then
+            echo "WARNING: changelog is 'none'"
+          fi
+        env:
+          PYTHONIOENCODING: "utf-8"
   base:
     needs: changelog
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        host: [x86_64-unknown-linux-gnu, i686-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc]
+        host:
+          [
+            x86_64-unknown-linux-gnu,
+            i686-unknown-linux-gnu,
+            x86_64-apple-darwin,
+            x86_64-pc-windows-msvc,
+          ]
         exclude:
-        - os: ubuntu-latest
-          host: x86_64-apple-darwin
-        - os: ubuntu-latest
-          host: x86_64-pc-windows-msvc
-        - os: macos-latest
-          host: x86_64-unknown-linux-gnu
-        - os: macos-latest
-          host: i686-unknown-linux-gnu
-        - os: macos-latest
-          host: x86_64-pc-windows-msvc
-        - os: windows-latest
-          host: x86_64-unknown-linux-gnu
-        - os: windows-latest
-          host: i686-unknown-linux-gnu
-        - os: windows-latest
-          host: x86_64-apple-darwin
+          - os: ubuntu-latest
+            host: x86_64-apple-darwin
+          - os: ubuntu-latest
+            host: x86_64-pc-windows-msvc
+          - os: macos-latest
+            host: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            host: i686-unknown-linux-gnu
+          - os: macos-latest
+            host: x86_64-pc-windows-msvc
+          - os: windows-latest
+            host: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            host: i686-unknown-linux-gnu
+          - os: windows-latest
+            host: x86_64-apple-darwin
 
     runs-on: ${{ matrix.os }}
 
     # NOTE: If you modify this job, make sure you copy the changes to clippy.yml
     steps:
-    # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
+      # Setup
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+        with:
+          github_token: "${{ secrets.github_token }}"
 
-    - name: Install dependencies (Linux-i686)
-      run: |
-        sudo dpkg --add-architecture i386
-        sudo apt-get update
-        sudo apt-get install gcc-multilib libssl-dev:i386 libgit2-dev:i386
-      if: matrix.host == 'i686-unknown-linux-gnu'
+      - name: Install dependencies (Linux-i686)
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install gcc-multilib libssl-dev:i386 libgit2-dev:i386
+        if: matrix.host == 'i686-unknown-linux-gnu'
 
-    - name: Checkout
-      uses: actions/checkout@v2.3.3
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
 
-    - name: Install toolchain
-      run: rustup show active-toolchain
+      - name: Install toolchain
+        run: rustup show active-toolchain
 
-    # Run
-    - name: Set LD_LIBRARY_PATH (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        SYSROOT=$(rustc --print sysroot)
-        echo "LD_LIBRARY_PATH=${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
-    - name: Link rustc dylib (MacOS)
-      if: runner.os == 'macOS'
-      run: |
-        SYSROOT=$(rustc --print sysroot)
-        sudo mkdir -p /usr/local/lib
-        sudo find "${SYSROOT}/lib" -maxdepth 1 -name '*dylib' -exec ln -s {} /usr/local/lib \;
-    - name: Set PATH (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        SYSROOT=$(rustc --print sysroot)
-        echo "$SYSROOT/bin" >> $GITHUB_PATH
+      # Run
+      - name: Set LD_LIBRARY_PATH (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          SYSROOT=$(rustc --print sysroot)
+          echo "LD_LIBRARY_PATH=${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
+      - name: Link rustc dylib (MacOS)
+        if: runner.os == 'macOS'
+        run: |
+          SYSROOT=$(rustc --print sysroot)
+          sudo mkdir -p /usr/local/lib
+          sudo find "${SYSROOT}/lib" -maxdepth 1 -name '*dylib' -exec ln -s {} /usr/local/lib \;
+      - name: Set PATH (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          SYSROOT=$(rustc --print sysroot)
+          echo "$SYSROOT/bin" >> $GITHUB_PATH
 
-    - name: Build
-      run: cargo build --features deny-warnings,internal-lints
+      - name: Build
+        run: cargo build --features deny-warnings,internal-lints
 
-    - name: Test
-      run: cargo test --features deny-warnings,internal-lints
+      - name: Test
+        run: cargo test --features deny-warnings,internal-lints
 
-    - name: Test clippy_lints
-      run: cargo test --features deny-warnings,internal-lints
-      working-directory: clippy_lints
+      - name: Test clippy_lints
+        run: cargo test --features deny-warnings,internal-lints
+        working-directory: clippy_lints
 
-    - name: Test rustc_tools_util
-      run: cargo test --features deny-warnings
-      working-directory: rustc_tools_util
+      - name: Test rustc_tools_util
+        run: cargo test --features deny-warnings
+        working-directory: rustc_tools_util
 
-    - name: Test clippy_dev
-      run: cargo test --features deny-warnings
-      working-directory: clippy_dev
+      - name: Test clippy_dev
+        run: cargo test --features deny-warnings
+        working-directory: clippy_dev
 
-    - name: Test cargo-clippy
-      run: ../target/debug/cargo-clippy
-      working-directory: clippy_workspace_tests
+      - name: Test cargo-clippy
+        run: ../target/debug/cargo-clippy
+        working-directory: clippy_workspace_tests
 
-    - name: Test cargo-clippy --fix
-      run: ../target/debug/cargo-clippy clippy --fix -Zunstable-options
-      working-directory: clippy_workspace_tests
+      - name: Test cargo-clippy --fix
+        run: ../target/debug/cargo-clippy clippy --fix -Zunstable-options
+        working-directory: clippy_workspace_tests
 
-    - name: Test clippy-driver
-      run: bash .github/driver.sh
-      env:
-        OS: ${{ runner.os }}
+      - name: Test clippy-driver
+        run: bash .github/driver.sh
+        env:
+          OS: ${{ runner.os }}
 
-    - name: Test cargo dev new lint
-      run: |
-        cargo dev new_lint --name new_early_pass --pass early
-        cargo dev new_lint --name new_late_pass --pass late
-        cargo check
-        git reset --hard HEAD
+      - name: Test cargo dev new lint
+        run: |
+          cargo dev new_lint --name new_early_pass --pass early
+          cargo dev new_lint --name new_late_pass --pass late
+          cargo check
+          git reset --hard HEAD
 
   integration_build:
     needs: changelog
     runs-on: ubuntu-latest
 
     steps:
-    # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
+      # Setup
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+        with:
+          github_token: "${{ secrets.github_token }}"
 
-    - name: Checkout
-      uses: actions/checkout@v2.3.3
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
 
-    - name: Install toolchain
-      run: rustup show active-toolchain
+      - name: Install toolchain
+        run: rustup show active-toolchain
 
-    # Run
-    - name: Build Integration Test
-      run: cargo test --test integration --features integration --no-run
+      # Run
+      - name: Build Integration Test
+        run: cargo test --test integration --features integration --no-run
 
-    # Upload
-    - name: Extract Binaries
-      run: |
-        DIR=$CARGO_TARGET_DIR/debug
-        rm $DIR/deps/integration-*.d
-        mv $DIR/deps/integration-* $DIR/integration
-        find $DIR ! -executable -o -type d ! -path $DIR | xargs rm -rf
-        rm -rf $CARGO_TARGET_DIR/release
+      # Upload
+      - name: Extract Binaries
+        run: |
+          DIR=$CARGO_TARGET_DIR/debug
+          rm $DIR/deps/integration-*.d
+          mv $DIR/deps/integration-* $DIR/integration
+          find $DIR ! -executable -o -type d ! -path $DIR | xargs rm -rf
+          rm -rf $CARGO_TARGET_DIR/release
 
-    - name: Upload Binaries
-      uses: actions/upload-artifact@v1
-      with:
-        name: target
-        path: target
+      - name: Upload Binaries
+        uses: actions/upload-artifact@v1
+        with:
+          name: target
+          path: target
 
   integration:
     needs: integration_build
@@ -190,55 +196,55 @@ jobs:
       max-parallel: 6
       matrix:
         integration:
-        - 'rust-lang/cargo'
-        # FIXME: re-enable once fmt_macros is renamed in RLS
-        # - 'rust-lang/rls'
-        - 'rust-lang/chalk'
-        - 'rust-lang/rustfmt'
-        - 'Marwes/combine'
-        - 'Geal/nom'
-        - 'rust-lang/stdarch'
-        - 'serde-rs/serde'
-        # FIXME: chrono currently cannot be compiled with `--all-targets`
-        # - 'chronotope/chrono'
-        - 'hyperium/hyper'
-        - 'rust-random/rand'
-        - 'rust-lang/futures-rs'
-        - 'rust-itertools/itertools'
-        - 'rust-lang-nursery/failure'
-        - 'rust-lang/log'
+          - "rust-lang/cargo"
+          # FIXME: re-enable once fmt_macros is renamed in RLS
+          # - 'rust-lang/rls'
+          - "rust-lang/chalk"
+          - "rust-lang/rustfmt"
+          - "Marwes/combine"
+          - "Geal/nom"
+          - "rust-lang/stdarch"
+          - "serde-rs/serde"
+          # FIXME: chrono currently cannot be compiled with `--all-targets`
+          # - 'chronotope/chrono'
+          - "hyperium/hyper"
+          - "rust-random/rand"
+          - "rust-lang/futures-rs"
+          - "rust-itertools/itertools"
+          - "rust-lang-nursery/failure"
+          - "rust-lang/log"
 
     runs-on: ubuntu-latest
 
     steps:
-    # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
+      # Setup
+      - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+        with:
+          github_token: "${{ secrets.github_token }}"
 
-    - name: Checkout
-      uses: actions/checkout@v2.3.3
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
 
-    - name: Install toolchain
-      run: rustup show active-toolchain
+      - name: Install toolchain
+        run: rustup show active-toolchain
 
-    # Download
-    - name: Download target dir
-      uses: actions/download-artifact@v1
-      with:
-        name: target
-        path: target
+      # Download
+      - name: Download target dir
+        uses: actions/download-artifact@v1
+        with:
+          name: target
+          path: target
 
-    - name: Make Binaries Executable
-      run: chmod +x $CARGO_TARGET_DIR/debug/*
+      - name: Make Binaries Executable
+        run: chmod +x $CARGO_TARGET_DIR/debug/*
 
-    # Run
-    - name: Test ${{ matrix.integration }}
-      run: |
-        RUSTUP_TOOLCHAIN="$(rustup show active-toolchain | grep -o -E "nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}")" \
-          $CARGO_TARGET_DIR/debug/integration
-      env:
-        INTEGRATION: ${{ matrix.integration }}
+      # Run
+      - name: Test ${{ matrix.integration }}
+        run: |
+          RUSTUP_TOOLCHAIN="$(rustup show active-toolchain | grep -o -E "nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}")" \
+            $CARGO_TARGET_DIR/debug/integration
+        env:
+          INTEGRATION: ${{ matrix.integration }}
 
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -113,9 +113,6 @@ jobs:
     - name: Build
       run: cargo build --features deny-warnings,internal-lints
 
-    - name: Test "--fix -Zunstable-options"
-      run: cargo run --features deny-warnings,internal-lints --bin cargo-clippy -- clippy --fix -Zunstable-options
-
     - name: Test
       run: cargo test --features deny-warnings,internal-lints
 
@@ -133,6 +130,10 @@ jobs:
 
     - name: Test cargo-clippy
       run: ../target/debug/cargo-clippy
+      working-directory: clippy_workspace_tests
+
+    - name: Test cargo-clippy --fix
+      run: ../target/debug/cargo-clippy clippy -- --fix
       working-directory: clippy_workspace_tests
 
     - name: Test clippy-driver

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -72,6 +72,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    # NOTE: If you modify this job, make sure you copy the changes to clippy.yml
     steps:
     # Setup
     - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
@@ -112,6 +113,9 @@ jobs:
     - name: Build
       run: cargo build --features deny-warnings,internal-lints
 
+    - name: Test "--fix -Zunstable-options"
+      run: cargo run --features deny-warnings,internal-lints --bin cargo-clippy -- clippy --fix -Zunstable-options
+
     - name: Test
       run: cargo test --features deny-warnings,internal-lints
 
@@ -123,8 +127,8 @@ jobs:
       run: cargo test --features deny-warnings
       working-directory: rustc_tools_util
 
-    - name: Test clippy_dev
-      run: cargo test --features deny-warnings
+    - name: Test clippy_dev and lintcheck
+      run: cargo test --features lintcheck,deny-warnings
       working-directory: clippy_dev
 
     - name: Test cargo-clippy
@@ -135,6 +139,13 @@ jobs:
       run: bash .github/driver.sh
       env:
         OS: ${{ runner.os }}
+
+    - name: Test cargo dev new lint
+      run: |
+        cargo dev new_lint --name new_early_pass --pass early
+        cargo dev new_lint --name new_late_pass --pass late
+        cargo check
+        git reset --hard HEAD
 
   integration_build:
     needs: changelog

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Test fmt
         run: cargo dev fmt --check
 
+      # Lintcheck
+      - name: build lintcheck
+        run: cargo build --features lintcheck,deny-warnings
+        working-directory: clippy_dev
+
+      - name: test lintcheck
+        run: cargo test --features lintcheck,deny-warnings
+        working-directory: clippy_dev
+
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a
   # workflow is successful listening to webhooks only.

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -38,13 +38,6 @@ jobs:
           components: rustfmt
           default: true
 
-      - name: Test fmt
-        run: cargo dev fmt --check
-
-      # Restore the rust-toolchain-file
-      - name: Restore rust-toolchain-file
-        run: git checkout rust-toolchain
-
       # Run
       - name: Build
         run: cargo build --features deny-warnings
@@ -55,6 +48,13 @@ jobs:
 
       - name: Test update_lints
         run: cargo dev update_lints --check
+
+      - name: Test fmt
+        run: cargo dev fmt --check
+
+      # Restore the rust-toolchain-file
+      - name: Restore rust-toolchain-file
+        run: git checkout rust-toolchain
 
       # Lintcheck
       - name: build lintcheck

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.3
 
+      # To test formatting, we need to temporarily disable the rust-toolchain file
       - name: remove toolchain file
         run: rm rust-toolchain
 
@@ -37,6 +38,13 @@ jobs:
           components: rustfmt
           default: true
 
+      - name: Test fmt
+        run: cargo dev fmt --check
+
+      # Restore the rust-toolchain-file
+      - name: Restore rust-toolchain-file
+        run: git checkout rust-toolchain
+
       # Run
       - name: Build
         run: cargo build --features deny-warnings
@@ -47,9 +55,6 @@ jobs:
 
       - name: Test update_lints
         run: cargo dev update_lints --check
-
-      - name: Test fmt
-        run: cargo dev fmt --check
 
       # Lintcheck
       - name: build lintcheck

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     # Only run on paths, that get checked by the clippy_dev tool
     paths:
-    - 'CHANGELOG.md'
-    - 'README.md'
-    - '**.stderr'
-    - '**.rs'
+      - "CHANGELOG.md"
+      - "README.md"
+      - "**.stderr"
+      - "**.rs"
 
 env:
   RUST_BACKTRACE: 1
@@ -21,35 +21,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Setup
-    - name: Checkout
-      uses: actions/checkout@v2.3.3
+      # Setup
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
 
-    - name: remove toolchain file
-      run: rm rust-toolchain
+      - name: remove toolchain file
+        run: rm rust-toolchain
 
-    - name: rust-toolchain
-      uses: actions-rs/toolchain@v1.0.6
-      with:
-        toolchain: nightly
-        target: x86_64-unknown-linux-gnu
-        profile: minimal
-        components: rustfmt
-        default: true
+      - name: rust-toolchain
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: nightly
+          target: x86_64-unknown-linux-gnu
+          profile: minimal
+          components: rustfmt
+          default: true
 
-    # Run
-    - name: Build
-      run: cargo build --features deny-warnings
-      working-directory: clippy_dev
+      # Run
+      - name: Build
+        run: cargo build --features deny-warnings
+        working-directory: clippy_dev
 
-    - name: Test limit_stderr_length
-      run: cargo dev limit_stderr_length
+      - name: Test limit_stderr_length
+        run: cargo dev limit_stderr_length
 
-    - name: Test update_lints
-      run: cargo dev update_lints --check
+      - name: Test update_lints
+        run: cargo dev update_lints --check
 
-    - name: Test fmt
-      run: cargo dev fmt --check
+      - name: Test fmt
+        run: cargo dev fmt --check
 
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     # Only run on paths, that get checked by the clippy_dev tool
     paths:
-      - "CHANGELOG.md"
-      - "README.md"
-      - "**.stderr"
-      - "**.rs"
+    - 'CHANGELOG.md'
+    - 'README.md'
+    - '**.stderr'
+    - '**.rs'
 
 env:
   RUST_BACKTRACE: 1
@@ -21,49 +21,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Setup
-      - name: Checkout
-        uses: actions/checkout@v2.3.3
+    # Setup
+    - name: Checkout
+      uses: actions/checkout@v2.3.3
 
-      # To test formatting, we need to temporarily disable the rust-toolchain file
-      - name: remove toolchain file
-        run: rm rust-toolchain
+    - name: remove toolchain file
+      run: rm rust-toolchain
 
-      - name: rust-toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: nightly
-          target: x86_64-unknown-linux-gnu
-          profile: minimal
-          components: rustfmt
-          default: true
+    - name: rust-toolchain
+      uses: actions-rs/toolchain@v1.0.6
+      with:
+        toolchain: nightly
+        target: x86_64-unknown-linux-gnu
+        profile: minimal
+        components: rustfmt
+        default: true
 
-      # Run
-      - name: Build
-        run: cargo build --features deny-warnings
-        working-directory: clippy_dev
+    # Run
+    - name: Build
+      run: cargo build --features deny-warnings
+      working-directory: clippy_dev
 
-      - name: Test limit_stderr_length
-        run: cargo dev limit_stderr_length
+    - name: Test limit_stderr_length
+      run: cargo dev limit_stderr_length
 
-      - name: Test update_lints
-        run: cargo dev update_lints --check
+    - name: Test update_lints
+      run: cargo dev update_lints --check
 
-      - name: Test fmt
-        run: cargo dev fmt --check
-
-      # Restore the rust-toolchain-file
-      - name: Restore rust-toolchain-file
-        run: git checkout rust-toolchain
-
-      # Lintcheck
-      - name: build lintcheck
-        run: cargo build --features lintcheck,deny-warnings
-        working-directory: clippy_dev
-
-      - name: test lintcheck
-        run: cargo test --features lintcheck,deny-warnings
-        working-directory: clippy_dev
+    - name: Test fmt
+      run: cargo dev fmt --check
 
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a

--- a/clippy_dev/ci_test_sources.toml
+++ b/clippy_dev/ci_test_sources.toml
@@ -1,0 +1,4 @@
+[crates]
+cc = {name = "cc", versions = ['1.0.67']}
+home = {name = "home", git_url = "https://github.com/brson/home", git_hash = "32044e53dfbdcd32bafad3109d1fbab805fc0f40"}
+rustc_tools_util = {name = "rustc_tools_util", versions = ['0.2.0']}

--- a/clippy_dev/src/lintcheck.rs
+++ b/clippy_dev/src/lintcheck.rs
@@ -6,6 +6,7 @@
 
 #![cfg(feature = "lintcheck")]
 #![allow(clippy::filter_map, clippy::collapsible_else_if)]
+#![allow(clippy::blocks_in_if_conditions)] // FP on `if x.iter().any(|x| ...)`
 
 use crate::clippy_project_root;
 
@@ -330,8 +331,9 @@ impl LintcheckConfig {
         // by default use a single thread
         let max_jobs = match clap_config.value_of("threads") {
             Some(threads) => {
-                let err_msg = format!("Failed to parse '{}' to a digit", threads);
-                let threads: usize = threads.parse().expect(&err_msg);
+                let threads: usize = threads
+                    .parse()
+                    .unwrap_or_else(|_| panic!("Failed to parse '{}' to a digit", threads));
                 if threads == 0 {
                     // automatic choice
                     // Rayon seems to return thread count so half that for core count
@@ -751,9 +753,7 @@ fn lintcheck_test() {
         "lintcheck",
         "--",
         "lintcheck",
-        //"--",
         "--crates-toml",
-        //"--",
         "clippy_dev/ci_test_sources.toml",
     ];
     let status = std::process::Command::new("cargo")

--- a/clippy_dev/src/lintcheck.rs
+++ b/clippy_dev/src/lintcheck.rs
@@ -501,6 +501,9 @@ fn gather_stats(clippy_warnings: &[ClippyWarning]) -> (String, HashMap<&String, 
 /// check if the latest modification of the logfile is older than the modification date of the
 /// clippy binary, if this is true, we should clean the lintchec shared target directory and recheck
 fn lintcheck_needs_rerun(lintcheck_logs_path: &Path) -> bool {
+    if !lintcheck_logs_path.exists() {
+        return true;
+    }
     let clippy_modified: std::time::SystemTime = {
         let mut times = [CLIPPY_DRIVER_PATH, CARGO_CLIPPY_PATH].iter().map(|p| {
             std::fs::metadata(p)
@@ -663,7 +666,6 @@ fn read_stats_from_file(file_path: &Path) -> HashMap<String, usize> {
     let file_content: String = match std::fs::read_to_string(file_path).ok() {
         Some(content) => content,
         None => {
-            eprintln!("RETURND");
             return HashMap::new();
         },
     };
@@ -731,4 +733,33 @@ fn print_stats(old_stats: HashMap<String, usize>, new_stats: HashMap<&String, us
         .for_each(|(old_key, old_value)| {
             println!("{} {} => 0", old_key, old_value);
         });
+}
+
+#[test]
+fn lintcheck_test() {
+    let args = [
+        "run",
+        "--target-dir",
+        "clippy_dev/target",
+        "--package",
+        "clippy_dev",
+        "--bin",
+        "clippy_dev",
+        "--manifest-path",
+        "clippy_dev/Cargo.toml",
+        "--features",
+        "lintcheck",
+        "--",
+        "lintcheck",
+        //"--",
+        "--crates-toml",
+        //"--",
+        "clippy_dev/ci_test_sources.toml",
+    ];
+    let status = std::process::Command::new("cargo")
+        .args(&args)
+        .current_dir("../" /* repo root */)
+        .status();
+
+    assert!(status.unwrap().success());
 }

--- a/clippy_dev/src/lintcheck.rs
+++ b/clippy_dev/src/lintcheck.rs
@@ -5,14 +5,18 @@
 // positives.
 
 #![cfg(feature = "lintcheck")]
-#![allow(clippy::filter_map)]
+#![allow(clippy::filter_map, clippy::collapsible_else_if)]
 
 use crate::clippy_project_root;
 
 use std::collections::HashMap;
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{env, fmt, fs::write, path::PathBuf};
+use std::{
+    env, fmt,
+    fs::write,
+    path::{Path, PathBuf},
+};
 
 use clap::ArgMatches;
 use rayon::prelude::*;
@@ -196,11 +200,9 @@ impl CrateSource {
                 if !crate_root.exists() {
                     println!("Copying {} to {}", path.display(), copy_dest.display());
 
-                    dir::copy(path, &copy_dest, &dir::CopyOptions::new()).expect(&format!(
-                        "Failed to copy from {}, to  {}",
-                        path.display(),
-                        crate_root.display()
-                    ));
+                    dir::copy(path, &copy_dest, &dir::CopyOptions::new()).unwrap_or_else(|_| {
+                        panic!("Failed to copy from {}, to  {}", path.display(), crate_root.display())
+                    });
                 } else {
                     println!(
                         "Not copying {} to {}, destination already exists",
@@ -225,7 +227,7 @@ impl Crate {
     /// issued
     fn run_clippy_lints(
         &self,
-        cargo_clippy_path: &PathBuf,
+        cargo_clippy_path: &Path,
         target_dir_index: &AtomicUsize,
         thread_limit: usize,
         total_crates_to_lint: usize,
@@ -308,13 +310,13 @@ impl LintcheckConfig {
         // first, check if we got anything passed via the LINTCHECK_TOML env var,
         // if not, ask clap if we got any value for --crates-toml  <foo>
         // if not, use the default "clippy_dev/lintcheck_crates.toml"
-        let sources_toml = env::var("LINTCHECK_TOML").unwrap_or(
+        let sources_toml = env::var("LINTCHECK_TOML").unwrap_or_else(|_| {
             clap_config
                 .value_of("crates-toml")
                 .clone()
                 .unwrap_or("clippy_dev/lintcheck_crates.toml")
-                .to_string(),
-        );
+                .to_string()
+        });
 
         let sources_toml_path = PathBuf::from(sources_toml);
 
@@ -328,9 +330,8 @@ impl LintcheckConfig {
         // by default use a single thread
         let max_jobs = match clap_config.value_of("threads") {
             Some(threads) => {
-                let threads: usize = threads
-                    .parse()
-                    .expect(&format!("Failed to parse '{}' to a digit", threads));
+                let err_msg = format!("Failed to parse '{}' to a digit", threads);
+                let threads: usize = threads.parse().expect(&err_msg);
                 if threads == 0 {
                     // automatic choice
                     // Rayon seems to return thread count so half that for core count
@@ -387,7 +388,7 @@ fn build_clippy() {
 }
 
 /// Read a `toml` file and return a list of `CrateSources` that we want to check with clippy
-fn read_crates(toml_path: &PathBuf) -> Vec<CrateSource> {
+fn read_crates(toml_path: &Path) -> Vec<CrateSource> {
     let toml_content: String =
         std::fs::read_to_string(&toml_path).unwrap_or_else(|_| panic!("Failed to read {}", toml_path.display()));
     let crate_list: SourceList =
@@ -499,7 +500,7 @@ fn gather_stats(clippy_warnings: &[ClippyWarning]) -> (String, HashMap<&String, 
 
 /// check if the latest modification of the logfile is older than the modification date of the
 /// clippy binary, if this is true, we should clean the lintchec shared target directory and recheck
-fn lintcheck_needs_rerun(lintcheck_logs_path: &PathBuf) -> bool {
+fn lintcheck_needs_rerun(lintcheck_logs_path: &Path) -> bool {
     let clippy_modified: std::time::SystemTime = {
         let mut times = [CLIPPY_DRIVER_PATH, CARGO_CLIPPY_PATH].iter().map(|p| {
             std::fs::metadata(p)
@@ -533,15 +534,13 @@ pub fn run(clap_config: &ArgMatches) {
     // refresh the logs
     if lintcheck_needs_rerun(&config.lintcheck_results_path) {
         let shared_target_dir = "target/lintcheck/shared_target_dir";
-        match std::fs::metadata(&shared_target_dir) {
-            Ok(metadata) => {
-                if metadata.is_dir() {
-                    println!("Clippy is newer than lint check logs, clearing lintcheck shared target dir...");
-                    std::fs::remove_dir_all(&shared_target_dir)
-                        .expect("failed to remove target/lintcheck/shared_target_dir");
-                }
-            },
-            Err(_) => { /*  dir probably does not exist, don't remove anything  */ },
+        // if we get an Err here, the shared target dir probably does simply not exist
+        if let Ok(metadata) = std::fs::metadata(&shared_target_dir) {
+            if metadata.is_dir() {
+                println!("Clippy is newer than lint check logs, clearing lintcheck shared target dir...");
+                std::fs::remove_dir_all(&shared_target_dir)
+                    .expect("failed to remove target/lintcheck/shared_target_dir");
+            }
         }
     }
 
@@ -660,7 +659,7 @@ pub fn run(clap_config: &ArgMatches) {
 }
 
 /// read the previous stats from the lintcheck-log file
-fn read_stats_from_file(file_path: &PathBuf) -> HashMap<String, usize> {
+fn read_stats_from_file(file_path: &Path) -> HashMap<String, usize> {
     let file_content: String = match std::fs::read_to_string(file_path).ok() {
         Some(content) => content,
         None => {
@@ -678,9 +677,9 @@ fn read_stats_from_file(file_path: &PathBuf) -> HashMap<String, usize> {
     let stats_lines = &lines[start + 1..=end - 1];
 
     stats_lines
-        .into_iter()
+        .iter()
         .map(|line| {
-            let mut spl = line.split(" ").into_iter();
+            let mut spl = line.split(' ');
             (
                 spl.next().unwrap().to_string(),
                 spl.next().unwrap().parse::<usize>().unwrap(),

--- a/lintcheck-logs/lintcheck_crates_logs.txt
+++ b/lintcheck-logs/lintcheck_crates_logs.txt
@@ -1,4 +1,4 @@
-clippy 0.1.52 (70d952e75 2021-02-28)
+clippy 0.1.52 (3c72f0b53 2021-03-02)
 
 target/lintcheck/sources/anyhow-1.0.38/build.rs:1:null clippy::cargo_common_metadata "package `anyhow` is missing `package.keywords` metadata"
 target/lintcheck/sources/anyhow-1.0.38/src/error.rs:350:5 clippy::missing_panics_doc "docs for function which may panic missing `# Panics` section"
@@ -99,6 +99,7 @@ target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:1:null clippy::multi
 target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:1:null clippy::multiple_crate_versions "multiple versions for dependency `hex`: 0.3.2, 0.4.0"
 target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:1:null clippy::multiple_crate_versions "multiple versions for dependency `humantime`: 1.3.0, 2.0.0"
 target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:72:22 clippy::redundant_closure_for_method_calls "redundant closure found"
+target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:79:40 clippy::manual_map "manual implementation of `Option::map`"
 target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:94:13 clippy::match_wildcard_for_single_variants "wildcard match will miss any future added variants"
 target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:96:41 clippy::redundant_closure_for_method_calls "redundant closure found"
 target/lintcheck/sources/cargo-0.49.0/src/bin/cargo/main.rs:98:60 clippy::redundant_closure_for_method_calls "redundant closure found"
@@ -1208,6 +1209,7 @@ target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/mod.rs:689:20 clippy
 target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/mod.rs:699:5 clippy::fn_params_excessive_bools "more than 3 bools in function parameters"
 target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/mod.rs:699:5 clippy::missing_errors_doc "docs for function returning `Result` missing `# Errors` section"
 target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/mod.rs:719:58 clippy::redundant_closure_for_method_calls "redundant closure found"
+target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/mod.rs:748:30 clippy::manual_map "manual implementation of `Option::map`"
 target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/mod.rs:816:5 clippy::missing_errors_doc "docs for function returning `Result` missing `# Errors` section"
 target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/path.rs:10:1 clippy::module_name_repetitions "item name ends with its containing module's name"
 target/lintcheck/sources/cargo-0.49.0/src/cargo/util/config/path.rs:14:5 clippy::must_use_candidate "this method could have a `#[must_use]` attribute"
@@ -1463,6 +1465,7 @@ target/lintcheck/sources/cfg-expr-0.7.1/src/expr/mod.rs:464:5 clippy::missing_pa
 target/lintcheck/sources/cfg-expr-0.7.1/src/expr/mod.rs:57:13 clippy::enum_glob_use "usage of wildcard import for enum variants"
 target/lintcheck/sources/cfg-expr-0.7.1/src/expr/mod.rs:586:33 clippy::match_same_arms "this `match` has identical arm bodies"
 target/lintcheck/sources/cfg-expr-0.7.1/src/expr/mod.rs:599:32 clippy::match_same_arms "this `match` has identical arm bodies"
+target/lintcheck/sources/cfg-expr-0.7.1/src/expr/mod.rs:609:9 clippy::manual_map "manual implementation of `Option::map`"
 target/lintcheck/sources/cfg-expr-0.7.1/src/expr/parser.rs:116:31 clippy::similar_names "binding's name is too similar to existing binding"
 target/lintcheck/sources/cfg-expr-0.7.1/src/expr/parser.rs:124:36 clippy::similar_names "binding's name is too similar to existing binding"
 target/lintcheck/sources/cfg-expr-0.7.1/src/expr/parser.rs:17:5 clippy::missing_errors_doc "docs for function returning `Result` missing `# Errors` section"
@@ -3509,6 +3512,7 @@ clippy::filter_map_next 3
 clippy::fn_params_excessive_bools 3
 clippy::if_same_then_else 3
 clippy::inconsistent_struct_constructor 3
+clippy::manual_map 3
 clippy::mut_mut 3
 clippy::ptr_arg 3
 clippy::zero_ptr 3


### PR DESCRIPTION
fixes clippy warnings in lintcheck and adds a small test (run on 3 small crates) to gha ci


changelog: none
