### PR TITLE
Fix subtraction overflow in `cast_possible_truncation`

### DIFF
--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -1,13 +1,13 @@
 #![feature(repr128)]
 #![allow(incomplete_features)]
-
-#[warn(
+#![warn(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap
 )]
-#[allow(clippy::cast_abs_to_unsigned, clippy::no_effect, clippy::unnecessary_operation)]
+#![allow(clippy::cast_abs_to_unsigned, clippy::no_effect, clippy::unnecessary_operation)]
+
 fn main() {
     // Test clippy::cast_precision_loss
     let x0 = 1i32;
@@ -251,4 +251,12 @@ fn main() {
             let _ = self as u64; // Don't lint.
         }
     }
+}
+
+fn avoid_subtract_overflow(q: u32) {
+    let c = (q >> 16) as u8;
+    c as usize;
+
+    let c = (q / 1000) as u8;
+    c as usize;
 }

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -194,5 +194,17 @@ error: casting `main::E10` to `u16` may truncate the value
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
 
-error: aborting due to 31 previous errors
+error: casting `u32` to `u8` may truncate the value
+  --> $DIR/cast.rs:257:13
+   |
+LL |     let c = (q >> 16) as u8;
+   |             ^^^^^^^^^^^^^^^
+
+error: casting `u32` to `u8` may truncate the value
+  --> $DIR/cast.rs:260:13
+   |
+LL |     let c = (q / 1000) as u8;
+   |             ^^^^^^^^^^^^^^^^
+
+error: aborting due to 33 previous errors
 


### PR DESCRIPTION
changelog: Fix false negative due to subtraction overflow in `cast_possible_truncation`

I *think* a false negative is the worst that can happen from this