### PR TITLE
tests: default to more threads for ui-tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ syn = { version = "1.0", features = ["full"] }
 futures = "0.3"
 parking_lot = "0.11.2"
 tokio = { version = "1", features = ["io-util"] }
+num_cpus = "1.13"
 
 [build-dependencies]
 rustc_tools_util = { version = "0.2", path = "rustc_tools_util" }

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -162,6 +162,11 @@ fn run_ui() {
     let config = base_config("ui");
     // use tests/clippy.toml
     let _g = VarGuard::set("CARGO_MANIFEST_DIR", fs::canonicalize("tests").unwrap());
+    let _threads = VarGuard::set(
+        "RUST_TEST_THREADS",
+        // if RUST_TEST_THREADS is set, adhere to it, otherwise override it
+        env::var("RUST_TEST_THREADS").unwrap_or_else(|_| num_cpus::get().to_string()),
+    );
     compiletest::run_tests(&config);
 }
 


### PR DESCRIPTION
Benchmarks (tested on i5-7200U, 2 cores, 4 threads)

```
master branch:

cargo test // prime caches
cargo --color=always test  70,39s user 21,91s system 180% cpu 51,035 total
cargo --color=always test  70,77s user 22,13s system 180% cpu 51,579 total
cargo --color=always test  70,97s user 22,12s system 180% cpu 51,673 total

cargo --color=always nextest run  78,74s user 22,27s system 220% cpu 45,829 total
cargo --color=always nextest run  78,46s user 21,92s system 224% cpu 44,674 total
cargo --color=always nextest run  78,31s user 22,21s system 228% cpu 43,909 total

Patched (ui_speedup branch):

cargo test // prime cache
cargo --color=always test  97,51s user 32,02s system 288% cpu 44,905 total
cargo --color=always test  99,19s user 31,91s system 276% cpu 47,436 total
cargo --color=always test  98,47s user 31,84s system 284% cpu 45,744 total

cargo --color=always nextest run  102,18s user 30,80s system 350% cpu 37,902 total
cargo --color=always nextest run  99,75s user 29,86s system 350% cpu 36,935 total
cargo --color=always nextest run  100,36s user 29,93s system 351% cpu 37,061 total
```

changelog: use more threads for running clippys ui-tests for ~10% walltime speedup
