### PR TITLE
Move testing of cargo dev new_lint to cargo dev workflow

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -74,10 +74,3 @@ jobs:
       run: bash .github/driver.sh
       env:
         OS: ${{ runner.os }}
-
-    - name: Test cargo dev new lint
-      run: |
-        cargo dev new_lint --name new_early_pass --pass early
-        cargo dev new_lint --name new_late_pass --pass late
-        cargo check
-        git reset --hard HEAD

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -143,13 +143,6 @@ jobs:
       env:
         OS: ${{ runner.os }}
 
-    - name: Test cargo dev new lint
-      run: |
-        cargo dev new_lint --name new_early_pass --pass early
-        cargo dev new_lint --name new_late_pass --pass late
-        cargo check
-        git reset --hard HEAD
-
   integration_build:
     needs: changelog
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -36,6 +36,13 @@ jobs:
     - name: Test fmt
       run: cargo dev fmt --check
 
+    - name: Test cargo dev new lint
+      run: |
+        cargo dev new_lint --name new_early_pass --pass early
+        cargo dev new_lint --name new_late_pass --pass late
+        cargo check
+        git reset --hard HEAD
+
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a
   # workflow is successful listening to webhooks only.


### PR DESCRIPTION
This should be placed there. No need to run this in PR CI, if clippy_dev
isn't touched. (It will be run by bors anyway)

changelog: none
