### PR TITLE
Lint enum-to-int casts with `cast_possible_truncation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3068,6 +3068,7 @@ Released 2018-09-13
 [`bytes_nth`]: https://rust-lang.github.io/rust-clippy/master/index.html#bytes_nth
 [`cargo_common_metadata`]: https://rust-lang.github.io/rust-clippy/master/index.html#cargo_common_metadata
 [`case_sensitive_file_extension_comparisons`]: https://rust-lang.github.io/rust-clippy/master/index.html#case_sensitive_file_extension_comparisons
+[`cast_enum_truncation`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_enum_truncation
 [`cast_lossless`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_lossless
 [`cast_possible_truncation`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
 [`cast_possible_wrap`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_wrap

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -445,13 +445,12 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
             fn_to_numeric_cast_with_truncation::check(cx, expr, cast_expr, cast_from, cast_to);
 
             if cast_to.is_numeric() && !in_external_macro(cx.sess(), expr.span) {
+                cast_possible_truncation::check(cx, expr, cast_expr, cast_from, cast_to);
                 if cast_from.is_numeric() {
-                    cast_possible_truncation::check(cx, expr, cast_expr, cast_from, cast_to);
                     cast_possible_wrap::check(cx, expr, cast_from, cast_to);
                     cast_precision_loss::check(cx, expr, cast_from, cast_to);
                     cast_sign_loss::check(cx, expr, cast_expr, cast_from, cast_to);
                 }
-
                 cast_lossless::check(cx, expr, cast_expr, cast_from, cast_to, &self.msrv);
             }
         }

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -390,6 +390,25 @@ declare_clippy_lint! {
     "casting using `as` from and to raw pointers that doesn't change its mutability, where `pointer::cast` could take the place of `as`"
 }
 
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for casts from an enum type to an integral type which will definitely truncate the
+    /// value.
+    ///
+    /// ### Why is this bad?
+    /// The resulting integral value will not match the value of the variant it came from.
+    ///
+    /// ### Example
+    /// ```rust
+    /// enum E { X = 256 };
+    /// let _ = E::X as u8;
+    /// ```
+    #[clippy::version = "1.60.0"]
+    pub CAST_ENUM_TRUNCATION,
+    suspicious,
+    "casts from an enum type to an integral type which will truncate the value"
+}
+
 pub struct Casts {
     msrv: Option<RustcVersion>,
 }
@@ -415,6 +434,7 @@ impl_lint_pass!(Casts => [
     FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
     CHAR_LIT_AS_U8,
     PTR_AS_PTR,
+    CAST_ENUM_TRUNCATION,
 ]);
 
 impl<'tcx> LateLintPass<'tcx> for Casts {

--- a/clippy_lints/src/casts/utils.rs
+++ b/clippy_lints/src/casts/utils.rs
@@ -1,4 +1,6 @@
-use rustc_middle::ty::{self, IntTy, Ty, TyCtxt, UintTy};
+use rustc_middle::mir::interpret::{ConstValue, Scalar};
+use rustc_middle::ty::{self, AdtDef, IntTy, Ty, TyCtxt, UintTy, VariantDiscr};
+use rustc_target::abi::Size;
 
 /// Returns the size in bits of an integral type.
 /// Will return 0 if the type is not an int or uint variant
@@ -21,5 +23,59 @@ pub(super) fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_>) -> u64 {
             UintTy::U128 => 128,
         },
         _ => 0,
