### PR TITLE
Adding the default lint level to the metadata collection

### DIFF
--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -49,7 +49,7 @@ const DEPRECATED_LINT_LEVEL: &str = "none";
 const DEFAULT_LINT_LEVELS: [(&str, &str); 8] = [
     ("correctness", "deny"),
     ("restriction", "allow"),
-    ("style", "warm"),
+    ("style", "warn"),
     ("pedantic", "allow"),
     ("complexity", "warn"),
     ("perf", "warn"),


### PR DESCRIPTION
I noticed while working on the website adaption that the lint groups still had the `clippy::` prefix in the JSON output. This PR removes this prefix and adds a `level` field to each lint and with that simplifies the website display and saves performance.

The deprecated lints get are assigned to the level `none`. This is a bit different in comparison to the current lint list, but I believe that this will look better overall. Unless there is any argument against this :).

That's it just a small baby PR in comparison to the original monster ^^

---

See: #7172 for the full metadata collection to-do list or to suggest a new feature in connection to it.

---

changelog: none

r? @flip1995