### PR TITLE
Fix ICE in `missing_panics_doc`

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -11,7 +11,7 @@ use rustc_errors::emitter::EmitterWriter;
 use rustc_errors::Handler;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
-use rustc_hir::{Expr, ExprKind, QPath};
+use rustc_hir::{AnonConst, Expr, ExprKind, QPath};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::hir::map::Map;
 use rustc_middle::lint::in_external_macro;
@@ -734,6 +734,9 @@ impl<'a, 'tcx> Visitor<'tcx> for FindPanicUnwrap<'a, 'tcx> {
         // and check sub-expressions
         intravisit::walk_expr(self, expr);
     }
+
+    // Panics in const blocks will cause compilation to fail.
+    fn visit_anon_const(&mut self, _: &'tcx AnonConst) {}
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
         NestedVisitorMap::OnlyBodies(self.cx.tcx.hir())

--- a/tests/ui/doc.rs
+++ b/tests/ui/doc.rs
@@ -1,8 +1,8 @@
 //! This file tests for the `DOC_MARKDOWN` lint.
 
-#![allow(dead_code)]
+#![allow(dead_code, incomplete_features)]
 #![warn(clippy::doc_markdown)]
-#![feature(custom_inner_attributes)]
+#![feature(custom_inner_attributes, const_generics, const_evaluatable_checked, const_option)]
 #![rustfmt::skip]
 
 /// The foo_bar function does _nothing_. See also foo::bar. (note the dot there)
@@ -202,3 +202,20 @@ fn issue_2343() {}
 /// This should not cause an ICE:
 /// __|_ _|__||_|
 fn pulldown_cmark_crash() {}
+
+// issue #7033 - const_evaluatable_checked ICE
+struct S<T, const N: usize>
+where [(); N.checked_next_power_of_two().unwrap()]: {
+    arr: [T; N.checked_next_power_of_two().unwrap()],
+    n: usize,
+}
+
+impl<T: Copy + Default, const N: usize> S<T, N>
+where [(); N.checked_next_power_of_two().unwrap()]: {
+    fn new() -> Self {
+        Self {
+            arr: [T::default(); N.checked_next_power_of_two().unwrap()],
+            n: 0,
+        }
+    }
+}


### PR DESCRIPTION
fixes: #7033
changelog: Fix ICE in `missing_panics_doc` while searching in a `const` block
