### PR TITLE
Add new lint `macros_hiding_unsafe_code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2613,6 +2613,7 @@ Released 2018-09-13
 [`logic_bug`]: https://rust-lang.github.io/rust-clippy/master/index.html#logic_bug
 [`lossy_float_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#lossy_float_literal
 [`macro_use_imports`]: https://rust-lang.github.io/rust-clippy/master/index.html#macro_use_imports
+[`macros_hiding_unsafe_code`]: https://rust-lang.github.io/rust-clippy/master/index.html#macros_hiding_unsafe_code
 [`main_recursion`]: https://rust-lang.github.io/rust-clippy/master/index.html#main_recursion
 [`manual_async_fn`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_async_fn
 [`manual_filter_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_filter_map

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -252,6 +252,7 @@ mod lifetimes;
 mod literal_representation;
 mod loops;
 mod macro_use;
+mod macros_hiding_unsafe_code;
 mod main_recursion;
 mod manual_async_fn;
 mod manual_map;
@@ -707,6 +708,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         loops::WHILE_LET_LOOP,
         loops::WHILE_LET_ON_ITERATOR,
         macro_use::MACRO_USE_IMPORTS,
+        macros_hiding_unsafe_code::MACROS_HIDING_UNSAFE_CODE,
         main_recursion::MAIN_RECURSION,
         manual_async_fn::MANUAL_ASYNC_FN,
         manual_map::MANUAL_MAP,
@@ -1018,6 +1020,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(integer_division::INTEGER_DIVISION),
         LintId::of(let_underscore::LET_UNDERSCORE_MUST_USE),
         LintId::of(literal_representation::DECIMAL_LITERAL_REPRESENTATION),
+        LintId::of(macros_hiding_unsafe_code::MACROS_HIDING_UNSAFE_CODE),
         LintId::of(map_err_ignore::MAP_ERR_IGNORE),
         LintId::of(matches::REST_PAT_IN_FULLY_BOUND_STRUCTS),
         LintId::of(matches::WILDCARD_ENUM_MATCH_ARM),
@@ -2101,6 +2104,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     let scripts = conf.allowed_scripts.clone();
     store.register_early_pass(move || box disallowed_script_idents::DisallowedScriptIdents::new(&scripts));
     store.register_late_pass(|| box strlen_on_c_strings::StrlenOnCStrings);
+    store.register_late_pass(|| box macros_hiding_unsafe_code::MacrosHidingUnsafeCode::default());
 }
 
 #[rustfmt::skip]

--- a/clippy_lints/src/macros_hiding_unsafe_code.rs
+++ b/clippy_lints/src/macros_hiding_unsafe_code.rs
@@ -1,0 +1,140 @@
+use clippy_utils::{diagnostics::span_lint_and_sugg, in_macro, is_lint_allowed, source::snippet_with_applicability};
+use rustc_errors::Applicability;
+use rustc_hir::{intravisit::FnKind, Block, BlockCheckMode, Body, FnDecl, FnSig, HirId, UnsafeSource, Unsafety};
+use rustc_lint::{
+    builtin::{UNSAFE_OP_IN_UNSAFE_FN, UNUSED_UNSAFE},
+    LateContext, LateLintPass, LintContext,
+};
+use rustc_middle::lint::in_external_macro;
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::Span;
+
+declare_clippy_lint! {
+    /// **What it does:** Checks for macro calls inside an `unsafe` function which expansion
+    /// contains an `unsafe` block, while the macro call is not wrapped in an `unsafe` block
+    /// itself. This lint only triggers in functions where the `unsafe_op_in_unsafe_fn` lint is
+    /// enabled.
+    ///
+    /// **Why is this bad?** This hides an unsafe operation inside a macro call. This is against
+    /// the intention of the `unsafe_op_in_unsafe_fn` lint, which is meant to make unsafe code more
+    /// visible by requiring `unsafe` blocks also in `unsafe` functions.
+    ///
+    /// **Known problems:**
+    /// - In some cases the intention of the macro is to actually hide the unsafety, because the
+    /// macro itself ensures the safety of the `unsafe` operation.
+    /// - For local macros, either an `#[allow(unused_unsafe)]` has to be added to the new unsafe
+    /// block or the unsafe block inside the macro has to be removed.
+    ///
+    /// **Example:**
+    ///
+    /// ```rust
+    /// macro_rules! unsafe_macro {
+    ///     ($e:expr) => {
+    ///         unsafe { $e };
+    ///     };
+    /// }
+    ///
+    /// #[warn(unsafe_op_in_unsafe_fn)]
+    /// unsafe fn foo(x: *const usize) {
+    ///     unsafe_macro!(std::ptr::read(x));
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// # macro_rules! unsafe_macro {
+    /// #     ($e:expr) => {
+    /// #         unsafe { $e };
+    /// #     };
+    /// # }
+    /// #[warn(unsafe_op_in_unsafe_fn)]
+    /// unsafe fn foo(x: *const usize) {
+    ///     #[allow(unused_unsafe)] unsafe { unsafe_macro!(std::ptr::read(x)) };
+    /// }
+    /// ```
+    pub MACROS_HIDING_UNSAFE_CODE,
+    restriction,
+    "macros hiding unsafe code, while `unsafe_op_in_unsafe_fn` is enabled"
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct MacrosHidingUnsafeCode {
+    in_unsafe_fn: bool,
+    in_unsafe_block: usize,
+}
+
+impl_lint_pass!(MacrosHidingUnsafeCode => [MACROS_HIDING_UNSAFE_CODE]);
+
+impl LateLintPass<'_> for MacrosHidingUnsafeCode {
+    fn check_block(&mut self, cx: &LateContext<'_>, block: &Block<'_>) {
+        if let BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided) = block.rules {
+            if in_macro(block.span) {
+                if self.in_unsafe_fn
+                    && self.in_unsafe_block == 0
+                    && !is_lint_allowed(cx, UNSAFE_OP_IN_UNSAFE_FN, block.hir_id)
+                {
+                    let macro_call_span = block.span.source_callsite();
+                    let unused_unsafe_sugg = if !in_external_macro(cx.sess(), block.span)
+                        && !is_lint_allowed(cx, UNUSED_UNSAFE, block.hir_id)
+                    {
+                        "#[allow(unused_unsafe)] "
+                    } else {
+                        ""
+                    };
+                    let mut applicability = Applicability::MaybeIncorrect;
+                    span_lint_and_sugg(
+                        cx,
+                        MACROS_HIDING_UNSAFE_CODE,
+                        macro_call_span,
+                        "this macro call hides unsafe code",
+                        "wrap it in an `unsafe` block",
+                        format!(
+                            "{}unsafe {{ {} }}",
+                            unused_unsafe_sugg,
+                            snippet_with_applicability(cx, macro_call_span, "...", &mut applicability),
+                        ),
+                        applicability,
+                    );
+                }
+            } else {
+                self.in_unsafe_block = self.in_unsafe_block.saturating_add(1);
+            }
+        }
+    }
+
+    fn check_block_post(&mut self, _: &LateContext<'_>, block: &Block<'_>) {
+        if let BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided) = block.rules {
+            if !in_macro(block.span) {
+                self.in_unsafe_block = self.in_unsafe_block.saturating_sub(1);
+            }
+        }
+    }
+
+    fn check_fn(&mut self, _: &LateContext<'_>, fn_kind: FnKind<'_>, _: &FnDecl<'_>, _: &Body<'_>, _: Span, _: HirId) {
+        if is_unsafe_fn(fn_kind) {
+            self.in_unsafe_fn = true;
+        }
+    }
+
+    fn check_fn_post(
+        &mut self,
+        _: &LateContext<'_>,
+        fn_kind: FnKind<'_>,
+        _: &FnDecl<'_>,
+        _: &Body<'_>,
+        _: Span,
+        _: HirId,
+    ) {
+        if is_unsafe_fn(fn_kind) {
+            self.in_unsafe_fn = false;
+        }
+    }
+}
+
+fn is_unsafe_fn(fn_kind: FnKind<'_>) -> bool {
+    match fn_kind {
+        FnKind::ItemFn(_, _, header, _) | FnKind::Method(_, &FnSig { header, .. }, _) => {
+            matches!(header.unsafety, Unsafety::Unsafe)
+        },
+        FnKind::Closure => false,
+    }
+}

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -113,3 +113,10 @@ macro_rules! default_numeric_fallback {
         let x = 22;
     };
 }
