### PR TITLE
Split `is_diagnostic_assoc_item`

### DIFF
--- a/clippy_lints/src/methods/implicit_clone.rs
+++ b/clippy_lints/src/methods/implicit_clone.rs
@@ -1,28 +1,36 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::{is_diag_item_method, is_diag_trait_item};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
-use rustc_hir::ExprKind;
 use rustc_lint::LateContext;
 use rustc_middle::ty::TyS;
-use rustc_span::symbol::Symbol;
+use rustc_span::{sym, Span};
 
 use super::IMPLICIT_CLONE;
-use clippy_utils::is_diagnostic_assoc_item;
 
-pub fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, trait_diagnostic: Symbol) {
+pub fn check(cx: &LateContext<'_>, method_name: &str, expr: &hir::Expr<'_>, recv: &hir::Expr<'_>, span: Span) {
     if_chain! {
-        if let ExprKind::MethodCall(method_path, _, [arg], _) = &expr.kind;
+        if let Some(method_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id);
+        if match method_name {
+            "to_os_string" => is_diag_item_method(cx, method_def_id, sym::OsStr),
+            "to_owned" => is_diag_trait_item(cx, method_def_id, sym::ToOwned),
+            "to_path_buf" => is_diag_item_method(cx, method_def_id, sym::Path),
+            "to_vec" => cx.tcx.impl_of_method(method_def_id)
+                .map(|impl_did| Some(impl_did) == cx.tcx.lang_items().slice_alloc_impl())
+                == Some(true),
+            _ => false,
+        };
         let return_type = cx.typeck_results().expr_ty(expr);
-        let input_type = cx.typeck_results().expr_ty(arg).peel_refs();
-        if let Some(expr_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id);
+        let input_type = cx.typeck_results().expr_ty(recv).peel_refs();
         if let Some(ty_name) = input_type.ty_adt_def().map(|adt_def| cx.tcx.item_name(adt_def.did));
         if TyS::same_type(return_type, input_type);
-        if is_diagnostic_assoc_item(cx, expr_def_id, trait_diagnostic);
         then {
             span_lint_and_sugg(
-                cx,IMPLICIT_CLONE,method_path.ident.span,
-                &format!("implicitly cloning a `{}` by calling `{}` on its dereferenced type", ty_name, method_path.ident.name),
+                cx,
+                IMPLICIT_CLONE,
+                span,
+                &format!("implicitly cloning a `{}` by calling `{}` on its dereferenced type", ty_name, method_name),
                 "consider using",
                 "clone".to_string(),
                 Applicability::MachineApplicable

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1987,10 +1987,9 @@ fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Optio
                 }
             },
             ("step_by", [arg]) => iterator_step_by_zero::check(cx, expr, arg),
-            ("to_os_string", []) => implicit_clone::check(cx, expr, sym::OsStr),
-            ("to_owned", []) => implicit_clone::check(cx, expr, sym::ToOwned),
-            ("to_path_buf", []) => implicit_clone::check(cx, expr, sym::Path),
-            ("to_vec", []) => implicit_clone::check(cx, expr, sym::slice),
+            ("to_os_string" | "to_owned" | "to_path_buf" | "to_vec", []) => {
+                implicit_clone::check(cx, name, expr, recv, span);
+            },
             ("unwrap", []) => match method_call!(recv) {
                 Some(("get", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, false),
                 Some(("get_mut", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, true),

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -20,7 +20,7 @@ use rustc_span::symbol::sym;
 use crate::consts::{constant, Constant};
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{
-    get_item_name, get_parent_expr, higher, in_constant, is_diagnostic_assoc_item, is_integer_const, iter_input_pats,
+    get_item_name, get_parent_expr, higher, in_constant, is_diag_trait_item, is_integer_const, iter_input_pats,
     last_path_segment, match_qpath, unsext, SpanlessEq,
 };
 
@@ -555,8 +555,8 @@ fn check_to_owned(cx: &LateContext<'_>, expr: &Expr<'_>, other: &Expr<'_>, left:
         ExprKind::MethodCall(.., args, _) if args.len() == 1 => {
             if_chain!(
                 if let Some(expr_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id);
-                if is_diagnostic_assoc_item(cx, expr_def_id, sym::ToString)
-                    || is_diagnostic_assoc_item(cx, expr_def_id, sym::ToOwned);
+                if is_diag_trait_item(cx, expr_def_id, sym::ToString)
+                    || is_diag_trait_item(cx, expr_def_id, sym::ToOwned);
                 then {
                     (cx.typeck_results().expr_ty(&args[0]), snippet(cx, args[0].span, ".."))
                 } else {

--- a/clippy_lints/src/to_string_in_display.rs
+++ b/clippy_lints/src/to_string_in_display.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::{is_diagnostic_assoc_item, match_def_path, path_to_local_id, paths};
+use clippy_utils::{is_diag_trait_item, match_def_path, path_to_local_id, paths};
 use if_chain::if_chain;
 use rustc_hir::{Expr, ExprKind, HirId, Impl, ImplItem, ImplItemKind, Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -95,7 +95,7 @@ impl LateLintPass<'_> for ToStringInDisplay {
             if let ExprKind::MethodCall(path, _, args, _) = expr.kind;
             if path.ident.name == sym!(to_string);
             if let Some(expr_def_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id);
-            if is_diagnostic_assoc_item(cx, expr_def_id, sym::ToString);
+            if is_diag_trait_item(cx, expr_def_id, sym::ToString);
             if path_to_local_id(&args[0], self_hir_id);
             then {
                 span_lint(


### PR DESCRIPTION
changelog: none

* Split `is_diagnostic_assoc_item` into `is_diag_item_method` and `is_diag_trait_item`
  * `is_diag_item_method` is a bit more nuanced with the `tcx.type_of(impl_id).ty_adt_def()` step, so it seems better to keep that separate.
  * No need to generalize over traits and Adt's since we know which one we want at compile time
  * "item" vs. "method" because a trait may have associated items.
* Replaces the usage of the `sym::slice` diagnostic item with the `slice_alloc` lang item. The diagnostic item should be removed from rustc because it is on the `slice_alloc` impl, not slice itself (and it's not needed).