### PR TITLE
Add `TAU` to `approx_constant`

### DIFF
--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
 }
 
 // Tuples are of the form (constant, name, min_digits, msrv)
-const KNOWN_CONSTS: [(f64, &str, usize, Option<RustcVersion>); 18] = [
+const KNOWN_CONSTS: [(f64, &str, usize, Option<RustcVersion>); 19] = [
     (f64::E, "E", 4, None),
     (f64::FRAC_1_PI, "FRAC_1_PI", 4, None),
     (f64::FRAC_1_SQRT_2, "FRAC_1_SQRT_2", 5, None),
@@ -58,6 +58,7 @@ const KNOWN_CONSTS: [(f64, &str, usize, Option<RustcVersion>); 18] = [
     (f64::LOG10_E, "LOG10_E", 5, None),
     (f64::PI, "PI", 3, None),
     (f64::SQRT_2, "SQRT_2", 5, None),
+    (f64::TAU, "TAU", 3, Some(msrvs::TAU)),
 ];
 
 pub struct ApproxConstant {

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -15,6 +15,7 @@ msrv_aliases! {
     1,53,0 { OR_PATTERNS }
     1,52,0 { STR_SPLIT_ONCE }
     1,50,0 { BOOL_THEN }
+    1,47,0 { TAU }
     1,46,0 { CONST_IF_MATCH }
     1,45,0 { STR_STRIP_PREFIX }
     1,43,0 { LOG2_10, LOG10_2 }

--- a/tests/ui/approx_const.rs
+++ b/tests/ui/approx_const.rs
@@ -57,4 +57,8 @@ fn main() {
 
     let my_sq2 = 1.4142;
     let no_sq2 = 1.414;
+
+    let my_tau = 6.2832;
+    let almost_tau = 6.28;
+    let no_tau = 6.3;
 }

--- a/tests/ui/approx_const.stderr
+++ b/tests/ui/approx_const.stderr
@@ -167,5 +167,21 @@ LL |     let my_sq2 = 1.4142;
    |
    = help: consider using the constant directly
 
-error: aborting due to 21 previous errors
+error: approximate value of `f{32, 64}::consts::TAU` found
+  --> $DIR/approx_const.rs:61:18
+   |
+LL |     let my_tau = 6.2832;
+   |                  ^^^^^^
+   |
+   = help: consider using the constant directly
+
+error: approximate value of `f{32, 64}::consts::TAU` found
+  --> $DIR/approx_const.rs:62:22
+   |
+LL |     let almost_tau = 6.28;
+   |                      ^^^^
+   |
+   = help: consider using the constant directly
+
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
changelog: [`approx_constant`]: Add `TAU`
