### PR TITLE
Upgrade `compiletest-rs` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = { version = "3.2", optional = true }
 termize = "0.1"
 
 [dev-dependencies]
-compiletest_rs = { version = "0.8", features = ["tmp"] }
+compiletest_rs = { version = "0.9", features = ["tmp"] }
 tester = "0.9"
 regex = "1.5"
 toml = "0.5"


### PR DESCRIPTION
From `0.8` to `0.9`.

The new version includes a [fix](https://github.com/Manishearth/compiletest-rs/pull/259) for what I suspect was one cause of the recent rustup failure: https://github.com/rust-lang/rust-clippy/actions/runs/3106438892/jobs/5033324694#step:11:911

changelog: none
