### PR TITLE
while_immutable_cond: check condition for mutation

### DIFF
--- a/tests/ui/infinite_loop.rs
+++ b/tests/ui/infinite_loop.rs
@@ -192,11 +192,23 @@ fn while_loop_with_break_and_return() {
     }
 }
 
+fn immutable_condition_false_positive(mut n: u64) -> u32 {
+    let mut count = 0;
+    while {
+        n >>= 1;
+        n != 0
+    } {
+        count += 1;
+    }
+    count
+}
+
 fn main() {
     immutable_condition();
     unused_var();
     used_immutable();
     internally_mutable();
+    immutable_condition_false_positive(5);
 
     let mut c = Counter { count: 0 };
     c.inc_n(5);


### PR DESCRIPTION
This fixes #6689 by also checking the bindings mutated in the condition, whereas it was previously only checked in the loop body.

---

changelog: none
