### PR TITLE
Organize functions into functions module

### DIFF
--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -56,7 +56,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// **What it does:** Checks for public functions that dereference raw pointer
-    /// arguments but are not marked unsafe.
+    /// arguments but are not marked `unsafe`.
     ///
     /// **Why is this bad?** The function should probably be marked `unsafe`, since
     /// for an arbitrary raw pointer, there is no way of telling for sure if it is
@@ -165,7 +165,7 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     /// **What it does:** Checks for public functions that return a `Result`
     /// with an `Err` type of `()`. It suggests using a custom type that
-    /// implements [`std::error::Error`].
+    /// implements `std::error::Error`.
     ///
     /// **Why is this bad?** Unit does not implement `Error` and carries no
     /// further information about what went wrong.

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -1,22 +1,17 @@
+mod must_use;
 mod not_unsafe_ptr_arg_deref;
 mod too_many_arguments;
 mod too_many_lines;
 
-use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
-use clippy_utils::source::snippet_opt;
-use clippy_utils::ty::{is_must_use_ty, is_type_diagnostic_item};
-use clippy_utils::{attr_by_name, attrs::is_proc_macro, match_def_path, must_use_attr, return_ty, trait_ref_of_method};
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::trait_ref_of_method;
+use clippy_utils::ty::is_type_diagnostic_item;
 use if_chain::if_chain;
-use rustc_ast::ast::Attribute;
-use rustc_data_structures::fx::FxHashSet;
-use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::intravisit;
-use rustc_hir::{def::Res, def_id::DefId, QPath};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_middle::hir::map::Map;
 use rustc_middle::lint::in_external_macro;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::{sym, Span};
 use rustc_typeck::hir_ty_to_ty;
@@ -260,54 +255,23 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
     }
 
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
-        let attrs = cx.tcx.hir().attrs(item.hir_id());
-        let attr = must_use_attr(attrs);
-        if let hir::ItemKind::Fn(ref sig, ref _generics, ref body_id) = item.kind {
+        must_use::check_item(cx, item);
+        if let hir::ItemKind::Fn(ref sig, ref _generics, _) = item.kind {
             let is_public = cx.access_levels.is_exported(item.hir_id());
             let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
             if is_public {
                 check_result_unit_err(cx, &sig.decl, item.span, fn_header_span);
             }
-            if let Some(attr) = attr {
-                check_needless_must_use(cx, &sig.decl, item.hir_id(), item.span, fn_header_span, attr);
-                return;
-            }
-            if is_public && !is_proc_macro(cx.sess(), attrs) && attr_by_name(attrs, "no_mangle").is_none() {
-                check_must_use_candidate(
-                    cx,
-                    &sig.decl,
-                    cx.tcx.hir().body(*body_id),
-                    item.span,
-                    item.hir_id(),
-                    item.span.with_hi(sig.decl.output.span().hi()),
-                    "this function could have a `#[must_use]` attribute",
-                );
-            }
         }
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'_>) {
-        if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind {
+        must_use::check_impl_item(cx, item);
+        if let hir::ImplItemKind::Fn(ref sig, _) = item.kind {
             let is_public = cx.access_levels.is_exported(item.hir_id());
             let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
             if is_public && trait_ref_of_method(cx, item.hir_id()).is_none() {
                 check_result_unit_err(cx, &sig.decl, item.span, fn_header_span);
-            }
-            let attrs = cx.tcx.hir().attrs(item.hir_id());
-            let attr = must_use_attr(attrs);
-            if let Some(attr) = attr {
-                check_needless_must_use(cx, &sig.decl, item.hir_id(), item.span, fn_header_span, attr);
-            } else if is_public && !is_proc_macro(cx.sess(), attrs) && trait_ref_of_method(cx, item.hir_id()).is_none()
-            {
-                check_must_use_candidate(
-                    cx,
-                    &sig.decl,
-                    cx.tcx.hir().body(*body_id),
-                    item.span,
-                    item.hir_id(),
-                    item.span.with_hi(sig.decl.output.span().hi()),
-                    "this method could have a `#[must_use]` attribute",
-                );
             }
         }
     }
@@ -315,32 +279,13 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
     fn check_trait_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::TraitItem<'_>) {
         too_many_arguments::check_trait_item(cx, item, self.too_many_arguments_threshold);
         not_unsafe_ptr_arg_deref::check_trait_item(cx, item);
+        must_use::check_trait_item(cx, item);
 
-        if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind {
+        if let hir::TraitItemKind::Fn(ref sig, _) = item.kind {
             let is_public = cx.access_levels.is_exported(item.hir_id());
             let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
             if is_public {
                 check_result_unit_err(cx, &sig.decl, item.span, fn_header_span);
-            }
-
-            let attrs = cx.tcx.hir().attrs(item.hir_id());
-            let attr = must_use_attr(attrs);
-            if let Some(attr) = attr {
-                check_needless_must_use(cx, &sig.decl, item.hir_id(), item.span, fn_header_span, attr);
-            }
-            if let hir::TraitFn::Provided(eid) = *eid {
-                let body = cx.tcx.hir().body(eid);
-                if attr.is_none() && is_public && !is_proc_macro(cx.sess(), attrs) {
-                    check_must_use_candidate(
-                        cx,
-                        &sig.decl,
-                        body,
-                        item.span,
-                        item.hir_id(),
-                        item.span.with_hi(sig.decl.output.span().hi()),
-                        "this method could have a `#[must_use]` attribute",
-                    );
-                }
             }
         }
     }
@@ -366,186 +311,4 @@ fn check_result_unit_err(cx: &LateContext<'_>, decl: &hir::FnDecl<'_>, item_span
             );
         }
     }
