### PR TITLE
`manual_split_once`: lint manual iteration of `SplitN`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2009,13 +2009,27 @@ declare_clippy_lint! {
     /// ### Example
     /// ```rust,ignore
     /// // Bad
-    ///  let (key, value) = _.splitn(2, '=').next_tuple()?;
-    ///  let value = _.splitn(2, '=').nth(1)?;
+    /// let s = "key=value=add";
+    /// let (key, value) = s.splitn(2, '=').next_tuple()?;
+    /// let value = s.splitn(2, '=').nth(1)?;
     ///
-    /// // Good
-    /// let (key, value) = _.split_once('=')?;
-    /// let value = _.split_once('=')?.1;
+    /// let mut parts = s.splitn(2, '=');
+    /// let key = parts.next()?;
+    /// let value = parts.next()?;
     /// ```
+    /// Use instead:
+    /// ```rust,ignore
+    /// // Good
+    /// let s = "key=value=add";
+    /// let (key, value) = s.split_once('=')?;
+    /// let value = s.split_once('=')?.1;
+    ///
+    /// let (key, value) = s.split_once('=')?;
+    /// ```
+    ///
+    /// ### Limitations
+    /// The multiple statement variant currently only detects `iter.next()?`/`iter.next().unwrap()`
+    /// in two separate `let` statements that immediately follow the `splitn()`
     #[clippy::version = "1.57.0"]
     pub MANUAL_SPLIT_ONCE,
     complexity,

--- a/tests/ui/manual_split_once.fixed
+++ b/tests/ui/manual_split_once.fixed
@@ -2,7 +2,7 @@
 
 #![feature(custom_inner_attributes)]
 #![warn(clippy::manual_split_once)]
-#![allow(clippy::iter_skip_next, clippy::iter_nth_zero)]
+#![allow(unused, clippy::iter_skip_next, clippy::iter_nth_zero)]
 
 extern crate itertools;
 
@@ -41,13 +41,107 @@ fn main() {
     let _ = s.rsplit_once('=').map(|x| x.0);
 }
 
+fn indirect() -> Option<()> {
+    let (l, r) = "a.b.c".split_once('.').unwrap();
+    
+    
+
+    let (l, r) = "a.b.c".split_once('.')?;
+    
+    
+
+    let (l, r) = "a.b.c".rsplit_once('.').unwrap();
+    
+    
+
+    let (l, r) = "a.b.c".rsplit_once('.')?;
+    
+    
+
+    // could lint, currently doesn't
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let other = 1;
+    let l = iter.next()?;
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let mut mut_binding = iter.next()?;
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let tuple = (iter.next()?, iter.next()?);
+
+    // should not lint
+
+    let mut missing_unwrap = "a.b.c".splitn(2, '.');
+    let l = missing_unwrap.next();
+    let r = missing_unwrap.next();
+
+    let mut mixed_unrap = "a.b.c".splitn(2, '.');
+    let unwrap = mixed_unrap.next().unwrap();
+    let question_mark = mixed_unrap.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let same_name = iter.next()?;
+    let same_name = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let shadows_existing = "d";
+    let shadows_existing = iter.next()?;
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let becomes_shadowed = iter.next()?;
+    let becomes_shadowed = "d";
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let l = iter.next()?;
+    let r = iter.next()?;
+    let third_usage = iter.next()?;
+
+    let mut n_three = "a.b.c".splitn(3, '.');
+    let l = n_three.next()?;
+    let r = n_three.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    {
+        let in_block = iter.next()?;
+    }
+    let r = iter.next()?;
+
+    let mut lacks_binding = "a.b.c".splitn(2, '.');
+    let _ = lacks_binding.next()?;
+    let r = lacks_binding.next()?;
+
+    let mut mapped = "a.b.c".splitn(2, '.').map(|_| "~");
+    let l = iter.next()?;
+    let r = iter.next()?;
+
+    let mut assigned = "";
+    let mut iter = "a.b.c".splitn(2, '.');
+    let l = iter.next()?;
+    assigned = iter.next()?;
+
+    None
+}
+
 fn _msrv_1_51() {
     #![clippy::msrv = "1.51"]
     // `str::split_once` was stabilized in 1.52. Do not lint this
     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let a = iter.next().unwrap();
+    let b = iter.next().unwrap();
 }
 
 fn _msrv_1_52() {
     #![clippy::msrv = "1.52"]
     let _ = "key=value".split_once('=').unwrap().1;
+
+    let (a, b) = "a.b.c".split_once('.').unwrap();
+    
+    
 }

--- a/tests/ui/manual_split_once.rs
+++ b/tests/ui/manual_split_once.rs
@@ -2,7 +2,7 @@
 
 #![feature(custom_inner_attributes)]
 #![warn(clippy::manual_split_once)]
-#![allow(clippy::iter_skip_next, clippy::iter_nth_zero)]
+#![allow(unused, clippy::iter_skip_next, clippy::iter_nth_zero)]
 
 extern crate itertools;
 
@@ -41,13 +41,107 @@ fn main() {
     let _ = s.rsplitn(2, '=').nth(1);
 }
 
+fn indirect() -> Option<()> {
+    let mut iter = "a.b.c".splitn(2, '.');
+    let l = iter.next().unwrap();
+    let r = iter.next().unwrap();
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let l = iter.next()?;
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".rsplitn(2, '.');
+    let r = iter.next().unwrap();
+    let l = iter.next().unwrap();
+
+    let mut iter = "a.b.c".rsplitn(2, '.');
+    let r = iter.next()?;
+    let l = iter.next()?;
+
+    // could lint, currently doesn't
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let other = 1;
+    let l = iter.next()?;
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let mut mut_binding = iter.next()?;
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let tuple = (iter.next()?, iter.next()?);
+
+    // should not lint
+
+    let mut missing_unwrap = "a.b.c".splitn(2, '.');
+    let l = missing_unwrap.next();
+    let r = missing_unwrap.next();
+
+    let mut mixed_unrap = "a.b.c".splitn(2, '.');
+    let unwrap = mixed_unrap.next().unwrap();
+    let question_mark = mixed_unrap.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let same_name = iter.next()?;
+    let same_name = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let shadows_existing = "d";
+    let shadows_existing = iter.next()?;
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let becomes_shadowed = iter.next()?;
+    let becomes_shadowed = "d";
+    let r = iter.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let l = iter.next()?;
+    let r = iter.next()?;
+    let third_usage = iter.next()?;
+
+    let mut n_three = "a.b.c".splitn(3, '.');
+    let l = n_three.next()?;
+    let r = n_three.next()?;
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    {
+        let in_block = iter.next()?;
+    }
+    let r = iter.next()?;
+
+    let mut lacks_binding = "a.b.c".splitn(2, '.');
+    let _ = lacks_binding.next()?;
+    let r = lacks_binding.next()?;
+
+    let mut mapped = "a.b.c".splitn(2, '.').map(|_| "~");
+    let l = iter.next()?;
+    let r = iter.next()?;
+
+    let mut assigned = "";
+    let mut iter = "a.b.c".splitn(2, '.');
+    let l = iter.next()?;
+    assigned = iter.next()?;
+
+    None
+}
+
 fn _msrv_1_51() {
     #![clippy::msrv = "1.51"]
     // `str::split_once` was stabilized in 1.52. Do not lint this
     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let a = iter.next().unwrap();
+    let b = iter.next().unwrap();
 }
 
 fn _msrv_1_52() {
     #![clippy::msrv = "1.52"]
     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
+
+    let mut iter = "a.b.c".splitn(2, '.');
+    let a = iter.next().unwrap();
+    let b = iter.next().unwrap();
 }

--- a/tests/ui/manual_split_once.stderr
+++ b/tests/ui/manual_split_once.stderr
@@ -79,10 +79,135 @@ LL |     let _ = s.rsplitn(2, '=').nth(1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit_once('=').map(|x| x.0)`
 
 error: manual implementation of `split_once`
-  --> $DIR/manual_split_once.rs:52:13
+  --> $DIR/manual_split_once.rs:45:5
+   |
+LL |     let mut iter = "a.b.c".splitn(2, '.');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let l = iter.next().unwrap();
+   |     ----------------------------- first usage here
+LL |     let r = iter.next().unwrap();
+   |     ----------------------------- second usage here
+   |
+help: try `split_once`
+   |
+LL |     let (l, r) = "a.b.c".split_once('.').unwrap();
+   |
+help: remove the `iter` usages
+   |
+LL -     let l = iter.next().unwrap();
+LL +     
+   | 
+help: remove the `iter` usages
+   |
+LL -     let r = iter.next().unwrap();
+LL +     
+   | 
+
+error: manual implementation of `split_once`
+  --> $DIR/manual_split_once.rs:49:5
+   |
+LL |     let mut iter = "a.b.c".splitn(2, '.');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let l = iter.next()?;
+   |     --------------------- first usage here
+LL |     let r = iter.next()?;
+   |     --------------------- second usage here
+   |
+help: try `split_once`
+   |
+LL |     let (l, r) = "a.b.c".split_once('.')?;
+   |
+help: remove the `iter` usages
+   |
+LL -     let l = iter.next()?;
+LL +     
+   | 
+help: remove the `iter` usages
+   |
+LL -     let r = iter.next()?;
+LL +     
+   | 
+
+error: manual implementation of `rsplit_once`
+  --> $DIR/manual_split_once.rs:53:5
+   |
+LL |     let mut iter = "a.b.c".rsplitn(2, '.');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let r = iter.next().unwrap();
+   |     ----------------------------- first usage here
+LL |     let l = iter.next().unwrap();
+   |     ----------------------------- second usage here
+   |
+help: try `rsplit_once`
+   |
+LL |     let (l, r) = "a.b.c".rsplit_once('.').unwrap();
+   |
+help: remove the `iter` usages
+   |
+LL -     let r = iter.next().unwrap();
+LL +     
+   | 
+help: remove the `iter` usages
+   |
+LL -     let l = iter.next().unwrap();
+LL +     
+   | 
+
+error: manual implementation of `rsplit_once`
+  --> $DIR/manual_split_once.rs:57:5
+   |
+LL |     let mut iter = "a.b.c".rsplitn(2, '.');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let r = iter.next()?;
+   |     --------------------- first usage here
+LL |     let l = iter.next()?;
+   |     --------------------- second usage here
+   |
+help: try `rsplit_once`
+   |
+LL |     let (l, r) = "a.b.c".rsplit_once('.')?;
+   |
+help: remove the `iter` usages
+   |
+LL -     let r = iter.next()?;
+LL +     
+   | 
+help: remove the `iter` usages
+   |
+LL -     let l = iter.next()?;
+LL +     
+   | 
+
+error: manual implementation of `split_once`
+  --> $DIR/manual_split_once.rs:142:13
    |
 LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
 
-error: aborting due to 14 previous errors
+error: manual implementation of `split_once`
+  --> $DIR/manual_split_once.rs:144:5
+   |
+LL |     let mut iter = "a.b.c".splitn(2, '.');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let a = iter.next().unwrap();
+   |     ----------------------------- first usage here
+LL |     let b = iter.next().unwrap();
+   |     ----------------------------- second usage here
+   |
+help: try `split_once`
+   |
+LL |     let (a, b) = "a.b.c".split_once('.').unwrap();
+   |
+help: remove the `iter` usages
+   |
+LL -     let a = iter.next().unwrap();
+LL +     
+   | 
+help: remove the `iter` usages
+   |
+LL -     let b = iter.next().unwrap();
+LL +     
+   | 
+
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
changelog: `manual_split_once`: lint manual iteration of `SplitN`

Now lints:

```rust
let mut iter = "a.b.c".splitn(2, '.');
let first = iter.next().unwrap();
let second = iter.next().unwrap();

let mut iter = "a.b.c".splitn(2, '.');
let first = iter.next()?;
let second = iter.next()?;

let mut iter = "a.b.c".rsplitn(2, '.');
let first = iter.next().unwrap();
let second = iter.next().unwrap();

let mut iter = "a.b.c".rsplitn(2, '.');
let first = iter.next()?;
let second = iter.next()?;
```

It suggests (minus leftover whitespace):

```rust
let (first, second) = "a.b.c".split_once('.').unwrap();

let (first, second) = "a.b.c".split_once('.')?;

let (second, first) = "a.b.c".rsplit_once('.').unwrap();

let (second, first) = "a.b.c".rsplit_once('.')?;
```

Currently only lints if the statements are next to each other, as detecting the various kinds of shadowing was tricky, so the following won't lint

```rust
let mut iter = "a.b.c".splitn(2, '.');
let something_else = 1;
let first = iter.next()?;
let second = iter.next()?;
```