### PR TITLE
Fix suggestion for deref expressions in redundant_pattern_matching

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1785,7 +1785,8 @@ mod redundant_pattern_match {
     use super::REDUNDANT_PATTERN_MATCHING;
     use clippy_utils::diagnostics::span_lint_and_then;
     use clippy_utils::higher;
-    use clippy_utils::source::{snippet, snippet_with_applicability};
+    use clippy_utils::source::snippet;
+    use clippy_utils::sugg::Sugg;
     use clippy_utils::ty::{implements_trait, is_type_diagnostic_item, is_type_lang_item, match_type};
     use clippy_utils::{is_lang_ctor, is_qpath_def_path, is_trait_method, paths};
     use if_chain::if_chain;
@@ -1795,7 +1796,7 @@ mod redundant_pattern_match {
     use rustc_hir::LangItem::{OptionNone, OptionSome, PollPending, PollReady, ResultErr, ResultOk};
     use rustc_hir::{
         intravisit::{walk_expr, ErasedMap, NestedVisitorMap, Visitor},
-        Arm, Block, Expr, ExprKind, LangItem, MatchSource, Node, Pat, PatKind, QPath,
+        Arm, Block, Expr, ExprKind, LangItem, MatchSource, Node, Pat, PatKind, QPath, UnOp,
     };
     use rustc_lint::LateContext;
     use rustc_middle::ty::{self, subst::GenericArgKind, Ty};
@@ -2049,8 +2050,10 @@ mod redundant_pattern_match {
 
         let result_expr = match &let_expr.kind {
             ExprKind::AddrOf(_, _, borrowed) => borrowed,
+            ExprKind::Unary(UnOp::Deref, deref) => deref,
             _ => let_expr,
         };
+
         span_lint_and_then(
             cx,
             REDUNDANT_PATTERN_MATCHING,
@@ -2069,12 +2072,15 @@ mod redundant_pattern_match {
                 // ^^^^^^^^^^^^^^^^^^^
                 let span = expr_span.until(op_span.shrink_to_hi());
 
-                let mut app = if needs_drop {
+                let app = if needs_drop {
                     Applicability::MaybeIncorrect
                 } else {
                     Applicability::MachineApplicable
                 };
-                let sugg = snippet_with_applicability(cx, op_span, "_", &mut app);
+
+                let sugg = Sugg::hir_with_macro_callsite(cx, result_expr, "_")
+                    .maybe_par()
+                    .to_string();
 
                 diag.span_suggestion(span, "try this", format!("{} {}.{}", keyword, sugg, good_method), app);
 

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -80,3 +80,9 @@ const fn issue6067() {
 
     None::<()>.is_none();
 }
+
+#[allow(clippy::deref_addrof, dead_code)]
+fn issue7921() {
+    if (&None::<()>).is_none() {}
+    if (&None::<()>).is_none() {}
+}

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -95,3 +95,9 @@ const fn issue6067() {
         None => true,
     };
 }
+
+#[allow(clippy::deref_addrof, dead_code)]
+fn issue7921() {
+    if let None = *(&None::<()>) {}
+    if let None = *&None::<()> {}
+}

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -130,5 +130,17 @@ LL | |         None => true,
 LL | |     };
    | |_____^ help: try this: `None::<()>.is_none()`
 
-error: aborting due to 19 previous errors
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:101:12
+   |
+LL |     if let None = *(&None::<()>) {}
+   |     -------^^^^----------------- help: try this: `if (&None::<()>).is_none()`
+
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:102:12
+   |
+LL |     if let None = *&None::<()> {}
+   |     -------^^^^--------------- help: try this: `if (&None::<()>).is_none()`
+
+error: aborting due to 21 previous errors
 

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -70,8 +70,8 @@ fn issue5504() {
     }
 
     fn try_result_opt() -> Result<i32, i32> {
-        while r#try!(result_opt()).is_some() {}
-        if r#try!(result_opt()).is_some() {}
+        while (r#try!(result_opt())).is_some() {}
+        if (r#try!(result_opt())).is_some() {}
         Ok(42)
     }
 

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -88,13 +88,13 @@ error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:85:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
-   |         ----------^^^^^^^----------------------- help: try this: `while r#try!(result_opt()).is_some()`
+   |         ----------^^^^^^^----------------------- help: try this: `while (r#try!(result_opt())).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:86:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
-   |         -------^^^^^^^----------------------- help: try this: `if r#try!(result_opt()).is_some()`
+   |         -------^^^^^^^----------------------- help: try this: `if (r#try!(result_opt())).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:92:12


### PR DESCRIPTION
changelog: Fix suggestion for deref expressions in [`redundant_pattern_matching`]

closes: #7921 
