### PR TITLE
Quick fix for the updated website theaming to access the correct css files

### DIFF
--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -9,12 +9,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/github.min.css"/>
 
-    <!-- This stylesheet is linked to a specific version to ensure that the link stays static even if mdbook does some refactoring. -->
-    <!-- gitcdn is used to get the css file as a stylesheet content type. It's open source and published under the GLP-3.0 License -->
-    <link rel="stylesheet" href="https://gitcdn.xyz/cdn/rust-lang/mdBook/v0.4.7/src/theme/css/variables.css"/>
-    <link id="styleHighlight" rel="stylesheet" href="https://gitcdn.xyz/repo/rust-lang/mdBook/master/src/theme/highlight.css" disabled="true">
-    <link id="styleNight" rel="stylesheet" href="https://gitcdn.xyz/repo/rust-lang/mdBook/master/src/theme/tomorrow-night.css">
-    <link id="styleAyu" rel="stylesheet" href="https://gitcdn.xyz/repo/rust-lang/mdBook/master/src/theme/ayu-highlight.css" disabled="true">
+    <!-- The files are not copied over into the Clippy project since they use the MPL-2.0 License -->
+    <link rel="stylesheet" href="https://rust-lang.github.io/mdBook/css/variables.css"/>
+    <link id="styleHighlight" rel="stylesheet" href="https://rust-lang.github.io/mdBook/highlight.css">
+    <link id="styleNight" rel="stylesheet" href="https://rust-lang.github.io/mdBook/tomorrow-night.css" disabled="true">
+    <link id="styleAyu" rel="stylesheet" href="https://rust-lang.github.io/mdBook/ayu-highlight.css" disabled="true">
     <style>
         blockquote { font-size: 1em; }
         [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak { display: none !important; }


### PR DESCRIPTION
This fixes a problem from #7030 that the service used to access css files was blocked by GitHub pages due to `SSL_ERROR_BAD_CERT_DOMAIN`. The css file loading worked fine during local development. The browser probably disabled some security options due to the local address.

This fix works locally and should also work online as it references the direct css files used by the [mdBook User Guide](https://rust-lang.github.io/mdBook/index.html) the disadvantage of this is that refactorings within the mdBook project can have effects on the theme loading of Clippy. This PR is therefor more meant as a quick fix until I find a better solution. 

I've tested these changes using the page editor in the browser and can now confirm that they work :)

changelog: none

r?  @llogiq
