### PR TITLE
fix comments in test for split_once

### DIFF
--- a/tests/ui/manual_split_once.fixed
+++ b/tests/ui/manual_split_once.fixed
@@ -46,7 +46,7 @@ fn main() {
 
 fn _msrv_1_51() {
     #![clippy::msrv = "1.51"]
-    // `str::split_once` was stabilized in 1.16. Do not lint this
+    // `str::split_once` was stabilized in 1.52. Do not lint this
     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
 }
 

--- a/tests/ui/manual_split_once.rs
+++ b/tests/ui/manual_split_once.rs
@@ -46,7 +46,7 @@ fn main() {
 
 fn _msrv_1_51() {
     #![clippy::msrv = "1.51"]
-    // `str::split_once` was stabilized in 1.16. Do not lint this
+    // `str::split_once` was stabilized in 1.52. Do not lint this
     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
 }
 


### PR DESCRIPTION
This PR fixed comments in test.

`split_once` was stabilized in 1.52, so I think the comments maybe be wrong.

ref:
https://doc.rust-lang.org/std/string/struct.String.html#method.split_once

thank you in advance.

changelog: none