-}
-
-fn check_needless_must_use(
-    cx: &LateContext<'_>,
-    decl: &hir::FnDecl<'_>,
-    item_id: hir::HirId,
-    item_span: Span,
-    fn_header_span: Span,
-    attr: &Attribute,
-) {
-    if in_external_macro(cx.sess(), item_span) {
-        return;
-    }
-    if returns_unit(decl) {
-        span_lint_and_then(
-            cx,
-            MUST_USE_UNIT,
-            fn_header_span,
-            "this unit-returning function has a `#[must_use]` attribute",
-            |diag| {
-                diag.span_suggestion(
-                    attr.span,
-                    "remove the attribute",
-                    "".into(),
-                    Applicability::MachineApplicable,
-                );
-            },
-        );
-    } else if !attr.is_value_str() && is_must_use_ty(cx, return_ty(cx, item_id)) {
-        span_lint_and_help(
-            cx,
-            DOUBLE_MUST_USE,
-            fn_header_span,
-            "this function has an empty `#[must_use]` attribute, but returns a type already marked as `#[must_use]`",
-            None,
-            "either add some descriptive text or remove the attribute",
-        );
-    }
-}
-
-fn check_must_use_candidate<'tcx>(
-    cx: &LateContext<'tcx>,
-    decl: &'tcx hir::FnDecl<'_>,
-    body: &'tcx hir::Body<'_>,
-    item_span: Span,
-    item_id: hir::HirId,
-    fn_span: Span,
-    msg: &str,
-) {
-    if has_mutable_arg(cx, body)
-        || mutates_static(cx, body)
-        || in_external_macro(cx.sess(), item_span)
-        || returns_unit(decl)
-        || !cx.access_levels.is_exported(item_id)
-        || is_must_use_ty(cx, return_ty(cx, item_id))
-    {
-        return;
-    }
-    span_lint_and_then(cx, MUST_USE_CANDIDATE, fn_span, msg, |diag| {
-        if let Some(snippet) = snippet_opt(cx, fn_span) {
-            diag.span_suggestion(
-                fn_span,
-                "add the attribute",
-                format!("#[must_use] {}", snippet),
-                Applicability::MachineApplicable,
-            );
-        }
-    });
-}
-
-fn returns_unit(decl: &hir::FnDecl<'_>) -> bool {
-    match decl.output {
-        hir::FnRetTy::DefaultReturn(_) => true,
-        hir::FnRetTy::Return(ref ty) => match ty.kind {
-            hir::TyKind::Tup(ref tys) => tys.is_empty(),
-            hir::TyKind::Never => true,
-            _ => false,
-        },
-    }
-}
-
-fn has_mutable_arg(cx: &LateContext<'_>, body: &hir::Body<'_>) -> bool {
-    let mut tys = FxHashSet::default();
-    body.params.iter().any(|param| is_mutable_pat(cx, &param.pat, &mut tys))
-}
-
-fn is_mutable_pat(cx: &LateContext<'_>, pat: &hir::Pat<'_>, tys: &mut FxHashSet<DefId>) -> bool {
-    if let hir::PatKind::Wild = pat.kind {
-        return false; // ignore `_` patterns
-    }
-    if cx.tcx.has_typeck_results(pat.hir_id.owner.to_def_id()) {
-        is_mutable_ty(cx, &cx.tcx.typeck(pat.hir_id.owner).pat_ty(pat), pat.span, tys)
-    } else {
-        false
-    }
-}
-
-static KNOWN_WRAPPER_TYS: &[&[&str]] = &[&["alloc", "rc", "Rc"], &["std", "sync", "Arc"]];
-
-fn is_mutable_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, span: Span, tys: &mut FxHashSet<DefId>) -> bool {
-    match *ty.kind() {
-        // primitive types are never mutable
-        ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Str => false,
-        ty::Adt(ref adt, ref substs) => {
-            tys.insert(adt.did) && !ty.is_freeze(cx.tcx.at(span), cx.param_env)
-                || KNOWN_WRAPPER_TYS.iter().any(|path| match_def_path(cx, adt.did, path))
-                    && substs.types().any(|ty| is_mutable_ty(cx, ty, span, tys))
-        },
-        ty::Tuple(ref substs) => substs.types().any(|ty| is_mutable_ty(cx, ty, span, tys)),
-        ty::Array(ty, _) | ty::Slice(ty) => is_mutable_ty(cx, ty, span, tys),
-        ty::RawPtr(ty::TypeAndMut { ty, mutbl }) | ty::Ref(_, ty, mutbl) => {
-            mutbl == hir::Mutability::Mut || is_mutable_ty(cx, ty, span, tys)
-        },
-        // calling something constitutes a side effect, so return true on all callables
-        // also never calls need not be used, so return true for them, too
-        _ => true,
-    }
-}
-
-struct StaticMutVisitor<'a, 'tcx> {
-    cx: &'a LateContext<'tcx>,
-    mutates_static: bool,
-}
-
-impl<'a, 'tcx> intravisit::Visitor<'tcx> for StaticMutVisitor<'a, 'tcx> {
-    type Map = Map<'tcx>;
-
-    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'_>) {
-        use hir::ExprKind::{AddrOf, Assign, AssignOp, Call, MethodCall};
-
-        if self.mutates_static {
-            return;
-        }
-        match expr.kind {
-            Call(_, args) | MethodCall(_, _, args, _) => {
-                let mut tys = FxHashSet::default();
-                for arg in args {
-                    if self.cx.tcx.has_typeck_results(arg.hir_id.owner.to_def_id())
-                        && is_mutable_ty(
-                            self.cx,
-                            self.cx.tcx.typeck(arg.hir_id.owner).expr_ty(arg),
-                            arg.span,
-                            &mut tys,
-                        )
-                        && is_mutated_static(arg)
-                    {
-                        self.mutates_static = true;
-                        return;
-                    }
-                    tys.clear();
-                }
-            },
-            Assign(ref target, ..) | AssignOp(_, ref target, _) | AddrOf(_, hir::Mutability::Mut, ref target) => {
-                self.mutates_static |= is_mutated_static(target)
-            },
-            _ => {},
-        }
-    }
-
-    fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<Self::Map> {
-        intravisit::NestedVisitorMap::None
-    }
-}
-
-fn is_mutated_static(e: &hir::Expr<'_>) -> bool {
-    use hir::ExprKind::{Field, Index, Path};
-
-    match e.kind {
-        Path(QPath::Resolved(_, path)) => !matches!(path.res, Res::Local(_)),
-        Path(_) => true,
-        Field(ref inner, _) | Index(ref inner, _) => is_mutated_static(inner),
-        _ => false,
-    }
-}
-
-fn mutates_static<'tcx>(cx: &LateContext<'tcx>, body: &'tcx hir::Body<'_>) -> bool {
-    let mut v = StaticMutVisitor {
-        cx,
-        mutates_static: false,
-    };
-    intravisit::walk_expr(&mut v, &body.value);
-    v.mutates_static
 }

