### PR TITLE
Fix `SAFETY` comment tag casing in undocumented_unsafe_blocks

### DIFF
--- a/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -15,7 +15,7 @@ use std::borrow::Cow;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for `unsafe` blocks without a `// Safety: ` comment
+    /// Checks for `unsafe` blocks without a `// SAFETY: ` comment
     /// explaining why the unsafe operations performed inside
     /// the block are safe.
     ///
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// use std::ptr::NonNull;
     /// let a = &mut 42;
     ///
-    /// // Safety: references are guaranteed to be non-null.
+    /// // SAFETY: references are guaranteed to be non-null.
     /// let ptr = unsafe { NonNull::new_unchecked(a) };
     /// ```
     #[clippy::version = "1.58.0"]
@@ -213,7 +213,7 @@ impl UndocumentedUnsafeBlocks {
             );
         } else {
             let block_indent = indent_of(cx, span);
-            let suggestion = format!("// Safety: ...\n{}", snippet(cx, span, ".."));
+            let suggestion = format!("// SAFETY: ...\n{}", snippet(cx, span, ".."));
 
             span_lint_and_sugg(
                 cx,

--- a/tests/ui/crashes/ice-7868.stderr
+++ b/tests/ui/crashes/ice-7868.stderr
@@ -7,7 +7,7 @@ LL |     unsafe { 0 };
    = note: `-D clippy::undocumented-unsafe-blocks` implied by `-D warnings`
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL ~     unsafe { 0 };
    |
 

--- a/tests/ui/undocumented_unsafe_blocks.rs
+++ b/tests/ui/undocumented_unsafe_blocks.rs
@@ -5,7 +5,7 @@
 fn nested_local() {
     let _ = {
         let _ = {
-            // Safety:
+            // SAFETY:
             let _ = unsafe {};
         };
     };
@@ -14,7 +14,7 @@ fn nested_local() {
 fn deep_nest() {
     let _ = {
         let _ = {
-            // Safety:
+            // SAFETY:
             let _ = unsafe {};
 
             // Safety:
@@ -28,7 +28,7 @@ fn deep_nest() {
                                 // Safety:
                                 let _ = unsafe {};
 
-                                // Safety:
+                                // SAFETY:
                                 unsafe {};
                             };
                         };
@@ -44,7 +44,7 @@ fn deep_nest() {
         unsafe {};
     };
 
-    // Safety:
+    // SAFETY:
     unsafe {};
 }
 
@@ -59,7 +59,7 @@ fn line_comment() {
 }
 
 fn line_comment_newlines() {
-    // Safety:
+    // SAFETY:
 
     unsafe {}
 }
@@ -84,7 +84,7 @@ fn block_comment() {
 }
 
 fn block_comment_newlines() {
-    /* Safety: */
+    /* SAFETY: */
 
     unsafe {}
 }
@@ -96,7 +96,7 @@ fn inline_block_comment() {
 
 fn block_comment_with_extras() {
     /* This is a description
-     * Safety:
+     * SAFETY:
      */
     unsafe {}
 }
@@ -122,7 +122,7 @@ fn buried_safety() {
 }
 
 fn safety_with_prepended_text() {
-    // This is a test. Safety:
+    // This is a test. safety:
     unsafe {}
 }
 
@@ -132,7 +132,7 @@ fn local_line_comment() {
 }
 
 fn local_block_comment() {
-    /* Safety: */
+    /* SAFETY: */
     let _ = unsafe {};
 }
 
@@ -142,18 +142,18 @@ fn comment_array() {
 }
 
 fn comment_tuple() {
-    // Safety:
+    // sAFETY:
     let _ = (42, unsafe {}, "test", unsafe {});
 }
 
 fn comment_unary() {
-    // Safety:
+    // SAFETY:
     let _ = *unsafe { &42 };
 }
 
 #[allow(clippy::match_single_binding)]
 fn comment_match() {
-    // Safety:
+    // SAFETY:
     let _ = match unsafe {} {
         _ => {},
     };
@@ -177,7 +177,7 @@ fn comment_macro_call() {
     }
 
     t!(
-        // Safety:
+        // SAFETY:
         unsafe {}
     );
 }
@@ -194,18 +194,18 @@ fn comment_macro_def() {
 }
 
 fn non_ascii_comment() {
-    // ॐ᧻໒ Safety: ௵∰
+    // ॐ᧻໒ SaFeTy: ௵∰
     unsafe {};
 }
 
 fn local_commented_block() {
     let _ =
-        // Safety:
+        // safety:
         unsafe {};
 }
 
 fn local_nest() {
-    // Safety:
+    // safety:
     let _ = [(42, unsafe {}, unsafe {}), (52, unsafe {}, unsafe {})];
 }
 
@@ -267,17 +267,17 @@ fn no_comment_macro_def() {
 }
 
 fn trailing_comment() {
-    unsafe {} // Safety:
+    unsafe {} // SAFETY:
 }
 
 fn internal_comment() {
     unsafe {
-        // Safety:
+        // SAFETY:
     }
 }
 
 fn interference() {
-    // Safety
+    // SAFETY
 
     let _ = 42;
 

--- a/tests/ui/undocumented_unsafe_blocks.stderr
+++ b/tests/ui/undocumented_unsafe_blocks.stderr
@@ -7,7 +7,7 @@ LL |     unsafe {}
    = note: `-D clippy::undocumented-unsafe-blocks` implied by `-D warnings`
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     unsafe {}
    |
 
@@ -19,7 +19,7 @@ LL |     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     let _ = [unsafe { 14 }, unsafe { 15 }, 42, unsafe { 16 }];
    |
 
@@ -31,7 +31,7 @@ LL |     let _ = (42, unsafe {}, "test", unsafe {});
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     let _ = (42, unsafe {}, "test", unsafe {});
    |
 
@@ -43,7 +43,7 @@ LL |     let _ = *unsafe { &42 };
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     let _ = *unsafe { &42 };
    |
 
@@ -55,7 +55,7 @@ LL |     let _ = match unsafe {} {
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     let _ = match unsafe {} {
    |
 
@@ -67,7 +67,7 @@ LL |     let _ = &unsafe {};
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     let _ = &unsafe {};
    |
 
@@ -79,7 +79,7 @@ LL |     let _ = [unsafe {}; 5];
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     let _ = [unsafe {}; 5];
    |
 
@@ -91,7 +91,7 @@ LL |     let _ = unsafe {};
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     let _ = unsafe {};
    |
 
@@ -103,7 +103,7 @@ LL |     t!(unsafe {});
    |
 help: consider adding a safety comment
    |
-LL ~     t!(// Safety: ...
+LL ~     t!(// SAFETY: ...
 LL ~     unsafe {});
    |
 
@@ -122,13 +122,13 @@ LL |     t!();
 error: unsafe block missing a safety comment
   --> $DIR/undocumented_unsafe_blocks.rs:270:5
    |
-LL |     unsafe {} // Safety:
+LL |     unsafe {} // SAFETY:
    |     ^^^^^^^^^
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
-LL ~     unsafe {} // Safety:
+LL ~     // SAFETY: ...
+LL ~     unsafe {} // SAFETY:
    |
 
 error: unsafe block missing a safety comment
@@ -139,7 +139,7 @@ LL |     unsafe {
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL +     unsafe {
    |
 
@@ -151,7 +151,7 @@ LL |     unsafe {};
    |
 help: consider adding a safety comment
    |
-LL ~     // Safety: ...
+LL ~     // SAFETY: ...
 LL ~     unsafe {};
    |
 
@@ -163,7 +163,7 @@ LL |     println!("{}", unsafe { String::from_utf8_unchecked(vec![]) });
    |
 help: consider adding a safety comment
    |
-LL ~     println!("{}", // Safety: ...
+LL ~     println!("{}", // SAFETY: ...
 LL ~     unsafe { String::from_utf8_unchecked(vec![]) });
    |
 


### PR DESCRIPTION
This changes the lint introduced in #7748 to suggest adding a `SAFETY` comment instead of a `Safety` comment.

Searching for `// Safety:` in rust-lang/rust yields 67 results while `// SAFETY:` yields 1072.
I think it's safe to say that this comment tag is written in upper case, just like `TODO`, `FIXME` and so on are. As such I would expect this lint to follow the official convention as well.

Note that I intentionally introduced some casing diversity in `tests/ui/undocumented_unsafe_blocks.rs` to test more cases than just `Safety:`.

changelog: Capitalize `SAFETY` comment in [`undocumented_unsafe_blocks`]