### PR TITLE
Fix example for `clippy::invalid_regex`

### DIFF
--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```ignore
-    /// Regex::new("|")
+    /// Regex::new("(")
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub INVALID_REGEX,


### PR DESCRIPTION
Close #9194 
changelog: previous example doesn't trigger lint
