### PR TITLE
clippy-driver usage should tell user the usage about clippy-driver but not cargo clippy

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -126,7 +126,7 @@ fn display_help() {
 Checks a package to catch common mistakes and improve your Rust code.
 
 Usage:
-    cargo clippy [options] [--] [<opts>...]
+    clippy-driver [options] [--] [<opts>...]
 
 Common options:
     -h, --help               Print this message


### PR DESCRIPTION
Thank you for making Clippy better!

fixes:  #7398 

---

changelog: modify the usage prompt for clippy-driver.
