### PR TITLE
Add known problem to redundant_clone suggestion

### DIFF
--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -43,6 +43,9 @@ declare_clippy_lint! {
     /// ### Known problems
     /// False-negatives: analysis performed by this lint is conservative and limited.
     ///
+    /// Sugestion causes errors: If the `Clone` implementation returns a different
+    /// value, removing the `.clone()` call might change the behavior of your code.
+    ///
     /// ### Example
     /// ```rust
     /// # use std::path::Path;


### PR DESCRIPTION
changelog:

Add note in known problems list of [`redundant_clone`] explaining that it might fail if the `Clone` has some unexpected behavior.