### PR TITLE
add suggestions to rc_clone_in_vec_init

### DIFF
--- a/clippy_lints/src/rc_clone_in_vec_init.rs
+++ b/clippy_lints/src/rc_clone_in_vec_init.rs
@@ -106,9 +106,9 @@ fn elem_snippet(cx: &LateContext<'_>, elem: &Expr<'_>, symbol_name: &str) -> Str
 fn loop_init_suggestion(elem: &str, len: &str, indent: &str) -> String {
     format!(
         r#"{{
-{indent}{indent}let mut v = Vec::with_capacity({len});
-{indent}{indent}(0..{len}).for_each(|_| v.push({elem}));
-{indent}{indent}v
+{indent}    let mut v = Vec::with_capacity({len});
+{indent}    (0..{len}).for_each(|_| v.push({elem}));
+{indent}    v
 {indent}}}"#
     )
 }
@@ -116,8 +116,8 @@ fn loop_init_suggestion(elem: &str, len: &str, indent: &str) -> String {
 fn extract_suggestion(elem: &str, len: &str, indent: &str) -> String {
     format!(
         "{{
-{indent}{indent}let data = {elem};
-{indent}{indent}vec![data; {len}]
+{indent}    let data = {elem};
+{indent}    vec![data; {len}]
 {indent}}}"
     )
 }

