### PR TITLE
Fix ICE in `needless_pass_by_value` with unsized `dyn Fn`

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -18,7 +18,7 @@ use rustc_middle::mir::FakeReadCause;
 use rustc_middle::ty::{self, TypeVisitable};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::symbol::kw;
-use rustc_span::{sym, Span};
+use rustc_span::{sym, Span, DUMMY_SP};
 use rustc_target::spec::abi::Abi;
 use rustc_trait_selection::traits;
 use rustc_trait_selection::traits::misc::can_type_implement_copy;
@@ -186,6 +186,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                 if !is_self(arg);
                 if !ty.is_mutable_ptr();
                 if !is_copy(cx, ty);
+                if ty.is_sized(cx.tcx.at(DUMMY_SP), cx.param_env);
                 if !allowed_traits.iter().any(|&t| implements_trait(cx, ty, t, &[]));
                 if !implements_borrow_trait;
                 if !all_borrowable_trait;

--- a/tests/ui/crashes/ice-9459.rs
+++ b/tests/ui/crashes/ice-9459.rs
@@ -1,0 +1,5 @@
+#![feature(unsized_fn_params)]
+
+pub fn f0(_f: dyn FnOnce()) {}
+
+fn main() {}


### PR DESCRIPTION
fixes #9459

Not really sure why a query for a type implementing `FnOnce` even works since the trait if `FnOnce<T>`, but it seems to. I would have expected it to crash like it does when passing `dyn FnOnce()` as the type.

changelog: [`needless_pass_by_value`](https://rust-lang.github.io/rust-clippy/master/#needless_pass_by_value) Fix ICE in with unsized `dyn Fn` argument
