### PR TITLE
Test metadata collection in Bors CI workflow

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -143,6 +143,25 @@ jobs:
       env:
         OS: ${{ runner.os }}
 
+  metadata_collection:
+    needs: base
+    runs-on: ubuntu-latest
+
+    steps:
+     # Setup
+    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
+      with:
+        github_token: "${{ secrets.github_token }}"
+
+    - name: Checkout
+      uses: actions/checkout@v3.0.2
+
+    - name: Install toolchain
+      run: rustup show active-toolchain
+
+    - name: Test metadata collection
+      run: cargo collect-metadata
+
   integration_build:
     needs: changelog
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a new check to bors CI workflows, which ensures that the metadata collection success, when it's run as part of the `deploy` script. I've only added it to bors workflows, as the runtime will be high while it'll also succeed most of the time. This is a preparation for rust-lang/rust-clippy#8947.

---

changelog: none

r? @ghost
