### PR TITLE
inconsistent_struct_constructor: try to make message and lint description a bit clearer

### DIFF
--- a/clippy_lints/src/inconsistent_struct_constructor.rs
+++ b/clippy_lints/src/inconsistent_struct_constructor.rs
@@ -10,8 +10,9 @@ use if_chain::if_chain;
 use crate::utils::{snippet, span_lint_and_sugg};
 
 declare_clippy_lint! {
-    /// **What it does:** Checks for struct constructors where the order of the field init
-    /// shorthand in the constructor is inconsistent with the order in the struct definition.
+    /// **What it does:** Checks for struct constructors where all fields are shorthand and
+    /// the order of the field init shorthand in the constructor is inconsistent
+    /// with the order in the struct definition.
     ///
     /// **Why is this bad?** Since the order of fields in a constructor doesn't affect the
     /// resulted instance as the below example indicates,
@@ -25,11 +26,11 @@ declare_clippy_lint! {
     /// let x = 1;
     /// let y = 2;
     ///
-    /// // This assertion never fails.
+    /// // This assertion never fails:
     /// assert_eq!(Foo { x, y }, Foo { y, x });
     /// ```
     ///
-    /// inconsistent order means nothing and just decreases readability and consistency.
+    /// inconsistent order can be confusing and decreases readability and consistency.
     ///
     /// **Known problems:** None.
     ///
@@ -42,6 +43,7 @@ declare_clippy_lint! {
     /// }
     /// let x = 1;
     /// let y = 2;
+    ///
     /// Foo { y, x };
     /// ```
     ///
@@ -107,7 +109,7 @@ impl LateLintPass<'_> for InconsistentStructConstructor {
                     cx,
                     INCONSISTENT_STRUCT_CONSTRUCTOR,
                     expr.span,
-                    "inconsistent struct constructor",
+                    "struct constructor field order is inconsistent with struct definition field order",
                     "try",
                     sugg,
                     Applicability::MachineApplicable,

--- a/tests/ui/inconsistent_struct_constructor.stderr
+++ b/tests/ui/inconsistent_struct_constructor.stderr
@@ -1,4 +1,4 @@
-error: inconsistent struct constructor
+error: struct constructor field order is inconsistent with struct definition field order
   --> $DIR/inconsistent_struct_constructor.rs:25:9
    |
 LL |         Foo { y, x, z };
@@ -6,7 +6,7 @@ LL |         Foo { y, x, z };
    |
    = note: `-D clippy::inconsistent-struct-constructor` implied by `-D warnings`
 
-error: inconsistent struct constructor
+error: struct constructor field order is inconsistent with struct definition field order
   --> $DIR/inconsistent_struct_constructor.rs:43:9
    |
 LL | /         Foo {


### PR DESCRIPTION

changelog: inconsistent_struct_constructor: try to make message and lint description a bit clearer
 
r? @ghost