### PR TITLE
Suggest using `unwrap_or_default()` instead of `unwrap_or(<default>)`

### DIFF
--- a/clippy_lints/src/exhaustive_items.rs
+++ b/clippy_lints/src/exhaustive_items.rs
@@ -90,7 +90,7 @@ impl LateLintPass<'_> for ExhaustiveItems {
                     (EXHAUSTIVE_ENUMS, "exported enums should not be exhaustive")
                 };
                 let suggestion_span = item.span.shrink_to_lo();
-                let indent = " ".repeat(indent_of(cx, item.span).unwrap_or(0));
+                let indent = " ".repeat(indent_of(cx, item.span).unwrap_or_default());
                 span_lint_and_then(
                     cx,
                     lint,

--- a/clippy_lints/src/loops/single_element_loop.rs
+++ b/clippy_lints/src/loops/single_element_loop.rs
@@ -77,7 +77,7 @@ pub(super) fn check<'tcx>(
             let mut block_str = snippet_with_applicability(cx, block.span, "..", &mut applicability).into_owned();
             block_str.remove(0);
             block_str.pop();
-            let indent = " ".repeat(indent_of(cx, block.stmts[0].span).unwrap_or(0));
+            let indent = " ".repeat(indent_of(cx, block.stmts[0].span).unwrap_or_default());
 
             // Reference iterator from `&(mut) []` or `[].iter(_mut)()`.
             if !prefix.is_empty() && (

--- a/clippy_lints/src/matches/match_same_arms.rs
+++ b/clippy_lints/src/matches/match_same_arms.rs
@@ -57,7 +57,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'_>]) {
                 .find_map(|((j, other), forward_block)| {
                     (forward_block == i || pat.has_overlapping_values(other)).then_some(j)
                 })
-                .unwrap_or(0)
+                .unwrap_or_default()
         })
         .collect();
 

--- a/clippy_lints/src/matches/match_single_binding.rs
+++ b/clippy_lints/src/matches/match_single_binding.rs
@@ -78,7 +78,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                         "let {} = {};\n{}let {} = {};",
                         snippet_with_applicability(cx, bind_names, "..", &mut applicability),
                         snippet_with_applicability(cx, matched_vars, "..", &mut applicability),
-                        " ".repeat(indent_of(cx, expr.span).unwrap_or(0)),
+                        " ".repeat(indent_of(cx, expr.span).unwrap_or_default()),
                         snippet_with_applicability(cx, pat_span, "..", &mut applicability),
                         snippet_body
                     ),
