### PR TITLE
fix [`redundant_closure`] fp with `Rc<F>`/`Arc<F>`

### DIFF
--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -248,3 +248,14 @@ mod type_param_bound {
         take(X::fun as fn());
     }
 }
+
+// #8073 Don't replace closure with `Arc<F>` or `Rc<F>`
+fn arc_fp() {
+    let rc = std::rc::Rc::new(|| 7);
+    let arc = std::sync::Arc::new(|n| n + 1);
+    let ref_arc = &std::sync::Arc::new(|_| 5);
+
+    true.then(|| rc());
+    (0..5).map(|n| arc(n));
+    Some(4).map(|n| ref_arc(n));
+}

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -248,3 +248,14 @@ mod type_param_bound {
         take(X::fun as fn());
     }
 }
+
+// #8073 Don't replace closure with `Arc<F>` or `Rc<F>`
+fn arc_fp() {
+    let rc = std::rc::Rc::new(|| 7);
+    let arc = std::sync::Arc::new(|n| n + 1);
+    let ref_arc = &std::sync::Arc::new(|_| 5);
+
+    true.then(|| rc());
+    (0..5).map(|n| arc(n));
+    Some(4).map(|n| ref_arc(n));
+}


### PR DESCRIPTION
fixes #8073 

changelog: don't trigger [`redundant_closure`] on `Arc<F>` or `Rc<F>`