### PR TITLE
use_self: Fix false positive in macro expansion

### DIFF
--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -461,3 +461,11 @@ mod issue6818 {
         a: i32,
     }
 }
+
+mod issue6902 {
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum Direction {
+        North,
+    }
+}

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -461,3 +461,11 @@ mod issue6818 {
         a: i32,
     }
 }
+
+mod issue6902 {
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum Direction {
+        North,
+    }
+}


### PR DESCRIPTION
fixes #6902 

changelog: `use_self`: Fix false positive related to macro expansion.
