### PR TITLE
Fix typo for invalid_null_ptr_usage and missing_inline_in_public_items.

### DIFF
--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -8,7 +8,7 @@ use rustc_span::sym;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// it lints if an exported function, method, trait method with default impl,
+    /// It lints if an exported function, method, trait method with default impl,
     /// or trait method impl is not `#[inline]`.
     ///
     /// ### Why is this bad?

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -139,6 +139,7 @@ declare_clippy_lint! {
     /// unsafe { std::slice::from_raw_parts(ptr::null(), 0); }
     /// ```
     ///
+    /// ```ignore
     /// // Good
     /// unsafe { std::slice::from_raw_parts(NonNull::dangling().as_ptr(), 0); }
     /// ```


### PR DESCRIPTION
Fix typo for invalid_null_ptr_usage and missing_inline_in_public_items.

changelog: none