### PR TITLE
Fix `multiple rlibs` error in `compile-test.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ cargo_metadata = "0.12"
 compiletest_rs = { version = "0.6.0", features = ["tmp"] }
 tester = "0.9"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+if_chain = "1"
+itertools = "0.9"
+clippy_utils = { path = "clippy_utils" }
 derive-new = "0.5"
 regex = "1.4"
 quote = "1"

--- a/tests/cargo/mod.rs
+++ b/tests/cargo/mod.rs
@@ -1,4 +1,6 @@
+use serde::{Deserialize, Deserializer};
 use std::env;
+use std::hash::{Hash, Hasher};
 use std::lazy::SyncLazy;
 use std::path::PathBuf;
 
@@ -23,4 +25,80 @@ pub static TARGET_LIB: SyncLazy<PathBuf> = SyncLazy::new(|| {
 #[must_use]
 pub fn is_rustc_test_suite() -> bool {
     option_env!("RUSTC_TEST_SUITE").is_some()
+}
+
+// from cargo/core/compiler/fingerprint.rs
+#[derive(Debug, Deserialize)]
+pub struct Fingerprint {
+    pub rustc: u64,
+    pub features: String,
+    pub target: u64,
+    pub profile: u64,
+    pub path: u64,
+    pub deps: Vec<DepFingerprint>,
+    pub local: Vec<LocalFingerprint>,
+    pub rustflags: Vec<String>,
+    pub metadata: u64,
+    pub config: u64,
+    pub compile_kind: u64,
+}
+impl Fingerprint {
+    pub fn get_hash(&self) -> u64 {
+        #[allow(deprecated)]
+        let mut hasher = core::hash::SipHasher::default();
+        self.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+impl Hash for Fingerprint {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        (
+            self.rustc,
+            &self.features,
+            self.target,
+            self.path,
+            self.profile,
+            &self.local,
+            self.metadata,
+            self.config,
+            self.compile_kind,
+            &self.rustflags,
+        )
+            .hash(h);
+
+        h.write_usize(self.deps.len());
+        for dep in &self.deps {
+            dep.pkg_id.hash(h);
+            dep.name.hash(h);
+            dep.public.hash(h);
+            h.write_u64(dep.fingerprint);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DepFingerprint {
+    pub pkg_id: u64,
+    pub name: String,
+    pub public: bool,
+    pub fingerprint: u64,
+}
+impl<'d> Deserialize<'d> for DepFingerprint {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> Result<Self, D::Error> {
+        let (pkg_id, name, public, fingerprint) = <(u64, String, bool, u64)>::deserialize(d)?;
+        Ok(Self {
+            pkg_id,
+            name,
+            public,
+            fingerprint,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Hash)]
+pub enum LocalFingerprint {
+    Precalculated(String),
+    CheckDepInfo { dep_info: PathBuf },
+    RerunIfChanged { output: PathBuf, paths: Vec<PathBuf> },
+    RerunIfEnvChanged { var: String, val: Option<String> },
 }


### PR DESCRIPTION
fixes: #7343

This solves the problem by looking up the dependencies of the currently running test.  There is a requirement that all the crates are mentioned in `Cargo.toml`, but I don't see that as a big downside (It also happens to guarantee they're built).

The only downside is this will break if/when cargo changes how fingerprint hashes are calculated. Really this should depend on cargo for that, but it's a large dependency and I don't think cargo is in the sysroot.

changelog: none
