### PR TITLE
Enable test for def_id_nocore for windows

### DIFF
--- a/tests/ui/def_id_nocore.rs
+++ b/tests/ui/def_id_nocore.rs
@@ -1,4 +1,3 @@
-// ignore-windows
 // ignore-macos
 
 #![feature(no_core, lang_items, start)]

--- a/tests/ui/def_id_nocore.stderr
+++ b/tests/ui/def_id_nocore.stderr
@@ -1,5 +1,5 @@
 error: methods called `as_*` usually take `self` by reference or `self` by mutable reference
-  --> $DIR/def_id_nocore.rs:28:19
+  --> $DIR/def_id_nocore.rs:27:19
    |
 LL |     pub fn as_ref(self) -> &'static str {
    |                   ^^^^


### PR DESCRIPTION
Verified that it actully works on windows
changelog: none
