### PR TITLE
[FP] identity_op in front of if

### DIFF
--- a/tests/ui/identity_op.rs
+++ b/tests/ui/identity_op.rs
@@ -77,4 +77,34 @@ fn main() {
     (x + 1) % 3; // no error
     4 % 3; // no error
     4 % -3; // no error
+
+    // See #8724
+    let a = 0;
+    let b = true;
+    0 + if b { 1 } else { 2 };
+    0 + if b { 1 } else { 2 } + if b { 3 } else { 4 }; // no error
+    0 + match a { 0 => 10, _ => 20 };
+    0 + match a { 0 => 10, _ => 20 } + match a { 0 => 30, _ => 40 }; // no error
+    0 + if b { 1 } else { 2 } + match a { 0 => 30, _ => 40 }; // no error
+    0 + match a { 0 => 10, _ => 20 } + if b { 3 } else { 4 }; // no error
+    
+    0 + if b { 0 + 1 } else { 2 };
+    0 + match a { 0 =>  0 + 10, _ => 20 };
+    0 + if b { 0 + 1 } else { 2 } + match a { 0 => 0 + 30, _ => 40 };
+
+    let _ = 0 + if 0 + 1 > 0 { 1 } else { 2 } + if 0 + 1 > 0 { 3 } else { 4 };
+    let _ = 0 + match 0 + 1 { 0 => 10, _ => 20 } + match 0 + 1  { 0 => 30, _ => 40 };
+
+    0 + if b { 1 } else { 2 } + if b { 3 } else { 4 } + 0;
+    
+    0 + { a } + 3; // no error
+    0 + loop { let mut c = 0; if c == 10 { break c; } c += 1; } + { a * 2 }; // no error
+    
+    fn f(_: i32) {
+        todo!();
+    }
+    f(1 * a + { 8 * 5 });
+    f(0 + if b { 1 } else { 2 } + 3); // no error
+    const _: i32 = { 2 * 4 } + 0 + 3;
+    const _: i32 = 0 + { 1 + 2 * 3 } + 3; // no error
 }

--- a/tests/ui/identity_op.stderr
+++ b/tests/ui/identity_op.stderr
@@ -108,5 +108,95 @@ error: the operation is ineffective. Consider reducing it to `1`
 LL |     x + 1 % 3;
    |         ^^^^^
 
-error: aborting due to 18 previous errors
+error: the operation is ineffective. Consider reducing it to `if b { 1 } else { 2 }`
+  --> $DIR/identity_op.rs:84:5
+   |
+LL |     0 + if b { 1 } else { 2 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `match a { 0 => 10, _ => 20 }`
+  --> $DIR/identity_op.rs:86:5
+   |
+LL |     0 + match a { 0 => 10, _ => 20 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `if b { 0 + 1 } else { 2 }`
+  --> $DIR/identity_op.rs:91:5
+   |
+LL |     0 + if b { 0 + 1 } else { 2 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `1`
+  --> $DIR/identity_op.rs:91:16
+   |
+LL |     0 + if b { 0 + 1 } else { 2 };
+   |                ^^^^^
+
+error: the operation is ineffective. Consider reducing it to `match a { 0 =>  0 + 10, _ => 20 }`
+  --> $DIR/identity_op.rs:92:5
+   |
+LL |     0 + match a { 0 =>  0 + 10, _ => 20 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `10`
+  --> $DIR/identity_op.rs:92:25
+   |
+LL |     0 + match a { 0 =>  0 + 10, _ => 20 };
+   |                         ^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `1`
+  --> $DIR/identity_op.rs:93:16
+   |
+LL |     0 + if b { 0 + 1 } else { 2 } + match a { 0 => 0 + 30, _ => 40 };
+   |                ^^^^^
+
+error: the operation is ineffective. Consider reducing it to `30`
+  --> $DIR/identity_op.rs:93:52
+   |
+LL |     0 + if b { 0 + 1 } else { 2 } + match a { 0 => 0 + 30, _ => 40 };
+   |                                                    ^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `1`
+  --> $DIR/identity_op.rs:95:20
+   |
+LL |     let _ = 0 + if 0 + 1 > 0 { 1 } else { 2 } + if 0 + 1 > 0 { 3 } else { 4 };
+   |                    ^^^^^
+
+error: the operation is ineffective. Consider reducing it to `1`
+  --> $DIR/identity_op.rs:95:52
+   |
+LL |     let _ = 0 + if 0 + 1 > 0 { 1 } else { 2 } + if 0 + 1 > 0 { 3 } else { 4 };
+   |                                                    ^^^^^
+
+error: the operation is ineffective. Consider reducing it to `1`
+  --> $DIR/identity_op.rs:96:23
+   |
+LL |     let _ = 0 + match 0 + 1 { 0 => 10, _ => 20 } + match 0 + 1  { 0 => 30, _ => 40 };
+   |                       ^^^^^
+
+error: the operation is ineffective. Consider reducing it to `1`
+  --> $DIR/identity_op.rs:96:58
+   |
+LL |     let _ = 0 + match 0 + 1 { 0 => 10, _ => 20 } + match 0 + 1  { 0 => 30, _ => 40 };
+   |                                                          ^^^^^
+
+error: the operation is ineffective. Consider reducing it to `0 + if b { 1 } else { 2 } + if b { 3 } else { 4 }`
+  --> $DIR/identity_op.rs:98:5
+   |
+LL |     0 + if b { 1 } else { 2 } + if b { 3 } else { 4 } + 0;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: the operation is ineffective. Consider reducing it to `a`
+  --> $DIR/identity_op.rs:106:7
+   |
+LL |     f(1 * a + { 8 * 5 });
+   |       ^^^^^
+
+error: the operation is ineffective. Consider reducing it to `{ 2 * 4 }`
+  --> $DIR/identity_op.rs:108:20
+   |
+LL |     const _: i32 = { 2 * 4 } + 0 + 3;
+   |                    ^^^^^^^^^^^^^
+
+error: aborting due to 33 previous errors
 


### PR DESCRIPTION
fix #8724 

changelog: FP: [`identity_op`]: is now allowed in front of if statements, blocks and other expressions where the suggestion would be invalid.
 
Resolved simular problems with blocks, mathces, and loops.
identity_op always does NOT suggest reducing `0 + if b { 1 } else { 2 } + 3` into  `if b { 1 } else { 2 } + 3` even in the case that the expression is in `f(expr)` or `let x = expr;` for now.