### PR TITLE
Update highlight.js

### DIFF
--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -15,7 +15,8 @@ Otherwise, have a great day =^.^=
     <title>Clippy Lints</title>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/styles/github.min.css"/>
+    <link id="githubLightHighlight" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/github.min.css" disabled="true" />
+    <link id="githubDarkHighlight" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/github-dark.min.css" disabled="true" />
 
     <!-- The files are not copied over into the Clippy project since they use the MPL-2.0 License -->
     <link rel="stylesheet" href="https://rust-lang.github.io/mdBook/css/variables.css"/>
@@ -561,8 +562,8 @@ Otherwise, have a great day =^.^=
     </a>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/12.3.2/markdown-it.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/highlight.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.5.0/languages/rust.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/languages/rust.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.12/angular.min.js"></script>
     <script src="script.js"></script>
 </body>

--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -7,7 +7,7 @@
             if (lang && hljs.getLanguage(lang)) {
                 try {
                     return '<pre class="hljs"><code>' +
-                        hljs.highlight(lang, str, true).value +
+                        hljs.highlight(str, { language: lang, ignoreIllegals: true }).value +
                         '</code></pre>';
                 } catch (__) {}
             }
@@ -364,6 +364,9 @@ function setTheme(theme, store) {
     }
 
     document.getElementsByTagName("body")[0].className = theme;
+
+    document.getElementById("githubLightHighlight").disabled = enableNight || !enableHighlight;
+    document.getElementById("githubDarkHighlight").disabled = !enableNight && !enableAyu;
 
     document.getElementById("styleHighlight").disabled = !enableHighlight;
     document.getElementById("styleNight").disabled = !enableNight;


### PR DESCRIPTION
changelog: none

With [highlight.js v11.6.0](https://github.com/highlightjs/highlight.js/releases/tag/11.6.0), the lint list can finally update from `9.5.0`. No more EOL warning in console! :smile:

I also made it switch to the `github-dark` theme when using `coal`, instead of just always using the normal github light theme.

r? @xFrednet  
