### PR TITLE
Don't suggest an empty variant name in `enum_variant_names`

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -172,6 +172,9 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
         let name = var.ident.name.as_str();
 
         let variant_split = camel_case_split(name);
+        if variant_split.len() == 1 {
+            return;
+        }
 
         pre = pre
             .iter()

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -151,4 +151,11 @@ enum North {
     NoRight,
 }
 
+// #8324
+enum Phase {
+    PreLookup,
+    Lookup,
+    PostLookup,
+}
+
 fn main() {}


### PR DESCRIPTION
changelog: false positive fix: [`enum_variant_names`]: No longer suggests an empty variant name

Fixes #8324