### PR TITLE
Pass through extra args in `cargo dev lint`

### DIFF
--- a/clippy_dev/src/lint.rs
+++ b/clippy_dev/src/lint.rs
@@ -13,7 +13,7 @@ fn exit_if_err(status: io::Result<ExitStatus>) {
     }
 }
 
-pub fn run(path: &str) {
+pub fn run<'a>(path: &str, args: impl Iterator<Item = &'a str>) {
     let is_file = match fs::metadata(path) {
         Ok(metadata) => metadata.is_file(),
         Err(e) => {
@@ -30,6 +30,7 @@ pub fn run(path: &str) {
                 .args(["-Z", "no-codegen"])
                 .args(["--edition", "2021"])
                 .arg(path)
+                .args(args)
                 .status(),
         );
     } else {
@@ -42,6 +43,8 @@ pub fn run(path: &str) {
             .expect("failed to create tempdir");
 
         let status = Command::new(cargo_clippy_path())
+            .arg("clippy")
+            .args(args)
             .current_dir(path)
             .env("CARGO_TARGET_DIR", target.as_ref())
             .status();

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -76,7 +76,8 @@ fn main() {
         },
         ("lint", Some(matches)) => {
             let path = matches.value_of("path").unwrap();
-            lint::run(path);
+            let args = matches.values_of("args").into_iter().flatten();
+            lint::run(path, args);
         },
         ("rename_lint", Some(matches)) => {
             let old_name = matches.value_of("old_name").unwrap();
@@ -278,11 +279,23 @@ fn get_clap_config<'a>() -> ArgMatches<'a> {
                         Lint a package directory:
                             cargo dev lint tests/ui-cargo/wildcard_dependencies/fail
                             cargo dev lint ~/my-project
+
+                        Run rustfix:
+                            cargo dev lint ~/my-project -- --fix
+
+                        Set lint levels:
+                            cargo dev lint file.rs -- -W clippy::pedantic
+                            cargo dev lint ~/my-project -- -- -W clippy::pedantic
                 "})
                 .arg(
                     Arg::with_name("path")
                         .required(true)
                         .help("The path to a file or package directory to lint"),
+                )
+                .arg(
+                    Arg::with_name("args")
+                        .multiple(true)
+                        .help("Pass extra arguments to cargo/clippy-driver"),
                 ),
         )
         .subcommand(


### PR DESCRIPTION
changelog: Pass through extra args in `cargo dev lint`

Lets you pass some useful flags through, like `-A/W/etc`, `--fix`, `--force-warn`