### PR TITLE
Enable rustbot shortcuts for rust-clippy

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -5,3 +5,8 @@ allow-unauthenticated = [
 ]
 
 [assign]
+
+# Allows shortcuts like `@rustbot ready`
+#
+# See https://github.com/rust-lang/triagebot/wiki/Shortcuts
+[shortcut]


### PR DESCRIPTION
This enables shortcuts for `@rustbot`. Just a quality of life feature for contributors.

|Shortcut| Full comment |
|---|---|
| `@rustbot ready` | `@rustbot label -S-waiting-on-author +S-waiting-on-review` |
| `@rustbot author` | `@rustbot label +S-waiting-on-author -S-waiting-on-review` |

See: https://github.com/rust-lang/triagebot/wiki/Shortcuts

The documentation also states that the author/assignee will be pinged. However, this doesn't seem to be the case, it at least hasn't done so for me and in this [PR](https://github.com/rust-lang/rust/pull/90642#issuecomment-962465404)

---

changelog: none