--- a/clippy_lints/src/rc_clone_in_vec_init.rs
+++ b/clippy_lints/src/rc_clone_in_vec_init.rs
@@ -92,6 +92,8 @@ fn construct_lint_suggestions(
 fn elem_snippet(cx: &LateContext<'_>, elem: &Expr<'_>, symbol_name: &str) -> String {
     let elem_snippet = snippet(cx, elem.span, "..").to_string();
     if elem_snippet.contains('\n') {
+        // This string must be found in `elem_snippet`, otherwise we won't be constructing
+        // the snippet in the first place.
         let reference_creation = format!("{symbol_name}::new");
         let (code_until_reference_creation, _right) = elem_snippet.split_once(&reference_creation).unwrap();
 
@@ -132,14 +134,14 @@ fn emit_lint(cx: &LateContext<'_>, symbol: Symbol, lint_span: Span, elem: &Expr<
             let suggestions = construct_lint_suggestions(cx, lint_span, symbol_name, elem, len);
 
             diag.note(format!("each element will point to the same `{symbol_name}` instance"));
-            suggestions.iter().for_each(|suggestion| {
+            for suggestion in suggestions {
                 diag.span_suggestion(
                     lint_span,
                     &suggestion.message,
                     &suggestion.snippet,
                     Applicability::Unspecified,
                 );
-            });
+            }
         },
     );
 }

--- a/tests/ui/rc_clone_in_vec_init/arc.rs
+++ b/tests/ui/rc_clone_in_vec_init/arc.rs
@@ -7,6 +7,16 @@ fn should_warn_simple_case() {
     let v = vec![Arc::new("x".to_string()); 2];
 }
 
+fn should_warn_simple_case_with_big_indentation() {
+    if true {
+        let k = 1;
+        dbg!(k);
+        if true {
+            let v = vec![Arc::new("x".to_string()); 2];
+        }
+    }
+}
+
 fn should_warn_complex_case() {
     let v = vec![
         std::sync::Arc::new(Mutex::new({

--- a/tests/ui/rc_clone_in_vec_init/arc.rs
+++ b/tests/ui/rc_clone_in_vec_init/arc.rs
@@ -16,6 +16,15 @@ fn should_warn_complex_case() {
         }));
         2
     ];
+
+    let v1 = vec![
+        Arc::new(Mutex::new({
+            let x = 1;
+            dbg!(x);
+            x
+        }));
+        2
+    ];
 }
 
 fn should_not_warn_custom_arc() {

--- a/tests/ui/rc_clone_in_vec_init/arc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/arc.stderr
@@ -6,8 +6,21 @@ LL |     let v = vec![Arc::new("x".to_string()); 2];
    |
    = note: `-D clippy::rc-clone-in-vec-init` implied by `-D warnings`
    = note: each element will point to the same `Arc` instance
-   = help: if this is intentional, consider extracting the `Arc` initialization to a variable
-   = help: or if not, initialize each element individually
+help: consider initializing each `Arc` element individually
+   |
+LL ~     let v = {
+LL +         let mut v = Vec::with_capacity(2);
+LL +         (0..2).for_each(|_| v.push(Arc::new("x".to_string())));
+LL +         v
+LL ~     };
+   |
+help: or if this is intentional, consider extracting the `Arc` initialization to a variable
+   |
+LL ~     let v = {
+LL +         let data = Arc::new("x".to_string());
+LL +         vec![data; 2]
+LL ~     };
+   |
 
 error: calling `Arc::new` in `vec![elem; len]`
   --> $DIR/arc.rs:11:13
@@ -23,8 +36,21 @@ LL | |     ];
    | |_____^
    |
    = note: each element will point to the same `Arc` instance
-   = help: if this is intentional, consider extracting the `Arc` initialization to a variable
-   = help: or if not, initialize each element individually
+help: consider initializing each `Arc` element individually
+   |
+LL ~     let v = {
+LL +         let mut v = Vec::with_capacity(2);
+LL +         (0..2).for_each(|_| v.push(std::sync::Arc::new..));
+LL +         v
+LL ~     };
+   |
+help: or if this is intentional, consider extracting the `Arc` initialization to a variable
+   |
+LL ~     let v = {
+LL +         let data = std::sync::Arc::new..;
+LL +         vec![data; 2]
+LL ~     };
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rc_clone_in_vec_init/arc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/arc.stderr
@@ -23,7 +23,30 @@ LL ~     };
    |
 
 error: calling `Arc::new` in `vec![elem; len]`
-  --> $DIR/arc.rs:11:13
+  --> $DIR/arc.rs:15:21
+   |
+LL |             let v = vec![Arc::new("x".to_string()); 2];
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: each element will point to the same `Arc` instance
+help: consider initializing each `Arc` element individually
+   |
+LL ~             let v = {
+LL +                 let mut v = Vec::with_capacity(2);
+LL +                 (0..2).for_each(|_| v.push(Arc::new("x".to_string())));
+LL +                 v
+LL ~             };
+   |
+help: or if this is intentional, consider extracting the `Arc` initialization to a variable
+   |
+LL ~             let v = {
+LL +                 let data = Arc::new("x".to_string());
+LL +                 vec![data; 2]
+LL ~             };
+   |
+
+error: calling `Arc::new` in `vec![elem; len]`
+  --> $DIR/arc.rs:21:13
    |
 LL |       let v = vec![
    |  _____________^
@@ -53,7 +76,7 @@ LL ~     };
    |
 
 error: calling `Arc::new` in `vec![elem; len]`
-  --> $DIR/arc.rs:20:14
+  --> $DIR/arc.rs:30:14
    |
 LL |       let v1 = vec![
    |  ______________^
@@ -82,5 +105,5 @@ LL +         vec![data; 2]
 LL ~     };
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/rc_clone_in_vec_init/arc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/arc.stderr
@@ -40,17 +40,47 @@ help: consider initializing each `Arc` element individually
    |
 LL ~     let v = {
 LL +         let mut v = Vec::with_capacity(2);
-LL +         (0..2).for_each(|_| v.push(std::sync::Arc::new..));
+LL +         (0..2).for_each(|_| v.push(std::sync::Arc::new(..)));
 LL +         v
 LL ~     };
    |
 help: or if this is intentional, consider extracting the `Arc` initialization to a variable
    |
 LL ~     let v = {
-LL +         let data = std::sync::Arc::new..;
+LL +         let data = std::sync::Arc::new(..);
 LL +         vec![data; 2]
 LL ~     };
    |
 
-error: aborting due to 2 previous errors
+error: calling `Arc::new` in `vec![elem; len]`
+  --> $DIR/arc.rs:20:14
+   |
+LL |       let v1 = vec![
+   |  ______________^
+LL | |         Arc::new(Mutex::new({
+LL | |             let x = 1;
+LL | |             dbg!(x);
+...  |
+LL | |         2
+LL | |     ];
+   | |_____^
+   |
+   = note: each element will point to the same `Arc` instance
+help: consider initializing each `Arc` element individually
+   |
+LL ~     let v1 = {
+LL +         let mut v = Vec::with_capacity(2);
+LL +         (0..2).for_each(|_| v.push(Arc::new(..)));
+LL +         v
+LL ~     };
+   |
+help: or if this is intentional, consider extracting the `Arc` initialization to a variable
+   |
+LL ~     let v1 = {
+LL +         let data = Arc::new(..);
+LL +         vec![data; 2]
+LL ~     };
+   |
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rc_clone_in_vec_init/rc.rs
+++ b/tests/ui/rc_clone_in_vec_init/rc.rs
@@ -17,6 +17,15 @@ fn should_warn_complex_case() {
         }));
         2
     ];
+
+    let v1 = vec![
+        Rc::new(Mutex::new({
+            let x = 1;
+            dbg!(x);
+            x
+        }));
+        2
+    ];
 }
 
 fn should_not_warn_custom_arc() {

--- a/tests/ui/rc_clone_in_vec_init/rc.rs
+++ b/tests/ui/rc_clone_in_vec_init/rc.rs
@@ -8,6 +8,16 @@ fn should_warn_simple_case() {
     let v = vec![Rc::new("x".to_string()); 2];
 }
 
+fn should_warn_simple_case_with_big_indentation() {
+    if true {
+        let k = 1;
+        dbg!(k);
+        if true {
+            let v = vec![Rc::new("x".to_string()); 2];
+        }
+    }
+}
+
 fn should_warn_complex_case() {
     let v = vec![
         std::rc::Rc::new(Mutex::new({

--- a/tests/ui/rc_clone_in_vec_init/rc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/rc.stderr
@@ -40,17 +40,47 @@ help: consider initializing each `Rc` element individually
    |
 LL ~     let v = {
 LL +         let mut v = Vec::with_capacity(2);
-LL +         (0..2).for_each(|_| v.push(std::rc::Rc::new..));
+LL +         (0..2).for_each(|_| v.push(std::rc::Rc::new(..)));
 LL +         v
 LL ~     };
    |
 help: or if this is intentional, consider extracting the `Rc` initialization to a variable
    |
 LL ~     let v = {
-LL +         let data = std::rc::Rc::new..;
+LL +         let data = std::rc::Rc::new(..);
 LL +         vec![data; 2]
 LL ~     };
    |
 
-error: aborting due to 2 previous errors
+error: calling `Rc::new` in `vec![elem; len]`
+  --> $DIR/rc.rs:21:14
+   |
+LL |       let v1 = vec![
+   |  ______________^
+LL | |         Rc::new(Mutex::new({
+LL | |             let x = 1;
+LL | |             dbg!(x);
+...  |
+LL | |         2
+LL | |     ];
+   | |_____^
+   |
+   = note: each element will point to the same `Rc` instance
+help: consider initializing each `Rc` element individually
+   |
+LL ~     let v1 = {
+LL +         let mut v = Vec::with_capacity(2);
+LL +         (0..2).for_each(|_| v.push(Rc::new(..)));
+LL +         v
+LL ~     };
+   |
+help: or if this is intentional, consider extracting the `Rc` initialization to a variable
+   |
+LL ~     let v1 = {
+LL +         let data = Rc::new(..);
+LL +         vec![data; 2]
+LL ~     };
+   |
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rc_clone_in_vec_init/rc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/rc.stderr
@@ -23,7 +23,30 @@ LL ~     };
    |
 
 error: calling `Rc::new` in `vec![elem; len]`
-  --> $DIR/rc.rs:12:13
+  --> $DIR/rc.rs:16:21
+   |
+LL |             let v = vec![Rc::new("x".to_string()); 2];
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: each element will point to the same `Rc` instance
+help: consider initializing each `Rc` element individually
+   |
+LL ~             let v = {
+LL +                 let mut v = Vec::with_capacity(2);
+LL +                 (0..2).for_each(|_| v.push(Rc::new("x".to_string())));
+LL +                 v
+LL ~             };
+   |
+help: or if this is intentional, consider extracting the `Rc` initialization to a variable
+   |
+LL ~             let v = {
+LL +                 let data = Rc::new("x".to_string());
+LL +                 vec![data; 2]
+LL ~             };
+   |
+
+error: calling `Rc::new` in `vec![elem; len]`
+  --> $DIR/rc.rs:22:13
    |
 LL |       let v = vec![
    |  _____________^
@@ -53,7 +76,7 @@ LL ~     };
    |
 
 error: calling `Rc::new` in `vec![elem; len]`
-  --> $DIR/rc.rs:21:14
+  --> $DIR/rc.rs:31:14
    |
 LL |       let v1 = vec![
    |  ______________^
@@ -82,5 +105,5 @@ LL +         vec![data; 2]
 LL ~     };
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/rc_clone_in_vec_init/rc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/rc.stderr
@@ -6,8 +6,21 @@ LL |     let v = vec![Rc::new("x".to_string()); 2];
    |
    = note: `-D clippy::rc-clone-in-vec-init` implied by `-D warnings`
    = note: each element will point to the same `Rc` instance
-   = help: if this is intentional, consider extracting the `Rc` initialization to a variable
-   = help: or if not, initialize each element individually
+help: consider initializing each `Rc` element individually
+   |
+LL ~     let v = {
+LL +         let mut v = Vec::with_capacity(2);
+LL +         (0..2).for_each(|_| v.push(Rc::new("x".to_string())));
+LL +         v
+LL ~     };
+   |
+help: or if this is intentional, consider extracting the `Rc` initialization to a variable
+   |
+LL ~     let v = {
+LL +         let data = Rc::new("x".to_string());
+LL +         vec![data; 2]
+LL ~     };
+   |
 
 error: calling `Rc::new` in `vec![elem; len]`
   --> $DIR/rc.rs:12:13
@@ -23,8 +36,21 @@ LL | |     ];
    | |_____^
    |
    = note: each element will point to the same `Rc` instance
-   = help: if this is intentional, consider extracting the `Rc` initialization to a variable
-   = help: or if not, initialize each element individually
+help: consider initializing each `Rc` element individually
+   |
+LL ~     let v = {
+LL +         let mut v = Vec::with_capacity(2);
+LL +         (0..2).for_each(|_| v.push(std::rc::Rc::new..));
+LL +         v
+LL ~     };
+   |
+help: or if this is intentional, consider extracting the `Rc` initialization to a variable
+   |
+LL ~     let v = {
+LL +         let data = std::rc::Rc::new..;
+LL +         vec![data; 2]
+LL ~     };
+   |
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
A followup to https://github.com/rust-lang/rust-clippy/pull/8769
I also switch the order of the 2 suggestions, since the loop initialization one is probably the common case.

@xFrednet I'm not letting you guys rest for a minute 😅 
changelog: add suggestions to [`rc_clone_in_vec_init`]