### PR TITLE
Fix invocation of `zst_offset` lint

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2036,7 +2036,7 @@ impl<'tcx> LateLintPass<'tcx> for Methods {
 fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Option<&RustcVersion>) {
     if let Some((name, [recv, args @ ..], span)) = method_call!(expr) {
         match (name, args) {
-            ("add" | "offset" | "sub" | "wrapping_offset" | "wrapping_add" | "wrapping_sub", [recv, _]) => {
+            ("add" | "offset" | "sub" | "wrapping_offset" | "wrapping_add" | "wrapping_sub", [_arg]) => {
                 zst_offset::check(cx, expr, recv);
             },
             ("and_then", [arg]) => {

--- a/tests/ui/zero_offset.rs
+++ b/tests/ui/zero_offset.rs
@@ -1,12 +1,18 @@
 fn main() {
     unsafe {
-        let x = &() as *const ();
-        x.offset(0);
-        x.wrapping_add(0);
-        x.sub(0);
-        x.wrapping_sub(0);
+        let m = &mut () as *mut ();
+        m.offset(0);
+        m.wrapping_add(0);
+        m.sub(0);
+        m.wrapping_sub(0);
 
-        let y = &1 as *const u8;
+        let c = &() as *const ();
+        c.offset(0);
+        c.wrapping_add(0);
+        c.sub(0);
+        c.wrapping_sub(0);
+
+        let y = &1 as *const i32;
         y.offset(0);
     }
 }

--- a/tests/ui/zero_offset.rs
+++ b/tests/ui/zero_offset.rs
@@ -12,7 +12,7 @@ fn main() {
         c.sub(0);
         c.wrapping_sub(0);
 
-        let y = &1 as *const i32;
-        y.offset(0);
+        let sized = &1 as *const i32;
+        sized.offset(0);
     }
 }

--- a/tests/ui/zero_offset.stderr
+++ b/tests/ui/zero_offset.stderr
@@ -1,9 +1,52 @@
-error[E0606]: casting `&i32` as `*const u8` is invalid
-  --> $DIR/zero_offset.rs:9:17
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:4:9
    |
-LL |         let y = &1 as *const u8;
-   |                 ^^^^^^^^^^^^^^^
+LL |         m.offset(0);
+   |         ^^^^^^^^^^^
+   |
+   = note: `#[deny(clippy::zst_offset)]` on by default
 
-error: aborting due to previous error
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:5:9
+   |
+LL |         m.wrapping_add(0);
+   |         ^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0606`.
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:6:9
+   |
+LL |         m.sub(0);
+   |         ^^^^^^^^
+
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:7:9
+   |
+LL |         m.wrapping_sub(0);
+   |         ^^^^^^^^^^^^^^^^^
+
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:10:9
+   |
+LL |         c.offset(0);
+   |         ^^^^^^^^^^^
+
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:11:9
+   |
+LL |         c.wrapping_add(0);
+   |         ^^^^^^^^^^^^^^^^^
+
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:12:9
+   |
+LL |         c.sub(0);
+   |         ^^^^^^^^
+
+error: offset calculation on zero-sized value
+  --> $DIR/zero_offset.rs:13:9
+   |
+LL |         c.wrapping_sub(0);
+   |         ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
The `zst_offset` lint was broken by a refactoring regression in 21083875d211c29fcfa4a21fcd66d4601d2b618b. In the invocation of the `zst_offset` check [here](https://github.com/rust-lang/rust-clippy/commit/21083875d211c29fcfa4a21fcd66d4601d2b618b#diff-7f73f6fe28c04b654223c09c42fe02937d2351fc58a91d21ab812aaf6f9b185dR1927), we shadow the already-destructured receiver `recv`, and accidentally pass the first argument of the method as if it were the receiver.

This was not caught because the UI test expectation was never correct (a bad cast obscured the actual test result).

This PR:
- Fixes the existing test expectation
- Tests both `const` and `mut` raw pointers
- Passes the actual receiver to the lint's implementation

Fixes #7395.

changelog: Fix [`zst_offset`] invocation and test
