### PR TITLE
Less authoritative stable_sort_primitive message

### DIFF
--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -278,7 +278,6 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(single_component_path_imports::SINGLE_COMPONENT_PATH_IMPORTS),
     LintId::of(size_of_in_element_count::SIZE_OF_IN_ELEMENT_COUNT),
     LintId::of(slow_vector_initialization::SLOW_VECTOR_INITIALIZATION),
-    LintId::of(stable_sort_primitive::STABLE_SORT_PRIMITIVE),
     LintId::of(strings::STRING_FROM_UTF8_AS_BYTES),
     LintId::of(strlen_on_c_strings::STRLEN_ON_C_STRINGS),
     LintId::of(suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL),

--- a/clippy_lints/src/lib.register_pedantic.rs
+++ b/clippy_lints/src/lib.register_pedantic.rs
@@ -82,6 +82,7 @@ store.register_group(true, "clippy::pedantic", Some("clippy_pedantic"), vec![
     LintId::of(ref_option_ref::REF_OPTION_REF),
     LintId::of(return_self_not_must_use::RETURN_SELF_NOT_MUST_USE),
     LintId::of(semicolon_if_nothing_returned::SEMICOLON_IF_NOTHING_RETURNED),
+    LintId::of(stable_sort_primitive::STABLE_SORT_PRIMITIVE),
     LintId::of(strings::STRING_ADD_ASSIGN),
     LintId::of(trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS),
     LintId::of(trait_bounds::TYPE_REPETITION_IN_BOUNDS),

--- a/clippy_lints/src/lib.register_perf.rs
+++ b/clippy_lints/src/lib.register_perf.rs
@@ -24,7 +24,6 @@ store.register_group(true, "clippy::perf", Some("clippy_perf"), vec![
     LintId::of(misc::CMP_OWNED),
     LintId::of(redundant_clone::REDUNDANT_CLONE),
     LintId::of(slow_vector_initialization::SLOW_VECTOR_INITIALIZATION),
-    LintId::of(stable_sort_primitive::STABLE_SORT_PRIMITIVE),
     LintId::of(types::BOX_COLLECTION),
     LintId::of(types::REDUNDANT_ALLOCATION),
     LintId::of(vec::USELESS_VEC),

--- a/clippy_lints/src/stable_sort_primitive.rs
+++ b/clippy_lints/src/stable_sort_primitive.rs
@@ -9,14 +9,24 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 declare_clippy_lint! {
     /// ### What it does
     /// When sorting primitive values (integers, bools, chars, as well
-    /// as arrays, slices, and tuples of such items), it is better to
+    /// as arrays, slices, and tuples of such items), it is typically better to
     /// use an unstable sort than a stable sort.
     ///
     /// ### Why is this bad?
-    /// Using a stable sort consumes more memory and cpu cycles. Because
-    /// values which compare equal are identical, preserving their
+    /// Typically, using a stable sort consumes more memory and cpu cycles.
+    /// Because values which compare equal are identical, preserving their
     /// relative order (the guarantee that a stable sort provides) means
     /// nothing, while the extra costs still apply.
+    ///
+    /// ### Known problems
+    ///
+    /// As pointed out in
+    /// [issue #8241](https://github.com/rust-lang/rust-clippy/issues/8241),
+    /// a stable sort can instead be significantly faster for certain scenarios
+    /// (eg. when a sorted vector is extended with new data and resorted).
+    ///
+    /// For more information and benchmarking results, please refer to the
+    /// issue linked above.
     ///
     /// ### Example
     /// ```rust

--- a/clippy_lints/src/stable_sort_primitive.rs
+++ b/clippy_lints/src/stable_sort_primitive.rs
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.47.0"]
     pub STABLE_SORT_PRIMITIVE,
-    perf,
+    pedantic,
     "use of sort() when sort_unstable() is equivalent"
 }
 
@@ -126,7 +126,7 @@ impl LateLintPass<'_> for StableSortPrimitive {
                         Applicability::MachineApplicable,
                     );
                     diag.note(
-                        "an unstable sort would perform faster without any observable difference for this data type",
+                        "an unstable sort typically performs faster without any observable difference for this data type",
                     );
                 },
             );

--- a/tests/ui/stable_sort_primitive.stderr
+++ b/tests/ui/stable_sort_primitive.stderr
@@ -5,7 +5,7 @@ LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
    |
    = note: `-D clippy::stable-sort-primitive` implied by `-D warnings`
-   = note: an unstable sort would perform faster without any observable difference for this data type
+   = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `bool`
   --> $DIR/stable_sort_primitive.rs:9:5
@@ -13,7 +13,7 @@ error: used `sort` on primitive type `bool`
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
    |
-   = note: an unstable sort would perform faster without any observable difference for this data type
+   = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `char`
   --> $DIR/stable_sort_primitive.rs:11:5
@@ -21,7 +21,7 @@ error: used `sort` on primitive type `char`
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
    |
-   = note: an unstable sort would perform faster without any observable difference for this data type
+   = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `str`
   --> $DIR/stable_sort_primitive.rs:13:5
@@ -29,7 +29,7 @@ error: used `sort` on primitive type `str`
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
    |
-   = note: an unstable sort would perform faster without any observable difference for this data type
+   = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `tuple`
   --> $DIR/stable_sort_primitive.rs:15:5
@@ -37,7 +37,7 @@ error: used `sort` on primitive type `tuple`
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
    |
-   = note: an unstable sort would perform faster without any observable difference for this data type
+   = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `array`
   --> $DIR/stable_sort_primitive.rs:17:5
@@ -45,7 +45,7 @@ error: used `sort` on primitive type `array`
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
    |
-   = note: an unstable sort would perform faster without any observable difference for this data type
+   = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `i32`
   --> $DIR/stable_sort_primitive.rs:19:5
@@ -53,7 +53,7 @@ error: used `sort` on primitive type `i32`
 LL |     arr.sort();
    |     ^^^^^^^^^^ help: try: `arr.sort_unstable()`
    |
-   = note: an unstable sort would perform faster without any observable difference for this data type
+   = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
fixes #8241 

Hey all - first contribution here so I'm deciding to start with something small.

Updated the linked message to be less authoritative as well as moved the lint grouping from `perf` to `pedantic` as suggested by @camsteffen under the issue.

changelog: [`stable_sort_primitive`]: emit less authoritative message and move to `pedantic`