### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,21 +24,21 @@ path = "src/driver.rs"
 # begin automatic update
 clippy_lints = { version = "0.1.50", path = "clippy_lints" }
 # end automatic update
-semver = "0.11"
+semver = "1.0.4"
 rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util" }
-tempfile = { version = "3.1.0", optional = true }
+tempfile = { version = "3.2.0", optional = true }
 
 [dev-dependencies]
-cargo_metadata = "0.12"
-compiletest_rs = { version = "0.6.0", features = ["tmp"] }
-tester = "0.9"
-serde = { version = "1.0", features = ["derive"] }
-derive-new = "0.5"
-regex = "1.4"
-quote = "1"
-syn = { version = "1", features = ["full"] }
+cargo_metadata = "0.14.0"
+compiletest_rs = { version = "0.7.0", features = ["tmp"] }
+tester = "0.9.0"
+serde = { version = "1.0.129", features = ["derive"] }
+derive-new = "0.5.9"
+regex = "1.5.4"
+quote = "1.0.9"
+syn = { version = "1.0.75", features = ["full"] }
 # This is used by the `collect-metadata` alias.
-filetime = "0.2"
+filetime = "0.2.15"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.0.1"
 edition = "2018"
 
 [dependencies]
-bytecount = "0.6"
-clap = "2.33"
-itertools = "0.9"
-opener = "0.5"
-regex = "1"
-shell-escape = "0.1"
-walkdir = "2"
+bytecount = "0.6.2"
+clap = "2.33.3"
+itertools = "0.10.1"
+opener = "0.5.0"
+regex = "1.5.4"
+shell-escape = "0.1.5"
+walkdir = "2.3.2"
 
 [features]
 deny-warnings = []

--- a/clippy_dummy/Cargo.toml
+++ b/clippy_dummy/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["clippy", "lint", "plugin"]
 categories = ["development-tools", "development-tools::cargo-plugins"]
 
 [build-dependencies]
-term = "0.6"
+term = "0.7.0"

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -11,23 +11,23 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.12"
+cargo_metadata = "0.14.0"
 clippy_utils = { path = "../clippy_utils" }
-if_chain = "1.0.0"
-itertools = "0.9"
-pulldown-cmark = { version = "0.8", default-features = false }
-quine-mc_cluskey = "0.2.2"
-regex-syntax = "0.6"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
-toml = "0.5.3"
-unicode-normalization = "0.1"
+if_chain = "1.0.2"
+itertools = "0.10.1"
+pulldown-cmark = { version = "0.8.0", default-features = false }
+quine-mc_cluskey = "0.2.4"
+regex-syntax = "0.6.25"
+serde = { version = "1.0.129", features = ["derive"] }
+serde_json = { version = "1.0.66", optional = true }
+toml = "0.5.8"
+unicode-normalization = "0.1.19"
 unicode-script = { version = "0.5.3", default-features = false }
-semver = "0.11"
+semver = "1.0.4"
 rustc-semver = "1.1.0"
 # NOTE: cargo requires serde feat in its url dep
 # see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
-url = { version = "2.1.0", features = ["serde"] }
+url = { version = "2.2.2", features = ["serde"] }
 
 [features]
 deny-warnings = ["clippy_utils/deny-warnings"]

--- a/clippy_lints/src/cargo_common_metadata.rs
+++ b/clippy_lints/src/cargo_common_metadata.rs
@@ -1,7 +1,5 @@
 //! lint on missing cargo common metadata
 
-use std::path::PathBuf;
-
 use clippy_utils::{diagnostics::span_lint, is_lint_allowed};
 use rustc_hir::{hir_id::CRATE_HIR_ID, Crate};
 use rustc_lint::{LateContext, LateLintPass};
@@ -69,12 +67,8 @@ fn missing_warning(cx: &LateContext<'_>, package: &cargo_metadata::Package, fiel
     span_lint(cx, CARGO_COMMON_METADATA, DUMMY_SP, &message);
 }
 
-fn is_empty_str(value: &Option<String>) -> bool {
-    value.as_ref().map_or(true, String::is_empty)
-}
-
-fn is_empty_path(value: &Option<PathBuf>) -> bool {
-    value.as_ref().and_then(|x| x.to_str()).map_or(true, str::is_empty)
+fn is_empty_str<T: AsRef<str>>(value: &Option<T>) -> bool {
+    value.as_ref().map_or(true, |s| s.as_ref().is_empty())
 }
 
 fn is_empty_vec(value: &[String]) -> bool {
@@ -98,7 +92,7 @@ impl LateLintPass<'_> for CargoCommonMetadata {
                     missing_warning(cx, &package, "package.description");
                 }
 
-                if is_empty_str(&package.license) && is_empty_path(&package.license_file) {
+                if is_empty_str(&package.license) && is_empty_str(&package.license_file) {
                     missing_warning(cx, &package, "either package.license or package.license_file");
                 }
 
@@ -106,7 +100,7 @@ impl LateLintPass<'_> for CargoCommonMetadata {
                     missing_warning(cx, &package, "package.repository");
                 }
 
-                if is_empty_path(&package.readme) {
+                if is_empty_str(&package.readme) {
                     missing_warning(cx, &package, "package.readme");
                 }
 

--- a/clippy_utils/Cargo.toml
+++ b/clippy_utils/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2018"
 publish = false
 
 [dependencies]
-if_chain = "1.0.0"
-itertools = "0.9"
-regex-syntax = "0.6"
-serde = { version = "1.0", features = ["derive"] }
-unicode-normalization = "0.1"
-rustc-semver="1.1.0"
+if_chain = "1.0.2"
+itertools = "0.10.1"
+regex-syntax = "0.6.25"
+serde = { version = "1.0.129", features = ["derive"] }
+unicode-normalization = "0.1.19"
+rustc-semver= "1.1.0"
 
 [features]
 deny-warnings = []

--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -10,16 +10,16 @@ edition = "2018"
 publish = false
 
 [dependencies]
-clap = "2.33"
-flate2 = {version = "1.0.19"}
-fs_extra = {version = "1.2.0"}
-rayon = {version = "1.5.0"}
-serde = {version = "1.0", features = ["derive"]}
-serde_json = {version = "1.0"}
-tar = {version = "0.4.30"}
-toml = {version = "0.5"}
-ureq = {version = "2.0.0-rc3"}
-walkdir = {version = "2.3.2"}
+clap = "2.33.3"
+flate2 = "1.0.20"
+fs_extra = "1.2.0"
+rayon = "1.5.1"
+serde = { version = "1.0.129", features = ["derive"] }
+serde_json = "1.0.66"
+tar = "0.4.37"
+toml = "0.5.8"
+ureq = "2.2.0"
+walkdir = "2.3.2"
 
 [features]
 deny-warnings = []


### PR DESCRIPTION
Is there a mechanism for keeping Clippy's dependencies up to date? If so, this PR can likely be ignored.

I ask because several of the dependencies look dated.

This PR updates them via:
```sh
find . -name Cargo.toml -not -path "./tests/*" -exec cargo upgrade --workspace --manifest-path={} \;
```

Some small changes to the `cargo_common_metadata` lint were needed because `cargo_metadata` 0.14.0 uses UTF8 paths.

changelog: update dependencies
