### PR TITLE
Read and use deprecated configuration (as well as emitting a warning)

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -487,7 +487,7 @@ pub fn read_conf(sess: &Session) -> Conf {
         },
     };
 
-    let TryConf { conf, errors } = utils::conf::read(&file_name);
+    let TryConf { conf, errors, warnings } = utils::conf::read(&file_name);
     // all conf errors are non-fatal, we just use the default conf in case of error
     for error in errors {
         sess.err(&format!(
@@ -495,6 +495,15 @@ pub fn read_conf(sess: &Session) -> Conf {
             file_name.display(),
             format_error(error)
         ));
+    }
+
+    for warning in warnings {
+        sess.struct_warn(&format!(
+            "error reading Clippy's configuration file `{}`: {}",
+            file_name.display(),
+            format_error(warning)
+        ))
+        .emit();
     }
 
     conf

--- a/tests/ui-toml/conf_deprecated_key/clippy.toml
+++ b/tests/ui-toml/conf_deprecated_key/clippy.toml
@@ -1,5 +1,5 @@
 # that one is an error
-cyclomatic-complexity-threshold = 42
+cyclomatic-complexity-threshold = 2
 
 # that one is white-listed
 [third-party]

--- a/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
+++ b/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
@@ -1,1 +1,11 @@
 fn main() {}
+
+#[warn(clippy::cognitive_complexity)]
+fn cognitive_complexity() {
+    let x = vec![1, 2, 3];
+    for i in x {
+        if i == 1 {
+            println!("{}", i);
+        }
+    }
+}

--- a/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.stderr
+++ b/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.stderr
@@ -1,4 +1,13 @@
-error: error reading Clippy's configuration file `$DIR/clippy.toml`: deprecated field `cyclomatic-complexity-threshold`. Please use `cognitive-complexity-threshold` instead
+warning: error reading Clippy's configuration file `$DIR/clippy.toml`: deprecated field `cyclomatic-complexity-threshold`. Please use `cognitive-complexity-threshold` instead
 
-error: aborting due to previous error
+error: the function has a cognitive complexity of (3/2)
+  --> $DIR/conf_deprecated_key.rs:4:4
+   |
+LL | fn cognitive_complexity() {
+   |    ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::cognitive-complexity` implied by `-D warnings`
+   = help: you could split it up into multiple smaller functions
+
+error: aborting due to previous error; 1 warning emitted
 


### PR DESCRIPTION
Original change written by @flip1995 I've simply rebased to master and fixed up the formatting/tests.  This change teaches the configuration parser which config key replaced a deprecated key and attempts to populate the latter from the former.  If both keys are provided this fails with a duplicate key error (rather than attempting to guess which the user intended).

Currently this on affects `cyclomatic-complexity-threshold` -> `cognitive-complexity-threshold` but will also be used in #8974 to handle `blacklisted-names` -> `disallowed-names`.

```
changelog: deprecated configuration keys are still applied as if they were provided as their non-deprecated name.
```

- [x] `cargo test` passes locally
- [x] Run `cargo dev fmt`
