### PR TITLE
Fix ICE in `implicit_return`

### DIFF
--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -147,7 +147,11 @@ fn lint_implicit_returns(
             visit_break_exprs(block, |break_expr, dest, sub_expr| {
                 if dest.target_id.ok() == Some(expr.hir_id) {
                     if call_site_span.is_none() && break_expr.span.ctxt() == ctxt {
-                        lint_break(cx, break_expr.span, sub_expr.unwrap().span);
+                        // At this point sub_expr can be `None` in async functions which either diverge, or return the
+                        // unit type.
+                        if let Some(sub_expr) = sub_expr {
+                            lint_break(cx, break_expr.span, sub_expr.span);
+                        }
                     } else {
                         // the break expression is from a macro call, add a return to the loop
                         add_return = true;

--- a/tests/ui/crashes/ice-7231.rs
+++ b/tests/ui/crashes/ice-7231.rs
@@ -1,0 +1,10 @@
+// edition:2018
+#![allow(clippy::never_loop)]
+
+async fn f() {
+    loop {
+        break;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
fixes: #7231

changelog: Fix ICE in `implicit_return` for async functions
