### PR TITLE
extend `single_element_loop` to match `.iter()`

### DIFF
--- a/clippy_lints/src/loops/single_element_loop.rs
+++ b/clippy_lints/src/loops/single_element_loop.rs
@@ -14,8 +14,14 @@ pub(super) fn check<'tcx>(
     body: &'tcx Expr<'_>,
     expr: &'tcx Expr<'_>,
 ) {
+    let arg_expr = match arg.kind {
+        ExprKind::AddrOf(BorrowKind::Ref, _, ref_arg) => ref_arg,
+        ExprKind::MethodCall(method, _, args, _) if args.len() == 1 && method.ident.name == rustc_span::sym::iter => {
+            &args[0]
+        },
+        _ => return,
+    };
     if_chain! {
-        if let ExprKind::AddrOf(BorrowKind::Ref, _, arg_expr) = arg.kind;
         if let PatKind::Binding(.., target, _) = pat.kind;
         if let ExprKind::Array([arg_expression]) = arg_expr.kind;
         if let ExprKind::Path(ref list_item) = arg_expression.kind;

--- a/tests/ui/single_element_loop.fixed
+++ b/tests/ui/single_element_loop.fixed
@@ -8,4 +8,9 @@ fn main() {
         let item = &item1;
         println!("{}", item);
     }
+
+    {
+        let item = &item1;
+        println!("{:?}", item);
+    }
 }

--- a/tests/ui/single_element_loop.rs
+++ b/tests/ui/single_element_loop.rs
@@ -7,4 +7,8 @@ fn main() {
     for item in &[item1] {
         println!("{}", item);
     }
+
+    for item in [item1].iter() {
+        println!("{:?}", item);
+    }
 }

--- a/tests/ui/single_element_loop.stderr
+++ b/tests/ui/single_element_loop.stderr
@@ -15,5 +15,21 @@ LL |         println!("{}", item);
 LL |     }
    |
 
-error: aborting due to previous error
+error: for loop over a single element
+  --> $DIR/single_element_loop.rs:11:5
+   |
+LL | /     for item in [item1].iter() {
+LL | |         println!("{:?}", item);
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL |     {
+LL |         let item = &item1;
+LL |         println!("{:?}", item);
+LL |     }
+   |
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This extends `single_element_loop` to also match `[..].iter()` in the loop argument. Related to #7125, but not completely fixing it due to the lint only firing if the array expression contains a local variable.

---

changelog: none
