### PR TITLE
Do not fire `integer_division` in a constant environment

### DIFF
--- a/clippy_lints/src/integer_division.rs
+++ b/clippy_lints/src/integer_division.rs
@@ -1,5 +1,4 @@
 use clippy_utils::diagnostics::span_lint_and_help;
-use if_chain::if_chain;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};

--- a/clippy_lints/src/integer_division.rs
+++ b/clippy_lints/src/integer_division.rs
@@ -47,14 +47,14 @@ impl<'tcx> LateLintPass<'tcx> for IntegerDivision {
 }
 
 fn is_integer_division<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) -> bool {
-    if_chain! {
-        if let hir::ExprKind::Binary(binop, left, right) = &expr.kind;
-        if binop.node == hir::BinOpKind::Div;
-        then {
-            let (left_ty, right_ty) = (cx.typeck_results().expr_ty(left), cx.typeck_results().expr_ty(right));
-            return left_ty.is_integral() && right_ty.is_integral();
-        }
+    if let hir::ExprKind::Binary(binop, left, right) = &expr.kind
+        && binop.node == hir::BinOpKind::Div
+        && !cx.tcx.hir().is_inside_const_context(expr.hir_id)
+    {
+        let (left_ty, right_ty) = (cx.typeck_results().expr_ty(left), cx.typeck_results().expr_ty(right));
+        left_ty.is_integral() && right_ty.is_integral()
     }
-
-    false
+    else {
+        false
+    }
 }

--- a/tests/ui/integer_division.rs
+++ b/tests/ui/integer_division.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::integer_division)]
 
+const _: usize = 64 / 3;
+
 fn main() {
     let two = 2;
     let n = 1 / 2;

--- a/tests/ui/integer_division.stderr
+++ b/tests/ui/integer_division.stderr
@@ -1,5 +1,5 @@
 error: integer division
-  --> $DIR/integer_division.rs:5:13
+  --> $DIR/integer_division.rs:7:13
    |
 LL |     let n = 1 / 2;
    |             ^^^^^
@@ -8,7 +8,7 @@ LL |     let n = 1 / 2;
    = help: division of integers may cause loss of precision. consider using floats
 
 error: integer division
-  --> $DIR/integer_division.rs:6:13
+  --> $DIR/integer_division.rs:8:13
    |
 LL |     let o = 1 / two;
    |             ^^^^^^^
@@ -16,7 +16,7 @@ LL |     let o = 1 / two;
    = help: division of integers may cause loss of precision. consider using floats
 
 error: integer division
-  --> $DIR/integer_division.rs:7:13
+  --> $DIR/integer_division.rs:9:13
    |
 LL |     let p = two / 4;
    |             ^^^^^^^


### PR DESCRIPTION
Let Rustc handle possible integer overflows

Similar PRs:

* https://github.com/rust-lang/rust-clippy/pull/8592
* https://github.com/rust-lang/rust-clippy/pull/8588