### PR TITLE
Don't lint `needless_borrow` in method receiver positions

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -528,7 +528,7 @@ fn is_auto_reborrow_position(parent: Option<Node<'_>>) -> bool {
 fn is_auto_borrow_position(parent: Option<Node<'_>>, child_id: HirId) -> bool {
     if let Some(Node::Expr(parent)) = parent {
         match parent.kind {
-            ExprKind::MethodCall(_, [self_arg, ..], _) => self_arg.hir_id == child_id,
+            // ExprKind::MethodCall(_, [self_arg, ..], _) => self_arg.hir_id == child_id,
             ExprKind::Field(..) => true,
             ExprKind::Call(f, _) => f.hir_id == child_id,
             _ => false,

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -64,9 +64,9 @@ fn main() {
     *x = 5;
 
     let s = String::new();
-    let _ = s.len();
-    let _ = s.capacity();
-    let _ = s.capacity();
+    // let _ = (&s).len();
+    // let _ = (&s).capacity();
+    // let _ = (&&s).capacity();
 
     let x = (1, 2);
     let _ = x.0;

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -64,9 +64,9 @@ fn main() {
     *x = 5;
 
     let s = String::new();
-    let _ = (&s).len();
-    let _ = (&s).capacity();
-    let _ = (&&s).capacity();
+    // let _ = (&s).len();
+    // let _ = (&s).capacity();
+    // let _ = (&&s).capacity();
 
     let x = (1, 2);
     let _ = (&x).0;

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -85,24 +85,6 @@ LL |     let y: &mut i32 = &mut &mut x;
    |                       ^^^^^^^^^^^ help: change this to: `x`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:67:13
-   |
-LL |     let _ = (&s).len();
-   |             ^^^^ help: change this to: `s`
-
-error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:68:13
-   |
-LL |     let _ = (&s).capacity();
-   |             ^^^^ help: change this to: `s`
-
-error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:69:13
-   |
-LL |     let _ = (&&s).capacity();
-   |             ^^^^^ help: change this to: `s`
-
-error: this expression borrows a value the compiler would automatically borrow
   --> $DIR/needless_borrow.rs:72:13
    |
 LL |     let _ = (&x).0;
@@ -114,5 +96,5 @@ error: this expression borrows a value the compiler would automatically borrow
 LL |     let _ = unsafe { (&*x).0 };
    |                      ^^^^^ help: change this to: `(*x)`
 
-error: aborting due to 19 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
fixes #8408 
fixes #8407 
fixes #8391
fixes #8367
fixes #8380

This is a temporary fix for `needless_borrow`. The proper fix is included in #8355.

This should probably be merged into rustc before beta branches on Friday. This issue has been reported six or seven times in the past couple of weeks.

changelog: Fix various issues with `needless_borrow` n´. Note to changelog writer: those issues might have been introduced in this release cycle, so this might not matter in the changelog.
