### PR TITLE
[`needless_return`] Recursively remove unneeded semicolons

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_hir_and_then;
+use clippy_utils::diagnostics::{span_lint_hir_and_then, span_lint_and_then};
 use clippy_utils::source::{snippet_opt, snippet_with_context};
 use clippy_utils::{fn_def_id, path_to_local_id};
 use if_chain::if_chain;
@@ -194,7 +194,6 @@ fn check_final_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, span: 
                 if !borrows {
                     emit_return_lint(
                         cx,
-                        inner.map_or(expr.hir_id, |inner| inner.hir_id),
                         span,
                         inner.as_ref().map(|i| i.span),
                         replacement,
@@ -224,7 +223,6 @@ fn check_final_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, span: 
 
 fn emit_return_lint(
     cx: &LateContext<'_>,
-    emission_place: HirId,
     ret_span: Span,
     inner_span: Option<Span>,
     replacement: RetReplacement,
@@ -245,10 +243,9 @@ fn emit_return_lint(
     } else {
         replacement.sugg_help()
     };
-    span_lint_hir_and_then(
+    span_lint_and_then(
         cx,
         NEEDLESS_RETURN,
-        emission_place,
         ret_span,
         "unneeded `return` statement",
         |diag| {

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -9,7 +9,7 @@ use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::source_map::{Span, DUMMY_SP};
+use rustc_span::source_map::Span;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -182,8 +182,10 @@ fn check_block_return<'tcx>(cx: &LateContext<'tcx>, expr_kind: &ExprKind<'tcx>, 
                 StmtKind::Semi(semi_expr) => {
                     let mut semi_spans_and_this_one = semi_spans;
                     // we only want the span containing the semicolon so we can remove it later. From `entry.rs:382`
-                    semi_spans_and_this_one.push(stmt.span.trim_start(semi_expr.span).unwrap_or(DUMMY_SP));
-                    check_final_expr(cx, semi_expr, semi_spans_and_this_one, RetReplacement::Empty);
+                    if let Some(semicolon_span) = stmt.span.trim_start(semi_expr.span) {
+                        semi_spans_and_this_one.push(semicolon_span);
+                        check_final_expr(cx, semi_expr, semi_spans_and_this_one, RetReplacement::Empty);
+                    }
                 },
                 _ => (),
             }

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -233,4 +233,31 @@ fn issue_9361() -> i32 {
     return 1 + 2;
 }
 
+fn issue8336(x: i32) -> bool {
+    if x > 0 {
+        println!("something");
+        true
+    } else {
+        false
+    }
+}
+
+fn issue8156(x: u8) -> u64 {
+    match x {
+        80 => {
+            10
+        },
+        _ => {
+            100
+        },
+    }
+}
+
+// Ideally the compiler should throw `unused_braces` in this case
+fn issue9192() -> i32 {
+    {
+        0
+    }
+}
+
 fn main() {}

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -260,4 +260,14 @@ fn issue9192() -> i32 {
     }
 }
 
+fn issue9503(x: usize) -> isize {
+    unsafe {
+        if x > 12 {
+            *(x as *const isize)
+        } else {
+            !*(x as *const isize)
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -233,4 +233,31 @@ fn issue_9361() -> i32 {
     return 1 + 2;
 }
 
+fn issue8336(x: i32) -> bool {
+    if x > 0 {
+        println!("something");
+        return true;
+    } else {
+        return false;
+    };
+}
+
+fn issue8156(x: u8) -> u64 {
+    match x {
+        80 => {
+            return 10;
+        },
+        _ => {
+            return 100;
+        },
+    };
+}
+
+// Ideally the compiler should throw `unused_braces` in this case
+fn issue9192() -> i32 {
+    {
+        return 0;
+    };
+}
+
 fn main() {}

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -260,4 +260,14 @@ fn issue9192() -> i32 {
     };
 }
 
+fn issue9503(x: usize) -> isize {
+    unsafe {
+        if x > 12 {
+            return *(x as *const isize);
+        } else {
+            return !*(x as *const isize);
+        };
+    };
+}
+
 fn main() {}

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -335,5 +335,21 @@ LL |         return 0;
    |
    = help: remove `return`
 
-error: aborting due to 42 previous errors
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:266:13
+   |
+LL |             return *(x as *const isize);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:268:13
+   |
+LL |             return !*(x as *const isize);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: aborting due to 44 previous errors
 

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -2,225 +2,338 @@ error: unneeded `return` statement
   --> $DIR/needless_return.rs:27:5
    |
 LL |     return true;
-   |     ^^^^^^^^^^^^ help: remove `return`: `true`
+   |     ^^^^^^^^^^^
    |
    = note: `-D clippy::needless-return` implied by `-D warnings`
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:31:5
    |
 LL |     return true;
-   |     ^^^^^^^^^^^^ help: remove `return`: `true`
+   |     ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:36:9
    |
 LL |         return true;
-   |         ^^^^^^^^^^^^ help: remove `return`: `true`
+   |         ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:38:9
    |
 LL |         return false;
-   |         ^^^^^^^^^^^^^ help: remove `return`: `false`
+   |         ^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:44:17
    |
 LL |         true => return false,
-   |                 ^^^^^^^^^^^^ help: remove `return`: `false`
+   |                 ^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:46:13
    |
 LL |             return true;
-   |             ^^^^^^^^^^^^ help: remove `return`: `true`
+   |             ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:53:9
    |
 LL |         return true;
-   |         ^^^^^^^^^^^^ help: remove `return`: `true`
+   |         ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:55:16
    |
 LL |     let _ = || return true;
-   |                ^^^^^^^^^^^ help: remove `return`: `true`
+   |                ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:59:5
    |
 LL |     return the_answer!();
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `the_answer!()`
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:63:5
    |
 LL |     return;
-   |     ^^^^^^^ help: remove `return`
+   |     ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:68:9
    |
 LL |         return;
-   |         ^^^^^^^ help: remove `return`
+   |         ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:70:9
    |
 LL |         return;
-   |         ^^^^^^^ help: remove `return`
+   |         ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:77:14
    |
 LL |         _ => return,
-   |              ^^^^^^ help: replace `return` with a unit value: `()`
+   |              ^^^^^^
+   |
+   = help: replace `return` with a unit value
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:86:13
    |
 LL |             return;
-   |             ^^^^^^^ help: remove `return`
+   |             ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:88:14
    |
 LL |         _ => return,
-   |              ^^^^^^ help: replace `return` with a unit value: `()`
+   |              ^^^^^^
+   |
+   = help: replace `return` with a unit value
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:101:9
    |
 LL |         return String::from("test");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `String::from("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:103:9
    |
 LL |         return String::new();
-   |         ^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `String::new()`
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:125:32
    |
 LL |         bar.unwrap_or_else(|_| return)
-   |                                ^^^^^^ help: replace `return` with an empty block: `{}`
+   |                                ^^^^^^
+   |
+   = help: replace `return` with an empty block
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:130:13
    |
 LL |             return;
-   |             ^^^^^^^ help: remove `return`
+   |             ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:132:20
    |
 LL |         let _ = || return;
-   |                    ^^^^^^ help: replace `return` with an empty block: `{}`
+   |                    ^^^^^^
+   |
+   = help: replace `return` with an empty block
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:138:32
    |
 LL |         res.unwrap_or_else(|_| return Foo)
-   |                                ^^^^^^^^^^ help: remove `return`: `Foo`
+   |                                ^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:147:5
    |
 LL |     return true;
-   |     ^^^^^^^^^^^^ help: remove `return`: `true`
+   |     ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:151:5
    |
 LL |     return true;
-   |     ^^^^^^^^^^^^ help: remove `return`: `true`
+   |     ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:156:9
    |
 LL |         return true;
-   |         ^^^^^^^^^^^^ help: remove `return`: `true`
+   |         ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:158:9
    |
 LL |         return false;
-   |         ^^^^^^^^^^^^^ help: remove `return`: `false`
+   |         ^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:164:17
    |
 LL |         true => return false,
-   |                 ^^^^^^^^^^^^ help: remove `return`: `false`
+   |                 ^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:166:13
    |
 LL |             return true;
-   |             ^^^^^^^^^^^^ help: remove `return`: `true`
+   |             ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:173:9
    |
 LL |         return true;
-   |         ^^^^^^^^^^^^ help: remove `return`: `true`
+   |         ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:175:16
    |
 LL |     let _ = || return true;
-   |                ^^^^^^^^^^^ help: remove `return`: `true`
+   |                ^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:179:5
    |
 LL |     return the_answer!();
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `the_answer!()`
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:183:5
    |
 LL |     return;
-   |     ^^^^^^^ help: remove `return`
+   |     ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:188:9
    |
 LL |         return;
-   |         ^^^^^^^ help: remove `return`
+   |         ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:190:9
    |
 LL |         return;
-   |         ^^^^^^^ help: remove `return`
+   |         ^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:197:14
    |
 LL |         _ => return,
-   |              ^^^^^^ help: replace `return` with a unit value: `()`
+   |              ^^^^^^
+   |
+   = help: replace `return` with a unit value
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:210:9
    |
 LL |         return String::from("test");
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `String::from("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:212:9
    |
 LL |         return String::new();
-   |         ^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `String::new()`
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:228:5
    |
 LL |     return format!("Hello {}", "world!");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `format!("Hello {}", "world!")`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
 
-error: aborting due to 37 previous errors
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:239:9
+   |
+LL |         return true;
+   |         ^^^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:241:9
+   |
+LL |         return false;
+   |         ^^^^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:248:13
+   |
+LL |             return 10;
+   |             ^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:251:13
+   |
+LL |             return 100;
+   |             ^^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:259:9
+   |
+LL |         return 0;
+   |         ^^^^^^^^
+   |
+   = help: remove `return`
+
+error: aborting due to 42 previous errors
 


### PR DESCRIPTION
fix #8336,
fix #8156,
fix https://github.com/rust-lang/rust-clippy/issues/7358,
fix #9192,
fix https://github.com/rust-lang/rust-clippy/issues/9503

changelog: [`needless_return`] Recursively remove unneeded semicolons

For now the suggestion about removing the semicolons are hidden because they would be very noisy and should be obvious if the user wants to apply the lint manually instead of using `--fix`. This could be an issue for beginner, but haven't found better way to display it.