### PR TITLE
Handle intra-doc links in doc_markdown

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -406,6 +406,15 @@ struct DocHeaders {
 }
 
 fn check_attrs<'a>(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, attrs: &'a [Attribute]) -> DocHeaders {
+    use pulldown_cmark::{BrokenLink, CowStr, Options};
+    /// We don't want the parser to choke on intra doc links. Since we don't
+    /// actually care about rendering them, just pretend that all broken links are
+    /// point to a fake address.
+    #[allow(clippy::unnecessary_wraps)] // we're following a type signature
+    fn fake_broken_link_callback<'a>(_: BrokenLink<'_>) -> Option<(CowStr<'a>, CowStr<'a>)> {
+        Some(("fake".into(), "fake".into()))
+    }
+
     let mut doc = String::new();
     let mut spans = vec![];
 
@@ -440,7 +449,10 @@ fn check_attrs<'a>(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, attrs
         };
     }
 
-    let parser = pulldown_cmark::Parser::new(&doc).into_offset_iter();
+    let mut cb = fake_broken_link_callback;
+
+    let parser =
+        pulldown_cmark::Parser::new_with_broken_link_callback(&doc, Options::empty(), Some(&mut cb)).into_offset_iter();
     // Iterate over all `Events` and combine consecutive events into one
     let events = parser.coalesce(|previous, current| {
         use pulldown_cmark::Event::Text;

--- a/tests/ui/doc/doc.rs
+++ b/tests/ui/doc/doc.rs
@@ -203,6 +203,11 @@ fn issue_2343() {}
 /// __|_ _|__||_|
 fn pulldown_cmark_crash() {}
 
+/// This should not lint
+/// (regression test for #7758)
+/// [plain text][path::to::item]
+fn intra_doc_link() {}
+
 // issue #7033 - generic_const_exprs ICE
 struct S<T, const N: usize>
 where [(); N.checked_next_power_of_two().unwrap()]: {

--- a/tests/ui/doc/doc.stderr
+++ b/tests/ui/doc/doc.stderr
@@ -186,11 +186,5 @@ error: you should put `mycrate::Collection` between ticks in the documentation
 LL | /// An iterator over mycrate::Collection's values.
    |                      ^^^^^^^^^^^^^^^^^^^
 
-error: you should put `text][path::to::item` between ticks in the documentation
-  --> $DIR/doc.rs:208:12
-   |
-LL | /// [plain text][path::to::item]
-   |            ^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 32 previous errors
+error: aborting due to 31 previous errors
 

--- a/tests/ui/doc/doc.stderr
+++ b/tests/ui/doc/doc.stderr
@@ -186,5 +186,11 @@ error: you should put `mycrate::Collection` between ticks in the documentation
 LL | /// An iterator over mycrate::Collection's values.
    |                      ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 31 previous errors
+error: you should put `text][path::to::item` between ticks in the documentation
+  --> $DIR/doc.rs:208:12
+   |
+LL | /// [plain text][path::to::item]
+   |            ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 32 previous errors
 


### PR DESCRIPTION
Fixes #7758

changelog: Handle intra-doc links in [`doc_markdown`]