### PR TITLE
Add some testcases for recent rustfix update

### DIFF
--- a/tests/ui/map_flatten_fixable.fixed
+++ b/tests/ui/map_flatten_fixable.fixed
@@ -28,4 +28,22 @@ fn main() {
 
     // mapping to Result on Result
     let _: Result<_, &str> = (Ok(Ok(1))).and_then(|x| x);
+
+    issue8878();
+}
+
+#[allow(clippy::bind_instead_of_map)] // map + flatten will be suggested to `and_then`, but afterwards `map` is suggested again
+#[rustfmt::skip] // whitespace is important for this one
+fn issue8878() {
+    std::collections::HashMap::<u32, u32>::new()
+        .get(&0)
+        .and_then(|_| {
+// we need some newlines
+// so that the span is big enough
+// we need some newlines
+// so that the span is big enough
+// for a splitted output of the diagnostic
+            Some("")
+ // whitespace beforehand is important as well
+        });
 }

--- a/tests/ui/map_flatten_fixable.fixed
+++ b/tests/ui/map_flatten_fixable.fixed
@@ -29,7 +29,26 @@ fn main() {
     // mapping to Result on Result
     let _: Result<_, &str> = (Ok(Ok(1))).and_then(|x| x);
 
+    issue8734();
     issue8878();
+}
+
+fn issue8734() {
+    //     let _ = [0u8, 1, 2, 3]
+    //         .into_iter()
+    //         .map(|n| match n {
+    //             1 => [n
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)],
+    //             n => [n],
+    //         })
+    //         .flatten();
 }
 
 #[allow(clippy::bind_instead_of_map)] // map + flatten will be suggested to `and_then`, but afterwards `map` is suggested again

--- a/tests/ui/map_flatten_fixable.rs
+++ b/tests/ui/map_flatten_fixable.rs
@@ -29,7 +29,26 @@ fn main() {
     // mapping to Result on Result
     let _: Result<_, &str> = (Ok(Ok(1))).map(|x| x).flatten();
 
+    issue8734();
     issue8878();
+}
+
+fn issue8734() {
+    //     let _ = [0u8, 1, 2, 3]
+    //         .into_iter()
+    //         .map(|n| match n {
+    //             1 => [n
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)
+    //                 .saturating_add(1)],
+    //             n => [n],
+    //         })
+    //         .flatten();
 }
 
 #[allow(clippy::bind_instead_of_map)] // map + flatten will be suggested to `and_then`, but afterwards `map` is suggested again

--- a/tests/ui/map_flatten_fixable.rs
+++ b/tests/ui/map_flatten_fixable.rs
@@ -28,4 +28,21 @@ fn main() {
 
     // mapping to Result on Result
     let _: Result<_, &str> = (Ok(Ok(1))).map(|x| x).flatten();
+
+    issue8878();
+}
+
+#[allow(clippy::bind_instead_of_map)] // map + flatten will be suggested to `and_then`, but afterwards `map` is suggested again
+#[rustfmt::skip] // whitespace is important for this one
+fn issue8878() {
+    std::collections::HashMap::<u32, u32>::new()
+        .get(&0)
+        .map(|_| {
+// we need some newlines
+// so that the span is big enough
+// for a splitted output of the diagnostic
+            Some("")
+ // whitespace beforehand is important as well
+        })
+        .flatten();
 }

--- a/tests/ui/map_flatten_fixable.stderr
+++ b/tests/ui/map_flatten_fixable.stderr
@@ -76,5 +76,31 @@ help: try replacing `map` with `and_then`, and remove the `.flatten()`
 LL |     let _: Result<_, &str> = (Ok(Ok(1))).and_then(|x| x);
    |                                          ~~~~~~~~~~~~~~~
 
-error: aborting due to 7 previous errors
+error: called `map(..).flatten()` on `Option`
+  --> $DIR/map_flatten_fixable.rs:40:10
+   |
+LL |           .map(|_| {
+   |  __________^
+LL | | // we need some newlines
+LL | | // so that the span is big enough
+LL | | // for a splitted output of the diagnostic
+...  |
+LL | |         })
+LL | |         .flatten();
+   | |__________________^
+   |
+help: try replacing `map` with `and_then`
+   |
+LL ~         .and_then(|_| {
+LL + // we need some newlines
+LL + // so that the span is big enough
+   |
+help: and remove the `.flatten()`
+   |
+LL +             Some("")
+LL +  // whitespace beforehand is important as well
+LL ~         });
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/map_flatten_fixable.stderr
+++ b/tests/ui/map_flatten_fixable.stderr
@@ -77,7 +77,7 @@ LL |     let _: Result<_, &str> = (Ok(Ok(1))).and_then(|x| x);
    |                                          ~~~~~~~~~~~~~~~
 
 error: called `map(..).flatten()` on `Option`
-  --> $DIR/map_flatten_fixable.rs:40:10
+  --> $DIR/map_flatten_fixable.rs:59:10
    |
 LL |           .map(|_| {
    |  __________^


### PR DESCRIPTION
changelog: none

This adds a testcase for a bugfix that has been fixed by https://github.com/rust-lang/rustfix/tree/v0.6.1

`rustfix` is pulled in by `compiletest_rs`. So to test that the correct rustfix version is used, I added one (and a half) testcase.

I tried to add a testcase for #8734 as well, but interesting enough the rustfix is wrong:

```diff
 fn issue8734() {
     let _ = [0u8, 1, 2, 3]
         .into_iter()
-        .and_then(|n| match n {
+        .flat_map(|n| match n {
+            1 => [n
+                .saturating_add(1)
             1 => [n
                 .saturating_add(1)
                 .saturating_add(1)
                 .saturating_add(1)
                 .saturating_add(1)
                 .saturating_add(1)
                 .saturating_add(1)
                 .saturating_add(1)
                 .saturating_add(1)],
             n => [n],
         });
 }
```

this needs some investigation and then this testcase needs to be enabled by commenting it out


closes #8878
related to #8734