### PR TITLE
Add extra check to format_impl lint for self.fmt()

### DIFF
--- a/tests/ui/recursive_format_impl.rs
+++ b/tests/ui/recursive_format_impl.rs
@@ -310,6 +310,43 @@ impl std::fmt::Debug for Tree {
     }
 }
 
+// Should also catch use of self.fmt within the Format trait
+
+enum Foo {
+    Foo(usize),
+    Bar(usize),
+}
+
+impl std::fmt::Display for Foo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Foo(_) => self.fmt(f),
+            Self::Bar(x) => x.fmt(f),
+        }
+    }
+}
+
+// Doesn't trigger on nested enum matching
+enum Tree2 {
+    Leaf,
+    Node(Vec<Tree>),
+}
+
+impl std::fmt::Display for Tree2 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Tree2::Leaf => write!(f, "*"),
+            Tree2::Node(children) => {
+                write!(f, "(")?;
+                for child in children.iter() {
+                    child.fmt(f)?;
+                }
+                write!(f, ")")
+            },
+        }
+    }
+}
+
 fn main() {
     let a = A;
     a.to_string();

--- a/tests/ui/recursive_format_impl.stderr
+++ b/tests/ui/recursive_format_impl.stderr
@@ -87,5 +87,11 @@ LL |         write!(f, "{}", &&**&&*self)
    |
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 11 previous errors
+error: using `self.fmt` as `Display` in `impl Display` will cause infinite recursion
+  --> $DIR/recursive_format_impl.rs:323:29
+   |
+LL |             Self::Foo(_) => self.fmt(f),
+   |                             ^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
As mentioned in this Reddit comment:
https://www.reddit.com/r/rust/comments/tq602q/my_first_clippy_lint_detecting_use_of_self_as/i2fhdy1/

Previously use of self.fmt within the Format trait wasn't detected

Note we don't check fully qualified paths atm, but that shouldn't happen by accident anyway.

changelog: format_impl lint now checks for recursive use of self.fmt() too.
