### PR TITLE
Fix indents

### DIFF
--- a/book/src/development/common_tools_writing_lints.md
+++ b/book/src/development/common_tools_writing_lints.md
@@ -227,9 +227,9 @@ functions to deal with macros:
   crates
 
   ```rust
- use rustc_middle::lint::in_external_macro;
+  use rustc_middle::lint::in_external_macro;
 
- use a_crate_with_macros::foo;
+  use a_crate_with_macros::foo;
 
   // `foo` is defined in `a_crate_with_macros`
   foo!("bar");


### PR DESCRIPTION
Markdowns are not displayed correctly.
https://github.com/rust-lang/rust-clippy/blob/master/book/src/development/common_tools_writing_lints.md#dealing-with-macros-and-expansions

changelog: none
