### PR TITLE
Add semicolon inside/outside block lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2905,6 +2905,7 @@ Released 2018-09-13
 [`self_named_constructors`]: https://rust-lang.github.io/rust-clippy/master/index.html#self_named_constructors
 [`semicolon_if_nothing_returned`]: https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned
 [`semicolon_inside_block`]: https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_inside_block
+[`semicolon_outside_block`]: https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_outside_block
 [`serde_api_misuse`]: https://rust-lang.github.io/rust-clippy/master/index.html#serde_api_misuse
 [`shadow_reuse`]: https://rust-lang.github.io/rust-clippy/master/index.html#shadow_reuse
 [`shadow_same`]: https://rust-lang.github.io/rust-clippy/master/index.html#shadow_same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2904,6 +2904,7 @@ Released 2018-09-13
 [`self_assignment`]: https://rust-lang.github.io/rust-clippy/master/index.html#self_assignment
 [`self_named_constructors`]: https://rust-lang.github.io/rust-clippy/master/index.html#self_named_constructors
 [`semicolon_if_nothing_returned`]: https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned
+[`semicolon_inside_block`]: https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_inside_block
 [`serde_api_misuse`]: https://rust-lang.github.io/rust-clippy/master/index.html#serde_api_misuse
 [`shadow_reuse`]: https://rust-lang.github.io/rust-clippy/master/index.html#shadow_reuse
 [`shadow_same`]: https://rust-lang.github.io/rust-clippy/master/index.html#shadow_same

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -332,6 +332,7 @@ mod self_assignment;
 mod self_named_constructors;
 mod semicolon_if_nothing_returned;
 mod semicolon_inside_block;
+mod semicolon_outside_block;
 mod serde_api;
 mod shadow;
 mod single_component_path_imports;
@@ -905,6 +906,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         self_named_constructors::SELF_NAMED_CONSTRUCTORS,
         semicolon_if_nothing_returned::SEMICOLON_IF_NOTHING_RETURNED,
         semicolon_inside_block::SEMICOLON_INSIDE_BLOCK,
+        semicolon_outside_block::SEMICOLON_OUTSIDE_BLOCK,
         serde_api::SERDE_API_MISUSE,
         shadow::SHADOW_REUSE,
         shadow::SHADOW_SAME,
@@ -1136,6 +1138,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(ref_option_ref::REF_OPTION_REF),
         LintId::of(semicolon_if_nothing_returned::SEMICOLON_IF_NOTHING_RETURNED),
         LintId::of(semicolon_inside_block::SEMICOLON_INSIDE_BLOCK),
+        LintId::of(semicolon_outside_block::SEMICOLON_OUTSIDE_BLOCK),
         LintId::of(shadow::SHADOW_UNRELATED),
         LintId::of(strings::STRING_ADD_ASSIGN),
         LintId::of(trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS),
@@ -2092,6 +2095,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box float_equality_without_abs::FloatEqualityWithoutAbs);
     store.register_late_pass(|| box semicolon_if_nothing_returned::SemicolonIfNothingReturned);
     store.register_late_pass(|| box semicolon_inside_block::SemicolonInsideBlock);
+    store.register_late_pass(|| box semicolon_outside_block::SemicolonOutsideBlock);
     store.register_late_pass(|| box async_yields_async::AsyncYieldsAsync);
     let disallowed_methods = conf.disallowed_methods.iter().cloned().collect::<FxHashSet<_>>();
     store.register_late_pass(move || box disallowed_method::DisallowedMethod::new(&disallowed_methods));

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -331,6 +331,7 @@ mod returns;
 mod self_assignment;
 mod self_named_constructors;
 mod semicolon_if_nothing_returned;
+mod semicolon_inside_block;
 mod serde_api;
 mod shadow;
 mod single_component_path_imports;
@@ -903,6 +904,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         self_assignment::SELF_ASSIGNMENT,
         self_named_constructors::SELF_NAMED_CONSTRUCTORS,
         semicolon_if_nothing_returned::SEMICOLON_IF_NOTHING_RETURNED,
+        semicolon_inside_block::SEMICOLON_INSIDE_BLOCK,
         serde_api::SERDE_API_MISUSE,
         shadow::SHADOW_REUSE,
         shadow::SHADOW_SAME,
