### PR TITLE
fix false positives of large_enum_variant

### DIFF
--- a/tests/ui/large_enum_variant.rs
+++ b/tests/ui/large_enum_variant.rs
@@ -74,6 +74,30 @@ enum LargeEnum8 {
     ContainingMoreThanOneField([i32; 8000], [i32; 2], [i32; 9500], [i32; 30]),
 }
 
+enum LargeEnum9 {
+    A(Struct<()>),
+    B(Struct2),
+}
+
+enum LargeEnumOk2<T> {
+    A(T),
+    B(Struct2),
+}
+
+enum LargeEnumOk3<T> {
+    A(Struct<T>),
+    B(Struct2),
+}
+
+struct Struct<T> {
+    a: i32,
+    t: T,
+}
+
+struct Struct2 {
+    a: [i32; 8000],
+}
+
 fn main() {
     large_enum_variant!();
 }

--- a/tests/ui/large_enum_variant.stderr
+++ b/tests/ui/large_enum_variant.stderr
@@ -111,5 +111,21 @@ help: consider boxing the large fields to reduce the total size of the enum
 LL |     ContainingMoreThanOneField(Box<[i32; 8000]>, [i32; 2], Box<[i32; 9500]>, [i32; 30]),
    |                                ~~~~~~~~~~~~~~~~            ~~~~~~~~~~~~~~~~
 
-error: aborting due to 7 previous errors
+error: large size difference between variants
+  --> $DIR/large_enum_variant.rs:79:5
+   |
+LL |     B(Struct2),
+   |     ^^^^^^^^^^ this variant is 32000 bytes
+   |
+note: and the second-largest variant is 4 bytes:
+  --> $DIR/large_enum_variant.rs:78:5
+   |
+LL |     A(Struct<()>),
+   |     ^^^^^^^^^^^^^
+help: consider boxing the large fields to reduce the total size of the enum
+   |
+LL |     B(Box<Struct2>),
+   |       ~~~~~~~~~~~~
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
fixes: #8321 
The size of enums containing generic type was calculated to be 0. 
I changed [large_enum_variant] so that such enums are not linted.

changelog: none
