### PR TITLE
Ignore str::len() in or_fun_call lint.

### DIFF
--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -91,7 +91,7 @@ pub(super) fn check<'tcx>(
                 let ty = cx.typeck_results().expr_ty(&args[0]).peel_refs();
 
                 match ty.kind() {
-                    ty::Slice(_) | ty::Array(_, _) => return,
+                    ty::Slice(_) | ty::Array(_, _) | ty::Str => return,
                     _ => (),
                 }
 

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -120,6 +120,9 @@ fn test_or_with_ctors() {
 
     let slice = &["foo"][..];
     let _ = opt.ok_or(slice.len());
+
+    let string = "foo";
+    let _ = opt.ok_or(string.len());
 }
 
 // Issue 4514 - early return

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -120,6 +120,9 @@ fn test_or_with_ctors() {
 
     let slice = &["foo"][..];
     let _ = opt.ok_or(slice.len());
+
+    let string = "foo";
+    let _ = opt.ok_or(string.len());
 }
 
 // Issue 4514 - early return

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -115,19 +115,19 @@ LL |         .or(Some(Bar(b, Duration::from_secs(2))));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some(Bar(b, Duration::from_secs(2))))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:138:14
+  --> $DIR/or_fun_call.rs:141:14
    |
 LL |         None.unwrap_or(s.as_mut_vec());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| s.as_mut_vec())`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:143:14
+  --> $DIR/or_fun_call.rs:146:14
    |
 LL |         None.unwrap_or(unsafe { s.as_mut_vec() });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { s.as_mut_vec() })`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:145:14
+  --> $DIR/or_fun_call.rs:148:14
    |
 LL |         None.unwrap_or( unsafe { s.as_mut_vec() }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { s.as_mut_vec() })`


### PR DESCRIPTION
changelog: Changed `or_fun_call` to ignore `str::len`, in the same way it ignores `slice::len` and `array::len`

Closes #6943 

