### PR TITLE
fix typo "Saturing" -> "Saturating"

### DIFF
--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -67,7 +67,7 @@ declare_clippy_lint! {
     /// Reference](https://doc.rust-lang.org/reference/expressions/operator-expr.html#overflow),
     /// or can panic (`/`, `%`).
     ///
-    /// Known safe built-in types like `Wrapping` or `Saturing`, floats, operations in constant
+    /// Known safe built-in types like `Wrapping` or `Saturating`, floats, operations in constant
     /// environments, allowed types and non-constant operations that won't overflow are ignored.
     ///
     /// ### Why is this bad?

--- a/src/docs/arithmetic_side_effects.txt
+++ b/src/docs/arithmetic_side_effects.txt
@@ -5,7 +5,7 @@ Operators like `+`, `-`, `*` or `<<` are usually capable of overflowing accordin
 Reference](https://doc.rust-lang.org/reference/expressions/operator-expr.html#overflow),
 or can panic (`/`, `%`).
 
-Known safe built-in types like `Wrapping` or `Saturing`, floats, operations in constant
+Known safe built-in types like `Wrapping` or `Saturating`, floats, operations in constant
 environments, allowed types and non-constant operations that won't overflow are ignored.
 
 ### Why is this bad?


### PR DESCRIPTION


---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: fix typo "Saturing" -> "Saturating"
