### PR TITLE
Check for `todo!` on every expression in `SpanlessEq`

### DIFF
--- a/tests/ui/match_same_arms2.rs
+++ b/tests/ui/match_same_arms2.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::match_same_arms)]
-#![allow(clippy::blacklisted_name)]
+#![allow(clippy::blacklisted_name, clippy::diverging_sub_expression)]
 
 fn bar<T>(_: T) {}
 fn foo() -> bool {
@@ -226,5 +226,13 @@ fn main() {
         None => 50,
         Some(Bar { y: 0, x: 5, .. }) => 1,
         _ => 200,
+    };
+
+    let _ = match 0 {
+        0 => todo!(),
+        1 => todo!(),
+        2 => core::convert::identity::<u32>(todo!()),
+        3 => core::convert::identity::<u32>(todo!()),
+        _ => 5,
     };
 }


### PR DESCRIPTION
fixes #9204
changelog: [`match_same_arms`](https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms): Don't lint on arms with `todo!`
