### PR TITLE
Let Cargo track CLIPPY_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ the lint(s) you are interested in:
 ```terminal
 cargo clippy -- -A clippy::all -W clippy::useless_format -W clippy::...
 ```
-Note that if you've run clippy before, this may only take effect after you've modified a file or ran `cargo clean`.
 
 ### Specifying the minimum supported Rust version
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -73,11 +73,13 @@ fn track_clippy_args(sess: &Session, args_env_var: &Option<String>) {
 struct DefaultCallbacks;
 impl rustc_driver::Callbacks for DefaultCallbacks {}
 
-struct ClippyArgsCallbacks {
+/// This is different from `DefaultCallbacks` that it will inform Cargo to track the value of
+/// `CLIPPY_ARGS` environment variable.
+struct RustcCallbacks {
     clippy_args_var: Option<String>,
 }
 
-impl rustc_driver::Callbacks for ClippyArgsCallbacks {
+impl rustc_driver::Callbacks for RustcCallbacks {
     fn config(&mut self, config: &mut interface::Config) {
         let previous = config.register_lints.take();
         let clippy_args_var = self.clippy_args_var.take();
@@ -351,7 +353,7 @@ pub fn main() {
         if clippy_enabled {
             rustc_driver::RunCompiler::new(&args, &mut ClippyCallbacks { clippy_args_var }).run()
         } else {
-            rustc_driver::RunCompiler::new(&args, &mut ClippyArgsCallbacks { clippy_args_var }).run()
+            rustc_driver::RunCompiler::new(&args, &mut RustcCallbacks { clippy_args_var }).run()
         }
     }))
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -20,7 +20,7 @@ use rustc_span::symbol::Symbol;
 use rustc_tools_util::VersionInfo;
 
 use std::borrow::Cow;
-use std::env::{self, VarError};
+use std::env;
 use std::lazy::SyncLazy;
 use std::ops::Deref;
 use std::panic;
@@ -314,13 +314,7 @@ pub fn main() {
         };
 
         let mut no_deps = false;
-        let clippy_args_var = env::var("CLIPPY_ARGS").map_or_else(
-            |e| match e {
-                VarError::NotPresent => None,
-                VarError::NotUnicode(s) => panic!("CLIPPY_ARGS is not valid Unicode: {:?}", s),
-            },
-            Some,
-        );
+        let clippy_args_var = env::var("CLIPPY_ARGS").ok();
         let clippy_args = clippy_args_var
             .as_deref()
             .unwrap_or_default()

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -3,7 +3,7 @@
 #![feature(once_cell)]
 
 use std::lazy::SyncLazy;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 mod cargo;
@@ -49,17 +49,6 @@ fn dogfood_clippy() {
 #[test]
 fn dogfood_subprojects() {
     fn test_no_deps_ignores_path_deps_in_workspaces() {
-        fn clean(cwd: &Path, target_dir: &Path) {
-            Command::new("cargo")
-                .current_dir(cwd)
-                .env("CARGO_TARGET_DIR", target_dir)
-                .arg("clean")
-                .args(&["-p", "subcrate"])
-                .args(&["-p", "path_dep"])
-                .output()
-                .unwrap();
-        }
-
         if cargo::is_rustc_test_suite() {
             return;
         }
@@ -68,7 +57,14 @@ fn dogfood_subprojects() {
         let cwd = root.join("clippy_workspace_tests");
 
         // Make sure we start with a clean state
-        clean(&cwd, &target_dir);
+        Command::new("cargo")
+            .current_dir(&cwd)
+            .env("CARGO_TARGET_DIR", &target_dir)
+            .arg("clean")
+            .args(&["-p", "subcrate"])
+            .args(&["-p", "path_dep"])
+            .output()
+            .unwrap();
 
         // `path_dep` is a path dependency of `subcrate` that would trigger a denied lint.
         // Make sure that with the `--no-deps` argument Clippy does not run on `path_dep`.
@@ -90,26 +86,65 @@ fn dogfood_subprojects() {
 
         assert!(output.status.success());
 
-        // Make sure we start with a clean state
-        clean(&cwd, &target_dir);
+        let lint_path_dep = || {
+            // Test that without the `--no-deps` argument, `path_dep` is linted.
+            let output = Command::new(&*CLIPPY_PATH)
+                .current_dir(&cwd)
+                .env("CLIPPY_DOGFOOD", "1")
+                .env("CARGO_INCREMENTAL", "0")
+                .arg("clippy")
+                .args(&["-p", "subcrate"])
+                .arg("--")
+                .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
+                .args(&["--cfg", r#"feature="primary_package_test""#])
+                .output()
+                .unwrap();
+            println!("status: {}", output.status);
+            println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+            println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
 
-        // Test that without the `--no-deps` argument, `path_dep` is linted.
-        let output = Command::new(&*CLIPPY_PATH)
-            .current_dir(&cwd)
-            .env("CLIPPY_DOGFOOD", "1")
-            .env("CARGO_INCREMENTAL", "0")
-            .arg("clippy")
-            .args(&["-p", "subcrate"])
-            .arg("--")
-            .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
-            .args(&["--cfg", r#"feature="primary_package_test""#])
-            .output()
-            .unwrap();
-        println!("status: {}", output.status);
-        println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
-        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            assert!(!output.status.success());
+            assert!(
+                String::from_utf8(output.stderr)
+                    .unwrap()
+                    .contains("error: empty `loop {}` wastes CPU cycles")
+            );
+        };
 
-        assert!(!output.status.success());
+        // Make sure Cargo is aware of the removal of `--no-deps`.
+        lint_path_dep();
+
+        let successful_build = || {
+            let output = Command::new(&*CLIPPY_PATH)
+                .current_dir(&cwd)
+                .env("CLIPPY_DOGFOOD", "1")
+                .env("CARGO_INCREMENTAL", "0")
+                .arg("clippy")
+                .args(&["-p", "subcrate"])
+                .arg("--")
+                .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
+                .output()
+                .unwrap();
+            println!("status: {}", output.status);
+            println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+            println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+            assert!(output.status.success());
+
+            output
+        };
+
+        // Trigger a sucessful build, so Cargo would like to cache the build result.
+        successful_build();
+
+        // Make sure there's no spurious rebuild when nothing changes.
+        let stderr = String::from_utf8(successful_build().stderr).unwrap();
+        assert!(!stderr.contains("Compiling"));
+        assert!(!stderr.contains("Checking"));
+        assert!(stderr.contains("Finished"));
+
+        // Make sure Cargo is aware of the new `--cfg` flag.
+        lint_path_dep();
     }
 
     // run clippy on remaining subprojects and fail the test if lint warnings are reported

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -46,28 +46,46 @@ fn dogfood_clippy() {
     assert!(output.status.success());
 }
 
-#[test]
-fn dogfood_subprojects() {
-    fn test_no_deps_ignores_path_deps_in_workspaces() {
-        if cargo::is_rustc_test_suite() {
-            return;
-        }
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let target_dir = root.join("target").join("dogfood");
-        let cwd = root.join("clippy_workspace_tests");
+fn test_no_deps_ignores_path_deps_in_workspaces() {
+    if cargo::is_rustc_test_suite() {
+        return;
+    }
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target_dir = root.join("target").join("dogfood");
+    let cwd = root.join("clippy_workspace_tests");
 
-        // Make sure we start with a clean state
-        Command::new("cargo")
-            .current_dir(&cwd)
-            .env("CARGO_TARGET_DIR", &target_dir)
-            .arg("clean")
-            .args(&["-p", "subcrate"])
-            .args(&["-p", "path_dep"])
-            .output()
-            .unwrap();
+    // Make sure we start with a clean state
+    Command::new("cargo")
+        .current_dir(&cwd)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .arg("clean")
+        .args(&["-p", "subcrate"])
+        .args(&["-p", "path_dep"])
+        .output()
+        .unwrap();
 
-        // `path_dep` is a path dependency of `subcrate` that would trigger a denied lint.
-        // Make sure that with the `--no-deps` argument Clippy does not run on `path_dep`.
+    // `path_dep` is a path dependency of `subcrate` that would trigger a denied lint.
+    // Make sure that with the `--no-deps` argument Clippy does not run on `path_dep`.
+    let output = Command::new(&*CLIPPY_PATH)
+        .current_dir(&cwd)
+        .env("CLIPPY_DOGFOOD", "1")
+        .env("CARGO_INCREMENTAL", "0")
+        .arg("clippy")
+        .args(&["-p", "subcrate"])
+        .arg("--")
+        .arg("--no-deps")
+        .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
+        .args(&["--cfg", r#"feature="primary_package_test""#])
+        .output()
+        .unwrap();
+    println!("status: {}", output.status);
+    println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+    println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success());
+
+    let lint_path_dep = || {
+        // Test that without the `--no-deps` argument, `path_dep` is linted.
         let output = Command::new(&*CLIPPY_PATH)
             .current_dir(&cwd)
             .env("CLIPPY_DOGFOOD", "1")
@@ -75,7 +93,6 @@ fn dogfood_subprojects() {
             .arg("clippy")
             .args(&["-p", "subcrate"])
             .arg("--")
-            .arg("--no-deps")
             .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
             .args(&["--cfg", r#"feature="primary_package_test""#])
             .output()
@@ -84,69 +101,52 @@ fn dogfood_subprojects() {
         println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
         println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
 
+        assert!(!output.status.success());
+        assert!(
+            String::from_utf8(output.stderr)
+                .unwrap()
+                .contains("error: empty `loop {}` wastes CPU cycles")
+        );
+    };
+
+    // Make sure Cargo is aware of the removal of `--no-deps`.
+    lint_path_dep();
+
+    let successful_build = || {
+        let output = Command::new(&*CLIPPY_PATH)
+            .current_dir(&cwd)
+            .env("CLIPPY_DOGFOOD", "1")
+            .env("CARGO_INCREMENTAL", "0")
+            .arg("clippy")
+            .args(&["-p", "subcrate"])
+            .arg("--")
+            .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
+            .output()
+            .unwrap();
+        println!("status: {}", output.status);
+        println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+
         assert!(output.status.success());
 
-        let lint_path_dep = || {
-            // Test that without the `--no-deps` argument, `path_dep` is linted.
-            let output = Command::new(&*CLIPPY_PATH)
-                .current_dir(&cwd)
-                .env("CLIPPY_DOGFOOD", "1")
-                .env("CARGO_INCREMENTAL", "0")
-                .arg("clippy")
-                .args(&["-p", "subcrate"])
-                .arg("--")
-                .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
-                .args(&["--cfg", r#"feature="primary_package_test""#])
-                .output()
-                .unwrap();
-            println!("status: {}", output.status);
-            println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
-            println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        output
+    };
 
-            assert!(!output.status.success());
-            assert!(
-                String::from_utf8(output.stderr)
-                    .unwrap()
-                    .contains("error: empty `loop {}` wastes CPU cycles")
-            );
-        };
+    // Trigger a sucessful build, so Cargo would like to cache the build result.
+    successful_build();
 
-        // Make sure Cargo is aware of the removal of `--no-deps`.
-        lint_path_dep();
+    // Make sure there's no spurious rebuild when nothing changes.
+    let stderr = String::from_utf8(successful_build().stderr).unwrap();
+    assert!(!stderr.contains("Compiling"));
+    assert!(!stderr.contains("Checking"));
+    assert!(stderr.contains("Finished"));
 
-        let successful_build = || {
-            let output = Command::new(&*CLIPPY_PATH)
-                .current_dir(&cwd)
-                .env("CLIPPY_DOGFOOD", "1")
-                .env("CARGO_INCREMENTAL", "0")
-                .arg("clippy")
-                .args(&["-p", "subcrate"])
-                .arg("--")
-                .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
-                .output()
-                .unwrap();
-            println!("status: {}", output.status);
-            println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
-            println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+    // Make sure Cargo is aware of the new `--cfg` flag.
+    lint_path_dep();
+}
 
-            assert!(output.status.success());
-
-            output
-        };
-
-        // Trigger a sucessful build, so Cargo would like to cache the build result.
-        successful_build();
-
-        // Make sure there's no spurious rebuild when nothing changes.
-        let stderr = String::from_utf8(successful_build().stderr).unwrap();
-        assert!(!stderr.contains("Compiling"));
-        assert!(!stderr.contains("Checking"));
-        assert!(stderr.contains("Finished"));
-
-        // Make sure Cargo is aware of the new `--cfg` flag.
-        lint_path_dep();
-    }
-
+#[test]
+fn dogfood_subprojects() {
     // run clippy on remaining subprojects and fail the test if lint warnings are reported
     if cargo::is_rustc_test_suite() {
         return;


### PR DESCRIPTION
This PR makes `clippy-driver` emit `CLIPPY_ARGS` in its `dep-info` output.

Just like #6441, this allows this workflow to work:
```shell
cargo clippy # warning: empty `loop {}` wastes CPU cycles
cargo clippy -- -A clippy::empty_loop # no warnings emitted
```
But without rebuilding all dependencies.

cc https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/CLIPPY_ARGS.20is.20not.20tracked.20by.20Cargo/near/228599088

changelog: Cargo now re-runs Clippy if arguments after `--` provided to `cargo clippy` are changed.