### PR TITLE
Do not spawn blacklisted_name lint in test context

### DIFF
--- a/clippy_lints/src/blacklisted_name.rs
+++ b/clippy_lints/src/blacklisted_name.rs
@@ -1,6 +1,6 @@
-use clippy_utils::diagnostics::span_lint;
+use clippy_utils::{diagnostics::span_lint, is_test_module_or_function};
 use rustc_data_structures::fx::FxHashSet;
-use rustc_hir::{Pat, PatKind};
+use rustc_hir::{Item, Pat, PatKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
@@ -25,18 +25,37 @@ declare_clippy_lint! {
 #[derive(Clone, Debug)]
 pub struct BlacklistedName {
     blacklist: FxHashSet<String>,
+    test_modules_deep: u32,
 }
 
 impl BlacklistedName {
     pub fn new(blacklist: FxHashSet<String>) -> Self {
-        Self { blacklist }
+        Self {
+            blacklist,
+            test_modules_deep: 0,
+        }
+    }
+
+    fn in_test_module(&self) -> bool {
+        self.test_modules_deep != 0
     }
 }
 
 impl_lint_pass!(BlacklistedName => [BLACKLISTED_NAME]);
 
 impl<'tcx> LateLintPass<'tcx> for BlacklistedName {
+    fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
+        if is_test_module_or_function(cx.tcx, item) {
+            self.test_modules_deep = self.test_modules_deep.saturating_add(1);
+        }
+    }
+
     fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>) {
+        // Check whether we are under the `test` attribute.
+        if self.in_test_module() {
+            return;
+        }
+
         if let PatKind::Binding(.., ident, _) = pat.kind {
             if self.blacklist.contains(&ident.name.to_string()) {
                 span_lint(
@@ -46,6 +65,12 @@ impl<'tcx> LateLintPass<'tcx> for BlacklistedName {
                     &format!("use of a blacklisted/placeholder name `{}`", ident.name),
                 );
             }
+        }
+    }
+
+    fn check_item_post(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
+        if is_test_module_or_function(cx.tcx, item) {
+            self.test_modules_deep = self.test_modules_deep.saturating_sub(1);
         }
     }
 }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1727,3 +1727,15 @@ pub fn is_hir_ty_cfg_dependant(cx: &LateContext<'_>, ty: &hir::Ty<'_>) -> bool {
         }
     }
 }
+
+/// Checks whether item either has `test` attribute applied, or
+/// is a module with `test` in its name.
+pub fn is_test_module_or_function(tcx: TyCtxt<'_>, item: &Item<'_>) -> bool {
+    if let Some(def_id) = tcx.hir().opt_local_def_id(item.hir_id()) {
+        if tcx.has_attr(def_id.to_def_id(), sym::test) {
+            return true;
+        }
+    }
+
+    matches!(item.kind, ItemKind::Mod(..)) && item.ident.name.as_str().contains("test")
+}

--- a/tests/ui/blacklisted_name.rs
+++ b/tests/ui/blacklisted_name.rs
@@ -43,3 +43,15 @@ fn issue_1647_ref_mut() {
     let ref mut baz = 0;
     if let Some(ref mut quux) = Some(42) {}
 }
+
+mod tests {
+    fn issue_7305() {
+        // `blackisted_name` lint should not be triggered inside of the test code.
+        let foo = 0;
+
+        // Check that even in nested functions warning is still not triggere.
+        fn nested() {
+            let foo = 0;
+        }
+    }
+}


### PR DESCRIPTION
---

fixed #7305 

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: `blacklisted_name` lint is not spawned in the test context anymore.
