### PR TITLE
Fix `semicolon_if_nothing_returned` FP on `let-else` stmts

### DIFF
--- a/clippy_lints/src/semicolon_if_nothing_returned.rs
+++ b/clippy_lints/src/semicolon_if_nothing_returned.rs
@@ -44,7 +44,7 @@ impl LateLintPass<'_> for SemicolonIfNothingReturned {
             let t_expr = cx.typeck_results().expr_ty(expr);
             if t_expr.is_unit();
             if let snippet = snippet_with_macro_callsite(cx, expr.span, "}");
-            if !snippet.ends_with('}');
+            if !snippet.ends_with('}') && !snippet.ends_with(';');
             if cx.sess().source_map().is_multiline(block.span);
             then {
                 // filter out the desugared `for` loop

--- a/tests/ui/semicolon_if_nothing_returned.rs
+++ b/tests/ui/semicolon_if_nothing_returned.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![allow(clippy::redundant_closure)]
 #![feature(label_break_value)]
+#![feature(let_else)]
 
 fn get_unit() {}
 
@@ -109,4 +110,13 @@ fn macro_with_semicolon() {
         };
     }
     repro!();
+}
+
+fn function_returning_option() -> Option<i32> {
+    Some(1)
+}
+
+// No warning
+fn let_else_stmts() {
+    let Some(x) = function_returning_option() else { return; };
 }

--- a/tests/ui/semicolon_if_nothing_returned.stderr
+++ b/tests/ui/semicolon_if_nothing_returned.stderr
@@ -1,5 +1,5 @@
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:9:5
+  --> $DIR/semicolon_if_nothing_returned.rs:10:5
    |
 LL |     println!("Hello")
    |     ^^^^^^^^^^^^^^^^^ help: add a `;` here: `println!("Hello");`
@@ -7,25 +7,25 @@ LL |     println!("Hello")
    = note: `-D clippy::semicolon-if-nothing-returned` implied by `-D warnings`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:13:5
+  --> $DIR/semicolon_if_nothing_returned.rs:14:5
    |
 LL |     get_unit()
    |     ^^^^^^^^^^ help: add a `;` here: `get_unit();`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:18:5
+  --> $DIR/semicolon_if_nothing_returned.rs:19:5
    |
 LL |     y = x + 1
    |     ^^^^^^^^^ help: add a `;` here: `y = x + 1;`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:24:9
+  --> $DIR/semicolon_if_nothing_returned.rs:25:9
    |
 LL |         hello()
    |         ^^^^^^^ help: add a `;` here: `hello();`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:35:9
+  --> $DIR/semicolon_if_nothing_returned.rs:36:9
    |
 LL |         ptr::drop_in_place(s.as_mut_ptr())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add a `;` here: `ptr::drop_in_place(s.as_mut_ptr());`


### PR DESCRIPTION
closes #7912

`semicolon_if_nothing_returned` now additionally checks if the statements ends in `;` , this will also prevent `let-else` statements to be linted.

changelog: fix [`semicolon_if_nothing_returned`] FP  firing on `let-else`
