### PR TITLE
put parentheses around neg_multiply suggestion if needed

### DIFF
--- a/tests/ui/neg_multiply.fixed
+++ b/tests/ui/neg_multiply.fixed
@@ -38,6 +38,9 @@ fn main() {
 
     0xcafe | -0xff00;
 
+    -(3_usize as i32);
+    -(3_usize as i32);
+
     -1 * -1; // should be ok
 
     X * -1; // should be ok

--- a/tests/ui/neg_multiply.rs
+++ b/tests/ui/neg_multiply.rs
@@ -38,6 +38,9 @@ fn main() {
 
     0xcafe | 0xff00 * -1;
 
+    3_usize as i32 * -1;
+    (3_usize as i32) * -1;
+
     -1 * -1; // should be ok
 
     X * -1; // should be ok

--- a/tests/ui/neg_multiply.stderr
+++ b/tests/ui/neg_multiply.stderr
@@ -36,5 +36,17 @@ error: this multiplication by -1 can be written more succinctly
 LL |     0xcafe | 0xff00 * -1;
    |              ^^^^^^^^^^^ help: consider using: `-0xff00`
 
-error: aborting due to 6 previous errors
+error: this multiplication by -1 can be written more succinctly
+  --> $DIR/neg_multiply.rs:41:5
+   |
+LL |     3_usize as i32 * -1;
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `-(3_usize as i32)`
+
+error: this multiplication by -1 can be written more succinctly
+  --> $DIR/neg_multiply.rs:42:5
+   |
+LL |     (3_usize as i32) * -1;
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `-(3_usize as i32)`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`neg_multiply`]: put parentheses around suggestion if needed
