### PR TITLE
Don't allow adjustments for `manual_map`

### DIFF
--- a/clippy_lints/src/manual_map.rs
+++ b/clippy_lints/src/manual_map.rs
@@ -104,9 +104,15 @@ impl LateLintPass<'_> for ManualMap {
                 None => return,
             };
 
+            // These two lints will go back and forth with each other.
             if cx.typeck_results().expr_ty(some_expr) == cx.tcx.types.unit
                 && !is_allowed(cx, OPTION_MAP_UNIT_FN, expr.hir_id)
             {
+                return;
+            }
+
+            // `map` won't perform any adjustments.
+            if !cx.typeck_results().expr_adjustments(some_expr).is_empty() {
                 return;
             }
 

--- a/tests/ui/manual_map_option.fixed
+++ b/tests/ui/manual_map_option.fixed
@@ -146,4 +146,11 @@ fn main() {
             None => None,
         };
     }
+
+    // #7077
+    let s = &String::new();
+    let _: Option<&str> = match Some(s) {
+        Some(s) => Some(s),
+        None => None,
+    };
 }

--- a/tests/ui/manual_map_option.rs
+++ b/tests/ui/manual_map_option.rs
@@ -212,4 +212,11 @@ fn main() {
             None => None,
         };
     }
+
+    // #7077
+    let s = &String::new();
+    let _: Option<&str> = match Some(s) {
+        Some(s) => Some(s),
+        None => None,
+    };
 }


### PR DESCRIPTION
fixes: #7077

The other option here would be to add the return type to the closure. It would be fine for simple types, but longer types can be rather unwieldy. Could also implement the adjustment manually.

changelog: Don't lint `manual_map` when type adjustments are added. e.g. autoderef
