### PR TITLE
Set binary-dep-depinfo in .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,6 @@ collect-metadata = "test --test dogfood --features metadata-collector-lint -- ru
 # -Zbinary-dep-depinfo allows us to track which rlib files to use for compiling UI tests
 rustflags = ["-Zunstable-options", "-Zbinary-dep-depinfo"]
 target-dir = "target"
+
+[unstable]
+binary-dep-depinfo = true


### PR DESCRIPTION
Fixes #8248

According to https://doc.rust-lang.org/cargo/reference/unstable this
seems to be the right place to set it, and it does fix the build for me.

I haven't removed the other `rustflags` because perhaps it's needed on
different cargo/rust versions?

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none
