### PR TITLE
Add lint `explicit_auto_deref` take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3400,6 +3400,7 @@ Released 2018-09-13
 [`expect_fun_call`]: https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call
 [`expect_used`]: https://rust-lang.github.io/rust-clippy/master/index.html#expect_used
 [`expl_impl_clone_on_copy`]: https://rust-lang.github.io/rust-clippy/master/index.html#expl_impl_clone_on_copy
+[`explicit_auto_deref`]: https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
 [`explicit_counter_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#explicit_counter_loop
 [`explicit_deref_methods`]: https://rust-lang.github.io/rust-clippy/master/index.html#explicit_deref_methods
 [`explicit_into_iter_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#explicit_into_iter_loop

--- a/clippy_dev/src/update_lints.rs
+++ b/clippy_dev/src/update_lints.rs
@@ -413,7 +413,7 @@ fn remove_lint_declaration(name: &str, path: &Path, lints: &mut Vec<Lint>) -> io
                 .find("declare_lint_pass!")
                 .unwrap_or_else(|| panic!("failed to find `impl_lint_pass`"))
         });
-        let mut impl_lint_pass_end = (&content[impl_lint_pass_start..])
+        let mut impl_lint_pass_end = content[impl_lint_pass_start..]
             .find(']')
             .expect("failed to find `impl_lint_pass` terminator");
 

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -44,6 +44,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(crate_in_macro_def::CRATE_IN_MACRO_DEF),
     LintId::of(default::FIELD_REASSIGN_WITH_DEFAULT),
     LintId::of(default_instead_of_iter_empty::DEFAULT_INSTEAD_OF_ITER_EMPTY),
+    LintId::of(dereference::EXPLICIT_AUTO_DEREF),
     LintId::of(dereference::NEEDLESS_BORROW),
     LintId::of(derivable_impls::DERIVABLE_IMPLS),
     LintId::of(derive::DERIVE_HASH_XOR_EQ),

--- a/clippy_lints/src/lib.register_complexity.rs
+++ b/clippy_lints/src/lib.register_complexity.rs
@@ -9,6 +9,7 @@ store.register_group(true, "clippy::complexity", Some("clippy_complexity"), vec!
     LintId::of(bytes_count_to_len::BYTES_COUNT_TO_LEN),
     LintId::of(casts::CHAR_LIT_AS_U8),
     LintId::of(casts::UNNECESSARY_CAST),
+    LintId::of(dereference::EXPLICIT_AUTO_DEREF),
     LintId::of(derivable_impls::DERIVABLE_IMPLS),
     LintId::of(double_comparison::DOUBLE_COMPARISONS),
     LintId::of(double_parens::DOUBLE_PARENS),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -110,6 +110,7 @@ store.register_lints(&[
     default_instead_of_iter_empty::DEFAULT_INSTEAD_OF_ITER_EMPTY,
     default_numeric_fallback::DEFAULT_NUMERIC_FALLBACK,
     default_union_representation::DEFAULT_UNION_REPRESENTATION,
+    dereference::EXPLICIT_AUTO_DEREF,
     dereference::EXPLICIT_DEREF_METHODS,
     dereference::NEEDLESS_BORROW,
     dereference::REF_BINDING_TO_REFERENCE,

--- a/clippy_lints/src/matches/match_same_arms.rs
+++ b/clippy_lints/src/matches/match_same_arms.rs
@@ -285,7 +285,7 @@ impl<'a> NormalizedPat<'a> {
                 // TODO: Handle negative integers. They're currently treated as a wild match.
                 ExprKind::Lit(lit) => match lit.node {
                     LitKind::Str(sym, _) => Self::LitStr(sym),
-                    LitKind::ByteStr(ref bytes) => Self::LitBytes(&**bytes),
+                    LitKind::ByteStr(ref bytes) => Self::LitBytes(bytes),
                     LitKind::Byte(val) => Self::LitInt(val.into()),
                     LitKind::Char(val) => Self::LitInt(val.into()),
                     LitKind::Int(val, _) => Self::LitInt(val),

--- a/clippy_lints/src/matches/match_single_binding.rs
+++ b/clippy_lints/src/matches/match_single_binding.rs
@@ -55,7 +55,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                         cx,
                         (ex, expr),
                         (bind_names, matched_vars),
-                        &*snippet_body,
+                        &snippet_body,
                         &mut applicability,
                         Some(span),
                     );
@@ -88,7 +88,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                         cx,
                         (ex, expr),
                         (bind_names, matched_vars),
-                        &*snippet_body,
+                        &snippet_body,
                         &mut applicability,
                         None,
                     );

--- a/clippy_lints/src/matches/match_str_case_mismatch.rs
+++ b/clippy_lints/src/matches/match_str_case_mismatch.rs
@@ -118,7 +118,7 @@ fn lint(cx: &LateContext<'_>, case_method: &CaseMethod, bad_case_span: Span, bad
         MATCH_STR_CASE_MISMATCH,
         bad_case_span,
         "this `match` arm has a differing case than its expression",
-        &*format!("consider changing the case of this arm to respect `{}`", method_str),
+        &format!("consider changing the case of this arm to respect `{}`", method_str),
         format!("\"{}\"", suggestion),
         Applicability::MachineApplicable,
     );

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -362,9 +362,9 @@ fn find_good_method_for_match<'a>(
         .qpath_res(path_right, arms[1].pat.hir_id)
         .opt_def_id()?;
     let body_node_pair = if match_def_path(cx, left_id, expected_left) && match_def_path(cx, right_id, expected_right) {
-        (&(*arms[0].body).kind, &(*arms[1].body).kind)
+        (&arms[0].body.kind, &arms[1].body.kind)
     } else if match_def_path(cx, right_id, expected_left) && match_def_path(cx, right_id, expected_right) {
-        (&(*arms[1].body).kind, &(*arms[0].body).kind)
+        (&arms[1].body.kind, &arms[0].body.kind)
     } else {
         return None;
     };

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -326,7 +326,7 @@ impl<'a, 'tcx> Visitor<'tcx> for SimilarNamesLocalVisitor<'a, 'tcx> {
         // add the pattern after the expression because the bindings aren't available
         // yet in the init
         // expression
-        SimilarNamesNameVisitor(self).visit_pat(&*local.pat);
+        SimilarNamesNameVisitor(self).visit_pat(&local.pat);
     }
     fn visit_block(&mut self, blk: &'tcx Block) {
         self.single_char_names.push(vec![]);

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -574,14 +574,13 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'_>, args:
                 Some((Node::Expr(e), child_id)) => match e.kind {
                     ExprKind::Call(f, expr_args) => {
                         let i = expr_args.iter().position(|arg| arg.hir_id == child_id).unwrap_or(0);
-                        if expr_sig(self.cx, f)
-                            .map(|sig| sig.input(i).skip_binder().peel_refs())
-                            .map_or(true, |ty| match *ty.kind() {
+                        if expr_sig(self.cx, f).and_then(|sig| sig.input(i)).map_or(true, |ty| {
+                            match *ty.skip_binder().peel_refs().kind() {
                                 ty::Param(_) => true,
                                 ty::Adt(def, _) => def.did() == args.ty_did,
                                 _ => false,
-                            })
-                        {
+                            }
+                        }) {
                             // Passed to a function taking the non-dereferenced type.
                             set_skip_flag();
                         }

--- a/clippy_lints/src/redundant_static_lifetimes.rs
+++ b/clippy_lints/src/redundant_static_lifetimes.rs
@@ -87,7 +87,7 @@ impl RedundantStaticLifetimes {
                         _ => {},
                     }
                 }
-                self.visit_type(&*borrow_type.ty, cx, reason);
+                self.visit_type(&borrow_type.ty, cx, reason);
             },
             _ => {},
         }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2215,19 +2215,12 @@ pub fn walk_to_expr_usage<'tcx, T>(
             _ => return None,
         };
         match parent.kind {
-            ExprKind::If(child, ..) | ExprKind::Match(child, ..) if child.hir_id != child_id => {
-                child_id = parent_id;
-                continue;
-            },
+            ExprKind::If(child, ..) | ExprKind::Match(child, ..) if child.hir_id != child_id => child_id = parent_id,
             ExprKind::Break(Destination { target_id: Ok(id), .. }, _) => {
                 child_id = id;
                 iter = map.parent_iter(id);
-                continue;
             },
-            ExprKind::Block(..) => {
-                child_id = parent_id;
-                continue;
-            },
+            ExprKind::Block(..) => child_id = parent_id,
             _ => return None,
         }
     }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2058,6 +2058,21 @@ pub fn peel_hir_expr_refs<'a>(expr: &'a Expr<'a>) -> (&'a Expr<'a>, usize) {
     (e, count)
 }
 
