### PR TITLE
Mini changelog update for Rust 1.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ document.
 
 [d0cf3481...master](https://github.com/rust-lang/rust-clippy/compare/d0cf3481...master)
 
-## Rust 1.61 (beta)
+## Rust 1.61
 
-Current beta, released 2022-05-19
+Current stable, released 2022-05-19
 
 [57b3c4b...d0cf3481](https://github.com/rust-lang/rust-clippy/compare/57b3c4b...d0cf3481)
 
@@ -111,7 +111,7 @@ Current beta, released 2022-05-19
 
 ## Rust 1.60
 
-Current stable, released 2022-04-07
+Released 2022-04-07
 
 [0eff589...57b3c4b](https://github.com/rust-lang/rust-clippy/compare/0eff589...57b3c4b)
 


### PR DESCRIPTION
I'll do the full release and sync tomorrow, as I sadly don't have the time today. This is a quick update to ensure that Rust's changelog will link to the correct section in our changelog.  The change is according to [our docs](https://github.com/rust-lang/rust-clippy/blob/8751e47bae68f6bf7ec833dbd42bde51a74f1a65/book/src/development/infrastructure/release.md#update-changelogmd)



changelog: none
