### PR TITLE
Remove error-pattern comments

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1,5 +1,3 @@
-// error-pattern:cargo-clippy
-
 #![feature(array_windows)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(box_patterns)]

--- a/tests/ui-toml/bad_toml/conf_bad_toml.rs
+++ b/tests/ui-toml/bad_toml/conf_bad_toml.rs
@@ -1,3 +1,1 @@
-// error-pattern: error reading Clippy's configuration file
-
 fn main() {}

--- a/tests/ui-toml/bad_toml_type/conf_bad_type.rs
+++ b/tests/ui-toml/bad_toml_type/conf_bad_type.rs
@@ -1,4 +1,1 @@
-// error-pattern: error reading Clippy's configuration file: `blacklisted-names` is expected to be a
-// `Vec < String >` but is a `integer`
-
 fn main() {}

--- a/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
+++ b/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
@@ -1,4 +1,1 @@
-// error-pattern: error reading Clippy's configuration file: found deprecated field
-// `cyclomatic-complexity-threshold`. Please use `cognitive-complexity-threshold` instead.
-
 fn main() {}

--- a/tests/ui-toml/good_toml_no_false_negatives/conf_no_false_negatives.rs
+++ b/tests/ui-toml/good_toml_no_false_negatives/conf_no_false_negatives.rs
@@ -1,3 +1,1 @@
-// error-pattern: should give absolutely no error
-
 fn main() {}

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.rs
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.rs
@@ -1,3 +1,1 @@
-// error-pattern: error reading Clippy's configuration file: unknown key `foobar`
-
 fn main() {}


### PR DESCRIPTION
The `clippy_lints` one [is unused](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/.60error-pattern.60), the others in `ui-toml` also appear not to have an effect

changelog: none
