### PR TITLE
wrong_self_convention: `to_` convention respects `Copy` types

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2348,10 +2348,10 @@ impl SelfKind {
     #[must_use]
     fn description(self) -> &'static str {
         match self {
-            Self::Value => "self by value",
-            Self::Ref => "self by reference",
-            Self::RefMut => "self by mutable reference",
-            Self::No => "no self",
+            Self::Value => "`self` by value",
+            Self::Ref => "`self` by reference",
+            Self::RefMut => "`self` by mutable reference",
+            Self::No => "no `self`",
         }
     }
 }

--- a/clippy_lints/src/methods/wrong_self_convention.rs
+++ b/clippy_lints/src/methods/wrong_self_convention.rs
@@ -51,13 +51,16 @@ impl Convention {
 impl fmt::Display for Convention {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
-            Self::Eq(this) => this.fmt(f),
-            Self::StartsWith(this) => this.fmt(f).and_then(|_| '*'.fmt(f)),
-            Self::EndsWith(this) => '*'.fmt(f).and_then(|_| this.fmt(f)),
-            Self::NotEndsWith(this) => '~'.fmt(f).and_then(|_| this.fmt(f)),
-            Self::IsSelfTypeCopy(is_true) => format!("self type is {} Copy", if is_true { "" } else { "not" }).fmt(f),
+            Self::Eq(this) => format!("`{}`", this).fmt(f),
+            Self::StartsWith(this) => format!("`{}*`", this).fmt(f),
+            Self::EndsWith(this) => format!("`*{}`", this).fmt(f),
+            Self::NotEndsWith(this) => format!("`~{}`", this).fmt(f),
+            Self::IsSelfTypeCopy(is_true) => {
+                format!("`self` type is{} `Copy`", if is_true { "" } else { " not" }).fmt(f)
+            },
             Self::ImplementsTrait(is_true) => {
-                format!("Method {} implement a trait", if is_true { "" } else { "do not" }).fmt(f)
+                let (negation, s_suffix) = if is_true { ("", "s") } else { (" does not", "") };
+                format!("Method{} implement{} a trait", negation, s_suffix).fmt(f)
             },
         }
     }
@@ -99,7 +102,7 @@ pub(super) fn check<'tcx>(
                             {
                                 None
                             } else {
-                                Some(format!("`{}`", &conv.to_string()))
+                                Some(conv.to_string())
                             }
                         })
                         .collect::<Vec<_>>()
@@ -107,7 +110,7 @@ pub(super) fn check<'tcx>(
 
                     format!("methods with the following characteristics: ({})", &s)
                 } else {
-                    format!("methods called `{}`", &conventions[0])
+                    format!("methods called {}", &conventions[0])
                 }
             };
 

--- a/clippy_lints/src/methods/wrong_self_convention.rs
+++ b/clippy_lints/src/methods/wrong_self_convention.rs
@@ -1,5 +1,6 @@
 use crate::methods::SelfKind;
 use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::ty::is_copy;
 use rustc_lint::LateContext;
 use rustc_middle::ty::TyS;
 use rustc_span::source_map::Span;
@@ -9,7 +10,7 @@ use super::WRONG_PUB_SELF_CONVENTION;
 use super::WRONG_SELF_CONVENTION;
 
 #[rustfmt::skip]
