### PR TITLE
emit `needless_return` on return stmts using borrow

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -181,15 +181,12 @@ fn check_final_expr<'tcx>(
             // allow `#[cfg(a)] return a; #[cfg(b)] return b;`
             let attrs = cx.tcx.hir().attrs(expr.hir_id);
             if !attrs.iter().any(attr_is_cfg) {
-                let borrows = inner.map_or(false, |inner| last_statement_borrows(cx, inner));
-                if !borrows {
-                    emit_return_lint(
-                        cx,
-                        span.expect("`else return` is not possible"),
-                        inner.as_ref().map(|i| i.span),
-                        replacement,
-                    );
-                }
+                emit_return_lint(
+                    cx,
+                    span.expect("`else return` is not possible"),
+                    inner.as_ref().map(|i| i.span),
+                    replacement,
+                );
             }
         },
         // a whole block? check it!

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -89,7 +89,7 @@ fn test_nested_match(x: u32) {
 fn read_line() -> String {
     use std::io::BufRead;
     let stdin = ::std::io::stdin();
-    return stdin.lock().lines().next().unwrap().unwrap();
+    stdin.lock().lines().next().unwrap().unwrap()
 }
 
 fn borrows_but_not_last(value: bool) -> String {
@@ -200,7 +200,7 @@ async fn async_test_void_match(x: u32) {
 async fn async_read_line() -> String {
     use std::io::BufRead;
     let stdin = ::std::io::stdin();
-    return stdin.lock().lines().next().unwrap().unwrap();
+    stdin.lock().lines().next().unwrap().unwrap()
 }
 
 async fn async_borrows_but_not_last(value: bool) -> String {

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -91,6 +91,12 @@ LL |         _ => return,
    |              ^^^^^^ help: replace `return` with a unit value: `()`
 
 error: unneeded `return` statement
+  --> $DIR/needless_return.rs:92:5
+   |
+LL |     return stdin.lock().lines().next().unwrap().unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `stdin.lock().lines().next().unwrap().unwrap()`
+
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:100:9
    |
 LL |         return String::from("test");
@@ -205,6 +211,12 @@ LL |         _ => return,
    |              ^^^^^^ help: replace `return` with a unit value: `()`
 
 error: unneeded `return` statement
+  --> $DIR/needless_return.rs:203:5
+   |
+LL |     return stdin.lock().lines().next().unwrap().unwrap();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `stdin.lock().lines().next().unwrap().unwrap()`
+
+error: unneeded `return` statement
   --> $DIR/needless_return.rs:211:9
    |
 LL |         return String::from("test");
@@ -222,5 +234,5 @@ error: unneeded `return` statement
 LL |     return format!("Hello {}", "world!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `format!("Hello {}", "world!")`
 
-error: aborting due to 37 previous errors
+error: aborting due to 39 previous errors
 


### PR DESCRIPTION
Fix #8978

This check is added on #5903 to fix #5858. Though, the test added here compiles as of today, so this can be removed. ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=7c0b5d980302c2de89d1aa7f59441934))

changelog: [`needless_return`] now emits on on return stmts using borrow
