### PR TITLE
Use sym::Iterator instead of paths::ITERATOR

### DIFF
--- a/clippy_lints/src/blocks_in_if_conditions.rs
+++ b/clippy_lints/src/blocks_in_if_conditions.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    differing_macro_contexts, get_parent_expr, get_trait_def_id, implements_trait, paths,
-    snippet_block_with_applicability, span_lint, span_lint_and_sugg,
+    differing_macro_contexts, get_parent_expr, implements_trait, snippet_block_with_applicability, span_lint,
+    span_lint_and_sugg,
 };
 use if_chain::if_chain;
 use rustc_errors::Applicability;
@@ -10,6 +10,7 @@ use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::hir::map::Map;
 use rustc_middle::lint::in_external_macro;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::sym;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for `if` conditions that use blocks containing an
@@ -61,7 +62,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ExVisitor<'a, 'tcx> {
                 if let Some(parent) = get_parent_expr(self.cx, expr);
                 if let ExprKind::MethodCall(_, _, args, _) = parent.kind;
                 let caller = self.cx.typeck_results().expr_ty(&args[0]);
-                if let Some(iter_id) = get_trait_def_id(self.cx, &paths::ITERATOR);
+                if let Some(iter_id) = self.cx.tcx.get_diagnostic_item(sym::Iterator);
                 if implements_trait(self.cx, caller, iter_id, &[]);
                 then {
                     return;

--- a/clippy_lints/src/copy_iterator.rs
+++ b/clippy_lints/src/copy_iterator.rs
@@ -1,7 +1,10 @@
-use crate::utils::{is_copy, match_path, paths, span_lint_and_note};
+use crate::utils::{is_copy, span_lint_and_note};
 use rustc_hir::{Impl, Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::sym;
+
+use if_chain::if_chain;
 
 declare_clippy_lint! {
     /// **What it does:** Checks for types that implement `Copy` as well as
@@ -33,14 +36,16 @@ declare_lint_pass!(CopyIterator => [COPY_ITERATOR]);
 
 impl<'tcx> LateLintPass<'tcx> for CopyIterator {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'_>) {
-        if let ItemKind::Impl(Impl {
-            of_trait: Some(ref trait_ref),
-            ..
-        }) = item.kind
-        {
+        if_chain! {
+            if let ItemKind::Impl(Impl {
+                of_trait: Some(ref trait_ref),
+                ..
+            }) = item.kind;
             let ty = cx.tcx.type_of(item.def_id);
-
-            if is_copy(cx, ty) && match_path(&trait_ref.path, &paths::ITERATOR) {
+            if is_copy(cx, ty);
+            if let Some(trait_id) = trait_ref.trait_def_id();
+            if cx.tcx.is_diagnostic_item(sym::Iterator, trait_id);
+            then {
                 span_lint_and_note(
                     cx,
                     COPY_ITERATOR,

--- a/clippy_lints/src/loops/iter_next_loop.rs
+++ b/clippy_lints/src/loops/iter_next_loop.rs
@@ -1,10 +1,12 @@
 use super::ITER_NEXT_LOOP;
-use crate::utils::{match_trait_method, paths, span_lint};
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
+use rustc_span::sym;
+
+use crate::utils::{is_trait_method, span_lint};
 
 pub(super) fn check(cx: &LateContext<'_>, arg: &Expr<'_>, expr: &Expr<'_>) -> bool {
-    if match_trait_method(cx, arg, &paths::ITERATOR) {
+    if is_trait_method(cx, arg, sym::Iterator) {
         span_lint(
             cx,
             ITER_NEXT_LOOP,

--- a/clippy_lints/src/loops/needless_collect.rs
+++ b/clippy_lints/src/loops/needless_collect.rs
@@ -1,7 +1,7 @@
 use super::NEEDLESS_COLLECT;
 use crate::utils::sugg::Sugg;
 use crate::utils::{
-    is_type_diagnostic_item, match_trait_method, match_type, path_to_local_id, paths, snippet, span_lint_and_sugg,
+    is_trait_method, is_type_diagnostic_item, match_type, path_to_local_id, paths, snippet, span_lint_and_sugg,
     span_lint_and_then,
 };
 use if_chain::if_chain;
@@ -23,7 +23,7 @@ fn check_needless_collect_direct_usage<'tcx>(expr: &'tcx Expr<'_>, cx: &LateCont
     if_chain! {
         if let ExprKind::MethodCall(ref method, _, ref args, _) = expr.kind;
         if let ExprKind::MethodCall(ref chain_method, _, _, _) = args[0].kind;
-        if chain_method.ident.name == sym!(collect) && match_trait_method(cx, &args[0], &paths::ITERATOR);
+        if chain_method.ident.name == sym!(collect) && is_trait_method(cx, &args[0], sym::Iterator);
         if let Some(ref generic_args) = chain_method.args;
         if let Some(GenericArg::Type(ref ty)) = generic_args.args.get(0);
         then {
@@ -94,7 +94,7 @@ fn check_needless_collect_indirect_usage<'tcx>(expr: &'tcx Expr<'_>, cx: &LateCo
                     init: Some(ref init_expr), .. }
                 ) = stmt.kind;
                 if let ExprKind::MethodCall(ref method_name, _, &[ref iter_source], ..) = init_expr.kind;
-                if method_name.ident.name == sym!(collect) && match_trait_method(cx, &init_expr, &paths::ITERATOR);
+                if method_name.ident.name == sym!(collect) && is_trait_method(cx, &init_expr, sym::Iterator);
                 if let Some(ref generic_args) = method_name.args;
                 if let Some(GenericArg::Type(ref ty)) = generic_args.args.get(0);
                 if let ty = cx.typeck_results().node_type(ty.hir_id);

--- a/clippy_lints/src/loops/utils.rs
+++ b/clippy_lints/src/loops/utils.rs
@@ -1,6 +1,5 @@
 use crate::utils::{
-    get_parent_expr, get_trait_def_id, has_iter_method, implements_trait, is_integer_const, path_to_local,
-    path_to_local_id, paths, sugg,
+    get_parent_expr, has_iter_method, implements_trait, is_integer_const, path_to_local, path_to_local_id, sugg,
 };
 use if_chain::if_chain;
 use rustc_data_structures::fx::FxHashMap;
@@ -10,7 +9,7 @@ use rustc_hir::{BinOpKind, BorrowKind, Expr, ExprKind, HirId, Mutability, Pat, P
 use rustc_lint::LateContext;
 use rustc_middle::hir::map::Map;
 use rustc_span::source_map::Span;
-use rustc_span::symbol::Symbol;
+use rustc_span::symbol::{sym, Symbol};
 use std::iter::Iterator;
 
 #[derive(Debug, PartialEq)]
@@ -316,7 +315,7 @@ pub(super) fn get_span_of_entire_for_loop(expr: &Expr<'_>) -> Span {
 /// If `arg` was the argument to a `for` loop, return the "cleanest" way of writing the
 /// actual `Iterator` that the loop uses.
 pub(super) fn make_iterator_snippet(cx: &LateContext<'_>, arg: &Expr<'_>, applic_ref: &mut Applicability) -> String {
-    let impls_iterator = get_trait_def_id(cx, &paths::ITERATOR).map_or(false, |id| {
+    let impls_iterator = cx.tcx.get_diagnostic_item(sym::Iterator).map_or(false, |id| {
         implements_trait(cx, cx.typeck_results().expr_ty(arg), id, &[])
     });
     if impls_iterator {

--- a/clippy_lints/src/loops/while_let_on_iterator.rs
+++ b/clippy_lints/src/loops/while_let_on_iterator.rs
@@ -2,8 +2,8 @@ use super::utils::{LoopNestVisitor, Nesting};
 use super::WHILE_LET_ON_ITERATOR;
 use crate::utils::usage::mutated_variables;
 use crate::utils::{
-    get_enclosing_block, get_trait_def_id, implements_trait, is_refutable, last_path_segment, match_trait_method,
-    path_to_local, path_to_local_id, paths, snippet_with_applicability, span_lint_and_sugg,
+    get_enclosing_block, implements_trait, is_refutable, is_trait_method, last_path_segment, path_to_local,
+    path_to_local_id, snippet_with_applicability, span_lint_and_sugg,
 };
 use if_chain::if_chain;
 use rustc_errors::Applicability;
@@ -27,7 +27,7 @@ pub(super) fn check(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
             // Don't lint when the iterator is recreated on every iteration
             if_chain! {
                 if let ExprKind::MethodCall(..) | ExprKind::Call(..) = iter_expr.kind;
-                if let Some(iter_def_id) = get_trait_def_id(cx, &paths::ITERATOR);
+                if let Some(iter_def_id) = cx.tcx.get_diagnostic_item(sym::Iterator);
                 if implements_trait(cx, cx.typeck_results().expr_ty(iter_expr), iter_def_id, &[]);
                 then {
                     return;
@@ -36,7 +36,7 @@ pub(super) fn check(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
 
             let lhs_constructor = last_path_segment(qpath);
             if method_path.ident.name == sym::next
-                && match_trait_method(cx, match_expr, &paths::ITERATOR)
+                && is_trait_method(cx, match_expr, sym::Iterator)
                 && lhs_constructor.ident.name == sym::Some
                 && (pat_args.is_empty()
                     || !is_refutable(cx, &pat_args[0])

--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -1,6 +1,5 @@
-use crate::utils::paths;
 use crate::utils::{
-    is_copy, is_type_diagnostic_item, match_trait_method, remove_blocks, snippet_with_applicability, span_lint_and_sugg,
+    is_copy, is_trait_method, is_type_diagnostic_item, remove_blocks, snippet_with_applicability, span_lint_and_sugg,
 };
 use if_chain::if_chain;
 use rustc_errors::Applicability;
@@ -55,7 +54,7 @@ impl<'tcx> LateLintPass<'tcx> for MapClone {
             if args.len() == 2;
             if method.ident.name == sym::map;
             let ty = cx.typeck_results().expr_ty(&args[0]);
-            if is_type_diagnostic_item(cx, ty, sym::option_type) || match_trait_method(cx, e, &paths::ITERATOR);
+            if is_type_diagnostic_item(cx, ty, sym::option_type) || is_trait_method(cx, e, sym::Iterator);
             if let hir::ExprKind::Closure(_, _, body_id, _, _) = args[1].kind;
             let closure_body = cx.tcx.hir().body(body_id);
             let closure_expr = remove_blocks(&closure_body.value);

--- a/clippy_lints/src/map_identity.rs
+++ b/clippy_lints/src/map_identity.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    is_adjusted, is_type_diagnostic_item, match_path, match_trait_method, match_var, paths, remove_blocks,
+    is_adjusted, is_trait_method, is_type_diagnostic_item, match_path, match_var, paths, remove_blocks,
     span_lint_and_sugg,
 };
 use if_chain::if_chain;
@@ -65,7 +65,7 @@ fn get_map_argument<'a>(cx: &LateContext<'_>, expr: &'a Expr<'a>) -> Option<&'a 
         if let ExprKind::MethodCall(ref method, _, ref args, _) = expr.kind;
         if args.len() == 2 && method.ident.name == sym::map;
         let caller_ty = cx.typeck_results().expr_ty(&args[0]);
-        if match_trait_method(cx, expr, &paths::ITERATOR)
+        if is_trait_method(cx, expr, sym::Iterator)
             || is_type_diagnostic_item(cx, caller_ty, sym::result_type)
             || is_type_diagnostic_item(cx, caller_ty, sym::option_type);
         then {

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1614,7 +1614,7 @@ where
 
 mod redundant_pattern_match {
     use super::REDUNDANT_PATTERN_MATCHING;
-    use crate::utils::{match_qpath, match_trait_method, paths, snippet, span_lint_and_then};
+    use crate::utils::{is_trait_method, match_qpath, paths, snippet, span_lint_and_then};
     use if_chain::if_chain;
     use rustc_ast::ast::LitKind;
     use rustc_errors::Applicability;
@@ -1679,7 +1679,7 @@ mod redundant_pattern_match {
             if keyword == "while";
             if let ExprKind::MethodCall(method_path, _, _, _) = op.kind;
             if method_path.ident.name == sym::next;
-            if match_trait_method(cx, op, &paths::ITERATOR);
+            if is_trait_method(cx, op, sym::Iterator);
             then {
                 return;
             }

--- a/clippy_lints/src/methods/filter_flat_map.rs
+++ b/clippy_lints/src/methods/filter_flat_map.rs
@@ -1,6 +1,7 @@
-use crate::utils::{match_trait_method, paths, span_lint_and_help};
+use crate::utils::{is_trait_method, span_lint_and_help};
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::FILTER_MAP;
 
@@ -12,7 +13,7 @@ pub(super) fn check<'tcx>(
     _map_args: &'tcx [hir::Expr<'_>],
 ) {
     // lint if caller of `.filter().flat_map()` is an Iterator
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let msg = "called `filter(..).flat_map(..)` on an `Iterator`";
         let hint = "this is more succinctly expressed by calling `.flat_map(..)` \
                     and filtering by returning `iter::empty()`";

--- a/clippy_lints/src/methods/filter_map.rs
+++ b/clippy_lints/src/methods/filter_map.rs
@@ -1,4 +1,4 @@
-use crate::utils::{match_trait_method, path_to_local_id, paths, snippet, span_lint_and_sugg, SpanlessEq};
+use crate::utils::{is_trait_method, path_to_local_id, snippet, span_lint_and_sugg, SpanlessEq};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -15,7 +15,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, is_
     if_chain! {
         if let ExprKind::MethodCall(_, _, [map_recv, map_arg], map_span) = expr.kind;
         if let ExprKind::MethodCall(_, _, [_, filter_arg], filter_span) = map_recv.kind;
-        if match_trait_method(cx, map_recv, &paths::ITERATOR);
+        if is_trait_method(cx, map_recv, sym::Iterator);
 
         // filter(|x| ...is_some())...
         if let ExprKind::Closure(_, _, filter_body_id, ..) = filter_arg.kind;

--- a/clippy_lints/src/methods/filter_map_flat_map.rs
+++ b/clippy_lints/src/methods/filter_map_flat_map.rs
@@ -1,6 +1,7 @@
-use crate::utils::{match_trait_method, paths, span_lint_and_help};
+use crate::utils::{is_trait_method, span_lint_and_help};
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::FILTER_MAP;
 
@@ -12,7 +13,7 @@ pub(super) fn check<'tcx>(
     _map_args: &'tcx [hir::Expr<'_>],
 ) {
     // lint if caller of `.filter_map().flat_map()` is an Iterator
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let msg = "called `filter_map(..).flat_map(..)` on an `Iterator`";
         let hint = "this is more succinctly expressed by calling `.flat_map(..)` \
                     and filtering by returning `iter::empty()`";

--- a/clippy_lints/src/methods/filter_map_identity.rs
+++ b/clippy_lints/src/methods/filter_map_identity.rs
@@ -1,9 +1,9 @@
-use crate::utils::{match_qpath, match_trait_method, path_to_local_id, paths, span_lint_and_sugg};
+use crate::utils::{is_trait_method, match_qpath, path_to_local_id, paths, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
-use rustc_span::source_map::Span;
+use rustc_span::{source_map::Span, sym};
 
 use super::FILTER_MAP_IDENTITY;
 
@@ -13,7 +13,7 @@ pub(super) fn check(
     filter_map_args: &[hir::Expr<'_>],
     filter_map_span: Span,
 ) {
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let arg_node = &filter_map_args[1].kind;
 
         let apply_lint = |message: &str| {

--- a/clippy_lints/src/methods/filter_map_map.rs
+++ b/clippy_lints/src/methods/filter_map_map.rs
@@ -1,6 +1,7 @@
-use crate::utils::{match_trait_method, paths, span_lint_and_help};
+use crate::utils::{is_trait_method, span_lint_and_help};
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::FILTER_MAP;
 
@@ -12,7 +13,7 @@ pub(super) fn check<'tcx>(
     _map_args: &'tcx [hir::Expr<'_>],
 ) {
     // lint if caller of `.filter_map().map()` is an Iterator
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let msg = "called `filter_map(..).map(..)` on an `Iterator`";
         let hint = "this is more succinctly expressed by only calling `.filter_map(..)` instead";
         span_lint_and_help(cx, FILTER_MAP, expr.span, msg, None, hint);

--- a/clippy_lints/src/methods/filter_map_next.rs
+++ b/clippy_lints/src/methods/filter_map_next.rs
@@ -1,8 +1,9 @@
-use crate::utils::{match_trait_method, meets_msrv, paths, snippet, span_lint, span_lint_and_sugg};
+use crate::utils::{is_trait_method, meets_msrv, snippet, span_lint, span_lint_and_sugg};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
 use rustc_semver::RustcVersion;
+use rustc_span::sym;
 
 use super::FILTER_MAP_NEXT;
 
@@ -14,7 +15,7 @@ pub(super) fn check<'tcx>(
     filter_args: &'tcx [hir::Expr<'_>],
     msrv: Option<&RustcVersion>,
 ) {
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         if !meets_msrv(msrv, &FILTER_MAP_NEXT_MSRV) {
             return;
         }

--- a/clippy_lints/src/methods/filter_next.rs
+++ b/clippy_lints/src/methods/filter_next.rs
@@ -1,14 +1,15 @@
-use crate::utils::{match_trait_method, paths, snippet, span_lint, span_lint_and_sugg};
+use crate::utils::{is_trait_method, snippet, span_lint, span_lint_and_sugg};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::FILTER_NEXT;
 
 /// lint use of `filter().next()` for `Iterators`
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, filter_args: &'tcx [hir::Expr<'_>]) {
     // lint if caller of `.filter().next()` is an Iterator
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let msg = "called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling \
                    `.find(..)` instead";
         let filter_snippet = snippet(cx, filter_args[1].span, "..");

--- a/clippy_lints/src/methods/flat_map_identity.rs
+++ b/clippy_lints/src/methods/flat_map_identity.rs
@@ -1,9 +1,9 @@
-use crate::utils::{match_qpath, match_trait_method, paths, span_lint_and_sugg};
+use crate::utils::{is_trait_method, match_qpath, paths, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
-use rustc_span::source_map::Span;
+use rustc_span::{source_map::Span, sym};
 
 use super::FLAT_MAP_IDENTITY;
 
@@ -14,7 +14,7 @@ pub(super) fn check<'tcx>(
     flat_map_args: &'tcx [hir::Expr<'_>],
     flat_map_span: Span,
 ) {
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let arg_node = &flat_map_args[1].kind;
 
         let apply_lint = |message: &str| {

--- a/clippy_lints/src/methods/from_iter_instead_of_collect.rs
+++ b/clippy_lints/src/methods/from_iter_instead_of_collect.rs
@@ -4,6 +4,7 @@ use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::Ty;
+use rustc_span::sym;
 
 use super::FROM_ITER_INSTEAD_OF_COLLECT;
 
@@ -13,7 +14,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, args: &[hir::Exp
 
     if_chain! {
         if let Some(from_iter_id) = get_trait_def_id(cx, &paths::FROM_ITERATOR);
-        if let Some(iter_id) = get_trait_def_id(cx, &paths::ITERATOR);
+        if let Some(iter_id) = cx.tcx.get_diagnostic_item(sym::Iterator);
 
         if implements_trait(cx, ty, from_iter_id, &[]) && implements_trait(cx, arg_ty, iter_id, &[]);
         then {

--- a/clippy_lints/src/methods/inspect_for_each.rs
+++ b/clippy_lints/src/methods/inspect_for_each.rs
@@ -1,14 +1,14 @@
 use rustc_hir as hir;
 use rustc_lint::LateContext;
-use rustc_span::source_map::Span;
+use rustc_span::{source_map::Span, sym};
 
-use crate::utils::{match_trait_method, paths, span_lint_and_help};
+use crate::utils::{is_trait_method, span_lint_and_help};
 
 use super::INSPECT_FOR_EACH;
 
 /// lint use of `inspect().for_each()` for `Iterators`
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, inspect_span: Span) {
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let msg = "called `inspect(..).for_each(..)` on an `Iterator`";
         let hint = "move the code from `inspect(..)` to `for_each(..)` and remove the `inspect(..)`";
         span_lint_and_help(

--- a/clippy_lints/src/methods/iter_nth_zero.rs
+++ b/clippy_lints/src/methods/iter_nth_zero.rs
@@ -1,15 +1,16 @@
 use crate::consts::{constant, Constant};
-use crate::utils::{match_trait_method, paths, snippet_with_applicability, span_lint_and_sugg};
+use crate::utils::{is_trait_method, snippet_with_applicability, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::ITER_NTH_ZERO;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, nth_args: &'tcx [hir::Expr<'_>]) {
     if_chain! {
-        if match_trait_method(cx, expr, &paths::ITERATOR);
+        if is_trait_method(cx, expr, sym::Iterator);
         if let Some((Constant::Int(0), _)) = constant(cx, cx.typeck_results(), &nth_args[1]);
         then {
             let mut applicability = Applicability::MachineApplicable;

--- a/clippy_lints/src/methods/iter_skip_next.rs
+++ b/clippy_lints/src/methods/iter_skip_next.rs
@@ -1,13 +1,14 @@
-use crate::utils::{match_trait_method, paths, snippet, span_lint_and_sugg};
+use crate::utils::{is_trait_method, snippet, span_lint_and_sugg};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::ITER_SKIP_NEXT;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, skip_args: &[hir::Expr<'_>]) {
     // lint if caller of skip is an Iterator
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         if let [caller, n] = skip_args {
             let hint = format!(".nth({})", snippet(cx, n.span, ".."));
             span_lint_and_sugg(

--- a/clippy_lints/src/methods/iterator_step_by_zero.rs
+++ b/clippy_lints/src/methods/iterator_step_by_zero.rs
@@ -1,12 +1,13 @@
 use crate::consts::{constant, Constant};
-use crate::utils::{match_trait_method, paths, span_lint};
+use crate::utils::{is_trait_method, span_lint};
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::ITERATOR_STEP_BY_ZERO;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, args: &'tcx [hir::Expr<'_>]) {
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         if let Some((Constant::Int(0), _)) = constant(cx, cx.typeck_results(), &args[1]) {
             span_lint(
                 cx,

--- a/clippy_lints/src/methods/map_collect_result_unit.rs
+++ b/clippy_lints/src/methods/map_collect_result_unit.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_type_diagnostic_item, match_trait_method, paths, snippet, span_lint_and_sugg};
+use crate::utils::{is_trait_method, is_type_diagnostic_item, snippet, span_lint_and_sugg};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -17,7 +17,7 @@ pub(super) fn check(
     if_chain! {
         // called on Iterator
         if let [map_expr] = collect_args;
-        if match_trait_method(cx, map_expr, &paths::ITERATOR);
+        if is_trait_method(cx, map_expr, sym::Iterator);
         // return of collect `Result<(),_>`
         let collect_ret_ty = cx.typeck_results().expr_ty(expr);
         if is_type_diagnostic_item(cx, collect_ret_ty, sym::result_type);

--- a/clippy_lints/src/methods/map_flatten.rs
+++ b/clippy_lints/src/methods/map_flatten.rs
@@ -1,4 +1,4 @@
-use crate::utils::{is_type_diagnostic_item, match_trait_method, paths, snippet, span_lint_and_sugg};
+use crate::utils::{is_trait_method, is_type_diagnostic_item, snippet, span_lint_and_sugg};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
@@ -10,7 +10,7 @@ use super::MAP_FLATTEN;
 /// lint use of `map().flatten()` for `Iterators` and 'Options'
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, map_args: &'tcx [hir::Expr<'_>]) {
     // lint if caller of `.map().flatten()` is an Iterator
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         let map_closure_ty = cx.typeck_results().expr_ty(&map_args[1]);
         let is_map_to_option = match map_closure_ty.kind() {
             ty::Closure(_, _) | ty::FnDef(_, _) | ty::FnPtr(_) => {

--- a/clippy_lints/src/methods/search_is_some.rs
+++ b/clippy_lints/src/methods/search_is_some.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    is_type_diagnostic_item, match_trait_method, paths, snippet, snippet_with_applicability, span_lint_and_help,
+    is_trait_method, is_type_diagnostic_item, snippet, snippet_with_applicability, span_lint_and_help,
     span_lint_and_sugg, strip_pat_refs,
 };
 use if_chain::if_chain;
@@ -24,7 +24,7 @@ pub(super) fn check<'tcx>(
     method_span: Span,
 ) {
     // lint if caller of search is an Iterator
-    if match_trait_method(cx, &is_some_args[0], &paths::ITERATOR) {
+    if is_trait_method(cx, &is_some_args[0], sym::Iterator) {
         let msg = format!(
             "called `is_some()` after searching an `Iterator` with `{}`",
             search_method

--- a/clippy_lints/src/methods/skip_while_next.rs
+++ b/clippy_lints/src/methods/skip_while_next.rs
@@ -1,13 +1,14 @@
-use crate::utils::{match_trait_method, paths, span_lint_and_help};
+use crate::utils::{is_trait_method, span_lint_and_help};
 use rustc_hir as hir;
 use rustc_lint::LateContext;
+use rustc_span::sym;
 
 use super::SKIP_WHILE_NEXT;
 
 /// lint use of `skip_while().next()` for `Iterators`
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>, _skip_while_args: &'tcx [hir::Expr<'_>]) {
     // lint if caller of `.skip_while().next()` is an Iterator
-    if match_trait_method(cx, expr, &paths::ITERATOR) {
+    if is_trait_method(cx, expr, sym::Iterator) {
         span_lint_and_help(
             cx,
             SKIP_WHILE_NEXT,

--- a/clippy_lints/src/methods/unnecessary_filter_map.rs
+++ b/clippy_lints/src/methods/unnecessary_filter_map.rs
@@ -1,16 +1,17 @@
 use crate::utils::usage::mutated_variables;
-use crate::utils::{match_qpath, match_trait_method, path_to_local_id, paths, span_lint};
+use crate::utils::{is_trait_method, match_qpath, path_to_local_id, paths, span_lint};
 use rustc_hir as hir;
 use rustc_hir::intravisit::{walk_expr, NestedVisitorMap, Visitor};
 use rustc_lint::LateContext;
 use rustc_middle::hir::map::Map;
+use rustc_span::sym;
 
 use if_chain::if_chain;
 
 use super::UNNECESSARY_FILTER_MAP;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, args: &[hir::Expr<'_>]) {
-    if !match_trait_method(cx, expr, &paths::ITERATOR) {
+    if !is_trait_method(cx, expr, sym::Iterator) {
         return;
     }
 

--- a/clippy_lints/src/methods/unnecessary_fold.rs
+++ b/clippy_lints/src/methods/unnecessary_fold.rs
@@ -1,6 +1,5 @@
 use crate::utils::{
-    match_trait_method, path_to_local_id, paths, remove_blocks, snippet_with_applicability, span_lint_and_sugg,
-    strip_pat_refs,
+    is_trait_method, path_to_local_id, remove_blocks, snippet_with_applicability, span_lint_and_sugg, strip_pat_refs,
 };
 use if_chain::if_chain;
 use rustc_ast::ast;
@@ -8,7 +7,7 @@ use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::PatKind;
 use rustc_lint::LateContext;
-use rustc_span::source_map::Span;
+use rustc_span::{source_map::Span, sym};
 
 use super::UNNECESSARY_FOLD;
 
@@ -71,7 +70,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, fold_args: &[hir
     }
 
     // Check that this is a call to Iterator::fold rather than just some function called fold
-    if !match_trait_method(cx, expr, &paths::ITERATOR) {
+    if !is_trait_method(cx, expr, sym::Iterator) {
         return;
     }
 

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -273,6 +273,7 @@ pub fn is_isize_or_usize(typ: Ty<'_>) -> bool {
 }
 
 /// Checks if the method call given in `expr` belongs to the given trait.
+/// This is a deprecated function, consider using [`is_trait_method`].
 pub fn match_trait_method(cx: &LateContext<'_>, expr: &Expr<'_>, path: &[&str]) -> bool {
     let def_id = cx.typeck_results().type_dependent_def_id(expr.hir_id).unwrap();
     let trt_id = cx.tcx.trait_of_item(def_id);
@@ -293,6 +294,13 @@ pub fn is_diagnostic_assoc_item(cx: &LateContext<'_>, def_id: DefId, diag_item: 
             },
         })
         .map_or(false, |assoc_def_id| cx.tcx.is_diagnostic_item(diag_item, assoc_def_id))
+}
+
+/// Checks if the method call given in `expr` belongs to the given trait.
+pub fn is_trait_method(cx: &LateContext<'_>, expr: &Expr<'_>, diag_item: Symbol) -> bool {
+    cx.typeck_results()
+        .type_dependent_def_id(expr.hir_id)
+        .map_or(false, |did| is_diagnostic_assoc_item(cx, did, diag_item))
 }
 
 /// Checks if an expression references a variable of the given name.

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -61,7 +61,6 @@ pub const IO_READ: [&str; 3] = ["std", "io", "Read"];
 pub const IO_WRITE: [&str; 3] = ["std", "io", "Write"];
 pub const IPADDR_V4: [&str; 4] = ["std", "net", "IpAddr", "V4"];
 pub const IPADDR_V6: [&str; 4] = ["std", "net", "IpAddr", "V6"];
-pub const ITERATOR: [&str; 5] = ["core", "iter", "traits", "iterator", "Iterator"];
 #[cfg(feature = "internal-lints")]
 pub const KW_MODULE: [&str; 3] = ["rustc_span", "symbol", "kw"];
 #[cfg(feature = "internal-lints")]


### PR DESCRIPTION
Since `sym::Iterator` was added to diagnostic_item, it's time to remove `paths::ITERATOR`.
ref: #5393

changelog: Add `is_trait_method` to `clippy_utils`
changelog: Remove `paths::ITERATOR`