### PR TITLE
Add `ui_cargo_toml_metadata` test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ compiletest_rs = { version = "0.8", features = ["tmp"] }
 tester = "0.9"
 regex = "1.5"
 toml = "0.5"
+walkdir = "2.3"
 # This is used by the `collect-metadata` alias.
 filetime = "0.2"
 

--- a/tests/ui-cargo/cargo_common_metadata/fail/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/fail/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata"
+name = "cargo_common_metadata_fail"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/cargo_common_metadata/fail/src/main.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail/src/main.stderr
@@ -1,16 +1,16 @@
-error: package `cargo_common_metadata` is missing `package.description` metadata
+error: package `cargo_common_metadata_fail` is missing `package.description` metadata
    |
    = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
 
-error: package `cargo_common_metadata` is missing `either package.license or package.license_file` metadata
+error: package `cargo_common_metadata_fail` is missing `either package.license or package.license_file` metadata
 
-error: package `cargo_common_metadata` is missing `package.repository` metadata
+error: package `cargo_common_metadata_fail` is missing `package.repository` metadata
 
-error: package `cargo_common_metadata` is missing `package.readme` metadata
+error: package `cargo_common_metadata_fail` is missing `package.readme` metadata
 
-error: package `cargo_common_metadata` is missing `package.keywords` metadata
+error: package `cargo_common_metadata_fail` is missing `package.keywords` metadata
 
-error: package `cargo_common_metadata` is missing `package.categories` metadata
+error: package `cargo_common_metadata_fail` is missing `package.categories` metadata
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata"
+name = "cargo_common_metadata_fail_publish"
 version = "0.1.0"
 publish = ["some-registry-name"]
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish/src/main.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish/src/main.stderr
@@ -1,16 +1,16 @@
-error: package `cargo_common_metadata` is missing `package.description` metadata
+error: package `cargo_common_metadata_fail_publish` is missing `package.description` metadata
    |
    = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
 
-error: package `cargo_common_metadata` is missing `either package.license or package.license_file` metadata
+error: package `cargo_common_metadata_fail_publish` is missing `either package.license or package.license_file` metadata
 
-error: package `cargo_common_metadata` is missing `package.repository` metadata
+error: package `cargo_common_metadata_fail_publish` is missing `package.repository` metadata
 
-error: package `cargo_common_metadata` is missing `package.readme` metadata
+error: package `cargo_common_metadata_fail_publish` is missing `package.readme` metadata
 
-error: package `cargo_common_metadata` is missing `package.keywords` metadata
+error: package `cargo_common_metadata_fail_publish` is missing `package.keywords` metadata
 
-error: package `cargo_common_metadata` is missing `package.categories` metadata
+error: package `cargo_common_metadata_fail_publish` is missing `package.categories` metadata
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish_true/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata"
+name = "cargo_common_metadata_fail_publish_true"
 version = "0.1.0"
 publish = true
 

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish_true/src/main.stderr
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish_true/src/main.stderr
@@ -1,16 +1,16 @@
-error: package `cargo_common_metadata` is missing `package.description` metadata
+error: package `cargo_common_metadata_fail_publish_true` is missing `package.description` metadata
    |
    = note: `-D clippy::cargo-common-metadata` implied by `-D warnings`
 
-error: package `cargo_common_metadata` is missing `either package.license or package.license_file` metadata
+error: package `cargo_common_metadata_fail_publish_true` is missing `either package.license or package.license_file` metadata
 
-error: package `cargo_common_metadata` is missing `package.repository` metadata
+error: package `cargo_common_metadata_fail_publish_true` is missing `package.repository` metadata
 
-error: package `cargo_common_metadata` is missing `package.readme` metadata
+error: package `cargo_common_metadata_fail_publish_true` is missing `package.readme` metadata
 
-error: package `cargo_common_metadata` is missing `package.keywords` metadata
+error: package `cargo_common_metadata_fail_publish_true` is missing `package.keywords` metadata
 
-error: package `cargo_common_metadata` is missing `package.categories` metadata
+error: package `cargo_common_metadata_fail_publish_true` is missing `package.categories` metadata
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata"
+name = "cargo_common_metadata_pass"
 version = "0.1.0"
 publish = false
 description = "A test package for the cargo_common_metadata lint"

--- a/tests/ui-cargo/cargo_common_metadata/pass_publish_empty/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass_publish_empty/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata"
+name = "cargo_common_metadata_pass_publish_empty"
 version = "0.1.0"
 publish = []
 

--- a/tests/ui-cargo/cargo_common_metadata/pass_publish_false/Cargo.toml
+++ b/tests/ui-cargo/cargo_common_metadata/pass_publish_false/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata"
+name = "cargo_common_metadata_pass_publish_false"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/cargo_rust_version/fail_both_diff/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/fail_both_diff/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fail-both-diff"
 version = "0.1.0"
 rust-version = "1.56"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/fail_both_same/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/fail_both_same/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fail-both-same"
 version = "0.1.0"
 rust-version = "1.57.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/fail_cargo/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/fail_cargo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fail-cargo"
 version = "0.1.0"
 rust-version = "1.56.1"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/fail_clippy/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/fail_clippy/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fail-clippy"
 version = "0.1.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/fail_file_attr/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/fail_file_attr/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fail-file-attr"
 version = "0.1.0"
 rust-version = "1.13"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/pass_both_same/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/pass_both_same/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "fail-both-same"
