### PR TITLE
Don't lint `large_stack_array` inside static items

### DIFF
--- a/clippy_lints/src/large_stack_arrays.rs
+++ b/clippy_lints/src/large_stack_arrays.rs
@@ -1,7 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::source::snippet;
-use if_chain::if_chain;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, Item, ItemKind, Node};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, ConstKind};
@@ -39,29 +38,28 @@ impl_lint_pass!(LargeStackArrays => [LARGE_STACK_ARRAYS]);
 
 impl<'tcx> LateLintPass<'tcx> for LargeStackArrays {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
-        if_chain! {
-            if let ExprKind::Repeat(_, _) = expr.kind;
-            if let ty::Array(element_type, cst) = cx.typeck_results().expr_ty(expr).kind();
-            if let ConstKind::Value(ty::ValTree::Leaf(element_count)) = cst.kind();
-            if let Ok(element_count) = element_count.try_to_machine_usize(cx.tcx);
-            if let Ok(element_size) = cx.layout_of(*element_type).map(|l| l.size.bytes());
-            if self.maximum_allowed_size < element_count * element_size;
-            then {
-                span_lint_and_help(
-                    cx,
-                    LARGE_STACK_ARRAYS,
-                    expr.span,
-                    &format!(
-                        "allocating a local array larger than {} bytes",
-                        self.maximum_allowed_size
-                    ),
-                    None,
-                    &format!(
-                        "consider allocating on the heap with `vec!{}.into_boxed_slice()`",
-                        snippet(cx, expr.span, "[...]")
-                    ),
-                );
-            }
-        }
+        if let ExprKind::Repeat(_, _) = expr.kind
+          && let ty::Array(element_type, cst) = cx.typeck_results().expr_ty(expr).kind()
+          && let ConstKind::Value(ty::ValTree::Leaf(element_count)) = cst.kind()
+          && let Ok(element_count) = element_count.try_to_machine_usize(cx.tcx)
+          && let Ok(element_size) = cx.layout_of(*element_type).map(|l| l.size.bytes())
+          && !cx.tcx.hir().parent_iter(expr.hir_id)
+              .any(|(_, node)| matches!(node, Node::Item(Item { kind: ItemKind::Static(..), .. })))
+          && self.maximum_allowed_size < element_count * element_size {
+              span_lint_and_help(
+                  cx,
+                  LARGE_STACK_ARRAYS,
+                  expr.span,
+                  &format!(
+                      "allocating a local array larger than {} bytes",
+                      self.maximum_allowed_size
+                  ),
+                  None,
+                  &format!(
+                      "consider allocating on the heap with `vec!{}.into_boxed_slice()`",
+                      snippet(cx, expr.span, "[...]")
+                  ),
+              );
+          }
     }
 }

--- a/tests/ui/large_stack_arrays.rs
+++ b/tests/ui/large_stack_arrays.rs
@@ -12,6 +12,12 @@ enum E {
     T(u32),
 }
 
+pub static DOESNOTLINT: [u8; 512_001] = [0; 512_001];
+pub static DOESNOTLINT2: [u8; 512_001] = {
+    let x = 0;
+    [x; 512_001]
+};
+
 fn main() {
     let bad = (
         [0u32; 20_000_000],

--- a/tests/ui/large_stack_arrays.stderr
+++ b/tests/ui/large_stack_arrays.stderr
@@ -1,5 +1,5 @@
 error: allocating a local array larger than 512000 bytes
-  --> $DIR/large_stack_arrays.rs:17:9
+  --> $DIR/large_stack_arrays.rs:23:9
    |
 LL |         [0u32; 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         [0u32; 20_000_000],
    = help: consider allocating on the heap with `vec![0u32; 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> $DIR/large_stack_arrays.rs:18:9
+  --> $DIR/large_stack_arrays.rs:24:9
    |
 LL |         [S { data: [0; 32] }; 5000],
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         [S { data: [0; 32] }; 5000],
    = help: consider allocating on the heap with `vec![S { data: [0; 32] }; 5000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> $DIR/large_stack_arrays.rs:19:9
+  --> $DIR/large_stack_arrays.rs:25:9
    |
 LL |         [Some(""); 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         [Some(""); 20_000_000],
    = help: consider allocating on the heap with `vec![Some(""); 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> $DIR/large_stack_arrays.rs:20:9
+  --> $DIR/large_stack_arrays.rs:26:9
    |
 LL |         [E::T(0); 5000],
    |         ^^^^^^^^^^^^^^^


### PR DESCRIPTION
We now check if the linted `Expr` is inside an `ItemKind::Static`, which can't take the suggested `Box<[...]`. I _think_ this is the correct fix for #9460

I removed `if_chain` while I was at it.

changelog: Don't lint `large_stack_array` inside static items
