### PR TITLE
Don't warn about `cfg!(..)` as a constant in assertions

### DIFF
--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -28,4 +28,7 @@ fn main() {
     debug_assert!(false); // #3948
     assert_const!(3);
     assert_const!(-1);
+
+    // Don't lint on this:
+    assert!(cfg!(feature = "hey") || cfg!(not(feature = "asdf")));
 }


### PR DESCRIPTION
This makes clippy understand that `cfg!(..)` is not just a hardcoded `true` or `false` (even though it expands to one of those).

cc @khyperia

changelog: Don't treat `cfg!(..)` as a constant in [`assertions-on-constants`]