### PR TITLE
Split `needless_collect` and downgrade the split one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3033,6 +3033,7 @@ Released 2018-09-13
 [`needless_continue`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
 [`needless_doctest_main`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main
 [`needless_for_each`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each
+[`needless_indirect_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_indirect_collect
 [`needless_late_init`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
 [`needless_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
 [`needless_option_as_deref`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_option_as_deref

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -213,6 +213,7 @@ store.register_lints(&[
     loops::MANUAL_MEMCPY,
     loops::MUT_RANGE_BOUND,
     loops::NEEDLESS_COLLECT,
+    loops::NEEDLESS_INDIRECT_COLLECT,
     loops::NEEDLESS_RANGE_LOOP,
     loops::NEVER_LOOP,
     loops::SAME_ITEM_PUSH,

--- a/clippy_lints/src/lib.register_nursery.rs
+++ b/clippy_lints/src/lib.register_nursery.rs
@@ -15,6 +15,7 @@ store.register_group(true, "clippy::nursery", Some("clippy_nursery"), vec![
     LintId::of(future_not_send::FUTURE_NOT_SEND),
     LintId::of(index_refutable_slice::INDEX_REFUTABLE_SLICE),
     LintId::of(let_if_seq::USELESS_LET_IF_SEQ),
+    LintId::of(loops::NEEDLESS_INDIRECT_COLLECT),
     LintId::of(missing_const_for_fn::MISSING_CONST_FOR_FN),
     LintId::of(mutable_debug_assertion::DEBUG_ASSERT_WITH_MUT_CALL),
     LintId::of(mutex_atomic::MUTEX_INTEGER),

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -269,6 +269,29 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Check the function collecting an iterator if it turns out
+    /// that collecting the iterator is not needed later.
+    ///
+    /// ### Why is this bad?
+    /// `collect` causes the allocation of a new data structure,
+    /// when this allocation may not be needed.
+    ///
+    /// ### Example
+    /// ```rust
+    /// let sample = [1; 5];
+    /// let indirect_len = sample.iter().collect::<Vec<_>>();
+    /// indirect_len.len();
+    /// // should be
+    /// sample.iter().count();
+    /// ```
+    #[clippy::version = "1.30.0"]
+    pub NEEDLESS_INDIRECT_COLLECT,
+    nursery,
+    "collecting an iterator when collect is not needed"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks `for` loops over slices with an explicit counter
     /// and suggests the use of `.enumerate()`.
     ///
@@ -570,6 +593,7 @@ declare_lint_pass!(Loops => [
     FOR_LOOPS_OVER_FALLIBLES,
     WHILE_LET_LOOP,
     NEEDLESS_COLLECT,
+    NEEDLESS_INDIRECT_COLLECT,
     EXPLICIT_COUNTER_LOOP,
     EMPTY_LOOP,
     WHILE_LET_ON_ITERATOR,

--- a/clippy_lints/src/loops/needless_collect.rs
+++ b/clippy_lints/src/loops/needless_collect.rs
@@ -1,4 +1,4 @@
-use super::NEEDLESS_COLLECT;
+use super::{NEEDLESS_COLLECT, NEEDLESS_INDIRECT_COLLECT};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
 use clippy_utils::source::{snippet, snippet_with_applicability};
 use clippy_utils::sugg::Sugg;
@@ -105,7 +105,7 @@ fn check_needless_collect_indirect_usage<'tcx>(expr: &'tcx Expr<'_>, cx: &LateCo
                     span.push_span_label(iter_call.span, "the iterator could be used here instead".into());
                     span_lint_hir_and_then(
                         cx,
-                        super::NEEDLESS_COLLECT,
+                        NEEDLESS_INDIRECT_COLLECT,
                         init_expr.hir_id,
                         span,
                         NEEDLESS_COLLECT_MSG,

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::needless_indirect_collect)]
 use std::collections::{BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 
 fn main() {
@@ -108,7 +109,7 @@ mod issue7975 {
 }
 
 fn allow_test() {
-    #[allow(clippy::needless_collect)]
+    #[allow(clippy::needless_indirect_collect)]
     let v = [1].iter().collect::<Vec<_>>();
     v.into_iter().collect::<HashSet<_>>();
 }

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -1,12 +1,12 @@
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:5:39
+  --> $DIR/needless_collect_indirect.rs:6:39
    |
 LL |     let indirect_iter = sample.iter().collect::<Vec<_>>();
    |                                       ^^^^^^^
 LL |     indirect_iter.into_iter().map(|x| (x, x + 1)).collect::<HashMap<_, _>>();
    |     ------------------------- the iterator could be used here instead
    |
-   = note: `-D clippy::needless-collect` implied by `-D warnings`
+   = note: `-D clippy::needless-indirect-collect` implied by `-D warnings`
 help: use the original Iterator instead of collecting it and then producing a new one
    |
 LL ~     
@@ -14,7 +14,7 @@ LL ~     sample.iter().map(|x| (x, x + 1)).collect::<HashMap<_, _>>();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:7:38
+  --> $DIR/needless_collect_indirect.rs:8:38
    |
 LL |     let indirect_len = sample.iter().collect::<VecDeque<_>>();
    |                                      ^^^^^^^
@@ -28,7 +28,7 @@ LL ~     sample.iter().count();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:9:40
+  --> $DIR/needless_collect_indirect.rs:10:40
    |
 LL |     let indirect_empty = sample.iter().collect::<VecDeque<_>>();
    |                                        ^^^^^^^
@@ -42,7 +42,7 @@ LL ~     sample.iter().next().is_none();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:11:43
+  --> $DIR/needless_collect_indirect.rs:12:43
    |
 LL |     let indirect_contains = sample.iter().collect::<VecDeque<_>>();
    |                                           ^^^^^^^
@@ -56,7 +56,7 @@ LL ~     sample.iter().any(|x| x == &5);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:23:48
+  --> $DIR/needless_collect_indirect.rs:24:48
    |
 LL |     let non_copy_contains = sample.into_iter().collect::<Vec<_>>();
    |                                                ^^^^^^^
@@ -70,7 +70,7 @@ LL ~     sample.into_iter().any(|x| x == a);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:52:51
+  --> $DIR/needless_collect_indirect.rs:53:51
    |
 LL |         let buffer: Vec<&str> = string.split('/').collect();
    |                                                   ^^^^^^^
@@ -84,7 +84,7 @@ LL ~         string.split('/').count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:57:55
+  --> $DIR/needless_collect_indirect.rs:58:55
    |
 LL |         let indirect_len: VecDeque<_> = sample.iter().collect();
    |                                                       ^^^^^^^
@@ -98,7 +98,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:62:57
+  --> $DIR/needless_collect_indirect.rs:63:57
    |
 LL |         let indirect_len: LinkedList<_> = sample.iter().collect();
    |                                                         ^^^^^^^
@@ -112,7 +112,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:67:57
+  --> $DIR/needless_collect_indirect.rs:68:57
    |
 LL |         let indirect_len: BinaryHeap<_> = sample.iter().collect();
    |                                                         ^^^^^^^


### PR DESCRIPTION
As discussed in [zulip](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/split.20and.20downgrade.20.60needless_collect.60), `needless_collect` has many false positives, so it's time to downgrade it to `nursery`. But false positives have been reported for the indirect usage, not for the direct usage. So `needless_collect` is split into two and the indirect usage is downgraded to nursery.

The naming of the new lint is bothering me.

changelog: Split `needless_collect` and downgrade the split one as the new lint `needless_indirect_collect`
