### PR TITLE
Remove powi, "square can be computed more efficiently"

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -323,7 +323,7 @@ fn check_powi(cx: &LateContext<'_>, expr: &Expr<'_>, args: &[Expr<'_>]) {
                         cx,
                         SUBOPTIMAL_FLOPS,
                         parent.span,
-                        "square can be computed more efficiently",
+                        "multiply and add expressions can be calculated more efficiently and accurately",
                         "consider using",
                         format!(
                             "{}.mul_add({}, {})",
@@ -337,16 +337,6 @@ fn check_powi(cx: &LateContext<'_>, expr: &Expr<'_>, args: &[Expr<'_>]) {
                     return;
                 }
             }
-
-            span_lint_and_sugg(
-                cx,
-                SUBOPTIMAL_FLOPS,
-                expr.span,
-                "square can be computed more efficiently",
-                "consider using",
-                format!("{} * {}", Sugg::hir(cx, &args[0], ".."), Sugg::hir(cx, &args[0], "..")),
-                Applicability::MachineApplicable,
-            );
         }
     }
 }

--- a/tests/ui/floating_point_powi.fixed
+++ b/tests/ui/floating_point_powi.fixed
@@ -4,8 +4,6 @@
 fn main() {
     let one = 1;
     let x = 3f32;
-    let _ = x * x;
-    let _ = x * x;
 
     let y = 4f32;
     let _ = x.mul_add(x, y);
@@ -13,7 +11,10 @@ fn main() {
     let _ = x.mul_add(x, y).sqrt();
     let _ = y.mul_add(y, x).sqrt();
     // Cases where the lint shouldn't be applied
+    let _ = x.powi(2);
+    let _ = x.powi(1 + 1);
     let _ = x.powi(3);
+    let _ = x.powi(4) + y;
     let _ = x.powi(one + 1);
     let _ = (x.powi(2) + y.powi(2)).sqrt();
 }

--- a/tests/ui/floating_point_powi.rs
+++ b/tests/ui/floating_point_powi.rs
@@ -4,8 +4,6 @@
 fn main() {
     let one = 1;
     let x = 3f32;
-    let _ = x.powi(2);
-    let _ = x.powi(1 + 1);
 
     let y = 4f32;
     let _ = x.powi(2) + y;
@@ -13,7 +11,10 @@ fn main() {
     let _ = (x.powi(2) + y).sqrt();
     let _ = (x + y.powi(2)).sqrt();
     // Cases where the lint shouldn't be applied
+    let _ = x.powi(2);
+    let _ = x.powi(1 + 1);
     let _ = x.powi(3);
+    let _ = x.powi(4) + y;
     let _ = x.powi(one + 1);
     let _ = (x.powi(2) + y.powi(2)).sqrt();
 }

--- a/tests/ui/floating_point_powi.stderr
+++ b/tests/ui/floating_point_powi.stderr
@@ -1,40 +1,28 @@
-error: square can be computed more efficiently
-  --> $DIR/floating_point_powi.rs:7:13
-   |
-LL |     let _ = x.powi(2);
-   |             ^^^^^^^^^ help: consider using: `x * x`
-   |
-   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
-
-error: square can be computed more efficiently
-  --> $DIR/floating_point_powi.rs:8:13
-   |
-LL |     let _ = x.powi(1 + 1);
-   |             ^^^^^^^^^^^^^ help: consider using: `x * x`
-
-error: square can be computed more efficiently
-  --> $DIR/floating_point_powi.rs:11:13
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:9:13
    |
 LL |     let _ = x.powi(2) + y;
    |             ^^^^^^^^^^^^^ help: consider using: `x.mul_add(x, y)`
+   |
+   = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
-error: square can be computed more efficiently
-  --> $DIR/floating_point_powi.rs:12:13
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:10:13
    |
 LL |     let _ = x + y.powi(2);
    |             ^^^^^^^^^^^^^ help: consider using: `y.mul_add(y, x)`
 
-error: square can be computed more efficiently
-  --> $DIR/floating_point_powi.rs:13:13
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:11:13
    |
 LL |     let _ = (x.powi(2) + y).sqrt();
    |             ^^^^^^^^^^^^^^^ help: consider using: `x.mul_add(x, y)`
 
-error: square can be computed more efficiently
-  --> $DIR/floating_point_powi.rs:14:13
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:12:13
    |
 LL |     let _ = (x + y.powi(2)).sqrt();
    |             ^^^^^^^^^^^^^^^ help: consider using: `y.mul_add(y, x)`
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
powi(2) produces exactly the same native code as x * x
powi was part of the [`suboptimal_flops`] lint

fixes #7058
changelog: Remove powi [`suboptimal_flops`], "square can be computed more efficiently"