### PR TITLE
Use `CARGO_TARGET_DIR` in compile-test

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -403,7 +403,8 @@ const RUSTFIX_COVERAGE_KNOWN_EXCEPTIONS: &[&str] = &[
 ];
 
 fn check_rustfix_coverage() {
-    let missing_coverage_path = Path::new("target/debug/test/ui/rustfix_missing_coverage.txt");
+    let target_dir = PathBuf::from(std::env::var("CARGO_TARGET_DIR").unwrap());
+    let missing_coverage_path = target_dir.join("debug/test/ui/rustfix_missing_coverage.txt");
 
     if let Ok(missing_coverage_contents) = std::fs::read_to_string(missing_coverage_path) {
         assert!(RUSTFIX_COVERAGE_KNOWN_EXCEPTIONS.iter().is_sorted_by_key(Path::new));


### PR DESCRIPTION
changelog: none

I have a global `CARGO_TARGET_DIR` set, but forgot to delete the old target dir. `compile-test` was getting tripped up on an outdated `rustfix_missing_coverage.txt` I had in there, keeping me from running tests :smile:.