### PR TITLE
Fix `cast_lossless` to avoid warning on `usize` to `f64` conversion.

### DIFF
--- a/clippy_lints/src/casts/cast_lossless.rs
+++ b/clippy_lints/src/casts/cast_lossless.rs
@@ -93,7 +93,7 @@ fn should_lint(
             } else {
                 64
             };
-            from_nbits < to_nbits
+            !is_isize_or_usize(cast_from) && from_nbits < to_nbits
         },
         (false, true) if matches!(cast_from.kind(), ty::Bool) && meets_msrv(msrv.as_ref(), &msrvs::FROM_BOOL) => true,
         (_, _) => {

--- a/tests/ui/cast_size_32bit.stderr
+++ b/tests/ui/cast_size_32bit.stderr
@@ -14,25 +14,11 @@ LL |     x0 as f64;
    |
    = note: `-D clippy::cast-precision-loss` implied by `-D warnings`
 
-error: casting `isize` to `f64` may become silently lossy if you later change the type
-  --> $DIR/cast_size_32bit.rs:15:5
-   |
-LL |     x0 as f64;
-   |     ^^^^^^^^^ help: try: `f64::from(x0)`
-   |
-   = note: `-D clippy::cast-lossless` implied by `-D warnings`
-
 error: casting `usize` to `f64` causes a loss of precision on targets with 64-bit wide pointers (`usize` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
   --> $DIR/cast_size_32bit.rs:16:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
-
-error: casting `usize` to `f64` may become silently lossy if you later change the type
-  --> $DIR/cast_size_32bit.rs:16:5
-   |
-LL |     x1 as f64;
-   |     ^^^^^^^^^ help: try: `f64::from(x1)`
 
 error: casting `isize` to `f32` causes a loss of precision (`isize` is 32 or 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
   --> $DIR/cast_size_32bit.rs:17:5


### PR DESCRIPTION
Previously, the `cast_lossless` lint would issue a warning on code that
converted a `usize` value to `f64`, on 32-bit targets.

`usize` to `f64` is a lossless cast on 32-bit targets, however there is
no corresponding `f64::from` that takes a `usize`, so `cast_lossless`'s
suggested replacement does not compile.

This PR disables the lint in the case of casting from `usize` or `isize`.

Fixes #3689.

changelog: [`cast_lossless`] no longer gives wrong suggestion on usize,isize->f64
