### PR TITLE
Improve `redundant_slicing`

### DIFF
--- a/tests/ui/redundant_slicing.rs
+++ b/tests/ui/redundant_slicing.rs
@@ -2,10 +2,31 @@
 #![warn(clippy::redundant_slicing)]
 
 fn main() {
-    let x: &[u32] = &[0];
-    let err = &x[..];
+    let slice: &[u32] = &[0];
+    let _ = &slice[..];
 
     let v = vec![0];
-    let ok = &v[..];
-    let err = &(&v[..])[..];
+    let _ = &v[..]; // Changes the type
+    let _ = &(&v[..])[..]; // Outer borrow is redundant
+
+    static S: &[u8] = &[0, 1, 2];
+    let err = &mut &S[..]; // Should reborrow instead of slice
+
+    let mut vec = vec![0];
+    let mut_slice = &mut *vec;
+    let _ = &mut mut_slice[..]; // Should reborrow instead of slice
+
+    macro_rules! m {
+        ($e:expr) => {
+            $e
+        };
+    }
+    let _ = &m!(slice)[..];
+
+    macro_rules! m2 {
+        ($e:expr) => {
+            &$e[..]
+        };
+    }
+    let _ = m2!(slice); // Don't lint in a macro
 }

--- a/tests/ui/redundant_slicing.stderr
+++ b/tests/ui/redundant_slicing.stderr
@@ -1,16 +1,34 @@
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:6:15
+  --> $DIR/redundant_slicing.rs:6:13
    |
-LL |     let err = &x[..];
-   |               ^^^^^^ help: use the original slice instead: `x`
+LL |     let _ = &slice[..];
+   |             ^^^^^^^^^^ help: use the original value instead: `slice`
    |
    = note: `-D clippy::redundant-slicing` implied by `-D warnings`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:10:15
+  --> $DIR/redundant_slicing.rs:10:13
    |
-LL |     let err = &(&v[..])[..];
-   |               ^^^^^^^^^^^^^ help: use the original slice instead: `(&v[..])`
+LL |     let _ = &(&v[..])[..]; // Outer borrow is redundant
+   |             ^^^^^^^^^^^^^ help: use the original value instead: `(&v[..])`
 
-error: aborting due to 2 previous errors
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:13:20
+   |
+LL |     let err = &mut &S[..]; // Should reborrow instead of slice
+   |                    ^^^^^^ help: reborrow the original value instead: `&*S`
+
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:17:13
+   |
+LL |     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
+   |             ^^^^^^^^^^^^^^^^^^ help: reborrow the original value instead: `&mut *mut_slice`
+
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:24:13
+   |
+LL |     let _ = &m!(slice)[..];
+   |             ^^^^^^^^^^^^^^ help: use the original value instead: `slice`
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
fixes: #6968

changelog: Fix `redundant_slicing` suggestion when a reborrow might be required or when the value is from a macro call
