### PR TITLE
Rename rustcSource in contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,11 +114,11 @@ As of [#6869][6869], [`rust-analyzer`][ra_homepage] can understand that Clippy u
 using `extern crate` when `package.metadata.rust-analyzer.rustc_private` is set to `true` in Clippy's `Cargo.toml.`
 You will require a `nightly` toolchain with the `rustc-dev` component installed.
 Make sure that in the `rust-analyzer` configuration, you set
-```
-{ "rust-analyzer.rustcSource": "discover" }
+```json
+{ "rust-analyzer.rustc.source": "discover" }
 ```
 and
-```
+```json
 { "rust-analyzer.updates.channel": "nightly" }
 ```
 You should be able to see information on things like `Expr` or `EarlyContext` now if you hover them, also


### PR DESCRIPTION
According to [rust-analyzer docs](https://rust-analyzer.github.io/manual.html#toolchain:~:text=rust%2Danalyzer.rustc.source), rustcSource has been renamed to rustc.source.

changelog: none