### PR TITLE
BREAKING CHANGE fix running path/to/cargo-clippy --fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
+#![feature(let_chains)]
 // warn on lints, that are included in `rust-lang/rust`s bootstrap
 #![warn(rust_2018_idioms, unused_lifetimes)]
 
@@ -43,7 +44,16 @@ pub fn main() {
         return;
     }
 
-    if let Err(code) = process(env::args().skip(2)) {
+    // if we run "cargo clippy" (as cargo subcommand), we have to strip "cargo clippy" (first 2 args)
+    // but if we are run via "..../target/debug/cargo-clippy", only ommit the first arg, the second one
+    // might be a normal cmdline arg already (which we don't want to ommit)
+    let args = if let Some(first_arg) = env::args().next() && first_arg.ends_with("cargo-clippy") {
+        env::args().skip(1)
+    } else {
+        env::args().skip(2)
+    };
+
+    if let Err(code) = process(args) {
         process::exit(code);
     }
 }
@@ -215,5 +225,15 @@ mod tests {
         let args = "cargo clippy".split_whitespace().map(ToString::to_string);
         let cmd = ClippyCmd::new(args);
         assert_eq!("check", cmd.cargo_subcommand);
+    }
+
+    #[test]
+    fn dont_skip_arg() {
+        let args = "target/debug/cargo-clippy --fix"
+            .split_whitespace()
+            .map(ToString::to_string);
+        let cmd = ClippyCmd::new(args);
+        assert_eq!("fix", cmd.cargo_subcommand);
+        assert!(!cmd.args.iter().any(|arg| arg.ends_with("unstable-options")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ pub fn main() {
     // if we run "cargo clippy" (as cargo subcommand), we have to strip "cargo clippy" (first 2 args)
     // but if we are run via "..../target/debug/cargo-clippy", only ommit the first arg, the second one
     // might be a normal cmdline arg already (which we don't want to ommit)
-    let args = if let Some(first_arg) = env::args().next() && first_arg.ends_with("cargo-clippy") {
+    let args = if let Some(first_arg) = env::args().next() && (first_arg.ends_with("cargo-clippy") || first_arg.ends_with("cargo-clippy.exe")) {
         env::args().skip(1)
     } else {
         env::args().skip(2)

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,15 @@ pub fn main() {
     // if we run "cargo clippy" (as cargo subcommand), we have to strip "cargo clippy" (first 2 args)
     // but if we are run via "..../target/debug/cargo-clippy", only ommit the first arg, the second one
     // might be a normal cmdline arg already (which we don't want to ommit)
-    let args = if let Some(first_arg) = env::args().next() && (first_arg.ends_with("cargo-clippy") || first_arg.ends_with("cargo-clippy.exe")) {
-        env::args().skip(1)
+    let args = if let Some(first_arg) = env::args().next()
+        && (first_arg.ends_with("cargo-clippy") || first_arg.ends_with("cargo-clippy.exe"))
+    {
+        // turn this of during the migration
+        // env::args().skip(1)
+        eprintln!(
+            "WARNING: potentially breaking change: 'cargo-clippy arg1 arg2...' will no longer ignore 'arg1' after edition=2024"
+        );
+        env::args().skip(2)
     } else {
         env::args().skip(2)
     };

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -98,7 +98,6 @@ fn run_clippy_for_package(project: &str, args: &[&str]) -> bool {
     command
         .current_dir(root_dir.join(project))
         .env("CARGO_INCREMENTAL", "0")
-        .arg("clippy")
         .arg("--all-targets")
         .arg("--all-features");
 

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -71,7 +71,6 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
         .current_dir(&cwd)
         .env("CARGO_INCREMENTAL", "0")
         .env("CARGO_TARGET_DIR", &target_dir)
-        .arg("clippy")
         .args(["-p", "subcrate"])
         .arg("--no-deps")
         .arg("--")
@@ -91,7 +90,6 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
             .current_dir(&cwd)
             .env("CARGO_INCREMENTAL", "0")
             .env("CARGO_TARGET_DIR", &target_dir)
-            .arg("clippy")
             .args(["-p", "subcrate"])
             .arg("--")
             .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir
@@ -118,7 +116,6 @@ fn test_no_deps_ignores_path_deps_in_workspaces() {
             .current_dir(&cwd)
             .env("CARGO_INCREMENTAL", "0")
             .env("CARGO_TARGET_DIR", &target_dir)
-            .arg("clippy")
             .args(["-p", "subcrate"])
             .arg("--")
             .arg("-Cdebuginfo=0") // disable debuginfo to generate less data in the target dir


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/9461)*

Previously, we would assume clippy is called as "cargo clippy --arg1 --arg2" so we stripped the first two items and parsed "--arg1" and "--arg2" as cmdline args.
The problem is when we run cargo-clippy binary directly as "target/debug/cargo-clippy --arg1 --arg2", we would still remove the first two args which would be "..cargo-clippy" and "--arg1" in this case which is wrong.

Fix this by checking if we run clippy via "cargo clippy" or "../path/to/cargo-clippy" and for the latter, only skip the first arg instead of two.

Spotted by Kraktus because lintcheck --fix was no longer working

This is potentially a breaking change because the "target/debug/cargo-clippy clippy --fix" will no longer work!
Use "target/debug/cargo-clippy --fix" directly instead.

---

changelog: Important change: `cargo-clippy` will now no longer ignore the first argument. `cargo-clippy clippy` will still work as documented (the second `clippy` is ignored). However, arguments like `--fix` will issue a warning for now and will no longer be ignored in a few releases. `cargo clippy` (without `-`!) is unaffected by this change.
[#9461](https://github.com/rust-lang/rust-clippy/pull/9461)
<!-- changelog_checked -->