### PR TITLE
Fix FP in `single_component_path_imports` lint

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1232,7 +1232,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_early_pass(|| box as_conversions::AsConversions);
     store.register_late_pass(|| box let_underscore::LetUnderscore);
     store.register_late_pass(|| box atomic_ordering::AtomicOrdering);
-    store.register_early_pass(|| box single_component_path_imports::SingleComponentPathImports);
+    store.register_early_pass(|| box single_component_path_imports::SingleComponentPathImports::default());
     let max_fn_params_bools = conf.max_fn_params_bools;
     let max_struct_bools = conf.max_struct_bools;
     store.register_early_pass(move || box excessive_bools::ExcessiveBools::new(max_struct_bools, max_fn_params_bools));

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1232,7 +1232,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_early_pass(|| box as_conversions::AsConversions);
     store.register_late_pass(|| box let_underscore::LetUnderscore);
     store.register_late_pass(|| box atomic_ordering::AtomicOrdering);
-    store.register_early_pass(|| box single_component_path_imports::SingleComponentPathImports::default());
+    store.register_early_pass(|| box single_component_path_imports::SingleComponentPathImports);
     let max_fn_params_bools = conf.max_fn_params_bools;
     let max_struct_bools = conf.max_struct_bools;
     store.register_early_pass(move || box excessive_bools::ExcessiveBools::new(max_struct_bools, max_fn_params_bools));

--- a/clippy_lints/src/single_component_path_imports.rs
+++ b/clippy_lints/src/single_component_path_imports.rs
@@ -1,11 +1,13 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::in_macro;
 use if_chain::if_chain;
-use rustc_ast::{Item, ItemKind, UseTreeKind};
+use rustc_ast::{Crate, Item, ItemKind, UseTreeKind};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
-use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::edition::Edition;
+use rustc_span::symbol::kw;
+use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
     /// **What it does:** Checking for imports with single component use path.
@@ -35,28 +37,86 @@ declare_clippy_lint! {
     "imports with single component path are redundant"
 }
 