+/// Peels off all references on the type. Returns the underlying type and the number of references
+/// removed.
+pub fn peel_hir_ty_refs<'a>(mut ty: &'a hir::Ty<'a>) -> (&'a hir::Ty<'a>, usize) {
+    let mut count = 0;
+    loop {
+        match &ty.kind {
+            TyKind::Rptr(_, ref_ty) => {
+                ty = ref_ty.ty;
+                count += 1;
+            },
+            _ => break (ty, count),
+        }
+    }
+}
+
 /// Removes `AddrOf` operators (`&`) or deref operators (`*`), but only if a reference type is
 /// dereferenced. An overloaded deref such as `Vec` to slice would not be removed.
 pub fn peel_ref_operators<'hir>(cx: &LateContext<'_>, mut expr: &'hir Expr<'hir>) -> &'hir Expr<'hir> {
@@ -2110,7 +2125,7 @@ fn with_test_item_names<'tcx>(tcx: TyCtxt<'tcx>, module: LocalDefId, f: impl Fn(
                 }
             }
             names.sort_unstable();
-            f(&*entry.insert(names))
+            f(entry.insert(names))
         },
     }
 }
@@ -2166,6 +2181,57 @@ pub fn is_test_module_or_function(tcx: TyCtxt<'_>, item: &Item<'_>) -> bool {
     is_in_test_function(tcx, item.hir_id())
         || matches!(item.kind, ItemKind::Mod(..))
             && item.ident.name.as_str().split('_').any(|a| a == "test" || a == "tests")
+}
+
+/// Walks the HIR tree from the given expression, up to the node where the value produced by the
+/// expression is consumed. Calls the function for every node encountered this way until it returns
+/// `Some`.
+///
+/// This allows walking through `if`, `match`, `break`, block expressions to find where the value
+/// produced by the expression is consumed.
+pub fn walk_to_expr_usage<'tcx, T>(
+    cx: &LateContext<'tcx>,
+    e: &Expr<'tcx>,
+    mut f: impl FnMut(Node<'tcx>, HirId) -> Option<T>,
+) -> Option<T> {
+    let map = cx.tcx.hir();
+    let mut iter = map.parent_iter(e.hir_id);
+    let mut child_id = e.hir_id;
+
+    while let Some((parent_id, parent)) = iter.next() {
+        if let Some(x) = f(parent, child_id) {
+            return Some(x);
+        }
+        let parent = match parent {
+            Node::Expr(e) => e,
+            Node::Block(Block { expr: Some(body), .. }) | Node::Arm(Arm { body, .. }) if body.hir_id == child_id => {
+                child_id = parent_id;
+                continue;
+            },
+            Node::Arm(a) if a.body.hir_id == child_id => {
+                child_id = parent_id;
+                continue;
+            },
+            _ => return None,
+        };
+        match parent.kind {
+            ExprKind::If(child, ..) | ExprKind::Match(child, ..) if child.hir_id != child_id => {
+                child_id = parent_id;
+                continue;
+            },
+            ExprKind::Break(Destination { target_id: Ok(id), .. }, _) => {
+                child_id = id;
+                iter = map.parent_iter(id);
+                continue;
+            },
+            ExprKind::Block(..) => {
+                child_id = parent_id;
+                continue;
+            },
+            _ => return None,
+        }
+    }
+    None
 }
 
 macro_rules! op_utils {

--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -775,6 +775,7 @@ pub fn for_each_top_level_late_bound_region<B>(
     ty.visit_with(&mut V { index: 0, f })
 }
 
+/// Gets the struct or enum variant from the given `Res`
 pub fn variant_of_res<'tcx>(cx: &LateContext<'tcx>, res: Res) -> Option<&'tcx VariantDef> {
     match res {
         Res::Def(DefKind::Struct, id) => Some(cx.tcx.adt_def(id).non_enum_variant()),

--- a/tests/ui/borrow_deref_ref_unfixable.rs
+++ b/tests/ui/borrow_deref_ref_unfixable.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unused_variables, clippy::explicit_auto_deref)]
+#![allow(dead_code, unused_variables)]
 
 fn main() {}
 

--- a/tests/ui/borrow_deref_ref_unfixable.rs
+++ b/tests/ui/borrow_deref_ref_unfixable.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code, unused_variables, clippy::explicit_auto_deref)]
 
 fn main() {}
 

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -6,6 +6,7 @@
     unused_braces,
     clippy::borrowed_box,
     clippy::needless_borrow,
+    clippy::needless_return,
     clippy::ptr_arg,
     clippy::redundant_field_names,
     clippy::too_many_arguments,
@@ -184,4 +185,17 @@ fn main() {
     }
     let s6 = S6 { foo: S5 { foo: 5 } };
     let _ = (*s6).foo; // Don't lint. `S6` also has a field named `foo`