@@ -1133,6 +1135,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         LintId::of(redundant_else::REDUNDANT_ELSE),
         LintId::of(ref_option_ref::REF_OPTION_REF),
         LintId::of(semicolon_if_nothing_returned::SEMICOLON_IF_NOTHING_RETURNED),
+        LintId::of(semicolon_inside_block::SEMICOLON_INSIDE_BLOCK),
         LintId::of(shadow::SHADOW_UNRELATED),
         LintId::of(strings::STRING_ADD_ASSIGN),
         LintId::of(trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS),
@@ -2088,6 +2091,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| box manual_ok_or::ManualOkOr);
     store.register_late_pass(|| box float_equality_without_abs::FloatEqualityWithoutAbs);
     store.register_late_pass(|| box semicolon_if_nothing_returned::SemicolonIfNothingReturned);
+    store.register_late_pass(|| box semicolon_inside_block::SemicolonInsideBlock);
     store.register_late_pass(|| box async_yields_async::AsyncYieldsAsync);
     let disallowed_methods = conf.disallowed_methods.iter().cloned().collect::<FxHashSet<_>>();
     store.register_late_pass(move || box disallowed_method::DisallowedMethod::new(&disallowed_methods));

--- a/clippy_lints/src/semicolon_inside_block.rs
+++ b/clippy_lints/src/semicolon_inside_block.rs
@@ -1,0 +1,75 @@
+use crate::rustc_lint::LintContext;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::in_macro;
+use clippy_utils::source::snippet_with_macro_callsite;
+use if_chain::if_chain;
+use rustc_errors::Applicability;
+use rustc_hir::{Block, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// **What it does:** For () returning expressions, check that the semicolon is inside the block.
+    ///
+    /// **Why is this bad?** For consistency it's best to have the semicolon inside/outside the block. Either way is fine and this lint suggests inside the block.
+    /// Take a look at `semicolon_outside_block` for the other alternative.
+    ///
+    /// **Known problems:** None.
+    ///
+    /// **Example:**
+    ///
+    /// ```rust
+    /// unsafe { f(x) };
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// unsafe { f(x); }
+    /// ```
+    pub SEMICOLON_INSIDE_BLOCK,
+    pedantic,
+    "add a semicolon inside the block"
+}
+
+declare_lint_pass!(SemicolonInsideBlock => [SEMICOLON_INSIDE_BLOCK]);
+
+impl LateLintPass<'_> for SemicolonInsideBlock {
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        if_chain! {
+         if !in_macro(block.span);
+         if let Some(expr) = block.expr;
+         let t_expr = cx.typeck_results().expr_ty(expr);
+         if t_expr.is_unit();
+         if let snippet = snippet_with_macro_callsite(cx, expr.span, "}");
+         if !snippet.ends_with("};") && !snippet.ends_with('}');
+         then {
+             // filter out the desugared `for` loop
+             if let ExprKind::DropTemps(..) = &expr.kind {
+                 return;
+             }
+
+             let expr_snip = snippet_with_macro_callsite(cx, expr.span, "..");
+
+             // check for the right suggestion and span, differs if the block spans
+             // multiple lines
+             let (suggestion, span) = if cx.sess().source_map().is_multiline(block.span) {
+                 (format!("{};", expr_snip), expr.span.source_callsite())
+            } else {
+                let block_with_pot_sem = cx.sess().source_map().span_extend_to_next_char(block.span, '\n', false);
+                let block_snip = snippet_with_macro_callsite(cx, block.span, "..");
+
+                (block_snip.replace(expr_snip.as_ref(), &format!("{};", expr_snip)), block_with_pot_sem)
+            };
+
+            span_lint_and_sugg(
+                cx,
+                SEMICOLON_INSIDE_BLOCK,
+                span,
+                "consider moving the `;` inside the block for consistent formatting",
+                "put the `;` here",
+                suggestion,
+                Applicability::MaybeIncorrect,
+            );
+         }
+        }
+    }
+}

--- a/clippy_lints/src/semicolon_outside_block.rs
+++ b/clippy_lints/src/semicolon_outside_block.rs
@@ -4,8 +4,9 @@ use clippy_utils::in_macro;
 use clippy_utils::source::snippet_with_macro_callsite;
 use if_chain::if_chain;
 use rustc_errors::Applicability;
+use rustc_hir::intravisit::FnKind;
 use rustc_hir::ExprKind;
