### PR TITLE
issue #8239: Printed hint for lint or_fun_call is cropped and does no…

### DIFF
--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -56,7 +56,7 @@ pub(super) fn check<'tcx>(
             then {
                 let mut applicability = Applicability::MachineApplicable;
                 let hint = "unwrap_or_default()";
-                let mut shrink = span;
+                let mut sugg_span = span;
 
                 let mut sugg: String = format!(
                     "{}.{}",
@@ -65,14 +65,14 @@ pub(super) fn check<'tcx>(
                 );
 
                 if sugg.lines().count() > MAX_SUGGESTION_HIGHLIGHT_LINES {
-                    shrink = method_span.with_hi(span.hi());
+                    sugg_span = method_span.with_hi(span.hi());
                     sugg = hint.to_string();
                 }
 
                 span_lint_and_sugg(
                     cx,
                     OR_FUN_CALL,
-                    shrink,
+                    sugg_span,
                     &format!("use of `{}` followed by a call to `{}`", name, path),
                     "try this",
                     sugg,

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -177,7 +177,7 @@ mod issue6675 {
 }
 
 mod issue8239 {
-    unsafe fn more_than_max_suggestion_highest_lines_0() {
+    fn more_than_max_suggestion_highest_lines_0() {
         let frames = Vec::new();
         frames
             .iter()
@@ -189,7 +189,7 @@ mod issue8239 {
             .unwrap_or_default();
     }
 
-    unsafe fn more_to_max_suggestion_highest_lines_1() {
+    fn more_to_max_suggestion_highest_lines_1() {
         let frames = Vec::new();
         let iter = frames.iter();
         iter.map(|f: &String| f.to_lowercase())
@@ -202,7 +202,7 @@ mod issue8239 {
             .unwrap_or_default();
     }
 
-    unsafe fn equal_to_max_suggestion_highest_lines() {
+    fn equal_to_max_suggestion_highest_lines() {
         let frames = Vec::new();
         let iter = frames.iter();
         iter.map(|f: &String| f.to_lowercase())
@@ -213,7 +213,7 @@ mod issue8239 {
             }).unwrap_or_default();
     }
 
-    unsafe fn less_than_max_suggestion_highest_lines() {
+    fn less_than_max_suggestion_highest_lines() {
         let frames = Vec::new();
         let iter = frames.iter();
         let map = iter.map(|f: &String| f.to_lowercase());

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -176,4 +176,52 @@ mod issue6675 {
     }
 }
 
+mod issue8239 {
+    unsafe fn more_than_max_suggestion_highest_lines_0() {
+        let frames = Vec::new();
+        frames
+            .iter()
+            .map(|f: &String| f.to_lowercase())
+            .reduce(|mut acc, f| {
+                acc.push_str(&f);
+                acc
+            })
+            .unwrap_or_default();
+    }
+
+    unsafe fn more_to_max_suggestion_highest_lines_1() {
+        let frames = Vec::new();
+        let iter = frames.iter();
+        iter.map(|f: &String| f.to_lowercase())
+            .reduce(|mut acc, f| {
+                let _ = "";
+                let _ = "";
+                acc.push_str(&f);
+                acc
+            })
+            .unwrap_or_default();
+    }
+
+    unsafe fn equal_to_max_suggestion_highest_lines() {
+        let frames = Vec::new();
+        let iter = frames.iter();
+        iter.map(|f: &String| f.to_lowercase())
+            .reduce(|mut acc, f| {
+                let _ = "";
+                acc.push_str(&f);
+                acc
+            }).unwrap_or_default();
+    }
+
+    unsafe fn less_than_max_suggestion_highest_lines() {
+        let frames = Vec::new();
+        let iter = frames.iter();
+        let map = iter.map(|f: &String| f.to_lowercase());
+        map.reduce(|mut acc, f| {
+            acc.push_str(&f);
+            acc
+        }).unwrap_or_default();
+    }
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -176,4 +176,54 @@ mod issue6675 {
     }
 }
 
+mod issue8239 {
+    unsafe fn more_than_max_suggestion_highest_lines_0() {
+        let frames = Vec::new();
+        frames
+            .iter()
+            .map(|f: &String| f.to_lowercase())
+            .reduce(|mut acc, f| {
+                acc.push_str(&f);
+                acc
+            })
+            .unwrap_or(String::new());
+    }
+
+    unsafe fn more_to_max_suggestion_highest_lines_1() {
+        let frames = Vec::new();
+        let iter = frames.iter();
+        iter.map(|f: &String| f.to_lowercase())
+            .reduce(|mut acc, f| {
+                let _ = "";
+                let _ = "";
+                acc.push_str(&f);
+                acc
+            })
+            .unwrap_or(String::new());
+    }
+
+    unsafe fn equal_to_max_suggestion_highest_lines() {
+        let frames = Vec::new();
+        let iter = frames.iter();
+        iter.map(|f: &String| f.to_lowercase())
+            .reduce(|mut acc, f| {
+                let _ = "";
+                acc.push_str(&f);
+                acc
+            })
+            .unwrap_or(String::new());
+    }
+
+    unsafe fn less_than_max_suggestion_highest_lines() {
+        let frames = Vec::new();
+        let iter = frames.iter();
+        let map = iter.map(|f: &String| f.to_lowercase());
+        map.reduce(|mut acc, f| {
+            acc.push_str(&f);
+            acc
+        })
+        .unwrap_or(String::new());
+    }
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -177,7 +177,7 @@ mod issue6675 {
 }
 
 mod issue8239 {
-    unsafe fn more_than_max_suggestion_highest_lines_0() {
+    fn more_than_max_suggestion_highest_lines_0() {
         let frames = Vec::new();
         frames
             .iter()
@@ -189,7 +189,7 @@ mod issue8239 {
             .unwrap_or(String::new());
     }
 
-    unsafe fn more_to_max_suggestion_highest_lines_1() {
+    fn more_to_max_suggestion_highest_lines_1() {
         let frames = Vec::new();
         let iter = frames.iter();
         iter.map(|f: &String| f.to_lowercase())
@@ -202,7 +202,7 @@ mod issue8239 {
             .unwrap_or(String::new());
     }
 
-    unsafe fn equal_to_max_suggestion_highest_lines() {
+    fn equal_to_max_suggestion_highest_lines() {
         let frames = Vec::new();
         let iter = frames.iter();
         iter.map(|f: &String| f.to_lowercase())
@@ -214,7 +214,7 @@ mod issue8239 {
             .unwrap_or(String::new());
     }
 
-    unsafe fn less_than_max_suggestion_highest_lines() {
+    fn less_than_max_suggestion_highest_lines() {
         let frames = Vec::new();
         let iter = frames.iter();
         let map = iter.map(|f: &String| f.to_lowercase());

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -108,5 +108,57 @@ error: use of `unwrap_or` followed by a function call
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
-error: aborting due to 18 previous errors
+error: use of `unwrap_or` followed by a call to `new`
+  --> $DIR/or_fun_call.rs:189:14
+   |
+LL |             .unwrap_or(String::new());
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
+error: use of `unwrap_or` followed by a call to `new`
+  --> $DIR/or_fun_call.rs:202:14
+   |
+LL |             .unwrap_or(String::new());
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
+error: use of `unwrap_or` followed by a call to `new`
+  --> $DIR/or_fun_call.rs:208:9
+   |
+LL | /         iter.map(|f: &String| f.to_lowercase())
+LL | |             .reduce(|mut acc, f| {
+LL | |                 let _ = "";
+LL | |                 acc.push_str(&f);
+LL | |                 acc
+LL | |             })
+LL | |             .unwrap_or(String::new());
+   | |_____________________________________^
+   |
+help: try this
+   |
+LL ~         iter.map(|f: &String| f.to_lowercase())
+LL +             .reduce(|mut acc, f| {
+LL +                 let _ = "";
+LL +                 acc.push_str(&f);
+LL +                 acc
+LL ~             }).unwrap_or_default();
+   |
+
+error: use of `unwrap_or` followed by a call to `new`
+  --> $DIR/or_fun_call.rs:221:9
+   |
+LL | /         map.reduce(|mut acc, f| {
+LL | |             acc.push_str(&f);
+LL | |             acc
+LL | |         })
+LL | |         .unwrap_or(String::new());
+   | |_________________________________^
+   |
+help: try this
+   |
+LL ~         map.reduce(|mut acc, f| {
+LL +             acc.push_str(&f);
+LL +             acc
+LL ~         }).unwrap_or_default();
+   |
+
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
fixes rust-lang/rust-clippy#8239

changelog: [`or_fun_call`]: if suggestion contains more lines than MAX_SUGGESTION_HIGHLIGHT_LINES it is stripped to one line
