### PR TITLE
fix [`shadow_reuse`] false negative for if let bindings

### DIFF
--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -220,14 +220,14 @@ fn is_self_shadow(cx: &LateContext<'_>, pat: &Pat<'_>, mut expr: &Expr<'_>, hir_
     }
 }
 
-/// Finds the "init" expression for a pattern: `let <pat> = <init>;` or
+/// Finds the "init" expression for a pattern: `let <pat> = <init>;` (or `if let`) or
 /// `match <init> { .., <pat> => .., .. }`
 fn find_init<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<&'tcx Expr<'tcx>> {
     for (_, node) in cx.tcx.hir().parent_iter(hir_id) {
         let init = match node {
             Node::Arm(_) | Node::Pat(_) => continue,
             Node::Expr(expr) => match expr.kind {
-                ExprKind::Match(e, _, _) => Some(e),
+                ExprKind::Match(e, _, _) | ExprKind::Let(_, e, _) => Some(e),
                 _ => None,
             },
             Node::Local(local) => local.init,

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -47,6 +47,8 @@ fn syntax() {
     let _ = |[x]: [u32; 1]| {
         let x = 1;
     };
+    let y = Some(1);
+    if let Some(y) = y {}
 }
 
 fn negative() {

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -241,17 +241,29 @@ note: previous binding is here
 LL |     let _ = |[x]: [u32; 1]| {
    |               ^
 
+error: `y` is shadowed
+  --> $DIR/shadow.rs:51:17
+   |
+LL |     if let Some(y) = y {}
+   |                 ^
+   |
+note: previous binding is here
+  --> $DIR/shadow.rs:50:9
+   |
+LL |     let y = Some(1);
+   |         ^
+
 error: `_b` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:85:9
+  --> $DIR/shadow.rs:87:9
    |
 LL |     let _b = _a;
    |         ^^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:84:28
+  --> $DIR/shadow.rs:86:28
    |
 LL | pub async fn foo2(_a: i32, _b: i64) {
    |                            ^^
 
-error: aborting due to 21 previous errors
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
fixes #8087 

changelog: trigger [`shadow_reuse`] instead of [`shadow_unrelated`] on shadowed `if let` bindings