### PR TITLE
Add missing components to rust-toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2021-11-18"
-components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]
+components = ["cargo", "llvm-tools-preview", "rust-src", "rust-std", "rustc", "rustc-dev", "rustfmt"]


### PR DESCRIPTION
Somehow these basic components are missing from the toolchain file...

changelog: none