### PR TITLE
Fix typo in example for `match_result_ok`

### DIFF
--- a/clippy_lints/src/match_result_ok.rs
+++ b/clippy_lints/src/match_result_ok.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// }
     ///
     /// if let Ok(value) = iter.next() {
-    ///        vec.push_value)
+    ///        vec.push(value)
     /// }
     /// ```
     pub MATCH_RESULT_OK,


### PR DESCRIPTION
changelog: Fix typo in example for ``[`match_result_ok`]``
