### PR TITLE
confirm  using chain in collapsible_span_lint_calls

### DIFF
--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -668,6 +668,7 @@ impl<'tcx> LateLintPass<'tcx> for CollapsibleCalls {
             let body = cx.tcx.hir().body(*body);
             let only_expr = peel_blocks_with_stmt(&body.value);
             if let ExprKind::MethodCall(ps, span_call_args, _) = &only_expr.kind;
+            if let ExprKind::Path(..) = span_call_args[0].kind;
             then {
                 let and_then_snippets = get_and_then_snippets(cx, and_then_args);
                 let mut sle = SpanlessEq::new(cx).deny_side_effects();

--- a/tests/ui-internal/collapsible_span_lint_calls.fixed
+++ b/tests/ui-internal/collapsible_span_lint_calls.fixed
@@ -45,7 +45,12 @@ impl EarlyLintPass for Pass {
             if predicate {
                 db.note(note_msg);
             }
-        })
+        });
+
+        // Issue #8798
+        span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+            db.help(help_msg).help(help_msg);
+        });
     }
 }
 

--- a/tests/ui-internal/collapsible_span_lint_calls.rs
+++ b/tests/ui-internal/collapsible_span_lint_calls.rs
@@ -55,7 +55,12 @@ impl EarlyLintPass for Pass {
             if predicate {
                 db.note(note_msg);
             }
-        })
+        });
+
+        // Issue #8798
+        span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+            db.help(help_msg).help(help_msg);
+        });
     }
 }
 


### PR DESCRIPTION
close #8798 

This PR fixes false positive when using chain in `collapsible_span_lint_calls`.


changelog: None
