### PR TITLE
Initial implementation of `mut_refcell_borrow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3908,6 +3908,7 @@ Released 2018-09-13
 [`mut_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#mut_mut
 [`mut_mutex_lock`]: https://rust-lang.github.io/rust-clippy/master/index.html#mut_mutex_lock
 [`mut_range_bound`]: https://rust-lang.github.io/rust-clippy/master/index.html#mut_range_bound
+[`mut_refcell_borrow`]: https://rust-lang.github.io/rust-clippy/master/index.html#mut_refcell_borrow
 [`mutable_key_type`]: https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type
 [`mutex_atomic`]: https://rust-lang.github.io/rust-clippy/master/index.html#mutex_atomic
 [`mutex_integer`]: https://rust-lang.github.io/rust-clippy/master/index.html#mutex_integer

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -186,6 +186,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(methods::MAP_FLATTEN),
     LintId::of(methods::MAP_IDENTITY),
     LintId::of(methods::MUT_MUTEX_LOCK),
+    LintId::of(methods::MUT_REFCELL_BORROW),
     LintId::of(methods::NEEDLESS_OPTION_AS_DEREF),
     LintId::of(methods::NEEDLESS_OPTION_TAKE),
     LintId::of(methods::NEEDLESS_SPLITN),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -334,6 +334,7 @@ store.register_lints(&[
     methods::MAP_IDENTITY,
     methods::MAP_UNWRAP_OR,
     methods::MUT_MUTEX_LOCK,
+    methods::MUT_REFCELL_BORROW,
     methods::NAIVE_BYTECOUNT,
     methods::NEEDLESS_OPTION_AS_DEREF,
     methods::NEEDLESS_OPTION_TAKE,

--- a/clippy_lints/src/lib.register_style.rs
+++ b/clippy_lints/src/lib.register_style.rs
@@ -71,6 +71,7 @@ store.register_group(true, "clippy::style", Some("clippy_style"), vec![
     LintId::of(methods::MAP_CLONE),
     LintId::of(methods::MAP_COLLECT_RESULT_UNIT),
     LintId::of(methods::MUT_MUTEX_LOCK),
+    LintId::of(methods::MUT_REFCELL_BORROW),
     LintId::of(methods::NEW_RET_NO_SELF),
     LintId::of(methods::OBFUSCATED_IF_ELSE),
     LintId::of(methods::OK_EXPECT),

--- a/clippy_lints/src/methods/mut_refcell_borrow.rs
+++ b/clippy_lints/src/methods/mut_refcell_borrow.rs
@@ -1,0 +1,123 @@
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use clippy_utils::{expr_custom_deref_adjustment, match_def_path, paths};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, Mutability};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+use rustc_span::Span;
+
+use super::MUT_REFCELL_BORROW;
+
+//TODO calls to RefCell's `Clone`-impl could be replaced by `RefCell::new(foo.get_mut().clone())`
+//to circumvent the runtime-check
+
+fn emit_replace(cx: &LateContext<'_>, name_span: Span) {
+    span_lint_and_help(
+        cx,
+        MUT_REFCELL_BORROW,
+        name_span,
+        "calling `&mut RefCell::replace()` unnecessarily performs a runtime-check that can never fail",
+        None,
+        "use `.get_mut()` to get a mutable reference to the value, and replace the value using `std::mem::replace()` or direct assignment",
+    );
+}
+
+fn emit_replace_with(cx: &LateContext<'_>, name_span: Span) {
+    span_lint_and_help(
+        cx,
+        MUT_REFCELL_BORROW,
+        name_span,
+        "calling `&mut RefCell::replace_with()` unnecessarily performs a runtime-check that can never fail",
+        None,
+        "use `.get_mut()` to get a mutable reference to the value, and replace the value using `std::mem::replace()` or direct assignment",
+    );
+}
+
+fn emit_borrow(cx: &LateContext<'_>, name_span: Span) {
+    // This is not MachineApplicable as `borrow` returns a `Ref` while `get_mut` returns a
+    // `&mut T`, and we don't check surrounding types
+    span_lint_and_sugg(
+        cx,
+        MUT_REFCELL_BORROW,
+        name_span,
+        "calling `&mut RefCell::borrow()` unnecessarily performs a runtime-check that can never fail",
+        "change this to",
+        "get_mut".to_owned(),
+        Applicability::MaybeIncorrect,
+    );
+}
+
+fn emit_try_borrow(cx: &LateContext<'_>, name_span: Span) {
+    span_lint_and_help(
+        cx,
+        MUT_REFCELL_BORROW,
+        name_span,
+        "calling `&mut RefCell::try_borrow()` unnecessarily performs a runtime-check that can never fail",
+        None,
+        "use `.get_mut()` instead of `.try_borrow()` to get a reference to the value; remove the error-handling",
+    );
+}
+
+fn emit_borrow_mut(cx: &LateContext<'_>, name_span: Span) {
+    // This is not MachineApplicable as `borrow_mut` returns a different type than `get_mut`, for
+    // which we don't check
+    span_lint_and_sugg(
+        cx,
+        MUT_REFCELL_BORROW,
+        name_span,
+        "calling `&mut RefCell::borrow_mut()` unnecessarily performs a runtime-check that can never fail",
+        "change this to",
+        "get_mut".to_owned(),
+        Applicability::MaybeIncorrect,
+    );
+}
+
+fn emit_try_borrow_mut(cx: &LateContext<'_>, name_span: Span) {
+    span_lint_and_help(
+        cx,
+        MUT_REFCELL_BORROW,
+        name_span,
+        "calling `&mut RefCell::try_borrow_mut()` unnecessarily performs a runtime-check that can never fail",
+        None,
+        "use `.get_mut()` instead of `.try_borrow_mut()` to get a mutable reference to the value; remove the error-handling",
+    );
+}
+
+fn emit_take(cx: &LateContext<'_>, name_span: Span) {
+    span_lint_and_help(
+        cx,
+        MUT_REFCELL_BORROW,
+        name_span,
+        "calling `&mut RefCell::take()` unnecessarily performs a runtime-check that can never fail",
+        None,
+        "use `.get_mut()` to get a mutable reference to the value, and `std::mem::take()` to get ownership via that reference",
+    );
+}
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    ex: &'tcx Expr<'tcx>,
+    recv: &'tcx Expr<'tcx>,
+    name_span: Span,
+    name: &'tcx str,
+    arg: Option<&'tcx Expr<'tcx>>,
+) {
+    if matches!(expr_custom_deref_adjustment(cx, recv), None | Some(Mutability::Mut))
+      && let ty::Ref(_, _, Mutability::Mut) = cx.typeck_results().expr_ty(recv).kind()
+      && let Some(method_id) = cx.typeck_results().type_dependent_def_id(ex.hir_id)
+      && let Some(impl_id) = cx.tcx.impl_of_method(method_id)
+      && match_def_path(cx, impl_id, &paths::REFCELL)
+    {
+        //TODO: Use `arg` to emit better suggestions
+        match (name, arg) {
+            ("replace", Some(_arg)) => emit_replace(cx, name_span),
+            ("replace_with", Some(_arg)) => emit_replace_with(cx, name_span),
+            ("borrow", None) => emit_borrow(cx, name_span),
+            ("try_borrow", None) => emit_try_borrow(cx, name_span),
+            ("borrow_mut", None) => emit_borrow_mut(cx, name_span),
+            ("try_borrow_mut", None) => emit_try_borrow_mut(cx, name_span),
+            ("take", None) => emit_take(cx, name_span),
+            _ => unreachable!(),
+        };
+    }
+}

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -122,6 +122,7 @@ pub const PTR_WRITE_VOLATILE: [&str; 3] = ["core", "ptr", "write_volatile"];
 pub const PUSH_STR: [&str; 4] = ["alloc", "string", "String", "push_str"];
 pub const RANGE_ARGUMENT_TRAIT: [&str; 3] = ["core", "ops", "RangeBounds"];
 pub const RC_PTR_EQ: [&str; 4] = ["alloc", "rc", "Rc", "ptr_eq"];
+pub const REFCELL: [&str; 3] = ["core", "cell", "RefCell"];
 pub const REFCELL_REF: [&str; 3] = ["core", "cell", "Ref"];
 pub const REFCELL_REFMUT: [&str; 3] = ["core", "cell", "RefMut"];
 #[expect(clippy::invalid_paths)] // internal lints do not know about all external crates

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -326,6 +326,7 @@ docs! {
     "mut_mut",
     "mut_mutex_lock",
     "mut_range_bound",
+    "mut_refcell_borrow",
     "mutable_key_type",
     "mutex_atomic",
     "mutex_integer",

--- a/src/docs/mut_refcell_borrow.txt
+++ b/src/docs/mut_refcell_borrow.txt
@@ -1,0 +1,40 @@
+### What it does
+Checks for `&mut std::cell::RefCell` method calls which perform
+runtime-checks that the compiler can statically guarantee
+
+### Why is this bad?
+Methods on `RefCell` explicitly or implicitly perform a runtime-check
+to guarantee the borrowing rules. If called on a `&mut RefCell` we
+can statically guarantee that the borrowing rules are upheld.
+
+### Example
+```
+use std::cell::RefCell;
+
+fn foo(x: &mut RefCell<i32>) -> i32 {
+    // This implicitly panics if the value is already borrowed. But it
+    // can't be borrowed because we have an exclusive reference to it
+    x.replace(42)
+}
+
+fn bar(x: &mut RefCell<i32>) {
+    // This check can never fail
+    if let Ok(mut value) = x.try_borrow_mut() {
+        *value = 42;
+    }
+}
+```
+Use instead:
+```
+use std::cell::RefCell;
+
+fn foo(x: &mut RefCell<i32>) -> i32 {
+    // No need for an implicit check
+    std::mem::replace(x.get_mut(), 42)
+}
+
+fn bar(x: &mut RefCell<i32>) {
+    // No need for an error path
+    *x.get_mut() = 42;
+}
+```

--- a/tests/ui/mut_refcell_borrow.rs
+++ b/tests/ui/mut_refcell_borrow.rs
@@ -1,0 +1,44 @@
+#![warn(clippy::mut_mutex_lock)]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub fn replace(x: &mut RefCell<i32>) {
+    x.replace(0);
+}
+
+pub fn replace_with(x: &mut RefCell<i32>) {
+    x.replace_with(|&mut old| old + 1);
+}
+
+pub fn borrow(x: &mut RefCell<i32>) {
+    let _: i32 = *x.borrow();
+}
+
+pub fn try_borrow(x: &mut RefCell<i32>) {
+    let _: i32 = *x.try_borrow().unwrap();
+}
+
+pub fn borrow_mut(x: &mut RefCell<i32>) {
+    *x.borrow_mut() += 1;
+}
+
+pub fn try_borrow_mut(x: &mut RefCell<i32>) {
+    *x.try_borrow_mut().unwrap() += 1;
+}
+
+pub fn take(x: &mut RefCell<i32>) {
+    let _: i32 = x.take();
+}
+
+// must not lint
+pub fn deref_refcell(x: Rc<RefCell<i32>>) {
+    *x.borrow_mut() += 1;
+}
+
+// must not lint
+pub fn mut_deref_refcell(x: &mut Rc<RefCell<i32>>) {
+    *x.borrow_mut() += 1;
+}
+
+fn main() {}

--- a/tests/ui/mut_refcell_borrow.stderr
+++ b/tests/ui/mut_refcell_borrow.stderr
@@ -1,0 +1,55 @@
+error: calling `&mut RefCell::replace()` unnecessarily performs a runtime-check that can never fail
+  --> $DIR/mut_refcell_borrow.rs:7:7
+   |
+LL |     x.replace(0);
+   |       ^^^^^^^
+   |
+   = note: `-D clippy::mut-refcell-borrow` implied by `-D warnings`
+   = help: use `.get_mut()` to get a mutable reference to the value, and replace the value using `std::mem::replace()` or direct assignment
+
+error: calling `&mut RefCell::replace_with()` unnecessarily performs a runtime-check that can never fail
+  --> $DIR/mut_refcell_borrow.rs:11:7
+   |
+LL |     x.replace_with(|&mut old| old + 1);
+   |       ^^^^^^^^^^^^
+   |
+   = help: use `.get_mut()` to get a mutable reference to the value, and replace the value using `std::mem::replace()` or direct assignment
+
+error: calling `&mut RefCell::borrow()` unnecessarily performs a runtime-check that can never fail
+  --> $DIR/mut_refcell_borrow.rs:15:21
+   |
+LL |     let _: i32 = *x.borrow();
+   |                     ^^^^^^ help: change this to: `get_mut`
+
+error: calling `&mut RefCell::try_borrow()` unnecessarily performs a runtime-check that can never fail
+  --> $DIR/mut_refcell_borrow.rs:19:21
+   |
+LL |     let _: i32 = *x.try_borrow().unwrap();
+   |                     ^^^^^^^^^^
+   |
+   = help: use `.get_mut()` instead of `.try_borrow()` to get a reference to the value; remove the error-handling
+
+error: calling `&mut RefCell::borrow_mut()` unnecessarily performs a runtime-check that can never fail
+  --> $DIR/mut_refcell_borrow.rs:23:8
+   |
+LL |     *x.borrow_mut() += 1;
+   |        ^^^^^^^^^^ help: change this to: `get_mut`
+
+error: calling `&mut RefCell::try_borrow_mut()` unnecessarily performs a runtime-check that can never fail
+  --> $DIR/mut_refcell_borrow.rs:27:8
+   |
+LL |     *x.try_borrow_mut().unwrap() += 1;
+   |        ^^^^^^^^^^^^^^
+   |
+   = help: use `.get_mut()` instead of `.try_borrow_mut()` to get a mutable reference to the value; remove the error-handling
+
+error: calling `&mut RefCell::take()` unnecessarily performs a runtime-check that can never fail
+  --> $DIR/mut_refcell_borrow.rs:31:20
+   |
+LL |     let _: i32 = x.take();
+   |                    ^^^^
+   |
+   = help: use `.get_mut()` to get a mutable reference to the value, and `std::mem::take()` to get ownership via that reference
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
Fixes #9044

This is an implementation of #9044: If we have an exclusive reference to a `RefCell`, the methods that perform an implicit (`panic`) or explicit (`Result`) check can be replaced by `RefCell::get_mut(&mut self) -> &mut T` and performing the operation on the `&mut T` directly. This situation may come up when the `RefCell` is created and did not yet disappear behind the immutable reference that is the reason for its existence. This is akin to `mut_mutex_lock`.

At least initially, I came up light with suggesting `MachineApplicable` due to the myriad ways `RefCell` can be used and the fact that its methods return a guard (instead of a `&mut`), which may not typecheck when changed.

`cargo lintcheck` comes up empty with this new lint.

Notice that this is a `style`-lint because this is where `mut_mutex_lock` lives; `perf` might actually be better suited?!

I noticed that the language around [`get_mut`](https://doc.rust-lang.org/stable/std/cell/struct.RefCell.html#method.get_mut) quite strongly discourages its use, which may be a misunderstanding with respect to when `get_mut` can be used, as `&mut RefCell` does not come up often. This is a separate issue.

---

changelog: new lint: [`mut_refcell_borrow`]
[#9423](https://github.com/rust-lang/rust-clippy/pull/9423)
<!-- changelog_checked -->