### PR TITLE
exclude enum from derivable impls

### DIFF
--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -83,6 +83,7 @@ impl<'tcx> LateLintPass<'tcx> for DerivableImpls {
             if !attrs.iter().any(|attr| attr.doc_str().is_some());
             if let child_attrs = cx.tcx.hir().attrs(impl_item_hir);
             if !child_attrs.iter().any(|attr| attr.doc_str().is_some());
+            if !adt_def.is_enum();
             then {
                 if let TyKind::Path(QPath::Resolved(_, p)) = self_ty.kind {
                     if let Some(PathSegment { args: Some(a), .. }) = p.segments.last() {

--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -83,7 +83,7 @@ impl<'tcx> LateLintPass<'tcx> for DerivableImpls {
             if !attrs.iter().any(|attr| attr.doc_str().is_some());
             if let child_attrs = cx.tcx.hir().attrs(impl_item_hir);
             if !child_attrs.iter().any(|attr| attr.doc_str().is_some());
-            if !adt_def.is_enum();
+            if adt_def.is_struct();
             then {
                 if let TyKind::Path(QPath::Resolved(_, p)) = self_ty.kind {
                     if let Some(PathSegment { args: Some(a), .. }) = p.segments.last() {

--- a/tests/ui/derivable_impls.rs
+++ b/tests/ui/derivable_impls.rs
@@ -227,4 +227,17 @@ impl Default for RepeatDefault2 {
     }
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/7753
+
+pub enum IntOrString {
+    Int(i32),
+    String(String),
+}
+
+impl Default for IntOrString {
+    fn default() -> Self {
+        IntOrString::Int(0)
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fix #7753 

changelog: Exclude enum from ``[`derivable_impls`]``