-const CONVENTIONS: [(&[Convention], &[SelfKind]); 8] = [
+const CONVENTIONS: [(&[Convention], &[SelfKind]); 9] = [
     (&[Convention::Eq("new")], &[SelfKind::No]),
     (&[Convention::StartsWith("as_")], &[SelfKind::Ref, SelfKind::RefMut]),
     (&[Convention::StartsWith("from_")], &[SelfKind::No]),
@@ -17,7 +18,11 @@ const CONVENTIONS: [(&[Convention], &[SelfKind]); 8] = [
     (&[Convention::StartsWith("is_")], &[SelfKind::Ref, SelfKind::No]),
     (&[Convention::Eq("to_mut")], &[SelfKind::RefMut]),
     (&[Convention::StartsWith("to_"), Convention::EndsWith("_mut")], &[SelfKind::RefMut]),
-    (&[Convention::StartsWith("to_"), Convention::NotEndsWith("_mut")], &[SelfKind::Ref]),
+
+    // Conversion using `to_` can use borrowed (non-Copy types) or owned (Copy types).
+    // Source: https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv
+    (&[Convention::StartsWith("to_"), Convention::NotEndsWith("_mut"), Convention::IsSelfTypeCopy(false), Convention::ImplementsTrait(false)], &[SelfKind::Ref]),
+    (&[Convention::StartsWith("to_"), Convention::NotEndsWith("_mut"), Convention::IsSelfTypeCopy(true), Convention::ImplementsTrait(false)], &[SelfKind::Value]),
 ];
 
 enum Convention {
@@ -25,16 +30,20 @@ enum Convention {
     StartsWith(&'static str),
     EndsWith(&'static str),
     NotEndsWith(&'static str),
+    IsSelfTypeCopy(bool),
+    ImplementsTrait(bool),
 }
 
 impl Convention {
     #[must_use]
-    fn check(&self, other: &str) -> bool {
+    fn check<'tcx>(&self, cx: &LateContext<'tcx>, self_ty: &'tcx TyS<'tcx>, other: &str, is_trait_def: bool) -> bool {
         match *self {
             Self::Eq(this) => this == other,
             Self::StartsWith(this) => other.starts_with(this) && this != other,
             Self::EndsWith(this) => other.ends_with(this) && this != other,
-            Self::NotEndsWith(this) => !Self::EndsWith(this).check(other),
+            Self::NotEndsWith(this) => !Self::EndsWith(this).check(cx, self_ty, other, is_trait_def),
+            Self::IsSelfTypeCopy(is_true) => is_true == is_copy(cx, self_ty),
+            Self::ImplementsTrait(is_true) => is_true == is_trait_def,
         }
     }
 }
@@ -46,6 +55,10 @@ impl fmt::Display for Convention {
             Self::StartsWith(this) => this.fmt(f).and_then(|_| '*'.fmt(f)),
             Self::EndsWith(this) => '*'.fmt(f).and_then(|_| this.fmt(f)),
             Self::NotEndsWith(this) => '~'.fmt(f).and_then(|_| this.fmt(f)),
+            Self::IsSelfTypeCopy(is_true) => format!("self type is {} Copy", if is_true { "" } else { "not" }).fmt(f),
+            Self::ImplementsTrait(is_true) => {
+                format!("Method {} implement a trait", if is_true { "" } else { "do not" }).fmt(f)
+            },
         }
     }
 }
@@ -57,45 +70,42 @@ pub(super) fn check<'tcx>(
     self_ty: &'tcx TyS<'tcx>,
     first_arg_ty: &'tcx TyS<'tcx>,
     first_arg_span: Span,
+    is_trait_item: bool,
 ) {
     let lint = if is_pub {
         WRONG_PUB_SELF_CONVENTION
     } else {
         WRONG_SELF_CONVENTION
     };
-    if let Some((conventions, self_kinds)) = &CONVENTIONS
-        .iter()
-        .find(|(convs, _)| convs.iter().all(|conv| conv.check(item_name)))
-    {
+    if let Some((conventions, self_kinds)) = &CONVENTIONS.iter().find(|(convs, _)| {
+        convs
+            .iter()
+            .all(|conv| conv.check(cx, self_ty, item_name, is_trait_item))
+    }) {
         if !self_kinds.iter().any(|k| k.matches(cx, self_ty, first_arg_ty)) {
             let suggestion = {
                 if conventions.len() > 1 {
-                    let special_case = {
-                        // Don't mention `NotEndsWith` when there is also `StartsWith` convention present
-                        if conventions.len() == 2 {
-                            match conventions {
-                                [Convention::StartsWith(starts_with), Convention::NotEndsWith(_)]
-                                | [Convention::NotEndsWith(_), Convention::StartsWith(starts_with)] => {
-                                    Some(format!("methods called `{}`", Convention::StartsWith(starts_with)))
-                                },
-                                _ => None,
-                            }
-                        } else {
-                            None
-                        }
-                    };
-
-                    if let Some(suggestion) = special_case {
-                        suggestion
-                    } else {
-                        let s = conventions
+                    // Don't mention `NotEndsWith` when there is also `StartsWith` convention present
+                    let cut_ends_with_conv = conventions.iter().any(|conv| matches!(conv, Convention::StartsWith(_)))
+                        && conventions
                             .iter()
-                            .map(|c| format!("`{}`", &c.to_string()))
-                            .collect::<Vec<_>>()
-                            .join(" and ");
+                            .any(|conv| matches!(conv, Convention::NotEndsWith(_)));
 
-                        format!("methods called like this: ({})", &s)
-                    }
+                    let s = conventions
+                        .iter()
+                        .filter_map(|conv| {
+                            if (cut_ends_with_conv && matches!(conv, Convention::NotEndsWith(_)))
+                                || matches!(conv, Convention::ImplementsTrait(_))
+                            {
+                                None
+                            } else {
+                                Some(format!("`{}`", &conv.to_string()))
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(" and ");
+
+                    format!("methods with the following characteristics: ({})", &s)
                 } else {
                     format!("methods called `{}`", &conventions[0])
                 }

--- a/tests/ui/def_id_nocore.stderr
+++ b/tests/ui/def_id_nocore.stderr
@@ -1,4 +1,4 @@
-error: methods called `as_*` usually take self by reference or self by mutable reference
+error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> $DIR/def_id_nocore.rs:26:19
    |
 LL |     pub fn as_ref(self) -> &'static str {

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -79,6 +79,7 @@ mod issue2894 {
     }
 
     // This should not be linted
+    #[allow(clippy::wrong_self_convention)]
     impl IntoBytes for u8 {
         fn to_bytes(&self) -> Vec<u8> {
             vec![*self]

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -75,14 +75,13 @@ mod lifetimes {
 
 mod issue2894 {
     trait IntoBytes {
-        fn to_bytes(&self) -> Vec<u8>;
+        fn to_bytes(self) -> Vec<u8>;
     }
 
     // This should not be linted
-    #[allow(clippy::wrong_self_convention)]
     impl IntoBytes for u8 {
-        fn to_bytes(&self) -> Vec<u8> {
-            vec![*self]
+        fn to_bytes(self) -> Vec<u8> {
+            vec![self]
         }
     }
 }

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -79,6 +79,7 @@ mod issue2894 {
     }
 
     // This should not be linted
+    #[allow(clippy::wrong_self_convention)]
     impl IntoBytes for u8 {
         fn to_bytes(&self) -> Vec<u8> {
             vec![*self]

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -75,14 +75,13 @@ mod lifetimes {
 
 mod issue2894 {
     trait IntoBytes {
-        fn to_bytes(&self) -> Vec<u8>;
+        fn to_bytes(self) -> Vec<u8>;
     }
 
     // This should not be linted
-    #[allow(clippy::wrong_self_convention)]
     impl IntoBytes for u8 {
-        fn to_bytes(&self) -> Vec<u8> {
-            vec![*self]
+        fn to_bytes(self) -> Vec<u8> {
+            vec![self]
         }
     }
 }

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -37,139 +37,139 @@ LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:93:24
+  --> $DIR/use_self.rs:94:24
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                        ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:93:55
+  --> $DIR/use_self.rs:94:55
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                                                       ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:108:13
+  --> $DIR/use_self.rs:109:13
    |
 LL |             TS(0)
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:143:29
+  --> $DIR/use_self.rs:144:29
    |
 LL |                 fn bar() -> Bar {
    |                             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:144:21
+  --> $DIR/use_self.rs:145:21
    |
 LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:155:21
+  --> $DIR/use_self.rs:156:21
    |
 LL |         fn baz() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:156:13
+  --> $DIR/use_self.rs:157:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:173:21
+  --> $DIR/use_self.rs:174:21
    |
 LL |             let _ = Enum::B(42);
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:174:21
+  --> $DIR/use_self.rs:175:21
    |
 LL |             let _ = Enum::C { field: true };
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:175:21
+  --> $DIR/use_self.rs:176:21
    |
 LL |             let _ = Enum::A;
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:217:13
+  --> $DIR/use_self.rs:218:13
    |
 LL |             nested::A::fun_1();
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:218:13
+  --> $DIR/use_self.rs:219:13
    |
 LL |             nested::A::A;
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:220:13
+  --> $DIR/use_self.rs:221:13
    |
 LL |             nested::A {};
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:239:13
+  --> $DIR/use_self.rs:240:13
    |
 LL |             TestStruct::from_something()
    |             ^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:253:25
+  --> $DIR/use_self.rs:254:25
    |
 LL |         async fn g() -> S {
    |                         ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:254:13
+  --> $DIR/use_self.rs:255:13
    |
 LL |             S {}
    |             ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:258:16
+  --> $DIR/use_self.rs:259:16
    |
 LL |             &p[S::A..S::B]
    |                ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:258:22
+  --> $DIR/use_self.rs:259:22
    |
 LL |             &p[S::A..S::B]
    |                      ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:281:29
+  --> $DIR/use_self.rs:282:29
    |
 LL |         fn foo(value: T) -> Foo<T> {
    |                             ^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:282:13
+  --> $DIR/use_self.rs:283:13
    |
 LL |             Foo { value }
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:319:21
+  --> $DIR/use_self.rs:320:21
    |
 LL |         type From = T::From;
    |                     ^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:320:19
+  --> $DIR/use_self.rs:321:19
    |
 LL |         type To = T::To;
    |                   ^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:453:13
+  --> $DIR/use_self.rs:454:13
    |
 LL |             A::new::<submod::B>(submod::B {})
    |             ^ help: use the applicable keyword: `Self`

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -37,139 +37,139 @@ LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:94:24
+  --> $DIR/use_self.rs:93:24
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                        ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:94:55
+  --> $DIR/use_self.rs:93:55
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                                                       ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:109:13
+  --> $DIR/use_self.rs:108:13
    |
 LL |             TS(0)
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:144:29
+  --> $DIR/use_self.rs:143:29
    |
 LL |                 fn bar() -> Bar {
    |                             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:145:21
+  --> $DIR/use_self.rs:144:21
    |
 LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:156:21
+  --> $DIR/use_self.rs:155:21
    |
 LL |         fn baz() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:157:13
+  --> $DIR/use_self.rs:156:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:174:21
+  --> $DIR/use_self.rs:173:21
    |
 LL |             let _ = Enum::B(42);
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:175:21
+  --> $DIR/use_self.rs:174:21
    |
 LL |             let _ = Enum::C { field: true };
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:176:21
+  --> $DIR/use_self.rs:175:21
    |
 LL |             let _ = Enum::A;
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:218:13
+  --> $DIR/use_self.rs:217:13
    |
 LL |             nested::A::fun_1();
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:219:13
+  --> $DIR/use_self.rs:218:13
    |
 LL |             nested::A::A;
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:221:13
+  --> $DIR/use_self.rs:220:13
    |
 LL |             nested::A {};
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:240:13
+  --> $DIR/use_self.rs:239:13
    |
 LL |             TestStruct::from_something()
    |             ^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:254:25
+  --> $DIR/use_self.rs:253:25
    |
 LL |         async fn g() -> S {
    |                         ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:255:13
+  --> $DIR/use_self.rs:254:13
    |
 LL |             S {}
    |             ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:259:16
+  --> $DIR/use_self.rs:258:16
    |
 LL |             &p[S::A..S::B]
    |                ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:259:22
+  --> $DIR/use_self.rs:258:22
    |
 LL |             &p[S::A..S::B]
    |                      ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:282:29
+  --> $DIR/use_self.rs:281:29
    |
 LL |         fn foo(value: T) -> Foo<T> {
    |                             ^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:283:13
+  --> $DIR/use_self.rs:282:13
    |
 LL |             Foo { value }
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:320:21
+  --> $DIR/use_self.rs:319:21
    |
 LL |         type From = T::From;
    |                     ^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:321:19
+  --> $DIR/use_self.rs:320:19
    |
 LL |         type To = T::To;
    |                   ^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:454:13
+  --> $DIR/use_self.rs:453:13
    |
 LL |             A::new::<submod::B>(submod::B {})
    |             ^ help: use the applicable keyword: `Self`

--- a/tests/ui/wrong_self_convention.rs
+++ b/tests/ui/wrong_self_convention.rs
@@ -163,3 +163,35 @@ mod issue6307 {
         fn to_mut(&mut self);
     }
 }
+
+mod issue6727 {
+    trait ToU64 {
+        fn to_u64(self) -> u64;
+        fn to_u64_v2(&self) -> u64;
+    }
+
+    #[derive(Clone, Copy)]
+    struct FooCopy;
+
+    impl ToU64 for FooCopy {
+        fn to_u64(self) -> u64 {
+            1
+        }
+        // trigger lint
+        fn to_u64_v2(&self) -> u64 {
+            1
+        }
+    }
+
+    struct FooNoCopy;
+
+    impl ToU64 for FooNoCopy {
+        // trigger lint
+        fn to_u64(self) -> u64 {
+            2
+        }
+        fn to_u64_v2(&self) -> u64 {
+            2
+        }
+    }
+}

--- a/tests/ui/wrong_self_convention.stderr
+++ b/tests/ui/wrong_self_convention.stderr
@@ -39,7 +39,7 @@ LL |     fn is_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `to_*` usually take self by reference
+error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
   --> $DIR/wrong_self_convention.rs:42:15
    |
 LL |     fn to_i32(self) {}
@@ -79,7 +79,7 @@ LL |     pub fn is_i64(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `to_*` usually take self by reference
+error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
   --> $DIR/wrong_self_convention.rs:49:19
    |
 LL |     pub fn to_i64(self) {}
@@ -119,14 +119,6 @@ LL |         fn is_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `to_*` usually take self by reference
-  --> $DIR/wrong_self_convention.rs:102:19
-   |
-LL |         fn to_i32(self) {}
-   |                   ^^^^
-   |
-   = help: consider choosing a less ambiguous name
-
 error: methods called `from_*` usually take no self
   --> $DIR/wrong_self_convention.rs:104:21
    |
@@ -159,14 +151,6 @@ LL |         fn is_i32(self);
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `to_*` usually take self by reference
-  --> $DIR/wrong_self_convention.rs:126:19
-   |
-LL |         fn to_i32(self);
-   |                   ^^^^
-   |
-   = help: consider choosing a less ambiguous name
-
 error: methods called `from_*` usually take no self
   --> $DIR/wrong_self_convention.rs:128:21
    |
@@ -188,6 +172,22 @@ error: methods called `from_*` usually take no self
    |
 LL |         fn from_i32(self);
    |                     ^^^^
+   |
+   = help: consider choosing a less ambiguous name
+
+error: methods with the following characteristics: (`to_*` and `self type is  Copy`) usually take self by value
+  --> $DIR/wrong_self_convention.rs:181:22
+   |
+LL |         fn to_u64_v2(&self) -> u64 {
+   |                      ^^^^^
+   |
+   = help: consider choosing a less ambiguous name
+
+error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
+  --> $DIR/wrong_self_convention.rs:190:19
+   |
+LL |         fn to_u64(self) -> u64 {
+   |                   ^^^^
    |
    = help: consider choosing a less ambiguous name
 

--- a/tests/ui/wrong_self_convention.stderr
+++ b/tests/ui/wrong_self_convention.stderr
@@ -1,4 +1,4 @@
-error: methods called `from_*` usually take no self
+error: methods called `from_*` usually take no `self`
   --> $DIR/wrong_self_convention.rs:18:17
    |
 LL |     fn from_i32(self) {}
@@ -7,7 +7,7 @@ LL |     fn from_i32(self) {}
    = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
    = help: consider choosing a less ambiguous name
 
-error: methods called `from_*` usually take no self
+error: methods called `from_*` usually take no `self`
   --> $DIR/wrong_self_convention.rs:24:21
    |
 LL |     pub fn from_i64(self) {}
@@ -15,7 +15,7 @@ LL |     pub fn from_i64(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `as_*` usually take self by reference or self by mutable reference
+error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> $DIR/wrong_self_convention.rs:36:15
    |
 LL |     fn as_i32(self) {}
@@ -23,7 +23,7 @@ LL |     fn as_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `into_*` usually take self by value
+error: methods called `into_*` usually take `self` by value
   --> $DIR/wrong_self_convention.rs:38:17
    |
 LL |     fn into_i32(&self) {}
@@ -31,7 +31,7 @@ LL |     fn into_i32(&self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `is_*` usually take self by reference or no self
+error: methods called `is_*` usually take `self` by reference or no `self`
   --> $DIR/wrong_self_convention.rs:40:15
    |
 LL |     fn is_i32(self) {}
@@ -39,7 +39,7 @@ LL |     fn is_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
+error: methods with the following characteristics: (`to_*` and `self` type is not `Copy`) usually take `self` by reference
   --> $DIR/wrong_self_convention.rs:42:15
    |
 LL |     fn to_i32(self) {}
@@ -47,7 +47,7 @@ LL |     fn to_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `from_*` usually take no self
+error: methods called `from_*` usually take no `self`
   --> $DIR/wrong_self_convention.rs:44:17
    |
 LL |     fn from_i32(self) {}
@@ -55,7 +55,7 @@ LL |     fn from_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `as_*` usually take self by reference or self by mutable reference
+error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> $DIR/wrong_self_convention.rs:46:19
    |
 LL |     pub fn as_i64(self) {}
@@ -63,7 +63,7 @@ LL |     pub fn as_i64(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `into_*` usually take self by value
+error: methods called `into_*` usually take `self` by value
   --> $DIR/wrong_self_convention.rs:47:21
    |
 LL |     pub fn into_i64(&self) {}
@@ -71,7 +71,7 @@ LL |     pub fn into_i64(&self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `is_*` usually take self by reference or no self
+error: methods called `is_*` usually take `self` by reference or no `self`
   --> $DIR/wrong_self_convention.rs:48:19
    |
 LL |     pub fn is_i64(self) {}
@@ -79,7 +79,7 @@ LL |     pub fn is_i64(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
+error: methods with the following characteristics: (`to_*` and `self` type is not `Copy`) usually take `self` by reference
   --> $DIR/wrong_self_convention.rs:49:19
    |
 LL |     pub fn to_i64(self) {}
@@ -87,7 +87,7 @@ LL |     pub fn to_i64(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `from_*` usually take no self
+error: methods called `from_*` usually take no `self`
   --> $DIR/wrong_self_convention.rs:50:21
    |
 LL |     pub fn from_i64(self) {}
@@ -95,7 +95,7 @@ LL |     pub fn from_i64(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `as_*` usually take self by reference or self by mutable reference
+error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> $DIR/wrong_self_convention.rs:95:19
    |
 LL |         fn as_i32(self) {}
@@ -103,7 +103,7 @@ LL |         fn as_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `into_*` usually take self by value
+error: methods called `into_*` usually take `self` by value
   --> $DIR/wrong_self_convention.rs:98:25
    |
 LL |         fn into_i32_ref(&self) {}
@@ -111,7 +111,7 @@ LL |         fn into_i32_ref(&self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `is_*` usually take self by reference or no self
+error: methods called `is_*` usually take `self` by reference or no `self`
   --> $DIR/wrong_self_convention.rs:100:19
    |
 LL |         fn is_i32(self) {}
@@ -119,7 +119,7 @@ LL |         fn is_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `from_*` usually take no self
+error: methods called `from_*` usually take no `self`
   --> $DIR/wrong_self_convention.rs:104:21
    |
 LL |         fn from_i32(self) {}
@@ -127,7 +127,7 @@ LL |         fn from_i32(self) {}
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `as_*` usually take self by reference or self by mutable reference
+error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> $DIR/wrong_self_convention.rs:119:19
    |
 LL |         fn as_i32(self);
@@ -135,7 +135,7 @@ LL |         fn as_i32(self);
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `into_*` usually take self by value
+error: methods called `into_*` usually take `self` by value
   --> $DIR/wrong_self_convention.rs:122:25
    |
 LL |         fn into_i32_ref(&self);
@@ -143,7 +143,7 @@ LL |         fn into_i32_ref(&self);
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `is_*` usually take self by reference or no self
+error: methods called `is_*` usually take `self` by reference or no `self`
   --> $DIR/wrong_self_convention.rs:124:19
    |
 LL |         fn is_i32(self);
@@ -151,7 +151,7 @@ LL |         fn is_i32(self);
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `from_*` usually take no self
+error: methods called `from_*` usually take no `self`
   --> $DIR/wrong_self_convention.rs:128:21
    |
 LL |         fn from_i32(self);
@@ -159,7 +159,7 @@ LL |         fn from_i32(self);
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `into_*` usually take self by value
+error: methods called `into_*` usually take `self` by value
   --> $DIR/wrong_self_convention.rs:146:25
    |
 LL |         fn into_i32_ref(&self);
@@ -167,7 +167,7 @@ LL |         fn into_i32_ref(&self);
    |
    = help: consider choosing a less ambiguous name
 
-error: methods called `from_*` usually take no self
+error: methods called `from_*` usually take no `self`
   --> $DIR/wrong_self_convention.rs:152:21
    |
 LL |         fn from_i32(self);
@@ -175,7 +175,7 @@ LL |         fn from_i32(self);
    |
    = help: consider choosing a less ambiguous name
 
-error: methods with the following characteristics: (`to_*` and `self type is  Copy`) usually take self by value
+error: methods with the following characteristics: (`to_*` and `self` type is `Copy`) usually take `self` by value
   --> $DIR/wrong_self_convention.rs:181:22
    |
 LL |         fn to_u64_v2(&self) -> u64 {
@@ -183,7 +183,7 @@ LL |         fn to_u64_v2(&self) -> u64 {
    |
    = help: consider choosing a less ambiguous name
 
-error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
+error: methods with the following characteristics: (`to_*` and `self` type is not `Copy`) usually take `self` by reference
   --> $DIR/wrong_self_convention.rs:190:19
    |
 LL |         fn to_u64(self) -> u64 {

--- a/tests/ui/wrong_self_conventions_mut.stderr
+++ b/tests/ui/wrong_self_conventions_mut.stderr
@@ -1,4 +1,4 @@
-error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
+error: methods with the following characteristics: (`to_*` and `self` type is not `Copy`) usually take `self` by reference
   --> $DIR/wrong_self_conventions_mut.rs:15:24
    |
 LL |         pub fn to_many(&mut self) -> Option<&mut [T]> {
@@ -7,7 +7,7 @@ LL |         pub fn to_many(&mut self) -> Option<&mut [T]> {
    = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
    = help: consider choosing a less ambiguous name
 
-error: methods with the following characteristics: (`to_*` and `*_mut`) usually take self by mutable reference
+error: methods with the following characteristics: (`to_*` and `*_mut`) usually take `self` by mutable reference
   --> $DIR/wrong_self_conventions_mut.rs:23:28
    |
 LL |         pub fn to_many_mut(&self) -> Option<&[T]> {

--- a/tests/ui/wrong_self_conventions_mut.stderr
+++ b/tests/ui/wrong_self_conventions_mut.stderr
@@ -1,4 +1,4 @@
-error: methods called `to_*` usually take self by reference
+error: methods with the following characteristics: (`to_*` and `self type is not Copy`) usually take self by reference
   --> $DIR/wrong_self_conventions_mut.rs:15:24
    |
 LL |         pub fn to_many(&mut self) -> Option<&mut [T]> {
@@ -7,7 +7,7 @@ LL |         pub fn to_many(&mut self) -> Option<&mut [T]> {
    = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
    = help: consider choosing a less ambiguous name
 
-error: methods called like this: (`to_*` and `*_mut`) usually take self by mutable reference
+error: methods with the following characteristics: (`to_*` and `*_mut`) usually take self by mutable reference
   --> $DIR/wrong_self_conventions_mut.rs:23:28
    |
 LL |         pub fn to_many_mut(&self) -> Option<&[T]> {


### PR DESCRIPTION
fixes #6727 
changelog: wrong_self_convention: `to_` convention respects `Copy` types
