### PR TITLE
Don't lint unstable moves in `std_instead_of_core`

### DIFF
--- a/tests/ui/std_instead_of_core.rs
+++ b/tests/ui/std_instead_of_core.rs
@@ -24,6 +24,12 @@ fn std_instead_of_core() {
     let cell_absolute = ::std::cell::Cell::new(8u32);
 
     let _ = std::env!("PATH");
+
+    // do not lint until `error_in_core` is stable
+    use std::error::Error;
+
+    // lint items re-exported from private modules, `core::iter::traits::iterator::Iterator`
+    use std::iter::Iterator;
 }
 
 #[warn(clippy::std_instead_of_alloc)]

--- a/tests/ui/std_instead_of_core.stderr
+++ b/tests/ui/std_instead_of_core.stderr
@@ -63,8 +63,16 @@ LL |     let cell_absolute = ::std::cell::Cell::new(8u32);
    |
    = help: consider importing the item from `core`
 
-error: used import from `std` instead of `alloc`
+error: used import from `std` instead of `core`
   --> $DIR/std_instead_of_core.rs:32:9
+   |
+LL |     use std::iter::Iterator;
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider importing the item from `core`
+
+error: used import from `std` instead of `alloc`
+  --> $DIR/std_instead_of_core.rs:38:9
    |
 LL |     use std::vec;
    |         ^^^^^^^^
@@ -73,7 +81,7 @@ LL |     use std::vec;
    = help: consider importing the item from `alloc`
 
 error: used import from `std` instead of `alloc`
-  --> $DIR/std_instead_of_core.rs:33:9
+  --> $DIR/std_instead_of_core.rs:39:9
    |
 LL |     use std::vec::Vec;
    |         ^^^^^^^^^^^^^
@@ -81,7 +89,7 @@ LL |     use std::vec::Vec;
    = help: consider importing the item from `alloc`
 
 error: used import from `alloc` instead of `core`
-  --> $DIR/std_instead_of_core.rs:38:9
+  --> $DIR/std_instead_of_core.rs:44:9
    |
 LL |     use alloc::slice::from_ref;
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -89,5 +97,5 @@ LL |     use alloc::slice::from_ref;
    = note: `-D clippy::alloc-instead-of-core` implied by `-D warnings`
    = help: consider importing the item from `core`
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Fixes #9515

changelog: [`std_instead_of_core`]: No longer suggests unstable modules such as `core::error`