+name = "pass-both-same"
 version = "0.1.0"
 rust-version = "1.13.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/pass_cargo/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/pass_cargo/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "fail-cargo"
+name = "pass-cargo"
 version = "0.1.0"
 rust-version = "1.13.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/pass_clippy/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/pass_clippy/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
-name = "fail-clippy"
+name = "pass-clippy"
 version = "0.1.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/pass_file_attr/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/pass_file_attr/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "fail-file-attr"
+name = "pass-file-attr"
 version = "0.1.0"
 rust-version = "1.59"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/cargo_rust_version/warn_both_diff/Cargo.toml
+++ b/tests/ui-cargo/cargo_rust_version/warn_both_diff/Cargo.toml
@@ -2,6 +2,7 @@
 name = "warn-both-diff"
 version = "0.1.0"
 rust-version = "1.56.0"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/module_style/fail_mod/Cargo.toml
+++ b/tests/ui-cargo/module_style/fail_mod/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "fail"
+name = "fail-mod"
 version = "0.1.0"
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/module_style/fail_no_mod/Cargo.toml
+++ b/tests/ui-cargo/module_style/fail_no_mod/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "fail"
+name = "fail-no-mod"
 version = "0.1.0"
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/module_style/pass_mod/Cargo.toml
+++ b/tests/ui-cargo/module_style/pass_mod/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "fail"
+name = "pass-mod"
 version = "0.1.0"
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/module_style/pass_no_mod/Cargo.toml
+++ b/tests/ui-cargo/module_style/pass_no_mod/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "pass"
+name = "pass-no-mod"
 version = "0.1.0"
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/multiple_config_files/no_warn/Cargo.toml
+++ b/tests/ui-cargo/multiple_config_files/no_warn/Cargo.toml
@@ -2,6 +2,7 @@
 name = "no_warn"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/multiple_config_files/warn/Cargo.toml
+++ b/tests/ui-cargo/multiple_config_files/warn/Cargo.toml
@@ -2,6 +2,7 @@
 name = "warn"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tests/ui-cargo/multiple_crate_versions/pass/Cargo.toml
+++ b/tests/ui-cargo/multiple_crate_versions/pass/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo_common_metadata"
+name = "multiple_crate_versions"
 version = "0.1.0"
 publish = false
 


### PR DESCRIPTION
This PR adds a test to check the metadata of packages in the `ui_cargo` directory.

A recent change to Cargo causes it to warn when it finds multiple packages with the same name in a git dependency (the issue is described [here](https://github.com/rust-lang/cargo/issues/10752)).

Many (if  not all) Dylint libraries depend upon `clippy_utils`. As a result of the change, one now sees the following when building a Dylint library:
```
warning: skipping duplicate package `fail` found at `/home/smoelius/.cargo/git/checkouts/rust-clippy-4b72815e96774b3d/0cb0f76/tests/ui-cargo/module_style/pass_mod`
warning: skipping duplicate package `fail` found at `/home/smoelius/.cargo/git/checkouts/rust-clippy-4b72815e96774b3d/0cb0f76/tests/ui-cargo/module_style/fail_no_mod`
warning: skipping duplicate package `cargo_common_metadata` found at `/home/smoelius/.cargo/git/checkouts/rust-clippy-4b72815e96774b3d/0cb0f76/tests/ui-cargo/cargo_common_metadata/fail_publish_true`
warning: skipping duplicate package `fail-cargo` found at `/home/smoelius/.cargo/git/checkouts/rust-clippy-4b72815e96774b3d/0cb0f76/tests/ui-cargo/cargo_rust_version/pass_cargo`
warning: skipping duplicate package `fail-clippy` found at `/home/smoelius/.cargo/git/checkouts/rust-clippy-4b72815e96774b3d/0cb0f76/tests/ui-cargo/cargo_rust_version/fail_clippy`
warning: skipping duplicate package `fail-both-same` found at `/home/smoelius/.cargo/git/checkouts/rust-clippy-4b72815e96774b3d/0cb0f76/tests/ui-cargo/cargo_rust_version/fail_both_same`
warning: skipping duplicate package `fail-file-attr` found at `/home/smoelius/.cargo/git/checkouts/rust-clippy-4b72815e96774b3d/0cb0f76/tests/ui-cargo/cargo_rust_version/fail_file_attr`
```
There appear to be two contributing factors:
- Some packages in `ui_cargo` could have a `publish = false` added to them.
- Some packages in `ui_cargo` seem to be inconsistently named.

The new test checks that each package in the `ui_cargo` directory has a name matching one of its parent directories, and `publish = false` in its metadata (with a few exceptions).

Note that the packages in `cargo_common_metadata` require special care because `publish` is the subject of some of the `cargo_common_metadata` tests.

Also note that this PR adds `walkdir` as a dev dependency to the `clippy` package. However, it was already a dependency of `clippy_dev` and `lintcheck`. So hopefully this is acceptable.

Our continued thanks for making `clippy_utils` available, BTW. :)

r? @flip1995

changelog: none