### PR TITLE
Add `cargo collect-metadata` as an cargo alias for the metadata collection lint

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,6 +2,7 @@
 uitest = "test --test compile-test"
 dev = "run --target-dir clippy_dev/target --package clippy_dev --bin clippy_dev --manifest-path clippy_dev/Cargo.toml --"
 lintcheck = "run --target-dir lintcheck/target --package lintcheck --bin lintcheck --manifest-path lintcheck/Cargo.toml  -- "
+collect-metadata = "test --test dogfood --features metadata-collector-lint -- run_metadata_collection_lint --ignored"
 
 [build]
 rustflags = ["-Zunstable-options"]


### PR DESCRIPTION
This PR adds a new alias to run the metadata collection monster on `clippy_lints`. I'm currently using it to create the `metadata_collection.json` file and I plan to use it in the `deply.sh` script. Having it as a new alias enables us to simply use:

```sh
cargo collect-metadata
```

It sometimes requires running `cargo clean` before collecting the metadata due to caching. I'm still debating if I should include a cargo clean as part of the `run_metadata_collection_lint` test or not. Input on this would be greatly appreciated :upside_down_face: 

That's it, just a small change that can be reviewed and merged in parallel to #7214. 

---

See: #7172 for the full metadata collection to-do list or to suggest a new feature in connection to it.

---

changelog: none

r? @flip1995 btw. feel free to pass these PRs one to other team members as well if you want. 
