### PR TITLE
Fix `extra_unused_lifetimes` false positive

### DIFF
--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -92,7 +92,9 @@ impl<'tcx> LateLintPass<'tcx> for Lifetimes {
         if let ItemKind::Fn(ref sig, generics, id) = item.kind {
             check_fn_inner(cx, sig.decl, Some(id), None, generics, item.span, true);
         } else if let ItemKind::Impl(impl_) = item.kind {
-            report_extra_impl_lifetimes(cx, impl_);
+            if !item.span.from_expansion() {
+                report_extra_impl_lifetimes(cx, impl_);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes #9014.

I confirmed the FP on the `crates.io` source as @JohnTitor mentioned, and confirmed that the FP is no longer present following this change.

I did not include a test in this PR because I think constructing one would be complicated, and the fix is pretty simple. But please let me know if this is unacceptable.

changelog: fix `extra_unused_lifetimes` FP