-declare_lint_pass!(SingleComponentPathImports => [SINGLE_COMPONENT_PATH_IMPORTS]);
+#[derive(Default)]
+pub struct SingleComponentPathImports {
+    /// keep track of imports reused with `self` keyword,
+    /// such as `self::crypto_hash` in the example below
+    ///
+    /// ```rust,ignore
+    /// use self::crypto_hash::{Algorithm, Hasher};
+    /// ```
+    imports_reused_with_self: Vec<Symbol>,
+    /// keep track of single use statements
+    /// such as `crypto_hash` in the example below
+    ///
+    /// ```rust,ignore
+    /// use crypto_hash;
+    /// ```
+    single_use_usages: Vec<(Symbol, Span)>,
+}
+
+impl_lint_pass!(SingleComponentPathImports => [SINGLE_COMPONENT_PATH_IMPORTS]);
 
 impl EarlyLintPass for SingleComponentPathImports {
-    fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
-        if_chain! {
-            if !in_macro(item.span);
-            if cx.sess.opts.edition >= Edition::Edition2018;
-            if !item.vis.kind.is_pub();
-            if let ItemKind::Use(use_tree) = &item.kind;
-            if let segments = &use_tree.prefix.segments;
-            if segments.len() == 1;
-            if let UseTreeKind::Simple(None, _, _) = use_tree.kind;
-            then {
+    fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &Crate) {
+        if cx.sess.opts.edition < Edition::Edition2018 {
+            return;
+        }
+        for item in &krate.items {
+            self.track_uses(&item);
+        }
+        for single_use in &self.single_use_usages {
+            if !self.imports_reused_with_self.contains(&single_use.0) {
                 span_lint_and_sugg(
                     cx,
                     SINGLE_COMPONENT_PATH_IMPORTS,
-                    item.span,
+                    single_use.1,
                     "this import is redundant",
                     "remove it entirely",
                     String::new(),
-                    Applicability::MachineApplicable
+                    Applicability::MachineApplicable,
                 );
+            }
+        }
+    }
+}
+
+impl SingleComponentPathImports {
+    fn track_uses(&mut self, item: &Item) {
+        if_chain! {
+            if !in_macro(item.span);
+            if !item.vis.kind.is_pub();
+            if let ItemKind::Use(use_tree) = &item.kind;
+            if let segments = &use_tree.prefix.segments;
+
+            then {
+                // keep track of `use some_module;` usages
+                if segments.len() == 1 {
+                    if let UseTreeKind::Simple(None, _, _) = use_tree.kind {
+                        let ident = &segments[0].ident;
+                        self.single_use_usages.push((ident.name, item.span));
+                    }
+                    return;
+                }
+
+                // keep track of `use self::some_module` usages
+                if segments[0].ident.name == kw::SelfLower {
+                    // simple case such as `use self::module::SomeStruct`
+                    if segments.len() > 1 {
+                        self.imports_reused_with_self.push(segments[1].ident.name);
+                        return;
+                    }
+
+                    // nested case such as `use self::{module1::Struct1, module2::Struct2}`
+                    if let UseTreeKind::Nested(trees) = &use_tree.kind {
+                        for tree in trees {
+                            let segments = &tree.0.prefix.segments;
+                            if !segments.is_empty() {
+                                self.imports_reused_with_self.push(segments[0].ident.name);
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/tests/ui/single_component_path_imports.fixed
+++ b/tests/ui/single_component_path_imports.fixed
@@ -25,3 +25,10 @@ mod hello_mod {
     #[allow(dead_code)]
     fn hello_mod() {}
 }
+
+mod hi_mod {
+    use self::regex::{Regex, RegexSet};
+    use regex;
+    #[allow(dead_code)]
+    fn hi_mod() {}
+}

--- a/tests/ui/single_component_path_imports.fixed
+++ b/tests/ui/single_component_path_imports.fixed
@@ -19,3 +19,9 @@ fn main() {
     // False positive #5154, shouldn't trigger lint.
     m!();
 }
+
+mod hello_mod {
+    
+    #[allow(dead_code)]
+    fn hello_mod() {}
+}

--- a/tests/ui/single_component_path_imports.rs
+++ b/tests/ui/single_component_path_imports.rs
@@ -25,3 +25,10 @@ mod hello_mod {
     #[allow(dead_code)]
     fn hello_mod() {}
 }
+
+mod hi_mod {
+    use self::regex::{Regex, RegexSet};
+    use regex;
+    #[allow(dead_code)]
+    fn hi_mod() {}
+}

--- a/tests/ui/single_component_path_imports.rs
+++ b/tests/ui/single_component_path_imports.rs
@@ -19,3 +19,9 @@ fn main() {
     // False positive #5154, shouldn't trigger lint.
     m!();
 }
+
+mod hello_mod {
+    use regex;
+    #[allow(dead_code)]
+    fn hello_mod() {}
+}

--- a/tests/ui/single_component_path_imports.stderr
+++ b/tests/ui/single_component_path_imports.stderr
@@ -6,5 +6,11 @@ LL | use regex;
    |
    = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
 
-error: aborting due to previous error
+error: this import is redundant
+  --> $DIR/single_component_path_imports.rs:24:5
+   |
+LL |     use regex;
+   |     ^^^^^^^^^^ help: remove it entirely
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/single_component_path_imports.stderr
+++ b/tests/ui/single_component_path_imports.stderr
@@ -1,16 +1,16 @@
 error: this import is redundant
-  --> $DIR/single_component_path_imports.rs:6:1
-   |
-LL | use regex;
-   | ^^^^^^^^^^ help: remove it entirely
-   |
-   = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
-
-error: this import is redundant
   --> $DIR/single_component_path_imports.rs:24:5
    |
 LL |     use regex;
    |     ^^^^^^^^^^ help: remove it entirely
+   |
+   = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
+
+error: this import is redundant
+  --> $DIR/single_component_path_imports.rs:6:1
+   |
+LL | use regex;
+   | ^^^^^^^^^^ help: remove it entirely
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/single_component_path_imports_nested_first.rs
+++ b/tests/ui/single_component_path_imports_nested_first.rs
@@ -1,0 +1,17 @@
+// edition:2018
+#![warn(clippy::single_component_path_imports)]
+#![allow(unused_imports)]
+
+use regex;
+use serde as edres;
+pub use serde;
+
+fn main() {
+    regex::Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
+}
+
+mod root_nested_use_mod {
+    use {regex, serde};
+    #[allow(dead_code)]
+    fn root_nested_use_mod() {}
+}

--- a/tests/ui/single_component_path_imports_nested_first.stderr
+++ b/tests/ui/single_component_path_imports_nested_first.stderr
@@ -1,0 +1,25 @@
+error: this import is redundant
+  --> $DIR/single_component_path_imports_nested_first.rs:14:10
+   |
+LL |     use {regex, serde};
+   |          ^^^^^
+   |
+   = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
+   = help: remove this import
+
+error: this import is redundant
+  --> $DIR/single_component_path_imports_nested_first.rs:14:17
+   |
+LL |     use {regex, serde};
+   |                 ^^^^^
+   |
+   = help: remove this import
+
+error: this import is redundant
+  --> $DIR/single_component_path_imports_nested_first.rs:5:1
+   |
+LL | use regex;
+   | ^^^^^^^^^^ help: remove it entirely
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/single_component_path_imports_self_after.rs
+++ b/tests/ui/single_component_path_imports_self_after.rs
@@ -1,0 +1,16 @@
+// edition:2018
+#![warn(clippy::single_component_path_imports)]
+#![allow(unused_imports)]
+
+use self::regex::{Regex as xeger, RegexSet as tesxeger};
+pub use self::{
+    regex::{Regex, RegexSet},
+    some_mod::SomeType,
+};
+use regex;
+
+mod some_mod {
+    pub struct SomeType;
+}
+
+fn main() {}

--- a/tests/ui/single_component_path_imports_self_before.rs
+++ b/tests/ui/single_component_path_imports_self_before.rs
@@ -1,0 +1,17 @@
+// edition:2018
+#![warn(clippy::single_component_path_imports)]
+#![allow(unused_imports)]
+
+use regex;
+
+use self::regex::{Regex as xeger, RegexSet as tesxeger};
+pub use self::{
+    regex::{Regex, RegexSet},
+    some_mod::SomeType,
+};
+
+mod some_mod {
+    pub struct SomeType;
+}
+
+fn main() {}


### PR DESCRIPTION
Fix FP in  `single_component_path_imports` lint when the import is reused with `self`, like in `use self::module`.

Fixes #5210 

changelog: none