### PR TITLE
uninit_vec: fix false positive with set_len(0)

### DIFF
--- a/tests/ui/uninit_vec.rs
+++ b/tests/ui/uninit_vec.rs
@@ -91,4 +91,10 @@ fn main() {
         vec1.set_len(200);
         vec2.set_len(200);
     }
+
+    // set_len(0) should not be detected
+    let mut vec: Vec<u8> = Vec::with_capacity(1000);
+    unsafe {
+        vec.set_len(0);
+    }
 }


### PR DESCRIPTION
`set_len(0)` does not create uninitialized elements. Fixes a false positive with the following pattern:

```rust
fn copy_slice_into_vec(dst: &mut Vec<u8>, src: &[u8]) {
    dst.reserve(src.len().saturating_sub(dst.len()));
    unsafe {
        dst.set_len(0);
        std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), src.len());
        dst.set_len(src.len());
    }
}
```

zulip thread: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/uninit_vec.20and.20set_len.280.29

changelog: FP: [`uninit_vec`]: No longer lints `Vec::set_len(0)`