+
+#[macro_export]
+macro_rules! unsafe_external_macro {
+    ($e:expr) => {
+        unsafe { $e }
+    };
+}

--- a/tests/ui/macros_hiding_unsafe_code.fixed
+++ b/tests/ui/macros_hiding_unsafe_code.fixed
@@ -1,0 +1,69 @@
+// run-rustfix
+// aux-build: macro_rules.rs
+
+#![warn(clippy::macros_hiding_unsafe_code)]
+// compiletest allows unused code by default. But we want to explicitely test
+// for this lint here.
+#![warn(unused_unsafe)]
+
+extern crate macro_rules;
+
+use macro_rules::unsafe_external_macro;
+
+macro_rules! unsafe_macro {
+    ($e:expr) => {
+        unsafe { $e }
+    };
+    (NESTED $e:expr) => {
+        unsafe { unsafe_function($e) }
+    };
+}
+
+unsafe fn unsafe_function(x: *const usize) {
+    let _ = std::ptr::read(x);
+}
+
+mod no_unsafe_op_in_unsafe_fn {
+    use super::*;
+
+    #[allow(unused_unsafe)]
+    pub unsafe fn ok(x: *const usize) {
+        unsafe_macro!(std::ptr::read(x));
+        unsafe_external_macro!(std::ptr::read(x));
+    }
+}
+
+mod unsafe_op_in_unsafe_fn {
+    #![warn(unsafe_op_in_unsafe_fn)]
+
+    use super::*;
+
+    pub unsafe fn bad(x: *const usize) {
+        #[allow(unused_unsafe)] unsafe { unsafe_macro!(std::ptr::read(x)); }
+        #[allow(unused_unsafe)] unsafe { unsafe_macro!(NESTED std::ptr::read(&x)); }
+        unsafe { unsafe_external_macro!(std::ptr::read(x)); }
+    }
+
+    pub unsafe fn ok(x: *const usize) {
+        #[allow(unused_unsafe)]
+        unsafe {
+            unsafe_macro!(std::ptr::read(x));
+            unsafe_external_macro!(std::ptr::read(x));
+        }
+    }
+
+    #[allow(unused_unsafe)]
+    pub unsafe fn unused_unsafe_disabled(x: *const usize) {
+        unsafe { unsafe_macro!(std::ptr::read(x)); }
+        unsafe { unsafe_external_macro!(std::ptr::read(x)); }
+    }
+}
+
+fn main() {
+    unsafe {
+        no_unsafe_op_in_unsafe_fn::ok(std::ptr::null());
+        unsafe_op_in_unsafe_fn::bad(std::ptr::null());
+        unsafe_op_in_unsafe_fn::ok(std::ptr::null());
+        unsafe_op_in_unsafe_fn::unused_unsafe_disabled(std::ptr::null());
+    }
+}

