### PR TITLE
update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,11 +3,15 @@ Thank you for making Clippy better!
 We're collecting our changelog from pull request descriptions.
 If your PR only includes internal changes, you can just write
 `changelog: none`. Otherwise, please write a short comment
-explaining your change. Also, it's helpful for us that
-the lint name is put into brackets `[]` and backticks `` ` ` ``,
-e.g. ``[`lint_name`]``.
+explaining your change.
 
-If your PR fixes an issue, you can add "fixes #issue_number" into this
+It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
+and then encapsulated by square brackets (`[]`), for example:
+```
+changelog: [`lint_name`]: your change
+```
+
+If your PR fixes an issue, you can add `fixes #issue_number` into this
 PR description. This way the issue will be automatically closed when
 your PR is merged.
 


### PR DESCRIPTION
Improved suggestion for formatting lint names in the PR template to use this format:
[`lint_name`]

changelog: none