--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -1,0 +1,272 @@
+use rustc_ast::ast::Attribute;
+use rustc_data_structures::fx::FxHashSet;
+use rustc_errors::Applicability;
+use rustc_hir::{self as hir, def::Res, def_id::DefId, intravisit, QPath};
+use rustc_lint::{LateContext, LintContext};
+use rustc_middle::{
+    hir::map::Map,
+    lint::in_external_macro,
+    ty::{self, Ty},
+};
+use rustc_span::Span;
+
+use clippy_utils::attrs::is_proc_macro;
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
+use clippy_utils::source::snippet_opt;
+use clippy_utils::ty::is_must_use_ty;
+use clippy_utils::{attr_by_name, match_def_path, must_use_attr, return_ty, trait_ref_of_method};
+
+use super::{DOUBLE_MUST_USE, MUST_USE_CANDIDATE, MUST_USE_UNIT};
+
+pub(super) fn check_item(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
+    let attrs = cx.tcx.hir().attrs(item.hir_id());
+    let attr = must_use_attr(attrs);
+    if let hir::ItemKind::Fn(ref sig, ref _generics, ref body_id) = item.kind {
+        let is_public = cx.access_levels.is_exported(item.hir_id());
+        let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
+        if let Some(attr) = attr {
+            check_needless_must_use(cx, &sig.decl, item.hir_id(), item.span, fn_header_span, attr);
+            return;
+        } else if is_public && !is_proc_macro(cx.sess(), attrs) && attr_by_name(attrs, "no_mangle").is_none() {
+            check_must_use_candidate(
+                cx,
+                &sig.decl,
+                cx.tcx.hir().body(*body_id),
+                item.span,
+                item.hir_id(),
+                item.span.with_hi(sig.decl.output.span().hi()),
+                "this function could have a `#[must_use]` attribute",
+            );
+        }
+    }
+}
+
+pub(super) fn check_impl_item(cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'_>) {
+    if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind {
+        let is_public = cx.access_levels.is_exported(item.hir_id());
+        let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
+        let attrs = cx.tcx.hir().attrs(item.hir_id());
+        let attr = must_use_attr(attrs);
+        if let Some(attr) = attr {
+            check_needless_must_use(cx, &sig.decl, item.hir_id(), item.span, fn_header_span, attr);
+        } else if is_public && !is_proc_macro(cx.sess(), attrs) && trait_ref_of_method(cx, item.hir_id()).is_none() {
+            check_must_use_candidate(
+                cx,
+                &sig.decl,
+                cx.tcx.hir().body(*body_id),
+                item.span,
+                item.hir_id(),
+                item.span.with_hi(sig.decl.output.span().hi()),
+                "this method could have a `#[must_use]` attribute",
+            );
+        }
+    }
+}
+
+pub(super) fn check_trait_item(cx: &LateContext<'tcx>, item: &'tcx hir::TraitItem<'_>) {
+    if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind {
+        let is_public = cx.access_levels.is_exported(item.hir_id());
+        let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
+
+        let attrs = cx.tcx.hir().attrs(item.hir_id());
+        let attr = must_use_attr(attrs);
+        if let Some(attr) = attr {
+            check_needless_must_use(cx, &sig.decl, item.hir_id(), item.span, fn_header_span, attr);
+        } else if let hir::TraitFn::Provided(eid) = *eid {
+            let body = cx.tcx.hir().body(eid);
+            if attr.is_none() && is_public && !is_proc_macro(cx.sess(), attrs) {
+                check_must_use_candidate(
+                    cx,
+                    &sig.decl,
+                    body,
+                    item.span,
+                    item.hir_id(),
+                    item.span.with_hi(sig.decl.output.span().hi()),
+                    "this method could have a `#[must_use]` attribute",
+                );
+            }
+        }
+    }
+}
+
+fn check_needless_must_use(
+    cx: &LateContext<'_>,
+    decl: &hir::FnDecl<'_>,
+    item_id: hir::HirId,
+    item_span: Span,
+    fn_header_span: Span,
+    attr: &Attribute,
+) {
+    if in_external_macro(cx.sess(), item_span) {
+        return;
+    }
+    if returns_unit(decl) {
+        span_lint_and_then(
+            cx,
+            MUST_USE_UNIT,
+            fn_header_span,
+            "this unit-returning function has a `#[must_use]` attribute",
+            |diag| {
+                diag.span_suggestion(
+                    attr.span,
+                    "remove the attribute",
+                    "".into(),
+                    Applicability::MachineApplicable,
+                );
+            },
+        );
+    } else if !attr.is_value_str() && is_must_use_ty(cx, return_ty(cx, item_id)) {
+        span_lint_and_help(
+            cx,
+            DOUBLE_MUST_USE,
+            fn_header_span,
+            "this function has an empty `#[must_use]` attribute, but returns a type already marked as `#[must_use]`",
+            None,
+            "either add some descriptive text or remove the attribute",
+        );
+    }
+}
+
+fn check_must_use_candidate<'tcx>(
+    cx: &LateContext<'tcx>,
+    decl: &'tcx hir::FnDecl<'_>,
+    body: &'tcx hir::Body<'_>,
+    item_span: Span,
+    item_id: hir::HirId,
+    fn_span: Span,
+    msg: &str,
+) {
+    if has_mutable_arg(cx, body)
+        || mutates_static(cx, body)
+        || in_external_macro(cx.sess(), item_span)
+        || returns_unit(decl)
+        || !cx.access_levels.is_exported(item_id)
+        || is_must_use_ty(cx, return_ty(cx, item_id))
+    {
+        return;
+    }
+    span_lint_and_then(cx, MUST_USE_CANDIDATE, fn_span, msg, |diag| {
+        if let Some(snippet) = snippet_opt(cx, fn_span) {
+            diag.span_suggestion(
+                fn_span,
+                "add the attribute",
+                format!("#[must_use] {}", snippet),
+                Applicability::MachineApplicable,
+            );
+        }
+    });
+}
+
+fn returns_unit(decl: &hir::FnDecl<'_>) -> bool {
+    match decl.output {
+        hir::FnRetTy::DefaultReturn(_) => true,
+        hir::FnRetTy::Return(ref ty) => match ty.kind {
+            hir::TyKind::Tup(ref tys) => tys.is_empty(),
+            hir::TyKind::Never => true,
+            _ => false,
+        },
+    }
+}
+
+fn has_mutable_arg(cx: &LateContext<'_>, body: &hir::Body<'_>) -> bool {
+    let mut tys = FxHashSet::default();
+    body.params.iter().any(|param| is_mutable_pat(cx, &param.pat, &mut tys))
+}
+
+fn is_mutable_pat(cx: &LateContext<'_>, pat: &hir::Pat<'_>, tys: &mut FxHashSet<DefId>) -> bool {
+    if let hir::PatKind::Wild = pat.kind {
+        return false; // ignore `_` patterns
+    }
+    if cx.tcx.has_typeck_results(pat.hir_id.owner.to_def_id()) {
+        is_mutable_ty(cx, &cx.tcx.typeck(pat.hir_id.owner).pat_ty(pat), pat.span, tys)
+    } else {
+        false
+    }
+}
+
+static KNOWN_WRAPPER_TYS: &[&[&str]] = &[&["alloc", "rc", "Rc"], &["std", "sync", "Arc"]];
+
+fn is_mutable_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, span: Span, tys: &mut FxHashSet<DefId>) -> bool {
+    match *ty.kind() {
+        // primitive types are never mutable
+        ty::Bool | ty::Char | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Str => false,
+        ty::Adt(ref adt, ref substs) => {
+            tys.insert(adt.did) && !ty.is_freeze(cx.tcx.at(span), cx.param_env)
+                || KNOWN_WRAPPER_TYS.iter().any(|path| match_def_path(cx, adt.did, path))
+                    && substs.types().any(|ty| is_mutable_ty(cx, ty, span, tys))
+        },
+        ty::Tuple(ref substs) => substs.types().any(|ty| is_mutable_ty(cx, ty, span, tys)),
+        ty::Array(ty, _) | ty::Slice(ty) => is_mutable_ty(cx, ty, span, tys),
+        ty::RawPtr(ty::TypeAndMut { ty, mutbl }) | ty::Ref(_, ty, mutbl) => {
+            mutbl == hir::Mutability::Mut || is_mutable_ty(cx, ty, span, tys)
+        },
+        // calling something constitutes a side effect, so return true on all callables
+        // also never calls need not be used, so return true for them, too
+        _ => true,
+    }
+}
+
+struct StaticMutVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    mutates_static: bool,
+}
+
+impl<'a, 'tcx> intravisit::Visitor<'tcx> for StaticMutVisitor<'a, 'tcx> {
+    type Map = Map<'tcx>;
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'_>) {
+        use hir::ExprKind::{AddrOf, Assign, AssignOp, Call, MethodCall};
+
+        if self.mutates_static {
+            return;
+        }
+        match expr.kind {
+            Call(_, args) | MethodCall(_, _, args, _) => {
+                let mut tys = FxHashSet::default();
+                for arg in args {
+                    if self.cx.tcx.has_typeck_results(arg.hir_id.owner.to_def_id())
+                        && is_mutable_ty(
+                            self.cx,
+                            self.cx.tcx.typeck(arg.hir_id.owner).expr_ty(arg),
+                            arg.span,
+                            &mut tys,
+                        )
+                        && is_mutated_static(arg)
+                    {
+                        self.mutates_static = true;
+                        return;
+                    }
+                    tys.clear();
+                }
+            },
+            Assign(ref target, ..) | AssignOp(_, ref target, _) | AddrOf(_, hir::Mutability::Mut, ref target) => {
+                self.mutates_static |= is_mutated_static(target)
+            },
+            _ => {},
+        }
+    }
+
+    fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<Self::Map> {
+        intravisit::NestedVisitorMap::None
+    }
+}
+
+fn is_mutated_static(e: &hir::Expr<'_>) -> bool {
+    use hir::ExprKind::{Field, Index, Path};
+
+    match e.kind {
+        Path(QPath::Resolved(_, path)) => !matches!(path.res, Res::Local(_)),
+        Path(_) => true,
+        Field(ref inner, _) | Index(ref inner, _) => is_mutated_static(inner),
+        _ => false,
+    }
+}
+
+fn mutates_static<'tcx>(cx: &LateContext<'tcx>, body: &'tcx hir::Body<'_>) -> bool {
+    let mut v = StaticMutVisitor {
+        cx,
+        mutates_static: false,
+    };
+    intravisit::walk_expr(&mut v, &body.value);
+    v.mutates_static
+}

