### PR TITLE
improved help message for `suspicious_map`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -1284,8 +1284,9 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     /// It looks suspicious. Maybe `map` was confused with `filter`.
-    /// If the `map` call is intentional, this should be rewritten. Or, if you intend to
-    /// drive the iterator to completion, you can just use `for_each` instead.
+    /// If the `map` call is intentional, this should be rewritten
+    /// using `inspect`. Or, if you intend to drive the iterator to
+    /// completion, you can just use `for_each` instead.
     ///
     /// ### Example
     /// ```rust

--- a/clippy_lints/src/methods/suspicious_map.rs
+++ b/clippy_lints/src/methods/suspicious_map.rs
@@ -28,7 +28,7 @@ pub fn check<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, count_recv: &hi
                 expr.span,
                 "this call to `map()` won't have an effect on the call to `count()`",
                 None,
-                "make sure you did not confuse `map` with `filter` or `for_each`",
+                "make sure you did not confuse `map` with `filter`, `for_each` or `inspect`",
             );
         }
     }

--- a/tests/ui/suspicious_map.stderr
+++ b/tests/ui/suspicious_map.stderr
@@ -5,7 +5,7 @@ LL |     let _ = (0..3).map(|x| x + 2).count();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::suspicious-map` implied by `-D warnings`
-   = help: make sure you did not confuse `map` with `filter` or `for_each`
+   = help: make sure you did not confuse `map` with `filter`, `for_each` or `inspect`
 
 error: this call to `map()` won't have an effect on the call to `count()`
   --> $DIR/suspicious_map.rs:7:13
@@ -13,7 +13,7 @@ error: this call to `map()` won't have an effect on the call to `count()`
 LL |     let _ = (0..3).map(f).count();
    |             ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: make sure you did not confuse `map` with `filter` or `for_each`
+   = help: make sure you did not confuse `map` with `filter`, `for_each` or `inspect`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
`suspicious_map`'s help message assumes that the literal behavior is never the intended one, although it's sometimes.  This PR adds a mention of `inspect`, offering a idiomatic alternative.

fixes #7767

---

changelog: Improved help message of [`suspicious_map`].
