### PR TITLE
`redundant_slicing` precedence fix

### DIFF
--- a/tests/ui/redundant_slicing.fixed
+++ b/tests/ui/redundant_slicing.fixed
@@ -4,25 +4,25 @@
 
 fn main() {
     let slice: &[u32] = &[0];
-    let _ = &slice[..];
+    let _ = slice;
 
     let v = vec![0];
     let _ = &v[..]; // Changes the type
-    let _ = &(&v[..])[..]; // Outer borrow is redundant
+    let _ = (&v[..]); // Outer borrow is redundant
 
     static S: &[u8] = &[0, 1, 2];
-    let err = &mut &S[..]; // Should reborrow instead of slice
+    let err = &mut &*S; // Should reborrow instead of slice
 
     let mut vec = vec![0];
     let mut_slice = &mut *vec;
-    let _ = &mut mut_slice[..]; // Should reborrow instead of slice
+    let _ = &mut *mut_slice; // Should reborrow instead of slice
 
     macro_rules! m {
         ($e:expr) => {
             $e
         };
     }
-    let _ = &m!(slice)[..];
+    let _ = slice;
 
     macro_rules! m2 {
         ($e:expr) => {
@@ -39,5 +39,5 @@ fn main() {
     }
 
     // Reborrow, `f` takes a mutable reference to the slice
-    (&slice[..]).f();
+    (&*slice).f();
 }

--- a/tests/ui/redundant_slicing.stderr
+++ b/tests/ui/redundant_slicing.stderr
@@ -1,5 +1,5 @@
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:6:13
+  --> $DIR/redundant_slicing.rs:7:13
    |
 LL |     let _ = &slice[..];
    |             ^^^^^^^^^^ help: use the original value instead: `slice`
@@ -7,28 +7,34 @@ LL |     let _ = &slice[..];
    = note: `-D clippy::redundant-slicing` implied by `-D warnings`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:10:13
+  --> $DIR/redundant_slicing.rs:11:13
    |
 LL |     let _ = &(&v[..])[..]; // Outer borrow is redundant
    |             ^^^^^^^^^^^^^ help: use the original value instead: `(&v[..])`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:13:20
+  --> $DIR/redundant_slicing.rs:14:20
    |
 LL |     let err = &mut &S[..]; // Should reborrow instead of slice
    |                    ^^^^^^ help: reborrow the original value instead: `&*S`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:17:13
+  --> $DIR/redundant_slicing.rs:18:13
    |
 LL |     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
    |             ^^^^^^^^^^^^^^^^^^ help: reborrow the original value instead: `&mut *mut_slice`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:24:13
+  --> $DIR/redundant_slicing.rs:25:13
    |
 LL |     let _ = &m!(slice)[..];
    |             ^^^^^^^^^^^^^^ help: use the original value instead: `slice`
 
-error: aborting due to 5 previous errors
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:42:5
+   |
+LL |     (&slice[..]).f();
+   |     ^^^^^^^^^^^^ help: reborrow the original value instead: `(&*slice)`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes: #7972
changelog: Fix `redundant_slicing` suggestion when the result is used in a postfix expression