### PR TITLE
similar_names: No longer suggest inserting or appending an underscore

### DIFF
--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -217,7 +217,6 @@ impl<'a, 'tcx, 'b> SimilarNamesNameVisitor<'a, 'tcx, 'b> {
             if allowed_to_be_similar(&interned_name, existing_name.exemptions) {
                 continue;
             }
-            let mut split_at = None;
             match existing_name.len.cmp(&count) {
                 Ordering::Greater => {
                     if existing_name.len - count != 1
@@ -268,7 +267,6 @@ impl<'a, 'tcx, 'b> SimilarNamesNameVisitor<'a, 'tcx, 'b> {
                                 // or too many chars differ (foo_x, boo_y) or (foox, booy)
                                 continue;
                             }
-                            split_at = interned_name.char_indices().rev().next().map(|(i, _)| i);
                         }
                     } else {
                         let second_i = interned_chars.next().expect("we know we have at least two chars");
@@ -281,7 +279,6 @@ impl<'a, 'tcx, 'b> SimilarNamesNameVisitor<'a, 'tcx, 'b> {
                             // or too many chars differ (x_foo, y_boo) or (xfoo, yboo)
                             continue;
                         }
-                        split_at = interned_name.chars().next().map(char::len_utf8);
                     }
                 },
             }
@@ -292,17 +289,6 @@ impl<'a, 'tcx, 'b> SimilarNamesNameVisitor<'a, 'tcx, 'b> {
                 "binding's name is too similar to existing binding",
                 |diag| {
                     diag.span_note(existing_name.span, "existing binding defined here");
-                    if let Some(split) = split_at {
-                        diag.span_help(
-                            ident.span,
-                            &format!(
-                                "separate the discriminating character by an \
-                                 underscore like: `{}_{}`",
-                                &interned_name[..split],
-                                &interned_name[split..]
-                            ),
-                        );
-                    }
                 },
             );
             return;

--- a/tests/ui/similar_names.stderr
+++ b/tests/ui/similar_names.stderr
@@ -10,11 +10,6 @@ note: existing binding defined here
    |
 LL |     let apple: i32;
    |         ^^^^^
-help: separate the discriminating character by an underscore like: `b_pple`
-  --> $DIR/similar_names.rs:15:9
-   |
-LL |     let bpple: i32;
-   |         ^^^^^
 
 error: binding's name is too similar to existing binding
   --> $DIR/similar_names.rs:17:9
@@ -27,11 +22,6 @@ note: existing binding defined here
    |
 LL |     let apple: i32;
    |         ^^^^^
-help: separate the discriminating character by an underscore like: `c_pple`
-  --> $DIR/similar_names.rs:17:9
-   |
-LL |     let cpple: i32;
-   |         ^^^^^
 
 error: binding's name is too similar to existing binding
   --> $DIR/similar_names.rs:41:9
@@ -43,11 +33,6 @@ note: existing binding defined here
   --> $DIR/similar_names.rs:40:9
    |
 LL |     let blubx: i32;
-   |         ^^^^^
-help: separate the discriminating character by an underscore like: `blub_y`
-  --> $DIR/similar_names.rs:41:9
-   |
-LL |     let bluby: i32;
    |         ^^^^^
 
 error: binding's name is too similar to existing binding
@@ -84,11 +69,6 @@ note: existing binding defined here
   --> $DIR/similar_names.rs:65:9
    |
 LL |     let parser: i32;
-   |         ^^^^^^
-help: separate the discriminating character by an underscore like: `parse_e`
-  --> $DIR/similar_names.rs:67:9
-   |
-LL |     let parsee: i32;
    |         ^^^^^^
 
 error: binding's name is too similar to existing binding


### PR DESCRIPTION
changelog: [`similar_names`] lint no longer suggests to insert or add an underscore to "fix" too similar names

