### PR TITLE
Check expr usage for  `manual_flatten`

### DIFF
--- a/tests/ui/manual_flatten.rs
+++ b/tests/ui/manual_flatten.rs
@@ -91,6 +91,19 @@ fn main() {
         }
     }
 
+    struct Test {
+        a: usize,
+    }
+
+    let mut vec_of_struct = [Some(Test { a: 1 }), None];
+
+    // Usage of `if let` expression should not trigger lint
+    for n in vec_of_struct.iter_mut() {
+        if let Some(z) = n {
+            *n = None;
+        }
+    }
+
     // Using manual flatten should not trigger the lint
     for n in vec![Some(1), Some(2), Some(3)].iter().flatten() {
         println!("{}", n);


### PR DESCRIPTION
Fixes #6784
Fixes #7538 

`manual_flatten` should not trigger when `if let` match expression will be used.

changelog: [`manual_flatten`] checks for expr usage after `if let`
