### PR TITLE
Remove overlap between `manual_split_once` and `needless_splitn`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2516,12 +2516,7 @@ fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Optio
             ("splitn" | "rsplitn", [count_arg, pat_arg]) => {
                 if let Some((Constant::Int(count), _)) = constant(cx, cx.typeck_results(), count_arg) {
                     suspicious_splitn::check(cx, name, expr, recv, count);
-                    if count == 2 && meets_msrv(msrv, &msrvs::STR_SPLIT_ONCE) {
-                        str_splitn::check_manual_split_once(cx, name, expr, recv, pat_arg);
-                    }
-                    if count >= 2 {
-                        str_splitn::check_needless_splitn(cx, name, expr, recv, pat_arg, count);
-                    }
+                    str_splitn::check(cx, name, expr, recv, pat_arg, count, msrv);
                 }
             },
             ("splitn_mut" | "rsplitn_mut", [count_arg, _]) => {

--- a/tests/ui/crashes/ice-8250.stderr
+++ b/tests/ui/crashes/ice-8250.stderr
@@ -1,11 +1,3 @@
-error: manual implementation of `split_once`
-  --> $DIR/ice-8250.rs:2:13
-   |
-LL |     let _ = s[1..].splitn(2, '.').next()?;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s[1..].split_once('.').map_or(s[1..], |x| x.0)`
-   |
-   = note: `-D clippy::manual-split-once` implied by `-D warnings`
-
 error: unnecessary use of `splitn`
   --> $DIR/ice-8250.rs:2:13
    |
@@ -14,5 +6,5 @@ LL |     let _ = s[1..].splitn(2, '.').next()?;
    |
    = note: `-D clippy::needless-splitn` implied by `-D warnings`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/tests/ui/manual_split_once.fixed
+++ b/tests/ui/manual_split_once.fixed
@@ -2,7 +2,7 @@
 
 #![feature(custom_inner_attributes)]
 #![warn(clippy::manual_split_once)]
-#![allow(clippy::iter_skip_next, clippy::iter_nth_zero, clippy::needless_splitn)]
+#![allow(clippy::iter_skip_next, clippy::iter_nth_zero)]
 
 extern crate itertools;
 
@@ -10,27 +10,25 @@ extern crate itertools;
 use itertools::Itertools;
 
 fn main() {
-    let _ = Some("key=value".split_once('=').map_or("key=value", |x| x.0));
     let _ = "key=value".splitn(2, '=').nth(2);
-    let _ = "key=value".split_once('=').map_or("key=value", |x| x.0);
-    let _ = "key=value".split_once('=').map_or("key=value", |x| x.0);
     let _ = "key=value".split_once('=').unwrap().1;
     let _ = "key=value".split_once('=').unwrap().1;
     let (_, _) = "key=value".split_once('=').unwrap();
 
     let s = String::from("key=value");
-    let _ = s.split_once('=').map_or(&*s, |x| x.0);
+    let _ = s.split_once('=').unwrap().1;
 
     let s = Box::<str>::from("key=value");
-    let _ = s.split_once('=').map_or(&*s, |x| x.0);
+    let _ = s.split_once('=').unwrap().1;
 
     let s = &"key=value";
-    let _ = s.split_once('=').map_or(*s, |x| x.0);
+    let _ = s.split_once('=').unwrap().1;
 
     fn _f(s: &str) -> Option<&str> {
-        let _ = s.split_once("key=value").map_or(s, |x| x.0);
-        let _ = s.split_once("key=value")?.1;
-        let _ = s.split_once("key=value")?.1;
+        let _ = s.split_once('=')?.1;
+        let _ = s.split_once('=')?.1;
+        let _ = s.rsplit_once('=')?.0;
+        let _ = s.rsplit_once('=')?.0;
         None
     }
 
@@ -38,10 +36,9 @@ fn main() {
     let _ = [0, 1, 2].splitn(2, |&x| x == 1).nth(1).unwrap();
 
     // `rsplitn` gives the results in the reverse order of `rsplit_once`
-    let _ = "key=value".rsplitn(2, '=').next().unwrap();
     let _ = "key=value".rsplit_once('=').unwrap().0;
-    let _ = "key=value".rsplit_once('=').map(|x| x.1);
     let (_, _) = "key=value".rsplit_once('=').map(|(x, y)| (y, x)).unwrap();
+    let _ = s.rsplit_once('=').map(|x| x.0);
 }
 
 fn _msrv_1_51() {

--- a/tests/ui/manual_split_once.rs
+++ b/tests/ui/manual_split_once.rs
@@ -2,7 +2,7 @@
 
 #![feature(custom_inner_attributes)]
 #![warn(clippy::manual_split_once)]
-#![allow(clippy::iter_skip_next, clippy::iter_nth_zero, clippy::needless_splitn)]
+#![allow(clippy::iter_skip_next, clippy::iter_nth_zero)]
 
 extern crate itertools;
 
@@ -10,27 +10,25 @@ extern crate itertools;
 use itertools::Itertools;
 
 fn main() {
-    let _ = "key=value".splitn(2, '=').next();
     let _ = "key=value".splitn(2, '=').nth(2);
-    let _ = "key=value".splitn(2, '=').next().unwrap();
-    let _ = "key=value".splitn(2, '=').nth(0).unwrap();
     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
     let _ = "key=value".splitn(2, '=').skip(1).next().unwrap();
     let (_, _) = "key=value".splitn(2, '=').next_tuple().unwrap();
 
     let s = String::from("key=value");
-    let _ = s.splitn(2, '=').next().unwrap();
+    let _ = s.splitn(2, '=').nth(1).unwrap();
 
     let s = Box::<str>::from("key=value");
-    let _ = s.splitn(2, '=').nth(0).unwrap();
+    let _ = s.splitn(2, '=').nth(1).unwrap();
 
     let s = &"key=value";
-    let _ = s.splitn(2, '=').skip(0).next().unwrap();
+    let _ = s.splitn(2, '=').skip(1).next().unwrap();
 
     fn _f(s: &str) -> Option<&str> {
-        let _ = s.splitn(2, "key=value").next()?;
-        let _ = s.splitn(2, "key=value").nth(1)?;
-        let _ = s.splitn(2, "key=value").skip(1).next()?;
+        let _ = s.splitn(2, '=').nth(1)?;
+        let _ = s.splitn(2, '=').skip(1).next()?;
+        let _ = s.rsplitn(2, '=').nth(1)?;
+        let _ = s.rsplitn(2, '=').skip(1).next()?;
         None
     }
 
@@ -38,10 +36,9 @@ fn main() {
     let _ = [0, 1, 2].splitn(2, |&x| x == 1).nth(1).unwrap();
 
     // `rsplitn` gives the results in the reverse order of `rsplit_once`
-    let _ = "key=value".rsplitn(2, '=').next().unwrap();
     let _ = "key=value".rsplitn(2, '=').nth(1).unwrap();
-    let _ = "key=value".rsplitn(2, '=').nth(0);
     let (_, _) = "key=value".rsplitn(2, '=').next_tuple().unwrap();
+    let _ = s.rsplitn(2, '=').nth(1);
 }
 
 fn _msrv_1_51() {

--- a/tests/ui/manual_split_once.stderr
+++ b/tests/ui/manual_split_once.stderr
@@ -1,100 +1,88 @@
 error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:13:13
+  --> $DIR/manual_split_once.rs:14:13
    |
-LL |     let _ = "key=value".splitn(2, '=').next();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `Some("key=value".split_once('=').map_or("key=value", |x| x.0))`
+LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
    |
    = note: `-D clippy::manual-split-once` implied by `-D warnings`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:15:13
    |
-LL |     let _ = "key=value".splitn(2, '=').next().unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').map_or("key=value", |x| x.0)`
-
-error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:16:13
-   |
-LL |     let _ = "key=value".splitn(2, '=').nth(0).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').map_or("key=value", |x| x.0)`
-
-error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:17:13
-   |
-LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
-
-error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:18:13
-   |
 LL |     let _ = "key=value".splitn(2, '=').skip(1).next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:19:18
+  --> $DIR/manual_split_once.rs:16:18
    |
 LL |     let (_, _) = "key=value".splitn(2, '=').next_tuple().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=')`
 
 error: manual implementation of `split_once`
+  --> $DIR/manual_split_once.rs:19:13
+   |
+LL |     let _ = s.splitn(2, '=').nth(1).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').unwrap().1`
+
+error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:22:13
    |
-LL |     let _ = s.splitn(2, '=').next().unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').map_or(&*s, |x| x.0)`
+LL |     let _ = s.splitn(2, '=').nth(1).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:25:13
    |
-LL |     let _ = s.splitn(2, '=').nth(0).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').map_or(&*s, |x| x.0)`
+LL |     let _ = s.splitn(2, '=').skip(1).next().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:28:13
+  --> $DIR/manual_split_once.rs:28:17
    |
-LL |     let _ = s.splitn(2, '=').skip(0).next().unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').map_or(*s, |x| x.0)`
+LL |         let _ = s.splitn(2, '=').nth(1)?;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=')?.1`
 
 error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:31:17
+  --> $DIR/manual_split_once.rs:29:17
    |
-LL |         let _ = s.splitn(2, "key=value").next()?;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once("key=value").map_or(s, |x| x.0)`
-
-error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:32:17
-   |
-LL |         let _ = s.splitn(2, "key=value").nth(1)?;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once("key=value")?.1`
-
-error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:33:17
-   |
-LL |         let _ = s.splitn(2, "key=value").skip(1).next()?;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once("key=value")?.1`
+LL |         let _ = s.splitn(2, '=').skip(1).next()?;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=')?.1`
 
 error: manual implementation of `rsplit_once`
-  --> $DIR/manual_split_once.rs:42:13
+  --> $DIR/manual_split_once.rs:30:17
+   |
+LL |         let _ = s.rsplitn(2, '=').nth(1)?;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit_once('=')?.0`
+
+error: manual implementation of `rsplit_once`
+  --> $DIR/manual_split_once.rs:31:17
+   |
+LL |         let _ = s.rsplitn(2, '=').skip(1).next()?;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit_once('=')?.0`
+
+error: manual implementation of `rsplit_once`
+  --> $DIR/manual_split_once.rs:39:13
    |
 LL |     let _ = "key=value".rsplitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".rsplit_once('=').unwrap().0`
 
 error: manual implementation of `rsplit_once`
-  --> $DIR/manual_split_once.rs:43:13
-   |
-LL |     let _ = "key=value".rsplitn(2, '=').nth(0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".rsplit_once('=').map(|x| x.1)`
-
-error: manual implementation of `rsplit_once`
-  --> $DIR/manual_split_once.rs:44:18
+  --> $DIR/manual_split_once.rs:40:18
    |
 LL |     let (_, _) = "key=value".rsplitn(2, '=').next_tuple().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".rsplit_once('=').map(|(x, y)| (y, x))`
 
+error: manual implementation of `rsplit_once`
+  --> $DIR/manual_split_once.rs:41:13
+   |
+LL |     let _ = s.rsplitn(2, '=').nth(1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit_once('=').map(|x| x.0)`
+
 error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:55:13
+  --> $DIR/manual_split_once.rs:52:13
    |
 LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
 
-error: aborting due to 16 previous errors
+error: aborting due to 14 previous errors
 

--- a/tests/ui/needless_splitn.fixed
+++ b/tests/ui/needless_splitn.fixed
@@ -24,4 +24,24 @@ fn main() {
     let _ = str.rsplitn(2, '=').nth(1);
     let (_, _) = str.rsplitn(2, '=').next_tuple().unwrap();
     let (_, _) = str.rsplit('=').next_tuple().unwrap();
+
+    let _ = str.split('=').next();
+    let _ = str.split('=').nth(3);
+    let _ = str.splitn(5, '=').nth(4);
+    let _ = str.splitn(5, '=').nth(5);
+}
+
+fn _question_mark(s: &str) -> Option<()> {
+    let _ = s.split('=').next()?;
+    let _ = s.split('=').nth(0)?;
+    let _ = s.rsplit('=').next()?;
+    let _ = s.rsplit('=').nth(0)?;
+
+    Some(())
+}
+
+fn _test_msrv() {
+    #![clippy::msrv = "1.51"]
+    // `manual_split_once` MSRV shouldn't apply to `needless_splitn`
+    let _ = "key=value".split('=').nth(0).unwrap();
 }

--- a/tests/ui/needless_splitn.rs
+++ b/tests/ui/needless_splitn.rs
@@ -24,4 +24,24 @@ fn main() {
     let _ = str.rsplitn(2, '=').nth(1);
     let (_, _) = str.rsplitn(2, '=').next_tuple().unwrap();
     let (_, _) = str.rsplitn(3, '=').next_tuple().unwrap();
+
+    let _ = str.splitn(5, '=').next();
+    let _ = str.splitn(5, '=').nth(3);
+    let _ = str.splitn(5, '=').nth(4);
+    let _ = str.splitn(5, '=').nth(5);
+}
+
+fn _question_mark(s: &str) -> Option<()> {
+    let _ = s.splitn(2, '=').next()?;
+    let _ = s.splitn(2, '=').nth(0)?;
+    let _ = s.rsplitn(2, '=').next()?;
+    let _ = s.rsplitn(2, '=').nth(0)?;
+
+    Some(())
+}
+
+fn _test_msrv() {
+    #![clippy::msrv = "1.51"]
+    // `manual_split_once` MSRV shouldn't apply to `needless_splitn`
+    let _ = "key=value".splitn(2, '=').nth(0).unwrap();
 }

--- a/tests/ui/needless_splitn.stderr
+++ b/tests/ui/needless_splitn.stderr
@@ -36,5 +36,47 @@ error: unnecessary use of `rsplitn`
 LL |     let (_, _) = str.rsplitn(3, '=').next_tuple().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^ help: try this: `str.rsplit('=')`
 
-error: aborting due to 6 previous errors
+error: unnecessary use of `splitn`
+  --> $DIR/needless_splitn.rs:28:13
+   |
+LL |     let _ = str.splitn(5, '=').next();
+   |             ^^^^^^^^^^^^^^^^^^ help: try this: `str.split('=')`
+
+error: unnecessary use of `splitn`
+  --> $DIR/needless_splitn.rs:29:13
+   |
+LL |     let _ = str.splitn(5, '=').nth(3);
+   |             ^^^^^^^^^^^^^^^^^^ help: try this: `str.split('=')`
+
+error: unnecessary use of `splitn`
+  --> $DIR/needless_splitn.rs:35:13
+   |
+LL |     let _ = s.splitn(2, '=').next()?;
+   |             ^^^^^^^^^^^^^^^^ help: try this: `s.split('=')`
+
+error: unnecessary use of `splitn`
+  --> $DIR/needless_splitn.rs:36:13
+   |
+LL |     let _ = s.splitn(2, '=').nth(0)?;
+   |             ^^^^^^^^^^^^^^^^ help: try this: `s.split('=')`
+
+error: unnecessary use of `rsplitn`
+  --> $DIR/needless_splitn.rs:37:13
+   |
+LL |     let _ = s.rsplitn(2, '=').next()?;
+   |             ^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit('=')`
+
+error: unnecessary use of `rsplitn`
+  --> $DIR/needless_splitn.rs:38:13
+   |
+LL |     let _ = s.rsplitn(2, '=').nth(0)?;
+   |             ^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit('=')`
+
+error: unnecessary use of `splitn`
+  --> $DIR/needless_splitn.rs:46:13
+   |
+LL |     let _ = "key=value".splitn(2, '=').nth(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split('=')`
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
changelog: Remove overlap between [`manual_split_once`] and [`needless_splitn`]. Fixes some incorrect `rsplitn` suggestions for [`manual_split_once`] 

Things that can trigger `needless_splitn` no longer trigger `manual_split_once`, e.g.

```rust
s.[r]splitn(2, '=').next();
s.[r]splitn(2, '=').nth(0);
s.[r]splitn(3, '=').next_tuple();
```

Fixes some suggestions:

```rust
let s = "should not match";

s.rsplitn(2, '.').nth(1);
// old -> Some("should not match")
Some(s.rsplit_once('.').map_or(s, |x| x.0));
// new -> None
s.rsplit_once('.').map(|x| x.0);

s.rsplitn(2, '.').nth(1)?;
// old -> "should not match"
s.rsplit_once('.').map_or(s, |x| x.0);
// new -> early returns
s.rsplit_once('.')?.0;
```