### PR TITLE
Fix FN in `iter_cloned_collect` with a large array

### DIFF
--- a/clippy_lints/src/methods/utils.rs
+++ b/clippy_lints/src/methods/utils.rs
@@ -18,9 +18,7 @@ pub(super) fn derefs_to_slice<'tcx>(
             ty::Slice(_) => true,
             ty::Adt(def, _) if def.is_box() => may_slice(cx, ty.boxed_ty()),
             ty::Adt(..) => is_type_diagnostic_item(cx, ty, sym::vec_type),
-            ty::Array(_, size) => size
-                .try_eval_usize(cx.tcx, cx.param_env)
-                .map_or(false, |size| size < 32),
+            ty::Array(_, size) => size.try_eval_usize(cx.tcx, cx.param_env).is_some(),
             ty::Ref(_, inner, _) => may_slice(cx, inner),
             _ => false,
         }

--- a/tests/ui/iter_cloned_collect.fixed
+++ b/tests/ui/iter_cloned_collect.fixed
@@ -19,4 +19,8 @@ fn main() {
         let _: Vec<u8> = std::ffi::CStr::from_ptr(std::ptr::null())
             .to_bytes().to_vec();
     }
+
+    // Issue #6808
+    let arr: [u8; 64] = [0; 64];
+    let _: Vec<_> = arr.to_vec();
 }

--- a/tests/ui/iter_cloned_collect.rs
+++ b/tests/ui/iter_cloned_collect.rs
@@ -22,4 +22,8 @@ fn main() {
             .cloned()
             .collect();
     }
+
+    // Issue #6808
+    let arr: [u8; 64] = [0; 64];
+    let _: Vec<_> = arr.iter().cloned().collect();
 }

--- a/tests/ui/iter_cloned_collect.stderr
+++ b/tests/ui/iter_cloned_collect.stderr
@@ -22,5 +22,11 @@ LL | |             .cloned()
 LL | |             .collect();
    | |______________________^ help: try: `.to_vec()`
 
-error: aborting due to 3 previous errors
+error: called `iter().cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+  --> $DIR/iter_cloned_collect.rs:28:24
+   |
+LL |     let _: Vec<_> = arr.iter().cloned().collect();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
fixes #6808 
changelog: Fix FN in `iter_cloned_collect` with a large array

I spotted that [is_iterable_array](https://github.com/rust-lang/rust-clippy/blob/a362a4d1d0edb66aef186c1d27b28c60573078f4/clippy_lints/src/loops/explicit_iter_loop.rs#L67-L75) function that `explicit_iter_loop` lint is using only works for array sizes <= 32.
There is this comment:
> IntoIterator is currently only implemented for array sizes <= 32 in rustc

I'm a bit confused, because I read that [IntoIterator for arrays](https://doc.rust-lang.org/src/core/array/mod.rs.html#194-201) with const generic `N` is stable since = "1.0.0". Although Const Generics MVP were stabilized in Rust 1.51.

Should I set MSRV for the current change? I will try to test with older compilers soon. 