### PR TITLE
Fix FP in `wrong_self_convention` lint

### DIFF
--- a/clippy_lints/src/methods/wrong_self_convention.rs
+++ b/clippy_lints/src/methods/wrong_self_convention.rs
@@ -102,6 +102,14 @@ pub(super) fn check<'tcx>(
             .iter()
             .all(|conv| conv.check(cx, self_ty, item_name, implements_trait, is_trait_item))
     }) {
+        // don't lint if it implements a trait but not willing to check `Copy` types conventions (see #7032)
+        if implements_trait
+            && !conventions
+                .iter()
+                .any(|conv| matches!(conv, Convention::IsSelfTypeCopy(_)))
+        {
+            return;
+        }
         if !self_kinds.iter().any(|k| k.matches(cx, self_ty, first_arg_ty)) {
             let suggestion = {
                 if conventions.len() > 1 {

--- a/tests/ui/wrong_self_convention2.rs
+++ b/tests/ui/wrong_self_convention2.rs
@@ -30,3 +30,15 @@ mod issue6983 {
         }
     }
 }
+
+mod issue7032 {
+    trait Foo {
+        fn from_usize(x: usize) -> Self;
+    }
+    // don't trigger
+    impl Foo for usize {
+        fn from_usize(x: usize) -> Self {
+            x
+        }
+    }
+}


### PR DESCRIPTION
Previously, this lint didn't check into impl block when it was implementing a trait.
Recent improvements (#6924) have moved this check and some impl blocks are now checked but they shouldn't, such as in #7032.

Fixes #7032 

changelog: Fix FP when not taking `self` in impl block for `wrong_self_convention` lint