### PR TITLE
Correct lint version for `format_push_string`

### DIFF
--- a/clippy_lints/src/format_push_string.rs
+++ b/clippy_lints/src/format_push_string.rs
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// let mut s = String::new();
     /// let _ = write!(s, "0x{:X}", 1024);
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub FORMAT_PUSH_STRING,
     perf,
     "`format!(..)` appended to existing `String`"


### PR DESCRIPTION
Closes #9081 

chaneglog: none

IDK what else to say. Look I can draw an ascii penguin =D:

```
 (^v^)
<(   )>
  w w
```