### PR TITLE
Enable test for entrypoint_recursion for windows

### DIFF
--- a/tests/ui/crate_level_checks/entrypoint_recursion.rs
+++ b/tests/ui/crate_level_checks/entrypoint_recursion.rs
@@ -1,5 +1,4 @@
 // ignore-macos
-// ignore-windows
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/crate_level_checks/entrypoint_recursion.stderr
+++ b/tests/ui/crate_level_checks/entrypoint_recursion.stderr
@@ -1,5 +1,5 @@
 error: recursing into entrypoint `a`
-  --> $DIR/entrypoint_recursion.rs:11:5
+  --> $DIR/entrypoint_recursion.rs:10:5
    |
 LL |     a();
    |     ^


### PR DESCRIPTION
Verified that this test actually works on windows
changelog: none
