### PR TITLE
Non ascii in sigle literal

### DIFF
--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -75,7 +75,7 @@ declare_lint_pass!(Unicode => [INVISIBLE_CHARACTERS, NON_ASCII_LITERAL, UNICODE_
 impl LateLintPass<'_> for Unicode {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &'_ Expr<'_>) {
         if let ExprKind::Lit(ref lit) = expr.kind {
-            if let LitKind::Str(_, _) = lit.node {
+            if let LitKind::Str(_, _) |  LitKind::Char(_)= lit.node {
                 check_str(cx, lit.span, expr.hir_id);
             }
         }

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -28,7 +28,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for non-ASCII characters in string literals or char.
+    /// Checks for non-ASCII characters in string and char literals.
     ///
     /// ### Why is this bad?
     /// Yeah, we know, the 90's called and wanted their charset

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -28,7 +28,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for non-ASCII characters in string literals.
+    /// Checks for non-ASCII characters in string literals or char.
     ///
     /// ### Why is this bad?
     /// Yeah, we know, the 90's called and wanted their charset

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -75,7 +75,7 @@ declare_lint_pass!(Unicode => [INVISIBLE_CHARACTERS, NON_ASCII_LITERAL, UNICODE_
 impl LateLintPass<'_> for Unicode {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &'_ Expr<'_>) {
         if let ExprKind::Lit(ref lit) = expr.kind {
-            if let LitKind::Str(_, _) |  LitKind::Char(_)= lit.node {
+            if let LitKind::Str(_, _) | LitKind::Char(_) = lit.node {
                 check_str(cx, lit.span, expr.hir_id);
             }
         }

--- a/tests/ui/unicode.rs
+++ b/tests/ui/unicode.rs
@@ -20,8 +20,16 @@ fn uni() {
     print!("\u{DC}ben!"); // this is ok
 }
 
+// issue 8013
+#[warn(clippy::non_ascii_literal)]
+fn single_quote() {
+    const _EMPTY_BLOCK: char = '▱';
+    const _FULL_BLOCK: char = '▰';
+}
+
 fn main() {
     zero();
     uni();
     canon();
+    single_quote();
 }

--- a/tests/ui/unicode.stderr
+++ b/tests/ui/unicode.stderr
@@ -34,5 +34,17 @@ LL |     print!("Üben!");
    |
    = note: `-D clippy::non-ascii-literal` implied by `-D warnings`
 
-error: aborting due to 5 previous errors
+error: literal non-ASCII character detected
+  --> $DIR/unicode.rs:26:32
+   |
+LL |     const _EMPTY_BLOCK: char = '▱';
+   |                                ^^^ help: consider replacing the string with: `'/u{25b1}'`
+
+error: literal non-ASCII character detected
+  --> $DIR/unicode.rs:27:31
+   |
+LL |     const _FULL_BLOCK: char = '▰';
+   |                               ^^^ help: consider replacing the string with: `'/u{25b0}'`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
fix: #8013 
changelog: `non_ascii_literal` warn against non-ASCII within `char`, not just `strings`
