### PR TITLE
`identity_op`: add parenthesis to suggestions where required

### DIFF
--- a/tests/ui/identity_op.fixed
+++ b/tests/ui/identity_op.fixed
@@ -40,44 +40,44 @@ impl core::ops::Mul<Meter> for u8 {
 fn main() {
     let x = 0;
 
-    x + 0;
-    x + (1 - 1);
+    x;
+    x;
     x + 1;
-    0 + x;
+    x;
     1 + x;
     x - ZERO; //no error, as we skip lookups (for now)
-    x | (0);
+    x;
     ((ZERO)) | x; //no error, as we skip lookups (for now)
 
-    x * 1;
-    1 * x;
+    x;
+    x;
     x / ONE; //no error, as we skip lookups (for now)
 
     x / 2; //no false positive
 
     x & NEG_ONE; //no error, as we skip lookups (for now)
-    -1 & x;
+    x;
 
     let u: u8 = 0;
-    u & 255;
+    u;
 
     1 << 0; // no error, this case is allowed, see issue 3430
-    42 << 0;
-    1 >> 0;
-    42 >> 0;
-    &x >> 0;
-    x >> &0;
+    42;
+    1;
+    42;
+    &x;
+    x;
 
     let mut a = A("".into());
     let b = a << 0; // no error: non-integer
 
     1 * Meter; // no error: non-integer
 
-    2 % 3;
-    -2 % 3;
-    2 % -3 + x;
-    -2 % -3 + x;
-    x + 1 % 3;
+    2;
+    -2;
+    2 + x;
+    -2 + x;
+    x + 1;
     (x + 1) % 3; // no error
     4 % 3; // no error
     4 % -3; // no error
@@ -85,35 +85,35 @@ fn main() {
     // See #8724
     let a = 0;
     let b = true;
-    0 + if b { 1 } else { 2 };
-    0 + if b { 1 } else { 2 } + if b { 3 } else { 4 };
-    0 + match a { 0 => 10, _ => 20 };
-    0 + match a { 0 => 10, _ => 20 } + match a { 0 => 30, _ => 40 };
-    0 + if b { 1 } else { 2 } + match a { 0 => 30, _ => 40 };
-    0 + match a { 0 => 10, _ => 20 } + if b { 3 } else { 4 };
-    (if b { 1 } else { 2 }) + 0;
+    (if b { 1 } else { 2 });
+    (if b { 1 } else { 2 }) + if b { 3 } else { 4 };
+    (match a { 0 => 10, _ => 20 });
+    (match a { 0 => 10, _ => 20 }) + match a { 0 => 30, _ => 40 };
+    (if b { 1 } else { 2 }) + match a { 0 => 30, _ => 40 };
+    (match a { 0 => 10, _ => 20 }) + if b { 3 } else { 4 };
+    (if b { 1 } else { 2 });
 
-    0 + { a } + 3;
-    0 + { a } * 2;
-    0 + loop { let mut c = 0; if c == 10 { break c; } c += 1; } + { a * 2 };
+    ({ a }) + 3;
+    ({ a } * 2);
+    (loop { let mut c = 0; if c == 10 { break c; } c += 1; }) + { a * 2 };
 
     fn f(_: i32) {
         todo!();
     }
-    f(1 * a + { 8 * 5 });
-    f(0 + if b { 1 } else { 2 } + 3);
-    const _: i32 = { 2 * 4 } + 0 + 3;
-    const _: i32 = 0 + { 1 + 2 * 3 } + 3;
+    f(a + { 8 * 5 });
+    f(if b { 1 } else { 2 } + 3);
+    const _: i32 = { 2 * 4 } + 3;
+    const _: i32 = { 1 + 2 * 3 } + 3;
 
-    0 + a as usize;
-    let _ = 0 + a as usize;
-    0 + { a } as usize;
+    a as usize;
+    let _ = a as usize;
+    ({ a } as usize);
 
-    2 * (0 + { a });
-    1 * ({ a } + 4);
-    1 * 1;
+    2 * { a };
+    (({ a } + 4));
+    1;
 }
 
 pub fn decide(a: bool, b: bool) -> u32 {
-    0 + if a { 1 } else { 2 } + if b { 3 } else { 5 }
+    (if a { 1 } else { 2 }) + if b { 3 } else { 5 }
 }

--- a/tests/ui/identity_op.stderr
+++ b/tests/ui/identity_op.stderr
@@ -1,202 +1,238 @@
-error: the operation is ineffective. Consider reducing it to `x`
-  --> $DIR/identity_op.rs:39:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:43:5
    |
 LL |     x + 0;
-   |     ^^^^^
+   |     ^^^^^ help: consider reducing it to: `x`
    |
    = note: `-D clippy::identity-op` implied by `-D warnings`
 
-error: the operation is ineffective. Consider reducing it to `x`
-  --> $DIR/identity_op.rs:40:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:44:5
    |
 LL |     x + (1 - 1);
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^ help: consider reducing it to: `x`
 
-error: the operation is ineffective. Consider reducing it to `x`
-  --> $DIR/identity_op.rs:42:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:46:5
    |
 LL |     0 + x;
-   |     ^^^^^
+   |     ^^^^^ help: consider reducing it to: `x`
 
-error: the operation is ineffective. Consider reducing it to `x`
-  --> $DIR/identity_op.rs:45:5
-   |
-LL |     x | (0);
-   |     ^^^^^^^
-
-error: the operation is ineffective. Consider reducing it to `x`
-  --> $DIR/identity_op.rs:48:5
-   |
-LL |     x * 1;
-   |     ^^^^^
-
-error: the operation is ineffective. Consider reducing it to `x`
+error: this operation has no effect
   --> $DIR/identity_op.rs:49:5
    |
-LL |     1 * x;
-   |     ^^^^^
+LL |     x | (0);
+   |     ^^^^^^^ help: consider reducing it to: `x`
 
-error: the operation is ineffective. Consider reducing it to `x`
-  --> $DIR/identity_op.rs:55:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:52:5
+   |
+LL |     x * 1;
+   |     ^^^^^ help: consider reducing it to: `x`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:53:5
+   |
+LL |     1 * x;
+   |     ^^^^^ help: consider reducing it to: `x`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:59:5
    |
 LL |     -1 & x;
-   |     ^^^^^^
+   |     ^^^^^^ help: consider reducing it to: `x`
 
-error: the operation is ineffective. Consider reducing it to `u`
-  --> $DIR/identity_op.rs:58:5
-   |
-LL |     u & 255;
-   |     ^^^^^^^
-
-error: the operation is ineffective. Consider reducing it to `42`
-  --> $DIR/identity_op.rs:61:5
-   |
-LL |     42 << 0;
-   |     ^^^^^^^
-
-error: the operation is ineffective. Consider reducing it to `1`
+error: this operation has no effect
   --> $DIR/identity_op.rs:62:5
    |
-LL |     1 >> 0;
-   |     ^^^^^^
+LL |     u & 255;
+   |     ^^^^^^^ help: consider reducing it to: `u`
 
-error: the operation is ineffective. Consider reducing it to `42`
-  --> $DIR/identity_op.rs:63:5
-   |
-LL |     42 >> 0;
-   |     ^^^^^^^
-
-error: the operation is ineffective. Consider reducing it to `&x`
-  --> $DIR/identity_op.rs:64:5
-   |
-LL |     &x >> 0;
-   |     ^^^^^^^
-
-error: the operation is ineffective. Consider reducing it to `x`
+error: this operation has no effect
   --> $DIR/identity_op.rs:65:5
    |
-LL |     x >> &0;
-   |     ^^^^^^^
+LL |     42 << 0;
+   |     ^^^^^^^ help: consider reducing it to: `42`
 
-error: the operation is ineffective. Consider reducing it to `2`
-  --> $DIR/identity_op.rs:72:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:66:5
+   |
+LL |     1 >> 0;
+   |     ^^^^^^ help: consider reducing it to: `1`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:67:5
+   |
+LL |     42 >> 0;
+   |     ^^^^^^^ help: consider reducing it to: `42`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:68:5
+   |
+LL |     &x >> 0;
+   |     ^^^^^^^ help: consider reducing it to: `&x`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:69:5
+   |
+LL |     x >> &0;
+   |     ^^^^^^^ help: consider reducing it to: `x`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:76:5
    |
 LL |     2 % 3;
-   |     ^^^^^
+   |     ^^^^^ help: consider reducing it to: `2`
 
-error: the operation is ineffective. Consider reducing it to `-2`
-  --> $DIR/identity_op.rs:73:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:77:5
    |
 LL |     -2 % 3;
-   |     ^^^^^^
+   |     ^^^^^^ help: consider reducing it to: `-2`
 
-error: the operation is ineffective. Consider reducing it to `2`
-  --> $DIR/identity_op.rs:74:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:78:5
    |
 LL |     2 % -3 + x;
-   |     ^^^^^^
+   |     ^^^^^^ help: consider reducing it to: `2`
 
-error: the operation is ineffective. Consider reducing it to `-2`
-  --> $DIR/identity_op.rs:75:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:79:5
    |
 LL |     -2 % -3 + x;
-   |     ^^^^^^^
+   |     ^^^^^^^ help: consider reducing it to: `-2`
 
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/identity_op.rs:76:9
+error: this operation has no effect
+  --> $DIR/identity_op.rs:80:9
    |
 LL |     x + 1 % 3;
-   |         ^^^^^
+   |         ^^^^^ help: consider reducing it to: `1`
 
-error: the operation is ineffective. Consider reducing it to `if b { 1 } else { 2 }`
-  --> $DIR/identity_op.rs:84:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:88:5
    |
 LL |     0 + if b { 1 } else { 2 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
 
-error: the operation is ineffective. Consider reducing it to `match a { 0 => 10, _ => 20 }`
-  --> $DIR/identity_op.rs:86:5
+error: this operation has no effect
+  --> $DIR/identity_op.rs:89:5
+   |
+LL |     0 + if b { 1 } else { 2 } + if b { 3 } else { 4 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:90:5
    |
 LL |     0 + match a { 0 => 10, _ => 20 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(match a { 0 => 10, _ => 20 })`
 
-error: the operation is ineffective. Consider reducing it to `if b { 0 + 1 } else { 2 }`
+error: this operation has no effect
   --> $DIR/identity_op.rs:91:5
    |
-LL |     0 + if b { 0 + 1 } else { 2 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     0 + match a { 0 => 10, _ => 20 } + match a { 0 => 30, _ => 40 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(match a { 0 => 10, _ => 20 })`
 
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/identity_op.rs:91:16
-   |
-LL |     0 + if b { 0 + 1 } else { 2 };
-   |                ^^^^^
-
-error: the operation is ineffective. Consider reducing it to `match a { 0 =>  0 + 10, _ => 20 }`
+error: this operation has no effect
   --> $DIR/identity_op.rs:92:5
    |
-LL |     0 + match a { 0 =>  0 + 10, _ => 20 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     0 + if b { 1 } else { 2 } + match a { 0 => 30, _ => 40 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
 
-error: the operation is ineffective. Consider reducing it to `10`
-  --> $DIR/identity_op.rs:92:25
+error: this operation has no effect
+  --> $DIR/identity_op.rs:93:5
    |
-LL |     0 + match a { 0 =>  0 + 10, _ => 20 };
-   |                         ^^^^^^
+LL |     0 + match a { 0 => 10, _ => 20 } + if b { 3 } else { 4 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(match a { 0 => 10, _ => 20 })`
 
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/identity_op.rs:93:16
+error: this operation has no effect
+  --> $DIR/identity_op.rs:94:5
    |
-LL |     0 + if b { 0 + 1 } else { 2 } + match a { 0 => 0 + 30, _ => 40 };
-   |                ^^^^^
+LL |     (if b { 1 } else { 2 }) + 0;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
 
-error: the operation is ineffective. Consider reducing it to `30`
-  --> $DIR/identity_op.rs:93:52
+error: this operation has no effect
+  --> $DIR/identity_op.rs:96:5
    |
-LL |     0 + if b { 0 + 1 } else { 2 } + match a { 0 => 0 + 30, _ => 40 };
-   |                                                    ^^^^^^
+LL |     0 + { a } + 3;
+   |     ^^^^^^^^^ help: consider reducing it to: `({ a })`
 
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/identity_op.rs:95:20
+error: this operation has no effect
+  --> $DIR/identity_op.rs:97:5
    |
-LL |     let _ = 0 + if 0 + 1 > 0 { 1 } else { 2 } + if 0 + 1 > 0 { 3 } else { 4 };
-   |                    ^^^^^
+LL |     0 + { a } * 2;
+   |     ^^^^^^^^^^^^^ help: consider reducing it to: `({ a } * 2)`
 
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/identity_op.rs:95:52
-   |
-LL |     let _ = 0 + if 0 + 1 > 0 { 1 } else { 2 } + if 0 + 1 > 0 { 3 } else { 4 };
-   |                                                    ^^^^^
-
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/identity_op.rs:96:23
-   |
-LL |     let _ = 0 + match 0 + 1 { 0 => 10, _ => 20 } + match 0 + 1  { 0 => 30, _ => 40 };
-   |                       ^^^^^
-
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/identity_op.rs:96:58
-   |
-LL |     let _ = 0 + match 0 + 1 { 0 => 10, _ => 20 } + match 0 + 1  { 0 => 30, _ => 40 };
-   |                                                          ^^^^^
-
-error: the operation is ineffective. Consider reducing it to `0 + if b { 1 } else { 2 } + if b { 3 } else { 4 }`
+error: this operation has no effect
   --> $DIR/identity_op.rs:98:5
    |
-LL |     0 + if b { 1 } else { 2 } + if b { 3 } else { 4 } + 0;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     0 + loop { let mut c = 0; if c == 10 { break c; } c += 1; } + { a * 2 };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(loop { let mut c = 0; if c == 10 { break c; } c += 1; })`
 
-error: the operation is ineffective. Consider reducing it to `a`
-  --> $DIR/identity_op.rs:106:7
+error: this operation has no effect
+  --> $DIR/identity_op.rs:103:7
    |
 LL |     f(1 * a + { 8 * 5 });
-   |       ^^^^^
+   |       ^^^^^ help: consider reducing it to: `a`
 
-error: the operation is ineffective. Consider reducing it to `{ 2 * 4 }`
-  --> $DIR/identity_op.rs:108:20
+error: this operation has no effect
+  --> $DIR/identity_op.rs:104:7
+   |
+LL |     f(0 + if b { 1 } else { 2 } + 3);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `if b { 1 } else { 2 }`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:105:20
    |
 LL |     const _: i32 = { 2 * 4 } + 0 + 3;
-   |                    ^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^ help: consider reducing it to: `{ 2 * 4 }`
 
-error: aborting due to 33 previous errors
+error: this operation has no effect
+  --> $DIR/identity_op.rs:106:20
+   |
+LL |     const _: i32 = 0 + { 1 + 2 * 3 } + 3;
+   |                    ^^^^^^^^^^^^^^^^^ help: consider reducing it to: `{ 1 + 2 * 3 }`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:108:5
+   |
+LL |     0 + a as usize;
+   |     ^^^^^^^^^^^^^^ help: consider reducing it to: `a as usize`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:109:13
+   |
+LL |     let _ = 0 + a as usize;
+   |             ^^^^^^^^^^^^^^ help: consider reducing it to: `a as usize`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:110:5
+   |
+LL |     0 + { a } as usize;
+   |     ^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `({ a } as usize)`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:112:9
+   |
+LL |     2 * (0 + { a });
+   |         ^^^^^^^^^^^ help: consider reducing it to: `{ a }`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:113:5
+   |
+LL |     1 * ({ a } + 4);
+   |     ^^^^^^^^^^^^^^^ help: consider reducing it to: `(({ a } + 4))`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:114:5
+   |
+LL |     1 * 1;
+   |     ^^^^^ help: consider reducing it to: `1`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:118:5
+   |
+LL |     0 + if a { 1 } else { 2 } + if b { 3 } else { 5 }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if a { 1 } else { 2 })`
+
+error: aborting due to 39 previous errors
 

--- a/tests/ui/modulo_one.rs
+++ b/tests/ui/modulo_one.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::modulo_one)]
-#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::identity_op)]
 
 static STATIC_ONE: usize = 2 - 1;
 static STATIC_NEG_ONE: i64 = 1 - 2;

--- a/tests/ui/modulo_one.stderr
+++ b/tests/ui/modulo_one.stderr
@@ -38,14 +38,6 @@ error: any number modulo -1 will panic/overflow or result in 0
 LL |     i32::MIN % (-1); // also caught by rustc
    |     ^^^^^^^^^^^^^^^
 
-error: the operation is ineffective. Consider reducing it to `1`
-  --> $DIR/modulo_one.rs:13:22
-   |
-LL |     const ONE: u32 = 1 * 1;
-   |                      ^^^^^
-   |
-   = note: `-D clippy::identity-op` implied by `-D warnings`
-
 error: any number modulo 1 will be 0
   --> $DIR/modulo_one.rs:17:5
    |
@@ -64,5 +56,5 @@ error: any number modulo -1 will panic/overflow or result in 0
 LL |     INT_MIN % NEG_ONE; // also caught by rustc
    |     ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
changelog: [`identity_op`]: add parenthesis to suggestions where required

Follow up to #8730, wraps the cases we can't lint as-is in parenthesis rather than ignoring them

Catches a couple new FPs with mixed operator precedences and `as` casts

```rust
// such as
0 + { a } * 2;
0 + a as usize;
```

The suggestions are now applied using `span_lint_and_sugg` rather than appearing in just the message and have a `run-rustfix` test