### PR TITLE
Fix FP in external macros for `mut_mut` lint

### DIFF
--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -82,6 +82,10 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for MutVisitor<'a, 'tcx> {
     }
 
     fn visit_ty(&mut self, ty: &'tcx hir::Ty<'_>) {
+        if in_external_macro(self.cx.sess(), ty.span) {
+            return;
+        }
+
         if let hir::TyKind::Rptr(
             _,
             hir::MutTy {

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -113,3 +113,10 @@ macro_rules! default_numeric_fallback {
         let x = 22;
     };
 }
+
+#[macro_export]
+macro_rules! mut_mut {
+    () => {
+        let mut_mut_ty: &mut &mut u32 = &mut &mut 1u32;
+    };
+}

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -1,5 +1,10 @@
+// aux-build:macro_rules.rs
+
 #![allow(unused, clippy::no_effect, clippy::unnecessary_operation)]
 #![warn(clippy::mut_mut)]
+
+#[macro_use]
+extern crate macro_rules;
 
 fn fun(x: &mut &mut u32) -> bool {
     **x > 0
@@ -46,4 +51,9 @@ fn issue939() {
     for arg in args {
         println!(":{}", arg);
     }
+}
+
+fn issue6922() {
+    // do not lint from an external macro
+    mut_mut!();
 }

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -1,5 +1,5 @@
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:4:11
+  --> $DIR/mut_mut.rs:9:11
    |
 LL | fn fun(x: &mut &mut u32) -> bool {
    |           ^^^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL | fn fun(x: &mut &mut u32) -> bool {
    = note: `-D clippy::mut-mut` implied by `-D warnings`
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:20:17
+  --> $DIR/mut_mut.rs:25:17
    |
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:14:9
+  --> $DIR/mut_mut.rs:19:9
    |
 LL |         &mut $p
    |         ^^^^^^^
@@ -24,37 +24,37 @@ LL |     let mut z = mut_ptr!(&mut 3u32);
    = note: this error originates in the macro `mut_ptr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this expression mutably borrows a mutable reference. Consider reborrowing
-  --> $DIR/mut_mut.rs:22:21
+  --> $DIR/mut_mut.rs:27:21
    |
 LL |         let mut y = &mut x;
    |                     ^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:26:32
+  --> $DIR/mut_mut.rs:31:32
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                                ^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:26:16
+  --> $DIR/mut_mut.rs:31:16
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                ^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:31:37
+  --> $DIR/mut_mut.rs:36:37
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                                     ^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:31:16
+  --> $DIR/mut_mut.rs:36:16
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                ^^^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:31:21
+  --> $DIR/mut_mut.rs:36:21
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                     ^^^^^^^^^^^^^


### PR DESCRIPTION
Fix FP in `mut_mut` lint when type is defined in external macros.

fixes: #6922

changelog: [`mut_mut`] Fix FP when type is defined in external macros
