### PR TITLE
suggest map_or in case_sensitive_file_extension_comparisons

### DIFF
--- a/clippy_lints/src/case_sensitive_file_extension_comparisons.rs
+++ b/clippy_lints/src/case_sensitive_file_extension_comparisons.rs
@@ -26,8 +26,7 @@ declare_clippy_lint! {
     /// fn is_rust_file(filename: &str) -> bool {
     ///     let filename = std::path::Path::new(filename);
     ///     filename.extension()
-    ///         .map(|ext| ext.eq_ignore_ascii_case("rs"))
-    ///         .unwrap_or(false)
+    ///         .map_or(false, |ext| ext.eq_ignore_ascii_case("rs"))
     /// }
     /// ```
     #[clippy::version = "1.51.0"]


### PR DESCRIPTION
changelog: [`case_sensitive_file_extension_comparisons `]: updated suggestion in the example to use `map_or`

Currently, case_sensitive_file_extension_comparisons suggests using `map(..).unwrap_or(..)` which trips up the `map_unwrap_or` lint.  This updates the suggestion to use `map_or`.