### PR TITLE
needless_late_init: fix ICE when all branches return the never type

### DIFF
--- a/clippy_lints/src/needless_late_init.rs
+++ b/clippy_lints/src/needless_late_init.rs
@@ -194,14 +194,15 @@ fn assignment_suggestions<'tcx>(
         }))
         .collect::<Option<Vec<(Span, String)>>>()?;
 
-    let applicability = if suggestions.len() > 1 {
+    match suggestions.len() {
+        // All of `exprs` are never types
+        // https://github.com/rust-lang/rust-clippy/issues/8911
+        0 => None,
+        1 => Some((Applicability::MachineApplicable, suggestions)),
         // multiple suggestions don't work with rustfix in multipart_suggest
         // https://github.com/rust-lang/rustfix/issues/141
-        Applicability::Unspecified
-    } else {
-        Applicability::MachineApplicable
-    };
-    Some((applicability, suggestions))
+        _ => Some((Applicability::Unspecified, suggestions)),
+    }
 }
 
 struct Usage<'tcx> {

--- a/tests/ui/needless_late_init.fixed
+++ b/tests/ui/needless_late_init.fixed
@@ -3,6 +3,7 @@
 #![allow(
     unused,
     clippy::assign_op_pattern,
+    clippy::blocks_in_if_conditions,
     clippy::let_and_return,
     clippy::let_unit_value,
     clippy::nonminimal_bool
