### PR TITLE
fallout2: rework clippy_dev & _lints fmt inlining

### DIFF
--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -82,16 +82,16 @@ pub fn run(check: bool, verbose: bool) {
     fn output_err(err: CliError) {
         match err {
             CliError::CommandFailed(command, stderr) => {
-                eprintln!("error: A command failed! `{}`\nstderr: {}", command, stderr);
+                eprintln!("error: A command failed! `{command}`\nstderr: {stderr}");
             },
             CliError::IoError(err) => {
-                eprintln!("error: {}", err);
+                eprintln!("error: {err}");
             },
             CliError::RustfmtNotInstalled => {
                 eprintln!("error: rustfmt nightly is not installed.");
             },
             CliError::WalkDirError(err) => {
-                eprintln!("error: {}", err);
+                eprintln!("error: {err}");
             },
             CliError::IntellijSetupActive => {
                 eprintln!(

--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -1,5 +1,5 @@
 use crate::clippy_project_root;
-use indoc::{indoc, writedoc};
+use indoc::{formatdoc, writedoc};
 use std::fmt::Write as _;
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
@@ -23,7 +23,7 @@ impl<T> Context for io::Result<T> {
         match self {
             Ok(t) => Ok(t),
             Err(e) => {
-                let message = format!("{}: {}", text.as_ref(), e);
+                let message = format!("{}: {e}", text.as_ref());
                 Err(io::Error::new(ErrorKind::Other, message))
             },
         }
@@ -72,7 +72,7 @@ fn create_lint(lint: &LintData<'_>, enable_msrv: bool) -> io::Result<()> {
         let lint_contents = get_lint_file_contents(lint, enable_msrv);
         let lint_path = format!("clippy_lints/src/{}.rs", lint.name);
         write_file(lint.project_root.join(&lint_path), lint_contents.as_bytes())?;
-        println!("Generated lint file: `{}`", lint_path);
+        println!("Generated lint file: `{lint_path}`");
 
         Ok(())
     }
@@ -86,7 +86,7 @@ fn create_test(lint: &LintData<'_>) -> io::Result<()> {
 
         path.push("src");
         fs::create_dir(&path)?;
-        let header = format!("// compile-flags: --crate-name={}", lint_name);
+        let header = format!("// compile-flags: --crate-name={lint_name}");
         write_file(path.join("main.rs"), get_test_file_contents(lint_name, Some(&header)))?;
 
         Ok(())
@@ -106,7 +106,7 @@ fn create_test(lint: &LintData<'_>) -> io::Result<()> {
         let test_contents = get_test_file_contents(lint.name, None);
         write_file(lint.project_root.join(&test_path), test_contents)?;
 
-        println!("Generated test file: `{}`", test_path);
+        println!("Generated test file: `{test_path}`");
     }
 
     Ok(())
@@ -184,38 +184,36 @@ pub(crate) fn get_stabilization_version() -> String {
 }
 
 fn get_test_file_contents(lint_name: &str, header_commands: Option<&str>) -> String {
-    let mut contents = format!(
-        indoc! {"
-            #![allow(unused)]
-            #![warn(clippy::{})]
+    let mut contents = formatdoc!(
+        r#"
+        #![allow(unused)]
+        #![warn(clippy::{lint_name})]
 
-            fn main() {{
-                // test code goes here
-            }}
-        "},
-        lint_name
+        fn main() {{
+            // test code goes here
+        }}
+    "#
     );
 
     if let Some(header) = header_commands {
-        contents = format!("{}\n{}", header, contents);
+        contents = format!("{header}\n{contents}");
     }
 
     contents
 }
 
 fn get_manifest_contents(lint_name: &str, hint: &str) -> String {
-    format!(
-        indoc! {r#"
-            # {}
+    formatdoc!(
+        r#"
+        # {hint}
 
-            [package]
-            name = "{}"
-            version = "0.1.0"
-            publish = false
+        [package]
+        name = "{lint_name}"
+        version = "0.1.0"
+        publish = false
 
-            [workspace]
-        "#},
-        hint, lint_name
+        [workspace]
+    "#
     )
 }
 
@@ -236,76 +234,61 @@ fn get_lint_file_contents(lint: &LintData<'_>, enable_msrv: bool) -> String {
     let name_upper = lint_name.to_uppercase();
 
     result.push_str(&if enable_msrv {
-        format!(
-            indoc! {"
-                use clippy_utils::msrvs;
-                {pass_import}
-                use rustc_lint::{{{context_import}, {pass_type}, LintContext}};
-                use rustc_semver::RustcVersion;
-                use rustc_session::{{declare_tool_lint, impl_lint_pass}};
+        formatdoc!(
+            r#"
+            use clippy_utils::msrvs;
+            {pass_import}
+            use rustc_lint::{{{context_import}, {pass_type}, LintContext}};
+            use rustc_semver::RustcVersion;
+            use rustc_session::{{declare_tool_lint, impl_lint_pass}};
 
-            "},
-            pass_type = pass_type,
-            pass_import = pass_import,
-            context_import = context_import,
+        "#
         )
     } else {
-        format!(
-            indoc! {"
-                {pass_import}
-                use rustc_lint::{{{context_import}, {pass_type}}};
-                use rustc_session::{{declare_lint_pass, declare_tool_lint}};
+        formatdoc!(
+            r#"
+            {pass_import}
+            use rustc_lint::{{{context_import}, {pass_type}}};
+            use rustc_session::{{declare_lint_pass, declare_tool_lint}};
 
-            "},
-            pass_import = pass_import,
-            pass_type = pass_type,
-            context_import = context_import
+        "#
         )
     });
 
     let _ = write!(result, "{}", get_lint_declaration(&name_upper, category));
 
     result.push_str(&if enable_msrv {
-        format!(
-            indoc! {"
-                pub struct {name_camel} {{
-                    msrv: Option<RustcVersion>,
+        formatdoc!(
+            r#"
+            pub struct {name_camel} {{
+                msrv: Option<RustcVersion>,
+            }}
+
+            impl {name_camel} {{
+                #[must_use]
+                pub fn new(msrv: Option<RustcVersion>) -> Self {{
+                    Self {{ msrv }}
                 }}
+            }}
 
-                impl {name_camel} {{
-                    #[must_use]
-                    pub fn new(msrv: Option<RustcVersion>) -> Self {{
-                        Self {{ msrv }}
-                    }}
-                }}
+            impl_lint_pass!({name_camel} => [{name_upper}]);
 
-                impl_lint_pass!({name_camel} => [{name_upper}]);
+            impl {pass_type}{pass_lifetimes} for {name_camel} {{
+                extract_msrv_attr!({context_import});
+            }}
 
-                impl {pass_type}{pass_lifetimes} for {name_camel} {{
-                    extract_msrv_attr!({context_import});
-                }}
-
-                // TODO: Add MSRV level to `clippy_utils/src/msrvs.rs` if needed.
-                // TODO: Add MSRV test to `tests/ui/min_rust_version_attr.rs`.
-                // TODO: Update msrv config comment in `clippy_lints/src/utils/conf.rs`
-            "},
-            pass_type = pass_type,
-            pass_lifetimes = pass_lifetimes,
-            name_upper = name_upper,
-            name_camel = name_camel,
-            context_import = context_import,
+            // TODO: Add MSRV level to `clippy_utils/src/msrvs.rs` if needed.
+            // TODO: Add MSRV test to `tests/ui/min_rust_version_attr.rs`.
+            // TODO: Update msrv config comment in `clippy_lints/src/utils/conf.rs`
+        "#
         )
     } else {
-        format!(
-            indoc! {"
-                declare_lint_pass!({name_camel} => [{name_upper}]);
+        formatdoc!(
+            r#"
+            declare_lint_pass!({name_camel} => [{name_upper}]);
 
-                impl {pass_type}{pass_lifetimes} for {name_camel} {{}}
-            "},
-            pass_type = pass_type,
-            pass_lifetimes = pass_lifetimes,
-            name_upper = name_upper,
-            name_camel = name_camel,
+            impl {pass_type}{pass_lifetimes} for {name_camel} {{}}
+        "#
         )
     });
 
@@ -313,8 +296,8 @@ fn get_lint_file_contents(lint: &LintData<'_>, enable_msrv: bool) -> String {
 }
 
 fn get_lint_declaration(name_upper: &str, category: &str) -> String {
-    format!(
-        indoc! {r#"
+    formatdoc!(
+        r#"
             declare_clippy_lint! {{
                 /// ### What it does
                 ///
@@ -328,15 +311,13 @@ fn get_lint_declaration(name_upper: &str, category: &str) -> String {
                 /// ```rust
                 /// // example code which does not raise clippy warning
                 /// ```
-                #[clippy::version = "{version}"]
+                #[clippy::version = "{}"]
                 pub {name_upper},
                 {category},
                 "default lint description"
             }}
-        "#},
-        version = get_stabilization_version(),
-        name_upper = name_upper,
-        category = category,
+        "#,
+        get_stabilization_version(),
     )
 }
 
@@ -350,7 +331,7 @@ fn create_lint_for_ty(lint: &LintData<'_>, enable_msrv: bool, ty: &str) -> io::R
         _ => {},
     }
 
-    let ty_dir = lint.project_root.join(format!("clippy_lints/src/{}", ty));
+    let ty_dir = lint.project_root.join(format!("clippy_lints/src/{ty}"));
     assert!(
         ty_dir.exists() && ty_dir.is_dir(),
         "Directory `{}` does not exist!",
@@ -410,10 +391,10 @@ fn create_lint_for_ty(lint: &LintData<'_>, enable_msrv: bool, ty: &str) -> io::R
     }
 
     write_file(lint_file_path.as_path(), lint_file_contents)?;
-    println!("Generated lint file: `clippy_lints/src/{}/{}.rs`", ty, lint.name);
+    println!("Generated lint file: `clippy_lints/src/{ty}/{}.rs`", lint.name);
     println!(
-        "Be sure to add a call to `{}::check` in `clippy_lints/src/{}/mod.rs`!",
-        lint.name, ty
+        "Be sure to add a call to `{}::check` in `clippy_lints/src/{ty}/mod.rs`!",
+        lint.name
     );
 
     Ok(())
@@ -540,7 +521,7 @@ fn setup_mod_file(path: &Path, lint: &LintData<'_>) -> io::Result<&'static str> 
         .chain(std::iter::once(&*lint_name_upper))
         .filter(|s| !s.is_empty())
     {
-        let _ = write!(new_arr_content, "\n    {},", ident);
+        let _ = write!(new_arr_content, "\n    {ident},");
     }
     new_arr_content.push('\n');
 

--- a/clippy_dev/src/serve.rs
+++ b/clippy_dev/src/serve.rs
@@ -10,8 +10,8 @@ use std::time::{Duration, SystemTime};
 /// Panics if the python commands could not be spawned
 pub fn run(port: u16, lint: Option<&String>) -> ! {
     let mut url = Some(match lint {
-        None => format!("http://localhost:{}", port),
-        Some(lint) => format!("http://localhost:{}/#{}", port, lint),
+        None => format!("http://localhost:{port}"),
+        Some(lint) => format!("http://localhost:{port}/#{lint}"),
     });
 
     loop {

--- a/clippy_dev/src/setup/git_hook.rs
+++ b/clippy_dev/src/setup/git_hook.rs
@@ -30,10 +30,7 @@ pub fn install_hook(force_override: bool) {
             println!("info: the hook can be removed with `cargo dev remove git-hook`");
             println!("git hook successfully installed");
         },
-        Err(err) => eprintln!(
-            "error: unable to copy `{}` to `{}` ({})",
-            HOOK_SOURCE_FILE, HOOK_TARGET_FILE, err
-        ),
+        Err(err) => eprintln!("error: unable to copy `{HOOK_SOURCE_FILE}` to `{HOOK_TARGET_FILE}` ({err})"),
     }
 }
 
@@ -77,7 +74,7 @@ pub fn remove_hook() {
 
 fn delete_git_hook_file(path: &Path) -> bool {
     if let Err(err) = fs::remove_file(path) {
-        eprintln!("error: unable to delete existing pre-commit git hook ({})", err);
+        eprintln!("error: unable to delete existing pre-commit git hook ({err})");
         false
     } else {
         true

--- a/clippy_dev/src/setup/intellij.rs
+++ b/clippy_dev/src/setup/intellij.rs
@@ -60,7 +60,7 @@ fn check_and_get_rustc_dir(rustc_path: &str) -> Result<PathBuf, ()> {
                 path = absolute_path;
             },
             Err(err) => {
-                eprintln!("error: unable to get the absolute path of rustc ({})", err);
+                eprintln!("error: unable to get the absolute path of rustc ({err})");
                 return Err(());
             },
         };
@@ -103,14 +103,14 @@ fn inject_deps_into_project(rustc_source_dir: &Path, project: &ClippyProjectInfo
 fn read_project_file(file_path: &str) -> Result<String, ()> {
     let path = Path::new(file_path);
     if !path.exists() {
-        eprintln!("error: unable to find the file `{}`", file_path);
+        eprintln!("error: unable to find the file `{file_path}`");
         return Err(());
     }
 
     match fs::read_to_string(path) {
         Ok(content) => Ok(content),
         Err(err) => {
-            eprintln!("error: the file `{}` could not be read ({})", file_path, err);
+            eprintln!("error: the file `{file_path}` could not be read ({err})");
             Err(())
         },
     }
@@ -124,10 +124,7 @@ fn inject_deps_into_manifest(
 ) -> std::io::Result<()> {
     // do not inject deps if we have already done so
     if cargo_toml.contains(RUSTC_PATH_SECTION) {
-        eprintln!(
-            "warn: dependencies are already setup inside {}, skipping file",
-            manifest_path
-        );
+        eprintln!("warn: dependencies are already setup inside {manifest_path}, skipping file");
         return Ok(());
     }
 
@@ -142,11 +139,7 @@ fn inject_deps_into_manifest(
 
     let new_deps = extern_crates.map(|dep| {
         // format the dependencies that are going to be put inside the Cargo.toml
-        format!(
-            "{dep} = {{ path = \"{source_path}/{dep}\" }}\n",
-            dep = dep,
-            source_path = rustc_source_dir.display()
-        )
+        format!("{dep} = {{ path = \"{}/{dep}\" }}\n", rustc_source_dir.display())
     });
 
     // format a new [dependencies]-block with the new deps we need to inject
@@ -163,11 +156,11 @@ fn inject_deps_into_manifest(
     // etc
     let new_manifest = cargo_toml.replacen("[dependencies]\n", &all_deps, 1);
 
-    // println!("{}", new_manifest);
+    // println!("{new_manifest}");
     let mut file = File::create(manifest_path)?;
     file.write_all(new_manifest.as_bytes())?;
 
-    println!("info: successfully setup dependencies inside {}", manifest_path);
+    println!("info: successfully setup dependencies inside {manifest_path}");
 
     Ok(())
 }
@@ -214,8 +207,8 @@ fn remove_rustc_src_from_project(project: &ClippyProjectInfo) -> bool {
         },
         Err(err) => {
             eprintln!(
-                "error: unable to open file `{}` to remove rustc dependencies for {} ({})",
-                project.cargo_file, project.name, err
+                "error: unable to open file `{}` to remove rustc dependencies for {} ({err})",
+                project.cargo_file, project.name
             );
             false
         },

--- a/clippy_dev/src/setup/vscode.rs
+++ b/clippy_dev/src/setup/vscode.rs
@@ -17,10 +17,7 @@ pub fn install_tasks(force_override: bool) {
             println!("info: the task file can be removed with `cargo dev remove vscode-tasks`");
             println!("vscode tasks successfully installed");
         },
-        Err(err) => eprintln!(
-            "error: unable to copy `{}` to `{}` ({})",
-            TASK_SOURCE_FILE, TASK_TARGET_FILE, err
-        ),
+        Err(err) => eprintln!("error: unable to copy `{TASK_SOURCE_FILE}` to `{TASK_TARGET_FILE}` ({err})"),
     }
 }
 
@@ -44,23 +41,17 @@ fn check_install_precondition(force_override: bool) -> bool {
                 return delete_vs_task_file(path);
             }
 
-            eprintln!(
-                "error: there is already a `task.json` file inside the `{}` directory",
-                VSCODE_DIR
-            );
+            eprintln!("error: there is already a `task.json` file inside the `{VSCODE_DIR}` directory");
             println!("info: use the `--force-override` flag to override the existing `task.json` file");
             return false;
         }
     } else {
         match fs::create_dir(vs_dir_path) {
             Ok(_) => {
-                println!("info: created `{}` directory for clippy", VSCODE_DIR);
+                println!("info: created `{VSCODE_DIR}` directory for clippy");
             },
             Err(err) => {
-                eprintln!(
-                    "error: the task target directory `{}` could not be created ({})",
-                    VSCODE_DIR, err
-                );
+                eprintln!("error: the task target directory `{VSCODE_DIR}` could not be created ({err})");
             },
         }
     }
@@ -82,7 +73,7 @@ pub fn remove_tasks() {
 
 fn delete_vs_task_file(path: &Path) -> bool {
     if let Err(err) = fs::remove_file(path) {
-        eprintln!("error: unable to delete the existing `tasks.json` file ({})", err);
+        eprintln!("error: unable to delete the existing `tasks.json` file ({err})");
         return false;
     }
 

--- a/clippy_dev/src/update_lints.rs
+++ b/clippy_dev/src/update_lints.rs
@@ -86,7 +86,7 @@ fn generate_lint_files(
                 )
                 .sorted()
             {
-                writeln!(res, "[`{}`]: {}#{}", lint, DOCS_LINK, lint).unwrap();
+                writeln!(res, "[`{lint}`]: {DOCS_LINK}#{lint}").unwrap();
             }
         },
     );
@@ -99,7 +99,7 @@ fn generate_lint_files(
         "// end lints modules, do not remove this comment, it’s used in `update_lints`",
         |res| {
             for lint_mod in usable_lints.iter().map(|l| &l.module).unique().sorted() {
-                writeln!(res, "mod {};", lint_mod).unwrap();
+                writeln!(res, "mod {lint_mod};").unwrap();
             }
         },
     );
@@ -129,7 +129,7 @@ fn generate_lint_files(
     for (lint_group, lints) in Lint::by_lint_group(usable_lints.into_iter().chain(internal_lints)) {
         let content = gen_lint_group_list(&lint_group, lints.iter());
         process_file(
-            &format!("clippy_lints/src/lib.register_{}.rs", lint_group),
+            &format!("clippy_lints/src/lib.register_{lint_group}.rs"),
             update_mode,
             &content,
         );
@@ -190,9 +190,9 @@ fn print_lint_names(header: &str, lints: &BTreeSet<String>) -> bool {
     if lints.is_empty() {
         return false;
     }
-    println!("{}", header);
+    println!("{header}");
     for lint in lints.iter().sorted() {
-        println!("    {}", lint);
+        println!("    {lint}");
     }
     println!();
     true
@@ -205,16 +205,16 @@ pub fn print_lints() {
     let grouped_by_lint_group = Lint::by_lint_group(usable_lints.into_iter());
 
     for (lint_group, mut lints) in grouped_by_lint_group {
-        println!("\n## {}", lint_group);
+        println!("\n## {lint_group}");
 
         lints.sort_by_key(|l| l.name.clone());
 
         for lint in lints {
-            println!("* [{}]({}#{}) ({})", lint.name, DOCS_LINK, lint.name, lint.desc);
+            println!("* [{}]({DOCS_LINK}#{}) ({})", lint.name, lint.name, lint.desc);
         }
     }
 
-    println!("there are {} lints", usable_lint_count);
+    println!("there are {usable_lint_count} lints");
 }
 
 /// Runs the `rename_lint` command.
@@ -235,10 +235,10 @@ pub fn print_lints() {
 #[allow(clippy::too_many_lines)]
 pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
     if let Some((prefix, _)) = old_name.split_once("::") {
-        panic!("`{}` should not contain the `{}` prefix", old_name, prefix);
+        panic!("`{old_name}` should not contain the `{prefix}` prefix");
     }
     if let Some((prefix, _)) = new_name.split_once("::") {
-        panic!("`{}` should not contain the `{}` prefix", new_name, prefix);
+        panic!("`{new_name}` should not contain the `{prefix}` prefix");
     }
 
     let (mut lints, deprecated_lints, mut renamed_lints) = gather_all();
@@ -251,14 +251,14 @@ pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
             found_new_name = true;
         }
     }
-    let old_lint_index = old_lint_index.unwrap_or_else(|| panic!("could not find lint `{}`", old_name));
+    let old_lint_index = old_lint_index.unwrap_or_else(|| panic!("could not find lint `{old_name}`"));
 
     let lint = RenamedLint {
-        old_name: format!("clippy::{}", old_name),
+        old_name: format!("clippy::{old_name}"),
         new_name: if uplift {
             new_name.into()
         } else {
-            format!("clippy::{}", new_name)
+            format!("clippy::{new_name}")
         },
     };
 
@@ -266,13 +266,11 @@ pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
     // case.
     assert!(
         !renamed_lints.iter().any(|l| lint.old_name == l.old_name),
-        "`{}` has already been renamed",
-        old_name
+        "`{old_name}` has already been renamed"
     );
     assert!(
         !deprecated_lints.iter().any(|l| lint.old_name == l.name),
-        "`{}` has already been deprecated",
-        old_name
+        "`{old_name}` has already been deprecated"
     );
 
     // Update all lint level attributes. (`clippy::lint_name`)
@@ -309,14 +307,12 @@ pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
     if uplift {
         write_file(Path::new("tests/ui/rename.rs"), &gen_renamed_lints_test(&renamed_lints));
         println!(
-            "`{}` has be uplifted. All the code inside `clippy_lints` related to it needs to be removed manually.",
-            old_name
+            "`{old_name}` has be uplifted. All the code inside `clippy_lints` related to it needs to be removed manually."
         );
     } else if found_new_name {
         write_file(Path::new("tests/ui/rename.rs"), &gen_renamed_lints_test(&renamed_lints));
         println!(
-            "`{}` is already defined. The old linting code inside `clippy_lints` needs to be updated/removed manually.",
-            new_name
+            "`{new_name}` is already defined. The old linting code inside `clippy_lints` needs to be updated/removed manually."
         );
     } else {
         // Rename the lint struct and source files sharing a name with the lint.
@@ -327,16 +323,16 @@ pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
 
         // Rename test files. only rename `.stderr` and `.fixed` files if the new test name doesn't exist.
         if try_rename_file(
-            Path::new(&format!("tests/ui/{}.rs", old_name)),
-            Path::new(&format!("tests/ui/{}.rs", new_name)),
+            Path::new(&format!("tests/ui/{old_name}.rs")),
+            Path::new(&format!("tests/ui/{new_name}.rs")),
         ) {
             try_rename_file(
-                Path::new(&format!("tests/ui/{}.stderr", old_name)),
-                Path::new(&format!("tests/ui/{}.stderr", new_name)),
+                Path::new(&format!("tests/ui/{old_name}.stderr")),
+                Path::new(&format!("tests/ui/{new_name}.stderr")),
             );
             try_rename_file(
-                Path::new(&format!("tests/ui/{}.fixed", old_name)),
-                Path::new(&format!("tests/ui/{}.fixed", new_name)),
+                Path::new(&format!("tests/ui/{old_name}.fixed")),
+                Path::new(&format!("tests/ui/{new_name}.fixed")),
             );
         }
 
@@ -344,8 +340,8 @@ pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
         let replacements;
         let replacements = if lint.module == old_name
             && try_rename_file(
-                Path::new(&format!("clippy_lints/src/{}.rs", old_name)),
-                Path::new(&format!("clippy_lints/src/{}.rs", new_name)),
+                Path::new(&format!("clippy_lints/src/{old_name}.rs")),
+                Path::new(&format!("clippy_lints/src/{new_name}.rs")),
             ) {
             // Edit the module name in the lint list. Note there could be multiple lints.
             for lint in lints.iter_mut().filter(|l| l.module == old_name) {
@@ -356,14 +352,14 @@ pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
         } else if !lint.module.contains("::")
             // Catch cases like `methods/lint_name.rs` where the lint is stored in `methods/mod.rs`
             && try_rename_file(
-                Path::new(&format!("clippy_lints/src/{}/{}.rs", lint.module, old_name)),
-                Path::new(&format!("clippy_lints/src/{}/{}.rs", lint.module, new_name)),
+                Path::new(&format!("clippy_lints/src/{}/{old_name}.rs", lint.module)),
+                Path::new(&format!("clippy_lints/src/{}/{new_name}.rs", lint.module)),
             )
         {
             // Edit the module name in the lint list. Note there could be multiple lints, or none.
-            let renamed_mod = format!("{}::{}", lint.module, old_name);
+            let renamed_mod = format!("{}::{old_name}", lint.module);
             for lint in lints.iter_mut().filter(|l| l.module == renamed_mod) {
-                lint.module = format!("{}::{}", lint.module, new_name);
+                lint.module = format!("{}::{new_name}", lint.module);
             }
             replacements = [(&*old_name_upper, &*new_name_upper), (old_name, new_name)];
             replacements.as_slice()
@@ -379,7 +375,7 @@ pub fn rename(old_name: &str, new_name: &str, uplift: bool) {
         }
 
         generate_lint_files(UpdateMode::Change, &lints, &deprecated_lints, &renamed_lints);
-        println!("{} has been successfully renamed", old_name);
+        println!("{old_name} has been successfully renamed");
     }
 
     println!("note: `cargo uitest` still needs to be run to update the test results");
@@ -408,7 +404,7 @@ pub fn deprecate(name: &str, reason: Option<&String>) {
         });
 
         generate_lint_files(UpdateMode::Change, &lints, &deprecated_lints, &renamed_lints);
-        println!("info: `{}` has successfully been deprecated", name);
+        println!("info: `{name}` has successfully been deprecated");
 
         if reason == DEFAULT_DEPRECATION_REASON {
             println!("note: the deprecation reason must be updated in `clippy_lints/src/deprecated_lints.rs`");
@@ -421,7 +417,7 @@ pub fn deprecate(name: &str, reason: Option<&String>) {
     let name_upper = name.to_uppercase();
 
     let (mut lints, deprecated_lints, renamed_lints) = gather_all();
-    let Some(lint) = lints.iter().find(|l| l.name == name_lower) else { eprintln!("error: failed to find lint `{}`", name); return; };
+    let Some(lint) = lints.iter().find(|l| l.name == name_lower) else { eprintln!("error: failed to find lint `{name}`"); return; };
 
     let mod_path = {
         let mut mod_path = PathBuf::from(format!("clippy_lints/src/{}", lint.module));
@@ -450,7 +446,7 @@ fn remove_lint_declaration(name: &str, path: &Path, lints: &mut Vec<Lint>) -> io
     }
 
     fn remove_test_assets(name: &str) {
-        let test_file_stem = format!("tests/ui/{}", name);
+        let test_file_stem = format!("tests/ui/{name}");
         let path = Path::new(&test_file_stem);
 
         // Some lints have their own directories, delete them
@@ -512,8 +508,7 @@ fn remove_lint_declaration(name: &str, path: &Path, lints: &mut Vec<Lint>) -> io
                     fs::read_to_string(path).unwrap_or_else(|_| panic!("failed to read `{}`", path.to_string_lossy()));
 
                 eprintln!(
-                    "warn: you will have to manually remove any code related to `{}` from `{}`",
-                    name,
+                    "warn: you will have to manually remove any code related to `{name}` from `{}`",
                     path.display()
                 );
 
@@ -528,7 +523,7 @@ fn remove_lint_declaration(name: &str, path: &Path, lints: &mut Vec<Lint>) -> io
                 content.replace_range(lint.declaration_range.clone(), "");
 
                 // Remove the module declaration (mod xyz;)
-                let mod_decl = format!("\nmod {};", name);
+                let mod_decl = format!("\nmod {name};");
                 content = content.replacen(&mod_decl, "", 1);
 
                 remove_impl_lint_pass(&lint.name.to_uppercase(), &mut content);
@@ -621,13 +616,13 @@ fn round_to_fifty(count: usize) -> usize {
 fn process_file(path: impl AsRef<Path>, update_mode: UpdateMode, content: &str) {
     if update_mode == UpdateMode::Check {
         let old_content =
-            fs::read_to_string(&path).unwrap_or_else(|e| panic!("Cannot read from {}: {}", path.as_ref().display(), e));
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("Cannot read from {}: {e}", path.as_ref().display()));
         if content != old_content {
             exit_with_failure();
         }
     } else {
         fs::write(&path, content.as_bytes())
-            .unwrap_or_else(|e| panic!("Cannot write to {}: {}", path.as_ref().display(), e));
+            .unwrap_or_else(|e| panic!("Cannot write to {}: {e}", path.as_ref().display()));
     }
 }
 
@@ -731,11 +726,10 @@ fn gen_lint_group_list<'a>(group_name: &str, lints: impl Iterator<Item = &'a Lin
 
     let _ = writeln!(
         output,
-        "store.register_group(true, \"clippy::{0}\", Some(\"clippy_{0}\"), vec![",
-        group_name
+        "store.register_group(true, \"clippy::{group_name}\", Some(\"clippy_{group_name}\"), vec![",
     );
     for (module, name) in details {
-        let _ = writeln!(output, "    LintId::of({}::{}),", module, name);
+        let _ = writeln!(output, "    LintId::of({module}::{name}),");
     }
     output.push_str("])\n");
 
@@ -783,7 +777,7 @@ fn gen_register_lint_list<'a>(
         if !is_public {
             output.push_str("    #[cfg(feature = \"internal\")]\n");
         }
-        let _ = writeln!(output, "    {}::{},", module_name, lint_name);
+        let _ = writeln!(output, "    {module_name}::{lint_name},");
     }
     output.push_str("])\n");
 
@@ -841,7 +835,7 @@ fn gather_all() -> (Vec<Lint>, Vec<DeprecatedLint>, Vec<RenamedLint>) {
     for (rel_path, file) in clippy_lints_src_files() {
         let path = file.path();
         let contents =
-            fs::read_to_string(path).unwrap_or_else(|e| panic!("Cannot read from `{}`: {}", path.display(), e));
+            fs::read_to_string(path).unwrap_or_else(|e| panic!("Cannot read from `{}`: {e}", path.display()));
         let module = rel_path
             .components()
             .map(|c| c.as_os_str().to_str().unwrap())
@@ -1050,7 +1044,7 @@ fn remove_line_splices(s: &str) -> String {
         .trim_matches('#')
         .strip_prefix('"')
         .and_then(|s| s.strip_suffix('"'))
-        .unwrap_or_else(|| panic!("expected quoted string, found `{}`", s));
+        .unwrap_or_else(|| panic!("expected quoted string, found `{s}`"));
     let mut res = String::with_capacity(s.len());
     unescape::unescape_literal(s, unescape::Mode::Str, &mut |range, ch| {
         if ch.is_ok() {
@@ -1076,10 +1070,10 @@ fn replace_region_in_file(
     end: &str,
     write_replacement: impl FnMut(&mut String),
 ) {
-    let contents = fs::read_to_string(path).unwrap_or_else(|e| panic!("Cannot read from `{}`: {}", path.display(), e));
+    let contents = fs::read_to_string(path).unwrap_or_else(|e| panic!("Cannot read from `{}`: {e}", path.display()));
     let new_contents = match replace_region_in_text(&contents, start, end, write_replacement) {
         Ok(x) => x,
-        Err(delim) => panic!("Couldn't find `{}` in file `{}`", delim, path.display()),
+        Err(delim) => panic!("Couldn't find `{delim}` in file `{}`", path.display()),
     };
 
     match update_mode {
@@ -1087,7 +1081,7 @@ fn replace_region_in_file(
         UpdateMode::Check => (),
         UpdateMode::Change => {
             if let Err(e) = fs::write(path, new_contents.as_bytes()) {
-                panic!("Cannot write to `{}`: {}", path.display(), e);
+                panic!("Cannot write to `{}`: {e}", path.display());
             }
         },
     }
@@ -1135,7 +1129,7 @@ fn try_rename_file(old_name: &Path, new_name: &Path) -> bool {
 
 #[allow(clippy::needless_pass_by_value)]
 fn panic_file(error: io::Error, name: &Path, action: &str) -> ! {
-    panic!("failed to {} file `{}`: {}", action, name.display(), error)
+    panic!("failed to {action} file `{}`: {error}", name.display())
 }
 
 fn rewrite_file(path: &Path, f: impl FnOnce(&str) -> Option<String>) {

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -530,7 +530,7 @@ impl<'tcx> LateLintPass<'tcx> for LintWithoutLintPass {
                     cx,
                     LINT_WITHOUT_LINT_PASS,
                     lint_span,
-                    &format!("the lint `{}` is not added to any `LintPass`", lint_name),
+                    &format!("the lint `{lint_name}` is not added to any `LintPass`"),
                 );
             }
         }
@@ -666,7 +666,7 @@ impl<'tcx> LateLintPass<'tcx> for CompilerLintFunctions {
                     path.ident.span,
                     "usage of a compiler lint function",
                     None,
-                    &format!("please use the Clippy variant of this function: `{}`", sugg),
+                    &format!("please use the Clippy variant of this function: `{sugg}`"),
                 );
             }
         }
@@ -854,13 +854,8 @@ fn suggest_help(
         "this call is collapsible",
         "collapse into",
         format!(
-            "span_lint_and_help({}, {}, {}, {}, {}, {})",
-            and_then_snippets.cx,
-            and_then_snippets.lint,
-            and_then_snippets.span,
-            and_then_snippets.msg,
-            &option_span,
-            help
+            "span_lint_and_help({}, {}, {}, {}, {}, {help})",
+            and_then_snippets.cx, and_then_snippets.lint, and_then_snippets.span, and_then_snippets.msg, &option_span,
         ),
         Applicability::MachineApplicable,
     );
@@ -886,13 +881,8 @@ fn suggest_note(
         "this call is collapsible",
         "collapse into",
         format!(
-            "span_lint_and_note({}, {}, {}, {}, {}, {})",
-            and_then_snippets.cx,
-            and_then_snippets.lint,
-            and_then_snippets.span,
-            and_then_snippets.msg,
-            note_span,
-            note
+            "span_lint_and_note({}, {}, {}, {}, {note_span}, {note})",
+            and_then_snippets.cx, and_then_snippets.lint, and_then_snippets.span, and_then_snippets.msg,
         ),
         Applicability::MachineApplicable,
     );
@@ -927,7 +917,7 @@ impl<'tcx> LateLintPass<'tcx> for MatchTypeOnDiagItem {
                     expr.span,
                     "usage of `clippy_utils::ty::match_type()` on a type diagnostic item",
                     "try",
-                    format!("clippy_utils::ty::is_type_diagnostic_item({}, {}, sym::{})", cx_snippet, ty_snippet, item_name),
+                    format!("clippy_utils::ty::is_type_diagnostic_item({cx_snippet}, {ty_snippet}, sym::{item_name})"),
                     Applicability::MaybeIncorrect,
                 );
             }


### PR DESCRIPTION
Continuing #9525 -- a few more inlining, but this time with some code changes to simplify format strings:

* Inline format args where possible
* simplify a few complex macros into format str
* use formatdoc!() instead format!(indoc!(...))

changelog: none

cc: @llogiq 