### PR TITLE
Fix `useless_format` spans for `format!("{foo}")`

### DIFF
--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -9,7 +9,7 @@ use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::symbol::kw;
-use rustc_span::{sym, BytePos, Span};
+use rustc_span::{sym, Span};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -85,22 +85,7 @@ impl<'tcx> LateLintPass<'tcx> for UselessFormat {
                         ExprKind::MethodCall(path, ..) => path.ident.name.as_str() == "to_string",
                         _ => false,
                     };
-                    let sugg = if format_args.format_string_span.contains(value.span) {
-                        // Implicit argument. e.g. `format!("{x}")` span points to `{x}`
-                        let spdata = value.span.data();
-                        let span = Span::new(
-                            spdata.lo + BytePos(1),
-                            spdata.hi - BytePos(1),
-                            spdata.ctxt,
-                            spdata.parent
-                        );
-                        let snip = snippet_with_applicability(cx, span, "..", &mut applicability);
-                        if is_new_string {
-                            snip.into()
-                        } else {
-                            format!("{snip}.to_string()")
-                        }
-                    } else if is_new_string {
+                    let sugg = if is_new_string {
                         snippet_with_applicability(cx, value.span, "..", &mut applicability).into_owned()
                     } else {
                         let sugg = Sugg::hir_with_applicability(cx, value, "<arg>", &mut applicability);

--- a/tests/ui/format.fixed
+++ b/tests/ui/format.fixed
@@ -84,4 +84,10 @@ fn main() {
     let _ = x.to_string();
     let _ = format!("{x:?}"); // Don't lint on debug
     let _ = x.to_string();
+
+    // Issue #9234
+    let abc = "abc";
+    let _ = abc.to_string();
+    let xx = "xx";
+    let _ = xx.to_string();
 }

--- a/tests/ui/format.rs
+++ b/tests/ui/format.rs
@@ -86,4 +86,10 @@ fn main() {
     let _ = format!("{x}");
     let _ = format!("{x:?}"); // Don't lint on debug
     let _ = format!("{y}", y = x);
+
+    // Issue #9234
+    let abc = "abc";
+    let _ = format!("{abc}");
+    let xx = "xx";
+    let _ = format!("{xx}");
 }

--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -111,5 +111,17 @@ error: useless use of `format!`
 LL |     let _ = format!("{y}", y = x);
    |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.to_string()`
 
-error: aborting due to 17 previous errors
+error: useless use of `format!`
+  --> $DIR/format.rs:92:13
+   |
+LL |     let _ = format!("{abc}");
+   |             ^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `abc.to_string()`
+
+error: useless use of `format!`
+  --> $DIR/format.rs:94:13
+   |
+LL |     let _ = format!("{xx}");
+   |             ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `xx.to_string()`
+
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
Fixes #9234

changelog: [`useless_format`]: Fix spans for `format!("{foo}")`

https://github.com/rust-lang/rust/pull/94030 made our workaround unneeded, but by coincidence our test still passed [because `Span::new()` swaps `hi` & `lo` if needed](https://github.com/rust-lang/rust/blob/c32dcbba187d1ee0dbe92dc152cb9c2f3f42900c/compiler/rustc_span/src/span_encoding.rs#L86-L88). So with a single character variable like `format!("{x}")` it still worked