### PR TITLE
Fix typo in alloc_instead_of_core

### DIFF
--- a/clippy_lints/src/std_instead_of_core.rs
+++ b/clippy_lints/src/std_instead_of_core.rs
@@ -63,7 +63,7 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     ///
     /// Crates which have `no_std` compatibility and may optionally require alloc may wish to ensure types are
-    /// imported from alloc to ensure disabling `alloc` does not cause the crate to fail to compile. This lint
+    /// imported from core to ensure disabling `alloc` does not cause the crate to fail to compile. This lint
     /// is also useful for crates migrating to become `no_std` compatible.
     ///
     /// ### Example


### PR DESCRIPTION
The description previously claimed it ensures items are imported from alloc, to ensure a crate won't require alloc, which can't be true.

I'm not sure know how to better phrase the changelog entry below.

changelog: [`alloc_instead_of_core`]: fixed typo in description
