### PR TITLE
Remove `or_patterns` feature gate in example

### DIFF
--- a/clippy_lints/src/unnested_or_patterns.rs
+++ b/clippy_lints/src/unnested_or_patterns.rs
@@ -35,8 +35,6 @@ declare_clippy_lint! {
     /// ```
     /// Use instead:
     /// ```rust
-    /// #![feature(or_patterns)]
-    ///
     /// fn main() {
     ///     if let Some(0 | 2) = Some(0) {}
     /// }


### PR DESCRIPTION
changelog: removed `or_patterns` feature gate in the code example for the [`unnested_or_patterns`] lint