### PR TITLE
fix `needless_question_mark` not considering async fn

### DIFF
--- a/tests/ui/needless_question_mark.fixed
+++ b/tests/ui/needless_question_mark.fixed
@@ -125,3 +125,16 @@ pub fn test2() {
     let x = Some(3);
     let _x = some_and_qmark_in_macro!(x?);
 }
+
+async fn async_option_bad(to: TO) -> Option<usize> {
+    let _ = Some(3);
+    to.magic
+}
+
+async fn async_deref_ref(s: Option<&String>) -> Option<&str> {
+    Some(s?)
+}
+
+async fn async_result_bad(s: TR) -> Result<usize, bool> {
+    s.magic
+}

--- a/tests/ui/needless_question_mark.rs
+++ b/tests/ui/needless_question_mark.rs
@@ -125,3 +125,16 @@ pub fn test2() {
     let x = Some(3);
     let _x = some_and_qmark_in_macro!(x?);
 }
+
+async fn async_option_bad(to: TO) -> Option<usize> {
+    let _ = Some(3);
+    Some(to.magic?)
+}
+
+async fn async_deref_ref(s: Option<&String>) -> Option<&str> {
+    Some(s?)
+}
+
+async fn async_result_bad(s: TR) -> Result<usize, bool> {
+    Ok(s.magic?)
+}

--- a/tests/ui/needless_question_mark.stderr
+++ b/tests/ui/needless_question_mark.stderr
@@ -77,5 +77,17 @@ LL |     let _x = some_and_qmark_in_macro!(x?);
    |
    = note: this error originates in the macro `some_and_qmark_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 12 previous errors
+error: question mark operator is useless here
+  --> $DIR/needless_question_mark.rs:131:5
+   |
+LL |     Some(to.magic?)
+   |     ^^^^^^^^^^^^^^^ help: try removing question mark and `Some()`: `to.magic`
+
+error: question mark operator is useless here
+  --> $DIR/needless_question_mark.rs:139:5
+   |
+LL |     Ok(s.magic?)
+   |     ^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `s.magic`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
closes #8277 


changelog: [`needless_question_mark`] Fix FN on async functions
