### PR TITLE
Easier readability for `needless_late_init` message

### DIFF
--- a/tests/ui/needless_late_init.stderr
+++ b/tests/ui/needless_late_init.stderr
@@ -123,7 +123,10 @@ error: unneeded late initialization
   --> $DIR/needless_late_init.rs:60:5
    |
 LL |     let x;
-   |     ^^^^^^
+   |     ^^^^^^ created here
+LL |     let y = SignificantDrop;
+LL |     x = 1;
+   |     ^^^^^ initialised here
    |
 help: declare `x` here
    |
@@ -134,7 +137,10 @@ error: unneeded late initialization
   --> $DIR/needless_late_init.rs:64:5
    |
 LL |     let x;
-   |     ^^^^^^
+   |     ^^^^^^ created here
+LL |     let y = 1;
+LL |     x = SignificantDrop;
+   |     ^^^^^^^^^^^^^^^^^^^ initialised here
    |
 help: declare `x` here
    |
@@ -145,7 +151,10 @@ error: unneeded late initialization
   --> $DIR/needless_late_init.rs:68:5
    |
 LL |     let x;
-   |     ^^^^^^
+   |     ^^^^^^ created here
+...
+LL |     x = SignificantDrop;
+   |     ^^^^^^^^^^^^^^^^^^^ initialised here
    |
 help: declare `x` here
    |

--- a/tests/ui/needless_late_init_fixable.stderr
+++ b/tests/ui/needless_late_init_fixable.stderr
@@ -2,7 +2,9 @@ error: unneeded late initialization
   --> $DIR/needless_late_init_fixable.rs:6:5
    |
 LL |     let a;
-   |     ^^^^^^
+   |     ^^^^^^ created here
+LL |     a = "zero";
+   |     ^^^^^^^^^^ initialised here
    |
    = note: `-D clippy::needless-late-init` implied by `-D warnings`
 help: declare `a` here
@@ -14,7 +16,10 @@ error: unneeded late initialization
   --> $DIR/needless_late_init_fixable.rs:9:5
    |
 LL |     let b;
-   |     ^^^^^^
+   |     ^^^^^^ created here
+LL |     let c;
+LL |     b = 1;
+   |     ^^^^^ initialised here
    |
 help: declare `b` here
    |
@@ -25,7 +30,10 @@ error: unneeded late initialization
   --> $DIR/needless_late_init_fixable.rs:10:5
    |
 LL |     let c;
-   |     ^^^^^^
+   |     ^^^^^^ created here
+LL |     b = 1;
+LL |     c = 2;
+   |     ^^^^^ initialised here
    |
 help: declare `c` here
    |
@@ -36,7 +44,9 @@ error: unneeded late initialization
   --> $DIR/needless_late_init_fixable.rs:14:5
    |
 LL |     let d: usize;
-   |     ^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^ created here
+LL |     d = 1;
+   |     ^^^^^ initialised here
    |
 help: declare `d` here
    |
@@ -47,7 +57,9 @@ error: unneeded late initialization
   --> $DIR/needless_late_init_fixable.rs:17:5
    |
 LL |     let e;
-   |     ^^^^^^
+   |     ^^^^^^ created here
+LL |     e = format!("{}", d);
+   |     ^^^^^^^^^^^^^^^^^^^^ initialised here
    |
 help: declare `e` here
    |


### PR DESCRIPTION
Closes #8530 

Updated the lint to use a `MultiSpan`, showing where the `let` statement was first used and where the initialisation statement was done, as in the format described, for easier readability.

Was wondering why, when pushing the span label for the initialisation statement, that sometimes the prior statement above the initialisation statement gets pulled into the output as well - any insight is appreciated!

---

changelog: [`needless_late_init`]: Now shows the `let` statement where it was first initialized