### PR TITLE
Revert "CI: update rustup before installing the toolchain on windows"

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -90,11 +90,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2.3.3
 
-    # FIXME: should not be necessary once 1.24.2 is the default version on the windows runner
-    - name: Update rustup
-      run: rustup self update
-      if: runner.os == 'Windows'
-
     - name: Install toolchain
       run: rustup show active-toolchain
 


### PR DESCRIPTION
This reverts commit 716d03f86bc9d72e56c2d803fd76ff44f29c9b3a.

This is no longer necessary, since rustup 1.24.2 is now the default
version on the windows runner.

changelog: none
