### PR TITLE
Add lint `[bool_to_int_with_if]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3297,6 +3297,7 @@ Released 2018-09-13
 [`blocks_in_if_conditions`]: https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_if_conditions
 [`bool_assert_comparison`]: https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison
 [`bool_comparison`]: https://rust-lang.github.io/rust-clippy/master/index.html#bool_comparison
+[`bool_to_int_with_if`]: https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if
 [`borrow_as_ptr`]: https://rust-lang.github.io/rust-clippy/master/index.html#borrow_as_ptr
 [`borrow_deref_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
 [`borrow_interior_mutable_const`]: https://rust-lang.github.io/rust-clippy/master/index.html#borrow_interior_mutable_const

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -1,0 +1,25 @@
+use rustc_hir::*;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// ### Why is this bad?
+    ///
+    /// ### Example
+    /// ```rust
+    /// // example code where clippy issues a warning
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// // example code which does not raise clippy warning
+    /// ```
+    #[clippy::version = "1.64.0"]
+    pub BOOL_TO_INT_WITH_IF,
+    style,
+    "default lint description"
+}
+declare_lint_pass!(BoolToIntWithIf => [BOOL_TO_INT_WITH_IF]);
+
+impl LateLintPass<'_> for BoolToIntWithIf {}

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.64.0"]
     pub BOOL_TO_INT_WITH_IF,
     style,
-    "default lint description"
+    "using if to convert bool to int"
 }
 declare_lint_pass!(BoolToIntWithIf => [BOOL_TO_INT_WITH_IF]);
 

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
-    /// let condition = false;
+    /// # let condition = false;
     /// if condition {
     ///     1_i64
     /// } else {
