### PR TITLE
add help message for ``[`double_neg`]``

### DIFF
--- a/clippy_lints/src/misc_early/double_neg.rs
+++ b/clippy_lints/src/misc_early/double_neg.rs
@@ -15,7 +15,7 @@ pub(super) fn check(cx: &EarlyContext<'_>, expr: &Expr) {
                 as in C/C++. Rust does not have unary increment (++) or decrement (--) operators \
                 at the moment",
                 None,
-                "consider using `x -= 1` if you intended to decrease the value of `x`"
+                "consider using `x -= 1` if you intended to decrease the value of `x`",
             );
         }
     }

--- a/clippy_lints/src/misc_early/double_neg.rs
+++ b/clippy_lints/src/misc_early/double_neg.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint;
+use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_ast::ast::{Expr, ExprKind, UnOp};
 use rustc_lint::EarlyContext;
 
@@ -7,11 +7,15 @@ use super::DOUBLE_NEG;
 pub(super) fn check(cx: &EarlyContext<'_>, expr: &Expr) {
     if let ExprKind::Unary(UnOp::Neg, ref inner) = expr.kind {
         if let ExprKind::Unary(UnOp::Neg, _) = inner.kind {
-            span_lint(
+            span_lint_and_help(
                 cx,
                 DOUBLE_NEG,
                 expr.span,
-                "`--x` could be misinterpreted as pre-decrement by C programmers, is usually a no-op",
+                "`--x`, which is a double negation of `x` and not a pre-decrement operator \
+                as in C/C++. Rust does not have unary increment (++) or decrement (--) operators \
+                at the moment",
+                None,
+                "consider using `x -= 1` if you intended to decrease the value of `x`"
             );
         }
     }

--- a/tests/ui/double_neg.stderr
+++ b/tests/ui/double_neg.stderr
@@ -5,7 +5,7 @@ LL |     --x;
    |     ^^^
    |
    = note: `-D clippy::double-neg` implied by `-D warnings`
-   = help: consider using `x -= 1` if you intended to decrease the value of `x`
+   = help: consider using `x -= 1` if you intend to decrease the value of `x`
 
 error: aborting due to previous error
 

--- a/tests/ui/double_neg.stderr
+++ b/tests/ui/double_neg.stderr
@@ -1,10 +1,11 @@
-error: `--x` could be misinterpreted as pre-decrement by C programmers, is usually a no-op
+error: `--x`, which is a double negation of `x` and not a pre-decrement operator as in C/C++. Rust does not have unary increment (++) or decrement (--) operators at the moment
   --> $DIR/double_neg.rs:7:5
    |
 LL |     --x;
    |     ^^^
    |
    = note: `-D clippy::double-neg` implied by `-D warnings`
+   = help: consider using `x -= 1` if you intended to decrease the value of `x`
 
 error: aborting due to previous error
 


### PR DESCRIPTION


---

changelog:
update lint message and add an additional help message for ``[`double_neg`]`` to make it appears more beginner friendly.