### PR TITLE
Fix false positive of `implicit_saturating_sub` with `else` clause

### DIFF
--- a/clippy_lints/src/implicit_saturating_sub.rs
+++ b/clippy_lints/src/implicit_saturating_sub.rs
@@ -43,7 +43,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitSaturatingSub {
             return;
         }
         if_chain! {
-            if let Some(higher::If { cond, then, .. }) = higher::If::hir(expr);
+            if let Some(higher::If { cond, then, r#else: None }) = higher::If::hir(expr);
 
             // Check if the conditional expression is a binary operation
             if let ExprKind::Binary(ref cond_op, cond_left, cond_right) = cond.kind;

--- a/tests/ui/implicit_saturating_sub.fixed
+++ b/tests/ui/implicit_saturating_sub.fixed
@@ -157,4 +157,12 @@ fn main() {
     if i_64 != 0 {
         i_64 -= 1;
     }
+
+    // issue #7831
+    // No Lint
+    if u_32 > 0 {
+        u_32 -= 1;
+    } else {
+        println!("side effect");
+    }
 }

--- a/tests/ui/implicit_saturating_sub.rs
+++ b/tests/ui/implicit_saturating_sub.rs
@@ -203,4 +203,12 @@ fn main() {
     if i_64 != 0 {
         i_64 -= 1;
     }
+
+    // issue #7831
+    // No Lint
+    if u_32 > 0 {
+        u_32 -= 1;
+    } else {
+        println!("side effect");
+    }
 }


### PR DESCRIPTION
Fixes #7831

changelog: Fix false positive of [`implicit_saturating_sub`] with `else` clause
