### PR TITLE
Ignore aarch64 for this test as it's x86 assembly only.  Fixes #7091

### DIFF
--- a/tests/ui/asm_syntax.rs
+++ b/tests/ui/asm_syntax.rs
@@ -1,5 +1,7 @@
-#![feature(asm)]
 // only-x86_64
+// ignore-aarch64
+
+#![feature(asm)]
 
 #[warn(clippy::inline_asm_x86_intel_syntax)]
 mod warn_intel {
@@ -23,6 +25,7 @@ mod warn_att {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 fn main() {
     unsafe {
         warn_att::use_asm();

--- a/tests/ui/asm_syntax.stderr
+++ b/tests/ui/asm_syntax.stderr
@@ -1,5 +1,5 @@
 error: Intel x86 assembly syntax used
-  --> $DIR/asm_syntax.rs:7:9
+  --> $DIR/asm_syntax.rs:9:9
    |
 LL |         asm!("");
    |         ^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         asm!("");
    = help: use AT&T x86 assembly syntax
 
 error: Intel x86 assembly syntax used
-  --> $DIR/asm_syntax.rs:8:9
+  --> $DIR/asm_syntax.rs:10:9
    |
 LL |         asm!("", options());
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         asm!("", options());
    = help: use AT&T x86 assembly syntax
 
 error: Intel x86 assembly syntax used
-  --> $DIR/asm_syntax.rs:9:9
+  --> $DIR/asm_syntax.rs:11:9
    |
 LL |         asm!("", options(nostack));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         asm!("", options(nostack));
    = help: use AT&T x86 assembly syntax
 
 error: AT&T x86 assembly syntax used
-  --> $DIR/asm_syntax.rs:21:9
+  --> $DIR/asm_syntax.rs:23:9
    |
 LL |         asm!("", options(att_syntax));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |         asm!("", options(att_syntax));
    = help: use Intel x86 assembly syntax
 
 error: AT&T x86 assembly syntax used
-  --> $DIR/asm_syntax.rs:22:9
+  --> $DIR/asm_syntax.rs:24:9
    |
 LL |         asm!("", options(nostack, att_syntax));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
fixes #7091 - asm_syntax lint test will not compile on aarch64

changelog: none