### PR TITLE
Add check if ty has_escaping_bound_vars in zero_sized_map_values lint

### DIFF
--- a/clippy_lints/src/zero_sized_map_values.rs
+++ b/clippy_lints/src/zero_sized_map_values.rs
@@ -4,7 +4,7 @@ use clippy_utils::ty::{is_normalizable, is_type_diagnostic_item, match_type};
 use if_chain::if_chain;
 use rustc_hir::{self as hir, HirId, ItemKind, Node};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty::{Adt, Ty};
+use rustc_middle::ty::{Adt, Ty, TypeFoldable};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::sym;
 use rustc_target::abi::LayoutOf as _;
@@ -52,6 +52,9 @@ impl LateLintPass<'_> for ZeroSizedMapValues {
             if is_type_diagnostic_item(cx, ty, sym::hashmap_type) || match_type(cx, ty, &paths::BTREEMAP);
             if let Adt(_, substs) = ty.kind();
             let ty = substs.type_at(1);
+            // Fixes https://github.com/rust-lang/rust-clippy/issues/7447 because of
+            // https://github.com/rust-lang/rust/blob/master/compiler/rustc_middle/src/ty/sty.rs#L968
+            if !ty.has_escaping_bound_vars();
             // Do this to prevent `layout_of` crashing, being unable to fully normalize `ty`.
             if is_normalizable(cx, cx.param_env, ty);
             if let Ok(layout) = cx.layout_of(ty);

--- a/tests/ui/issue-7447.rs
+++ b/tests/ui/issue-7447.rs
@@ -1,0 +1,25 @@
+use std::{borrow::Cow, collections::BTreeMap, marker::PhantomData, sync::Arc};
+
+fn byte_view<'a>(s: &'a ByteView<'_>) -> BTreeMap<&'a str, ByteView<'a>> {
+    panic!()
+}
+
+fn group_entries(s: &()) -> BTreeMap<Cow<'_, str>, Vec<Cow<'_, str>>> {
+    todo!()
+}
+
+struct Mmap;
+
+enum ByteViewBacking<'a> {
+    Buf(Cow<'a, [u8]>),
+    Mmap(Mmap),
+}
+
+pub struct ByteView<'a> {
+    backing: Arc<ByteViewBacking<'a>>,
+}
+
+fn main() {
+    byte_view(panic!());
+    group_entries(panic!());
+}


### PR DESCRIPTION
Fixes: #7447

changelog: fix ICE in [`zero_sized_map_values`]
