### PR TITLE
Use `check_proc_macro` for `missing_const_for_fn`

### DIFF
--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -14,9 +14,9 @@
 
 use rustc_ast::ast::{IntTy, LitIntType, LitKind, StrStyle, UintTy};
 use rustc_hir::{
-    Block, BlockCheckMode, Closure, Destination, Expr, ExprKind, FieldDef, FnHeader, Impl, ImplItem, ImplItemKind,
-    IsAuto, Item, ItemKind, LoopSource, MatchSource, QPath, TraitItem, TraitItemKind, UnOp, UnsafeSource, Unsafety,
-    Variant, VariantData, YieldSource,
+    intravisit::FnKind, Block, BlockCheckMode, Body, Closure, Destination, Expr, ExprKind, FieldDef, FnHeader, HirId,
+    Impl, ImplItem, ImplItemKind, IsAuto, Item, ItemKind, LoopSource, MatchSource, QPath, TraitItem, TraitItemKind,
+    UnOp, UnsafeSource, Unsafety, Variant, VariantData, YieldSource,
 };
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty::TyCtxt;
@@ -250,6 +250,27 @@ fn variant_search_pat(v: &Variant<'_>) -> (Pat, Pat) {
     }
 }
 
+fn fn_kind_pat(tcx: TyCtxt<'_>, kind: &FnKind<'_>, body: &Body<'_>, hir_id: HirId) -> (Pat, Pat) {
+    let (start_pat, end_pat, visibility) = match kind {
+        FnKind::ItemFn(.., header) => (
+            fn_header_search_pat(*header),
+            Pat::Str(""),
+            tcx.visibility(tcx.hir().local_def_id(hir_id)),
+        ),
+        FnKind::Method(.., sig) => (
+            fn_header_search_pat(sig.header),
+            Pat::Str(""),
+            tcx.visibility(tcx.hir().local_def_id(hir_id)),
+        ),
+        FnKind::Closure => return (Pat::Str(""), expr_search_pat(tcx, &body.value).1),
+    };
+    if visibility.is_public() {
+        (Pat::Str("pub"), end_pat)
+    } else {
+        (start_pat, end_pat)
+    }
+}
+
 pub trait WithSearchPat {
     type Context: LintContext;
     fn search_pat(&self, cx: &Self::Context) -> (Pat, Pat);
@@ -276,6 +297,18 @@ impl_with_search_pat!(LateContext: TraitItem with trait_item_search_pat);
 impl_with_search_pat!(LateContext: ImplItem with impl_item_search_pat);
 impl_with_search_pat!(LateContext: FieldDef with field_def_search_pat);
 impl_with_search_pat!(LateContext: Variant with variant_search_pat);
+
+impl<'cx> WithSearchPat for (&FnKind<'cx>, &Body<'cx>, HirId, Span) {
+    type Context = LateContext<'cx>;
+
+    fn search_pat(&self, cx: &Self::Context) -> (Pat, Pat) {
+        fn_kind_pat(cx.tcx, self.0, self.1, self.2)
+    }
+
+    fn span(&self) -> Span {
+        self.3
+    }
+}
 
 /// Checks if the item likely came from a proc-macro.
 ///

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -3,12 +3,16 @@
 //! The .stderr output of this test should be empty. Otherwise it's a bug somewhere.
 
 // aux-build:helper.rs
+// aux-build:../../auxiliary/proc_macro_with_span.rs
 
 #![warn(clippy::missing_const_for_fn)]
 #![feature(start)]
 #![feature(custom_inner_attributes)]
 
 extern crate helper;
+extern crate proc_macro_with_span;
+
+use proc_macro_with_span::with_span;
 
 struct Game;
 
@@ -118,4 +122,9 @@ mod const_fn_stabilized_after_msrv {
     fn const_fn_stabilized_after_msrv(byte: u8) {
         byte.is_ascii_digit();
     }
+}
+
+with_span! {
+    span
+    fn dont_check_in_proc_macro() {}
 }


### PR DESCRIPTION
This uses @Jarcho's #8694 implementation to fix `missing_const_for_fn` linting in proc-macros.
I'm not 100% sure what I'm doing here, any feedback is appreciated.

Previously: https://github.com/Jarcho/rust-clippy/pull/1.
Fixes #8854.

changelog: [`missing_const_for_fn`]: No longer lints in proc-macros
