### PR TITLE
Check for loops/closures in `local_used_after_expr`

### DIFF
--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -3,7 +3,7 @@ use clippy_utils::higher::VecArgs;
 use clippy_utils::source::snippet_opt;
 use clippy_utils::ty::is_type_diagnostic_item;
 use clippy_utils::usage::local_used_after_expr;
-use clippy_utils::{get_enclosing_loop_or_closure, higher, path_to_local, path_to_local_id};
+use clippy_utils::{higher, path_to_local, path_to_local_id};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
@@ -125,8 +125,7 @@ impl<'tcx> LateLintPass<'tcx> for EtaReduction {
                         if_chain! {
                             if let ty::Closure(_, substs) = callee_ty.peel_refs().kind();
                             if substs.as_closure().kind() == ClosureKind::FnMut;
-                            if get_enclosing_loop_or_closure(cx.tcx, expr).is_some()
-                                || path_to_local(callee).map_or(false, |l| local_used_after_expr(cx, l, callee));
+                            if path_to_local(callee).map_or(false, |l| local_used_after_expr(cx, l, expr));
 
                             then {
                                 // Mutable closure is used after current expr; we cannot consume it.

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -211,6 +211,10 @@ fn mutable_closure_in_loop() {
     let mut closure = |n| value += n;
     for _ in 0..5 {
         Some(1).map(&mut closure);
+
+        let mut value = 0;
+        let mut in_loop = |n| value += n;
+        Some(1).map(in_loop);
     }
 }
 

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -211,6 +211,10 @@ fn mutable_closure_in_loop() {
     let mut closure = |n| value += n;
     for _ in 0..5 {
         Some(1).map(|n| closure(n));
+
+        let mut value = 0;
+        let mut in_loop = |n| value += n;
+        Some(1).map(|n| in_loop(n));
     }
 }
 

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -117,10 +117,16 @@ LL |         Some(1).map(|n| closure(n));
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut closure`
 
 error: redundant closure
-  --> $DIR/eta.rs:232:21
+  --> $DIR/eta.rs:217:21
+   |
+LL |         Some(1).map(|n| in_loop(n));
+   |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `in_loop`
+
+error: redundant closure
+  --> $DIR/eta.rs:236:21
    |
 LL |     map_str_to_path(|s| s.as_ref());
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::convert::AsRef::as_ref`
 
-error: aborting due to 20 previous errors
+error: aborting due to 21 previous errors
 

--- a/tests/ui/needless_option_as_deref.fixed
+++ b/tests/ui/needless_option_as_deref.fixed
@@ -16,6 +16,20 @@ fn main() {
     let _ = Some(Box::new(1)).as_deref();
     let _ = Some(Box::new(1)).as_deref_mut();
 
+    let mut y = 0;
+    let mut x = Some(&mut y);
+    for _ in 0..3 {
+        let _ = x.as_deref_mut();
+    }
+
+    let mut y = 0;
+    let mut x = Some(&mut y);
+    let mut closure = || {
+        let _ = x.as_deref_mut();
+    };
+    closure();
+    closure();
+
     // #7846
     let mut i = 0;
     let mut opt_vec = vec![Some(&mut i)];

--- a/tests/ui/needless_option_as_deref.rs
+++ b/tests/ui/needless_option_as_deref.rs
@@ -16,6 +16,20 @@ fn main() {
     let _ = Some(Box::new(1)).as_deref();
     let _ = Some(Box::new(1)).as_deref_mut();
 
+    let mut y = 0;
+    let mut x = Some(&mut y);
+    for _ in 0..3 {
+        let _ = x.as_deref_mut();
+    }
+
+    let mut y = 0;
+    let mut x = Some(&mut y);
+    let mut closure = || {
+        let _ = x.as_deref_mut();
+    };
+    closure();
+    closure();
+
     // #7846
     let mut i = 0;
     let mut opt_vec = vec![Some(&mut i)];


### PR DESCRIPTION
Follow up to #8646, catches when a local is used multiple times because it's in a loop or a closure

changelog: none