### PR TITLE
Remove extra dereference from the borrow_deref_ref lint example

### DIFF
--- a/clippy_lints/src/borrow_deref_ref.rs
+++ b/clippy_lints/src/borrow_deref_ref.rs
@@ -29,20 +29,15 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
-    /// fn foo(_x: &str) {}
-    ///
     /// let s = &String::new();
     ///
     /// let a: &String = &* s;
-    /// foo(&*s);
     /// ```
     ///
     /// Use instead:
     /// ```rust
-    /// # fn foo(_x: &str) {}
     /// # let s = &String::new();
     /// let a: &String = s;
-    /// foo(&**s);
     /// ```
     #[clippy::version = "1.63.0"]
     pub BORROW_DEREF_REF,


### PR DESCRIPTION
I don't think such minor change should be mentioned in the changelog.

changelog: none