### PR TITLE
Don't lint Default::default if it is the udpate syntax base

### DIFF
--- a/tests/ui/default_trait_access.fixed
+++ b/tests/ui/default_trait_access.fixed
@@ -46,9 +46,14 @@ fn main() {
 
     let s19 = <DerivedDefault as Default>::default();
 
+    let s20 = UpdateSyntax {
+        s: "foo",
+        ..Default::default()
+    };
+
     println!(
-        "[{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}], [{:?}]",
-        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19,
+        "[{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}]",
+        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20,
     );
 }
 
@@ -86,3 +91,9 @@ struct ArrayDerivedDefault {
 
 #[derive(Debug, Default)]
 struct TupleStructDerivedDefault(String);
+
+#[derive(Debug, Default)]
+struct UpdateSyntax {
+    pub s: &'static str,
+    pub u: u64,
+}

--- a/tests/ui/default_trait_access.rs
+++ b/tests/ui/default_trait_access.rs
@@ -46,9 +46,14 @@ fn main() {
 
     let s19 = <DerivedDefault as Default>::default();
 
+    let s20 = UpdateSyntax {
+        s: "foo",
+        ..Default::default()
+    };
+
     println!(
-        "[{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}], [{:?}]",
-        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19,
+        "[{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}] [{:?}]",
+        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20,
     );
 }
 
@@ -86,3 +91,9 @@ struct ArrayDerivedDefault {
 
 #[derive(Debug, Default)]
 struct TupleStructDerivedDefault(String);
+
+#[derive(Debug, Default)]
+struct UpdateSyntax {
+    pub s: &'static str,
+    pub u: u64,
+}


### PR DESCRIPTION
changelog: Don't lint `Default::default` it is part of the update syntax


Current clippy warns about this:

```
warning: calling `Foo::default()` is more clear than this expression
  --> src/main.rs:12:11
   |
12 |         ..Default::default()
   |           ^^^^^^^^^^^^^^^^^^ help: try: `Foo::default()`
   |
```

With these changes, it will not lint that particular expression anymore.

