### PR TITLE
fix for issue #7683

### DIFF
--- a/tests/ui/derivable_impls.rs
+++ b/tests/ui/derivable_impls.rs
@@ -207,4 +207,24 @@ impl Default for Color2 {
     }
 }
 
+pub struct RepeatDefault1 {
+    a: [i8; 32],
+}
+
+impl Default for RepeatDefault1 {
+    fn default() -> Self {
+        RepeatDefault1 { a: [0; 32] }
+    }
+}
+
+pub struct RepeatDefault2 {
+    a: [i8; 33],
+}
+
+impl Default for RepeatDefault2 {
+    fn default() -> Self {
+        RepeatDefault2 { a: [0; 33] }
+    }
+}
+
 fn main() {}

--- a/tests/ui/derivable_impls.stderr
+++ b/tests/ui/derivable_impls.stderr
@@ -73,5 +73,17 @@ LL | | }
    |
    = help: try annotating `WithoutSelfParan` with `#[derive(Default)]`
 
-error: aborting due to 6 previous errors
+error: this `impl` can be derived
+  --> $DIR/derivable_impls.rs:214:1
+   |
+LL | / impl Default for RepeatDefault1 {
+LL | |     fn default() -> Self {
+LL | |         RepeatDefault1 { a: [0; 32] }
+LL | |     }
+LL | | }
+   | |_^
+   |
+   = help: try annotating `RepeatDefault1` with `#[derive(Default)]`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes #7683.

For Repeat  [x; y] (x is the type and y is the times to repeat) . When y > 32, the compiler will report an error:

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=7148558162685e91056e0550797ea74c

Because https://github.com/rust-lang/rust/blob/6cdd42f9f8dd4e5e5ba0aa816bc4c99ab8b102f9/library/std/src/primitive_docs.rs#L538
/// Arrays of sizes from 0 to 32 (inclusive) implement [`Default`] trait
/// if the element type allows it. As a stopgap, trait implementations are
/// statically generated up to size 32.

So here to detect this situation.

changelog: [`derivable_impls`]: No longer lints when arrays bigger than 32 elements are involved
