### PR TITLE
Enable test empty_loop_no_std on windows

### DIFF
--- a/tests/ui/empty_loop_no_std.rs
+++ b/tests/ui/empty_loop_no_std.rs
@@ -1,6 +1,5 @@
 // compile-flags: -Clink-arg=-nostartfiles
 // ignore-macos
-// ignore-windows
 
 #![warn(clippy::empty_loop)]
 #![feature(lang_items, start, libc)]

--- a/tests/ui/empty_loop_no_std.stderr
+++ b/tests/ui/empty_loop_no_std.stderr
@@ -1,5 +1,5 @@
 error: empty `loop {}` wastes CPU cycles
-  --> $DIR/empty_loop_no_std.rs:14:5
+  --> $DIR/empty_loop_no_std.rs:13:5
    |
 LL |     loop {}
    |     ^^^^^^^
@@ -8,7 +8,7 @@ LL |     loop {}
    = help: you should either use `panic!()` or add a call pausing or sleeping the thread to the loop body
 
 error: empty `loop {}` wastes CPU cycles
-  --> $DIR/empty_loop_no_std.rs:26:5
+  --> $DIR/empty_loop_no_std.rs:25:5
    |
 LL |     loop {}
    |     ^^^^^^^


### PR DESCRIPTION
Verified that it actully works on windows
changelog: none
