### PR TITLE
Improve `redundant_slicing` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3105,6 +3105,7 @@ Released 2018-09-13
 [`deprecated_cfg_attr`]: https://rust-lang.github.io/rust-clippy/master/index.html#deprecated_cfg_attr
 [`deprecated_semver`]: https://rust-lang.github.io/rust-clippy/master/index.html#deprecated_semver
 [`deref_addrof`]: https://rust-lang.github.io/rust-clippy/master/index.html#deref_addrof
+[`deref_by_slicing`]: https://rust-lang.github.io/rust-clippy/master/index.html#deref_by_slicing
 [`derivable_impls`]: https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls
 [`derive_hash_xor_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq
 [`derive_ord_xor_partial_ord`]: https://rust-lang.github.io/rust-clippy/master/index.html#derive_ord_xor_partial_ord

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -420,6 +420,7 @@ store.register_lints(&[
     redundant_else::REDUNDANT_ELSE,
     redundant_field_names::REDUNDANT_FIELD_NAMES,
     redundant_pub_crate::REDUNDANT_PUB_CRATE,
+    redundant_slicing::DEREF_BY_SLICING,
     redundant_slicing::REDUNDANT_SLICING,
     redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES,
     ref_option_ref::REF_OPTION_REF,

--- a/clippy_lints/src/lib.register_restriction.rs
+++ b/clippy_lints/src/lib.register_restriction.rs
@@ -51,6 +51,7 @@ store.register_group(true, "clippy::restriction", Some("clippy_restriction"), ve
     LintId::of(panic_unimplemented::UNIMPLEMENTED),
     LintId::of(panic_unimplemented::UNREACHABLE),
     LintId::of(pattern_type_mismatch::PATTERN_TYPE_MISMATCH),
+    LintId::of(redundant_slicing::DEREF_BY_SLICING),
     LintId::of(same_name_method::SAME_NAME_METHOD),
     LintId::of(shadow::SHADOW_REUSE),
     LintId::of(shadow::SHADOW_SAME),

--- a/clippy_lints/src/redundant_slicing.rs
+++ b/clippy_lints/src/redundant_slicing.rs
@@ -1,11 +1,12 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::get_parent_expr;
 use clippy_utils::source::snippet_with_context;
-use clippy_utils::ty::is_type_lang_item;
+use clippy_utils::ty::{is_type_lang_item, peel_mid_ty_refs};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::{BorrowKind, Expr, ExprKind, LangItem, Mutability};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::subst::GenericArg;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
@@ -53,25 +54,55 @@ impl<'tcx> LateLintPass<'tcx> for RedundantSlicing {
             if addressee.span.ctxt() == ctxt;
             if let ExprKind::Index(indexed, range) = addressee.kind;
             if is_type_lang_item(cx, cx.typeck_results().expr_ty_adjusted(range), LangItem::RangeFull);
-            if cx.typeck_results().expr_ty(expr) == cx.typeck_results().expr_ty(indexed);
             then {
+                let (expr_ty, expr_ref_count) = peel_mid_ty_refs(cx.typeck_results().expr_ty(expr));
+                let (indexed_ty, indexed_ref_count) = peel_mid_ty_refs(cx.typeck_results().expr_ty(indexed));
                 let mut app = Applicability::MachineApplicable;
-                let snip = snippet_with_context(cx, indexed.span, ctxt, "..", &mut app).0;
 
-                let (reborrow_str, help_str) = if mutability == Mutability::Mut {
-                    // The slice was used to reborrow the mutable reference.
-                    ("&mut *", "reborrow the original value instead")
-                } else if matches!(
-                    get_parent_expr(cx, expr),
-                    Some(Expr {
-                        kind: ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, _),
-                        ..
-                    })
-                ) {
-                    // The slice was used to make a temporary reference.
-                    ("&*", "reborrow the original value instead")
+                let (help, sugg) = if expr_ty == indexed_ty {
+                    if expr_ref_count > indexed_ref_count {
+                        return;
+                    }
+
+                    let (reborrow_str, help_str) = if mutability == Mutability::Mut {
+                        // The slice was used to reborrow the mutable reference.
+                        ("&mut *", "reborrow the original value instead")
+                    } else if matches!(
+                        get_parent_expr(cx, expr),
+                        Some(Expr {
+                            kind: ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, _),
+                            ..
+                        })
+                    ) {
+                        // The slice was used to make a temporary reference.
+                        ("&*", "reborrow the original value instead")
+                    } else if expr_ref_count != indexed_ref_count {
+                        ("", "dereference the original value instead")
+                    } else {
+                        ("", "use the original value instead")
+                    };
+
+                    let snip = snippet_with_context(cx, indexed.span, ctxt, "..", &mut app).0;
+                    (help_str, format!("{}{}{}", reborrow_str, "*".repeat(indexed_ref_count - expr_ref_count), snip))
+                } else if let Some(target_id) = cx.tcx.lang_items().deref_target() {
+                    if let Ok(deref_ty) = cx.tcx.try_normalize_erasing_regions(
+                        cx.param_env,
+                        cx.tcx.mk_projection(target_id, cx.tcx.mk_substs([GenericArg::from(indexed_ty)].into_iter())),
+                    ) {
+                        if deref_ty == expr_ty {
+                            let snip = snippet_with_context(cx, indexed.span, ctxt, "..", &mut app).0;
+                            (
+                                "dereference the original value instead",
+                                format!("&{}{}*{}", mutability.prefix_str(), "*".repeat(indexed_ref_count), snip),
+                            )
+                        } else {
+                            return;
+                        }
+                    } else {
+                        return;
+                    }
                 } else {
-                    ("", "use the original value instead")
+                    return;
                 };
 
                 span_lint_and_sugg(
@@ -79,8 +110,8 @@ impl<'tcx> LateLintPass<'tcx> for RedundantSlicing {
                     REDUNDANT_SLICING,
                     expr.span,
                     "redundant slicing of the whole range",
-                    help_str,
-                    format!("{}{}", reborrow_str, snip),
+                    help,
+                    sugg,
                     app,
                 );
             }

--- a/tests/ui/deref_by_slicing.fixed
+++ b/tests/ui/deref_by_slicing.fixed
@@ -1,0 +1,16 @@
+// run-rustfix
+
+#![warn(clippy::deref_by_slicing)]
+
+fn main() {
+    let mut vec = vec![0];
+    let _ = &*vec;
+    let _ = &mut *vec;
+
+    let ref_vec = &mut vec;
+    let _ = &**ref_vec;
+    let _ = &mut **ref_vec;
+
+    let s = String::new();
+    let _ = &*s;
+}

--- a/tests/ui/deref_by_slicing.fixed
+++ b/tests/ui/deref_by_slicing.fixed
@@ -2,6 +2,8 @@
 
 #![warn(clippy::deref_by_slicing)]
 
+use std::io::Read;
+
 fn main() {
     let mut vec = vec![0];
     let _ = &*vec;
@@ -9,8 +11,19 @@ fn main() {
 
     let ref_vec = &mut vec;
     let _ = &**ref_vec;
-    let _ = &mut **ref_vec;
+    let mut_slice = &mut **ref_vec;
+    let _ = &mut *mut_slice; // Err, re-borrows slice
 
     let s = String::new();
     let _ = &*s;
+
+    static S: &[u8] = &[0, 1, 2];
+    let _ = &mut &*S; // Err, re-borrows slice
+
+    let slice: &[u32] = &[0u32, 1u32];
+    let slice_ref = &slice;
+    let _ = *slice_ref; // Err, derefs slice
+
+    let bytes: &[u8] = &[];
+    let _ = (&*bytes).read_to_end(&mut vec![]).unwrap(); // Err, re-borrows slice
 }

--- a/tests/ui/deref_by_slicing.rs
+++ b/tests/ui/deref_by_slicing.rs
@@ -1,0 +1,16 @@
+// run-rustfix
+
+#![warn(clippy::deref_by_slicing)]
+
+fn main() {
+    let mut vec = vec![0];
+    let _ = &vec[..];
+    let _ = &mut vec[..];
+
+    let ref_vec = &mut vec;
+    let _ = &ref_vec[..];
+    let _ = &mut ref_vec[..];
+
+    let s = String::new();
+    let _ = &s[..];
+}

--- a/tests/ui/deref_by_slicing.rs
+++ b/tests/ui/deref_by_slicing.rs
@@ -2,6 +2,8 @@
 
 #![warn(clippy::deref_by_slicing)]
 
+use std::io::Read;
+
 fn main() {
     let mut vec = vec![0];
     let _ = &vec[..];
@@ -9,8 +11,19 @@ fn main() {
 
     let ref_vec = &mut vec;
     let _ = &ref_vec[..];
-    let _ = &mut ref_vec[..];
+    let mut_slice = &mut ref_vec[..];
+    let _ = &mut mut_slice[..]; // Err, re-borrows slice
 
     let s = String::new();
     let _ = &s[..];
+
+    static S: &[u8] = &[0, 1, 2];
+    let _ = &mut &S[..]; // Err, re-borrows slice
+
+    let slice: &[u32] = &[0u32, 1u32];
+    let slice_ref = &slice;
+    let _ = &slice_ref[..]; // Err, derefs slice
+
+    let bytes: &[u8] = &[];
+    let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap(); // Err, re-borrows slice
 }

--- a/tests/ui/deref_by_slicing.stderr
+++ b/tests/ui/deref_by_slicing.stderr
@@ -1,0 +1,34 @@
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:7:13
+   |
+LL |     let _ = &vec[..];
+   |             ^^^^^^^^ help: dereference the original value instead: `&*vec`
+   |
+   = note: `-D clippy::deref-by-slicing` implied by `-D warnings`
+
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:8:13
+   |
+LL |     let _ = &mut vec[..];
+   |             ^^^^^^^^^^^^ help: dereference the original value instead: `&mut *vec`
+
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:11:13
+   |
+LL |     let _ = &ref_vec[..];
+   |             ^^^^^^^^^^^^ help: dereference the original value instead: `&**ref_vec`
+
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:12:13
+   |
+LL |     let _ = &mut ref_vec[..];
+   |             ^^^^^^^^^^^^^^^^ help: dereference the original value instead: `&mut **ref_vec`
+
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:15:13
+   |
+LL |     let _ = &s[..];
+   |             ^^^^^^ help: dereference the original value instead: `&*s`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/deref_by_slicing.stderr
+++ b/tests/ui/deref_by_slicing.stderr
@@ -1,5 +1,5 @@
 error: slicing when dereferencing would work
-  --> $DIR/deref_by_slicing.rs:7:13
+  --> $DIR/deref_by_slicing.rs:9:13
    |
 LL |     let _ = &vec[..];
    |             ^^^^^^^^ help: dereference the original value instead: `&*vec`
@@ -7,28 +7,52 @@ LL |     let _ = &vec[..];
    = note: `-D clippy::deref-by-slicing` implied by `-D warnings`
 
 error: slicing when dereferencing would work
-  --> $DIR/deref_by_slicing.rs:8:13
+  --> $DIR/deref_by_slicing.rs:10:13
    |
 LL |     let _ = &mut vec[..];
    |             ^^^^^^^^^^^^ help: dereference the original value instead: `&mut *vec`
 
 error: slicing when dereferencing would work
-  --> $DIR/deref_by_slicing.rs:11:13
+  --> $DIR/deref_by_slicing.rs:13:13
    |
 LL |     let _ = &ref_vec[..];
    |             ^^^^^^^^^^^^ help: dereference the original value instead: `&**ref_vec`
 
 error: slicing when dereferencing would work
-  --> $DIR/deref_by_slicing.rs:12:13
+  --> $DIR/deref_by_slicing.rs:14:21
    |
-LL |     let _ = &mut ref_vec[..];
-   |             ^^^^^^^^^^^^^^^^ help: dereference the original value instead: `&mut **ref_vec`
+LL |     let mut_slice = &mut ref_vec[..];
+   |                     ^^^^^^^^^^^^^^^^ help: dereference the original value instead: `&mut **ref_vec`
 
 error: slicing when dereferencing would work
   --> $DIR/deref_by_slicing.rs:15:13
    |
+LL |     let _ = &mut mut_slice[..]; // Err, re-borrows slice
+   |             ^^^^^^^^^^^^^^^^^^ help: reborrow the original value instead: `&mut *mut_slice`
+
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:18:13
+   |
 LL |     let _ = &s[..];
    |             ^^^^^^ help: dereference the original value instead: `&*s`
 
-error: aborting due to 5 previous errors
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:21:18
+   |
+LL |     let _ = &mut &S[..]; // Err, re-borrows slice
+   |                  ^^^^^^ help: reborrow the original value instead: `&*S`
+
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:25:13
+   |
+LL |     let _ = &slice_ref[..]; // Err, derefs slice
+   |             ^^^^^^^^^^^^^^ help: dereference the original value instead: `*slice_ref`
+
+error: slicing when dereferencing would work
+  --> $DIR/deref_by_slicing.rs:28:13
+   |
+LL |     let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap(); // Err, re-borrows slice
+   |             ^^^^^^^^^^^^ help: reborrow the original value instead: `(&*bytes)`
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/redundant_slicing.fixed
+++ b/tests/ui/redundant_slicing.fixed
@@ -3,6 +3,8 @@
 #![allow(unused)]
 #![warn(clippy::redundant_slicing)]
 
+use std::io::Read;
+
 fn main() {
     let slice: &[u32] = &[0];
     let _ = slice; // Redundant slice
@@ -37,4 +39,8 @@ fn main() {
 
     let slice_ref = &slice;
     let _ = *slice_ref; // Deref instead of slice
+
+    // Issue #7972
+    let bytes: &[u8] = &[];
+    let _ = (&*bytes).read_to_end(&mut vec![]).unwrap();
 }

--- a/tests/ui/redundant_slicing.fixed
+++ b/tests/ui/redundant_slicing.fixed
@@ -14,11 +14,11 @@ fn main() {
     let _ = (&*v); // Outer borrow is redundant
 
     static S: &[u8] = &[0, 1, 2];
-    let err = &mut &*S; // Should reborrow instead of slice
+    let _ = &mut &S[..]; // Ok, re-borrows slice
 
     let mut vec = vec![0];
     let mut_slice = &mut vec[..]; // Ok, results in `&mut [_]`
-    let _ = &mut *mut_slice; // Should reborrow instead of slice
+    let _ = &mut mut_slice[..]; // Ok, re-borrows slice
 
     let ref_vec = &vec;
     let _ = &ref_vec[..]; // Ok, results in `&[_]`
@@ -38,9 +38,9 @@ fn main() {
     let _ = m2!(slice); // Don't lint in a macro
 
     let slice_ref = &slice;
-    let _ = *slice_ref; // Deref instead of slice
+    let _ = &slice_ref[..]; // Ok, derefs slice
 
     // Issue #7972
     let bytes: &[u8] = &[];
-    let _ = (&*bytes).read_to_end(&mut vec![]).unwrap();
+    let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap(); // Ok, re-borrows slice
 }

--- a/tests/ui/redundant_slicing.fixed
+++ b/tests/ui/redundant_slicing.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![allow(unused)]
+#![allow(unused, clippy::deref_by_slicing)]
 #![warn(clippy::redundant_slicing)]
 
 use std::io::Read;
@@ -10,18 +10,18 @@ fn main() {
     let _ = slice; // Redundant slice
 
     let v = vec![0];
-    let _ = &*v; // Deref instead of slice
+    let _ = &v[..]; // Ok, results in `&[_]`
     let _ = (&*v); // Outer borrow is redundant
 
     static S: &[u8] = &[0, 1, 2];
     let err = &mut &*S; // Should reborrow instead of slice
 
     let mut vec = vec![0];
-    let mut_slice = &mut *vec; // Deref instead of slice
+    let mut_slice = &mut vec[..]; // Ok, results in `&mut [_]`
     let _ = &mut *mut_slice; // Should reborrow instead of slice
 
     let ref_vec = &vec;
-    let _ = &**ref_vec; // Deref instead of slice
+    let _ = &ref_vec[..]; // Ok, results in `&[_]`
 
     macro_rules! m {
         ($e:expr) => {

--- a/tests/ui/redundant_slicing.fixed
+++ b/tests/ui/redundant_slicing.fixed
@@ -1,0 +1,40 @@
+// run-rustfix
+
+#![allow(unused)]
+#![warn(clippy::redundant_slicing)]
+
+fn main() {
+    let slice: &[u32] = &[0];
+    let _ = slice; // Redundant slice
+
+    let v = vec![0];
+    let _ = &*v; // Deref instead of slice
+    let _ = (&*v); // Outer borrow is redundant
+
+    static S: &[u8] = &[0, 1, 2];
+    let err = &mut &*S; // Should reborrow instead of slice
+
+    let mut vec = vec![0];
+    let mut_slice = &mut *vec; // Deref instead of slice
+    let _ = &mut *mut_slice; // Should reborrow instead of slice
+
+    let ref_vec = &vec;
+    let _ = &**ref_vec; // Deref instead of slice
+
+    macro_rules! m {
+        ($e:expr) => {
+            $e
+        };
+    }
+    let _ = slice;
+
+    macro_rules! m2 {
+        ($e:expr) => {
+            &$e[..]
+        };
+    }
+    let _ = m2!(slice); // Don't lint in a macro
+
+    let slice_ref = &slice;
+    let _ = *slice_ref; // Deref instead of slice
+}

--- a/tests/ui/redundant_slicing.rs
+++ b/tests/ui/redundant_slicing.rs
@@ -3,6 +3,8 @@
 #![allow(unused)]
 #![warn(clippy::redundant_slicing)]
 
+use std::io::Read;
+
 fn main() {
     let slice: &[u32] = &[0];
     let _ = &slice[..]; // Redundant slice
@@ -37,4 +39,8 @@ fn main() {
 
     let slice_ref = &slice;
     let _ = &slice_ref[..]; // Deref instead of slice
+
+    // Issue #7972
+    let bytes: &[u8] = &[];
+    let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap();
 }

--- a/tests/ui/redundant_slicing.rs
+++ b/tests/ui/redundant_slicing.rs
@@ -1,20 +1,25 @@
+// run-rustfix
+
 #![allow(unused)]
 #![warn(clippy::redundant_slicing)]
 
 fn main() {
     let slice: &[u32] = &[0];
-    let _ = &slice[..];
+    let _ = &slice[..]; // Redundant slice
 
     let v = vec![0];
-    let _ = &v[..]; // Changes the type
-    let _ = &(&v[..])[..]; // Outer borrow is redundant
+    let _ = &v[..]; // Deref instead of slice
+    let _ = &(&*v)[..]; // Outer borrow is redundant
 
     static S: &[u8] = &[0, 1, 2];
     let err = &mut &S[..]; // Should reborrow instead of slice
 
     let mut vec = vec![0];
-    let mut_slice = &mut *vec;
+    let mut_slice = &mut vec[..]; // Deref instead of slice
     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
+
+    let ref_vec = &vec;
+    let _ = &ref_vec[..]; // Deref instead of slice
 
     macro_rules! m {
         ($e:expr) => {
@@ -29,4 +34,7 @@ fn main() {
         };
     }
     let _ = m2!(slice); // Don't lint in a macro
+
+    let slice_ref = &slice;
+    let _ = &slice_ref[..]; // Deref instead of slice
 }

--- a/tests/ui/redundant_slicing.rs
+++ b/tests/ui/redundant_slicing.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![allow(unused)]
+#![allow(unused, clippy::deref_by_slicing)]
 #![warn(clippy::redundant_slicing)]
 
 use std::io::Read;
@@ -10,18 +10,18 @@ fn main() {
     let _ = &slice[..]; // Redundant slice
 
     let v = vec![0];
-    let _ = &v[..]; // Deref instead of slice
+    let _ = &v[..]; // Ok, results in `&[_]`
     let _ = &(&*v)[..]; // Outer borrow is redundant
 
     static S: &[u8] = &[0, 1, 2];
     let err = &mut &S[..]; // Should reborrow instead of slice
 
     let mut vec = vec![0];
-    let mut_slice = &mut vec[..]; // Deref instead of slice
+    let mut_slice = &mut vec[..]; // Ok, results in `&mut [_]`
     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
 
     let ref_vec = &vec;
-    let _ = &ref_vec[..]; // Deref instead of slice
+    let _ = &ref_vec[..]; // Ok, results in `&[_]`
 
     macro_rules! m {
         ($e:expr) => {

--- a/tests/ui/redundant_slicing.rs
+++ b/tests/ui/redundant_slicing.rs
@@ -14,11 +14,11 @@ fn main() {
     let _ = &(&*v)[..]; // Outer borrow is redundant
 
     static S: &[u8] = &[0, 1, 2];
-    let err = &mut &S[..]; // Should reborrow instead of slice
+    let _ = &mut &S[..]; // Ok, re-borrows slice
 
     let mut vec = vec![0];
     let mut_slice = &mut vec[..]; // Ok, results in `&mut [_]`
-    let _ = &mut mut_slice[..]; // Should reborrow instead of slice
+    let _ = &mut mut_slice[..]; // Ok, re-borrows slice
 
     let ref_vec = &vec;
     let _ = &ref_vec[..]; // Ok, results in `&[_]`
@@ -38,9 +38,9 @@ fn main() {
     let _ = m2!(slice); // Don't lint in a macro
 
     let slice_ref = &slice;
-    let _ = &slice_ref[..]; // Deref instead of slice
+    let _ = &slice_ref[..]; // Ok, derefs slice
 
     // Issue #7972
     let bytes: &[u8] = &[];
-    let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap();
+    let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap(); // Ok, re-borrows slice
 }

--- a/tests/ui/redundant_slicing.stderr
+++ b/tests/ui/redundant_slicing.stderr
@@ -1,5 +1,5 @@
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:8:13
+  --> $DIR/redundant_slicing.rs:10:13
    |
 LL |     let _ = &slice[..]; // Redundant slice
    |             ^^^^^^^^^^ help: use the original value instead: `slice`
@@ -7,52 +7,58 @@ LL |     let _ = &slice[..]; // Redundant slice
    = note: `-D clippy::redundant-slicing` implied by `-D warnings`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:11:13
+  --> $DIR/redundant_slicing.rs:13:13
    |
 LL |     let _ = &v[..]; // Deref instead of slice
    |             ^^^^^^ help: dereference the original value instead: `&*v`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:12:13
+  --> $DIR/redundant_slicing.rs:14:13
    |
 LL |     let _ = &(&*v)[..]; // Outer borrow is redundant
    |             ^^^^^^^^^^ help: use the original value instead: `(&*v)`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:15:20
+  --> $DIR/redundant_slicing.rs:17:20
    |
 LL |     let err = &mut &S[..]; // Should reborrow instead of slice
    |                    ^^^^^^ help: reborrow the original value instead: `&*S`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:18:21
+  --> $DIR/redundant_slicing.rs:20:21
    |
 LL |     let mut_slice = &mut vec[..]; // Deref instead of slice
    |                     ^^^^^^^^^^^^ help: dereference the original value instead: `&mut *vec`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:19:13
+  --> $DIR/redundant_slicing.rs:21:13
    |
 LL |     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
    |             ^^^^^^^^^^^^^^^^^^ help: reborrow the original value instead: `&mut *mut_slice`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:22:13
+  --> $DIR/redundant_slicing.rs:24:13
    |
 LL |     let _ = &ref_vec[..]; // Deref instead of slice
    |             ^^^^^^^^^^^^ help: dereference the original value instead: `&**ref_vec`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:29:13
+  --> $DIR/redundant_slicing.rs:31:13
    |
 LL |     let _ = &m!(slice)[..];
    |             ^^^^^^^^^^^^^^ help: use the original value instead: `slice`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:39:13
+  --> $DIR/redundant_slicing.rs:41:13
    |
 LL |     let _ = &slice_ref[..]; // Deref instead of slice
    |             ^^^^^^^^^^^^^^ help: dereference the original value instead: `*slice_ref`
 
-error: aborting due to 9 previous errors
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:45:13
+   |
+LL |     let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap();
+   |             ^^^^^^^^^^^^ help: reborrow the original value instead: `(&*bytes)`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/redundant_slicing.stderr
+++ b/tests/ui/redundant_slicing.stderr
@@ -1,34 +1,58 @@
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:6:13
+  --> $DIR/redundant_slicing.rs:8:13
    |
-LL |     let _ = &slice[..];
+LL |     let _ = &slice[..]; // Redundant slice
    |             ^^^^^^^^^^ help: use the original value instead: `slice`
    |
    = note: `-D clippy::redundant-slicing` implied by `-D warnings`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:10:13
+  --> $DIR/redundant_slicing.rs:11:13
    |
-LL |     let _ = &(&v[..])[..]; // Outer borrow is redundant
-   |             ^^^^^^^^^^^^^ help: use the original value instead: `(&v[..])`
+LL |     let _ = &v[..]; // Deref instead of slice
+   |             ^^^^^^ help: dereference the original value instead: `&*v`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:13:20
+  --> $DIR/redundant_slicing.rs:12:13
+   |
+LL |     let _ = &(&*v)[..]; // Outer borrow is redundant
+   |             ^^^^^^^^^^ help: use the original value instead: `(&*v)`
+
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:15:20
    |
 LL |     let err = &mut &S[..]; // Should reborrow instead of slice
    |                    ^^^^^^ help: reborrow the original value instead: `&*S`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:17:13
+  --> $DIR/redundant_slicing.rs:18:21
+   |
+LL |     let mut_slice = &mut vec[..]; // Deref instead of slice
+   |                     ^^^^^^^^^^^^ help: dereference the original value instead: `&mut *vec`
+
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:19:13
    |
 LL |     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
    |             ^^^^^^^^^^^^^^^^^^ help: reborrow the original value instead: `&mut *mut_slice`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:24:13
+  --> $DIR/redundant_slicing.rs:22:13
+   |
+LL |     let _ = &ref_vec[..]; // Deref instead of slice
+   |             ^^^^^^^^^^^^ help: dereference the original value instead: `&**ref_vec`
+
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:29:13
    |
 LL |     let _ = &m!(slice)[..];
    |             ^^^^^^^^^^^^^^ help: use the original value instead: `slice`
 
-error: aborting due to 5 previous errors
+error: redundant slicing of the whole range
+  --> $DIR/redundant_slicing.rs:39:13
+   |
+LL |     let _ = &slice_ref[..]; // Deref instead of slice
+   |             ^^^^^^^^^^^^^^ help: dereference the original value instead: `*slice_ref`
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/redundant_slicing.stderr
+++ b/tests/ui/redundant_slicing.stderr
@@ -13,34 +13,10 @@ LL |     let _ = &(&*v)[..]; // Outer borrow is redundant
    |             ^^^^^^^^^^ help: use the original value instead: `(&*v)`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:17:20
-   |
-LL |     let err = &mut &S[..]; // Should reborrow instead of slice
-   |                    ^^^^^^ help: reborrow the original value instead: `&*S`
-
-error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:21:13
-   |
-LL |     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
-   |             ^^^^^^^^^^^^^^^^^^ help: reborrow the original value instead: `&mut *mut_slice`
-
-error: redundant slicing of the whole range
   --> $DIR/redundant_slicing.rs:31:13
    |
 LL |     let _ = &m!(slice)[..];
    |             ^^^^^^^^^^^^^^ help: use the original value instead: `slice`
 
-error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:41:13
-   |
-LL |     let _ = &slice_ref[..]; // Deref instead of slice
-   |             ^^^^^^^^^^^^^^ help: dereference the original value instead: `*slice_ref`
-
-error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:45:13
-   |
-LL |     let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap();
-   |             ^^^^^^^^^^^^ help: reborrow the original value instead: `(&*bytes)`
-
-error: aborting due to 7 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/redundant_slicing.stderr
+++ b/tests/ui/redundant_slicing.stderr
@@ -7,12 +7,6 @@ LL |     let _ = &slice[..]; // Redundant slice
    = note: `-D clippy::redundant-slicing` implied by `-D warnings`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:13:13
-   |
-LL |     let _ = &v[..]; // Deref instead of slice
-   |             ^^^^^^ help: dereference the original value instead: `&*v`
-
-error: redundant slicing of the whole range
   --> $DIR/redundant_slicing.rs:14:13
    |
 LL |     let _ = &(&*v)[..]; // Outer borrow is redundant
@@ -25,22 +19,10 @@ LL |     let err = &mut &S[..]; // Should reborrow instead of slice
    |                    ^^^^^^ help: reborrow the original value instead: `&*S`
 
 error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:20:21
-   |
-LL |     let mut_slice = &mut vec[..]; // Deref instead of slice
-   |                     ^^^^^^^^^^^^ help: dereference the original value instead: `&mut *vec`
-
-error: redundant slicing of the whole range
   --> $DIR/redundant_slicing.rs:21:13
    |
 LL |     let _ = &mut mut_slice[..]; // Should reborrow instead of slice
    |             ^^^^^^^^^^^^^^^^^^ help: reborrow the original value instead: `&mut *mut_slice`
-
-error: redundant slicing of the whole range
-  --> $DIR/redundant_slicing.rs:24:13
-   |
-LL |     let _ = &ref_vec[..]; // Deref instead of slice
-   |             ^^^^^^^^^^^^ help: dereference the original value instead: `&**ref_vec`
 
 error: redundant slicing of the whole range
   --> $DIR/redundant_slicing.rs:31:13
@@ -60,5 +42,5 @@ error: redundant slicing of the whole range
 LL |     let _ = (&bytes[..]).read_to_end(&mut vec![]).unwrap();
    |             ^^^^^^^^^^^^ help: reborrow the original value instead: `(&*bytes)`
 
-error: aborting due to 10 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
fixes #7972
fixes #7257

This can supersede #7976

changelog: Fix suggestion for `redundant_slicing` when re-borrowing for a method call
changelog: New lint `deref_as_slicing`
