### PR TITLE
make unwrap_used also trigger on .get().unwrap()

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2404,8 +2404,12 @@ fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Optio
             },
             ("unwrap", []) => {
                 match method_call(recv) {
-                    Some(("get", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, false),
-                    Some(("get_mut", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, true),
+                    Some(("get", [recv, get_arg], _)) => {
+                        get_unwrap::check(cx, expr, recv, get_arg, false);
+                    },
+                    Some(("get_mut", [recv, get_arg], _)) => {
+                        get_unwrap::check(cx, expr, recv, get_arg, true);
+                    },
                     _ => {},
                 }
                 unwrap_used::check(cx, expr, recv);

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2402,10 +2402,13 @@ fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Optio
             ("to_os_string" | "to_owned" | "to_path_buf" | "to_vec", []) => {
                 implicit_clone::check(cx, name, expr, recv);
             },
-            ("unwrap", []) => match method_call(recv) {
-                Some(("get", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, false),
-                Some(("get_mut", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, true),
-                _ => unwrap_used::check(cx, expr, recv),
+            ("unwrap", []) => {
+                match method_call(recv) {
+                    Some(("get", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, false),
+                    Some(("get_mut", [recv, get_arg], _)) => get_unwrap::check(cx, expr, recv, get_arg, true),
+                    _ => {},
+                }
+                unwrap_used::check(cx, expr, recv);
             },
             ("unwrap_or", [u_arg]) => match method_call(recv) {
                 Some((arith @ ("checked_add" | "checked_sub" | "checked_mul"), [lhs, rhs], _)) => {

--- a/tests/ui/get_unwrap.fixed
+++ b/tests/ui/get_unwrap.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 #![allow(unused_mut, clippy::from_iter_instead_of_collect)]
-#![deny(clippy::get_unwrap)]
+#![deny(clippy::get_unwrap, clippy::unwrap_used)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/get_unwrap.fixed
+++ b/tests/ui/get_unwrap.fixed
@@ -39,6 +39,7 @@ fn main() {
         let _ = &some_vecdeque[0];
         let _ = &some_hashmap[&1];
         let _ = &some_btreemap[&1];
+        #[allow(clippy::unwrap_used)]
         let _ = false_positive.get(0).unwrap();
         // Test with deref
         let _: u8 = boxed_slice[1];
@@ -51,9 +52,12 @@ fn main() {
         some_vec[0] = 1;
         some_vecdeque[0] = 1;
         // Check false positives
-        *some_hashmap.get_mut(&1).unwrap() = 'b';
-        *some_btreemap.get_mut(&1).unwrap() = 'b';
-        *false_positive.get_mut(0).unwrap() = 1;
+        #[allow(clippy::unwrap_used)]
+        {
+            *some_hashmap.get_mut(&1).unwrap() = 'b';
+            *some_btreemap.get_mut(&1).unwrap() = 'b';
+            *false_positive.get_mut(0).unwrap() = 1;
+        }
     }
 
     {

--- a/tests/ui/get_unwrap.fixed
+++ b/tests/ui/get_unwrap.fixed
@@ -1,6 +1,8 @@
 // run-rustfix
+
 #![allow(unused_mut, clippy::from_iter_instead_of_collect)]
-#![deny(clippy::get_unwrap, clippy::unwrap_used)]
+#![warn(clippy::unwrap_used)]
+#![deny(clippy::get_unwrap)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/get_unwrap.rs
+++ b/tests/ui/get_unwrap.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 #![allow(unused_mut, clippy::from_iter_instead_of_collect)]
-#![deny(clippy::get_unwrap)]
+#![deny(clippy::get_unwrap, clippy::unwrap_used)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/get_unwrap.rs
+++ b/tests/ui/get_unwrap.rs
@@ -39,6 +39,7 @@ fn main() {
         let _ = some_vecdeque.get(0).unwrap();
         let _ = some_hashmap.get(&1).unwrap();
         let _ = some_btreemap.get(&1).unwrap();
+        #[allow(clippy::unwrap_used)]
         let _ = false_positive.get(0).unwrap();
         // Test with deref
         let _: u8 = *boxed_slice.get(1).unwrap();
@@ -51,9 +52,12 @@ fn main() {
         *some_vec.get_mut(0).unwrap() = 1;
         *some_vecdeque.get_mut(0).unwrap() = 1;
         // Check false positives
-        *some_hashmap.get_mut(&1).unwrap() = 'b';
-        *some_btreemap.get_mut(&1).unwrap() = 'b';
-        *false_positive.get_mut(0).unwrap() = 1;
+        #[allow(clippy::unwrap_used)]
+        {
+            *some_hashmap.get_mut(&1).unwrap() = 'b';
+            *some_btreemap.get_mut(&1).unwrap() = 'b';
+            *false_positive.get_mut(0).unwrap() = 1;
+        }
     }
 
     {

--- a/tests/ui/get_unwrap.rs
+++ b/tests/ui/get_unwrap.rs
@@ -1,6 +1,8 @@
 // run-rustfix
+
 #![allow(unused_mut, clippy::from_iter_instead_of_collect)]
-#![deny(clippy::get_unwrap, clippy::unwrap_used)]
+#![warn(clippy::unwrap_used)]
+#![deny(clippy::get_unwrap)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/get_unwrap.stderr
+++ b/tests/ui/get_unwrap.stderr
@@ -7,8 +7,21 @@ LL |         let _ = boxed_slice.get(1).unwrap();
 note: the lint level is defined here
   --> $DIR/get_unwrap.rs:3:9
    |
-LL | #![deny(clippy::get_unwrap)]
+LL | #![deny(clippy::get_unwrap, clippy::unwrap_used)]
    |         ^^^^^^^^^^^^^^^^^^
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:34:17
+   |
+LL |         let _ = boxed_slice.get(1).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/get_unwrap.rs:3:29
+   |
+LL | #![deny(clippy::get_unwrap, clippy::unwrap_used)]
+   |                             ^^^^^^^^^^^^^^^^^^^
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:35:17
@@ -16,11 +29,27 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
 
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:35:17
+   |
+LL |         let _ = some_slice.get(0).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:36:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:36:17
+   |
+LL |         let _ = some_vec.get(0).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:37:17
@@ -28,11 +57,27 @@ error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
 
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:37:17
+   |
+LL |         let _ = some_vecdeque.get(0).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
 error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:38:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:38:17
+   |
+LL |         let _ = some_hashmap.get(&1).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:39:17
@@ -40,11 +85,35 @@ error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
 
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:39:17
+   |
+LL |         let _ = some_btreemap.get(&1).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:40:17
+   |
+LL |         let _ = false_positive.get(0).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:42:21
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:42:22
+   |
+LL |         let _: u8 = *boxed_slice.get(1).unwrap();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:47:9
@@ -52,11 +121,27 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
 
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:47:10
+   |
+LL |         *boxed_slice.get_mut(0).unwrap() = 1;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:48:9
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:48:10
+   |
+LL |         *some_slice.get_mut(0).unwrap() = 1;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:49:9
@@ -64,11 +149,51 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
 
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:49:10
+   |
+LL |         *some_vec.get_mut(0).unwrap() = 1;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
 error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:50:9
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:50:10
+   |
+LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:52:10
+   |
+LL |         *some_hashmap.get_mut(&1).unwrap() = 'b';
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:53:10
+   |
+LL |         *some_btreemap.get_mut(&1).unwrap() = 'b';
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:54:10
+   |
+LL |         *false_positive.get_mut(0).unwrap() = 1;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:59:17
@@ -76,11 +201,27 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:59:17
+   |
+LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:60:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
-error: aborting due to 13 previous errors
+error: used `unwrap()` on `an Option` value
+  --> $DIR/get_unwrap.rs:60:17
+   |
+LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
+
+error: aborting due to 30 previous errors
 

--- a/tests/ui/get_unwrap.stderr
+++ b/tests/ui/get_unwrap.stderr
@@ -1,36 +1,32 @@
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:34:17
+  --> $DIR/get_unwrap.rs:36:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
    |
 note: the lint level is defined here
-  --> $DIR/get_unwrap.rs:3:9
+  --> $DIR/get_unwrap.rs:5:9
    |
-LL | #![deny(clippy::get_unwrap, clippy::unwrap_used)]
+LL | #![deny(clippy::get_unwrap)]
    |         ^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:34:17
+  --> $DIR/get_unwrap.rs:36:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the lint level is defined here
-  --> $DIR/get_unwrap.rs:3:29
-   |
-LL | #![deny(clippy::get_unwrap, clippy::unwrap_used)]
-   |                             ^^^^^^^^^^^^^^^^^^^
+   = note: `-D clippy::unwrap-used` implied by `-D warnings`
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:35:17
+  --> $DIR/get_unwrap.rs:37:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:35:17
+  --> $DIR/get_unwrap.rs:37:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,13 +34,13 @@ LL |         let _ = some_slice.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:36:17
+  --> $DIR/get_unwrap.rs:38:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:36:17
+  --> $DIR/get_unwrap.rs:38:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,13 +48,13 @@ LL |         let _ = some_vec.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:37:17
+  --> $DIR/get_unwrap.rs:39:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:37:17
+  --> $DIR/get_unwrap.rs:39:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,13 +62,13 @@ LL |         let _ = some_vecdeque.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:38:17
+  --> $DIR/get_unwrap.rs:40:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:38:17
+  --> $DIR/get_unwrap.rs:40:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,13 +76,13 @@ LL |         let _ = some_hashmap.get(&1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:39:17
+  --> $DIR/get_unwrap.rs:41:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:39:17
+  --> $DIR/get_unwrap.rs:41:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +90,7 @@ LL |         let _ = some_btreemap.get(&1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:40:17
+  --> $DIR/get_unwrap.rs:42:17
    |
 LL |         let _ = false_positive.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,13 +98,13 @@ LL |         let _ = false_positive.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:42:21
+  --> $DIR/get_unwrap.rs:44:21
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:42:22
+  --> $DIR/get_unwrap.rs:44:22
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -116,13 +112,13 @@ LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:47:9
+  --> $DIR/get_unwrap.rs:49:9
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:47:10
+  --> $DIR/get_unwrap.rs:49:10
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -130,13 +126,13 @@ LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:48:9
+  --> $DIR/get_unwrap.rs:50:9
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:48:10
+  --> $DIR/get_unwrap.rs:50:10
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -144,13 +140,13 @@ LL |         *some_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:49:9
+  --> $DIR/get_unwrap.rs:51:9
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:49:10
+  --> $DIR/get_unwrap.rs:51:10
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,13 +154,13 @@ LL |         *some_vec.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:50:9
+  --> $DIR/get_unwrap.rs:52:9
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:50:10
+  --> $DIR/get_unwrap.rs:52:10
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,7 +168,7 @@ LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:52:10
+  --> $DIR/get_unwrap.rs:54:10
    |
 LL |         *some_hashmap.get_mut(&1).unwrap() = 'b';
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,7 +176,7 @@ LL |         *some_hashmap.get_mut(&1).unwrap() = 'b';
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:53:10
+  --> $DIR/get_unwrap.rs:55:10
    |
 LL |         *some_btreemap.get_mut(&1).unwrap() = 'b';
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -188,7 +184,7 @@ LL |         *some_btreemap.get_mut(&1).unwrap() = 'b';
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:54:10
+  --> $DIR/get_unwrap.rs:56:10
    |
 LL |         *false_positive.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -196,13 +192,13 @@ LL |         *false_positive.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:59:17
+  --> $DIR/get_unwrap.rs:61:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:59:17
+  --> $DIR/get_unwrap.rs:61:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,13 +206,13 @@ LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:60:17
+  --> $DIR/get_unwrap.rs:62:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:60:17
+  --> $DIR/get_unwrap.rs:62:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/get_unwrap.stderr
+++ b/tests/ui/get_unwrap.stderr
@@ -89,22 +89,14 @@ LL |         let _ = some_btreemap.get(&1).unwrap();
    |
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
-error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:42:17
-   |
-LL |         let _ = false_positive.get(0).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
-
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:44:21
+  --> $DIR/get_unwrap.rs:45:21
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:44:22
+  --> $DIR/get_unwrap.rs:45:22
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,13 +104,13 @@ LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:49:9
+  --> $DIR/get_unwrap.rs:50:9
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:49:10
+  --> $DIR/get_unwrap.rs:50:10
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -126,13 +118,13 @@ LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:50:9
+  --> $DIR/get_unwrap.rs:51:9
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:50:10
+  --> $DIR/get_unwrap.rs:51:10
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,13 +132,13 @@ LL |         *some_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:51:9
+  --> $DIR/get_unwrap.rs:52:9
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:51:10
+  --> $DIR/get_unwrap.rs:52:10
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,51 +146,27 @@ LL |         *some_vec.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:52:9
+  --> $DIR/get_unwrap.rs:53:9
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:52:10
+  --> $DIR/get_unwrap.rs:53:10
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
-error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:54:10
-   |
-LL |         *some_hashmap.get_mut(&1).unwrap() = 'b';
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
-
-error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:55:10
-   |
-LL |         *some_btreemap.get_mut(&1).unwrap() = 'b';
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
-
-error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:56:10
-   |
-LL |         *false_positive.get_mut(0).unwrap() = 1;
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
-
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:61:17
+  --> $DIR/get_unwrap.rs:65:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:61:17
+  --> $DIR/get_unwrap.rs:65:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -206,18 +174,18 @@ LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:62:17
+  --> $DIR/get_unwrap.rs:66:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on `an Option` value
-  --> $DIR/get_unwrap.rs:62:17
+  --> $DIR/get_unwrap.rs:66:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
-error: aborting due to 30 previous errors
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
fixes #8124 
changelog: make the [unwrap_used] lint trigger for code of the form such as `.get(i).unwrap()` and `.get_mut(i).unwrap()`
