### PR TITLE
Use uppercase for MSRV

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -18,7 +18,7 @@ because that's clearly a non-descriptive name.
   - [Lint passes](#lint-passes)
   - [Emitting a lint](#emitting-a-lint)
   - [Adding the lint logic](#adding-the-lint-logic)
-  - [Specifying the lint's minimum supported Rust version (msrv)](#specifying-the-lints-minimum-supported-rust-version-msrv)
+  - [Specifying the lint's minimum supported Rust version (MSRV)](#specifying-the-lints-minimum-supported-rust-version-msrv)
   - [Author lint](#author-lint)
   - [Documentation](#documentation)
   - [Running rustfmt](#running-rustfmt)


### PR DESCRIPTION
A follow-up of <https://github.com/rust-lang/rust-clippy/pull/6977/files#diff-dac623e7b9c58138761aa527bf5f026bf113cda5b22eea61e655b44dd113389e>

changelog: none
