### PR TITLE
Fix `single_match`

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -738,8 +738,11 @@ fn report_single_match_single_pattern(
     let (msg, sugg) = if_chain! {
         if let PatKind::Path(_) | PatKind::Lit(_) = pat.kind;
         let (ty, ty_ref_count) = peel_mid_ty_refs(cx.typeck_results().expr_ty(ex));
-        if let Some(trait_id) = cx.tcx.lang_items().structural_peq_trait();
-        if ty.is_integral() || ty.is_char() || ty.is_str() || implements_trait(cx, ty, trait_id, &[]);
+        if let Some(spe_trait_id) = cx.tcx.lang_items().structural_peq_trait();
+        if let Some(pe_trait_id) = cx.tcx.lang_items().eq_trait();
+        if ty.is_integral() || ty.is_char() || ty.is_str()
+            || (implements_trait(cx, ty, spe_trait_id, &[])
+                && implements_trait(cx, ty, pe_trait_id, &[ty.into()]));
         then {
             // scrutinee derives PartialEq and the pattern is a constant.
             let pat_ref_count = match pat.kind {

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -135,6 +135,14 @@ fn if_suggestion() {
         Bar::A => println!(),
         _ => (),
     }
+
+    // issue #7038
+    struct X;
+    let x = Some(X);
+    match x {
+        None => println!(),
+        _ => (),
+    };
 }
 
 macro_rules! single_match {

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -119,5 +119,14 @@ LL | |         _ => (),
 LL | |     }
    | |_____^ help: try this: `if let Bar::A = x { println!() }`
 
-error: aborting due to 12 previous errors
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:142:5
+   |
+LL | /     match x {
+LL | |         None => println!(),
+LL | |         _ => (),
+LL | |     };
+   | |_____^ help: try this: `if let None = x { println!() }`
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
fixes: #7038
changelog: Don't suggest an equality check for types which don't implement `PartialEq` in `single_match`
