### PR TITLE
Tweak pedantic description for occasional FPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can choose how much Clippy is supposed to ~~annoy~~ help you by changing the
 | `clippy::style`       | code that should be written in a more idiomatic way                                 | **warn**      |
 | `clippy::complexity`  | code that does something simple but in a complex way                                | **warn**      |
 | `clippy::perf`        | code that can be written to run faster                                              | **warn**      |
-| `clippy::pedantic`    | lints which are rather strict or might have false positives                         | allow         |
+| `clippy::pedantic`    | lints which are rather strict or have occasional false positives                    | allow         |
 | `clippy::nursery`     | new lints that are still under development                                          | allow         |
 | `clippy::cargo`       | lints for the cargo manifest                                                        | allow         |
 


### PR DESCRIPTION
changelog: none

Okay this is getting a bit picky (you might even say pedantic). I think we need to be careful not use the pedantic category as cover-all for lints with any amount of false positives. Lints with a high degree of FPs should be nursery or restriction IMO. If the pedantic category were to yield, say hypothetically, over 50% FPs, it would just be too annoying to use at all (to be sure, "too picky for me" is not a FP).

CC @rust-lang/clippy