### PR TITLE
Fix duplicated "Rust 1.52" version section header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ document.
 
 [7c7683c...master](https://github.com/rust-lang/rust-clippy/compare/7c7683c...master)
 
-## Rust 1.52
+## Rust 1.53
 
 Current beta, release 2021-06-17
 


### PR DESCRIPTION
The most recent changelog update 037ddf282bbf011babd4b7f9a851f6028fc6fd70 accompanying the 1.52 release added a second "Rust 1.52" section header, with the result that the Rust release announcement https://blog.rust-lang.org/2021/05/06/Rust-1.52.0.html is linking to the "current beta" changelog section for Clippy rather than the stable changelog. I don't know the release process but based on previous changes to this file, I assume the correct thing to do is to mark the topmost section as being for Rust 1.53, not 1.52.

changelog: none
