### PR TITLE
unused_async: lint async methods

### DIFF
--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -15,6 +15,7 @@
     clippy::use_self,
     clippy::useless_format,
     clippy::wrong_self_convention,
+    clippy::unused_async,
     clippy::unused_self,
     unused
 )]

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -1,5 +1,5 @@
 error: methods called `new` usually return `Self`
-  --> $DIR/methods.rs:103:5
+  --> $DIR/methods.rs:104:5
    |
 LL | /     fn new() -> i32 {
 LL | |         0
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(..)` instead
-  --> $DIR/methods.rs:124:13
+  --> $DIR/methods.rs:125:13
    |
 LL |       let _ = v.iter().filter(|&x| {
    |  _____________^

--- a/tests/ui/should_impl_trait/corner_cases.rs
+++ b/tests/ui/should_impl_trait/corner_cases.rs
@@ -8,7 +8,8 @@
     clippy::missing_safety_doc,
     clippy::wrong_self_convention,
     clippy::missing_panics_doc,
-    clippy::return_self_not_must_use
+    clippy::return_self_not_must_use,
+    clippy::unused_async
 )]
 
 use std::ops::Mul;

--- a/tests/ui/unused_async.rs
+++ b/tests/ui/unused_async.rs
@@ -1,5 +1,8 @@
 #![warn(clippy::unused_async)]
 
+use std::future::Future;
+use std::pin::Pin;
+
 async fn foo() -> i32 {
     4
 }
@@ -7,6 +10,37 @@ async fn foo() -> i32 {
 async fn bar() -> i32 {
     foo().await
 }
+
+struct S;
+
+impl S {
+    async fn unused(&self) -> i32 {
+        1
+    }
+
+    async fn used(&self) -> i32 {
+        self.unused().await
+    }
+}
+
+trait AsyncTrait {
+    fn trait_method() -> Pin<Box<dyn Future<Output = i32>>>;
+}
+
+macro_rules! async_trait_impl {
+    () => {
+        impl AsyncTrait for S {
+            fn trait_method() -> Pin<Box<dyn Future<Output = i32>>> {
+                async fn unused() -> i32 {
+                    5
+                }
+
+                Box::pin(unused())
+            }
+        }
+    };
+}
+async_trait_impl!();
 
 fn main() {
     foo();

--- a/tests/ui/unused_async.stderr
+++ b/tests/ui/unused_async.stderr
@@ -1,5 +1,5 @@
 error: unused `async` for function with no await statements
-  --> $DIR/unused_async.rs:3:1
+  --> $DIR/unused_async.rs:6:1
    |
 LL | / async fn foo() -> i32 {
 LL | |     4
@@ -9,5 +9,15 @@ LL | | }
    = note: `-D clippy::unused-async` implied by `-D warnings`
    = help: consider removing the `async` from this function
 
-error: aborting due to previous error
+error: unused `async` for function with no await statements
+  --> $DIR/unused_async.rs:17:5
+   |
+LL | /     async fn unused(&self) -> i32 {
+LL | |         1
+LL | |     }
+   | |_____^
+   |
+   = help: consider removing the `async` from this function
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Now lints:

```rust
impl Foo {
    async fn method(&self) -> &'static str {
        "no await here"
    }
}
```

changelog: [`unused_async`]: lint async methods

Fixes #9024