### PR TITLE
Maybe trait bound on type repetition

### DIFF
--- a/tests/ui/type_repetition_in_bounds.rs
+++ b/tests/ui/type_repetition_in_bounds.rs
@@ -79,6 +79,18 @@ where
     u: U,
 }
 
+// Check for the `?` in `?Sized`
+pub fn f<T: ?Sized>()
+where
+    T: Clone,
+{
+}
+pub fn g<T: Clone>()
+where
+    T: ?Sized,
+{
+}
+
 // This should not lint
 fn impl_trait(_: impl AsRef<str>, _: impl AsRef<str>) {}
 

--- a/tests/ui/type_repetition_in_bounds.stderr
+++ b/tests/ui/type_repetition_in_bounds.stderr
@@ -19,5 +19,21 @@ LL |     Self: Copy + Default + Ord,
    |
    = help: consider combining the bounds: `Self: Clone + Copy + Default + Ord`
 
-error: aborting due to 2 previous errors
+error: this type has already been used as a bound predicate
+  --> $DIR/type_repetition_in_bounds.rs:85:5
+   |
+LL |     T: Clone,
+   |     ^^^^^^^^
+   |
+   = help: consider combining the bounds: `T: ?Sized + Clone`
+
+error: this type has already been used as a bound predicate
+  --> $DIR/type_repetition_in_bounds.rs:90:5
+   |
+LL |     T: ?Sized,
+   |     ^^^^^^^^^
+   |
+   = help: consider combining the bounds: `T: Clone + ?Sized`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: fix maybe trait on [`type_repetition_in_bounds`] lint

I simplified the two for loops, which did exactly the same. Only downside is, that I need a `copied`, but that's to convert from `&&` to `&`, to that should be a noop?

One more thing: I only handle [`TraitBoundModifier::Maybe`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/enum.TraitBoundModifier.html#variant.Maybe). Can anyone give me an example (and testcase) for [`TraitBoundModifier::MaybeConst`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/enum.TraitBoundModifier.html#variant.MaybeConst)?


