### PR TITLE
Fix `ptr_arg`

### DIFF
--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -547,7 +547,7 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'_>, args:
 
             // Helper function to handle early returns.
             let mut set_skip_flag = || {
-                if result.skip {
+                if !result.skip {
                     self.skip_count += 1;
                 }
                 result.skip = true;

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -186,3 +186,11 @@ pub trait Trait {
     fn f(v: &mut Vec<i32>);
     fn f2(v: &mut Vec<i32>) {}
 }
+
+// Issue #8463
+fn two_vecs(a: &mut Vec<u32>, b: &mut Vec<u32>) {
+    a.push(0);
+    a.push(0);
+    a.push(0);
+    b.push(1);
+}


### PR DESCRIPTION
fixes: #8463

changelog: Fix `ptr_arg` when multiple arguments are being checked in one function
