### PR TITLE
Fix syntax highlighting for no_run blocks

### DIFF
--- a/util/export.py
+++ b/util/export.py
@@ -23,7 +23,7 @@ def parse_code_block(match):
 
     for line in match.group(0).split('\n'):
         # fix syntax highlighting for headers like ```rust,ignore
-        if line.startswith('```rust') | line.startswith('```no_run'):
+        if line.startswith('```rust') or line.startswith('```no_run'):
             lines.append('```rust')
         elif not line.startswith('# '):
             lines.append(line)

--- a/util/export.py
+++ b/util/export.py
@@ -10,7 +10,7 @@ import json
 from lintlib import parse_all, log
 
 lint_subheadline = re.compile(r'''^\*\*([\w\s]+?)[:?.!]?\*\*(.*)''')
-rust_code_block = re.compile(r'''```rust.+?```''', flags=re.DOTALL)
+rust_code_block = re.compile(r'''```(rust|no_run).+?```''', flags=re.DOTALL)
 
 CONF_TEMPLATE = """\
 This lint has the following configuration variables:
@@ -23,7 +23,7 @@ def parse_code_block(match):
 
     for line in match.group(0).split('\n'):
         # fix syntax highlighting for headers like ```rust,ignore
-        if line.startswith('```rust'):
+        if line.startswith('```rust') | line.startswith('```no_run'):
             lines.append('```rust')
         elif not line.startswith('# '):
             lines.append(line)


### PR DESCRIPTION
I was reading the lint documentation and I noticed that some of the lints weren't getting syntax highlighting.

changelog: Fix syntax highlighting for no_run blocks. 