### PR TITLE
Add missing quite in `large_include_file` example

### DIFF
--- a/clippy_lints/src/large_include_file.rs
+++ b/clippy_lints/src/large_include_file.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// ### Example
     /// ```rust,ignore
     /// let included_str = include_str!("very_large_file.txt");
-    /// let included_bytes = include_bytes!("very_large_file.txt);
+    /// let included_bytes = include_bytes!("very_large_file.txt");
     /// ```
     ///
     /// Instead, you can load the file at runtime:


### PR DESCRIPTION
Roses are red,
violets are blue,
this fix,
was simple to do


Closes: https://github.com/rust-lang/rust-clippy/issues/8765

changelog: None
