### PR TITLE
Add `disallowed_macros` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3820,6 +3820,7 @@ Released 2018-09-13
 [`derive_hash_xor_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#derive_hash_xor_eq
 [`derive_ord_xor_partial_ord`]: https://rust-lang.github.io/rust-clippy/master/index.html#derive_ord_xor_partial_ord
 [`derive_partial_eq_without_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
+[`disallowed_macros`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_macros
 [`disallowed_method`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_method
 [`disallowed_methods`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
 [`disallowed_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_names

--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -1,14 +1,15 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::{match_def_path, paths};
 use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def::{Namespace, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{def::Res, AsyncGeneratorKind, Body, BodyId, GeneratorKind};
+use rustc_hir::{AsyncGeneratorKind, Body, BodyId, GeneratorKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::GeneratorInteriorTypeCause;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::{sym, Span};
 
-use crate::utils::conf::DisallowedType;
+use crate::utils::conf::DisallowedPath;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -171,12 +172,12 @@ impl_lint_pass!(AwaitHolding => [AWAIT_HOLDING_LOCK, AWAIT_HOLDING_REFCELL_REF, 
 
 #[derive(Debug)]
 pub struct AwaitHolding {
-    conf_invalid_types: Vec<DisallowedType>,
-    def_ids: FxHashMap<DefId, DisallowedType>,
+    conf_invalid_types: Vec<DisallowedPath>,
+    def_ids: FxHashMap<DefId, DisallowedPath>,
 }
 
 impl AwaitHolding {
-    pub(crate) fn new(conf_invalid_types: Vec<DisallowedType>) -> Self {
+    pub(crate) fn new(conf_invalid_types: Vec<DisallowedPath>) -> Self {
         Self {
             conf_invalid_types,
             def_ids: FxHashMap::default(),
@@ -187,11 +188,8 @@ impl AwaitHolding {
 impl LateLintPass<'_> for AwaitHolding {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
         for conf in &self.conf_invalid_types {
-            let path = match conf {
-                DisallowedType::Simple(path) | DisallowedType::WithReason { path, .. } => path,
-            };
-            let segs: Vec<_> = path.split("::").collect();
-            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs) {
+            let segs: Vec<_> = conf.path().split("::").collect();
+            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, Some(Namespace::TypeNS)) {
                 self.def_ids.insert(id, conf.clone());
             }
         }
@@ -256,20 +254,18 @@ impl AwaitHolding {
     }
 }
 
-fn emit_invalid_type(cx: &LateContext<'_>, span: Span, disallowed: &DisallowedType) {
-    let (type_name, reason) = match disallowed {
-        DisallowedType::Simple(path) => (path, &None),
-        DisallowedType::WithReason { path, reason } => (path, reason),
-    };
-
+fn emit_invalid_type(cx: &LateContext<'_>, span: Span, disallowed: &DisallowedPath) {
     span_lint_and_then(
         cx,
         AWAIT_HOLDING_INVALID_TYPE,
         span,
-        &format!("`{type_name}` may not be held across an `await` point per `clippy.toml`",),
+        &format!(
+            "`{}` may not be held across an `await` point per `clippy.toml`",
+            disallowed.path()
+        ),
         |diag| {
-            if let Some(reason) = reason {
-                diag.note(reason.clone());
+            if let Some(reason) = disallowed.reason() {
+                diag.note(reason);
             }
         },
     );

--- a/clippy_lints/src/disallowed_macros.rs
+++ b/clippy_lints/src/disallowed_macros.rs
@@ -1,0 +1,151 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::macros::macro_backtrace;
+use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::def::{Namespace, Res};
+use rustc_hir::def_id::DefIdMap;
+use rustc_hir::{Expr, ForeignItem, HirId, ImplItem, Item, Pat, Path, Stmt, TraitItem, Ty};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::{ExpnId, Span};
+
+use crate::utils::conf;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Denies the configured macros in clippy.toml
+    ///
+    /// Note: Even though this lint is warn-by-default, it will only trigger if
+    /// macros are defined in the clippy.toml file.
+    ///
+    /// ### Why is this bad?
+    /// Some macros are undesirable in certain contexts, and it's beneficial to
+    /// lint for them as needed.
+    ///
+    /// ### Example
+    /// An example clippy.toml configuration:
+    /// ```toml
+    /// # clippy.toml
+    /// disallowed-macros = [
+    ///     # Can use a string as the path of the disallowed macro.
+    ///     "std::print",
+    ///     # Can also use an inline table with a `path` key.
+    ///     { path = "std::println" },
+    ///     # When using an inline table, can add a `reason` for why the macro
+    ///     # is disallowed.
+    ///     { path = "serde::Serialize", reason = "no serializing" },
+    /// ]
+    /// ```
+    /// ```
+    /// use serde::Serialize;
+    ///
+    /// // Example code where clippy issues a warning
+    /// println!("warns");
+    ///
+    /// // The diagnostic will contain the message "no serializing"
+    /// #[derive(Serialize)]
+    /// struct Data {
+    ///     name: String,
+    ///     value: usize,
+    /// }
+    /// ```
+    #[clippy::version = "1.65.0"]
+    pub DISALLOWED_MACROS,
+    style,
+    "use of a disallowed macro"
+}
+
+pub struct DisallowedMacros {
+    conf_disallowed: Vec<conf::DisallowedPath>,
+    disallowed: DefIdMap<usize>,
+    seen: FxHashSet<ExpnId>,
+}
+
+impl DisallowedMacros {
+    pub fn new(conf_disallowed: Vec<conf::DisallowedPath>) -> Self {
+        Self {
+            conf_disallowed,
+            disallowed: DefIdMap::default(),
+            seen: FxHashSet::default(),
+        }
+    }
+
+    fn check(&mut self, cx: &LateContext<'_>, span: Span) {
+        if self.conf_disallowed.is_empty() {
+            return;
+        }
+
+        for mac in macro_backtrace(span) {
+            if !self.seen.insert(mac.expn) {
+                return;
+            }
+
+            if let Some(&index) = self.disallowed.get(&mac.def_id) {
+                let conf = &self.conf_disallowed[index];
+
+                span_lint_and_then(
+                    cx,
+                    DISALLOWED_MACROS,
+                    mac.span,
+                    &format!("use of a disallowed macro `{}`", conf.path()),
+                    |diag| {
+                        if let Some(reason) = conf.reason() {
+                            diag.note(&format!("{reason} (from clippy.toml)"));
+                        }
+                    },
+                );
+            }
+        }
+    }
+}
+
+impl_lint_pass!(DisallowedMacros => [DISALLOWED_MACROS]);
+
+impl LateLintPass<'_> for DisallowedMacros {
+    fn check_crate(&mut self, cx: &LateContext<'_>) {
+        for (index, conf) in self.conf_disallowed.iter().enumerate() {
+            let segs: Vec<_> = conf.path().split("::").collect();
+            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, Some(Namespace::MacroNS)) {
+                self.disallowed.insert(id, index);
+            }
+        }
+    }
+
+    fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
+        self.check(cx, expr.span);
+    }
+
+    fn check_stmt(&mut self, cx: &LateContext<'_>, stmt: &Stmt<'_>) {
+        self.check(cx, stmt.span);
+    }
+
+    fn check_ty(&mut self, cx: &LateContext<'_>, ty: &Ty<'_>) {
+        self.check(cx, ty.span);
+    }
+
+    fn check_pat(&mut self, cx: &LateContext<'_>, pat: &Pat<'_>) {
+        self.check(cx, pat.span);
+    }
+
+    fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
+        self.check(cx, item.span);
+        self.check(cx, item.vis_span);
+    }
+
+    fn check_foreign_item(&mut self, cx: &LateContext<'_>, item: &ForeignItem<'_>) {
+        self.check(cx, item.span);
+        self.check(cx, item.vis_span);
+    }
+
+    fn check_impl_item(&mut self, cx: &LateContext<'_>, item: &ImplItem<'_>) {
+        self.check(cx, item.span);
+        self.check(cx, item.vis_span);
+    }
+
+    fn check_trait_item(&mut self, cx: &LateContext<'_>, item: &TraitItem<'_>) {
+        self.check(cx, item.span);
+    }
+
+    fn check_path(&mut self, cx: &LateContext<'_>, path: &Path<'_>, _: HirId) {
+        self.check(cx, path.span);
+    }
+}

