### PR TITLE
Deploy Clippy book through CI/CD

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -3,7 +3,7 @@
 set -ex
 
 echo "Removing the current docs for master"
-rm -rf out/master/ || exit 0
+rm -rf out/master/ out/book/ || exit 0
 
 echo "Making the docs for master"
 mkdir out/master/
@@ -28,6 +28,9 @@ cp util/gh-pages/versions.html out/index.html
 
 echo "Making the versions.json file"
 python3 ./util/versions.py out
+
+# Copying the book
+mv book/book out
 
 # Now let's go have some fun with the cloned repo
 cd out

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,12 @@ jobs:
         ref: ${{ env.TARGET_BRANCH }}
         path: 'out'
 
+    - name: Install mdbook
+      run: |
+        mkdir mdbook
+        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        echo `pwd`/mdbook >> $GITHUB_PATH
+
     # Run
     - name: Set tag name
       if: startswith(github.ref, 'refs/tags/')
@@ -56,6 +62,9 @@ jobs:
 
     - name: cargo collect-metadata
       run: cargo collect-metadata
+
+    - name: Build book
+      run: mdbook build book
 
     - name: Deploy
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,7 @@ All contributors are expected to follow the [Rust Code of Conduct].
 If you're new to Clippy and don't know where to start the [Clippy book] includes
 a developer guide and is a good place to start your journey.
 
-<!-- FIXME: Link to the deployed book, once it is deployed through CI -->
-[Clippy book]: book/src
+[Clippy book]: https://rust-lang.github.io/rust-clippy/book/index.html
 
 ## High level approach
 

--- a/util/versions.py
+++ b/util/versions.py
@@ -31,7 +31,7 @@ def main():
 
     outdir = sys.argv[1]
     versions = [
-        dir for dir in os.listdir(outdir) if not dir.startswith(".") and os.path.isdir(os.path.join(outdir, dir))
+        dir for dir in os.listdir(outdir) if not dir.startswith(".") and dir != "book" and os.path.isdir(os.path.join(outdir, dir))
     ]
     versions.sort(key=key)
 


### PR DESCRIPTION
Now that #7359 is finally merged, we can start looking at the deployment of the book. 

Marking this as draft for now, because I created this 2 months ago and I still have to think about if we want to actually do this if we end up publishing the book through the rust-lang/rust repo.

r? @xFrednet 

changelog: none