@@ -108,7 +108,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
         },
         PatKind::Wild => {
             if ex.can_have_side_effects() {
-                let indent = " ".repeat(indent_of(cx, expr.span).unwrap_or(0));
+                let indent = " ".repeat(indent_of(cx, expr.span).unwrap_or_default());
                 let sugg = format!(
                     "{};\n{}{}",
                     snippet_with_applicability(cx, ex.span, "..", &mut applicability),
@@ -173,14 +173,14 @@ fn sugg_with_curlies<'a>(
     applicability: &mut Applicability,
     assignment: Option<Span>,
 ) -> String {
-    let mut indent = " ".repeat(indent_of(cx, ex.span).unwrap_or(0));
+    let mut indent = " ".repeat(indent_of(cx, ex.span).unwrap_or_default());
 
     let (mut cbrace_start, mut cbrace_end) = (String::new(), String::new());
     if let Some(parent_expr) = get_parent_expr(cx, match_expr) {
         if let ExprKind::Closure { .. } = parent_expr.kind {
             cbrace_end = format!("\n{}}}", indent);
             // Fix body indent due to the closure
-            indent = " ".repeat(indent_of(cx, bind_names).unwrap_or(0));
+            indent = " ".repeat(indent_of(cx, bind_names).unwrap_or_default());
             cbrace_start = format!("{{\n{}", indent);
         }
     }
@@ -192,7 +192,7 @@ fn sugg_with_curlies<'a>(
         if let ExprKind::Match(..) = arm.body.kind {
             cbrace_end = format!("\n{}}}", indent);
             // Fix body indent due to the match
-            indent = " ".repeat(indent_of(cx, bind_names).unwrap_or(0));
+            indent = " ".repeat(indent_of(cx, bind_names).unwrap_or_default());
             cbrace_start = format!("{{\n{}", indent);
         }
     }

--- a/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
+++ b/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
@@ -47,7 +47,7 @@ fn set_diagnostic<'tcx>(diag: &mut Diagnostic, cx: &LateContext<'tcx>, expr: &'t
     }
 
     let original = snippet(cx, found.found_span, "..");
-    let trailing_indent = " ".repeat(indent_of(cx, found.found_span).unwrap_or(0));
+    let trailing_indent = " ".repeat(indent_of(cx, found.found_span).unwrap_or_default());
 
     let replacement = if found.lint_suggestion == LintSuggestion::MoveAndDerefToCopy {
         format!("let value = *{};\n{}", original, trailing_indent)

--- a/clippy_lints/src/methods/from_iter_instead_of_collect.rs
+++ b/clippy_lints/src/methods/from_iter_instead_of_collect.rs
@@ -68,7 +68,7 @@ fn extract_turbofish(cx: &LateContext<'_>, expr: &hir::Expr<'_>, ty: Ty<'_>) -> 
                         // type is not explicitly specified so wildcards are needed
                         // i.e.: 2 wildcards in `std::collections::BTreeMap<&i32, &char>`
                         let ty_str = ty.to_string();
-                        let start = ty_str.find('<').unwrap_or(0);
+                        let start = ty_str.find('<').unwrap_or_default();
                         let end = ty_str.find('>').unwrap_or(ty_str.len());
                         let nb_wildcard = ty_str[start..end].split(',').count();
                         let wildcards = format!("_{}", ", _".repeat(nb_wildcard - 1));

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -320,7 +320,7 @@ fn suggestion_snippet_for_continue_inside_if<'a>(cx: &EarlyContext<'_>, data: &'
 
     let else_code = snippet_block(cx, data.else_expr.span, "..", Some(data.if_expr.span));
 
-    let indent_if = indent_of(cx, data.if_expr.span).unwrap_or(0);
+    let indent_if = indent_of(cx, data.if_expr.span).unwrap_or_default();
     format!(
         "{indent}if {} {}\n{indent}{}",
         cond_code,
@@ -342,7 +342,7 @@ fn suggestion_snippet_for_continue_inside_else<'a>(cx: &EarlyContext<'_>, data: 
     // `then` block of the `if` statement.
     let indent = span_of_first_expr_in_block(data.if_block)
         .and_then(|span| indent_of(cx, span))
-        .unwrap_or(0);
+        .unwrap_or_default();
     let to_annex = data.loop_block.stmts[data.stmt_idx + 1..]
         .iter()
         .map(|stmt| {
@@ -356,7 +356,7 @@ fn suggestion_snippet_for_continue_inside_else<'a>(cx: &EarlyContext<'_>, data: 
         .collect::<Vec<_>>()
         .join("\n");
 
-    let indent_if = indent_of(cx, data.if_expr.span).unwrap_or(0);
+    let indent_if = indent_of(cx, data.if_expr.span).unwrap_or_default();
     format!(
         "{indent_if}if {} {}\n{indent}// merged code follows:\n{}\n{indent_if}}}",
         cond_code,

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -579,7 +579,10 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'_>, args:
                 },
                 Some((Node::Expr(e), child_id)) => match e.kind {
                     ExprKind::Call(f, expr_args) => {
-                        let i = expr_args.iter().position(|arg| arg.hir_id == child_id).unwrap_or(0);
+                        let i = expr_args
+                            .iter()
+                            .position(|arg| arg.hir_id == child_id)
+                            .unwrap_or_default();
                         if expr_sig(self.cx, f).and_then(|sig| sig.input(i)).map_or(true, |ty| {
                             match *ty.skip_binder().peel_refs().kind() {
                                 ty::Param(_) => true,
@@ -592,7 +595,10 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'_>, args:
                         }
                     },
                     ExprKind::MethodCall(name, expr_args @ [self_arg, ..], _) => {
-                        let i = expr_args.iter().position(|arg| arg.hir_id == child_id).unwrap_or(0);
+                        let i = expr_args
+                            .iter()
+                            .position(|arg| arg.hir_id == child_id)
+                            .unwrap_or_default();
                         if i == 0 {
                             // Check if the method can be renamed.
                             let name = name.ident.as_str();

--- a/clippy_lints/src/rc_clone_in_vec_init.rs
+++ b/clippy_lints/src/rc_clone_in_vec_init.rs
@@ -88,7 +88,7 @@ fn emit_lint(cx: &LateContext<'_>, symbol: Symbol, lint_span: Span, elem: &Expr<
         |diag| {
             let len_snippet = snippet(cx, len.span, "..");
             let elem_snippet = format!("{}(..)", snippet(cx, elem.span.with_hi(func_span.hi()), ".."));
-            let indentation = " ".repeat(indent_of(cx, lint_span).unwrap_or(0));
+            let indentation = " ".repeat(indent_of(cx, lint_span).unwrap_or_default());
             let loop_init_suggestion = loop_init_suggestion(&elem_snippet, len_snippet.as_ref(), &indentation);
             let extract_suggestion = extract_suggestion(&elem_snippet, len_snippet.as_ref(), &indentation);
 

--- a/clippy_lints/src/unit_types/unit_arg.rs
+++ b/clippy_lints/src/unit_types/unit_arg.rs
@@ -175,7 +175,7 @@ fn fmt_stmts_and_call(
     args_snippets: &[impl AsRef<str>],
     non_empty_block_args_snippets: &[impl AsRef<str>],
 ) -> String {
-    let call_expr_indent = indent_of(cx, call_expr.span).unwrap_or(0);
+    let call_expr_indent = indent_of(cx, call_expr.span).unwrap_or_default();
     let call_snippet_with_replacements = args_snippets
         .iter()
         .fold(call_snippet.to_owned(), |acc, arg| acc.replacen(arg.as_ref(), "()", 1));

--- a/tests/ui/manual_saturating_arithmetic.fixed
+++ b/tests/ui/manual_saturating_arithmetic.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![allow(unused_imports)]
+#![allow(unused_imports, clippy::or_fun_call)]
 
 use std::{i128, i32, u128, u32};
 

--- a/tests/ui/manual_saturating_arithmetic.rs
+++ b/tests/ui/manual_saturating_arithmetic.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
-#![allow(unused_imports)]
+#![allow(unused_imports, clippy::or_fun_call)]
 
 use std::{i128, i32, u128, u32};
 

--- a/tests/ui/manual_unwrap_or.fixed
+++ b/tests/ui/manual_unwrap_or.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 #![allow(dead_code)]
-#![allow(unused_variables, clippy::unnecessary_wraps)]
+#![allow(unused_variables, clippy::unnecessary_wraps, clippy::or_fun_call)]
 
 fn option_unwrap_or() {
     // int case

--- a/tests/ui/manual_unwrap_or.rs
+++ b/tests/ui/manual_unwrap_or.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 #![allow(dead_code)]
-#![allow(unused_variables, clippy::unnecessary_wraps)]
+#![allow(unused_variables, clippy::unnecessary_wraps, clippy::or_fun_call)]
 
 fn option_unwrap_or() {
     // int case

--- a/tests/ui/map_unwrap_or.rs
+++ b/tests/ui/map_unwrap_or.rs
@@ -36,7 +36,7 @@ fn option_methods() {
         .map(|x| Some(x + 1))
         .unwrap_or(None);
     // macro case
-    let _ = opt_map!(opt, |x| x + 1).unwrap_or(0); // should not lint
+    let _ = opt_map!(opt, |x| x + 1).unwrap_or(0);
 
     // Should not lint if not copyable
     let id: String = "identifier".to_string();

--- a/tests/ui/map_unwrap_or.stderr
+++ b/tests/ui/map_unwrap_or.stderr
@@ -14,6 +14,14 @@ LL -     let _ = opt.map(|x| x + 1)
 LL +     let _ = opt.map_or(0, |x| x + 1);
    |
 
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/map_unwrap_or.rs:18:10
+   |
+LL |         .unwrap_or(0);
+   |          ^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |
+   = note: `-D clippy::or-fun-call` implied by `-D warnings`
+
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value. This can be done more directly by calling `map_or(<a>, <f>)` instead
   --> $DIR/map_unwrap_or.rs:20:13
    |
@@ -32,6 +40,12 @@ LL |     }
 LL ~     );
    |
 
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/map_unwrap_or.rs:23:7
+   |
+LL |     ).unwrap_or(0);
+   |       ^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value. This can be done more directly by calling `map_or(<a>, <f>)` instead
   --> $DIR/map_unwrap_or.rs:24:13
    |
@@ -48,6 +62,15 @@ LL ~     let _ = opt.map_or({
 LL +             0
 LL ~         }, |x| x + 1);
    |
+
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/map_unwrap_or.rs:25:10
+   |
+LL |           .unwrap_or({
+   |  __________^
+LL | |             0
+LL | |         });
+   | |__________^ help: try this: `unwrap_or_default()`
 
 error: called `map(<f>).unwrap_or(None)` on an `Option` value. This can be done more directly by calling `and_then(<f>)` instead
   --> $DIR/map_unwrap_or.rs:29:13
@@ -93,6 +116,12 @@ help: use `and_then(<f>)` instead
 LL -         .map(|x| Some(x + 1))
 LL +         .and_then(|x| Some(x + 1));
    |
+
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/map_unwrap_or.rs:39:38
+   |
+LL |     let _ = opt_map!(opt, |x| x + 1).unwrap_or(0);
+   |                                      ^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value. This can be done more directly by calling `map_or(<a>, <f>)` instead
   --> $DIR/map_unwrap_or.rs:46:13
@@ -146,5 +175,5 @@ LL | |             0
 LL | |         });
    | |__________^
 
-error: aborting due to 11 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui/min_rust_version_attr.stderr
+++ b/tests/ui/min_rust_version_attr.stderr
@@ -1,3 +1,11 @@
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/min_rust_version_attr.rs:127:10
+   |
+LL |         .unwrap_or(0);
+   |          ^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |
+   = note: `-D clippy::or-fun-call` implied by `-D warnings`
+
 error: stripping a prefix manually
   --> $DIR/min_rust_version_attr.rs:204:24
    |
@@ -33,5 +41,5 @@ LL ~         if let Some(<stripped>) = s.strip_prefix("hello, ") {
 LL ~             assert_eq!(<stripped>.to_uppercase(), "WORLD!");
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -105,6 +105,18 @@ fn or_fun_call() {
     // don't lint index vec
     let vec = vec![1];
     let _ = Some(1).unwrap_or(vec[1]);
+
+    let should_default = None::<bool>;
+    should_default.unwrap_or_default();
+
+    let should_default = None::<usize>;
+    should_default.unwrap_or_default();
+
+    let should_default = None::<isize>;
+    should_default.unwrap_or_default();
+
+    let should_default = None::<f32>;
+    should_default.unwrap_or_default();
 }
 
 struct Foo(u8);

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -105,6 +105,18 @@ fn or_fun_call() {
     // don't lint index vec
     let vec = vec![1];
     let _ = Some(1).unwrap_or(vec[1]);
+
+    let should_default = None::<bool>;
+    should_default.unwrap_or(false);
+
+    let should_default = None::<usize>;
+    should_default.unwrap_or(0);
+
+    let should_default = None::<isize>;
+    should_default.unwrap_or(0);
+
+    let should_default = None::<f32>;
+    should_default.unwrap_or(0_f32);
 }
 
 struct Foo(u8);

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -108,38 +108,56 @@ error: use of `unwrap_or` followed by a function call
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
 
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/or_fun_call.rs:110:20
+   |
+LL |     should_default.unwrap_or(false);
+   |                    ^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/or_fun_call.rs:113:20
+   |
+LL |     should_default.unwrap_or(0);
+   |                    ^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/or_fun_call.rs:116:20
+   |
+LL |     should_default.unwrap_or(0);
+   |                    ^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
+error: use of `unwrap_or(..)` to construct default value
+  --> $DIR/or_fun_call.rs:119:20
+   |
+LL |     should_default.unwrap_or(0_f32);
+   |                    ^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
 error: use of `or` followed by a function call
-  --> $DIR/or_fun_call.rs:128:35
+  --> $DIR/or_fun_call.rs:140:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some("b".to_string()))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:167:14
+  --> $DIR/or_fun_call.rs:179:14
    |
 LL |         None.unwrap_or(ptr_to_ref(s));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:173:14
+  --> $DIR/or_fun_call.rs:185:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:175:14
+  --> $DIR/or_fun_call.rs:187:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:189:14
-   |
-LL |             .unwrap_or(String::new());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
-
-error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:202:14
+  --> $DIR/or_fun_call.rs:201:14
    |
 LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
@@ -151,10 +169,16 @@ LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:225:10
+  --> $DIR/or_fun_call.rs:226:14
+   |
+LL |             .unwrap_or(String::new());
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+
+error: use of `unwrap_or` followed by a call to `new`
+  --> $DIR/or_fun_call.rs:237:10
    |
 LL |         .unwrap_or(String::new());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
-error: aborting due to 26 previous errors
+error: aborting due to 30 previous errors
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-clippy/issues/9435

changelog: [`or_fun_call`]: Suggest using `unwrap_or_default()` instead of `unwrap_or(<default>)`