### PR TITLE
Fix ICE when reading literals with weird proc-macro spans

### DIFF
--- a/clippy_utils/src/numeric_literal.rs
+++ b/clippy_utils/src/numeric_literal.rs
@@ -223,10 +223,12 @@ impl<'a> NumericLiteral<'a> {
 
 fn split_suffix<'a>(src: &'a str, lit_kind: &LitKind) -> (&'a str, Option<&'a str>) {
     debug_assert!(lit_kind.is_numeric());
-    lit_suffix_length(lit_kind).map_or((src, None), |suffix_length| {
-        let (unsuffixed, suffix) = src.split_at(src.len() - suffix_length);
-        (unsuffixed, Some(suffix))
-    })
+    lit_suffix_length(lit_kind)
+        .and_then(|suffix_length| src.len().checked_sub(suffix_length))
+        .map_or((src, None), |split_pos| {
+            let (unsuffixed, suffix) = src.split_at(split_pos);
+            (unsuffixed, Some(suffix))
+        })
 }
 
 fn lit_suffix_length(lit_kind: &LitKind) -> Option<usize> {

--- a/tests/ui/mistyped_literal_suffix.fixed
+++ b/tests/ui/mistyped_literal_suffix.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+// aux-build: proc_macro_with_span.rs
 
 #![allow(
     dead_code,
@@ -8,6 +9,9 @@
     clippy::inconsistent_digit_grouping,
     clippy::unusual_byte_groupings
 )]
+
+extern crate proc_macro_with_span;
+use proc_macro_with_span::with_span;
 
 fn main() {
     let fail14 = 2_i32;
@@ -40,4 +44,6 @@ fn main() {
     let ok38 = 124_64.0;
 
     let _ = 1.123_45E1_f32;
+
+    let _ = with_span!(1 2_u32);
 }

--- a/tests/ui/mistyped_literal_suffix.rs
+++ b/tests/ui/mistyped_literal_suffix.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+// aux-build: proc_macro_with_span.rs
 
 #![allow(
     dead_code,
@@ -8,6 +9,9 @@
     clippy::inconsistent_digit_grouping,
     clippy::unusual_byte_groupings
 )]
+
+extern crate proc_macro_with_span;
+use proc_macro_with_span::with_span;
 
 fn main() {
     let fail14 = 2_32;
@@ -40,4 +44,6 @@ fn main() {
     let ok38 = 124_64.0;
 
     let _ = 1.12345E1_32;
+
+    let _ = with_span!(1 2_u32);
 }

--- a/tests/ui/mistyped_literal_suffix.stderr
+++ b/tests/ui/mistyped_literal_suffix.stderr
@@ -1,5 +1,5 @@
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:13:18
+  --> $DIR/mistyped_literal_suffix.rs:17:18
    |
 LL |     let fail14 = 2_32;
    |                  ^^^^ help: did you mean to write: `2_i32`
@@ -7,91 +7,91 @@ LL |     let fail14 = 2_32;
    = note: `#[deny(clippy::mistyped_literal_suffixes)]` on by default
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:14:18
+  --> $DIR/mistyped_literal_suffix.rs:18:18
    |
 LL |     let fail15 = 4_64;
    |                  ^^^^ help: did you mean to write: `4_i64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:15:18
+  --> $DIR/mistyped_literal_suffix.rs:19:18
    |
 LL |     let fail16 = 7_8; //
    |                  ^^^ help: did you mean to write: `7_i8`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:16:18
+  --> $DIR/mistyped_literal_suffix.rs:20:18
    |
 LL |     let fail17 = 23_16; //
    |                  ^^^^^ help: did you mean to write: `23_i16`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:19:18
+  --> $DIR/mistyped_literal_suffix.rs:23:18
    |
 LL |     let fail20 = 2__8; //
    |                  ^^^^ help: did you mean to write: `2_i8`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:20:18
+  --> $DIR/mistyped_literal_suffix.rs:24:18
    |
 LL |     let fail21 = 4___16; //
    |                  ^^^^^^ help: did you mean to write: `4_i16`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:23:18
+  --> $DIR/mistyped_literal_suffix.rs:27:18
    |
 LL |     let fail25 = 1E2_32;
    |                  ^^^^^^ help: did you mean to write: `1E2_f32`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:24:18
+  --> $DIR/mistyped_literal_suffix.rs:28:18
    |
 LL |     let fail26 = 43E7_64;
    |                  ^^^^^^^ help: did you mean to write: `43E7_f64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:25:18
+  --> $DIR/mistyped_literal_suffix.rs:29:18
    |
 LL |     let fail27 = 243E17_32;
    |                  ^^^^^^^^^ help: did you mean to write: `243E17_f32`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:26:18
+  --> $DIR/mistyped_literal_suffix.rs:30:18
    |
 LL |     let fail28 = 241251235E723_64;
    |                  ^^^^^^^^^^^^^^^^ help: did you mean to write: `241_251_235E723_f64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:30:18
+  --> $DIR/mistyped_literal_suffix.rs:34:18
    |
 LL |     let fail30 = 127_8; // should be i8
    |                  ^^^^^ help: did you mean to write: `127_i8`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:31:18
+  --> $DIR/mistyped_literal_suffix.rs:35:18
    |
 LL |     let fail31 = 240_8; // should be u8
    |                  ^^^^^ help: did you mean to write: `240_u8`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:33:18
+  --> $DIR/mistyped_literal_suffix.rs:37:18
    |
 LL |     let fail33 = 0x1234_16;
    |                  ^^^^^^^^^ help: did you mean to write: `0x1234_i16`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:34:18
+  --> $DIR/mistyped_literal_suffix.rs:38:18
    |
 LL |     let fail34 = 0xABCD_16;
    |                  ^^^^^^^^^ help: did you mean to write: `0xABCD_u16`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:36:18
+  --> $DIR/mistyped_literal_suffix.rs:40:18
    |
 LL |     let fail36 = 0xFFFF_FFFF_FFFF_FFFF_64; // u64
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean to write: `0xFFFF_FFFF_FFFF_FFFF_u64`
 
 error: mistyped literal suffix
-  --> $DIR/mistyped_literal_suffix.rs:42:13
+  --> $DIR/mistyped_literal_suffix.rs:46:13
    |
 LL |     let _ = 1.12345E1_32;
    |             ^^^^^^^^^^^^ help: did you mean to write: `1.123_45E1_f32`


### PR DESCRIPTION
fixes #9297
changelog: Fix ICE when reading literals with weird proc-macro spans

