### PR TITLE
`len_without_is_empty` will now consider multiple impl blocks

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -63,9 +63,9 @@ use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_hir::Node;
 use rustc_hir::{
-    def, Arm, Block, Body, Constness, Crate, Expr, ExprKind, FnDecl, GenericArgs, HirId, ImplItem, ImplItemKind, Item,
-    ItemKind, MatchSource, Param, Pat, PatKind, Path, PathSegment, QPath, TraitItem, TraitItemKind, TraitRef, TyKind,
-    Unsafety,
+    def, Arm, Block, Body, Constness, Crate, Expr, ExprKind, FnDecl, GenericArgs, HirId, Impl, ImplItem, ImplItemKind,
+    Item, ItemKind, MatchSource, Param, Pat, PatKind, Path, PathSegment, QPath, TraitItem, TraitItemKind, TraitRef,
+    TyKind, Unsafety,
 };
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::{LateContext, Level, Lint, LintContext};
@@ -1002,6 +1002,21 @@ pub fn get_enclosing_block<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Optio
         },
         _ => None,
     })
+}
+
+/// Gets the parent node if it's an impl block.
+pub fn get_parent_as_impl(tcx: TyCtxt<'_>, id: HirId) -> Option<&Impl<'_>> {
+    let map = tcx.hir();
+    match map.parent_iter(id).next() {
+        Some((
+            _,
+            Node::Item(Item {
+                kind: ItemKind::Impl(imp),
+                ..
+            }),
+        )) => Some(imp),
+        _ => None,
+    }
 }
 
 /// Returns the base type for HIR references and pointers.

--- a/tests/ui/len_without_is_empty.rs
+++ b/tests/ui/len_without_is_empty.rs
@@ -34,6 +34,24 @@ impl PubAllowed {
     }
 }
 
+pub struct PubAllowedFn;
+
+impl PubAllowedFn {
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> isize {
+        1
+    }
+}
+
+#[allow(clippy::len_without_is_empty)]
+pub struct PubAllowedStruct;
+
+impl PubAllowedStruct {
+    pub fn len(&self) -> isize {
+        1
+    }
+}
+
 pub trait PubTraitsToo {
     fn len(&self) -> isize;
 }
@@ -64,6 +82,18 @@ impl HasWrongIsEmpty {
     }
 
     pub fn is_empty(&self, x: u32) -> bool {
+        false
+    }
+}
+
+pub struct MismatchedSelf;
+
+impl MismatchedSelf {
+    pub fn len(self) -> isize {
+        1
+    }
+
+    pub fn is_empty(&self) -> bool {
         false
     }
 }
@@ -140,6 +170,21 @@ pub trait Foo: Sized {}
 
 pub trait DependsOnFoo: Foo {
     fn len(&mut self) -> usize;
+}
+
+pub struct MultipleImpls;
+
+// issue #1562
+impl MultipleImpls {
+    pub fn len(&self) -> usize {
+        1
+    }
+}
+
+impl MultipleImpls {
+    pub fn is_empty(&self) -> bool {
+        false
+    }
 }
 
 fn main() {}

--- a/tests/ui/len_without_is_empty.stderr
+++ b/tests/ui/len_without_is_empty.stderr
@@ -1,54 +1,64 @@
-error: item `PubOne` has a public `len` method but no corresponding `is_empty` method
-  --> $DIR/len_without_is_empty.rs:6:1
+error: struct `PubOne` has a public `len` method, but no `is_empty` method
+  --> $DIR/len_without_is_empty.rs:7:5
    |
-LL | / impl PubOne {
-LL | |     pub fn len(&self) -> isize {
-LL | |         1
-LL | |     }
-LL | | }
-   | |_^
+LL |     pub fn len(&self) -> isize {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::len-without-is-empty` implied by `-D warnings`
 
 error: trait `PubTraitsToo` has a `len` method but no (possibly inherited) `is_empty` method
-  --> $DIR/len_without_is_empty.rs:37:1
+  --> $DIR/len_without_is_empty.rs:55:1
    |
 LL | / pub trait PubTraitsToo {
 LL | |     fn len(&self) -> isize;
 LL | | }
    | |_^
 
-error: item `HasIsEmpty` has a public `len` method but a private `is_empty` method
-  --> $DIR/len_without_is_empty.rs:49:1
+error: struct `HasIsEmpty` has a public `len` method, but a private `is_empty` method
+  --> $DIR/len_without_is_empty.rs:68:5
    |
-LL | / impl HasIsEmpty {
-LL | |     pub fn len(&self) -> isize {
-LL | |         1
-LL | |     }
-...  |
-LL | |     }
-LL | | }
-   | |_^
+LL |     pub fn len(&self) -> isize {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `is_empty` defined here
+  --> $DIR/len_without_is_empty.rs:72:5
+   |
+LL |     fn is_empty(&self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: item `HasWrongIsEmpty` has a public `len` method but no corresponding `is_empty` method
-  --> $DIR/len_without_is_empty.rs:61:1
+error: struct `HasWrongIsEmpty` has a public `len` method, but the `is_empty` method has an unexpected signature
+  --> $DIR/len_without_is_empty.rs:80:5
    |
-LL | / impl HasWrongIsEmpty {
-LL | |     pub fn len(&self) -> isize {
-LL | |         1
-LL | |     }
-...  |
-LL | |     }
-LL | | }
-   | |_^
+LL |     pub fn len(&self) -> isize {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `is_empty` defined here
+  --> $DIR/len_without_is_empty.rs:84:5
+   |
+LL |     pub fn is_empty(&self, x: u32) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected signature: `(&self) -> bool`
+
+error: struct `MismatchedSelf` has a public `len` method, but the `is_empty` method has an unexpected signature
+  --> $DIR/len_without_is_empty.rs:92:5
+   |
+LL |     pub fn len(self) -> isize {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `is_empty` defined here
+  --> $DIR/len_without_is_empty.rs:96:5
+   |
+LL |     pub fn is_empty(&self) -> bool {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: expected signature: `(self) -> bool`
 
 error: trait `DependsOnFoo` has a `len` method but no (possibly inherited) `is_empty` method
-  --> $DIR/len_without_is_empty.rs:141:1
+  --> $DIR/len_without_is_empty.rs:171:1
    |
 LL | / pub trait DependsOnFoo: Foo {
 LL | |     fn len(&mut self) -> usize;
 LL | | }
    | |_^
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes #1562

This also reverts #1559 as the `#[allow]` now works on the `len` method. A note has also been added to point out where the `empty` method is, if it exists.

changelog: `len_without_is_empty` will now consider multiple impl blocks
changelog: `len_without_is_empty` will now consider `#[allow]` on both the `len` method, and the type definition
