### PR TITLE
#8294 unncecessary_lazy_eval clippy suggestion too long

### DIFF
--- a/tests/ui/unnecessary_lazy_eval.fixed
+++ b/tests/ui/unnecessary_lazy_eval.fixed
@@ -120,3 +120,21 @@ fn main() {
     let _: Result<usize, usize> = res.and_then(|x| Err(x));
     let _: Result<usize, usize> = res.or_else(|err| Ok(err));
 }
+
+pub struct Stub {}
+
+impl Stub {
+    fn idx_change(&self, pos: usize) -> Result<usize, ()> {
+        pos.checked_sub(2).ok_or(())
+    }
+
+    pub fn idx_map(&self, pos: usize) {
+        let _: usize = self
+            .idx_change(pos)
+            .ok()
+            .and_then(|idx| {
+                let offset = Some(1);
+                offset.map(|off| idx.saturating_sub(off))
+            }).unwrap_or(0);
+    }
+}

--- a/tests/ui/unnecessary_lazy_eval.rs
+++ b/tests/ui/unnecessary_lazy_eval.rs
@@ -120,3 +120,22 @@ fn main() {
     let _: Result<usize, usize> = res.and_then(|x| Err(x));
     let _: Result<usize, usize> = res.or_else(|err| Ok(err));
 }
+
+pub struct Stub {}
+
+impl Stub {
+    fn idx_change(&self, pos: usize) -> Result<usize, ()> {
+        pos.checked_sub(2).ok_or(())
+    }
+
+    pub fn idx_map(&self, pos: usize) {
+        let _: usize = self
+            .idx_change(pos)
+            .ok()
+            .and_then(|idx| {
+                let offset = Some(1);
+                offset.map(|off| idx.saturating_sub(off))
+            })
+            .unwrap_or_else(|| 0);
+    }
+}

--- a/tests/ui/unnecessary_lazy_eval.stderr
+++ b/tests/ui/unnecessary_lazy_eval.stderr
@@ -192,5 +192,13 @@ error: unnecessary closure used to substitute value for `Result::Err`
 LL |     let _: Result<usize, usize> = res.or_else(|_| Ok(ext_str.some_field));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `or` instead: `res.or(Ok(ext_str.some_field))`
 
-error: aborting due to 32 previous errors
+error: unnecessary closure used to substitute value for `Option::None`
+  --> $DIR/unnecessary_lazy_eval.rs:138:15
+   |
+LL |               })
+   |  _______________^
+LL | |             .unwrap_or_else(|| 0);
+   | |_________________________________^ help: try this: `.unwrap_or(0)`
+
+error: aborting due to 33 previous errors
 


### PR DESCRIPTION
changelog: ``[`unncecessary_lazy_eval`]`` fixes too long suggestion 
