### PR TITLE
Don't emit `too_many_lines` for closures

### DIFF
--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -251,7 +251,7 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
         hir_id: hir::HirId,
     ) {
         too_many_arguments::check_fn(cx, kind, decl, span, hir_id, self.too_many_arguments_threshold);
-        too_many_lines::check_fn(cx, span, body, self.too_many_lines_threshold);
+        too_many_lines::check_fn(cx, kind, span, body, self.too_many_lines_threshold);
         not_unsafe_ptr_arg_deref::check_fn(cx, kind, decl, body, hir_id);
     }
 

--- a/tests/ui-toml/functions_maxlines/test.rs
+++ b/tests/ui-toml/functions_maxlines/test.rs
@@ -1,3 +1,5 @@
+// edition:2018
+
 #![warn(clippy::too_many_lines)]
 
 // This function should be considered one line.
@@ -18,6 +20,20 @@ fn many_comments_but_one_line_of_code() {
 fn too_many_lines() {
     println!("This is bad.");
     println!("This is bad.");
+}
+
+// This should only fail once (#7517).
+async fn async_too_many_lines() {
+    println!("This is bad.");
+    println!("This is bad.");
+}
+
+// This should fail only once, without failing on the closure.
+fn closure_too_many_lines() {
+    let _ = {
+        println!("This is bad.");
+        println!("This is bad.");
+    };
 }
 
 // This should be considered one line.

--- a/tests/ui-toml/functions_maxlines/test.stderr
+++ b/tests/ui-toml/functions_maxlines/test.stderr
@@ -1,5 +1,5 @@
 error: this function has too many lines (2/1)
-  --> $DIR/test.rs:18:1
+  --> $DIR/test.rs:20:1
    |
 LL | / fn too_many_lines() {
 LL | |     println!("This is bad.");
@@ -9,8 +9,28 @@ LL | | }
    |
    = note: `-D clippy::too-many-lines` implied by `-D warnings`
 
+error: this function has too many lines (4/1)
+  --> $DIR/test.rs:26:1
+   |
+LL | / async fn async_too_many_lines() {
+LL | |     println!("This is bad.");
+LL | |     println!("This is bad.");
+LL | | }
+   | |_^
+
+error: this function has too many lines (4/1)
+  --> $DIR/test.rs:32:1
+   |
+LL | / fn closure_too_many_lines() {
+LL | |     let _ = {
+LL | |         println!("This is bad.");
+LL | |         println!("This is bad.");
+LL | |     };
+LL | | }
+   | |_^
+
 error: this function has too many lines (2/1)
-  --> $DIR/test.rs:38:1
+  --> $DIR/test.rs:54:1
    |
 LL | / fn comment_before_code() {
 LL | |     let _ = "test";
@@ -19,5 +39,5 @@ LL | |     the code but this line should still count. */ let _ = 5;
 LL | | }
    | |_^
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
changelog: don't emit the [`too_many_lines`] lint inside closures to avoir duplicated diagnostics.

Fixes #7517.