### PR TITLE
Improve doc on `map_flatten`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -403,7 +403,7 @@ declare_clippy_lint! {
 }
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for usage of `_.map(_).flatten(_)`,
+    /// **What it does:** Checks for usage of `_.map(_).flatten(_)` on `Iterator` and `Option`
     ///
     /// **Why is this bad?** Readability, this can be written more concisely as
     /// `_.flat_map(_)`


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust-clippy/issues/6870. It's because this doc lacks the description that this lint is also used for `Option`.

changelog: none