@@ -24,12 +24,12 @@ declare_clippy_lint! {
     /// ```
     /// Use instead:
     /// ```rust
-    /// let condition = false;
+    /// # let condition = false;
     /// i64::from(condition);
     /// ```
     /// or
     /// ```rust
-    /// let condition = false;
+    /// # let condition = false;
     /// condition as i64;
     /// ```
     #[clippy::version = "1.64.0"]

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -46,7 +46,7 @@ impl<'tcx> LateLintPass<'tcx> for BoolToIntWithIf {
 
 fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx>) {
     if_chain!(
-        if let ExprKind::If(check, then, Some(else_)) = &expr.kind;
+        if let ExprKind::If(check, then, Some(else_)) = expr.kind;
 
         if let Some(then_lit) = int_literal(then);
         if let Some(else_lit) = int_literal(else_);

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -71,7 +71,7 @@ fn int_literal<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>) -> Option<&'tcx rustc_hi
         } = block;
         if let ExprKind::Lit(lit) = &expr.kind;
 
-        if let LitKind::Int(val, _) = lit.node;
+        if let LitKind::Int(_, _) = lit.node;
 
         then {
             return Some(expr)

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -8,10 +8,13 @@ use rustc_errors::Applicability;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Instead of using an if statement to convert a bool to an int, this lint suggests using a `as` coercion or a `from()` function.
+    /// Instead of using an if statement to convert a bool to an int,
+    /// this lint suggests using a `from()` function or an `as` coercion.
     /// ### Why is this bad?
     /// Coercion or `from()` is idiomatic way to convert bool to a number.
-    /// Both methods are guaranteed to return 1 for true, and 0 for false. See https://doc.rust-lang.org/std/primitive.bool.html#impl-From%3Cbool%3E
+    /// Both methods are guaranteed to return 1 for true, and 0 for false.
+    ///
+    /// See https://doc.rust-lang.org/std/primitive.bool.html#impl-From%3Cbool%3E
     ///
     /// ### Example
     /// ```rust

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -1,5 +1,5 @@
 use rustc_ast::LitKind;
-use rustc_hir::*;
+use rustc_hir::{Block, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
@@ -119,5 +119,5 @@ fn check_int_literal_equals_val<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>, expecte
         }
     );
 
-    return false;
+    false
 }

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -51,29 +51,29 @@ impl<'tcx> LateLintPass<'tcx> for BoolToIntWithIf {
 }
 
 fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx>) {
-    if 	let ExprKind::If(check, then, Some(else_)) = expr.kind &&
-    	let Some(then_lit) = int_literal(then) &&
-		let Some(else_lit) = int_literal(else_) &&
-    	check_int_literal_equals_val(then_lit, 1) &&
-    	check_int_literal_equals_val(else_lit, 0)
+    if let ExprKind::If(check, then, Some(else_)) = expr.kind
+        && let Some(then_lit) = int_literal(then)
+        && let Some(else_lit) = int_literal(else_)
+        && check_int_literal_equals_val(then_lit, 1)
+        && check_int_literal_equals_val(else_lit, 0)
     {
-		let mut applicability = Applicability::MachineApplicable;
+        let mut applicability = Applicability::MachineApplicable;
         let snippet = snippet_block_with_applicability(ctx, check.span, "..", None, &mut applicability);
         let snippet_with_braces = {
-			let need_parens = should_have_parentheses(check);
-			let (left_paren, right_paren) = if need_parens {("(", ")")} else {("", "")};
-			format!("{left_paren}{snippet}{right_paren}")
-		};
+            let need_parens = should_have_parentheses(check);
+            let (left_paren, right_paren) = if need_parens {("(", ")")} else {("", "")};
+            format!("{left_paren}{snippet}{right_paren}")
+        };
 
-		let ty = ctx.typeck_results().expr_ty(then_lit); // then and else must be of same type
+        let ty = ctx.typeck_results().expr_ty(then_lit); // then and else must be of same type
 
-		let suggestion = {
-			let wrap_in_curly = is_else_clause(ctx.tcx, expr);
-			let (left_curly, right_curly) = if wrap_in_curly {("{", "}")} else {("", "")};
-			format!(
-				"{left_curly}{ty}::from({snippet}){right_curly}"
-			)
-		}; // when used in else clause if statement should be wrapped in curly braces
+        let suggestion = {
+            let wrap_in_curly = is_else_clause(ctx.tcx, expr);
+            let (left_curly, right_curly) = if wrap_in_curly {("{", "}")} else {("", "")};
+            format!(
+                "{left_curly}{ty}::from({snippet}){right_curly}"
+            )
+        }; // when used in else clause if statement should be wrapped in curly braces
 
         span_lint_and_then(ctx,
             BOOL_TO_INT_WITH_IF,
@@ -93,15 +93,14 @@ fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx
 
 // If block contains only a int literal expression, return literal expression
 fn int_literal<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>) -> Option<&'tcx rustc_hir::Expr<'tcx>> {
-    if  let ExprKind::Block(block, _) = expr.kind &&
-        let Block {
+    if let ExprKind::Block(block, _) = expr.kind
+        && let Block {
             stmts: [],       // Shouldn't lint if statements with side effects
             expr: Some(expr),
             ..
-        } = block &&
-        let ExprKind::Lit(lit) = &expr.kind &&
-
-        let LitKind::Int(_, _) = lit.node
+        } = block
+        && let ExprKind::Lit(lit) = &expr.kind
+        && let LitKind::Int(_, _) = lit.node
     {
         Some(expr)
     } else {
@@ -110,9 +109,9 @@ fn int_literal<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>) -> Option<&'tcx rustc_hi
 }
 
 fn check_int_literal_equals_val<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>, expected_value: u128) -> bool {
-    if  let ExprKind::Lit(lit) = &expr.kind &&
-        let LitKind::Int(val, _) = lit.node &&
-        val == expected_value
+    if let ExprKind::Lit(lit) = &expr.kind
+        && let LitKind::Int(val, _) = lit.node
+        && val == expected_value
     {
         true
     } else {

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -1,19 +1,30 @@
+use rustc_ast::LitKind;
 use rustc_hir::*;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
     /// ### What it does
-    ///
+    /// Instead of using an if statement to convert a bool to an int, this lint suggests using a `as` coercion or a `from()` function.
     /// ### Why is this bad?
+    /// Coersion or `from()` is idiomatic way to convert bool to a number.
+    /// Both methods are guaranteed to return 1 for true, and 0 for false. See https://doc.rust-lang.org/std/primitive.bool.html#impl-From%3Cbool%3E
     ///
     /// ### Example
     /// ```rust
-    /// // example code where clippy issues a warning
+    /// if condition {
+    ///     1_i64
+    /// } else {
+    ///     0
+    /// }
     /// ```
     /// Use instead:
     /// ```rust
-    /// // example code which does not raise clippy warning
+    /// i64::from(condition)
+    /// ```
+    /// or
+    /// ```rust
+    /// condition as i64
     /// ```
     #[clippy::version = "1.64.0"]
     pub BOOL_TO_INT_WITH_IF,
@@ -22,4 +33,64 @@ declare_clippy_lint! {
 }
 declare_lint_pass!(BoolToIntWithIf => [BOOL_TO_INT_WITH_IF]);
 
-impl LateLintPass<'_> for BoolToIntWithIf {}
+impl<'tcx> LateLintPass<'tcx> for BoolToIntWithIf {
+    fn check_expr(&mut self, ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx>) {
+        if !expr.span.from_expansion() {
+            check_if_else(ctx, expr);
+        }
+    }
+}
+
+fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx>) {
+    if_chain!(
+        if let ExprKind::If(check, then, Some(else_)) = &expr.kind;
+
+        if let Some(then_lit) = int_literal(then);
+        if let Some(else_lit) = int_literal(else_);
+
+        if check_int_literal_equals_val(then_lit, 1);
+        if check_int_literal_equals_val(else_lit, 0);
+
+        then {
+            dbg!(expr.span);
+        }
+    );
+}
+
+// If block contains only a int literal expression, return literal expression
+fn int_literal<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>) -> Option<&'tcx rustc_hir::Expr<'tcx>> {
+    if_chain!(
+        if let ExprKind::Block(block, _) = expr.kind;
+        if let Block {
+            stmts: [],       // Shouldn't lint if statements with side effects
+            expr: Some(expr),
+            hir_id: _,
+            rules: _,
+            span: _,
+            targeted_by_break: _,
+        } = block;
+        if let ExprKind::Lit(lit) = &expr.kind;
+
+        if let LitKind::Int(val, _) = lit.node;
+
+        then {
+            return Some(expr)
+        }
+    );
+
+    None
+}
+
+fn check_int_literal_equals_val<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>, expected_value: u128) -> bool {
+    if_chain!(
+        if let ExprKind::Lit(lit) = &expr.kind;
+        if let LitKind::Int(val, _) = lit.node;
+        if val == expected_value;
+
+        then {
+            return true;
+        }
+    );
+
+    return false;
+}

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -69,16 +69,16 @@ fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx
                     Applicability::MachineApplicable,
                 );
 
-                diag.span_suggestion(
-                    expr.span,
-                    "replace with coercion",
-                    format!(
-                        "({}) as {}",
-                        snippet_block(ctx, check.span, "..", None),
-                        lit_type,
-                    ),
-                    Applicability::MachineApplicable,
-                );
+                // diag.span_suggestion(
+                //     expr.span,
+                //     "replace with coercion",
+                //     format!(
+                //         "({}) as {}",
+                //         snippet_block(ctx, check.span, "..", None),
+                //         lit_type,
+                //     ),
+                //     Applicability::MaybeIncorrect,
+                // );
             });
         }
     );

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -58,19 +58,20 @@ fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx
             let ty = ctx.typeck_results().expr_ty(then_lit); // then and else must be of same type
 
             let need_parens = should_have_parentheses(check);
