### PR TITLE
List configuration values can now be extended instead of replaced

### DIFF
--- a/tests/ui-toml/blacklisted_names_append/blacklisted_names.rs
+++ b/tests/ui-toml/blacklisted_names_append/blacklisted_names.rs
@@ -1,0 +1,10 @@
+#[warn(clippy::blacklisted_name)]
+
+fn main() {
+    // `foo` is part of the default configuration
+    let foo = "bar";
+    // `ducks` was unrightfully blacklisted
+    let ducks = ["quack", "quack"];
+    // `fox` is okay
+    let fox = ["what", "does", "the", "fox", "say", "?"];
+}

--- a/tests/ui-toml/blacklisted_names_append/blacklisted_names.stderr
+++ b/tests/ui-toml/blacklisted_names_append/blacklisted_names.stderr
@@ -1,0 +1,16 @@
+error: use of a blacklisted/placeholder name `foo`
+  --> $DIR/blacklisted_names.rs:5:9
+   |
+LL |     let foo = "bar";
+   |         ^^^
+   |
+   = note: `-D clippy::blacklisted-name` implied by `-D warnings`
+
+error: use of a blacklisted/placeholder name `ducks`
+  --> $DIR/blacklisted_names.rs:7:9
+   |
+LL |     let ducks = ["quack", "quack"];
+   |         ^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui-toml/blacklisted_names_append/clippy.toml
+++ b/tests/ui-toml/blacklisted_names_append/clippy.toml
@@ -1,0 +1,1 @@
+blacklisted-names = ["ducks", ".."]

--- a/tests/ui-toml/blacklisted_names_replace/blacklisted_names.rs
+++ b/tests/ui-toml/blacklisted_names_replace/blacklisted_names.rs
@@ -1,0 +1,10 @@
+#[warn(clippy::blacklisted_name)]
+
+fn main() {
+    // `foo` is part of the default configuration
+    let foo = "bar";
+    // `ducks` was unrightfully blacklisted
+    let ducks = ["quack", "quack"];
+    // `fox` is okay
+    let fox = ["what", "does", "the", "fox", "say", "?"];
+}

--- a/tests/ui-toml/blacklisted_names_replace/blacklisted_names.stderr
+++ b/tests/ui-toml/blacklisted_names_replace/blacklisted_names.stderr
@@ -1,0 +1,10 @@
+error: use of a blacklisted/placeholder name `ducks`
+  --> $DIR/blacklisted_names.rs:7:9
+   |
+LL |     let ducks = ["quack", "quack"];
+   |         ^^^^^
+   |
+   = note: `-D clippy::blacklisted-name` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/blacklisted_names_replace/clippy.toml
+++ b/tests/ui-toml/blacklisted_names_replace/clippy.toml
@@ -1,0 +1,1 @@
+blacklisted-names = ["ducks"]

--- a/tests/ui-toml/doc_valid_idents_append/clippy.toml
+++ b/tests/ui-toml/doc_valid_idents_append/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["ClipPy", ".."]

--- a/tests/ui-toml/doc_valid_idents_append/doc_markdown.rs
+++ b/tests/ui-toml/doc_valid_idents_append/doc_markdown.rs
@@ -1,0 +1,12 @@
+#![warn(clippy::doc_markdown)]
+
+/// This is a special interface for ClipPy which doesn't require backticks
+fn allowed_name() {}
+
+/// OAuth and LaTeX are inside Clippy's default list.
+fn default_name() {}
+
+/// TestItemThingyOfCoolness might sound cool but is not on the list and should be linted.
+fn unknown_name() {}
+
+fn main() {}

--- a/tests/ui-toml/doc_valid_idents_append/doc_markdown.stderr
+++ b/tests/ui-toml/doc_valid_idents_append/doc_markdown.stderr
@@ -1,0 +1,14 @@
+error: item in documentation is missing backticks
+  --> $DIR/doc_markdown.rs:9:5
+   |
+LL | /// TestItemThingyOfCoolness might sound cool but is not on the list and should be linted.
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::doc-markdown` implied by `-D warnings`
+help: try
+   |
+LL | /// `TestItemThingyOfCoolness` might sound cool but is not on the list and should be linted.
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/doc_valid_idents_replace/clippy.toml
+++ b/tests/ui-toml/doc_valid_idents_replace/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["ClipPy"]

--- a/tests/ui-toml/doc_valid_idents_replace/doc_markdown.rs
+++ b/tests/ui-toml/doc_valid_idents_replace/doc_markdown.rs
@@ -1,0 +1,12 @@
+#![warn(clippy::doc_markdown)]
+
+/// This is a special interface for ClipPy which doesn't require backticks
+fn allowed_name() {}
+
+/// OAuth and LaTeX are inside Clippy's default list.
+fn default_name() {}
+
+/// TestItemThingyOfCoolness might sound cool but is not on the list and should be linted.
+fn unknown_name() {}
+
+fn main() {}

--- a/tests/ui-toml/doc_valid_idents_replace/doc_markdown.stderr
+++ b/tests/ui-toml/doc_valid_idents_replace/doc_markdown.stderr
@@ -1,0 +1,36 @@
+error: item in documentation is missing backticks
+  --> $DIR/doc_markdown.rs:6:5
+   |
+LL | /// OAuth and LaTeX are inside Clippy's default list.
+   |     ^^^^^
+   |
+   = note: `-D clippy::doc-markdown` implied by `-D warnings`
+help: try
+   |
+LL | /// `OAuth` and LaTeX are inside Clippy's default list.
+   |     ~~~~~~~
+
+error: item in documentation is missing backticks
+  --> $DIR/doc_markdown.rs:6:15
+   |
+LL | /// OAuth and LaTeX are inside Clippy's default list.
+   |               ^^^^^
+   |
+help: try
+   |
+LL | /// OAuth and `LaTeX` are inside Clippy's default list.
+   |               ~~~~~~~
+
+error: item in documentation is missing backticks
+  --> $DIR/doc_markdown.rs:9:5
+   |
+LL | /// TestItemThingyOfCoolness might sound cool but is not on the list and should be linted.
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL | /// `TestItemThingyOfCoolness` might sound cool but is not on the list and should be linted.
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
I've seen some `clippy.toml` files, that have a few additions to the default list of a configuration and then a copy of our default. The list will therefore not be updated, when we add new names. This change should make it simple for new users to append values instead of replacing them.

I'm uncertain if the documentation of the `".."` is apparent. Any suggestions are welcome. I've also check that the lint list displays the examples correctly.

<details>
<summary>Lint list screenshots</summary>

![image](https://user-images.githubusercontent.com/17087237/171999434-393f2f83-09aa-4bab-8b05-bd4973150f27.png)

![image](https://user-images.githubusercontent.com/17087237/171999401-e6942b53-25e6-4b09-89e5-d867c7463156.png)

</details> 

---

changelog: enhancement: [`doc_markdown`]: Users can now indicate, that the `doc-valid-idents` should extend the default and not replace it
changelog: enhancement: [`blacklisted-name`]: Users can now indicate, that the `blacklisted-names` should extend the default and not replace it

Closes: #8877

That's it. Have a fantastic weekend to everyone reading this. Here is a cookie :cookie: 