### PR TITLE
fix op_ref false positive

### DIFF
--- a/clippy_lints/src/eq_op.rs
+++ b/clippy_lints/src/eq_op.rs
@@ -1,12 +1,16 @@
 use clippy_utils::diagnostics::{multispan_sugg, span_lint, span_lint_and_then};
+use clippy_utils::get_enclosing_block;
 use clippy_utils::macros::{find_assert_eq_args, first_node_macro_backtrace};
 use clippy_utils::source::snippet;
 use clippy_utils::ty::{implements_trait, is_copy};
 use clippy_utils::{ast_utils::is_useless_with_eq_exprs, eq_expr_value, is_in_test_function};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
-use rustc_hir::{BinOpKind, BorrowKind, Expr, ExprKind};
+use rustc_hir::{
+    def::Res, def_id::DefId, BinOpKind, BorrowKind, Expr, ExprKind, GenericArg, ItemKind, QPath, Ty, TyKind,
+};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::{self, TyS};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
@@ -146,6 +150,13 @@ impl<'tcx> LateLintPass<'tcx> for EqOp {
                         let rty = cx.typeck_results().expr_ty(r);
                         let lcpy = is_copy(cx, lty);
                         let rcpy = is_copy(cx, rty);
+                        if let Some((self_ty, other_ty)) = in_impl(cx, e, trait_id) {
+                            if (are_equal(cx, rty, self_ty) && are_equal(cx, lty, other_ty))
+                                || (are_equal(cx, rty, other_ty) && are_equal(cx, lty, self_ty))
+                            {
+                                return; // Don't lint
+                            }
+                        }
                         // either operator autorefs or both args are copyable
                         if (requires_ref || (lcpy && rcpy)) && implements_trait(cx, lty, trait_id, &[rty.into()]) {
                             span_lint_and_then(
@@ -206,6 +217,14 @@ impl<'tcx> LateLintPass<'tcx> for EqOp {
                     // &foo == bar
                     (&ExprKind::AddrOf(BorrowKind::Ref, _, l), _) => {
                         let lty = cx.typeck_results().expr_ty(l);
+                        if let Some((self_ty, other_ty)) = in_impl(cx, e, trait_id) {
+                            let rty = cx.typeck_results().expr_ty(right);
+                            if (are_equal(cx, rty, self_ty) && are_equal(cx, lty, other_ty))
+                                || (are_equal(cx, rty, other_ty) && are_equal(cx, lty, self_ty))
+                            {
+                                return; // Don't lint
+                            }
+                        }
                         let lcpy = is_copy(cx, lty);
                         if (requires_ref || lcpy)
                             && implements_trait(cx, lty, trait_id, &[cx.typeck_results().expr_ty(right).into()])
@@ -230,6 +249,14 @@ impl<'tcx> LateLintPass<'tcx> for EqOp {
                     // foo == &bar
                     (_, &ExprKind::AddrOf(BorrowKind::Ref, _, r)) => {
                         let rty = cx.typeck_results().expr_ty(r);
+                        if let Some((self_ty, other_ty)) = in_impl(cx, e, trait_id) {
+                            let lty = cx.typeck_results().expr_ty(left);
+                            if (are_equal(cx, rty, self_ty) && are_equal(cx, lty, other_ty))
+                                || (are_equal(cx, rty, other_ty) && are_equal(cx, lty, self_ty))
+                            {
+                                return; // Don't lint
+                            }
+                        }
                         let rcpy = is_copy(cx, rty);
                         if (requires_ref || rcpy)
                             && implements_trait(cx, cx.typeck_results().expr_ty(left), trait_id, &[rty.into()])
@@ -248,6 +275,46 @@ impl<'tcx> LateLintPass<'tcx> for EqOp {
                     _ => {},
                 }
             }
+        }
+    }
+}
+
+fn in_impl<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>, bin_op: DefId) -> Option<(&'tcx Ty<'tcx>, &'tcx Ty<'tcx>)> {
+    if_chain! {
+        if let Some(block) = get_enclosing_block(cx, e.hir_id);
+        if let Some(impl_def_id) = cx.tcx.impl_of_method(block.hir_id.owner.to_def_id());
+        let item = cx.tcx.hir().expect_item(impl_def_id.expect_local());
+        if let ItemKind::Impl(item) = &item.kind;
+        if let Some(of_trait) = &item.of_trait;
+        if let Some(seg) = of_trait.path.segments.last();
+        if let Some(Res::Def(_, trait_id)) = seg.res;
+        if trait_id == bin_op;
+        if let Some(generic_args) = seg.args;
+        if let Some(GenericArg::Type(other_ty)) = generic_args.args.last();
+
+        then {
+            Some((item.self_ty, other_ty))
+        }
+        else {
+            None
+        }
+    }
+}
+
+fn are_equal<'tcx>(cx: &LateContext<'tcx>, middle_ty: &TyS<'_>, hir_ty: &Ty<'_>) -> bool {
+    if_chain! {
+        if let ty::Adt(adt_def, _) = middle_ty.kind();
+        if let Some(local_did) = adt_def.did.as_local();
+        let item = cx.tcx.hir().expect_item(local_did);
+        let middle_ty_id = item.def_id.to_def_id();
+        if let TyKind::Path(QPath::Resolved(_, path)) = hir_ty.kind;
+        if let Res::Def(_, hir_ty_id) = path.res;
+
+        then {
+            hir_ty_id == middle_ty_id
+        }
+        else {
+            false
         }
     }
 }

--- a/tests/ui/op_ref.stderr
+++ b/tests/ui/op_ref.stderr
@@ -18,5 +18,21 @@ LL |     let z = x & &y;
    |                 |
    |                 help: use the right value directly: `y`
 
-error: aborting due to 2 previous errors
+error: taken reference of right operand
+  --> $DIR/op_ref.rs:89:17
+   |
+LL |         let _ = one * &self;
+   |                 ^^^^^^-----
+   |                       |
+   |                       help: use the right value directly: `self`
+
+error: taken reference of right operand
+  --> $DIR/op_ref.rs:90:17
+   |
+LL |         let _ = two + &three;
+   |                 ^^^^^^------
+   |                       |
+   |                       help: use the right value directly: `three`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
fixes #7572 

changelog: `op_ref` don't lint for unnecessary reference in BinOp impl if removing the reference will lead to unconditional recursion
