### PR TITLE
Fix false-positive in `use_self`

### DIFF
--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -262,12 +262,17 @@ impl<'tcx> LateLintPass<'tcx> for UseSelf {
             // FIXME: this span manipulation should not be necessary
             // @flip1995 found an ast lowering issue in
             // https://github.com/rust-lang/rust/blob/master/src/librustc_ast_lowering/path.rs#l142-l162
-            match cx.tcx.hir().find(cx.tcx.hir().get_parent_node(hir_ty.hir_id)) {
-                Some(Node::Expr(Expr {
-                    kind: ExprKind::Path(QPath::TypeRelative(_, segment)),
-                    ..
-                })) => span_lint_until_last_segment(cx, hir_ty.span, segment),
-                _ => span_lint(cx, hir_ty.span),
+            let hir = cx.tcx.hir();
+            let id = hir.get_parent_node(hir_ty.hir_id);
+
+            if !hir.opt_span(id).map(in_macro).unwrap_or(false) {
+                match hir.find(id) {
+                    Some(Node::Expr(Expr {
+                        kind: ExprKind::Path(QPath::TypeRelative(_, segment)),
+                        ..
+                    })) => span_lint_until_last_segment(cx, hir_ty.span, segment),
+                    _ => span_lint(cx, hir_ty.span),
+                }
             }
         }
     }

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -454,3 +454,10 @@ mod nested_paths {
         }
     }
 }
+
+mod issue6818 {
+    #[derive(serde::Deserialize)]
+    struct A {
+        a: i32,
+    }
+}

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -454,3 +454,10 @@ mod nested_paths {
         }
     }
 }
+
+mod issue6818 {
+    #[derive(serde::Deserialize)]
+    struct A {
+        a: i32,
+    }
+}


### PR DESCRIPTION
Fixes  #6818. 

changelog: Fix false positives for use_self in macros.