--- a/tests/ui/macros_hiding_unsafe_code.rs
+++ b/tests/ui/macros_hiding_unsafe_code.rs
@@ -1,0 +1,69 @@
+// run-rustfix
+// aux-build: macro_rules.rs
+
+#![warn(clippy::macros_hiding_unsafe_code)]
+// compiletest allows unused code by default. But we want to explicitely test
+// for this lint here.
+#![warn(unused_unsafe)]
+
+extern crate macro_rules;
+
+use macro_rules::unsafe_external_macro;
+
+macro_rules! unsafe_macro {
+    ($e:expr) => {
+        unsafe { $e }
+    };
+    (NESTED $e:expr) => {
+        unsafe { unsafe_function($e) }
+    };
+}
+
+unsafe fn unsafe_function(x: *const usize) {
+    let _ = std::ptr::read(x);
+}
+
+mod no_unsafe_op_in_unsafe_fn {
+    use super::*;
+
+    #[allow(unused_unsafe)]
+    pub unsafe fn ok(x: *const usize) {
+        unsafe_macro!(std::ptr::read(x));
+        unsafe_external_macro!(std::ptr::read(x));
+    }
+}
+
+mod unsafe_op_in_unsafe_fn {
+    #![warn(unsafe_op_in_unsafe_fn)]
+
+    use super::*;
+
+    pub unsafe fn bad(x: *const usize) {
+        unsafe_macro!(std::ptr::read(x));
+        unsafe_macro!(NESTED std::ptr::read(&x));
+        unsafe_external_macro!(std::ptr::read(x));
+    }
+
+    pub unsafe fn ok(x: *const usize) {
+        #[allow(unused_unsafe)]
+        unsafe {
+            unsafe_macro!(std::ptr::read(x));
+            unsafe_external_macro!(std::ptr::read(x));
+        }
+    }
+
+    #[allow(unused_unsafe)]
+    pub unsafe fn unused_unsafe_disabled(x: *const usize) {
+        unsafe_macro!(std::ptr::read(x));
+        unsafe_external_macro!(std::ptr::read(x));
+    }
+}
+
+fn main() {
+    unsafe {
+        no_unsafe_op_in_unsafe_fn::ok(std::ptr::null());
+        unsafe_op_in_unsafe_fn::bad(std::ptr::null());
+        unsafe_op_in_unsafe_fn::ok(std::ptr::null());
+        unsafe_op_in_unsafe_fn::unused_unsafe_disabled(std::ptr::null());
+    }
+}

