### PR TITLE
[`collapsible_if`] fix typo in code-block kind specifier

### DIFF
--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -42,7 +42,7 @@ declare_clippy_lint! {
     ///
     /// Should be written:
     ///
-    /// ```rust.ignore
+    /// ```rust,ignore
     /// if x && y {
     ///     …
     /// }

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -76,7 +76,7 @@ declare_clippy_lint! {
     ///
     /// Should be written:
     ///
-    /// ```rust.ignore
+    /// ```rust,ignore
     /// if x {
     ///     …
     /// } else if y {


### PR DESCRIPTION


*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`collapsible_if`] fix typo in code-block kind specifier