-            let snippet = format!("{lbrace}{snippet}{rbrace}", snippet=snippet_block(ctx, check.span, "..", None), lbrace=if need_parens {"("} else {""}, rbrace=if need_parens {")"} else {""});
+            let snippet = snippet_block(ctx, check.span, "..", None);
+            let snippet_with_braces = format!("{lbrace}{snippet}{rbrace}", lbrace=if need_parens {"("} else {""}, rbrace=if need_parens {")"} else {""});
 
             span_lint_and_then(ctx, BOOL_TO_INT_WITH_IF, expr.span, "boolean to int conversion using if", |diag| {
                 diag.span_suggestion(
                     expr.span,
                     "replace with from",
                     format!(
-                        "{snippet} as {ty}",
+                        "{ty}::from({snippet})"
                     ),
                     Applicability::MachineApplicable,
                 );
 
-                diag.note(format!("`{ty}::from({snippet})` or `{snippet}.into()` can also be valid options"));
+                diag.note(format!("`{snippet_with_braces} as {ty}` or `{snippet_with_braces}.into()` can also be valid options"));
             });
         }
     );

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -48,7 +48,7 @@ impl<'tcx> LateLintPass<'tcx> for BoolToIntWithIf {
 }
 
 fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx>) {
-    if_chain!(
+    if_chain! {
         if let ExprKind::If(check, then, Some(else_)) = expr.kind;
 
         if let Some(then_lit) = int_literal(then);
@@ -77,12 +77,12 @@ fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx
                 diag.note(format!("`{snippet_with_braces} as {ty}` or `{snippet_with_braces}.into()` can also be valid options"));
             });
         }
-    );
+    };
 }
 
 // If block contains only a int literal expression, return literal expression
 fn int_literal<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>) -> Option<&'tcx rustc_hir::Expr<'tcx>> {
-    if_chain!(
+    if_chain! {
         if let ExprKind::Block(block, _) = expr.kind;
         if let Block {
             stmts: [],       // Shouldn't lint if statements with side effects
@@ -99,13 +99,13 @@ fn int_literal<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>) -> Option<&'tcx rustc_hi
         then {
             return Some(expr)
         }
-    );
+    };
 
     None
 }
 
 fn check_int_literal_equals_val<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>, expected_value: u128) -> bool {
-    if_chain!(
+    if_chain! {
         if let ExprKind::Lit(lit) = &expr.kind;
         if let LitKind::Int(val, _) = lit.node;
         if val == expected_value;
@@ -113,7 +113,7 @@ fn check_int_literal_equals_val<'tcx>(expr: &'tcx rustc_hir::Expr<'tcx>, expecte
         then {
             return true;
         }
-    );
+    };
 
     false
 }

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -15,19 +15,22 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
+    /// let condition = false;
     /// if condition {
     ///     1_i64
     /// } else {
     ///     0
-    /// }
+    /// };
     /// ```
     /// Use instead:
     /// ```rust
-    /// i64::from(condition)
+    /// let condition = false;
+    /// i64::from(condition);
     /// ```
     /// or
     /// ```rust
-    /// condition as i64
+    /// let condition = false;
+    /// condition as i64;
     /// ```
     #[clippy::version = "1.64.0"]
     pub BOOL_TO_INT_WITH_IF,

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -55,23 +55,22 @@ fn check_if_else<'tcx>(ctx: &LateContext<'tcx>, expr: &'tcx rustc_hir::Expr<'tcx
         if check_int_literal_equals_val(else_lit, 0);
 
         then {
-            let lit_type = ctx.typeck_results().expr_ty(then_lit); // then and else must be of same type
+            let ty = ctx.typeck_results().expr_ty(then_lit); // then and else must be of same type
 
             let need_parens = should_have_parentheses(check);
+            let snippet = format!("{lbrace}{snippet}{rbrace}", snippet=snippet_block(ctx, check.span, "..", None), lbrace=if need_parens {"("} else {""}, rbrace=if need_parens {")"} else {""});
 
             span_lint_and_then(ctx, BOOL_TO_INT_WITH_IF, expr.span, "boolean to int conversion using if", |diag| {
                 diag.span_suggestion(
                     expr.span,
                     "replace with from",
                     format!(
-                        "{lbrace}{snippet}{rbrace} as {ty}",
-                        lbrace=if need_parens {"("} else {""},
-                        rbrace=if need_parens {")"} else {""},
-                        ty=lit_type,
-                        snippet=snippet_block(ctx, check.span, "..", None),
+                        "{snippet} as {ty}",
                     ),
                     Applicability::MachineApplicable,
                 );
+
+                diag.note(format!("`{ty}::from({snippet})` or `{snippet}.into()` can also be valid options"));
             });
         }
     );

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -18,6 +18,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(blacklisted_name::BLACKLISTED_NAME),
     LintId::of(blocks_in_if_conditions::BLOCKS_IN_IF_CONDITIONS),
     LintId::of(bool_assert_comparison::BOOL_ASSERT_COMPARISON),
