### PR TITLE
redundant_pattern_matching: look inside Refs

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1723,7 +1723,13 @@ mod redundant_pattern_match {
         arms: &[Arm<'_>],
         keyword: &'static str,
     ) {
-        let good_method = match arms[0].pat.kind {
+        // also look inside refs
+        let mut kind = &arms[0].pat.kind;
+        // if we have &None for example, peel it so we can detect "if let None = x"
+        if let PatKind::Ref(inner, _mutability) = kind {
+            kind = &inner.kind;
+        }
+        let good_method = match kind {
             PatKind::TupleStruct(ref path, ref patterns, _) if patterns.len() == 1 => {
                 if let PatKind::Wild = patterns[0].kind {
                     if match_qpath(path, &paths::RESULT_OK) {

--- a/tests/ui/match_ref_pats.stderr
+++ b/tests/ui/match_ref_pats.stderr
@@ -46,6 +46,14 @@ LL |         Some(v) => println!("{:?}", v),
 LL |         None => println!("none"),
    |
 
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/match_ref_pats.rs:35:12
+   |
+LL |     if let &None = a {
+   |     -------^^^^^---- help: try this: `if a.is_none()`
+   |
+   = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
+
 error: you don't need to add `&` to all patterns
   --> $DIR/match_ref_pats.rs:35:5
    |
@@ -58,6 +66,12 @@ help: instead of prefixing all patterns with `&`, you can dereference the expres
    |
 LL |     if let None = *a {
    |            ^^^^   ^^
+
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/match_ref_pats.rs:40:12
+   |
+LL |     if let &None = &b {
+   |     -------^^^^^----- help: try this: `if b.is_none()`
 
 error: you don't need to add `&` to both the expression and the patterns
   --> $DIR/match_ref_pats.rs:40:5
@@ -87,5 +101,5 @@ LL |         match *foo_variant!(0) {
 LL |             Foo::A => println!("A"),
    |
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
look inside refs and detect if let &None = ...

Fixes https://github.com/rust-lang/rust-clippy/issues/5396

changelog:  redundant_pattern_matching: look inside Refs to fix FNs with "if let &None = .. "
