### PR TITLE
Metadata collection monster searching for Clippy's configuration options

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1009,7 +1009,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     #[cfg(feature = "metadata-collector-lint")]
     {
         if std::env::var("ENABLE_METADATA_COLLECTION").eq(&Ok("1".to_string())) {
-            store.register_late_pass(|| box utils::internal_lints::metadata_collector::MetadataCollector::default());
+            store.register_late_pass(|| box utils::internal_lints::metadata_collector::MetadataCollector::new());
         }
     }
 

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -26,13 +26,13 @@ impl TryConf {
 
 macro_rules! define_Conf {
     ($(
-        #[$doc:meta]
+        #[doc = $doc:literal]
         $(#[conf_deprecated($dep:literal)])?
         ($name:ident: $ty:ty = $default:expr),
     )*) => {
         /// Clippy lint configuration
         pub struct Conf {
-            $(#[$doc] pub $name: $ty,)*
+            $(#[doc = $doc] pub $name: $ty,)*
         }
 
         mod defaults {
@@ -89,6 +89,24 @@ macro_rules! define_Conf {
                 Ok(TryConf { conf, errors })
             }
         }
+
+        #[cfg(feature = "metadata-collector-lint")]
+        pub mod metadata {
+            use crate::utils::internal_lints::metadata_collector::ClippyConfigurationBasicInfo;
+
+            pub(crate) fn get_configuration_metadata() -> Vec<ClippyConfigurationBasicInfo> {
+                vec![
+                    $(
+                        ClippyConfigurationBasicInfo {
+                            name: stringify!($name),
+                            config_type: stringify!($ty),
+                            default: stringify!($default),
+                            doc_comment: $doc,
+                        },
+                    )+
+                ]
+            }
+        }
     };
 }
 
@@ -100,7 +118,7 @@ define_Conf! {
     (blacklisted_names: Vec<String> = ["foo", "baz", "quux"].iter().map(ToString::to_string).collect()),
     /// Lint: COGNITIVE_COMPLEXITY. The maximum cognitive complexity a function can have
     (cognitive_complexity_threshold: u64 = 25),
-    /// DEPRECATED LINT: CYCLOMATIC_COMPLEXITY. Use the Cognitive Complexity lint instead.
+    /// Lint: CYCLOMATIC_COMPLEXITY. Use the Cognitive Complexity lint instead.
     #[conf_deprecated("Please use `cognitive-complexity-threshold` instead")]
     (cyclomatic_complexity_threshold: Option<u64> = None),
     /// Lint: DOC_MARKDOWN. The list of words this lint should not consider as identifiers needing ticks

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -92,25 +92,26 @@ macro_rules! define_Conf {
 
         #[cfg(feature = "metadata-collector-lint")]
         pub mod metadata {
-            use crate::utils::internal_lints::metadata_collector::ClippyConfigurationBasicInfo;
+            use crate::utils::internal_lints::metadata_collector::ClippyConfiguration;
 
-            pub(crate) fn get_configuration_metadata() -> Vec<ClippyConfigurationBasicInfo> {
+            macro_rules! wrap_option {
+                () => (None);
+                ($x:literal) => (Some($x));
+            }
+
+            pub(crate) fn get_configuration_metadata() -> Vec<ClippyConfiguration> {
                 vec![
                     $(
                         {
-                            #[allow(unused_mut, unused_assignments)]
-                            let mut deprecation_reason = None;
+                            let deprecation_reason = wrap_option!($($dep)?);
 
-                            // only set if a deprecation reason was set
-                            $(deprecation_reason = Some(stringify!($dep));)?
-
-                            ClippyConfigurationBasicInfo {
-                                name: stringify!($name),
-                                config_type: stringify!($ty),
-                                default: stringify!($default),
-                                doc_comment: $doc,
+                            ClippyConfiguration::new(
+                                stringify!($name),
+                                stringify!($ty),
+                                format!("{:?}", super::defaults::$name()),
+                                $doc,
                                 deprecation_reason,
-                            }
+                            )
                         },
                     )+
                 ]

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -97,11 +97,20 @@ macro_rules! define_Conf {
             pub(crate) fn get_configuration_metadata() -> Vec<ClippyConfigurationBasicInfo> {
                 vec![
                     $(
-                        ClippyConfigurationBasicInfo {
-                            name: stringify!($name),
-                            config_type: stringify!($ty),
-                            default: stringify!($default),
-                            doc_comment: $doc,
+                        {
+                            #[allow(unused_mut, unused_assignments)]
+                            let mut deprecation_reason = None;
+
+                            // only set if a deprecation reason was set
+                            $(deprecation_reason = Some(stringify!($dep));)?
+
+                            ClippyConfigurationBasicInfo {
+                                name: stringify!($name),
+                                config_type: stringify!($ty),
+                                default: stringify!($default),
+                                doc_comment: $doc,
+                                deprecation_reason,
+                            }
                         },
                     )+
                 ]
@@ -118,7 +127,7 @@ define_Conf! {
     (blacklisted_names: Vec<String> = ["foo", "baz", "quux"].iter().map(ToString::to_string).collect()),
     /// Lint: COGNITIVE_COMPLEXITY. The maximum cognitive complexity a function can have
     (cognitive_complexity_threshold: u64 = 25),
-    /// Lint: CYCLOMATIC_COMPLEXITY. Use the Cognitive Complexity lint instead.
+    /// DEPRECATED LINT: CYCLOMATIC_COMPLEXITY. Use the Cognitive Complexity lint instead.
     #[conf_deprecated("Please use `cognitive-complexity-threshold` instead")]
     (cyclomatic_complexity_threshold: Option<u64> = None),
     /// Lint: DOC_MARKDOWN. The list of words this lint should not consider as identifiers needing ticks

--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -267,6 +267,7 @@ pub(crate) struct ClippyConfigurationBasicInfo {
     pub config_type: &'static str,
     pub default: &'static str,
     pub doc_comment: &'static str,
+    pub deprecation_reason: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -276,6 +277,7 @@ struct ClippyConfiguration {
     doc: String,
     config_type: &'static str,
     default: String,
+    deprecation_reason: Option<&'static str>,
 }
 
 fn collect_configs() -> Vec<ClippyConfiguration> {
@@ -291,18 +293,19 @@ fn collect_configs() -> Vec<ClippyConfiguration> {
                 doc,
                 config_type: x.config_type,
                 default: clarify_default(x.default),
+                deprecation_reason: x.deprecation_reason,
             }
         })
         .collect()
 }
 
 fn clarify_default(default: &'static str) -> String {
-    if let Some((_start, init))  = default.split_once('[') {
+    if let Some((_start, init)) = default.split_once('[') {
         if let Some((init, _end)) = init.split_once(']') {
             return format!("[{}]", init);
         }
     }
-    
+
     default.to_string()
 }
 

--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -290,10 +290,20 @@ fn collect_configs() -> Vec<ClippyConfiguration> {
                 lints,
                 doc,
                 config_type: x.config_type,
-                default: x.default.to_string(),
+                default: clarify_default(x.default),
             }
         })
         .collect()
+}
+
+fn clarify_default(default: &'static str) -> String {
+    if let Some((_start, init))  = default.split_once('[') {
+        if let Some((init, _end)) = init.split_once(']') {
+            return format!("[{}]", init);
+        }
+    }
+    
+    default.to_string()
 }
 
 /// This parses the field documentation of the config struct.


### PR DESCRIPTION
This PR teaches our lovely metadata collection monster which configurations are available inside Clippy. It then adds a new *Configuration* section to the lint documentation.

---

The implementation uses the `define_Conf!` macro to create a vector of metadata during compilation. This enables easy collection and parsing without the need of searching for the struct during a lint-pass (and it's quite elegant IMO). The information is then parsed into an intermediate struct called `ClippyConfiguration` which will be saved inside the `MetadataCollector` struct itself. It is currently only used to generate the *Configuration* section in the lint documentation, but I'm thinking about adding an overview of available configurations to the website. Saving them in this intermediate state without formatting them right away enables this in the future. 

The new parsing will also allow us to have a documentation that spans over multiple lines in the future. For example, this will be valid when the old script has been removed:
```rust
/// Lint: BLACKLISTED_NAME.
/// The list of blacklisted names to lint about. NB: `bar` is not here since it has legitimate uses
(blacklisted_names: Vec<String> = ["foo", "baz", "quux"].iter().map(ToString::to_string).collect())
``` 

The deprecation reason is also currently being collected but not used any further and that's basically it.

---

See: #7172 for the full metadata collection to-do list or to suggest a new feature in connection to it :upside_down_face: 

---

changelog: none

r? @flip1995
cc @camsteffen It would be great if you could also review this PR as you have recently worked on Clippy's `define_Conf!` macro.