### PR TITLE
Fix Clippy version in `derive_partial_eq_without_eq` lint

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -189,7 +189,7 @@ declare_clippy_lint! {
     ///     i_am_eq_too: Vec<String>,
     /// }
     /// ```
-    #[clippy::version = "1.62.0"]
+    #[clippy::version = "1.63.0"]
     pub DERIVE_PARTIAL_EQ_WITHOUT_EQ,
     style,
     "deriving `PartialEq` on a type that can implement `Eq`, without implementing `Eq`"


### PR DESCRIPTION
It was first added to Rust in https://github.com/rust-lang/rust/pull/97248 which missed 1.62 just by few days.

changelog: none