### PR TITLE
adding condition for map_clone message

### DIFF
--- a/clippy_lints/src/map_clone.rs
+++ b/clippy_lints/src/map_clone.rs
@@ -143,7 +143,7 @@ fn lint_needless_cloning(cx: &LateContext<'_>, root: Span, receiver: Span) {
 impl MapClone {
     fn lint_explicit_closure(&self, cx: &LateContext<'_>, replace: Span, root: Span, is_copy: bool) {
         let mut applicability = Applicability::MachineApplicable;
-        let message = if is_copy {
+        let message = if is_copy && meets_msrv(self.msrv.as_ref(), &msrvs::ITERATOR_COPIED) {
             "you are using an explicit closure for copying elements"
         } else {
             "you are using an explicit closure for cloning elements"

--- a/tests/ui-toml/min_rust_version/min_rust_version.stderr
+++ b/tests/ui-toml/min_rust_version/min_rust_version.stderr
@@ -1,4 +1,4 @@
-error: you are using an explicit closure for copying elements
+error: you are using an explicit closure for cloning elements
   --> $DIR/min_rust_version.rs:74:26
    |
 LL |     let _: Option<u64> = Some(&16).map(|b| *b);


### PR DESCRIPTION
This PR fixes the message about `map_clone`.

if msrv >= 1.36, the message is correct.

```bash
$ cat main.rs 
fn main() {
  let x: Vec<&i32> = vec![&1, &2];
  let y: Vec<_>  = x.iter().map(|i| *i).collect();
  println!("{:?}", y);
}

$ cargo clippy
warning: you are using an explicit closure for copying elements
 --> main.rs:3:20
  |
3 |   let y: Vec<_>  = x.iter().map(|i| *i).collect();
  |                    ^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `x.iter().copied()`
  |
  = note: `#[warn(clippy::map_clone)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone

warning: `test` (build script) generated 1 warning
warning: `test` (bin "test") generated 1 warning (1 duplicate)
    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
```

but, if msrv < 1.36, the suggestion is `cloned`, but the message is `copying`.
```bash
$ cat clippy.toml 
msrv = "1.35"
 
$ cargo clippy
warning: you are using an explicit closure for copying elements
 --> main.rs:3:20
  |
3 |   let y: Vec<_>  = x.iter().map(|i| *i).collect();
  |                    ^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `x.iter().cloned()`
```

I think  the separation of messages will make it more user-friendly.

thank you in advance.

changelog: Fixed a message in map_clone.