+    }
+}
+
+pub(super) fn enum_ty_to_nbits(adt: &AdtDef, tcx: TyCtxt<'_>) -> u64 {
+    let mut explicit = 0i128;
+    let (start, end) = adt
+        .variants
+        .iter()
+        .fold((i128::MAX, i128::MIN), |(start, end), variant| match variant.discr {
+            VariantDiscr::Relative(x) => match explicit.checked_add(i128::from(x)) {
+                Some(x) => (start, end.max(x)),
+                None => (i128::MIN, end),
+            },
+            VariantDiscr::Explicit(id) => {
+                let ty = tcx.type_of(id);
+                if let Ok(ConstValue::Scalar(Scalar::Int(value))) = tcx.const_eval_poly(id) {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+                    let value = match (value.size().bytes(), ty.kind()) {
+                        (1, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(1)) as u8 as i8),
+                        (1, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(1)) as u8),
+                        (2, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(2)) as u16 as i16),
+                        (2, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(2)) as u16),
+                        (4, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(4)) as u32 as i32),
+                        (4, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(4)) as u32),
+                        (8, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(8)) as u64 as i64),
+                        (8, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(8)) as u64),
+                        (16, ty::Int(_)) => value.assert_bits(Size::from_bytes(16)) as i128,
+                        (16, ty::Uint(_)) => match i128::try_from(value.assert_bits(Size::from_bytes(16))) {
+                            Ok(x) => x,
+                            // Requires 128 bits
+                            Err(_) => return (i128::MIN, end),
+                        },
+                        // Shouldn't happen if compilation was successful
+                        _ => return (start, end),
+                    };
+                    explicit = value;
+                    (start.min(value), end.max(value))
+                } else {
+                    // Shouldn't happen if compilation was successful
+                    (start, end)
+                }
+            },
+        });
+
+    if start >= end {
+        0
+    } else {
+        let neg_bits = if start < 0 {
+            128 - (-(start + 1)).leading_zeros() + 1
+        } else {
+            0
+        };
+        let pos_bits = if end > 0 { 128 - end.leading_zeros() } else { 0 };
+        neg_bits.max(pos_bits).into()
     }
 }

--- a/clippy_lints/src/casts/utils.rs
+++ b/clippy_lints/src/casts/utils.rs
@@ -1,5 +1,6 @@
 use rustc_middle::mir::interpret::{ConstValue, Scalar};
 use rustc_middle::ty::{self, AdtDef, IntTy, Ty, TyCtxt, UintTy, VariantDiscr};
+use rustc_span::def_id::DefId;
 use rustc_target::abi::Size;
 
 /// Returns the size in bits of an integral type.
@@ -26,48 +27,83 @@ pub(super) fn int_ty_to_nbits(typ: Ty<'_>, tcx: TyCtxt<'_>) -> u64 {
     }
 }
 
