### PR TITLE
Remove code block from `pub_enum_variant_names`

### DIFF
--- a/clippy_lints/src/deprecated_lints.rs
+++ b/clippy_lints/src/deprecated_lints.rs
@@ -194,7 +194,6 @@ declare_deprecated_lint! {
     /// ### Deprecation reason
     /// The `avoid_breaking_exported_api` config option was added, which
     /// enables the `enum_variant_names` lint for public items.
-    /// ```
     #[clippy::version = "1.54.0"]
     pub PUB_ENUM_VARIANT_NAMES,
     "set the `avoid-breaking-exported-api` config option to `false` to enable the `enum_variant_names` lint for public items"


### PR DESCRIPTION
changelog: none

Just noticed this empty code block that no other lint has :smile:.
![old](https://user-images.githubusercontent.com/69764315/169314573-098ce938-8a4c-4451-afd7-7b082823a0de.png)

r? @xFrednet 