### PR TITLE
Add `repeated_where_clause_or_trait_bound` lint

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -397,6 +397,7 @@ const RUSTFIX_COVERAGE_KNOWN_EXCEPTIONS: &[&str] = &[
     "single_component_path_imports_nested_first.rs",
     "string_add.rs",
     "toplevel_ref_arg_non_rustfix.rs",
+    "trait_duplication_in_bounds.rs",
     "unit_arg.rs",
     "unnecessary_clone.rs",
     "unnecessary_lazy_eval_unfixable.rs",

--- a/tests/ui/trait_duplication_in_bounds.rs
+++ b/tests/ui/trait_duplication_in_bounds.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::trait_duplication_in_bounds)]
+#![allow(unused)]
 
 use std::collections::BTreeMap;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
@@ -97,5 +98,115 @@ trait FooIter: Iterator<Item = Foo> {
 
 // This should not lint
 fn impl_trait(_: impl AsRef<str>, _: impl AsRef<str>) {}
+
+mod repeated_where_clauses_or_trait_bounds {
+    fn bad_foo<T: Clone + Clone + Clone + Copy, U: Clone + Copy>(arg0: T, argo1: U) {
+        unimplemented!();
+    }
+
+    fn bad_bar<T, U>(arg0: T, arg1: U)
+    where
+        T: Clone + Clone + Clone + Copy,
+        U: Clone + Copy,
+    {
+        unimplemented!();
+    }
+
+    fn good_bar<T: Clone + Copy, U: Clone + Copy>(arg0: T, arg1: U) {
+        unimplemented!();
+    }
+
+    fn good_foo<T, U>(arg0: T, arg1: U)
+    where
+        T: Clone + Copy,
+        U: Clone + Copy,
+    {
+        unimplemented!();
+    }
+
+    trait GoodSelfTraitBound: Clone + Copy {
+        fn f();
+    }
+
+    trait GoodSelfWhereClause {
+        fn f()
+        where
+            Self: Clone + Copy;
+    }
+
+    trait BadSelfTraitBound: Clone + Clone + Clone {
+        fn f();
+    }
+
+    trait BadSelfWhereClause {
+        fn f()
+        where
+            Self: Clone + Clone + Clone;
+    }
+
+    trait GoodTraitBound<T: Clone + Copy, U: Clone + Copy> {
+        fn f();
+    }
+
+    trait GoodWhereClause<T, U> {
+        fn f()
+        where
+            T: Clone + Copy,
+            U: Clone + Copy;
+    }
+
+    trait BadTraitBound<T: Clone + Clone + Clone + Copy, U: Clone + Copy> {
+        fn f();
+    }
+
+    trait BadWhereClause<T, U> {
+        fn f()
+        where
+            T: Clone + Clone + Clone + Copy,
+            U: Clone + Copy;
+    }
+
+    struct GoodStructBound<T: Clone + Copy, U: Clone + Copy> {
+        t: T,
+        u: U,
+    }
+
+    impl<T: Clone + Copy, U: Clone + Copy> GoodTraitBound<T, U> for GoodStructBound<T, U> {
+        // this should not warn
+        fn f() {}
+    }
+
+    struct GoodStructWhereClause;
+
+    impl<T, U> GoodTraitBound<T, U> for GoodStructWhereClause
+    where
+        T: Clone + Copy,
+        U: Clone + Copy,
+    {
+        // this should not warn
+        fn f() {}
+    }
+
+    fn no_error_separate_arg_bounds(program: impl AsRef<()>, dir: impl AsRef<()>, args: &[impl AsRef<()>]) {}
+
+    trait GenericTrait<T> {}
+
+    // This should not warn but currently does see #8757
+    fn good_generic<T: GenericTrait<u64> + GenericTrait<u32>>(arg0: T) {
+        unimplemented!();
+    }
+
+    fn bad_generic<T: GenericTrait<u64> + GenericTrait<u32> + GenericTrait<u64>>(arg0: T) {
+        unimplemented!();
+    }
+
+    mod foo {
+        pub trait Clone {}
+    }
+
+    fn qualified_path<T: std::clone::Clone + Clone + foo::Clone>(arg0: T) {
+        unimplemented!();
+    }
+}
 
 fn main() {}

--- a/tests/ui/trait_duplication_in_bounds.stderr
+++ b/tests/ui/trait_duplication_in_bounds.stderr
@@ -1,5 +1,5 @@
 error: this trait bound is already specified in the where clause
-  --> $DIR/trait_duplication_in_bounds.rs:6:15
+  --> $DIR/trait_duplication_in_bounds.rs:7:15
    |
 LL | fn bad_foo<T: Clone + Default, Z: Copy>(arg0: T, arg1: Z)
    |               ^^^^^
@@ -12,7 +12,7 @@ LL | #![deny(clippy::trait_duplication_in_bounds)]
    = help: consider removing this trait bound
 
 error: this trait bound is already specified in the where clause
-  --> $DIR/trait_duplication_in_bounds.rs:6:23
+  --> $DIR/trait_duplication_in_bounds.rs:7:23
    |
 LL | fn bad_foo<T: Clone + Default, Z: Copy>(arg0: T, arg1: Z)
    |                       ^^^^^^^
@@ -20,7 +20,7 @@ LL | fn bad_foo<T: Clone + Default, Z: Copy>(arg0: T, arg1: Z)
    = help: consider removing this trait bound
 
 error: this trait bound is already specified in trait declaration
-  --> $DIR/trait_duplication_in_bounds.rs:35:15
+  --> $DIR/trait_duplication_in_bounds.rs:36:15
    |
 LL |         Self: Default;
    |               ^^^^^^^
@@ -28,7 +28,7 @@ LL |         Self: Default;
    = help: consider removing this trait bound
 
 error: this trait bound is already specified in trait declaration
-  --> $DIR/trait_duplication_in_bounds.rs:49:15
+  --> $DIR/trait_duplication_in_bounds.rs:50:15
    |
 LL |         Self: Default + Clone;
    |               ^^^^^^^
@@ -36,7 +36,7 @@ LL |         Self: Default + Clone;
    = help: consider removing this trait bound
 
 error: this trait bound is already specified in trait declaration
-  --> $DIR/trait_duplication_in_bounds.rs:55:15
+  --> $DIR/trait_duplication_in_bounds.rs:56:15
    |
 LL |         Self: Default + Clone;
    |               ^^^^^^^
@@ -44,7 +44,7 @@ LL |         Self: Default + Clone;
    = help: consider removing this trait bound
 
 error: this trait bound is already specified in trait declaration
-  --> $DIR/trait_duplication_in_bounds.rs:55:25
+  --> $DIR/trait_duplication_in_bounds.rs:56:25
    |
 LL |         Self: Default + Clone;
    |                         ^^^^^
@@ -52,7 +52,7 @@ LL |         Self: Default + Clone;
    = help: consider removing this trait bound
 
 error: this trait bound is already specified in trait declaration
-  --> $DIR/trait_duplication_in_bounds.rs:58:15
+  --> $DIR/trait_duplication_in_bounds.rs:59:15
    |
 LL |         Self: Default;
    |               ^^^^^^^
@@ -60,12 +60,108 @@ LL |         Self: Default;
    = help: consider removing this trait bound
 
 error: this trait bound is already specified in trait declaration
-  --> $DIR/trait_duplication_in_bounds.rs:93:15
+  --> $DIR/trait_duplication_in_bounds.rs:94:15
    |
 LL |         Self: Iterator<Item = Foo>,
    |               ^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider removing this trait bound
 
-error: aborting due to 8 previous errors
+error: this trait bound is already specified in the where clause
+  --> $DIR/trait_duplication_in_bounds.rs:103:19
+   |
+LL |     fn bad_foo<T: Clone + Clone + Clone + Copy, U: Clone + Copy>(arg0: T, argo1: U) {
+   |                   ^^^^^
+   |
+   = help: consider removing this trait bound
+
+error: these bounds contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:103:19
+   |
+LL |     fn bad_foo<T: Clone + Clone + Clone + Copy, U: Clone + Copy>(arg0: T, argo1: U) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
+
+error: this trait bound is already specified in the where clause
+  --> $DIR/trait_duplication_in_bounds.rs:109:12
+   |
+LL |         T: Clone + Clone + Clone + Copy,
+   |            ^^^^^
+   |
+   = help: consider removing this trait bound
+
+error: these where clauses contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:109:12
+   |
+LL |         T: Clone + Clone + Clone + Copy,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
+
+error: these bounds contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:137:30
+   |
+LL |     trait BadSelfTraitBound: Clone + Clone + Clone {
+   |                              ^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone`
+
+error: these where clauses contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:144:19
+   |
+LL |             Self: Clone + Clone + Clone;
+   |                   ^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone`
+
+error: this trait bound is already specified in the where clause
+  --> $DIR/trait_duplication_in_bounds.rs:158:28
+   |
+LL |     trait BadTraitBound<T: Clone + Clone + Clone + Copy, U: Clone + Copy> {
+   |                            ^^^^^
+   |
+   = help: consider removing this trait bound
+
+error: these bounds contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:158:28
+   |
+LL |     trait BadTraitBound<T: Clone + Clone + Clone + Copy, U: Clone + Copy> {
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
+
+error: these where clauses contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:165:16
+   |
+LL |             T: Clone + Clone + Clone + Copy,
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
+
+error: this trait bound is already specified in the where clause
+  --> $DIR/trait_duplication_in_bounds.rs:195:24
+   |
+LL |     fn good_generic<T: GenericTrait<u64> + GenericTrait<u32>>(arg0: T) {
+   |                        ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing this trait bound
+
+error: this trait bound is already specified in the where clause
+  --> $DIR/trait_duplication_in_bounds.rs:199:23
+   |
+LL |     fn bad_generic<T: GenericTrait<u64> + GenericTrait<u32> + GenericTrait<u64>>(arg0: T) {
+   |                       ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing this trait bound
+
+error: these bounds contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:199:23
+   |
+LL |     fn bad_generic<T: GenericTrait<u64> + GenericTrait<u32> + GenericTrait<u64>>(arg0: T) {
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `GenericTrait<u32> + GenericTrait<u64>`
+
+error: this trait bound is already specified in the where clause
+  --> $DIR/trait_duplication_in_bounds.rs:207:26
+   |
+LL |     fn qualified_path<T: std::clone::Clone + Clone + foo::Clone>(arg0: T) {
+   |                          ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing this trait bound
+
+error: these bounds contain repeated elements
+  --> $DIR/trait_duplication_in_bounds.rs:207:26
+   |
+LL |     fn qualified_path<T: std::clone::Clone + Clone + foo::Clone>(arg0: T) {
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + foo::Clone`
+
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
I thought I would try and scratch my own itch for #8674.

1. Is comparing the `Res` the correct way for ensuring we have the same trait?
2. Is there a way to get the spans for the bounds and clauses for suggestions?
I tried to use `GenericParam::bounds_span_for_suggestions` but it only gave me an empty span at the end of the spans.
I tried `WhereClause::span_for_predicates_or_empty_place` and it included the comma.
3. Is there a simpler way to get the trait names? I have used the spans of the traits because I didn't see a way to get it off the `Res` or `Def`.

changelog: Add ``[`repeated_where_clause_or_trait_bound`]`` lint.
