### PR TITLE
CI: update rustup before installing the toolchain on windows

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -90,6 +90,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2.3.3
 
+    # FIXME: should not be necessary once 1.24.2 is the default version on the windows runner
+    - name: Update rustup
+      run: rustup self update
+      if: runner.os == 'Windows'
+
     - name: Install toolchain
       run: rustup show active-toolchain
 


### PR DESCRIPTION
Ok, fine windows, if this is what you want, take it...

r? @ghost

changelog: none
