### PR TITLE
useless_format: fix examples in the description

### DIFF
--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -28,11 +28,11 @@ declare_clippy_lint! {
     /// ```rust
     ///
     /// // Bad
-    /// # let foo = "foo";
+    /// let foo = "foo";
     /// format!("{}", foo);
     ///
     /// // Good
-    /// format!("foo");
+    /// foo.to_owned();
     /// ```
     pub USELESS_FORMAT,
     complexity,


### PR DESCRIPTION
fixes #6844 
changelog: useless_format: fix examples in the description
