### PR TITLE
corrected README.md book link

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -1,4 +1,4 @@
 # Clippy Book
 
 This is the source for the Clippy Book. See the
-[book](src/infrastructure/book.md) for more information.
+[book](src/development/infrastructure/book.md) for more information.


### PR DESCRIPTION
This change corrects the book link on the Clippy Book README.md.

changelog: none