### PR TITLE
New `[suspicious_arguments]` lint for possibly swapped arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3923,6 +3923,7 @@ Released 2018-09-13
 [`struct_excessive_bools`]: https://rust-lang.github.io/rust-clippy/master/index.html#struct_excessive_bools
 [`stutter`]: https://rust-lang.github.io/rust-clippy/master/index.html#stutter
 [`suboptimal_flops`]: https://rust-lang.github.io/rust-clippy/master/index.html#suboptimal_flops
+[`suspicious_arguments`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_arguments
 [`suspicious_arithmetic_impl`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_arithmetic_impl
 [`suspicious_assignment_formatting`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_assignment_formatting
 [`suspicious_else_formatting`]: https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting

--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -215,6 +215,7 @@ fn check_lower_bound<'tcx>(expr: &'tcx Expr<'tcx>) -> Option<Conversion<'tcx>> {
 
     // First of we need a binary containing the expression & the cast
     if let ExprKind::Binary(ref op, left, right) = &expr.kind {
+        #[expect(clippy::suspicious_arguments, reason = "these are intentionally reversed")]
         normalize_le_ge(op, right, left).and_then(|(l, r)| check_function(l, r))
     } else {
         None

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -297,6 +297,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(strings::STRING_FROM_UTF8_AS_BYTES),
     LintId::of(strings::TRIM_SPLIT_WHITESPACE),
     LintId::of(strlen_on_c_strings::STRLEN_ON_C_STRINGS),
+    LintId::of(suspicious_arguments::SUSPICIOUS_ARGUMENTS),
     LintId::of(suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL),
     LintId::of(suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL),
     LintId::of(swap::ALMOST_SWAPPED),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -514,6 +514,7 @@ store.register_lints(&[
     strings::STR_TO_STRING,
     strings::TRIM_SPLIT_WHITESPACE,
     strlen_on_c_strings::STRLEN_ON_C_STRINGS,
+    suspicious_arguments::SUSPICIOUS_ARGUMENTS,
     suspicious_operation_groupings::SUSPICIOUS_OPERATION_GROUPINGS,
     suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL,
     suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL,

--- a/clippy_lints/src/lib.register_suspicious.rs
+++ b/clippy_lints/src/lib.register_suspicious.rs
@@ -29,6 +29,7 @@ store.register_group(true, "clippy::suspicious", Some("clippy_suspicious"), vec!
     LintId::of(operators::FLOAT_EQUALITY_WITHOUT_ABS),
     LintId::of(operators::MISREFACTORED_ASSIGN_OP),
     LintId::of(rc_clone_in_vec_init::RC_CLONE_IN_VEC_INIT),
+    LintId::of(suspicious_arguments::SUSPICIOUS_ARGUMENTS),
     LintId::of(suspicious_trait_impl::SUSPICIOUS_ARITHMETIC_IMPL),
     LintId::of(suspicious_trait_impl::SUSPICIOUS_OP_ASSIGN_IMPL),
     LintId::of(swap_ptr_to_ref::SWAP_PTR_TO_REF),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -370,6 +370,7 @@ mod stable_sort_primitive;
 mod std_instead_of_core;
 mod strings;
 mod strlen_on_c_strings;
+mod suspicious_arguments;
 mod suspicious_operation_groupings;
 mod suspicious_trait_impl;
 mod swap;
@@ -933,6 +934,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|| Box::new(std_instead_of_core::StdReexports::default()));
     store.register_late_pass(|| Box::new(manual_instant_elapsed::ManualInstantElapsed));
     store.register_late_pass(|| Box::new(partialeq_to_none::PartialeqToNone));
+    store.register_late_pass(|| Box::new(suspicious_arguments::SuspiciousArguments));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/suspicious_arguments.rs
+++ b/clippy_lints/src/suspicious_arguments.rs
@@ -1,10 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::path_res;
+use rustc_data_structure::fs::FxHashMap;
 use rustc_hir::{Expr, ExprKind, PatKind, QPath};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
-use std::collections::HashMap;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -39,7 +39,7 @@ declare_clippy_lint! {
 declare_lint_pass!(SuspiciousArguments => [SUSPICIOUS_ARGUMENTS]);
 
 fn arguments_are_sus(cx: &LateContext<'_>, definition: &[(String, Span)], call: &[Option<(String, Span)>]) {
-    let idxs: HashMap<&String, usize> = definition
+    let idxs: FxHashMap<&String, usize> = definition
         .iter()
         .enumerate()
         .map(|(idx, (item, _))| (item, idx))

--- a/clippy_lints/src/suspicious_arguments.rs
+++ b/clippy_lints/src/suspicious_arguments.rs
@@ -1,0 +1,141 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use rustc_hir::{def, def_id, Expr, ExprKind, PatKind, QPath};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::Span;
+use std::collections::HashMap;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for calls to a function where the parameters look swapped
+    ///
+    /// ### Why is this bad?
+    ///
+    /// This likely indicates an error, where the arguments were reversed.
+    ///
+    /// ### Example
+    /// ```rust
+    /// fn resize(width: usize, height: usize) {}
+    ///
+    /// let height = 100;
+    /// let width = 200;
+    /// resize(height, width);
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// fn resize(width: usize, height: usize) {}
+    ///
+    /// let height = 100;
+    /// let width = 200;
+    /// resize(width, height);
+    /// ```
+    #[clippy::version = "1.64.0"]
+    pub SUSPICIOUS_ARGUMENTS,
+    suspicious,
+    "function call with probably swapped arguments"
+}
+declare_lint_pass!(SuspiciousArguments => [SUSPICIOUS_ARGUMENTS]);
+
+
+fn arguments_are_sus(cx: &LateContext<'_>, definition: &[(String, Span)], call: &[Option<(String, Span)>]) {
+    let idxs: HashMap<&String, usize> = definition
+        .iter()
+        .enumerate()
+        .map(|(idx, (item, _))| (item, idx))
+        .collect();
+
+    for (call_idx, arg_and_span) in call.iter().enumerate() {
+        if let Some((arg, call_span)) = arg_and_span {
+            if let Some(&def_idx) = idxs.get(arg) {
+                if call_idx != def_idx {
+                    if let Some((reverse_call, reverse_call_span)) = &call[def_idx] {
+                        let def_for_call = &definition[call_idx];
+                        if reverse_call == &def_for_call.0 {
+                            // This is technically being called twice, but it's being
+                            // deduplicated?
+                            span_lint_and_then(
+                                cx,
+                                SUSPICIOUS_ARGUMENTS,
+                                vec![*call_span, *reverse_call_span],
+                                "these arguments are possibly swapped",
+                                |diag| {
+                                    let second_span = definition[def_idx].1;
+                                    diag.span_note(vec![def_for_call.1, second_span], "the arguments are defined here");
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for SuspiciousArguments {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
+        if expr.span.from_expansion() {
+            return;
+        }
+
+        if let ExprKind::Call(f, args) = &expr.kind
+            && let ExprKind::Path(qp) = &f.kind {
+                let hirid = match qp {
+                    QPath::Resolved(_, p) => {
+                        let last_segment = p.segments.last().unwrap().res.unwrap();
+
+                        match last_segment {
+                            def::Res::Def(_, defid) => {
+                                if defid.krate != def_id::LOCAL_CRATE {
+                                    return;
+                                }
+                                let local = def_id::LocalDefId {
+                                    local_def_index: defid.index,
+                                };
+                                let hirid = cx.tcx.hir().local_def_id_to_hir_id(local);
+                                hirid
+                            }
+                            _ => return,
+                        }
+                    }
+                    QPath::TypeRelative(_, _) => {
+                        let res = cx.typeck_results().qpath_res(qp, f.hir_id);
+                        let Some(defid) = res.opt_def_id() else { return };
+                        if defid.krate != def_id::LOCAL_CRATE {
+                            return;
+                        }
+                        let local = def_id::LocalDefId {
+                            local_def_index: defid.index,
+                        };
+                        let hirid = cx.tcx.hir().local_def_id_to_hir_id(local);
+                        hirid
+                    }
+                    QPath::LangItem(_, _, _) => { return; }
+                };
+
+
+                let Some(bodyid) = cx.tcx.hir().maybe_body_owned_by(hirid) else { return; };
+                let body = cx.tcx.hir().body(bodyid);
+
+                let mut def_args = Vec::new();
+                for param in body.params {
+                    let PatKind::Binding(_, _, ident, _) = &param.pat.kind else { return };
+                    def_args.push((ident.to_string(), ident.span));
+                }
+
+                let mut call_args = Vec::new();
+
+                for call_arg in *args {
+                    if let ExprKind::Path(qp) = &call_arg.kind
+                    && let QPath::Resolved(_, p) = qp
+                    && let &[segment] = &p.segments {
+                        call_args.push(Some((segment.ident.to_string(), call_arg.span)));
+                    } else {
+                        call_args.push(None);
+                    }
+                }
+
+                arguments_are_sus(cx, &def_args, &call_args);
+        }
+    }
+}

--- a/clippy_lints/src/suspicious_arguments.rs
+++ b/clippy_lints/src/suspicious_arguments.rs
@@ -1,5 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_hir::{def, def_id, Expr, ExprKind, PatKind, QPath};
+use clippy_utils::path_res;
+use rustc_hir::{Expr, ExprKind, PatKind, QPath};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
@@ -36,7 +37,6 @@ declare_clippy_lint! {
     "function call with probably swapped arguments"
 }
 declare_lint_pass!(SuspiciousArguments => [SUSPICIOUS_ARGUMENTS]);
-
 
 fn arguments_are_sus(cx: &LateContext<'_>, definition: &[(String, Span)], call: &[Option<(String, Span)>]) {
     let idxs: HashMap<&String, usize> = definition
@@ -78,64 +78,32 @@ impl<'tcx> LateLintPass<'tcx> for SuspiciousArguments {
             return;
         }
 
-        if let ExprKind::Call(f, args) = &expr.kind
-            && let ExprKind::Path(qp) = &f.kind {
-                let hirid = match qp {
-                    QPath::Resolved(_, p) => {
-                        let last_segment = p.segments.last().unwrap().res.unwrap();
+        if let ExprKind::Call(f, args) = expr.kind
+            && let Some(def_id) = path_res(cx, f).opt_def_id()
+            && let Some(node) = cx.tcx.hir().get_if_local(def_id)
+            && let Some(body_id) = node.body_id() {
 
-                        match last_segment {
-                            def::Res::Def(_, defid) => {
-                                if defid.krate != def_id::LOCAL_CRATE {
-                                    return;
-                                }
-                                let local = def_id::LocalDefId {
-                                    local_def_index: defid.index,
-                                };
-                                let hirid = cx.tcx.hir().local_def_id_to_hir_id(local);
-                                hirid
-                            }
-                            _ => return,
-                        }
-                    }
-                    QPath::TypeRelative(_, _) => {
-                        let res = cx.typeck_results().qpath_res(qp, f.hir_id);
-                        let Some(defid) = res.opt_def_id() else { return };
-                        if defid.krate != def_id::LOCAL_CRATE {
-                            return;
-                        }
-                        let local = def_id::LocalDefId {
-                            local_def_index: defid.index,
-                        };
-                        let hirid = cx.tcx.hir().local_def_id_to_hir_id(local);
-                        hirid
-                    }
-                    QPath::LangItem(_, _, _) => { return; }
-                };
+            let body = cx.tcx.hir().body(body_id);
 
+            let mut def_args = Vec::new();
+            for param in body.params {
+                let PatKind::Binding(_, _, ident, _) = &param.pat.kind else { return };
+                def_args.push((ident.to_string(), ident.span));
+            }
 
-                let Some(bodyid) = cx.tcx.hir().maybe_body_owned_by(hirid) else { return; };
-                let body = cx.tcx.hir().body(bodyid);
+            let mut call_args = Vec::new();
 
-                let mut def_args = Vec::new();
-                for param in body.params {
-                    let PatKind::Binding(_, _, ident, _) = &param.pat.kind else { return };
-                    def_args.push((ident.to_string(), ident.span));
+            for call_arg in args {
+                if let ExprKind::Path(qp) = &call_arg.kind
+                && let QPath::Resolved(_, p) = qp
+                && let &[segment] = &p.segments {
+                    call_args.push(Some((segment.ident.to_string(), call_arg.span)));
+                } else {
+                    call_args.push(None);
                 }
+            }
 
-                let mut call_args = Vec::new();
-
-                for call_arg in *args {
-                    if let ExprKind::Path(qp) = &call_arg.kind
-                    && let QPath::Resolved(_, p) = qp
-                    && let &[segment] = &p.segments {
-                        call_args.push(Some((segment.ident.to_string(), call_arg.span)));
-                    } else {
-                        call_args.push(None);
-                    }
-                }
-
-                arguments_are_sus(cx, &def_args, &call_args);
+            arguments_are_sus(cx, &def_args, &call_args);
         }
     }
 }

--- a/clippy_lints/src/suspicious_arguments.rs
+++ b/clippy_lints/src/suspicious_arguments.rs
@@ -83,7 +83,6 @@ impl<'tcx> LateLintPass<'tcx> for SuspiciousArguments {
         if let ExprKind::Call(f, args) = expr.kind
             && let Some(def_id) = path_res(cx, f).opt_def_id() {
 
-                       
             let mut def_args = Vec::new();
             for ident in cx.tcx.fn_arg_names(def_id) {
                 def_args.push((ident.to_string(), ident.span));

--- a/tests/ui/suspicious_arguments.rs
+++ b/tests/ui/suspicious_arguments.rs
@@ -1,6 +1,6 @@
 // edition:2015
 #![warn(clippy::suspicious_arguments)]
-#![allow(anonymous_parameters)]
+#![allow(anonymous_parameters, clippy::no_effect)]
 
 trait AnonymousArgs {
     fn scale(&self, usize, usize) {}
@@ -24,28 +24,90 @@ impl Bitmap {
     }
 }
 
-fn main() {
+struct TupleStruct(usize, usize);
+
+enum TupleEnum {
+    Hello,
+    World(usize, usize),
+}
+
+#[derive(Default)]
+struct Dimensions {
+    width: usize,
+    height: usize,
+}
+
+fn function_names() {
+    fn height() -> usize { 0 }
+    fn width() -> usize { 0 }
+
+    resize(height(), width());
+}
+
+fn pathed_function_names() {
+    mod uwu {
+        pub fn height() -> usize { 0 }
+        pub fn width() -> usize { 0 }
+    }
+
+    resize(uwu::height(), uwu::width());
+}
+
+fn variable_names() {
     let width = 0;
     let height = 0;
 
     resize(height, width);
     Bitmap::new(height, width);
+}
+
+#[rustfmt::ignore]
+fn struct_names() {
+    let dims = Dimensions::default();
+    resize(dims.height, dims.width);
+
+    resize(
+        dims
+        .height,
+        // Very long!
+        dims
+        .width);
+}
+
+fn should_not_lint() {
+    let width = 0;
+    let height = 0;
+    TupleStruct(width, height);
+    TupleEnum::World(width, height);
 
     resize(0, width);
     resize(height, 0);
     resize(height, height);
     resize(width, width);
+}
 
+fn cross_crate() {
     let f = vec![0_u8];
     let iterable = |_| { true };
 
     itertools::all(f, iterable);
+}
 
+fn cross_std() {
     let mut xvalue = 42;
     let mut yvalue = 42;
     let x = &mut xvalue;
     let y = &mut yvalue;
 
     std::mem::swap(y, x);
-    
+}
+
+
+fn main() {
+    function_names();
+    variable_names();
+    struct_names();
+    should_not_lint();
+    cross_crate();
+    cross_std();
 }

--- a/tests/ui/suspicious_arguments.rs
+++ b/tests/ui/suspicious_arguments.rs
@@ -1,0 +1,24 @@
+#![warn(clippy::suspicious_arguments)]
+
+fn resize(width: usize, height: usize) {}
+
+struct Bitmap;
+
+impl Bitmap {
+    fn new(width: usize, height: usize) -> Self {
+        Bitmap
+    }
+}
+
+fn main() {
+    let width = 0;
+    let height = 0;
+
+    resize(height, width);
+    Bitmap::new(height, width);
+
+    resize(0, width);
+    resize(height, 0);
+    resize(height, height);
+    resize(width, width);
+}

--- a/tests/ui/suspicious_arguments.rs
+++ b/tests/ui/suspicious_arguments.rs
@@ -1,4 +1,18 @@
+// edition:2015
 #![warn(clippy::suspicious_arguments)]
+#![allow(anonymous_parameters)]
+
+trait AnonymousArgs {
+    fn scale(&self, usize, usize) {}
+}
+
+fn scale_this<A: AnonymousArgs>(value: A) {
+    // We don't expect a lint, we just don't want an ICE here.
+    let width = 1;
+    let height = 2;
+    value.scale(width, height);
+    A::scale(&value, width, height);
+}
 
 fn resize(width: usize, height: usize) {}
 
@@ -21,4 +35,17 @@ fn main() {
     resize(height, 0);
     resize(height, height);
     resize(width, width);
+
+    let f = vec![0_u8];
+    let iterable = |_| { true };
+
+    itertools::all(f, iterable);
+
+    let mut xvalue = 42;
+    let mut yvalue = 42;
+    let x = &mut xvalue;
+    let y = &mut yvalue;
+
+    std::mem::swap(y, x);
+    
 }

--- a/tests/ui/suspicious_arguments.rs
+++ b/tests/ui/suspicious_arguments.rs
@@ -117,6 +117,16 @@ fn varargs() {
     }
 }
 
+fn tri_rotate() {
+    fn large_resize(width: usize, height: usize, depth: usize) {}
+
+    let width = 0;
+    let height = 0;
+    let depth = 0;
+
+    large_resize(height, depth, width);
+}
+
 
 fn main() {
     function_names();

--- a/tests/ui/suspicious_arguments.rs
+++ b/tests/ui/suspicious_arguments.rs
@@ -1,6 +1,6 @@
 // edition:2015
 #![warn(clippy::suspicious_arguments)]
-#![allow(anonymous_parameters, clippy::no_effect)]
+#![allow(anonymous_parameters, clippy::no_effect, dead_code)]
 
 trait AnonymousArgs {
     fn scale(&self, usize, usize) {}
@@ -127,12 +127,19 @@ fn tri_rotate() {
     large_resize(height, depth, width);
 }
 
+fn patterns() {
+    fn array([width, height]: [usize; 2]) {
 
-fn main() {
-    function_names();
-    variable_names();
-    struct_names();
-    should_not_lint();
-    cross_crate();
-    cross_std();
+    }
+
+    fn tuple((width, height): (usize, usize)) {
+    }
+
+    let width = 0;
+    let height = 0;
+
+    array([height, width]);
+    tuple((height, width));
 }
+
+fn main() {}

--- a/tests/ui/suspicious_arguments.rs
+++ b/tests/ui/suspicious_arguments.rs
@@ -102,6 +102,21 @@ fn cross_std() {
     std::mem::swap(y, x);
 }
 
+fn varargs() {
+    extern "C" {
+        fn test_var_args(width: usize, height: usize, ...);
+    }
+    
+    if false {
+        unsafe {
+            let width = 0;
+            let height = 0;
+            let not_foo = 0;
+            test_var_args(height, width, not_foo, width, height);
+        }
+    }
+}
+
 
 fn main() {
     function_names();

--- a/tests/ui/suspicious_arguments.stderr
+++ b/tests/ui/suspicious_arguments.stderr
@@ -1,0 +1,27 @@
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:17:12
+   |
+LL |     resize(height, width);
+   |            ^^^^^^  ^^^^^
+   |
+   = note: `-D clippy::suspicious-arguments` implied by `-D warnings`
+note: the arguments are defined here
+  --> $DIR/suspicious_arguments.rs:3:11
+   |
+LL | fn resize(width: usize, height: usize) {}
+   |           ^^^^^         ^^^^^^
+
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:18:17
+   |
+LL |     Bitmap::new(height, width);
+   |                 ^^^^^^  ^^^^^
+   |
+note: the arguments are defined here
+  --> $DIR/suspicious_arguments.rs:8:12
+   |
+LL |     fn new(width: usize, height: usize) -> Self {
+   |            ^^^^^         ^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/suspicious_arguments.stderr
+++ b/tests/ui/suspicious_arguments.stderr
@@ -1,8 +1,8 @@
 error: these arguments are possibly swapped
-  --> $DIR/suspicious_arguments.rs:31:12
+  --> $DIR/suspicious_arguments.rs:44:12
    |
-LL |     resize(height, width);
-   |            ^^^^^^  ^^^^^
+LL |     resize(height(), width());
+   |            ^^^^^^    ^^^^^
    |
    = note: `-D clippy::suspicious-arguments` implied by `-D warnings`
 note: the arguments are defined here
@@ -12,7 +12,31 @@ LL | fn resize(width: usize, height: usize) {}
    |           ^^^^^         ^^^^^^
 
 error: these arguments are possibly swapped
-  --> $DIR/suspicious_arguments.rs:32:17
+  --> $DIR/suspicious_arguments.rs:53:17
+   |
+LL |     resize(uwu::height(), uwu::width());
+   |                 ^^^^^^         ^^^^^
+   |
+note: the arguments are defined here
+  --> $DIR/suspicious_arguments.rs:17:11
+   |
+LL | fn resize(width: usize, height: usize) {}
+   |           ^^^^^         ^^^^^^
+
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:60:12
+   |
+LL |     resize(height, width);
+   |            ^^^^^^  ^^^^^
+   |
+note: the arguments are defined here
+  --> $DIR/suspicious_arguments.rs:17:11
+   |
+LL | fn resize(width: usize, height: usize) {}
+   |           ^^^^^         ^^^^^^
+
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:61:17
    |
 LL |     Bitmap::new(height, width);
    |                 ^^^^^^  ^^^^^
@@ -24,7 +48,34 @@ LL |     fn new(width: usize, height: usize) -> Self {
    |            ^^^^^         ^^^^^^
 
 error: these arguments are possibly swapped
-  --> $DIR/suspicious_arguments.rs:42:20
+  --> $DIR/suspicious_arguments.rs:67:17
+   |
+LL |     resize(dims.height, dims.width);
+   |                 ^^^^^^       ^^^^^
+   |
+note: the arguments are defined here
+  --> $DIR/suspicious_arguments.rs:17:11
+   |
+LL | fn resize(width: usize, height: usize) {}
+   |           ^^^^^         ^^^^^^
+
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:71:10
+   |
+LL |         .height,
+   |          ^^^^^^
+...
+LL |         .width);
+   |          ^^^^^
+   |
+note: the arguments are defined here
+  --> $DIR/suspicious_arguments.rs:17:11
+   |
+LL | fn resize(width: usize, height: usize) {}
+   |           ^^^^^         ^^^^^^
+
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:93:20
    |
 LL |     itertools::all(f, iterable);
    |                    ^  ^^^^^^^^
@@ -36,7 +87,7 @@ LL | pub fn all<I, F>(iterable: I, f: F) -> bool
    |                  ^^^^^^^^     ^
 
 error: these arguments are possibly swapped
-  --> $DIR/suspicious_arguments.rs:49:20
+  --> $DIR/suspicious_arguments.rs:102:20
    |
 LL |     std::mem::swap(y, x);
    |                    ^  ^
@@ -47,5 +98,5 @@ note: the arguments are defined here
 LL | pub const fn swap<T>(x: &mut T, y: &mut T) {
    |                      ^          ^
 
-error: aborting due to 4 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/suspicious_arguments.stderr
+++ b/tests/ui/suspicious_arguments.stderr
@@ -1,27 +1,51 @@
 error: these arguments are possibly swapped
-  --> $DIR/suspicious_arguments.rs:17:12
+  --> $DIR/suspicious_arguments.rs:31:12
    |
 LL |     resize(height, width);
    |            ^^^^^^  ^^^^^
    |
    = note: `-D clippy::suspicious-arguments` implied by `-D warnings`
 note: the arguments are defined here
-  --> $DIR/suspicious_arguments.rs:3:11
+  --> $DIR/suspicious_arguments.rs:17:11
    |
 LL | fn resize(width: usize, height: usize) {}
    |           ^^^^^         ^^^^^^
 
 error: these arguments are possibly swapped
-  --> $DIR/suspicious_arguments.rs:18:17
+  --> $DIR/suspicious_arguments.rs:32:17
    |
 LL |     Bitmap::new(height, width);
    |                 ^^^^^^  ^^^^^
    |
 note: the arguments are defined here
-  --> $DIR/suspicious_arguments.rs:8:12
+  --> $DIR/suspicious_arguments.rs:22:12
    |
 LL |     fn new(width: usize, height: usize) -> Self {
    |            ^^^^^         ^^^^^^
 
-error: aborting due to 2 previous errors
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:42:20
+   |
+LL |     itertools::all(f, iterable);
+   |                    ^  ^^^^^^^^
+   |
+note: the arguments are defined here
+  --> /home/jess/.cargo/registry/src/github.com-1ecc6299db9ec823/itertools-0.10.1/src/free.rs:151:18
+   |
+LL | pub fn all<I, F>(iterable: I, f: F) -> bool
+   |                  ^^^^^^^^     ^
+
+error: these arguments are possibly swapped
+  --> $DIR/suspicious_arguments.rs:49:20
+   |
+LL |     std::mem::swap(y, x);
+   |                    ^  ^
+   |
+note: the arguments are defined here
+  --> /home/jess/.rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/mem/mod.rs:711:22
+   |
+LL | pub const fn swap<T>(x: &mut T, y: &mut T) {
+   |                      ^          ^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
changelog: [`suspicious_arguments`]: add lint for probably accidentally swapped arguments

---