### PR TITLE
Add macro export exemption to `redundant_pub_crate`

### DIFF
--- a/clippy_lints/src/redundant_pub_crate.rs
+++ b/clippy_lints/src/redundant_pub_crate.rs
@@ -1,8 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_errors::Applicability;
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Item, ItemKind, VisibilityKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::hygiene::MacroKind;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -41,8 +43,11 @@ impl_lint_pass!(RedundantPubCrate => [REDUNDANT_PUB_CRATE]);
 
 impl<'tcx> LateLintPass<'tcx> for RedundantPubCrate {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
-        if let VisibilityKind::Crate { .. } = item.vis.node {
-            if !cx.access_levels.is_exported(item.def_id) && self.is_exported.last() == Some(&false) {
+        if_chain! {
+            if let VisibilityKind::Crate { .. } = item.vis.node;
+            if !cx.access_levels.is_exported(item.def_id) && self.is_exported.last() == Some(&false);
+            if is_not_macro_export(item);
+            then {
                 let span = item.span.with_hi(item.ident.span.hi());
                 let descr = cx.tcx.def_kind(item.def_id).descr(item.def_id.to_def_id());
                 span_lint_and_then(
@@ -72,4 +77,14 @@ impl<'tcx> LateLintPass<'tcx> for RedundantPubCrate {
             self.is_exported.pop().expect("unbalanced check_item/check_item_post");
         }
     }
+}
+
+fn is_not_macro_export<'tcx>(item: &'tcx Item<'tcx>) -> bool {
+    if let ItemKind::Use(path, _) = item.kind {
+        if let Res::Def(DefKind::Macro(MacroKind::Bang), _) = path.res {
+            return false;
+        }
+    }
+
+    true
 }

--- a/tests/ui/redundant_pub_crate.fixed
+++ b/tests/ui/redundant_pub_crate.fixed
@@ -104,4 +104,14 @@ mod m4 {
 
 pub use m4::*;
 
+mod issue_8732 {
+    #[allow(unused_macros)]
+    macro_rules! some_macro {
+        () => {};
+    }
+
+    #[allow(unused_imports)]
+    pub(crate) use some_macro; // ok: macro exports are exempt
+}
+
 fn main() {}

--- a/tests/ui/redundant_pub_crate.rs
+++ b/tests/ui/redundant_pub_crate.rs
@@ -104,4 +104,14 @@ mod m4 {
 
 pub use m4::*;
 
+mod issue_8732 {
+    #[allow(unused_macros)]
+    macro_rules! some_macro {
+        () => {};
+    }
+
+    #[allow(unused_imports)]
+    pub(crate) use some_macro; // ok: macro exports are exempt
+}
+
 fn main() {}


### PR DESCRIPTION
changelog: Add macro export exemption to `redundant_pub_crate`
closes #8732
