### PR TITLE
Fix `mut_mutex_lock` when Mutex is behind immutable deref

### DIFF
--- a/clippy_lints/src/methods/mut_mutex_lock.rs
+++ b/clippy_lints/src/methods/mut_mutex_lock.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::ty::is_type_diagnostic_item;
+use clippy_utils::{expr_custom_deref_adjustment, ty::is_type_diagnostic_item};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, Mutability};
@@ -11,6 +11,7 @@ use super::MUT_MUTEX_LOCK;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, ex: &'tcx Expr<'tcx>, recv: &'tcx Expr<'tcx>, name_span: Span) {
     if_chain! {
+        if matches!(expr_custom_deref_adjustment(cx, recv), None | Some(Mutability::Mut));
         if let ty::Ref(_, _, Mutability::Mut) = cx.typeck_results().expr_ty(recv).kind();
         if let Some(method_id) = cx.typeck_results().type_dependent_def_id(ex.hir_id);
         if let Some(impl_id) = cx.tcx.impl_of_method(method_id);

--- a/tests/ui/mut_mutex_lock.fixed
+++ b/tests/ui/mut_mutex_lock.fixed
@@ -18,4 +18,11 @@ fn no_owned_mutex_lock() {
     *value += 1;
 }
 
+fn issue9415() {
+    let mut arc_mutex = Arc::new(Mutex::new(42_u8));
+    let arc_mutex: &mut Arc<Mutex<u8>> = &mut arc_mutex;
+    let mut guard = arc_mutex.lock().unwrap();
+    *guard += 1;
+}
+
 fn main() {}

--- a/tests/ui/mut_mutex_lock.rs
+++ b/tests/ui/mut_mutex_lock.rs
@@ -18,4 +18,11 @@ fn no_owned_mutex_lock() {
     *value += 1;
 }
 
+fn issue9415() {
+    let mut arc_mutex = Arc::new(Mutex::new(42_u8));
+    let arc_mutex: &mut Arc<Mutex<u8>> = &mut arc_mutex;
+    let mut guard = arc_mutex.lock().unwrap();
+    *guard += 1;
+}
+
 fn main() {}


### PR DESCRIPTION
I *think* the problem here is the `if let ty::Ref(_, _, Mutability::Mut) = cx.typeck_results().expr_ty(recv).kind()` line tries to check if the `Mutex` can be mutably borrowed (there already is a test for `Arc<Mutex<_>>`), but gets bamboozled by the `&mut Arc` indirection. And I *think* checking the deref-adjustment to filter immutable-adjust (the deref through the `Arc`, starting from `&mut Arc`) is the correct fix.

Fixes #9415

changelog: Fix `mut_mutex_lock` when Mutex is behind immutable deref
