### PR TITLE
Add FreeBSD as identifier not needing ticks

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -149,7 +149,7 @@ define_Conf! {
         "WebGL",
         "TensorFlow",
         "TrueType",
-        "iOS", "macOS",
+        "iOS", "macOS", "FreeBSD",
         "TeX", "LaTeX", "BibTeX", "BibLaTeX",
         "MinGW",
         "CamelCase",

--- a/tests/ui/doc.rs
+++ b/tests/ui/doc.rs
@@ -64,7 +64,7 @@ fn test_units() {
 /// WebGL
 /// TensorFlow
 /// TrueType
-/// iOS macOS
+/// iOS macOS FreeBSD
 /// TeX LaTeX BibTeX BibLaTeX
 /// MinGW
 /// CamelCase (see also #2395)


### PR DESCRIPTION
For the doc-markdown lint.

changelog: Add FreeBSD as identifier not needing ticks for ``[`doc-markdown`]`` lint.