### PR TITLE
match_wild_err_arm: Fix typo in note text

### DIFF
--- a/clippy_lints/src/matches/match_wild_err_arm.rs
+++ b/clippy_lints/src/matches/match_wild_err_arm.rs
@@ -40,7 +40,7 @@ pub(crate) fn check<'tcx>(cx: &LateContext<'tcx>, ex: &Expr<'tcx>, arms: &[Arm<'
                                 arm.pat.span,
                                 &format!("`Err({})` matches all errors", ident_bind_name),
                                 None,
-                                "match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable",
+                                "match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable",
                             );
                         }
                     }

--- a/tests/ui/match_wild_err_arm.edition2018.stderr
+++ b/tests/ui/match_wild_err_arm.edition2018.stderr
@@ -5,7 +5,7 @@ LL |         Err(_) => panic!("err"),
    |         ^^^^^^
    |
    = note: `-D clippy::match-wild-err-arm` implied by `-D warnings`
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_)` matches all errors
   --> $DIR/match_wild_err_arm.rs:20:9
@@ -13,7 +13,7 @@ error: `Err(_)` matches all errors
 LL |         Err(_) => panic!(),
    |         ^^^^^^
    |
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_)` matches all errors
   --> $DIR/match_wild_err_arm.rs:26:9
@@ -21,7 +21,7 @@ error: `Err(_)` matches all errors
 LL |         Err(_) => {
    |         ^^^^^^
    |
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_e)` matches all errors
   --> $DIR/match_wild_err_arm.rs:34:9
@@ -29,7 +29,7 @@ error: `Err(_e)` matches all errors
 LL |         Err(_e) => panic!(),
    |         ^^^^^^^
    |
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/match_wild_err_arm.edition2021.stderr
+++ b/tests/ui/match_wild_err_arm.edition2021.stderr
@@ -5,7 +5,7 @@ LL |         Err(_) => panic!("err"),
    |         ^^^^^^
    |
    = note: `-D clippy::match-wild-err-arm` implied by `-D warnings`
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_)` matches all errors
   --> $DIR/match_wild_err_arm.rs:20:9
@@ -13,7 +13,7 @@ error: `Err(_)` matches all errors
 LL |         Err(_) => panic!(),
    |         ^^^^^^
    |
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_)` matches all errors
   --> $DIR/match_wild_err_arm.rs:26:9
@@ -21,7 +21,7 @@ error: `Err(_)` matches all errors
 LL |         Err(_) => {
    |         ^^^^^^
    |
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_e)` matches all errors
   --> $DIR/match_wild_err_arm.rs:34:9
@@ -29,7 +29,7 @@ error: `Err(_e)` matches all errors
 LL |         Err(_e) => panic!(),
    |         ^^^^^^^
    |
-   = note: match each error separately or use the error output, or use `.except(msg)` if the error case is unreachable
+   = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
changelog: [`match_wild_err_arm`]: fix typo in note text