### PR TITLE
Introduce needless_option_take lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3473,6 +3473,7 @@ Released 2018-09-13
 [`needless_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
 [`needless_match`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_match
 [`needless_option_as_deref`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_option_as_deref
+[`needless_option_take`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_option_take
 [`needless_pass_by_value`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value
 [`needless_question_mark`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark
 [`needless_range_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -183,6 +183,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(methods::MAP_FLATTEN),
     LintId::of(methods::MAP_IDENTITY),
     LintId::of(methods::NEEDLESS_OPTION_AS_DEREF),
+    LintId::of(methods::NEEDLESS_OPTION_TAKE),
     LintId::of(methods::NEEDLESS_SPLITN),
     LintId::of(methods::NEW_RET_NO_SELF),
     LintId::of(methods::OK_EXPECT),

--- a/clippy_lints/src/lib.register_complexity.rs
+++ b/clippy_lints/src/lib.register_complexity.rs
@@ -45,6 +45,7 @@ store.register_group(true, "clippy::complexity", Some("clippy_complexity"), vec!
     LintId::of(methods::MAP_FLATTEN),
     LintId::of(methods::MAP_IDENTITY),
     LintId::of(methods::NEEDLESS_OPTION_AS_DEREF),
+    LintId::of(methods::NEEDLESS_OPTION_TAKE),
     LintId::of(methods::NEEDLESS_SPLITN),
     LintId::of(methods::OPTION_AS_REF_DEREF),
     LintId::of(methods::OPTION_FILTER_MAP),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -322,6 +322,7 @@ store.register_lints(&[
     methods::MAP_IDENTITY,
     methods::MAP_UNWRAP_OR,
     methods::NEEDLESS_OPTION_AS_DEREF,
+    methods::NEEDLESS_OPTION_TAKE,
     methods::NEEDLESS_SPLITN,
     methods::NEW_RET_NO_SELF,
     methods::OK_EXPECT,

--- a/clippy_lints/src/lib.register_suspicious.rs
+++ b/clippy_lints/src/lib.register_suspicious.rs
@@ -22,7 +22,6 @@ store.register_group(true, "clippy::suspicious", Some("clippy_suspicious"), vec!
     LintId::of(loops::EMPTY_LOOP),
     LintId::of(loops::FOR_LOOPS_OVER_FALLIBLES),
     LintId::of(loops::MUT_RANGE_BOUND),
-    LintId::of(methods::OPTION_TAKE_ON_TEMPORARY),
     LintId::of(methods::SUSPICIOUS_MAP),
     LintId::of(mut_key::MUTABLE_KEY_TYPE),
     LintId::of(octal_escapes::OCTAL_ESCAPES),

--- a/clippy_lints/src/lib.register_suspicious.rs
+++ b/clippy_lints/src/lib.register_suspicious.rs
@@ -22,6 +22,7 @@ store.register_group(true, "clippy::suspicious", Some("clippy_suspicious"), vec!
     LintId::of(loops::EMPTY_LOOP),
     LintId::of(loops::FOR_LOOPS_OVER_FALLIBLES),
     LintId::of(loops::MUT_RANGE_BOUND),
+    LintId::of(methods::OPTION_TAKE_ON_TEMPORARY),
     LintId::of(methods::SUSPICIOUS_MAP),
     LintId::of(mut_key::MUTABLE_KEY_TYPE),
     LintId::of(octal_escapes::OCTAL_ESCAPES),

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2177,7 +2177,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.61.0"]
     pub NEEDLESS_OPTION_TAKE,
-    suspicious,
+    complexity,
     "using `.as_ref().take()` on a temporary value"
 }
 

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -43,6 +43,7 @@ mod map_flatten;
 mod map_identity;
 mod map_unwrap_or;
 mod needless_option_as_deref;
+mod needless_option_take;
 mod ok_expect;
 mod option_as_ref_deref;
 mod option_map_or_none;
@@ -2162,6 +2163,24 @@ declare_clippy_lint! {
     "use of `char::is_digit(..)` with literal radix of 10 or 16"
 }
 
+declare_clippy_lint! {
+    ///
+    /// ### Why is this bad?
+    ///
+    /// ### Example
+    /// ```rust
+    /// // example code where clippy issues a warning
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// // example code which does not raise clippy warning
+    /// ```
+    #[clippy::version = "1.61.0"]
+    pub NEEDLESS_OPTION_TAKE,
+    suspicious,
+    "using `.as_ref().take()` on a temporary value"
+}
+
 pub struct Methods {
     avoid_breaking_exported_api: bool,
     msrv: Option<RustcVersion>,
@@ -2251,6 +2270,7 @@ impl_lint_pass!(Methods => [
     ERR_EXPECT,
     NEEDLESS_OPTION_AS_DEREF,
     IS_DIGIT_ASCII_RADIX,
+    NEEDLESS_OPTION_TAKE,
 ]);
 
 /// Extracts a method call name, args, and `Span` of the method name.
@@ -2623,6 +2643,7 @@ fn check_methods<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, msrv: Optio
                     }
                 }
             },
+            ("take", []) => needless_option_take::check(cx, expr, recv),
             ("to_os_string" | "to_owned" | "to_path_buf" | "to_vec", []) => {
                 implicit_clone::check(cx, name, expr, recv);
             },

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2169,11 +2169,13 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
-    /// // example code where clippy issues a warning
+    /// let x = Some(3);
+    /// x.as_ref().take();
     /// ```
     /// Use instead:
     /// ```rust
-    /// // example code which does not raise clippy warning
+    /// let x = Some(3);
+    /// x.as_ref();
     /// ```
     #[clippy::version = "1.61.0"]
     pub NEEDLESS_OPTION_TAKE,

--- a/clippy_lints/src/methods/needless_option_take.rs
+++ b/clippy_lints/src/methods/needless_option_take.rs
@@ -1,0 +1,23 @@
+use clippy_utils::diagnostics::span_lint;
+use clippy_utils::ty::is_type_diagnostic_item;
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_span::sym::Result as sym_result;
+
+use super::NEEDLESS_OPTION_TAKE;
+
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'tcx Expr<'_>) {
+    if_chain! {
+        if is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym_result);
+        let result_type = cx.typeck_results().expr_ty(recv);
+
+        then {
+            span_lint(
+                cx,
+                NEEDLESS_OPTION_TAKE,
+                expr.span,
+                "Format test"
+            );
+        }
+    };
+}

--- a/clippy_lints/src/methods/needless_option_take.rs
+++ b/clippy_lints/src/methods/needless_option_take.rs
@@ -10,7 +10,7 @@ use super::NEEDLESS_OPTION_TAKE;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'tcx Expr<'_>) {
     // Checks if expression type is equal to sym::Option and if the expr is not a syntactic place
-    if is_expr_option(cx, expr) && !expr.is_syntactic_place_expr() {
+    if is_expr_option(cx, recv) && !recv.is_syntactic_place_expr() {
         let mut applicability = Applicability::MachineApplicable;
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/methods/needless_option_take.rs
+++ b/clippy_lints/src/methods/needless_option_take.rs
@@ -2,15 +2,17 @@ use clippy_utils::diagnostics::span_lint;
 use clippy_utils::ty::is_type_diagnostic_item;
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
-use rustc_span::sym::Result as sym_result;
+use rustc_span::sym;
 
 use super::NEEDLESS_OPTION_TAKE;
 
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'tcx Expr<'_>) {
-    if_chain! {
-        if is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym_result);
-        let result_type = cx.typeck_results().expr_ty(recv);
-
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, _recv: &'tcx Expr<'_>) {
+    // Checks if expression type is equal to sym::Option and if the expr is not a syntactic place
+    if is_expr_option(cx, expr) && !expr.is_syntactic_place_expr() {
+        span_lint(cx, OPTION_TAKE_ON_TEMPORARY, expr.span, "Format test");
+    }
+    /*    if_chain! {
+        is_expr_option(cx, expr);
         then {
             span_lint(
                 cx,
@@ -19,5 +21,10 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'
                 "Format test"
             );
         }
-    };
+    };*/
+}
+
+fn is_expr_option(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    let expr_type = cx.typeck_results().expr_ty(expr);
+    is_type_diagnostic_item(cx, expr_type, sym::Option)
 }

--- a/clippy_lints/src/methods/needless_option_take.rs
+++ b/clippy_lints/src/methods/needless_option_take.rs
@@ -17,7 +17,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'
             cx,
             NEEDLESS_OPTION_TAKE,
             expr.span,
-            "Called `Option::take()` on a temporary value",
+            "called `Option::take()` on a temporary value",
             "try",
             format!(
                 "{}",

--- a/clippy_lints/src/methods/needless_option_take.rs
+++ b/clippy_lints/src/methods/needless_option_take.rs
@@ -1,27 +1,30 @@
-use clippy_utils::diagnostics::span_lint;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::is_type_diagnostic_item;
+use rustc_errors::Applicability;
 use rustc_hir::Expr;
 use rustc_lint::LateContext;
 use rustc_span::sym;
 
 use super::NEEDLESS_OPTION_TAKE;
 
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, _recv: &'tcx Expr<'_>) {
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'tcx Expr<'_>) {
     // Checks if expression type is equal to sym::Option and if the expr is not a syntactic place
     if is_expr_option(cx, expr) && !expr.is_syntactic_place_expr() {
-        span_lint(cx, OPTION_TAKE_ON_TEMPORARY, expr.span, "Format test");
+        let mut applicability = Applicability::MachineApplicable;
+        span_lint_and_sugg(
+            cx,
+            NEEDLESS_OPTION_TAKE,
+            expr.span,
+            "Called `Option::take()` on a temporary value",
+            "try",
+            format!(
+                "{}",
+                snippet_with_applicability(cx, recv.span, "..", &mut applicability)
+            ),
+            applicability,
+        );
     }
-    /*    if_chain! {
-        is_expr_option(cx, expr);
-        then {
-            span_lint(
-                cx,
-                NEEDLESS_OPTION_TAKE,
-                expr.span,
-                "Format test"
-            );
-        }
-    };*/
 }
 
 fn is_expr_option(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {

--- a/clippy_lints/src/methods/needless_option_take.rs
+++ b/clippy_lints/src/methods/needless_option_take.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::match_def_path;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::is_type_diagnostic_item;
 use rustc_errors::Applicability;
@@ -10,7 +11,7 @@ use super::NEEDLESS_OPTION_TAKE;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'tcx Expr<'_>) {
     // Checks if expression type is equal to sym::Option and if the expr is not a syntactic place
-    if is_expr_option(cx, recv) && !recv.is_syntactic_place_expr() {
+    if !recv.is_syntactic_place_expr() && is_expr_option(cx, recv) && has_expr_as_ref_path(cx, recv) {
         let mut applicability = Applicability::MachineApplicable;
         span_lint_and_sugg(
             cx,
@@ -30,4 +31,11 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'
 fn is_expr_option(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     let expr_type = cx.typeck_results().expr_ty(expr);
     is_type_diagnostic_item(cx, expr_type, sym::Option)
+}
+
+fn has_expr_as_ref_path(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    if let Some(ref_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
+        return match_def_path(cx, ref_id, &["core", "option", "Option", "as_ref"]);
+    }
+    false
 }

--- a/tests/ui/needless_option_take.fixed
+++ b/tests/ui/needless_option_take.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+fn main() {
+    println!("Testing non erroneous option_take_on_temporary");
+    let mut option = Some(1);
+    let _ = Box::new(move || option.take().unwrap());
+
+    println!("Testing non erroneous option_take_on_temporary");
+    let x = Some(3);
+    x.as_ref();
+
+    println!("Testing erroneous option_take_on_temporary");
+    let x = Some(3);
+    x.as_ref();
+}

--- a/tests/ui/needless_option_take.rs
+++ b/tests/ui/needless_option_take.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("Testing option_take_on_temporary");
+    let x = Some(3);
+    let y = x.as_ref().take();
+}

--- a/tests/ui/needless_option_take.rs
+++ b/tests/ui/needless_option_take.rs
@@ -3,5 +3,5 @@
 fn main() {
     println!("Testing option_take_on_temporary");
     let x = Some(3);
-    let y = x.as_ref().take();
+    x.as_ref().take();
 }

--- a/tests/ui/needless_option_take.rs
+++ b/tests/ui/needless_option_take.rs
@@ -1,7 +1,15 @@
 // run-rustfix
 
 fn main() {
-    println!("Testing option_take_on_temporary");
+    println!("Testing non erroneous option_take_on_temporary");
+    let mut option = Some(1);
+    let _ = Box::new(move || option.take().unwrap());
+
+    println!("Testing non erroneous option_take_on_temporary");
+    let x = Some(3);
+    x.as_ref();
+
+    println!("Testing erroneous option_take_on_temporary");
     let x = Some(3);
     x.as_ref().take();
 }

--- a/tests/ui/needless_option_take.stderr
+++ b/tests/ui/needless_option_take.stderr
@@ -1,0 +1,10 @@
+error: called `Option::take()` on a temporary value
+  --> $DIR/needless_option_take.rs:14:5
+   |
+LL |     x.as_ref().take();
+   |     ^^^^^^^^^^^^^^^^^ help: try: `x.as_ref()`
+   |
+   = note: `-D clippy::needless-option-take` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/tests/ui/option_take_on_temporary.fixed
+++ b/tests/ui/option_take_on_temporary.fixed
@@ -3,5 +3,5 @@
 fn main() {
     println!("Testing option_take_on_temporary");
     let x = Some(3);
-    let y = x.as_ref().take();
+    let y = x.as_ref();
 }

--- a/tests/ui/option_take_on_temporary.fixed
+++ b/tests/ui/option_take_on_temporary.fixed
@@ -1,7 +1,15 @@
 // run-rustfix
 
 fn main() {
-    println!("Testing option_take_on_temporary");
+    println!("Testing non erroneous option_take_on_temporary");
+    let mut option = Some(1);
+    let _ = Box::new(move || option.take().unwrap());
+
+    println!("Testing non erroneous option_take_on_temporary");
+    let x = Some(3);
+    x.as_ref();
+
+    println!("Testing erroneous option_take_on_temporary");
     let x = Some(3);
     x.as_ref();
 }

--- a/tests/ui/option_take_on_temporary.fixed
+++ b/tests/ui/option_take_on_temporary.fixed
@@ -3,5 +3,5 @@
 fn main() {
     println!("Testing option_take_on_temporary");
     let x = Some(3);
-    let y = x.as_ref();
+    x.as_ref();
 }


### PR DESCRIPTION
- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

Fixes #8618 
 
changelog: Introduce [`needless_option_take`] lint