### PR TITLE
`extra_unused_lifetimes` add FP test case emitting from derived attributes.

### DIFF
--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -72,3 +72,17 @@ pub fn mini_macro(_: TokenStream) -> TokenStream {
         }
     )
 }
+
+#[proc_macro_derive(ExtraLifetimeDerive)]
+#[allow(unused)]
+pub fn extra_lifetime(_input: TokenStream) -> TokenStream {
+    quote!(
+        pub struct ExtraLifetime;
+
+        impl<'b> ExtraLifetime {
+            pub fn something<'c>() -> Self {
+                Self
+            }
+        }
+    )
+}

--- a/tests/ui/extra_unused_lifetimes.rs
+++ b/tests/ui/extra_unused_lifetimes.rs
@@ -1,3 +1,5 @@
+// aux-build:proc_macro_derive.rs
+
 #![allow(
     unused,
     dead_code,
@@ -6,6 +8,9 @@
     clippy::needless_arbitrary_self_type
 )]
 #![warn(clippy::extra_unused_lifetimes)]
+
+#[macro_use]
+extern crate proc_macro_derive;
 
 fn empty() {}
 
@@ -112,6 +117,13 @@ mod second_case {
     impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
         fn hey() {}
     }
+}
+
+// Should not lint
+#[derive(ExtraLifetimeDerive)]
+struct Human<'a> {
+    pub bones: i32,
+    pub name: &'a str,
 }
 
 fn main() {}

--- a/tests/ui/extra_unused_lifetimes.stderr
+++ b/tests/ui/extra_unused_lifetimes.stderr
@@ -1,5 +1,5 @@
 error: this lifetime isn't used in the function definition
-  --> $DIR/extra_unused_lifetimes.rs:14:14
+  --> $DIR/extra_unused_lifetimes.rs:19:14
    |
 LL | fn unused_lt<'a>(x: u8) {}
    |              ^^
@@ -7,31 +7,31 @@ LL | fn unused_lt<'a>(x: u8) {}
    = note: `-D clippy::extra-unused-lifetimes` implied by `-D warnings`
 
 error: this lifetime isn't used in the function definition
-  --> $DIR/extra_unused_lifetimes.rs:41:10
+  --> $DIR/extra_unused_lifetimes.rs:46:10
    |
 LL |     fn x<'a>(&self) {}
    |          ^^
 
 error: this lifetime isn't used in the function definition
-  --> $DIR/extra_unused_lifetimes.rs:67:22
+  --> $DIR/extra_unused_lifetimes.rs:72:22
    |
 LL |         fn unused_lt<'a>(x: u8) {}
    |                      ^^
 
 error: this lifetime isn't used in the impl
-  --> $DIR/extra_unused_lifetimes.rs:78:10
+  --> $DIR/extra_unused_lifetimes.rs:83:10
    |
 LL |     impl<'a> std::ops::AddAssign<&Scalar> for &mut Scalar {
    |          ^^
 
 error: this lifetime isn't used in the impl
-  --> $DIR/extra_unused_lifetimes.rs:84:10
+  --> $DIR/extra_unused_lifetimes.rs:89:10
    |
 LL |     impl<'b> Scalar {
    |          ^^
 
 error: this lifetime isn't used in the function definition
-  --> $DIR/extra_unused_lifetimes.rs:85:26
+  --> $DIR/extra_unused_lifetimes.rs:90:26
    |
 LL |         pub fn something<'c>() -> Self {
    |                          ^^


### PR DESCRIPTION
Add test to cover for #9014 which is fixed in #9037.

changelog: [`extra_unused_lifetimes`] Add FP test case emitting from derived attributes.

---

Seeing the FP from the test:

```sh
$ git revert -m 1 1d1ae10876d3eaa5c982dd3daa083b7c2fc363b9
$ TESTNAME=extra_unused_lifetime cargo uitest
```