### PR TITLE
Fix `[use_self]` false negative with on struct and tuple struct patterns

### DIFF
--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -542,3 +542,69 @@ mod use_self_in_pat {
         }
     }
 }
+
+mod issue8845 {
+    pub enum Something {
+        Num(u8),
+        TupleNums(u8, u8),
+        StructNums { one: u8, two: u8 },
+    }
+
+    struct Foo(u8);
+
+    struct Bar {
+        x: u8,
+        y: usize,
+    }
+
+    impl Something {
+        fn get_value(&self) -> u8 {
+            match self {
+                Self::Num(n) => *n,
+                Self::TupleNums(n, _m) => *n,
+                Self::StructNums { one, two: _ } => *one,
+            }
+        }
+
+        fn use_crate(&self) -> u8 {
+            match self {
+                Self::Num(n) => *n,
+                Self::TupleNums(n, _m) => *n,
+                Self::StructNums { one, two: _ } => *one,
+            }
+        }
+
+        fn imported_values(&self) -> u8 {
+            use Something::*;
+            match self {
+                Num(n) => *n,
+                TupleNums(n, _m) => *n,
+                StructNums { one, two: _ } => *one,
+            }
+        }
+    }
+
+    impl Foo {
+        fn get_value(&self) -> u8 {
+            let Self(x) = self;
+            *x
+        }
+
+        fn use_crate(&self) -> u8 {
+            let Self(x) = self;
+            *x
+        }
+    }
+
+    impl Bar {
+        fn get_value(&self) -> u8 {
+            let Self { x, .. } = self;
+            *x
+        }
+
+        fn use_crate(&self) -> u8 {
+            let Self { x, .. } = self;
+            *x
+        }
+    }
+}

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -542,3 +542,69 @@ mod use_self_in_pat {
         }
     }
 }
+
+mod issue8845 {
+    pub enum Something {
+        Num(u8),
+        TupleNums(u8, u8),
+        StructNums { one: u8, two: u8 },
+    }
+
+    struct Foo(u8);
+
+    struct Bar {
+        x: u8,
+        y: usize,
+    }
+
+    impl Something {
+        fn get_value(&self) -> u8 {
+            match self {
+                Something::Num(n) => *n,
+                Something::TupleNums(n, _m) => *n,
+                Something::StructNums { one, two: _ } => *one,
+            }
+        }
+
+        fn use_crate(&self) -> u8 {
+            match self {
+                crate::issue8845::Something::Num(n) => *n,
+                crate::issue8845::Something::TupleNums(n, _m) => *n,
+                crate::issue8845::Something::StructNums { one, two: _ } => *one,
+            }
+        }
+
+        fn imported_values(&self) -> u8 {
+            use Something::*;
+            match self {
+                Num(n) => *n,
+                TupleNums(n, _m) => *n,
+                StructNums { one, two: _ } => *one,
+            }
+        }
+    }
+
+    impl Foo {
+        fn get_value(&self) -> u8 {
+            let Foo(x) = self;
+            *x
+        }
+
+        fn use_crate(&self) -> u8 {
+            let crate::issue8845::Foo(x) = self;
+            *x
+        }
+    }
+
+    impl Bar {
+        fn get_value(&self) -> u8 {
+            let Bar { x, .. } = self;
+            *x
+        }
+
+        fn use_crate(&self) -> u8 {
+            let crate::issue8845::Bar { x, .. } = self;
+            *x
+        }
+    }
+}

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -186,5 +186,65 @@ error: unnecessary structure name repetition
 LL |             if let Foo::Bar = self {
    |                    ^^^ help: use the applicable keyword: `Self`
 
-error: aborting due to 31 previous errors
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:563:17
+   |
+LL |                 Something::Num(n) => *n,
+   |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:564:17
+   |
+LL |                 Something::TupleNums(n, _m) => *n,
+   |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:565:17
+   |
+LL |                 Something::StructNums { one, two: _ } => *one,
+   |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:571:17
+   |
+LL |                 crate::issue8845::Something::Num(n) => *n,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:572:17
+   |
+LL |                 crate::issue8845::Something::TupleNums(n, _m) => *n,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:573:17
+   |
+LL |                 crate::issue8845::Something::StructNums { one, two: _ } => *one,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:589:17
+   |
+LL |             let Foo(x) = self;
+   |                 ^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:594:17
+   |
+LL |             let crate::issue8845::Foo(x) = self;
+   |                 ^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:601:17
+   |
+LL |             let Bar { x, .. } = self;
+   |                 ^^^ help: use the applicable keyword: `Self`
+
+error: unnecessary structure name repetition
+  --> $DIR/use_self.rs:606:17
+   |
+LL |             let crate::issue8845::Bar { x, .. } = self;
+   |                 ^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
+
+error: aborting due to 41 previous errors
 


### PR DESCRIPTION
fixes #8845 

changelog: Triggered the warning for ``[`use_self`]`` on `TupleStruct` and `Struct` patterns, whereas currently it's only triggered for `Path` patterns
