### PR TITLE
feat(fix): ignore `todo!` and `unimplemented!` in `if_same_then_else`

### DIFF
--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -8,7 +8,7 @@ use clippy_utils::{
 use core::iter;
 use rustc_errors::Applicability;
 use rustc_hir::intravisit;
-use rustc_hir::{BinOpKind, Block, Expr, ExprKind, HirId, QPath, Stmt, StmtKind};
+use rustc_hir::{BinOpKind, Block, Expr, ExprKind, HirId, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::hygiene::walk_chain;
@@ -389,13 +389,11 @@ fn contains_acceptable_macro(cx: &LateContext<'_>, block: &Block<'_>) -> bool {
 }
 
 fn acceptable_macro(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    if let ExprKind::Call(call_expr, _)  = expr.kind
-        && let ExprKind::Path(QPath::Resolved(None, path)) = call_expr.kind
-        && macro_backtrace(path.span).last().map_or(false, |macro_call|
-            matches!(
-                &cx.tcx.get_diagnostic_name(macro_call.def_id),
-                Some(sym::todo_macro | sym::unimplemented_macro)
-            )
+    if macro_backtrace(expr.span).last().map_or(false, |macro_call|
+        matches!(
+            &cx.tcx.get_diagnostic_name(macro_call.def_id),
+            Some(sym::todo_macro | sym::unimplemented_macro)
+        )
     ) {
         return true;
     }

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -372,11 +372,13 @@ fn eq_stmts(
 }
 
 fn contains_acceptable_macro(cx: &LateContext<'_>, block: &Block<'_>) -> bool {
-    for stmt in block.stmts {
-        match stmt.kind {
-            StmtKind::Semi(semi_expr) if acceptable_macro(cx, semi_expr) => return true,
-            _ => {},
-        }
+    if block.stmts.first().map_or(false, |stmt|
+        matches!(
+            stmt.kind,
+            StmtKind::Semi(semi_expr) if acceptable_macro(cx, semi_expr)
+        )
+    ) {
+        return true;
     }
 
     if let Some(block_expr) = block.expr

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -13,10 +13,8 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::hygiene::walk_chain;
 use rustc_span::source_map::SourceMap;
-use rustc_span::{BytePos, Span, Symbol};
+use rustc_span::{sym, BytePos, Span, Symbol};
 use std::borrow::Cow;
-
-const ACCEPTABLE_MACRO: [&str; 2] = ["todo", "unimplemented"];
 
 declare_clippy_lint! {
     /// ### What it does
@@ -394,7 +392,10 @@ fn acceptable_macro(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     if let ExprKind::Call(call_expr, _)  = expr.kind
         && let ExprKind::Path(QPath::Resolved(None, path)) = call_expr.kind
         && macro_backtrace(path.span).any(|macro_call| {
-            ACCEPTABLE_MACRO.contains(&cx.tcx.item_name(macro_call.def_id).as_str())
+            matches!(
+                &cx.tcx.get_diagnostic_name(macro_call.def_id),
+                Some(sym::todo_macro | sym::unimplemented_macro)
+            )
     }) {
         return true;
     }

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -391,12 +391,12 @@ fn contains_acceptable_macro(cx: &LateContext<'_>, block: &Block<'_>) -> bool {
 fn acceptable_macro(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     if let ExprKind::Call(call_expr, _)  = expr.kind
         && let ExprKind::Path(QPath::Resolved(None, path)) = call_expr.kind
-        && macro_backtrace(path.span).any(|macro_call| {
+        && macro_backtrace(path.span).last().map_or(false, |macro_call|
             matches!(
                 &cx.tcx.get_diagnostic_name(macro_call.def_id),
                 Some(sym::todo_macro | sym::unimplemented_macro)
             )
-    }) {
+    ) {
         return true;
     }
 

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -195,10 +195,7 @@ fn lint_if_same_then_else(cx: &LateContext<'_>, conds: &[&Expr<'_>], blocks: &[&
         .array_windows::<2>()
         .enumerate()
         .fold(true, |all_eq, (i, &[lhs, rhs])| {
-            if eq.eq_block(lhs, rhs)
-                && !contains_let(conds[i])
-                && conds.get(i + 1).map_or(true, |e| !contains_let(e))
-            {
+            if eq.eq_block(lhs, rhs) && !contains_let(conds[i]) && conds.get(i + 1).map_or(true, |e| !contains_let(e)) {
                 span_lint_and_note(
                     cx,
                     IF_SAME_THEN_ELSE,
@@ -367,10 +364,6 @@ fn eq_stmts(
         .iter()
         .all(|b| get_stmt(b).map_or(false, |s| eq.eq_stmt(s, stmt)))
 }
-
-
-
-
 
 fn scan_block_for_eq(cx: &LateContext<'_>, _conds: &[&Expr<'_>], block: &Block<'_>, blocks: &[&Block<'_>]) -> BlockEq {
     let mut eq = SpanlessEq::new(cx);

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -1,6 +1,6 @@
 use crate::consts::constant_simple;
-use crate::source::snippet_opt;
 use crate::macros::macro_backtrace;
+use crate::source::snippet_opt;
 use rustc_ast::ast::InlineAsmTemplatePiece;
 use rustc_data_structures::fx::FxHasher;
 use rustc_hir::def::Res;
@@ -88,12 +88,12 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
     }
 
     fn cannot_be_compared_block(&mut self, block: &Block<'_>) -> bool {
-        if block.stmts.first().map_or(false, |stmt|
+        if block.stmts.first().map_or(false, |stmt| {
             matches!(
                 stmt.kind,
                 StmtKind::Semi(semi_expr) if self.should_ignore(semi_expr)
             )
-        ) {
+        }) {
             return true;
         }
 
@@ -107,12 +107,12 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
     }
 
     fn should_ignore(&mut self, expr: &Expr<'_>) -> bool {
-        if macro_backtrace(expr.span).last().map_or(false, |macro_call|
+        if macro_backtrace(expr.span).last().map_or(false, |macro_call| {
             matches!(
                 &self.cx.tcx.get_diagnostic_name(macro_call.def_id),
                 Some(sym::todo_macro | sym::unimplemented_macro)
             )
-        ) {
+        }) {
             return true;
         }
 

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -88,7 +88,7 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
     }
 
     fn cannot_be_compared_block(&mut self, block: &Block<'_>) -> bool {
-        if block.stmts.first().map_or(false, |stmt| {
+        if block.stmts.last().map_or(false, |stmt| {
             matches!(
                 stmt.kind,
                 StmtKind::Semi(semi_expr) if self.should_ignore(semi_expr)

--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -179,6 +179,38 @@ mod issue_8836 {
         } else {
             unimplemented!();
         }
+
+        if true {
+            println!("FOO");
+            todo!();
+        } else {
+            println!("FOO");
+            todo!();
+        }
+
+        if true {
+            println!("FOO");
+            unimplemented!();
+        } else {
+            println!("FOO");
+            unimplemented!();
+        }
+
+        if true {
+            println!("FOO");
+            todo!()
+        } else {
+            println!("FOO");
+            todo!()
+        }
+
+        if true {
+            println!("FOO");
+            unimplemented!()
+        } else {
+            println!("FOO");
+            unimplemented!()
+        }
     }
 }
 

--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -126,6 +126,9 @@ fn if_same_then_else() {
             _ => 4,
         };
     }
+
+    // Issue #8836
+    if true { todo!() } else { todo!() }
 }
 
 // Issue #2423. This was causing an ICE.

--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -6,7 +6,9 @@
     clippy::no_effect,
     clippy::unused_unit,
     clippy::zero_divided_by_zero,
-    clippy::branches_sharing_code
+    clippy::branches_sharing_code,
+    dead_code,
+    unreachable_code
 )]
 
 struct Foo {
@@ -126,9 +128,6 @@ fn if_same_then_else() {
             _ => 4,
         };
     }
-
-    // Issue #8836
-    if true { todo!() } else { todo!() }
 }
 
 // Issue #2423. This was causing an ICE.
@@ -154,6 +153,63 @@ mod issue_5698 {
             y * x
         } else {
             0
+        }
+    }
+}
+
+mod issue_8836 {
+    fn do_not_lint() {
+        if true {
+            todo!()
+        } else {
+            todo!()
+        }
+        if true {
+            todo!();
+        } else {
+            todo!();
+        }
+        if true {
+            unimplemented!()
+        } else {
+            unimplemented!()
+        }
+        if true {
+            unimplemented!();
+        } else {
+            unimplemented!();
+        }
+
+        if true {
+            println!("FOO");
+            todo!();
+        } else {
+            println!("FOO");
+            todo!();
+        }
+
+        if true {
+            println!("FOO");
+            unimplemented!();
+        } else {
+            println!("FOO");
+            unimplemented!();
+        }
+
+        if true {
+            println!("FOO");
+            todo!()
+        } else {
+            println!("FOO");
+            todo!()
+        }
+
+        if true {
+            println!("FOO");
+            unimplemented!()
+        } else {
+            println!("FOO");
+            unimplemented!()
         }
     }
 }

--- a/tests/ui/if_same_then_else.rs
+++ b/tests/ui/if_same_then_else.rs
@@ -179,38 +179,6 @@ mod issue_8836 {
         } else {
             unimplemented!();
         }
-
-        if true {
-            println!("FOO");
-            todo!();
-        } else {
-            println!("FOO");
-            todo!();
-        }
-
-        if true {
-            println!("FOO");
-            unimplemented!();
-        } else {
-            println!("FOO");
-            unimplemented!();
-        }
-
-        if true {
-            println!("FOO");
-            todo!()
-        } else {
-            println!("FOO");
-            todo!()
-        }
-
-        if true {
-            println!("FOO");
-            unimplemented!()
-        } else {
-            println!("FOO");
-            unimplemented!()
-        }
     }
 }
 

--- a/tests/ui/if_same_then_else.stderr
+++ b/tests/ui/if_same_then_else.stderr
@@ -1,5 +1,5 @@
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else.rs:21:13
+  --> $DIR/if_same_then_else.rs:23:13
    |
 LL |       if true {
    |  _____________^
@@ -13,7 +13,7 @@ LL | |     } else {
    |
    = note: `-D clippy::if-same-then-else` implied by `-D warnings`
 note: same as this
-  --> $DIR/if_same_then_else.rs:29:12
+  --> $DIR/if_same_then_else.rs:31:12
    |
 LL |       } else {
    |  ____________^
@@ -26,7 +26,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else.rs:65:21
+  --> $DIR/if_same_then_else.rs:67:21
    |
 LL |       let _ = if true {
    |  _____________________^
@@ -35,7 +35,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else.rs:67:12
+  --> $DIR/if_same_then_else.rs:69:12
    |
 LL |       } else {
    |  ____________^
@@ -45,7 +45,7 @@ LL | |     };
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else.rs:72:21
+  --> $DIR/if_same_then_else.rs:74:21
    |
 LL |       let _ = if true {
    |  _____________________^
@@ -54,7 +54,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else.rs:74:12
+  --> $DIR/if_same_then_else.rs:76:12
    |
 LL |       } else {
    |  ____________^
@@ -64,7 +64,7 @@ LL | |     };
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else.rs:88:21
+  --> $DIR/if_same_then_else.rs:90:21
    |
 LL |       let _ = if true {
    |  _____________________^
@@ -73,7 +73,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else.rs:90:12
+  --> $DIR/if_same_then_else.rs:92:12
    |
 LL |       } else {
    |  ____________^
@@ -83,7 +83,7 @@ LL | |     };
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else.rs:95:13
+  --> $DIR/if_same_then_else.rs:97:13
    |
 LL |       if true {
    |  _____________^
@@ -96,7 +96,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else.rs:102:12
+  --> $DIR/if_same_then_else.rs:104:12
    |
 LL |       } else {
    |  ____________^


### PR DESCRIPTION
close: #8836
take over:  #8853 

This PR adds  check `todo!` and `unimplemented!` in if_same_then_else. 
( I thought `unimplemented` should not be checked as well as todo!.)

Thank you in advance.


changelog: ignore todo! and unimplemented! in if_same_then_else

r? @Jarcho 