### PR TITLE
ignore `&x | &y` in unnested_or_patterns

### DIFF
--- a/clippy_lints/src/unnested_or_patterns.rs
+++ b/clippy_lints/src/unnested_or_patterns.rs
@@ -5,7 +5,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::{meets_msrv, msrvs, over};
 use rustc_ast::mut_visit::*;
 use rustc_ast::ptr::P;
-use rustc_ast::{self as ast, Pat, PatKind, PatKind::*, DUMMY_NODE_ID};
+use rustc_ast::{self as ast, Mutability, Pat, PatKind, PatKind::*, DUMMY_NODE_ID};
 use rustc_ast_pretty::pprust;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
@@ -230,6 +230,10 @@ fn transform_with_focus_on_idx(alternatives: &mut Vec<P<Pat>>, focus_idx: usize)
         // with which a pattern `C(p_0)` may be formed,
         // which we would want to join with other `C(p_j)`s.
         Ident(.., None) | Lit(_) | Wild | Path(..) | Range(..) | Rest | MacCall(_)
+        // Skip immutable refs, as grouping them saves few characters,
+        // and almost always requires adding parens (increasing noisiness).
+        // In the case of only two patterns, replacement adds net characters.
+        | Ref(_, Mutability::Not)
         // Dealt with elsewhere.
         | Or(_) | Paren(_) => false,
         // Transform `box x | ... | box y` into `box (x | y)`.
@@ -241,10 +245,10 @@ fn transform_with_focus_on_idx(alternatives: &mut Vec<P<Pat>>, focus_idx: usize)
             |k| matches!(k, Box(_)),
             |k| always_pat!(k, Box(p) => p),
         ),
