### PR TITLE
Fix the minimal version for `clap`

### DIFF
--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 cargo_metadata = "0.14"
-clap = "3.1"
+clap = "3.2"
 flate2 = "1.0"
 rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
changelog: none

`clap >= 3.2.0` for lintcheck  has been needed from https://github.com/rust-lang/rust-clippy/pull/8997.