### PR TITLE
check macro statements in `[non_copy_const]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1.0.125", features = ["derive"] }
 syn = { version = "1.0", features = ["full"] }
 futures = "0.3"
 parking_lot = "0.12"
-tokio = { version = "1", features = ["io-util"] }
+tokio = { version = "1", features = ["full"] }
 rustc-semver = "1.1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1.0.125", features = ["derive"] }
 syn = { version = "1.0", features = ["full"] }
 futures = "0.3"
 parking_lot = "0.12"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["io-util"] }
 rustc-semver = "1.1"
 
 [build-dependencies]

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -251,14 +251,7 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst {
     fn check_item(&mut self, cx: &LateContext<'tcx>, it: &'tcx Item<'_>) {
         if let ItemKind::Const(hir_ty, body_id) = it.kind {
             let ty = hir_ty_to_ty(cx.tcx, hir_ty);
-            if !macro_backtrace(it.span).last().map_or(false, |macro_call| {
-                matches!(
-                    cx.tcx.get_diagnostic_name(macro_call.def_id),
-                    Some(sym::thread_local_macro)
-                )
-            }) && is_unfrozen(cx, ty)
-                && is_value_unfrozen_poly(cx, body_id, ty)
-            {
+            if !ignored_macro(cx, it) && is_unfrozen(cx, ty) && is_value_unfrozen_poly(cx, body_id, ty) {
                 lint(cx, Source::Item { item: it.span });
             }
         }
@@ -444,4 +437,13 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst {
             }
         }
     }
+}
+
+fn ignored_macro(cx: &LateContext<'_>, it: &rustc_hir::Item<'_>) -> bool {
+    macro_backtrace(it.span).any(|macro_call| {
+        matches!(
+            cx.tcx.get_diagnostic_name(macro_call.def_id),
+            Some(sym::thread_local_macro)
+        )
+    })
 }

--- a/tests/ui/declare_interior_mutable_const/others.rs
+++ b/tests/ui/declare_interior_mutable_const/others.rs
@@ -34,11 +34,6 @@ static STATIC_TUPLE: (AtomicUsize, String) = (ATOMIC, STRING);
 mod issue_8493 {
     use std::cell::Cell;
 
-    // https://github.com/rust-lang/rust-clippy/issues/9224
-    tokio::task_local! {
-        pub static _FOO: String;
-    }
-
     thread_local! {
         static _BAR: Cell<i32> = const { Cell::new(0) };
     }

--- a/tests/ui/declare_interior_mutable_const/others.rs
+++ b/tests/ui/declare_interior_mutable_const/others.rs
@@ -31,9 +31,30 @@ const NO_ANN: &dyn Display = &70;
 static STATIC_TUPLE: (AtomicUsize, String) = (ATOMIC, STRING);
 //^ there should be no lints on this line
 
-// issue #8493
-thread_local! {
-    static THREAD_LOCAL: Cell<i32> = const { Cell::new(0) };
+mod issue_8493 {
+    use std::cell::Cell;
+
+    // https://github.com/rust-lang/rust-clippy/issues/9224
+    tokio::task_local! {
+        pub static _FOO: String;
+    }
+
+    thread_local! {
+        static _BAR: Cell<i32> = const { Cell::new(0) };
+    }
+
+    macro_rules! issue_8493 {
+        () => {
+            const _BAZ: Cell<usize> = Cell::new(0); //~ ERROR interior mutable
+            static _FOOBAR: () = {
+                thread_local! {
+                    static _VAR: Cell<i32> = const { Cell::new(0) };
+                }
+            };
+        };
+    }
+
+    issue_8493!();
 }
 
 fn main() {}

--- a/tests/ui/declare_interior_mutable_const/others.stderr
+++ b/tests/ui/declare_interior_mutable_const/others.stderr
@@ -36,7 +36,7 @@ LL | declare_const!(_ONCE: Once = Once::new()); //~ ERROR interior mutable
    = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: a `const` item should never be interior mutable
-  --> $DIR/others.rs:48:13
+  --> $DIR/others.rs:43:13
    |
 LL |             const _BAZ: Cell<usize> = Cell::new(0); //~ ERROR interior mutable
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/declare_interior_mutable_const/others.stderr
+++ b/tests/ui/declare_interior_mutable_const/others.stderr
@@ -35,5 +35,16 @@ LL | declare_const!(_ONCE: Once = Once::new()); //~ ERROR interior mutable
    |
    = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 4 previous errors
+error: a `const` item should never be interior mutable
+  --> $DIR/others.rs:48:13
+   |
+LL |             const _BAZ: Cell<usize> = Cell::new(0); //~ ERROR interior mutable
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL |     issue_8493!();
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `issue_8493` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
close #8493 
close #9224 

This PR fixes false positives in `[non_copy_const]`.



changelog: fix false positives in`[non_copy_const]`

---

r? @Jarcho 
