### PR TITLE
Add `cargo dev lint` to manually run clippy on a file

### DIFF
--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 pub mod bless;
 pub mod fmt;
+pub mod lint;
 pub mod new_lint;
 pub mod serve;
 pub mod setup;

--- a/clippy_dev/src/lint.rs
+++ b/clippy_dev/src/lint.rs
@@ -1,0 +1,20 @@
+use std::process::{self, Command};
+
+pub fn run(filename: &str) {
+    let code = Command::new("cargo")
+        .args(["run", "--bin", "clippy-driver", "--"])
+        .args(["-L", "./target/debug"])
+        .args(["-Z", "no-codegen"])
+        .args(["--edition", "2021"])
+        .arg(filename)
+        .env("__CLIPPY_INTERNAL_TESTS", "true")
+        .status()
+        .expect("failed to run cargo")
+        .code();
+
+    if code.is_none() {
+        eprintln!("Killed by signal");
+    }
+
+    process::exit(code.unwrap_or(1));
+}

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -3,7 +3,7 @@
 #![warn(rust_2018_idioms, unused_lifetimes)]
 
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
-use clippy_dev::{bless, fmt, new_lint, serve, setup, update_lints};
+use clippy_dev::{bless, fmt, lint, new_lint, serve, setup, update_lints};
 fn main() {
     let matches = get_clap_config();
 
@@ -54,6 +54,10 @@ fn main() {
             let port = matches.value_of("port").unwrap().parse().unwrap();
             let lint = matches.value_of("lint");
             serve::run(port, lint);
+        },
+        ("lint", Some(matches)) => {
+            let filename = matches.value_of("filename").unwrap();
+            lint::run(filename);
         },
         _ => {},
     }
@@ -218,6 +222,15 @@ fn get_clap_config<'a>() -> ArgMatches<'a> {
                         .validator_os(serve::validate_port),
                 )
                 .arg(Arg::with_name("lint").help("Which lint's page to load initially (optional)")),
+        )
+        .subcommand(
+            SubCommand::with_name("lint")
+                .about("Manually run clippy on a file")
+                .arg(
+                    Arg::with_name("filename")
+                        .required(true)
+                        .help("The path to a file to lint"),
+                ),
         )
         .get_matches()
 }

--- a/doc/adding_lints.md
+++ b/doc/adding_lints.md
@@ -157,7 +157,7 @@ Manually testing against an example file can be useful if you have added some
 your local modifications, run
 
 ```
-env __CLIPPY_INTERNAL_TESTS=true cargo run --bin clippy-driver -- -L ./target/debug input.rs
+cargo dev lint input.rs
 ```
 
 from the working copy root. With tests in place, let's have a look at


### PR DESCRIPTION
I found the manual run command really useful, this makes it a bit easier to type

Not sure if this belongs in the changelog or not

changelog: Add `cargo dev lint` to manually run clippy on a file