--- a/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
+++ b/clippy_lints/src/functions/not_unsafe_ptr_arg_deref.rs
@@ -1,0 +1,125 @@
+use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::{self as hir, intravisit};
+use rustc_lint::LateContext;
+use rustc_middle::{hir::map::Map, ty};
+
+use clippy_utils::diagnostics::span_lint;
+use clippy_utils::ty::type_is_unsafe_function;
+use clippy_utils::{iter_input_pats, path_to_local};
+
+use super::NOT_UNSAFE_PTR_ARG_DEREF;
+
+pub(super) fn check_fn(
+    cx: &LateContext<'tcx>,
+    kind: intravisit::FnKind<'tcx>,
+    decl: &'tcx hir::FnDecl<'tcx>,
+    body: &'tcx hir::Body<'tcx>,
+    hir_id: hir::HirId,
+) {
+    let unsafety = match kind {
+        intravisit::FnKind::ItemFn(_, _, hir::FnHeader { unsafety, .. }, _) => unsafety,
+        intravisit::FnKind::Method(_, sig, _) => sig.header.unsafety,
+        intravisit::FnKind::Closure => return,
+    };
+
+    check_raw_ptr(cx, unsafety, decl, body, hir_id);
+}
+
+pub(super) fn check_trait_item(cx: &LateContext<'tcx>, item: &'tcx hir::TraitItem<'_>) {
+    if let hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(eid)) = item.kind {
+        let body = cx.tcx.hir().body(eid);
+        check_raw_ptr(cx, sig.header.unsafety, &sig.decl, body, item.hir_id());
+    }
+}
+
+fn check_raw_ptr(
+    cx: &LateContext<'tcx>,
+    unsafety: hir::Unsafety,
+    decl: &'tcx hir::FnDecl<'tcx>,
+    body: &'tcx hir::Body<'tcx>,
+    hir_id: hir::HirId,
+) {
+    let expr = &body.value;
+    if unsafety == hir::Unsafety::Normal && cx.access_levels.is_exported(hir_id) {
+        let raw_ptrs = iter_input_pats(decl, body)
+            .zip(decl.inputs.iter())
+            .filter_map(|(arg, ty)| raw_ptr_arg(arg, ty))
+            .collect::<FxHashSet<_>>();
+
+        if !raw_ptrs.is_empty() {
+            let typeck_results = cx.tcx.typeck_body(body.id());
+            let mut v = DerefVisitor {
+                cx,
+                ptrs: raw_ptrs,
+                typeck_results,
+            };
+
+            intravisit::walk_expr(&mut v, expr);
+        }
+    }
+}
+
+fn raw_ptr_arg(arg: &hir::Param<'_>, ty: &hir::Ty<'_>) -> Option<hir::HirId> {
+    if let (&hir::PatKind::Binding(_, id, _, _), &hir::TyKind::Ptr(_)) = (&arg.pat.kind, &ty.kind) {
+        Some(id)
+    } else {
+        None
+    }
+}
+
+struct DerefVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    ptrs: FxHashSet<hir::HirId>,
+    typeck_results: &'a ty::TypeckResults<'tcx>,
+}
+
+impl<'a, 'tcx> intravisit::Visitor<'tcx> for DerefVisitor<'a, 'tcx> {
+    type Map = Map<'tcx>;
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'_>) {
+        match expr.kind {
+            hir::ExprKind::Call(ref f, args) => {
+                let ty = self.typeck_results.expr_ty(f);
+
+                if type_is_unsafe_function(self.cx, ty) {
+                    for arg in args {
+                        self.check_arg(arg);
+                    }
+                }
+            },
+            hir::ExprKind::MethodCall(_, _, args, _) => {
+                let def_id = self.typeck_results.type_dependent_def_id(expr.hir_id).unwrap();
+                let base_type = self.cx.tcx.type_of(def_id);
+
+                if type_is_unsafe_function(self.cx, base_type) {
+                    for arg in args {
+                        self.check_arg(arg);
+                    }
+                }
+            },
+            hir::ExprKind::Unary(hir::UnOp::Deref, ref ptr) => self.check_arg(ptr),
+            _ => (),
+        }
+
+        intravisit::walk_expr(self, expr);
+    }
+
+    fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<Self::Map> {
+        intravisit::NestedVisitorMap::None
+    }
+}
+
+impl<'a, 'tcx> DerefVisitor<'a, 'tcx> {
+    fn check_arg(&self, ptr: &hir::Expr<'_>) {
+        if let Some(id) = path_to_local(ptr) {
+            if self.ptrs.contains(&id) {
+                span_lint(
+                    self.cx,
+                    NOT_UNSAFE_PTR_ARG_DEREF,
+                    ptr.span,
+                    "this public function dereferences a raw pointer but is not marked `unsafe`",
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/functions/result_unit_err.rs
+++ b/clippy_lints/src/functions/result_unit_err.rs
@@ -1,0 +1,66 @@
+use rustc_hir as hir;
+use rustc_lint::{LateContext, LintContext};
+use rustc_middle::lint::in_external_macro;
+use rustc_middle::ty;
+use rustc_span::{sym, Span};
+use rustc_typeck::hir_ty_to_ty;
+
+use if_chain::if_chain;
+
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::trait_ref_of_method;
+use clippy_utils::ty::is_type_diagnostic_item;
+
+use super::RESULT_UNIT_ERR;
+
+pub(super) fn check_item(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
+    if let hir::ItemKind::Fn(ref sig, ref _generics, _) = item.kind {
+        let is_public = cx.access_levels.is_exported(item.hir_id());
+        let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
+        if is_public {
+            check_result_unit_err(cx, &sig.decl, item.span, fn_header_span);
+        }
+    }
+}
+
+pub(super) fn check_impl_item(cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'_>) {
+    if let hir::ImplItemKind::Fn(ref sig, _) = item.kind {
+        let is_public = cx.access_levels.is_exported(item.hir_id());
+        let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
+        if is_public && trait_ref_of_method(cx, item.hir_id()).is_none() {
+            check_result_unit_err(cx, &sig.decl, item.span, fn_header_span);
+        }
+    }
+}
+
+pub(super) fn check_trait_item(cx: &LateContext<'tcx>, item: &'tcx hir::TraitItem<'_>) {
+    if let hir::TraitItemKind::Fn(ref sig, _) = item.kind {
+        let is_public = cx.access_levels.is_exported(item.hir_id());
+        let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
+        if is_public {
+            check_result_unit_err(cx, &sig.decl, item.span, fn_header_span);
+        }
+    }
+}
+
+fn check_result_unit_err(cx: &LateContext<'_>, decl: &hir::FnDecl<'_>, item_span: Span, fn_header_span: Span) {
+    if_chain! {
+        if !in_external_macro(cx.sess(), item_span);
+        if let hir::FnRetTy::Return(ref ty) = decl.output;
+        let ty = hir_ty_to_ty(cx.tcx, ty);
+        if is_type_diagnostic_item(cx, ty, sym::result_type);
+        if let ty::Adt(_, substs) = ty.kind();
+        let err_ty = substs.type_at(1);
+        if err_ty.is_unit();
+        then {
+            span_lint_and_help(
+                cx,
+                RESULT_UNIT_ERR,
+                fn_header_span,
+                "this returns a `Result<_, ()>",
+                None,
+                "use a custom Error type instead",
+            );
+        }
+    }
+}

--- a/clippy_lints/src/functions/too_many_arguments.rs
+++ b/clippy_lints/src/functions/too_many_arguments.rs
@@ -1,0 +1,73 @@
+use rustc_hir::{self as hir, intravisit};
+use rustc_lint::LateContext;
+use rustc_span::Span;
+use rustc_target::spec::abi::Abi;
+
+use clippy_utils::diagnostics::span_lint;
+use clippy_utils::is_trait_impl_item;
+
+use super::TOO_MANY_ARGUMENTS;
+
+pub(super) fn check_fn(
+    cx: &LateContext<'tcx>,
+    kind: intravisit::FnKind<'tcx>,
+    decl: &'tcx hir::FnDecl<'_>,
+    span: Span,
+    hir_id: hir::HirId,
+    too_many_arguments_threshold: u64,
+) {
+    // don't warn for implementations, it's not their fault
+    if !is_trait_impl_item(cx, hir_id) {
+        // don't lint extern functions decls, it's not their fault either
+        match kind {
+            intravisit::FnKind::Method(
+                _,
+                &hir::FnSig {
+                    header: hir::FnHeader { abi: Abi::Rust, .. },
+                    ..
+                },
+                _,
+            )
+            | intravisit::FnKind::ItemFn(_, _, hir::FnHeader { abi: Abi::Rust, .. }, _) => check_arg_number(
+                cx,
+                decl,
+                span.with_hi(decl.output.span().hi()),
+                too_many_arguments_threshold,
+            ),
+            _ => {},
+        }
+    }
+}
+
+pub(super) fn check_trait_item(
+    cx: &LateContext<'tcx>,
+    item: &'tcx hir::TraitItem<'_>,
+    too_many_arguments_threshold: u64,
+) {
+    if let hir::TraitItemKind::Fn(ref sig, _) = item.kind {
+        // don't lint extern functions decls, it's not their fault
+        if sig.header.abi == Abi::Rust {
+            check_arg_number(
+                cx,
+                &sig.decl,
+                item.span.with_hi(sig.decl.output.span().hi()),
+                too_many_arguments_threshold,
+            );
+        }
+    }
+}
+
+fn check_arg_number(cx: &LateContext<'_>, decl: &hir::FnDecl<'_>, fn_span: Span, too_many_arguments_threshold: u64) {
+    let args = decl.inputs.len() as u64;
+    if args > too_many_arguments_threshold {
+        span_lint(
+            cx,
+            TOO_MANY_ARGUMENTS,
+            fn_span,
+            &format!(
+                "this function has too many arguments ({}/{})",
+                args, too_many_arguments_threshold
+            ),
+        );
+    }
+}

--- a/clippy_lints/src/functions/too_many_lines.rs
+++ b/clippy_lints/src/functions/too_many_lines.rs
@@ -1,0 +1,68 @@
+use rustc_hir as hir;
+use rustc_lint::{LateContext, LintContext};
+use rustc_middle::lint::in_external_macro;
+use rustc_span::Span;
+
+use clippy_utils::diagnostics::span_lint;
+use clippy_utils::source::snippet;
+
+use super::TOO_MANY_LINES;
+
+pub(super) fn check(cx: &LateContext<'_>, span: Span, body: &'tcx hir::Body<'_>, too_many_lines_threshold: u64) {
+    if in_external_macro(cx.sess(), span) {
+        return;
+    }
+
+    let code_snippet = snippet(cx, body.value.span, "..");
+    let mut line_count: u64 = 0;
+    let mut in_comment = false;
+    let mut code_in_line;
+
+    // Skip the surrounding function decl.
+    let start_brace_idx = code_snippet.find('{').map_or(0, |i| i + 1);
+    let end_brace_idx = code_snippet.rfind('}').unwrap_or_else(|| code_snippet.len());
+    let function_lines = code_snippet[start_brace_idx..end_brace_idx].lines();
+
+    for mut line in function_lines {
+        code_in_line = false;
+        loop {
+            line = line.trim_start();
+            if line.is_empty() {
+                break;
+            }
+            if in_comment {
+                if let Some(i) = line.find("*/") {
+                    line = &line[i + 2..];
+                    in_comment = false;
+                    continue;
+                }
+            } else {
+                let multi_idx = line.find("/*").unwrap_or_else(|| line.len());
+                let single_idx = line.find("//").unwrap_or_else(|| line.len());
+                code_in_line |= multi_idx > 0 && single_idx > 0;
+                // Implies multi_idx is below line.len()
+                if multi_idx < single_idx {
+                    line = &line[multi_idx + 2..];
+                    in_comment = true;
+                    continue;
+                }
+            }
+            break;
+        }
+        if code_in_line {
+            line_count += 1;
+        }
+    }
+
+    if line_count > too_many_lines_threshold {
+        span_lint(
+            cx,
+            TOO_MANY_LINES,
+            span,
+            &format!(
+                "this function has too many lines ({}/{})",
+                line_count, too_many_lines_threshold
+            ),
+        )
+    }
+}

--- a/clippy_lints/src/functions/too_many_lines.rs
+++ b/clippy_lints/src/functions/too_many_lines.rs
@@ -8,7 +8,7 @@ use clippy_utils::source::snippet;
 
 use super::TOO_MANY_LINES;
 
-pub(super) fn check(cx: &LateContext<'_>, span: Span, body: &'tcx hir::Body<'_>, too_many_lines_threshold: u64) {
+pub(super) fn check_fn(cx: &LateContext<'_>, span: Span, body: &'tcx hir::Body<'_>, too_many_lines_threshold: u64) {
     if in_external_macro(cx.sess(), span) {
         return;
     }

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1124,9 +1124,9 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box new_without_default::NewWithoutDefault::default());
     let blacklisted_names = conf.blacklisted_names.iter().cloned().collect::<FxHashSet<_>>();
     store.register_late_pass(move || box blacklisted_name::BlacklistedName::new(blacklisted_names.clone()));
-    let too_many_arguments_threshold1 = conf.too_many_arguments_threshold;
-    let too_many_lines_threshold2 = conf.too_many_lines_threshold;
-    store.register_late_pass(move || box functions::Functions::new(too_many_arguments_threshold1, too_many_lines_threshold2));
+    let too_many_arguments_threshold = conf.too_many_arguments_threshold;
+    let too_many_lines_threshold = conf.too_many_lines_threshold;
+    store.register_late_pass(move || box functions::Functions::new(too_many_arguments_threshold, too_many_lines_threshold));
     let doc_valid_idents = conf.doc_valid_idents.iter().cloned().collect::<FxHashSet<_>>();
     store.register_late_pass(move || box doc::DocMarkdown::new(doc_valid_idents.clone()));
     store.register_late_pass(|| box neg_multiply::NegMultiply);


### PR DESCRIPTION
Ref: #6680 
Rearrange lints in `functions`.

changelog: none
