### PR TITLE
Fix false positive for `never_loop` struct expression fields

### DIFF
--- a/tests/ui/never_loop.rs
+++ b/tests/ui/never_loop.rs
@@ -186,6 +186,23 @@ pub fn test16() {
     }
 }
 
+// Issue #9001: `continue` in struct expression fields
+pub fn test17() {
+    struct Foo {
+        f: (),
+    }
+
+    let mut n = 0;
+    let _ = loop {
+        break Foo {
+            f: if n < 5 {
+                n += 1;
+                continue;
+            },
+        };
+    };
+}
+
 fn main() {
     test1();
     test2();


### PR DESCRIPTION
Fixes #9001.

changelog: [`never_loop`]: Now checks for `continue` in struct expression