### PR TITLE
Ignore as_deref_mut in needless_option_as_deref

### DIFF
--- a/clippy_lints/src/needless_option_as_deref.rs
+++ b/clippy_lints/src/needless_option_as_deref.rs
@@ -10,8 +10,8 @@ use rustc_span::symbol::sym;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for no-op uses of Option::{as_deref,as_deref_mut},
-    /// for example, `Option<&T>::as_deref()` returns the same type.
+    /// Checks for no-op uses of `Option::as_deref`, for example,
+    /// `Option<&T>::as_deref()` returns the same type.
     ///
     /// ### Why is this bad?
     /// Redundant code and improving readability.
@@ -29,12 +29,10 @@ declare_clippy_lint! {
     #[clippy::version = "1.57.0"]
     pub NEEDLESS_OPTION_AS_DEREF,
     complexity,
-    "no-op use of `deref` or `deref_mut` method to `Option`."
+    "no-op use of `as_deref` method to `Option`."
 }
 
-declare_lint_pass!(OptionNeedlessDeref=> [
-    NEEDLESS_OPTION_AS_DEREF,
-]);
+declare_lint_pass!(OptionNeedlessDeref => [NEEDLESS_OPTION_AS_DEREF]);
 
 impl<'tcx> LateLintPass<'tcx> for OptionNeedlessDeref {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
@@ -45,19 +43,18 @@ impl<'tcx> LateLintPass<'tcx> for OptionNeedlessDeref {
         let outer_ty = typeck.expr_ty(expr);
 
         if_chain! {
-            if is_type_diagnostic_item(cx,outer_ty,sym::Option);
+            if is_type_diagnostic_item(cx, outer_ty, sym::Option);
             if let ExprKind::MethodCall(path, _, [sub_expr], _) = expr.kind;
-            let symbol = path.ident.as_str();
-            if symbol == "as_deref" || symbol == "as_deref_mut";
-            if TyS::same_type( outer_ty, typeck.expr_ty(sub_expr) );
-            then{
+            if path.ident.as_str() == "as_deref";
+            if TyS::same_type(outer_ty, typeck.expr_ty(sub_expr));
+            then {
                 span_lint_and_sugg(
                     cx,
                     NEEDLESS_OPTION_AS_DEREF,
                     expr.span,
                     "derefed type is same as origin",
                     "try this",
-                    snippet_opt(cx,sub_expr.span).unwrap(),
+                    snippet_opt(cx, sub_expr.span).unwrap(),
                     Applicability::MachineApplicable
                 );
             }

--- a/tests/ui/needless_option_as_deref.fixed
+++ b/tests/ui/needless_option_as_deref.fixed
@@ -5,9 +5,22 @@
 fn main() {
     // should lint
     let _: Option<&usize> = Some(&1);
-    let _: Option<&mut usize> = Some(&mut 1);
+
+    // false negative, could lint if the source Option is movable and not used later
+    let _: Option<&mut usize> = Some(&mut 1).as_deref_mut();
 
     // should not lint
     let _ = Some(Box::new(1)).as_deref();
     let _ = Some(Box::new(1)).as_deref_mut();
+
+    // #7846
+    let mut i = 0;
+    let mut opt_vec = vec![Some(&mut i)];
+    opt_vec[0].as_deref_mut().unwrap();
+
+    // #8047
+    let mut y = 0;
+    let mut x = Some(&mut y);
+    x.as_deref_mut();
+    println!("{:?}", x);
 }

--- a/tests/ui/needless_option_as_deref.rs
+++ b/tests/ui/needless_option_as_deref.rs
@@ -5,9 +5,22 @@
 fn main() {
     // should lint
     let _: Option<&usize> = Some(&1).as_deref();
+
+    // false negative, could lint if the source Option is movable and not used later
     let _: Option<&mut usize> = Some(&mut 1).as_deref_mut();
 
     // should not lint
     let _ = Some(Box::new(1)).as_deref();
     let _ = Some(Box::new(1)).as_deref_mut();
+
+    // #7846
+    let mut i = 0;
+    let mut opt_vec = vec![Some(&mut i)];
+    opt_vec[0].as_deref_mut().unwrap();
+
+    // #8047
+    let mut y = 0;
+    let mut x = Some(&mut y);
+    x.as_deref_mut();
+    println!("{:?}", x);
 }

--- a/tests/ui/needless_option_as_deref.stderr
+++ b/tests/ui/needless_option_as_deref.stderr
@@ -6,11 +6,5 @@ LL |     let _: Option<&usize> = Some(&1).as_deref();
    |
    = note: `-D clippy::needless-option-as-deref` implied by `-D warnings`
 
-error: derefed type is same as origin
-  --> $DIR/needless_option_as_deref.rs:8:33
-   |
-LL |     let _: Option<&mut usize> = Some(&mut 1).as_deref_mut();
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `Some(&mut 1)`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #7846
Fixes #8047

It would be possible to only lint `as_deref_mut` where the `Option` is movable + unused later, but it wasn't clear to me how to test for that. So for now at least ignore it

changelog: [`needless_option_as_deref`]: No longer lints on `as_deref_mut`