### PR TITLE
Use `action/checkout@v3` in the book

### DIFF
--- a/book/src/continuous_integration/github_actions.md
+++ b/book/src/continuous_integration/github_actions.md
@@ -15,7 +15,7 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features
 ```


### PR DESCRIPTION
As this type of document is often copied/pasted, using a newer version of `actions/checkout` would be better.

changelog: none

Signed-off-by: Yuki Okushi <jtitor@2k36.org>