+pub(super) enum EnumValue {
+    Unsigned(u128),
+    Signed(i128),
+}
+impl EnumValue {
+    pub(super) fn add(self, n: u32) -> Self {
+        match self {
+            Self::Unsigned(x) => Self::Unsigned(x + u128::from(n)),
+            Self::Signed(x) => Self::Signed(x + i128::from(n)),
+        }
+    }
+
+    pub(super) fn nbits(self) -> u64 {
+        match self {
+            Self::Unsigned(x) => 128 - x.leading_zeros(),
+            Self::Signed(x) if x < 0 => 128 - (-(x + 1)).leading_zeros() + 1,
+            Self::Signed(x) => 128 - x.leading_zeros(),
+        }
+        .into()
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+pub(super) fn read_explicit_enum_value(tcx: TyCtxt<'_>, id: DefId) -> Option<EnumValue> {
+    if let Ok(ConstValue::Scalar(Scalar::Int(value))) = tcx.const_eval_poly(id) {
+        match tcx.type_of(id).kind() {
+            ty::Int(_) => Some(EnumValue::Signed(match value.size().bytes() {
+                1 => i128::from(value.assert_bits(Size::from_bytes(1)) as u8 as i8),
+                2 => i128::from(value.assert_bits(Size::from_bytes(2)) as u16 as i16),
+                4 => i128::from(value.assert_bits(Size::from_bytes(4)) as u32 as i32),
+                8 => i128::from(value.assert_bits(Size::from_bytes(8)) as u64 as i64),
+                16 => value.assert_bits(Size::from_bytes(16)) as i128,
+                _ => return None,
+            })),
+            ty::Uint(_) => Some(EnumValue::Unsigned(match value.size().bytes() {
+                1 => value.assert_bits(Size::from_bytes(1)),
+                2 => value.assert_bits(Size::from_bytes(2)),
+                4 => value.assert_bits(Size::from_bytes(4)),
+                8 => value.assert_bits(Size::from_bytes(8)),
+                16 => value.assert_bits(Size::from_bytes(16)),
+                _ => return None,
+            })),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
 pub(super) fn enum_ty_to_nbits(adt: &AdtDef, tcx: TyCtxt<'_>) -> u64 {
     let mut explicit = 0i128;
     let (start, end) = adt
         .variants
         .iter()
-        .fold((i128::MAX, i128::MIN), |(start, end), variant| match variant.discr {
+        .fold((0, i128::MIN), |(start, end), variant| match variant.discr {
             VariantDiscr::Relative(x) => match explicit.checked_add(i128::from(x)) {
                 Some(x) => (start, end.max(x)),
                 None => (i128::MIN, end),
             },
-            VariantDiscr::Explicit(id) => {
-                let ty = tcx.type_of(id);
-                if let Ok(ConstValue::Scalar(Scalar::Int(value))) = tcx.const_eval_poly(id) {
-                    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-                    let value = match (value.size().bytes(), ty.kind()) {
-                        (1, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(1)) as u8 as i8),
-                        (1, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(1)) as u8),
-                        (2, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(2)) as u16 as i16),
-                        (2, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(2)) as u16),
-                        (4, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(4)) as u32 as i32),
-                        (4, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(4)) as u32),
-                        (8, ty::Int(_)) => i128::from(value.assert_bits(Size::from_bytes(8)) as u64 as i64),
-                        (8, ty::Uint(_)) => i128::from(value.assert_bits(Size::from_bytes(8)) as u64),
-                        (16, ty::Int(_)) => value.assert_bits(Size::from_bytes(16)) as i128,
-                        (16, ty::Uint(_)) => match i128::try_from(value.assert_bits(Size::from_bytes(16))) {
-                            Ok(x) => x,
-                            // Requires 128 bits
-                            Err(_) => return (i128::MIN, end),
-                        },
-                        // Shouldn't happen if compilation was successful
-                        _ => return (start, end),
-                    };
-                    explicit = value;
-                    (start.min(value), end.max(value))
-                } else {
-                    // Shouldn't happen if compilation was successful
-                    (start, end)
-                }
+            VariantDiscr::Explicit(id) => match read_explicit_enum_value(tcx, id) {
+                Some(EnumValue::Signed(x)) => {
+                    explicit = x;
+                    (start.min(x), end.max(x))
+                },
+                Some(EnumValue::Unsigned(x)) => match i128::try_from(x) {
+                    Ok(x) => {
+                        explicit = x;
+                        (start, end.max(x))
+                    },
+                    Err(_) => (i128::MIN, end),
+                },
+                None => (start, end),
             },
         });
 
-    if start >= end {
+    if start > end {
+        // No variants.
         0
     } else {
         let neg_bits = if start < 0 {

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -23,6 +23,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(bool_assert_comparison::BOOL_ASSERT_COMPARISON),
     LintId::of(booleans::LOGIC_BUG),
     LintId::of(booleans::NONMINIMAL_BOOL),
+    LintId::of(casts::CAST_ENUM_TRUNCATION),
     LintId::of(casts::CAST_REF_TO_MUT),
     LintId::of(casts::CHAR_LIT_AS_U8),
     LintId::of(casts::FN_TO_NUMERIC_CAST),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -67,6 +67,7 @@ store.register_lints(&[
     cargo::REDUNDANT_FEATURE_NAMES,
     cargo::WILDCARD_DEPENDENCIES,
     case_sensitive_file_extension_comparisons::CASE_SENSITIVE_FILE_EXTENSION_COMPARISONS,
+    casts::CAST_ENUM_TRUNCATION,
     casts::CAST_LOSSLESS,
     casts::CAST_POSSIBLE_TRUNCATION,
     casts::CAST_POSSIBLE_WRAP,

--- a/clippy_lints/src/lib.register_suspicious.rs
+++ b/clippy_lints/src/lib.register_suspicious.rs
@@ -7,6 +7,7 @@ store.register_group(true, "clippy::suspicious", Some("clippy_suspicious"), vec!
     LintId::of(attrs::BLANKET_CLIPPY_RESTRICTION_LINTS),
     LintId::of(await_holding_invalid::AWAIT_HOLDING_LOCK),
     LintId::of(await_holding_invalid::AWAIT_HOLDING_REFCELL_REF),
+    LintId::of(casts::CAST_ENUM_TRUNCATION),
     LintId::of(eval_order_dependence::EVAL_ORDER_DEPENDENCE),
     LintId::of(float_equality_without_abs::FLOAT_EQUALITY_WITHOUT_ABS),
     LintId::of(formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -25,6 +25,7 @@
 // (Currently there is no way to opt into sysroot crates without `extern crate`.)
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
+extern crate rustc_attr;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;

--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -10,12 +10,14 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, TyKind, Unsafety};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::LateContext;
+use rustc_middle::mir::interpret::{ConstValue, Scalar};
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, Subst};
 use rustc_middle::ty::{
-    self, AdtDef, Binder, FnSig, IntTy, Predicate, PredicateKind, Ty, TyCtxt, TypeFoldable, UintTy,
+    self, AdtDef, Binder, FnSig, IntTy, Predicate, PredicateKind, Ty, TyCtxt, TypeFoldable, UintTy, VariantDiscr,
 };
 use rustc_span::symbol::Ident;
 use rustc_span::{sym, Span, Symbol, DUMMY_SP};
+use rustc_target::abi::{Size, VariantIdx};
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::query::normalize::AtExt;
 use std::iter;
@@ -513,5 +515,60 @@ pub fn expr_sig<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>) -> Option<ExprFnS
             },
             _ => None,
         }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum EnumValue {
+    Unsigned(u128),
+    Signed(i128),
+}
+impl core::ops::Add<u32> for EnumValue {
+    type Output = Self;
+    fn add(self, n: u32) -> Self::Output {
+        match self {
+            Self::Unsigned(x) => Self::Unsigned(x + u128::from(n)),
+            Self::Signed(x) => Self::Signed(x + i128::from(n)),
+        }
+    }
+}
+
+/// Attempts to read the given constant as though it were an an enum value.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+pub fn read_explicit_enum_value(tcx: TyCtxt<'_>, id: DefId) -> Option<EnumValue> {
+    if let Ok(ConstValue::Scalar(Scalar::Int(value))) = tcx.const_eval_poly(id) {
+        match tcx.type_of(id).kind() {
+            ty::Int(_) => Some(EnumValue::Signed(match value.size().bytes() {
+                1 => i128::from(value.assert_bits(Size::from_bytes(1)) as u8 as i8),
+                2 => i128::from(value.assert_bits(Size::from_bytes(2)) as u16 as i16),
+                4 => i128::from(value.assert_bits(Size::from_bytes(4)) as u32 as i32),
+                8 => i128::from(value.assert_bits(Size::from_bytes(8)) as u64 as i64),
+                16 => value.assert_bits(Size::from_bytes(16)) as i128,
+                _ => return None,
+            })),
+            ty::Uint(_) => Some(EnumValue::Unsigned(match value.size().bytes() {
+                1 => value.assert_bits(Size::from_bytes(1)),
+                2 => value.assert_bits(Size::from_bytes(2)),
+                4 => value.assert_bits(Size::from_bytes(4)),
+                8 => value.assert_bits(Size::from_bytes(8)),
+                16 => value.assert_bits(Size::from_bytes(16)),
+                _ => return None,
+            })),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+/// Gets the value of the given variant.
+pub fn get_discriminant_value(tcx: TyCtxt<'_>, adt: &'_ AdtDef, i: VariantIdx) -> EnumValue {
+    let variant = &adt.variants[i];
+    match variant.discr {
+        VariantDiscr::Explicit(id) => read_explicit_enum_value(tcx, id).unwrap(),
+        VariantDiscr::Relative(x) => match adt.variants[(i.as_usize() - x as usize).into()].discr {
+            VariantDiscr::Explicit(id) => read_explicit_enum_value(tcx, id).unwrap() + x,
+            VariantDiscr::Relative(_) => EnumValue::Unsigned(x.into()),
+        },
     }
 }

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -1,3 +1,6 @@
+#![feature(repr128)]
+#![allow(incomplete_features)]
+
 #[warn(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
@@ -115,4 +118,116 @@ fn main() {
     }) as u8;
     999999u64.clamp(0, 255) as u8;
     999999u64.clamp(0, 256) as u8; // should still be linted
+
+    #[derive(Clone, Copy)]
+    enum E1 {
+        A,
+        B,
+        C,
+    }
+    impl E1 {
+        fn test(self) {
+            let _ = self as u8; // Don't lint. `0..=2` fits in u8
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum E2 {
+        A = 255,
+        B,
+    }
+    impl E2 {
+        fn test(self) {
+            let _ = self as u8;
+            let _ = self as i16; // Don't lint. `255..=256` fits in i16
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum E3 {
+        A = -1,
+        B,
+        C = 50,
+    }
+    impl E3 {
+        fn test(self) {
+            let _ = self as i8; // Don't lint. `-1..=50` fits in i8
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum E4 {
+        A = -128,
+        B,
+    }
+    impl E4 {
+        fn test(self) {
+            let _ = self as i8; // Don't lint. `-128..=-127` fits in i8
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum E5 {
+        A = -129,
+        B = 127,
+    }
+    impl E5 {
+        fn test(self) {
+            let _ = self as i8;
+            let _ = self as i16; // Don't lint. `-129..=127` fits in i16
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    #[repr(u32)]
+    enum E6 {
+        A = u16::MAX as u32,
+        B,
+    }
+    impl E6 {
+        fn test(self) {
+            let _ = self as i16;
+            let _ = Self::A as u16; // Don't lint. `2^16-1` fits in u16
+            let _ = self as u32; // Don't lint. `2^16-1..=2^16` fits in u32
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    #[repr(u64)]
+    enum E7 {
+        A = u32::MAX as u64,
+        B,
+    }
+    impl E7 {
+        fn test(self) {
+            let _ = self as usize;
+            let _ = self as u64; // Don't lint. `2^32-1..=2^32` fits in u64
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    #[repr(i128)]
+    enum E8 {
+        A = i128::MIN,
+        B,
+        C = 0,
+        D = i128::MAX,
+    }
+    impl E8 {
+        fn test(self) {
+            let _ = self as i128; // Don't lint. `-(2^127)..=2^127-1` fits it i128
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    #[repr(u128)]
+    enum E9 {
+        A,
+        B = u128::MAX,
+    }
+    impl E9 {
+        fn test(self) {
+            let _ = self as u128; // Don't lint. `0..=2^128-1` fits in u128
+        }
+    }
 }

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -139,7 +139,9 @@ fn main() {
     impl E2 {
         fn test(self) {
             let _ = self as u8;
+            let _ = Self::B as u8;
             let _ = self as i16; // Don't lint. `255..=256` fits in i16
+            let _ = Self::A as u8; // Don't lint.
         }
     }
 
@@ -174,7 +176,9 @@ fn main() {
     impl E5 {
         fn test(self) {
             let _ = self as i8;
+            let _ = Self::A as i8;
             let _ = self as i16; // Don't lint. `-129..=127` fits in i16
+            let _ = Self::B as u8; // Don't lint.
         }
     }
 
@@ -189,6 +193,7 @@ fn main() {
             let _ = self as i16;
             let _ = Self::A as u16; // Don't lint. `2^16-1` fits in u16
             let _ = self as u32; // Don't lint. `2^16-1..=2^16` fits in u32
+            let _ = Self::A as u16; // Don't lint.
         }
     }
 
@@ -201,6 +206,7 @@ fn main() {
     impl E7 {
         fn test(self) {
             let _ = self as usize;
+            let _ = Self::A as usize; // Don't lint.
             let _ = self as u64; // Don't lint. `2^32-1..=2^32` fits in u64
         }
     }
@@ -227,7 +233,22 @@ fn main() {
     }
     impl E9 {
         fn test(self) {
+            let _ = Self::A as u8; // Don't lint.
             let _ = self as u128; // Don't lint. `0..=2^128-1` fits in u128
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    #[repr(usize)]
+    enum E10 {
+        A,
+        B = u32::MAX as usize,
+    }
+    impl E10 {
+        fn test(self) {
+            let _ = self as u16;
+            let _ = Self::B as u32; // Don't lint.
+            let _ = self as u64; // Don't lint.
         }
     }
 }

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -156,23 +156,43 @@ error: casting `main::E2` to `u8` may truncate the value
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
 
+error: casting `main::E2::B` to `u8` will truncate the value
+  --> $DIR/cast.rs:142:21
+   |
+LL |             let _ = Self::B as u8;
+   |                     ^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::cast-enum-truncation` implied by `-D warnings`
+
 error: casting `main::E5` to `i8` may truncate the value
-  --> $DIR/cast.rs:176:21
+  --> $DIR/cast.rs:178:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
 
+error: casting `main::E5::A` to `i8` will truncate the value
+  --> $DIR/cast.rs:179:21
+   |
+LL |             let _ = Self::A as i8;
+   |                     ^^^^^^^^^^^^^
+
 error: casting `main::E6` to `i16` may truncate the value
-  --> $DIR/cast.rs:189:21
+  --> $DIR/cast.rs:193:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> $DIR/cast.rs:203:21
+  --> $DIR/cast.rs:208:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
 
-error: aborting due to 28 previous errors
+error: casting `main::E10` to `u16` may truncate the value
+  --> $DIR/cast.rs:249:21
+   |
+LL |             let _ = self as u16;
+   |                     ^^^^^^^^^^^
+
+error: aborting due to 31 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -1,5 +1,5 @@
 error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:11:5
+  --> $DIR/cast.rs:14:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
@@ -7,37 +7,37 @@ LL |     x0 as f32;
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
 
 error: casting `i64` to `f32` causes a loss of precision (`i64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:13:5
+  --> $DIR/cast.rs:16:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
 error: casting `i64` to `f64` causes a loss of precision (`i64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:14:5
+  --> $DIR/cast.rs:17:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
 error: casting `u32` to `f32` causes a loss of precision (`u32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:16:5
+  --> $DIR/cast.rs:19:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f32` causes a loss of precision (`u64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> $DIR/cast.rs:18:5
+  --> $DIR/cast.rs:21:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> $DIR/cast.rs:19:5
+  --> $DIR/cast.rs:22:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^
 
 error: casting `f32` to `i32` may truncate the value
-  --> $DIR/cast.rs:21:5
+  --> $DIR/cast.rs:24:5
    |
 LL |     1f32 as i32;
    |     ^^^^^^^^^^^
@@ -45,13 +45,13 @@ LL |     1f32 as i32;
    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
 
 error: casting `f32` to `u32` may truncate the value
-  --> $DIR/cast.rs:22:5
+  --> $DIR/cast.rs:25:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> $DIR/cast.rs:22:5
+  --> $DIR/cast.rs:25:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -59,43 +59,43 @@ LL |     1f32 as u32;
    = note: `-D clippy::cast-sign-loss` implied by `-D warnings`
 
 error: casting `f64` to `f32` may truncate the value
-  --> $DIR/cast.rs:23:5
+  --> $DIR/cast.rs:26:5
    |
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
 
 error: casting `i32` to `i8` may truncate the value
-  --> $DIR/cast.rs:24:5
+  --> $DIR/cast.rs:27:5
    |
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
 
 error: casting `i32` to `u8` may truncate the value
-  --> $DIR/cast.rs:25:5
+  --> $DIR/cast.rs:28:5
    |
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
 
 error: casting `f64` to `isize` may truncate the value
-  --> $DIR/cast.rs:26:5
+  --> $DIR/cast.rs:29:5
    |
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `f64` to `usize` may truncate the value
-  --> $DIR/cast.rs:27:5
+  --> $DIR/cast.rs:30:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting `f64` to `usize` may lose the sign of the value
-  --> $DIR/cast.rs:27:5
+  --> $DIR/cast.rs:30:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u8` to `i8` may wrap around the value
-  --> $DIR/cast.rs:29:5
+  --> $DIR/cast.rs:32:5
    |
 LL |     1u8 as i8;
    |     ^^^^^^^^^
@@ -103,52 +103,76 @@ LL |     1u8 as i8;
    = note: `-D clippy::cast-possible-wrap` implied by `-D warnings`
 
 error: casting `u16` to `i16` may wrap around the value
-  --> $DIR/cast.rs:30:5
+  --> $DIR/cast.rs:33:5
    |
 LL |     1u16 as i16;
    |     ^^^^^^^^^^^
 
 error: casting `u32` to `i32` may wrap around the value
-  --> $DIR/cast.rs:31:5
+  --> $DIR/cast.rs:34:5
    |
 LL |     1u32 as i32;
    |     ^^^^^^^^^^^
 
 error: casting `u64` to `i64` may wrap around the value
-  --> $DIR/cast.rs:32:5
+  --> $DIR/cast.rs:35:5
    |
 LL |     1u64 as i64;
    |     ^^^^^^^^^^^
 
 error: casting `usize` to `isize` may wrap around the value
-  --> $DIR/cast.rs:33:5
+  --> $DIR/cast.rs:36:5
    |
 LL |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> $DIR/cast.rs:36:5
+  --> $DIR/cast.rs:39:5
    |
 LL |     -1i32 as u32;
    |     ^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> $DIR/cast.rs:38:5
+  --> $DIR/cast.rs:41:5
    |
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `i8` may truncate the value
-  --> $DIR/cast.rs:105:5
+  --> $DIR/cast.rs:108:5
    |
 LL |     (-99999999999i64).min(1) as i8; // should be linted because signed
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `u64` to `u8` may truncate the value
-  --> $DIR/cast.rs:117:5
+  --> $DIR/cast.rs:120:5
    |
 LL |     999999u64.clamp(0, 256) as u8; // should still be linted
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 24 previous errors
+error: casting `main::E2` to `u8` may truncate the value
+  --> $DIR/cast.rs:141:21
+   |
+LL |             let _ = self as u8;
+   |                     ^^^^^^^^^^
+
+error: casting `main::E5` to `i8` may truncate the value
+  --> $DIR/cast.rs:176:21
+   |
+LL |             let _ = self as i8;
+   |                     ^^^^^^^^^^
+
+error: casting `main::E6` to `i16` may truncate the value
+  --> $DIR/cast.rs:189:21
+   |
+LL |             let _ = self as i16;
+   |                     ^^^^^^^^^^^
+
+error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
+  --> $DIR/cast.rs:203:21
+   |
+LL |             let _ = self as usize;
+   |                     ^^^^^^^^^^^^^
+
+error: aborting due to 28 previous errors
 


### PR DESCRIPTION
fixes: #542

~~This will not lint casting a specific variant to an integer. That really should be a new lint as it's definitely a truncation (other than `isize`/`usize` values).~~

changelog: Lint enum-to-int casts with `cast_possible_truncation`
changelog: New lint `cast_enum_truncation`
