### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -261,6 +261,8 @@ jobs:
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
 
   end-success:
+    permissions:
+      contents: none
     name: bors test finished
     if: github.event.pusher.name == 'bors' && success()
     runs-on: ubuntu-latest
@@ -271,6 +273,8 @@ jobs:
         run: exit 0
 
   end-failure:
+    permissions:
+      contents: none
     name: bors test finished
     if: github.event.pusher.name == 'bors' && (failure() || cancelled())
     runs-on: ubuntu-latest

--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -16,6 +16,9 @@ on:
 env:
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   clippy_dev:
     runs-on: ubuntu-latest
@@ -50,6 +53,8 @@ jobs:
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
 
   end-success:
+    permissions:
+      contents: none
     name: bors dev test finished
     if: github.event.pusher.name == 'bors' && success()
     runs-on: ubuntu-latest
@@ -60,6 +65,8 @@ jobs:
         run: exit 0
 
   end-failure:
+    permissions:
+      contents: none
     name: bors dev test finished
     if: github.event.pusher.name == 'bors' && (failure() || cancelled())
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ env:
   SHA: '${{ github.sha }}'
   SSH_REPO: 'git@github.com:${{ github.repository }}.git'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -9,6 +9,9 @@ on:
     paths:
     - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   remark:
     runs-on: ubuntu-latest
@@ -46,6 +49,8 @@ jobs:
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
 
   end-success:
+    permissions:
+      contents: none
     name: bors remark test finished
     if: github.event.pusher.name == 'bors' && success()
     runs-on: ubuntu-latest
@@ -56,6 +61,8 @@ jobs:
         run: exit 0
 
   end-failure:
+    permissions:
+      contents: none
     name: bors remark test finished
     if: github.event.pusher.name == 'bors' && (failure() || cancelled())
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
