### PR TITLE
[`chars_next_cmp`] Fix unescaped suggestion

### DIFF
--- a/clippy_lints/src/methods/chars_cmp_with_unwrap.rs
+++ b/clippy_lints/src/methods/chars_cmp_with_unwrap.rs
@@ -32,7 +32,7 @@ pub(super) fn check<'tcx>(
                         if info.eq { "" } else { "!" },
                         snippet_with_applicability(cx, args[0][0].span, "..", &mut applicability),
                         suggest,
-                        c),
+                        c.escape_default()),
                 applicability,
             );
 

--- a/tests/ui/starts_ends_with.fixed
+++ b/tests/ui/starts_ends_with.fixed
@@ -7,6 +7,10 @@ fn main() {}
 fn starts_with() {
     "".starts_with(' ');
     !"".starts_with(' ');
+
+    // Ensure that suggestion is escaped correctly
+    "".starts_with('\n');
+    !"".starts_with('\n');
 }
 
 fn chars_cmp_with_unwrap() {
@@ -31,7 +35,7 @@ fn chars_cmp_with_unwrap() {
         // !s.ends_with('o')
         // Nothing here
     }
-    if !s.ends_with('o') {
+    if !s.ends_with('\n') {
         // !s.ends_with('o')
         // Nothing here
     }
@@ -43,4 +47,8 @@ fn ends_with() {
     !"".ends_with(' ');
     "".ends_with(' ');
     !"".ends_with(' ');
+
+    // Ensure that suggestion is escaped correctly
+    "".ends_with('\n');
+    !"".ends_with('\n');
 }

--- a/tests/ui/starts_ends_with.rs
+++ b/tests/ui/starts_ends_with.rs
@@ -7,6 +7,10 @@ fn main() {}
 fn starts_with() {
     "".chars().next() == Some(' ');
     Some(' ') != "".chars().next();
+
+    // Ensure that suggestion is escaped correctly
+    "".chars().next() == Some('\n');
+    Some('\n') != "".chars().next();
 }
 
 fn chars_cmp_with_unwrap() {
@@ -31,7 +35,7 @@ fn chars_cmp_with_unwrap() {
         // !s.ends_with('o')
         // Nothing here
     }
-    if s.chars().last().unwrap() != 'o' {
+    if s.chars().last().unwrap() != '\n' {
         // !s.ends_with('o')
         // Nothing here
     }
@@ -43,4 +47,8 @@ fn ends_with() {
     Some(' ') != "".chars().last();
     "".chars().next_back() == Some(' ');
     Some(' ') != "".chars().next_back();
+
+    // Ensure that suggestion is escaped correctly
+    "".chars().last() == Some('\n');
+    Some('\n') != "".chars().last();
 }

--- a/tests/ui/starts_ends_with.stderr
+++ b/tests/ui/starts_ends_with.stderr
@@ -13,13 +13,25 @@ LL |     Some(' ') != "".chars().next();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!"".starts_with(' ')`
 
 error: you should use the `starts_with` method
-  --> $DIR/starts_ends_with.rs:14:8
+  --> $DIR/starts_ends_with.rs:12:5
+   |
+LL |     "".chars().next() == Some('/n');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `"".starts_with('/n')`
+
+error: you should use the `starts_with` method
+  --> $DIR/starts_ends_with.rs:13:5
+   |
+LL |     Some('/n') != "".chars().next();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!"".starts_with('/n')`
+
+error: you should use the `starts_with` method
+  --> $DIR/starts_ends_with.rs:18:8
    |
 LL |     if s.chars().next().unwrap() == 'f' {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `s.starts_with('f')`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:18:8
+  --> $DIR/starts_ends_with.rs:22:8
    |
 LL |     if s.chars().next_back().unwrap() == 'o' {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `s.ends_with('o')`
@@ -27,52 +39,64 @@ LL |     if s.chars().next_back().unwrap() == 'o' {
    = note: `-D clippy::chars-last-cmp` implied by `-D warnings`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:22:8
+  --> $DIR/starts_ends_with.rs:26:8
    |
 LL |     if s.chars().last().unwrap() == 'o' {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `s.ends_with('o')`
 
 error: you should use the `starts_with` method
-  --> $DIR/starts_ends_with.rs:26:8
+  --> $DIR/starts_ends_with.rs:30:8
    |
 LL |     if s.chars().next().unwrap() != 'f' {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!s.starts_with('f')`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:30:8
+  --> $DIR/starts_ends_with.rs:34:8
    |
 LL |     if s.chars().next_back().unwrap() != 'o' {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!s.ends_with('o')`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:34:8
+  --> $DIR/starts_ends_with.rs:38:8
    |
-LL |     if s.chars().last().unwrap() != 'o' {
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!s.ends_with('o')`
+LL |     if s.chars().last().unwrap() != '/n' {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!s.ends_with('/n')`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:42:5
+  --> $DIR/starts_ends_with.rs:46:5
    |
 LL |     "".chars().last() == Some(' ');
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `"".ends_with(' ')`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:43:5
+  --> $DIR/starts_ends_with.rs:47:5
    |
 LL |     Some(' ') != "".chars().last();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!"".ends_with(' ')`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:44:5
+  --> $DIR/starts_ends_with.rs:48:5
    |
 LL |     "".chars().next_back() == Some(' ');
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `"".ends_with(' ')`
 
 error: you should use the `ends_with` method
-  --> $DIR/starts_ends_with.rs:45:5
+  --> $DIR/starts_ends_with.rs:49:5
    |
 LL |     Some(' ') != "".chars().next_back();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!"".ends_with(' ')`
 
-error: aborting due to 12 previous errors
+error: you should use the `ends_with` method
+  --> $DIR/starts_ends_with.rs:52:5
+   |
+LL |     "".chars().last() == Some('/n');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `"".ends_with('/n')`
+
+error: you should use the `ends_with` method
+  --> $DIR/starts_ends_with.rs:53:5
+   |
+LL |     Some('/n') != "".chars().last();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: like this: `!"".ends_with('/n')`
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
closes #8373 

changelog: [`chars_next_cmp`] Fix unescaped suggestion