+
+    let ref_str = &"foo";
+    let _ = f_str(ref_str);
+    let ref_ref_str = &ref_str;
+    let _ = f_str(ref_ref_str);
+
+    fn _f5(x: &u32) -> u32 {
+        if true {
+            *x
+        } else {
+            return *x;
+        }
+    }
 }

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -8,7 +8,8 @@
     clippy::needless_borrow,
     clippy::ptr_arg,
     clippy::redundant_field_names,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    clippy::borrow_deref_ref
 )]
 
 trait CallableStr {
@@ -48,6 +49,7 @@ impl<U: ?Sized> CallableT<U> for i32 {
 }
 
 fn f_str(_: &str) {}
+fn f_string(_: &String) {}
 fn f_t<T>(_: T) {}
 fn f_ref_t<T: ?Sized>(_: &T) {}
 
@@ -158,4 +160,8 @@ fn main() {
     }
     let _ = E2::S1(&*s); // Don't lint. Inferred type would change.
     let _ = E2::S2 { s: &*s }; // Don't lint. Inferred type would change.
+
+    let ref_s = &s;
+    let _: &String = &*ref_s; // Don't lint reborrow.
+    f_string(&*ref_s); // Don't lint reborrow.
 }

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -1,0 +1,161 @@
+// run-rustfix
+
+#![warn(clippy::explicit_auto_deref)]
+#![allow(
+    dead_code,
+    unused_braces,
+    clippy::borrowed_box,
+    clippy::needless_borrow,
+    clippy::ptr_arg,
+    clippy::redundant_field_names,
+    clippy::too_many_arguments
+)]
+
+trait CallableStr {
+    type T: Fn(&str);
+    fn callable_str(&self) -> Self::T;
+}
+impl CallableStr for () {
+    type T = fn(&str);
+    fn callable_str(&self) -> Self::T {
+        fn f(_: &str) {}
+        f
+    }
+}
+impl CallableStr for i32 {
+    type T = <() as CallableStr>::T;
+    fn callable_str(&self) -> Self::T {
+        ().callable_str()
+    }
+}
+
+trait CallableT<U: ?Sized> {
+    type T: Fn(&U);
+    fn callable_t(&self) -> Self::T;
+}
+impl<U: ?Sized> CallableT<U> for () {
+    type T = fn(&U);
+    fn callable_t(&self) -> Self::T {
+        fn f<U: ?Sized>(_: &U) {}
+        f::<U>
+    }
+}
+impl<U: ?Sized> CallableT<U> for i32 {
+    type T = <() as CallableT<U>>::T;
+    fn callable_t(&self) -> Self::T {
+        ().callable_t()
+    }
+}
+
+fn f_str(_: &str) {}
+fn f_t<T>(_: T) {}
+fn f_ref_t<T: ?Sized>(_: &T) {}
+
+fn f_str_t<T>(_: &str, _: T) {}
+
+fn f_box_t<T>(_: &Box<T>) {}
+
+fn main() {
+    let s = String::new();
+
+    let _: &str = &s;
+    let _ = &*s; // Don't lint. Inferred type would change.
+    let _: &_ = &*s; // Don't lint. Inferred type would change.
+
+    f_str(&s);
+    f_t(&*s); // Don't lint. Inferred type would change.
+    f_ref_t(&*s); // Don't lint. Inferred type would change.
+
+    f_str_t(&s, &*s); // Don't lint second param.
+
+    let b = Box::new(Box::new(Box::new(5)));
+    let _: &Box<i32> = &b;
+    let _: &Box<_> = &**b; // Don't lint. Inferred type would change.
+
+    f_box_t(&**b); // Don't lint. Inferred type would change.
+
+    let c = |_x: &str| ();
+    c(&s);
+
+    let c = |_x| ();
+    c(&*s); // Don't lint. Inferred type would change.
+
+    fn _f(x: &String) -> &str {
+        x
+    }
+
+    fn _f1(x: &String) -> &str {
+        { x }
+    }
+
+    fn _f2(x: &String) -> &str {
+        { x }
+    }
+
+    fn _f3(x: &Box<Box<Box<i32>>>) -> &Box<i32> {
+        x
+    }
+
+    fn _f4(
+        x: String,
+        f1: impl Fn(&str),
+        f2: &dyn Fn(&str),
+        f3: fn(&str),
+        f4: impl CallableStr,
+        f5: <() as CallableStr>::T,
+        f6: <i32 as CallableStr>::T,
+        f7: &dyn CallableStr<T = fn(&str)>,
+        f8: impl CallableT<str>,
+        f9: <() as CallableT<str>>::T,
+        f10: <i32 as CallableT<str>>::T,
+        f11: &dyn CallableT<str, T = fn(&str)>,
+    ) {
+        f1(&x);
+        f2(&x);
+        f3(&x);
+        f4.callable_str()(&x);
+        f5(&x);
+        f6(&x);
+        f7.callable_str()(&x);
+        f8.callable_t()(&x);
+        f9(&x);
+        f10(&x);
+        f11.callable_t()(&x);
+    }
+
+    struct S1<'a>(&'a str);
+    let _ = S1(&s);
+
+    struct S2<'a> {
+        s: &'a str,
+    }
+    let _ = S2 { s: &s };
+
+    struct S3<'a, T: ?Sized>(&'a T);
+    let _ = S3(&*s); // Don't lint. Inferred type would change.
+
+    struct S4<'a, T: ?Sized> {
+        s: &'a T,
+    }
+    let _ = S4 { s: &*s }; // Don't lint. Inferred type would change.
+
+    enum E1<'a> {
+        S1(&'a str),
+        S2 { s: &'a str },
+    }
+    impl<'a> E1<'a> {
+        fn m1(s: &'a String) {
+            let _ = Self::S1(s);
+            let _ = Self::S2 { s: s };
+        }
+    }
+    let _ = E1::S1(&s);
+    let _ = E1::S2 { s: &s };
+
+    enum E2<'a, T: ?Sized> {
+        S1(&'a T),
+        S2 { s: &'a T },
+    }
+    let _ = E2::S1(&*s); // Don't lint. Inferred type would change.
+    let _ = E2::S2 { s: &*s }; // Don't lint. Inferred type would change.
+}

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -198,4 +198,7 @@ fn main() {
             return *x;
         }
     }
+
+    f_str(&&ref_str); // `needless_borrow` will suggest removing both references
+    f_str(&ref_str); // `needless_borrow` will suggest removing only one reference
 }

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -10,7 +10,8 @@
     clippy::ptr_arg,
     clippy::redundant_field_names,
     clippy::too_many_arguments,
