### PR TITLE
Add lint `ref_mut_iter_method_chain`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3107,6 +3107,7 @@ Released 2018-09-13
 [`redundant_static_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes
 [`ref_binding_to_reference`]: https://rust-lang.github.io/rust-clippy/master/index.html#ref_binding_to_reference
 [`ref_in_deref`]: https://rust-lang.github.io/rust-clippy/master/index.html#ref_in_deref
+[`ref_mut_iter_method_chain`]: https://rust-lang.github.io/rust-clippy/master/index.html#ref_mut_iter_method_chain
 [`ref_option_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#ref_option_ref
 [`regex_macro`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_macro
 [`repeat_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_once

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -165,6 +165,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(methods::OPTION_FILTER_MAP),
     LintId::of(methods::OPTION_MAP_OR_NONE),
     LintId::of(methods::OR_FUN_CALL),
+    LintId::of(methods::REF_MUT_ITER_METHOD_CHAIN),
     LintId::of(methods::RESULT_MAP_OR_INTO_OPTION),
     LintId::of(methods::SEARCH_IS_SOME),
     LintId::of(methods::SHOULD_IMPLEMENT_TRAIT),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -299,6 +299,7 @@ store.register_lints(&[
     methods::OPTION_FILTER_MAP,
     methods::OPTION_MAP_OR_NONE,
     methods::OR_FUN_CALL,
+    methods::REF_MUT_ITER_METHOD_CHAIN,
     methods::RESULT_MAP_OR_INTO_OPTION,
     methods::SEARCH_IS_SOME,
     methods::SHOULD_IMPLEMENT_TRAIT,

--- a/clippy_lints/src/lib.register_style.rs
+++ b/clippy_lints/src/lib.register_style.rs
@@ -64,6 +64,7 @@ store.register_group(true, "clippy::style", Some("clippy_style"), vec![
     LintId::of(methods::NEW_RET_NO_SELF),
     LintId::of(methods::OK_EXPECT),
     LintId::of(methods::OPTION_MAP_OR_NONE),
+    LintId::of(methods::REF_MUT_ITER_METHOD_CHAIN),
     LintId::of(methods::RESULT_MAP_OR_INTO_OPTION),
     LintId::of(methods::SHOULD_IMPLEMENT_TRAIT),
     LintId::of(methods::SINGLE_CHAR_ADD_STR),

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1867,19 +1867,17 @@ declare_clippy_lint! {
     /// Check for `&mut iter` followed by a method call.
     ///
     /// ### Why is this bad?
-    /// This requires using parenthesis to signify precedence.
+    /// Using `(&mut iter)._` requires using parenthesis to signify precedence.
     ///
     /// ### Example
     /// ```rust
     /// let mut iter = ['a', 'b', '.', 'd'].iter();
     /// let before_dot = (&mut iter).take_while(|&&c| c != '.').collect::<Vec<_>>();
-    /// let after_dot = iter.collect::<Vec<_>>();
     /// ```
     /// Use instead:
     /// ```rust
     /// let mut iter = ['a', 'b', '.', 'd'].iter();
     /// let before_dot = iter.by_ref().take_while(|&&c| c != '.').collect::<Vec<_>>();
-    /// let after_dot = iter.collect::<Vec<_>>();
     /// ```
     pub REF_MUT_ITER_METHOD_CHAIN,
     style,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1879,6 +1879,7 @@ declare_clippy_lint! {
     /// let mut iter = ['a', 'b', '.', 'd'].iter();
     /// let before_dot = iter.by_ref().take_while(|&&c| c != '.').collect::<Vec<_>>();
     /// ```
+    #[clippy::version = "1.58.0"]
     pub REF_MUT_ITER_METHOD_CHAIN,
     style,
     "`&mut iter` used in a method chain"

--- a/clippy_lints/src/methods/ref_mut_iter_method_chain.rs
+++ b/clippy_lints/src/methods/ref_mut_iter_method_chain.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::{snippet_expr, TargetPrecedence};
+use clippy_utils::source::{snippet_expr, ExprPosition};
 use clippy_utils::ty::implements_trait;
 use if_chain::if_chain;
 use rustc_errors::Applicability;
@@ -17,7 +17,8 @@ pub(crate) fn check(cx: &LateContext<'_>, self_arg: &Expr<'_>) {
         if implements_trait(cx, cx.typeck_results().expr_ty(base_expr).peel_refs(), iter_trait, &[]);
         then {
             let snip_expr = match base_expr.kind {
-                ExprKind::Unary(UnOp::Deref, e) if cx.typeck_results().expr_ty(e).is_ref() && !base_expr.span.from_expansion()
+                ExprKind::Unary(UnOp::Deref, e)
+                if cx.typeck_results().expr_ty(e).is_ref() && !base_expr.span.from_expansion()
                     => e,
                 _ => base_expr,
             };
@@ -30,7 +31,7 @@ pub(crate) fn check(cx: &LateContext<'_>, self_arg: &Expr<'_>) {
                 "try",
                 format!(
                     "{}.by_ref()",
-                    snippet_expr(cx, snip_expr, TargetPrecedence::Postfix, self_arg.span.ctxt(), &mut app),
+                    snippet_expr(cx, snip_expr, ExprPosition::Postfix, self_arg.span.ctxt(), &mut app),
                 ),
                 app,
             );

--- a/clippy_lints/src/methods/ref_mut_iter_method_chain.rs
+++ b/clippy_lints/src/methods/ref_mut_iter_method_chain.rs
@@ -1,0 +1,40 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::in_macro;
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::ty::implements_trait;
+use if_chain::if_chain;
+use rustc_errors::Applicability;
+use rustc_hir::{BorrowKind, Expr, ExprKind, Mutability, UnOp};
+use rustc_lint::LateContext;
+use rustc_span::sym;
+
+use super::REF_MUT_ITER_METHOD_CHAIN;
+
+pub(crate) fn check(cx: &LateContext<'_>, self_arg: &Expr<'_>) {
+    if_chain! {
+        if let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, base_expr) = self_arg.kind;
+        if !in_macro(self_arg.span);
+        if let Some(&iter_trait) = cx.tcx.all_diagnostic_items(()).get(&sym::Iterator);
+        if implements_trait(cx, cx.typeck_results().expr_ty(base_expr).peel_refs(), iter_trait, &[]);
+        then {
+            let snip_span = match base_expr.kind {
+                ExprKind::Unary(UnOp::Deref, e) if cx.typeck_results().expr_ty(e).is_ref() && !in_macro(base_expr.span)
+                    => e.span,
+                _ => base_expr.span,
+            };
+            let mut app = Applicability::MachineApplicable;
+            span_lint_and_sugg(
+                cx,
+                REF_MUT_ITER_METHOD_CHAIN,
+                self_arg.span,
+                "use of `&mut` on an iterator in a method chain",
+                "try",
+                format!(
+                    "{}.by_ref()",
+                    snippet_with_context(cx, snip_span, self_arg.span.ctxt(), "..", &mut app).0,
+                ),
+                app,
+            );
+        }
+    }
+}

--- a/tests/ui/ref_mut_iter_method_chain.fixed
+++ b/tests/ui/ref_mut_iter_method_chain.fixed
@@ -31,4 +31,7 @@ fn main() {
 
     let iter = &mut iter;
     iter.by_ref().find(|&&x| x == 1);
+    let mut iter = iter;
+    let iter = &mut iter;
+    (*iter).by_ref().find(|&&x| x == 1);
 }

--- a/tests/ui/ref_mut_iter_method_chain.fixed
+++ b/tests/ui/ref_mut_iter_method_chain.fixed
@@ -26,7 +26,11 @@ fn main() {
 
     // Don't lint. No method chain.
     for &x in &mut iter {
-        print!("{}", x)
+        print!("{}", x);
+    }
+
+    for &x in iter.by_ref().filter(|&&x| x % 2 == 0) {
+        print!("{}", x);
     }
 
     let iter = &mut iter;

--- a/tests/ui/ref_mut_iter_method_chain.fixed
+++ b/tests/ui/ref_mut_iter_method_chain.fixed
@@ -1,0 +1,34 @@
+// run-rustfix
+#![warn(clippy::ref_mut_iter_method_chain)]
+
+macro_rules! m {
+    ($i:ident) => {
+        $i
+    };
+    (&mut $i:ident) => {
+        &mut $i
+    };
+    (($i:expr).$m:ident($arg:expr)) => {
+        ($i).$m($arg)
+    };
+}
+
+fn main() {
+    let mut iter = [0, 1, 2].iter();
+    let _ = iter.by_ref().find(|&&x| x == 1);
+    let _ = m!(iter).by_ref().find(|&&x| x == 1);
+
+    // Don't lint. `&mut` comes from macro expansion.
+    let _ = m!(&mut iter).find(|&&x| x == 1);
+
+    // Don't lint. Method call from expansion
+    let _ = m!((&mut iter).find(|&&x| x == 1));
+
+    // Don't lint. No method chain.
+    for &x in &mut iter {
+        print!("{}", x)
+    }
+
+    let iter = &mut iter;
+    iter.by_ref().find(|&&x| x == 1);
+}

--- a/tests/ui/ref_mut_iter_method_chain.rs
+++ b/tests/ui/ref_mut_iter_method_chain.rs
@@ -1,0 +1,34 @@
+// run-rustfix
+#![warn(clippy::ref_mut_iter_method_chain)]
+
+macro_rules! m {
+    ($i:ident) => {
+        $i
+    };
+    (&mut $i:ident) => {
+        &mut $i
+    };
+    (($i:expr).$m:ident($arg:expr)) => {
+        ($i).$m($arg)
+    };
+}
+
+fn main() {
+    let mut iter = [0, 1, 2].iter();
+    let _ = (&mut iter).find(|&&x| x == 1);
+    let _ = (&mut m!(iter)).find(|&&x| x == 1);
+
+    // Don't lint. `&mut` comes from macro expansion.
+    let _ = m!(&mut iter).find(|&&x| x == 1);
+
+    // Don't lint. Method call from expansion
+    let _ = m!((&mut iter).find(|&&x| x == 1));
+
+    // Don't lint. No method chain.
+    for &x in &mut iter {
+        print!("{}", x)
+    }
+
+    let iter = &mut iter;
+    (&mut *iter).find(|&&x| x == 1);
+}

--- a/tests/ui/ref_mut_iter_method_chain.rs
+++ b/tests/ui/ref_mut_iter_method_chain.rs
@@ -26,7 +26,11 @@ fn main() {
 
     // Don't lint. No method chain.
     for &x in &mut iter {
-        print!("{}", x)
+        print!("{}", x);
+    }
+
+    for &x in (&mut iter).filter(|&&x| x % 2 == 0) {
+        print!("{}", x);
     }
 
     let iter = &mut iter;

--- a/tests/ui/ref_mut_iter_method_chain.rs
+++ b/tests/ui/ref_mut_iter_method_chain.rs
@@ -31,4 +31,7 @@ fn main() {
 
     let iter = &mut iter;
     (&mut *iter).find(|&&x| x == 1);
+    let mut iter = iter;
+    let iter = &mut iter;
+    (&mut **iter).find(|&&x| x == 1);
 }

--- a/tests/ui/ref_mut_iter_method_chain.stderr
+++ b/tests/ui/ref_mut_iter_method_chain.stderr
@@ -18,5 +18,11 @@ error: use of `&mut` on an iterator in a method chain
 LL |     (&mut *iter).find(|&&x| x == 1);
    |     ^^^^^^^^^^^^ help: try: `iter.by_ref()`
 
-error: aborting due to 3 previous errors
+error: use of `&mut` on an iterator in a method chain
+  --> $DIR/ref_mut_iter_method_chain.rs:36:5
+   |
+LL |     (&mut **iter).find(|&&x| x == 1);
+   |     ^^^^^^^^^^^^^ help: try: `(*iter).by_ref()`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/ref_mut_iter_method_chain.stderr
+++ b/tests/ui/ref_mut_iter_method_chain.stderr
@@ -1,0 +1,22 @@
+error: use of `&mut` on an iterator in a method chain
+  --> $DIR/ref_mut_iter_method_chain.rs:18:13
+   |
+LL |     let _ = (&mut iter).find(|&&x| x == 1);
+   |             ^^^^^^^^^^^ help: try: `iter.by_ref()`
+   |
+   = note: `-D clippy::ref-mut-iter-method-chain` implied by `-D warnings`
+
+error: use of `&mut` on an iterator in a method chain
+  --> $DIR/ref_mut_iter_method_chain.rs:19:13
+   |
+LL |     let _ = (&mut m!(iter)).find(|&&x| x == 1);
+   |             ^^^^^^^^^^^^^^^ help: try: `m!(iter).by_ref()`
+
+error: use of `&mut` on an iterator in a method chain
+  --> $DIR/ref_mut_iter_method_chain.rs:33:5
+   |
+LL |     (&mut *iter).find(|&&x| x == 1);
+   |     ^^^^^^^^^^^^ help: try: `iter.by_ref()`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/ref_mut_iter_method_chain.stderr
+++ b/tests/ui/ref_mut_iter_method_chain.stderr
@@ -13,16 +13,22 @@ LL |     let _ = (&mut m!(iter)).find(|&&x| x == 1);
    |             ^^^^^^^^^^^^^^^ help: try: `m!(iter).by_ref()`
 
 error: use of `&mut` on an iterator in a method chain
-  --> $DIR/ref_mut_iter_method_chain.rs:33:5
+  --> $DIR/ref_mut_iter_method_chain.rs:32:15
+   |
+LL |     for &x in (&mut iter).filter(|&&x| x % 2 == 0) {
+   |               ^^^^^^^^^^^ help: try: `iter.by_ref()`
+
+error: use of `&mut` on an iterator in a method chain
+  --> $DIR/ref_mut_iter_method_chain.rs:37:5
    |
 LL |     (&mut *iter).find(|&&x| x == 1);
    |     ^^^^^^^^^^^^ help: try: `iter.by_ref()`
 
 error: use of `&mut` on an iterator in a method chain
-  --> $DIR/ref_mut_iter_method_chain.rs:36:5
+  --> $DIR/ref_mut_iter_method_chain.rs:40:5
    |
 LL |     (&mut **iter).find(|&&x| x == 1);
    |     ^^^^^^^^^^^^^ help: try: `(*iter).by_ref()`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Mentioned here: https://github.com/rust-lang/rust-clippy/issues/7659#issuecomment-920582174

changelog: New lint: [`ref_mut_iter_method_chain`]
[#7688](https://github.com/rust-lang/rust-clippy/pull/7688)
<!-- changelog_checked -->