### PR TITLE
Do not expand macro in `nonminimal_bool` suggestions

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -237,7 +237,7 @@ impl<'a, 'tcx, 'v> SuggestContext<'a, 'tcx, 'v> {
                 }
             },
             &Term(n) => {
-                let snip = snippet_opt(self.cx, self.terminals[n as usize].span)?;
+                let snip = snippet_opt(self.cx, self.terminals[n as usize].span.source_callsite())?;
                 self.output.push_str(&snip);
             },
         }

--- a/tests/ui/nonminimal_bool.rs
+++ b/tests/ui/nonminimal_bool.rs
@@ -57,3 +57,9 @@ fn check_expect() {
     #[expect(clippy::nonminimal_bool)]
     let _ = !!a;
 }
+
+fn issue9428() {
+    if matches!(true, true) && true {
+        println!("foo");
+    }
+}

--- a/tests/ui/nonminimal_bool.stderr
+++ b/tests/ui/nonminimal_bool.stderr
@@ -107,5 +107,11 @@ LL |     let _ = !(a == b || c == d);
 LL |     let _ = a != b && c != d;
    |             ~~~~~~~~~~~~~~~~
 
-error: aborting due to 12 previous errors
+error: this boolean expression can be simplified
+  --> $DIR/nonminimal_bool.rs:62:8
+   |
+LL |     if matches!(true, true) && true {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(true, true)`
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
fix https://github.com/rust-lang/rust-clippy/issues/9428

changelog: Do not expand macros in [`nonminimal_bool`] suggestions