--- a/tests/ui/macros_hiding_unsafe_code.stderr
+++ b/tests/ui/macros_hiding_unsafe_code.stderr
@@ -1,0 +1,34 @@
+error: this macro call hides unsafe code
+  --> $DIR/macros_hiding_unsafe_code.rs:42:9
+   |
+LL |         unsafe_macro!(std::ptr::read(x));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: wrap it in an `unsafe` block: `#[allow(unused_unsafe)] unsafe { unsafe_macro!(std::ptr::read(x)); }`
+   |
+   = note: `-D clippy::macros-hiding-unsafe-code` implied by `-D warnings`
+
+error: this macro call hides unsafe code
+  --> $DIR/macros_hiding_unsafe_code.rs:43:9
+   |
+LL |         unsafe_macro!(NESTED std::ptr::read(&x));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: wrap it in an `unsafe` block: `#[allow(unused_unsafe)] unsafe { unsafe_macro!(NESTED std::ptr::read(&x)); }`
+
+error: this macro call hides unsafe code
+  --> $DIR/macros_hiding_unsafe_code.rs:44:9
+   |
+LL |         unsafe_external_macro!(std::ptr::read(x));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: wrap it in an `unsafe` block: `unsafe { unsafe_external_macro!(std::ptr::read(x)); }`
+
+error: this macro call hides unsafe code
+  --> $DIR/macros_hiding_unsafe_code.rs:57:9
+   |
+LL |         unsafe_macro!(std::ptr::read(x));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: wrap it in an `unsafe` block: `unsafe { unsafe_macro!(std::ptr::read(x)); }`
+
+error: this macro call hides unsafe code
+  --> $DIR/macros_hiding_unsafe_code.rs:58:9
+   |
+LL |         unsafe_external_macro!(std::ptr::read(x));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: wrap it in an `unsafe` block: `unsafe { unsafe_external_macro!(std::ptr::read(x)); }`
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
This lint only triggers if the `unsafe_op_in_unsafe_fn` lint is enabled.

This lint is placed in the restriction group, since it suggests code,
that requires to allow the `unused_unsafe` lint locally. Instead of
allowing this lint, the unsafe block in the macro could be removed.

Closes #7323 

changelog: Add new lint [`macros_hiding_unsafe_code`]

