### PR TITLE
Add `#[allow(unused)]` to test in `cargo dev new_lint`

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -90,6 +90,7 @@ We start by opening the test file created at `tests/ui/foo_functions.rs`.
 Update the file with some examples to get started:
 
 ```rust
+#![allow(unused)]
 #![warn(clippy::foo_functions)]
 
 // Impl methods

--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -186,6 +186,7 @@ pub(crate) fn get_stabilization_version() -> String {
 fn get_test_file_contents(lint_name: &str, header_commands: Option<&str>) -> String {
     let mut contents = format!(
         indoc! {"
+            #![allow(unused)]
             #![warn(clippy::{})]
 
             fn main() {{


### PR DESCRIPTION
`rustfix` tests don't automatically apply `-Aunused` which leads to some tests having `_workarounds`, add it to new test files automatically so people don't have to worry about it

changelog: none 