### PR TITLE
Cache rustfmt path

### DIFF
--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -141,8 +141,11 @@ fn exec(
         println!("{}", format_command(&program, &dir, args));
     }
 
-    let child = Command::new(&program).current_dir(&dir).args(args.iter()).spawn()?;
-    let output = child.wait_with_output()?;
+    let output = Command::new(&program)
+        .current_dir(&dir)
+        .args(args.iter())
+        .output()
+        .unwrap();
     let success = output.status.success();
 
     if !context.check && !success {


### PR DESCRIPTION
changelog: none

Call `rustup which rustfmt` and use the output. This shaves off  ~0.7 seconds for `cargo dev fmt` for me.