### PR TITLE
tests: use std::thread::available_parallelism() instead of num_cpus to get thread count

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ futures = "0.3"
 parking_lot = "0.11.2"
 tokio = { version = "1", features = ["io-util"] }
 rustc-semver = "1.1"
-num_cpus = "1.13"
 
 [build-dependencies]
 rustc_tools_util = { version = "0.2", path = "rustc_tools_util" }

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -168,7 +168,11 @@ fn run_ui() {
     let _threads = VarGuard::set(
         "RUST_TEST_THREADS",
         // if RUST_TEST_THREADS is set, adhere to it, otherwise override it
-        env::var("RUST_TEST_THREADS").unwrap_or_else(|_| num_cpus::get().to_string()),
+        env::var("RUST_TEST_THREADS").unwrap_or_else(|_| {
+            std::thread::available_parallelism()
+                .map_or(1, std::num::NonZeroUsize::get)
+                .to_string()
+        }),
     );
     compiletest::run_tests(&config);
 }


### PR DESCRIPTION
removes the dependency added in https://github.com/rust-lang/rust-clippy/pull/8451
---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: tests: use std::thread::available_parallelism() instead of num_cpus to get thread count
