### PR TITLE
Fix FP on `question_mark` if returned object is not local

### DIFF
--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -183,7 +183,7 @@ impl QuestionMark {
                 false
             },
             ExprKind::Ret(Some(ret_expr)) => Self::expression_returns_unmodified_err(cx, ret_expr, cond_expr),
-            ExprKind::Path(_) => path_to_local(expr) == path_to_local(cond_expr),
+            ExprKind::Path(_) => path_to_local(expr).is_some() && path_to_local(expr) == path_to_local(cond_expr),
             _ => false,
         }
     }

--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -136,6 +136,24 @@ fn result_func(x: Result<i32, i32>) -> Result<i32, i32> {
     Ok(y)
 }
 
+// see issue #8019
+pub enum NotOption {
+    None,
+    First,
+    AfterFirst,
+}
+
+fn obj(_: i32) -> Result<(), NotOption> {
+    Err(NotOption::First)
+}
+
+fn f() -> NotOption {
+    if obj(2).is_err() {
+        return NotOption::None;
+    }
+    NotOption::First
+}
+
 fn main() {
     some_func(Some(42));
     some_func(None);
@@ -157,4 +175,5 @@ fn main() {
     func();
 
     let _ = result_func(Ok(42));
+    let _ = f();
 }

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -168,6 +168,24 @@ fn result_func(x: Result<i32, i32>) -> Result<i32, i32> {
     Ok(y)
 }
 
+// see issue #8019
+pub enum NotOption {
+    None,
+    First,
+    AfterFirst,
+}
+
+fn obj(_: i32) -> Result<(), NotOption> {
+    Err(NotOption::First)
+}
+
+fn f() -> NotOption {
+    if obj(2).is_err() {
+        return NotOption::None;
+    }
+    NotOption::First
+}
+
 fn main() {
     some_func(Some(42));
     some_func(None);
@@ -189,4 +207,5 @@ fn main() {
     func();
 
     let _ = result_func(Ok(42));
+    let _ = f();
 }


### PR DESCRIPTION
Closes #8019 

changelog: [`question_mark`] Fix FP when returned object is not local
