### PR TITLE
fix wording for `derivable_impls`

### DIFF
--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -40,7 +40,7 @@ declare_clippy_lint! {
     ///
     /// ### Known problems
     /// Derive macros [sometimes use incorrect bounds](https://github.com/rust-lang/rust/issues/26925)
-    /// in generic types and the user defined `impl` maybe is more generalized or
+    /// in generic types and the user defined `impl` may be more generalized or
     /// specialized than what derive will produce. This lint can't detect the manual `impl`
     /// has exactly equal bounds, and therefore this lint is disabled for types with
     /// generic parameters.

--- a/src/docs/derivable_impls.txt
+++ b/src/docs/derivable_impls.txt
@@ -29,7 +29,7 @@ struct Foo {
 
 ### Known problems
 Derive macros [sometimes use incorrect bounds](https://github.com/rust-lang/rust/issues/26925)
-in generic types and the user defined `impl` maybe is more generalized or
+in generic types and the user defined `impl` may be more generalized or
 specialized than what derive will produce. This lint can't detect the manual `impl`
 has exactly equal bounds, and therefore this lint is disabled for types with
 generic parameters.


### PR DESCRIPTION
While looking at the explanation as to why this lint was not automatically applicable, found the explanation a bit clunky grammatically.

 Feel free to close if you consider the wording was correct in the first place.

changelog: none