### PR TITLE
fix doc_markdown false positive

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -549,7 +549,7 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
             FootnoteReference(text) | Text(text) => {
                 let (begin, span) = get_current_span(spans, range.start);
                 paragraph_span = paragraph_span.with_hi(span.hi());
-                ticks_unbalanced |= text.contains('`');
+                ticks_unbalanced |= text.contains('`') && !in_code;
                 if Some(&text) == in_link.as_ref() || ticks_unbalanced {
                     // Probably a link of the form `<http://example.com>`
                     // Which are represented as a link to "http://example.com" with

--- a/tests/ui/doc/unbalanced_ticks.rs
+++ b/tests/ui/doc/unbalanced_ticks.rs
@@ -34,3 +34,10 @@ fn in_code_block() {}
 /// - This `item has unbalanced tick marks
 /// - This item needs backticks_here
 fn other_markdown() {}
+
+#[rustfmt::skip]
+/// - ```rust
+///   /// `lol`
+///   pub struct Struct;
+///   ```
+fn iss_7421() {}


### PR DESCRIPTION
fixes #7421 

changelog: don't lint unbalanced tick marks in code blocks
