### PR TITLE
fix(lint): check const context

### DIFF
--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -2,7 +2,7 @@
 
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_applicability;
-use clippy_utils::{meets_msrv, msrvs, SpanlessEq};
+use clippy_utils::{in_constant, meets_msrv, msrvs, SpanlessEq};
 use if_chain::if_chain;
 use rustc_ast::ast::LitKind;
 use rustc_errors::Applicability;
@@ -61,6 +61,7 @@ impl<'tcx> LateLintPass<'tcx> for CheckedConversions {
         }
 
         let result = if_chain! {
+            if !in_constant(cx, item.hir_id);
             if !in_external_macro(cx.sess(), item.span);
             if let ExprKind::Binary(op, left, right) = &item.kind;
 

--- a/tests/ui/checked_conversions.fixed
+++ b/tests/ui/checked_conversions.fixed
@@ -71,4 +71,9 @@ pub fn i8_to_u8(value: i8) {
     let _ = value >= 0;
 }
 
+// Do not lint
+pub const fn issue_8898(i: u32) -> bool {
+    i <= i32::MAX as u32
+}
+
 fn main() {}

--- a/tests/ui/checked_conversions.rs
+++ b/tests/ui/checked_conversions.rs
@@ -71,4 +71,9 @@ pub fn i8_to_u8(value: i8) {
     let _ = value >= 0;
 }
 
+// Do not lint
+pub const fn issue_8898(i: u32) -> bool {
+    i <= i32::MAX as u32
+}
+
 fn main() {}


### PR DESCRIPTION
close: https://github.com/rust-lang/rust-clippy/issues/8898

This PR fixes a bug in checked_conversions.

Thank you in advance.

changelog: check const context in checked_conversions.
