### PR TITLE
fix typo in Clippy Lints page

### DIFF
--- a/clippy_lints/src/large_const_arrays.rs
+++ b/clippy_lints/src/large_const_arrays.rs
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust.ignore
+    /// ```rust,ignore
     /// pub static a = [0u32; 1_000_000];
     /// ```
     #[clippy::version = "1.44.0"]

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -791,7 +791,7 @@ declare_clippy_lint! {
     /// the match block and thus will not unlock.
     ///
     /// ### Example
-    /// ```rust.ignore
+    /// ```rust,ignore
     /// # use std::sync::Mutex;
     ///
     /// # struct State {}


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/#significant_drop_in_scrutinee

changelog: none