### PR TITLE
Re-write shadow lints

### DIFF
--- a/clippy_lints/src/lib.register_pedantic.rs
+++ b/clippy_lints/src/lib.register_pedantic.rs
@@ -81,7 +81,6 @@ store.register_group(true, "clippy::pedantic", Some("clippy_pedantic"), vec![
     LintId::of(redundant_else::REDUNDANT_ELSE),
     LintId::of(ref_option_ref::REF_OPTION_REF),
     LintId::of(semicolon_if_nothing_returned::SEMICOLON_IF_NOTHING_RETURNED),
-    LintId::of(shadow::SHADOW_UNRELATED),
     LintId::of(strings::STRING_ADD_ASSIGN),
     LintId::of(trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS),
     LintId::of(trait_bounds::TYPE_REPETITION_IN_BOUNDS),

--- a/clippy_lints/src/lib.register_restriction.rs
+++ b/clippy_lints/src/lib.register_restriction.rs
@@ -50,6 +50,7 @@ store.register_group(true, "clippy::restriction", Some("clippy_restriction"), ve
     LintId::of(same_name_method::SAME_NAME_METHOD),
     LintId::of(shadow::SHADOW_REUSE),
     LintId::of(shadow::SHADOW_SAME),
+    LintId::of(shadow::SHADOW_UNRELATED),
     LintId::of(strings::STRING_ADD),
     LintId::of(strings::STRING_TO_STRING),
     LintId::of(strings::STR_TO_STRING),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -324,7 +324,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| Box::new(same_name_method::SameNameMethod));
     store.register_late_pass(|| Box::new(map_clone::MapClone));
     store.register_late_pass(|| Box::new(map_err_ignore::MapErrIgnore));
-    store.register_late_pass(|| Box::new(shadow::Shadow));
+    store.register_late_pass(|| Box::new(shadow::Shadow::default()));
     store.register_late_pass(|| Box::new(unit_types::UnitTypes));
     store.register_late_pass(|| Box::new(loops::Loops));
     store.register_late_pass(|| Box::new(main_recursion::MainRecursion::default()));

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -1,17 +1,14 @@
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::span_lint_and_note;
 use clippy_utils::source::snippet;
-use clippy_utils::{contains_name, higher, iter_input_pats};
-use rustc_hir::intravisit::FnKind;
-use rustc_hir::{
-    Block, Body, Expr, ExprKind, FnDecl, Guard, HirId, Local, MutTy, Pat, PatKind, Path, QPath, StmtKind, Ty, TyKind,
-    UnOp,
-};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_middle::lint::in_external_macro;
-use rustc_middle::ty;
-use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::source_map::Span;
-use rustc_span::symbol::Symbol;
+use clippy_utils::visitors::is_local_used;
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def::Res;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::hir_id::ItemLocalId;
+use rustc_hir::{Block, Body, BodyOwnerKind, Expr, ExprKind, HirId, Node, Pat, PatKind, QPath, UnOp};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::{Span, Symbol};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -22,10 +19,6 @@ declare_clippy_lint! {
     /// Not much, in fact it's a very common pattern in Rust
     /// code. Still, some may opt to avoid it in their code base, they can set this
     /// lint to `Warn`.
-    ///
-    /// ### Known problems
-    /// This lint, as the other shadowing related lints,
-    /// currently only catches very simple patterns.
     ///
     /// ### Example
     /// ```rust
@@ -51,10 +44,6 @@ declare_clippy_lint! {
     /// code. Still, some argue that name shadowing like this hurts readability,
     /// because a value may be bound to different things depending on position in
     /// the code.
-    ///
-    /// ### Known problems
-    /// This lint, as the other shadowing related lints,
-    /// currently only catches very simple patterns.
     ///
     /// ### Example
     /// ```rust
@@ -83,12 +72,6 @@ declare_clippy_lint! {
     /// any place in the code. This can be alleviated by either giving more specific
     /// names to bindings or introducing more scopes to contain the bindings.
     ///
-    /// ### Known problems
-    /// This lint, as the other shadowing related lints,
-    /// currently only catches very simple patterns. Note that
-    /// `allow`/`warn`/`deny`/`forbid` attributes only work on the function level
-    /// for this lint.
-    ///
     /// ### Example
     /// ```rust
     /// # let y = 1;
@@ -106,301 +89,147 @@ declare_clippy_lint! {
     "rebinding a name without even using the original value"
 }
 
-declare_lint_pass!(Shadow => [SHADOW_SAME, SHADOW_REUSE, SHADOW_UNRELATED]);
+#[derive(Default)]
+pub(crate) struct Shadow {
+    bindings: Vec<FxHashMap<Symbol, Vec<ItemLocalId>>>,
+}
+
+impl_lint_pass!(Shadow => [SHADOW_SAME, SHADOW_REUSE, SHADOW_UNRELATED]);
 
 impl<'tcx> LateLintPass<'tcx> for Shadow {
-    fn check_fn(
-        &mut self,
-        cx: &LateContext<'tcx>,
-        _: FnKind<'tcx>,
-        decl: &'tcx FnDecl<'_>,
-        body: &'tcx Body<'_>,
-        _: Span,
-        _: HirId,
-    ) {
-        if in_external_macro(cx.sess(), body.value.span) {
+    fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>) {
+        let (id, ident) = match pat.kind {
+            PatKind::Binding(_, hir_id, ident, _) => (hir_id, ident),
+            _ => return,
+        };
+        if ident.span.from_expansion() || ident.span.is_dummy() {
             return;
         }
-        check_fn(cx, decl, body);
-    }
-}
+        let HirId { owner, local_id } = id;
 
-fn check_fn<'tcx>(cx: &LateContext<'tcx>, decl: &'tcx FnDecl<'_>, body: &'tcx Body<'_>) {
-    let mut bindings = Vec::with_capacity(decl.inputs.len());
-    for arg in iter_input_pats(decl, body) {
-        if let PatKind::Binding(.., ident, _) = arg.pat.kind {
-            bindings.push((ident.name, ident.span));
+        // get (or insert) the list of items for this owner and symbol
+        let data = self.bindings.last_mut().unwrap();
+        let items_with_name = data.entry(ident.name).or_default();
+
+        // check other bindings with the same name, most recently seen first
+        for &prev in items_with_name.iter().rev() {
+            if prev == local_id {
+                // repeated binding in an `Or` pattern
+                return;
+            }
+
+            if is_shadow(cx, owner, prev, local_id) {
+                let prev_hir_id = HirId { owner, local_id: prev };
+                lint_shadow(cx, pat, prev_hir_id, ident.span);
+                // only lint against the "nearest" shadowed binding
+                break;
+            }
+        }
+        // store the binding
+        items_with_name.push(local_id);
+    }
+
+    fn check_body(&mut self, cx: &LateContext<'_>, body: &Body<'_>) {
+        let hir = cx.tcx.hir();
+        if !matches!(hir.body_owner_kind(hir.body_owner(body.id())), BodyOwnerKind::Closure) {
+            self.bindings.push(FxHashMap::default());
         }
     }
-    check_expr(cx, &body.value, &mut bindings);
-}
 
-fn check_block<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'_>, bindings: &mut Vec<(Symbol, Span)>) {
-    let len = bindings.len();
-    for stmt in block.stmts {
-        match stmt.kind {
-            StmtKind::Local(local) => check_local(cx, local, bindings),
-            StmtKind::Expr(e) | StmtKind::Semi(e) => check_expr(cx, e, bindings),
-            StmtKind::Item(..) => {},
+    fn check_body_post(&mut self, cx: &LateContext<'_>, body: &Body<'_>) {
+        let hir = cx.tcx.hir();
+        if !matches!(hir.body_owner_kind(hir.body_owner(body.id())), BodyOwnerKind::Closure) {
+            self.bindings.pop();
         }
     }
-    if let Some(o) = block.expr {
-        check_expr(cx, o, bindings);
-    }
-    bindings.truncate(len);
 }
 
-fn check_local<'tcx>(cx: &LateContext<'tcx>, local: &'tcx Local<'_>, bindings: &mut Vec<(Symbol, Span)>) {
-    if in_external_macro(cx.sess(), local.span) {
-        return;
-    }
-    if higher::is_from_for_desugar(local) {
-        return;
-    }
-    let Local {
-        pat,
-        ref ty,
-        ref init,
+fn is_shadow(cx: &LateContext<'_>, owner: LocalDefId, first: ItemLocalId, second: ItemLocalId) -> bool {
+    let scope_tree = cx.tcx.region_scope_tree(owner.to_def_id());
+    let first_scope = scope_tree.var_scope(first);
+    let second_scope = scope_tree.var_scope(second);
+    scope_tree.is_subscope_of(second_scope, first_scope)
+}
+
+fn lint_shadow(cx: &LateContext<'_>, pat: &Pat<'_>, shadowed: HirId, span: Span) {
+    let (lint, msg) = match find_init(cx, pat.hir_id) {
+        Some(expr) if is_self_shadow(cx, pat, expr, shadowed) => {
+            let msg = format!(
+                "`{}` is shadowed by itself in `{}`",
+                snippet(cx, pat.span, "_"),
+                snippet(cx, expr.span, "..")
+            );
+            (SHADOW_SAME, msg)
+        },
+        Some(expr) if is_local_used(cx, expr, shadowed) => {
+            let msg = format!(
+                "`{}` is shadowed by `{}` which reuses the original value",
+                snippet(cx, pat.span, "_"),
+                snippet(cx, expr.span, "..")
+            );
+            (SHADOW_REUSE, msg)
+        },
+        _ => {
+            let msg = format!("`{}` shadows a previous, unrelated binding", snippet(cx, pat.span, "_"));
+            (SHADOW_UNRELATED, msg)
+        },
+    };
+    span_lint_and_note(
+        cx,
+        lint,
         span,
-        ..
-    } = *local;
-    if let Some(t) = *ty {
-        check_ty(cx, t, bindings);
-    }
-    if let Some(o) = *init {
-        check_expr(cx, o, bindings);
-        check_pat(cx, pat, Some(o), span, bindings);
-    } else {
-        check_pat(cx, pat, None, span, bindings);
-    }
+        &msg,
+        Some(cx.tcx.hir().span(shadowed)),
+        "previous binding is here",
+    );
 }
 
-fn is_binding(cx: &LateContext<'_>, pat_id: HirId) -> bool {
-    let var_ty = cx.typeck_results().node_type_opt(pat_id);
-    var_ty.map_or(false, |var_ty| !matches!(var_ty.kind(), ty::Adt(..)))
-}
-
-fn check_pat<'tcx>(
-    cx: &LateContext<'tcx>,
-    pat: &'tcx Pat<'_>,
-    init: Option<&'tcx Expr<'_>>,
-    span: Span,
-    bindings: &mut Vec<(Symbol, Span)>,
-) {
-    // TODO: match more stuff / destructuring
-    match pat.kind {
-        PatKind::Binding(.., ident, ref inner) => {
-            let name = ident.name;
-            if is_binding(cx, pat.hir_id) {
-                let mut new_binding = true;
-                for tup in bindings.iter_mut() {
-                    if tup.0 == name {
-                        lint_shadow(cx, name, span, pat.span, init, tup.1);
-                        tup.1 = ident.span;
-                        new_binding = false;
-                        break;
-                    }
-                }
-                if new_binding {
-                    bindings.push((name, ident.span));
-                }
-            }
-            if let Some(p) = *inner {
-                check_pat(cx, p, init, span, bindings);
-            }
-        },
-        PatKind::Struct(_, pfields, _) => {
-            if let Some(init_struct) = init {
-                if let ExprKind::Struct(_, efields, _) = init_struct.kind {
-                    for field in pfields {
-                        let name = field.ident.name;
-                        let efield = efields
-                            .iter()
-                            .find_map(|f| if f.ident.name == name { Some(&*f.expr) } else { None });
-                        check_pat(cx, field.pat, efield, span, bindings);
-                    }
-                } else {
-                    for field in pfields {
-                        check_pat(cx, field.pat, init, span, bindings);
-                    }
-                }
-            } else {
-                for field in pfields {
-                    check_pat(cx, field.pat, None, span, bindings);
-                }
-            }
-        },
-        PatKind::Tuple(inner, _) => {
-            if let Some(init_tup) = init {
-                if let ExprKind::Tup(tup) = init_tup.kind {
-                    for (i, p) in inner.iter().enumerate() {
-                        check_pat(cx, p, Some(&tup[i]), p.span, bindings);
-                    }
-                } else {
-                    for p in inner {
-                        check_pat(cx, p, init, span, bindings);
-                    }
-                }
-            } else {
-                for p in inner {
-                    check_pat(cx, p, None, span, bindings);
-                }
-            }
-        },
-        PatKind::Box(inner) => {
-            if let Some(initp) = init {
-                if let ExprKind::Box(inner_init) = initp.kind {
-                    check_pat(cx, inner, Some(inner_init), span, bindings);
-                } else {
-                    check_pat(cx, inner, init, span, bindings);
-                }
-            } else {
-                check_pat(cx, inner, init, span, bindings);
-            }
-        },
-        PatKind::Ref(inner, _) => check_pat(cx, inner, init, span, bindings),
-        // PatVec(Vec<P<Pat>>, Option<P<Pat>>, Vec<P<Pat>>),
-        _ => (),
+/// Returns true if the expression is a simple transformation of a local binding such as `&x`
+fn is_self_shadow(cx: &LateContext<'_>, pat: &Pat<'_>, mut expr: &Expr<'_>, hir_id: HirId) -> bool {
+    let hir = cx.tcx.hir();
+    let is_direct_binding = hir
+        .parent_iter(pat.hir_id)
+        .map_while(|(_id, node)| match node {
+            Node::Pat(pat) => Some(pat),
+            _ => None,
+        })
+        .all(|pat| matches!(pat.kind, PatKind::Ref(..) | PatKind::Or(_)));
+    if !is_direct_binding {
+        return false;
     }
-}
-
-fn lint_shadow<'tcx>(
-    cx: &LateContext<'tcx>,
-    name: Symbol,
-    span: Span,
-    pattern_span: Span,
-    init: Option<&'tcx Expr<'_>>,
-    prev_span: Span,
-) {
-    if let Some(expr) = init {
-        if is_self_shadow(name, expr) {
-            span_lint_and_then(
-                cx,
-                SHADOW_SAME,
-                span,
-                &format!(
-                    "`{}` is shadowed by itself in `{}`",
-                    snippet(cx, pattern_span, "_"),
-                    snippet(cx, expr.span, "..")
-                ),
-                |diag| {
-                    diag.span_note(prev_span, "previous binding is here");
+    loop {
+        expr = match expr.kind {
+            ExprKind::Box(e)
+            | ExprKind::AddrOf(_, _, e)
+            | ExprKind::Block(
+                &Block {
+                    stmts: [],
+                    expr: Some(e),
+                    ..
                 },
-            );
-        } else if contains_name(name, expr) {
-            span_lint_and_then(
-                cx,
-                SHADOW_REUSE,
-                pattern_span,
-                &format!(
-                    "`{}` is shadowed by `{}` which reuses the original value",
-                    snippet(cx, pattern_span, "_"),
-                    snippet(cx, expr.span, "..")
-                ),
-                |diag| {
-                    diag.span_note(prev_span, "previous binding is here");
-                },
-            );
-        } else {
-            span_lint_and_then(
-                cx,
-                SHADOW_UNRELATED,
-                pattern_span,
-                &format!("`{}` is being shadowed", snippet(cx, pattern_span, "_")),
-                |diag| {
-                    diag.span_note(prev_span, "previous binding is here");
-                },
-            );
+                _,
+            )
+            | ExprKind::Unary(UnOp::Deref, e) => e,
+            ExprKind::Path(QPath::Resolved(None, path)) => break path.res == Res::Local(hir_id),
+            _ => break false,
         }
-    } else {
-        span_lint_and_then(
-            cx,
-            SHADOW_UNRELATED,
-            span,
-            &format!("`{}` shadows a previous declaration", snippet(cx, pattern_span, "_")),
-            |diag| {
-                diag.span_note(prev_span, "previous binding is here");
+    }
+}
+
+/// Finds the "init" expression for a pattern: `let <pat> = <init>;` or
+/// `match <init> { .., <pat> => .., .. }`
+fn find_init<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<&'tcx Expr<'tcx>> {
+    for (_, node) in cx.tcx.hir().parent_iter(hir_id) {
+        let init = match node {
+            Node::Arm(_) | Node::Pat(_) => continue,
+            Node::Expr(expr) => match expr.kind {
+                ExprKind::Match(e, _, _) => Some(e),
+                _ => None,
             },
-        );
+            Node::Local(local) => local.init,
+            _ => None,
+        };
+        return init;
     }
-}
-
-fn check_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, bindings: &mut Vec<(Symbol, Span)>) {
-    if in_external_macro(cx.sess(), expr.span) {
-        return;
-    }
-    match expr.kind {
-        ExprKind::Unary(_, e) | ExprKind::Field(e, _) | ExprKind::AddrOf(_, _, e) | ExprKind::Box(e) => {
-            check_expr(cx, e, bindings);
-        },
-        ExprKind::Block(block, _) | ExprKind::Loop(block, ..) => check_block(cx, block, bindings),
-        // ExprKind::Call
-        // ExprKind::MethodCall
-        ExprKind::Array(v) | ExprKind::Tup(v) => {
-            for e in v {
-                check_expr(cx, e, bindings);
-            }
-        },
-        ExprKind::If(cond, then, ref otherwise) => {
-            check_expr(cx, cond, bindings);
-            check_expr(cx, then, bindings);
-            if let Some(o) = *otherwise {
-                check_expr(cx, o, bindings);
-            }
-        },
-        ExprKind::Match(init, arms, _) => {
-            check_expr(cx, init, bindings);
-            let len = bindings.len();
-            for arm in arms {
-                check_pat(cx, arm.pat, Some(init), arm.pat.span, bindings);
-                // This is ugly, but needed to get the right type
-                if let Some(ref guard) = arm.guard {
-                    match guard {
-                        Guard::If(if_expr) => check_expr(cx, if_expr, bindings),
-                        Guard::IfLet(guard_pat, guard_expr) => {
-                            check_pat(cx, guard_pat, Some(*guard_expr), guard_pat.span, bindings);
-                            check_expr(cx, guard_expr, bindings);
-                        },
-                    }
-                }
-                check_expr(cx, arm.body, bindings);
-                bindings.truncate(len);
-            }
-        },
-        _ => (),
-    }
-}
-
-fn check_ty<'tcx>(cx: &LateContext<'tcx>, ty: &'tcx Ty<'_>, bindings: &mut Vec<(Symbol, Span)>) {
-    match ty.kind {
-        TyKind::Slice(sty) => check_ty(cx, sty, bindings),
-        TyKind::Array(fty, ref anon_const) => {
-            check_ty(cx, fty, bindings);
-            check_expr(cx, &cx.tcx.hir().body(anon_const.body).value, bindings);
-        },
-        TyKind::Ptr(MutTy { ty: mty, .. }) | TyKind::Rptr(_, MutTy { ty: mty, .. }) => check_ty(cx, mty, bindings),
-        TyKind::Tup(tup) => {
-            for t in tup {
-                check_ty(cx, t, bindings);
-            }
-        },
-        TyKind::Typeof(ref anon_const) => check_expr(cx, &cx.tcx.hir().body(anon_const.body).value, bindings),
-        _ => (),
-    }
-}
-
-fn is_self_shadow(name: Symbol, expr: &Expr<'_>) -> bool {
-    match expr.kind {
-        ExprKind::Box(inner) | ExprKind::AddrOf(_, _, inner) => is_self_shadow(name, inner),
-        ExprKind::Block(block, _) => {
-            block.stmts.is_empty() && block.expr.as_ref().map_or(false, |e| is_self_shadow(name, e))
-        },
-        ExprKind::Unary(op, inner) => (UnOp::Deref == op) && is_self_shadow(name, inner),
-        ExprKind::Path(QPath::Resolved(_, path)) => path_eq_name(name, path),
-        _ => false,
-    }
-}
-
-fn path_eq_name(name: Symbol, path: &Path<'_>) -> bool {
-    !path.is_global() && path.segments.len() == 1 && path.segments[0].ident.name == name
+    None
 }

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -102,7 +102,7 @@ declare_clippy_lint! {
     /// let w = z; // use different variable name
     /// ```
     pub SHADOW_UNRELATED,
-    pedantic,
+    restriction,
     "rebinding a name without even using the original value"
 }
 

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -298,7 +298,6 @@ fn lint_shadow<'tcx>(
                     snippet(cx, expr.span, "..")
                 ),
                 |diag| {
-                    diag.span_note(expr.span, "initialization happens here");
                     diag.span_note(prev_span, "previous binding is here");
                 },
             );
@@ -309,7 +308,6 @@ fn lint_shadow<'tcx>(
                 pattern_span,
                 &format!("`{}` is being shadowed", snippet(cx, pattern_span, "_")),
                 |diag| {
-                    diag.span_note(expr.span, "initialization happens here");
                     diag.span_note(prev_span, "previous binding is here");
                 },
             );

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -510,7 +510,6 @@ pub fn path_to_local_id(expr: &Expr<'_>, id: HirId) -> bool {
 }
 
 /// Gets the definition associated to a path.
-#[allow(clippy::shadow_unrelated)] // false positive #6563
 pub fn path_to_res(cx: &LateContext<'_>, path: &[&str]) -> Res {
     macro_rules! try_res {
         ($e:expr) => {

--- a/tests/ui/approx_const.rs
+++ b/tests/ui/approx_const.rs
@@ -1,5 +1,5 @@
 #[warn(clippy::approx_constant)]
-#[allow(unused, clippy::shadow_unrelated, clippy::similar_names)]
+#[allow(clippy::similar_names)]
 fn main() {
     let my_e = 2.7182;
     let almost_e = 2.718;

--- a/tests/ui/for_loop_fixable.fixed
+++ b/tests/ui/for_loop_fixable.fixed
@@ -23,12 +23,7 @@ impl Unrelated {
     clippy::iter_next_loop,
     clippy::for_kv_map
 )]
-#[allow(
-    clippy::linkedlist,
-    clippy::shadow_unrelated,
-    clippy::unnecessary_mut_passed,
-    clippy::similar_names
-)]
+#[allow(clippy::linkedlist, clippy::unnecessary_mut_passed, clippy::similar_names)]
 #[allow(unused_variables)]
 fn main() {
     let mut vec = vec![1, 2, 3, 4];

--- a/tests/ui/for_loop_fixable.rs
+++ b/tests/ui/for_loop_fixable.rs
@@ -23,12 +23,7 @@ impl Unrelated {
     clippy::iter_next_loop,
     clippy::for_kv_map
 )]
-#[allow(
-    clippy::linkedlist,
-    clippy::shadow_unrelated,
-    clippy::unnecessary_mut_passed,
-    clippy::similar_names
-)]
+#[allow(clippy::linkedlist, clippy::unnecessary_mut_passed, clippy::similar_names)]
 #[allow(unused_variables)]
 fn main() {
     let mut vec = vec![1, 2, 3, 4];

--- a/tests/ui/for_loop_fixable.stderr
+++ b/tests/ui/for_loop_fixable.stderr
@@ -1,5 +1,5 @@
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:43:15
+  --> $DIR/for_loop_fixable.rs:38:15
    |
 LL |     for _v in vec.iter() {}
    |               ^^^^^^^^^^ help: to write this more concisely, try: `&vec`
@@ -7,13 +7,13 @@ LL |     for _v in vec.iter() {}
    = note: `-D clippy::explicit-iter-loop` implied by `-D warnings`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:45:15
+  --> $DIR/for_loop_fixable.rs:40:15
    |
 LL |     for _v in vec.iter_mut() {}
    |               ^^^^^^^^^^^^^^ help: to write this more concisely, try: `&mut vec`
 
 error: it is more concise to loop over containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:48:15
+  --> $DIR/for_loop_fixable.rs:43:15
    |
 LL |     for _v in out_vec.into_iter() {}
    |               ^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `out_vec`
@@ -21,73 +21,73 @@ LL |     for _v in out_vec.into_iter() {}
    = note: `-D clippy::explicit-into-iter-loop` implied by `-D warnings`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:53:15
+  --> $DIR/for_loop_fixable.rs:48:15
    |
 LL |     for _v in [1, 2, 3].iter() {}
    |               ^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&[1, 2, 3]`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:57:15
+  --> $DIR/for_loop_fixable.rs:52:15
    |
 LL |     for _v in [0; 32].iter() {}
    |               ^^^^^^^^^^^^^^ help: to write this more concisely, try: `&[0; 32]`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:62:15
+  --> $DIR/for_loop_fixable.rs:57:15
    |
 LL |     for _v in ll.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&ll`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:65:15
+  --> $DIR/for_loop_fixable.rs:60:15
    |
 LL |     for _v in vd.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&vd`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:68:15
+  --> $DIR/for_loop_fixable.rs:63:15
    |
 LL |     for _v in bh.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&bh`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:71:15
+  --> $DIR/for_loop_fixable.rs:66:15
    |
 LL |     for _v in hm.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&hm`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:74:15
+  --> $DIR/for_loop_fixable.rs:69:15
    |
 LL |     for _v in bt.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&bt`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:77:15
+  --> $DIR/for_loop_fixable.rs:72:15
    |
 LL |     for _v in hs.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&hs`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:80:15
+  --> $DIR/for_loop_fixable.rs:75:15
    |
 LL |     for _v in bs.iter() {}
    |               ^^^^^^^^^ help: to write this more concisely, try: `&bs`
 
 error: it is more concise to loop over containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:255:18
+  --> $DIR/for_loop_fixable.rs:250:18
    |
 LL |         for i in iterator.into_iter() {
    |                  ^^^^^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `iterator`
 
 error: it is more concise to loop over references to containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:275:18
+  --> $DIR/for_loop_fixable.rs:270:18
    |
 LL |         for _ in t.into_iter() {}
    |                  ^^^^^^^^^^^^^ help: to write this more concisely, try: `&t`
 
 error: it is more concise to loop over containers instead of using explicit iteration methods
-  --> $DIR/for_loop_fixable.rs:277:18
+  --> $DIR/for_loop_fixable.rs:272:18
    |
 LL |         for _ in r.into_iter() {}
    |                  ^^^^^^^^^^^^^ help: to write this more concisely, try: `r`

--- a/tests/ui/for_loop_unfixable.rs
+++ b/tests/ui/for_loop_unfixable.rs
@@ -7,14 +7,7 @@
     clippy::iter_next_loop,
     clippy::for_kv_map
 )]
-#[allow(
-    clippy::linkedlist,
-    clippy::shadow_unrelated,
-    clippy::unnecessary_mut_passed,
-    clippy::similar_names,
-    unused,
-    dead_code
-)]
+#[allow(clippy::linkedlist, clippy::unnecessary_mut_passed, clippy::similar_names)]
 fn main() {
     let vec = vec![1, 2, 3, 4];
 

--- a/tests/ui/for_loop_unfixable.stderr
+++ b/tests/ui/for_loop_unfixable.stderr
@@ -1,5 +1,5 @@
 error: you are iterating over `Iterator::next()` which is an Option; this will compile but is probably not what you want
-  --> $DIR/for_loop_unfixable.rs:21:15
+  --> $DIR/for_loop_unfixable.rs:14:15
    |
 LL |     for _v in vec.iter().next() {}
    |               ^^^^^^^^^^^^^^^^^

--- a/tests/ui/integer_arithmetic.rs
+++ b/tests/ui/integer_arithmetic.rs
@@ -1,12 +1,5 @@
 #![warn(clippy::integer_arithmetic, clippy::float_arithmetic)]
-#![allow(
-    unused,
-    clippy::shadow_reuse,
-    clippy::shadow_unrelated,
-    clippy::no_effect,
-    clippy::unnecessary_operation,
-    clippy::op_ref
-)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::op_ref)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui/integer_arithmetic.stderr
+++ b/tests/ui/integer_arithmetic.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/integer_arithmetic.rs:37:5
+  --> $DIR/integer_arithmetic.rs:30:5
    |
 LL |     i /= 0;
    |     ^^^^^^ attempt to divide `_` by zero
@@ -7,13 +7,13 @@ LL |     i /= 0;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/integer_arithmetic.rs:42:5
+  --> $DIR/integer_arithmetic.rs:35:5
    |
 LL |     i %= 0;
    |     ^^^^^^ attempt to calculate the remainder of `_` with a divisor of zero
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:16:5
+  --> $DIR/integer_arithmetic.rs:9:5
    |
 LL |     1 + i;
    |     ^^^^^
@@ -21,146 +21,146 @@ LL |     1 + i;
    = note: `-D clippy::integer-arithmetic` implied by `-D warnings`
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:17:5
+  --> $DIR/integer_arithmetic.rs:10:5
    |
 LL |     i * 2;
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:18:5
+  --> $DIR/integer_arithmetic.rs:11:5
    |
 LL | /     1 %
 LL | |     i / 2; // no error, this is part of the expression in the preceding line
    | |_____^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:20:5
+  --> $DIR/integer_arithmetic.rs:13:5
    |
 LL |     i - 2 + 2 - i;
    |     ^^^^^^^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:21:5
+  --> $DIR/integer_arithmetic.rs:14:5
    |
 LL |     -i;
    |     ^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:22:5
+  --> $DIR/integer_arithmetic.rs:15:5
    |
 LL |     i >> 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:23:5
+  --> $DIR/integer_arithmetic.rs:16:5
    |
 LL |     i << 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:33:5
+  --> $DIR/integer_arithmetic.rs:26:5
    |
 LL |     i += 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:34:5
+  --> $DIR/integer_arithmetic.rs:27:5
    |
 LL |     i -= 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:35:5
+  --> $DIR/integer_arithmetic.rs:28:5
    |
 LL |     i *= 2;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:38:11
+  --> $DIR/integer_arithmetic.rs:31:11
    |
 LL |     i /= -1;
    |           ^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:39:5
+  --> $DIR/integer_arithmetic.rs:32:5
    |
 LL |     i /= var1;
    |     ^^^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:40:5
+  --> $DIR/integer_arithmetic.rs:33:5
    |
 LL |     i /= var2;
    |     ^^^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:43:11
+  --> $DIR/integer_arithmetic.rs:36:11
    |
 LL |     i %= -1;
    |           ^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:44:5
+  --> $DIR/integer_arithmetic.rs:37:5
    |
 LL |     i %= var1;
    |     ^^^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:45:5
+  --> $DIR/integer_arithmetic.rs:38:5
    |
 LL |     i %= var2;
    |     ^^^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:46:5
+  --> $DIR/integer_arithmetic.rs:39:5
    |
 LL |     i <<= 3;
    |     ^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:47:5
+  --> $DIR/integer_arithmetic.rs:40:5
    |
 LL |     i >>= 2;
    |     ^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:89:5
+  --> $DIR/integer_arithmetic.rs:82:5
    |
 LL |     3 + &1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:90:5
+  --> $DIR/integer_arithmetic.rs:83:5
    |
 LL |     &3 + 1;
    |     ^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:91:5
+  --> $DIR/integer_arithmetic.rs:84:5
    |
 LL |     &3 + &1;
    |     ^^^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:96:5
+  --> $DIR/integer_arithmetic.rs:89:5
    |
 LL |     a + x
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:100:5
+  --> $DIR/integer_arithmetic.rs:93:5
    |
 LL |     x + y
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:104:5
+  --> $DIR/integer_arithmetic.rs:97:5
    |
 LL |     x + y
    |     ^^^^^
 
 error: integer arithmetic detected
-  --> $DIR/integer_arithmetic.rs:108:5
+  --> $DIR/integer_arithmetic.rs:101:5
    |
 LL |     (&x + &y)
    |     ^^^^^^^^^

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -1,11 +1,11 @@
 // run-rustfix
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::iter_cloned_collect)]
-#![allow(clippy::clone_on_copy, clippy::redundant_clone)]
-#![allow(clippy::let_underscore_drop)]
-#![allow(clippy::missing_docs_in_private_items)]
-#![allow(clippy::redundant_closure_for_method_calls)]
-#![allow(clippy::many_single_char_names)]
+#![warn(clippy::map_clone)]
+#![allow(
+    clippy::clone_on_copy,
+    clippy::iter_cloned_collect,
+    clippy::many_single_char_names,
+    clippy::redundant_clone
+)]
 
 fn main() {
     let _: Vec<i8> = vec![5_i8; 6].iter().copied().collect();

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -1,11 +1,11 @@
 // run-rustfix
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::iter_cloned_collect)]
-#![allow(clippy::clone_on_copy, clippy::redundant_clone)]
-#![allow(clippy::let_underscore_drop)]
-#![allow(clippy::missing_docs_in_private_items)]
-#![allow(clippy::redundant_closure_for_method_calls)]
-#![allow(clippy::many_single_char_names)]
+#![warn(clippy::map_clone)]
+#![allow(
+    clippy::clone_on_copy,
+    clippy::iter_cloned_collect,
+    clippy::many_single_char_names,
+    clippy::redundant_clone
+)]
 
 fn main() {
     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();

--- a/tests/ui/modulo_arithmetic_float.rs
+++ b/tests/ui/modulo_arithmetic_float.rs
@@ -1,12 +1,5 @@
 #![warn(clippy::modulo_arithmetic)]
-#![allow(
-    unused,
-    clippy::shadow_reuse,
-    clippy::shadow_unrelated,
-    clippy::no_effect,
-    clippy::unnecessary_operation,
-    clippy::modulo_one
-)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::modulo_one)]
 
 fn main() {
     // Lint when both sides are const and of the opposite sign

--- a/tests/ui/modulo_arithmetic_float.stderr
+++ b/tests/ui/modulo_arithmetic_float.stderr
@@ -1,5 +1,5 @@
 error: you are using modulo operator on constants with different signs: `-1.600 % 2.100`
-  --> $DIR/modulo_arithmetic_float.rs:13:5
+  --> $DIR/modulo_arithmetic_float.rs:6:5
    |
 LL |     -1.6 % 2.1;
    |     ^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     -1.6 % 2.1;
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on constants with different signs: `1.600 % -2.100`
-  --> $DIR/modulo_arithmetic_float.rs:14:5
+  --> $DIR/modulo_arithmetic_float.rs:7:5
    |
 LL |     1.6 % -2.1;
    |     ^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     1.6 % -2.1;
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on constants with different signs: `-1.200 % 3.400`
-  --> $DIR/modulo_arithmetic_float.rs:15:5
+  --> $DIR/modulo_arithmetic_float.rs:8:5
    |
 LL |     (1.1 - 2.3) % (1.1 + 2.3);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     (1.1 - 2.3) % (1.1 + 2.3);
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on constants with different signs: `3.400 % -1.200`
-  --> $DIR/modulo_arithmetic_float.rs:16:5
+  --> $DIR/modulo_arithmetic_float.rs:9:5
    |
 LL |     (1.1 + 2.3) % (1.1 - 2.3);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     (1.1 + 2.3) % (1.1 - 2.3);
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_float.rs:21:5
+  --> $DIR/modulo_arithmetic_float.rs:14:5
    |
 LL |     a_f32 % b_f32;
    |     ^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |     a_f32 % b_f32;
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_float.rs:22:5
+  --> $DIR/modulo_arithmetic_float.rs:15:5
    |
 LL |     b_f32 % a_f32;
    |     ^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     b_f32 % a_f32;
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_float.rs:23:5
+  --> $DIR/modulo_arithmetic_float.rs:16:5
    |
 LL |     b_f32 %= a_f32;
    |     ^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     b_f32 %= a_f32;
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_float.rs:27:5
+  --> $DIR/modulo_arithmetic_float.rs:20:5
    |
 LL |     a_f64 % b_f64;
    |     ^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |     a_f64 % b_f64;
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_float.rs:28:5
+  --> $DIR/modulo_arithmetic_float.rs:21:5
    |
 LL |     b_f64 % a_f64;
    |     ^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     b_f64 % a_f64;
    = note: double check for expected result especially when interoperating with different languages
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_float.rs:29:5
+  --> $DIR/modulo_arithmetic_float.rs:22:5
    |
 LL |     b_f64 %= a_f64;
    |     ^^^^^^^^^^^^^^

--- a/tests/ui/modulo_arithmetic_integral.rs
+++ b/tests/ui/modulo_arithmetic_integral.rs
@@ -1,12 +1,5 @@
 #![warn(clippy::modulo_arithmetic)]
-#![allow(
-    unused,
-    clippy::shadow_reuse,
-    clippy::shadow_unrelated,
-    clippy::no_effect,
-    clippy::unnecessary_operation,
-    clippy::modulo_one
-)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::modulo_one)]
 
 fn main() {
     // Lint on signed integral numbers

--- a/tests/ui/modulo_arithmetic_integral.stderr
+++ b/tests/ui/modulo_arithmetic_integral.stderr
@@ -1,5 +1,5 @@
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:15:5
+  --> $DIR/modulo_arithmetic_integral.rs:8:5
    |
 LL |     a % b;
    |     ^^^^^
@@ -9,7 +9,7 @@ LL |     a % b;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:16:5
+  --> $DIR/modulo_arithmetic_integral.rs:9:5
    |
 LL |     b % a;
    |     ^^^^^
@@ -18,7 +18,7 @@ LL |     b % a;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:17:5
+  --> $DIR/modulo_arithmetic_integral.rs:10:5
    |
 LL |     b %= a;
    |     ^^^^^^
@@ -27,7 +27,7 @@ LL |     b %= a;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:21:5
+  --> $DIR/modulo_arithmetic_integral.rs:14:5
    |
 LL |     a_i8 % b_i8;
    |     ^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     a_i8 % b_i8;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:22:5
+  --> $DIR/modulo_arithmetic_integral.rs:15:5
    |
 LL |     b_i8 %= a_i8;
    |     ^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     b_i8 %= a_i8;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:26:5
+  --> $DIR/modulo_arithmetic_integral.rs:19:5
    |
 LL |     a_i16 % b_i16;
    |     ^^^^^^^^^^^^^
@@ -54,7 +54,7 @@ LL |     a_i16 % b_i16;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:27:5
+  --> $DIR/modulo_arithmetic_integral.rs:20:5
    |
 LL |     b_i16 %= a_i16;
    |     ^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     b_i16 %= a_i16;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:31:5
+  --> $DIR/modulo_arithmetic_integral.rs:24:5
    |
 LL |     a_i32 % b_i32;
    |     ^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     a_i32 % b_i32;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:32:5
+  --> $DIR/modulo_arithmetic_integral.rs:25:5
    |
 LL |     b_i32 %= a_i32;
    |     ^^^^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     b_i32 %= a_i32;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:36:5
+  --> $DIR/modulo_arithmetic_integral.rs:29:5
    |
 LL |     a_i64 % b_i64;
    |     ^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     a_i64 % b_i64;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:37:5
+  --> $DIR/modulo_arithmetic_integral.rs:30:5
    |
 LL |     b_i64 %= a_i64;
    |     ^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     b_i64 %= a_i64;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:41:5
+  --> $DIR/modulo_arithmetic_integral.rs:34:5
    |
 LL |     a_i128 % b_i128;
    |     ^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL |     a_i128 % b_i128;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:42:5
+  --> $DIR/modulo_arithmetic_integral.rs:35:5
    |
 LL |     b_i128 %= a_i128;
    |     ^^^^^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     b_i128 %= a_i128;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:46:5
+  --> $DIR/modulo_arithmetic_integral.rs:39:5
    |
 LL |     a_isize % b_isize;
    |     ^^^^^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL |     a_isize % b_isize;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:47:5
+  --> $DIR/modulo_arithmetic_integral.rs:40:5
    |
 LL |     b_isize %= a_isize;
    |     ^^^^^^^^^^^^^^^^^^
@@ -135,7 +135,7 @@ LL |     b_isize %= a_isize;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:51:5
+  --> $DIR/modulo_arithmetic_integral.rs:44:5
    |
 LL |     a % b;
    |     ^^^^^
@@ -144,7 +144,7 @@ LL |     a % b;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on types that might have different signs
-  --> $DIR/modulo_arithmetic_integral.rs:52:5
+  --> $DIR/modulo_arithmetic_integral.rs:45:5
    |
 LL |     b %= a;
    |     ^^^^^^

--- a/tests/ui/modulo_arithmetic_integral_const.rs
+++ b/tests/ui/modulo_arithmetic_integral_const.rs
@@ -1,12 +1,5 @@
 #![warn(clippy::modulo_arithmetic)]
-#![allow(
-    unused,
-    clippy::shadow_reuse,
-    clippy::shadow_unrelated,
-    clippy::no_effect,
-    clippy::unnecessary_operation,
-    clippy::modulo_one
-)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::modulo_one)]
 
 fn main() {
     // Lint when both sides are const and of the opposite sign

--- a/tests/ui/modulo_arithmetic_integral_const.stderr
+++ b/tests/ui/modulo_arithmetic_integral_const.stderr
@@ -1,5 +1,5 @@
 error: you are using modulo operator on constants with different signs: `-1 % 2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:13:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:6:5
    |
 LL |     -1 % 2;
    |     ^^^^^^
@@ -9,7 +9,7 @@ LL |     -1 % 2;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `1 % -2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:14:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:7:5
    |
 LL |     1 % -2;
    |     ^^^^^^
@@ -18,7 +18,7 @@ LL |     1 % -2;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-1 % 3`
-  --> $DIR/modulo_arithmetic_integral_const.rs:15:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:8:5
    |
 LL |     (1 - 2) % (1 + 2);
    |     ^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     (1 - 2) % (1 + 2);
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `3 % -1`
-  --> $DIR/modulo_arithmetic_integral_const.rs:16:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:9:5
    |
 LL |     (1 + 2) % (1 - 2);
    |     ^^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     (1 + 2) % (1 - 2);
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-35 % 300000`
-  --> $DIR/modulo_arithmetic_integral_const.rs:17:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:10:5
    |
 LL |     35 * (7 - 4 * 2) % (-500 * -600);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     35 * (7 - 4 * 2) % (-500 * -600);
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-1 % 2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:19:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:12:5
    |
 LL |     -1i8 % 2i8;
    |     ^^^^^^^^^^
@@ -54,7 +54,7 @@ LL |     -1i8 % 2i8;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `1 % -2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:20:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:13:5
    |
 LL |     1i8 % -2i8;
    |     ^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     1i8 % -2i8;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-1 % 2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:21:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:14:5
    |
 LL |     -1i16 % 2i16;
    |     ^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     -1i16 % 2i16;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `1 % -2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:22:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:15:5
    |
 LL |     1i16 % -2i16;
    |     ^^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL |     1i16 % -2i16;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-1 % 2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:23:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:16:5
    |
 LL |     -1i32 % 2i32;
    |     ^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     -1i32 % 2i32;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `1 % -2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:24:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:17:5
    |
 LL |     1i32 % -2i32;
    |     ^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     1i32 % -2i32;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-1 % 2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:25:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:18:5
    |
 LL |     -1i64 % 2i64;
    |     ^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL |     -1i64 % 2i64;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `1 % -2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:26:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:19:5
    |
 LL |     1i64 % -2i64;
    |     ^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     1i64 % -2i64;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-1 % 2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:27:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:20:5
    |
 LL |     -1i128 % 2i128;
    |     ^^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL |     -1i128 % 2i128;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `1 % -2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:28:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:21:5
    |
 LL |     1i128 % -2i128;
    |     ^^^^^^^^^^^^^^
@@ -135,7 +135,7 @@ LL |     1i128 % -2i128;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `-1 % 2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:29:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:22:5
    |
 LL |     -1isize % 2isize;
    |     ^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL |     -1isize % 2isize;
    = note: or consider using `rem_euclid` or similar function
 
 error: you are using modulo operator on constants with different signs: `1 % -2`
-  --> $DIR/modulo_arithmetic_integral_const.rs:30:5
+  --> $DIR/modulo_arithmetic_integral_const.rs:23:5
    |
 LL |     1isize % -2isize;
    |     ^^^^^^^^^^^^^^^^

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -1,54 +1,77 @@
-#![warn(
-    clippy::all,
-    clippy::pedantic,
-    clippy::shadow_same,
-    clippy::shadow_reuse,
-    clippy::shadow_unrelated
-)]
-#![allow(
-    unused_parens,
-    unused_variables,
-    clippy::manual_unwrap_or,
-    clippy::missing_docs_in_private_items,
-    clippy::single_match
-)]
+#![warn(clippy::shadow_same, clippy::shadow_reuse, clippy::shadow_unrelated)]
 
-fn id<T>(x: T) -> T {
-    x
-}
-
-#[must_use]
-fn first(x: (isize, isize)) -> isize {
-    x.0
-}
-
-fn main() {
-    let mut x = 1;
+fn shadow_same() {
+    let x = 1;
+    let x = x;
+    let mut x = &x;
     let x = &mut x;
-    let x = { x };
-    let x = (&*x);
-    let x = { *x + 1 };
-    let x = id(x);
-    let x = (1, x);
-    let x = first(x);
-    let y = 1;
-    let x = y;
-
-    let x;
-    x = 42;
-
-    let o = Some(1_u8);
-
-    if let Some(p) = o {
-        assert_eq!(1, p);
-    }
-    match o {
-        Some(p) => p, // no error, because the p above is in its own scope
-        None => 0,
-    };
-
-    match (x, o) {
-        (1, Some(a)) | (a, Some(1)) => (), // no error though `a` appears twice
-        _ => (),
-    }
+    let x = *x;
 }
+
+fn shadow_reuse() -> Option<()> {
+    let x = ([[0]], ());
+    let x = x.0;
+    let x = x[0];
+    let [x] = x;
+    let x = Some(x);
+    let x = foo(x);
+    let x = || x;
+    let x = Some(1).map(|_| x)?;
+    None
+}
+
+fn shadow_unrelated() {
+    let x = 1;
+    let x = 2;
+}
+
+fn syntax() {
+    fn f(x: u32) {
+        let x = 1;
+    }
+    let x = 1;
+    match Some(1) {
+        Some(1) => {},
+        Some(x) => {
+            let x = 1;
+        },
+        _ => {},
+    }
+    if let Some(x) = Some(1) {}
+    while let Some(x) = Some(1) {}
+    let _ = |[x]: [u32; 1]| {
+        let x = 1;
+    };
+}
+
+fn negative() {
+    match Some(1) {
+        Some(x) if x == 1 => {},
+        Some(x) => {},
+        None => {},
+    }
+    match [None, Some(1)] {
+        [Some(x), None] | [None, Some(x)] => {},
+        _ => {},
+    }
+    if let Some(x) = Some(1) {
+        let y = 1;
+    } else {
+        let x = 1;
+        let y = 1;
+    }
+    let x = 1;
+    #[allow(clippy::shadow_unrelated)]
+    let x = 1;
+}
+
+fn foo<T>(_: T) {}
+
+fn question_mark() -> Option<()> {
+    let val = 1;
+    // `?` expands with a `val` binding
+    None?;
+    None
+}
+
+fn main() {}

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -1,113 +1,233 @@
-error: `x` is shadowed by itself in `&mut x`
-  --> $DIR/shadow.rs:27:5
+error: `x` is shadowed by itself in `x`
+  --> $DIR/shadow.rs:5:9
    |
-LL |     let x = &mut x;
-   |     ^^^^^^^^^^^^^^^
+LL |     let x = x;
+   |         ^
    |
    = note: `-D clippy::shadow-same` implied by `-D warnings`
 note: previous binding is here
-  --> $DIR/shadow.rs:26:13
+  --> $DIR/shadow.rs:4:9
    |
-LL |     let mut x = 1;
-   |             ^
+LL |     let x = 1;
+   |         ^
 
-error: `x` is shadowed by itself in `{ x }`
-  --> $DIR/shadow.rs:28:5
+error: `mut x` is shadowed by itself in `&x`
+  --> $DIR/shadow.rs:6:13
    |
-LL |     let x = { x };
-   |     ^^^^^^^^^^^^^^
+LL |     let mut x = &x;
+   |             ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:27:9
+  --> $DIR/shadow.rs:5:9
+   |
+LL |     let x = x;
+   |         ^
+
+error: `x` is shadowed by itself in `&mut x`
+  --> $DIR/shadow.rs:7:9
+   |
+LL |     let x = &mut x;
+   |         ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:6:9
+   |
+LL |     let mut x = &x;
+   |         ^^^^^
+
+error: `x` is shadowed by itself in `*x`
+  --> $DIR/shadow.rs:8:9
+   |
+LL |     let x = *x;
+   |         ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:7:9
    |
 LL |     let x = &mut x;
    |         ^
 
-error: `x` is shadowed by itself in `(&*x)`
-  --> $DIR/shadow.rs:29:5
+error: `x` is shadowed by `x.0` which reuses the original value
+  --> $DIR/shadow.rs:13:9
    |
-LL |     let x = (&*x);
-   |     ^^^^^^^^^^^^^^
-   |
-note: previous binding is here
-  --> $DIR/shadow.rs:28:9
-   |
-LL |     let x = { x };
-   |         ^
-
-error: `x` is shadowed by `{ *x + 1 }` which reuses the original value
-  --> $DIR/shadow.rs:30:9
-   |
-LL |     let x = { *x + 1 };
+LL |     let x = x.0;
    |         ^
    |
    = note: `-D clippy::shadow-reuse` implied by `-D warnings`
 note: previous binding is here
-  --> $DIR/shadow.rs:29:9
+  --> $DIR/shadow.rs:12:9
    |
-LL |     let x = (&*x);
+LL |     let x = ([[0]], ());
    |         ^
 
-error: `x` is shadowed by `id(x)` which reuses the original value
-  --> $DIR/shadow.rs:31:9
+error: `x` is shadowed by `x[0]` which reuses the original value
+  --> $DIR/shadow.rs:14:9
    |
-LL |     let x = id(x);
+LL |     let x = x[0];
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:30:9
+  --> $DIR/shadow.rs:13:9
    |
-LL |     let x = { *x + 1 };
+LL |     let x = x.0;
    |         ^
 
-error: `x` is shadowed by `(1, x)` which reuses the original value
-  --> $DIR/shadow.rs:32:9
+error: `x` is shadowed by `x` which reuses the original value
+  --> $DIR/shadow.rs:15:10
    |
-LL |     let x = (1, x);
+LL |     let [x] = x;
+   |          ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:14:9
+   |
+LL |     let x = x[0];
+   |         ^
+
+error: `x` is shadowed by `Some(x)` which reuses the original value
+  --> $DIR/shadow.rs:16:9
+   |
+LL |     let x = Some(x);
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:31:9
+  --> $DIR/shadow.rs:15:10
    |
-LL |     let x = id(x);
-   |         ^
+LL |     let [x] = x;
+   |          ^
 
-error: `x` is shadowed by `first(x)` which reuses the original value
-  --> $DIR/shadow.rs:33:9
+error: `x` is shadowed by `foo(x)` which reuses the original value
+  --> $DIR/shadow.rs:17:9
    |
-LL |     let x = first(x);
+LL |     let x = foo(x);
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:32:9
+  --> $DIR/shadow.rs:16:9
    |
-LL |     let x = (1, x);
+LL |     let x = Some(x);
    |         ^
 
-error: `x` is being shadowed
-  --> $DIR/shadow.rs:35:9
+error: `x` is shadowed by `|| x` which reuses the original value
+  --> $DIR/shadow.rs:18:9
    |
-LL |     let x = y;
+LL |     let x = || x;
+   |         ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:17:9
+   |
+LL |     let x = foo(x);
+   |         ^
+
+error: `x` is shadowed by `Some(1).map(|_| x)?` which reuses the original value
+  --> $DIR/shadow.rs:19:9
+   |
+LL |     let x = Some(1).map(|_| x)?;
+   |         ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:18:9
+   |
+LL |     let x = || x;
+   |         ^
+
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:25:9
+   |
+LL |     let x = 2;
    |         ^
    |
    = note: `-D clippy::shadow-unrelated` implied by `-D warnings`
 note: previous binding is here
-  --> $DIR/shadow.rs:33:9
+  --> $DIR/shadow.rs:24:9
    |
-LL |     let x = first(x);
+LL |     let x = 1;
    |         ^
 
-error: `x` shadows a previous declaration
-  --> $DIR/shadow.rs:37:5
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:30:13
    |
-LL |     let x;
-   |     ^^^^^^
+LL |         let x = 1;
+   |             ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:35:9
+  --> $DIR/shadow.rs:29:10
    |
-LL |     let x = y;
+LL |     fn f(x: u32) {
+   |          ^
+
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:35:14
+   |
+LL |         Some(x) => {
+   |              ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:32:9
+   |
+LL |     let x = 1;
    |         ^
 
-error: aborting due to 9 previous errors
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:36:17
+   |
+LL |             let x = 1;
+   |                 ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:35:14
+   |
+LL |         Some(x) => {
+   |              ^
+
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:40:17
+   |
+LL |     if let Some(x) = Some(1) {}
+   |                 ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:32:9
+   |
+LL |     let x = 1;
+   |         ^
+
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:41:20
+   |
+LL |     while let Some(x) = Some(1) {}
+   |                    ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:32:9
+   |
+LL |     let x = 1;
+   |         ^
+
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:42:15
+   |
+LL |     let _ = |[x]: [u32; 1]| {
+   |               ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:32:9
+   |
+LL |     let x = 1;
+   |         ^
+
+error: `x` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:43:13
+   |
+LL |         let x = 1;
+   |             ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:42:15
+   |
+LL |     let _ = |[x]: [u32; 1]| {
+   |               ^
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -42,11 +42,6 @@ LL |     let x = { *x + 1 };
    |         ^
    |
    = note: `-D clippy::shadow-reuse` implied by `-D warnings`
-note: initialization happens here
-  --> $DIR/shadow.rs:30:13
-   |
-LL |     let x = { *x + 1 };
-   |             ^^^^^^^^^^
 note: previous binding is here
   --> $DIR/shadow.rs:29:9
    |
@@ -59,11 +54,6 @@ error: `x` is shadowed by `id(x)` which reuses the original value
 LL |     let x = id(x);
    |         ^
    |
-note: initialization happens here
-  --> $DIR/shadow.rs:31:13
-   |
-LL |     let x = id(x);
-   |             ^^^^^
 note: previous binding is here
   --> $DIR/shadow.rs:30:9
    |
@@ -76,11 +66,6 @@ error: `x` is shadowed by `(1, x)` which reuses the original value
 LL |     let x = (1, x);
    |         ^
    |
-note: initialization happens here
-  --> $DIR/shadow.rs:32:13
-   |
-LL |     let x = (1, x);
-   |             ^^^^^^
 note: previous binding is here
   --> $DIR/shadow.rs:31:9
    |
@@ -93,11 +78,6 @@ error: `x` is shadowed by `first(x)` which reuses the original value
 LL |     let x = first(x);
    |         ^
    |
-note: initialization happens here
-  --> $DIR/shadow.rs:33:13
-   |
-LL |     let x = first(x);
-   |             ^^^^^^^^
 note: previous binding is here
   --> $DIR/shadow.rs:32:9
    |
@@ -111,11 +91,6 @@ LL |     let x = y;
    |         ^
    |
    = note: `-D clippy::shadow-unrelated` implied by `-D warnings`
-note: initialization happens here
-  --> $DIR/shadow.rs:35:13
-   |
-LL |     let x = y;
-   |             ^
 note: previous binding is here
   --> $DIR/shadow.rs:33:9
    |


### PR DESCRIPTION
changelog: Move shadow_unrelated to restriction
changelog: The shadow lints find a lot more shadows and are not limited to certain patterns

Drastically simplifies the implementation. Catches a lot more cases.

I removed the "initialization happens here" note. It is not helpful IMO.

Closes #318
Fixes #2890
Fixes #6563
Fixes #7588
Fixes #7620