### PR TITLE
Lint indirect usages in `disallowed_methods`

### DIFF
--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -14,4 +14,10 @@ fn main() {
 
     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
     let _ = 2.0f64.clamp(3.0f64, 4.0f64);
+
+    let indirect: fn(&str) -> Result<Regex, regex::Error> = Regex::new;
+    let re = indirect(".").unwrap();
+
+    let in_call = Box::new(f32::clamp);
+    let in_method_call = ["^", "$"].into_iter().map(Regex::new);
 }

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -32,5 +32,23 @@ error: use of a disallowed method `f32::clamp`
 LL |     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: use of a disallowed method `regex::Regex::new`
+  --> $DIR/conf_disallowed_methods.rs:18:61
+   |
+LL |     let indirect: fn(&str) -> Result<Regex, regex::Error> = Regex::new;
+   |                                                             ^^^^^^^^^^
+
+error: use of a disallowed method `f32::clamp`
+  --> $DIR/conf_disallowed_methods.rs:21:28
+   |
+LL |     let in_call = Box::new(f32::clamp);
+   |                            ^^^^^^^^^^
+
+error: use of a disallowed method `regex::Regex::new`
+  --> $DIR/conf_disallowed_methods.rs:22:53
+   |
+LL |     let in_method_call = ["^", "$"].into_iter().map(Regex::new);
+   |                                                     ^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Fixes #8849

changelog: Lint indirect usages in [`disallowed_methods`]
