### PR TITLE
Correct `[clippy::version]` for 1.62 lints and add note to docs

### DIFF
--- a/book/src/development/infrastructure/changelog_update.md
+++ b/book/src/development/infrastructure/changelog_update.md
@@ -95,6 +95,9 @@ As section headers, we use:
 Please also be sure to update the Beta/Unreleased sections at the top with the
 relevant commit ranges.
 
+If you have the time, it would be appreciated if you double-check, that the
+`#[clippy::version]` attributes for the added lints contains the correct version.
+
 [changelog]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md
 [forge]: https://forge.rust-lang.org/
 [rust_master_tools]: https://github.com/rust-lang/rust/tree/master/src/tools/clippy

--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -161,7 +161,7 @@ declare_clippy_lint! {
     ///   baz().await; // Lint violation
     /// }
     /// ```
-    #[clippy::version = "1.49.0"]
+    #[clippy::version = "1.62.0"]
     pub AWAIT_HOLDING_INVALID_TYPE,
     suspicious,
     "holding a type across an await point which is not allowed to be held as per the configuration"

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -500,7 +500,7 @@ declare_clippy_lint! {
     /// let x: i32 = -42;
     /// let y: u32 = x.unsigned_abs();
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub CAST_ABS_TO_UNSIGNED,
     suspicious,
     "casting the result of `abs()` to an unsigned integer can panic"

--- a/clippy_lints/src/crate_in_macro_def.rs
+++ b/clippy_lints/src/crate_in_macro_def.rs
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// #[allow(clippy::crate_in_macro_def)]
     /// macro_rules! ok { ... crate::foo ... }
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub CRATE_IN_MACRO_DEF,
     suspicious,
     "using `crate` in a macro definition"

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -116,7 +116,7 @@ declare_clippy_lint! {
     /// let x = Foo;
     /// std::mem::drop(x);
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub DROP_NON_DROP,
     suspicious,
     "call to `std::mem::drop` with a value which does not implement `Drop`"
@@ -136,7 +136,7 @@ declare_clippy_lint! {
     /// let x = Foo;
     /// std::mem::forget(x);
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub FORGET_NON_DROP,
     suspicious,
     "call to `std::mem::forget` with a value which does not implement `Drop`"

--- a/clippy_lints/src/empty_drop.rs
+++ b/clippy_lints/src/empty_drop.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```rust
     /// struct S;
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub EMPTY_DROP,
     restriction,
     "empty `Drop` implementations"

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -369,7 +369,7 @@ declare_clippy_lint! {
     /// let x: Result<u32, &str> = Ok(10);
     /// x.expect_err("Testing expect_err");
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub ERR_EXPECT,
     style,
     r#"using `.err().expect("")` when `.expect_err("")` can be used"#
@@ -2215,7 +2215,7 @@ declare_clippy_lint! {
     /// c.is_ascii_digit();
     /// c.is_ascii_hexdigit();
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub IS_DIGIT_ASCII_RADIX,
     style,
     "use of `char::is_digit(..)` with literal radix of 10 or 16"
@@ -2235,7 +2235,7 @@ declare_clippy_lint! {
     /// let x = Some(3);
     /// x.as_ref();
     /// ```
-    #[clippy::version = "1.61.0"]
+    #[clippy::version = "1.62.0"]
     pub NEEDLESS_OPTION_TAKE,
     complexity,
     "using `.as_ref().take()` on a temporary value"


### PR DESCRIPTION
closes: https://github.com/rust-lang/rust-clippy/issues/9088

changelog: none

---

It feels weird to have such a short PR description. So, what should I add to this one... Yes, art:


```txt
 ,-----.,--.,--.                       
'  .--./|  |`--' ,---.  ,---.,--. ,--. 
|  |    |  |,--.| .-. || .-. |\  '  /  
'  '--'\|  ||  || '-' '| '-' ' \   '   
 `-----'`--'`--'|  |-' |  |-'.-'  /    
                `--'   `--'  `---'     
```

```txt
 ,-----.,--.   ,--.,------. ,------.,--.   ,--. 
'  .--./|  |   |  ||  .--. '|  .--. '\  `.'  /  
|  |    |  |   |  ||  '--' ||  '--' | '.    /   
'  '--'\|  '--.|  ||  | --' |  | --'    |  |    
 `-----'`-----'`--'`--'     `--'        `--'    
```

```txt
   _____ _      _____ _____  _______     __
  / ____| |    |_   _|  __ \|  __ \ \   / /
 | |    | |      | | | |__) | |__) \ \_/ / 
 | |    | |      | | |  ___/|  ___/ \   /  
 | |____| |____ _| |_| |    | |      | |   
  \_____|______|_____|_|    |_|      |_|   
```