### PR TITLE
Updated known problems section for pre-expansion lints about level attributes

### DIFF
--- a/clippy_lints/src/dbg_macro.rs
+++ b/clippy_lints/src/dbg_macro.rs
@@ -15,6 +15,14 @@ declare_clippy_lint! {
     /// `dbg!` macro is intended as a debugging tool. It
     /// should not be in version control.
     ///
+    /// ### Known problems
+    /// * The lint level is unaffected by crate attributes. The level can still
+    ///   be set for functions, modules and other items. To change the level for
+    ///   the entire crate, please use command line flags. More information and a
+    ///   configuration example can be found in [clippy#6610].
+    ///
+    /// [clippy#6610]: https://github.com/rust-lang/rust-clippy/issues/6610#issuecomment-977120558
+    ///
     /// ### Example
     /// ```rust,ignore
     /// // Bad

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -72,7 +72,13 @@ declare_clippy_lint! {
     /// application and might forget to remove those prints afterward.
     ///
     /// ### Known problems
-    /// Only catches `print!` and `println!` calls.
+    /// * Only catches `print!` and `println!` calls.
+    /// * The lint level is unaffected by crate attributes. The level can still
+    ///   be set for functions, modules and other items. To change the level for
+    ///   the entire crate, please use command line flags. More information and a
+    ///   configuration example can be found in [clippy#6610].
+    ///
+    /// [clippy#6610]: https://github.com/rust-lang/rust-clippy/issues/6610#issuecomment-977120558
     ///
     /// ### Example
     /// ```rust
@@ -94,7 +100,13 @@ declare_clippy_lint! {
     /// application and might forget to remove those prints afterward.
     ///
     /// ### Known problems
-    /// Only catches `eprint!` and `eprintln!` calls.
+    /// * Only catches `eprint!` and `eprintln!` calls.
+    /// * The lint level is unaffected by crate attributes. The level can still
+    ///   be set for functions, modules and other items. To change the level for
+    ///   the entire crate, please use command line flags. More information and a
+    ///   configuration example can be found in [clippy#6610].
+    ///
+    /// [clippy#6610]: https://github.com/rust-lang/rust-clippy/issues/6610#issuecomment-977120558
     ///
     /// ### Example
     /// ```rust

--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -336,7 +336,7 @@ Otherwise, have a great day =^.^=
                     </h2>
                 </header>
 
-                <ul class="list-group lint-docs" ng-class="{collapse: true, in: open[lint.id]}">
+                <div class="list-group lint-docs" ng-class="{collapse: true, in: open[lint.id]}">
                     <div class="list-group-item lint-doc-md" ng-bind-html="lint.docs | markdown"></div>
                     <div class="lint-additional-info-container">
                         <!-- Applicability -->
@@ -359,7 +359,7 @@ Otherwise, have a great day =^.^=
                             <a href="https://github.com/rust-lang/rust-clippy/blob/{{docVersion}}/clippy_lints/{{lint.id_span.path}}#L{{lint.id_span.line}}">View Source</a>
                         </div>
                     </div>
-                </ul>
+                </div>
             </article>
         </div>
     </div>


### PR DESCRIPTION
Our last three pre-macro expansion lints aren't affected by lint level attributes. This adds a comment to the know problems section of them. I've also updated some CSS to add some spacing after lists on Clippy's lint list:

Before:

![image](https://user-images.githubusercontent.com/17087237/143783579-064326d4-4e58-4d7d-bbe4-fad8b115fcd4.png)

After:

![image](https://user-images.githubusercontent.com/17087237/143783650-9803fa03-c332-4e0e-886f-523d4217c6e6.png)

---

changelog: [`print_stdout`], [`print_stderr`], [`dbg_macro`]: Document how the lint level can be changed and reference rust-lang/rust-clippy#6610

cc: rust-lang/rust-clippy#6610