### PR TITLE
`cast_abs_to_unsigned`: do not remove cast if it's required

### DIFF
--- a/tests/ui/cast_abs_to_unsigned.fixed
+++ b/tests/ui/cast_abs_to_unsigned.fixed
@@ -5,4 +5,25 @@ fn main() {
     let x: i32 = -42;
     let y: u32 = x.unsigned_abs();
     println!("The absolute value of {} is {}", x, y);
+
+    let a: i32 = -3;
+    let _: usize = a.unsigned_abs() as usize;
+    let _: usize = a.unsigned_abs() as _;
+    let _ = a.unsigned_abs() as usize;
+
+    let a: i64 = -3;
+    let _ = a.unsigned_abs() as usize;
+    let _ = a.unsigned_abs() as u8;
+    let _ = a.unsigned_abs() as u16;
+    let _ = a.unsigned_abs() as u32;
+    let _ = a.unsigned_abs();
+    let _ = a.unsigned_abs() as u128;
+
+    let a: isize = -3;
+    let _ = a.unsigned_abs();
+    let _ = a.unsigned_abs() as u8;
+    let _ = a.unsigned_abs() as u16;
+    let _ = a.unsigned_abs() as u32;
+    let _ = a.unsigned_abs() as u64;
+    let _ = a.unsigned_abs() as u128;
 }

--- a/tests/ui/cast_abs_to_unsigned.rs
+++ b/tests/ui/cast_abs_to_unsigned.rs
@@ -5,4 +5,25 @@ fn main() {
     let x: i32 = -42;
     let y: u32 = x.abs() as u32;
     println!("The absolute value of {} is {}", x, y);
+
+    let a: i32 = -3;
+    let _: usize = a.abs() as usize;
+    let _: usize = a.abs() as _;
+    let _ = a.abs() as usize;
+
+    let a: i64 = -3;
+    let _ = a.abs() as usize;
+    let _ = a.abs() as u8;
+    let _ = a.abs() as u16;
+    let _ = a.abs() as u32;
+    let _ = a.abs() as u64;
+    let _ = a.abs() as u128;
+
+    let a: isize = -3;
+    let _ = a.abs() as usize;
+    let _ = a.abs() as u8;
+    let _ = a.abs() as u16;
+    let _ = a.abs() as u32;
+    let _ = a.abs() as u64;
+    let _ = a.abs() as u128;
 }

--- a/tests/ui/cast_abs_to_unsigned.stderr
+++ b/tests/ui/cast_abs_to_unsigned.stderr
@@ -6,5 +6,95 @@ LL |     let y: u32 = x.abs() as u32;
    |
    = note: `-D clippy::cast-abs-to-unsigned` implied by `-D warnings`
 
-error: aborting due to previous error
+error: casting the result of `i32::abs()` to usize
+  --> $DIR/cast_abs_to_unsigned.rs:10:20
+   |
+LL |     let _: usize = a.abs() as usize;
+   |                    ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i32::abs()` to usize
+  --> $DIR/cast_abs_to_unsigned.rs:11:20
+   |
+LL |     let _: usize = a.abs() as _;
+   |                    ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i32::abs()` to usize
+  --> $DIR/cast_abs_to_unsigned.rs:12:13
+   |
+LL |     let _ = a.abs() as usize;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i64::abs()` to usize
+  --> $DIR/cast_abs_to_unsigned.rs:15:13
+   |
+LL |     let _ = a.abs() as usize;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i64::abs()` to u8
+  --> $DIR/cast_abs_to_unsigned.rs:16:13
+   |
+LL |     let _ = a.abs() as u8;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i64::abs()` to u16
+  --> $DIR/cast_abs_to_unsigned.rs:17:13
+   |
+LL |     let _ = a.abs() as u16;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i64::abs()` to u32
+  --> $DIR/cast_abs_to_unsigned.rs:18:13
+   |
+LL |     let _ = a.abs() as u32;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i64::abs()` to u64
+  --> $DIR/cast_abs_to_unsigned.rs:19:13
+   |
+LL |     let _ = a.abs() as u64;
+   |             ^^^^^^^^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `i64::abs()` to u128
+  --> $DIR/cast_abs_to_unsigned.rs:20:13
+   |
+LL |     let _ = a.abs() as u128;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `isize::abs()` to usize
+  --> $DIR/cast_abs_to_unsigned.rs:23:13
+   |
+LL |     let _ = a.abs() as usize;
+   |             ^^^^^^^^^^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `isize::abs()` to u8
+  --> $DIR/cast_abs_to_unsigned.rs:24:13
+   |
+LL |     let _ = a.abs() as u8;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `isize::abs()` to u16
+  --> $DIR/cast_abs_to_unsigned.rs:25:13
+   |
+LL |     let _ = a.abs() as u16;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `isize::abs()` to u32
+  --> $DIR/cast_abs_to_unsigned.rs:26:13
+   |
+LL |     let _ = a.abs() as u32;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `isize::abs()` to u64
+  --> $DIR/cast_abs_to_unsigned.rs:27:13
+   |
+LL |     let _ = a.abs() as u64;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: casting the result of `isize::abs()` to u128
+  --> $DIR/cast_abs_to_unsigned.rs:28:13
+   |
+LL |     let _ = a.abs() as u128;
+   |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Fixes #8873

If `iX` is not cast to `uX` then keep the cast rather than removing it

changelog: [`cast_abs_to_unsigned`]: do not remove cast if it's required
