### PR TITLE
Add test for pattern_type_mismatch.

### DIFF
--- a/tests/ui/pattern_type_mismatch/mutability.rs
+++ b/tests/ui/pattern_type_mismatch/mutability.rs
@@ -37,4 +37,13 @@ fn should_not_lint() {
         Some(_) => (),
         _ => (),
     }
+
+    const FOO: &str = "foo";
+
+    fn foo(s: &str) -> i32 {
+        match s {
+            FOO => 1,
+            _ => 0,
+        }
+    }
 }


### PR DESCRIPTION
This issue has been fixed by [commit](https://github.com/rust-lang/rust-clippy/commit/8c1c763c2d5897c66f52bd5e7c16f48ae66c894c)
This PR is used for close #7946(Fixes #7946).

changelog: Add test for pattern_type_mismatch.