### PR TITLE
Check for `.to_string().into_bytes()` in string_lit_to_bytes

### DIFF
--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -8,9 +8,15 @@ fn str_lit_as_bytes() {
 
     let bs = br###"raw string with 3# plus " ""###;
 
+    let bs = b"lit to string".to_vec();
+    let bs = b"lit to owned".to_vec();
+
     // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();
     let ubs = "hello there! this is a very long string".as_bytes();
+
+    let ubs = "☃".to_string().into_bytes();
+    let ubs = "this is also too long and shouldn't be fixed".to_string().into_bytes();
 
     let strify = stringify!(foobar).as_bytes();
 

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -8,9 +8,15 @@ fn str_lit_as_bytes() {
 
     let bs = r###"raw string with 3# plus " ""###.as_bytes();
 
+    let bs = "lit to string".to_string().into_bytes();
+    let bs = "lit to owned".to_owned().into_bytes();
+
     // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();
     let ubs = "hello there! this is a very long string".as_bytes();
+
+    let ubs = "☃".to_string().into_bytes();
+    let ubs = "this is also too long and shouldn't be fixed".to_string().into_bytes();
 
     let strify = stringify!(foobar).as_bytes();
 

--- a/tests/ui/string_lit_as_bytes.stderr
+++ b/tests/ui/string_lit_as_bytes.stderr
@@ -12,17 +12,29 @@ error: calling `as_bytes()` on a string literal
 LL |     let bs = r###"raw string with 3# plus " ""###.as_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with 3# plus " ""###`
 
+error: calling `into_bytes()` on a string literal
+  --> $DIR/string_lit_as_bytes.rs:11:14
+   |
+LL |     let bs = "lit to string".to_string().into_bytes();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"lit to string".to_vec()`
+
+error: calling `into_bytes()` on a string literal
+  --> $DIR/string_lit_as_bytes.rs:12:14
+   |
+LL |     let bs = "lit to owned".to_owned().into_bytes();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"lit to owned".to_vec()`
+
 error: calling `as_bytes()` on `include_str!(..)`
-  --> $DIR/string_lit_as_bytes.rs:19:22
+  --> $DIR/string_lit_as_bytes.rs:25:22
    |
 LL |     let includestr = include_str!("entry_unfixable.rs").as_bytes();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("entry_unfixable.rs")`
 
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:21:13
+  --> $DIR/string_lit_as_bytes.rs:27:13
    |
 LL |     let _ = "string with newline/t/n".as_bytes();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"string with newline/t/n"`
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes #6927 

changelog: Add a check for `into_bytes()` to string_lit_to_bytes lint