### PR TITLE
Suggest usage of array and Vec .as_slice() and as_mut_slice() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3254,6 +3254,7 @@ Released 2018-09-13
 [`manual_ok_or`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_or
 [`manual_range_contains`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
 [`manual_saturating_arithmetic`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic
+[`manual_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_slice
 [`manual_split_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_split_once
 [`manual_str_repeat`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_str_repeat
 [`manual_strip`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_strip

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -231,6 +231,7 @@ store.register_lints(&[
     manual_map::MANUAL_MAP,
     manual_non_exhaustive::MANUAL_NON_EXHAUSTIVE,
     manual_ok_or::MANUAL_OK_OR,
+    manual_slice::MANUAL_SLICE,
     manual_strip::MANUAL_STRIP,
     manual_unwrap_or::MANUAL_UNWRAP_OR,
     map_clone::MAP_CLONE,

--- a/clippy_lints/src/lib.register_restriction.rs
+++ b/clippy_lints/src/lib.register_restriction.rs
@@ -26,6 +26,7 @@ store.register_group(true, "clippy::restriction", Some("clippy_restriction"), ve
     LintId::of(integer_division::INTEGER_DIVISION),
     LintId::of(let_underscore::LET_UNDERSCORE_MUST_USE),
     LintId::of(literal_representation::DECIMAL_LITERAL_REPRESENTATION),
+    LintId::of(manual_slice::MANUAL_SLICE),
     LintId::of(map_err_ignore::MAP_ERR_IGNORE),
     LintId::of(matches::REST_PAT_IN_FULLY_BOUND_STRUCTS),
     LintId::of(matches::WILDCARD_ENUM_MATCH_ARM),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -863,7 +863,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(move || Box::new(borrow_as_ptr::BorrowAsPtr::new(msrv)));
     store.register_late_pass(move || Box::new(manual_bits::ManualBits::new(msrv)));
     store.register_late_pass(|| Box::new(default_union_representation::DefaultUnionRepresentation));
-    store.register_early_pass(move || Box::new(manual_slice::ManualSlice::new(msrv)));
+    store.register_late_pass(move || Box::new(manual_slice::ManualSlice::new(msrv)));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -267,6 +267,7 @@ mod manual_bits;
 mod manual_map;
 mod manual_non_exhaustive;
 mod manual_ok_or;
+mod manual_slice;
 mod manual_strip;
 mod manual_unwrap_or;
 mod map_clone;
@@ -862,6 +863,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(move || Box::new(borrow_as_ptr::BorrowAsPtr::new(msrv)));
     store.register_late_pass(move || Box::new(manual_bits::ManualBits::new(msrv)));
     store.register_late_pass(|| Box::new(default_union_representation::DefaultUnionRepresentation));
+    store.register_early_pass(move || Box::new(manual_slice::ManualSlice::new(msrv)));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/manual_slice.rs
+++ b/clippy_lints/src/manual_slice.rs
@@ -1,0 +1,76 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::{meets_msrv, msrvs};
+use rustc_ast::ast::*;
+use rustc_errors::Applicability;
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_semver::RustcVersion;
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Finds arrays or vectors being converted to slices of the same length.
+    /// ### Why is this bad?
+    /// The methods `as_slice()` or `as_mut_slice()` could be used instead.
+    /// ### Example
+    /// ```rust
+    /// let mut arr: [u32; 1] = [1];
+    /// let slice = &arr[..];
+    /// let mutable_slice = &mut arr[..];
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// let mut arr: [u32; 1] = [1];
+    /// let slice = arr.as_slice();
+    /// let mutable_slice = arr.as_mut_slice();
+    /// ```
+    #[clippy::version = "1.60.0"]
+    pub MANUAL_SLICE,
+    restriction,
+    "default lint description"
+}
+
+#[derive(Clone)]
+pub struct ManualSlice {
+    msrv: Option<RustcVersion>,
+}
+
+impl ManualSlice {
+    #[must_use]
+    pub fn new(msrv: Option<RustcVersion>) -> Self {
+        Self { msrv }
+    }
+}
+
+impl_lint_pass!(ManualSlice => [MANUAL_SLICE]);
+
+impl EarlyLintPass for ManualSlice {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if !meets_msrv(self.msrv.as_ref(), &msrvs::NON_EXHAUSTIVE) {
+            return;
+        }
+
+        if_chain! {
+            if let ExprKind::AddrOf(BorrowKind::Ref, mutability, inner) = &expr.kind;
+            if let ExprKind::Index(object, index) = &inner.kind;
+            if let ExprKind::Path(_, ref ident) = object.kind;
+            if let ExprKind::Range(None, None, _) = index.kind;
+            then {
+                let suggestion = match mutability {
+                    Mutability::Not => "to_slice()",
+                    Mutability::Mut => "to_mut_slice()",
+                };
+                span_lint_and_sugg(
+                    cx,
+                    MANUAL_SLICE,
+                    expr.span,
+                    "converting to a slice of the same length",
+                    "use",
+                    format!("{:?}.{}", ident, suggestion),
+                    Applicability::MachineApplicable
+                );
+            }
+        }
+    }
+
+    extract_msrv_attr!(EarlyContext);
+}

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -12,6 +12,7 @@ macro_rules! msrv_aliases {
 
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
+    1,58,0 { MANUAL_SLICE }
     1,53,0 { OR_PATTERNS, MANUAL_BITS }
     1,52,0 { STR_SPLIT_ONCE }
     1,51,0 { BORROW_AS_PTR }

--- a/tests/ui/manual_slice.rs
+++ b/tests/ui/manual_slice.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::manual_slice)]
+
+fn main() {
+    let mut arr: [u32; 1] = [1];
+    let slice = &arr[..];
+    let mutable_slice = &mut arr[..];
+}

--- a/tests/ui/manual_slice.rs
+++ b/tests/ui/manual_slice.rs
@@ -1,7 +1,29 @@
 #![warn(clippy::manual_slice)]
 
 fn main() {
-    let mut arr: [u32; 1] = [1];
-    let slice = &arr[..];
-    let mutable_slice = &mut arr[..];
+    let mut arr: [u32; 3] = [1, 2, 3];
+
+    let arr_slice = &arr[..];
+    let mutable_arr_slice = &mut arr[..];
+
+    let mut vec = vec![1, 2, 3];
+
+    let vec_slice = &vec[..];
+    let mutable_vec_slice = &mut vec[..];
+
+    // Will not fire on any of these
+
+    let partial_slice_1 = &arr[1..];
+    let partial_slice_2 = &arr[..3];
+    let partial_slice_3 = &arr[1..3];
+    let partial_mut_slice_1 = &mut arr[1..];
+    let partial_mut_slice_2 = &mut arr[..3];
+    let partial_mut_slice_3 = &mut arr[1..3];
+
+    let partial_slice_1 = &vec[1..];
+    let partial_slice_2 = &vec[..3];
+    let partial_slice_3 = &vec[1..3];
+    let partial_mut_slice_1 = &mut vec[1..];
+    let partial_mut_slice_2 = &mut vec[..3];
+    let partial_mut_slice_3 = &mut vec[1..3];
 }

--- a/tests/ui/manual_slice.stderr
+++ b/tests/ui/manual_slice.stderr
@@ -1,0 +1,28 @@
+error: converting to a slice of the same length
+  --> $DIR/manual_slice.rs:6:21
+   |
+LL |     let arr_slice = &arr[..];
+   |                     ^^^^^^^^ help: use: `arr.to_slice()`
+   |
+   = note: `-D clippy::manual-slice` implied by `-D warnings`
+
+error: converting to a slice of the same length
+  --> $DIR/manual_slice.rs:7:29
+   |
+LL |     let mutable_arr_slice = &mut arr[..];
+   |                             ^^^^^^^^^^^^ help: use: `arr.to_mut_slice()`
+
+error: converting to a slice of the same length
+  --> $DIR/manual_slice.rs:11:21
+   |
+LL |     let vec_slice = &vec[..];
+   |                     ^^^^^^^^ help: use: `vec.to_slice()`
+
+error: converting to a slice of the same length
+  --> $DIR/manual_slice.rs:12:29
+   |
+LL |     let mutable_vec_slice = &mut vec[..];
+   |                             ^^^^^^^^^^^^ help: use: `vec.to_mut_slice()`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
- WIP Manual Slice
- Convert to LateLintPass

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change. Also, it's helpful for us that
the lint name is put into brackets `[]` and backticks `` ` ` ``,
e.g. ``[`lint_name`]``.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
