### PR TITLE
Documented constant expression evaluation for `repeat_once`

### DIFF
--- a/clippy_lints/src/repeat_once.rs
+++ b/clippy_lints/src/repeat_once.rs
@@ -16,7 +16,11 @@ declare_clippy_lint! {
     /// - `.clone()` for `String`
     /// - `.to_vec()` for `slice`
     ///
-    /// **Why is this bad?** For example, `String.repeat(1)` is equivalent to `.clone()`. If cloning the string is the intention behind this, `clone()` should be used.
+    /// The lint will evaluate constant expressions and values as arguments of `.repeat(..)` and emit a message if
+    /// they are equivalent to `1`. (Related discussion in [rust-clippy#7306](https://github.com/rust-lang/rust-clippy/issues/7306))
+    ///
+    /// **Why is this bad?** For example, `String.repeat(1)` is equivalent to `.clone()`. If cloning
+    /// the string is the intention behind this, `clone()` should be used.
     ///
     /// **Known problems:** None.
     ///


### PR DESCRIPTION
Documents the fact that the `repeat_once` lint evaluates constant expressions

---

closes: #7306 

changelog: none
(I don't think it's worth a change log entry, as nothing has really changed)

r? @giraffate as you've implemented the lint and were part of the discussion in the issue :upside_down_face: 