### PR TITLE
tabs_in_doc_comments: Fix ICE due to char indexing

### DIFF
--- a/clippy_lints/src/tabs_in_doc_comments.rs
+++ b/clippy_lints/src/tabs_in_doc_comments.rs
@@ -106,7 +106,7 @@ fn get_chunks_of_tabs(the_str: &str) -> Vec<(u32, u32)> {
 
     let char_indices: Vec<_> = the_str.char_indices().collect();
 
-    if let &[(_, '\t')] = &char_indices.as_slice() {
+    if let [(_, '\t')] = char_indices.as_slice() {
         return vec![(0, 1)];
     }
 
@@ -121,12 +121,12 @@ fn get_chunks_of_tabs(the_str: &str) -> Vec<(u32, u32)> {
                 // as ['\t', '\t'] is excluded, this has to be a start of a tab group,
                 // set indices accordingly
                 is_active = true;
-                current_start = *index_b as u32;
+                current_start = u32::try_from(*index_b).unwrap();
             },
             [(_, '\t'), (index_b, _)] => {
                 // this now has to be an end of the group, hence we have to push a new tuple
                 is_active = false;
-                spans.push((current_start, *index_b as u32));
+                spans.push((current_start, u32::try_from(*index_b).unwrap()));
             },
             _ => {},
         }
@@ -149,7 +149,7 @@ mod tests_for_get_chunks_of_tabs {
 
     #[test]
     fn test_unicode_han_string() {
-        let res = get_chunks_of_tabs(" 位\t");
+        let res = get_chunks_of_tabs(" \u{4f4d}\t");
 
         assert_eq!(res, vec![(4, 5)]);
     }

--- a/clippy_lints/src/tabs_in_doc_comments.rs
+++ b/clippy_lints/src/tabs_in_doc_comments.rs
@@ -106,7 +106,7 @@ fn get_chunks_of_tabs(the_str: &str) -> Vec<(u32, u32)> {
 
     let char_indices: Vec<_> = the_str.char_indices().collect();
 
-    if char_indices.len() == 1 && char_indices.first().unwrap().1 == '\t' {
+    if let &[(_, '\t')] = &char_indices.as_slice() {
         return vec![(0, 1)];
     }
 

--- a/clippy_lints/src/tabs_in_doc_comments.rs
+++ b/clippy_lints/src/tabs_in_doc_comments.rs
@@ -104,6 +104,9 @@ fn get_chunks_of_tabs(the_str: &str) -> Vec<(u32, u32)> {
     // tracker to decide if the last group of tabs is not closed by a non-tab character
     let mut is_active = false;
 
+    // Note that we specifically need the char _byte_ indices here, not the positional indexes
+    // within the char array to deal with multi-byte characters properly. `char_indices` does
+    // exactly that. It provides an iterator over tuples of the form `(byte position, char)`.
     let char_indices: Vec<_> = the_str.char_indices().collect();
 
     if let [(_, '\t')] = char_indices.as_slice() {

--- a/tests/ui/crashes/ice-5835.rs
+++ b/tests/ui/crashes/ice-5835.rs
@@ -1,0 +1,8 @@
+#![rustfmt::skip]
+
+pub struct Foo {
+    /// 位	
+    pub bar: u8,
+}
+
+fn main() {}

--- a/tests/ui/crashes/ice-5835.rs
+++ b/tests/ui/crashes/ice-5835.rs
@@ -1,7 +1,8 @@
-#![rustfmt::skip]
-
+#[rustfmt::skip]
 pub struct Foo {
     /// 位	
+    ///   ^ Do not remove this tab character.
+    ///   It was required to trigger the ICE.
     pub bar: u8,
 }
 

--- a/tests/ui/crashes/ice-5835.stderr
+++ b/tests/ui/crashes/ice-5835.stderr
@@ -1,0 +1,20 @@
+error[E0658]: custom inner attributes are unstable
+  --> $DIR/ice-5835.rs:1:4
+   |
+LL | #![rustfmt::skip]
+   |    ^^^^^^^^^^^^^
+   |
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+
+error: using tabs in doc comments is not recommended
+  --> $DIR/ice-5835.rs:4:10
+   |
+LL |     /// 位    
+   |           ^^^^ help: consider using four spaces per tab
+   |
+   = note: `-D clippy::tabs-in-doc-comments` implied by `-D warnings`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/crashes/ice-5835.stderr
+++ b/tests/ui/crashes/ice-5835.stderr
@@ -1,20 +1,10 @@
-error[E0658]: custom inner attributes are unstable
-  --> $DIR/ice-5835.rs:1:4
-   |
-LL | #![rustfmt::skip]
-   |    ^^^^^^^^^^^^^
-   |
-   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
-   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
-
 error: using tabs in doc comments is not recommended
-  --> $DIR/ice-5835.rs:4:10
+  --> $DIR/ice-5835.rs:3:10
    |
 LL |     /// 位    
    |           ^^^^ help: consider using four spaces per tab
    |
    = note: `-D clippy::tabs-in-doc-comments` implied by `-D warnings`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This is a quick-fix for an ICE in `tabs_in_doc_comments`. The problem
was that we we're indexing into possibly multi-byte characters, such as '位'.

More specifically `get_chunks_of_tabs` was returning indices into
multi-byte characters. Those were passed on to a `Span` creation that
then caused the ICE.

This fix makes sure that we don't return indices that point inside a
multi-byte character. *However*, we are still iterating over unicode
codepoints, not grapheme clusters. So a seemingly single character like y̆ ,
which actually consists of two codepoints, will probably still cause
incorrect spans in the output. But I don't think we handle those cases
anywhere in Clippy currently?

Fixes #5835
 
changelog: Fix ICE in `tabs_in_doc_comments`
