### PR TITLE
FIx FP in `missing_safety_doc` lint

### DIFF
--- a/tests/ui/doc_unsafe.rs
+++ b/tests/ui/doc_unsafe.rs
@@ -115,3 +115,13 @@ fn main() {
         drive();
     }
 }
+
+// do not lint if any parent has `#[doc(hidden)]` attribute
+// see #7347
+#[doc(hidden)]
+pub mod __macro {
+    pub struct T;
+    impl T {
+        pub unsafe fn f() {}
+    }
+}


### PR DESCRIPTION
Fix FP where lint souldn't fire if any parent has `#[doc(hidden)]` attribute

fixes: #7347 

changelog: [`missing_safety_doc`] Fix FP if any parent has `#[doc(hidden)]` attribute
