### PR TITLE
disable upper_case_acronyms for pub items - enum edition

### DIFF
--- a/clippy_lints/src/upper_case_acronyms.rs
+++ b/clippy_lints/src/upper_case_acronyms.rs
@@ -1,7 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use if_chain::if_chain;
 use itertools::Itertools;
-use rustc_ast::ast::{Item, ItemKind, Variant, VisibilityKind};
+use rustc_ast::ast::{Item, ItemKind, VisibilityKind};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
@@ -109,7 +108,7 @@ impl EarlyLintPass for UpperCaseAcronyms {
             } else if let ItemKind::Enum(ref enumdef, _) = it.kind {
                 // check enum variants seperately because again we only want to lint on private enums and
                 // the fn check_variant does not know about the vis of the enum of its variants
-                &enumdef
+                enumdef
                     .variants
                     .iter()
                     .for_each(|variant| check_ident(cx, &variant.ident, self.upper_case_acronyms_aggressive));

--- a/clippy_lints/src/upper_case_acronyms.rs
+++ b/clippy_lints/src/upper_case_acronyms.rs
@@ -99,21 +99,21 @@ fn check_ident(cx: &EarlyContext<'_>, ident: &Ident, be_aggressive: bool) {
 
 impl EarlyLintPass for UpperCaseAcronyms {
     fn check_item(&mut self, cx: &EarlyContext<'_>, it: &Item) {
-        if_chain! {
-            if !in_external_macro(cx.sess(), it.span);
+        // do not lint public items or in macros
+        if !in_external_macro(cx.sess(), it.span) && !matches!(it.vis.kind, VisibilityKind::Public) {
             if matches!(
                 it.kind,
-                ItemKind::TyAlias(..) | ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Trait(..)
-            );
-            // do not lint public items
-            if !matches!(it.vis.kind, VisibilityKind::Public);
-            then {
+                ItemKind::TyAlias(..) | ItemKind::Struct(..) | ItemKind::Trait(..)
+            ) {
                 check_ident(cx, &it.ident, self.upper_case_acronyms_aggressive);
+            } else if let ItemKind::Enum(ref enumdef, _) = it.kind {
+                // check enum variants seperately because again we only want to lint on private enums and
+                // the fn check_variant does not know about the vis of the enum of its variants
+                &enumdef
+                    .variants
+                    .iter()
+                    .for_each(|variant| check_ident(cx, &variant.ident, self.upper_case_acronyms_aggressive));
             }
         }
-    }
-
-    fn check_variant(&mut self, cx: &EarlyContext<'_>, v: &Variant) {
-        check_ident(cx, &v.ident, self.upper_case_acronyms_aggressive);
     }
 }

--- a/tests/ui-toml/upper_case_acronyms_aggressive/upper_case_acronyms.rs
+++ b/tests/ui-toml/upper_case_acronyms_aggressive/upper_case_acronyms.rs
@@ -25,4 +25,20 @@ pub struct MIXEDCapital;
 
 pub struct FULLCAPITAL;
 
+// enum variants should not be linted if the num is pub
+pub enum ParseError<T> {
+    FULLCAPITAL(u8),
+    MIXEDCapital(String),
+    Utf8(std::string::FromUtf8Error),
+    Parse(T, String),
+}
+
+// private, do lint here
+enum ParseErrorPrivate<T> {
+    WASD(u8),
+    WASDMixed(String),
+    Utf8(std::string::FromUtf8Error),
+    Parse(T, String),
+}
+
 fn main() {}

--- a/tests/ui-toml/upper_case_acronyms_aggressive/upper_case_acronyms.stderr
+++ b/tests/ui-toml/upper_case_acronyms_aggressive/upper_case_acronyms.stderr
@@ -66,5 +66,17 @@ error: name `GCCLLVMSomething` contains a capitalized acronym
 LL | struct GCCLLVMSomething;
    |        ^^^^^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GccllvmSomething`
 
-error: aborting due to 11 previous errors
+error: name `WASD` contains a capitalized acronym
+  --> $DIR/upper_case_acronyms.rs:38:5
+   |
+LL |     WASD(u8),
+   |     ^^^^ help: consider making the acronym lowercase, except the initial letter: `Wasd`
+
+error: name `WASDMixed` contains a capitalized acronym
+  --> $DIR/upper_case_acronyms.rs:39:5
+   |
+LL |     WASDMixed(String),
+   |     ^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `WasdMixed`
+
+error: aborting due to 13 previous errors
 

--- a/tests/ui/upper_case_acronyms.rs
+++ b/tests/ui/upper_case_acronyms.rs
@@ -24,4 +24,18 @@ struct GCCLLVMSomething;
 pub struct NOWARNINGHERE;
 pub struct ALSONoWarningHERE;
 
+// enum variants should not be linted if the num is pub
+pub enum ParseError<T> {
+    YDB(u8),
+    Utf8(std::string::FromUtf8Error),
+    Parse(T, String),
+}
+
+// private, do lint here
+enum ParseErrorPrivate<T> {
+    WASD(u8),
+    Utf8(std::string::FromUtf8Error),
+    Parse(T, String),
+}
+
 fn main() {}

--- a/tests/ui/upper_case_acronyms.stderr
+++ b/tests/ui/upper_case_acronyms.stderr
@@ -48,5 +48,11 @@ error: name `FIN` contains a capitalized acronym
 LL |     FIN,
    |     ^^^ help: consider making the acronym lowercase, except the initial letter: `Fin`
 
-error: aborting due to 8 previous errors
+error: name `WASD` contains a capitalized acronym
+  --> $DIR/upper_case_acronyms.rs:36:5
+   |
+LL |     WASD(u8),
+   |     ^^^^ help: consider making the acronym lowercase, except the initial letter: `Wasd`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/6803 (again... :sweat_smile:  )

My previous fix did not work for enums because enum variants were checked separately in the `check_variant` function but it looks like we can't use that because we can't tell if the enum the variants belong to is declared as public or not (it always said `Inherited` for me)

I went and special-cased enums and iterated over all the variants "manually", but only, if the enums is not public.


---

changelog: fix upper_case_acronyms still firing on public enums (#6803)
