### PR TITLE
Explain flags missing in cargo check in --help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,6 @@ Common options:
     -h, --help               Print this message
     -V, --version            Print version info and exit
 
-Note: --no-deps flag is used with `cargo clippy --`. Example: `cargo clippy -- --no-deps`
-
 Other options are the same as `cargo check`.
 
 To allow or deny a lint from the command line you can use `cargo clippy --`
@@ -75,11 +73,16 @@ impl ClippyCmd {
     {
         let mut cargo_subcommand = "check";
         let mut args = vec![];
+        let mut clippy_args: Vec<String> = vec![];
 
         for arg in old_args.by_ref() {
             match arg.as_str() {
                 "--fix" => {
                     cargo_subcommand = "fix";
+                    continue;
+                },
+                "--no-deps" => {
+                    clippy_args.push("--no-deps".into());
                     continue;
                 },
                 "--" => break,
@@ -89,7 +92,7 @@ impl ClippyCmd {
             args.push(arg);
         }
 
-        let mut clippy_args: Vec<String> = old_args.collect();
+        clippy_args.append(&mut (old_args.collect()));
         if cargo_subcommand == "fix" && !clippy_args.iter().any(|arg| arg == "--no-deps") {
             clippy_args.push("--no-deps".into());
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ Usage:
     cargo clippy [options] [--] [<opts>...]
 
 Common options:
+    --fix                    Automatically apply lint suggestions
+    --no-deps                Run Clippy only on the given crate
     -h, --help               Print this message
     -V, --version            Print version info and exit
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,12 @@ Usage:
     cargo clippy [options] [--] [<opts>...]
 
 Common options:
-    --fix                    Automatically apply lint suggestions
-    --no-deps                Run Clippy only on the given crate
+    --no-deps                Run Clippy only on the given crate, without linting the dependencies 
+    --fix                    Automatically apply lint suggestions. This flag implies `--no-deps`
     -h, --help               Print this message
     -V, --version            Print version info and exit
+
+Note: --no-deps flag is used with `cargo clippy --`. Example: `cargo clippy -- --no-deps`
 
 Other options are the same as `cargo check`.
 

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -76,8 +76,8 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
         .env("CARGO_INCREMENTAL", "0")
         .arg("clippy")
         .args(&["-p", "subcrate"])
-        .arg("--")
         .arg("--no-deps")
+        .arg("--")
         .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
         .args(&["--cfg", r#"feature="primary_package_test""#])
         .output()


### PR DESCRIPTION
This commit closes #7389. As stated in the issue, `cargo clippy --help`
provides explanation for some flags and states that the rest are same
as in `cargo check --help`, even though some clippy specific flags
exist.

This commit extends the `cargo clippy --help` with two additional flags,
  - `cargo clippy --fix`
  - `cargo clippy --no-deps`

If there are more flags which are not present in `cargo check --help`
please bring these to my attention, I will include these aswell.
For now, I noticed only the two flags mentioned above.

changelog: `cargo clippy --help` now explains additional flags missing in `cargo check --help`. 
