### PR TITLE
Enhance needless continue to detect loop {continue;}

### DIFF
--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -370,15 +370,14 @@ fn suggestion_snippet_for_continue_inside_else<'a>(cx: &EarlyContext<'_>, data: 
 fn check_and_warn<'a>(cx: &EarlyContext<'_>, expr: &'a ast::Expr) {
     if_chain! {
         if let ast::ExprKind::Loop(loop_block, ..) = &expr.kind;
-        if !loop_block.stmts.is_empty();
-        if let ast::StmtKind::Expr(ref statement)
-        | ast::StmtKind::Semi(ref statement) = loop_block.stmts.last().unwrap().kind;
-        if let ast::ExprKind::Continue(_) = statement.kind;
+        if let Some(last_stmt) = loop_block.stmts.last();
+        if let ast::StmtKind::Expr(inner_expr) | ast::StmtKind::Semi(inner_expr) = &last_stmt.kind;
+        if let ast::ExprKind::Continue(_) = inner_expr.kind;
         then {
             span_lint_and_help(
                 cx,
                 NEEDLESS_CONTINUE,
-                loop_block.stmts.last().unwrap().span,
+                last_stmt.span,
                 MSG_REDUNDANT_CONTINUE_EXPRESSION,
                 None,
                 DROP_CONTINUE_EXPRESSION_MSG,

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -370,14 +370,14 @@ fn suggestion_snippet_for_continue_inside_else<'a>(cx: &EarlyContext<'_>, data: 
 fn check_and_warn<'a>(cx: &EarlyContext<'_>, expr: &'a ast::Expr) {
     if_chain! {
         if let ast::ExprKind::Loop(loop_block, ..) = &expr.kind;
-        if loop_block.stmts.len() == 1;
-        if let ast::StmtKind::Semi(ref statement) = loop_block.stmts.first().unwrap().kind;
+        if !loop_block.stmts.is_empty();
+        if let ast::StmtKind::Semi(ref statement) = loop_block.stmts.last().unwrap().kind;
         if let ast::ExprKind::Continue(_) = statement.kind;
         then {
             span_lint_and_help(
                 cx,
                 NEEDLESS_CONTINUE,
-                loop_block.stmts.first().unwrap().span,
+                loop_block.stmts.last().unwrap().span,
                 MSG_REDUNDANT_CONTINUE_EXPRESSION,
                 None,
                 DROP_CONTINUE_EXPRESSION_MSG,

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -371,7 +371,8 @@ fn check_and_warn<'a>(cx: &EarlyContext<'_>, expr: &'a ast::Expr) {
     if_chain! {
         if let ast::ExprKind::Loop(loop_block, ..) = &expr.kind;
         if !loop_block.stmts.is_empty();
-        if let ast::StmtKind::Semi(ref statement) = loop_block.stmts.last().unwrap().kind;
+        if let ast::StmtKind::Expr(ref statement)
+        | ast::StmtKind::Semi(ref statement) = loop_block.stmts.last().unwrap().kind;
         if let ast::ExprKind::Continue(_) = statement.kind;
         then {
             span_lint_and_help(

--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -49,6 +49,9 @@ fn main() {
 
         println!("bleh");
     }
+    loop {
+        continue;
+    }
 }
 
 mod issue_2329 {

--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -64,6 +64,21 @@ fn simple_loop2() {
     }
 }
 
+#[rustfmt::skip]
+fn simple_loop3() {
+    loop {
+        continue // should lint here
+    }
+}
+
+#[rustfmt::skip]
+fn simple_loop4() {
+    loop {
+        println!("bleh");
+        continue // should lint here
+    }
+}
+
 mod issue_2329 {
     fn condition() -> bool {
         unimplemented!()

--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -49,8 +49,18 @@ fn main() {
 
         println!("bleh");
     }
+}
+
+fn simple_loop() {
     loop {
-        continue;
+        continue; // should lint here
+    }
+}
+
+fn simple_loop2() {
+    loop {
+        println!("bleh");
+        continue; // should lint here
     }
 }
 

--- a/tests/ui/needless_continue.stderr
+++ b/tests/ui/needless_continue.stderr
@@ -55,15 +55,23 @@ LL | |         }
                    }
 
 error: this `continue` expression is redundant
-  --> $DIR/needless_continue.rs:53:9
+  --> $DIR/needless_continue.rs:56:9
    |
-LL |         continue;
+LL |         continue; // should lint here
+   |         ^^^^^^^^^
+   |
+   = help: consider dropping the `continue` expression
+
+error: this `continue` expression is redundant
+  --> $DIR/needless_continue.rs:63:9
+   |
+LL |         continue; // should lint here
    |         ^^^^^^^^^
    |
    = help: consider dropping the `continue` expression
 
 error: this `else` block is redundant
-  --> $DIR/needless_continue.rs:103:24
+  --> $DIR/needless_continue.rs:113:24
    |
 LL |                   } else {
    |  ________________________^
@@ -86,7 +94,7 @@ LL | |                 }
                            }
 
 error: there is no need for an explicit `else` block for this `if` expression
-  --> $DIR/needless_continue.rs:109:17
+  --> $DIR/needless_continue.rs:119:17
    |
 LL | /                 if condition() {
 LL | |                     continue; // should lint here
@@ -103,5 +111,5 @@ LL | |                 }
                                println!("bar-5");
                            }
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/needless_continue.stderr
+++ b/tests/ui/needless_continue.stderr
@@ -70,8 +70,24 @@ LL |         continue; // should lint here
    |
    = help: consider dropping the `continue` expression
 
+error: this `continue` expression is redundant
+  --> $DIR/needless_continue.rs:70:9
+   |
+LL |         continue // should lint here
+   |         ^^^^^^^^
+   |
+   = help: consider dropping the `continue` expression
+
+error: this `continue` expression is redundant
+  --> $DIR/needless_continue.rs:78:9
+   |
+LL |         continue // should lint here
+   |         ^^^^^^^^
+   |
+   = help: consider dropping the `continue` expression
+
 error: this `else` block is redundant
-  --> $DIR/needless_continue.rs:113:24
+  --> $DIR/needless_continue.rs:128:24
    |
 LL |                   } else {
    |  ________________________^
@@ -94,7 +110,7 @@ LL | |                 }
                            }
 
 error: there is no need for an explicit `else` block for this `if` expression
-  --> $DIR/needless_continue.rs:119:17
+  --> $DIR/needless_continue.rs:134:17
    |
 LL | /                 if condition() {
 LL | |                     continue; // should lint here
@@ -111,5 +127,5 @@ LL | |                 }
                                println!("bar-5");
                            }
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/needless_continue.stderr
+++ b/tests/ui/needless_continue.stderr
@@ -54,8 +54,16 @@ LL | |         }
                        println!("Jabber");
                    }
 
+error: this `continue` expression is redundant
+  --> $DIR/needless_continue.rs:53:9
+   |
+LL |         continue;
+   |         ^^^^^^^^^
+   |
+   = help: consider dropping the `continue` expression
+
 error: this `else` block is redundant
-  --> $DIR/needless_continue.rs:100:24
+  --> $DIR/needless_continue.rs:103:24
    |
 LL |                   } else {
    |  ________________________^
@@ -78,7 +86,7 @@ LL | |                 }
                            }
 
 error: there is no need for an explicit `else` block for this `if` expression
-  --> $DIR/needless_continue.rs:106:17
+  --> $DIR/needless_continue.rs:109:17
    |
 LL | /                 if condition() {
 LL | |                     continue; // should lint here
@@ -95,5 +103,5 @@ LL | |                 }
                                println!("bar-5");
                            }
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes #7417

changelog: Report [`needless_continue`] in `loop { continue; }` case