### PR TITLE
Fix direct `#[allow]` attributes in `let_unit_value`

### DIFF
--- a/clippy_lints/src/unit_types/mod.rs
+++ b/clippy_lints/src/unit_types/mod.rs
@@ -3,7 +3,7 @@ mod unit_arg;
 mod unit_cmp;
 mod utils;
 
-use rustc_hir::{Expr, Stmt};
+use rustc_hir::{Expr, Local};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
@@ -99,8 +99,8 @@ declare_clippy_lint! {
 declare_lint_pass!(UnitTypes => [LET_UNIT_VALUE, UNIT_CMP, UNIT_ARG]);
 
 impl LateLintPass<'_> for UnitTypes {
-    fn check_stmt(&mut self, cx: &LateContext<'_>, stmt: &Stmt<'_>) {
-        let_unit_value::check(cx, stmt);
+    fn check_local(&mut self, cx: &LateContext<'_>, local: &Local<'_>) {
+        let_unit_value::check(cx, local);
     }
 
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {

--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -1,8 +1,9 @@
 // run-rustfix
 
+#![feature(lint_reasons)]
 #![warn(clippy::let_unit_value)]
 #![allow(clippy::no_effect)]
-#![allow(unused_variables)]
+#![allow(unused)]
 
 macro_rules! let_and_return {
     ($n:expr) => {{
@@ -112,4 +113,13 @@ fn _returns_generic() {
         Some(1) => f2(3),
         Some(_) => (),
     };
+}
+
+fn attributes() {
+    fn f() {}
+
+    #[allow(clippy::let_unit_value)]
+    let _ = f();
+    #[expect(clippy::let_unit_value)]
+    let _ = f();
 }

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -1,8 +1,9 @@
 // run-rustfix
 
+#![feature(lint_reasons)]
 #![warn(clippy::let_unit_value)]
 #![allow(clippy::no_effect)]
-#![allow(unused_variables)]
+#![allow(unused)]
 
 macro_rules! let_and_return {
     ($n:expr) => {{
@@ -112,4 +113,13 @@ fn _returns_generic() {
         Some(1) => f2(3),
         Some(_) => (),
     };
+}
+
+fn attributes() {
+    fn f() {}
+
+    #[allow(clippy::let_unit_value)]
+    let _ = f();
+    #[expect(clippy::let_unit_value)]
+    let _ = f();
 }

--- a/tests/ui/let_unit.stderr
+++ b/tests/ui/let_unit.stderr
@@ -1,5 +1,5 @@
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:14:5
+  --> $DIR/let_unit.rs:15:5
    |
 LL |     let _x = println!("x");
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `println!("x");`
@@ -7,13 +7,13 @@ LL |     let _x = println!("x");
    = note: `-D clippy::let-unit-value` implied by `-D warnings`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:18:9
+  --> $DIR/let_unit.rs:19:9
    |
 LL |         let _a = ();
    |         ^^^^^^^^^^^^ help: omit the `let` binding: `();`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:53:5
+  --> $DIR/let_unit.rs:54:5
    |
 LL | /     let _ = v
 LL | |         .into_iter()
@@ -36,7 +36,7 @@ LL +         .unwrap();
    |
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:80:5
+  --> $DIR/let_unit.rs:81:5
    |
 LL |     let x: () = f(); // Lint.
    |     ^^^^-^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     let x: () = f(); // Lint.
    |         help: use a wild (`_`) binding: `_`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:83:5
+  --> $DIR/let_unit.rs:84:5
    |
 LL |     let x: () = f2(0i32); // Lint.
    |     ^^^^-^^^^^^^^^^^^^^^^
@@ -52,31 +52,31 @@ LL |     let x: () = f2(0i32); // Lint.
    |         help: use a wild (`_`) binding: `_`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:85:5
+  --> $DIR/let_unit.rs:86:5
    |
 LL |     let _: () = f3(()); // Lint
    |     ^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `f3(());`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:86:5
+  --> $DIR/let_unit.rs:87:5
    |
 LL |     let x: () = f3(()); // Lint
    |     ^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `f3(());`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:88:5
+  --> $DIR/let_unit.rs:89:5
    |
 LL |     let _: () = f4(vec![()]); // Lint
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `f4(vec![()]);`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:89:5
+  --> $DIR/let_unit.rs:90:5
    |
 LL |     let x: () = f4(vec![()]); // Lint
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `f4(vec![()]);`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:98:5
+  --> $DIR/let_unit.rs:99:5
    |
 LL |     let x: () = if true { f() } else { f2(0) }; // Lint
    |     ^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL |     let x: () = if true { f() } else { f2(0) }; // Lint
    |         help: use a wild (`_`) binding: `_`
 
 error: this let-binding has unit value
-  --> $DIR/let_unit.rs:109:5
+  --> $DIR/let_unit.rs:110:5
    |
 LL | /     let _: () = match Some(0) {
 LL | |         None => f2(1),


### PR DESCRIPTION
Fixes part of #9080

Not sure why it doesn't work when the lint is emitted at the statement, but switching it to the local works fine

changelog: Fix direct `#[allow]` attributes in [`let_unit_value`]
