### PR TITLE
Fix unused_unit macro false positive

### DIFF
--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -47,7 +47,9 @@ impl EarlyLintPass for UnusedUnit {
         if_chain! {
             if let Some(stmt) = block.stmts.last();
             if let ast::StmtKind::Expr(ref expr) = stmt.kind;
-            if is_unit_expr(expr) && !stmt.span.from_expansion();
+            if is_unit_expr(expr);
+            let ctxt = block.span.ctxt();
+            if stmt.span.ctxt() == ctxt && expr.span.ctxt() == ctxt;
             then {
                 let sp = expr.span;
                 span_lint_and_sugg(

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -80,3 +80,10 @@ fn test2(){}
 
 #[rustfmt::skip]
 fn test3(){}
+
+fn macro_expr() {
+    macro_rules! e {
+        () => (());
+    }
+    e!()
+}

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -80,3 +80,10 @@ fn test2() ->(){}
 
 #[rustfmt::skip]
 fn test3()-> (){}
+
+fn macro_expr() {
+    macro_rules! e {
+        () => (());
+    }
+    e!()
+}


### PR DESCRIPTION
changelog: Fix [`unused_unit`] false positive with macros

Fixes #7055