### PR TITLE
Suggest from_utf8_unchecked in const contexts

### DIFF
--- a/clippy_lints/src/transmute/transmute_ref_to_ref.rs
+++ b/clippy_lints/src/transmute/transmute_ref_to_ref.rs
@@ -41,7 +41,7 @@ pub(super) fn check<'tcx>(
                     &format!("transmute from a `{}` to a `{}`", from_ty, to_ty),
                     "consider using",
                     if const_context {
-                        format!("unsafe {{ std::str::from_utf8_unchecked{postfix}({snippet}) }}")
+                        format!("std::str::from_utf8_unchecked{postfix}({snippet})")
                     } else {
                         format!("std::str::from_utf8{postfix}({snippet}).unwrap()")
                     },

--- a/clippy_lints/src/transmute/transmute_ref_to_ref.rs
+++ b/clippy_lints/src/transmute/transmute_ref_to_ref.rs
@@ -32,17 +32,19 @@ pub(super) fn check<'tcx>(
                     ""
                 };
 
+                let snippet = snippet(cx, arg.span, "..");
+
                 span_lint_and_sugg(
                     cx,
                     TRANSMUTE_BYTES_TO_STR,
                     e.span,
                     &format!("transmute from a `{}` to a `{}`", from_ty, to_ty),
                     "consider using",
-                    format!(
-                        "std::str::from_utf8{}({}).unwrap()",
-                        postfix,
-                        snippet(cx, arg.span, ".."),
-                    ),
+                    if const_context {
+                        format!("unsafe {{ std::str::from_utf8_unchecked{postfix}({snippet}) }}")
+                    } else {
+                        format!("std::str::from_utf8{postfix}({snippet}).unwrap()")
+                    },
                     Applicability::Unspecified,
                 );
                 triggered = true;

--- a/clippy_lints/src/transmute/transmute_ref_to_ref.rs
+++ b/clippy_lints/src/transmute/transmute_ref_to_ref.rs
@@ -45,7 +45,7 @@ pub(super) fn check<'tcx>(
                     } else {
                         format!("std::str::from_utf8{postfix}({snippet}).unwrap()")
                     },
-                    Applicability::Unspecified,
+                    Applicability::MaybeIncorrect,
                 );
                 triggered = true;
             } else {

--- a/tests/ui/transmute.rs
+++ b/tests/ui/transmute.rs
@@ -134,9 +134,12 @@ mod num_to_bytes {
     }
 }
 
-fn bytes_to_str(b: &[u8], mb: &mut [u8]) {
-    let _: &str = unsafe { std::mem::transmute(b) };
+fn bytes_to_str(mb: &mut [u8]) {
+    const B: &[u8] = b"";
+
+    let _: &str = unsafe { std::mem::transmute(B) };
     let _: &mut str = unsafe { std::mem::transmute(mb) };
+    const _: &str = unsafe { std::mem::transmute(B) };
 }
 
 fn main() {}

--- a/tests/ui/transmute.stderr
+++ b/tests/ui/transmute.stderr
@@ -227,18 +227,24 @@ LL |             let _: [u8; 16] = std::mem::transmute(0i128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i128.to_ne_bytes()`
 
 error: transmute from a `&[u8]` to a `&str`
-  --> $DIR/transmute.rs:138:28
+  --> $DIR/transmute.rs:140:28
    |
-LL |     let _: &str = unsafe { std::mem::transmute(b) };
-   |                            ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8(b).unwrap()`
+LL |     let _: &str = unsafe { std::mem::transmute(B) };
+   |                            ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8(B).unwrap()`
    |
    = note: `-D clippy::transmute-bytes-to-str` implied by `-D warnings`
 
 error: transmute from a `&mut [u8]` to a `&mut str`
-  --> $DIR/transmute.rs:139:32
+  --> $DIR/transmute.rs:141:32
    |
 LL |     let _: &mut str = unsafe { std::mem::transmute(mb) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_mut(mb).unwrap()`
 
-error: aborting due to 38 previous errors
+error: transmute from a `&[u8]` to a `&str`
+  --> $DIR/transmute.rs:142:30
+   |
+LL |     const _: &str = unsafe { std::mem::transmute(B) };
+   |                              ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `unsafe { std::str::from_utf8_unchecked(B) }`
+
+error: aborting due to 39 previous errors
 

--- a/tests/ui/transmute.stderr
+++ b/tests/ui/transmute.stderr
@@ -244,7 +244,7 @@ error: transmute from a `&[u8]` to a `&str`
   --> $DIR/transmute.rs:142:30
    |
 LL |     const _: &str = unsafe { std::mem::transmute(B) };
-   |                              ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `unsafe { std::str::from_utf8_unchecked(B) }`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_unchecked(B)`
 
 error: aborting due to 39 previous errors
 


### PR DESCRIPTION
Unfortunately I couldn't figure out how to check whether a given expression is in an `unsafe` context or not, so I just unconditionally emit the wrapping `unsafe {}` block in the suggestion. If there is an easy way to get it to work better then I would love to hear it.

changelog: Suggest `from_utf8_unchecked` instead of `from_utf8` in const contexts for ``[`transmute_bytes_to_str`]``

refs: #8379