### PR TITLE
Fix a `manual_unwrap_or` FP with deref coercion

### DIFF
--- a/tests/ui/manual_unwrap_or.fixed
+++ b/tests/ui/manual_unwrap_or.fixed
@@ -163,4 +163,12 @@ mod issue6965 {
     }
 }
 
+use std::rc::Rc;
+fn format_name(name: Option<&Rc<str>>) -> &str {
+    match name {
+        None => "<anon>",
+        Some(name) => name,
+    }
+}
+
 fn main() {}

--- a/tests/ui/manual_unwrap_or.rs
+++ b/tests/ui/manual_unwrap_or.rs
@@ -205,4 +205,12 @@ mod issue6965 {
     }
 }
 
+use std::rc::Rc;
+fn format_name(name: Option<&Rc<str>>) -> &str {
+    match name {
+        None => "<anon>",
+        Some(name) => name,
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust-clippy/issues/7228.

changelog: Fix a [`manual_unwrap_or`] FP with deref coercion
