### PR TITLE
make unwrap_used also trigger on .get().unwrap()

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2314,10 +2314,13 @@ fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Optio
             ("to_os_string" | "to_owned" | "to_path_buf" | "to_vec", []) => {
                 implicit_clone::check(cx, name, expr, recv, span);
             },
-            ("unwrap", []) => match method_call!(recv) {
-                Some(("get", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, false),
-                Some(("get_mut", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, true),
-                _ => unwrap_used::check(cx, expr, recv),
+            ("unwrap", []) => {
+                match method_call!(recv) {
+                    Some(("get", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, false),
+                    Some(("get_mut", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, true),
+                    _ => {},
+                }
+                unwrap_used::check(cx, expr, recv);
             },
             ("unwrap_or", [u_arg]) => match method_call!(recv) {
                 Some((arith @ ("checked_add" | "checked_sub" | "checked_mul"), [lhs, rhs], _)) => {

--- a/tests/ui/unwrap.rs
+++ b/tests/ui/unwrap.rs
@@ -10,7 +10,49 @@ fn unwrap_result() {
     let _ = res.unwrap();
 }
 
+fn unwrap_get() {
+    let v = vec![1, 2, 3];
+    let _ = v.get(0).unwrap();
+}
+
+fn unwrap_get_mut() {
+    let mut v = vec![1, 2, 3];
+    let _ = v.get_mut(0).unwrap();
+}
+
+#[warn(clippy::get_unwrap)]
+fn unwrap_get2() {
+    let v = vec![1, 2, 3];
+    let _ = v.get(0).unwrap();
+}
+
+#[warn(clippy::get_unwrap)]
+fn unwrap_get_mut2() {
+    let mut v = vec![1, 2, 3];
+    let _ = v.get_mut(0).unwrap();
+}
+
+#[warn(clippy::get_unwrap)]
+#[allow(clippy::unwrap_used)]
+fn unwrap_get3() {
+    let v = vec![1, 2, 3];
+    let _ = v.get(0).unwrap();
+}
+
+#[warn(clippy::get_unwrap)]
+#[allow(clippy::unwrap_used)]
+fn unwrap_get_mut3() {
+    let mut v = vec![1, 2, 3];
+    let _ = v.get_mut(0).unwrap();
+}
+
 fn main() {
     unwrap_option();
     unwrap_result();
+    unwrap_get();
+    unwrap_get_mut();
+    unwrap_get2();
+    unwrap_get_mut2();
+    unwrap_get3();
+    unwrap_get_mut3();
 }

--- a/tests/ui/unwrap.stderr
+++ b/tests/ui/unwrap.stderr
@@ -15,5 +15,63 @@ LL |     let _ = res.unwrap();
    |
    = help: if you don't want to handle the `Err` case gracefully, consider using `expect()` to provide a better panic message
 
-error: aborting due to 2 previous errors
+error: used `unwrap()` on `an Option` value
+  --> $DIR/unwrap.rs:15:13
+   |
+LL |     let _ = v.get(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/unwrap.rs:20:13
+   |
+LL |     let _ = v.get_mut(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
+  --> $DIR/unwrap.rs:26:13
+   |
+LL |     let _ = v.get(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^ help: try this: `&v[0]`
+   |
+   = note: `-D clippy::get-unwrap` implied by `-D warnings`
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/unwrap.rs:26:13
+   |
+LL |     let _ = v.get(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
+  --> $DIR/unwrap.rs:32:13
+   |
+LL |     let _ = v.get_mut(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut v[0]`
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/unwrap.rs:32:13
+   |
+LL |     let _ = v.get_mut(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
+  --> $DIR/unwrap.rs:39:13
+   |
+LL |     let _ = v.get(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^ help: try this: `&v[0]`
+
+error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
+  --> $DIR/unwrap.rs:46:13
+   |
+LL |     let _ = v.get_mut(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut v[0]`
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: Fix the [`unwrap_used`] lint to also trigger for code of the form `.get(i).unwrap()` and `.get_mut(i).unwrap()`

fixes #8124 
