### PR TITLE
Add new lint manual_memmove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3078,6 +3078,7 @@ Released 2018-09-13
 [`manual_flatten`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_flatten
 [`manual_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
 [`manual_memcpy`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_memcpy
+[`manual_memmove`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_memmove
 [`manual_non_exhaustive`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive
 [`manual_ok_or`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_or
 [`manual_range_contains`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -104,6 +104,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(loops::ITER_NEXT_LOOP),
     LintId::of(loops::MANUAL_FLATTEN),
     LintId::of(loops::MANUAL_MEMCPY),
+    LintId::of(loops::MANUAL_MEMMOVE),
     LintId::of(loops::MUT_RANGE_BOUND),
     LintId::of(loops::NEEDLESS_COLLECT),
     LintId::of(loops::NEEDLESS_RANGE_LOOP),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -213,6 +213,7 @@ store.register_lints(&[
     loops::ITER_NEXT_LOOP,
     loops::MANUAL_FLATTEN,
     loops::MANUAL_MEMCPY,
+    loops::MANUAL_MEMMOVE,
     loops::MUT_RANGE_BOUND,
     loops::NEEDLESS_COLLECT,
     loops::NEEDLESS_RANGE_LOOP,

--- a/clippy_lints/src/lib.register_perf.rs
+++ b/clippy_lints/src/lib.register_perf.rs
@@ -10,6 +10,7 @@ store.register_group(true, "clippy::perf", Some("clippy_perf"), vec![
     LintId::of(large_const_arrays::LARGE_CONST_ARRAYS),
     LintId::of(large_enum_variant::LARGE_ENUM_VARIANT),
     LintId::of(loops::MANUAL_MEMCPY),
+    LintId::of(loops::MANUAL_MEMMOVE),
     LintId::of(loops::NEEDLESS_COLLECT),
     LintId::of(methods::EXPECT_FUN_CALL),
     LintId::of(methods::EXTEND_WITH_DRAIN),

--- a/clippy_lints/src/loops/manual_memmove.rs
+++ b/clippy_lints/src/loops/manual_memmove.rs
@@ -1,0 +1,233 @@
+use super::MANUAL_MEMCPY;
+use crate::loops::manual_memcpy::{
+    apply_offset, get_assignment, get_assignments, get_details_from_idx, get_loop_counters, get_slice_like_element_ty,
+    IndexExpr, MinifyingSugg, Start, StartKind,
+};
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet;
+use clippy_utils::sugg::Sugg;
+use clippy_utils::ty::is_copy;
+use clippy_utils::{higher, path_to_local, sugg};
+use if_chain::if_chain;
+use rustc_ast::ast;
+use rustc_errors::Applicability;
+use rustc_hir::{BinOpKind, Expr, ExprKind, Pat, PatKind};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+use rustc_span::symbol::sym;
+use std::iter::Iterator;
+
+/// Checks for for loops that sequentially copy items within a slice
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    pat: &'tcx Pat<'_>,
+    arg: &'tcx Expr<'_>,
+    body: &'tcx Expr<'_>,
+    expr: &'tcx Expr<'_>,
+) -> bool {
+    if let Some(higher::Range {
+        start: Some(start),
+        end: Some(end),
+        limits,
+    }) = higher::Range::hir(arg)
+    {
+        // the var must be a single name
+        if let PatKind::Binding(_, canonical_id, _, _) = pat.kind {
+            let starts = &[Start {
+                id: canonical_id,
+                kind: StartKind::Range,
+            }];
+
+            // This is one of few ways to return different iterators
+            // derived from: https://stackoverflow.com/questions/29760668/conditionally-iterate-over-one-of-several-possible-iterators/52064434#52064434
+            let mut iter_a = None;
+            let mut iter_b = None;
+
+            if let ExprKind::Block(block, _) = body.kind {
+                if let Some(mut loop_counters) = get_loop_counters(cx, block, expr) {
+                    // we currently do not support loop counters at all, as we would need to know
+                    // their initial value to assess whether the copy is safe to do (same reason we
+                    // require positive offsets in source)
+                    if loop_counters.next().is_some() {
+                        return false;
+                    }
+                }
+                iter_a = Some(get_assignments(block, starts));
+            } else {
+                iter_b = Some(get_assignment(body));
+            }
+
+            let assignments = iter_a.into_iter().flatten().chain(iter_b.into_iter());
+
+            let big_sugg = assignments
+                // The only statements in the for loops can be indexed assignments from
+                // indexed retrievals (except increments of loop counters).
+                .map(|o| {
+                    o.and_then(|(lhs, rhs)| {
+                        if_chain! {
+                            if let ExprKind::Index(base_left, idx_left) = lhs.kind;
+                            if let ExprKind::Index(base_right, idx_right) = rhs.kind;
+                            // Source and destination must be same
+                            if let Some(base_left_local) = path_to_local(base_left);
+                            if let Some(base_right_local) = path_to_local(base_right);
+                            if base_left_local == base_right_local;
+                            if let Some(ty) = get_slice_like_element_ty(cx, cx.typeck_results().expr_ty(base_left));
+                            if let Some((start_left, offset_left)) = get_details_from_idx(cx, idx_left, starts);
+                            if let Some((start_right, offset_right)) = get_details_from_idx(cx, idx_right, starts);
+
+                            if left_is_smaller_than_right(cx, idx_left, idx_right);
+
+                            if let StartKind::Range = start_left;
+                            if let StartKind::Range = start_right;
+
+                            if is_copy(cx, ty);
+
+                            then {
+                                Some((IndexExpr { base: base_left, idx: start_left, idx_offset: offset_left },
+                                        IndexExpr { base: base_right, idx: start_right, idx_offset: offset_right }))
+                            } else {
+                                None
+                            }
+                        }
+                    })
+                })
+                .map(|o| o.map(|(dst, src)| build_manual_memmove_suggestion(cx, start, end, limits, &dst, &src)))
+                .collect::<Option<Vec<_>>>()
+                .filter(|v| {
+                    // we currently do not support more than one assignment, as it's "too hard" to
+                    // prove that the to-be-moved slices (+ their destinations) are nonoverlapping
+                    v.len() == 1
+                })
+                .map(|v| v.join("\n    "));
+
+            if let Some(big_sugg) = big_sugg {
+                span_lint_and_sugg(
+                    cx,
+                    MANUAL_MEMCPY,
+                    expr.span,
+                    "it looks like you're manually copying within a slice",
+                    "try replacing the loop by",
+                    big_sugg,
+                    Applicability::Unspecified,
+                );
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn build_manual_memmove_suggestion<'tcx>(
+    cx: &LateContext<'tcx>,
+    start: &Expr<'_>,
+    end: &Expr<'_>,
+    limits: ast::RangeLimits,
+    src: &IndexExpr<'_>,
+    dst: &IndexExpr<'_>,
+) -> String {
+    fn print_offset(offset: MinifyingSugg<'static>) -> MinifyingSugg<'static> {
+        if offset.to_string() == "0" {
+            sugg::EMPTY.into()
+        } else {
+            offset
+        }
+    }
+
+    let print_limit = |end: &Expr<'_>, end_str: &str, base: &Expr<'_>, sugg: MinifyingSugg<'static>| {
+        if_chain! {
+            if let ExprKind::MethodCall(method, _, len_args, _) = end.kind;
+            if method.ident.name == sym::len;
+            if len_args.len() == 1;
+            if let Some(arg) = len_args.get(0);
+            if path_to_local(arg) == path_to_local(base);
+            then {
+                if sugg.to_string() == end_str {
+                    sugg::EMPTY.into()
+                } else {
+                    sugg
+                }
+            } else {
+                match limits {
+                    ast::RangeLimits::Closed => {
+                        sugg + &sugg::ONE.into()
+                    },
+                    ast::RangeLimits::HalfOpen => sugg,
+                }
+            }
+        }
+    };
+
+    let start_str = Sugg::hir(cx, start, "").into();
+    let end_str: MinifyingSugg<'_> = Sugg::hir(cx, end, "").into();
+
+    let (src_offset, src_limit) = match src.idx {
+        StartKind::Range => (
+            print_offset(apply_offset(
+                &apply_offset(&start_str, &src.idx_offset),
+                &dst.idx_offset,
+            ))
+            .into_sugg(),
+            print_limit(
+                end,
+                end_str.to_string().as_str(),
+                src.base,
+                apply_offset(&apply_offset(&end_str, &src.idx_offset), &dst.idx_offset),
+            )
+            .into_sugg(),
+        ),
+        StartKind::Counter { initializer } => {
+            let counter_start = Sugg::hir(cx, initializer, "").into();
+            (
+                print_offset(apply_offset(
+                    &apply_offset(&counter_start, &src.idx_offset),
+                    &dst.idx_offset,
+                ))
+                .into_sugg(),
+                print_limit(
+                    end,
+                    end_str.to_string().as_str(),
+                    src.base,
+                    apply_offset(&apply_offset(&end_str, &src.idx_offset), &dst.idx_offset) + &counter_start
+                        - &start_str,
+                )
+                .into_sugg(),
+            )
+        },
+    };
+
+    let src_base_str = snippet(cx, src.base.span, "???");
+
+    format!(
+        "{}.copy_within({}..{}, {});",
+        src_base_str,
+        src_offset.maybe_par(),
+        src_limit.maybe_par(),
+        start_str,
+    )
+}
+
+fn left_is_smaller_than_right<'tcx>(
+    cx: &LateContext<'tcx>,
+    idx_left: &'tcx Expr<'_>,
+    idx_right: &'tcx Expr<'_>,
+) -> bool {
+    // in order to be a memmove-type loop, read indices must be iterated
+    // over at a later point than written indices. we currently enforce
+    // this by ensuring that:
+    //
+    // - rhs is `path + offset` with offset >= 0
+    // - lhs is just `path` (same path as rhs)
+    if_chain! {
+        if let ExprKind::Binary(idx_right_op, idx_right_lhs, idx_right_rhs) = idx_right.kind;
+        if idx_right_op.node == BinOpKind::Add;
+        if let Some(idx_left_local) = path_to_local(idx_left);
+        if let Some(idx_right_local) = path_to_local(idx_right_lhs);
+        if idx_right_local == idx_left_local;
+        if let ty::Uint(_) = cx.typeck_results().expr_ty(idx_right_rhs).kind();
+        then {
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/tests/ui/manual_memmove.rs
+++ b/tests/ui/manual_memmove.rs
@@ -1,0 +1,91 @@
+#![warn(clippy::manual_memmove)]
+
+use std::ops::{Index, IndexMut};
+
+const OFFSET: usize = 4;
+
+pub fn manual_memmove(arr: &mut [u8]) {
+    for i in 0..(arr.len() - 4) {
+        // left shift by 4
+        arr[i] = arr[i + 4];
+    }
+
+    for i in 0..(arr.len() - 4) {
+        // left shift by 4 with more type inference
+        arr[i] = arr[i + OFFSET];
+    }
+
+    for i in (0..(arr.len() - 4)).rev() {
+        // right shift by 4, currently not supported
+        arr[i] = arr[i - 4];
+    }
+
+    for i in 0..arr.len() {
+        // left shift by 4, currently not supported
+        arr[i] = arr[i + 4];
+        if i >= (arr.len() - 4) {
+            break;
+        }
+    }
+
+    for i in 10..256 {
+        // multiple memmoves, currently not supported
+        arr[i] = arr[i + 4];
+        arr[i + 500] = arr[i + 508];
+    }
+
+    for i in 10..256 {
+        // not sure what sense this would make but that's not a memmove
+        arr[i + 4] = arr[i];
+    }
+
+    for i in 10..256 {
+        // not sure what sense this would make but that's not a memmove either
+        arr[i] = arr[i - 1];
+    }
+
+    let mut arr = vec![1, 2, 3, 4, 5];
+
+    for i in 0..(arr.len() - 4) {
+        // make sure vectors are supported
+        arr[i] = arr[i + 4];
+    }
+
+    struct DummyStruct(u8);
+
+    impl Index<usize> for DummyStruct {
+        type Output = u8;
+        fn index(&self, _: usize) -> &u8 {
+            &self.0
+        }
+    }
+
+    impl IndexMut<usize> for DummyStruct {
+        fn index_mut(&mut self, _: usize) -> &mut u8 {
+            &mut self.0
+        }
+    }
+
+    let mut arr = DummyStruct(0);
+
+    for i in 0..4 {
+        // lint should not trigger when `arr` is not slice-like, like DummyStruct
+        arr[i] = arr[i + 4];
+    }
+
+    let mut arr = std::collections::VecDeque::from_iter([0; 5]);
+    for i in 0..(arr.len() - 4) {
+        // VecDeque - ideally this should work
+        arr[i] = arr[i + 4];
+    }
+}
+
+#[warn(clippy::needless_range_loop, clippy::manual_memmove)]
+pub fn manual_clone(arr: &mut [String]) {
+    for i in 0..arr.len() {
+        // should not suggest for non-copy items
+        arr[i] = arr[i + 1].clone();
+    }
+}
+
+fn main() {}

--- a/tests/ui/manual_memmove.rs
+++ b/tests/ui/manual_memmove.rs
@@ -3,6 +3,7 @@
 use std::ops::{Index, IndexMut};
 
 const OFFSET: usize = 4;
+const NEGATIVE_OFFSET: isize = 4;
 
 pub fn manual_memmove(arr: &mut [u8]) {
     for i in 0..(arr.len() - 4) {
@@ -18,6 +19,16 @@ pub fn manual_memmove(arr: &mut [u8]) {
     for i in (0..(arr.len() - 4)).rev() {
         // right shift by 4, currently not supported
         arr[i] = arr[i - 4];
+    }
+
+    for i in 0..(arr.len() - 4) {
+        // right shift by 4 with more type inference, currently not supported
+        arr[i] = arr[i - OFFSET];
+    }
+
+    for i in 0..(arr.len() - 4) {
+        // right shift by 4 with more type inference (alt version), currently not supported
+        arr[i] = arr[i + NEGATIVE_OFFSET as usize];
     }
 
     for i in 0..arr.len() {

--- a/tests/ui/manual_memmove.stderr
+++ b/tests/ui/manual_memmove.stderr
@@ -1,5 +1,5 @@
 error: it looks like you're manually copying within a slice
-  --> $DIR/manual_memmove.rs:8:5
+  --> $DIR/manual_memmove.rs:9:5
    |
 LL | /     for i in 0..(arr.len() - 4) {
 LL | |         // left shift by 4
@@ -10,7 +10,7 @@ LL | |     }
    = note: `-D clippy::manual-memcpy` implied by `-D warnings`
 
 error: it looks like you're manually copying within a slice
-  --> $DIR/manual_memmove.rs:13:5
+  --> $DIR/manual_memmove.rs:14:5
    |
 LL | /     for i in 0..(arr.len() - 4) {
 LL | |         // left shift by 4 with more type inference
@@ -19,7 +19,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `arr.copy_within(OFFSET..((arr.len() - 4) + OFFSET), 0);`
 
 error: it looks like you're manually copying within a slice
-  --> $DIR/manual_memmove.rs:49:5
+  --> $DIR/manual_memmove.rs:60:5
    |
 LL | /     for i in 0..(arr.len() - 4) {
 LL | |         // make sure vectors are supported

--- a/tests/ui/manual_memmove.stderr
+++ b/tests/ui/manual_memmove.stderr
@@ -1,0 +1,31 @@
+error: it looks like you're manually copying within a slice
+  --> $DIR/manual_memmove.rs:8:5
+   |
+LL | /     for i in 0..(arr.len() - 4) {
+LL | |         // left shift by 4
+LL | |         arr[i] = arr[i + 4];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `arr.copy_within(4..((arr.len() - 4) + 4), 0);`
+   |
+   = note: `-D clippy::manual-memcpy` implied by `-D warnings`
+
+error: it looks like you're manually copying within a slice
+  --> $DIR/manual_memmove.rs:13:5
+   |
+LL | /     for i in 0..(arr.len() - 4) {
+LL | |         // left shift by 4 with more type inference
+LL | |         arr[i] = arr[i + OFFSET];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `arr.copy_within(OFFSET..((arr.len() - 4) + OFFSET), 0);`
+
+error: it looks like you're manually copying within a slice
+  --> $DIR/manual_memmove.rs:49:5
+   |
+LL | /     for i in 0..(arr.len() - 4) {
+LL | |         // make sure vectors are supported
+LL | |         arr[i] = arr[i + 4];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `arr.copy_within(4..((arr.len() - 4) + 4), 0);`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Add a very basic lint that checks against unnecessary reimplementations of `copy_within`. The lint reuses some now-public parts of the memcpy lint, but supports almost none of the fanciness that the memcpy lint has. The main reason being that overlapping indices/ranges change behavior in memmove, but do not in memcpy (because src is immutable). The secondary reason being that this is my first lint.

Fixes #8335 

----

changelog: New lint [`manual_memmove`]