### PR TITLE
[single_char_pattern] add strip_prefix and strip_suffix

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2189,29 +2189,6 @@ const TRAIT_METHODS: [ShouldImplTraitCase; 30] = [
     ShouldImplTraitCase::new("std::ops::Sub", "sub",  2,  FN_HEADER,  SelfKind::Value,  OutType::Any, true),
 ];
 
-#[rustfmt::skip]
-const PATTERN_METHODS: [(&str, usize); 19] = [
-    ("contains", 1),
-    ("starts_with", 1),
-    ("ends_with", 1),
-    ("find", 1),
-    ("rfind", 1),
-    ("split", 1),
-    ("rsplit", 1),
-    ("split_terminator", 1),
-    ("rsplit_terminator", 1),
-    ("splitn", 2),
-    ("rsplitn", 2),
-    ("matches", 1),
-    ("rmatches", 1),
-    ("match_indices", 1),
-    ("rmatch_indices", 1),
-    ("strip_prefix", 1),
-    ("strip_suffix", 1),
-    ("trim_start_matches", 1),
-    ("trim_end_matches", 1),
-];
-
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum SelfKind {
     Value,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2190,7 +2190,7 @@ const TRAIT_METHODS: [ShouldImplTraitCase; 30] = [
 ];
 
 #[rustfmt::skip]
-const PATTERN_METHODS: [(&str, usize); 17] = [
+const PATTERN_METHODS: [(&str, usize); 19] = [
     ("contains", 1),
     ("starts_with", 1),
     ("ends_with", 1),
@@ -2206,6 +2206,8 @@ const PATTERN_METHODS: [(&str, usize); 17] = [
     ("rmatches", 1),
     ("match_indices", 1),
     ("rmatch_indices", 1),
+    ("strip_prefix", 1),
+    ("strip_suffix", 1),
     ("trim_start_matches", 1),
     ("trim_end_matches", 1),
 ];

--- a/clippy_lints/src/methods/single_char_pattern.rs
+++ b/clippy_lints/src/methods/single_char_pattern.rs
@@ -9,9 +9,31 @@ use rustc_span::symbol::Symbol;
 
 use super::SINGLE_CHAR_PATTERN;
 
+const PATTERN_METHODS: [(&str, usize); 19] = [
+    ("contains", 1),
+    ("starts_with", 1),
+    ("ends_with", 1),
+    ("find", 1),
+    ("rfind", 1),
+    ("split", 1),
+    ("rsplit", 1),
+    ("split_terminator", 1),
+    ("rsplit_terminator", 1),
+    ("splitn", 2),
+    ("rsplitn", 2),
+    ("matches", 1),
+    ("rmatches", 1),
+    ("match_indices", 1),
+    ("rmatch_indices", 1),
+    ("strip_prefix", 1),
+    ("strip_suffix", 1),
+    ("trim_start_matches", 1),
+    ("trim_end_matches", 1),
+];
+
 /// lint for length-1 `str`s for methods in `PATTERN_METHODS`
 pub(super) fn check(cx: &LateContext<'_>, _expr: &hir::Expr<'_>, method_name: Symbol, args: &[hir::Expr<'_>]) {
-    for &(method, pos) in &crate::methods::PATTERN_METHODS {
+    for &(method, pos) in &PATTERN_METHODS {
         if_chain! {
             if let ty::Ref(_, ty, _) = cx.typeck_results().expr_ty_adjusted(&args[0]).kind();
             if *ty.kind() == ty::Str;

--- a/tests/ui/single_char_pattern.fixed
+++ b/tests/ui/single_char_pattern.fixed
@@ -33,6 +33,8 @@ fn main() {
     x.rmatch_indices('x');
     x.trim_start_matches('x');
     x.trim_end_matches('x');
+    x.strip_prefix('x');
+    x.strip_suffix('x');
     // Make sure we escape characters correctly.
     x.split('\n');
     x.split('\'');

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -33,6 +33,8 @@ fn main() {
     x.rmatch_indices("x");
     x.trim_start_matches("x");
     x.trim_end_matches("x");
+    x.strip_prefix("x");
+    x.strip_suffix("x");
     // Make sure we escape characters correctly.
     x.split("\n");
     x.split("'");

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -121,64 +121,76 @@ LL |     x.trim_end_matches("x");
    |                        ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:37:13
+  --> $DIR/single_char_pattern.rs:36:20
+   |
+LL |     x.strip_prefix("x");
+   |                    ^^^ help: try using a `char` instead: `'x'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:37:20
+   |
+LL |     x.strip_suffix("x");
+   |                    ^^^ help: try using a `char` instead: `'x'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:39:13
    |
 LL |     x.split("/n");
    |             ^^^^ help: try using a `char` instead: `'/n'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:38:13
+  --> $DIR/single_char_pattern.rs:40:13
    |
 LL |     x.split("'");
    |             ^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:39:13
+  --> $DIR/single_char_pattern.rs:41:13
    |
 LL |     x.split("/'");
    |             ^^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:44:31
+  --> $DIR/single_char_pattern.rs:46:31
    |
 LL |     x.replace(";", ",").split(","); // issue #2978
    |                               ^^^ help: try using a `char` instead: `','`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:45:19
+  --> $DIR/single_char_pattern.rs:47:19
    |
 LL |     x.starts_with("/x03"); // issue #2996
    |                   ^^^^^^ help: try using a `char` instead: `'/x03'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:52:13
+  --> $DIR/single_char_pattern.rs:54:13
    |
 LL |     x.split(r"a");
    |             ^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:53:13
+  --> $DIR/single_char_pattern.rs:55:13
    |
 LL |     x.split(r#"a"#);
    |             ^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:54:13
+  --> $DIR/single_char_pattern.rs:56:13
    |
 LL |     x.split(r###"a"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:55:13
+  --> $DIR/single_char_pattern.rs:57:13
    |
 LL |     x.split(r###"'"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:56:13
+  --> $DIR/single_char_pattern.rs:58:13
    |
 LL |     x.split(r###"#"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'#'`
 
-error: aborting due to 30 previous errors
+error: aborting due to 32 previous errors
 


### PR DESCRIPTION
Title says it all. Adjusted ui tests.

I added the second commit in case you don't like that I moved that table into `single_char_pattern.rs` directly. I don't see any reason why it shouldn't be in that file. It isn't used anywhere else.

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: add strip_prefix and strip_suffix to single_char_pattern lint