### PR TITLE
Remove a couple MIR usages

### DIFF
--- a/clippy_lints/src/async_yields_async.rs
+++ b/clippy_lints/src/async_yields_async.rs
@@ -50,8 +50,7 @@ impl<'tcx> LateLintPass<'tcx> for AsyncYieldsAsync {
                 let body_id = BodyId {
                     hir_id: body.value.hir_id,
                 };
-                let def_id = cx.tcx.hir().body_owner_def_id(body_id);
-                let typeck_results = cx.tcx.typeck(def_id);
+                let typeck_results = cx.tcx.typeck_body(body_id);
                 let expr_ty = typeck_results.expr_ty(&body.value);
 
                 if implements_trait(cx, expr_ty, future_trait_def_id, &[]) {

--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -97,8 +97,7 @@ impl LateLintPass<'_> for AwaitHolding {
             let body_id = BodyId {
                 hir_id: body.value.hir_id,
             };
-            let def_id = cx.tcx.hir().body_owner_def_id(body_id);
-            let typeck_results = cx.tcx.typeck(def_id);
+            let typeck_results = cx.tcx.typeck_body(body_id);
             check_interior_types(
                 cx,
                 &typeck_results.generator_interior_types.as_ref().skip_binder(),

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -325,9 +325,9 @@ fn lint_for_missing_headers<'tcx>(
             if_chain! {
                 if let Some(body_id) = body_id;
                 if let Some(future) = cx.tcx.lang_items().future_trait();
-                let def_id = cx.tcx.hir().body_owner_def_id(body_id);
-                let mir = cx.tcx.optimized_mir(def_id.to_def_id());
-                let ret_ty = mir.return_ty();
+                let typeck = cx.tcx.typeck_body(body_id);
+                let body = cx.tcx.hir().body(body_id);
+                let ret_ty = typeck.expr_ty(&body.value);
                 if implements_trait(cx, ret_ty, future, &[]);
                 if let ty::Opaque(_, subs) = ret_ty.kind();
                 if let Some(gen) = subs.types().next();

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -1,4 +1,4 @@
-use crate::utils::{fn_has_unsatisfiable_preds, match_panic_def_id, snippet_opt, span_lint_and_then};
+use crate::utils::{match_panic_def_id, snippet_opt, span_lint_and_then};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::intravisit::FnKind;
@@ -133,19 +133,13 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitReturn {
         span: Span,
         _: HirId,
     ) {
-        let def_id = cx.tcx.hir().body_owner_def_id(body.id());
-
-        // Building MIR for `fn`s with unsatisfiable preds results in ICE.
-        if fn_has_unsatisfiable_preds(cx, def_id.to_def_id()) {
+        if span.from_expansion() {
             return;
         }
-
-        let mir = cx.tcx.optimized_mir(def_id.to_def_id());
-
-        // checking return type through MIR, HIR is not able to determine inferred closure return types
-        // make sure it's not a macro
-        if !mir.return_ty().is_unit() && !span.from_expansion() {
-            expr_match(cx, &body.value);
+        let body = cx.tcx.hir().body(body.id());
+        if cx.typeck_results().expr_ty(&body.value).is_unit() {
+            return;
         }
+        expr_match(cx, &body.value);
     }
 }


### PR DESCRIPTION
changelog: none

We use MIR to get the return type of a closure/function in a couple places. But typeck seems like a better approach.

This is the easy part of #6080.

Also did a tiny cleanup with `typeck` -> `typeck_body`.