### PR TITLE
Fix sorting in ` cargo dev update_lints` script

### DIFF
--- a/clippy_dev/src/update_lints.rs
+++ b/clippy_dev/src/update_lints.rs
@@ -45,9 +45,8 @@ fn generate_lint_files(
     renamed_lints: &[RenamedLint],
 ) {
     let internal_lints = Lint::internal_lints(lints);
-    let usable_lints = Lint::usable_lints(lints);
-    let mut sorted_usable_lints = usable_lints.clone();
-    sorted_usable_lints.sort_by_key(|lint| lint.name.clone());
+    let mut usable_lints = Lint::usable_lints(lints);
+    usable_lints.sort_by_key(|lint| lint.name.clone());
 
     replace_region_in_file(
         update_mode,


### PR DESCRIPTION
changelog: none

The old code cloned and sorted `usable_lints` into `sorted_usable_lints`, but then failed to do anything with `sorted_usable_lints`.

This was discovered by my new `collection_is_never_read` lint (#9267) that I'm working on!

Fix: I renamed the sorted vector to `usable_lints`.  Therefore it now gets used where the unsorted one was used previously.

