### PR TITLE
ignore item in `thread_local!` macro

### DIFF
--- a/tests/ui/declare_interior_mutable_const/others.rs
+++ b/tests/ui/declare_interior_mutable_const/others.rs
@@ -31,4 +31,9 @@ const NO_ANN: &dyn Display = &70;
 static STATIC_TUPLE: (AtomicUsize, String) = (ATOMIC, STRING);
 //^ there should be no lints on this line
 
+// issue #8493
+thread_local! {
+    static THREAD_LOCAL: Cell<i32> = const { Cell::new(0) };
+}
+
 fn main() {}


### PR DESCRIPTION
close #8493 

This PR ignores `thread_local` macro in `declare_interior_mutable_const`.

changelog: ignore `thread_local!` macro in `declare_interior_mutable_const`
