### PR TITLE
Compare empty blocks for equality based on tokens

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -14,6 +14,7 @@ extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_hir_pretty;
 extern crate rustc_infer;
+extern crate rustc_lexer;
 extern crate rustc_lint;
 extern crate rustc_middle;
 extern crate rustc_mir;

--- a/tests/ui/match_same_arms2.rs
+++ b/tests/ui/match_same_arms2.rs
@@ -120,6 +120,35 @@ fn match_same_arms() {
         },
     }
 
+    // False positive #1390
+    macro_rules! empty {
+        ($e:expr) => {};
+    }
+    match 0 {
+        0 => {
+            empty!(0);
+        },
+        1 => {
+            empty!(1);
+        },
+        x => {
+            empty!(x);
+        },
+    };
+
+    // still lint if the tokens are the same
+    match 0 {
+        0 => {
+            empty!(0);
+        },
+        1 => {
+            empty!(0);
+        },
+        x => {
+            empty!(x);
+        },
+    }
+
     match_expr_like_matches_macro_priority();
 }
 

--- a/tests/ui/match_same_arms2.stderr
+++ b/tests/ui/match_same_arms2.stderr
@@ -141,8 +141,31 @@ LL |         Ok(3) => println!("ok"),
    |         ^^^^^
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: this `match` has identical arm bodies
+  --> $DIR/match_same_arms2.rs:144:14
+   |
+LL |           1 => {
+   |  ______________^
+LL | |             empty!(0);
+LL | |         },
+   | |_________^
+   |
+note: same as this
+  --> $DIR/match_same_arms2.rs:141:14
+   |
+LL |           0 => {
+   |  ______________^
+LL | |             empty!(0);
+LL | |         },
+   | |_________^
+help: consider refactoring into `0 | 1`
+  --> $DIR/match_same_arms2.rs:141:9
+   |
+LL |         0 => {
+   |         ^
+
 error: match expression looks like `matches!` macro
-  --> $DIR/match_same_arms2.rs:133:16
+  --> $DIR/match_same_arms2.rs:162:16
    |
 LL |       let _ans = match x {
    |  ________________^
@@ -154,5 +177,5 @@ LL | |     };
    |
    = note: `-D clippy::match-like-matches-macro` implied by `-D warnings`
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
fixes: #1390

This only considers empty blocks for now, though we should also catch something like this:

```rust
match 0 {
    0 => {
        do_something();
        trace!(0);
        0
    }
    1 => {
        do_something();
        trace!(1);
        1
    }
    x => x,
}
```

As far as I can tell there aren't any negative effects on other lints. These blocks only happen to be the same for a given compilation, not all compilations.

changelog: Fix `match_on_same_arms` and others. Only consider empty blocks equal if the tokens contained are the same.
