### PR TITLE
Adding a dev website path for the new `lints.json` format and testing deployment

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -4,11 +4,22 @@ set -ex
 
 echo "Removing the current docs for master"
 rm -rf out/master/ || exit 0
+rm -rf out/dev/ || exit 0
 
 echo "Making the docs for master"
 mkdir out/master/
 cp util/gh-pages/index.html out/master
 python3 ./util/export.py out/master/lints.json
+
+# Feeding the beast
+# This will run in parallel to the current lint list version until everything is fully adapted
+echo "Building dev environment"
+mkdir -p out/dev/
+cp util/gh-pages/dev-index.html out/dev/index.html
+cargo collect-metadata
+# Temporary fix until the old headline syntax will be replaced with the markdown ### syntax
+sed -i -e 's/ \*\*/### /g' -e 's/\*\*/\\n/g' util/gh-pages/metadata_collection.json
+cp util/gh-pages/metadata_collection.json out/dev/lints.json
 
 if [[ -n $TAG_NAME ]]; then
   echo "Save the doc for the current tag ($TAG_NAME) and point stable/ to it"

--- a/util/gh-pages/dev-index.html
+++ b/util/gh-pages/dev-index.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+    <title>ALL the Clippy Lints</title>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/github.min.css"/>
+
+    <!-- The files are not copied over into the Clippy project since they use the MPL-2.0 License -->
+    <link rel="stylesheet" href="https://rust-lang.github.io/mdBook/css/variables.css"/>
+    <link id="styleHighlight" rel="stylesheet" href="https://rust-lang.github.io/mdBook/highlight.css">
+    <link id="styleNight" rel="stylesheet" href="https://rust-lang.github.io/mdBook/tomorrow-night.css" disabled="true">
+    <link id="styleAyu" rel="stylesheet" href="https://rust-lang.github.io/mdBook/ayu-highlight.css" disabled="true">
+    <style>
+        blockquote { font-size: 1em; }
+        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak { display: none !important; }
+
+        .form-inline .checkbox { margin-right: 0.6em }
+
+        .panel-heading { cursor: pointer; }
+
+        .panel-title { display: flex; }
+        .panel-title .label { display: inline-block; }
+
+        .panel-title-name { flex: 1; }
+        .panel-title-name span { vertical-align: bottom; }
+
+        .panel .panel-title-name .anchor { display: none; }
+        .panel:hover .panel-title-name .anchor { display: inline;}
+
+    </style>
+    <style>
+        /* Expanding the mdBoom theme*/
+        .light {
+            --inline-code-bg: #f6f7f6;
+        }
+        .rust {
+            --inline-code-bg: #f6f7f6;
+        }
+        .coal {
+            --inline-code-bg: #1d1f21;
+        }
+        .navy {
+            --inline-code-bg: #1d1f21;
+        }
+        .ayu {
+            --inline-code-bg: #191f26;
+        }
+
+        /* Applying the mdBook theme */
+        .theme-icon {
+            position: absolute;
+            text-align: center;
+            width: 2em;
+            height: 2em;
+            margin: 0.7em;
+            line-height: 2em;
+            border: solid 1px var(--icons);
+            border-radius: 5px;
+            user-select: none;
+            cursor: pointer;
+        }
+        .theme-icon:hover {
+            background: var(--theme-hover);
+        }
+        .theme-choice {
+            position: absolute;
+            margin-top: calc(2em + 0.7em);
+            margin-left: 0.7em;
+            list-style: none;
+            border: 1px solid var(--theme-popup-border);
+            border-radius: 5px;
+            color: var(--fg);
+            background: var(--theme-popup-bg);
+            padding: 0 0;
+        }
+        .theme-choice > li {
+            padding: 5px 10px;
+            font-size: 0.8em;
+            user-select: none;
+            cursor: pointer;
+        }
+        .theme-choice > li:hover {
+            background: var(--theme-hover);
+        }
+
+        .alert {
+            color: var(--fg);
+            background: var(--theme-hover);
+            border: 1px solid var(--theme-popup-border);
+        }
+        .page-header {
+            border-color: var(--theme-popup-border);
+        }
+        .panel-default > .panel-heading {
+            background: var(--theme-hover);
+            color: var(--fg);
+            border: 1px solid var(--theme-popup-border);
+        }
+        .panel-default > .panel-heading:hover {
+            filter: brightness(90%);
+        }
+        .list-group-item {
+            background: 0%;
+            border: 1px solid var(--theme-popup-border);
+        }
+        .panel, pre, hr {
+            background: var(--bg);
+            border: 1px solid var(--theme-popup-border);
+        }
+
+        #filter-label, #filter-clear {
+            background: var(--searchbar-bg);
+            color: var(--searchbar-fg);
+            border-color: var(--theme-popup-border);
+            filter: brightness(95%);
+        }
+        #filter-label:hover, #filter-clear:hover {
+            filter: brightness(90%);
+        }
+        #filter-input {
+            background: var(--searchbar-bg);
+            color: var(--searchbar-fg);
+            border-color: var(--theme-popup-border);
+        }
+
+        #filter-input::-webkit-input-placeholder,
+        #filter-input::-moz-placeholder {
+            color: var(--searchbar-fg);
+            opacity: 30%;
+        }
+
+        :not(pre) > code {
+            color: var(--inline-code-color);
+            background-color: var(--inline-code-bg);
+        }
+        html {
+            scrollbar-color: var(--scrollbar) var(--bg);
+        }
+        body {
+            background: var(--bg);
+            color: var(--fg);
+        }
+
+    </style>
+</head>
+<body>
+    <div id="theme-icon" class="theme-icon">&#128396;</div>
+    <ul id="theme-menu" class="theme-choice" style="display: none;">
+        <li id="light">Light</li>
+        <li id="rust">Rust</li>
+        <li id="coal">Coal</li>
+        <li id="navy">Navy</li>
+        <li id="ayu">Ayu</li>
+    </ul>
+
+    <div class="container" ng-app="clippy" ng-controller="lintList">
+        <div class="page-header">
+            <h1>ALL the Clippy Lints</h1>
+        </div>
+
+        <noscript>
+            <div class="alert alert-danger" role="alert">
+                Sorry, this site only works with JavaScript! :(
+            </div>
+        </noscript>
+
+        <div ng-cloak>
+
+            <div class="alert alert-info" role="alert" ng-if="loading">
+                Loading&#x2026;
+            </div>
+            <div class="alert alert-danger" role="alert" ng-if="error">
+                Error loading lints!
+            </div>
+
+            <div class="panel panel-default" ng-show="data">
+                <div class="panel-body row filter-panel">
+                    <div class="col-md-6 form-inline">
+                        <div class="form-group form-group-lg">
+                            <p class="h4">Lint levels</p>
+                            <div class="checkbox" ng-repeat="(level, enabled) in levels">
+                                <label>
+                                    <input type="checkbox" ng-model="levels[level]" />
+                                    {{level}}
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-6 form-inline">
+                        <div class="form-group form-group-lg">
+                            <p class="h4">Lint groups</p>
+                            <div class="checkbox" ng-repeat="(group, enabled) in groups">
+                                <label class="text-capitalize">
+                                    <input type="checkbox" ng-model="groups[group]" />
+                                    {{group}}
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="panel-body row">
+                    <div class="col-md-12 form-horizontal">
+                        <div class="input-group">
+                            <label class="input-group-addon" id="filter-label" for="filter-input">Filter:</label>
+                            <input type="text" class="form-control" placeholder="Keywords or search string" id="filter-input" ng-model="search" ng-model-options="{debounce: 50}"/>
+                            <span class="input-group-btn">
+                                <button id="filter-clear" class="btn" type="button" ng-click="search = ''">
+                                    Clear
+                                </button>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <article class="panel panel-default" id="{{lint.id}}"
+                ng-repeat="lint in data | filter:byLevels | filter:byGroups | filter:bySearch | orderBy:'id' track by lint.id">
+                <header class="panel-heading" ng-click="open[lint.id] = !open[lint.id]">
+                    <h2 class="panel-title">
+                        <div class="panel-title-name">
+                            <span>{{lint.id}}</span>
+                            <a href="#{{lint.id}}" class="anchor label label-default" ng-click="open[lint.id] = true; $event.stopPropagation()">&para;</a>
+                        </div>
+
+                        <div class="panel-title-addons">
+                            <span class="label label-default text-capitalize">{{lint.group}}</span>
+
+                            <span ng-if="lint.level == 'Allow'" class="label label-success">Allow</span>
+                            <span ng-if="lint.level == 'Warn'" class="label label-warning">Warn</span>
+                            <span ng-if="lint.level == 'Deny'" class="label label-danger">Deny</span>
+                            <span ng-if="lint.level == 'Deprecated'" class="label label-default">Deprecated</span>
+
+                            <button class="btn btn-default btn-xs">
+                                <span ng-show="open[lint.id]">&minus;</span>
+                                <span ng-hide="open[lint.id]">&plus;</span>
+                            </button>
+                        </div>
+                    </h2>
+                </header>
+
+                <ul class="list-group lint-docs" ng-if="lint.docs" ng-class="{collapse: true, in: open[lint.id]}">
+                    <li class="list-group-item" ng-repeat="(title, text) in lint.docs">
+                        <h4 class="list-group-item-heading">
+                            {{title}}
+                        </h4>
+                        <div class="list-group-item-text" ng-bind-html="text | markdown"></div>
+                        <a ng-if="title == 'Known problems'" href="https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+is%3Aopen+{{lint.id}}">Search on GitHub</a>
+                    </li>
+                </ul>
+            </article>
+        </div>
+    </div>
+
+    <a href="https://github.com/rust-lang/rust-clippy">
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on Github"/>
+    </a>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/7.0.0/markdown-it.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/languages/rust.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.12/angular.min.js"></script>
+    <script>
+    (function () {
+        var md = window.markdownit({
+            html: true,
+            linkify: true,
+            typographer: true,
+            highlight: function (str, lang) {
+                if (lang && hljs.getLanguage(lang)) {
+                    try {
+                        return '<pre class="hljs"><code>' +
+                            hljs.highlight(lang, str, true).value +
+                            '</code></pre>';
+                    } catch (__) {}
+                }
+
+                return '<pre class="hljs"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
+            }
+        });
+
+        function scrollToLint(lintId) {
+            var target = document.getElementById(lintId);
+            if (!target) {
+                return;
+            }
+            target.scrollIntoView();
+        }
+
+        function scrollToLintByURL($scope) {
+            var removeListener = $scope.$on('ngRepeatFinished', function(ngRepeatFinishedEvent) {
+                scrollToLint(window.location.hash.slice(1));
+                removeListener();
+            });
+        }
+
+        function selectGroup($scope, selectedGroup) {
+            var groups = $scope.groups;
+            for (var group in groups) {
+                if (groups.hasOwnProperty(group)) {
+                    if (group === selectedGroup) {
+                        groups[group] = true;
+                    } else {
+                        groups[group] = false;
+                    }
+                }
+            }
+        }
+
+        function searchLint(lint, term) {
+            for (const field in lint.docs) {
+                // Continue if it's not a property
+                if (!lint.docs.hasOwnProperty(field)) {
+                    continue;
+                }
+
+                // Return if not found
+                if (lint.docs[field].toLowerCase().indexOf(term) !== -1) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        angular.module("clippy", [])
+        .filter('markdown', function ($sce) {
+            return function (text) {
+                return $sce.trustAsHtml(
+                    md.render(text || '')
+                    // Oh deer, what a hack :O
+                    .replace('<table', '<table class="table"')
+                );
+            };
+        })
+        .directive('onFinishRender', function ($timeout) {
+            return {
+                restrict: 'A',
+                link: function (scope, element, attr) {
+                    if (scope.$last === true) {
+                        $timeout(function () {
+                            scope.$emit(attr.onFinishRender);
+                        });
+                    }
+                }
+            };
+        })
+        .controller("lintList", function ($scope, $http, $timeout) {
+            // Level filter
+            var LEVEL_FILTERS_DEFAULT = {Allow: true, Warn: true, Deny: true, Deprecated: true};
+            $scope.levels = LEVEL_FILTERS_DEFAULT;
+            $scope.byLevels = function (lint) {
+                return $scope.levels[lint.level];
+            };
+
+            $scope.groups = {};
+            $scope.byGroups = function (lint) {
+                return $scope.groups[lint.group];
+            };
+
+            $scope.bySearch = function (lint, index, array) {
+                let searchStr = $scope.search;
+                // It can be `null` I haven't missed this value 
+                if (searchStr == null || searchStr.length < 3) {
+                    return true;
+                }
+                searchStr = searchStr.toLowerCase();
+
+                // Search by id
+                if (lint.id.indexOf(searchStr.replace("-", "_")) !== -1) {
+                    return true;
+                }
+
+                // Search the description
+                // The use of `for`-loops instead of `foreach` enables us to return early 
+                let terms = searchStr.split(" ");
+                for (index = 0; index < terms.length; index++) {
+                    if (lint.id.indexOf(terms[index]) !== -1) {
+                        continue;
+                    }
+
+                    if (searchLint(lint, terms[index])) {
+                        continue;
+                    }
+
+                    return false;
+                }
+
+                return true;
+            }
+
+            // Get data
+            $scope.open = {};
+            $scope.loading = true;
+
+            if (window.location.hash.length > 1) {
+                $scope.search = window.location.hash.slice(1);
+                $scope.open[window.location.hash.slice(1)] = true;
+                scrollToLintByURL($scope);
+            }
+
+            $http.get('./lints.json')
+            .success(function (data) {
+                $scope.data = data;
+                $scope.loading = false;
+
+                // Initialize lint groups (the same structure is also used to enable filtering)
+                $scope.groups = data.reduce(function (result, val) {
+                    result[val.group] = true;
+                    return result;
+                }, {});
+
+                var selectedGroup = getQueryVariable("sel");
+                if (selectedGroup) {
+                    selectGroup($scope, selectedGroup.toLowerCase());
+                }
+
+                scrollToLintByURL($scope);
+            })
+            .error(function (data) {
+                $scope.error = data;
+                $scope.loading = false;
+            });
+
+            window.addEventListener('hashchange', function () {
+                // trigger re-render
+                $timeout(function () {
+                    $scope.levels = LEVEL_FILTERS_DEFAULT;
+                    $scope.search = window.location.hash.slice(1);
+                    $scope.open[window.location.hash.slice(1)] = true;
+
+                    scrollToLintByURL($scope);
+                });
+                return true;
+            }, false);
+        });
+    })();
+
+    function getQueryVariable(variable) {
+        var query = window.location.search.substring(1);
+        var vars = query.split('&');
+        for (var i = 0; i < vars.length; i++) {
+            var pair = vars[i].split('=');
+            if (decodeURIComponent(pair[0]) == variable) {
+                return decodeURIComponent(pair[1]);
+            }
+        }
+    }
+
+    function setupListeners() {
+        let themeIcon = document.getElementById("theme-icon");
+        let themeMenu = document.getElementById("theme-menu");
+        themeIcon.addEventListener("click", function(e) {
+            if (themeMenu.style.display == "none") {
+                themeMenu.style.display = "block";
+            } else {
+                themeMenu.style.display = "none";
+            }
+        });
+
+        let children = themeMenu.children;
+        for (let index = 0; index < children.length; index++) {
+            let child = children[index]; 
+            child.addEventListener("click", function(e) {
+                setTheme(child.id, true);
+            });
+        }
+    }
+
+    setupListeners();
+
+    function setTheme(theme, store) {
+        let enableHighlight = false;
+        let enableNight = false;
+        let enableAyu = false;
+        
+        if (theme == "ayu") {
+            enableAyu = true;
+        } else if (theme == "coal" || theme == "navy") {
+            enableNight = true;
+        } else if (theme == "rust") {
+            enableHighlight = true;
+        } else {
+            enableHighlight = true;
+            // this makes sure that an unknown theme request gets set to a known one
+            theme = "light";
+        }
+        document.getElementsByTagName("body")[0].className = theme;
+
+        document.getElementById("styleHighlight").disabled = !enableHighlight;
+        document.getElementById("styleNight").disabled = !enableNight;
+        document.getElementById("styleAyu").disabled = !enableAyu;
+
+        if (store) {
+            try {
+                localStorage.setItem('clippy-lint-list-theme', theme);
+            } catch (e) { }
+        }
+    }
+
+    // loading the theme after the initial load
+    setTheme(localStorage.getItem('clippy-lint-list-theme'), false);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
A new PR to feed the beast. This one simply added a new dev path to *GitHub Pages* and automatically deploys the new `dev-index.html` as well as a `lints.json` file along it. The `lints.json` file for the dev environment will be created using our new metadata collection (monster).

The dev website is currently fairly broken and with that I mean: *It doesn't display any lints at all*. This is on purpose as this PR only aims to create the basic setup to make future reviews simpler. The adapting to the new `lints.json` format will be done on the `dev-index.html` to allow a preview while not impacting our main lint list.

The changes are split into two commits which will probably help with the review as the `dev-index.html` is just a straight copy from `index.html` and doesn't have to be reviewed.

This is also a test to see if the new deploy script works in the CI environment, It works locally so I have high hopes ^^

---

See: #7172 for the full metadata collection to-do list or to suggest a new feature in connection to it :upside_down_face: 

---

changelog: none

r? @flip1995

This is the last branch I had in my backlog. The next one will take some time again xD.