### PR TITLE
Fix a FP in `missing_const_for_fn`

### DIFF
--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -138,7 +138,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
 
         let mir = cx.tcx.optimized_mir(def_id);
 
-        if let Err((span, err)) = is_min_const_fn(cx.tcx, mir) {
+        if let Err((span, err)) = is_min_const_fn(cx.tcx, mir, self.msrv.as_ref()) {
             if rustc_mir::const_eval::is_min_const_fn(cx.tcx, def_id.to_def_id()) {
                 cx.tcx.sess.span_err(span, &err);
             }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -9,6 +9,7 @@
 // (Currently there is no way to opt into sysroot crates without `extern crate`.)
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
+extern crate rustc_attr;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hir;

--- a/tests/ui/missing_const_for_fn/auxiliary/helper.rs
+++ b/tests/ui/missing_const_for_fn/auxiliary/helper.rs
@@ -1,0 +1,8 @@
+// This file provides a const function that is unstably const forever.
+
+#![feature(staged_api)]
+#![stable(feature = "1", since = "1.0.0")]
+
+#[stable(feature = "1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "foo", issue = "none")]
+pub const fn unstably_const_fn() {}

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -2,9 +2,14 @@
 //! compilation error.
 //! The .stderr output of this test should be empty. Otherwise it's a bug somewhere.
 
+// aux-build:helper.rs
+
 #![warn(clippy::missing_const_for_fn)]
 #![allow(incomplete_features)]
 #![feature(start, const_generics)]
+#![feature(custom_inner_attributes)]
+
+extern crate helper;
 
 struct Game;
 
@@ -100,4 +105,18 @@ fn const_generic_return<T, const N: usize>(t: &[T]) -> &[T; N] {
     let p = t.as_ptr() as *const [T; N];
 
     unsafe { &*p }
+}
+
+// Do not lint this because it calls a function whose constness is unstable.
+fn unstably_const_fn() {
+    helper::unstably_const_fn()
+}
+
+mod const_fn_stabilized_after_msrv {
+    #![clippy::msrv = "1.46.0"]
+
+    // Do not lint this because `u8::is_ascii_digit` is stabilized as a const function in 1.47.0.
+    fn const_fn_stabilized_after_msrv(byte: u8) {
+        byte.is_ascii_digit();
+    }
 }

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::missing_const_for_fn)]
 #![allow(incomplete_features, clippy::let_and_return)]
 #![feature(const_generics)]
+#![feature(custom_inner_attributes)]
 
 use std::mem::transmute;
 
@@ -67,6 +68,15 @@ mod with_drop {
         pub fn b(self, a: &A) -> B {
             B
         }
+    }
+}
+
+mod const_fn_stabilized_before_msrv {
+    #![clippy::msrv = "1.47.0"]
+
+    // This could be const because `u8::is_ascii_digit` is a stable const function in 1.47.
+    fn const_fn_stabilized_before_msrv(byte: u8) {
+        byte.is_ascii_digit();
     }
 }
 

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -1,5 +1,5 @@
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:13:5
+  --> $DIR/could_be_const.rs:14:5
    |
 LL | /     pub fn new() -> Self {
 LL | |         Self { guess: 42 }
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::missing-const-for-fn` implied by `-D warnings`
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:17:5
+  --> $DIR/could_be_const.rs:18:5
    |
 LL | /     fn const_generic_params<'a, T, const N: usize>(&self, b: &'a [T; N]) -> &'a [T; N] {
 LL | |         b
@@ -17,7 +17,7 @@ LL | |     }
    | |_____^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:23:1
+  --> $DIR/could_be_const.rs:24:1
    |
 LL | / fn one() -> i32 {
 LL | |     1
@@ -25,7 +25,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:28:1
+  --> $DIR/could_be_const.rs:29:1
    |
 LL | / fn two() -> i32 {
 LL | |     let abc = 2;
@@ -34,7 +34,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:34:1
+  --> $DIR/could_be_const.rs:35:1
    |
 LL | / fn string() -> String {
 LL | |     String::new()
@@ -42,7 +42,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:39:1
+  --> $DIR/could_be_const.rs:40:1
    |
 LL | / unsafe fn four() -> i32 {
 LL | |     4
@@ -50,7 +50,7 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:44:1
+  --> $DIR/could_be_const.rs:45:1
    |
 LL | / fn generic<T>(t: T) -> T {
 LL | |     t
@@ -58,12 +58,20 @@ LL | | }
    | |_^
 
 error: this could be a `const fn`
-  --> $DIR/could_be_const.rs:67:9
+  --> $DIR/could_be_const.rs:68:9
    |
 LL | /         pub fn b(self, a: &A) -> B {
 LL | |             B
 LL | |         }
    | |_________^
 
-error: aborting due to 8 previous errors
+error: this could be a `const fn`
+  --> $DIR/could_be_const.rs:78:5
+   |
+LL | /     fn const_fn_stabilized_before_msrv(byte: u8) {
+LL | |         byte.is_ascii_digit();
+LL | |     }
+   | |_____^
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
where a function that calls a standard library function whose constness
is unstable is considered as being able to be a const function. Fixes #5995.

The core change is the move from `rustc_mir::const_eval::is_min_const_fn` to `rustc_mir::const_eval::is_const_fn`. I'm not clear about the difference in their purpose between them so I'm not sure if it's acceptable to call `qualify_min_const_fn::is_min_const_fn` this way now.

---

changelog: `missing_const_for_fn`: No longer lints when an unstably const function is called
