### PR TITLE
Deny warnings in every main sub-crate 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rustc-workspace-hack = "1.0.0"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util" }
 
 [features]
-deny-warnings = []
+deny-warnings = ["clippy_lints/deny-warnings"]
 integration = ["tempfile"]
 internal-lints = ["clippy_lints/internal-lints"]
 metadata-collector-lint = ["internal-lints", "clippy_lints/metadata-collector-lint"]

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -1,5 +1,7 @@
-#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![feature(once_cell)]
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
+// warn on lints, that are included in `rust-lang/rust`s bootstrap
+#![warn(rust_2018_idioms, unused_lifetimes)]
 
 use itertools::Itertools;
 use regex::Regex;

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
+// warn on lints, that are included in `rust-lang/rust`s bootstrap
+#![warn(rust_2018_idioms, unused_lifetimes)]
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use clippy_dev::{bless, fmt, ide_setup, new_lint, serve, stderr_length_check, update_lints};

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -30,7 +30,7 @@ rustc-semver = "1.1.0"
 url = { version = "2.1.0", features = ["serde"] }
 
 [features]
-deny-warnings = []
+deny-warnings = ["clippy_utils/deny-warnings"]
 # build clippy with internal lints enabled, off by default
 internal-lints = ["clippy_utils/internal-lints"]
 metadata-collector-lint = ["serde_json", "clippy_utils/metadata-collector-lint"]

--- a/clippy_utils/Cargo.toml
+++ b/clippy_utils/Cargo.toml
@@ -14,6 +14,7 @@ unicode-normalization = "0.1"
 rustc-semver="1.1.0"
 
 [features]
+deny-warnings = []
 internal-lints = []
 metadata-collector-lint = []
 

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -3,7 +3,14 @@
 #![feature(iter_zip)]
 #![feature(rustc_private)]
 #![recursion_limit = "512"]
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::must_use_candidate)]
+// warn on the same lints as `clippy_lints`
+#![warn(trivial_casts, trivial_numeric_casts)]
+// warn on lints, that are included in `rust-lang/rust`s bootstrap
+#![warn(rust_2018_idioms, unused_lifetimes)]
+// warn on rustc internal lints
+#![warn(rustc::internal)]
 
 // FIXME: switch to something more ergonomic here, once available.
 // (Currently there is no way to opt into sysroot crates without `extern crate`.)

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -20,7 +20,6 @@ extern crate rustc_attr;
 extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hir;
-extern crate rustc_hir_pretty;
 extern crate rustc_infer;
 extern crate rustc_lexer;
 extern crate rustc_lint;
@@ -1333,7 +1332,7 @@ pub fn if_sequence<'tcx>(mut expr: &'tcx Expr<'tcx>) -> (Vec<&'tcx Expr<'tcx>>, 
 }
 
 /// Checks if the given function kind is an async function.
-pub fn is_async_fn(kind: FnKind) -> bool {
+pub fn is_async_fn(kind: FnKind<'_>) -> bool {
     matches!(kind, FnKind::ItemFn(_, _, header, _) if header.asyncness == IsAsync::Async)
 }
 

--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -2,9 +2,8 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use std::collections::HashMap;
-
 use rustc_ast::ast::Mutability;
+use rustc_data_structures::fx::FxHashMap;
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{TyKind, Unsafety};
@@ -184,14 +183,14 @@ pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
 /// Checks if `Ty` is normalizable. This function is useful
 /// to avoid crashes on `layout_of`.
 pub fn is_normalizable<'tcx>(cx: &LateContext<'tcx>, param_env: ty::ParamEnv<'tcx>, ty: Ty<'tcx>) -> bool {
-    is_normalizable_helper(cx, param_env, ty, &mut HashMap::new())
+    is_normalizable_helper(cx, param_env, ty, &mut FxHashMap::default())
 }
 
 fn is_normalizable_helper<'tcx>(
     cx: &LateContext<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     ty: Ty<'tcx>,
-    cache: &mut HashMap<Ty<'tcx>, bool>,
+    cache: &mut FxHashMap<Ty<'tcx>, bool>,
 ) -> bool {
     if let Some(&cached_result) = cache.get(ty) {
         return cached_result;


### PR DESCRIPTION
Pointed out by @xFrednet in https://github.com/rust-lang/rust-clippy/pull/7229#issuecomment-842978909

This enables the same (rustc) lints in every main sub-crate:

- `clippy`
- `clippy_lints`
- `clippy_utils`
- `clippy_dev`

In addition it forwards the `deny-warnings` feature to those sub-crates, so we don't miss warnings that then become a problem during sync. (I wanted to fix that before, but forgot about it, so thanks for pointing it out @xFrednet!)

changelog: none
