### PR TITLE
Fix ICE 6840 - make is_normalizable more strict

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1506,13 +1506,13 @@ fn is_normalizable_helper<'tcx>(
         let cause = rustc_middle::traits::ObligationCause::dummy();
         if infcx.at(&cause, param_env).normalize(ty).is_ok() {
             match ty.kind() {
-                ty::Adt(def, substs) => !def.variants.iter().any(|variant| {
+                ty::Adt(def, substs) => def.variants.iter().all(|variant| {
                     variant
                         .fields
                         .iter()
-                        .any(|field| !is_normalizable_helper(cx, param_env, field.ty(cx.tcx, substs), cache))
+                        .all(|field| is_normalizable_helper(cx, param_env, field.ty(cx.tcx, substs), cache))
                 }),
-                _ => !ty.walk().any(|generic_arg| !match generic_arg.unpack() {
+                _ => ty.walk().all(|generic_arg| match generic_arg.unpack() {
                     GenericArgKind::Type(inner_ty) if inner_ty != ty => {
                         is_normalizable_helper(cx, param_env, inner_ty, cache)
                     },

--- a/tests/ui/crashes/ice-6840.rs
+++ b/tests/ui/crashes/ice-6840.rs
@@ -1,0 +1,23 @@
+//! This is a reproducer for the ICE 6840: https://github.com/rust-lang/rust-clippy/issues/6840.
+//! The ICE is caused by `TyCtxt::layout_of` and `is_normalizable` not being strict enough
+#![allow(dead_code)]
+use std::collections::HashMap;
+
+pub trait Rule {
+    type DependencyKey;
+}
+
+pub struct RuleEdges<R: Rule> {
+    dependencies: R::DependencyKey,
+}
+
+type RuleDependencyEdges<R> = HashMap<u32, RuleEdges<R>>;
+
+// and additional potential variants
+type RuleDependencyEdgesArray<R> = HashMap<u32, [RuleEdges<R>; 8]>;
+type RuleDependencyEdgesSlice<R> = HashMap<u32, &'static [RuleEdges<R>]>;
+type RuleDependencyEdgesRef<R> = HashMap<u32, &'static RuleEdges<R>>;
+type RuleDependencyEdgesRaw<R> = HashMap<u32, *const RuleEdges<R>>;
+type RuleDependencyEdgesTuple<R> = HashMap<u32, (RuleEdges<R>, RuleEdges<R>)>;
+
+fn main() {}

--- a/tests/ui/crashes/ice-6840.rs
+++ b/tests/ui/crashes/ice-6840.rs
@@ -13,11 +13,19 @@ pub struct RuleEdges<R: Rule> {
 
 type RuleDependencyEdges<R> = HashMap<u32, RuleEdges<R>>;
 
-// and additional potential variants
+// reproducer from the GitHub issue ends here
+//   but check some additional variants
 type RuleDependencyEdgesArray<R> = HashMap<u32, [RuleEdges<R>; 8]>;
 type RuleDependencyEdgesSlice<R> = HashMap<u32, &'static [RuleEdges<R>]>;
 type RuleDependencyEdgesRef<R> = HashMap<u32, &'static RuleEdges<R>>;
 type RuleDependencyEdgesRaw<R> = HashMap<u32, *const RuleEdges<R>>;
 type RuleDependencyEdgesTuple<R> = HashMap<u32, (RuleEdges<R>, RuleEdges<R>)>;
+
+// and an additional checks to make sure fix doesn't have stack-overflow issue
+//   on self-containing types
+pub struct SelfContaining {
+    inner: Box<SelfContaining>,
+}
+type SelfContainingEdges = HashMap<u32, SelfContaining>;
 
 fn main() {}


### PR DESCRIPTION
fixes #6840

make `is_normalizable` more strict, which should catch this ICE and related cases

changelog: Fix ICE in [`zero_sized_map_values`]
