### PR TITLE
Target directory cleanup

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,7 @@
 [alias]
 uitest = "test --test compile-test"
-dev = "run --target-dir clippy_dev/target --package clippy_dev --bin clippy_dev --manifest-path clippy_dev/Cargo.toml --"
-lintcheck = "run --target-dir lintcheck/target --package lintcheck --bin lintcheck --manifest-path lintcheck/Cargo.toml  -- "
+dev = "run --package clippy_dev --bin clippy_dev --manifest-path clippy_dev/Cargo.toml --"
+lintcheck = "run --package lintcheck --bin lintcheck --manifest-path lintcheck/Cargo.toml  -- "
 collect-metadata = "test --test dogfood --features metadata-collector-lint -- run_metadata_collection_lint --ignored"
 
 [build]

--- a/.cargo/config
+++ b/.cargo/config
@@ -7,3 +7,4 @@ collect-metadata = "test --test dogfood --features metadata-collector-lint -- ru
 [build]
 # -Zbinary-dep-depinfo allows us to track which rlib files to use for compiling UI tests
 rustflags = ["-Zunstable-options", "-Zbinary-dep-depinfo"]
+target-dir = "target"

--- a/clippy_dev/src/bless.rs
+++ b/clippy_dev/src/bless.rs
@@ -85,10 +85,7 @@ fn updated_since_clippy_build(path: &Path) -> Option<bool> {
 }
 
 fn build_dir() -> PathBuf {
-    let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
-    let mut path = PathBuf::new();
-    path.push(CARGO_TARGET_DIR.clone());
-    path.push(profile);
-    path.push("test_build_base");
+    let mut path = std::env::current_exe().unwrap();
+    path.set_file_name("test_build_base");
     path
 }

