### PR TITLE
Add `if_none_blocks` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3610,6 +3610,7 @@ Released 2018-09-13
 [`if_let_mutex`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_let_mutex
 [`if_let_redundant_pattern_matching`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_let_redundant_pattern_matching
 [`if_let_some_result`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_let_some_result
+[`if_none_blocks`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_none_blocks
 [`if_not_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_not_else
 [`if_same_then_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_same_then_else
 [`if_then_some_else_none`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_then_some_else_none

--- a/clippy_lints/src/if_none_blocks.rs
+++ b/clippy_lints/src/if_none_blocks.rs
@@ -1,0 +1,85 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::eager_or_lazy::switch_to_eager_eval;
+use clippy_utils::higher::If;
+use clippy_utils::is_lang_ctor;
+use rustc_hir::{Expr, ExprKind, LangItem};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `if` expressions where one branch immediately returns None, and the other branch
+    /// returns `Some(_)` (with or without side-effects).
+    ///
+    /// ### Why is this bad?
+    /// Contributes to code noise, and can be simpler expressed using methods on `bool`.
+    ///
+    /// ### Example
+    /// ```rust
+    /// let _ = if x {
+    ///     Some("asdf")
+    /// } else {
+    ///     None
+    /// };
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// let _ = x.then_some("asdf");
+    /// ```
+    #[clippy::version = "1.64.0"]
+    pub IF_NONE_BLOCKS,
+    pedantic,
+    "if expression containing a branch that just returns `None`"
+}
+declare_lint_pass!(IfNoneBlocks => [IF_NONE_BLOCKS]);
+
+impl<'tcx> LateLintPass<'tcx> for IfNoneBlocks {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if let Some(if_expr) = If::hir(expr)
+            && let Some(else_block) = if_expr.r#else
+            && let Some(negation) = check_lint(cx, if_expr.then, else_block)
+        {
+            let negation_msg = negation.then_some("first negating the condition, then ").unwrap_or_default();
+            let method_name = switch_to_eager_eval(cx, expr).then_some("then_some").unwrap_or("then");
+            span_lint_and_help(
+                cx,
+                IF_NONE_BLOCKS,
+                expr.span,
+                "if expression simply returns `None` in one of its branches",
+                None,
+                &format!("consider {}using `bool::{}`", negation_msg, method_name),
+            );
+        }
+    }
+}
+
+// Checks if the lint applies and whether or not to recommend negating the condition.
+fn check_lint<'tcx>(cx: &LateContext<'tcx>, then: &'tcx Expr<'tcx>, r#else: &'tcx Expr<'tcx>) -> Option<bool> {
+    if check_none(cx, r#else) && check_some(cx, then) {
+        Some(false) // None in `else` block
+    } else if check_none(cx, then) && check_some(cx, r#else) {
+        Some(true) // None in `then` block
+    } else {
+        None // lint does not apply
+    }
+}
+
+// Checks if an expression returns `Some(_)`; side-effects and extra statements are allowed.
+fn check_some<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+    if let ExprKind::Block(block, _) = expr.kind
+        && let Some(expr) = block.expr
+        && let ExprKind::Call(call, _) = &expr.peel_blocks().kind
+        && let ExprKind::Path(q) = &call.kind
+    {
+        return is_lang_ctor(cx, q, LangItem::OptionSome)
+    }
+    false
+}
+
+// Checks if an expression immediately returns `None`.
+fn check_none<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
+    if let ExprKind::Path(q) = &expr.peel_blocks().kind {
+        return is_lang_ctor(cx, q, LangItem::OptionNone);
+    }
+    false
+}

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -179,6 +179,7 @@ store.register_lints(&[
     future_not_send::FUTURE_NOT_SEND,
     get_first::GET_FIRST,
     if_let_mutex::IF_LET_MUTEX,
+    if_none_blocks::IF_NONE_BLOCKS,
     if_not_else::IF_NOT_ELSE,
     if_then_some_else_none::IF_THEN_SOME_ELSE_NONE,
     implicit_hasher::IMPLICIT_HASHER,

--- a/clippy_lints/src/lib.register_pedantic.rs
+++ b/clippy_lints/src/lib.register_pedantic.rs
@@ -33,6 +33,7 @@ store.register_group(true, "clippy::pedantic", Some("clippy_pedantic"), vec![
     LintId::of(excessive_bools::STRUCT_EXCESSIVE_BOOLS),
     LintId::of(functions::MUST_USE_CANDIDATE),
     LintId::of(functions::TOO_MANY_LINES),
+    LintId::of(if_none_blocks::IF_NONE_BLOCKS),
     LintId::of(if_not_else::IF_NOT_ELSE),
     LintId::of(implicit_hasher::IMPLICIT_HASHER),
     LintId::of(implicit_saturating_sub::IMPLICIT_SATURATING_SUB),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -240,6 +240,7 @@ mod functions;
 mod future_not_send;
 mod get_first;
 mod if_let_mutex;
+mod if_none_blocks;
 mod if_not_else;
 mod if_then_some_else_none;
 mod implicit_hasher;
@@ -931,6 +932,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| Box::new(invalid_utf8_in_unchecked::InvalidUtf8InUnchecked));
     store.register_late_pass(|| Box::new(std_instead_of_core::StdReexports::default()));
     store.register_late_pass(|| Box::new(manual_instant_elapsed::ManualInstantElapsed));
+    store.register_late_pass(|| Box::new(if_none_blocks::IfNoneBlocks));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/tests/ui/if_none_blocks.rs
+++ b/tests/ui/if_none_blocks.rs
@@ -17,10 +17,7 @@ fn main() {
     #[allow(unused_braces)]
     let _ = if a {
         {
-            {
-                let x = 8;
-                Some(x)
-            }
+            { Some(8) }
         }
     } else {
         {

--- a/tests/ui/if_none_blocks.rs
+++ b/tests/ui/if_none_blocks.rs
@@ -1,0 +1,68 @@
+#![warn(clippy::if_none_blocks)]
+
+fn side_effects() -> u32 {
+    println!("Side effect.");
+    8
+}
+
+fn main() {
+    let a = true;
+    let b = Some(8);
+    let c = Some(10);
+    let d = false;
+
+    // Eager Positives
+    let _ = if a { Some(8) } else { None };
+
+    #[allow(unused_braces)]
+    let _ = if a {
+        {
+            {
+                let x = 8;
+                Some(x)
+            }
+        }
+    } else {
+        {
+            {
+                { None }
+            }
+        }
+    };
+
+    let _ = if a {
+        Some(8)
+    } else if d {
+        Some(10)
+    } else {
+        None
+    };
+
+    // Flipped Eager Positives
+    let _ = if a { None } else { Some(8) };
+
+    // Lazy Positives
+    let _ = if a { Some(side_effects()) } else { None };
+
+    let _ = if a {
+        side_effects();
+        Some(8)
+    } else {
+        None
+    };
+
+    // Flipped Lazy Positives
+    let _ = if a { None } else { Some(side_effects()) };
+
+    // Negatives
+    let _ = if a && let Some(_) = b && let Some(_) = c {
+        Some(8)
+    } else {
+        None
+    };
+
+    let _ = if a { "Some" } else { "None" };
+
+    // Intentionally left as negative
+    let _: Option<u8> = if a { panic!() } else { None };
+}

--- a/tests/ui/if_none_blocks.stderr
+++ b/tests/ui/if_none_blocks.stderr
@@ -1,0 +1,77 @@
+error: if expression simply returns `None` in one of its branches
+  --> $DIR/if_none_blocks.rs:15:13
+   |
+LL |     let _ = if a { Some(8) } else { None };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::if-none-blocks` implied by `-D warnings`
+   = help: consider using `bool::then_some`
+
+error: if expression simply returns `None` in one of its branches
+  --> $DIR/if_none_blocks.rs:18:13
+   |
+LL |       let _ = if a {
+   |  _____________^
+LL | |         {
+LL | |             {
+LL | |                 let x = 8;
+...  |
+LL | |         }
+LL | |     };
+   | |_____^
+   |
+   = help: consider using `bool::then`
+
+error: if expression simply returns `None` in one of its branches
+  --> $DIR/if_none_blocks.rs:35:12
+   |
+LL |       } else if d {
+   |  ____________^
+LL | |         Some(10)
+LL | |     } else {
+LL | |         None
+LL | |     };
+   | |_____^
+   |
+   = help: consider using `bool::then_some`
+
+error: if expression simply returns `None` in one of its branches
+  --> $DIR/if_none_blocks.rs:42:13
+   |
+LL |     let _ = if a { None } else { Some(8) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider first negating the condition, then using `bool::then_some`
+
+error: if expression simply returns `None` in one of its branches
+  --> $DIR/if_none_blocks.rs:45:13
+   |
+LL |     let _ = if a { Some(side_effects()) } else { None };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `bool::then`
+
+error: if expression simply returns `None` in one of its branches
+  --> $DIR/if_none_blocks.rs:47:13
+   |
+LL |       let _ = if a {
+   |  _____________^
+LL | |         side_effects();
+LL | |         Some(8)
+LL | |     } else {
+LL | |         None
+LL | |     };
+   | |_____^
+   |
+   = help: consider using `bool::then`
+
+error: if expression simply returns `None` in one of its branches
+  --> $DIR/if_none_blocks.rs:55:13
+   |
+LL |     let _ = if a { None } else { Some(side_effects()) };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider first negating the condition, then using `bool::then`
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
Closes #9094; this lint detects `None` blocks in both `then` and `else` arms. Some thoughts I have right now are:
 - I think the error messages could be prettier, maybe by using a MultiSpan? I'd like some help with this.
 - I think a special case help message can be introduced if the condition should be negated, and the expression is a single variable. Instead of saying "first consider negating the condition", say "first consider negating `a`".
   - On a related note, should the case when the condition is a single variable be the *only* time this lint is enabled, instead of on all boolean conditions? I'm not sure if `(long_boolean_condition_chain_here).then_some()` is more or less idiomatic than a simple if statement.
 - Should suggestion be enabled for this lint? Maybe some heuristic could be used in cases where the block returning `Some(_)` is quite complex.

This is my first contribution to Rust, so I'm excited but also a bit nervous :) Bikeshedding on the lint's name and error/help messages is appreciated, to get the wording right.

Finally, this currently changes the stderr for one ui test (`filter_map_next`) and also catches one thing when dogfooding, but I'll wait to resolve those until point 2 above has been settled.

PR checklist:
- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

---

changelog: [`if_none_blocks`]: Add lint