--- a/clippy_lints/src/disallowed_methods.rs
+++ b/clippy_lints/src/disallowed_methods.rs
@@ -1,7 +1,9 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::{fn_def_id, get_parent_expr, path_def_id};
 
-use rustc_hir::{def::Res, def_id::DefIdMap, Expr, ExprKind};
+use rustc_hir::def::{Namespace, Res};
+use rustc_hir::def_id::DefIdMap;
+use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
@@ -58,12 +60,12 @@ declare_clippy_lint! {
 
 #[derive(Clone, Debug)]
 pub struct DisallowedMethods {
-    conf_disallowed: Vec<conf::DisallowedMethod>,
+    conf_disallowed: Vec<conf::DisallowedPath>,
     disallowed: DefIdMap<usize>,
 }
 
 impl DisallowedMethods {
-    pub fn new(conf_disallowed: Vec<conf::DisallowedMethod>) -> Self {
+    pub fn new(conf_disallowed: Vec<conf::DisallowedPath>) -> Self {
         Self {
             conf_disallowed,
             disallowed: DefIdMap::default(),
@@ -77,7 +79,7 @@ impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
         for (index, conf) in self.conf_disallowed.iter().enumerate() {
             let segs: Vec<_> = conf.path().split("::").collect();
-            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs) {
+            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, Some(Namespace::ValueNS)) {
                 self.disallowed.insert(id, index);
             }
         }
@@ -102,10 +104,7 @@ impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
         };
         let msg = format!("use of a disallowed method `{}`", conf.path());
         span_lint_and_then(cx, DISALLOWED_METHODS, expr.span, &msg, |diag| {
-            if let conf::DisallowedMethod::WithReason {
-                reason: Some(reason), ..
-            } = conf
-            {
+            if let Some(reason) = conf.reason() {
                 diag.note(&format!("{reason} (from clippy.toml)"));
             }
         });

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -45,6 +45,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(derivable_impls::DERIVABLE_IMPLS),
     LintId::of(derive::DERIVE_HASH_XOR_EQ),
     LintId::of(derive::DERIVE_ORD_XOR_PARTIAL_ORD),
+    LintId::of(disallowed_macros::DISALLOWED_MACROS),
     LintId::of(disallowed_methods::DISALLOWED_METHODS),
     LintId::of(disallowed_names::DISALLOWED_NAMES),
     LintId::of(disallowed_types::DISALLOWED_TYPES),

--- a/clippy_lints/src/lib.register_lints.rs
+++ b/clippy_lints/src/lib.register_lints.rs
@@ -114,6 +114,7 @@ store.register_lints(&[
     derive::DERIVE_PARTIAL_EQ_WITHOUT_EQ,
     derive::EXPL_IMPL_CLONE_ON_COPY,
     derive::UNSAFE_DERIVE_DESERIALIZE,
+    disallowed_macros::DISALLOWED_MACROS,
     disallowed_methods::DISALLOWED_METHODS,
     disallowed_names::DISALLOWED_NAMES,
     disallowed_script_idents::DISALLOWED_SCRIPT_IDENTS,

--- a/clippy_lints/src/lib.register_style.rs
+++ b/clippy_lints/src/lib.register_style.rs
@@ -15,6 +15,7 @@ store.register_group(true, "clippy::style", Some("clippy_style"), vec![
     LintId::of(default::FIELD_REASSIGN_WITH_DEFAULT),
     LintId::of(default_instead_of_iter_empty::DEFAULT_INSTEAD_OF_ITER_EMPTY),
     LintId::of(dereference::NEEDLESS_BORROW),
+    LintId::of(disallowed_macros::DISALLOWED_MACROS),
     LintId::of(disallowed_methods::DISALLOWED_METHODS),
     LintId::of(disallowed_names::DISALLOWED_NAMES),
     LintId::of(disallowed_types::DISALLOWED_TYPES),

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -199,6 +199,7 @@ mod default_union_representation;
 mod dereference;
 mod derivable_impls;
 mod derive;
+mod disallowed_macros;
 mod disallowed_methods;
 mod disallowed_names;
 mod disallowed_script_idents;
@@ -820,6 +821,8 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|_| Box::new(unwrap_in_result::UnwrapInResult));
     store.register_late_pass(|_| Box::new(semicolon_if_nothing_returned::SemicolonIfNothingReturned));
     store.register_late_pass(|_| Box::new(async_yields_async::AsyncYieldsAsync));
+    let disallowed_macros = conf.disallowed_macros.clone();
+    store.register_late_pass(move |_| Box::new(disallowed_macros::DisallowedMacros::new(disallowed_macros.clone())));
     let disallowed_methods = conf.disallowed_methods.clone();
     store.register_late_pass(move |_| Box::new(disallowed_methods::DisallowedMethods::new(disallowed_methods.clone())));
     store.register_early_pass(|| Box::new(asm_syntax::InlineAsmX86AttSyntax));

--- a/clippy_lints/src/missing_enforced_import_rename.rs
+++ b/clippy_lints/src/missing_enforced_import_rename.rs
@@ -58,7 +58,8 @@ impl_lint_pass!(ImportRename => [MISSING_ENFORCED_IMPORT_RENAMES]);
 impl LateLintPass<'_> for ImportRename {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
         for Rename { path, rename } in &self.conf_renames {
-            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &path.split("::").collect::<Vec<_>>()) {
+            let segs = path.split("::").collect::<Vec<_>>();
+            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, None) {
                 self.renames.insert(id, Symbol::intern(rename));
             }
         }

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -39,28 +39,28 @@ pub struct Rename {
     pub rename: String,
 }
 
-/// A single disallowed method, used by the `DISALLOWED_METHODS` lint.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
-pub enum DisallowedMethod {
+pub enum DisallowedPath {
     Simple(String),
     WithReason { path: String, reason: Option<String> },
 }
 
-impl DisallowedMethod {
+impl DisallowedPath {
     pub fn path(&self) -> &str {
         let (Self::Simple(path) | Self::WithReason { path, .. }) = self;
 
         path
     }
-}
 
-/// A single disallowed type, used by the `DISALLOWED_TYPES` lint.
-#[derive(Clone, Debug, Deserialize)]
-#[serde(untagged)]
-pub enum DisallowedType {
-    Simple(String),
-    WithReason { path: String, reason: Option<String> },
+    pub fn reason(&self) -> Option<&str> {
+        match self {
+            Self::WithReason {
+                reason: Some(reason), ..
+            } => Some(reason),
+            _ => None,
+        }
+    }
 }
 
 /// Conf with parse errors
@@ -315,14 +315,18 @@ define_Conf! {
     ///
     /// Whether to allow certain wildcard imports (prelude, super in tests).
     (warn_on_all_wildcard_imports: bool = false),
+    /// Lint: DISALLOWED_MACROS.
+    ///
+    /// The list of disallowed macros, written as fully qualified paths.
+    (disallowed_macros: Vec<crate::utils::conf::DisallowedPath> = Vec::new()),
     /// Lint: DISALLOWED_METHODS.
     ///
     /// The list of disallowed methods, written as fully qualified paths.
-    (disallowed_methods: Vec<crate::utils::conf::DisallowedMethod> = Vec::new()),
+    (disallowed_methods: Vec<crate::utils::conf::DisallowedPath> = Vec::new()),
     /// Lint: DISALLOWED_TYPES.
     ///
     /// The list of disallowed types, written as fully qualified paths.
-    (disallowed_types: Vec<crate::utils::conf::DisallowedType> = Vec::new()),
+    (disallowed_types: Vec<crate::utils::conf::DisallowedPath> = Vec::new()),
     /// Lint: UNREADABLE_LITERAL.
     ///
     /// Should the fraction of a decimal be linted to include separators.
@@ -362,7 +366,7 @@ define_Conf! {
     /// For example, `[_, _, _, e, ..]` is a slice pattern with 4 elements.
     (max_suggested_slice_pattern_length: u64 = 3),
     /// Lint: AWAIT_HOLDING_INVALID_TYPE
-    (await_holding_invalid_types: Vec<crate::utils::conf::DisallowedType> = Vec::new()),
+    (await_holding_invalid_types: Vec<crate::utils::conf::DisallowedPath> = Vec::new()),
     /// Lint: LARGE_INCLUDE_FILE.
     ///
     /// The maximum size of a file included via `include_bytes!()` or `include_str!()`, in bytes

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -106,6 +106,7 @@ docs! {
     "derive_hash_xor_eq",
     "derive_ord_xor_partial_ord",
     "derive_partial_eq_without_eq",
+    "disallowed_macros",
     "disallowed_methods",
     "disallowed_names",
     "disallowed_script_idents",

--- a/src/docs/disallowed_macros.txt
+++ b/src/docs/disallowed_macros.txt
@@ -1,0 +1,36 @@
+### What it does
+Denies the configured macros in clippy.toml
+
+Note: Even though this lint is warn-by-default, it will only trigger if
+macros are defined in the clippy.toml file.
+
+### Why is this bad?
+Some macros are undesirable in certain contexts, and it's beneficial to
+lint for them as needed.
+
+### Example
+An example clippy.toml configuration:
+```
+disallowed-macros = [
+    # Can use a string as the path of the disallowed macro.
+    "std::print",
+    # Can also use an inline table with a `path` key.
+    { path = "std::println" },
+    # When using an inline table, can add a `reason` for why the macro
+    # is disallowed.
+    { path = "serde::Serialize", reason = "no serializing" },
+]
+```
+```
+use serde::Serialize;
+
+// Example code where clippy issues a warning
+println!("warns");
+
+// The diagnostic will contain the message "no serializing"
+#[derive(Serialize)]
+struct Data {
+    name: String,
+    value: usize,
+}
+```

--- a/tests/ui-toml/disallowed_macros/auxiliary/macros.rs
+++ b/tests/ui-toml/disallowed_macros/auxiliary/macros.rs
@@ -1,0 +1,32 @@
+#[macro_export]
+macro_rules! expr {
+    () => {
+        1
+    };
+}
+
+#[macro_export]
+macro_rules! stmt {
+    () => {
+        let _x = ();
+    };
+}
+
+#[macro_export]
+macro_rules! ty {
+    () => { &'static str };
+}
+
+#[macro_export]
+macro_rules! pat {
+    () => {
+        _
+    };
+}
+
+#[macro_export]
+macro_rules! item {
+    () => {
+        const ITEM: usize = 1;
+    };
+}

--- a/tests/ui-toml/disallowed_macros/clippy.toml
+++ b/tests/ui-toml/disallowed_macros/clippy.toml
@@ -1,0 +1,11 @@
+disallowed-macros = [
+    "std::println",
+    "std::vec",
+    { path = "std::cfg" },
+    { path = "serde::Serialize", reason = "no serializing" },
+    "macros::expr",
+    "macros::stmt",
+    "macros::ty",
+    "macros::pat",
+    "macros::item",
+]

--- a/tests/ui-toml/disallowed_macros/disallowed_macros.rs
+++ b/tests/ui-toml/disallowed_macros/disallowed_macros.rs
@@ -1,0 +1,39 @@
+// aux-build:macros.rs
+
+#![allow(unused)]
+
+extern crate macros;
+
+use serde::Serialize;
+
+fn main() {
+    println!("one");
+    println!("two");
+    cfg!(unix);
+    vec![1, 2, 3];
+
+    #[derive(Serialize)]
+    struct Derive;
+
+    let _ = macros::expr!();
+    macros::stmt!();
+    let macros::pat!() = 1;
+    let _: macros::ty!() = "";
+    macros::item!();
+
+    eprintln!("allowed");
+}
+
+struct S;
+
+impl S {
+    macros::item!();
+}
+
+trait Y {
+    macros::item!();
+}
+
+impl Y for S {
+    macros::item!();
+}

--- a/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
+++ b/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
@@ -1,0 +1,84 @@
+error: use of a disallowed macro `std::println`
+  --> $DIR/disallowed_macros.rs:10:5
+   |
+LL |     println!("one");
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
+
+error: use of a disallowed macro `std::println`
+  --> $DIR/disallowed_macros.rs:11:5
+   |
+LL |     println!("two");
+   |     ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `std::cfg`
+  --> $DIR/disallowed_macros.rs:12:5
+   |
+LL |     cfg!(unix);
+   |     ^^^^^^^^^^
+
+error: use of a disallowed macro `std::vec`
+  --> $DIR/disallowed_macros.rs:13:5
+   |
+LL |     vec![1, 2, 3];
+   |     ^^^^^^^^^^^^^
+
+error: use of a disallowed macro `serde::Serialize`
+  --> $DIR/disallowed_macros.rs:15:14
+   |
+LL |     #[derive(Serialize)]
+   |              ^^^^^^^^^
+   |
+   = note: no serializing (from clippy.toml)
+
+error: use of a disallowed macro `macros::expr`
+  --> $DIR/disallowed_macros.rs:18:13
+   |
+LL |     let _ = macros::expr!();
+   |             ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `macros::stmt`
+  --> $DIR/disallowed_macros.rs:19:5
+   |
+LL |     macros::stmt!();
+   |     ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `macros::pat`
+  --> $DIR/disallowed_macros.rs:20:9
+   |
+LL |     let macros::pat!() = 1;
+   |         ^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `macros::ty`
+  --> $DIR/disallowed_macros.rs:21:12
+   |
+LL |     let _: macros::ty!() = "";
+   |            ^^^^^^^^^^^^^
+
+error: use of a disallowed macro `macros::item`
+  --> $DIR/disallowed_macros.rs:22:5
+   |
+LL |     macros::item!();
+   |     ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `macros::item`
+  --> $DIR/disallowed_macros.rs:30:5
+   |
+LL |     macros::item!();
+   |     ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `macros::item`
+  --> $DIR/disallowed_macros.rs:34:5
+   |
+LL |     macros::item!();
+   |     ^^^^^^^^^^^^^^^
+
+error: use of a disallowed macro `macros::item`
+  --> $DIR/disallowed_macros.rs:38:5
+   |
+LL |     macros::item!();
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 13 previous errors
+

--- a/tests/ui-toml/toml_disallowed_methods/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_methods/clippy.toml
@@ -3,6 +3,7 @@ disallowed-methods = [
     "std::iter::Iterator::sum",
     "f32::clamp",
     "slice::sort_unstable",
+    "futures::stream::select_all",
     # can give path and reason with an inline table
     { path = "regex::Regex::is_match", reason = "no matching allowed" },
     # can use an inline table but omit reason

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -1,6 +1,9 @@
 #![warn(clippy::disallowed_methods)]
 
+extern crate futures;
 extern crate regex;
+
+use futures::stream::{empty, select_all};
 use regex::Regex;
 
 fn main() {
@@ -20,4 +23,7 @@ fn main() {
 
     let in_call = Box::new(f32::clamp);
     let in_method_call = ["^", "$"].into_iter().map(Regex::new);
+
+    // resolve ambiguity between `futures::stream::select_all` the module and the function
+    let same_name_as_module = select_all(vec![empty::<()>()]);
 }

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -1,5 +1,5 @@
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:7:14
+  --> $DIR/conf_disallowed_methods.rs:10:14
    |
 LL |     let re = Regex::new(r"ab.*c").unwrap();
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     let re = Regex::new(r"ab.*c").unwrap();
    = note: `-D clippy::disallowed-methods` implied by `-D warnings`
 
 error: use of a disallowed method `regex::Regex::is_match`
-  --> $DIR/conf_disallowed_methods.rs:8:5
+  --> $DIR/conf_disallowed_methods.rs:11:5
    |
 LL |     re.is_match("abc");
    |     ^^^^^^^^^^^^^^^^^^
@@ -15,40 +15,46 @@ LL |     re.is_match("abc");
    = note: no matching allowed (from clippy.toml)
 
 error: use of a disallowed method `std::iter::Iterator::sum`
-  --> $DIR/conf_disallowed_methods.rs:11:5
+  --> $DIR/conf_disallowed_methods.rs:14:5
    |
 LL |     a.iter().sum::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `slice::sort_unstable`
-  --> $DIR/conf_disallowed_methods.rs:13:5
+  --> $DIR/conf_disallowed_methods.rs:16:5
    |
 LL |     a.sort_unstable();
    |     ^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:15:13
+  --> $DIR/conf_disallowed_methods.rs:18:13
    |
 LL |     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:18:61
+  --> $DIR/conf_disallowed_methods.rs:21:61
    |
 LL |     let indirect: fn(&str) -> Result<Regex, regex::Error> = Regex::new;
    |                                                             ^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:21:28
+  --> $DIR/conf_disallowed_methods.rs:24:28
    |
 LL |     let in_call = Box::new(f32::clamp);
    |                            ^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:22:53
+  --> $DIR/conf_disallowed_methods.rs:25:53
    |
 LL |     let in_method_call = ["^", "$"].into_iter().map(Regex::new);
    |                                                     ^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: use of a disallowed method `futures::stream::select_all`
+  --> $DIR/conf_disallowed_methods.rs:28:31
+   |
+LL |     let same_name_as_module = select_all(vec![empty::<()>()]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -11,6 +11,7 @@ error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown fie
            cargo-ignore-publish
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold
+           disallowed-macros
            disallowed-methods
            disallowed-names
            disallowed-types


### PR DESCRIPTION
Closes #7790
Fixes #9558

`clippy_utils::def_path_res` already resolved macro definitions which is nice, it just needed a tweak to be able to disambiguate e.g. `std::vec` the module & `std::vec` the macro, and `serde::Serialize` the trait & `serde::Serialize` the derive macro

changelog: new lint: [`disallowed_macros`]
changelog: [`disallowed_methods`], [`disallowed_types`]: Fix false negative when a type/fn/macro share the same path