### PR TITLE
Warn on structs with a trailing zero-sized array but no `repr` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3021,7 +3021,7 @@ Released 2018-09-13
 [`too_many_arguments`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
 [`too_many_lines`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines
 [`toplevel_ref_arg`]: https://rust-lang.github.io/rust-clippy/master/index.html#toplevel_ref_arg
-[`trailing_zero_sized_array_without_repr`]: https://rust-lang.github.io/rust-clippy/master/index.html#trailing_zero_sized_array_without_repr
+[`trailing_empty_array`]: https://rust-lang.github.io/rust-clippy/master/index.html#trailing_empty_array
 [`trait_duplication_in_bounds`]: https://rust-lang.github.io/rust-clippy/master/index.html#trait_duplication_in_bounds
 [`transmute_bytes_to_str`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_bytes_to_str
 [`transmute_float_to_int`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_float_to_int

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -443,7 +443,7 @@ store.register_lints(&[
     temporary_assignment::TEMPORARY_ASSIGNMENT,
     to_digit_is_some::TO_DIGIT_IS_SOME,
     to_string_in_display::TO_STRING_IN_DISPLAY,
-    trailing_zero_sized_array_without_repr::TRAILING_ZERO_SIZED_ARRAY_WITHOUT_REPR,
+    trailing_empty_array::TRAILING_EMPTY_ARRAY,
     trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS,
     trait_bounds::TYPE_REPETITION_IN_BOUNDS,
     transmute::CROSSPOINTER_TRANSMUTE,

--- a/clippy_lints/src/lib.register_nursery.rs
+++ b/clippy_lints/src/lib.register_nursery.rs
@@ -25,7 +25,7 @@ store.register_group(true, "clippy::nursery", Some("clippy_nursery"), vec![
     LintId::of(regex::TRIVIAL_REGEX),
     LintId::of(strings::STRING_LIT_AS_BYTES),
     LintId::of(suspicious_operation_groupings::SUSPICIOUS_OPERATION_GROUPINGS),
-    LintId::of(trailing_zero_sized_array_without_repr::TRAILING_ZERO_SIZED_ARRAY_WITHOUT_REPR),
+    LintId::of(trailing_empty_array::TRAILING_EMPTY_ARRAY),
     LintId::of(transmute::USELESS_TRANSMUTE),
     LintId::of(use_self::USE_SELF),
 ])

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -355,7 +355,7 @@ mod tabs_in_doc_comments;
 mod temporary_assignment;
 mod to_digit_is_some;
 mod to_string_in_display;
-mod trailing_zero_sized_array_without_repr;
+mod trailing_empty_array;
 mod trait_bounds;
 mod transmute;
 mod transmuting_null;
@@ -778,7 +778,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(move || Box::new(undocumented_unsafe_blocks::UndocumentedUnsafeBlocks::default()));
     store.register_late_pass(|| Box::new(match_str_case_mismatch::MatchStrCaseMismatch));
     store.register_late_pass(move || Box::new(format_args::FormatArgs));
-    store.register_late_pass(|| Box::new(trailing_zero_sized_array_without_repr::TrailingZeroSizedArrayWithoutRepr));
+    store.register_late_pass(|| Box::new(trailing_empty_array::TrailingEmptyArray));
 
 }
 

--- a/clippy_lints/src/trailing_empty_array.rs
+++ b/clippy_lints/src/trailing_empty_array.rs
@@ -28,18 +28,18 @@ declare_clippy_lint! {
     ///     last: [u32; 0],
     /// }
     /// ```
-    pub TRAILING_ZERO_SIZED_ARRAY_WITHOUT_REPR,
+    pub TRAILING_EMPTY_ARRAY,
     nursery,
     "struct with a trailing zero-sized array but without `#[repr(C)]` or another `repr` attribute"
 }
-declare_lint_pass!(TrailingZeroSizedArrayWithoutRepr => [TRAILING_ZERO_SIZED_ARRAY_WITHOUT_REPR]);
+declare_lint_pass!(TrailingEmptyArray => [TRAILING_EMPTY_ARRAY]);
 
-impl<'tcx> LateLintPass<'tcx> for TrailingZeroSizedArrayWithoutRepr {
+impl<'tcx> LateLintPass<'tcx> for TrailingEmptyArray {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
         if is_struct_with_trailing_zero_sized_array(cx, item) && !has_repr_attr(cx, item.hir_id()) {
             span_lint_and_help(
                 cx,
-                TRAILING_ZERO_SIZED_ARRAY_WITHOUT_REPR,
+                TRAILING_EMPTY_ARRAY,
                 item.span,
                 "trailing zero-sized array in a struct which is not marked with a `repr` attribute",
                 None,

--- a/tests/ui/trailing_empty_array.rs
+++ b/tests/ui/trailing_empty_array.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::trailing_zero_sized_array_without_repr)]
+#![warn(clippy::trailing_empty_array)]
 #![feature(const_generics_defaults)]
 
 // Do lint:

--- a/tests/ui/trailing_empty_array.stderr
+++ b/tests/ui/trailing_empty_array.stderr
@@ -1,5 +1,5 @@
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:6:1
+  --> $DIR/trailing_empty_array.rs:6:1
    |
 LL | / struct RarelyUseful {
 LL | |     field: i32,
@@ -7,11 +7,11 @@ LL | |     last: [usize; 0],
 LL | | }
    | |_^
    |
-   = note: `-D clippy::trailing-zero-sized-array-without-repr` implied by `-D warnings`
+   = note: `-D clippy::trailing-empty-array` implied by `-D warnings`
    = help: consider annotating `RarelyUseful` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:11:1
+  --> $DIR/trailing_empty_array.rs:11:1
    |
 LL | / struct OnlyField {
 LL | |     first_and_last: [usize; 0],
@@ -21,7 +21,7 @@ LL | | }
    = help: consider annotating `OnlyField` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:15:1
+  --> $DIR/trailing_empty_array.rs:15:1
    |
 LL | / struct GenericArrayType<T> {
 LL | |     field: i32,
@@ -32,7 +32,7 @@ LL | | }
    = help: consider annotating `GenericArrayType` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:21:1
+  --> $DIR/trailing_empty_array.rs:21:1
    |
 LL | / struct OnlyAnotherAttribute {
 LL | |     field: i32,
@@ -43,7 +43,7 @@ LL | | }
    = help: consider annotating `OnlyAnotherAttribute` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:29:1
+  --> $DIR/trailing_empty_array.rs:27:1
    |
 LL | / struct OnlyADeriveAttribute {
 LL | |     field: i32,
@@ -54,7 +54,7 @@ LL | | }
    = help: consider annotating `OnlyADeriveAttribute` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:35:1
+  --> $DIR/trailing_empty_array.rs:33:1
    |
 LL | / struct ZeroSizedWithConst {
 LL | |     field: i32,
@@ -65,7 +65,7 @@ LL | | }
    = help: consider annotating `ZeroSizedWithConst` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:44:1
+  --> $DIR/trailing_empty_array.rs:42:1
    |
 LL | / struct ZeroSizedWithConstFunction {
 LL | |     field: i32,
@@ -76,7 +76,7 @@ LL | | }
    = help: consider annotating `ZeroSizedWithConstFunction` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:52:1
+  --> $DIR/trailing_empty_array.rs:50:1
    |
 LL | / struct ZeroSizedWithConstFunction2 {
 LL | |     field: i32,
@@ -87,7 +87,7 @@ LL | | }
    = help: consider annotating `ZeroSizedWithConstFunction2` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:57:1
+  --> $DIR/trailing_empty_array.rs:55:1
    |
 LL | struct ZeroSizedArrayWrapper([usize; 0]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL | struct ZeroSizedArrayWrapper([usize; 0]);
    = help: consider annotating `ZeroSizedArrayWrapper` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:59:1
+  --> $DIR/trailing_empty_array.rs:57:1
    |
 LL | struct TupleStruct(i32, [usize; 0]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | struct TupleStruct(i32, [usize; 0]);
    = help: consider annotating `TupleStruct` with `#[repr(C)]` or another `repr` attribute
 
 error: trailing zero-sized array in a struct which is not marked with a `repr` attribute
-  --> $DIR/trailing_zero_sized_array_without_repr.rs:61:1
+  --> $DIR/trailing_empty_array.rs:59:1
    |
 LL | / struct LotsOfFields {
 LL | |     f1: u32,


### PR DESCRIPTION
Closes #2868

changelog: Implement ``[`trailing_empty_array`]``, which warns if a struct is defined where the last field is a zero-sized array but there are no `repr` attributes. Zero-sized arrays aren't very useful in Rust itself, so such a struct is likely being created to pass to C code or in some other situation where control over memory layout matters. Either way, a `repr` attribute is needed.