### PR TITLE
Lint `[single_match]` on `Option` matches

### DIFF
--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -242,7 +242,10 @@ fn form_exhaustive_matches<'a>(cx: &LateContext<'a>, ty: Ty<'a>, left: &Pat<'_>,
             }
             true
         },
-        (PatKind::TupleStruct(..), PatKind::Path(_) | PatKind::TupleStruct(..)) => in_candidate_enum(cx, ty),
+        (PatKind::TupleStruct(..), PatKind::Path(_)) => in_candidate_enum(cx, ty),
+        (PatKind::TupleStruct(..), PatKind::TupleStruct(_, inner, _)) => {
+            in_candidate_enum(cx, ty) && inner.iter().all(contains_only_wilds)
+        },
         _ => false,
     }
 }

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -147,7 +147,8 @@ fn check_opt_like<'a>(
     }
 }
 
-/// Returns `true` if all of the types in the pattern are candidate enums
+/// Returns `true` if all of the types in the pattern are enums which we know
+/// won't be expanded in the future
 fn pat_in_candidate_enum<'a>(cx: &LateContext<'a>, ty: Ty<'a>, pat: &Pat<'_>) -> bool {
     let mut paths_and_types = Vec::new();
     collect_pat_paths(&mut paths_and_types, cx, pat, ty);

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -147,6 +147,7 @@ fn check_opt_like<'a>(
     }
 }
 
+/// Returns `true` if all of the types in the pattern are candidate enums
 fn pat_in_candidate_enum<'a>(cx: &LateContext<'a>, ty: Ty<'a>, pat: &Pat<'_>) -> bool {
     let mut paths_and_types = Vec::new();
     collect_pat_paths(&mut paths_and_types, cx, pat, ty);
@@ -166,7 +167,7 @@ fn in_candidate_enum<'a>(cx: &LateContext<'a>, ty: Ty<'_>) -> bool {
     false
 }
 
-/// Collects paths and their types from the given patterns
+/// Collects types from the given pattern
 fn collect_pat_paths<'a>(acc: &mut Vec<Ty<'a>>, cx: &LateContext<'a>, pat: &Pat<'_>, ty: Ty<'a>) {
     match pat.kind {
         PatKind::Tuple(inner, _) => inner.iter().for_each(|p| {

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -39,6 +39,15 @@ LL | |     };
    | |_____^ help: try this: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:54:5
+   |
+LL | /     match x {
+LL | |         Some(y) => dummy(),
+LL | |         None => (),
+LL | |     };
+   | |_____^ help: try this: `if let Some(y) = x { dummy() }`
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:59:5
    |
 LL | /     match y {
@@ -146,5 +155,5 @@ LL | |         (..) => {},
 LL | |     }
    | |_____^ help: try this: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
-error: aborting due to 15 previous errors
+error: aborting due to 16 previous errors
 

--- a/tests/ui/single_match_else.rs
+++ b/tests/ui/single_match_else.rs
@@ -97,4 +97,23 @@ fn main() {
             return;
         },
     }
+
+    // lint here
+    use std::convert::Infallible;
+    match Result::<i32, Infallible>::Ok(1) {
+        Ok(a) => println!("${:?}", a),
+        Err(_) => {
+            println!("else block");
+            return;
+        }
+    }
+
+    use std::borrow::Cow;
+    match Cow::from("moo") {
+        Cow::Owned(a) => println!("${:?}", a),
+        Cow::Borrowed(_) => {
+            println!("else block");
+            return;
+        }
+    }
 }

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -20,5 +20,45 @@ LL +         None
 LL ~     };
    |
 
-error: aborting due to previous error
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:84:5
+   |
+LL | /     match Some(1) {
+LL | |         Some(a) => println!("${:?}", a),
+LL | |         None => {
+LL | |             println!("else block");
+LL | |             return
+LL | |         },
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(a) = Some(1) { println!("${:?}", a) } else {
+LL +         println!("else block");
+LL +         return
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:93:5
+   |
+LL | /     match Some(1) {
+LL | |         Some(a) => println!("${:?}", a),
+LL | |         None => {
+LL | |             println!("else block");
+LL | |             return;
+LL | |         },
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(a) = Some(1) { println!("${:?}", a) } else {
+LL +         println!("else block");
+LL +         return;
+LL +     }
+   |
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -60,5 +60,45 @@ LL +         return;
 LL +     }
    |
 
-error: aborting due to 3 previous errors
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:103:5
+   |
+LL | /     match Result::<i32, Infallible>::Ok(1) {
+LL | |         Ok(a) => println!("${:?}", a),
+LL | |         Err(_) => {
+LL | |             println!("else block");
+LL | |             return;
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Ok(a) = Result::<i32, Infallible>::Ok(1) { println!("${:?}", a) } else {
+LL +         println!("else block");
+LL +         return;
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:112:5
+   |
+LL | /     match Cow::from("moo") {
+LL | |         Cow::Owned(a) => println!("${:?}", a),
+LL | |         Cow::Borrowed(_) => {
+LL | |             println!("else block");
+LL | |             return;
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Cow::Owned(a) = Cow::from("moo") { println!("${:?}", a) } else {
+LL +         println!("else block");
+LL +         return;
+LL +     }
+   |
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
fixes #8928 

changelog: did some cleanup of the logic for ``[`single_match`]`` and ``[`single_match_else`]`` which fixes the bug where `Option` matches were not linted unless a wildcard was used for one of the arms.
