### PR TITLE
Added missing `### What it does`

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -413,6 +413,7 @@ declare_clippy_lint! {
 }
 
 declare_clippy_lint! {
+    /// ### What it does
     /// Checks for `as` casts between raw pointers to slices with differently sized elements.
     ///
     /// ### Why is this bad?


### PR DESCRIPTION
Adds the missing line to ``[`cast-slice-different-sizes`]`` lint documentation
fixes #8781 

changelog: none