### PR TITLE
Fix false-positive `assert` in `panic`

### DIFF
--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -74,7 +74,9 @@ declare_lint_pass!(PanicUnimplemented => [UNIMPLEMENTED, UNREACHABLE, TODO, PANI
 
 impl<'tcx> LateLintPass<'tcx> for PanicUnimplemented {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if match_panic_call(cx, expr).is_some() && is_expn_of(expr.span, "debug_assert").is_none() {
+        if match_panic_call(cx, expr).is_some()
+            && (is_expn_of(expr.span, "debug_assert").is_none() && is_expn_of(expr.span, "assert").is_none())
+        {
             let span = get_outer_span(expr);
             if is_expn_of(expr.span, "unimplemented").is_some() {
                 span_lint(

--- a/tests/ui/panicking_macros.rs
+++ b/tests/ui/panicking_macros.rs
@@ -43,6 +43,18 @@ fn core_versions() {
     unreachable!();
 }
 
+fn assert() {
+    assert!(true);
+    assert_eq!(true, true);
+    assert_ne!(true, false);
+}
+
+fn assert_msg() {
+    assert!(true, "this should not panic");
+    assert_eq!(true, true, "this should not panic");
+    assert_ne!(true, false, "this should not panic");
+}
+
 fn debug_assert() {
     debug_assert!(true);
     debug_assert_eq!(true, true);
@@ -61,4 +73,8 @@ fn main() {
     unimplemented();
     unreachable();
     core_versions();
+    assert();
+    assert_msg();
+    debug_assert();
+    debug_assert_msg();
 }


### PR DESCRIPTION
This PR fixes a false-positive in `clippy::panic` when using the `assert` macro with its optional message parameter.

Fixes: #7433 


changelog: `panic_unimplemented.rs`: added condition to exclude `assert` macro, similar to `debug_assert`
changelog: `panicking_macros.rs`: relevant tests to check for `assert` usage.
