### PR TITLE
Fix false-positive `debug_assert` in `panic`

### DIFF
--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -74,7 +74,7 @@ declare_lint_pass!(PanicUnimplemented => [UNIMPLEMENTED, UNREACHABLE, TODO, PANI
 
 impl<'tcx> LateLintPass<'tcx> for PanicUnimplemented {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if match_panic_call(cx, expr).is_some() {
+        if match_panic_call(cx, expr).is_some() && is_expn_of(expr.span, "debug_assert").is_none() {
             let span = get_outer_span(expr);
             if is_expn_of(expr.span, "unimplemented").is_some() {
                 span_lint(

--- a/tests/ui/panicking_macros.rs
+++ b/tests/ui/panicking_macros.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::unimplemented, clippy::unreachable, clippy::todo, clippy::panic)]
-#![allow(clippy::assertions_on_constants)]
+#![allow(clippy::assertions_on_constants, clippy::eq_op)]
 
 extern crate core;
 
@@ -41,6 +41,18 @@ fn core_versions() {
     todo!();
     unimplemented!();
     unreachable!();
+}
+
+fn debug_assert() {
+    debug_assert!(true);
+    debug_assert_eq!(true, true);
+    debug_assert_ne!(true, false);
+}
+
+fn debug_assert_msg() {
+    debug_assert!(true, "test");
+    debug_assert_eq!(true, true, "test");
+    debug_assert_ne!(true, false, "test");
 }
 
 fn main() {


### PR DESCRIPTION
This fixes a false-positive in `clippy::panic` when `debug_assert` is used with a message.

Fixes https://github.com/rust-lang/rust-clippy/issues/7062.

changelog: Fix false-positive in `panic` when `debug_assert` is used with a message
