### PR TITLE
fix misspelling in diagnostic message of `bytes_nth`

### DIFF
--- a/clippy_lints/src/methods/bytes_nth.rs
+++ b/clippy_lints/src/methods/bytes_nth.rs
@@ -22,7 +22,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'_>, recv: &'tcx E
         cx,
         BYTES_NTH,
         expr.span,
-        &format!("called `.byte().nth()` on a `{}`", caller_type),
+        &format!("called `.bytes().nth()` on a `{}`", caller_type),
         "try",
         format!(
             "{}.as_bytes().get({})",

--- a/tests/ui/bytes_nth.stderr
+++ b/tests/ui/bytes_nth.stderr
@@ -1,4 +1,4 @@
-error: called `.byte().nth()` on a `String`
+error: called `.bytes().nth()` on a `String`
   --> $DIR/bytes_nth.rs:8:5
    |
 LL |     s.bytes().nth(3);
@@ -6,13 +6,13 @@ LL |     s.bytes().nth(3);
    |
    = note: `-D clippy::bytes-nth` implied by `-D warnings`
 
-error: called `.byte().nth()` on a `String`
+error: called `.bytes().nth()` on a `String`
   --> $DIR/bytes_nth.rs:9:14
    |
 LL |     let _ = &s.bytes().nth(3);
    |              ^^^^^^^^^^^^^^^^ help: try: `s.as_bytes().get(3)`
 
-error: called `.byte().nth()` on a `str`
+error: called `.bytes().nth()` on a `str`
   --> $DIR/bytes_nth.rs:10:5
    |
 LL |     s[..].bytes().nth(3);


### PR DESCRIPTION

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: fix misspelling in diagnostic message in ``[`bytes_nth`]``