+    LintId::of(bool_to_int_with_if::BOOL_TO_INT_WITH_IF),
     LintId::of(booleans::LOGIC_BUG),
     LintId::of(booleans::NONMINIMAL_BOOL),
     LintId::of(borrow_deref_ref::BORROW_DEREF_REF),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -57,6 +57,7 @@ store.register_lints(&[
     blacklisted_name::BLACKLISTED_NAME,
     blocks_in_if_conditions::BLOCKS_IN_IF_CONDITIONS,
     bool_assert_comparison::BOOL_ASSERT_COMPARISON,
+    bool_to_int_with_if::BOOL_TO_INT_WITH_IF,
     booleans::LOGIC_BUG,
     booleans::NONMINIMAL_BOOL,
     borrow_as_ptr::BORROW_AS_PTR,

--- a/clippy_lints/src/lib.register_style.rs
+++ b/clippy_lints/src/lib.register_style.rs
@@ -7,6 +7,7 @@ store.register_group(true, "clippy::style", Some("clippy_style"), vec![
     LintId::of(blacklisted_name::BLACKLISTED_NAME),
     LintId::of(blocks_in_if_conditions::BLOCKS_IN_IF_CONDITIONS),
     LintId::of(bool_assert_comparison::BOOL_ASSERT_COMPARISON),
+    LintId::of(bool_to_int_with_if::BOOL_TO_INT_WITH_IF),
     LintId::of(casts::FN_TO_NUMERIC_CAST),
     LintId::of(casts::FN_TO_NUMERIC_CAST_WITH_TRUNCATION),
     LintId::of(collapsible_if::COLLAPSIBLE_ELSE_IF),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -180,6 +180,7 @@ mod await_holding_invalid;
 mod blacklisted_name;
 mod blocks_in_if_conditions;
 mod bool_assert_comparison;
+mod bool_to_int_with_if;
 mod booleans;
 mod borrow_as_ptr;
 mod borrow_deref_ref;
@@ -913,6 +914,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(move || Box::new(manual_retain::ManualRetain::new(msrv)));
     let verbose_bit_mask_threshold = conf.verbose_bit_mask_threshold;
     store.register_late_pass(move || Box::new(operators::Operators::new(verbose_bit_mask_threshold)));
+    store.register_late_pass(|| Box::new(bool_to_int_with_if::BoolToIntWithIf));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -201,12 +201,8 @@ fn form_exhaustive_matches<'a>(cx: &LateContext<'a>, ty: Ty<'a>, left: &Pat<'_>,
             // in the arms, so we need to evaluate the correct offsets here in order to iterate in
             // both arms at the same time.
             let len = max(
-                left_in.len() + {
-                    if left_pos.is_some() { 1 } else { 0 }
-                },
-                right_in.len() + {
-                    if right_pos.is_some() { 1 } else { 0 }
-                },
+                left_in.len() + usize::from(left_pos.is_some()),
+                right_in.len() + usize::from(right_pos.is_some()),
             );
             let mut left_pos = left_pos.unwrap_or(usize::MAX);
             let mut right_pos = right_pos.unwrap_or(usize::MAX);

--- a/clippy_lints/src/only_used_in_recursion.rs
+++ b/clippy_lints/src/only_used_in_recursion.rs
@@ -134,7 +134,7 @@ impl<'tcx> LateLintPass<'tcx> for OnlyUsedInRecursion {
                     });
                     v
                 })
-                .skip(if has_self { 1 } else { 0 })
+                .skip(usize::from(has_self))
                 .filter(|(_, _, ident)| !ident.name.as_str().starts_with('_'))
                 .collect_vec();
 

--- a/tests/ui/author/struct.rs
+++ b/tests/ui/author/struct.rs
@@ -1,13 +1,11 @@
-#[allow(clippy::unnecessary_operation, clippy::single_match)]
+#![allow(clippy::unnecessary_operation, clippy::single_match, clippy::no_effect)]
 fn main() {
     struct Test {
         field: u32,
     }
 
     #[clippy::author]
-    Test {
-        field: if true { 1 } else { 0 },
-    };
+    Test { field: true as u32 };
 
     let test = Test { field: 1 };
 

--- a/tests/ui/author/struct.rs
+++ b/tests/ui/author/struct.rs
@@ -1,11 +1,18 @@
-#![allow(clippy::unnecessary_operation, clippy::single_match, clippy::no_effect)]
+#![allow(
+    clippy::unnecessary_operation,
+    clippy::single_match,
+    clippy::no_effect,
+    clippy::bool_to_int_with_if
+)]
 fn main() {
     struct Test {
         field: u32,
     }
 
     #[clippy::author]
-    Test { field: true as u32 };
+    Test {
+        field: if true { 1 } else { 0 },
+    };
 
     let test = Test { field: 1 };
 

--- a/tests/ui/author/struct.stdout
+++ b/tests/ui/author/struct.stdout
@@ -3,11 +3,20 @@ if_chain! {
     if match_qpath(qpath, &["Test"]);
     if fields.len() == 1;
     if fields[0].ident.as_str() == "field";
-    if let ExprKind::Cast(expr1, cast_ty) = fields[0].expr.kind;
-    if let TyKind::Path(ref qpath1) = cast_ty.kind;
-    if match_qpath(qpath1, &["u32"]);
+    if let ExprKind::If(cond, then, Some(else_expr)) = fields[0].expr.kind;
+    if let ExprKind::DropTemps(expr1) = cond.kind;
     if let ExprKind::Lit(ref lit) = expr1.kind;
     if let LitKind::Bool(true) = lit.node;
+    if let ExprKind::Block(block, None) = then.kind;
+    if block.stmts.is_empty();
+    if let Some(trailing_expr) = block.expr;
+    if let ExprKind::Lit(ref lit1) = trailing_expr.kind;
+    if let LitKind::Int(1, LitIntType::Unsuffixed) = lit1.node;
+    if let ExprKind::Block(block1, None) = else_expr.kind;
+    if block1.stmts.is_empty();
+    if let Some(trailing_expr1) = block1.expr;
+    if let ExprKind::Lit(ref lit2) = trailing_expr1.kind;
+    if let LitKind::Int(0, LitIntType::Unsuffixed) = lit2.node;
     then {
         // report your lint here
     }

--- a/tests/ui/author/struct.stdout
+++ b/tests/ui/author/struct.stdout
@@ -3,20 +3,11 @@ if_chain! {
     if match_qpath(qpath, &["Test"]);
     if fields.len() == 1;
     if fields[0].ident.as_str() == "field";
-    if let ExprKind::If(cond, then, Some(else_expr)) = fields[0].expr.kind;
-    if let ExprKind::DropTemps(expr1) = cond.kind;
+    if let ExprKind::Cast(expr1, cast_ty) = fields[0].expr.kind;
+    if let TyKind::Path(ref qpath1) = cast_ty.kind;
+    if match_qpath(qpath1, &["u32"]);
     if let ExprKind::Lit(ref lit) = expr1.kind;
     if let LitKind::Bool(true) = lit.node;
-    if let ExprKind::Block(block, None) = then.kind;
-    if block.stmts.is_empty();
-    if let Some(trailing_expr) = block.expr;
-    if let ExprKind::Lit(ref lit1) = trailing_expr.kind;
-    if let LitKind::Int(1, LitIntType::Unsuffixed) = lit1.node;
-    if let ExprKind::Block(block1, None) = else_expr.kind;
-    if block1.stmts.is_empty();
-    if let Some(trailing_expr1) = block1.expr;
-    if let ExprKind::Lit(ref lit2) = trailing_expr1.kind;
-    if let LitKind::Int(0, LitIntType::Unsuffixed) = lit2.node;
     then {
         // report your lint here
     }

--- a/tests/ui/bool_to_int_with_if.fixed
+++ b/tests/ui/bool_to_int_with_if.fixed
@@ -18,7 +18,29 @@ fn main() {
     i32::from(cond(a, b));
     i32::from(x + y < 4);
 
+    // if else if
+    if a {
+        123
+    } else {i32::from(b)};
+
     // Shouldn't lint
+
+    if a {
+        1
+    } else if b {
+        0
+    } else {
+        3
+    };
+
+    if a {
+        3
+    } else if b {
+        1
+    } else {
+        -2
+    };
+
     if a {
         3
     } else {
@@ -29,6 +51,23 @@ fn main() {
         1
     } else {
         0
+    };
+    if a {
+        1
+    } else {
+        side_effect();
+        0
+    };
+
+    // multiple else ifs
+    if a {
+        123
+    } else if b {
+        1
+    } else if a | b {
+        0
+    } else {
+        123
     };
 
     some_fn(a);

--- a/tests/ui/bool_to_int_with_if.fixed
+++ b/tests/ui/bool_to_int_with_if.fixed
@@ -1,35 +1,44 @@
 // run-rustfix
 
 #![warn(clippy::bool_to_int_with_if)]
+#[allow(unused)]
 
 fn main() {
-    let cond = true;
+    let a = true;
+    let b = false;
 
-    // should warn
-    let _x = i32::from(cond);
+    let x = 1;
+    let y = 2;
 
-    let _x = i32::from(cond ^ true);
+    /// Should lint
+    // precedence
+    a as i32;
+    !a as i32;
+    (a || b) as i32;
+    cond(a, b) as i32;
+    (x + y < 4) as i32;
 
-    // it should be type aware
-    let _x: u8 = u8::from(cond);
-
-    let _x = i16::from(cond);
-
-    // shouldn't
-    let _x = if cond { Some(1) } else { None };
-
-    let _x = if cond {
+    /// Shouldn't lint
+    if a {
+        3
+    } else {
+        0
+    };
+    if a {
         side_effect();
         1
     } else {
         0
     };
+}
 
-    let _x = if cond { 2 } else { 0 };
-
-    // questionable
-    // maybe `!cond as usize` is reasonable
-    let _x = if cond { 0 } else { 1 };
+// Lint returns and type inference
+fn some_fn(a: bool) -> u8 {
+    a as u8
 }
 
 fn side_effect() {}
+
+fn cond(a: bool, b: bool) -> bool {
+    a || b
+}

--- a/tests/ui/bool_to_int_with_if.fixed
+++ b/tests/ui/bool_to_int_with_if.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 
 #![warn(clippy::bool_to_int_with_if)]
-#[allow(unused)]
+#![allow(unused, dead_code, clippy::unnecessary_operation, clippy::no_effect)]
 
 fn main() {
     let a = true;
@@ -10,7 +10,7 @@ fn main() {
     let x = 1;
     let y = 2;
 
-    /// Should lint
+    // Should lint
     // precedence
     a as i32;
     !a as i32;
@@ -18,7 +18,7 @@ fn main() {
     cond(a, b) as i32;
     (x + y < 4) as i32;
 
-    /// Shouldn't lint
+    // Shouldn't lint
     if a {
         3
     } else {
@@ -30,6 +30,8 @@ fn main() {
     } else {
         0
     };
+
+    some_fn(a);
 }
 
 // Lint returns and type inference

--- a/tests/ui/bool_to_int_with_if.fixed
+++ b/tests/ui/bool_to_int_with_if.fixed
@@ -6,30 +6,30 @@ fn main() {
     let cond = true;
 
     // should warn
-    let x = i32::from(cond);
+    let _x = i32::from(cond);
 
-    let x = i32::from(cond ^ true);
+    let _x = i32::from(cond ^ true);
 
     // it should be type aware
-    let x: u8 = u8::from(cond);
-    let x = i16::from(cond);
+    let _x: u8 = u8::from(cond);
+
+    let _x = i16::from(cond);
 
     // shouldn't
+    let _x = if cond { Some(1) } else { None };
 
-    let x = if cond { Some(1) } else { None };
-
-    let x = if cond {
+    let _x = if cond {
         side_effect();
         1
     } else {
         0
     };
 
-    let x = if cond { 2 } else { 0 };
+    let _x = if cond { 2 } else { 0 };
 
     // questionable
     // maybe `!cond as usize` is reasonable
-    let x = if cond { 0 } else { 1 };
+    let _x = if cond { 0 } else { 1 };
 }
 
 fn side_effect() {}

--- a/tests/ui/bool_to_int_with_if.fixed
+++ b/tests/ui/bool_to_int_with_if.fixed
@@ -12,11 +12,11 @@ fn main() {
 
     // Should lint
     // precedence
-    a as i32;
-    !a as i32;
-    (a || b) as i32;
-    cond(a, b) as i32;
-    (x + y < 4) as i32;
+    i32::from(a);
+    i32::from(!a);
+    i32::from(a || b);
+    i32::from(cond(a, b));
+    i32::from(x + y < 4);
 
     // Shouldn't lint
     if a {
@@ -36,7 +36,7 @@ fn main() {
 
 // Lint returns and type inference
 fn some_fn(a: bool) -> u8 {
-    a as u8
+    u8::from(a)
 }
 
 fn side_effect() {}

--- a/tests/ui/bool_to_int_with_if.fixed
+++ b/tests/ui/bool_to_int_with_if.fixed
@@ -1,0 +1,35 @@
+// run-rustfix
+
+#![warn(clippy::bool_to_int_with_if)]
+
+fn main() {
+    let cond = true;
+
+    // should warn
+    let x = i32::from(cond);
+
+    let x = i32::from(cond ^ true);
+
+    // it should be type aware
+    let x: u8 = u8::from(cond);
+    let x = i16::from(cond);
+
+    // shouldn't
+
+    let x = if cond { Some(1) } else { None };
+
+    let x = if cond {
+        side_effect();
+        1
+    } else {
+        0
+    };
+
+    let x = if cond { 2 } else { 0 };
+
+    // questionable
+    // maybe `!cond as usize` is reasonable
+    let x = if cond { 0 } else { 1 };
+}
+
+fn side_effect() {}

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -1,0 +1,5 @@
+#![warn(clippy::bool_to_int_with_if)]
+
+fn main() {
+    // test code goes here
+}

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -1,3 +1,5 @@
+// run-rustfix
+
 #![warn(clippy::bool_to_int_with_if)]
 
 fn main() {

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -1,5 +1,25 @@
 #![warn(clippy::bool_to_int_with_if)]
 
 fn main() {
-    // test code goes here
+    // should warn
+    let cond = true;
+    let x = if (cond) { 1 } else { 0 };
+
+    // shouldn't
+    let x = if (cond) { Some(1) } else { None };
+
+    let x = if (cond) {
+        side_effect();
+        1
+    } else {
+        0
+    };
+
+    let x = if (cond) { 2 } else { 0 };
+
+    // questionable
+    // maybe `!cond as usize` is reasonable
+    let x = if (cond) { 0 } else { 1 };
 }
+
+fn side_effect() {}

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -47,6 +47,8 @@ fn main() {
         0
     };
 
+    // Shouldn't lint
+
     if a {
         1
     } else if b {
@@ -56,14 +58,13 @@ fn main() {
     };
 
     if a {
-        1
+        3
     } else if b {
         1
     } else {
         -2
     };
 
-    // Shouldn't lint
     if a {
         3
     } else {
@@ -80,6 +81,17 @@ fn main() {
     } else {
         side_effect();
         0
+    };
+
+    // multiple else ifs
+    if a {
+        123
+    } else if b {
+        1
+    } else if a | b {
+        0
+    } else {
+        123
     };
 
     some_fn(a);

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -1,25 +1,29 @@
 #![warn(clippy::bool_to_int_with_if)]
 
 fn main() {
-    // should warn
     let cond = true;
-    let x = if (cond) { 1 } else { 0 };
+
+    // should warn
+    let x = if cond { 1 } else { 0 };
+
+    let x = if cond ^ true { 1 } else { 0 };
 
     // shouldn't
-    let x = if (cond) { Some(1) } else { None };
 
-    let x = if (cond) {
+    let x = if cond { Some(1) } else { None };
+
+    let x = if cond {
         side_effect();
         1
     } else {
         0
     };
 
-    let x = if (cond) { 2 } else { 0 };
+    let x = if cond { 2 } else { 0 };
 
     // questionable
     // maybe `!cond as usize` is reasonable
-    let x = if (cond) { 0 } else { 1 };
+    let x = if cond { 0 } else { 1 };
 }
 
 fn side_effect() {}

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -10,6 +10,7 @@ fn main() {
 
     // it should be type aware
     let x: u8 = if cond { 1 } else { 0 };
+    let x = if cond { 1i16 } else { 0i16 };
 
     // shouldn't
 

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -6,30 +6,30 @@ fn main() {
     let cond = true;
 
     // should warn
-    let x = if cond { 1 } else { 0 };
+    let _x = if cond { 1 } else { 0 };
 
-    let x = if cond ^ true { 1 } else { 0 };
+    let _x = if cond ^ true { 1 } else { 0 };
 
     // it should be type aware
-    let x: u8 = if cond { 1 } else { 0 };
-    let x = if cond { 1i16 } else { 0i16 };
+    let _x: u8 = if cond { 1 } else { 0 };
+
+    let _x = if cond { 1i16 } else { 0i16 };
 
     // shouldn't
+    let _x = if cond { Some(1) } else { None };
 
-    let x = if cond { Some(1) } else { None };
-
-    let x = if cond {
+    let _x = if cond {
         side_effect();
         1
     } else {
         0
     };
 
-    let x = if cond { 2 } else { 0 };
+    let _x = if cond { 2 } else { 0 };
 
     // questionable
     // maybe `!cond as usize` is reasonable
-    let x = if cond { 0 } else { 1 };
+    let _x = if cond { 0 } else { 1 };
 }
 
 fn side_effect() {}

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -38,6 +38,31 @@ fn main() {
         0
     };
 
+    // if else if
+    if a {
+        123
+    } else if b {
+        1
+    } else {
+        0
+    };
+
+    if a {
+        1
+    } else if b {
+        0
+    } else {
+        3
+    };
+
+    if a {
+        1
+    } else if b {
+        1
+    } else {
+        -2
+    };
+
     // Shouldn't lint
     if a {
         3
@@ -48,6 +73,12 @@ fn main() {
         side_effect();
         1
     } else {
+        0
+    };
+    if a {
+        1
+    } else {
+        side_effect();
         0
     };
 

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -1,35 +1,64 @@
 // run-rustfix
 
 #![warn(clippy::bool_to_int_with_if)]
+#[allow(unused)]
 
 fn main() {
-    let cond = true;
+    let a = true;
+    let b = false;
 
-    // should warn
-    let _x = if cond { 1 } else { 0 };
+    let x = 1;
+    let y = 2;
 
-    let _x = if cond ^ true { 1 } else { 0 };
-
-    // it should be type aware
-    let _x: u8 = if cond { 1 } else { 0 };
-
-    let _x = if cond { 1i16 } else { 0i16 };
-
-    // shouldn't
-    let _x = if cond { Some(1) } else { None };
-
-    let _x = if cond {
-        side_effect();
+    /// Should lint
+    // precedence
+    if a {
+        1
+    } else {
+        0
+    };
+    if !a {
+        1
+    } else {
+        0
+    };
+    if a || b {
+        1
+    } else {
+        0
+    };
+    if cond(a, b) {
+        1
+    } else {
+        0
+    };
+    if x + y < 4 {
         1
     } else {
         0
     };
 
-    let _x = if cond { 2 } else { 0 };
+    /// Shouldn't lint
+    if a {
+        3
+    } else {
+        0
+    };
+    if a {
+        side_effect();
+        1
+    } else {
+        0
+    };
+}
 
-    // questionable
-    // maybe `!cond as usize` is reasonable
-    let _x = if cond { 0 } else { 1 };
+// Lint returns and type inference
+fn some_fn(a: bool) -> u8 {
+    if a { 1 } else { 0 }
 }
 
 fn side_effect() {}
+
+fn cond(a: bool, b: bool) -> bool {
+    a || b
+}

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 
 #![warn(clippy::bool_to_int_with_if)]
-#[allow(unused)]
+#![allow(unused, dead_code, clippy::unnecessary_operation, clippy::no_effect)]
 
 fn main() {
     let a = true;
@@ -10,7 +10,7 @@ fn main() {
     let x = 1;
     let y = 2;
 
-    /// Should lint
+    // Should lint
     // precedence
     if a {
         1
@@ -38,7 +38,7 @@ fn main() {
         0
     };
 
-    /// Shouldn't lint
+    // Shouldn't lint
     if a {
         3
     } else {
@@ -50,6 +50,8 @@ fn main() {
     } else {
         0
     };
+
+    some_fn(a);
 }
 
 // Lint returns and type inference

--- a/tests/ui/bool_to_int_with_if.rs
+++ b/tests/ui/bool_to_int_with_if.rs
@@ -8,6 +8,9 @@ fn main() {
 
     let x = if cond ^ true { 1 } else { 0 };
 
+    // it should be type aware
+    let x: u8 = if cond { 1 } else { 0 };
+
     // shouldn't
 
     let x = if cond { Some(1) } else { None };

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -1,28 +1,28 @@
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:9:13
+  --> $DIR/bool_to_int_with_if.rs:9:14
    |
-LL |     let x = if cond { 1 } else { 0 };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond)`
+LL |     let _x = if cond { 1 } else { 0 };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond)`
    |
    = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:11:13
+  --> $DIR/bool_to_int_with_if.rs:11:14
    |
-LL |     let x = if cond ^ true { 1 } else { 0 };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond ^ true)`
+LL |     let _x = if cond ^ true { 1 } else { 0 };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond ^ true)`
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:14:17
+  --> $DIR/bool_to_int_with_if.rs:14:18
    |
-LL |     let x: u8 = if cond { 1 } else { 0 };
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(cond)`
+LL |     let _x: u8 = if cond { 1 } else { 0 };
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(cond)`
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:15:13
+  --> $DIR/bool_to_int_with_if.rs:16:14
    |
-LL |     let x = if cond { 1i16 } else { 0i16 };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i16::from(cond)`
+LL |     let _x = if cond { 1i16 } else { 0i16 };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i16::from(cond)`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -60,12 +60,25 @@ LL | |     };
    = note: `(x + y < 4) as i32` or `(x + y < 4).into()` can also be valid options
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:59:5
+  --> $DIR/bool_to_int_with_if.rs:44:12
+   |
+LL |       } else if b {
+   |  ____________^
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     };
+   | |_____^ help: replace with from: `{i32::from(b)}`
+   |
+   = note: `b as i32` or `b.into()` can also be valid options
+
+error: boolean to int conversion using if
+  --> $DIR/bool_to_int_with_if.rs:102:5
    |
 LL |     if a { 1 } else { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(a)`
    |
    = note: `a as u8` or `a.into()` can also be valid options
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -6,10 +6,10 @@ LL | |         1
 LL | |     } else {
 LL | |         0
 LL | |     };
-   | |_____^ help: replace with from: `a as i32`
+   | |_____^ help: replace with from: `i32::from(a)`
    |
    = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
-   = note: `i32::from(a)` or `a.into()` can also be valid options
+   = note: `a` or `a.into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:20:5
@@ -19,9 +19,9 @@ LL | |         1
 LL | |     } else {
 LL | |         0
 LL | |     };
-   | |_____^ help: replace with from: `!a as i32`
+   | |_____^ help: replace with from: `i32::from(!a)`
    |
-   = note: `i32::from(!a)` or `!a.into()` can also be valid options
+   = note: `!a` or `!a.into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:25:5
@@ -31,9 +31,9 @@ LL | |         1
 LL | |     } else {
 LL | |         0
 LL | |     };
-   | |_____^ help: replace with from: `(a || b) as i32`
+   | |_____^ help: replace with from: `i32::from(a || b)`
    |
-   = note: `i32::from((a || b))` or `(a || b).into()` can also be valid options
+   = note: `(a || b)` or `(a || b).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:30:5
@@ -43,9 +43,9 @@ LL | |         1
 LL | |     } else {
 LL | |         0
 LL | |     };
-   | |_____^ help: replace with from: `cond(a, b) as i32`
+   | |_____^ help: replace with from: `i32::from(cond(a, b))`
    |
-   = note: `i32::from(cond(a, b))` or `cond(a, b).into()` can also be valid options
+   = note: `cond(a, b)` or `cond(a, b).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:35:5
@@ -55,17 +55,17 @@ LL | |         1
 LL | |     } else {
 LL | |         0
 LL | |     };
-   | |_____^ help: replace with from: `(x + y < 4) as i32`
+   | |_____^ help: replace with from: `i32::from(x + y < 4)`
    |
-   = note: `i32::from((x + y < 4))` or `(x + y < 4).into()` can also be valid options
+   = note: `(x + y < 4)` or `(x + y < 4).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:59:5
    |
 LL |     if a { 1 } else { 0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `a as u8`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(a)`
    |
-   = note: `u8::from(a)` or `a.into()` can also be valid options
+   = note: `a` or `a.into()` can also be valid options
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -1,28 +1,60 @@
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:9:14
+  --> $DIR/bool_to_int_with_if.rs:15:5
    |
-LL |     let _x = if cond { 1 } else { 0 };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond)`
+LL | /     if a {
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     };
+   | |_____^ help: replace with from: `a as i32`
    |
    = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:11:14
+  --> $DIR/bool_to_int_with_if.rs:20:5
    |
-LL |     let _x = if cond ^ true { 1 } else { 0 };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond ^ true)`
+LL | /     if !a {
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     };
+   | |_____^ help: replace with from: `!a as i32`
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:14:18
+  --> $DIR/bool_to_int_with_if.rs:25:5
    |
-LL |     let _x: u8 = if cond { 1 } else { 0 };
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(cond)`
+LL | /     if a || b {
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     };
+   | |_____^ help: replace with from: `(a || b) as i32`
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:16:14
+  --> $DIR/bool_to_int_with_if.rs:30:5
    |
-LL |     let _x = if cond { 1i16 } else { 0i16 };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i16::from(cond)`
+LL | /     if cond(a, b) {
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     };
+   | |_____^ help: replace with from: `cond(a, b) as i32`
 
-error: aborting due to 4 previous errors
+error: boolean to int conversion using if
+  --> $DIR/bool_to_int_with_if.rs:35:5
+   |
+LL | /     if x + y < 4 {
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     };
+   | |_____^ help: replace with from: `(x + y < 4) as i32`
+
+error: boolean to int conversion using if
+  --> $DIR/bool_to_int_with_if.rs:57:5
+   |
+LL |     if a { 1 } else { 0 }
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `a as u8`
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -9,7 +9,7 @@ LL | |     };
    | |_____^ help: replace with from: `i32::from(a)`
    |
    = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
-   = note: `a` or `a.into()` can also be valid options
+   = note: `a as i32` or `a.into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:20:5
@@ -21,7 +21,7 @@ LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `i32::from(!a)`
    |
-   = note: `!a` or `!a.into()` can also be valid options
+   = note: `!a as i32` or `!a.into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:25:5
@@ -33,7 +33,7 @@ LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `i32::from(a || b)`
    |
-   = note: `(a || b)` or `(a || b).into()` can also be valid options
+   = note: `(a || b) as i32` or `(a || b).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:30:5
@@ -45,7 +45,7 @@ LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `i32::from(cond(a, b))`
    |
-   = note: `cond(a, b)` or `cond(a, b).into()` can also be valid options
+   = note: `cond(a, b) as i32` or `cond(a, b).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:35:5
@@ -57,7 +57,7 @@ LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `i32::from(x + y < 4)`
    |
-   = note: `(x + y < 4)` or `(x + y < 4).into()` can also be valid options
+   = note: `(x + y < 4) as i32` or `(x + y < 4).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:59:5
@@ -65,7 +65,7 @@ error: boolean to int conversion using if
 LL |     if a { 1 } else { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(a)`
    |
-   = note: `a` or `a.into()` can also be valid options
+   = note: `a as u8` or `a.into()` can also be valid options
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -1,0 +1,28 @@
+error: boolean to int conversion using if
+  --> $DIR/bool_to_int_with_if.rs:9:13
+   |
+LL |     let x = if cond { 1 } else { 0 };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond)`
+   |
+   = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
+
+error: boolean to int conversion using if
+  --> $DIR/bool_to_int_with_if.rs:11:13
+   |
+LL |     let x = if cond ^ true { 1 } else { 0 };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i32::from(cond ^ true)`
+
+error: boolean to int conversion using if
+  --> $DIR/bool_to_int_with_if.rs:14:17
+   |
+LL |     let x: u8 = if cond { 1 } else { 0 };
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `u8::from(cond)`
+
+error: boolean to int conversion using if
+  --> $DIR/bool_to_int_with_if.rs:15:13
+   |
+LL |     let x = if cond { 1i16 } else { 0i16 };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `i16::from(cond)`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -9,6 +9,7 @@ LL | |     };
    | |_____^ help: replace with from: `a as i32`
    |
    = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
+   = note: `i32::from(a)` or `a.into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:20:5
@@ -19,6 +20,8 @@ LL | |     } else {
 LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `!a as i32`
+   |
+   = note: `i32::from(!a)` or `!a.into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:25:5
@@ -29,6 +32,8 @@ LL | |     } else {
 LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `(a || b) as i32`
+   |
+   = note: `i32::from((a || b))` or `(a || b).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:30:5
@@ -39,6 +44,8 @@ LL | |     } else {
 LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `cond(a, b) as i32`
+   |
+   = note: `i32::from(cond(a, b))` or `cond(a, b).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:35:5
@@ -49,12 +56,16 @@ LL | |     } else {
 LL | |         0
 LL | |     };
    | |_____^ help: replace with from: `(x + y < 4) as i32`
+   |
+   = note: `i32::from((x + y < 4))` or `(x + y < 4).into()` can also be valid options
 
 error: boolean to int conversion using if
   --> $DIR/bool_to_int_with_if.rs:57:5
    |
 LL |     if a { 1 } else { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `a as u8`
+   |
+   = note: `u8::from(a)` or `a.into()` can also be valid options
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/bool_to_int_with_if.stderr
+++ b/tests/ui/bool_to_int_with_if.stderr
@@ -60,7 +60,7 @@ LL | |     };
    = note: `i32::from((x + y < 4))` or `(x + y < 4).into()` can also be valid options
 
 error: boolean to int conversion using if
-  --> $DIR/bool_to_int_with_if.rs:57:5
+  --> $DIR/bool_to_int_with_if.rs:59:5
    |
 LL |     if a { 1 } else { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^ help: replace with from: `a as u8`


### PR DESCRIPTION
If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

---

fixes #8131

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: added lint ``[`bool_to_int_with_if`]``