### PR TITLE
`mut_range_bound` check for immediate break after mutation

### DIFF
--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -397,6 +397,21 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// One might think that modifying the mutable variable changes the loop bounds
     ///
+    /// ### Known problems
+    /// False positive when mutation is followed by a `break`, but the `break` is not immediately
+    /// after the mutation:
+    ///
+    /// ```rust
+    /// let mut x = 5;
+    /// for _ in 0..x {
+    ///     x += 1; // x is a range bound that is mutated
+    ///     ..; // some other expression
+    ///     break; // leaves the loop, so mutation is not an issue
+    /// }
+    /// ```
+    ///
+    /// False positive on nested loops ([#6072](https://github.com/rust-lang/rust-clippy/issues/6072))
+    ///
     /// ### Example
     /// ```rust
     /// let mut foo = 42;

--- a/tests/ui/mut_range_bound.rs
+++ b/tests/ui/mut_range_bound.rs
@@ -1,14 +1,6 @@
 #![allow(unused)]
 
-fn main() {
-    mut_range_bound_upper();
-    mut_range_bound_lower();
-    mut_range_bound_both();
-    mut_range_bound_no_mutation();
-    immut_range_bound();
-    mut_borrow_range_bound();
-    immut_borrow_range_bound();
-}
+fn main() {}
 
 fn mut_range_bound_upper() {
     let mut m = 4;
@@ -60,4 +52,33 @@ fn immut_range_bound() {
     for i in 0..m {
         continue;
     } // no warning
+}
+
+fn mut_range_bound_break() {
+    let mut m = 4;
+    for i in 0..m {
+        if m == 4 {
+            m = 5; // no warning because of immediate break
+            break;
+        }
+    }
+}
+
+fn mut_range_bound_no_immediate_break() {
+    let mut m = 4;
+    for i in 0..m {
+        m = 2; // warning because it is not immediately followed by break
+        if m == 4 {
+            break;
+        }
+    }
+
+    let mut n = 3;
+    for i in n..10 {
+        if n == 4 {
+            n = 1; // FIXME: warning because is is not immediately followed by break
+            let _ = 2;
+            break;
+        }
+    }
 }

--- a/tests/ui/mut_range_bound.stderr
+++ b/tests/ui/mut_range_bound.stderr
@@ -1,34 +1,59 @@
-error: attempt to mutate range bound within loop; note that the range of the loop is unchanged
-  --> $DIR/mut_range_bound.rs:16:9
+error: attempt to mutate range bound within loop
+  --> $DIR/mut_range_bound.rs:8:9
    |
 LL |         m = 5;
    |         ^
    |
    = note: `-D clippy::mut-range-bound` implied by `-D warnings`
+   = note: the range of the loop is unchanged
 
-error: attempt to mutate range bound within loop; note that the range of the loop is unchanged
-  --> $DIR/mut_range_bound.rs:23:9
+error: attempt to mutate range bound within loop
+  --> $DIR/mut_range_bound.rs:15:9
    |
 LL |         m *= 2;
    |         ^
+   |
+   = note: the range of the loop is unchanged
 
-error: attempt to mutate range bound within loop; note that the range of the loop is unchanged
-  --> $DIR/mut_range_bound.rs:31:9
+error: attempt to mutate range bound within loop
+  --> $DIR/mut_range_bound.rs:23:9
    |
 LL |         m = 5;
    |         ^
+   |
+   = note: the range of the loop is unchanged
 
-error: attempt to mutate range bound within loop; note that the range of the loop is unchanged
-  --> $DIR/mut_range_bound.rs:32:9
+error: attempt to mutate range bound within loop
+  --> $DIR/mut_range_bound.rs:24:9
    |
 LL |         n = 7;
    |         ^
+   |
+   = note: the range of the loop is unchanged
 
-error: attempt to mutate range bound within loop; note that the range of the loop is unchanged
-  --> $DIR/mut_range_bound.rs:46:22
+error: attempt to mutate range bound within loop
+  --> $DIR/mut_range_bound.rs:38:22
    |
 LL |         let n = &mut m; // warning
    |                      ^
+   |
+   = note: the range of the loop is unchanged
 
-error: aborting due to 5 previous errors
+error: attempt to mutate range bound within loop
+  --> $DIR/mut_range_bound.rs:70:9
+   |
+LL |         m = 2; // warning because it is not immediately followed by break
+   |         ^
+   |
+   = note: the range of the loop is unchanged
+
+error: attempt to mutate range bound within loop
+  --> $DIR/mut_range_bound.rs:79:13
+   |
+LL |             n = 1; // FIXME: warning because is is not immediately followed by break
+   |             ^
+   |
+   = note: the range of the loop is unchanged
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
closes #7532 

`mut_range_bound` ignores mutation on range bounds that is placed immediately before break. Still warns if the break is not always reachable.

changelog: [`mut_range_bound`] ignore range bound mutations before immediate break
