### PR TITLE
Fix some false negatives for [`single_char_pattern`]

### DIFF
--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -190,7 +190,7 @@ fn unit_closure<'tcx>(
 /// Anything else will return `a`.
 fn let_binding_name(cx: &LateContext<'_>, var_arg: &hir::Expr<'_>) -> String {
     match &var_arg.kind {
-        hir::ExprKind::Field(_, _) => snippet(cx, var_arg.span, "_").replace(".", "_"),
+        hir::ExprKind::Field(_, _) => snippet(cx, var_arg.span, "_").replace('.', "_"),
         hir::ExprKind::Path(_) => format!("_{}", snippet(cx, var_arg.span, "")),
         _ => "a".to_string(),
     }

--- a/clippy_lints/src/methods/single_char_pattern.rs
+++ b/clippy_lints/src/methods/single_char_pattern.rs
@@ -9,18 +9,21 @@ use rustc_span::symbol::Symbol;
 
 use super::SINGLE_CHAR_PATTERN;
 
-const PATTERN_METHODS: [(&str, usize); 19] = [
+const PATTERN_METHODS: [(&str, usize); 24] = [
     ("contains", 1),
     ("starts_with", 1),
     ("ends_with", 1),
     ("find", 1),
     ("rfind", 1),
     ("split", 1),
+    ("split_inclusive", 1),
     ("rsplit", 1),
     ("split_terminator", 1),
     ("rsplit_terminator", 1),
     ("splitn", 2),
     ("rsplitn", 2),
+    ("split_once", 1),
+    ("rsplit_once", 1),
     ("matches", 1),
     ("rmatches", 1),
     ("match_indices", 1),
@@ -29,6 +32,8 @@ const PATTERN_METHODS: [(&str, usize); 19] = [
     ("strip_suffix", 1),
     ("trim_start_matches", 1),
     ("trim_end_matches", 1),
+    ("replace", 1),
+    ("replacen", 1),
 ];
 
 /// lint for length-1 `str`s for methods in `PATTERN_METHODS`

--- a/clippy_lints/src/nonstandard_macro_braces.rs
+++ b/clippy_lints/src/nonstandard_macro_braces.rs
@@ -112,7 +112,7 @@ fn is_offending_macro<'a>(cx: &EarlyContext<'_>, span: Span, mac_braces: &'a Mac
         if snip.starts_with(&format!("{}!", name));
         if unnested_or_local();
         // make formatting consistent
-        let c = snip.replace(" ", "");
+        let c = snip.replace(' ', "");
         if !c.starts_with(&format!("{}!{}", name, braces.0));
         if !mac_braces.done.contains(&span.ctxt().outer_expn_data().call_site);
         then {

--- a/clippy_lints/src/self_named_constructors.rs
+++ b/clippy_lints/src/self_named_constructors.rs
@@ -76,7 +76,7 @@ impl<'tcx> LateLintPass<'tcx> for SelfNamedConstructors {
             let self_id = cx.tcx.hir().local_def_id_to_hir_id(self_local_did);
             if let Some(Node::Item(x)) = cx.tcx.hir().find(self_id);
             let type_name = x.ident.name.as_str().to_lowercase();
-            if impl_item.ident.name.as_str() == type_name || impl_item.ident.name.as_str().replace("_", "") == type_name;
+            if impl_item.ident.name.as_str() == type_name || impl_item.ident.name.as_str().replace('_', "") == type_name;
 
             then {
                 span_lint(

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -106,9 +106,9 @@ fn check_str(cx: &LateContext<'_>, span: Span, id: HirId) {
             "invisible character detected",
             "consider replacing the string with",
             string
-                .replace("\u{200B}", "\\u{200B}")
-                .replace("\u{ad}", "\\u{AD}")
-                .replace("\u{2060}", "\\u{2060}"),
+                .replace('\u{200B}', "\\u{200B}")
+                .replace('\u{ad}', "\\u{AD}")
+                .replace('\u{2060}', "\\u{2060}"),
             Applicability::MachineApplicable,
         );
     }

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -583,10 +583,10 @@ impl Write {
             let replacement: String = match lit.token.kind {
                 LitKind::Integer | LitKind::Float | LitKind::Err => continue,
                 LitKind::StrRaw(_) | LitKind::ByteStrRaw(_) if matches!(fmtstr.style, StrStyle::Raw(_)) => {
-                    lit.token.symbol.as_str().replace("{", "{{").replace("}", "}}")
+                    lit.token.symbol.as_str().replace('{', "{{").replace('}', "}}")
                 },
                 LitKind::Str | LitKind::ByteStr if matches!(fmtstr.style, StrStyle::Cooked) => {
-                    lit.token.symbol.as_str().replace("{", "{{").replace("}", "}}")
+                    lit.token.symbol.as_str().replace('{', "{{").replace('}', "}}")
                 },
                 LitKind::StrRaw(_) | LitKind::Str | LitKind::ByteStrRaw(_) | LitKind::ByteStr => continue,
                 LitKind::Byte | LitKind::Char => match &*lit.token.symbol.as_str() {

--- a/tests/ui/single_char_pattern.fixed
+++ b/tests/ui/single_char_pattern.fixed
@@ -17,6 +17,7 @@ fn main() {
     x.split('💣');
     // Can't use this lint for unicode code points which don't fit in a char
     x.split("❤️");
+    x.split_inclusive('x');
     x.contains('x');
     x.starts_with('x');
     x.ends_with('x');
@@ -27,6 +28,8 @@ fn main() {
     x.rsplit_terminator('x');
     x.splitn(2, 'x');
     x.rsplitn(2, 'x');
+    x.split_once('x');
+    x.rsplit_once('x');
     x.matches('x');
     x.rmatches('x');
     x.match_indices('x');
@@ -35,6 +38,8 @@ fn main() {
     x.trim_end_matches('x');
     x.strip_prefix('x');
     x.strip_suffix('x');
+    x.replace('x', "y");
+    x.replacen('x', "y", 3);
     // Make sure we escape characters correctly.
     x.split('\n');
     x.split('\'');
@@ -43,7 +48,7 @@ fn main() {
     let h = HashSet::<String>::new();
     h.contains("X"); // should not warn
 
-    x.replace(";", ",").split(','); // issue #2978
+    x.replace(';', ",").split(','); // issue #2978
     x.starts_with('\x03'); // issue #2996
 
     // Issue #3204

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -17,6 +17,7 @@ fn main() {
     x.split("💣");
     // Can't use this lint for unicode code points which don't fit in a char
     x.split("❤️");
+    x.split_inclusive("x");
     x.contains("x");
     x.starts_with("x");
     x.ends_with("x");
@@ -27,6 +28,8 @@ fn main() {
     x.rsplit_terminator("x");
     x.splitn(2, "x");
     x.rsplitn(2, "x");
+    x.split_once("x");
+    x.rsplit_once("x");
     x.matches("x");
     x.rmatches("x");
     x.match_indices("x");
@@ -35,6 +38,8 @@ fn main() {
     x.trim_end_matches("x");
     x.strip_prefix("x");
     x.strip_suffix("x");
+    x.replace("x", "y");
+    x.replacen("x", "y", 3);
     // Make sure we escape characters correctly.
     x.split("\n");
     x.split("'");
@@ -43,7 +48,7 @@ fn main() {
     let h = HashSet::<String>::new();
     h.contains("X"); // should not warn
 
-    x.replace(";", ",").split(","); // issue #2978
+    x.replace(';', ",").split(","); // issue #2978
     x.starts_with("\x03"); // issue #2996
 
     // Issue #3204

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -25,184 +25,214 @@ LL |     x.split("💣");
    |             ^^^^ help: try using a `char` instead: `'💣'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:20:16
+  --> $DIR/single_char_pattern.rs:20:23
+   |
+LL |     x.split_inclusive("x");
+   |                       ^^^ help: try using a `char` instead: `'x'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:21:16
    |
 LL |     x.contains("x");
    |                ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:21:19
+  --> $DIR/single_char_pattern.rs:22:19
    |
 LL |     x.starts_with("x");
    |                   ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:22:17
+  --> $DIR/single_char_pattern.rs:23:17
    |
 LL |     x.ends_with("x");
    |                 ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:23:12
+  --> $DIR/single_char_pattern.rs:24:12
    |
 LL |     x.find("x");
    |            ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:24:13
+  --> $DIR/single_char_pattern.rs:25:13
    |
 LL |     x.rfind("x");
    |             ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:25:14
+  --> $DIR/single_char_pattern.rs:26:14
    |
 LL |     x.rsplit("x");
    |              ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:26:24
+  --> $DIR/single_char_pattern.rs:27:24
    |
 LL |     x.split_terminator("x");
    |                        ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:27:25
+  --> $DIR/single_char_pattern.rs:28:25
    |
 LL |     x.rsplit_terminator("x");
    |                         ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:28:17
+  --> $DIR/single_char_pattern.rs:29:17
    |
 LL |     x.splitn(2, "x");
    |                 ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:29:18
+  --> $DIR/single_char_pattern.rs:30:18
    |
 LL |     x.rsplitn(2, "x");
    |                  ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:30:15
+  --> $DIR/single_char_pattern.rs:31:18
+   |
+LL |     x.split_once("x");
+   |                  ^^^ help: try using a `char` instead: `'x'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:32:19
+   |
+LL |     x.rsplit_once("x");
+   |                   ^^^ help: try using a `char` instead: `'x'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:33:15
    |
 LL |     x.matches("x");
    |               ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:31:16
+  --> $DIR/single_char_pattern.rs:34:16
    |
 LL |     x.rmatches("x");
    |                ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:32:21
+  --> $DIR/single_char_pattern.rs:35:21
    |
 LL |     x.match_indices("x");
    |                     ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:33:22
+  --> $DIR/single_char_pattern.rs:36:22
    |
 LL |     x.rmatch_indices("x");
    |                      ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:34:26
+  --> $DIR/single_char_pattern.rs:37:26
    |
 LL |     x.trim_start_matches("x");
    |                          ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:35:24
+  --> $DIR/single_char_pattern.rs:38:24
    |
 LL |     x.trim_end_matches("x");
    |                        ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:36:20
+  --> $DIR/single_char_pattern.rs:39:20
    |
 LL |     x.strip_prefix("x");
    |                    ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:37:20
+  --> $DIR/single_char_pattern.rs:40:20
    |
 LL |     x.strip_suffix("x");
    |                    ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:39:13
+  --> $DIR/single_char_pattern.rs:41:15
+   |
+LL |     x.replace("x", "y");
+   |               ^^^ help: try using a `char` instead: `'x'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:42:16
+   |
+LL |     x.replacen("x", "y", 3);
+   |                ^^^ help: try using a `char` instead: `'x'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:44:13
    |
 LL |     x.split("/n");
    |             ^^^^ help: try using a `char` instead: `'/n'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:40:13
+  --> $DIR/single_char_pattern.rs:45:13
    |
 LL |     x.split("'");
    |             ^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:41:13
+  --> $DIR/single_char_pattern.rs:46:13
    |
 LL |     x.split("/'");
    |             ^^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:46:31
+  --> $DIR/single_char_pattern.rs:51:31
    |
-LL |     x.replace(";", ",").split(","); // issue #2978
+LL |     x.replace(';', ",").split(","); // issue #2978
    |                               ^^^ help: try using a `char` instead: `','`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:47:19
+  --> $DIR/single_char_pattern.rs:52:19
    |
 LL |     x.starts_with("/x03"); // issue #2996
    |                   ^^^^^^ help: try using a `char` instead: `'/x03'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:54:13
+  --> $DIR/single_char_pattern.rs:59:13
    |
 LL |     x.split(r"a");
    |             ^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:55:13
+  --> $DIR/single_char_pattern.rs:60:13
    |
 LL |     x.split(r#"a"#);
    |             ^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:56:13
+  --> $DIR/single_char_pattern.rs:61:13
    |
 LL |     x.split(r###"a"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:57:13
+  --> $DIR/single_char_pattern.rs:62:13
    |
 LL |     x.split(r###"'"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'/''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:58:13
+  --> $DIR/single_char_pattern.rs:63:13
    |
 LL |     x.split(r###"#"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'#'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:60:13
+  --> $DIR/single_char_pattern.rs:65:13
    |
 LL |     x.split(r#"/"#);
    |             ^^^^^^ help: try using a `char` instead: `'/'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:61:13
+  --> $DIR/single_char_pattern.rs:66:13
    |
 LL |     x.split(r"/");
    |             ^^^^ help: try using a `char` instead: `'/'`
 
-error: aborting due to 34 previous errors
+error: aborting due to 39 previous errors
 


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: Fix some false negatives for [`single_char_pattern`]

I noticed that clippy wasn't complaining about my usage of `split_once("x")` in a personal project so I updated the list of functions.

I had to update the test case for an unrelated issue because replace is now included in the list of functions to be linted.