### PR TITLE
Fix formatting of `cast_abs_to_unsigned` docs

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -487,6 +487,7 @@ declare_clippy_lint! {
     /// let y: u32 = x.abs() as u32;
     /// ```
     /// Use instead:
+    /// ```rust
     /// let x: i32 = -42;
     /// let y: u32 = x.unsigned_abs();
     /// ```


### PR DESCRIPTION
The "use instead" section of the example was not being formatted as Rust code, and the "configuration" documentation was being formatted as Rust code.

changelog: `[cast_abs_to_unsigned]` Fix example/configuration formatting
