### PR TITLE
lintcheck: add --fix mode which tries to apply lint suggestions to th…

### DIFF
--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -77,7 +77,8 @@ fn get_clap_config<'a>() -> ArgMatches<'a> {
                 .short("j")
                 .long("jobs")
                 .help("number of threads to use, 0 automatic choice"),
-        );
+        )
+        .arg(Arg::with_name("fix").help("runs cargo clippy --fix and checks if all suggestions apply"));
 
     let app = App::new("Clippy developer tooling")
         .subcommand(


### PR DESCRIPTION
…e sources and prints a warning if that fails

Great for spotting false positives/broken suggestions of applicable lints.

There are false positives though because I'm not sure yet how to silence rustc warnings while keeping clippy warnings.
Sometimes rustc makes a suggestion that fails to apply and the implementation does not differentiate between clippy and rustc warnings when applying lint suggestions.

changelog: none
