### PR TITLE
fix an ICE on unwrapping a None

### DIFF
--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -49,8 +49,9 @@ pub(super) fn check(
                 if cast_from.kind() == cast_to.kind() =>
             {
                 if let Some(src) = snippet_opt(cx, lit.span) {
-                    let num_lit = NumericLiteral::from_lit_kind(&src, &lit.node).unwrap();
-                    lint_unnecessary_cast(cx, expr, num_lit.integer, cast_from, cast_to);
+                    if let Some(num_lit) = NumericLiteral::from_lit_kind(&src, &lit.node) {
+                        lint_unnecessary_cast(cx, expr, num_lit.integer, cast_from, cast_to);
+                    }
                 }
             },
             _ => {


### PR DESCRIPTION
This very likely fixes #8166 though I wasn't able to meaningfully reduce a test case. This line is the only call to `unwrap` within that function, which was the one in the stack trace that triggered the ICE, so I think we'll be OK.

@hackmad can you pull and build this branch and check if it indeed fixes your problem?
 
---

changelog: Fixed ICE in [`unnecessary_cast`]