### PR TITLE
Fix ICE checking for feature gated const fn

### DIFF
--- a/clippy_utils/src/qualify_min_const_fn.rs
+++ b/clippy_utils/src/qualify_min_const_fn.rs
@@ -364,7 +364,7 @@ fn check_terminator(
 
 fn is_const_fn(tcx: TyCtxt<'_>, def_id: DefId, msrv: Option<&RustcVersion>) -> bool {
     rustc_mir::const_eval::is_const_fn(tcx, def_id)
-        && if let Some(const_stab) = tcx.lookup_const_stability(def_id) {
+        && tcx.lookup_const_stability(def_id).map_or(true, |const_stab| {
             if let rustc_attr::StabilityLevel::Stable { since } = const_stab.level {
                 // Checking MSRV is manually necessary because `rustc` has no such concept. This entire
                 // function could be removed if `rustc` provided a MSRV-aware version of `is_const_fn`.
@@ -375,10 +375,8 @@ fn is_const_fn(tcx: TyCtxt<'_>, def_id: DefId, msrv: Option<&RustcVersion>) -> b
                         .expect("`rustc_attr::StabilityLevel::Stable::since` is ill-formatted"),
                 )
             } else {
-                // `rustc_mir::const_eval::is_const_fn` should return false for unstably const functions.
-                unreachable!();
+                // Unstable const fn with the feature enabled.
+                msrv.is_none()
             }
-        } else {
-            true
-        }
+        })
 }

--- a/tests/ui/crashes/ice-7126.rs
+++ b/tests/ui/crashes/ice-7126.rs
@@ -1,0 +1,14 @@
+// This test requires a feature gated const fn and will stop working in the future.
+
+#![feature(const_btree_new)]
+
+use std::collections::BTreeMap;
+
+struct Foo(BTreeMap<i32, i32>);
+impl Foo {
+    fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
fixes: #7126
changelog: Fix ICE in `missing_const_for_fn` when using a feature-gated `const fn`
