### PR TITLE
Do not trigger match-same-arms lint on never-type arms

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -2229,6 +2229,9 @@ fn lint_match_arms<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>) {
                 && SpanlessEq::new(cx)
                     .expr_fallback(eq_fallback)
                     .eq_expr(lhs.body, rhs.body)
+                // we don't need to spawn the lint for always-panicking branches,
+                // e.g. `A => todo!(), B => todo!()`
+                && !cx.typeck_results().expr_ty(lhs.body).is_never()
                 // these checks could be removed to allow unused bindings
                 && bindings_eq(lhs.pat, local_map.keys().copied().collect())
                 && bindings_eq(rhs.pat, local_map.values().copied().collect())

--- a/tests/ui/match_same_arms.rs
+++ b/tests/ui/match_same_arms.rs
@@ -53,4 +53,23 @@ mod issue4244 {
     }
 }
 
+mod issue7331 {
+    #![warn(clippy::pedantic)]
+    #![allow(dead_code, clippy::blacklisted_name)]
+
+    #[derive(Copy, Clone)]
+    enum Foo {
+        A,
+        B,
+    }
+
+    // Lint should not be triggered for panicking branches.
+    fn test(foo: Foo) {
+        match foo {
+            Foo::A => todo!(),
+            Foo::B => todo!(),
+        }
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fixes #7331 

With this PR, never-type arms (such as `todo!()` and `unimplemeted!()`) will not result in the lint being triggered.

This has a side effect of `A => panic!("foo"), B => panic!("foo")` not being triggered, but I think it's hard to decide whether it's a placeholder for the future or not. I lean towards not considering it a false negative, at least unless someone directly reports it. 

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: `match-same-arms` lint is no longer triggered for arms that always panic (e.g. `todo`).
