### PR TITLE
Do not trigger ``[`rest_pat_in_fully_bound_structs`]`` on `#[non_exhaustive]` structs

### DIFF
--- a/clippy_lints/src/matches/rest_pat_in_fully_bound_struct.rs
+++ b/clippy_lints/src/matches/rest_pat_in_fully_bound_struct.rs
@@ -14,6 +14,7 @@ pub(crate) fn check(cx: &LateContext<'_>, pat: &Pat<'_>) {
         if let ty::Adt(def, _) = ty.kind();
         if def.is_struct() || def.is_union();
         if fields.len() == def.non_enum_variant().fields.len();
+        if !def.non_enum_variant().is_field_list_non_exhaustive();
 
         then {
             span_lint_and_help(

--- a/tests/ui/rest_pat_in_fully_bound_structs.rs
+++ b/tests/ui/rest_pat_in_fully_bound_structs.rs
@@ -39,4 +39,19 @@ fn main() {
 
     // No lint
     foo!(a_struct);
+
+    #[non_exhaustive]
+    struct B {
+        a: u32,
+        b: u32,
+        c: u64,
+    }
+
+    let b_struct = B { a: 5, b: 42, c: 342 };
+
+    match b_struct {
+        B { a: 5, b: 42, .. } => {},
+        B { a: 0, b: 0, c: 128, .. } => {}, // No Lint
+        _ => {},
+    }
 }


### PR DESCRIPTION
fixes #8029

Just adds an additional check to ensure that the`ty::VariantDef` is not marked as `#[non_exhaustive]`.

changelog: Do not apply ``[`rest_pat_in_fully_bound_structs`]`` on structs marked as non exhaustive.