### PR TITLE
Make `search_is_some`s suggestion `MachineApplicable`

### DIFF
--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -808,7 +808,7 @@ pub fn deref_closure_args<'tcx>(cx: &LateContext<'_>, closure: &'tcx hir::Expr<'
             closure_arg_is_type_annotated_double_ref,
             next_pos: closure.span.lo(),
             suggestion_start: String::new(),
-            applicability: Applicability::MaybeIncorrect,
+            applicability: Applicability::MachineApplicable,
         };
 
         let fn_def_id = cx.tcx.hir().local_def_id(closure.hir_id);


### PR DESCRIPTION
My biggest PR to date, about 0.3 Lines have been changed!

Closes https://github.com/rust-lang/rust-clippy/issues/8062

The suggestion seems to work well, as we've received no error reports since the implementation in December. This PR therefore promotes the suggestion to `MachineApplicable`. The tests already include `.fixed` files :)

changelog: [`search_is_some`]: Make more suggestions `MachineApplicable` 