### PR TITLE
Ignore `into_iter` in `significant_drop_in_scrutinee`

### DIFF
--- a/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
+++ b/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
@@ -89,6 +89,10 @@ fn has_significant_drop_in_scrutinee<'tcx, 'a>(
     source: MatchSource,
 ) -> Option<(Vec<FoundSigDrop>, &'static str)> {
     let mut helper = SigDropHelper::new(cx);
+    let scrutinee = match (source, &scrutinee.kind) {
+        (MatchSource::ForLoopDesugar, ExprKind::Call(_, [e])) => e,
+        _ => scrutinee,
+    };
     helper.find_sig_drop(scrutinee).map(|drops| {
         let message = if source == MatchSource::Normal {
             "temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression"

--- a/tests/ui/significant_drop_in_scrutinee.rs
+++ b/tests/ui/significant_drop_in_scrutinee.rs
@@ -620,4 +620,11 @@ fn should_trigger_lint_without_significant_drop_in_arm() {
     };
 }
 
+fn should_not_trigger_on_significant_iterator_drop() {
+    let lines = std::io::stdin().lines();
+    for line in lines {
+        println!("foo: {}", line.unwrap());
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fixes #9135
changelog: Ignore the `IntoIterator::into_iter` call from for loops in `significant_drop_in_scrutinee`
