### PR TITLE
Ignore type aliases in `init_numbered_fields`

### DIFF
--- a/clippy_lints/src/init_numbered_fields.rs
+++ b/clippy_lints/src/init_numbered_fields.rs
@@ -1,6 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_applicability;
 use rustc_errors::Applicability;
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -49,6 +50,7 @@ impl<'tcx> LateLintPass<'tcx> for NumberedFields {
                 && fields
                     .iter()
                     .all(|f| f.ident.as_str().as_bytes().iter().all(u8::is_ascii_digit))
+                && !matches!(cx.qpath_res(path, e.hir_id), Res::Def(DefKind::TyAlias, ..))
             {
                 let expr_spans = fields
                     .iter()

--- a/tests/ui/numbered_fields.fixed
+++ b/tests/ui/numbered_fields.fixed
@@ -30,4 +30,9 @@ fn main() {
 
     // Ok because it's in macro
     let _ = tuple_struct_init!();
+
+    type Alias = TupleStruct;
+
+    // Aliases can't be tuple constructed #8638
+    let _ = Alias { 0: 0, 1: 1, 2: 2 };
 }

--- a/tests/ui/numbered_fields.rs
+++ b/tests/ui/numbered_fields.rs
@@ -38,4 +38,9 @@ fn main() {
 
     // Ok because it's in macro
     let _ = tuple_struct_init!();
+
+    type Alias = TupleStruct;
+
+    // Aliases can't be tuple constructed #8638
+    let _ = Alias { 0: 0, 1: 1, 2: 2 };
 }


### PR DESCRIPTION
changelog: Ignore type aliases in [`init_numbered_fields`]

Fixes #8638
