### PR TITLE
apply iter_cloned_collect to collect() using copied()

### DIFF
--- a/clippy_lints/src/methods/iter_cloned_collect.rs
+++ b/clippy_lints/src/methods/iter_cloned_collect.rs
@@ -9,7 +9,7 @@ use rustc_span::sym;
 
 use super::ITER_CLONED_COLLECT;
 
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, recv: &'tcx hir::Expr<'_>) {
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, method_name: &str, expr: &hir::Expr<'_>, recv: &'tcx hir::Expr<'_>) {
     if_chain! {
         if is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(expr), sym::Vec);
         if let Some(slice) = derefs_to_slice(cx, recv, cx.typeck_results().expr_ty(recv));
@@ -20,8 +20,8 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, recv: &'
                 cx,
                 ITER_CLONED_COLLECT,
                 to_replace,
-                "called `iter().cloned().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and \
-                more readable",
+                &format!("called `iter().{}().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and \
+                more readable", method_name),
                 "try",
                 ".to_vec()".to_string(),
                 Applicability::MachineApplicable,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2204,7 +2204,9 @@ fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Optio
             ("assume_init", []) => uninit_assumed_init::check(cx, expr, recv),
             ("cloned", []) => cloned_instead_of_copied::check(cx, expr, recv, span, msrv),
             ("collect", []) => match method_call!(recv) {
-                Some(("cloned", [recv2], _)) => iter_cloned_collect::check(cx, expr, recv2),
+                Some((name @ ("cloned" | "copied"), [recv2], _)) => {
+                    iter_cloned_collect::check(cx, name, expr, recv2);
+                },
                 Some(("map", [m_recv, m_arg], _)) => {
                     map_collect_result_unit::check(cx, expr, m_recv, m_arg, recv);
                 },

--- a/tests/ui/iter_cloned_collect.fixed
+++ b/tests/ui/iter_cloned_collect.fixed
@@ -23,4 +23,7 @@ fn main() {
     // Issue #6808
     let arr: [u8; 64] = [0; 64];
     let _: Vec<_> = arr.to_vec();
+
+    // Issue #6703
+    let _: Vec<isize> = v.to_vec();
 }

--- a/tests/ui/iter_cloned_collect.rs
+++ b/tests/ui/iter_cloned_collect.rs
@@ -26,4 +26,7 @@ fn main() {
     // Issue #6808
     let arr: [u8; 64] = [0; 64];
     let _: Vec<_> = arr.iter().cloned().collect();
+
+    // Issue #6703
+    let _: Vec<isize> = v.iter().copied().collect();
 }

--- a/tests/ui/iter_cloned_collect.stderr
+++ b/tests/ui/iter_cloned_collect.stderr
@@ -28,5 +28,11 @@ error: called `iter().cloned().collect()` on a slice to create a `Vec`. Calling 
 LL |     let _: Vec<_> = arr.iter().cloned().collect();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
 
-error: aborting due to 4 previous errors
+error: called `iter().copied().collect()` on a slice to create a `Vec`. Calling `to_vec()` is both faster and more readable
+  --> $DIR/iter_cloned_collect.rs:31:26
+   |
+LL |     let _: Vec<isize> = v.iter().copied().collect();
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `.to_vec()`
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
fix: #6703

changelog: apply `iter_cloned_collect` to `collect()` using`copied()` 
