### PR TITLE
`needless_borrow` checks for mutable borrow

### DIFF
--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -1,17 +1,16 @@
 // run-rustfix
 
-#![allow(clippy::needless_borrowed_reference)]
-
-fn x(y: &i32) -> i32 {
-    *y
-}
-
 #[warn(clippy::all, clippy::needless_borrow)]
 #[allow(unused_variables)]
 fn main() {
     let a = 5;
-    let b = x(&a);
-    let c = x(&a);
+    let _ = x(&a); // no warning
+    let _ = x(&a); // warn
+
+    let mut b = 5;
+    mut_ref(&mut b); // no warning
+    mut_ref(&mut b); // warn
+
     let s = &String::from("hi");
     let s_ident = f(&s); // should not error, because `&String` implements Copy, but `String` does not
     let g_val = g(&Vec::new()); // should not error, because `&Vec<T>` derefs to `&[T]`
@@ -27,6 +26,15 @@ fn main() {
         46 => &a,
         _ => panic!(),
     };
+}
+
+#[allow(clippy::needless_borrowed_reference)]
+fn x(y: &i32) -> i32 {
+    *y
+}
+
+fn mut_ref(y: &mut i32) {
+    *y = 5;
 }
 
 fn f<T: Copy>(y: &T) -> T {

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -1,17 +1,16 @@
 // run-rustfix
 
-#![allow(clippy::needless_borrowed_reference)]
-
-fn x(y: &i32) -> i32 {
-    *y
-}
-
 #[warn(clippy::all, clippy::needless_borrow)]
 #[allow(unused_variables)]
 fn main() {
     let a = 5;
-    let b = x(&a);
-    let c = x(&&a);
+    let _ = x(&a); // no warning
+    let _ = x(&&a); // warn
+
+    let mut b = 5;
+    mut_ref(&mut b); // no warning
+    mut_ref(&mut &mut b); // warn
+
     let s = &String::from("hi");
     let s_ident = f(&s); // should not error, because `&String` implements Copy, but `String` does not
     let g_val = g(&Vec::new()); // should not error, because `&Vec<T>` derefs to `&[T]`
@@ -27,6 +26,15 @@ fn main() {
         46 => &&a,
         _ => panic!(),
     };
+}
+
+#[allow(clippy::needless_borrowed_reference)]
+fn x(y: &i32) -> i32 {
+    *y
+}
+
+fn mut_ref(y: &mut i32) {
+    *y = 5;
 }
 
 fn f<T: Copy>(y: &T) -> T {

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -1,16 +1,22 @@
 error: this expression borrows a reference (`&i32`) that is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:14:15
+  --> $DIR/needless_borrow.rs:8:15
    |
-LL |     let c = x(&&a);
+LL |     let _ = x(&&a); // warn
    |               ^^^ help: change this to: `&a`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
 
+error: this expression borrows a reference (`&mut i32`) that is immediately dereferenced by the compiler
+  --> $DIR/needless_borrow.rs:12:13
+   |
+LL |     mut_ref(&mut &mut b); // warn
+   |             ^^^^^^^^^^^ help: change this to: `&mut b`
+
 error: this expression borrows a reference (`&i32`) that is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:27:15
+  --> $DIR/needless_borrow.rs:26:15
    |
 LL |         46 => &&a,
    |               ^^^ help: change this to: `&a`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
closes #7635

changelog: [`needless_borrow`] now checks for needless mutable borrow
