### PR TITLE
Support negative ints in manual_range_contains

### DIFF
--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -130,12 +130,10 @@ impl Constant {
         match (left, right) {
             (&Self::Str(ref ls), &Self::Str(ref rs)) => Some(ls.cmp(rs)),
             (&Self::Char(ref l), &Self::Char(ref r)) => Some(l.cmp(r)),
-            (&Self::Int(l), &Self::Int(r)) => {
-                if let ty::Int(int_ty) = *cmp_type.kind() {
-                    Some(sext(tcx, l, int_ty).cmp(&sext(tcx, r, int_ty)))
-                } else {
-                    Some(l.cmp(&r))
-                }
+            (&Self::Int(l), &Self::Int(r)) => match *cmp_type.kind() {
+                ty::Int(int_ty) => Some(sext(tcx, l, int_ty).cmp(&sext(tcx, r, int_ty))),
+                ty::Uint(_) => Some(l.cmp(&r)),
+                _ => bug!("Not an int type"),
             },
             (&Self::F64(l), &Self::F64(r)) => l.partial_cmp(&r),
             (&Self::F32(l), &Self::F32(r)) => l.partial_cmp(&r),

--- a/tests/ui/range_contains.fixed
+++ b/tests/ui/range_contains.fixed
@@ -6,7 +6,7 @@
 #[allow(clippy::short_circuit_statement)]
 #[allow(clippy::unnecessary_operation)]
 fn main() {
-    let x = 9_u32;
+    let x = 9_i32;
 
     // order shouldn't matter
     (8..12).contains(&x);
@@ -43,6 +43,12 @@ fn main() {
     let y = 3.;
     (0. ..1.).contains(&y);
     !(0. ..=1.).contains(&y);
+
+    // handle negatives #8721
+    (-10..=10).contains(&x);
+    x >= 10 && x <= -10;
+    (-3. ..=3.).contains(&y);
+    y >= 3. && y <= -3.;
 }
 
 // Fix #6373

--- a/tests/ui/range_contains.rs
+++ b/tests/ui/range_contains.rs
@@ -6,7 +6,7 @@
 #[allow(clippy::short_circuit_statement)]
 #[allow(clippy::unnecessary_operation)]
 fn main() {
-    let x = 9_u32;
+    let x = 9_i32;
 
     // order shouldn't matter
     x >= 8 && x < 12;
@@ -43,6 +43,12 @@ fn main() {
     let y = 3.;
     y >= 0. && y < 1.;
     y < 0. || y > 1.;
+
+    // handle negatives #8721
+    x >= -10 && x <= 10;
+    x >= 10 && x <= -10;
+    y >= -3. && y <= 3.;
+    y >= 3. && y <= -3.;
 }
 
 // Fix #6373

--- a/tests/ui/range_contains.stderr
+++ b/tests/ui/range_contains.stderr
@@ -84,5 +84,17 @@ error: manual `!RangeInclusive::contains` implementation
 LL |     y < 0. || y > 1.;
    |     ^^^^^^^^^^^^^^^^ help: use: `!(0. ..=1.).contains(&y)`
 
-error: aborting due to 14 previous errors
+error: manual `RangeInclusive::contains` implementation
+  --> $DIR/range_contains.rs:48:5
+   |
+LL |     x >= -10 && x <= 10;
+   |     ^^^^^^^^^^^^^^^^^^^ help: use: `(-10..=10).contains(&x)`
+
+error: manual `RangeInclusive::contains` implementation
+  --> $DIR/range_contains.rs:50:5
+   |
+LL |     y >= -3. && y <= 3.;
+   |     ^^^^^^^^^^^^^^^^^^^ help: use: `(-3. ..=3.).contains(&y)`
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
fixes: #8721 
changelog: Fixes issue where ranges containing ints with different signs would be
incorrect due to comparing as unsigned.