-use rustc_hir::{Block, BodyOwnerKind, StmtKind};
+use rustc_hir::{Block, Body, Expr, FnDecl, HirId, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::BytePos;
@@ -36,94 +37,118 @@ declare_clippy_lint! {
 
 declare_lint_pass!(SemicolonOutsideBlock => [SEMICOLON_OUTSIDE_BLOCK]);
 
-/// Checks if an ExprKind is of an illegal variant (aka blocks that we don't want)
-/// to lint on as it's illegal or unnecessary to put a semicolon afterwards.
-/// This macro then inserts a `return` statement to return out of the check_block
-/// method.
-macro_rules! check_expr_return {
-    ($l:expr) => {
-        if let ExprKind::If(..) | ExprKind::Loop(..) | ExprKind::DropTemps(..) | ExprKind::Match(..) = $l {
-            return;
+impl LateLintPass<'_> for SemicolonOutsideBlock {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        fn_kind: FnKind<'tcx>,
+        _: &'tcx FnDecl<'_>,
+        body: &'tcx Body<'_>,
+        _: Span,
+        _: HirId,
+    ) {
+        if let ExprKind::Block(block, ..) = body.value.kind {
+            // also check this block if we're inside a closure
+            if matches!(fn_kind, FnKind::Closure) {
+                check_block(cx, block);
+            }
+
+            // iterate over the statements and check if we find a potential
+            // block to check
+            for stmt in block.stmts {
+                match stmt.kind {
+                    StmtKind::Expr(Expr {
+                        kind: ExprKind::Block(bl, ..),
+                        ..
+                    })
+                    | StmtKind::Semi(Expr {
+                        kind: ExprKind::Block(bl, ..),
+                        ..
+                    }) => check_block(cx, bl),
+                    _ => (),
+                }
+            }
+
+            // check if the potential trailing expr is a block and check it if necessary
+            if let Some(Expr {
+                kind: ExprKind::Block(bl, ..),
+                ..
+            }) = block.expr
+            {
+                check_block(cx, bl);
+            }
         }
-    };
+    }
 }
 
-impl LateLintPass<'_> for SemicolonOutsideBlock {
-    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
-        if_chain! {
-            if !in_macro(block.span);
-            if block.expr.is_none();
-            if let Some(last) = block.stmts.last();
-            if let StmtKind::Semi(expr) = last.kind;
-            let t_expr = cx.typeck_results().expr_ty(expr);
-            if t_expr.is_unit();
-            then {
-                // make sure that the block does not belong to a function by iterating over the parents
-                for (hir_id, _) in cx.tcx.hir().parent_iter(block.hir_id) {
-                    if let Some(body_id) = cx.tcx.hir().maybe_body_owned_by(hir_id) {
-                        // if we're in a body, check if it's an fn or a closure
-                        if cx.tcx.hir().body_owner_kind(hir_id).is_fn_or_closure() {
-                            let item_body = cx.tcx.hir().body(body_id);
-                            if let ExprKind::Block(fn_block, _) = item_body.value.kind {
-                                // check for an illegal statement in the list of statements...
-                                for stmt in fn_block.stmts {
-                                    if let StmtKind::Expr(pot_ille_expr) = stmt.kind {
-                                        check_expr_return!(pot_ille_expr.kind);
-                                    }
-                                }
+/// Checks for a block if it's a target of this lint and spans a suggestion
+/// if applicable. This method also recurses through all other statements that
+/// are blocks.
+fn check_block(cx: &LateContext<'_>, block: &Block<'_>) {
+    // check all subblocks
+    for stmt in block.stmts {
+        match stmt.kind {
+            StmtKind::Expr(Expr {
+                kind: ExprKind::Block(bl, ..),
+                ..
+            })
+            | StmtKind::Semi(Expr {
+                kind: ExprKind::Block(bl, ..),
+                ..
+            }) => check_block(cx, bl),
+            _ => (),
+        }
+    }
+    // check the potential trailing expression
+    if let Some(Expr {
+        kind: ExprKind::Block(bl, ..),
+        ..
+    }) = block.expr
+    {
+        check_block(cx, bl);
+    }
 
-                                //.. the potential last statement ..
-                                if let Some(last_expr) = fn_block.expr {
-                                    check_expr_return!(last_expr.kind);
-                                }
+    if_chain! {
+        if !in_macro(block.span);
+        if block.expr.is_none();
+        if let Some(last) = block.stmts.last();
+        if let StmtKind::Semi(expr) = last.kind;
+        let t_expr = cx.typeck_results().expr_ty(expr);
+        if t_expr.is_unit();
+        then {
+            // make sure we're also having the semicolon at the end of the expression...
+            let expr_w_sem = expand_span_to_semicolon(cx, expr.span);
+            let expr_snip = snippet_with_macro_callsite(cx, expr_w_sem, "..");
+            let mut expr_sugg = expr_snip.to_string();
+            expr_sugg.pop();
 
-                                // .. or if this is the body of an fn
-                                if fn_block.hir_id == block.hir_id &&
-                                    !matches!(cx.tcx.hir().body_owner_kind(hir_id), BodyOwnerKind::Closure) {
-                                    return
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // filter out other blocks and the desugared for loop
-                check_expr_return!(expr.kind);
-
-                // make sure we're also having the semicolon at the end of the expression...
-                let expr_w_sem = expand_span_to_semicolon(cx, expr.span);
-                let expr_snip = snippet_with_macro_callsite(cx, expr_w_sem, "..");
-                let mut expr_sugg = expr_snip.to_string();
-                expr_sugg.pop();
-
-                // and the block
-                let block_w_sem = expand_span_to_semicolon(cx, block.span);
-                let mut block_snip: String = snippet_with_macro_callsite(cx, block_w_sem, "..").to_string();
-                if block_snip.ends_with('\n') {
-                    block_snip.pop();
-                }
-
-                // retrieve the suggestion
-                let suggestion = if block_snip.ends_with(';') {
-                    block_snip.replace(expr_snip.as_ref(), &format!("{}", expr_sugg.as_str()))
-                } else {
-                    format!("{};", block_snip.replace(expr_snip.as_ref(), &format!("{}", expr_sugg.as_str())))
-                };
-
-                span_lint_and_sugg(
-                    cx,
-                    SEMICOLON_OUTSIDE_BLOCK,
-                    if block_snip.ends_with(';') {
-                        block_w_sem
-                    } else {
-                        block.span
-                    },
-                    "consider moving the `;` outside the block for consistent formatting",
-                    "put the `;` outside the block",
-                    suggestion,
-                    Applicability::MaybeIncorrect,
-                );
+            // and the block
+            let block_w_sem = expand_span_to_semicolon(cx, block.span);
+            let mut block_snip: String = snippet_with_macro_callsite(cx, block_w_sem, "..").to_string();
+            if block_snip.ends_with('\n') {
+                block_snip.pop();
             }
+
+            // retrieve the suggestion
+            let suggestion = if block_snip.ends_with(';') {
+                block_snip.replace(expr_snip.as_ref(), &format!("{}", expr_sugg.as_str()))
+            } else {
+                format!("{};", block_snip.replace(expr_snip.as_ref(), &format!("{}", expr_sugg.as_str())))
+            };
+
+            span_lint_and_sugg(
+                cx,
+                SEMICOLON_OUTSIDE_BLOCK,
+                if block_snip.ends_with(';') {
+                    block_w_sem
+                } else {
+                    block.span
+                },
+                "consider moving the `;` outside the block for consistent formatting",
+                "put the `;` outside the block",
+                suggestion,
+                Applicability::MaybeIncorrect,
+            );
         }
     }
 }

--- a/clippy_lints/src/semicolon_outside_block.rs
+++ b/clippy_lints/src/semicolon_outside_block.rs
@@ -1,0 +1,102 @@
+use crate::rustc_lint::LintContext;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::in_macro;
+use clippy_utils::source::snippet_with_macro_callsite;
+use if_chain::if_chain;
+use rustc_errors::Applicability;
+use rustc_hir::ExprKind;
+use rustc_hir::{Block, StmtKind, ItemKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::BytePos;
+use rustc_span::Span;
+use std::ops::Add;
+
+declare_clippy_lint! {
+    /// **What it does:** For () returning expressions, check that the semicolon is outside the block.
+    ///
+    /// **Why is this bad?** For consistency it's best to have the semicolon inside/outside the block. Either way is fine and this lint suggests outside the block.
+    /// Take a look at `semicolon_inside_block` for the other alternative.
+    ///
+    /// **Known problems:** None.
+    ///
+    /// **Example:**
+    ///
+    /// ```rust
+    /// unsafe { f(x); }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// unsafe { f(x) };
+    /// ```
+    pub SEMICOLON_OUTSIDE_BLOCK,
+    pedantic,
+    "add a semicolon outside the block"
+}
+
+declare_lint_pass!(SemicolonOutsideBlock => [SEMICOLON_OUTSIDE_BLOCK]);
+
+impl LateLintPass<'_> for SemicolonOutsideBlock {
+    fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) {
+        if_chain! {
+            if !in_macro(block.span);
+            if block.expr.is_none();
+            if let Some(last) = block.stmts.last();
+            if let StmtKind::Semi(expr) = last.kind;
+            let t_expr = cx.typeck_results().expr_ty(expr);
+            if t_expr.is_unit();
+
+            // make sure that the block does not belong to a function
+            let parent_item_id = cx.tcx.hir().get_parent_item(block.hir_id);
+            let parent_item = cx.tcx.hir().expect_item(parent_item_id);
+            if let ItemKind::Fn(_, _, body_id) = parent_item.kind;
+            let item_body = cx.tcx.hir().body(body_id);
+            if let ExprKind::Block(fn_block, _) = item_body.value.kind;
+            if fn_block.hir_id != block.hir_id;
+            then {
+                // filter out other blocks and the desugared for loop
+                if let ExprKind::Block(..) | ExprKind::DropTemps(..) = expr.kind { return }
+
+                // make sure we're also having the semicolon at the end of the expression...
+                let expr_w_sem = expand_span_to_semicolon(cx, expr.span);
+                let expr_snip = snippet_with_macro_callsite(cx, expr_w_sem, "..");
+                let mut expr_sugg = expr_snip.to_string();
+                expr_sugg.pop();
+
+                // and the block
+                let block_w_sem = expand_span_to_semicolon(cx, block.span);
+                let mut block_snip: String = snippet_with_macro_callsite(cx, block_w_sem, "..").to_string();
+                if block_snip.ends_with('\n') {
+                    block_snip.pop();
+                }
+
+                // retrieve the suggestion
+                let suggestion = if block_snip.ends_with(';') {
+                    block_snip.replace(expr_snip.as_ref(), &format!("{}", expr_sugg.as_str()))
+                } else {
+                    format!("{};", block_snip.replace(expr_snip.as_ref(), &format!("{}", expr_sugg.as_str())))
+                };
+
+                span_lint_and_sugg(
+                    cx,
+                    SEMICOLON_OUTSIDE_BLOCK,
+                    if block_snip.ends_with(';') {
+                        block_w_sem
+                    } else {
+                        block.span
+                    },
+                    "consider moving the `;` outside the block for consistent formatting",
+                    "put the `;` outside the block",
+                    suggestion,
+                    Applicability::MaybeIncorrect,
+                );
+            }
+        }
+    }
+}
+
+/// Takes a span and extzends it until after a semicolon in the last line of the span.
+fn expand_span_to_semicolon<'tcx>(cx: &LateContext<'tcx>, expr_span: Span) -> Span {
+    let expr_span_with_sem = cx.sess().source_map().span_extend_to_next_char(expr_span, ';', false);
+    expr_span_with_sem.with_hi(expr_span_with_sem.hi().add(BytePos(1)))
+}

--- a/tests/ui/semicolon_inside_block.rs
+++ b/tests/ui/semicolon_inside_block.rs
@@ -1,0 +1,48 @@
+#![warn(clippy::semicolon_inside_block)]
+
+unsafe fn f(arg: u32) {}
+
+fn main() {
+    let x = 32;
+
+    unsafe { f(x) };
+}
+
+fn get_unit() {}
+
+fn fooooo() {
+    unsafe { f(32) }
+}
+
+fn moin() {
+    println!("Hello")
+}
+
+fn hello() {
+    get_unit()
+}
+
+fn basic101(x: i32) {
+    let y: i32;
+    y = x + 1
+}
+
+#[rustfmt::skip]
+fn closure_error() {
+    let _d = || {
+        hello()
+    };
+}
+
+fn my_own_block() {
+    let x: i32;
+    {
+        let y = 42;
+        x = y + 1;
+        basic101(x)
+    }
+    assert_eq!(43, 43)
+}
+
+#[rustfmt::skip]
+fn one_line_block() { println!("Foo") }

--- a/tests/ui/semicolon_inside_block.stderr
+++ b/tests/ui/semicolon_inside_block.stderr
@@ -1,0 +1,58 @@
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:8:5
+   |
+LL |     unsafe { f(x) };
+   |     ^^^^^^^^^^^^^^^^ help: put the `;` here: `unsafe { f(x); }`
+   |
+   = note: `-D clippy::semicolon-inside-block` implied by `-D warnings`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:14:5
+   |
+LL |     unsafe { f(32) }
+   |     ^^^^^^^^^^^^^^^^ help: put the `;` here: `unsafe { f(32); }`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:18:5
+   |
+LL |     println!("Hello")
+   |     ^^^^^^^^^^^^^^^^^ help: put the `;` here: `println!("Hello");`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:22:5
+   |
+LL |     get_unit()
+   |     ^^^^^^^^^^ help: put the `;` here: `get_unit();`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:27:5
+   |
+LL |     y = x + 1
+   |     ^^^^^^^^^ help: put the `;` here: `y = x + 1;`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:33:9
+   |
+LL |         hello()
+   |         ^^^^^^^ help: put the `;` here: `hello();`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:44:5
+   |
+LL |     assert_eq!(43, 43)
+   |     ^^^^^^^^^^^^^^^^^^ help: put the `;` here: `assert_eq!(43, 43);`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:42:9
+   |
+LL |         basic101(x)
+   |         ^^^^^^^^^^^ help: put the `;` here: `basic101(x);`
+
+error: consider moving the `;` inside the block for consistent formatting
+  --> $DIR/semicolon_inside_block.rs:48:21
+   |
+LL | fn one_line_block() { println!("Foo") }
+   |                     ^^^^^^^^^^^^^^^^^^^ help: put the `;` here: `{ println!("Foo"); }`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/semicolon_outside_block.fixed
+++ b/tests/ui/semicolon_outside_block.fixed
@@ -8,15 +8,15 @@ unsafe fn f(_arg: u32) {}
 fn main() {
     let x = 32;
 
-    unsafe { f(x); }
+    unsafe { f(x) };
 }
 
 fn foo() {
     let x = 32;
 
     unsafe {
-        f(x);
-    }
+        f(x)
+    };
 }
 
 fn bar() {
@@ -30,7 +30,7 @@ fn bar() {
         let _list = 5;
         let _of = 6;
         let _variables = 7;
-        f(x);
+        f(x)
     };
 }
 
@@ -39,7 +39,7 @@ fn get_unit() {}
 #[rustfmt::skip]
 fn closure_error() {
     let _d = || {
-        get_unit();
+        get_unit()
     };
 }
 
@@ -48,8 +48,8 @@ fn my_own_block() {
     {
         let y = 42;
         x = y + 1;
-        get_unit();
-    }
+        get_unit()
+    };
     assert_eq!(x, 43)
 }
 

--- a/tests/ui/semicolon_outside_block.rs
+++ b/tests/ui/semicolon_outside_block.rs
@@ -61,3 +61,11 @@ fn my_own_block() {
 fn just_get_unit() {
     get_unit();
 }
+
+fn test_if() {
+    if 1 > 2 {
+        get_unit();
+    } else {
+        println!("everything alright!");
+    }
+}

--- a/tests/ui/semicolon_outside_block.rs
+++ b/tests/ui/semicolon_outside_block.rs
@@ -1,0 +1,63 @@
+#![warn(clippy::semicolon_outside_block)]
+
+unsafe fn f(arg: u32) {}
+
+#[rustfmt::skip]
+fn main() {
+    let x = 32;
+
+    unsafe { f(x); }
+}
+
+fn foo() {
+    let x = 32;
+
+    unsafe {
+        f(x);
+    }
+}
+
+fn bar() {
+    let x = 32;
+
+    unsafe {
+        let _this = 1;
+        let _is = 2;
+        let _a = 3;
+        let _long = 4;
+        let _list = 5;
+        let _of = 6;
+        let _variables = 7;
+        f(x);
+    };
+}
+
+fn get_unit() {}
+
+fn moin() {
+    {
+        let _u = get_unit();
+        println!("Hello");
+    }
+}
+
+#[rustfmt::skip]
+fn closure_error() {
+    let _d = || {
+        get_unit();
+    };
+}
+
+fn my_own_block() {
+    let x: i32;
+    {
+        let y = 42;
+        x = y + 1;
+        get_unit();
+    }
+    assert_eq!(43, 43)
+}
+
+fn just_get_unit() {
+    get_unit();
+}

--- a/tests/ui/semicolon_outside_block.rs
+++ b/tests/ui/semicolon_outside_block.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::semicolon_outside_block)]
+#![allow(clippy::single_match)]
 
 unsafe fn f(arg: u32) {}
 
@@ -68,4 +69,21 @@ fn test_if() {
     } else {
         println!("everything alright!");
     }
+}
+
+fn test_for() {
+    for project in &[
+        "clippy_workspace_tests",
+        "clippy_workspace_tests/src",
+        "clippy_workspace_tests/subcrate",
+        "clippy_workspace_tests/subcrate/src",
+        "clippy_dev",
+        "clippy_lints",
+        "clippy_utils",
+        "rustc_tools_util",
+    ] {
+        get_unit();
+    }
+
+    get_unit();
 }

--- a/tests/ui/semicolon_outside_block.stderr
+++ b/tests/ui/semicolon_outside_block.stderr
@@ -1,5 +1,5 @@
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:9:5
+  --> $DIR/semicolon_outside_block.rs:10:5
    |
 LL |     unsafe { f(x); }
    |     ^^^^^^^^^^^^^^^^ help: put the `;` outside the block: `unsafe { f(x) };`
@@ -7,7 +7,7 @@ LL |     unsafe { f(x); }
    = note: `-D clippy::semicolon-outside-block` implied by `-D warnings`
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:15:5
+  --> $DIR/semicolon_outside_block.rs:16:5
    |
 LL | /     unsafe {
 LL | |         f(x);
@@ -22,7 +22,7 @@ LL |     };
    |
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:23:5
+  --> $DIR/semicolon_outside_block.rs:24:5
    |
 LL | /     unsafe {
 LL | |         let _this = 1;
@@ -44,7 +44,7 @@ LL |         let _list = 5;
  ...
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:46:17
+  --> $DIR/semicolon_outside_block.rs:47:17
    |
 LL |       let _d = || {
    |  _________________^
@@ -60,7 +60,7 @@ LL |     };
    |
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:53:5
+  --> $DIR/semicolon_outside_block.rs:54:5
    |
 LL | /     {
 LL | |         let y = 42;

--- a/tests/ui/semicolon_outside_block.stderr
+++ b/tests/ui/semicolon_outside_block.stderr
@@ -16,9 +16,9 @@ LL | |     }
    |
 help: put the `;` outside the block
    |
-LL |     unsafe {
-LL |         f(x)
-LL |     };
+LL ~     unsafe {
+LL +         f(x)
+LL +     };
    |
 
 error: consider moving the `;` outside the block for consistent formatting
@@ -35,12 +35,12 @@ LL | |     };
    |
 help: put the `;` outside the block
    |
-LL |     unsafe {
-LL |         let _this = 1;
-LL |         let _is = 2;
-LL |         let _a = 3;
-LL |         let _long = 4;
-LL |         let _list = 5;
+LL ~     unsafe {
+LL +         let _this = 1;
+LL +         let _is = 2;
+LL +         let _a = 3;
+LL +         let _long = 4;
+LL +         let _list = 5;
  ...
 
 error: consider moving the `;` outside the block for consistent formatting
@@ -54,9 +54,9 @@ LL | |     };
    |
 help: put the `;` outside the block
    |
-LL |     let _d = || {
-LL |         get_unit()
-LL |     };
+LL ~     let _d = || {
+LL +         get_unit()
+LL +     };
    |
 
 error: consider moving the `;` outside the block for consistent formatting
@@ -71,11 +71,11 @@ LL | |     }
    |
 help: put the `;` outside the block
    |
-LL |     {
-LL |         let y = 42;
-LL |         x = y + 1;
-LL |         get_unit()
-LL |     };
+LL ~     {
+LL +         let y = 42;
+LL +         x = y + 1;
+LL +         get_unit()
+LL +     };
    |
 
 error: aborting due to 5 previous errors

--- a/tests/ui/semicolon_outside_block.stderr
+++ b/tests/ui/semicolon_outside_block.stderr
@@ -1,5 +1,5 @@
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:10:5
+  --> $DIR/semicolon_outside_block.rs:11:5
    |
 LL |     unsafe { f(x); }
    |     ^^^^^^^^^^^^^^^^ help: put the `;` outside the block: `unsafe { f(x) };`
@@ -7,7 +7,7 @@ LL |     unsafe { f(x); }
    = note: `-D clippy::semicolon-outside-block` implied by `-D warnings`
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:16:5
+  --> $DIR/semicolon_outside_block.rs:17:5
    |
 LL | /     unsafe {
 LL | |         f(x);
@@ -22,7 +22,7 @@ LL |     };
    |
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:24:5
+  --> $DIR/semicolon_outside_block.rs:25:5
    |
 LL | /     unsafe {
 LL | |         let _this = 1;
@@ -44,7 +44,7 @@ LL |         let _list = 5;
  ...
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:47:17
+  --> $DIR/semicolon_outside_block.rs:41:17
    |
 LL |       let _d = || {
    |  _________________^
@@ -60,7 +60,7 @@ LL |     };
    |
 
 error: consider moving the `;` outside the block for consistent formatting
-  --> $DIR/semicolon_outside_block.rs:54:5
+  --> $DIR/semicolon_outside_block.rs:48:5
    |
 LL | /     {
 LL | |         let y = 42;

--- a/tests/ui/semicolon_outside_block.stderr
+++ b/tests/ui/semicolon_outside_block.stderr
@@ -1,0 +1,82 @@
+error: consider moving the `;` outside the block for consistent formatting
+  --> $DIR/semicolon_outside_block.rs:9:5
+   |
+LL |     unsafe { f(x); }
+   |     ^^^^^^^^^^^^^^^^ help: put the `;` outside the block: `unsafe { f(x) };`
+   |
+   = note: `-D clippy::semicolon-outside-block` implied by `-D warnings`
+
+error: consider moving the `;` outside the block for consistent formatting
+  --> $DIR/semicolon_outside_block.rs:15:5
+   |
+LL | /     unsafe {
+LL | |         f(x);
+LL | |     }
+   | |_____^
+   |
+help: put the `;` outside the block
+   |
+LL |     unsafe {
+LL |         f(x)
+LL |     };
+   |
+
+error: consider moving the `;` outside the block for consistent formatting
+  --> $DIR/semicolon_outside_block.rs:23:5
+   |
+LL | /     unsafe {
+LL | |         let _this = 1;
+LL | |         let _is = 2;
+LL | |         let _a = 3;
+...  |
+LL | |         f(x);
+LL | |     };
+   | |______^
+   |
+help: put the `;` outside the block
+   |
+LL |     unsafe {
+LL |         let _this = 1;
+LL |         let _is = 2;
+LL |         let _a = 3;
+LL |         let _long = 4;
+LL |         let _list = 5;
+ ...
+
+error: consider moving the `;` outside the block for consistent formatting
+  --> $DIR/semicolon_outside_block.rs:46:17
+   |
+LL |       let _d = || {
+   |  _________________^
+LL | |         get_unit();
+LL | |     };
+   | |______^
+   |
+help: put the `;` outside the block
+   |
+LL |     let _d = || {
+LL |         get_unit()
+LL |     };
+   |
+
+error: consider moving the `;` outside the block for consistent formatting
+  --> $DIR/semicolon_outside_block.rs:53:5
+   |
+LL | /     {
+LL | |         let y = 42;
+LL | |         x = y + 1;
+LL | |         get_unit();
+LL | |     }
+   | |_____^
+   |
+help: put the `;` outside the block
+   |
+LL |     {
+LL |         let y = 42;
+LL |         x = y + 1;
+LL |         get_unit()
+LL |     };
+   |
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
This PR adds two new lints to clippy according to #7322. The two lints offer two flavors of the same thing: they check if for `()` returning blocks the semicolon is inside or outside the block and correct it if possible. At the moment the `semicolon_outside_block` lint fires in the `dogfood` test.

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

changelog:
Added two new lints according to #7322.
``[`semicolon_inside_block`]``: Checks for a block with a `()` returning expression if the semicolon is inside the block.
``[`semicolon_outside_block`]``: Checks for a block with a `()` returning expression if the semicolon is outside the block.