### PR TITLE
Make `clippy::todo` and `clippy::unimplemented` warn by default.

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -126,11 +126,16 @@ macro_rules! declare_clippy_lint {
             $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true
         }
     };
-    { $(#[$attr:meta])* pub $name:tt, restriction, $description:tt } => {
+
+    { $(#[$attr:meta])* pub $name:ident, restriction, $description:tt } => {
+        declare_clippy_lint! { $(#[$attr])* pub $name, restriction, $description, level = Allow }
+    };
+    { $(#[$attr:meta])* pub $name:ident, restriction, $description:tt, level = $level:ident } => {
         declare_tool_lint! {
-            $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true
+            $(#[$attr])* pub clippy::$name, $level, $description, report_in_external_macro: true
         }
     };
+
     { $(#[$attr:meta])* pub $name:tt, cargo, $description:tt } => {
         declare_tool_lint! {
             $(#[$attr])* pub clippy::$name, Allow, $description, report_in_external_macro: true

--- a/clippy_lints/src/panic_unimplemented.rs
+++ b/clippy_lints/src/panic_unimplemented.rs
@@ -35,7 +35,8 @@ declare_clippy_lint! {
     /// ```
     pub UNIMPLEMENTED,
     restriction,
-    "`unimplemented!` should not be present in production code"
+    "`unimplemented!` should not be present in production code",
+    level = Warn
 }
 
 declare_clippy_lint! {
@@ -51,7 +52,8 @@ declare_clippy_lint! {
     /// ```
     pub TODO,
     restriction,
-    "`todo!` should not be present in production code"
+    "`todo!` should not be present in production code",
+    level = Warn
 }
 
 declare_clippy_lint! {


### PR DESCRIPTION
Unlike panic, it's almost never correct to have this in a production context.
Make them warn by default to avoid bugs slipping through.

It looks like this is the first time a lint level hasn't been solely determined by the group it's in, but I think it's correct: denying `todo!` is both a restriction, and should be a loud warning.

This would have caught a bug I introduced in my own codebase last week: https://github.com/cloudflare/wrangler/pull/2012

changelog: Make [`clippy::todo`] and [`clippy::unimplemented`] warn by default.