### PR TITLE
needless_collect: Lint cases with type annotations for indirect usage and recognize `BinaryHeap`

### DIFF
--- a/clippy_lints/src/loops/needless_collect.rs
+++ b/clippy_lints/src/loops/needless_collect.rs
@@ -85,6 +85,7 @@ fn check_needless_collect_indirect_usage<'tcx>(expr: &'tcx Expr<'_>, cx: &LateCo
                 if let ty = cx.typeck_results().node_type(hir_id);
                 if is_type_diagnostic_item(cx, ty, sym::vec_type) ||
                     is_type_diagnostic_item(cx, ty, sym::vecdeque_type) ||
+                    is_type_diagnostic_item(cx, ty, sym::BinaryHeap) ||
                     match_type(cx, ty, &paths::LINKED_LIST);
                 if let Some(iter_calls) = detect_iter_and_into_iters(block, *ident);
                 if let [iter_call] = &*iter_calls;

--- a/clippy_lints/src/loops/needless_collect.rs
+++ b/clippy_lints/src/loops/needless_collect.rs
@@ -27,7 +27,7 @@ fn check_needless_collect_direct_usage<'tcx>(expr: &'tcx Expr<'_>, cx: &LateCont
         if chain_method.ident.name == sym!(collect) && is_trait_method(cx, &args[0], sym::Iterator);
         if let Some(generic_args) = chain_method.args;
         if let Some(GenericArg::Type(ref ty)) = generic_args.args.get(0);
-        let ty = cx.typeck_results().node_type(ty.hir_id);
+        if let Some(ty) = cx.typeck_results().node_type_opt(ty.hir_id);
         if is_type_diagnostic_item(cx, ty, sym::vec_type)
             || is_type_diagnostic_item(cx, ty, sym::vecdeque_type)
             || match_type(cx, ty, &paths::BTREEMAP)
@@ -82,7 +82,7 @@ fn check_needless_collect_indirect_usage<'tcx>(expr: &'tcx Expr<'_>, cx: &LateCo
                 if let ExprKind::MethodCall(method_name, collect_span, &[ref iter_source], ..) = init_expr.kind;
                 if method_name.ident.name == sym!(collect) && is_trait_method(cx, init_expr, sym::Iterator);
                 if let Some(hir_id) = get_hir_id(*ty, method_name.args);
-                if let ty = cx.typeck_results().node_type(hir_id);
+                if let Some(ty) = cx.typeck_results().node_type_opt(hir_id);
                 if is_type_diagnostic_item(cx, ty, sym::vec_type) ||
                     is_type_diagnostic_item(cx, ty, sym::vecdeque_type) ||
                     is_type_diagnostic_item(cx, ty, sym::BinaryHeap) ||

--- a/tests/ui/copy_iterator.rs
+++ b/tests/ui/copy_iterator.rs
@@ -16,8 +16,6 @@ impl Iterator for Countdown {
 
 fn main() {
     let my_iterator = Countdown(5);
-    let a: Vec<_> = my_iterator.take(1).collect();
-    assert_eq!(a.len(), 1);
-    let b: Vec<_> = my_iterator.collect();
-    assert_eq!(b.len(), 5);
+    assert_eq!(my_iterator.take(1).count(), 1);
+    assert_eq!(my_iterator.count(), 5);
 }

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, LinkedList, VecDeque};
+use std::collections::{BinaryHeap, HashMap, LinkedList, VecDeque};
 
 fn main() {
     let sample = [1; 5];
@@ -60,6 +60,11 @@ mod issue7110 {
     fn lint_linked_list() -> usize {
         let sample = [1; 5];
         let indirect_len: LinkedList<_> = sample.iter().collect();
+        indirect_len.len()
+    }
+    fn lint_binary_heap() -> usize {
+        let sample = [1; 5];
+        let indirect_len: BinaryHeap<_> = sample.iter().collect();
         indirect_len.len()
     }
     fn dont_lint(string: &str) -> usize {

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, LinkedList, VecDeque};
 
 fn main() {
     let sample = [1; 5];
@@ -41,5 +41,32 @@ fn main() {
             .iter()
             .filter(|i| multiple_indirect.iter().any(|s| **s % **i == 0))
             .collect::<Vec<_>>();
+    }
+}
+
+mod issue7110 {
+    // #7110 - lint for type annotation cases
+    use super::*;
+
+    fn lint_vec(string: &str) -> usize {
+        let buffer: Vec<&str> = string.split('/').collect();
+        buffer.len()
+    }
+    fn lint_vec_deque() -> usize {
+        let sample = [1; 5];
+        let indirect_len: VecDeque<_> = sample.iter().collect();
+        indirect_len.len()
+    }
+    fn lint_linked_list() -> usize {
+        let sample = [1; 5];
+        let indirect_len: LinkedList<_> = sample.iter().collect();
+        indirect_len.len()
+    }
+    fn dont_lint(string: &str) -> usize {
+        let buffer: Vec<&str> = string.split('/').collect();
+        for buff in &buffer {
+            println!("{}", buff);
+        }
+        buffer.len()
     }
 }

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -69,5 +69,47 @@ LL |
 LL |     sample.into_iter().any(|x| x == a);
    |
 
-error: aborting due to 5 previous errors
+error: avoid using `collect()` when not needed
+  --> $DIR/needless_collect_indirect.rs:52:51
+   |
+LL |         let buffer: Vec<&str> = string.split('/').collect();
+   |                                                   ^^^^^^^
+LL |         buffer.len()
+   |         ------------ the iterator could be used here instead
+   |
+help: take the original Iterator's count instead of collecting it and finding the length
+   |
+LL |         
+LL |         string.split('/').count()
+   |
+
+error: avoid using `collect()` when not needed
+  --> $DIR/needless_collect_indirect.rs:57:55
+   |
+LL |         let indirect_len: VecDeque<_> = sample.iter().collect();
+   |                                                       ^^^^^^^
+LL |         indirect_len.len()
+   |         ------------------ the iterator could be used here instead
+   |
+help: take the original Iterator's count instead of collecting it and finding the length
+   |
+LL |         
+LL |         sample.iter().count()
+   |
+
+error: avoid using `collect()` when not needed
+  --> $DIR/needless_collect_indirect.rs:62:57
+   |
+LL |         let indirect_len: LinkedList<_> = sample.iter().collect();
+   |                                                         ^^^^^^^
+LL |         indirect_len.len()
+   |         ------------------ the iterator could be used here instead
+   |
+help: take the original Iterator's count instead of collecting it and finding the length
+   |
+LL |         
+LL |         sample.iter().count()
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -111,5 +111,19 @@ LL |
 LL |         sample.iter().count()
    |
 
-error: aborting due to 8 previous errors
+error: avoid using `collect()` when not needed
+  --> $DIR/needless_collect_indirect.rs:67:57
+   |
+LL |         let indirect_len: BinaryHeap<_> = sample.iter().collect();
+   |                                                         ^^^^^^^
+LL |         indirect_len.len()
+   |         ------------------ the iterator could be used here instead
+   |
+help: take the original Iterator's count instead of collecting it and finding the length
+   |
+LL |         
+LL |         sample.iter().count()
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
fixes #7110
changelog: needless_collect: Lint cases with type annotations for indirect usage and recognize `BinaryHeap`.

