### PR TITLE
Update docs for `expl_impl_clone_on_copy`

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -105,9 +105,6 @@ declare_clippy_lint! {
     /// nothing more than copy the object, which is what `#[derive(Copy, Clone)]`
     /// gets you.
     ///
-    /// ### Known problems
-    /// Bounds of generic types are sometimes wrong: https://github.com/rust-lang/rust/issues/26925
-    ///
     /// ### Example
     /// ```rust,ignore
     /// #[derive(Copy)]


### PR DESCRIPTION
The known issue was fixed in #6993. I missed updating the docs then, so it's happening now.

changelog: None