-    clippy::borrow_deref_ref
+    clippy::borrow_deref_ref,
+    clippy::let_unit_value
 )]
 
 trait CallableStr {

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -164,4 +164,24 @@ fn main() {
     let ref_s = &s;
     let _: &String = &*ref_s; // Don't lint reborrow.
     f_string(&*ref_s); // Don't lint reborrow.
+
+    struct S5 {
+        foo: u32,
+    }
+    let b = Box::new(Box::new(S5 { foo: 5 }));
+    let _ = b.foo;
+    let _ = b.foo;
+    let _ = b.foo;
+
+    struct S6 {
+        foo: S5,
+    }
+    impl core::ops::Deref for S6 {
+        type Target = S5;
+        fn deref(&self) -> &Self::Target {
+            &self.foo
+        }
+    }
+    let s6 = S6 { foo: S5 { foo: 5 } };
+    let _ = (*s6).foo; // Don't lint. `S6` also has a field named `foo`
 }

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -59,6 +59,10 @@ fn f_str_t<T>(_: &str, _: T) {}
 
 fn f_box_t<T>(_: &Box<T>) {}
 
+extern "C" {
+    fn var(_: u32, ...);
+}
+
 fn main() {
     let s = String::new();
 
@@ -202,4 +206,9 @@ fn main() {
 
     f_str(&&ref_str); // `needless_borrow` will suggest removing both references
     f_str(&ref_str); // `needless_borrow` will suggest removing only one reference
+
+    let x = &&40;
+    unsafe {
+        var(0, &**x);
+    }
 }

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -164,4 +164,24 @@ fn main() {
     let ref_s = &s;
     let _: &String = &*ref_s; // Don't lint reborrow.
     f_string(&*ref_s); // Don't lint reborrow.
+
+    struct S5 {
+        foo: u32,
+    }
+    let b = Box::new(Box::new(S5 { foo: 5 }));
+    let _ = b.foo;
+    let _ = (*b).foo;
+    let _ = (**b).foo;
+
+    struct S6 {
+        foo: S5,
+    }
+    impl core::ops::Deref for S6 {
+        type Target = S5;
+        fn deref(&self) -> &Self::Target {
+            &self.foo
+        }
+    }
+    let s6 = S6 { foo: S5 { foo: 5 } };
+    let _ = (*s6).foo; // Don't lint. `S6` also has a field named `foo`
 }

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -8,7 +8,8 @@
     clippy::needless_borrow,
     clippy::ptr_arg,
     clippy::redundant_field_names,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    clippy::borrow_deref_ref
 )]
 
 trait CallableStr {
@@ -48,6 +49,7 @@ impl<U: ?Sized> CallableT<U> for i32 {
 }
 
 fn f_str(_: &str) {}
+fn f_string(_: &String) {}
 fn f_t<T>(_: T) {}
 fn f_ref_t<T: ?Sized>(_: &T) {}
 
@@ -158,4 +160,8 @@ fn main() {
     }
     let _ = E2::S1(&*s); // Don't lint. Inferred type would change.
     let _ = E2::S2 { s: &*s }; // Don't lint. Inferred type would change.
+
+    let ref_s = &s;
+    let _: &String = &*ref_s; // Don't lint reborrow.
+    f_string(&*ref_s); // Don't lint reborrow.
 }

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -1,0 +1,161 @@
+// run-rustfix
+
+#![warn(clippy::explicit_auto_deref)]
+#![allow(
+    dead_code,
+    unused_braces,
+    clippy::borrowed_box,
+    clippy::needless_borrow,
+    clippy::ptr_arg,
+    clippy::redundant_field_names,
+    clippy::too_many_arguments
+)]
+
+trait CallableStr {
+    type T: Fn(&str);
+    fn callable_str(&self) -> Self::T;
+}
+impl CallableStr for () {
+    type T = fn(&str);
+    fn callable_str(&self) -> Self::T {
+        fn f(_: &str) {}
+        f
+    }
+}
+impl CallableStr for i32 {
+    type T = <() as CallableStr>::T;
+    fn callable_str(&self) -> Self::T {
+        ().callable_str()
+    }
+}
+
+trait CallableT<U: ?Sized> {
+    type T: Fn(&U);
+    fn callable_t(&self) -> Self::T;
+}
+impl<U: ?Sized> CallableT<U> for () {
+    type T = fn(&U);
+    fn callable_t(&self) -> Self::T {
+        fn f<U: ?Sized>(_: &U) {}
+        f::<U>
+    }
+}
+impl<U: ?Sized> CallableT<U> for i32 {
+    type T = <() as CallableT<U>>::T;
+    fn callable_t(&self) -> Self::T {
+        ().callable_t()
+    }
+}
+
+fn f_str(_: &str) {}
+fn f_t<T>(_: T) {}
+fn f_ref_t<T: ?Sized>(_: &T) {}
+
+fn f_str_t<T>(_: &str, _: T) {}
+
+fn f_box_t<T>(_: &Box<T>) {}
+
+fn main() {
+    let s = String::new();
+
+    let _: &str = &*s;
+    let _ = &*s; // Don't lint. Inferred type would change.
+    let _: &_ = &*s; // Don't lint. Inferred type would change.
+
+    f_str(&*s);
+    f_t(&*s); // Don't lint. Inferred type would change.
+    f_ref_t(&*s); // Don't lint. Inferred type would change.
+
+    f_str_t(&*s, &*s); // Don't lint second param.
+
+    let b = Box::new(Box::new(Box::new(5)));
+    let _: &Box<i32> = &**b;
+    let _: &Box<_> = &**b; // Don't lint. Inferred type would change.
+
+    f_box_t(&**b); // Don't lint. Inferred type would change.
+
+    let c = |_x: &str| ();
+    c(&*s);
+
+    let c = |_x| ();
+    c(&*s); // Don't lint. Inferred type would change.
+
+    fn _f(x: &String) -> &str {
+        &**x
+    }
+
+    fn _f1(x: &String) -> &str {
+        { &**x }
+    }
+
+    fn _f2(x: &String) -> &str {
+        &**{ x }
+    }
+
+    fn _f3(x: &Box<Box<Box<i32>>>) -> &Box<i32> {
+        &***x
+    }
+
+    fn _f4(
+        x: String,
+        f1: impl Fn(&str),
+        f2: &dyn Fn(&str),
+        f3: fn(&str),
+        f4: impl CallableStr,
+        f5: <() as CallableStr>::T,
+        f6: <i32 as CallableStr>::T,
+        f7: &dyn CallableStr<T = fn(&str)>,
+        f8: impl CallableT<str>,
+        f9: <() as CallableT<str>>::T,
+        f10: <i32 as CallableT<str>>::T,
+        f11: &dyn CallableT<str, T = fn(&str)>,
+    ) {
+        f1(&*x);
+        f2(&*x);
+        f3(&*x);
+        f4.callable_str()(&*x);
+        f5(&*x);
+        f6(&*x);
+        f7.callable_str()(&*x);
+        f8.callable_t()(&*x);
+        f9(&*x);
+        f10(&*x);
+        f11.callable_t()(&*x);
+    }
+
+    struct S1<'a>(&'a str);
+    let _ = S1(&*s);
+
+    struct S2<'a> {
+        s: &'a str,
+    }
+    let _ = S2 { s: &*s };
+
+    struct S3<'a, T: ?Sized>(&'a T);
+    let _ = S3(&*s); // Don't lint. Inferred type would change.
+
+    struct S4<'a, T: ?Sized> {
+        s: &'a T,
+    }
+    let _ = S4 { s: &*s }; // Don't lint. Inferred type would change.
+
+    enum E1<'a> {
+        S1(&'a str),
+        S2 { s: &'a str },
+    }
+    impl<'a> E1<'a> {
+        fn m1(s: &'a String) {
+            let _ = Self::S1(&**s);
+            let _ = Self::S2 { s: &**s };
+        }
+    }
+    let _ = E1::S1(&*s);
+    let _ = E1::S2 { s: &*s };
+
+    enum E2<'a, T: ?Sized> {
+        S1(&'a T),
+        S2 { s: &'a T },
+    }
+    let _ = E2::S1(&*s); // Don't lint. Inferred type would change.
+    let _ = E2::S2 { s: &*s }; // Don't lint. Inferred type would change.
+}

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -10,7 +10,8 @@
     clippy::ptr_arg,
     clippy::redundant_field_names,
     clippy::too_many_arguments,
-    clippy::borrow_deref_ref
+    clippy::borrow_deref_ref,
+    clippy::let_unit_value
 )]
 
 trait CallableStr {

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -198,4 +198,7 @@ fn main() {
             return *x;
         }
     }
+
+    f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
+    f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
 }

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -59,6 +59,10 @@ fn f_str_t<T>(_: &str, _: T) {}
 
 fn f_box_t<T>(_: &Box<T>) {}
 
+extern "C" {
+    fn var(_: u32, ...);
+}
+
 fn main() {
     let s = String::new();
 
@@ -202,4 +206,9 @@ fn main() {
 
     f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
     f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
+
+    let x = &&40;
+    unsafe {
+        var(0, &**x);
+    }
 }

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -6,6 +6,7 @@
     unused_braces,
     clippy::borrowed_box,
     clippy::needless_borrow,
+    clippy::needless_return,
     clippy::ptr_arg,
     clippy::redundant_field_names,
     clippy::too_many_arguments,
@@ -184,4 +185,17 @@ fn main() {
     }
     let s6 = S6 { foo: S5 { foo: 5 } };
     let _ = (*s6).foo; // Don't lint. `S6` also has a field named `foo`
+
+    let ref_str = &"foo";
+    let _ = f_str(*ref_str);
+    let ref_ref_str = &ref_str;
+    let _ = f_str(**ref_ref_str);
+
+    fn _f5(x: &u32) -> u32 {
+        if true {
+            *x
+        } else {
+            return *x;
+        }
+    }
 }

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -1,5 +1,5 @@
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:61:20
+  --> $DIR/explicit_auto_deref.rs:63:20
    |
 LL |     let _: &str = &*s;
    |                    ^^ help: try this: `s`
