### PR TITLE
Improve `strlen_on_c_string`

### DIFF
--- a/clippy_lints/src/strlen_on_c_strings.rs
+++ b/clippy_lints/src/strlen_on_c_strings.rs
@@ -1,10 +1,11 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::match_libc_symbol;
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::ty::is_type_diagnostic_item;
+use clippy_utils::visitors::is_expr_unsafe;
+use clippy_utils::{get_parent_node, match_libc_symbol};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
-use rustc_hir as hir;
+use rustc_hir::{Block, BlockCheckMode, Expr, ExprKind, Node, UnsafeSource};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::symbol::sym;
@@ -39,20 +40,31 @@ declare_clippy_lint! {
 declare_lint_pass!(StrlenOnCStrings => [STRLEN_ON_C_STRINGS]);
 
 impl LateLintPass<'tcx> for StrlenOnCStrings {
-    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if_chain! {
             if !expr.span.from_expansion();
-            if let hir::ExprKind::Call(func, [recv]) = expr.kind;
-            if let hir::ExprKind::Path(path) = &func.kind;
+            if let ExprKind::Call(func, [recv]) = expr.kind;
+            if let ExprKind::Path(path) = &func.kind;
             if let Some(did) = cx.qpath_res(path, func.hir_id).opt_def_id();
             if match_libc_symbol(cx, did, "strlen");
-            if let hir::ExprKind::MethodCall(path, _, [self_arg], _) = recv.kind;
+            if let ExprKind::MethodCall(path, _, [self_arg], _) = recv.kind;
             if !recv.span.from_expansion();
             if path.ident.name == sym::as_ptr;
             then {
+                let ctxt = expr.span.ctxt();
+                let span = match get_parent_node(cx.tcx, expr.hir_id) {
+                    Some(Node::Block(&Block {
+                        rules: BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided), span, ..
+                    }))
+                    if span.ctxt() == ctxt && !is_expr_unsafe(cx, self_arg) => {
+                        span
+                    }
+                    _ => expr.span,
+                };
+
                 let ty = cx.typeck_results().expr_ty(self_arg).peel_refs();
-                let mut app = Applicability::Unspecified;
-                let val_name = snippet_with_context(cx, self_arg.span, expr.span.ctxt(), "..", &mut app).0;
+                let mut app = Applicability::MachineApplicable;
+                let val_name = snippet_with_context(cx, self_arg.span, ctxt, "..", &mut app).0;
                 let method_name = if is_type_diagnostic_item(cx, ty, sym::cstring_type) {
                     "as_bytes"
                 } else if is_type_diagnostic_item(cx, ty, sym::CStr) {
@@ -64,11 +76,11 @@ impl LateLintPass<'tcx> for StrlenOnCStrings {
                 span_lint_and_sugg(
                     cx,
                     STRLEN_ON_C_STRINGS,
-                    expr.span,
+                    span,
                     "using `libc::strlen` on a `CString` or `CStr` value",
-                    "try this (you might also need to get rid of `unsafe` block in some cases):",
+                    "try this",
                     format!("{}.{}().len()", val_name, method_name),
-                    Applicability::Unspecified // Sometimes unnecessary `unsafe` block
+                    app,
                 );
             }
         }

--- a/clippy_lints/src/strlen_on_c_strings.rs
+++ b/clippy_lints/src/strlen_on_c_strings.rs
@@ -1,13 +1,13 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::paths;
-use clippy_utils::source::snippet_with_macro_callsite;
-use clippy_utils::ty::{is_type_diagnostic_item, is_type_ref_to_diagnostic_item};
+use clippy_utils::match_libc_symbol;
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::ty::is_type_diagnostic_item;
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::symbol::{sym, Symbol};
+use rustc_span::symbol::sym;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -40,28 +40,23 @@ declare_lint_pass!(StrlenOnCStrings => [STRLEN_ON_C_STRINGS]);
 
 impl LateLintPass<'tcx> for StrlenOnCStrings {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
-        if expr.span.from_expansion() {
-            return;
-        }
-
         if_chain! {
+            if !expr.span.from_expansion();
             if let hir::ExprKind::Call(func, [recv]) = expr.kind;
-            if let hir::ExprKind::Path(hir::QPath::Resolved(_, path)) = func.kind;
-
-            if (&paths::LIBC_STRLEN).iter().map(|x| Symbol::intern(x)).eq(
-                path.segments.iter().map(|seg| seg.ident.name));
-            if let hir::ExprKind::MethodCall(path, _, args, _) = recv.kind;
-            if args.len() == 1;
-            if !args.iter().any(|e| e.span.from_expansion());
+            if let hir::ExprKind::Path(path) = &func.kind;
+            if let Some(did) = cx.qpath_res(path, func.hir_id).opt_def_id();
+            if match_libc_symbol(cx, did, "strlen");
+            if let hir::ExprKind::MethodCall(path, _, [self_arg], _) = recv.kind;
+            if !recv.span.from_expansion();
             if path.ident.name == sym::as_ptr;
             then {
-                let cstring = &args[0];
-                let ty = cx.typeck_results().expr_ty(cstring);
-                let val_name = snippet_with_macro_callsite(cx, cstring.span, "..");
-                let sugg = if is_type_diagnostic_item(cx, ty, sym::cstring_type){
-                    format!("{}.as_bytes().len()", val_name)
-                } else if is_type_ref_to_diagnostic_item(cx, ty, sym::CStr){
-                    format!("{}.to_bytes().len()", val_name)
+                let ty = cx.typeck_results().expr_ty(self_arg).peel_refs();
+                let mut app = Applicability::Unspecified;
+                let val_name = snippet_with_context(cx, self_arg.span, expr.span.ctxt(), "..", &mut app).0;
+                let method_name = if is_type_diagnostic_item(cx, ty, sym::cstring_type) {
+                    "as_bytes"
+                } else if is_type_diagnostic_item(cx, ty, sym::CStr) {
+                    "to_bytes"
                 } else {
                     return;
                 };
@@ -72,7 +67,7 @@ impl LateLintPass<'tcx> for StrlenOnCStrings {
                     expr.span,
                     "using `libc::strlen` on a `CString` or `CStr` value",
                     "try this (you might also need to get rid of `unsafe` block in some cases):",
-                    sugg,
+                    format!("{}.{}().len()", val_name, method_name),
                     Applicability::Unspecified // Sometimes unnecessary `unsafe` block
                 );
             }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1597,6 +1597,14 @@ pub fn match_def_path<'tcx>(cx: &LateContext<'tcx>, did: DefId, syms: &[&str]) -
     syms.iter().map(|x| Symbol::intern(x)).eq(path.iter().copied())
 }
 
