### PR TITLE
`match_overlapping_arm` refactoring

### DIFF
--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1735,21 +1735,21 @@ where
 
     let mut started = vec![];
 
-    for RangeBound(_, kind, r) in values {
+    for RangeBound(_, kind, range) in values {
         match kind {
-            BoundKind::Start => started.push(r),
+            BoundKind::Start => started.push(range),
             BoundKind::EndExcluded | BoundKind::EndIncluded => {
                 let mut overlap = None;
 
-                while let Some(sr) = started.pop() {
-                    if sr == r {
+                while let Some(last_started) = started.pop() {
+                    if last_started == range {
                         break;
                     }
-                    overlap = Some(sr);
+                    overlap = Some(last_started);
                 }
 
-                if let Some(sr) = overlap {
-                    return Some((r, sr));
+                if let Some(first_overlapping) = overlap {
+                    return Some((range, first_overlapping));
                 }
             },
         }

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1643,7 +1643,7 @@ pub enum EndBound<T> {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct SpannedRange<T> {
+struct SpannedRange<T> {
     pub span: Span,
     pub node: (T, EndBound<T>),
 }
@@ -1694,7 +1694,7 @@ where
     ref_count > 1
 }
 
-pub fn overlapping<T>(ranges: &[SpannedRange<T>]) -> Option<(&SpannedRange<T>, &SpannedRange<T>)>
+fn overlapping<T>(ranges: &[SpannedRange<T>]) -> Option<(&SpannedRange<T>, &SpannedRange<T>)>
 where
     T: Copy + Ord,
 {

--- a/clippy_lints/src/matches.rs
+++ b/clippy_lints/src/matches.rs
@@ -1601,17 +1601,17 @@ fn all_ranges<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'_>], ty: Ty<'tcx>)
         .filter_map(|arm| {
             if let Arm { pat, guard: None, .. } = *arm {
                 if let PatKind::Range(ref lhs, ref rhs, range_end) = pat.kind {
-                    let lhs = match lhs {
+                    let lhs_const = match lhs {
                         Some(lhs) => constant(cx, cx.typeck_results(), lhs)?.0,
                         None => miri_to_const(ty.numeric_min_val(cx.tcx)?)?,
                     };
-                    let rhs = match rhs {
+                    let rhs_const = match rhs {
                         Some(rhs) => constant(cx, cx.typeck_results(), rhs)?.0,
                         None => miri_to_const(ty.numeric_max_val(cx.tcx)?)?,
                     };
 
-                    let lhs_val = lhs.int_value(cx, ty)?;
-                    let rhs_val = rhs.int_value(cx, ty)?;
+                    let lhs_val = lhs_const.int_value(cx, ty)?;
+                    let rhs_val = rhs_const.int_value(cx, ty)?;
 
                     let rhs_bound = match range_end {
                         RangeEnd::Included => EndBound::Included(rhs_val),


### PR DESCRIPTION
The main purpose of this pull request is to remove the unneeded and scary `unimplented!()` in the `match_arm_overlapping` code.

The rest is gratuitous refactoring.

changelog: none
