### PR TITLE
Ignore bodies containing `todo!()` in `clippy::if_same_then_else`

### DIFF
--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -126,6 +126,9 @@ fn if_same_then_else() {
             _ => 4,
         };
     }
+
+    // Issue #8836
+    if true { todo!() } else { todo!() }
 }
 
 // Issue #2423. This was causing an ICE.


### PR DESCRIPTION
changelog: [`clippy::if_same_then_else`] Ignore bodies containing `todo!()`

Fixes #8836
