### PR TITLE
Enable trimmed paths

### DIFF
--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
+use clippy_utils::diagnostics::{span_clippy_lint, span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::higher::VecArgs;
 use clippy_utils::source::snippet_opt;
 use clippy_utils::usage::UsedAfterExprVisitor;
@@ -144,9 +144,9 @@ impl<'tcx> LateLintPass<'tcx> for EtaReduction {
             let call_ty = cx.tcx.type_of(method_def_id).subst(cx.tcx, substs);
             if check_sig(cx, closure_ty, call_ty);
             then {
-                span_lint_and_then(cx, REDUNDANT_CLOSURE_FOR_METHOD_CALLS, expr.span, "redundant closure", |diag| {
+                span_clippy_lint(cx, REDUNDANT_CLOSURE_FOR_METHOD_CALLS, expr.span, |diag| {
                     let name = get_ufcs_type_name(cx, method_def_id);
-                    diag.span_suggestion(
+                    diag.build("redundant closure").span_suggestion(
                         expr.span,
                         "replace the closure with the method itself",
                         format!("{}::{}", name, path.ident.name),

--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_clippy_lint;
 use clippy_utils::{meets_msrv, msrvs};
 use if_chain::if_chain;
 use rustc_hir as hir;
@@ -64,13 +64,14 @@ impl LateLintPass<'_> for FromOverInto {
             if cx.tcx.is_diagnostic_item(sym::into_trait, impl_trait_ref.def_id);
 
             then {
-                span_lint_and_help(
+                span_clippy_lint(
                     cx,
                     FROM_OVER_INTO,
                     cx.tcx.sess.source_map().guess_head_span(item.span),
-                    "an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true",
-                    None,
-                    &format!("consider to implement `From<{}>` instead", impl_trait_ref.self_ty()),
+                    |diag| {
+                        diag.build("an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true")
+                            .help(&format!("consider to implement `From<{}>` instead", impl_trait_ref.self_ty()));
+                    }
                 );
             }
         }

--- a/clippy_lints/src/macro_use.rs
+++ b/clippy_lints/src/macro_use.rs
@@ -1,13 +1,14 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::in_macro;
 use clippy_utils::source::snippet;
-use hir::def::{DefKind, Res};
 use if_chain::if_chain;
 use rustc_ast::ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
+use rustc_hir::def::{DefKind, Res};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::{edition::Edition, sym, Span};
 
@@ -118,7 +119,7 @@ impl<'tcx> LateLintPass<'tcx> for MacroUseImports {
                 for kid in cx.tcx.item_children(id).iter() {
                     if let Res::Def(DefKind::Macro(_mac_type), mac_id) = kid.res {
                         let span = mac_attr.span;
-                        let def_path = cx.tcx.def_path_str(mac_id);
+                        let def_path = with_no_trimmed_paths(|| cx.tcx.def_path_str(mac_id));
                         self.imports.push((def_path, span));
                     }
                 }

--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use clippy_utils::diagnostics::{span_clippy_lint, span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::source::{snippet, snippet_with_macro_callsite};
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::{is_type_diagnostic_item, same_type_and_consts};
@@ -90,16 +90,16 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
                     let a = cx.typeck_results().expr_ty(e);
                     let b = cx.typeck_results().expr_ty(&args[0]);
                     if same_type_and_consts(a, b) {
-                        let sugg = snippet(cx, args[0].span, "<expr>").into_owned();
-                        span_lint_and_sugg(
-                            cx,
-                            USELESS_CONVERSION,
-                            e.span,
-                            &format!("useless conversion to the same type: `{}`", b),
-                            "consider removing `.into_iter()`",
-                            sugg,
-                            Applicability::MachineApplicable, // snippet
-                        );
+                        span_clippy_lint(cx, USELESS_CONVERSION, e.span, |diag| {
+                            let sugg = snippet(cx, args[0].span, "<expr>").into_owned();
+                            diag.build(&format!("useless conversion to the same type: `{}`", b))
+                                .span_suggestion(
+                                    e.span,
+                                    "consider removing `.into_iter()`",
+                                    sugg,
+                                    Applicability::MachineApplicable,
+                                );
+                        });
                     }
                 }
                 if_chain! {

--- a/clippy_utils/src/diagnostics.rs
+++ b/clippy_utils/src/diagnostics.rs
@@ -58,14 +58,28 @@ impl Drop for ClippyDiagnosticBuilder<'_> {
 
 /// Same as [`LintContext::struct_span_lint`] but automatically adds additional Clippy lint info to
 /// the diagnostic via [`docs_lint`].
-pub fn span_clippy_lint<C, S, F>(cx: &C, lint: &'static Lint, sp: S, f: F)
-where
-    C: LintContext,
-    S: Into<MultiSpan>,
-    F: FnOnce(ClippyLintDiagnosticBuilder<'_>),
-{
+pub fn span_clippy_lint(
+    cx: &impl LintContext,
+    lint: &'static Lint,
+    sp: impl Into<MultiSpan>,
+    decorate: impl FnOnce(ClippyLintDiagnosticBuilder<'_>),
+) {
     cx.struct_span_lint(lint, sp, |diag| {
-        f(ClippyLintDiagnosticBuilder { lint, diag });
+        decorate(ClippyLintDiagnosticBuilder { lint, diag });
+    });
+}
+
+/// Same as [`TyCtxt::struct_span_lint_hir`] but automatically adds additional Clippy lint info to
+/// the diagnostic via [`docs_lint`].
+pub fn span_clippy_lint_hir(
+    cx: &LateContext<'_>,
+    lint: &'static Lint,
+    hir_id: HirId,
+    sp: impl Into<MultiSpan>,
+    decorate: impl FnOnce(ClippyLintDiagnosticBuilder<'_>),
+) {
+    cx.tcx.struct_span_lint_hir(lint, hir_id, sp, |diag| {
+        decorate(ClippyLintDiagnosticBuilder { lint, diag });
     });
 }
 
@@ -102,10 +116,8 @@ fn docs_link(diag: &mut DiagnosticBuilder<'_>, lint: &'static Lint) {
 ///    |     ^^^^^^^^^^^^^^^^^^^^^^^
 /// ```
 pub fn span_lint<T: LintContext>(cx: &T, lint: &'static Lint, sp: impl Into<MultiSpan>, msg: &str) {
-    cx.struct_span_lint(lint, sp, |diag| {
-        let mut diag = diag.build(msg);
-        docs_link(&mut diag, lint);
-        diag.emit();
+    span_clippy_lint(cx, lint, sp, |diag| {
+        diag.build(msg);
     });
 }
 
@@ -137,15 +149,13 @@ pub fn span_lint_and_help<'a, T: LintContext>(
     help_span: Option<Span>,
     help: &str,
 ) {
-    cx.struct_span_lint(lint, span, |diag| {
+    span_clippy_lint(cx, lint, span, |diag| {
         let mut diag = diag.build(msg);
         if let Some(help_span) = help_span {
             diag.span_help(help_span, help);
         } else {
             diag.help(help);
         }
-        docs_link(&mut diag, lint);
-        diag.emit();
     });
 }
 
@@ -180,15 +190,13 @@ pub fn span_lint_and_note<'a, T: LintContext>(
     note_span: Option<Span>,
     note: &str,
 ) {
-    cx.struct_span_lint(lint, span, |diag| {
+    span_clippy_lint(cx, lint, span, |diag| {
         let mut diag = diag.build(msg);
         if let Some(note_span) = note_span {
             diag.span_note(note_span, note);
         } else {
             diag.note(note);
         }
-        docs_link(&mut diag, lint);
-        diag.emit();
     });
 }
 
@@ -202,19 +210,14 @@ where
     S: Into<MultiSpan>,
     F: FnOnce(&mut DiagnosticBuilder<'_>),
 {
-    cx.struct_span_lint(lint, sp, |diag| {
-        let mut diag = diag.build(msg);
-        f(&mut diag);
-        docs_link(&mut diag, lint);
-        diag.emit();
+    span_clippy_lint(cx, lint, sp, |diag| {
+        f(&mut diag.build(msg));
     });
 }
 
 pub fn span_lint_hir(cx: &LateContext<'_>, lint: &'static Lint, hir_id: HirId, sp: Span, msg: &str) {
-    cx.tcx.struct_span_lint_hir(lint, hir_id, sp, |diag| {
-        let mut diag = diag.build(msg);
-        docs_link(&mut diag, lint);
-        diag.emit();
+    span_clippy_lint_hir(cx, lint, hir_id, sp, |diag| {
+        diag.build(msg);
     });
 }
 
@@ -226,11 +229,8 @@ pub fn span_lint_hir_and_then(
     msg: &str,
     f: impl FnOnce(&mut DiagnosticBuilder<'_>),
 ) {
-    cx.tcx.struct_span_lint_hir(lint, hir_id, sp, |diag| {
-        let mut diag = diag.build(msg);
-        f(&mut diag);
-        docs_link(&mut diag, lint);
-        diag.emit();
+    span_clippy_lint_hir(cx, lint, hir_id, sp, |diag| {
+        f(&mut diag.build(msg));
     });
 }
 
@@ -263,8 +263,8 @@ pub fn span_lint_and_sugg<'a, T: LintContext>(
     sugg: String,
     applicability: Applicability,
 ) {
-    span_lint_and_then(cx, lint, sp, msg, |diag| {
-        diag.span_suggestion(sp, help, sugg, applicability);
+    span_clippy_lint(cx, lint, sp, |diag| {
+        diag.build(msg).span_suggestion(sp, help, sugg, applicability);
     });
 }
 

--- a/clippy_utils/src/qualify_min_const_fn.rs
+++ b/clippy_utils/src/qualify_min_const_fn.rs
@@ -9,6 +9,7 @@ use rustc_middle::mir::{
     Body, CastKind, NullOp, Operand, Place, ProjectionElem, Rvalue, Statement, StatementKind, Terminator,
     TerminatorKind,
 };
+use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::{self, adjustment::PointerCast, Ty, TyCtxt};
 use rustc_semver::RustcVersion;
@@ -318,15 +319,14 @@ fn check_terminator(
             let fn_ty = func.ty(body, tcx);
             if let ty::FnDef(fn_def_id, _) = *fn_ty.kind() {
                 if !is_const_fn(tcx, fn_def_id, msrv) {
-                    return Err((
-                        span,
+                    let msg = with_no_trimmed_paths(|| {
                         format!(
                             "can only call other `const fn` within a `const fn`, \
                              but `{:?}` is not stable as `const fn`",
                             func,
                         )
-                        .into(),
-                    ));
+                    });
+                    return Err((span, msg.into()));
                 }
 
                 // HACK: This is to "unstabilize" the `transmute` intrinsic

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -15,6 +15,7 @@ extern crate rustc_session;
 extern crate rustc_span;
 
 use rustc_interface::interface;
+use rustc_session::config::TrimmedDefPaths;
 use rustc_session::parse::ParseSess;
 use rustc_span::symbol::Symbol;
 use rustc_tools_util::VersionInfo;
@@ -117,6 +118,7 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
         // MIR passes can be enabled / disabled separately, we should figure out, what passes to
         // use for Clippy.
         config.opts.debugging_opts.mir_opt_level = Some(0);
+        config.opts.trimmed_def_paths = TrimmedDefPaths::GoodPath;
     }
 }
 

--- a/tests/ui-toml/toml_disallowed_type/conf_disallowed_type.stderr
+++ b/tests/ui-toml/toml_disallowed_type/conf_disallowed_type.stderr
@@ -1,4 +1,4 @@
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `AtomicU32` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:7:1
    |
 LL | use std::sync::atomic::AtomicU32;
@@ -6,25 +6,25 @@ LL | use std::sync::atomic::AtomicU32;
    |
    = note: `-D clippy::disallowed-type` implied by `-D warnings`
 
-error: `std::time::Instant` is not allowed according to config
+error: `Instant` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:8:1
    |
 LL | use std::time::Instant as Sneaky;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `std::time::Instant` is not allowed according to config
+error: `Instant` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:12:33
    |
 LL | fn bad_return_type() -> fn() -> Sneaky {
    |                                 ^^^^^^
 
-error: `std::time::Instant` is not allowed according to config
+error: `Instant` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:16:28
    |
 LL | fn bad_arg_type(_: impl Fn(Sneaky) -> foo::atomic::AtomicU32) {}
    |                            ^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `AtomicU32` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:16:39
    |
 LL | fn bad_arg_type(_: impl Fn(Sneaky) -> foo::atomic::AtomicU32) {}
@@ -72,31 +72,31 @@ error: `std::collections::HashMap` is not allowed according to config
 LL |     let _: std::collections::HashMap<(), ()> = std::collections::HashMap::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `std::time::Instant` is not allowed according to config
+error: `Instant` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:31:13
    |
 LL |     let _ = Sneaky::now();
    |             ^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `AtomicU32` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:32:13
    |
 LL |     let _ = foo::atomic::AtomicU32::new(0);
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `AtomicU32` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:33:17
    |
 LL |     static FOO: std::sync::atomic::AtomicU32 = foo::atomic::AtomicU32::new(1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
+error: `AtomicU32` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:33:48
    |
 LL |     static FOO: std::sync::atomic::AtomicU32 = foo::atomic::AtomicU32::new(1);
    |                                                ^^^^^^^^^^^^^^^^^^^^^^
 
-error: `syn::TypePath` is not allowed according to config
+error: `TypePath` is not allowed according to config
   --> $DIR/conf_disallowed_type.rs:34:43
    |
 LL |     let _: std::collections::BTreeMap<(), syn::TypePath> = Default::default();

--- a/tests/ui/crashes/ice-6251.stderr
+++ b/tests/ui/crashes/ice-6251.stderr
@@ -12,7 +12,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
    |                                             ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `[u8]`
+   = help: the trait `Sized` is not implemented for `[u8]`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
@@ -25,7 +25,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
    |                                                      ^ doesn't have a size known at compile-time
    |
-   = help: the trait `std::marker::Sized` is not implemented for `[u8]`
+   = help: the trait `Sized` is not implemented for `[u8]`
    = note: the return type of a function must have a statically known size
 
 error[E0308]: mismatched types

--- a/tests/ui/default_trait_access.fixed
+++ b/tests/ui/default_trait_access.fixed
@@ -8,17 +8,17 @@ use std::default::Default as D2;
 use std::string;
 
 fn main() {
-    let s1: String = std::string::String::default();
+    let s1: String = String::default();
 
     let s2 = String::default();
 
-    let s3: String = std::string::String::default();
+    let s3: String = String::default();
 
-    let s4: String = std::string::String::default();
+    let s4: String = String::default();
 
     let s5 = string::String::default();
 
-    let s6: String = std::string::String::default();
+    let s6: String = String::default();
 
     let s7 = std::string::String::default();
 

--- a/tests/ui/default_trait_access.stderr
+++ b/tests/ui/default_trait_access.stderr
@@ -1,8 +1,8 @@
-error: calling `std::string::String::default()` is more clear than this expression
+error: calling `String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:11:22
    |
 LL |     let s1: String = Default::default();
-   |                      ^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
+   |                      ^^^^^^^^^^^^^^^^^^ help: try: `String::default()`
    |
 note: the lint level is defined here
   --> $DIR/default_trait_access.rs:4:9
@@ -10,23 +10,23 @@ note: the lint level is defined here
 LL | #![deny(clippy::default_trait_access)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: calling `std::string::String::default()` is more clear than this expression
+error: calling `String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:15:22
    |
 LL |     let s3: String = D2::default();
-   |                      ^^^^^^^^^^^^^ help: try: `std::string::String::default()`
+   |                      ^^^^^^^^^^^^^ help: try: `String::default()`
 
-error: calling `std::string::String::default()` is more clear than this expression
+error: calling `String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:17:22
    |
 LL |     let s4: String = std::default::Default::default();
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `String::default()`
 
-error: calling `std::string::String::default()` is more clear than this expression
+error: calling `String::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:21:22
    |
 LL |     let s6: String = default::Default::default();
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `String::default()`
 
 error: calling `GenericDerivedDefault::default()` is more clear than this expression
   --> $DIR/default_trait_access.rs:31:46

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -91,11 +91,11 @@ fn test_redundant_closures_containing_method_calls() {
     let e = Some(TestStruct { some_ref: &i }).map(TestStruct::foo);
     let e = Some(TestStruct { some_ref: &i }).map(TestTrait::trait_foo);
     let e = Some(TestStruct { some_ref: &i }).map(|a| a.trait_foo_ref());
-    let e = Some(&mut vec![1, 2, 3]).map(std::vec::Vec::clear);
+    let e = Some(&mut vec![1, 2, 3]).map(Vec::clear);
     unsafe {
         let e = Some(TestStruct { some_ref: &i }).map(|a| a.foo_unsafe());
     }
-    let e = Some("str").map(std::string::ToString::to_string);
+    let e = Some("str").map(ToString::to_string);
     let e = Some('a').map(char::to_uppercase);
     let e: std::vec::Vec<usize> = vec!['a', 'b', 'c'].iter().map(|c| c.len_utf8()).collect();
     let e: std::vec::Vec<char> = vec!['a', 'b', 'c'].iter().map(char::to_ascii_uppercase).collect();
@@ -233,7 +233,7 @@ fn late_bound_lifetimes() {
     {
     }
     map_str(|s| take_asref_path(s));
-    map_str_to_path(std::convert::AsRef::as_ref);
+    map_str_to_path(AsRef::as_ref);
 }
 
 mod type_param_bound {

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -62,13 +62,13 @@ error: redundant closure
   --> $DIR/eta.rs:94:42
    |
 LL |     let e = Some(&mut vec![1, 2, 3]).map(|v| v.clear());
-   |                                          ^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::vec::Vec::clear`
+   |                                          ^^^^^^^^^^^^^ help: replace the closure with the method itself: `Vec::clear`
 
 error: redundant closure
   --> $DIR/eta.rs:98:29
    |
 LL |     let e = Some("str").map(|s| s.to_string());
-   |                             ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::string::ToString::to_string`
+   |                             ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `ToString::to_string`
 
 error: redundant closure
   --> $DIR/eta.rs:99:27
@@ -128,7 +128,7 @@ error: redundant closure
   --> $DIR/eta.rs:236:21
    |
 LL |     map_str_to_path(|s| s.as_ref());
-   |                     ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::convert::AsRef::as_ref`
+   |                     ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `AsRef::as_ref`
 
 error: aborting due to 21 previous errors
 

--- a/tests/ui/from_over_into.stderr
+++ b/tests/ui/from_over_into.stderr
@@ -5,7 +5,7 @@ LL | impl Into<StringWrapper> for String {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::from-over-into` implied by `-D warnings`
-   = help: consider to implement `From<std::string::String>` instead
+   = help: consider to implement `From<String>` instead
 
 error: aborting due to previous error
 

--- a/tests/ui/future_not_send.stderr
+++ b/tests/ui/future_not_send.stderr
@@ -9,22 +9,22 @@ note: future is not `Send` as this value is used across an await
   --> $DIR/future_not_send.rs:9:5
    |
 LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
-   |                         -- has type `std::rc::Rc<[u8]>` which is not `Send`
+   |                         -- has type `Rc<[u8]>` which is not `Send`
 LL |     async { true }.await
    |     ^^^^^^^^^^^^^^^^^^^^ await occurs here, with `rc` maybe used later
 LL | }
    | - `rc` is later dropped here
-   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+   = note: `Rc<[u8]>` doesn't implement `Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/future_not_send.rs:9:5
    |
 LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
-   |                                       ---- has type `&std::cell::Cell<usize>` which is not `Send`
+   |                                       ---- has type `&Cell<usize>` which is not `Send`
 LL |     async { true }.await
    |     ^^^^^^^^^^^^^^^^^^^^ await occurs here, with `cell` maybe used later
 LL | }
    | - `cell` is later dropped here
-   = note: `std::cell::Cell<usize>` doesn't implement `std::marker::Sync`
+   = note: `Cell<usize>` doesn't implement `Sync`
 
 error: future cannot be sent between threads safely
   --> $DIR/future_not_send.rs:12:42
@@ -36,12 +36,12 @@ note: future is not `Send` as this value is used across an await
   --> $DIR/future_not_send.rs:13:5
    |
 LL | pub async fn public_future(rc: Rc<[u8]>) {
-   |                            -- has type `std::rc::Rc<[u8]>` which is not `Send`
+   |                            -- has type `Rc<[u8]>` which is not `Send`
 LL |     async { true }.await;
    |     ^^^^^^^^^^^^^^^^^^^^ await occurs here, with `rc` maybe used later
 LL | }
    | - `rc` is later dropped here
-   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+   = note: `Rc<[u8]>` doesn't implement `Send`
 
 error: future cannot be sent between threads safely
   --> $DIR/future_not_send.rs:20:63
@@ -53,14 +53,14 @@ note: captured value is not `Send`
   --> $DIR/future_not_send.rs:20:26
    |
 LL | async fn private_future2(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
-   |                          ^^ has type `std::rc::Rc<[u8]>` which is not `Send`
-   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+   |                          ^^ has type `Rc<[u8]>` which is not `Send`
+   = note: `Rc<[u8]>` doesn't implement `Send`
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/future_not_send.rs:20:40
    |
 LL | async fn private_future2(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
-   |                                        ^^^^ has type `&std::cell::Cell<usize>` which is not `Send`, because `std::cell::Cell<usize>` is not `Sync`
-   = note: `std::cell::Cell<usize>` doesn't implement `std::marker::Sync`
+   |                                        ^^^^ has type `&Cell<usize>` which is not `Send`, because `Cell<usize>` is not `Sync`
+   = note: `Cell<usize>` doesn't implement `Sync`
 
 error: future cannot be sent between threads safely
   --> $DIR/future_not_send.rs:24:43
@@ -72,8 +72,8 @@ note: captured value is not `Send`
   --> $DIR/future_not_send.rs:24:29
    |
 LL | pub async fn public_future2(rc: Rc<[u8]>) {}
-   |                             ^^ has type `std::rc::Rc<[u8]>` which is not `Send`
-   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
+   |                             ^^ has type `Rc<[u8]>` which is not `Send`
+   = note: `Rc<[u8]>` doesn't implement `Send`
 
 error: future cannot be sent between threads safely
   --> $DIR/future_not_send.rs:35:39
@@ -91,7 +91,7 @@ LL |         async { true }.await;
 LL |         self.rc.len()
 LL |     }
    |     - `&self` is later dropped here
-   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Sync`
+   = note: `Rc<[u8]>` doesn't implement `Sync`
 
 error: future cannot be sent between threads safely
   --> $DIR/future_not_send.rs:40:39
@@ -108,7 +108,7 @@ LL |         self.private_future().await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ await occurs here, with `&self` maybe used later
 LL |     }
    |     - `&self` is later dropped here
-   = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Sync`
+   = note: `Rc<[u8]>` doesn't implement `Sync`
 
 error: future cannot be sent between threads safely
   --> $DIR/future_not_send.rs:50:37
@@ -126,7 +126,7 @@ LL |     async { true }.await;
 LL |     t
 LL | }
    | - `rt` is later dropped here
-   = note: `T` doesn't implement `std::marker::Sync`
+   = note: `T` doesn't implement `Sync`
 
 error: future cannot be sent between threads safely
   --> $DIR/future_not_send.rs:66:34
@@ -139,7 +139,7 @@ note: captured value is not `Send`
    |
 LL | async fn unclear_future<T>(t: T) {}
    |                            ^ has type `T` which is not `Send`
-   = note: `T` doesn't implement `std::marker::Send`
+   = note: `T` doesn't implement `Send`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/inefficient_to_string.stderr
+++ b/tests/ui/inefficient_to_string.stderr
@@ -19,37 +19,37 @@ LL |     let _: String = rrrstr.to_string();
    |
    = help: `&&str` implements `ToString` through a slower blanket impl, but `str` has a fast specialization of `ToString`
 
-error: calling `to_string` on `&&std::string::String`
+error: calling `to_string` on `&&String`
   --> $DIR/inefficient_to_string.rs:20:21
    |
 LL |     let _: String = rrstring.to_string();
    |                     ^^^^^^^^^^^^^^^^^^^^ help: try dereferencing the receiver: `(*rrstring).to_string()`
    |
-   = help: `&std::string::String` implements `ToString` through a slower blanket impl, but `std::string::String` has a fast specialization of `ToString`
+   = help: `&String` implements `ToString` through a slower blanket impl, but `String` has a fast specialization of `ToString`
 
-error: calling `to_string` on `&&&std::string::String`
+error: calling `to_string` on `&&&String`
   --> $DIR/inefficient_to_string.rs:21:21
    |
 LL |     let _: String = rrrstring.to_string();
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try dereferencing the receiver: `(**rrrstring).to_string()`
    |
-   = help: `&&std::string::String` implements `ToString` through a slower blanket impl, but `std::string::String` has a fast specialization of `ToString`
+   = help: `&&String` implements `ToString` through a slower blanket impl, but `String` has a fast specialization of `ToString`
 
-error: calling `to_string` on `&&std::borrow::Cow<str>`
+error: calling `to_string` on `&&Cow<str>`
   --> $DIR/inefficient_to_string.rs:29:21
    |
 LL |     let _: String = rrcow.to_string();
    |                     ^^^^^^^^^^^^^^^^^ help: try dereferencing the receiver: `(*rrcow).to_string()`
    |
-   = help: `&std::borrow::Cow<str>` implements `ToString` through a slower blanket impl, but `std::borrow::Cow<str>` has a fast specialization of `ToString`
+   = help: `&Cow<str>` implements `ToString` through a slower blanket impl, but `Cow<str>` has a fast specialization of `ToString`
 
-error: calling `to_string` on `&&&std::borrow::Cow<str>`
+error: calling `to_string` on `&&&Cow<str>`
   --> $DIR/inefficient_to_string.rs:30:21
    |
 LL |     let _: String = rrrcow.to_string();
    |                     ^^^^^^^^^^^^^^^^^^ help: try dereferencing the receiver: `(**rrrcow).to_string()`
    |
-   = help: `&&std::borrow::Cow<str>` implements `ToString` through a slower blanket impl, but `std::borrow::Cow<str>` has a fast specialization of `ToString`
+   = help: `&&Cow<str>` implements `ToString` through a slower blanket impl, but `Cow<str>` has a fast specialization of `ToString`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/mem_discriminant.stderr
+++ b/tests/ui/mem_discriminant.stderr
@@ -1,4 +1,4 @@
-error: calling `mem::discriminant` on non-enum type `&std::option::Option<i32>`
+error: calling `mem::discriminant` on non-enum type `&Option<i32>`
   --> $DIR/mem_discriminant.rs:14:5
    |
 LL |     mem::discriminant(&&Some(2));
@@ -12,7 +12,7 @@ note: the lint level is defined here
 LL | #![deny(clippy::mem_discriminant_non_enum)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: calling `mem::discriminant` on non-enum type `&std::option::Option<u8>`
+error: calling `mem::discriminant` on non-enum type `&Option<u8>`
   --> $DIR/mem_discriminant.rs:15:5
    |
 LL |     mem::discriminant(&&None::<u8>);
@@ -36,7 +36,7 @@ LL |     mem::discriminant(&&Foo::Two(5));
    |                       |
    |                       help: try dereferencing: `&Foo::Two(5)`
 
-error: calling `mem::discriminant` on non-enum type `&std::option::Option<i32>`
+error: calling `mem::discriminant` on non-enum type `&Option<i32>`
   --> $DIR/mem_discriminant.rs:21:5
    |
 LL |     mem::discriminant(&ro);
@@ -44,7 +44,7 @@ LL |     mem::discriminant(&ro);
    |                       |
    |                       help: try dereferencing: `ro`
 
-error: calling `mem::discriminant` on non-enum type `&std::option::Option<i32>`
+error: calling `mem::discriminant` on non-enum type `&Option<i32>`
   --> $DIR/mem_discriminant.rs:22:5
    |
 LL |     mem::discriminant(rro);
@@ -52,7 +52,7 @@ LL |     mem::discriminant(rro);
    |                       |
    |                       help: try dereferencing: `*rro`
 
-error: calling `mem::discriminant` on non-enum type `&&std::option::Option<i32>`
+error: calling `mem::discriminant` on non-enum type `&&Option<i32>`
   --> $DIR/mem_discriminant.rs:23:5
    |
 LL |     mem::discriminant(&rro);
@@ -60,7 +60,7 @@ LL |     mem::discriminant(&rro);
    |                       |
    |                       help: try dereferencing: `*rro`
 
-error: calling `mem::discriminant` on non-enum type `&&std::option::Option<i32>`
+error: calling `mem::discriminant` on non-enum type `&&Option<i32>`
   --> $DIR/mem_discriminant.rs:27:13
    |
 LL |             mem::discriminant($param)
@@ -74,7 +74,7 @@ LL |     mem_discriminant_but_in_a_macro!(&rro);
    |
    = note: this error originates in the macro `mem_discriminant_but_in_a_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: calling `mem::discriminant` on non-enum type `&&&&&std::option::Option<i32>`
+error: calling `mem::discriminant` on non-enum type `&&&&&Option<i32>`
   --> $DIR/mem_discriminant.rs:34:5
    |
 LL |     mem::discriminant(&rrrrro);
@@ -82,7 +82,7 @@ LL |     mem::discriminant(&rrrrro);
    |                       |
    |                       help: try dereferencing: `****rrrrro`
 
-error: calling `mem::discriminant` on non-enum type `&&&std::option::Option<i32>`
+error: calling `mem::discriminant` on non-enum type `&&&Option<i32>`
   --> $DIR/mem_discriminant.rs:35:5
    |
 LL |     mem::discriminant(*rrrrro);

--- a/tests/ui/transmute.stderr
+++ b/tests/ui/transmute.stderr
@@ -24,31 +24,31 @@ error: transmute from a reference to a pointer
 LL |     let _: *const U = core::intrinsics::transmute(t);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T as *const U`
 
-error: transmute from a type (`std::vec::Vec<i32>`) to itself
+error: transmute from a type (`Vec<i32>`) to itself
   --> $DIR/transmute.rs:33:27
    |
 LL |         let _: Vec<i32> = core::intrinsics::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from a type (`std::vec::Vec<i32>`) to itself
+error: transmute from a type (`Vec<i32>`) to itself
   --> $DIR/transmute.rs:35:27
    |
 LL |         let _: Vec<i32> = core::mem::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from a type (`std::vec::Vec<i32>`) to itself
+error: transmute from a type (`Vec<i32>`) to itself
   --> $DIR/transmute.rs:37:27
    |
 LL |         let _: Vec<i32> = std::intrinsics::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from a type (`std::vec::Vec<i32>`) to itself
+error: transmute from a type (`Vec<i32>`) to itself
   --> $DIR/transmute.rs:39:27
    |
 LL |         let _: Vec<i32> = std::mem::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from a type (`std::vec::Vec<i32>`) to itself
+error: transmute from a type (`Vec<i32>`) to itself
   --> $DIR/transmute.rs:41:27
    |
 LL |         let _: Vec<i32> = my_transmute(my_vec());

--- a/tests/ui/transmute_collection.stderr
+++ b/tests/ui/transmute_collection.stderr
@@ -1,4 +1,4 @@
-error: transmute from `std::vec::Vec<u8>` to `std::vec::Vec<u32>` with mismatched layout is unsound
+error: transmute from `Vec<u8>` to `Vec<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:9:17
    |
 LL |         let _ = transmute::<_, Vec<u32>>(vec![0u8]);
@@ -6,103 +6,103 @@ LL |         let _ = transmute::<_, Vec<u32>>(vec![0u8]);
    |
    = note: `-D clippy::unsound-collection-transmute` implied by `-D warnings`
 
-error: transmute from `std::vec::Vec<u32>` to `std::vec::Vec<[u8; 4]>` with mismatched layout is unsound
+error: transmute from `Vec<u32>` to `Vec<[u8; 4]>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:11:17
    |
 LL |         let _ = transmute::<_, Vec<[u8; 4]>>(vec![1234u32]);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::VecDeque<u8>` to `std::collections::VecDeque<u32>` with mismatched layout is unsound
+error: transmute from `VecDeque<u8>` to `VecDeque<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:14:17
    |
 LL |         let _ = transmute::<_, VecDeque<u32>>(VecDeque::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::VecDeque<[u8; 4]>` to `std::collections::VecDeque<u32>` with mismatched layout is unsound
+error: transmute from `VecDeque<[u8; 4]>` to `VecDeque<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:16:17
    |
 LL |         let _ = transmute::<_, VecDeque<u32>>(VecDeque::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BinaryHeap<u8>` to `std::collections::BinaryHeap<u32>` with mismatched layout is unsound
+error: transmute from `BinaryHeap<u8>` to `BinaryHeap<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:19:17
    |
 LL |         let _ = transmute::<_, BinaryHeap<u32>>(BinaryHeap::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BinaryHeap<[u8; 4]>` to `std::collections::BinaryHeap<u32>` with mismatched layout is unsound
+error: transmute from `BinaryHeap<[u8; 4]>` to `BinaryHeap<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:21:17
    |
 LL |         let _ = transmute::<_, BinaryHeap<u32>>(BinaryHeap::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BTreeSet<u8>` to `std::collections::BTreeSet<u32>` with mismatched layout is unsound
+error: transmute from `BTreeSet<u8>` to `BTreeSet<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:24:17
    |
 LL |         let _ = transmute::<_, BTreeSet<u32>>(BTreeSet::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BTreeSet<[u8; 4]>` to `std::collections::BTreeSet<u32>` with mismatched layout is unsound
+error: transmute from `BTreeSet<[u8; 4]>` to `BTreeSet<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:26:17
    |
 LL |         let _ = transmute::<_, BTreeSet<u32>>(BTreeSet::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::HashSet<u8>` to `std::collections::HashSet<u32>` with mismatched layout is unsound
+error: transmute from `HashSet<u8>` to `HashSet<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:29:17
    |
 LL |         let _ = transmute::<_, HashSet<u32>>(HashSet::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::HashSet<[u8; 4]>` to `std::collections::HashSet<u32>` with mismatched layout is unsound
+error: transmute from `HashSet<[u8; 4]>` to `HashSet<u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:31:17
    |
 LL |         let _ = transmute::<_, HashSet<u32>>(HashSet::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BTreeMap<u8, u8>` to `std::collections::BTreeMap<u8, u32>` with mismatched layout is unsound
+error: transmute from `BTreeMap<u8, u8>` to `BTreeMap<u8, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:34:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u8, u32>>(BTreeMap::<u8, u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BTreeMap<u32, u32>` to `std::collections::BTreeMap<u8, u32>` with mismatched layout is unsound
+error: transmute from `BTreeMap<u32, u32>` to `BTreeMap<u8, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:35:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u8, u32>>(BTreeMap::<u32, u32>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BTreeMap<u8, [u8; 4]>` to `std::collections::BTreeMap<u8, u32>` with mismatched layout is unsound
+error: transmute from `BTreeMap<u8, [u8; 4]>` to `BTreeMap<u8, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:37:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u8, u32>>(BTreeMap::<u8, [u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::BTreeMap<[u8; 4], u32>` to `std::collections::BTreeMap<u32, u32>` with mismatched layout is unsound
+error: transmute from `BTreeMap<[u8; 4], u32>` to `BTreeMap<u32, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:38:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u32, u32>>(BTreeMap::<[u8; 4], u32>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::HashMap<u8, u8>` to `std::collections::HashMap<u8, u32>` with mismatched layout is unsound
+error: transmute from `HashMap<u8, u8>` to `HashMap<u8, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:41:17
    |
 LL |         let _ = transmute::<_, HashMap<u8, u32>>(HashMap::<u8, u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::HashMap<u32, u32>` to `std::collections::HashMap<u8, u32>` with mismatched layout is unsound
+error: transmute from `HashMap<u32, u32>` to `HashMap<u8, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:42:17
    |
 LL |         let _ = transmute::<_, HashMap<u8, u32>>(HashMap::<u32, u32>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::HashMap<u8, [u8; 4]>` to `std::collections::HashMap<u8, u32>` with mismatched layout is unsound
+error: transmute from `HashMap<u8, [u8; 4]>` to `HashMap<u8, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:44:17
    |
 LL |         let _ = transmute::<_, HashMap<u8, u32>>(HashMap::<u8, [u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from `std::collections::HashMap<[u8; 4], u32>` to `std::collections::HashMap<u32, u32>` with mismatched layout is unsound
+error: transmute from `HashMap<[u8; 4], u32>` to `HashMap<u32, u32>` with mismatched layout is unsound
   --> $DIR/transmute_collection.rs:45:17
    |
 LL |         let _ = transmute::<_, HashMap<u32, u32>>(HashMap::<[u8; 4], u32>::new());

--- a/tests/ui/transmute_ptr_to_ref.stderr
+++ b/tests/ui/transmute_ptr_to_ref.stderr
@@ -42,13 +42,13 @@ error: transmute from a pointer type (`*mut U`) to a reference type (`&T`)
 LL |     let _: &T = std::mem::transmute(om);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(om as *const T)`
 
-error: transmute from a pointer type (`*const i32`) to a reference type (`&issue1231::Foo<u8>`)
+error: transmute from a pointer type (`*const i32`) to a reference type (`&Foo<u8>`)
   --> $DIR/transmute_ptr_to_ref.rs:32:32
    |
 LL |     let _: &Foo<u8> = unsafe { std::mem::transmute::<_, &Foo<_>>(raw) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(raw as *const Foo<_>)`
 
-error: transmute from a pointer type (`*const i32`) to a reference type (`&issue1231::Foo<&u8>`)
+error: transmute from a pointer type (`*const i32`) to a reference type (`&Foo<&u8>`)
   --> $DIR/transmute_ptr_to_ref.rs:34:33
    |
 LL |     let _: &Foo<&u8> = unsafe { std::mem::transmute::<_, &Foo<&_>>(raw) };

--- a/tests/ui/transmutes_expressible_as_ptr_casts.stderr
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.stderr
@@ -34,13 +34,13 @@ error: transmute from a reference to a pointer
 LL |     let _array_ptr_transmute = unsafe { transmute::<&[i32; 4], *const [i32; 4]>(array_ref) };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `array_ref as *const [i32; 4]`
 
-error: transmute from `fn(usize) -> u8 {main::foo}` to `*const usize` which could be expressed as a pointer cast instead
+error: transmute from `fn(usize) -> u8 {foo}` to `*const usize` which could be expressed as a pointer cast instead
   --> $DIR/transmutes_expressible_as_ptr_casts.rs:49:41
    |
 LL |     let _usize_ptr_transmute = unsafe { transmute::<fn(usize) -> u8, *const usize>(foo) };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `foo as *const usize`
 
-error: transmute from `fn(usize) -> u8 {main::foo}` to `usize` which could be expressed as a pointer cast instead
+error: transmute from `fn(usize) -> u8 {foo}` to `usize` which could be expressed as a pointer cast instead
   --> $DIR/transmutes_expressible_as_ptr_casts.rs:53:49
    |
 LL |     let _usize_from_fn_ptr_transmute = unsafe { transmute::<fn(usize) -> u8, usize>(foo) };

--- a/tests/ui/unnecessary_clone.stderr
+++ b/tests/ui/unnecessary_clone.stderr
@@ -38,13 +38,13 @@ LL |     t.clone();
    |
    = note: `-D clippy::clone-on-copy` implied by `-D warnings`
 
-error: using `clone` on type `std::option::Option<T>` which implements the `Copy` trait
+error: using `clone` on type `Option<T>` which implements the `Copy` trait
   --> $DIR/unnecessary_clone.rs:42:5
    |
 LL |     Some(t).clone();
    |     ^^^^^^^^^^^^^^^ help: try removing the `clone` call: `Some(t)`
 
-error: using `clone` on a double-reference; this will copy the reference of type `&std::vec::Vec<i32>` instead of cloning the inner type
+error: using `clone` on a double-reference; this will copy the reference of type `&Vec<i32>` instead of cloning the inner type
   --> $DIR/unnecessary_clone.rs:48:22
    |
 LL |     let z: &Vec<_> = y.clone();
@@ -57,10 +57,10 @@ LL |     let z: &Vec<_> = &(*y).clone();
    |                      ~~~~~~~~~~~~~
 help: or try being explicit if you are sure, that you want to clone a reference
    |
-LL |     let z: &Vec<_> = <&std::vec::Vec<i32>>::clone(y);
-   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     let z: &Vec<_> = <&Vec<i32>>::clone(y);
+   |                      ~~~~~~~~~~~~~~~~~~~~~
 
-error: using `clone` on type `many_derefs::E` which implements the `Copy` trait
+error: using `clone` on type `E` which implements the `Copy` trait
   --> $DIR/unnecessary_clone.rs:84:20
    |
 LL |         let _: E = a.clone();

--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -22,25 +22,25 @@ error: useless conversion to the same type: `i32`
 LL |         let _: i32 = 0i32.into();
    |                      ^^^^^^^^^^^ help: consider removing `.into()`: `0i32`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion.rs:61:21
    |
 LL |     let _: String = "foo".to_string().into();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `"foo".to_string()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion.rs:62:21
    |
 LL |     let _: String = From::from("foo".to_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `From::from()`: `"foo".to_string()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion.rs:63:13
    |
 LL |     let _ = String::from("foo".to_string());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `String::from()`: `"foo".to_string()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion.rs:64:13
    |
 LL |     let _ = String::from(format!("A: {:04}", 123));
@@ -58,7 +58,7 @@ error: useless conversion to the same type: `std::vec::IntoIter<i32>`
 LL |     let _ = vec![1, 2, 3].into_iter().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2, 3].into_iter()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion.rs:67:21
    |
 LL |     let _: String = format!("Hello {}", "world").into();

--- a/tests/ui/useless_conversion_try.stderr
+++ b/tests/ui/useless_conversion_try.stderr
@@ -19,7 +19,7 @@ LL |     val.try_into().unwrap()
    |
    = help: consider removing `.try_into()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion_try.rs:29:21
    |
 LL |     let _: String = "foo".to_string().try_into().unwrap();
@@ -27,7 +27,7 @@ LL |     let _: String = "foo".to_string().try_into().unwrap();
    |
    = help: consider removing `.try_into()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion_try.rs:30:21
    |
 LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
@@ -35,7 +35,7 @@ LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
    |
    = help: consider removing `TryFrom::try_from()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion_try.rs:31:13
    |
 LL |     let _ = String::try_from("foo".to_string()).unwrap();
@@ -43,7 +43,7 @@ LL |     let _ = String::try_from("foo".to_string()).unwrap();
    |
    = help: consider removing `String::try_from()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion_try.rs:32:13
    |
 LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
@@ -51,7 +51,7 @@ LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
    |
    = help: consider removing `String::try_from()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion_try.rs:33:21
    |
 LL |     let _: String = format!("Hello {}", "world").try_into().unwrap();
@@ -59,7 +59,7 @@ LL |     let _: String = format!("Hello {}", "world").try_into().unwrap();
    |
    = help: consider removing `.try_into()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion_try.rs:34:21
    |
 LL |     let _: String = "".to_owned().try_into().unwrap();
@@ -67,7 +67,7 @@ LL |     let _: String = "".to_owned().try_into().unwrap();
    |
    = help: consider removing `.try_into()`
 
-error: useless conversion to the same type: `std::string::String`
+error: useless conversion to the same type: `String`
   --> $DIR/useless_conversion_try.rs:35:27
    |
 LL |     let _: String = match String::from("_").try_into() {


### PR DESCRIPTION
changelog: Uses "trimmed paths" instead of fully qualified paths in output

This flips a magic switch in driver.rs so that we get `Option` instead of `std::option::Option` from `cx.tcx.def_path_str`, for example. This improves Clippy output all around. There aren't a whole lot of these cases. But I suspect there are a number of cases where `def_path_str` would be a better choice than the current implementation, and it might have been used more if this feature were already enabled.

---

Unfortunately this comes with a footgun. Any time we fetch a trimmed path (usually through `Ty::to_string` or `cx.tcx.def_path_str`), but then *don't* use it to emit a lint, rustc [ICEs](https://github.com/rust-lang/rust/blob/517c28e421b0d601c6f8eb07ea6aafb8e16975ad/compiler/rustc_middle/src/ty/print/pretty.rs#L2401). This is especially problematic with our utility functions `span_lint_*` because *these functions don't emit if the lint is allowed*.

```rust
let msg = format!("you did a bad thing with with `{}`", cx.tcx.def_path_str(def_id));
// ICEBERGS AHEAD!!! Will ICE if SILLY_LINT is allowed!
span_lint(cx, SILLY_LINT, span, msg);
```

To solve this, I created a new util `span_clippy_lint` that works similarly to `span_lint_and_then`. It uses a Drop guard to add our special Clippy messages at the end.

```rust
span_clippy_lint(cx, SILLY_LINT, span, |diag| {
    // the lint is enabled at this point so we're safe!
    diag.build(format!("you did a bad thing with with `{}`", cx.tcx.def_path_str(def_id)))
});
```

And of course you can use anything in [`Diagnostic`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_errors/diagnostic/struct.Diagnostic.html) like `span_suggestion` or `help` in a call chain. TBH I like this API a lot more than our current util functions.

This still leaves a rough edge for Clippy contributors since we can't ever fetch a trimmed path outside of the "diag" closure, and *our tests don't necessarily catch the problem if we do it wrong*. So this is something all maintainers would need to be wary of when reviewing.

For now, I just converted some lints to `span_clippy_lint` to avoid ICE where needed. But I think we need to convert all the lints over and delete the `span_lint_*` functions to get rid of the footgun. Opening for feedback. @rust-lang/clippy

Closes #6385
Closes #7212