### PR TITLE
Do not expand macros in equatable_if_let suggestion

### DIFF
--- a/clippy_lints/src/equatable_if_let.rs
+++ b/clippy_lints/src/equatable_if_let.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::source::snippet_with_context;
 use clippy_utils::ty::implements_trait;
 use if_chain::if_chain;
 use rustc_errors::Applicability;
@@ -77,9 +77,9 @@ impl<'tcx> LateLintPass<'tcx> for PatternEquality {
                 let pat_str = match pat.kind {
                     PatKind::Struct(..) => format!(
                         "({})",
-                        snippet_with_applicability(cx, pat.span, "..", &mut applicability),
+                        snippet_with_context(cx, pat.span, expr.span.ctxt(), "..", &mut applicability).0,
                     ),
-                    _ => snippet_with_applicability(cx, pat.span, "..", &mut applicability).to_string(),
+                    _ => snippet_with_context(cx, pat.span, expr.span.ctxt(), "..", &mut applicability).0.to_string(),
                 };
                 span_lint_and_sugg(
                     cx,
@@ -89,7 +89,7 @@ impl<'tcx> LateLintPass<'tcx> for PatternEquality {
                     "try",
                     format!(
                         "{} == {}",
-                        snippet_with_applicability(cx, exp.span, "..", &mut applicability),
+                        snippet_with_context(cx, exp.span, expr.span.ctxt(), "..", &mut applicability).0,
                         pat_str,
                     ),
                     applicability,

--- a/tests/ui/equatable_if_let.fixed
+++ b/tests/ui/equatable_if_let.fixed
@@ -66,4 +66,13 @@ fn main() {
     if g == NotStructuralEq::A {}
     if let Some(NotPartialEq::A) = Some(f) {}
     if Some(g) == Some(NotStructuralEq::A) {}
+
+    macro_rules! m1 {
+        (x) => {
+            "abc"
+        };
+    }
+    if "abc" == m1!(x) {
+        println!("OK");
+    }
 }

--- a/tests/ui/equatable_if_let.rs
+++ b/tests/ui/equatable_if_let.rs
@@ -66,4 +66,13 @@ fn main() {
     if let NotStructuralEq::A = g {}
     if let Some(NotPartialEq::A) = Some(f) {}
     if let Some(NotStructuralEq::A) = Some(g) {}
+
+    macro_rules! m1 {
+        (x) => {
+            "abc"
+        };
+    }
+    if let m1!(x) = "abc" {
+        println!("OK");
+    }
 }

--- a/tests/ui/equatable_if_let.stderr
+++ b/tests/ui/equatable_if_let.stderr
@@ -60,5 +60,11 @@ error: this pattern matching can be expressed using equality
 LL |     if let Some(NotStructuralEq::A) = Some(g) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(g) == Some(NotStructuralEq::A)`
 
-error: aborting due to 10 previous errors
+error: this pattern matching can be expressed using equality
+  --> $DIR/equatable_if_let.rs:75:8
+   |
+LL |     if let m1!(x) = "abc" {
+   |        ^^^^^^^^^^^^^^^^^^ help: try: `"abc" == m1!(x)`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Fixes #7781 

Let's use Hacktoberfest as a motivation to start contributing PRs myself again :)

changelog: [`equatable_if_let`]: No longer expands macros in the suggestion
