### PR TITLE
Fix redundant_allocation warning for Rc<Box<str>>

### DIFF
--- a/tests/ui/redundant_allocation.rs
+++ b/tests/ui/redundant_allocation.rs
@@ -97,4 +97,22 @@ mod box_dyn {
     pub fn test_rc_box(_: Rc<Box<Box<dyn T>>>) {}
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/8604
+mod box_str {
+    use std::boxed::Box;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    struct S {
+        a: Box<Box<str>>,
+        b: Rc<Box<str>>,
+        c: Arc<Box<str>>,
+    }
+
+    pub fn test_box(_: Box<Box<str>>) {}
+    pub fn test_rc(_: Rc<Box<str>>) {}
+    pub fn test_arc(_: Arc<Box<str>>) {}
+    pub fn test_rc_box(_: Rc<Box<Box<str>>>) {}
+}
+
 fn main() {}

--- a/tests/ui/redundant_allocation.stderr
+++ b/tests/ui/redundant_allocation.stderr
@@ -143,5 +143,14 @@ LL |     pub fn test_rc_box(_: Rc<Box<Box<dyn T>>>) {}
    = note: `Box<Box<dyn T>>` is already on the heap, `Rc<Box<Box<dyn T>>>` makes an extra allocation
    = help: consider using just `Rc<Box<dyn T>>` or `Box<Box<dyn T>>`
 
-error: aborting due to 16 previous errors
+error: usage of `Rc<Box<Box<str>>>`
+  --> $DIR/redundant_allocation.rs:115:27
+   |
+LL |     pub fn test_rc_box(_: Rc<Box<Box<str>>>) {}
+   |                           ^^^^^^^^^^^^^^^^^
+   |
+   = note: `Box<Box<str>>` is already on the heap, `Rc<Box<Box<str>>>` makes an extra allocation
+   = help: consider using just `Rc<Box<str>>` or `Box<Box<str>>`
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
changelog: [`redundant_allocation`] Fixes #8604 

Fixes false positives where a fat pointer with `str` type was made thin by another allocation, but that thinning allocation was marked as redundant