### PR TITLE
`no_std_swap`: Fix typo in TODO

### DIFF
--- a/tests/ui/crate_level_checks/no_std_swap.rs
+++ b/tests/ui/crate_level_checks/no_std_swap.rs
@@ -6,7 +6,6 @@ use core::panic::PanicInfo;
 
 #[warn(clippy::all)]
 fn main() {
-    // TODO: do somethjing with swap
     let mut a = 42;
     let mut b = 1337;
 

--- a/tests/ui/crate_level_checks/no_std_swap.stderr
+++ b/tests/ui/crate_level_checks/no_std_swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/no_std_swap.rs:13:5
+  --> $DIR/no_std_swap.rs:12:5
    |
 LL | /     a = b;
 LL | |     b = a;


### PR DESCRIPTION
changelog: none
