### PR TITLE
similar_names: allow "iter" and "item"

### DIFF
--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -126,6 +126,7 @@ const ALLOWED_TO_BE_SIMILAR: &[&[&str]] = &[
     &["qpath", "path"],
     &["lit", "lint"],
     &["wparam", "lparam"],
+    &["iter", "item"],
 ];
 
 struct SimilarNamesNameVisitor<'a, 'tcx, 'b>(&'b mut SimilarNamesLocalVisitor<'a, 'tcx>);

--- a/tests/ui/similar_names.rs
+++ b/tests/ui/similar_names.rs
@@ -76,7 +76,7 @@ fn main() {
     // names often used in win32 code (for example WindowProc)
     let wparam: i32;
     let lparam: i32;
-    
+
     let iter: i32;
     let item: i32;
 }

--- a/tests/ui/similar_names.rs
+++ b/tests/ui/similar_names.rs
@@ -76,6 +76,9 @@ fn main() {
     // names often used in win32 code (for example WindowProc)
     let wparam: i32;
     let lparam: i32;
+    
+    let iter: i32;
+    let item: i32;
 }
 
 fn foo() {

--- a/tests/ui/similar_names.stderr
+++ b/tests/ui/similar_names.stderr
@@ -72,13 +72,13 @@ LL |     let parser: i32;
    |         ^^^^^^
 
 error: binding's name is too similar to existing binding
-  --> $DIR/similar_names.rs:85:16
+  --> $DIR/similar_names.rs:88:16
    |
 LL |         bpple: sprang,
    |                ^^^^^^
    |
 note: existing binding defined here
-  --> $DIR/similar_names.rs:84:16
+  --> $DIR/similar_names.rs:87:16
    |
 LL |         apple: spring,
    |                ^^^^^^


### PR DESCRIPTION
changelog: [`similar_names`] no longer complains about `iter` and `item` being too similar
