### PR TITLE
Fix commits and formatting of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ document.
 
 ## Unreleased / In Rust Nightly
 
-[e181011...master](https://github.com/rust-lang/rust-clippy/compare/b7f3f7f...master)
+[e181011...master](https://github.com/rust-lang/rust-clippy/compare/e181011...master)
 
 ## Rust 1.58 (beta)
 
 Current beta, release 2022-01-13
 
-[b7f3f7f..e181011](https://github.com/rust-lang/rust-clippy/compare/b7f3f7f..e181011)
+[00e31fa...e181011](https://github.com/rust-lang/rust-clippy/compare/00e31fa...e181011)
 
 ### New lints
 
@@ -32,7 +32,6 @@ Current beta, release 2022-01-13
   [#7838](https://github.com/rust-lang/rust-clippy/pull/7838)
 * [`string_slice`]
   [#7878](https://github.com/rust-lang/rust-clippy/pull/7878)
-
 
 ### Moves or deprecations of lints
 
@@ -62,22 +61,22 @@ Current beta, release 2022-01-13
   [#7795](https://github.com/rust-lang/rust-clippy/pull/7795)
 * Avoid [`eq_op`] in test functions
   [#7811](https://github.com/rust-lang/rust-clippy/pull/7811)
-* [`cast_possible_truncation`] no longer lints when cast is coming from `signum` method call
-  [#7850](https://github.com/rust-lang/rust-clippy/pull/7850)
+* [`cast_possible_truncation`] no longer lints when cast is coming from `signum`
+  method call [#7850](https://github.com/rust-lang/rust-clippy/pull/7850)
 * [`match_str_case_mismatch`] no longer lints on uncased characters
   [#7865](https://github.com/rust-lang/rust-clippy/pull/7865)
 * [`ptr_arg`] no longer lints references to type aliases
   [#7890](https://github.com/rust-lang/rust-clippy/pull/7890)
 * [`missing_safety_doc`] now also accepts "implementation safety" headers
   [#7856](https://github.com/rust-lang/rust-clippy/pull/7856)
-* [`missing_safety_doc`] no longer lints if any parent has `#[doc(hidden)]` attribute
-  [#7849](https://github.com/rust-lang/rust-clippy/pull/7849)
+* [`missing_safety_doc`] no longer lints if any parent has `#[doc(hidden)]`
+  attribute [#7849](https://github.com/rust-lang/rust-clippy/pull/7849)
 * [`if_not_else`] now ignores else-if statements
   [#7895](https://github.com/rust-lang/rust-clippy/pull/7895)
-* Avoid linting [`cast_possible_truncation`] on bit-reducing operations 
+* Avoid linting [`cast_possible_truncation`] on bit-reducing operations
   [#7819](https://github.com/rust-lang/rust-clippy/pull/7819)
-* Avoid linting [`field_reassign_with_default`] when `Drop` and `Copy` are involved
-  [#7794](https://github.com/rust-lang/rust-clippy/pull/7794)
+* Avoid linting [`field_reassign_with_default`] when `Drop` and `Copy` are
+  involved [#7794](https://github.com/rust-lang/rust-clippy/pull/7794)
 * [`unnecessary_sort_by`] now checks if argument implements `Ord` trait
   [#7824](https://github.com/rust-lang/rust-clippy/pull/7824)
 * Fix false positive in [`match_overlapping_arm`]
@@ -89,8 +88,8 @@ Current beta, release 2022-01-13
 
 * Keep an initial `::` when [`doc_markdown`] suggests to use ticks
   [#7916](https://github.com/rust-lang/rust-clippy/pull/7916)
-* Add a machine applicable suggestion for the [`doc_markdown`] missing backticks lint
-  [#7904](https://github.com/rust-lang/rust-clippy/pull/7904)
+* Add a machine applicable suggestion for the [`doc_markdown`] missing backticks
+  lint [#7904](https://github.com/rust-lang/rust-clippy/pull/7904)
 * [`equatable_if_let`] no longer expands macros in the suggestion
   [#7788](https://github.com/rust-lang/rust-clippy/pull/7788)
 * Make [`shadow_reuse`] suggestion less verbose
@@ -105,7 +104,8 @@ Current beta, release 2022-01-13
 
 ### Documentation improvements
 
-* Fixed naive doc formatting for `#[must_use]` lints ([`must_use_unit`], [`double_must_use`], [`must_use_candidate`], [`let_underscore_must_use`])
+* Fixed naive doc formatting for `#[must_use]` lints ([`must_use_unit`],
+  [`double_must_use`], [`must_use_candidate`], [`let_underscore_must_use`])
   [#7827](https://github.com/rust-lang/rust-clippy/pull/7827)
 * Fix typo in example for [`match_result_ok`]
   [#7815](https://github.com/rust-lang/rust-clippy/pull/7815)
@@ -114,19 +114,19 @@ Current beta, release 2022-01-13
 
 * Allow giving reasons for [`disallowed_types`]
   [#7791](https://github.com/rust-lang/rust-clippy/pull/7791)
-* Fix [`manual_assert`] and [`match_wild_err_arm`] for `#![no_std]` and Rust 2021.
-  [#7851](https://github.com/rust-lang/rust-clippy/pull/7851)
-* Fix regression in [`semicolon_if_nothing_returned`] on macros containing while loops
-  [#7789](https://github.com/rust-lang/rust-clippy/pull/7789)
-* Added a new configuration `literal-suffix-style` to enforce a certain style writing [`unseparated_literal_suffix`]
+* Fix [`manual_assert`] and [`match_wild_err_arm`] for `#![no_std]` and Rust
+  2021. [#7851](https://github.com/rust-lang/rust-clippy/pull/7851)
+* Fix regression in [`semicolon_if_nothing_returned`] on macros containing while
+  loops [#7789](https://github.com/rust-lang/rust-clippy/pull/7789)
+* Added a new configuration `literal-suffix-style` to enforce a certain style
+  writing [`unseparated_literal_suffix`]
   [#7726](https://github.com/rust-lang/rust-clippy/pull/7726)
-
 
 ## Rust 1.57
 
-Current stable
+Current stable, released 2021-12-02
 
-[7bfc26e...b7f3f7f](https://github.com/rust-lang/rust-clippy/compare/7bfc26e...b7f3f7f)
+[7bfc26e...00e31fa](https://github.com/rust-lang/rust-clippy/compare/7bfc26e...00e31fa)
 
 ### New Lints
 
@@ -275,7 +275,7 @@ Current stable
 
 ## Rust 1.56
 
-Current stable, released 2021-10-21
+Released 2021-10-21
 
 [74d1561...7bfc26e](https://github.com/rust-lang/rust-clippy/compare/74d1561...7bfc26e)
 


### PR DESCRIPTION
r? @Manishearth 

Follow up to #8136 

I think the beta commit update didn't take the backport we've done into account. I fixed the commit ranges. And while I was at it, I also applied my usual formatting to the changelog entries.

changelog: none
