### PR TITLE
Add sized trait for `wrong_self_convention` lint test

### DIFF
--- a/tests/ui/wrong_self_convention2.rs
+++ b/tests/ui/wrong_self_convention2.rs
@@ -64,4 +64,8 @@ mod issue7179 {
         // lint
         fn from_be_self(self) -> Self;
     }
+
+    trait Foo: Sized {
+        fn as_byte_slice(slice: &[Self]) -> &[u8];
+    }
 }


### PR DESCRIPTION
This has been solved a few hours ago by #7215 😉 

Fixes: #7219 

changelog: none