### PR TITLE
Updated issue templates(formatting and rustbot label reference)

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -2,3 +2,16 @@
 name: Blank Issue
 about: Create a blank issue.
 ---
+
+
+<!--
+Additional labels can be added to this issue by including the following command:
+
+@rustbot label +<label>
+
+Common labels for this issue type are:
+* C-an-interesting-project
+* C-enhancement
+* C-question
+* C-tracking-issue
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,28 +20,23 @@ Instead, this happened: *explanation*
 
 ### Meta
 
-- `cargo clippy -V`: e.g. clippy 0.0.212 (f455e46 2020-06-20)
-- `rustc -Vv`:
-  ```
-  rustc 1.46.0-nightly (f455e46ea 2020-06-20)
-  binary: rustc
-  commit-hash: f455e46eae1a227d735091091144601b467e1565
-  commit-date: 2020-06-20
-  host: x86_64-unknown-linux-gnu
-  release: 1.46.0-nightly
-  LLVM version: 10.0
-  ```
+**Rust version (`rustc -Vv`):**
+
+```
+rustc 1.46.0-nightly (f455e46ea 2020-06-20)
+binary: rustc
+commit-hash: f455e46eae1a227d735091091144601b467e1565
+commit-date: 2020-06-20
+host: x86_64-unknown-linux-gnu
+release: 1.46.0-nightly
+LLVM version: 10.0
+```
 
 <!--
-Include a backtrace in the code block by setting `RUST_BACKTRACE=1` in your
-environment. E.g. `RUST_BACKTRACE=1 cargo clippy`.
+Additional labels can be added to this issue by including the following command:
+
+@rustbot label +<label>
+
+Common labels for this issue type are:
+* `I-suggestion-causes-error`
 -->
-<details><summary>Backtrace</summary>
-  <p>
-  
-  ```
-  <backtrace>
-  ```
-  
-  </p>
-</details>

--- a/.github/ISSUE_TEMPLATE/false_negative.md
+++ b/.github/ISSUE_TEMPLATE/false_negative.md
@@ -22,14 +22,14 @@ Instead, this happened: *explanation*
 
 ### Meta
 
-- `cargo clippy -V`: e.g. clippy 0.0.212 (f455e46 2020-06-20)
-- `rustc -Vv`:
-  ```
-  rustc 1.46.0-nightly (f455e46ea 2020-06-20)
-  binary: rustc
-  commit-hash: f455e46eae1a227d735091091144601b467e1565
-  commit-date: 2020-06-20
-  host: x86_64-unknown-linux-gnu
-  release: 1.46.0-nightly
-  LLVM version: 10.0
-  ```
+**Rust version (`rustc -Vv`):**
+
+```
+rustc 1.46.0-nightly (f455e46ea 2020-06-20)
+binary: rustc
+commit-hash: f455e46eae1a227d735091091144601b467e1565
+commit-date: 2020-06-20
+host: x86_64-unknown-linux-gnu
+release: 1.46.0-nightly
+LLVM version: 10.0
+```

--- a/.github/ISSUE_TEMPLATE/false_positive.md
+++ b/.github/ISSUE_TEMPLATE/false_positive.md
@@ -22,14 +22,22 @@ Instead, this happened: *explanation*
 
 ### Meta
 
-- `cargo clippy -V`: e.g. clippy 0.0.212 (f455e46 2020-06-20)
-- `rustc -Vv`:
-  ```
-  rustc 1.46.0-nightly (f455e46ea 2020-06-20)
-  binary: rustc
-  commit-hash: f455e46eae1a227d735091091144601b467e1565
-  commit-date: 2020-06-20
-  host: x86_64-unknown-linux-gnu
-  release: 1.46.0-nightly
-  LLVM version: 10.0
-  ```
+**Rust version (`rustc -Vv`):**
+```
+rustc 1.46.0-nightly (f455e46ea 2020-06-20)
+binary: rustc
+commit-hash: f455e46eae1a227d735091091144601b467e1565
+commit-date: 2020-06-20
+host: x86_64-unknown-linux-gnu
+release: 1.46.0-nightly
+LLVM version: 10.0
+```
+
+<!--
+Additional labels can be added to this issue by including the following command:
+
+@rustbot label +<label>
+
+Common labels for this issue type are:
+* I-suggestion-causes-error
+-->

--- a/.github/ISSUE_TEMPLATE/ice.md
+++ b/.github/ISSUE_TEMPLATE/ice.md
@@ -20,17 +20,16 @@ http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
 
 ### Meta
 
-- `cargo clippy -V`: e.g. clippy 0.0.212 (f455e46 2020-06-20)
-- `rustc -Vv`:
-  ```
-  rustc 1.46.0-nightly (f455e46ea 2020-06-20)
-  binary: rustc
-  commit-hash: f455e46eae1a227d735091091144601b467e1565
-  commit-date: 2020-06-20
-  host: x86_64-unknown-linux-gnu
-  release: 1.46.0-nightly
-  LLVM version: 10.0
-  ```
+**Rust version (`rustc -Vv`):**
+```
+rustc 1.46.0-nightly (f455e46ea 2020-06-20)
+binary: rustc
+commit-hash: f455e46eae1a227d735091091144601b467e1565
+commit-date: 2020-06-20
+host: x86_64-unknown-linux-gnu
+release: 1.46.0-nightly
+LLVM version: 10.0
+```
 
 ### Error output
 


### PR DESCRIPTION
This PR updates our issue templates. The changes are:

1. **Make the *Meta* section smaller and not indented**

    The current format sometimes gets messed up when a user simply pasts the rustc version into the issue without indenting it to match the code block. Removing the indention should hopefully help with formatting in the future.

    <details><summary>Example of messed up formatting </summary>
    
    ![image](https://user-images.githubusercontent.com/17087237/130811809-2b9bc58e-c13f-4338-b34e-18648a5de413.png)

    </details>

    Additionally, I've removed the Version of Clippy from the template. Every issue that I have seen had matching rustc and Clippy versions, and just asking for `rustc -Vv` makes the issue look cleaner IMO.

2. **Add a comment explaining how additional labels can be added with `@rustbot label +<label>`. The explanation looks like this:**

    ```
    <!--
    Additional labels can be added to this issue by including the following command:

    @rustbot label +<label>

    Common labels for this issue type are:
    * `I-suggestion-causes-error`
    -->
    ```

    The example `@rustbot` call can sadly not be marked as code inside a comment block. But the example will not cause the bot to add any labels. See rust-lang/rust-clippy#7599

---

changelog: none

cc: @rust-lang/clippy
