### PR TITLE
Fix ICE in `let_unit_value` when calling a static or const callable type

### DIFF
--- a/tests/ui/crashes/ice-8821.rs
+++ b/tests/ui/crashes/ice-8821.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::let_unit_value)]
+
+fn f() {}
+static FN: fn() = f;
+
+fn main() {
+    let _: () = FN();
+}

--- a/tests/ui/crashes/ice-8821.stderr
+++ b/tests/ui/crashes/ice-8821.stderr
@@ -1,0 +1,10 @@
+error: this let-binding has unit value
+  --> $DIR/ice-8821.rs:7:5
+   |
+LL |     let _: () = FN();
+   |     ^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `FN();`
+   |
+   = note: `-D clippy::let-unit-value` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
fixes #8821

changelog: Fix ICE in `let_unit_value` when calling a static or const callable type