--- a/clippy_dev/src/bless.rs
+++ b/clippy_dev/src/bless.rs
@@ -86,6 +86,6 @@ fn updated_since_clippy_build(path: &Path) -> Option<bool> {
 
 fn build_dir() -> PathBuf {
     let mut path = std::env::current_exe().unwrap();
-    path.set_file_name("test_build_base");
+    path.set_file_name("test");
     path
 }

--- a/clippy_dev/src/bless.rs
+++ b/clippy_dev/src/bless.rs
@@ -1,7 +1,6 @@
 //! `bless` updates the reference files in the repo with changed output files
 //! from the last test run.
 
-use std::env;
 use std::ffi::OsStr;
 use std::fs;
 use std::lazy::SyncLazy;
@@ -10,17 +9,9 @@ use walkdir::WalkDir;
 
 use crate::clippy_project_root;
 
-// NOTE: this is duplicated with tests/cargo/mod.rs What to do?
-pub static CARGO_TARGET_DIR: SyncLazy<PathBuf> = SyncLazy::new(|| match env::var_os("CARGO_TARGET_DIR") {
-    Some(v) => v.into(),
-    None => env::current_dir().unwrap().join("target"),
-});
-
 static CLIPPY_BUILD_TIME: SyncLazy<Option<std::time::SystemTime>> = SyncLazy::new(|| {
-    let profile = env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
-    let mut path = PathBuf::from(&**CARGO_TARGET_DIR);
-    path.push(profile);
-    path.push("cargo-clippy");
+    let mut path = std::env::current_exe().unwrap();
+    path.set_file_name("cargo-clippy");
     fs::metadata(path).ok()?.modified().ok()
 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@
 
 use rustc_tools_util::VersionInfo;
 use std::env;
-use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::{self, Command};
 
@@ -14,7 +13,7 @@ Usage:
     cargo clippy [options] [--] [<opts>...]
 
 Common options:
-    --no-deps                Run Clippy only on the given crate, without linting the dependencies 
+    --no-deps                Run Clippy only on the given crate, without linting the dependencies
     --fix                    Automatically apply lint suggestions. This flag implies `--no-deps`
     -h, --help               Print this message
     -V, --version            Print version info and exit
@@ -116,22 +115,6 @@ impl ClippyCmd {
         path
     }
 
-    fn target_dir() -> Option<(&'static str, OsString)> {
-        env::var_os("CLIPPY_DOGFOOD")
-            .map(|_| {
-                env::var_os("CARGO_MANIFEST_DIR").map_or_else(
-                    || std::ffi::OsString::from("clippy_dogfood"),
-                    |d| {
-                        std::path::PathBuf::from(d)
-                            .join("target")
-                            .join("dogfood")
-                            .into_os_string()
-                    },
-                )
-            })
-            .map(|p| ("CARGO_TARGET_DIR", p))
-    }
-
     fn into_std_cmd(self) -> Command {
         let mut cmd = Command::new("cargo");
         let clippy_args: String = self
@@ -141,7 +124,6 @@ impl ClippyCmd {
             .collect();
 
         cmd.env("RUSTC_WORKSPACE_WRAPPER", Self::path())
-            .envs(ClippyCmd::target_dir())
             .env("CLIPPY_ARGS", clippy_args)
             .arg(self.cargo_subcommand)
             .args(&self.args);

--- a/tests/cargo/mod.rs
+++ b/tests/cargo/mod.rs
@@ -7,19 +7,6 @@ pub static CARGO_TARGET_DIR: SyncLazy<PathBuf> = SyncLazy::new(|| match env::var
     None => env::current_dir().unwrap().join("target"),
 });
 
-pub static TARGET_LIB: SyncLazy<PathBuf> = SyncLazy::new(|| {
-    if let Some(path) = option_env!("TARGET_LIBS") {
-        path.into()
-    } else {
-        let mut dir = CARGO_TARGET_DIR.clone();
-        if let Some(target) = env::var_os("CARGO_BUILD_TARGET") {
-            dir.push(target);
-        }
-        dir.push(env!("PROFILE"));
-        dir
-    }
-});
-
 #[must_use]
 pub fn is_rustc_test_suite() -> bool {
     option_env!("RUSTC_TEST_SUITE").is_some()

--- a/tests/cargo/mod.rs
+++ b/tests/cargo/mod.rs
@@ -1,12 +1,3 @@
-use std::env;
-use std::lazy::SyncLazy;
-use std::path::PathBuf;
-
-pub static CARGO_TARGET_DIR: SyncLazy<PathBuf> = SyncLazy::new(|| match env::var_os("CARGO_TARGET_DIR") {
-    Some(v) => v.into(),
-    None => env::current_dir().unwrap().join("target"),
-});
-
 #[must_use]
 pub fn is_rustc_test_suite() -> bool {
     option_env!("RUSTC_TEST_SUITE").is_some()

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -1,5 +1,4 @@
 #![feature(test)] // compiletest_rs requires this attribute
-#![feature(once_cell)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(rust_2018_idioms, unused_lifetimes)]
 
@@ -45,10 +44,6 @@ extern crate itertools;
 extern crate quote;
 #[allow(unused_extern_crates)]
 extern crate syn;
-
-fn host_lib() -> PathBuf {
-    option_env!("HOST_LIBS").map_or(cargo::CARGO_TARGET_DIR.join(env!("PROFILE")), PathBuf::from)
-}
 
 /// Produces a string with an `--extern` flag for all UI test crate
 /// dependencies.
@@ -133,7 +128,7 @@ fn default_config() -> compiletest::Config {
         extern_flags(),
     ));
 
-    config.build_base = host_lib().join("test_build_base");
+    config.build_base = profile_path.join("test_build_base");
     config.rustc_path = profile_path.join(if cfg!(windows) {
         "clippy-driver.exe"
     } else {

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -120,6 +120,8 @@ fn default_config() -> compiletest::Config {
         config.run_lib_path = path.clone();
         config.compile_lib_path = path;
     }
+    let current_exe_path = std::env::current_exe().unwrap();
+    let deps_path = current_exe_path.parent().unwrap();
 
     // Using `-L dependency={}` enforces that external dependencies are added with `--extern`.
     // This is valuable because a) it allows us to monitor what external dependencies are used
@@ -127,7 +129,7 @@ fn default_config() -> compiletest::Config {
     config.target_rustcflags = Some(format!(
         "--emit=metadata -L dependency={} -L dependency={} -Dwarnings -Zui-testing {}",
         host_lib().join("deps").display(),
-        cargo::TARGET_LIB.join("deps").display(),
+        deps_path.display(),
         extern_flags(),
     ));
 

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -104,7 +104,7 @@ fn extern_flags() -> String {
     }
     crates
         .into_iter()
-        .map(|(name, path)| format!("--extern {}={} ", name, path))
+        .map(|(name, path)| format!(" --extern {}={}", name, path))
         .collect()
 }
 
@@ -126,10 +126,13 @@ fn default_config() -> compiletest::Config {
     // Using `-L dependency={}` enforces that external dependencies are added with `--extern`.
     // This is valuable because a) it allows us to monitor what external dependencies are used
     // and b) it ensures that conflicting rlibs are resolved properly.
+    let host_libs = option_env!("HOST_LIBS")
+        .map(|p| format!(" -L dependency={}", Path::new(p).join("deps").display()))
+        .unwrap_or_default();
     config.target_rustcflags = Some(format!(
-        "--emit=metadata -L dependency={} -L dependency={} -Dwarnings -Zui-testing {}",
-        host_lib().join("deps").display(),
+        "--emit=metadata -Dwarnings -Zui-testing -L dependency={}{}{}",
         deps_path.display(),
+        host_libs,
         extern_flags(),
     ));
 

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -128,7 +128,7 @@ fn default_config() -> compiletest::Config {
         extern_flags(),
     ));
 
-    config.build_base = profile_path.join("test_build_base");
+    config.build_base = profile_path.join("test");
     config.rustc_path = profile_path.join(if cfg!(windows) {
         "clippy-driver.exe"
     } else {

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -50,10 +50,6 @@ fn host_lib() -> PathBuf {
     option_env!("HOST_LIBS").map_or(cargo::CARGO_TARGET_DIR.join(env!("PROFILE")), PathBuf::from)
 }
 
-fn clippy_driver_path() -> PathBuf {
-    option_env!("CLIPPY_DRIVER_PATH").map_or(cargo::TARGET_LIB.join("clippy-driver"), PathBuf::from)
-}
-
 /// Produces a string with an `--extern` flag for all UI test crate
 /// dependencies.
 ///
@@ -122,6 +118,7 @@ fn default_config() -> compiletest::Config {
     }
     let current_exe_path = std::env::current_exe().unwrap();
     let deps_path = current_exe_path.parent().unwrap();
+    let profile_path = deps_path.parent().unwrap();
 
     // Using `-L dependency={}` enforces that external dependencies are added with `--extern`.
     // This is valuable because a) it allows us to monitor what external dependencies are used
@@ -137,7 +134,11 @@ fn default_config() -> compiletest::Config {
     ));
 
     config.build_base = host_lib().join("test_build_base");
-    config.rustc_path = clippy_driver_path();
+    config.rustc_path = profile_path.join(if cfg!(windows) {
+        "clippy-driver.exe"
+    } else {
+        "clippy-driver"
+    });
     config
 }
 

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -33,7 +33,6 @@ fn dogfood_clippy() {
     let mut command = Command::new(&*CLIPPY_PATH);
     command
         .current_dir(root_dir)
-        .env("CLIPPY_DOGFOOD", "1")
         .env("CARGO_INCREMENTAL", "0")
         .arg("clippy")
         .arg("--all-targets")
@@ -79,7 +78,6 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
     // Make sure that with the `--no-deps` argument Clippy does not run on `path_dep`.
     let output = Command::new(&*CLIPPY_PATH)
         .current_dir(&cwd)
-        .env("CLIPPY_DOGFOOD", "1")
         .env("CARGO_INCREMENTAL", "0")
         .arg("clippy")
         .args(&["-p", "subcrate"])
@@ -99,7 +97,6 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
         // Test that without the `--no-deps` argument, `path_dep` is linted.
         let output = Command::new(&*CLIPPY_PATH)
             .current_dir(&cwd)
-            .env("CLIPPY_DOGFOOD", "1")
             .env("CARGO_INCREMENTAL", "0")
             .arg("clippy")
             .args(&["-p", "subcrate"])
@@ -126,7 +123,6 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
     let successful_build = || {
         let output = Command::new(&*CLIPPY_PATH)
             .current_dir(&cwd)
-            .env("CLIPPY_DOGFOOD", "1")
             .env("CARGO_INCREMENTAL", "0")
             .arg("clippy")
             .args(&["-p", "subcrate"])
@@ -228,7 +224,6 @@ fn run_clippy_for_project(project: &str) {
 
     command
         .current_dir(root_dir.join(project))
-        .env("CLIPPY_DOGFOOD", "1")
         .env("CARGO_INCREMENTAL", "0")
         .arg("clippy")
         .arg("--all-targets")

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -15,7 +15,12 @@ use std::process::Command;
 
 mod cargo;
 
-static CLIPPY_PATH: SyncLazy<PathBuf> = SyncLazy::new(|| cargo::TARGET_LIB.join("cargo-clippy"));
+static CLIPPY_PATH: SyncLazy<PathBuf> = SyncLazy::new(|| {
+    let mut path = std::env::current_exe().unwrap();
+    assert!(path.pop()); // deps
+    path.set_file_name("cargo-clippy");
+    path
+});
 
 #[test]
 fn dogfood_clippy() {


### PR DESCRIPTION
changelog: none

* .cargo/config now has `target-dir` specified so that it is inherited by child projects. The target directory needs to be shared with clippy_dev, but not necessarily at the project root. (cc #7625)
* Uses `std::env::current_exe` (and its parent directories) whenever possible
* `CLIPPY_DRIVER_PATH` and `TARGET_LIBS` are no longer required from rustc bootstrap (but `HOST_LIBS` still is). These can be removed from the rustc side after merging.
* `CLIPPY_DOGFOOD` and the separate target directory are removed. This was originally added to mitigate #7343.

r? @flip1995 