### PR TITLE
Some lintcheck cleanup

### DIFF
--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -6,16 +6,15 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/rust-clippy"
 categories = ["development-tools"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]
+cargo_metadata = "0.14"
 clap = "2.33"
 flate2 = "1.0"
-fs_extra = "1.2"
 rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 tar = "0.4"
 toml = "0.5"
 ureq = "2.2"

--- a/lintcheck/lintcheck_crates.toml
+++ b/lintcheck/lintcheck_crates.toml
@@ -24,7 +24,7 @@ unicode-xid = {name = "unicode-xid", versions = ['0.2.1']}
 anyhow = {name = "anyhow", versions = ['1.0.38']}
 async-trait = {name = "async-trait", versions = ['0.1.42']}
 cxx = {name = "cxx", versions = ['1.0.32']}
-ryu = {name = "ryu", version = ['1.0.5']}
+ryu = {name = "ryu", versions = ['1.0.5']}
 serde_yaml = {name = "serde_yaml", versions = ['0.8.17']}
 thiserror = {name = "thiserror", versions = ['1.0.24']}
 # some embark crates, there are other interesting crates but

--- a/lintcheck/src/config.rs
+++ b/lintcheck/src/config.rs
@@ -1,0 +1,140 @@
+use clap::{App, Arg, ArgMatches};
+use std::env;
+use std::path::PathBuf;
+
+fn get_clap_config<'a>() -> ArgMatches<'a> {
+    App::new("lintcheck")
+        .about("run clippy on a set of crates and check output")
+        .arg(
+            Arg::with_name("only")
+                .takes_value(true)
+                .value_name("CRATE")
+                .long("only")
+                .help("Only process a single crate of the list"),
+        )
+        .arg(
+            Arg::with_name("crates-toml")
+                .takes_value(true)
+                .value_name("CRATES-SOURCES-TOML-PATH")
+                .long("crates-toml")
+                .help("Set the path for a crates.toml where lintcheck should read the sources from"),
+        )
+        .arg(
+            Arg::with_name("threads")
+                .takes_value(true)
+                .value_name("N")
+                .short("j")
+                .long("jobs")
+                .help("Number of threads to use, 0 automatic choice"),
+        )
+        .arg(
+            Arg::with_name("fix")
+                .long("--fix")
+                .help("Runs cargo clippy --fix and checks if all suggestions apply"),
+        )
+        .arg(
+            Arg::with_name("filter")
+                .long("--filter")
+                .takes_value(true)
+                .multiple(true)
+                .value_name("clippy_lint_name")
+                .help("Apply a filter to only collect specified lints, this also overrides `allow` attributes"),
+        )
+        .arg(
+            Arg::with_name("markdown")
+                .long("--markdown")
+                .help("Change the reports table to use markdown links"),
+        )
+        .get_matches()
+}
+
+#[derive(Debug)]
+pub(crate) struct LintcheckConfig {
+    /// max number of jobs to spawn (default 1)
+    pub max_jobs: usize,
+    /// we read the sources to check from here
+    pub sources_toml_path: PathBuf,
+    /// we save the clippy lint results here
+    pub lintcheck_results_path: PathBuf,
+    /// Check only a specified package
+    pub only: Option<String>,
+    /// whether to just run --fix and not collect all the warnings
+    pub fix: bool,
+    /// A list of lints that this lintcheck run should focus on
+    pub lint_filter: Vec<String>,
+    /// Indicate if the output should support markdown syntax
+    pub markdown: bool,
+}
+
+impl LintcheckConfig {
+    pub fn new() -> Self {
+        let clap_config = get_clap_config();
+
+        // first, check if we got anything passed via the LINTCHECK_TOML env var,
+        // if not, ask clap if we got any value for --crates-toml  <foo>
+        // if not, use the default "lintcheck/lintcheck_crates.toml"
+        let sources_toml = env::var("LINTCHECK_TOML").unwrap_or_else(|_| {
+            clap_config
+                .value_of("crates-toml")
+                .clone()
+                .unwrap_or("lintcheck/lintcheck_crates.toml")
+                .to_string()
+        });
+
+        let markdown = clap_config.is_present("markdown");
+        let sources_toml_path = PathBuf::from(sources_toml);
+
+        // for the path where we save the lint results, get the filename without extension (so for
+        // wasd.toml, use "wasd"...)
+        let filename: PathBuf = sources_toml_path.file_stem().unwrap().into();
+        let lintcheck_results_path = PathBuf::from(format!(
+            "lintcheck-logs/{}_logs.{}",
+            filename.display(),
+            if markdown { "md" } else { "txt" }
+        ));
+
+        // look at the --threads arg, if 0 is passed, ask rayon rayon how many threads it would spawn and
+        // use half of that for the physical core count
+        // by default use a single thread
+        let max_jobs = match clap_config.value_of("threads") {
+            Some(threads) => {
+                let threads: usize = threads
+                    .parse()
+                    .unwrap_or_else(|_| panic!("Failed to parse '{}' to a digit", threads));
+                if threads == 0 {
+                    // automatic choice
+                    // Rayon seems to return thread count so half that for core count
+                    (rayon::current_num_threads() / 2) as usize
+                } else {
+                    threads
+                }
+            },
+            // no -j passed, use a single thread
+            None => 1,
+        };
+
+        let lint_filter: Vec<String> = clap_config
+            .values_of("filter")
+            .map(|iter| {
+                iter.map(|lint_name| {
+                    let mut filter = lint_name.replace('_', "-");
+                    if !filter.starts_with("clippy::") {
+                        filter.insert_str(0, "clippy::");
+                    }
+                    filter
+                })
+                .collect()
+            })
+            .unwrap_or_default();
+
+        LintcheckConfig {
+            max_jobs,
+            sources_toml_path,
+            lintcheck_results_path,
+            only: clap_config.value_of("only").map(String::from),
+            fix: clap_config.is_present("fix"),
+            lint_filter,
+            markdown,
+        }
+    }
+}


### PR DESCRIPTION
A grab bag of smaller changes:

Panics if a crate source isn't valid, and fixes the `ryu` crate entry so it's picked up. Took me a while to realise why I couldn't do `cargo lintcheck --only ryu` 😅

Parses messages with `cargo_metadata`, this catches a few more lints that were ignored because the message had an [expansion field](https://docs.rs/cargo_metadata/latest/cargo_metadata/diagnostic/struct.DiagnosticSpanMacroExpansion.html) that contained a path pointing into `.../.toolchains/...`. It also no longer emits some log lines with `null` as the column

It also merges the `run_clippy_lint` invocations and splits `LintcheckConfig` out into its own file

changelog: none
