### PR TITLE
More `manual_map` improvements

### DIFF
--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -7,8 +7,9 @@ use clippy_utils::{
 };
 use rustc_errors::Applicability;
 use rustc_hir::{
+    hir_id::HirIdSet,
     intravisit::{walk_expr, ErasedMap, NestedVisitorMap, Visitor},
-    Block, Expr, ExprKind, Guard, HirId, Local, Stmt, StmtKind, UnOp,
+    Block, Expr, ExprKind, Guard, HirId, Local, Pat, Stmt, StmtKind, UnOp,
 };
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -333,6 +334,8 @@ struct InsertSearcher<'cx, 'tcx> {
     edits: Vec<Edit<'tcx>>,
     /// A stack of loops the visitor is currently in.
     loops: Vec<HirId>,
+    /// Local variables created in the expression. These don't need to be captured.
+    locals: HirIdSet,
 }
 impl<'tcx> InsertSearcher<'_, 'tcx> {
     /// Visit the expression as a branch in control flow. Multiple insert calls can be used, but
@@ -363,6 +366,12 @@ impl<'tcx> Visitor<'tcx> for InsertSearcher<'_, 'tcx> {
         NestedVisitorMap::None
     }
 
+    fn visit_pat(&mut self, p: &'tcx Pat<'tcx>) {
+        p.each_binding_or_first(&mut |_, id, _, _| {
+            self.locals.insert(id);
+        });
+    }
+
     fn visit_stmt(&mut self, stmt: &'tcx Stmt<'_>) {
         match stmt.kind {
             StmtKind::Semi(e) => {
@@ -380,7 +389,8 @@ impl<'tcx> Visitor<'tcx> for InsertSearcher<'_, 'tcx> {
                 }
             },
             StmtKind::Expr(e) => self.visit_expr(e),
-            StmtKind::Local(Local { init: Some(e), .. }) => {
+            StmtKind::Local(Local { pat, init: Some(e), .. }) => {
+                self.visit_pat(pat);
                 self.allow_insert_closure &= !self.in_tail_pos;
                 self.in_tail_pos = false;
                 self.is_single_insert = false;
@@ -468,6 +478,7 @@ impl<'tcx> Visitor<'tcx> for InsertSearcher<'_, 'tcx> {
                     // Each branch may contain it's own insert expression.
                     let mut is_map_used = self.is_map_used;
                     for arm in arms {
+                        self.visit_pat(arm.pat);
                         if let Some(Guard::If(guard) | Guard::IfLet(_, guard)) = arm.guard {
                             self.visit_non_tail_expr(guard)
                         }
@@ -493,7 +504,8 @@ impl<'tcx> Visitor<'tcx> for InsertSearcher<'_, 'tcx> {
                 },
                 _ => {
                     self.allow_insert_closure &= !self.in_tail_pos;
-                    self.allow_insert_closure &= can_move_expr_to_closure_no_visit(self.cx, expr, &self.loops);
+                    self.allow_insert_closure &=
+                        can_move_expr_to_closure_no_visit(self.cx, expr, &self.loops, &self.locals);
                     // Sub expressions are no longer in the tail position.
                     self.is_single_insert = false;
                     self.in_tail_pos = false;
@@ -627,6 +639,7 @@ fn find_insert_calls(
         in_tail_pos: true,
         is_single_insert: true,
         loops: Vec::new(),
+        locals: HirIdSet::default(),
     };
     s.visit_expr(expr);
     let allow_insert_closure = s.allow_insert_closure;

--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -30,7 +30,10 @@ pub fn can_partially_move_ty(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
     }
     match ty.kind() {
         ty::Param(_) => false,
-        ty::Adt(def, subs) => def.all_fields().any(|f| !is_copy(cx, f.ty(cx.tcx, subs))),
+        // Fields can't be moved if they can't be accessed.
+        ty::Adt(def, subs) => def
+            .all_fields()
+            .any(|f| f.vis.is_visible_locally() && !is_copy(cx, f.ty(cx.tcx, subs))),
         _ => true,
     }
 }

--- a/tests/ui/manual_map_option_2.fixed
+++ b/tests/ui/manual_map_option_2.fixed
@@ -1,0 +1,100 @@
+// edition:2018
+// run-rustfix
+
+#![warn(clippy::manual_map)]
+#![allow(
+    clippy::no_effect,
+    clippy::map_identity,
+    clippy::unit_arg,
+    clippy::match_ref_pats,
+    clippy::redundant_pattern_matching,
+    dead_code
+)]
+
+fn main() {
+    fn f1(s: String) -> String {
+        s
+    }
+
+    let s = String::new();
+    // Ok, `s` is consumed.
+    let _: Option<String> = Some(0).map(move |_| f1(s));
+
+    let s = String::new();
+    let s2 = &String::new();
+    // Ok, `s` is consumed, and `s2` is copied.
+    let _: Option<(String, &str)> = Some(0).map(move |_| (f1(s), s2.as_str()));
+    println!("{}", s2);
+
+    let s = String::new();
+    let s2 = &mut String::new();
+    // Ok, `s` is borrowed, and `s2` is reborrowed.
+    let _: Option<(&str, &str)> = Some(0).map(|_| (s.as_str(), s2.as_str()));
+    println!("{}", s2);
+
+    fn f2(s: &mut String) -> &mut str {
+        s
+    }
+
+    let s = String::new();
+    let s2 = &mut String::new();
+    // Ok, `s` is borrowed, and `s2` is reborrowed.
+    let _: Option<(&str, &mut str)> = Some(0).map(|_| (s.as_str(), f2(s2)));
+    println!("{}", s2);
+
+    let v = vec![0];
+    // Ok, `v` is borrowed.
+    let _: Option<u32> = Some(0).map(|i| v[i]);
+    println!("{}", v[0]);
+
+    // Ok, no need for a move closure.
+    let _: Option<String> = Some(0).map(|_| {
+            let s = String::new();
+            f1(s)
+        });
+
+    let s = String::new();
+    let x = 0u32;
+    // Can't use map, `s` is consumed, but `x` is borrowed.
+    let _: Option<(String, &u32)> = match Some(0) {
+        Some(_) => Some((f1(s), &x)),
+        None => None,
+    };
+    println!("{}", v[0]);
+
+    let s = String::new();
+    let s2 = String::new();
+    // Can't use map, `s` is consumed, but `s2` is used afterwards.
+    let _: Option<(String, &str)> = match Some(0) {
+        Some(_) => Some((f1(s), s2.as_str())),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let s = String::new();
+    let s2 = String::new();
+    // Can't use map, `s` is consumed, but `s2` is used afterwards.
+    let _: Option<(String, &String)> = match Some(0) {
+        Some(_) => Some((f1(s), &s2)),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let s = String::new();
+    let s2 = &mut String::new();
+    // Can't use map, `s` is consumed, but `s2` is used afterwards.
+    let _: Option<(String, &str)> = match Some(0) {
+        Some(_) => Some((f1(s), s2.as_str())),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let s = String::new();
+    let v = vec![0];
+    // Can't use map, `s` is consumed, but `v` is used afterwards.
+    let _: Option<(String, u32)> = match Some(0) {
+        Some(i) => Some((f1(s), v[i])),
+        None => None,
+    };
+    println!("{}", v[0]);
+}

--- a/tests/ui/manual_map_option_2.rs
+++ b/tests/ui/manual_map_option_2.rs
@@ -1,0 +1,118 @@
+// edition:2018
+// run-rustfix
+
+#![warn(clippy::manual_map)]
+#![allow(
+    clippy::no_effect,
+    clippy::map_identity,
+    clippy::unit_arg,
+    clippy::match_ref_pats,
+    clippy::redundant_pattern_matching,
+    dead_code
+)]
+
+fn main() {
+    fn f1(s: String) -> String {
+        s
+    }
+
+    let s = String::new();
+    // Ok, `s` is consumed.
+    let _: Option<String> = match Some(0) {
+        Some(_) => Some(f1(s)),
+        None => None,
+    };
+
+    let s = String::new();
+    let s2 = &String::new();
+    // Ok, `s` is consumed, and `s2` is copied.
+    let _: Option<(String, &str)> = match Some(0) {
+        Some(_) => Some((f1(s), s2.as_str())),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let s = String::new();
+    let s2 = &mut String::new();
+    // Ok, `s` is borrowed, and `s2` is reborrowed.
+    let _: Option<(&str, &str)> = match Some(0) {
+        Some(_) => Some((s.as_str(), s2.as_str())),
+        None => None,
+    };
+    println!("{}", s2);
+
+    fn f2(s: &mut String) -> &mut str {
+        s
+    }
+
+    let s = String::new();
+    let s2 = &mut String::new();
+    // Ok, `s` is borrowed, and `s2` is reborrowed.
+    let _: Option<(&str, &mut str)> = match Some(0) {
+        Some(_) => Some((s.as_str(), f2(s2))),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let v = vec![0];
+    // Ok, `v` is borrowed.
+    let _: Option<u32> = match Some(0) {
+        Some(i) => Some(v[i]),
+        None => None,
+    };
+    println!("{}", v[0]);
+
+    // Ok, no need for a move closure.
+    let _: Option<String> = match Some(0) {
+        Some(_) => Some({
+            let s = String::new();
+            f1(s)
+        }),
+        None => None,
+    };
+
+    let s = String::new();
+    let x = 0u32;
+    // Can't use map, `s` is consumed, but `x` is borrowed.
+    let _: Option<(String, &u32)> = match Some(0) {
+        Some(_) => Some((f1(s), &x)),
+        None => None,
+    };
+    println!("{}", v[0]);
+
+    let s = String::new();
+    let s2 = String::new();
+    // Can't use map, `s` is consumed, but `s2` is used afterwards.
+    let _: Option<(String, &str)> = match Some(0) {
+        Some(_) => Some((f1(s), s2.as_str())),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let s = String::new();
+    let s2 = String::new();
+    // Can't use map, `s` is consumed, but `s2` is used afterwards.
+    let _: Option<(String, &String)> = match Some(0) {
+        Some(_) => Some((f1(s), &s2)),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let s = String::new();
+    let s2 = &mut String::new();
+    // Can't use map, `s` is consumed, but `s2` is used afterwards.
+    let _: Option<(String, &str)> = match Some(0) {
+        Some(_) => Some((f1(s), s2.as_str())),
+        None => None,
+    };
+    println!("{}", s2);
+
+    let s = String::new();
+    let v = vec![0];
+    // Can't use map, `s` is consumed, but `v` is used afterwards.
+    let _: Option<(String, u32)> = match Some(0) {
+        Some(i) => Some((f1(s), v[i])),
+        None => None,
+    };
+    println!("{}", v[0]);
+}

--- a/tests/ui/manual_map_option_2.stderr
+++ b/tests/ui/manual_map_option_2.stderr
@@ -1,0 +1,75 @@
+error: manual implementation of `Option::map`
+  --> $DIR/manual_map_option_2.rs:21:29
+   |
+LL |       let _: Option<String> = match Some(0) {
+   |  _____________________________^
+LL | |         Some(_) => Some(f1(s)),
+LL | |         None => None,
+LL | |     };
+   | |_____^ help: try this: `Some(0).map(move |_| f1(s))`
+   |
+   = note: `-D clippy::manual-map` implied by `-D warnings`
+
+error: manual implementation of `Option::map`
+  --> $DIR/manual_map_option_2.rs:29:37
+   |
+LL |       let _: Option<(String, &str)> = match Some(0) {
+   |  _____________________________________^
+LL | |         Some(_) => Some((f1(s), s2.as_str())),
+LL | |         None => None,
+LL | |     };
+   | |_____^ help: try this: `Some(0).map(move |_| (f1(s), s2.as_str()))`
+
+error: manual implementation of `Option::map`
+  --> $DIR/manual_map_option_2.rs:38:35
+   |
+LL |       let _: Option<(&str, &str)> = match Some(0) {
+   |  ___________________________________^
+LL | |         Some(_) => Some((s.as_str(), s2.as_str())),
+LL | |         None => None,
+LL | |     };
+   | |_____^ help: try this: `Some(0).map(|_| (s.as_str(), s2.as_str()))`
+
+error: manual implementation of `Option::map`
+  --> $DIR/manual_map_option_2.rs:51:39
+   |
+LL |       let _: Option<(&str, &mut str)> = match Some(0) {
+   |  _______________________________________^
+LL | |         Some(_) => Some((s.as_str(), f2(s2))),
+LL | |         None => None,
+LL | |     };
+   | |_____^ help: try this: `Some(0).map(|_| (s.as_str(), f2(s2)))`
+
+error: manual implementation of `Option::map`
+  --> $DIR/manual_map_option_2.rs:59:26
+   |
+LL |       let _: Option<u32> = match Some(0) {
+   |  __________________________^
+LL | |         Some(i) => Some(v[i]),
+LL | |         None => None,
+LL | |     };
+   | |_____^ help: try this: `Some(0).map(|i| v[i])`
+
+error: manual implementation of `Option::map`
+  --> $DIR/manual_map_option_2.rs:66:29
+   |
+LL |       let _: Option<String> = match Some(0) {
+   |  _____________________________^
+LL | |         Some(_) => Some({
+LL | |             let s = String::new();
+LL | |             f1(s)
+LL | |         }),
+LL | |         None => None,
+LL | |     };
+   | |_____^
+   |
+help: try this
+   |
+LL |     let _: Option<String> = Some(0).map(|_| {
+LL |             let s = String::new();
+LL |             f1(s)
+LL |         });
+   |
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Hopefully there are no more false positives with this. Other lints that move an expression into a closure should also be checked at some point, there will likely be some of the same issues this lint had.

changelog: Suggest move closure in `manual_map` when needed
changelog: Fix false positive in `manual_map` where one local needs to be captured by reference, and another by value.
