### PR TITLE
Remove author requirement for `cargo_common_metadata`

### DIFF
--- a/clippy_lints/src/cargo_common_metadata.rs
+++ b/clippy_lints/src/cargo_common_metadata.rs
@@ -20,11 +20,10 @@ declare_clippy_lint! {
     ///
     /// **Example:**
     /// ```toml
-    /// # This `Cargo.toml` is missing an authors field:
+    /// # This `Cargo.toml` is missing a description field:
     /// [package]
     /// name = "clippy"
     /// version = "0.0.212"
-    /// description = "A bunch of helpful lints to avoid common pitfalls in Rust"
     /// repository = "https://github.com/rust-lang/rust-clippy"
     /// readme = "README.md"
     /// license = "MIT OR Apache-2.0"
@@ -32,14 +31,13 @@ declare_clippy_lint! {
     /// categories = ["development-tools", "development-tools::cargo-plugins"]
     /// ```
     ///
-    /// Should include an authors field like:
+    /// Should include a description field like:
     ///
     /// ```toml
     /// # This `Cargo.toml` includes all common metadata
     /// [package]
     /// name = "clippy"
     /// version = "0.0.212"
-    /// authors = ["Someone <someone@rust-lang.org>"]
     /// description = "A bunch of helpful lints to avoid common pitfalls in Rust"
     /// repository = "https://github.com/rust-lang/rust-clippy"
     /// readme = "README.md"
@@ -97,10 +95,6 @@ impl LateLintPass<'_> for CargoCommonMetadata {
             // only run the lint if publish is `None` (`publish = true` or skipped entirely)
             // or if the vector isn't empty (`publish = ["something"]`)
             if package.publish.as_ref().filter(|publish| publish.is_empty()).is_none() || self.ignore_publish {
-                if is_empty_vec(&package.authors) {
-                    missing_warning(cx, &package, "package.authors");
-                }
-
                 if is_empty_str(&package.description) {
                     missing_warning(cx, &package, "package.description");
                 }

--- a/tests/ui-cargo/cargo_common_metadata/fail/src/main.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail/src/main.stderr
@@ -1,8 +1,6 @@
-error: package `cargo_common_metadata` is missing `package.authors` metadata
+error: package `cargo_common_metadata` is missing `package.description` metadata
    |
    = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
-
-error: package `cargo_common_metadata` is missing `package.description` metadata
 
 error: package `cargo_common_metadata` is missing `either package.license or package.license_file` metadata
 
@@ -14,5 +12,5 @@ error: package `cargo_common_metadata` is missing `package.keywords` metadata
 
 error: package `cargo_common_metadata` is missing `package.categories` metadata
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish/src/main.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish/src/main.stderr
@@ -1,8 +1,6 @@
-error: package `cargo_common_metadata` is missing `package.authors` metadata
+error: package `cargo_common_metadata` is missing `package.description` metadata
    |
    = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
-
-error: package `cargo_common_metadata` is missing `package.description` metadata
 
 error: package `cargo_common_metadata` is missing `either package.license or package.license_file` metadata
 
@@ -14,5 +12,5 @@ error: package `cargo_common_metadata` is missing `package.keywords` metadata
 
 error: package `cargo_common_metadata` is missing `package.categories` metadata
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish_true/src/main.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish_true/src/main.stderr
@@ -1,8 +1,6 @@
-error: package `cargo_common_metadata` is missing `package.authors` metadata
+error: package `cargo_common_metadata` is missing `package.description` metadata
    |
    = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
-
-error: package `cargo_common_metadata` is missing `package.description` metadata
 
 error: package `cargo_common_metadata` is missing `either package.license or package.license_file` metadata
 
@@ -14,5 +12,5 @@ error: package `cargo_common_metadata` is missing `package.keywords` metadata
 
 error: package `cargo_common_metadata` is missing `package.categories` metadata
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
@@ -2,7 +2,6 @@
 name = "cargo_common_metadata"
 version = "0.1.0"
 publish = false
-authors = ["Random person from the Internet <someone@someplace.org>"]
 description = "A test package for the cargo_common_metadata lint"
 repository = "https://github.com/someone/cargo_common_metadata"
 readme = "README.md"


### PR DESCRIPTION
This PR follows https://github.com/rust-lang/cargo/pull/9282, I'm not fully informed about all of this, it would be great if somebody knowledgeable about this topic agrees.

changelog: Changed `cargo_common_metadata` to stop linting on the optional author field.
