### PR TITLE
Don't use `hir_ty_to_ty` in `result_large_err`

### DIFF
--- a/tests/ui/crashes/ice-9414.rs
+++ b/tests/ui/crashes/ice-9414.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::result_large_err)]
+
+trait T {}
+fn f(_: &u32) -> Result<(), *const (dyn '_ + T)> {
+    Ok(())
+}
+
+fn main() {}


### PR DESCRIPTION
fixes #9414

This occurs starting with 2022-09-01. I checked that this does fix the ICE on rust-lang/rust@9353538. Not sure which pr caused the late-bound region to leak through `hir_ty_to_ty`.

changelog: None
