### PR TITLE
Update edition in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,6 +2,6 @@ max_width = 120
 comment_width = 100
 match_block_trailing_comma = true
 wrap_comments = true
-edition = "2018"
+edition = "2021"
 error_on_line_overflow = true
 version = "Two"


### PR DESCRIPTION
I noticed that our `rustfmt.toml` still has the edition 2018 listed. This updates the configuration to use 2021.

This luckily doesn't introduce any formatting changes :upside_down_face: 

changelog: none
