### PR TITLE
Format `if_chain` invocations in clippy_utils

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -331,17 +331,16 @@ impl<'a, 'tcx> ConstEvalLateContext<'a, 'tcx> {
                     let def_path: Vec<&str> = def_path.iter().take(4).map(Symbol::as_str).collect();
                     if let ["core", "num", int_impl, "max_value"] = *def_path;
                     then {
-                       let value = match int_impl {
-                           "<impl i8>" => i8::MAX as u128,
-                           "<impl i16>" => i16::MAX as u128,
-                           "<impl i32>" => i32::MAX as u128,
-                           "<impl i64>" => i64::MAX as u128,
-                           "<impl i128>" => i128::MAX as u128,
-                           _ => return None,
-                       };
-                       Some(Constant::Int(value))
-                    }
-                    else {
+                        let value = match int_impl {
+                            "<impl i8>" => i8::MAX as u128,
+                            "<impl i16>" => i16::MAX as u128,
+                            "<impl i32>" => i32::MAX as u128,
+                            "<impl i64>" => i64::MAX as u128,
+                            "<impl i128>" => i128::MAX as u128,
+                            _ => return None,
+                        };
+                        Some(Constant::Int(value))
+                    } else {
                         None
                     }
                 }

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -284,8 +284,7 @@ impl<'a> VecArgs<'a> {
                 return if match_def_path(cx, fun_def_id, &paths::VEC_FROM_ELEM) && args.len() == 2 {
                     // `vec![elem; size]` case
                     Some(VecArgs::Repeat(&args[0], &args[1]))
-                }
-                else if match_def_path(cx, fun_def_id, &paths::SLICE_INTO_VEC) && args.len() == 1 {
+                } else if match_def_path(cx, fun_def_id, &paths::SLICE_INTO_VEC) && args.len() == 1 {
                     // `vec![a, b, c]` case
                     if_chain! {
                         if let hir::ExprKind::Box(boxed) = args[0].kind;
@@ -296,11 +295,9 @@ impl<'a> VecArgs<'a> {
                     }
 
                     None
-                }
-                else if match_def_path(cx, fun_def_id, &paths::VEC_NEW) && args.is_empty() {
+                } else if match_def_path(cx, fun_def_id, &paths::VEC_NEW) && args.is_empty() {
                     Some(VecArgs::Vec(&[]))
-                }
-                else {
+                } else {
                     None
                 };
             }
@@ -456,7 +453,7 @@ pub fn get_vec_init_kind<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -
                         if let ExprKind::Lit(lit) = &arg.kind;
                         if let LitKind::Int(num, _) = lit.node;
                         then {
-                            return Some(VecInitKind::WithLiteralCapacity(num.try_into().ok()?))
+                            return Some(VecInitKind::WithLiteralCapacity(num.try_into().ok()?));
                         }
                     }
                     return Some(VecInitKind::WithExprCapacity(arg.hir_id));

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -603,7 +603,9 @@ pub fn trait_ref_of_method<'tcx>(cx: &LateContext<'tcx>, def_id: LocalDefId) -> 
         if parent_impl != CRATE_DEF_ID;
         if let hir::Node::Item(item) = cx.tcx.hir().get_by_def_id(parent_impl);
         if let hir::ItemKind::Impl(impl_) = &item.kind;
-        then { return impl_.of_trait.as_ref(); }
+        then {
+            return impl_.of_trait.as_ref();
+        }
     }
     None
 }
@@ -713,12 +715,7 @@ pub fn is_default_equivalent_call(cx: &LateContext<'_>, repl_func: &Expr<'_>) ->
         if let Some(repl_def_id) = cx.qpath_res(repl_func_qpath, repl_func.hir_id).opt_def_id();
         if is_diag_trait_item(cx, repl_def_id, sym::Default)
             || is_default_equivalent_ctor(cx, repl_def_id, repl_func_qpath);
-        then {
-            true
-        }
-        else {
-            false
-        }
+        then { true } else { false }
     }
 }
 
@@ -1553,8 +1550,7 @@ pub fn is_try<'tcx>(cx: &LateContext<'_>, expr: &'tcx Expr<'tcx>) -> Option<&'tc
             if arms.len() == 2;
             if arms[0].guard.is_none();
             if arms[1].guard.is_none();
-            if (is_ok(cx, &arms[0]) && is_err(cx, &arms[1])) ||
-                (is_ok(cx, &arms[1]) && is_err(cx, &arms[0]));
+            if (is_ok(cx, &arms[0]) && is_err(cx, &arms[1])) || (is_ok(cx, &arms[1]) && is_err(cx, &arms[0]));
             then {
                 return Some(expr);
             }
@@ -1644,7 +1640,7 @@ pub fn match_function_call<'tcx>(
         if let Some(fun_def_id) = cx.qpath_res(qpath, fun.hir_id).opt_def_id();
         if match_def_path(cx, fun_def_id, path);
         then {
-            return Some(args)
+            return Some(args);
         }
     };
     None

--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -452,7 +452,11 @@ impl<'tcx> FormatArgsExpn<'tcx> {
                     if let Ok(i) = usize::try_from(position);
                     if let Some(&(j, format_trait)) = self.formatters.get(i);
                     then {
-                        Some(FormatArgsArg { value: self.value_args[j], format_trait, spec: Some(spec) })
+                        Some(FormatArgsArg {
+                            value: self.value_args[j],
+                            format_trait,
+                            spec: Some(spec),
+                        })
                     } else {
                         None
                     }


### PR DESCRIPTION
Not realizing it was [already obsolete](https://github.com/rust-lang/rust-clippy/pull/8360), I built a [tool to format inside `if_chain` invocations](https://crates.io/crates/rustfmt_if_chain).

This PR applies the tool to clippy_utils. (If you apply it to clippy_lints, the changes are extensive.)

Anyway, I'm making it known here in case anyone wants to use it while `if-let` chain support is developed for `rustfmt`. (There could be a few Clippy PRs between now and then, and IMHO, the code looks better with the `if_chain` invocations formatted.)

Cheers.

---

changelog: none