@@ -7,151 +7,151 @@ LL |     let _: &str = &*s;
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:65:12
+  --> $DIR/explicit_auto_deref.rs:67:12
    |
 LL |     f_str(&*s);
    |            ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:69:14
+  --> $DIR/explicit_auto_deref.rs:71:14
    |
 LL |     f_str_t(&*s, &*s); // Don't lint second param.
    |              ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:72:25
+  --> $DIR/explicit_auto_deref.rs:74:25
    |
 LL |     let _: &Box<i32> = &**b;
    |                         ^^^ help: try this: `b`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:78:8
+  --> $DIR/explicit_auto_deref.rs:80:8
    |
 LL |     c(&*s);
    |        ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:84:9
+  --> $DIR/explicit_auto_deref.rs:86:9
    |
 LL |         &**x
    |         ^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:88:11
+  --> $DIR/explicit_auto_deref.rs:90:11
    |
 LL |         { &**x }
    |           ^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:92:9
+  --> $DIR/explicit_auto_deref.rs:94:9
    |
 LL |         &**{ x }
    |         ^^^^^^^^ help: try this: `{ x }`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:96:9
+  --> $DIR/explicit_auto_deref.rs:98:9
    |
 LL |         &***x
    |         ^^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:113:13
+  --> $DIR/explicit_auto_deref.rs:115:13
    |
 LL |         f1(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:114:13
+  --> $DIR/explicit_auto_deref.rs:116:13
    |
 LL |         f2(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:115:13
+  --> $DIR/explicit_auto_deref.rs:117:13
    |
 LL |         f3(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:116:28
+  --> $DIR/explicit_auto_deref.rs:118:28
    |
 LL |         f4.callable_str()(&*x);
    |                            ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:117:13
+  --> $DIR/explicit_auto_deref.rs:119:13
    |
 LL |         f5(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:118:13
+  --> $DIR/explicit_auto_deref.rs:120:13
    |
 LL |         f6(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:119:28
+  --> $DIR/explicit_auto_deref.rs:121:28
    |
 LL |         f7.callable_str()(&*x);
    |                            ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:120:26
+  --> $DIR/explicit_auto_deref.rs:122:26
    |
 LL |         f8.callable_t()(&*x);
    |                          ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:121:13
+  --> $DIR/explicit_auto_deref.rs:123:13
    |
 LL |         f9(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:122:14
+  --> $DIR/explicit_auto_deref.rs:124:14
    |
 LL |         f10(&*x);
    |              ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:123:27
+  --> $DIR/explicit_auto_deref.rs:125:27
    |
 LL |         f11.callable_t()(&*x);
    |                           ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:127:17
+  --> $DIR/explicit_auto_deref.rs:129:17
    |
 LL |     let _ = S1(&*s);
    |                 ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:132:22
+  --> $DIR/explicit_auto_deref.rs:134:22
    |
 LL |     let _ = S2 { s: &*s };
    |                      ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:148:30
+  --> $DIR/explicit_auto_deref.rs:150:30
    |
 LL |             let _ = Self::S1(&**s);
    |                              ^^^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:149:35
+  --> $DIR/explicit_auto_deref.rs:151:35
    |
 LL |             let _ = Self::S2 { s: &**s };
    |                                   ^^^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:152:21
+  --> $DIR/explicit_auto_deref.rs:154:21
    |
 LL |     let _ = E1::S1(&*s);
    |                     ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:153:26
+  --> $DIR/explicit_auto_deref.rs:155:26
    |
 LL |     let _ = E1::S2 { s: &*s };
    |                          ^^ help: try this: `s`

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -180,5 +180,17 @@ error: deref which would be done by auto-deref
 LL |     let _ = f_str(**ref_ref_str);
    |                   ^^^^^^^^^^^^^ help: try this: `ref_ref_str`
 
-error: aborting due to 30 previous errors
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:201:13
+   |
+LL |     f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
+   |             ^^^^^^^^ help: try this: `ref_str`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:202:12
+   |
+LL |     f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
+   |            ^^^^^^^^^^ help: try this: `ref_str`
+
+error: aborting due to 32 previous errors
 

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -168,5 +168,17 @@ error: deref which would be done by auto-deref
 LL |     let _ = (**b).foo;
    |             ^^^^^ help: try this: `b`
 
-error: aborting due to 28 previous errors
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:189:19
+   |
+LL |     let _ = f_str(*ref_str);
+   |                   ^^^^^^^^ help: try this: `ref_str`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:191:19
+   |
+LL |     let _ = f_str(**ref_ref_str);
+   |                   ^^^^^^^^^^^^^ help: try this: `ref_ref_str`
+
+error: aborting due to 30 previous errors
 

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -1,5 +1,5 @@
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:65:20
+  --> $DIR/explicit_auto_deref.rs:69:20
    |
 LL |     let _: &str = &*s;
    |                    ^^ help: try this: `s`
@@ -7,187 +7,187 @@ LL |     let _: &str = &*s;
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:69:12
+  --> $DIR/explicit_auto_deref.rs:73:12
    |
 LL |     f_str(&*s);
    |            ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:73:14
+  --> $DIR/explicit_auto_deref.rs:77:14
    |
 LL |     f_str_t(&*s, &*s); // Don't lint second param.
    |              ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:76:25
+  --> $DIR/explicit_auto_deref.rs:80:25
    |
 LL |     let _: &Box<i32> = &**b;
    |                         ^^^ help: try this: `b`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:82:8
+  --> $DIR/explicit_auto_deref.rs:86:8
    |
 LL |     c(&*s);
    |        ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:88:9
+  --> $DIR/explicit_auto_deref.rs:92:9
    |
 LL |         &**x
    |         ^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:92:11
+  --> $DIR/explicit_auto_deref.rs:96:11
    |
 LL |         { &**x }
    |           ^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:96:9
+  --> $DIR/explicit_auto_deref.rs:100:9
    |
 LL |         &**{ x }
    |         ^^^^^^^^ help: try this: `{ x }`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:100:9
+  --> $DIR/explicit_auto_deref.rs:104:9
    |
 LL |         &***x
    |         ^^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:117:13
+  --> $DIR/explicit_auto_deref.rs:121:13
    |
 LL |         f1(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:118:13
+  --> $DIR/explicit_auto_deref.rs:122:13
    |
 LL |         f2(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:119:13
+  --> $DIR/explicit_auto_deref.rs:123:13
    |
 LL |         f3(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:120:28
+  --> $DIR/explicit_auto_deref.rs:124:28
    |
 LL |         f4.callable_str()(&*x);
    |                            ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:121:13
+  --> $DIR/explicit_auto_deref.rs:125:13
    |
 LL |         f5(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:122:13
+  --> $DIR/explicit_auto_deref.rs:126:13
    |
 LL |         f6(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:123:28
+  --> $DIR/explicit_auto_deref.rs:127:28
    |
 LL |         f7.callable_str()(&*x);
    |                            ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:124:26
+  --> $DIR/explicit_auto_deref.rs:128:26
    |
 LL |         f8.callable_t()(&*x);
    |                          ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:125:13
+  --> $DIR/explicit_auto_deref.rs:129:13
    |
 LL |         f9(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:126:14
+  --> $DIR/explicit_auto_deref.rs:130:14
    |
 LL |         f10(&*x);
    |              ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:127:27
+  --> $DIR/explicit_auto_deref.rs:131:27
    |
 LL |         f11.callable_t()(&*x);
    |                           ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:131:17
+  --> $DIR/explicit_auto_deref.rs:135:17
    |
 LL |     let _ = S1(&*s);
    |                 ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:136:22
+  --> $DIR/explicit_auto_deref.rs:140:22
    |
 LL |     let _ = S2 { s: &*s };
    |                      ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:152:30
+  --> $DIR/explicit_auto_deref.rs:156:30
    |
 LL |             let _ = Self::S1(&**s);
    |                              ^^^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:153:35
+  --> $DIR/explicit_auto_deref.rs:157:35
    |
 LL |             let _ = Self::S2 { s: &**s };
    |                                   ^^^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:156:21
+  --> $DIR/explicit_auto_deref.rs:160:21
    |
 LL |     let _ = E1::S1(&*s);
    |                     ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:157:26
+  --> $DIR/explicit_auto_deref.rs:161:26
    |
 LL |     let _ = E1::S2 { s: &*s };
    |                          ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:175:13
+  --> $DIR/explicit_auto_deref.rs:179:13
    |
 LL |     let _ = (*b).foo;
    |             ^^^^ help: try this: `b`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:176:13
+  --> $DIR/explicit_auto_deref.rs:180:13
    |
 LL |     let _ = (**b).foo;
    |             ^^^^^ help: try this: `b`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:191:19
+  --> $DIR/explicit_auto_deref.rs:195:19
    |
 LL |     let _ = f_str(*ref_str);
    |                   ^^^^^^^^ help: try this: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:193:19
+  --> $DIR/explicit_auto_deref.rs:197:19
    |
 LL |     let _ = f_str(**ref_ref_str);
    |                   ^^^^^^^^^^^^^ help: try this: `ref_ref_str`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:203:13
+  --> $DIR/explicit_auto_deref.rs:207:13
    |
 LL |     f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
    |             ^^^^^^^^ help: try this: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:204:12
+  --> $DIR/explicit_auto_deref.rs:208:12
    |
 LL |     f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
    |            ^^^^^^^^^^ help: try this: `ref_str`

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -1,5 +1,5 @@
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:63:20
+  --> $DIR/explicit_auto_deref.rs:65:20
    |
 LL |     let _: &str = &*s;
    |                    ^^ help: try this: `s`
@@ -7,187 +7,187 @@ LL |     let _: &str = &*s;
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:67:12
+  --> $DIR/explicit_auto_deref.rs:69:12
    |
 LL |     f_str(&*s);
    |            ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:71:14
+  --> $DIR/explicit_auto_deref.rs:73:14
    |
 LL |     f_str_t(&*s, &*s); // Don't lint second param.
    |              ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:74:25
+  --> $DIR/explicit_auto_deref.rs:76:25
    |
 LL |     let _: &Box<i32> = &**b;
    |                         ^^^ help: try this: `b`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:80:8
+  --> $DIR/explicit_auto_deref.rs:82:8
    |
 LL |     c(&*s);
    |        ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:86:9
+  --> $DIR/explicit_auto_deref.rs:88:9
    |
 LL |         &**x
    |         ^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:90:11
+  --> $DIR/explicit_auto_deref.rs:92:11
    |
 LL |         { &**x }
    |           ^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:94:9
+  --> $DIR/explicit_auto_deref.rs:96:9
    |
 LL |         &**{ x }
    |         ^^^^^^^^ help: try this: `{ x }`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:98:9
+  --> $DIR/explicit_auto_deref.rs:100:9
    |
 LL |         &***x
    |         ^^^^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:115:13
+  --> $DIR/explicit_auto_deref.rs:117:13
    |
 LL |         f1(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:116:13
+  --> $DIR/explicit_auto_deref.rs:118:13
    |
 LL |         f2(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:117:13
+  --> $DIR/explicit_auto_deref.rs:119:13
    |
 LL |         f3(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:118:28
+  --> $DIR/explicit_auto_deref.rs:120:28
    |
 LL |         f4.callable_str()(&*x);
    |                            ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:119:13
+  --> $DIR/explicit_auto_deref.rs:121:13
    |
 LL |         f5(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:120:13
+  --> $DIR/explicit_auto_deref.rs:122:13
    |
 LL |         f6(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:121:28
+  --> $DIR/explicit_auto_deref.rs:123:28
    |
 LL |         f7.callable_str()(&*x);
    |                            ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:122:26
+  --> $DIR/explicit_auto_deref.rs:124:26
    |
 LL |         f8.callable_t()(&*x);
    |                          ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:123:13
+  --> $DIR/explicit_auto_deref.rs:125:13
    |
 LL |         f9(&*x);
    |             ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:124:14
+  --> $DIR/explicit_auto_deref.rs:126:14
    |
 LL |         f10(&*x);
    |              ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:125:27
+  --> $DIR/explicit_auto_deref.rs:127:27
    |
 LL |         f11.callable_t()(&*x);
    |                           ^^ help: try this: `x`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:129:17
+  --> $DIR/explicit_auto_deref.rs:131:17
    |
 LL |     let _ = S1(&*s);
    |                 ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:134:22
+  --> $DIR/explicit_auto_deref.rs:136:22
    |
 LL |     let _ = S2 { s: &*s };
    |                      ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:150:30
+  --> $DIR/explicit_auto_deref.rs:152:30
    |
 LL |             let _ = Self::S1(&**s);
    |                              ^^^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:151:35
+  --> $DIR/explicit_auto_deref.rs:153:35
    |
 LL |             let _ = Self::S2 { s: &**s };
    |                                   ^^^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:154:21
+  --> $DIR/explicit_auto_deref.rs:156:21
    |
 LL |     let _ = E1::S1(&*s);
    |                     ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:155:26
+  --> $DIR/explicit_auto_deref.rs:157:26
    |
 LL |     let _ = E1::S2 { s: &*s };
    |                          ^^ help: try this: `s`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:173:13
+  --> $DIR/explicit_auto_deref.rs:175:13
    |
 LL |     let _ = (*b).foo;
    |             ^^^^ help: try this: `b`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:174:13
+  --> $DIR/explicit_auto_deref.rs:176:13
    |
 LL |     let _ = (**b).foo;
    |             ^^^^^ help: try this: `b`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:189:19
+  --> $DIR/explicit_auto_deref.rs:191:19
    |
 LL |     let _ = f_str(*ref_str);
    |                   ^^^^^^^^ help: try this: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:191:19
+  --> $DIR/explicit_auto_deref.rs:193:19
    |
 LL |     let _ = f_str(**ref_ref_str);
    |                   ^^^^^^^^^^^^^ help: try this: `ref_ref_str`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:201:13
+  --> $DIR/explicit_auto_deref.rs:203:13
    |
 LL |     f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
    |             ^^^^^^^^ help: try this: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> $DIR/explicit_auto_deref.rs:202:12
+  --> $DIR/explicit_auto_deref.rs:204:12
    |
 LL |     f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
    |            ^^^^^^^^^^ help: try this: `ref_str`

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -156,5 +156,17 @@ error: deref which would be done by auto-deref
 LL |     let _ = E1::S2 { s: &*s };
    |                          ^^ help: try this: `s`
 
-error: aborting due to 26 previous errors
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:173:13
+   |
+LL |     let _ = (*b).foo;
+   |             ^^^^ help: try this: `b`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:174:13
+   |
+LL |     let _ = (**b).foo;
+   |             ^^^^^ help: try this: `b`
+
+error: aborting due to 28 previous errors
 

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -1,0 +1,160 @@
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:61:20
+   |
+LL |     let _: &str = &*s;
+   |                    ^^ help: try this: `s`
+   |
+   = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:65:12
+   |
+LL |     f_str(&*s);
+   |            ^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:69:14
+   |
+LL |     f_str_t(&*s, &*s); // Don't lint second param.
+   |              ^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:72:25
+   |
+LL |     let _: &Box<i32> = &**b;
+   |                         ^^^ help: try this: `b`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:78:8
+   |
+LL |     c(&*s);
+   |        ^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:84:9
+   |
+LL |         &**x
+   |         ^^^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:88:11
+   |
+LL |         { &**x }
+   |           ^^^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:92:9
+   |
+LL |         &**{ x }
+   |         ^^^^^^^^ help: try this: `{ x }`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:96:9
+   |
+LL |         &***x
+   |         ^^^^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:113:13
+   |
+LL |         f1(&*x);
+   |             ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:114:13
+   |
+LL |         f2(&*x);
+   |             ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:115:13
+   |
+LL |         f3(&*x);
+   |             ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:116:28
+   |
+LL |         f4.callable_str()(&*x);
+   |                            ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:117:13
+   |
+LL |         f5(&*x);
+   |             ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:118:13
+   |
+LL |         f6(&*x);
+   |             ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:119:28
+   |
+LL |         f7.callable_str()(&*x);
+   |                            ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:120:26
+   |
+LL |         f8.callable_t()(&*x);
+   |                          ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:121:13
+   |
+LL |         f9(&*x);
+   |             ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:122:14
+   |
+LL |         f10(&*x);
+   |              ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:123:27
+   |
+LL |         f11.callable_t()(&*x);
+   |                           ^^ help: try this: `x`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:127:17
+   |
+LL |     let _ = S1(&*s);
+   |                 ^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:132:22
+   |
+LL |     let _ = S2 { s: &*s };
+   |                      ^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:148:30
+   |
+LL |             let _ = Self::S1(&**s);
+   |                              ^^^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:149:35
+   |
+LL |             let _ = Self::S2 { s: &**s };
+   |                                   ^^^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:152:21
+   |
+LL |     let _ = E1::S1(&*s);
+   |                     ^^ help: try this: `s`
+
+error: deref which would be done by auto-deref
+  --> $DIR/explicit_auto_deref.rs:153:26
+   |
+LL |     let _ = E1::S2 { s: &*s };
+   |                          ^^ help: try this: `s`
+
+error: aborting due to 26 previous errors
+

--- a/tests/ui/explicit_deref_methods.fixed
+++ b/tests/ui/explicit_deref_methods.fixed
@@ -4,7 +4,8 @@
     unused_variables,
     clippy::clone_double_ref,
     clippy::needless_borrow,
-    clippy::borrow_deref_ref
+    clippy::borrow_deref_ref,
+    clippy::explicit_auto_deref
 )]
 #![warn(clippy::explicit_deref_methods)]
 

--- a/tests/ui/explicit_deref_methods.rs
+++ b/tests/ui/explicit_deref_methods.rs
@@ -4,7 +4,8 @@
     unused_variables,
     clippy::clone_double_ref,
     clippy::needless_borrow,
-    clippy::borrow_deref_ref
+    clippy::borrow_deref_ref,
+    clippy::explicit_auto_deref
 )]
 #![warn(clippy::explicit_deref_methods)]
 

--- a/tests/ui/explicit_deref_methods.stderr
+++ b/tests/ui/explicit_deref_methods.stderr
@@ -1,5 +1,5 @@
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:35:19
+  --> $DIR/explicit_deref_methods.rs:36:19
    |
 LL |     let b: &str = a.deref();
    |                   ^^^^^^^^^ help: try this: `&*a`
@@ -7,67 +7,67 @@ LL |     let b: &str = a.deref();
    = note: `-D clippy::explicit-deref-methods` implied by `-D warnings`
 
 error: explicit `deref_mut` method call
-  --> $DIR/explicit_deref_methods.rs:37:23
+  --> $DIR/explicit_deref_methods.rs:38:23
    |
 LL |     let b: &mut str = a.deref_mut();
    |                       ^^^^^^^^^^^^^ help: try this: `&mut **a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:40:39
+  --> $DIR/explicit_deref_methods.rs:41:39
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
    |                                       ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:40:50
+  --> $DIR/explicit_deref_methods.rs:41:50
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
    |                                                  ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:42:20
+  --> $DIR/explicit_deref_methods.rs:43:20
    |
 LL |     println!("{}", a.deref());
    |                    ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:45:11
+  --> $DIR/explicit_deref_methods.rs:46:11
    |
 LL |     match a.deref() {
    |           ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:49:28
+  --> $DIR/explicit_deref_methods.rs:50:28
    |
 LL |     let b: String = concat(a.deref());
    |                            ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:51:13
+  --> $DIR/explicit_deref_methods.rs:52:13
    |
 LL |     let b = just_return(a).deref();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `just_return(a)`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:53:28
+  --> $DIR/explicit_deref_methods.rs:54:28
    |
 LL |     let b: String = concat(just_return(a).deref());
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `just_return(a)`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:55:19
+  --> $DIR/explicit_deref_methods.rs:56:19
    |
 LL |     let b: &str = a.deref().deref();
    |                   ^^^^^^^^^^^^^^^^^ help: try this: `&**a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:58:13
+  --> $DIR/explicit_deref_methods.rs:59:13
    |
 LL |     let b = opt_a.unwrap().deref();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&*opt_a.unwrap()`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:84:31
+  --> $DIR/explicit_deref_methods.rs:85:31
    |
 LL |     let b: &str = expr_deref!(a.deref());
    |                               ^^^^^^^^^ help: try this: `&*a`

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -85,6 +85,36 @@ fn main() {
     let _ = x.0;
     let x = &x as *const (i32, i32);
     let _ = unsafe { (*x).0 };
+
+    // Issue #8367
+    trait Foo {
+        fn foo(self);
+    }
+    impl Foo for &'_ () {
+        fn foo(self) {}
+    }
+    (&()).foo(); // Don't lint. `()` doesn't implement `Foo`
+    (&()).foo();
+
+    impl Foo for i32 {
+        fn foo(self) {}
+    }
+    impl Foo for &'_ i32 {
+        fn foo(self) {}
+    }
+    (&5).foo(); // Don't lint. `5` will call `<i32 as Foo>::foo`
+    (&5).foo();
+
+    trait FooRef {
+        fn foo_ref(&self);
+    }
+    impl FooRef for () {
+        fn foo_ref(&self) {}
+    }
+    impl FooRef for &'_ () {
+        fn foo_ref(&self) {}
+    }
+    (&&()).foo_ref(); // Don't lint. `&()` will call `<() as FooRef>::foo_ref`
 }
 
 #[allow(clippy::needless_borrowed_reference)]

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -62,7 +62,18 @@ fn main() {
         0 => &mut x,
         _ => &mut *x,
     };
-
+    let y: &mut i32 = match 0 {
+        // Lint here. The type given above triggers auto-borrow.
+        0 => x,
+        _ => &mut *x,
+    };
+    fn ref_mut_i32(_: &mut i32) {}
+    ref_mut_i32(match 0 {
+        // Lint here. The type given above triggers auto-borrow.
+        0 => x,
+        _ => &mut *x,
+    });
+    // use 'x' after to make sure it's still usable in the fixed code.
     *x = 5;
 
     let s = String::new();

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -85,6 +85,36 @@ fn main() {
     let _ = (&x).0;
     let x = &x as *const (i32, i32);
     let _ = unsafe { (&*x).0 };
+
+    // Issue #8367
+    trait Foo {
+        fn foo(self);
+    }
+    impl Foo for &'_ () {
+        fn foo(self) {}
+    }
+    (&()).foo(); // Don't lint. `()` doesn't implement `Foo`
+    (&&()).foo();
+
+    impl Foo for i32 {
+        fn foo(self) {}
+    }
+    impl Foo for &'_ i32 {
+        fn foo(self) {}
+    }
+    (&5).foo(); // Don't lint. `5` will call `<i32 as Foo>::foo`
+    (&&5).foo();
+
+    trait FooRef {
+        fn foo_ref(&self);
+    }
+    impl FooRef for () {
+        fn foo_ref(&self) {}
+    }
+    impl FooRef for &'_ () {
+        fn foo_ref(&self) {}
+    }
+    (&&()).foo_ref(); // Don't lint. `&()` will call `<() as FooRef>::foo_ref`
 }
 
 #[allow(clippy::needless_borrowed_reference)]

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -62,7 +62,18 @@ fn main() {
         0 => &mut x,
         _ => &mut *x,
     };
-
+    let y: &mut i32 = match 0 {
+        // Lint here. The type given above triggers auto-borrow.
+        0 => &mut x,
+        _ => &mut *x,
+    };
+    fn ref_mut_i32(_: &mut i32) {}
+    ref_mut_i32(match 0 {
+        // Lint here. The type given above triggers auto-borrow.
+        0 => &mut x,
+        _ => &mut *x,
+    });
+    // use 'x' after to make sure it's still usable in the fixed code.
     *x = 5;
 
     let s = String::new();

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -84,17 +84,29 @@ error: this expression creates a reference which is immediately dereferenced by 
 LL |     let y: &mut i32 = &mut &mut x;
    |                       ^^^^^^^^^^^ help: change this to: `x`
 
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> $DIR/needless_borrow.rs:67:14
+   |
+LL |         0 => &mut x,
+   |              ^^^^^^ help: change this to: `x`
+
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> $DIR/needless_borrow.rs:73:14
+   |
+LL |         0 => &mut x,
+   |              ^^^^^^ help: change this to: `x`
+
 error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:74:13
+  --> $DIR/needless_borrow.rs:85:13
    |
 LL |     let _ = (&x).0;
    |             ^^^^ help: change this to: `x`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:76:22
+  --> $DIR/needless_borrow.rs:87:22
    |
 LL |     let _ = unsafe { (&*x).0 };
    |                      ^^^^^ help: change this to: `(*x)`
 
-error: aborting due to 16 previous errors
+error: aborting due to 18 previous errors
 

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -108,5 +108,17 @@ error: this expression borrows a value the compiler would automatically borrow
 LL |     let _ = unsafe { (&*x).0 };
    |                      ^^^^^ help: change this to: `(*x)`
 
-error: aborting due to 18 previous errors
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> $DIR/needless_borrow.rs:97:5
+   |
+LL |     (&&()).foo();
+   |     ^^^^^^ help: change this to: `(&())`
+
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> $DIR/needless_borrow.rs:106:5
+   |
+LL |     (&&5).foo();
+   |     ^^^^^ help: change this to: `(&5)`
+
+error: aborting due to 20 previous errors
 

--- a/tests/ui/needless_borrow_pat.rs
+++ b/tests/ui/needless_borrow_pat.rs
@@ -1,7 +1,7 @@
 // FIXME: run-rustfix waiting on multi-span suggestions
 
 #![warn(clippy::needless_borrow)]
-#![allow(clippy::needless_borrowed_reference)]
+#![allow(clippy::needless_borrowed_reference, clippy::explicit_auto_deref)]
 
 fn f1(_: &str) {}
 macro_rules! m1 {

--- a/tests/ui/ref_binding_to_reference.rs
+++ b/tests/ui/ref_binding_to_reference.rs
@@ -2,7 +2,7 @@
 
 #![feature(lint_reasons)]
 #![warn(clippy::ref_binding_to_reference)]
-#![allow(clippy::needless_borrowed_reference)]
+#![allow(clippy::needless_borrowed_reference, clippy::explicit_auto_deref)]
 
 fn f1(_: &str) {}
 macro_rules! m2 {

--- a/tests/ui/search_is_some_fixable_none.fixed
+++ b/tests/ui/search_is_some_fixable_none.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![allow(dead_code)]
+#![allow(dead_code, clippy::explicit_auto_deref)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/search_is_some_fixable_none.rs
+++ b/tests/ui/search_is_some_fixable_none.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![allow(dead_code)]
+#![allow(dead_code, clippy::explicit_auto_deref)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/search_is_some_fixable_some.fixed
+++ b/tests/ui/search_is_some_fixable_some.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-#![allow(dead_code)]
+#![allow(dead_code, clippy::explicit_auto_deref)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/search_is_some_fixable_some.rs
+++ b/tests/ui/search_is_some_fixable_some.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-#![allow(dead_code)]
+#![allow(dead_code, clippy::explicit_auto_deref)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
 
 #![deny(clippy::useless_asref)]
+#![allow(clippy::explicit_auto_deref)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -1,6 +1,7 @@
 // run-rustfix
 
 #![deny(clippy::useless_asref)]
+#![allow(clippy::explicit_auto_deref)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/useless_asref.stderr
+++ b/tests/ui/useless_asref.stderr
@@ -1,5 +1,5 @@
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:43:18
+  --> $DIR/useless_asref.rs:44:18
    |
 LL |         foo_rstr(rstr.as_ref());
    |                  ^^^^^^^^^^^^^ help: try this: `rstr`
@@ -11,61 +11,61 @@ LL | #![deny(clippy::useless_asref)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:45:20
+  --> $DIR/useless_asref.rs:46:20
    |
 LL |         foo_rslice(rslice.as_ref());
    |                    ^^^^^^^^^^^^^^^ help: try this: `rslice`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:49:21
+  --> $DIR/useless_asref.rs:50:21
    |
 LL |         foo_mrslice(mrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:51:20
+  --> $DIR/useless_asref.rs:52:20
    |
 LL |         foo_rslice(mrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:58:20
+  --> $DIR/useless_asref.rs:59:20
    |
 LL |         foo_rslice(rrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^ help: try this: `rrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:60:18
+  --> $DIR/useless_asref.rs:61:18
    |
 LL |         foo_rstr(rrrrrstr.as_ref());
    |                  ^^^^^^^^^^^^^^^^^ help: try this: `rrrrrstr`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:65:21
+  --> $DIR/useless_asref.rs:66:21
    |
 LL |         foo_mrslice(mrrrrrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:67:20
+  --> $DIR/useless_asref.rs:68:20
    |
 LL |         foo_rslice(mrrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:71:16
+  --> $DIR/useless_asref.rs:72:16
    |
 LL |     foo_rrrrmr((&&&&MoreRef).as_ref());
    |                ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(&&&&MoreRef)`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:121:13
+  --> $DIR/useless_asref.rs:122:13
    |
 LL |     foo_mrt(mrt.as_mut());
    |             ^^^^^^^^^^^^ help: try this: `mrt`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:123:12
+  --> $DIR/useless_asref.rs:124:12
    |
 LL |     foo_rt(mrt.as_ref());
    |            ^^^^^^^^^^^^ help: try this: `mrt`


### PR DESCRIPTION
fixes: #234
fixes: #8367
fixes: #8380

Still things to do:

* ~~This currently only lints `&*<expr>` when it doesn't trigger `needless_borrow`.~~
* ~~This requires a borrow after a deref to trigger. So `*<expr>` changing `&&T` to `&T` won't be caught.~~
* The `deref` and `deref_mut` trait methods aren't linted.
* Neither ~~field accesses~~, nor method receivers are linted.
* ~~This probably shouldn't lint reborrowing.~~
* Full slicing to deref should probably be handled here as well. e.g. `&vec[..]` when just `&vec` would do

changelog: new lint `explicit_auto_deref`
