### PR TITLE
Use node v12.x in CI

### DIFF
--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Setup Node.js
       uses: actions/setup-node@v1.4.4
+      with:
+        node-version: '12.x'
 
     - name: Install remark
       run: npm install remark-cli remark-lint remark-lint-maximum-line-length remark-preset-lint-recommended remark-gfm

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -166,8 +166,8 @@ rustup component add clippy
 ```
 
 > **DO NOT** install using `cargo install --path . --force` since this will overwrite rustup
-[proxies](https://rust-lang.github.io/rustup/concepts/proxies.html). That is, `~/.cargo/bin/cargo-clippy` and
-`~/.cargo/bin/clippy-driver` should be hard or soft links to `~/.cargo/bin/rustup`. You can repair these by running
-`rustup update`.
+> [proxies](https://rust-lang.github.io/rustup/concepts/proxies.html). That is, `~/.cargo/bin/cargo-clippy` and
+> `~/.cargo/bin/clippy-driver` should be hard or soft links to `~/.cargo/bin/rustup`. You can repair these by running
+> `rustup update`.
 
 [glossary]: https://rustc-dev-guide.rust-lang.org/appendix/glossary.html


### PR DESCRIPTION
In https://github.com/rust-lang/rust-clippy/pull/7528#issuecomment-892281632, remark-cli version has been updated recently and it requires to use ESM module: https://github.com/remarkjs/remark/releases/tag/14.0.0. Node version in CI was v10.24.1, it seems to be old.

changelog: none
