### PR TITLE
Example for `WHILE_LET_ON_ITERATOR`

### DIFF
--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -346,7 +346,14 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```ignore
-    /// while let Some(val) = iter() {
+    /// while let Some(val) = iter.next() {
+    ///     ..
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    /// ```ignore
+    /// for val in &mut iter {
     ///     ..
     /// }
     /// ```


### PR DESCRIPTION
changelog: none

example for `WHILE_LET_ON_ITERATOR`, using `for` instead of `while let`
