### PR TITLE
Add fixed example to unused_unit documentation

### DIFF
--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -24,6 +24,10 @@ declare_clippy_lint! {
     ///     ()
     /// }
     /// ```
+    /// is equivalent to
+    /// ```rust
+    /// fn return_unit() {}
+    /// ```
     pub UNUSED_UNIT,
     style,
     "needless unit expression"


### PR DESCRIPTION
changelog: none

(don't think this is worth a changelog mention)