### PR TITLE
Ignore references to type aliases in ptr_arg

### DIFF
--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -160,3 +160,7 @@ mod issue6509 {
         let _ = str.clone().clone();
     }
 }
+
+// No error for types behind an alias (#7699)
+type A = Vec<u8>;
+fn aliased(a: &A) {}


### PR DESCRIPTION
Works using the fact that the hir path will point to a TyAlias, rather than being resolved to the underlying type

Fixes #7699

changelog: [`ptr_arg`] No longer lints references to type aliases
