### PR TITLE
Set Clippy authors to "The Rust Clippy Developers"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,7 @@
 [package]
 name = "clippy"
 version = "0.1.52"
-authors = [
-	"Manish Goregaokar <manishsmail@gmail.com>",
-	"Andre Bogus <bogusandre@gmail.com>",
-	"Georg Brandl <georg@python.org>",
-	"Martin Carton <cartonmartin@gmail.com>",
-	"Oliver Schneider <clippy-iethah7aipeen8neex1a@oli-obk.de>"
-]
+authors = ["The Rust Clippy Developers"]
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "clippy_dev"
 version = "0.0.1"
-authors = ["Philipp Hansch <dev@phansch.net>"]
+authors = ["The Rust Clippy Developers"]
 edition = "2018"
-
 
 [dependencies]
 bytecount = "0.6"

--- a/clippy_dummy/Cargo.toml
+++ b/clippy_dummy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clippy_dummy" # rename to clippy before publishing
 version = "0.0.303"
-authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
+authors = ["The Rust Clippy Developers"]
 edition = "2018"
 readme = "crates-readme.md"
 description = "A bunch of helpful lints to avoid common pitfalls in Rust."

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -3,12 +3,7 @@ name = "clippy_lints"
 # begin automatic update
 version = "0.1.52"
 # end automatic update
-authors = [
-	"Manish Goregaokar <manishsmail@gmail.com>",
-	"Andre Bogus <bogusandre@gmail.com>",
-	"Georg Brandl <georg@python.org>",
-	"Martin Carton <cartonmartin@gmail.com>",
-]
+authors = ["The Rust Clippy Developers"]
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"

--- a/mini-macro/Cargo.toml
+++ b/mini-macro/Cargo.toml
@@ -1,13 +1,7 @@
 [package]
 name = "clippy-mini-macro-test"
 version = "0.2.0"
-authors = [
-	"Manish Goregaokar <manishsmail@gmail.com>",
-	"Andre Bogus <bogusandre@gmail.com>",
-	"Georg Brandl <georg@python.org>",
-	"Martin Carton <cartonmartin@gmail.com>",
-	"Oliver Schneider <clippy-iethah7aipeen8neex1a@oli-obk.de>"
-]
+authors = ["The Rust Clippy Developers"]
 license = "MIT OR Apache-2.0"
 description = "A macro to test clippy's procedural macro checks"
 repository = "https://github.com/rust-lang/rust-clippy"

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustc_tools_util"
 version = "0.2.0"
-authors = ["Matthias Krüger <matthias.krueger@famsik.de>"]
+authors = ["The Rust Clippy Developers"]
 description = "small helper to generate version information for git packages"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"


### PR DESCRIPTION
Clippy has grown enough, that putting specific people in the "authors"
field isn't warranted anymore.

As a heads-up: @Manishearth @llogiq @birkenfeld @mcarton @oli-obk @phansch @matthiaskrgr your names will be removed from one or more of the `Cargo.toml` files of Clippy. This of course does not mean that we value your previous work on Clippy any less :heart: 

As per our discussion in today's meeting: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Meeting.202021-03-09/near/229502514

changelog: none
