### PR TITLE
Improve `unwrap_or_else_default` when handling `unwrap_or_else(XXX::new)`

### DIFF
--- a/clippy_lints/src/methods/unwrap_or_else_default.rs
+++ b/clippy_lints/src/methods/unwrap_or_else_default.rs
@@ -1,8 +1,9 @@
 //! Lint for `some_result_or_option.unwrap_or_else(Default::default)`
 
 use super::UNWRAP_OR_ELSE_DEFAULT;
-use clippy_utils::{diagnostics::span_lint_and_sugg, is_trait_item, source::snippet_with_applicability, ty::is_type_diagnostic_item,
-                   is_default_equivalent_ctor, is_diag_trait_item
+use clippy_utils::{
+    diagnostics::span_lint_and_sugg, is_default_equivalent_ctor, is_diag_trait_item, is_trait_item,
+    source::snippet_with_applicability, ty::is_type_diagnostic_item,
 };
 use rustc_hir::ExprKind;
 
@@ -28,7 +29,8 @@ pub(super) fn check<'tcx>(
         ExprKind::Path(qpath) => {
             if let Some(repl_def_id) = cx.qpath_res(qpath, u_arg.hir_id).opt_def_id() {
                 if is_diag_trait_item(cx, repl_def_id, sym::Default)
-                    || is_default_equivalent_ctor(cx, repl_def_id, qpath) {
+                    || is_default_equivalent_ctor(cx, repl_def_id, qpath)
+                {
                     true
                 } else {
                     false
@@ -37,7 +39,7 @@ pub(super) fn check<'tcx>(
                 false
             }
         },
-        _ => {false}
+        _ => false,
     };
 
     if_chain! {

--- a/clippy_lints/src/methods/unwrap_or_else_default.rs
+++ b/clippy_lints/src/methods/unwrap_or_else_default.rs
@@ -5,8 +5,6 @@ use clippy_utils::{
     diagnostics::span_lint_and_sugg, is_default_equivalent_ctor, is_diag_trait_item, is_trait_item,
     source::snippet_with_applicability, ty::is_type_diagnostic_item,
 };
-use rustc_hir::ExprKind;
-
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
@@ -26,7 +24,7 @@ pub(super) fn check<'tcx>(
     let is_result = is_type_diagnostic_item(cx, recv_ty, sym::Result);
 
     let is_default_eq = match &u_arg.kind {
-        ExprKind::Path(qpath) => {
+        hir::ExprKind::Path(qpath) => {
             if let Some(repl_def_id) = cx.qpath_res(qpath, u_arg.hir_id).opt_def_id() {
                 if is_diag_trait_item(cx, repl_def_id, sym::Default)
                     || is_default_equivalent_ctor(cx, repl_def_id, qpath)

--- a/clippy_lints/src/methods/unwrap_or_else_default.rs
+++ b/clippy_lints/src/methods/unwrap_or_else_default.rs
@@ -2,7 +2,7 @@
 
 use super::UNWRAP_OR_ELSE_DEFAULT;
 use clippy_utils::{
-    diagnostics::span_lint_and_sugg, is_default_equivalent_call, is_trait_item, source::snippet_with_applicability,
+    diagnostics::span_lint_and_sugg, is_default_equivalent_call, source::snippet_with_applicability,
     ty::is_type_diagnostic_item,
 };
 use rustc_errors::Applicability;
@@ -25,7 +25,7 @@ pub(super) fn check<'tcx>(
 
     if_chain! {
         if is_option || is_result;
-        if is_trait_item(cx, u_arg, sym::Default) || is_default_equivalent_call(cx, u_arg);
+        if is_default_equivalent_call(cx, u_arg);
         then {
             let mut applicability = Applicability::MachineApplicable;
 

--- a/clippy_lints/src/methods/unwrap_or_else_default.rs
+++ b/clippy_lints/src/methods/unwrap_or_else_default.rs
@@ -2,7 +2,8 @@
 
 use super::UNWRAP_OR_ELSE_DEFAULT;
 use clippy_utils::{
-    diagnostics::span_lint_and_sugg, is_trait_item, source::snippet_with_applicability, ty::is_type_diagnostic_item,
+    diagnostics::span_lint_and_sugg, is_default_equivalent, is_trait_item, source::snippet_with_applicability,
+    ty::is_type_diagnostic_item,
 };
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -24,7 +25,7 @@ pub(super) fn check<'tcx>(
 
     if_chain! {
         if is_option || is_result;
-        if is_trait_item(cx, u_arg, sym::Default);
+        if is_trait_item(cx, u_arg, sym::Default) || is_default_equivalent(cx, u_arg);
         then {
             let mut applicability = Applicability::MachineApplicable;
 

--- a/clippy_lints/src/methods/unwrap_or_else_default.rs
+++ b/clippy_lints/src/methods/unwrap_or_else_default.rs
@@ -2,8 +2,8 @@
 
 use super::UNWRAP_OR_ELSE_DEFAULT;
 use clippy_utils::{
-    diagnostics::span_lint_and_sugg, is_default_equivalent_ctor, is_diag_trait_item, is_trait_item,
-    source::snippet_with_applicability, ty::is_type_diagnostic_item,
+    diagnostics::span_lint_and_sugg, is_default_equivalent_call, is_trait_item, source::snippet_with_applicability,
+    ty::is_type_diagnostic_item,
 };
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -23,21 +23,9 @@ pub(super) fn check<'tcx>(
     let is_option = is_type_diagnostic_item(cx, recv_ty, sym::Option);
     let is_result = is_type_diagnostic_item(cx, recv_ty, sym::Result);
 
-    let is_default_eq = match &u_arg.kind {
-        hir::ExprKind::Path(qpath) => {
-            if let Some(repl_def_id) = cx.qpath_res(qpath, u_arg.hir_id).opt_def_id() {
-                is_diag_trait_item(cx, repl_def_id, sym::Default)
-                    || is_default_equivalent_ctor(cx, repl_def_id, qpath)
-            } else {
-                false
-            }
-        },
-        _ => false,
-    };
-
     if_chain! {
         if is_option || is_result;
-        if is_trait_item(cx, u_arg, sym::Default) || is_default_eq;
+        if is_trait_item(cx, u_arg, sym::Default) || is_default_equivalent_call(cx, u_arg);
         then {
             let mut applicability = Applicability::MachineApplicable;
 

--- a/clippy_lints/src/methods/unwrap_or_else_default.rs
+++ b/clippy_lints/src/methods/unwrap_or_else_default.rs
@@ -26,13 +26,8 @@ pub(super) fn check<'tcx>(
     let is_default_eq = match &u_arg.kind {
         hir::ExprKind::Path(qpath) => {
             if let Some(repl_def_id) = cx.qpath_res(qpath, u_arg.hir_id).opt_def_id() {
-                if is_diag_trait_item(cx, repl_def_id, sym::Default)
+                is_diag_trait_item(cx, repl_def_id, sym::Default)
                     || is_default_equivalent_ctor(cx, repl_def_id, qpath)
-                {
-                    true
-                } else {
-                    false
-                }
             } else {
                 false
             }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -637,7 +637,7 @@ pub fn can_mut_borrow_both(cx: &LateContext<'_>, e1: &Expr<'_>, e2: &Expr<'_>) -
 
 /// Returns true if the `def_id` associated with the `path` is recognized as a "default-equivalent"
 /// constructor from the std library
-fn is_default_equivalent_ctor(cx: &LateContext<'_>, def_id: DefId, path: &QPath<'_>) -> bool {
+pub fn is_default_equivalent_ctor(cx: &LateContext<'_>, def_id: DefId, path: &QPath<'_>) -> bool {
     let std_types_symbols = &[
         sym::String,
         sym::Vec,

--- a/tests/ui/unwrap_or_else_default.fixed
+++ b/tests/ui/unwrap_or_else_default.fixed
@@ -45,7 +45,7 @@ fn unwrap_or_else_default() {
     with_enum.unwrap_or_else(Enum::A);
 
     let with_new = Some(vec![1]);
-    with_new.unwrap_or_else(Vec::new);
+    with_new.unwrap_or_default();
 
     let with_err: Result<_, ()> = Ok(vec![1]);
     with_err.unwrap_or_else(make);

--- a/tests/ui/unwrap_or_else_default.fixed
+++ b/tests/ui/unwrap_or_else_default.fixed
@@ -66,6 +66,9 @@ fn unwrap_or_else_default() {
 
     let with_default_type = Some(1);
     with_default_type.unwrap_or_default();
+
+    let with_default_type: Option<Vec<u64>> = None;
+    with_default_type.unwrap_or_default();
 }
 
 fn main() {}

--- a/tests/ui/unwrap_or_else_default.rs
+++ b/tests/ui/unwrap_or_else_default.rs
@@ -66,6 +66,9 @@ fn unwrap_or_else_default() {
 
     let with_default_type = Some(1);
     with_default_type.unwrap_or_else(u64::default);
+
+    let with_default_type: Option<Vec<u64>> = None;
+    with_default_type.unwrap_or_else(Vec::new);
 }
 
 fn main() {}

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -32,4 +32,3 @@ LL |     with_default_type.unwrap_or_else(Vec::new);
 
 error: aborting due to 5 previous errors
 
-

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -1,10 +1,16 @@
 error: use of `.unwrap_or_else(..)` to construct default value
+  --> $DIR/unwrap_or_else_default.rs:48:5
+   |
+LL |     with_new.unwrap_or_else(Vec::new);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `with_new.unwrap_or_default()`
+   |
+   = note: `-D clippy::unwrap-or-else-default` implied by `-D warnings`
+
+error: use of `.unwrap_or_else(..)` to construct default value
   --> $DIR/unwrap_or_else_default.rs:62:5
    |
 LL |     with_real_default.unwrap_or_else(<HasDefaultAndDuplicate as Default>::default);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `with_real_default.unwrap_or_default()`
-   |
-   = note: `-D clippy::unwrap-or-else-default` implied by `-D warnings`
 
 error: use of `.unwrap_or_else(..)` to construct default value
   --> $DIR/unwrap_or_else_default.rs:65:5

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -24,5 +24,12 @@ error: use of `.unwrap_or_else(..)` to construct default value
 LL |     with_default_type.unwrap_or_else(u64::default);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `with_default_type.unwrap_or_default()`
 
-error: aborting due to 3 previous errors
+error: use of `.unwrap_or_else(..)` to construct default value
+  --> $DIR/unwrap_or_else_default.rs:71:5
+   |
+LL |     with_default_type.unwrap_or_else(Vec::new);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `with_default_type.unwrap_or_default()`
+
+error: aborting due to 5 previous errors
+
 


### PR DESCRIPTION
changelog:  change `unwrap_or_else_default` to work with std constructors like `Vec::new`, `HashSet::new`, `HashMap::new`.

Notes:
- Code to handle detecting those constructors is already there. I moved it out to `is_default_equivalent_call`