### PR TITLE
[WIP] new lint: not op in integer cmp

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -57,11 +57,17 @@ declare_clippy_lint! {
     correctness,
     "boolean expressions that contain terminals which can be eliminated"
 }
+declare_clippy_lint! {
+    #[clippy::version = ""]
+    pub NOT_OP_IN_INT_CMP,
+    pedantic,
+    "uses of `!` operator in integer comparision might be unexpected"
+}
 
 // For each pairs, both orders are considered.
 const METHODS_WITH_NEGATION: [(&str, &str); 2] = [("is_some", "is_none"), ("is_err", "is_ok")];
 
-declare_lint_pass!(NonminimalBool => [NONMINIMAL_BOOL, LOGIC_BUG]);
+declare_lint_pass!(NonminimalBool => [NONMINIMAL_BOOL, LOGIC_BUG, NOT_OP_IN_INT_CMP]);
 
 impl<'tcx> LateLintPass<'tcx> for NonminimalBool {
     fn check_fn(


### PR DESCRIPTION
Fixes #5794

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
