### PR TITLE
Rename the arithmetic lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3583,7 +3583,7 @@ Released 2018-09-13
 [`almost_complete_letter_range`]: https://rust-lang.github.io/rust-clippy/master/index.html#almost_complete_letter_range
 [`almost_swapped`]: https://rust-lang.github.io/rust-clippy/master/index.html#almost_swapped
 [`approx_constant`]: https://rust-lang.github.io/rust-clippy/master/index.html#approx_constant
-[`arithmetic`]: https://rust-lang.github.io/rust-clippy/master/index.html#arithmetic
+[`arithmetic_side_effects`]: https://rust-lang.github.io/rust-clippy/master/index.html#arithmetic_side_effects
 [`as_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_conversions
 [`as_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_underscore
 [`assertions_on_constants`]: https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -437,7 +437,7 @@ store.register_lints(&[
     octal_escapes::OCTAL_ESCAPES,
     only_used_in_recursion::ONLY_USED_IN_RECURSION,
     operators::ABSURD_EXTREME_COMPARISONS,
-    operators::ARITHMETIC,
+    operators::ARITHMETIC_SIDE_EFFECTS,
     operators::ASSIGN_OP_PATTERN,
     operators::BAD_BIT_MASK,
     operators::CMP_NAN,

--- a/clippy_lints/src/lib.register_restriction.rs
+++ b/clippy_lints/src/lib.register_restriction.rs
@@ -50,7 +50,7 @@ store.register_group(true, "clippy::restriction", Some("clippy_restriction"), ve
     LintId::of(mixed_read_write_in_expression::MIXED_READ_WRITE_IN_EXPRESSION),
     LintId::of(module_style::MOD_MODULE_FILES),
     LintId::of(module_style::SELF_NAMED_MODULE_FILES),
-    LintId::of(operators::ARITHMETIC),
+    LintId::of(operators::ARITHMETIC_SIDE_EFFECTS),
     LintId::of(operators::FLOAT_ARITHMETIC),
     LintId::of(operators::FLOAT_CMP_CONST),
     LintId::of(operators::INTEGER_ARITHMETIC),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -544,8 +544,12 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         store.register_late_pass(|| Box::new(utils::internal_lints::MsrvAttrImpl));
     }
 
-    let arithmetic_allowed = conf.arithmetic_allowed.clone();
-    store.register_late_pass(move || Box::new(operators::arithmetic::Arithmetic::new(arithmetic_allowed.clone())));
+    let arithmetic_side_effects_allowed = conf.arithmetic_side_effects_allowed.clone();
+    store.register_late_pass(move || {
+        Box::new(operators::arithmetic_side_effects::ArithmeticSideEffects::new(
+            arithmetic_side_effects_allowed.clone(),
+        ))
+    });
     store.register_late_pass(|| Box::new(utils::dump_hir::DumpHir));
     store.register_late_pass(|| Box::new(utils::author::Author));
     let await_holding_invalid_types = conf.await_holding_invalid_types.clone();

--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -3,7 +3,7 @@
     clippy::match_same_arms
 )]
 
-use super::ARITHMETIC;
+use super::ARITHMETIC_SIDE_EFFECTS;
 use clippy_utils::{consts::constant_simple, diagnostics::span_lint};
 use rustc_ast as ast;
 use rustc_data_structures::fx::FxHashSet;
@@ -22,16 +22,16 @@ const HARD_CODED_ALLOWED: &[&str] = &[
 ];
 
 #[derive(Debug)]
-pub struct Arithmetic {
+pub struct ArithmeticSideEffects {
     allowed: FxHashSet<String>,
     // Used to check whether expressions are constants, such as in enum discriminants and consts
     const_span: Option<Span>,
     expr_span: Option<Span>,
 }
 
-impl_lint_pass!(Arithmetic => [ARITHMETIC]);
+impl_lint_pass!(ArithmeticSideEffects => [ARITHMETIC_SIDE_EFFECTS]);
 
-impl Arithmetic {
+impl ArithmeticSideEffects {
     #[must_use]
     pub fn new(mut allowed: FxHashSet<String>) -> Self {
         allowed.extend(HARD_CODED_ALLOWED.iter().copied().map(String::from));
@@ -83,7 +83,7 @@ impl Arithmetic {
     }
 
     fn issue_lint(&mut self, cx: &LateContext<'_>, expr: &hir::Expr<'_>) {
-        span_lint(cx, ARITHMETIC, expr.span, "arithmetic detected");
+        span_lint(cx, ARITHMETIC_SIDE_EFFECTS, expr.span, "arithmetic detected");
         self.expr_span = Some(expr.span);
     }
 
@@ -125,7 +125,7 @@ impl Arithmetic {
     }
 }
 
-impl<'tcx> LateLintPass<'tcx> for Arithmetic {
+impl<'tcx> LateLintPass<'tcx> for ArithmeticSideEffects {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'_>) {
         if self.expr_span.is_some() || self.const_span.map_or(false, |sp| sp.contains(expr.span)) {
             return;

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -21,7 +21,7 @@ mod ptr_eq;
 mod self_assignment;
 mod verbose_bit_mask;
 
-pub(crate) mod arithmetic;
+pub(crate) mod arithmetic_side_effects;
 
 use rustc_hir::{Body, Expr, ExprKind, UnOp};
 use rustc_lint::{LateContext, LateLintPass};
@@ -92,11 +92,11 @@ declare_clippy_lint! {
     /// ```
     ///
     /// ### Allowed types
-    /// Custom allowed types can be specified through the "arithmetic-allowed" filter.
+    /// Custom allowed types can be specified through the "arithmetic-side-effects-allowed" filter.
     #[clippy::version = "1.64.0"]
-    pub ARITHMETIC,
+    pub ARITHMETIC_SIDE_EFFECTS,
     restriction,
-    "any arithmetic expression that could overflow or panic"
+    "any arithmetic expression that can cause side effects like overflows or panics"
 }
 
 declare_clippy_lint! {
@@ -789,7 +789,7 @@ pub struct Operators {
 }
 impl_lint_pass!(Operators => [
     ABSURD_EXTREME_COMPARISONS,
-    ARITHMETIC,
+    ARITHMETIC_SIDE_EFFECTS,
     INTEGER_ARITHMETIC,
     FLOAT_ARITHMETIC,
     ASSIGN_OP_PATTERN,

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -208,7 +208,7 @@ define_Conf! {
     /// Lint: Arithmetic.
     ///
     /// Suppress checking of the passed type names.
-    (arithmetic_allowed: rustc_data_structures::fx::FxHashSet<String> = <_>::default()),
+    (arithmetic_side_effects_allowed: rustc_data_structures::fx::FxHashSet<String> = <_>::default()),
     /// Lint: ENUM_VARIANT_NAMES, LARGE_TYPES_PASSED_BY_VALUE, TRIVIALLY_COPY_PASS_BY_REF, UNNECESSARY_WRAPS, UNUSED_SELF, UPPER_CASE_ACRONYMS, WRONG_SELF_CONVENTION, BOX_COLLECTION, REDUNDANT_ALLOCATION, RC_BUFFER, VEC_BOX, OPTION_OPTION, LINKEDLIST, RC_MUTEX.
     ///
     /// Suppress lints whenever the suggested change would cause breakage for other crates.

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -26,7 +26,7 @@ docs! {
     "almost_complete_letter_range",
     "almost_swapped",
     "approx_constant",
-    "arithmetic",
+    "arithmetic_side_effects",
     "as_conversions",
     "as_underscore",
     "assertions_on_constants",

--- a/src/docs/arithmetic_side_effects.txt
+++ b/src/docs/arithmetic_side_effects.txt
@@ -30,4 +30,4 @@ let _n = Decimal::MAX + Decimal::MAX;
 ```
 
 ### Allowed types
-Custom allowed types can be specified through the "arithmetic-allowed" filter.
+Custom allowed types can be specified through the "arithmetic-side-effects-allowed" filter.

--- a/tests/ui-toml/arithmetic_allowed/clippy.toml
+++ b/tests/ui-toml/arithmetic_allowed/clippy.toml
@@ -1,1 +1,0 @@
-arithmetic-allowed = ["Point"]

--- a/tests/ui-toml/arithmetic_side_effects_allowed/arithmetic_side_effects_allowed.rs
+++ b/tests/ui-toml/arithmetic_side_effects_allowed/arithmetic_side_effects_allowed.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::arithmetic)]
+#![warn(clippy::arithmetic_side_effects)]
 
 use core::ops::Add;
 

--- a/tests/ui-toml/arithmetic_side_effects_allowed/clippy.toml
+++ b/tests/ui-toml/arithmetic_side_effects_allowed/clippy.toml
@@ -1,0 +1,1 @@
+arithmetic-side-effects-allowed = ["Point"]

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -3,7 +3,7 @@ error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown fie
            allow-expect-in-tests
            allow-unwrap-in-tests
            allowed-scripts
-           arithmetic-allowed
+           arithmetic-side-effects-allowed
            array-size-threshold
            avoid-breaking-exported-api
            await-holding-invalid-types

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::assign_op_pattern, clippy::unnecessary_owned_empty_strings)]
 #![feature(inline_const, saturating_int_impl)]
-#![warn(clippy::arithmetic)]
+#![warn(clippy::arithmetic_side_effects)]
 
 use core::num::{Saturating, Wrapping};
 

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -1,19 +1,19 @@
 error: arithmetic detected
-  --> $DIR/arithmetic.rs:50:21
+  --> $DIR/arithmetic_side_effects.rs:50:21
    |
 LL |     let mut _a = 1; _a += 1;
    |                     ^^^^^^^
    |
-   = note: `-D clippy::arithmetic` implied by `-D warnings`
+   = note: `-D clippy::arithmetic-side-effects` implied by `-D warnings`
 
 error: arithmetic detected
-  --> $DIR/arithmetic.rs:52:26
+  --> $DIR/arithmetic_side_effects.rs:52:26
    |
 LL |     let mut _b = 1; _b = _b + 1;
    |                          ^^^^^^
 
 error: arithmetic detected
-  --> $DIR/arithmetic.rs:54:26
+  --> $DIR/arithmetic_side_effects.rs:54:26
    |
 LL |     let mut _c = 1; _c = 1 + _c;
    |                          ^^^^^^


### PR DESCRIPTION
changelog: Rename the `arithmetic` lint