@@ -16,6 +17,22 @@ impl std::ops::Drop for SignificantDrop {
     fn drop(&mut self) {
         println!("dropped");
     }
+}
+
+fn simple() {
+    
+    let a = "zero";
+
+    
+    
+    let b = 1;
+    let c = 2;
+
+    
+    let d: usize = 1;
+
+    
+    let e = format!("{}", d);
 }
 
 fn main() {
@@ -237,22 +254,20 @@ fn does_not_lint() {
     x = SignificantDrop;
 }
 
-mod fixable {
-    #![allow(dead_code)]
-
-    fn main() {
-        
-        let a = "zero";
-
-        
-        
-        let b = 1;
-        let c = 2;
-
-        
-        let d: usize = 1;
-
-        
-        let e = format!("{}", d);
+#[rustfmt::skip]
+fn issue8911() -> u32 {
+    let x;
+    match 1 {
+        _ if { x = 1; false } => return 1,
+        _ => return 2,
     }
+
+    let x;
+    if { x = 1; true } {
+        return 1;
+    } else {
+        return 2;
+    }
+
+    3
 }

--- a/tests/ui/needless_late_init.rs
+++ b/tests/ui/needless_late_init.rs
@@ -3,6 +3,7 @@
 #![allow(
     unused,
     clippy::assign_op_pattern,
+    clippy::blocks_in_if_conditions,
     clippy::let_and_return,
     clippy::let_unit_value,
     clippy::nonminimal_bool
@@ -16,6 +17,22 @@ impl std::ops::Drop for SignificantDrop {
     fn drop(&mut self) {
         println!("dropped");
     }
+}
+
+fn simple() {
+    let a;
+    a = "zero";
+
+    let b;
+    let c;
+    b = 1;
+    c = 2;
+
+    let d: usize;
+    d = 1;
+
+    let e;
+    e = format!("{}", d);
 }
 
 fn main() {
@@ -237,22 +254,20 @@ fn does_not_lint() {
     x = SignificantDrop;
 }
 
-mod fixable {
-    #![allow(dead_code)]
-
-    fn main() {
-        let a;
-        a = "zero";
-
-        let b;
-        let c;
-        b = 1;
-        c = 2;
-
-        let d: usize;
-        d = 1;
-
-        let e;
-        e = format!("{}", d);
+#[rustfmt::skip]
+fn issue8911() -> u32 {
+    let x;
+    match 1 {
+        _ if { x = 1; false } => return 1,
+        _ => return 2,
     }
+
+    let x;
+    if { x = 1; true } {
+        return 1;
+    } else {
+        return 2;
+    }
+
+    3
 }

--- a/tests/ui/needless_late_init.stderr
+++ b/tests/ui/needless_late_init.stderr
@@ -1,10 +1,77 @@
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:22:5
+  --> $DIR/needless_late_init.rs:23:5
+   |
+LL |     let a;
+   |     ^^^^^^ created here
+LL |     a = "zero";
+   |     ^^^^^^^^^^ initialised here
+   |
+   = note: `-D clippy::needless-late-init` implied by `-D warnings`
+help: declare `a` here
+   |
+LL |     let a = "zero";
+   |     ~~~~~
+
+error: unneeded late initialization
+  --> $DIR/needless_late_init.rs:26:5
+   |
+LL |     let b;
+   |     ^^^^^^ created here
+LL |     let c;
+LL |     b = 1;
+   |     ^^^^^ initialised here
+   |
+help: declare `b` here
+   |
+LL |     let b = 1;
+   |     ~~~~~
+
+error: unneeded late initialization
+  --> $DIR/needless_late_init.rs:27:5
+   |
+LL |     let c;
+   |     ^^^^^^ created here
+LL |     b = 1;
+LL |     c = 2;
+   |     ^^^^^ initialised here
+   |
+help: declare `c` here
+   |
+LL |     let c = 2;
+   |     ~~~~~
+
+error: unneeded late initialization
+  --> $DIR/needless_late_init.rs:31:5
+   |
+LL |     let d: usize;
+   |     ^^^^^^^^^^^^^ created here
+LL |     d = 1;
+   |     ^^^^^ initialised here
+   |
+help: declare `d` here
+   |
+LL |     let d: usize = 1;
+   |     ~~~~~~~~~~~~
+
+error: unneeded late initialization
+  --> $DIR/needless_late_init.rs:34:5
+   |
+LL |     let e;
+   |     ^^^^^^ created here
+LL |     e = format!("{}", d);
+   |     ^^^^^^^^^^^^^^^^^^^^ initialised here
+   |
+help: declare `e` here
+   |
+LL |     let e = format!("{}", d);
+   |     ~~~~~
+
+error: unneeded late initialization
+  --> $DIR/needless_late_init.rs:39:5
    |
 LL |     let a;
    |     ^^^^^^
    |
-   = note: `-D clippy::needless-late-init` implied by `-D warnings`
 help: declare `a` here
    |
 LL |     let a = match n {
@@ -21,7 +88,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:31:5
+  --> $DIR/needless_late_init.rs:48:5
    |
 LL |     let b;
    |     ^^^^^^
@@ -42,7 +109,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:38:5
+  --> $DIR/needless_late_init.rs:55:5
    |
 LL |     let d;
    |     ^^^^^^
@@ -63,7 +130,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:46:5
+  --> $DIR/needless_late_init.rs:63:5
    |
 LL |     let e;
    |     ^^^^^^
@@ -84,7 +151,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:53:5
+  --> $DIR/needless_late_init.rs:70:5
    |
 LL |     let f;
    |     ^^^^^^
@@ -100,7 +167,7 @@ LL +         1 => "three",
    | 
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:59:5
+  --> $DIR/needless_late_init.rs:76:5
    |
 LL |     let g: usize;
    |     ^^^^^^^^^^^^^
@@ -120,7 +187,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:67:5
+  --> $DIR/needless_late_init.rs:84:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -134,7 +201,7 @@ LL |     let x = 1;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:71:5
+  --> $DIR/needless_late_init.rs:88:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -148,7 +215,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:75:5
+  --> $DIR/needless_late_init.rs:92:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -162,7 +229,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:94:5
+  --> $DIR/needless_late_init.rs:111:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -183,7 +250,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:111:5
+  --> $DIR/needless_late_init.rs:128:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -202,73 +269,6 @@ help: add a semicolon after the `match` expression
    |
 LL |     };
    |      +
-
-error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:244:9
-   |
-LL |         let a;
-   |         ^^^^^^ created here
-LL |         a = "zero";
-   |         ^^^^^^^^^^ initialised here
-   |
-help: declare `a` here
-   |
-LL |         let a = "zero";
-   |         ~~~~~
-
-error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:247:9
-   |
-LL |         let b;
-   |         ^^^^^^ created here
-LL |         let c;
-LL |         b = 1;
-   |         ^^^^^ initialised here
-   |
-help: declare `b` here
-   |
-LL |         let b = 1;
-   |         ~~~~~
-
-error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:248:9
-   |
-LL |         let c;
-   |         ^^^^^^ created here
-LL |         b = 1;
-LL |         c = 2;
-   |         ^^^^^ initialised here
-   |
-help: declare `c` here
-   |
-LL |         let c = 2;
-   |         ~~~~~
-
-error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:252:9
-   |
-LL |         let d: usize;
-   |         ^^^^^^^^^^^^^ created here
-LL |         d = 1;
-   |         ^^^^^ initialised here
-   |
-help: declare `d` here
-   |
-LL |         let d: usize = 1;
-   |         ~~~~~~~~~~~~
-
-error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:255:9
-   |
-LL |         let e;
-   |         ^^^^^^ created here
-LL |         e = format!("{}", d);
-   |         ^^^^^^^^^^^^^^^^^^^^ initialised here
-   |
-help: declare `e` here
-   |
-LL |         let e = format!("{}", d);
-   |         ~~~~~
 
 error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Fixes #8911

When the assignment is done in a match guard or the if condition and all of the branches return the never type `assignment_suggestions` would return an empty `Vec` which caused the ICE. It now returns `None` in that scenario

Also moves some tests to the top of the file

changelog: ICE Fixes: [`needless_late_init`] #8911 
