### PR TITLE
un-double `return` on try_err

### DIFF
--- a/tests/ui/try_err.fixed
+++ b/tests/ui/try_err.fixed
@@ -160,3 +160,11 @@ pub fn poll_next(ready: bool) -> Poll<Option<io::Result<()>>> {
 
     Poll::Ready(None)
 }
+
+// Tests that `return` is not duplicated
+pub fn try_return(x: bool) -> Result<i32, i32> {
+    if x {
+        return Err(42);
+    }
+    Ok(0)
+}

--- a/tests/ui/try_err.rs
+++ b/tests/ui/try_err.rs
@@ -160,3 +160,11 @@ pub fn poll_next(ready: bool) -> Poll<Option<io::Result<()>>> {
 
     Poll::Ready(None)
 }
+
+// Tests that `return` is not duplicated
+pub fn try_return(x: bool) -> Result<i32, i32> {
+    if x {
+        return Err(42)?;
+    }
+    Ok(0)
+}

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -74,5 +74,11 @@ error: returning an `Err(_)` with the `?` operator
 LL |         Err(io::ErrorKind::NotFound)?
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `return Poll::Ready(Some(Err(io::ErrorKind::NotFound.into())))`
 
-error: aborting due to 10 previous errors
+error: returning an `Err(_)` with the `?` operator
+  --> $DIR/try_err.rs:167:16
+   |
+LL |         return Err(42)?;
+   |                ^^^^^^^^ help: try this: `Err(42)`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
This fixes #7103 by looking at the parent expression and omitting the "return " in the suggestion when its already a `return` expression.

---

changelog: none
