### PR TITLE
Updating issue templates again for rustbot

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -5,9 +5,10 @@ about: Create a blank issue.
 
 
 <!--
-Additional labels can be added to this issue by including the following command:
+Additional labels can be added to this issue by including the following command
+(without the space after the @ symbol):
 
-@rustbot label +<label>
+`@rustbot label +<label>`
 
 Common labels for this issue type are:
 * C-an-interesting-project

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,9 +33,10 @@ LLVM version: 10.0
 ```
 
 <!--
-Additional labels can be added to this issue by including the following command:
+Additional labels can be added to this issue by including the following command
+(without the space after the @ symbol):
 
-@rustbot label +<label>
+`@rustbot label +<label>`
 
 Common labels for this issue type are:
 * `I-suggestion-causes-error`

--- a/.github/ISSUE_TEMPLATE/false_positive.md
+++ b/.github/ISSUE_TEMPLATE/false_positive.md
@@ -34,9 +34,10 @@ LLVM version: 10.0
 ```
 
 <!--
-Additional labels can be added to this issue by including the following command:
+Additional labels can be added to this issue by including the following command
+(without the space after the @ symbol):
 
-@rustbot label +<label>
+`@rustbot label +<label>`
 
 Common labels for this issue type are:
 * I-suggestion-causes-error

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -556,7 +556,7 @@ directory. Adding a configuration to a lint can be useful for thresholds or to c
 behavior that can be seen as a false positive for some users. Adding a configuration is done
 in the following steps:
 
-1. Adding a new configuration entry to [clippy_utils::conf](/clippy_utils/src/conf.rs)
+1. Adding a new configuration entry to [clippy_lints::utils::conf](/clippy_lints/src/utils/conf.rs)
     like this:
     ```rust
     /// Lint: LINT_NAME.


### PR DESCRIPTION
It turns out that our current issue template can sometimes trigger a rustbot error message, as can be seen in [#7626](https://github.com/rust-lang/rust-clippy/issues/7626). I originally tested this in #7599, but it's apparently a bit inconsistent. This PR adds backticks to the commands, as correctly suggested by @mikerite in the comments. (Thank you!)

`@rustbot label +S-blocked`

---

Now I also pushed a tiny link fix as well. :upside_down_face: 

---

changelog: none
