### PR TITLE
useless use of format! should return function directly

### DIFF
--- a/tests/ui/format.fixed
+++ b/tests/ui/format.fixed
@@ -65,4 +65,8 @@ fn main() {
     // False positive
     let a = "foo".to_string();
     let _ = Some(a + "bar");
+
+    // Wrap it with braces
+    let v: Vec<String> = vec!["foo".to_string(), "bar".to_string()];
+    let _s: String = (&*v.join("\n")).to_string();
 }

--- a/tests/ui/format.rs
+++ b/tests/ui/format.rs
@@ -67,4 +67,8 @@ fn main() {
     // False positive
     let a = "foo".to_string();
     let _ = Some(format!("{}", a + "bar"));
+
+    // Wrap it with braces
+    let v: Vec<String> = vec!["foo".to_string(), "bar".to_string()];
+    let _s: String = format!("{}", &*v.join("\n"));
 }

--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -87,5 +87,11 @@ error: useless use of `format!`
 LL |     let _ = Some(format!("{}", a + "bar"));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `a + "bar"`
 
-error: aborting due to 13 previous errors
+error: useless use of `format!`
+  --> $DIR/format.rs:73:22
+   |
+LL |     let _s: String = format!("{}", &*v.join("/n"));
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `(&*v.join("/n")).to_string()`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
fixes #7066 

changelog: [`useless_format`] wraps the content in the braces when it's needed.

r? @giraffate 
