### PR TITLE
Fixed naive doc formatting for `#[must_use]` lints

### DIFF
--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -91,10 +91,8 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for a [`#[must_use]`] attribute on
+    /// Checks for a `#[must_use]` attribute on
     /// unit-returning functions and methods.
-    ///
-    /// [`#[must_use]`]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
     ///
     /// ### Why is this bad?
     /// Unit values are useless. The attribute is likely
@@ -112,11 +110,9 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for a [`#[must_use]`] attribute without
+    /// Checks for a `#[must_use]` attribute without
     /// further information on functions and methods that return a type already
     /// marked as `#[must_use]`.
-    ///
-    /// [`#[must_use]`]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
     ///
     /// ### Why is this bad?
     /// The attribute isn't needed. Not using the result
@@ -138,10 +134,8 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     /// ### What it does
     /// Checks for public functions that have no
-    /// [`#[must_use]`] attribute, but return something not already marked
+    /// `#[must_use]` attribute, but return something not already marked
     /// must-use, have no mutable arg and mutate no statics.
-    ///
-    /// [`#[must_use]`]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
     ///
     /// ### Why is this bad?
     /// Not bad at all, this lint just shows places where

--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -10,12 +10,11 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for `let _ = <expr>`
-    /// where expr is #[must_use]
+    /// Checks for `let _ = <expr>` where expr is `#[must_use]`
     ///
     /// ### Why is this bad?
-    /// It's better to explicitly
-    /// handle the value of a #[must_use] expr
+    /// It's better to explicitly handle the value of a `#[must_use]`
+    /// expr
     ///
     /// ### Example
     /// ```rust


### PR DESCRIPTION
The documentation of a few lints around the `#[must_use]` attribute had a few times "[`#[must_use]`]" (without the parentheses, but with the `[]`) and once the "`" was missing.

changelog: Fixed naive doc formatting for `#[must_use]` lints ([`must_use_unit`], [`double_must_use`], [`must_use_candidate`], [`let_underscore_must_use`])
