### PR TITLE
lintcheck always copies in a fresh crate when provided with a crate path

### DIFF
--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = {version = "1.0"}
 tar = {version = "0.4.30"}
 toml = {version = "0.5"}
 ureq = {version = "2.0.0-rc3"}
+walkdir = {version = "2.3.2"}
 
 [features]
 deny-warnings = []


### PR DESCRIPTION
changelog: none

When lintcheck is run on local crates it copies the crate to `target/lintcheck/sources/crate_name` on the first run only.
Then in subsequent runs of lintcheck it reuses this same copy.
This caching behaviour makes sense when dealing with immutable crates.io releases and git commits.
However it is quite surprising that the changes to my local crate are not used when I run lintcheck.

To fix this I removed the copy, instead clippy runs directly off the provided crate folder.
I have tested this and have not observed any negative effects from doing this.
But maybe i'm missing something as im not familiar with clippy!

Alternatively we could make it copy the entire crate every run, but that seems problematic to me as multi-gigabyte target folders will take a long time to copy and wear down SSDs for developers who frequently run lintcheck.