### PR TITLE
`single_component_path_imports`: ignore `pub(crate) use some_macro;`

### DIFF
--- a/tests/ui/single_component_path_imports_macro.fixed
+++ b/tests/ui/single_component_path_imports_macro.fixed
@@ -1,0 +1,21 @@
+// run-rustfix
+// edition:2018
+#![warn(clippy::single_component_path_imports)]
+#![allow(unused_imports)]
+
+// #7106: use statements exporting a macro within a crate should not trigger lint
+
+macro_rules! m1 {
+    () => {};
+}
+pub(crate) use m1; // ok
+
+macro_rules! m2 {
+    () => {};
+}
+ // fail
+
+fn main() {
+    m1!();
+    m2!();
+}

--- a/tests/ui/single_component_path_imports_macro.rs
+++ b/tests/ui/single_component_path_imports_macro.rs
@@ -1,0 +1,21 @@
+// run-rustfix
+// edition:2018
+#![warn(clippy::single_component_path_imports)]
+#![allow(unused_imports)]
+
+// #7106: use statements exporting a macro within a crate should not trigger lint
+
+macro_rules! m1 {
+    () => {};
+}
+pub(crate) use m1; // ok
+
+macro_rules! m2 {
+    () => {};
+}
+use m2; // fail
+
+fn main() {
+    m1!();
+    m2!();
+}

--- a/tests/ui/single_component_path_imports_macro.stderr
+++ b/tests/ui/single_component_path_imports_macro.stderr
@@ -1,0 +1,10 @@
+error: this import is redundant
+  --> $DIR/single_component_path_imports_macro.rs:16:1
+   |
+LL | use m2; // fail
+   | ^^^^^^^ help: remove it entirely
+   |
+   = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #7106

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: Ignore exporting a macro within a crate using `pub(crate) use some_macro;` for [`single_component_path_imports`]