### PR TITLE
Downgrade deref_addrof to nursery

### DIFF
--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -243,7 +243,6 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(redundant_field_names::REDUNDANT_FIELD_NAMES),
     LintId::of(redundant_slicing::REDUNDANT_SLICING),
     LintId::of(redundant_static_lifetimes::REDUNDANT_STATIC_LIFETIMES),
-    LintId::of(reference::DEREF_ADDROF),
     LintId::of(reference::REF_IN_DEREF),
     LintId::of(regex::INVALID_REGEX),
     LintId::of(repeat_once::REPEAT_ONCE),

--- a/clippy_lints/src/lib.register_complexity.rs
+++ b/clippy_lints/src/lib.register_complexity.rs
@@ -70,7 +70,6 @@ store.register_group(true, "clippy::complexity", Some("clippy_complexity"), vec!
     LintId::of(ranges::RANGE_ZIP_WITH_LEN),
     LintId::of(redundant_closure_call::REDUNDANT_CLOSURE_CALL),
     LintId::of(redundant_slicing::REDUNDANT_SLICING),
-    LintId::of(reference::DEREF_ADDROF),
     LintId::of(reference::REF_IN_DEREF),
     LintId::of(repeat_once::REPEAT_ONCE),
     LintId::of(strings::STRING_FROM_UTF8_AS_BYTES),

--- a/clippy_lints/src/lib.register_nursery.rs
+++ b/clippy_lints/src/lib.register_nursery.rs
@@ -23,6 +23,7 @@ store.register_group(true, "clippy::nursery", Some("clippy_nursery"), vec![
     LintId::of(option_if_let_else::OPTION_IF_LET_ELSE),
     LintId::of(path_buf_push_overwrite::PATH_BUF_PUSH_OVERWRITE),
     LintId::of(redundant_pub_crate::REDUNDANT_PUB_CRATE),
+    LintId::of(reference::DEREF_ADDROF),
     LintId::of(regex::TRIVIAL_REGEX),
     LintId::of(strings::STRING_LIT_AS_BYTES),
     LintId::of(suspicious_operation_groupings::SUSPICIOUS_OPERATION_GROUPINGS),

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -17,8 +17,11 @@ declare_clippy_lint! {
     /// makes the code less clear.
     ///
     /// ### Known problems
-    /// Multiple dereference/addrof pairs are not handled so
+    /// * Multiple dereference/addrof pairs are not handled so
     /// the suggested fix for `x = **&&y` is `x = *&y`, which is still incorrect.
+    ///
+    /// * [False positive for code that uses `ptr::addr_of` or
+    /// `ptr::addr_of_mut`.](https://github.com/rust-lang/rust-clippy/issues/8247)
     ///
     /// ### Example
     /// ```rust,ignore
@@ -32,7 +35,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub DEREF_ADDROF,
-    complexity,
+    nursery,
     "use of `*&` or `*&mut` in an expression"
 }
 


### PR DESCRIPTION
This lint currently suggests replacing the sound code with unsound code: #8247
Until that problem is fixed, I don't think it is good for this lint to be warned by default.

changelog: Moved [`deref_addrof`] to `nursery`
