### PR TITLE
Correct some `#[clippy::version]`s

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -414,7 +414,7 @@ declare_clippy_lint! {
     /// enum E { X = 256 };
     /// let _ = E::X as u8;
     /// ```
-    #[clippy::version = "1.60.0"]
+    #[clippy::version = "1.61.0"]
     pub CAST_ENUM_TRUNCATION,
     suspicious,
     "casts from an enum type to an integral type which will truncate the value"
@@ -459,7 +459,7 @@ declare_clippy_lint! {
     ///     println!("{:?}", &*new_ptr);
     /// }
     /// ```
-    #[clippy::version = "1.60.0"]
+    #[clippy::version = "1.61.0"]
     pub CAST_SLICE_DIFFERENT_SIZES,
     correctness,
     "casting using `as` between raw pointers to slices of types with different sizes"

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -163,7 +163,7 @@ declare_clippy_lint! {
     ///     }
     /// }
     /// ```
-    #[clippy::version = "1.52.0"]
+    #[clippy::version = "1.51.0"]
     pub MISSING_PANICS_DOC,
     pedantic,
     "`pub fn` may panic without `# Panics` in doc comment"

--- a/clippy_lints/src/index_refutable_slice.rs
+++ b/clippy_lints/src/index_refutable_slice.rs
@@ -45,7 +45,7 @@ declare_clippy_lint! {
     ///     println!("{}", first);
     /// }
     /// ```
-    #[clippy::version = "1.58.0"]
+    #[clippy::version = "1.59.0"]
     pub INDEX_REFUTABLE_SLICE,
     nursery,
     "avoid indexing on slices which could be destructed"

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -596,7 +596,7 @@ declare_clippy_lint! {
     ///     std::hint::spin_loop()
     /// }
     /// ```
-    #[clippy::version = "1.59.0"]
+    #[clippy::version = "1.61.0"]
     pub MISSING_SPIN_LOOP,
     perf,
     "An empty busy waiting loop"

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -141,7 +141,7 @@ declare_clippy_lint! {
     /// vec.iter().take(10).cloned();
     /// vec.iter().last().cloned();
     /// ```
-    #[clippy::version = "1.59.0"]
+    #[clippy::version = "1.60.0"]
     pub ITER_OVEREAGER_CLONED,
     perf,
     "using `cloned()` early with `Iterator::iter()` can lead to some performance inefficiencies"
@@ -1907,7 +1907,7 @@ declare_clippy_lint! {
     /// let x = [1, 2, 3];
     /// let y: Vec<_> = x.iter().map(|x| 2*x).collect();
     /// ```
-    #[clippy::version = "1.52.0"]
+    #[clippy::version = "1.47.0"]
     pub MAP_IDENTITY,
     complexity,
     "using iterator.map(|x| x)"
@@ -2100,7 +2100,7 @@ declare_clippy_lint! {
     /// let str = "key=value=add";
     /// let _ = str.split('=').next().unwrap();
     /// ```
-    #[clippy::version = "1.58.0"]
+    #[clippy::version = "1.59.0"]
     pub NEEDLESS_SPLITN,
     complexity,
     "usages of `str::splitn` that can be replaced with `str::split`"
@@ -2131,7 +2131,7 @@ declare_clippy_lint! {
     /// foo(&path.to_string_lossy());
     /// fn foo(s: &str) {}
     /// ```
-    #[clippy::version = "1.58.0"]
+    #[clippy::version = "1.59.0"]
     pub UNNECESSARY_TO_OWNED,
     perf,
     "unnecessary calls to `to_owned`-like functions"

--- a/clippy_lints/src/needless_late_init.rs
+++ b/clippy_lints/src/needless_late_init.rs
@@ -56,7 +56,7 @@ declare_clippy_lint! {
     ///     -1
     /// };
     /// ```
-    #[clippy::version = "1.58.0"]
+    #[clippy::version = "1.59.0"]
     pub NEEDLESS_LATE_INIT,
     style,
     "late initializations that can be replaced by a `let` statement with an initializer"

--- a/clippy_lints/src/octal_escapes.rs
+++ b/clippy_lints/src/octal_escapes.rs
@@ -42,7 +42,7 @@ declare_clippy_lint! {
     /// let one = "\x1b[1mWill this be bold?\x1b[0m";
     /// let two = "\x0033\x00";
     /// ```
-    #[clippy::version = "1.58.0"]
+    #[clippy::version = "1.59.0"]
     pub OCTAL_ESCAPES,
     suspicious,
     "string escape sequences looking like octal characters"

--- a/clippy_lints/src/only_used_in_recursion.rs
+++ b/clippy_lints/src/only_used_in_recursion.rs
@@ -87,7 +87,7 @@ declare_clippy_lint! {
     /// #     print!("{}", f(1));
     /// # }
     /// ```
-    #[clippy::version = "1.60.0"]
+    #[clippy::version = "1.61.0"]
     pub ONLY_USED_IN_RECURSION,
     nursery,
     "arguments that is only used in recursion can be removed"

--- a/clippy_lints/src/redundant_slicing.rs
+++ b/clippy_lints/src/redundant_slicing.rs
@@ -60,7 +60,7 @@ declare_clippy_lint! {
     /// let vec = vec![1, 2, 3];
     /// let slice = &*vec;
     /// ```
-    #[clippy::version = "1.60.0"]
+    #[clippy::version = "1.61.0"]
     pub DEREF_BY_SLICING,
     restriction,
     "slicing instead of dereferencing"

--- a/clippy_lints/src/single_char_lifetime_names.rs
+++ b/clippy_lints/src/single_char_lifetime_names.rs
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     ///     source: &'src str,
     /// }
     /// ```
-    #[clippy::version = "1.59.0"]
+    #[clippy::version = "1.60.0"]
     pub SINGLE_CHAR_LIFETIME_NAMES,
     restriction,
     "warns against single-character lifetime names"


### PR DESCRIPTION
Some were a bit off

changelog: none
