### PR TITLE
Trigger [`wrong_self_convention`] only if it has implicit self

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1838,16 +1838,18 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
                     }
                 }
 
-                wrong_self_convention::check(
-                    cx,
-                    &name,
-                    item.vis.node.is_pub(),
-                    self_ty,
-                    first_arg_ty,
-                    first_arg.pat.span,
-                    implements_trait,
-                    false
-                );
+                if sig.decl.implicit_self.has_implicit_self() {
+                    wrong_self_convention::check(
+                        cx,
+                        &name,
+                        item.vis.node.is_pub(),
+                        self_ty,
+                        first_arg_ty,
+                        first_arg.pat.span,
+                        implements_trait,
+                        false
+                    );
+                }
             }
         }
 
@@ -1903,7 +1905,9 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
 
         if_chain! {
             if let TraitItemKind::Fn(ref sig, _) = item.kind;
+            if sig.decl.implicit_self.has_implicit_self();
             if let Some(first_arg_ty) = sig.decl.inputs.iter().next();
+
             then {
                 let first_arg_span = first_arg_ty.span;
                 let first_arg_ty = hir_ty_to_ty(cx.tcx, first_arg_ty);

--- a/tests/ui/wrong_self_convention2.rs
+++ b/tests/ui/wrong_self_convention2.rs
@@ -42,3 +42,26 @@ mod issue7032 {
         }
     }
 }
+
+mod issue7179 {
+    pub struct S(i32);
+
+    impl S {
+        // don't trigger (`s` is not `self`)
+        pub fn from_be(s: Self) -> Self {
+            S(i32::from_be(s.0))
+        }
+
+        // lint
+        pub fn from_be_self(self) -> Self {
+            S(i32::from_be(self.0))
+        }
+    }
+
+    trait T {
+        // don't trigger (`s` is not `self`)
+        fn from_be(s: Self) -> Self;
+        // lint
+        fn from_be_self(self) -> Self;
+    }
+}

--- a/tests/ui/wrong_self_convention2.stderr
+++ b/tests/ui/wrong_self_convention2.stderr
@@ -1,0 +1,19 @@
+error: methods called `from_*` usually take no `self`
+  --> $DIR/wrong_self_convention2.rs:56:29
+   |
+LL |         pub fn from_be_self(self) -> Self {
+   |                             ^^^^
+   |
+   = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
+   = help: consider choosing a less ambiguous name
+
+error: methods called `from_*` usually take no `self`
+  --> $DIR/wrong_self_convention2.rs:65:25
+   |
+LL |         fn from_be_self(self) -> Self;
+   |                         ^^^^
+   |
+   = help: consider choosing a less ambiguous name
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Lint [`wrong_self_convention`] only if the impl or trait has `self` _per sé_.

Fixes: #7179 

changelog: trigger [`wrong_self_convention`] only if it has implicit self
