### PR TITLE
result_unit_err: Fix typo

### DIFF
--- a/clippy_lints/src/functions/result_unit_err.rs
+++ b/clippy_lints/src/functions/result_unit_err.rs
@@ -57,9 +57,9 @@ fn check_result_unit_err(cx: &LateContext<'_>, decl: &hir::FnDecl<'_>, item_span
                 cx,
                 RESULT_UNIT_ERR,
                 fn_header_span,
-                "this returns a `Result<_, ()>",
+                "this returns a `Result<_, ()>`",
                 None,
-                "use a custom Error type instead",
+                "use a custom `Error` type instead",
             );
         }
     }

--- a/tests/ui/len_without_is_empty.stderr
+++ b/tests/ui/len_without_is_empty.stderr
@@ -86,38 +86,38 @@ LL |     pub fn is_empty(&self) -> Option<bool> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected signature: `(&self) -> bool` or `(&self) -> Result<bool>
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/len_without_is_empty.rs:230:5
    |
 LL |     pub fn len(&self) -> Result<usize, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::result-unit-err` implied by `-D warnings`
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/len_without_is_empty.rs:242:5
    |
 LL |     pub fn len(&self) -> Result<usize, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/len_without_is_empty.rs:246:5
    |
 LL |     pub fn is_empty(&self) -> Result<bool, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/len_without_is_empty.rs:253:5
    |
 LL |     pub fn len(&self) -> Result<usize, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/result_unit_error.stderr
+++ b/tests/ui/result_unit_error.stderr
@@ -1,43 +1,43 @@
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/result_unit_error.rs:3:1
    |
 LL | pub fn returns_unit_error() -> Result<u32, ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::result-unit-err` implied by `-D warnings`
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/result_unit_error.rs:12:5
    |
 LL |     fn get_that_error(&self) -> Result<bool, ()>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/result_unit_error.rs:14:5
    |
 LL |     fn get_this_one_too(&self) -> Result<bool, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/result_unit_error.rs:32:5
    |
 LL |     pub fn unit_error(&self) -> Result<usize, ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
-error: this returns a `Result<_, ()>
+error: this returns a `Result<_, ()>`
   --> $DIR/result_unit_error.rs:41:5
    |
 LL |     pub fn should_lint() -> ResInv<(), usize> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use a custom Error type instead
+   = help: use a custom `Error` type instead
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
changelog: result_unit_err: fix typo in a diagnostic message

r? @giraffate 
fixes https://github.com/rust-lang/rust-clippy/pull/6990#discussion_r603292920.
