### PR TITLE
trigger  `ptr_as_ptr` inside macros 

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -419,6 +419,10 @@ impl_lint_pass!(Casts => [
 
 impl<'tcx> LateLintPass<'tcx> for Casts {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if !in_external_macro(cx.sess(), expr.span) {
+            ptr_as_ptr::check(cx, expr, &self.msrv);
+        }
+
         if expr.span.from_expansion() {
             return;
         }
@@ -455,7 +459,6 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
         cast_ref_to_mut::check(cx, expr);
         cast_ptr_alignment::check(cx, expr);
         char_lit_as_u8::check(cx, expr);
-        ptr_as_ptr::check(cx, expr, &self.msrv);
     }
 
     extract_msrv_attr!(LateContext);

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -120,3 +120,10 @@ macro_rules! mut_mut {
         let mut_mut_ty: &mut &mut u32 = &mut &mut 1u32;
     };
 }
+
+#[macro_export]
+macro_rules! ptr_as_ptr_cast {
+    ($ptr: ident) => {
+        $ptr as *const i32
+    };
+}

--- a/tests/ui/ptr_as_ptr.fixed
+++ b/tests/ui/ptr_as_ptr.fixed
@@ -1,7 +1,16 @@
 // run-rustfix
+// aux-build:macro_rules.rs
 
 #![warn(clippy::ptr_as_ptr)]
 #![feature(custom_inner_attributes)]
+
+extern crate macro_rules;
+
+macro_rules! cast_it {
+    ($ptr: ident) => {
+        $ptr.cast::<i32>()
+    };
+}
 
 fn main() {
     let ptr: *const u32 = &42_u32;
@@ -28,6 +37,12 @@ fn main() {
     // Ensure the lint doesn't produce unnecessary turbofish for inferred types.
     let _: *const i32 = ptr.cast();
     let _: *mut i32 = mut_ptr.cast();
+
+    // Make sure the lint is triggered inside a macro
+    let _ = cast_it!(ptr);
+
+    // Do not lint inside macros from external crates
+    let _ = macro_rules::ptr_as_ptr_cast!(ptr);
 }
 
 fn _msrv_1_37() {

--- a/tests/ui/ptr_as_ptr.rs
+++ b/tests/ui/ptr_as_ptr.rs
@@ -1,7 +1,16 @@
 // run-rustfix
+// aux-build:macro_rules.rs
 
 #![warn(clippy::ptr_as_ptr)]
 #![feature(custom_inner_attributes)]
+
+extern crate macro_rules;
+
+macro_rules! cast_it {
+    ($ptr: ident) => {
+        $ptr as *const i32
+    };
+}
 
 fn main() {
     let ptr: *const u32 = &42_u32;
@@ -28,6 +37,12 @@ fn main() {
     // Ensure the lint doesn't produce unnecessary turbofish for inferred types.
     let _: *const i32 = ptr as *const _;
     let _: *mut i32 = mut_ptr as _;
+
+    // Make sure the lint is triggered inside a macro
+    let _ = cast_it!(ptr);
+
+    // Do not lint inside macros from external crates
+    let _ = macro_rules::ptr_as_ptr_cast!(ptr);
 }
 
 fn _msrv_1_37() {

--- a/tests/ui/ptr_as_ptr.stderr
+++ b/tests/ui/ptr_as_ptr.stderr
@@ -1,5 +1,5 @@
 error: `as` casting between raw pointers without changing its mutability
-  --> $DIR/ptr_as_ptr.rs:10:13
+  --> $DIR/ptr_as_ptr.rs:19:13
    |
 LL |     let _ = ptr as *const i32;
    |             ^^^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `ptr.cast::<i32>()`
@@ -7,40 +7,51 @@ LL |     let _ = ptr as *const i32;
    = note: `-D clippy::ptr-as-ptr` implied by `-D warnings`
 
 error: `as` casting between raw pointers without changing its mutability
-  --> $DIR/ptr_as_ptr.rs:11:13
+  --> $DIR/ptr_as_ptr.rs:20:13
    |
 LL |     let _ = mut_ptr as *mut i32;
    |             ^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `mut_ptr.cast::<i32>()`
 
 error: `as` casting between raw pointers without changing its mutability
-  --> $DIR/ptr_as_ptr.rs:16:17
+  --> $DIR/ptr_as_ptr.rs:25:17
    |
 LL |         let _ = *ptr_ptr as *const i32;
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `(*ptr_ptr).cast::<i32>()`
 
 error: `as` casting between raw pointers without changing its mutability
-  --> $DIR/ptr_as_ptr.rs:29:25
+  --> $DIR/ptr_as_ptr.rs:38:25
    |
 LL |     let _: *const i32 = ptr as *const _;
    |                         ^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `ptr.cast()`
 
 error: `as` casting between raw pointers without changing its mutability
-  --> $DIR/ptr_as_ptr.rs:30:23
+  --> $DIR/ptr_as_ptr.rs:39:23
    |
 LL |     let _: *mut i32 = mut_ptr as _;
    |                       ^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `mut_ptr.cast()`
 
 error: `as` casting between raw pointers without changing its mutability
-  --> $DIR/ptr_as_ptr.rs:48:13
+  --> $DIR/ptr_as_ptr.rs:11:9
+   |
+LL |         $ptr as *const i32
+   |         ^^^^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `$ptr.cast::<i32>()`
+...
+LL |     let _ = cast_it!(ptr);
+   |             ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `cast_it` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `as` casting between raw pointers without changing its mutability
+  --> $DIR/ptr_as_ptr.rs:63:13
    |
 LL |     let _ = ptr as *const i32;
    |             ^^^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `ptr.cast::<i32>()`
 
 error: `as` casting between raw pointers without changing its mutability
-  --> $DIR/ptr_as_ptr.rs:49:13
+  --> $DIR/ptr_as_ptr.rs:64:13
    |
 LL |     let _ = mut_ptr as *mut i32;
    |             ^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast`, a safer alternative: `mut_ptr.cast::<i32>()`
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
This PR makes `ptr_as_ptr` trigger inside macros

Fixes issue #8120

changelog: ``[`ptr_as_ptr`]`` is now triggered inside macros

r? @llogiq
