### PR TITLE
Escape `mod.rs` file mentions to avoid links in our documentation

### DIFF
--- a/clippy_lints/src/module_style.rs
+++ b/clippy_lints/src/module_style.rs
@@ -8,7 +8,7 @@ use std::path::{Component, Path};
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks that module layout uses only self named module files, bans mod.rs files.
+    /// Checks that module layout uses only self named module files, bans `mod.rs` files.
     ///
     /// ### Why is this bad?
     /// Having multiple module layout styles in a project can be confusing.
@@ -37,7 +37,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks that module layout uses only mod.rs files.
+    /// Checks that module layout uses only `mod.rs` files.
     ///
     /// ### Why is this bad?
     /// Having multiple module layout styles in a project can be confusing.


### PR DESCRIPTION
As the title says nothing special, still a fun fix :)

Closes: #8627

changelog: none