### PR TITLE
Improve panic message on "Found multiple rlibs" error in compile-test

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -48,13 +48,23 @@ fn third_party_crates() -> String {
                     && name.rsplit('.').next().map(|ext| ext.eq_ignore_ascii_case("rlib")) == Some(true)
                 {
                     if let Some(old) = crates.insert(dep, path.clone()) {
+                        // Check which action should be done in order to remove compiled deps.
+                        // If pre-installed version of compiler is used, `cargo clean` will do.
+                        // Otherwise (for bootstrapped compiler), the dependencies directory
+                        // must be removed manually.
+                        let suggested_action = if std::env::var_os("RUSTC_BOOTSTRAP").is_some() {
+                            "remove the stageN-tools directory"
+                        } else {
+                            "run `cargo clean`"
+                        };
+
                         panic!(
                             "\n---------------------------------------------------\n\n \
                             Found multiple rlibs for crate `{}`: `{:?}` and `{:?}`.\n \
-                            Probably, you need to run `cargo clean` before running tests again.\n \
+                            Probably, you need to {} before running tests again.\n \
                             \nFor details on that error see https://github.com/rust-lang/rust-clippy/issues/7343 \
                             \n---------------------------------------------------\n",
-                            dep, old, path
+                            dep, old, path, suggested_action
                         );
                     }
                     break;

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -52,6 +52,7 @@ fn third_party_crates() -> String {
                             "\n---------------------------------------------------\n\n \
                             Found multiple rlibs for crate `{}`: `{:?}` and `{:?}`.\n \
                             Probably, you need to run `cargo clean` before running tests again.\n \
+                            \nFor details on that error see https://github.com/rust-lang/rust-clippy/issues/7343 \
                             \n---------------------------------------------------\n",
                             dep, old, path
                         );

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -48,7 +48,13 @@ fn third_party_crates() -> String {
                     && name.rsplit('.').next().map(|ext| ext.eq_ignore_ascii_case("rlib")) == Some(true)
                 {
                     if let Some(old) = crates.insert(dep, path.clone()) {
-                        panic!("Found multiple rlibs for crate `{}`: `{:?}` and `{:?}", dep, old, path);
+                        panic!(
+                            "\n---------------------------------------------------\n\n \
+                            Found multiple rlibs for crate `{}`: `{:?}` and `{:?}`.\n \
+                            Probably, you need to run `cargo clean` before running tests again.\n \
+                            \n---------------------------------------------------\n",
+                            dep, old, path
+                        );
                     }
                     break;
                 }


### PR DESCRIPTION
Related to #7343 

When I first met this error I was pretty much confused, so I thought it may be a good idea to:

- Give a hint on what to do to users that don't want to dig into specifics and just want to quickly resolve the issue.
- Give a link for those who are interested in details.

## Old appearance:

<img width="1121" alt="Screenshot 2021-06-20 at 08 30 34" src="https://user-images.githubusercontent.com/12111581/122663361-df8ae780-d1aa-11eb-9236-775b4fd754d5.png">

## New appearance:

<img width="1121" alt="Screenshot 2021-06-20 at 08 32 18" src="https://user-images.githubusercontent.com/12111581/122663363-e4e83200-d1aa-11eb-9c46-f62d83eb79e2.png">

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none
