### PR TITLE
Fixed issues with to_radians and to_degrees lints

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -654,26 +654,52 @@ fn check_radians(cx: &LateContext<'_>, expr: &Expr<'_>) {
             if (F32(f32_consts::PI) == rvalue || F64(f64_consts::PI) == rvalue) &&
                (F32(180_f32) == lvalue || F64(180_f64) == lvalue)
             {
+                let mut proposal = format!("{}.to_degrees()", Sugg::hir(cx, mul_lhs, ".."));
+                if_chain! {
+                    if let ExprKind::Lit(ref literal) = mul_lhs.kind;
+                    if let ast::LitKind::Float(ref value, float_type) = literal.node;
+                    if float_type == ast::LitFloatType::Unsuffixed;
+                    then {
+                        if value.as_str().ends_with('.') {
+                            proposal = format!("{}0_f64.to_degrees()", Sugg::hir(cx, mul_lhs, ".."));
+                        } else {
+                            proposal = format!("{}_f64.to_degrees()", Sugg::hir(cx, mul_lhs, ".."));
+                        }
+                    }
+                }
                 span_lint_and_sugg(
                     cx,
                     SUBOPTIMAL_FLOPS,
                     expr.span,
                     "conversion to degrees can be done more accurately",
                     "consider using",
-                    format!("{}.to_degrees()", Sugg::hir(cx, mul_lhs, "..")),
+                    proposal,
                     Applicability::MachineApplicable,
                 );
             } else if
                 (F32(180_f32) == rvalue || F64(180_f64) == rvalue) &&
                 (F32(f32_consts::PI) == lvalue || F64(f64_consts::PI) == lvalue)
             {
+                let mut proposal = format!("{}.to_radians()", Sugg::hir(cx, mul_lhs, ".."));
+                if_chain! {
+                    if let ExprKind::Lit(ref literal) = mul_lhs.kind;
+                    if let ast::LitKind::Float(ref value, float_type) = literal.node;
+                    if float_type == ast::LitFloatType::Unsuffixed;
+                    then {
+                        if value.as_str().ends_with('.') {
+                            proposal = format!("{}0_f64.to_radians()", Sugg::hir(cx, mul_lhs, ".."));
+                        } else {
+                            proposal = format!("{}_f64.to_radians()", Sugg::hir(cx, mul_lhs, ".."));
+                        }
+                    }
+                }
                 span_lint_and_sugg(
                     cx,
                     SUBOPTIMAL_FLOPS,
                     expr.span,
                     "conversion to radians can be done more accurately",
                     "consider using",
-                    format!("{}.to_radians()", Sugg::hir(cx, mul_lhs, "..")),
+                    proposal,
                     Applicability::MachineApplicable,
                 );
             }

--- a/tests/ui/floating_point_rad.fixed
+++ b/tests/ui/floating_point_rad.fixed
@@ -11,7 +11,12 @@ pub const fn const_context() {
 fn main() {
     let x = 3f32;
     let _ = x.to_degrees();
+    let _ = 90.0_f64.to_degrees();
+    let _ = 90.5_f64.to_degrees();
     let _ = x.to_radians();
+    let _ = 90.0_f64.to_radians();
+    let _ = 90.5_f64.to_radians();
+    // let _ = 90.5 * 80. * std::f32::consts::PI / 180f32;
     // Cases where the lint shouldn't be applied
     let _ = x * 90f32 / std::f32::consts::PI;
     let _ = x * std::f32::consts::PI / 90f32;

--- a/tests/ui/floating_point_rad.rs
+++ b/tests/ui/floating_point_rad.rs
@@ -11,7 +11,12 @@ pub const fn const_context() {
 fn main() {
     let x = 3f32;
     let _ = x * 180f32 / std::f32::consts::PI;
+    let _ = 90. * 180f64 / std::f64::consts::PI;
+    let _ = 90.5 * 180f64 / std::f64::consts::PI;
     let _ = x * std::f32::consts::PI / 180f32;
+    let _ = 90. * std::f32::consts::PI / 180f32;
+    let _ = 90.5 * std::f32::consts::PI / 180f32;
+    // let _ = 90.5 * 80. * std::f32::consts::PI / 180f32;
     // Cases where the lint shouldn't be applied
     let _ = x * 90f32 / std::f32::consts::PI;
     let _ = x * std::f32::consts::PI / 90f32;

--- a/tests/ui/floating_point_rad.stderr
+++ b/tests/ui/floating_point_rad.stderr
@@ -6,11 +6,35 @@ LL |     let _ = x * 180f32 / std::f32::consts::PI;
    |
    = note: `-D clippy::suboptimal-flops` implied by `-D warnings`
 
-error: conversion to radians can be done more accurately
+error: conversion to degrees can be done more accurately
   --> $DIR/floating_point_rad.rs:14:13
+   |
+LL |     let _ = 90. * 180f64 / std::f64::consts::PI;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `90.0_f64.to_degrees()`
+
+error: conversion to degrees can be done more accurately
+  --> $DIR/floating_point_rad.rs:15:13
+   |
+LL |     let _ = 90.5 * 180f64 / std::f64::consts::PI;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `90.5_f64.to_degrees()`
+
+error: conversion to radians can be done more accurately
+  --> $DIR/floating_point_rad.rs:16:13
    |
 LL |     let _ = x * std::f32::consts::PI / 180f32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `x.to_radians()`
 
-error: aborting due to 2 previous errors
+error: conversion to radians can be done more accurately
+  --> $DIR/floating_point_rad.rs:17:13
+   |
+LL |     let _ = 90. * std::f32::consts::PI / 180f32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `90.0_f64.to_radians()`
+
+error: conversion to radians can be done more accurately
+  --> $DIR/floating_point_rad.rs:18:13
+   |
+LL |     let _ = 90.5 * std::f32::consts::PI / 180f32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `90.5_f64.to_radians()`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes #7651 

I fixed the original problem as described in the issue, but the bug remains for complex expressions (the commented out TC I added is an example). I would also love some feedback on how to cleanup my code and reduce duplication. I hope it's not a problem that the issue has been claimed by someone else - that was over two months ago.

changelog: ``[`suboptimal_flops`]`` no longer proposes broken code with `to_radians` and `to_degrees`

