### PR TITLE
Fixed inconsistent_struct_constructor triggers in macro-generated code

### DIFF
--- a/clippy_lints/src/inconsistent_struct_constructor.rs
+++ b/clippy_lints/src/inconsistent_struct_constructor.rs
@@ -66,6 +66,7 @@ declare_lint_pass!(InconsistentStructConstructor => [INCONSISTENT_STRUCT_CONSTRU
 impl LateLintPass<'_> for InconsistentStructConstructor {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
         if_chain! {
+            if !expr.span.from_expansion();
             if let ExprKind::Struct(qpath, fields, base) = expr.kind;
             let ty = cx.typeck_results().expr_ty(expr);
             if let Some(adt_def) = ty.ty_adt_def();

--- a/clippy_lints/src/inconsistent_struct_constructor.rs
+++ b/clippy_lints/src/inconsistent_struct_constructor.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::in_macro;
 use clippy_utils::source::snippet;
 use if_chain::if_chain;
 use rustc_data_structures::fx::FxHashMap;
@@ -66,7 +67,7 @@ declare_lint_pass!(InconsistentStructConstructor => [INCONSISTENT_STRUCT_CONSTRU
 impl LateLintPass<'_> for InconsistentStructConstructor {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
         if_chain! {
-            if !expr.span.from_expansion();
+            if !in_macro(expr.span);
             if let ExprKind::Struct(qpath, fields, base) = expr.kind;
             let ty = cx.typeck_results().expr_ty(expr);
             if let Some(adt_def) = ty.ty_adt_def();

--- a/tests/ui/inconsistent_struct_constructor.fixed
+++ b/tests/ui/inconsistent_struct_constructor.fixed
@@ -13,6 +13,15 @@ struct Foo {
     z: i32,
 }
 
+macro_rules! new_foo {
+    () => {
+        let x = 1;
+        let y = 1;
+        let z = 1;
+        Foo { y, x, z }
+    };
+}
+
 mod without_base {
     use super::Foo;
 
@@ -23,6 +32,10 @@ mod without_base {
 
         // Should lint.
         Foo { x, y, z };
+
+        // Should NOT lint.
+        // issue #7069.
+        new_foo!();
 
         // Shoule NOT lint because the order is the same as in the definition.
         Foo { x, y, z };

--- a/tests/ui/inconsistent_struct_constructor.rs
+++ b/tests/ui/inconsistent_struct_constructor.rs
@@ -13,6 +13,15 @@ struct Foo {
     z: i32,
 }
 
+macro_rules! new_foo {
+    () => {
+        let x = 1;
+        let y = 1;
+        let z = 1;
+        Foo { y, x, z }
+    };
+}
+
 mod without_base {
     use super::Foo;
 
@@ -23,6 +32,10 @@ mod without_base {
 
         // Should lint.
         Foo { y, x, z };
+
+        // Should NOT lint.
+        // issue #7069.
+        new_foo!();
 
         // Shoule NOT lint because the order is the same as in the definition.
         Foo { x, y, z };

--- a/tests/ui/inconsistent_struct_constructor.stderr
+++ b/tests/ui/inconsistent_struct_constructor.stderr
@@ -1,5 +1,5 @@
 error: struct constructor field order is inconsistent with struct definition field order
-  --> $DIR/inconsistent_struct_constructor.rs:25:9
+  --> $DIR/inconsistent_struct_constructor.rs:34:9
    |
 LL |         Foo { y, x, z };
    |         ^^^^^^^^^^^^^^^ help: try: `Foo { x, y, z }`
@@ -7,7 +7,7 @@ LL |         Foo { y, x, z };
    = note: `-D clippy::inconsistent-struct-constructor` implied by `-D warnings`
 
 error: struct constructor field order is inconsistent with struct definition field order
-  --> $DIR/inconsistent_struct_constructor.rs:43:9
+  --> $DIR/inconsistent_struct_constructor.rs:56:9
    |
 LL | /         Foo {
 LL | |             z,


### PR DESCRIPTION
fixes #7069 

changelog: `inconsistent_struct_constructor`: Fix FP in macro expansion.
