### PR TITLE
Opt-in to rustc_private for `rust-analyzer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,7 @@ rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util" }
 deny-warnings = []
 integration = ["tempfile"]
 internal-lints = ["clippy_lints/internal-lints"]
+
+[package.metadata.rust-analyzer]
+# This package uses #[feature(rustc_private)]
+rustc_private = true

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 	"Manish Goregaokar <manishsmail@gmail.com>",
 	"Andre Bogus <bogusandre@gmail.com>",
 	"Georg Brandl <georg@python.org>",
-	"Martin Carton <cartonmartin@gmail.com>"
+	"Martin Carton <cartonmartin@gmail.com>",
 ]
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
@@ -29,10 +29,10 @@ smallvec = { version = "1", features = ["union"] }
 toml = "0.5.3"
 unicode-normalization = "0.1"
 semver = "0.11"
-rustc-semver="1.1.0"
+rustc-semver = "1.1.0"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
-url = { version =  "2.1.0", features = ["serde"] }
+url = { version = "2.1.0", features = ["serde"] }
 quote = "1"
 syn = { version = "1", features = ["full"] }
 
@@ -40,3 +40,7 @@ syn = { version = "1", features = ["full"] }
 deny-warnings = []
 # build clippy with internal lints enabled, off by default
 internal-lints = ["clippy_utils/internal-lints"]
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true

--- a/clippy_utils/Cargo.toml
+++ b/clippy_utils/Cargo.toml
@@ -17,3 +17,7 @@ rustc-semver="1.1.0"
 
 [features]
 internal-lints = []
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)]
+rustc_private = true


### PR DESCRIPTION
rust-analyzer/rust-analyzer#7891

changelog: none

This will also help priroda and any other package which depends on the `miri` library crate.