### PR TITLE
update node.js version in `remark.yml`

### DIFF
--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v1.4.4
       with:
-        node-version: '12.x'
+        node-version: '14.x'
 
     - name: Install remark
       run: npm install remark-cli remark-lint remark-lint-maximum-line-length remark-preset-lint-recommended remark-gfm


### PR DESCRIPTION
Optional chain (`?.`) is available in `node v14`, but node version in CI is `node v12`, so CI is failed now.

ref:
https://github.com/rust-lang/rust-clippy/runs/7059529735?check_suite_focus=true

optional chain:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#browser_compatibility

Corresponding PR (maybe)
https://github.com/remarkjs/remark/pull/1007

changelog: None