-        // Transform `&m x | ... | &m y` into `&m (x | y)`.
-        Ref(target, m1) => extend_with_matching(
+        // Transform `&mut x | ... | &mut y` into `&mut (x | y)`.
+        Ref(target, Mutability::Mut) => extend_with_matching(
             target, start, alternatives,
-            |k| matches!(k, Ref(_, m2) if m1 == m2), // Mutabilities must match.
+            |k| matches!(k, Ref(_, Mutability::Mut)),
             |k| always_pat!(k, Ref(p, _) => p),
         ),
         // Transform `b @ p0 | ... b @ p1` into `b @ (p0 | p1)`.

--- a/tests/ui/unnested_or_patterns.fixed
+++ b/tests/ui/unnested_or_patterns.fixed
@@ -6,10 +6,13 @@
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused_variables)]
 
 fn main() {
+    // Should be ignored by this lint, as nesting requires more characters.
+    if let &0 | &2 = &0 {}
+
     if let box (0 | 2) = Box::new(0) {}
     if let box (0 | 1 | 2 | 3 | 4) = Box::new(0) {}
-    const C0: &u8 = &1;
-    if let &(0 | 2) | C0 = &0 {}
+    const C0: Option<u8> = Some(1);
+    if let Some(1 | 2) | C0 = None {}
     if let &mut (0 | 2) = &mut 0 {}
     if let x @ (0 | 2) = 0 {}
     if let (0, 1 | 2 | 3) = (0, 0) {}

--- a/tests/ui/unnested_or_patterns.rs
+++ b/tests/ui/unnested_or_patterns.rs
@@ -6,10 +6,13 @@
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused_variables)]
 
 fn main() {
+    // Should be ignored by this lint, as nesting requires more characters.
+    if let &0 | &2 = &0 {}
+
     if let box 0 | box 2 = Box::new(0) {}
     if let box ((0 | 1)) | box (2 | 3) | box 4 = Box::new(0) {}
-    const C0: &u8 = &1;
-    if let &0 | C0 | &2 = &0 {}
+    const C0: Option<u8> = Some(1);
+    if let Some(1) | C0 | Some(2) = None {}
     if let &mut 0 | &mut 2 = &mut 0 {}
     if let x @ 0 | x @ 2 = 0 {}
     if let (0, 1) | (0, 2) | (0, 3) = (0, 0) {}

--- a/tests/ui/unnested_or_patterns.stderr
+++ b/tests/ui/unnested_or_patterns.stderr
@@ -1,5 +1,5 @@
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:9:12
+  --> $DIR/unnested_or_patterns.rs:12:12
    |
 LL |     if let box 0 | box 2 = Box::new(0) {}
    |            ^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     if let box (0 | 2) = Box::new(0) {}
    |            ~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:10:12
+  --> $DIR/unnested_or_patterns.rs:13:12
    |
 LL |     if let box ((0 | 1)) | box (2 | 3) | box 4 = Box::new(0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,18 +22,18 @@ LL |     if let box (0 | 1 | 2 | 3 | 4) = Box::new(0) {}
    |            ~~~~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:12:12
+  --> $DIR/unnested_or_patterns.rs:15:12
    |
-LL |     if let &0 | C0 | &2 = &0 {}
-   |            ^^^^^^^^^^^^
+LL |     if let Some(1) | C0 | Some(2) = None {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^
    |
 help: nest the patterns
    |
-LL |     if let &(0 | 2) | C0 = &0 {}
-   |            ~~~~~~~~~~~~~
+LL |     if let Some(1 | 2) | C0 = None {}
+   |            ~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:13:12
+  --> $DIR/unnested_or_patterns.rs:16:12
    |
 LL |     if let &mut 0 | &mut 2 = &mut 0 {}
    |            ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     if let &mut (0 | 2) = &mut 0 {}
    |            ~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:14:12
+  --> $DIR/unnested_or_patterns.rs:17:12
    |
 LL |     if let x @ 0 | x @ 2 = 0 {}
    |            ^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     if let x @ (0 | 2) = 0 {}
    |            ~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:15:12
+  --> $DIR/unnested_or_patterns.rs:18:12
    |
 LL |     if let (0, 1) | (0, 2) | (0, 3) = (0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |     if let (0, 1 | 2 | 3) = (0, 0) {}
    |            ~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:16:12
+  --> $DIR/unnested_or_patterns.rs:19:12
    |
 LL |     if let (1, 0) | (2, 0) | (3, 0) = (0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     if let (1 | 2 | 3, 0) = (0, 0) {}
    |            ~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:17:12
+  --> $DIR/unnested_or_patterns.rs:20:12
    |
 LL |     if let (x, ..) | (x, 1) | (x, 2) = (0, 1) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL |     if let (x, ..) | (x, 1 | 2) = (0, 1) {}
    |            ~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:18:12
+  --> $DIR/unnested_or_patterns.rs:21:12
    |
 LL |     if let [0] | [1] = [0] {}
    |            ^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     if let [0 | 1] = [0] {}
    |            ~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:19:12
+  --> $DIR/unnested_or_patterns.rs:22:12
    |
 LL |     if let [x, 0] | [x, 1] = [0, 1] {}
    |            ^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ LL |     if let [x, 0 | 1] = [0, 1] {}
    |            ~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:20:12
+  --> $DIR/unnested_or_patterns.rs:23:12
    |
 LL |     if let [x, 0] | [x, 1] | [x, 2] = [0, 1] {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     if let [x, 0 | 1 | 2] = [0, 1] {}
    |            ~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:21:12
+  --> $DIR/unnested_or_patterns.rs:24:12
    |
 LL |     if let [x, ..] | [x, 1] | [x, 2] = [0, 1] {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL |     if let [x, ..] | [x, 1 | 2] = [0, 1] {}
    |            ~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:23:12
+  --> $DIR/unnested_or_patterns.rs:26:12
    |
 LL |     if let TS(0, x) | TS(1, x) = TS(0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     if let TS(0 | 1, x) = TS(0, 0) {}
    |            ~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:24:12
+  --> $DIR/unnested_or_patterns.rs:27:12
    |
 LL |     if let TS(1, 0) | TS(2, 0) | TS(3, 0) = TS(0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,7 +154,7 @@ LL |     if let TS(1 | 2 | 3, 0) = TS(0, 0) {}
    |            ~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:25:12
+  --> $DIR/unnested_or_patterns.rs:28:12
    |
 LL |     if let TS(x, ..) | TS(x, 1) | TS(x, 2) = TS(0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL |     if let TS(x, ..) | TS(x, 1 | 2) = TS(0, 0) {}
    |            ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:30:12
+  --> $DIR/unnested_or_patterns.rs:33:12
    |
 LL |     if let S { x: 0, y } | S { y, x: 1 } = (S { x: 0, y: 1 }) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
replacing it with `&(x | y)` is actually more characters

Fixes #6973

changelog: [`unnested_or_patterns`] ignore `&x | &y`, nesting would result in more characters
