### PR TITLE
Allow `suboptimal_flops` in const functions

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -4,7 +4,7 @@ use clippy_utils::consts::{
 };
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::higher;
-use clippy_utils::{eq_expr_value, get_parent_expr, numeric_literal, sugg};
+use clippy_utils::{eq_expr_value, get_parent_expr, in_constant, numeric_literal, sugg};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, PathSegment, UnOp};
@@ -687,6 +687,11 @@ fn check_radians(cx: &LateContext<'_>, expr: &Expr<'_>) {
 
 impl<'tcx> LateLintPass<'tcx> for FloatingPointArithmetic {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        // All of these operations are currently not const.
+        if in_constant(cx, expr.hir_id) {
+            return;
+        }
+
         if let ExprKind::MethodCall(path, _, args, _) = &expr.kind {
             let recv_ty = cx.typeck_results().expr_ty(&args[0]);
 

--- a/tests/ui/floating_point_abs.fixed
+++ b/tests/ui/floating_point_abs.fixed
@@ -1,5 +1,11 @@
 // run-rustfix
+#![feature(const_fn_floating_point_arithmetic)]
 #![warn(clippy::suboptimal_flops)]
+
+/// Allow suboptimal ops in constant context
+pub const fn in_const_context(num: f64) -> f64 {
+    if num >= 0.0 { num } else { -num }
+}
 
 struct A {
     a: f64,

--- a/tests/ui/floating_point_abs.rs
+++ b/tests/ui/floating_point_abs.rs
@@ -1,5 +1,11 @@
 // run-rustfix
+#![feature(const_fn_floating_point_arithmetic)]
 #![warn(clippy::suboptimal_flops)]
+
+/// Allow suboptimal ops in constant context
+pub const fn in_const_context(num: f64) -> f64 {
+    if num >= 0.0 { num } else { -num }
+}
 
 struct A {
     a: f64,

--- a/tests/ui/floating_point_abs.stderr
+++ b/tests/ui/floating_point_abs.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of `abs` method
-  --> $DIR/floating_point_abs.rs:10:5
+  --> $DIR/floating_point_abs.rs:16:5
    |
 LL |     if num >= 0.0 { num } else { -num }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.abs()`
@@ -7,43 +7,43 @@ LL |     if num >= 0.0 { num } else { -num }
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
 error: manual implementation of `abs` method
-  --> $DIR/floating_point_abs.rs:14:5
+  --> $DIR/floating_point_abs.rs:20:5
    |
 LL |     if 0.0 < num { num } else { -num }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.abs()`
 
 error: manual implementation of `abs` method
-  --> $DIR/floating_point_abs.rs:18:5
+  --> $DIR/floating_point_abs.rs:24:5
    |
 LL |     if a.a > 0.0 { a.a } else { -a.a }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.a.abs()`
 
 error: manual implementation of `abs` method
-  --> $DIR/floating_point_abs.rs:22:5
+  --> $DIR/floating_point_abs.rs:28:5
    |
 LL |     if 0.0 >= num { -num } else { num }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.abs()`
 
 error: manual implementation of `abs` method
-  --> $DIR/floating_point_abs.rs:26:5
+  --> $DIR/floating_point_abs.rs:32:5
    |
 LL |     if a.a < 0.0 { -a.a } else { a.a }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.a.abs()`
 
 error: manual implementation of negation of `abs` method
-  --> $DIR/floating_point_abs.rs:30:5
+  --> $DIR/floating_point_abs.rs:36:5
    |
 LL |     if num < 0.0 { num } else { -num }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `-num.abs()`
 
 error: manual implementation of negation of `abs` method
-  --> $DIR/floating_point_abs.rs:34:5
+  --> $DIR/floating_point_abs.rs:40:5
    |
 LL |     if 0.0 >= num { num } else { -num }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `-num.abs()`
 
 error: manual implementation of negation of `abs` method
-  --> $DIR/floating_point_abs.rs:39:12
+  --> $DIR/floating_point_abs.rs:45:12
    |
 LL |         a: if a.a >= 0.0 { -a.a } else { a.a },
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `-a.a.abs()`

--- a/tests/ui/floating_point_mul_add.fixed
+++ b/tests/ui/floating_point_mul_add.fixed
@@ -1,5 +1,16 @@
 // run-rustfix
+#![feature(const_fn_floating_point_arithmetic)]
 #![warn(clippy::suboptimal_flops)]
+
+/// Allow suboptimal_ops in constant context
+pub const fn in_const_context() {
+    let a: f64 = 1234.567;
+    let b: f64 = 45.67834;
+    let c: f64 = 0.0004;
+
+    let _ = a * b + c;
+    let _ = c + a * b;
+}
 
 fn main() {
     let a: f64 = 1234.567;

--- a/tests/ui/floating_point_mul_add.rs
+++ b/tests/ui/floating_point_mul_add.rs
@@ -1,5 +1,16 @@
 // run-rustfix
+#![feature(const_fn_floating_point_arithmetic)]
 #![warn(clippy::suboptimal_flops)]
+
+/// Allow suboptimal_ops in constant context
+pub const fn in_const_context() {
+    let a: f64 = 1234.567;
+    let b: f64 = 45.67834;
+    let c: f64 = 0.0004;
+
+    let _ = a * b + c;
+    let _ = c + a * b;
+}
 
 fn main() {
     let a: f64 = 1234.567;

--- a/tests/ui/floating_point_mul_add.stderr
+++ b/tests/ui/floating_point_mul_add.stderr
@@ -1,5 +1,5 @@
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:10:13
+  --> $DIR/floating_point_mul_add.rs:21:13
    |
 LL |     let _ = a * b + c;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
@@ -7,55 +7,55 @@ LL |     let _ = a * b + c;
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:11:13
+  --> $DIR/floating_point_mul_add.rs:22:13
    |
 LL |     let _ = c + a * b;
    |             ^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:12:13
+  --> $DIR/floating_point_mul_add.rs:23:13
    |
 LL |     let _ = a + 2.0 * 4.0;
    |             ^^^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4.0, a)`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:13:13
+  --> $DIR/floating_point_mul_add.rs:24:13
    |
 LL |     let _ = a + 2. * 4.;
    |             ^^^^^^^^^^^ help: consider using: `2.0f64.mul_add(4., a)`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:15:13
+  --> $DIR/floating_point_mul_add.rs:26:13
    |
 LL |     let _ = (a * b) + c;
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:16:13
+  --> $DIR/floating_point_mul_add.rs:27:13
    |
 LL |     let _ = c + (a * b);
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(b, c)`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:17:13
+  --> $DIR/floating_point_mul_add.rs:28:13
    |
 LL |     let _ = a * b * c + d;
    |             ^^^^^^^^^^^^^ help: consider using: `(a * b).mul_add(c, d)`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:19:13
+  --> $DIR/floating_point_mul_add.rs:30:13
    |
 LL |     let _ = a.mul_add(b, c) * a.mul_add(b, c) + a.mul_add(b, c) + c;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `a.mul_add(b, c).mul_add(a.mul_add(b, c), a.mul_add(b, c))`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:20:13
+  --> $DIR/floating_point_mul_add.rs:31:13
    |
 LL |     let _ = 1234.567_f64 * 45.67834_f64 + 0.0004_f64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1234.567_f64.mul_add(45.67834_f64, 0.0004_f64)`
 
 error: multiply and add expressions can be calculated more efficiently and accurately
-  --> $DIR/floating_point_mul_add.rs:22:13
+  --> $DIR/floating_point_mul_add.rs:33:13
    |
 LL |     let _ = (a * a + b).sqrt();
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(a, b)`

--- a/tests/ui/floating_point_rad.fixed
+++ b/tests/ui/floating_point_rad.fixed
@@ -1,5 +1,12 @@
 // run-rustfix
+#![feature(const_fn_floating_point_arithmetic)]
 #![warn(clippy::suboptimal_flops)]
+
+/// Allow suboptimal_flops in constant context
+pub const fn const_context() {
+    let x = 3f32;
+    let _ = x * 180f32 / std::f32::consts::PI;
+}
 
 fn main() {
     let x = 3f32;

--- a/tests/ui/floating_point_rad.rs
+++ b/tests/ui/floating_point_rad.rs
@@ -1,5 +1,12 @@
 // run-rustfix
+#![feature(const_fn_floating_point_arithmetic)]
 #![warn(clippy::suboptimal_flops)]
+
+/// Allow suboptimal_flops in constant context
+pub const fn const_context() {
+    let x = 3f32;
+    let _ = x * 180f32 / std::f32::consts::PI;
+}
 
 fn main() {
     let x = 3f32;

--- a/tests/ui/floating_point_rad.stderr
+++ b/tests/ui/floating_point_rad.stderr
@@ -1,5 +1,5 @@
 error: conversion to degrees can be done more accurately
-  --> $DIR/floating_point_rad.rs:6:13
+  --> $DIR/floating_point_rad.rs:13:13
    |
 LL |     let _ = x * 180f32 / std::f32::consts::PI;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.to_degrees()`
@@ -7,7 +7,7 @@ LL |     let _ = x * 180f32 / std::f32::consts::PI;
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
 error: conversion to radians can be done more accurately
-  --> $DIR/floating_point_rad.rs:7:13
+  --> $DIR/floating_point_rad.rs:14:13
    |
 LL |     let _ = x * std::f32::consts::PI / 180f32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.to_radians()`


### PR DESCRIPTION
This PR allows `clippy::suboptimal_flops` in constant functions. The check also effects the `clippy::imprecise_flops` lint logic. However, this doesn't have any effects as all functions checked for are not const and can therefore not be found in such functions. 

---

changelog: [`suboptimal_flops`]: No longer triggers in constant functions

Closes: rust-lang/rust-clippy#8004