### PR TITLE
Fix needless_match false positive for if-let when the else block doesn't match to given expr

### DIFF
--- a/clippy_lints/src/matches/needless_match.rs
+++ b/clippy_lints/src/matches/needless_match.rs
@@ -99,7 +99,7 @@ fn check_if_let(cx: &LateContext<'_>, if_let: &higher::IfLet<'_>) -> bool {
                 if let ExprKind::Path(ref qpath) = ret.kind {
                     return is_lang_ctor(cx, qpath, OptionNone) || eq_expr_value(cx, if_let.let_expr, ret);
                 }
-                return true;
+                return false;
             }
             return eq_expr_value(cx, if_let.let_expr, ret);
         }

--- a/tests/ui/needless_match.fixed
+++ b/tests/ui/needless_match.fixed
@@ -80,6 +80,18 @@ fn if_let_option() {
     } else {
         None
     };
+
+    // Don't trigger
+    let _ = if let Some(a) = Some(1) { Some(a) } else { Some(2) };
+}
+
+fn if_let_option_result() -> Result<(), ()> {
+    fn f(x: i32) -> Result<Option<i32>, ()> {
+        Ok(Some(x))
+    }
+    // Don't trigger
+    let _ = if let Some(v) = f(1)? { Some(v) } else { f(2)? };
+    Ok(())
 }
 
 fn if_let_result() {

--- a/tests/ui/needless_match.rs
+++ b/tests/ui/needless_match.rs
@@ -103,6 +103,18 @@ fn if_let_option() {
     } else {
         None
     };
+
+    // Don't trigger
+    let _ = if let Some(a) = Some(1) { Some(a) } else { Some(2) };
+}
+
+fn if_let_option_result() -> Result<(), ()> {
+    fn f(x: i32) -> Result<Option<i32>, ()> {
+        Ok(Some(x))
+    }
+    // Don't trigger
+    let _ = if let Some(v) = f(1)? { Some(v) } else { f(2)? };
+    Ok(())
 }
 
 fn if_let_result() {

--- a/tests/ui/needless_match.stderr
+++ b/tests/ui/needless_match.stderr
@@ -72,19 +72,19 @@ LL |     let _ = if let Some(a) = Some(1) { Some(a) } else { None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `Some(1)`
 
 error: this if-let expression is unnecessary
-  --> $DIR/needless_match.rs:110:31
+  --> $DIR/needless_match.rs:122:31
    |
 LL |     let _: Result<i32, i32> = if let Err(e) = x { Err(e) } else { x };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `x`
 
 error: this if-let expression is unnecessary
-  --> $DIR/needless_match.rs:111:31
+  --> $DIR/needless_match.rs:123:31
    |
 LL |     let _: Result<i32, i32> = if let Ok(val) = x { Ok(val) } else { x };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `x`
 
 error: this if-let expression is unnecessary
-  --> $DIR/needless_match.rs:117:21
+  --> $DIR/needless_match.rs:129:21
    |
 LL |       let _: Simple = if let Simple::A = x {
    |  _____________________^
@@ -97,7 +97,7 @@ LL | |     };
    | |_____^ help: replace it with: `x`
 
 error: this match expression is unnecessary
-  --> $DIR/needless_match.rs:156:26
+  --> $DIR/needless_match.rs:168:26
    |
 LL |           let _: Complex = match ce {
    |  __________________________^


### PR DESCRIPTION
<!--

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change. Also, it's helpful for us that
the lint name is put into brackets `[]` and backticks `` ` ` ``,
e.g. ``[`lint_name`]``.

If your PR fixes an issue, you can add "fixes #issue_number" into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

--->

fix #8695

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: Fixed ``[`needless_match`]`` false positive when else block expression differs.