+/// Checks if the given `DefId` matches the `libc` item.
+pub fn match_libc_symbol(cx: &LateContext<'_>, did: DefId, name: &str) -> bool {
+    let path = cx.get_def_path(did);
+    // libc is meant to be used as a flat list of names, but they're all actually defined in different
+    // modules based on the target platform. Ignore everything but crate name and the item name.
+    path.first().map_or(false, |s| s.as_str() == "libc") && path.last().map_or(false, |s| s.as_str() == name)
+}
+
 pub fn match_panic_call(cx: &LateContext<'_>, expr: &'tcx Expr<'_>) -> Option<&'tcx Expr<'tcx>> {
     if let ExprKind::Call(func, [arg]) = expr.kind {
         expr_path_res(cx, func)

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -86,7 +86,6 @@ pub const ITERTOOLS_NEXT_TUPLE: [&str; 3] = ["itertools", "Itertools", "next_tup
 pub const KW_MODULE: [&str; 3] = ["rustc_span", "symbol", "kw"];
 #[cfg(feature = "internal-lints")]
 pub const LATE_CONTEXT: [&str; 2] = ["rustc_lint", "LateContext"];
-pub const LIBC_STRLEN: [&str; 2] = ["libc", "strlen"];
 #[cfg(any(feature = "internal-lints", feature = "metadata-collector-lint"))]
 pub const LINT: [&str; 2] = ["rustc_lint_defs", "Lint"];
 pub const MEM_DISCRIMINANT: [&str; 3] = ["core", "mem", "discriminant"];

--- a/tests/ui/strlen_on_c_strings.fixed
+++ b/tests/ui/strlen_on_c_strings.fixed
@@ -12,23 +12,23 @@ use std::ffi::{CStr, CString};
 fn main() {
     // CString
     let cstring = CString::new("foo").expect("CString::new failed");
-    let _ = unsafe { libc::strlen(cstring.as_ptr()) };
+    let _ = cstring.as_bytes().len();
 
     // CStr
     let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
-    let _ = unsafe { libc::strlen(cstr.as_ptr()) };
+    let _ = cstr.to_bytes().len();
 
-    let _ = unsafe { strlen(cstr.as_ptr()) };
+    let _ = cstr.to_bytes().len();
 
     let pcstr: *const &CStr = &cstr;
-    let _ = unsafe { strlen((*pcstr).as_ptr()) };
+    let _ = unsafe { (*pcstr).to_bytes().len() };
 
     unsafe fn unsafe_identity<T>(x: T) -> T {
         x
     }
-    let _ = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
-    let _ = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
+    let _ = unsafe { unsafe_identity(cstr).to_bytes().len() };
+    let _ = unsafe { unsafe_identity(cstr) }.to_bytes().len();
 
     let f: unsafe fn(_) -> _ = unsafe_identity;
-    let _ = unsafe { strlen(f(cstr).as_ptr()) };
+    let _ = unsafe { f(cstr).to_bytes().len() };
 }

--- a/tests/ui/strlen_on_c_strings.rs
+++ b/tests/ui/strlen_on_c_strings.rs
@@ -16,4 +16,16 @@ fn main() {
     let len = unsafe { libc::strlen(cstr.as_ptr()) };
 
     let len = unsafe { strlen(cstr.as_ptr()) };
+
+    let pcstr: *const &CStr = &cstr;
+    let len = unsafe { strlen((*pcstr).as_ptr()) };
+
+    unsafe fn unsafe_identity<T>(x: T) -> T {
+        x
+    }
+    let len = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
+    let len = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
+
+    let f: unsafe fn(_) -> _ = unsafe_identity;
+    let len = unsafe { strlen(f(cstr).as_ptr()) };
 }

--- a/tests/ui/strlen_on_c_strings.rs
+++ b/tests/ui/strlen_on_c_strings.rs
@@ -3,6 +3,7 @@
 #![feature(rustc_private)]
 extern crate libc;
 
+use libc::strlen;
 use std::ffi::{CStr, CString};
 
 fn main() {
@@ -13,4 +14,6 @@ fn main() {
     // CStr
     let cstr = CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed");
     let len = unsafe { libc::strlen(cstr.as_ptr()) };
+
+    let len = unsafe { strlen(cstr.as_ptr()) };
 }

--- a/tests/ui/strlen_on_c_strings.stderr
+++ b/tests/ui/strlen_on_c_strings.stderr
@@ -1,46 +1,46 @@
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:12:15
+  --> $DIR/strlen_on_c_strings.rs:15:13
    |
-LL |     let len = unsafe { libc::strlen(cstring.as_ptr()) };
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstring.as_bytes().len()`
+LL |     let _ = unsafe { libc::strlen(cstring.as_ptr()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstring.as_bytes().len()`
    |
    = note: `-D clippy::strlen-on-c-strings` implied by `-D warnings`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:16:15
+  --> $DIR/strlen_on_c_strings.rs:19:13
    |
-LL |     let len = unsafe { libc::strlen(cstr.as_ptr()) };
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
+LL |     let _ = unsafe { libc::strlen(cstr.as_ptr()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:18:15
+  --> $DIR/strlen_on_c_strings.rs:21:13
    |
-LL |     let len = unsafe { strlen(cstr.as_ptr()) };
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
+LL |     let _ = unsafe { strlen(cstr.as_ptr()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:21:24
+  --> $DIR/strlen_on_c_strings.rs:24:22
    |
-LL |     let len = unsafe { strlen((*pcstr).as_ptr()) };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(*pcstr).to_bytes().len()`
+LL |     let _ = unsafe { strlen((*pcstr).as_ptr()) };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(*pcstr).to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:26:24
+  --> $DIR/strlen_on_c_strings.rs:29:22
    |
-LL |     let len = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe_identity(cstr).to_bytes().len()`
+LL |     let _ = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe_identity(cstr).to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:27:15
+  --> $DIR/strlen_on_c_strings.rs:30:13
    |
-LL |     let len = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe { unsafe_identity(cstr) }.to_bytes().len()`
+LL |     let _ = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe { unsafe_identity(cstr) }.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:30:24
+  --> $DIR/strlen_on_c_strings.rs:33:22
    |
-LL |     let len = unsafe { strlen(f(cstr).as_ptr()) };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `f(cstr).to_bytes().len()`
+LL |     let _ = unsafe { strlen(f(cstr).as_ptr()) };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `f(cstr).to_bytes().len()`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/strlen_on_c_strings.stderr
+++ b/tests/ui/strlen_on_c_strings.stderr
@@ -1,5 +1,5 @@
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:11:24
+  --> $DIR/strlen_on_c_strings.rs:12:24
    |
 LL |     let len = unsafe { libc::strlen(cstring.as_ptr()) };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     let len = unsafe { cstring.as_bytes().len() };
    |                        ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:15:24
+  --> $DIR/strlen_on_c_strings.rs:16:24
    |
 LL |     let len = unsafe { libc::strlen(cstr.as_ptr()) };
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,5 +21,16 @@ help: try this (you might also need to get rid of `unsafe` block in some cases):
 LL |     let len = unsafe { cstr.to_bytes().len() };
    |                        ~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 2 previous errors
+error: using `libc::strlen` on a `CString` or `CStr` value
+  --> $DIR/strlen_on_c_strings.rs:18:24
+   |
+LL |     let len = unsafe { strlen(cstr.as_ptr()) };
+   |                        ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try this (you might also need to get rid of `unsafe` block in some cases):
+   |
+LL |     let len = unsafe { cstr.to_bytes().len() };
+   |                        ~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/strlen_on_c_strings.stderr
+++ b/tests/ui/strlen_on_c_strings.stderr
@@ -1,36 +1,46 @@
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:12:24
+  --> $DIR/strlen_on_c_strings.rs:12:15
    |
 LL |     let len = unsafe { libc::strlen(cstring.as_ptr()) };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstring.as_bytes().len()`
    |
    = note: `-D clippy::strlen-on-c-strings` implied by `-D warnings`
-help: try this (you might also need to get rid of `unsafe` block in some cases):
-   |
-LL |     let len = unsafe { cstring.as_bytes().len() };
-   |                        ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:16:24
+  --> $DIR/strlen_on_c_strings.rs:16:15
    |
 LL |     let len = unsafe { libc::strlen(cstr.as_ptr()) };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: try this (you might also need to get rid of `unsafe` block in some cases):
-   |
-LL |     let len = unsafe { cstr.to_bytes().len() };
-   |                        ~~~~~~~~~~~~~~~~~~~~~
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
-  --> $DIR/strlen_on_c_strings.rs:18:24
+  --> $DIR/strlen_on_c_strings.rs:18:15
    |
 LL |     let len = unsafe { strlen(cstr.as_ptr()) };
-   |                        ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: try this (you might also need to get rid of `unsafe` block in some cases):
-   |
-LL |     let len = unsafe { cstr.to_bytes().len() };
-   |                        ~~~~~~~~~~~~~~~~~~~~~
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
 
-error: aborting due to 3 previous errors
+error: using `libc::strlen` on a `CString` or `CStr` value
+  --> $DIR/strlen_on_c_strings.rs:21:24
+   |
+LL |     let len = unsafe { strlen((*pcstr).as_ptr()) };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(*pcstr).to_bytes().len()`
+
+error: using `libc::strlen` on a `CString` or `CStr` value
+  --> $DIR/strlen_on_c_strings.rs:26:24
+   |
+LL |     let len = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe_identity(cstr).to_bytes().len()`
+
+error: using `libc::strlen` on a `CString` or `CStr` value
+  --> $DIR/strlen_on_c_strings.rs:27:15
+   |
+LL |     let len = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe { unsafe_identity(cstr) }.to_bytes().len()`
+
+error: using `libc::strlen` on a `CString` or `CStr` value
+  --> $DIR/strlen_on_c_strings.rs:30:24
+   |
+LL |     let len = unsafe { strlen(f(cstr).as_ptr()) };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `f(cstr).to_bytes().len()`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
fixes: #7436

changelog: lint `strlen_on_c_string` when used without a fully-qualified path
changelog: suggest removing the surrounding unsafe block for `strlen_on_c_string` when possible
