### PR TITLE
Use `avoid-breaking-exported-api` configuration in types module

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1840,7 +1840,12 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box serde_api::SerdeApi);
     let vec_box_size_threshold = conf.vec_box_size_threshold;
     let type_complexity_threshold = conf.type_complexity_threshold;
-    store.register_late_pass(move || box types::Types::new(vec_box_size_threshold, type_complexity_threshold));
+    let avoid_breaking_exported_api = conf.avoid_breaking_exported_api;
+    store.register_late_pass(move || box types::Types::new(
+        vec_box_size_threshold,
+        type_complexity_threshold,
+        avoid_breaking_exported_api,
+    ));
     store.register_late_pass(|| box booleans::NonminimalBool);
     store.register_late_pass(|| box needless_bitwise_bool::NeedlessBitwiseBool);
     store.register_late_pass(|| box eq_op::EqOp);

--- a/clippy_lints/src/types/rc_mutex.rs
+++ b/clippy_lints/src/types/rc_mutex.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint;
+use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::is_ty_param_diagnostic_item;
 use if_chain::if_chain;
 use rustc_hir::{self as hir, def_id::DefId, QPath};
@@ -11,13 +11,14 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
     if_chain! {
         if cx.tcx.is_diagnostic_item(sym::Rc, def_id) ;
         if let Some(_) = is_ty_param_diagnostic_item(cx, qpath, sym!(mutex_type)) ;
-
-        then{
-            span_lint(
+        then {
+            span_lint_and_help(
                 cx,
                 RC_MUTEX,
                 hir_ty.span,
-                "found `Rc<Mutex<_>>`. Consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead",
+                "usage of `Rc<Mutex<_>>`",
+                None,
+                "consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead",
             );
             return true;
         }

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -132,7 +132,7 @@ macro_rules! define_Conf {
 
 // N.B., this macro is parsed by util/lintlib.py
 define_Conf! {
-    /// Lint: ENUM_VARIANT_NAMES, LARGE_TYPES_PASSED_BY_VALUE, TRIVIALLY_COPY_PASS_BY_REF, UNNECESSARY_WRAPS, UPPER_CASE_ACRONYMS, WRONG_SELF_CONVENTION.
+    /// Lint: ENUM_VARIANT_NAMES, LARGE_TYPES_PASSED_BY_VALUE, TRIVIALLY_COPY_PASS_BY_REF, UNNECESSARY_WRAPS, UPPER_CASE_ACRONYMS, WRONG_SELF_CONVENTION, BOX_VEC, REDUNDANT_ALLOCATION, RC_BUFFER, VEC_BOX, OPTION_OPTION, LINKEDLIST, RC_MUTEX.
     ///
     /// Suppress lints whenever the suggested change would cause breakage for other crates.
     (avoid_breaking_exported_api: bool = true),

--- a/tests/ui/box_vec.rs
+++ b/tests/ui/box_vec.rs
@@ -1,6 +1,10 @@
 #![warn(clippy::all)]
-#![allow(clippy::boxed_local, clippy::needless_pass_by_value)]
-#![allow(clippy::blacklisted_name)]
+#![allow(
+    clippy::boxed_local,
+    clippy::needless_pass_by_value,
+    clippy::blacklisted_name,
+    unused
+)]
 
 macro_rules! boxit {
     ($init:expr, $x:ty) => {
@@ -11,22 +15,22 @@ macro_rules! boxit {
 fn test_macro() {
     boxit!(Vec::new(), Vec<u8>);
 }
-pub fn test(foo: Box<Vec<bool>>) {
-    println!("{:?}", foo.get(0))
-}
+fn test(foo: Box<Vec<bool>>) {}
 
-pub fn test2(foo: Box<dyn Fn(Vec<u32>)>) {
+fn test2(foo: Box<dyn Fn(Vec<u32>)>) {
     // pass if #31 is fixed
     foo(vec![1, 2, 3])
 }
 
-pub fn test_local_not_linted() {
+fn test_local_not_linted() {
     let _: Box<Vec<bool>>;
 }
 
-fn main() {
-    test(Box::new(Vec::new()));
-    test2(Box::new(|v| println!("{:?}", v)));
-    test_macro();
-    test_local_not_linted();
+// All of these test should be allowed because they are part of the
+// public api and `avoid_breaking_exported_api` is `false` by default.
+pub fn pub_test(foo: Box<Vec<bool>>) {}
+pub fn pub_test_ret() -> Box<Vec<bool>> {
+    Box::new(Vec::new())
 }
+
+fn main() {}

--- a/tests/ui/box_vec.stderr
+++ b/tests/ui/box_vec.stderr
@@ -1,8 +1,8 @@
 error: you seem to be trying to use `Box<Vec<T>>`. Consider using just `Vec<T>`
-  --> $DIR/box_vec.rs:14:18
+  --> $DIR/box_vec.rs:18:14
    |
-LL | pub fn test(foo: Box<Vec<bool>>) {
-   |                  ^^^^^^^^^^^^^^
+LL | fn test(foo: Box<Vec<bool>>) {}
+   |              ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::box-vec` implied by `-D warnings`
    = help: `Vec<T>` is already on the heap, `Box<Vec<T>>` makes an extra allocation

--- a/tests/ui/linkedlist.rs
+++ b/tests/ui/linkedlist.rs
@@ -1,6 +1,6 @@
 #![feature(associated_type_defaults)]
 #![warn(clippy::linkedlist)]
-#![allow(dead_code, clippy::needless_pass_by_value)]
+#![allow(unused, dead_code, clippy::needless_pass_by_value)]
 
 extern crate alloc;
 use alloc::collections::linked_list::LinkedList;
@@ -20,24 +20,29 @@ impl Foo for LinkedList<u8> {
     const BAR: Option<LinkedList<u8>> = None;
 }
 
-struct Bar;
+pub struct Bar {
+    priv_linked_list_field: LinkedList<u8>,
+    pub pub_linked_list_field: LinkedList<u8>,
+}
 impl Bar {
     fn foo(_: LinkedList<u8>) {}
 }
 
-pub fn test(my_favourite_linked_list: LinkedList<u8>) {
-    println!("{:?}", my_favourite_linked_list)
+// All of these test should be trigger the lint because they are not
+// part of the public api
+fn test(my_favorite_linked_list: LinkedList<u8>) {}
+fn test_ret() -> Option<LinkedList<u8>> {
+    None
 }
-
-pub fn test_ret() -> Option<LinkedList<u8>> {
-    unimplemented!();
-}
-
-pub fn test_local_not_linted() {
+fn test_local_not_linted() {
     let _: LinkedList<u8>;
 }
 
-fn main() {
-    test(LinkedList::new());
-    test_local_not_linted();
+// All of these test should be allowed because they are part of the
+// public api and `avoid_breaking_exported_api` is `false` by default.
+pub fn pub_test(the_most_awesome_linked_list: LinkedList<u8>) {}
+pub fn pub_test_ret() -> Option<LinkedList<u8>> {
+    None
 }
+
+fn main() {}

--- a/tests/ui/linkedlist.stderr
+++ b/tests/ui/linkedlist.stderr
@@ -40,7 +40,15 @@ LL |     const BAR: Option<LinkedList<u8>>;
    = help: a `VecDeque` might work
 
 error: you seem to be using a `LinkedList`! Perhaps you meant some other data structure?
-  --> $DIR/linkedlist.rs:25:15
+  --> $DIR/linkedlist.rs:24:29
+   |
+LL |     priv_linked_list_field: LinkedList<u8>,
+   |                             ^^^^^^^^^^^^^^
+   |
+   = help: a `VecDeque` might work
+
+error: you seem to be using a `LinkedList`! Perhaps you meant some other data structure?
+  --> $DIR/linkedlist.rs:28:15
    |
 LL |     fn foo(_: LinkedList<u8>) {}
    |               ^^^^^^^^^^^^^^
@@ -48,20 +56,20 @@ LL |     fn foo(_: LinkedList<u8>) {}
    = help: a `VecDeque` might work
 
 error: you seem to be using a `LinkedList`! Perhaps you meant some other data structure?
-  --> $DIR/linkedlist.rs:28:39
+  --> $DIR/linkedlist.rs:33:34
    |
-LL | pub fn test(my_favourite_linked_list: LinkedList<u8>) {
-   |                                       ^^^^^^^^^^^^^^
+LL | fn test(my_favorite_linked_list: LinkedList<u8>) {}
+   |                                  ^^^^^^^^^^^^^^
    |
    = help: a `VecDeque` might work
 
 error: you seem to be using a `LinkedList`! Perhaps you meant some other data structure?
-  --> $DIR/linkedlist.rs:32:29
+  --> $DIR/linkedlist.rs:34:25
    |
-LL | pub fn test_ret() -> Option<LinkedList<u8>> {
-   |                             ^^^^^^^^^^^^^^
+LL | fn test_ret() -> Option<LinkedList<u8>> {
+   |                         ^^^^^^^^^^^^^^
    |
    = help: a `VecDeque` might work
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/rc_mutex.rs
+++ b/tests/ui/rc_mutex.rs
@@ -1,11 +1,15 @@
 #![warn(clippy::rc_mutex)]
-#![allow(clippy::blacklisted_name)]
+#![allow(unused, clippy::blacklisted_name)]
 
 use std::rc::Rc;
 use std::sync::Mutex;
 
-pub struct MyStruct {
+pub struct MyStructWithPrivItem {
     foo: Rc<Mutex<i32>>,
+}
+
+pub struct MyStructWithPubItem {
+    pub foo: Rc<Mutex<i32>>,
 }
 
 pub struct SubT<T> {
@@ -17,18 +21,16 @@ pub enum MyEnum {
     Two,
 }
 
-pub fn test1<T>(foo: Rc<Mutex<T>>) {}
+// All of these test should be trigger the lint because they are not
+// part of the public api
+fn test1<T>(foo: Rc<Mutex<T>>) {}
+fn test2(foo: Rc<Mutex<MyEnum>>) {}
+fn test3(foo: Rc<Mutex<SubT<usize>>>) {}
 
-pub fn test2(foo: Rc<Mutex<MyEnum>>) {}
+// All of these test should be allowed because they are part of the
+// public api and `avoid_breaking_exported_api` is `false` by default.
+pub fn pub_test1<T>(foo: Rc<Mutex<T>>) {}
+pub fn pub_test2(foo: Rc<Mutex<MyEnum>>) {}
+pub fn pub_test3(foo: Rc<Mutex<SubT<usize>>>) {}
 
-pub fn test3(foo: Rc<Mutex<SubT<usize>>>) {}
-
-fn main() {
-    test1(Rc::new(Mutex::new(1)));
-    test2(Rc::new(Mutex::new(MyEnum::One)));
-    test3(Rc::new(Mutex::new(SubT { foo: 1 })));
-
-    let _my_struct = MyStruct {
-        foo: Rc::new(Mutex::new(1)),
-    };
-}
+fn main() {}

--- a/tests/ui/rc_mutex.stderr
+++ b/tests/ui/rc_mutex.stderr
@@ -8,26 +8,26 @@ LL |     foo: Rc<Mutex<i32>>,
    = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
 
 error: usage of `Rc<Mutex<_>>`
-  --> $DIR/rc_mutex.rs:20:22
+  --> $DIR/rc_mutex.rs:26:18
    |
-LL | pub fn test1<T>(foo: Rc<Mutex<T>>) {}
-   |                      ^^^^^^^^^^^^
-   |
-   = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
-
-error: usage of `Rc<Mutex<_>>`
-  --> $DIR/rc_mutex.rs:22:19
-   |
-LL | pub fn test2(foo: Rc<Mutex<MyEnum>>) {}
-   |                   ^^^^^^^^^^^^^^^^^
+LL | fn test1<T>(foo: Rc<Mutex<T>>) {}
+   |                  ^^^^^^^^^^^^
    |
    = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
 
 error: usage of `Rc<Mutex<_>>`
-  --> $DIR/rc_mutex.rs:24:19
+  --> $DIR/rc_mutex.rs:27:15
    |
-LL | pub fn test3(foo: Rc<Mutex<SubT<usize>>>) {}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^
+LL | fn test2(foo: Rc<Mutex<MyEnum>>) {}
+   |               ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
+
+error: usage of `Rc<Mutex<_>>`
+  --> $DIR/rc_mutex.rs:28:15
+   |
+LL | fn test3(foo: Rc<Mutex<SubT<usize>>>) {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
 

--- a/tests/ui/rc_mutex.stderr
+++ b/tests/ui/rc_mutex.stderr
@@ -1,28 +1,35 @@
-error: found `Rc<Mutex<_>>`. Consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
+error: usage of `Rc<Mutex<_>>`
   --> $DIR/rc_mutex.rs:8:10
    |
 LL |     foo: Rc<Mutex<i32>>,
    |          ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::rc-mutex` implied by `-D warnings`
+   = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
 
-error: found `Rc<Mutex<_>>`. Consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
+error: usage of `Rc<Mutex<_>>`
   --> $DIR/rc_mutex.rs:20:22
    |
 LL | pub fn test1<T>(foo: Rc<Mutex<T>>) {}
    |                      ^^^^^^^^^^^^
+   |
+   = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
 
-error: found `Rc<Mutex<_>>`. Consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
+error: usage of `Rc<Mutex<_>>`
   --> $DIR/rc_mutex.rs:22:19
    |
 LL | pub fn test2(foo: Rc<Mutex<MyEnum>>) {}
    |                   ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
 
-error: found `Rc<Mutex<_>>`. Consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
+error: usage of `Rc<Mutex<_>>`
   --> $DIR/rc_mutex.rs:24:19
    |
 LL | pub fn test3(foo: Rc<Mutex<SubT<usize>>>) {}
    |                   ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `Rc<RefCell<_>>` or `Arc<Mutex<_>>` instead
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This PR empowers our lovely `avoid-breaking-exported-api` configuration value to also influence the emission of lints inside the `types` module. 

(That's pretty much it, not really a change worthy of writing a fairy tale about. Don't get me wrong, I would love to write a short one, but I sadly need to study now).

---

Closes: rust-lang/rust-clippy#7489

changelog: The `avoid-breaking-exported-api` configuration now also works for [`box_vec`], [`redundant_allocation`], [`rc_buffer`], [`vec_box`], [`option_option`], [`linkedlist`], [`rc_mutex`]

changelog: [`rc_mutex`]: update the lint message to comply with the normal format

---

r? @camsteffen, as you implemented the configuration value

cc: @flip1995, as we've discussed this change in rust-lang/rust-clippy#7308