### PR TITLE
Adding test about msrv for map clone

### DIFF
--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -1,4 +1,6 @@
 // run-rustfix
+
+#![feature(custom_inner_attributes)]
 #![warn(clippy::map_clone)]
 #![allow(
     clippy::clone_on_copy,
@@ -60,4 +62,15 @@ fn main() {
 
         let _ = Some(RefCell::new(String::new()).borrow()).map(|s| s.clone());
     }
+}
+
+fn _msrv_1_35() {
+    #![clippy::msrv = "1.35"]
+    // `copied` was stabilized in 1.36, so clippy should use `cloned`.
+    let _: Vec<i8> = vec![5_i8; 6].iter().cloned().collect();
+}
+
+fn _msrv_1_36() {
+    #![clippy::msrv = "1.36"]
+    let _: Vec<i8> = vec![5_i8; 6].iter().copied().collect();
 }

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -1,4 +1,6 @@
 // run-rustfix
+
+#![feature(custom_inner_attributes)]
 #![warn(clippy::map_clone)]
 #![allow(
     clippy::clone_on_copy,
@@ -60,4 +62,15 @@ fn main() {
 
         let _ = Some(RefCell::new(String::new()).borrow()).map(|s| s.clone());
     }
+}
+
+fn _msrv_1_35() {
+    #![clippy::msrv = "1.35"]
+    // `copied` was stabilized in 1.36, so clippy should use `cloned`.
+    let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
+}
+
+fn _msrv_1_36() {
+    #![clippy::msrv = "1.36"]
+    let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
 }

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -1,5 +1,5 @@
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:11:22
+  --> $DIR/map_clone.rs:13:22
    |
 LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `vec![5_i8; 6].iter().copied()`
@@ -7,34 +7,46 @@ LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
    = note: `-D clippy::map-clone` implied by `-D warnings`
 
 error: you are using an explicit closure for cloning elements
-  --> $DIR/map_clone.rs:12:26
+  --> $DIR/map_clone.rs:14:26
    |
 LL |     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `vec![String::new()].iter().cloned()`
 
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:13:23
+  --> $DIR/map_clone.rs:15:23
    |
 LL |     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `vec![42, 43].iter().copied()`
 
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:15:26
+  --> $DIR/map_clone.rs:17:26
    |
 LL |     let _: Option<u64> = Some(&16).map(|b| *b);
    |                          ^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `Some(&16).copied()`
 
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:16:25
+  --> $DIR/map_clone.rs:18:25
    |
 LL |     let _: Option<u8> = Some(&1).map(|x| x.clone());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `Some(&1).copied()`
 
 error: you are needlessly cloning iterator elements
-  --> $DIR/map_clone.rs:27:29
+  --> $DIR/map_clone.rs:29:29
    |
 LL |     let _ = std::env::args().map(|v| v.clone());
    |                             ^^^^^^^^^^^^^^^^^^^ help: remove the `map` call
 
-error: aborting due to 6 previous errors
+error: you are using an explicit closure for copying elements
+  --> $DIR/map_clone.rs:70:22
+   |
+LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `vec![5_i8; 6].iter().cloned()`
+
+error: you are using an explicit closure for copying elements
+  --> $DIR/map_clone.rs:75:22
+   |
+LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `vec![5_i8; 6].iter().copied()`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Close #8623

This PR adds tests for `map_clone`, because this rule does not have tests about MSRV.

I have tried, but the contents of the issue could not be verified.

The rule seems to separate `copied` and `cloned` according to the value of MSRV. `cloned` was [established in 1.1.0](https://doc.rust-lang.org/stable/std/iter/struct.Cloned.html), so this logic seems to be correct. (maybe misreading of clone and copied?)

https://github.com/rust-lang/rust-clippy/blob/c7e68638431b2a6639fcbeb44de790619de3b9b1/clippy_lints/src/map_clone.rs#L151-L155


However, [other tests seem to test according to the msrv value](https://github.com/rust-lang/rust-clippy/blob/c7e68638431b2a6639fcbeb44de790619de3b9b1/tests/ui/if_then_some_else_none.rs#L69-L88),
so I created PR to add tests.

Thank you in advance.


changelog: None
