### PR TITLE
Add matches! checking to nonstandard_macro_braces

### DIFF
--- a/clippy_lints/src/nonstandard_macro_braces.rs
+++ b/clippy_lints/src/nonstandard_macro_braces.rs
@@ -184,6 +184,10 @@ fn macro_braces(conf: FxHashSet<MacroMatcher>) -> FxHashMap<String, (String, Str
             name: "vec",
             braces: ("[", "]"),
         ),
+        macro_matcher!(
+            name: "matches",
+            braces: ("(", ")"),
+        ),
     ]
     .into_iter()
     .collect::<FxHashMap<_, _>>();

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.rs
@@ -42,6 +42,7 @@ macro_rules! printlnfoo {
 fn main() {
     let _ = vec! {1, 2, 3};
     let _ = format!["ugh {} stop being such a good compiler", "hello"];
+    let _ = matches!{{}, ()};
     let _ = quote!(let x = 1;);
     let _ = quote::quote!(match match match);
     let _ = test!(); // trigger when macro def is inside our own crate

--- a/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
+++ b/tests/ui-toml/nonstandard_macro_braces/conf_nonstandard_macro_braces.stderr
@@ -23,26 +23,38 @@ help: consider writing `format!("ugh () stop being such a good compiler", "hello
 LL |     let _ = format!["ugh {} stop being such a good compiler", "hello"];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of irregular braces for `quote!` macro
+error: use of irregular braces for `matches!` macro
   --> $DIR/conf_nonstandard_macro_braces.rs:45:13
+   |
+LL |     let _ = matches!{{}, ()};
+   |             ^^^^^^^^^^^^^^^^
+   |
+help: consider writing `matches!((), ())`
+  --> $DIR/conf_nonstandard_macro_braces.rs:45:13
+   |
+LL |     let _ = matches!{{}, ()};
+   |             ^^^^^^^^^^^^^^^^
+
+error: use of irregular braces for `quote!` macro
+  --> $DIR/conf_nonstandard_macro_braces.rs:46:13
    |
 LL |     let _ = quote!(let x = 1;);
    |             ^^^^^^^^^^^^^^^^^^
    |
 help: consider writing `quote! {let x = 1;}`
-  --> $DIR/conf_nonstandard_macro_braces.rs:45:13
+  --> $DIR/conf_nonstandard_macro_braces.rs:46:13
    |
 LL |     let _ = quote!(let x = 1;);
    |             ^^^^^^^^^^^^^^^^^^
 
 error: use of irregular braces for `quote::quote!` macro
-  --> $DIR/conf_nonstandard_macro_braces.rs:46:13
+  --> $DIR/conf_nonstandard_macro_braces.rs:47:13
    |
 LL |     let _ = quote::quote!(match match match);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider writing `quote::quote! {match match match}`
-  --> $DIR/conf_nonstandard_macro_braces.rs:46:13
+  --> $DIR/conf_nonstandard_macro_braces.rs:47:13
    |
 LL |     let _ = quote::quote!(match match match);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -67,28 +79,28 @@ LL |     let _ = test!(); // trigger when macro def is inside our own crate
    = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: use of irregular braces for `type_pos!` macro
-  --> $DIR/conf_nonstandard_macro_braces.rs:55:12
+  --> $DIR/conf_nonstandard_macro_braces.rs:56:12
    |
 LL |     let _: type_pos!(usize) = vec![];
    |            ^^^^^^^^^^^^^^^^
    |
 help: consider writing `type_pos![usize]`
-  --> $DIR/conf_nonstandard_macro_braces.rs:55:12
+  --> $DIR/conf_nonstandard_macro_braces.rs:56:12
    |
 LL |     let _: type_pos!(usize) = vec![];
    |            ^^^^^^^^^^^^^^^^
 
 error: use of irregular braces for `eprint!` macro
-  --> $DIR/conf_nonstandard_macro_braces.rs:57:5
+  --> $DIR/conf_nonstandard_macro_braces.rs:58:5
    |
 LL |     eprint!("test if user config overrides defaults");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider writing `eprint!["test if user config overrides defaults"]`
-  --> $DIR/conf_nonstandard_macro_braces.rs:57:5
+  --> $DIR/conf_nonstandard_macro_braces.rs:58:5
    |
 LL |     eprint!("test if user config overrides defaults");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
changelog: Enhancement: [`nonstandard_macro_braces`]: Now includes `matches!()` in the default lint config
  [#9471](https://github.com/rust-lang/rust-clippy/pull/9471)
