### PR TITLE
Fix `clippy::use-self`` warning in ` src/main.rs`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ impl ClippyCmd {
             clippy_args.push("--no-deps".into());
         }
 
-        ClippyCmd {
+        Self {
             cargo_subcommand,
             args,
             clippy_args,


### PR DESCRIPTION
`ClippyCmd` warnings gets generated due to addition of `clippy::use-self`. This PR fixes that.

```
warning: unnecessary structure name repetition
  --> src/main.rs:99:9
   |
99 |         ClippyCmd {
   |         ^^^^^^^^^ help: use the applicable keyword: `Self`
   |
   = note: `-W clippy::use-self` implied by `-W clippy::nursery`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self
```

---

changelog: none