### PR TITLE
Strip `clippy::` prefix from search strings

### DIFF
--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -232,6 +232,9 @@
                     return true;
                 }
                 searchStr = searchStr.toLowerCase();
+                if (searchStr.startsWith("clippy::")) {
+                    searchStr = searchStr.slice(8);
+                }
 
                 // Search by id
                 if (lint.id.indexOf(searchStr.replace("-", "_")) !== -1) {


### PR DESCRIPTION
changelog: none
closes: #8865

r? @xFrednet 
