### PR TITLE
Allow all `unused` lints inside ui tests

### DIFF
--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -99,6 +99,8 @@ currently this test is meaningless though.
 
 While we are working on implementing our lint, we can keep running the UI
 test. That allows us to check if the output is turning into what we want.
+Other lints can be allowed inside the test file to focus on the current
+implementation, most [unused lints] are already ignored by default.
 
 Once we are satisfied with the output, we need to run
 `cargo dev bless` to update the `.stderr` file for our lint.
@@ -112,6 +114,8 @@ empty, they should be removed.
 
 Note that you can run multiple test files by specifying a comma separated list:
 `TESTNAME=foo_functions,test2,test3`.
+
+[unused lints]: https://doc.rust-lang.org/rustc/lints/groups.html#lint-groups
 
 ### Cargo lints
 

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -16,6 +16,8 @@ mod cargo;
 // whether to run internal tests or not
 const RUN_INTERNAL_TESTS: bool = cfg!(feature = "internal-lints");
 
+const DEFAULT_LINT_CONFIG: &str = "-A unused";
+
 fn host_lib() -> PathBuf {
     option_env!("HOST_LIBS").map_or(cargo::CARGO_TARGET_DIR.join(env!("PROFILE")), PathBuf::from)
 }
@@ -106,10 +108,11 @@ fn default_config() -> compiletest::Config {
     }
 
     config.target_rustcflags = Some(format!(
-        "--emit=metadata -L {0} -L {1} -Dwarnings -Zui-testing {2}",
+        "--emit=metadata -L {0} -L {1} -Dwarnings -Zui-testing {2} {3}",
         host_lib().join("deps").display(),
         cargo::TARGET_LIB.join("deps").display(),
         third_party_crates(),
+        DEFAULT_LINT_CONFIG,
     ));
 
     config.build_base = host_lib().join("test_build_base");


### PR DESCRIPTION
Clippy currently allows some unused lints inside UI tests, but not all of them during the compilation tests of the `.fixed` files. As a result, we often have attributes like `#[allow(unused)]`... in our tests. This PR allows all lints inside the [`unused` group](https://doc.rust-lang.org/rustc/lints/groups.html) during Clippy's execution and the compilation test.

Other lints are already allowed during this compilation, like `unused_imports`. I sadly couldn't find where they are allowed and by I'm guessing that they are allowed by default in `compiletest_rs`. Therefore, I opted to pass the `allow` flag to the compiler inside `compile-test.rs`.

An example can be tested by removing `#[allow(dead_code, unused_assignments)]` from line 3 in `tests/ui/assign_ops.rs` on master (The compilation test fails) and then on this branch (`cargo uitest` is happy). Reproduction:

```cmd
# Cleanup (Warning can delete files and changes)
git reset --hard
cargo clean

# Normal test
cargo uitest

# Remove allow arrtibute from file
cargo uitest # Fails due to line changes
cargo dev bless # Update `.stderr` and `.fixed` files

# Final test
cargo uitest
# Red on master due to the `unused-assignments` lint
# Green on my branch
```

I thought about removing all the now unused `#[allow()]` attributes, but that resulted in changes to a lot of files with little benefit. If this is accepted, it might be worth to do this in a followup PR or so. :upside_down_face:

---

changelog: none

r? @flip1995 I'm guessing that you have the most knowledge about this right now.

cc: @camsteffen since you've also worked a bit with compile test inside Clippy

Hope you're having a good day after reading this :upside_down_face: 