### PR TITLE
Improve lint message for match-same-arms lint

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -2266,7 +2266,8 @@ fn lint_match_arms<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>) {
                             ),
                         );
                     } else {
-                        diag.span_help(i.pat.span, &format!("consider refactoring into `{} | {}`", lhs, rhs));
+                        diag.span_help(i.pat.span, &format!("consider refactoring into `{} | {}`", lhs, rhs,))
+                            .help("...or consider changing the match arm bodies");
                     }
                 },
             );

--- a/tests/ui/match_same_arms.stderr
+++ b/tests/ui/match_same_arms.stderr
@@ -32,6 +32,7 @@ help: consider refactoring into `(1, .., 3) | (.., 3)`
    |
 LL |         (1, .., 3) => 42,
    |         ^^^^^^^^^^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:24:15
@@ -49,6 +50,7 @@ help: consider refactoring into `42 | 51`
    |
 LL |         42 => 1,
    |         ^^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:26:15
@@ -66,6 +68,7 @@ help: consider refactoring into `41 | 52`
    |
 LL |         41 => 2,
    |         ^^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:32:14
@@ -83,6 +86,7 @@ help: consider refactoring into `1 | 2`
    |
 LL |         1 => 2,
    |         ^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:33:14
@@ -100,6 +104,7 @@ help: consider refactoring into `1 | 3`
    |
 LL |         1 => 2,
    |         ^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:33:14
@@ -117,6 +122,7 @@ help: consider refactoring into `2 | 3`
    |
 LL |         2 => 2, //~ ERROR 2nd matched arms have same body
    |         ^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms.rs:50:55
@@ -134,6 +140,7 @@ help: consider refactoring into `CommandInfo::BuiltIn { name, .. } | CommandInfo
    |
 LL |                 CommandInfo::BuiltIn { name, .. } => name.to_string(),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: ...or consider changing the match arm bodies
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/match_same_arms2.stderr
+++ b/tests/ui/match_same_arms2.stderr
@@ -53,6 +53,7 @@ help: consider refactoring into `42 | 51`
    |
 LL |         42 => foo(),
    |         ^^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms2.rs:40:17
@@ -70,6 +71,7 @@ help: consider refactoring into `Some(_) | None`
    |
 LL |         Some(_) => 24,
    |         ^^^^^^^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms2.rs:62:28
@@ -87,6 +89,7 @@ help: consider refactoring into `(Some(a), None) | (None, Some(a))`
    |
 LL |         (Some(a), None) => bar(a),
    |         ^^^^^^^^^^^^^^^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms2.rs:68:26
@@ -104,6 +107,7 @@ help: consider refactoring into `(Some(a), ..) | (.., Some(a))`
    |
 LL |         (Some(a), ..) => bar(a),
    |         ^^^^^^^^^^^^^
+   = help: ...or consider changing the match arm bodies
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms2.rs:102:29
@@ -121,6 +125,7 @@ help: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
    |         ^^^^^^^^^^^^^^^^
+   = help: ...or consider changing the match arm bodies
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -139,6 +144,7 @@ help: consider refactoring into `Ok(3) | Ok(_)`
    |
 LL |         Ok(3) => println!("ok"),
    |         ^^^^^
+   = help: ...or consider changing the match arm bodies
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
@@ -163,6 +169,7 @@ help: consider refactoring into `0 | 1`
    |
 LL |         0 => {
    |         ^
+   = help: ...or consider changing the match arm bodies
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_same_arms2.rs:162:16


### PR DESCRIPTION
fixes #7331

Follow-up to #7377 

This PR improves the lint message for `match-same-arms` lint and adds `todo!(..)`  example to the lint docs.

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: None