### PR TITLE
enum_variant_names should ignore when all prefixes are _

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -213,7 +213,7 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
 }
 
 #[must_use]
-fn have_no_extra_prefix(prefixes: &Vec<&str>) -> bool {
+fn have_no_extra_prefix(prefixes: &[&str]) -> bool {
     prefixes.is_empty() || prefixes.join("") == "_"
 }
 

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -190,7 +190,7 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
             .map(|e| *e.0)
             .collect();
     }
-    let (what, value) = match (pre.is_empty(), post.is_empty()) {
+    let (what, value) = match (have_no_extra_prefix(&pre), post.is_empty()) {
         (true, true) => return,
         (false, _) => ("pre", pre.join("")),
         (true, false) => {
@@ -210,6 +210,11 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
             what
         ),
     );
+}
+
+#[must_use]
+fn have_no_extra_prefix(prefixes: &Vec<&str>) -> bool {
+    prefixes.is_empty() || prefixes.join("") == "_"
 }
 
 #[must_use]

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -214,7 +214,7 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
 
 #[must_use]
 fn have_no_extra_prefix(prefixes: &[&str]) -> bool {
-    prefixes.is_empty() || prefixes.join("") == "_"
+    prefixes.iter().all(|p| p == &"" || p == &"_")
 }
 
 #[must_use]

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -158,4 +158,25 @@ enum Phase {
     PostLookup,
 }
 
+mod issue9018 {
+    enum DoLint {
+        _TypeCreate,
+        _TypeRead,
+        _TypeUpdate,
+        _TypeDestroy,
+    }
+
+    enum DoLintToo {
+        _CreateType,
+        _UpdateType,
+        _DeleteType,
+    }
+
+    enum DoNotLint {
+        _Foo,
+        _Bar,
+        _Baz,
+    }
+}
+
 fn main() {}

--- a/tests/ui/enum_variants.stderr
+++ b/tests/ui/enum_variants.stderr
@@ -120,5 +120,30 @@ LL | | }
    |
    = help: remove the postfixes and use full paths to the variants instead of glob imports
 
-error: aborting due to 12 previous errors
+error: all variants have the same prefix: `_Type`
+  --> $DIR/enum_variants.rs:162:5
+   |
+LL | /     enum DoLint {
+LL | |         _TypeCreate,
+LL | |         _TypeRead,
+LL | |         _TypeUpdate,
+LL | |         _TypeDestroy,
+LL | |     }
+   | |_____^
+   |
+   = help: remove the prefixes and use full paths to the variants instead of glob imports
+
+error: all variants have the same postfix: `Type`
+  --> $DIR/enum_variants.rs:169:5
+   |
+LL | /     enum DoLintToo {
+LL | |         _CreateType,
+LL | |         _UpdateType,
+LL | |         _DeleteType,
+LL | |     }
+   | |_____^
+   |
+   = help: remove the postfixes and use full paths to the variants instead of glob imports
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
close #9018 

When Enum prefix is only an underscore, we should not issue warnings.

changelog: fix false positive in enum_variant_names