### PR TITLE
Fixes shadow_same's false positive for #7915

### DIFF
--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -105,11 +105,16 @@ impl<'tcx> LateLintPass<'tcx> for Shadow {
             PatKind::Binding(_, hir_id, ident, _) => (hir_id, ident),
             _ => return,
         };
+
+        if pat.span.desugaring_kind().is_some() {
+            return;
+        }
+
         if ident.span.from_expansion() || ident.span.is_dummy() {
             return;
         }
-        let HirId { owner, local_id } = id;
 
+        let HirId { owner, local_id } = id;
         // get (or insert) the list of items for this owner and symbol
         let data = self.bindings.last_mut().unwrap();
         let items_with_name = data.entry(ident.name).or_default();

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -79,4 +79,10 @@ fn question_mark() -> Option<()> {
     None
 }
 
+pub async fn foo1(_a: i32) {}
+
+pub async fn foo2(_a: i32, _b: i64) {
+    let _b = _a;
+}
+
 fn main() {}

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -241,5 +241,17 @@ note: previous binding is here
 LL |     let _ = |[x]: [u32; 1]| {
    |               ^
 
-error: aborting due to 20 previous errors
+error: `_b` shadows a previous, unrelated binding
+  --> $DIR/shadow.rs:85:9
+   |
+LL |     let _b = _a;
+   |         ^^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:84:28
+   |
+LL | pub async fn foo2(_a: i32, _b: i64) {
+   |                            ^^
+
+error: aborting due to 21 previous errors
 


### PR DESCRIPTION
Fix shadow_same's false positive for async function's params(Fixes #7915):

Example Code:
```rust
#![deny(clippy::shadow_same)]

pub async fn foo(_a: i32) {
}
```
Output:
```
error: `_a` is shadowed by itself in `_a
```

Hir:
```rust
pub async fn foo(_a: i32)
 ->
     /*impl Trait*/ #[lang = "from_generator"](move |mut _task_context|
                                                   {
                                                       let _a = _a;
                                                       { let _t = { }; _t }
                                                   })
```

Skip checking async function's params.

changelog: Fix shadow_same's false positive for async function's params
