### PR TITLE
Add reference to another doc with explanation

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -93,9 +93,10 @@ cargo dev update_lints
 cargo dev new_lint
 # automatically formatting all code before each commit
 cargo dev setup git-hook
-# (experimental) Setup Clippy to work with IntelliJ-Rust. Details here: https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md#intellij-rust
+# (experimental) Setup Clippy to work with IntelliJ-Rust
 cargo dev setup intellij
 ```
+More about intellij command usage and reasons [here](../CONTRIBUTING.md#intellij-rust)
 
 ## lintcheck
 `cargo lintcheck` will build and run clippy on a fixed set of crates and generate a log of the results.  


### PR DESCRIPTION
Add reference to another doc that explains which repository should be passed in this command since this is not covered in the command help itself.
changelog: none