### PR TITLE
Adding the ability to invalidate caches to force metadata collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ derive-new = "0.5"
 regex = "1.4"
 quote = "1"
 syn = { version = "1", features = ["full"] }
+# This is used by the `collect-metadata` alias.
+filetime = "0.2"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`


### PR DESCRIPTION
This adds the discussed hack to touch `clippy_lints/src/lib.rs` to invalidate cargos cache and force metadata collection. I've decided to use the [`filetime`](https://github.com/alexcrichton/filetime) crate instead of the touch command to make is cross-platform and just cleaner in general. Looking at the maintainers I would say that it's a save crate to use xD.

---

cc: #7172 I know this ID without looking it up now... This is not good

changelog: none

r? @flip1995 