### PR TITLE
Add missing quite in `large_include_file` example

### DIFF
--- a/clippy_lints/src/large_include_file.rs
+++ b/clippy_lints/src/large_include_file.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// ### Example
     /// ```rust,ignore
     /// let included_str = include_str!("very_large_file.txt");
-    /// let included_bytes = include_bytes!("very_large_file.txt);
+    /// let included_bytes = include_bytes!("very_large_file.txt");
     /// ```
     ///
     /// Instead, you can load the file at runtime:


### PR DESCRIPTION
Just a simple fix. Sorry that this branch is not in my fork, I just applied this online, and it created on in this repo :upside_down_face: 

Closes #8765

changelog:none
