### PR TITLE
[`box_collection`]: raise warn for all std collections

### DIFF
--- a/clippy_lints/src/types/box_collection.rs
+++ b/clippy_lints/src/types/box_collection.rs
@@ -15,19 +15,17 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
                 sym::String => "",
                 _ => "<..>",
             };
+
+            let box_content = format!("{outer}{generic}", outer = item_type);
             span_lint_and_help(
                 cx,
                 BOX_COLLECTION,
                 hir_ty.span,
                 &format!(
-                    "you seem to be trying to use `Box<{outer}{generic}>`. Consider using just `{outer}{generic}`",
-                    outer=item_type,
-                    generic = generic),
+                    "you seem to be trying to use `Box<{box_content}>`. Consider using just `{box_content}`"),
                 None,
                 &format!(
-                    "`{outer}{generic}` is already on the heap, `Box<{outer}{generic}>` makes an extra allocation",
-                    outer=item_type,
-                    generic = generic)
+                    "`{box_content}` is already on the heap, `Box<{box_content}>` makes an extra allocation")
             );
             true
         } else {
@@ -39,7 +37,18 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
 fn get_std_collection(cx: &LateContext<'_>, qpath: &QPath<'_>) -> Option<Symbol> {
     let param = qpath_generic_tys(qpath).next()?;
     let id = path_def_id(cx, param)?;
-    cx.tcx
-        .get_diagnostic_name(id)
-        .filter(|&name| matches!(name, sym::HashMap | sym::String | sym::Vec))
+    cx.tcx.get_diagnostic_name(id).filter(|&name| {
+        matches!(
+            name,
+            sym::HashMap
+                | sym::String
+                | sym::Vec
+                | sym::HashSet
+                | sym::VecDeque
+                | sym::LinkedList
+                | sym::BTreeMap
+                | sym::BTreeSet
+                | sym::BinaryHeap
+        )
+    })
 }

--- a/tests/ui/box_collection.rs
+++ b/tests/ui/box_collection.rs
@@ -6,7 +6,7 @@
     unused
 )]
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 
 macro_rules! boxit {
     ($init:expr, $x:ty) => {
@@ -18,7 +18,7 @@ fn test_macro() {
     boxit!(Vec::new(), Vec<u8>);
 }
 
-fn test(foo: Box<Vec<bool>>) {}
+fn test1(foo: Box<Vec<bool>>) {}
 
 fn test2(foo: Box<dyn Fn(Vec<u32>)>) {
     // pass if #31 is fixed
@@ -28,6 +28,18 @@ fn test2(foo: Box<dyn Fn(Vec<u32>)>) {
 fn test3(foo: Box<String>) {}
 
 fn test4(foo: Box<HashMap<String, String>>) {}
+
+fn test5(foo: Box<HashSet<i64>>) {}
+
+fn test6(foo: Box<VecDeque<i32>>) {}
+
+fn test7(foo: Box<LinkedList<i16>>) {}
+
+fn test8(foo: Box<BTreeMap<i8, String>>) {}
+
+fn test9(foo: Box<BTreeSet<u64>>) {}
+
+fn test10(foo: Box<BinaryHeap<u32>>) {}
 
 fn test_local_not_linted() {
     let _: Box<Vec<bool>>;

--- a/tests/ui/box_collection.stderr
+++ b/tests/ui/box_collection.stderr
@@ -1,8 +1,8 @@
 error: you seem to be trying to use `Box<Vec<..>>`. Consider using just `Vec<..>`
-  --> $DIR/box_collection.rs:21:14
+  --> $DIR/box_collection.rs:21:15
    |
-LL | fn test(foo: Box<Vec<bool>>) {}
-   |              ^^^^^^^^^^^^^^
+LL | fn test1(foo: Box<Vec<bool>>) {}
+   |               ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::box-collection` implied by `-D warnings`
    = help: `Vec<..>` is already on the heap, `Box<Vec<..>>` makes an extra allocation
@@ -23,5 +23,53 @@ LL | fn test4(foo: Box<HashMap<String, String>>) {}
    |
    = help: `HashMap<..>` is already on the heap, `Box<HashMap<..>>` makes an extra allocation
 
-error: aborting due to 3 previous errors
+error: you seem to be trying to use `Box<HashSet<..>>`. Consider using just `HashSet<..>`
+  --> $DIR/box_collection.rs:32:15
+   |
+LL | fn test5(foo: Box<HashSet<i64>>) {}
+   |               ^^^^^^^^^^^^^^^^^
+   |
+   = help: `HashSet<..>` is already on the heap, `Box<HashSet<..>>` makes an extra allocation
+
+error: you seem to be trying to use `Box<VecDeque<..>>`. Consider using just `VecDeque<..>`
+  --> $DIR/box_collection.rs:34:15
+   |
+LL | fn test6(foo: Box<VecDeque<i32>>) {}
+   |               ^^^^^^^^^^^^^^^^^^
+   |
+   = help: `VecDeque<..>` is already on the heap, `Box<VecDeque<..>>` makes an extra allocation
+
+error: you seem to be trying to use `Box<LinkedList<..>>`. Consider using just `LinkedList<..>`
+  --> $DIR/box_collection.rs:36:15
+   |
+LL | fn test7(foo: Box<LinkedList<i16>>) {}
+   |               ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `LinkedList<..>` is already on the heap, `Box<LinkedList<..>>` makes an extra allocation
+
+error: you seem to be trying to use `Box<BTreeMap<..>>`. Consider using just `BTreeMap<..>`
+  --> $DIR/box_collection.rs:38:15
+   |
+LL | fn test8(foo: Box<BTreeMap<i8, String>>) {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `BTreeMap<..>` is already on the heap, `Box<BTreeMap<..>>` makes an extra allocation
+
+error: you seem to be trying to use `Box<BTreeSet<..>>`. Consider using just `BTreeSet<..>`
+  --> $DIR/box_collection.rs:40:15
+   |
+LL | fn test9(foo: Box<BTreeSet<u64>>) {}
+   |               ^^^^^^^^^^^^^^^^^^
+   |
+   = help: `BTreeSet<..>` is already on the heap, `Box<BTreeSet<..>>` makes an extra allocation
+
+error: you seem to be trying to use `Box<BinaryHeap<..>>`. Consider using just `BinaryHeap<..>`
+  --> $DIR/box_collection.rs:42:16
+   |
+LL | fn test10(foo: Box<BinaryHeap<u32>>) {}
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `BinaryHeap<..>` is already on the heap, `Box<BinaryHeap<..>>` makes an extra allocation
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
So far, only [`Vec`, `String`, `HashMap`] were considered.

Extend collection checklist for this lint with:
- `HashSet`
- `VecDeque`
- `LinkedList`
- `BTreeMap`
- `BTreeSet`
- `BinaryHeap`

changelog: [`box_collection`]: raise warn for all std collections