### PR TITLE
Remove leftover plugin conf_file code

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -399,56 +399,41 @@ pub fn register_pre_expansion_lints(store: &mut rustc_lint::LintStore) {
 }
 
 #[doc(hidden)]
-pub fn read_conf(args: &[rustc_ast::NestedMetaItem], sess: &Session) -> Conf {
+pub fn read_conf(sess: &Session) -> Conf {
     use std::path::Path;
-    match utils::conf::file_from_args(args) {
-        Ok(file_name) => {
-            // if the user specified a file, it must exist, otherwise default to `clippy.toml` but
-            // do not require the file to exist
-            let file_name = match file_name {
-                Some(file_name) => file_name,
-                None => match utils::conf::lookup_conf_file() {
-                    Ok(Some(path)) => path,
-                    Ok(None) => return Conf::default(),
-                    Err(error) => {
-                        sess.struct_err(&format!("error finding Clippy's configuration file: {}", error))
-                            .emit();
-                        return Conf::default();
-                    },
-                },
-            };
-
-            let file_name = if file_name.is_relative() {
-                sess.local_crate_source_file
-                    .as_deref()
-                    .and_then(Path::parent)
-                    .unwrap_or_else(|| Path::new(""))
-                    .join(file_name)
-            } else {
-                file_name
-            };
-
-            let (conf, errors) = utils::conf::read(&file_name);
-
-            // all conf errors are non-fatal, we just use the default conf in case of error
-            for error in errors {
-                sess.struct_err(&format!(
-                    "error reading Clippy's configuration file `{}`: {}",
-                    file_name.display(),
-                    error
-                ))
+    let file_name = match utils::conf::lookup_conf_file() {
+        Ok(Some(path)) => path,
+        Ok(None) => return Conf::default(),
+        Err(error) => {
+            sess.struct_err(&format!("error finding Clippy's configuration file: {}", error))
                 .emit();
-            }
+            return Conf::default();
+        },
+    };
 
-            conf
-        },
-        Err((err, span)) => {
-            sess.struct_span_err(span, err)
-                .span_note(span, "Clippy will use default configuration")
-                .emit();
-            Conf::default()
-        },
+    let file_name = if file_name.is_relative() {
+        sess.local_crate_source_file
+            .as_deref()
+            .and_then(Path::parent)
+            .unwrap_or_else(|| Path::new(""))
+            .join(file_name)
+    } else {
+        file_name
+    };
+
+    let (conf, errors) = utils::conf::read(&file_name);
+
+    // all conf errors are non-fatal, we just use the default conf in case of error
+    for error in errors {
+        sess.struct_err(&format!(
+            "error reading Clippy's configuration file `{}`: {}",
+            file_name.display(),
+            error
+        ))
+        .emit();
     }
+
+    conf
 }
 
 /// Register all lints and lint groups with the rustc plugin registry

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -2,33 +2,10 @@
 
 #![deny(clippy::missing_docs_in_private_items)]
 
-use rustc_ast::ast::{LitKind, MetaItemKind, NestedMetaItem};
-use rustc_span::source_map;
-use source_map::Span;
 use std::lazy::SyncLazy;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::{env, fmt, fs, io};
-
-/// Gets the configuration file from arguments.
-pub fn file_from_args(args: &[NestedMetaItem]) -> Result<Option<PathBuf>, (&'static str, Span)> {
-    for arg in args.iter().filter_map(NestedMetaItem::meta_item) {
-        if arg.has_name(sym!(conf_file)) {
-            return match arg.kind {
-                MetaItemKind::Word | MetaItemKind::List(_) => Err(("`conf_file` must be a named value", arg.span)),
-                MetaItemKind::NameValue(ref value) => {
-                    if let LitKind::Str(ref file, _) = value.kind {
-                        Ok(Some(file.to_string().into()))
-                    } else {
-                        Err(("`conf_file` value must be a string", value.span))
-                    }
-                },
-            };
-        }
-    }
-
-    Ok(None)
-}
 
 /// Error from reading a configuration file.
 #[derive(Debug)]

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -106,7 +106,7 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
                 (previous)(sess, lint_store);
             }
 
-            let conf = clippy_lints::read_conf(&[], sess);
+            let conf = clippy_lints::read_conf(sess);
             clippy_lints::register_plugins(lint_store, sess, &conf);
             clippy_lints::register_pre_expansion_lints(lint_store);
             clippy_lints::register_renamed(lint_store);


### PR DESCRIPTION
changelog: none

Removes dead code that used to support the following syntax:

```rust
#![plugin(clippy(conf_file="path/to/clippy's/configuration"))]
```

RLS (and others?) will need to remove the `&[]` from `clippy_lints::read_conf(&[], sess)`.

r? @flip1995