### PR TITLE
Make `doc_unsafe` warn on unsafe traits as well

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -242,7 +242,7 @@ impl<'tcx> LateLintPass<'tcx> for DocMarkdown {
                         cx,
                         MISSING_SAFETY_DOC,
                         item.span,
-                        "unsafe trait's docs miss `# Safety` section",
+                        "docs for unsafe trait missing `# Safety` section",
                     );
                 }
             },

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -236,7 +236,17 @@ impl<'tcx> LateLintPass<'tcx> for DocMarkdown {
             hir::ItemKind::Impl(ref impl_) => {
                 self.in_trait_impl = impl_.of_trait.is_some();
             },
-            _ => {},
+            hir::ItemKind::Trait(_, unsafety, ..) => {
+                if !headers.safety && unsafety == hir::Unsafety::Unsafe {
+                    span_lint(
+                        cx,
+                        MISSING_SAFETY_DOC,
+                        item.span,
+                        "unsafe trait's docs miss `# Safety` section",
+                    );
+                }
+            },
+            _ => (),
         }
     }
 

--- a/tests/ui/def_id_nocore.rs
+++ b/tests/ui/def_id_nocore.rs
@@ -3,6 +3,7 @@
 
 #![feature(no_core, lang_items, start)]
 #![no_core]
+#![allow(clippy::missing_safety_doc)]
 
 #[link(name = "c")]
 extern "C" {}

--- a/tests/ui/def_id_nocore.stderr
+++ b/tests/ui/def_id_nocore.stderr
@@ -1,5 +1,5 @@
 error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
-  --> $DIR/def_id_nocore.rs:26:19
+  --> $DIR/def_id_nocore.rs:27:19
    |
 LL |     pub fn as_ref(self) -> &'static str {
    |                   ^^^^

--- a/tests/ui/doc_unsafe.rs
+++ b/tests/ui/doc_unsafe.rs
@@ -34,16 +34,25 @@ mod private_mod {
 
 pub use private_mod::republished;
 
-pub trait UnsafeTrait {
+pub trait SafeTraitUnsafeMethods {
     unsafe fn woefully_underdocumented(self);
 
     /// # Safety
     unsafe fn at_least_somewhat_documented(self);
 }
 
+pub unsafe trait UnsafeTrait {
+    fn method();
+}
+
+/// # Safety
+pub unsafe trait DocumentedUnsafeTrait {
+    fn method2();
+}
+
 pub struct Struct;
 
-impl UnsafeTrait for Struct {
+impl SafeTraitUnsafeMethods for Struct {
     unsafe fn woefully_underdocumented(self) {
         // all is well
     }
@@ -51,6 +60,14 @@ impl UnsafeTrait for Struct {
     unsafe fn at_least_somewhat_documented(self) {
         // all is still well
     }
+}
+
+unsafe impl UnsafeTrait for Struct {
+    fn method() {}
+}
+
+unsafe impl DocumentedUnsafeTrait for Struct {
+    fn method2() {}
 }
 
 impl Struct {

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -22,8 +22,16 @@ error: unsafe function's docs miss `# Safety` section
 LL |     unsafe fn woefully_underdocumented(self);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: unsafe trait's docs miss `# Safety` section
+  --> $DIR/doc_unsafe.rs:44:1
+   |
+LL | / pub unsafe trait UnsafeTrait {
+LL | |     fn method();
+LL | | }
+   | |_^
+
 error: unsafe function's docs miss `# Safety` section
-  --> $DIR/doc_unsafe.rs:57:5
+  --> $DIR/doc_unsafe.rs:74:5
    |
 LL | /     pub unsafe fn more_undocumented_unsafe() -> Self {
 LL | |         unimplemented!();
@@ -31,7 +39,7 @@ LL | |     }
    | |_____^
 
 error: unsafe function's docs miss `# Safety` section
-  --> $DIR/doc_unsafe.rs:73:9
+  --> $DIR/doc_unsafe.rs:90:9
    |
 LL | /         pub unsafe fn whee() {
 LL | |             unimplemented!()
@@ -43,5 +51,5 @@ LL |   very_unsafe!();
    |
    = note: this error originates in the macro `very_unsafe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -22,7 +22,7 @@ error: unsafe function's docs miss `# Safety` section
 LL |     unsafe fn woefully_underdocumented(self);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unsafe trait's docs miss `# Safety` section
+error: docs for unsafe trait missing `# Safety` section
   --> $DIR/doc_unsafe.rs:44:1
    |
 LL | / pub unsafe trait UnsafeTrait {


### PR DESCRIPTION
Fixes #7732

changelog: Make [`doc_unsafe`] warn on unsafe traits as well