### PR TITLE
fallout: fix tests to allow uninlined_format_args

### DIFF
--- a/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
+++ b/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+
 fn main() {}
 
 #[warn(clippy::cognitive_complexity)]

--- a/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.stderr
+++ b/tests/ui-toml/conf_deprecated_key/conf_deprecated_key.stderr
@@ -3,7 +3,7 @@ warning: error reading Clippy's configuration file `$DIR/clippy.toml`: deprecate
 warning: error reading Clippy's configuration file `$DIR/clippy.toml`: deprecated field `blacklisted-names`. Please use `disallowed-names` instead
 
 error: the function has a cognitive complexity of (3/2)
-  --> $DIR/conf_deprecated_key.rs:4:4
+  --> $DIR/conf_deprecated_key.rs:6:4
    |
 LL | fn cognitive_complexity() {
    |    ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/assign_ops2.rs
+++ b/tests/ui/assign_ops2.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+
 #[allow(unused_assignments)]
 #[warn(clippy::misrefactored_assign_op, clippy::assign_op_pattern)]
 fn main() {

--- a/tests/ui/assign_ops2.stderr
+++ b/tests/ui/assign_ops2.stderr
@@ -1,5 +1,5 @@
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:5:5
+  --> $DIR/assign_ops2.rs:7:5
    |
 LL |     a += a + 1;
    |     ^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     a = a + a + 1;
    |     ~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:6:5
+  --> $DIR/assign_ops2.rs:8:5
    |
 LL |     a += 1 + a;
    |     ^^^^^^^^^^
@@ -30,7 +30,7 @@ LL |     a = a + 1 + a;
    |     ~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:7:5
+  --> $DIR/assign_ops2.rs:9:5
    |
 LL |     a -= a - 1;
    |     ^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     a = a - (a - 1);
    |     ~~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:8:5
+  --> $DIR/assign_ops2.rs:10:5
    |
 LL |     a *= a * 99;
    |     ^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL |     a = a * a * 99;
    |     ~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:9:5
+  --> $DIR/assign_ops2.rs:11:5
    |
 LL |     a *= 42 * a;
    |     ^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |     a = a * 42 * a;
    |     ~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:10:5
+  --> $DIR/assign_ops2.rs:12:5
    |
 LL |     a /= a / 2;
    |     ^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     a = a / (a / 2);
    |     ~~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:11:5
+  --> $DIR/assign_ops2.rs:13:5
    |
 LL |     a %= a % 5;
    |     ^^^^^^^^^^
@@ -105,7 +105,7 @@ LL |     a = a % (a % 5);
    |     ~~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:12:5
+  --> $DIR/assign_ops2.rs:14:5
    |
 LL |     a &= a & 1;
    |     ^^^^^^^^^^
@@ -120,7 +120,7 @@ LL |     a = a & a & 1;
    |     ~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> $DIR/assign_ops2.rs:13:5
+  --> $DIR/assign_ops2.rs:15:5
    |
 LL |     a *= a * a;
    |     ^^^^^^^^^^
@@ -135,7 +135,7 @@ LL |     a = a * a * a;
    |     ~~~~~~~~~~~~~
 
 error: manual implementation of an assign operation
-  --> $DIR/assign_ops2.rs:50:5
+  --> $DIR/assign_ops2.rs:52:5
    |
 LL |     buf = buf + cows.clone();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `buf += cows.clone()`

--- a/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/tests/ui/auxiliary/proc_macro_attr.rs
@@ -4,7 +4,7 @@
 #![crate_type = "proc-macro"]
 #![feature(repr128, proc_macro_hygiene, proc_macro_quote, box_patterns)]
 #![allow(incomplete_features)]
-#![allow(clippy::useless_conversion)]
+#![allow(clippy::useless_conversion, clippy::uninlined_format_args)]
 
 extern crate proc_macro;
 extern crate quote;

--- a/tests/ui/bind_instead_of_map.fixed
+++ b/tests/ui/bind_instead_of_map.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![deny(clippy::bind_instead_of_map)]
+#![allow(clippy::uninlined_format_args)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map.rs
+++ b/tests/ui/bind_instead_of_map.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![deny(clippy::bind_instead_of_map)]
+#![allow(clippy::uninlined_format_args)]
 
 // need a main anyway, use it get rid of unused warnings too
 pub fn main() {

--- a/tests/ui/bind_instead_of_map.stderr
+++ b/tests/ui/bind_instead_of_map.stderr
@@ -1,5 +1,5 @@
 error: using `Option.and_then(Some)`, which is a no-op
-  --> $DIR/bind_instead_of_map.rs:8:13
+  --> $DIR/bind_instead_of_map.rs:9:13
    |
 LL |     let _ = x.and_then(Some);
    |             ^^^^^^^^^^^^^^^^ help: use the expression directly: `x`
@@ -11,13 +11,13 @@ LL | #![deny(clippy::bind_instead_of_map)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
-  --> $DIR/bind_instead_of_map.rs:9:13
+  --> $DIR/bind_instead_of_map.rs:10:13
    |
 LL |     let _ = x.and_then(|o| Some(o + 1));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `x.map(|o| o + 1)`
 
 error: using `Result.and_then(Ok)`, which is a no-op
-  --> $DIR/bind_instead_of_map.rs:15:13
+  --> $DIR/bind_instead_of_map.rs:16:13
    |
 LL |     let _ = x.and_then(Ok);
    |             ^^^^^^^^^^^^^^ help: use the expression directly: `x`

--- a/tests/ui/borrow_box.rs
+++ b/tests/ui/borrow_box.rs
@@ -1,7 +1,6 @@
 #![deny(clippy::borrowed_box)]
-#![allow(clippy::disallowed_names)]
-#![allow(unused_variables)]
-#![allow(dead_code)]
+#![allow(dead_code, unused_variables)]
+#![allow(clippy::uninlined_format_args, clippy::disallowed_names)]
 
 use std::fmt::Display;
 

--- a/tests/ui/borrow_box.stderr
+++ b/tests/ui/borrow_box.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:21:14
+  --> $DIR/borrow_box.rs:20:14
    |
 LL |     let foo: &Box<bool>;
    |              ^^^^^^^^^^ help: try: `&bool`
@@ -11,55 +11,55 @@ LL | #![deny(clippy::borrowed_box)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:25:10
+  --> $DIR/borrow_box.rs:24:10
    |
 LL |     foo: &'a Box<bool>,
    |          ^^^^^^^^^^^^^ help: try: `&'a bool`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:29:17
+  --> $DIR/borrow_box.rs:28:17
    |
 LL |     fn test4(a: &Box<bool>);
    |                 ^^^^^^^^^^ help: try: `&bool`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:95:25
+  --> $DIR/borrow_box.rs:94:25
    |
 LL | pub fn test14(_display: &Box<dyn Display>) {}
    |                         ^^^^^^^^^^^^^^^^^ help: try: `&dyn Display`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:96:25
+  --> $DIR/borrow_box.rs:95:25
    |
 LL | pub fn test15(_display: &Box<dyn Display + Send>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(dyn Display + Send)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:97:29
+  --> $DIR/borrow_box.rs:96:29
    |
 LL | pub fn test16<'a>(_display: &'a Box<dyn Display + 'a>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a (dyn Display + 'a)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:99:25
+  --> $DIR/borrow_box.rs:98:25
    |
 LL | pub fn test17(_display: &Box<impl Display>) {}
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `&impl Display`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:100:25
+  --> $DIR/borrow_box.rs:99:25
    |
 LL | pub fn test18(_display: &Box<impl Display + Send>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(impl Display + Send)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:101:29
+  --> $DIR/borrow_box.rs:100:29
    |
 LL | pub fn test19<'a>(_display: &'a Box<impl Display + 'a>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a (impl Display + 'a)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:106:25
+  --> $DIR/borrow_box.rs:105:25
    |
 LL | pub fn test20(_display: &Box<(dyn Display + Send)>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(dyn Display + Send)`

--- a/tests/ui/branches_sharing_code/shared_at_bottom.rs
+++ b/tests/ui/branches_sharing_code/shared_at_bottom.rs
@@ -1,5 +1,6 @@
-#![allow(dead_code, clippy::equatable_if_let)]
 #![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
+#![allow(dead_code)]
+#![allow(clippy::equatable_if_let, clippy::uninlined_format_args)]
 
 // This tests the branches_sharing_code lint at the end of blocks
 

--- a/tests/ui/branches_sharing_code/shared_at_bottom.stderr
+++ b/tests/ui/branches_sharing_code/shared_at_bottom.stderr
@@ -1,5 +1,5 @@
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:30:5
+  --> $DIR/shared_at_bottom.rs:31:5
    |
 LL | /         let result = false;
 LL | |         println!("Block end!");
@@ -8,7 +8,7 @@ LL | |     };
    | |_____^
    |
 note: the lint level is defined here
-  --> $DIR/shared_at_bottom.rs:2:36
+  --> $DIR/shared_at_bottom.rs:1:36
    |
 LL | #![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL ~     result;
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:48:5
+  --> $DIR/shared_at_bottom.rs:49:5
    |
 LL | /         println!("Same end of block");
 LL | |     }
@@ -35,7 +35,7 @@ LL +     println!("Same end of block");
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:65:5
+  --> $DIR/shared_at_bottom.rs:66:5
    |
 LL | /         println!(
 LL | |             "I'm moveable because I know: `outer_scope_value`: '{}'",
@@ -54,7 +54,7 @@ LL +     );
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:77:9
+  --> $DIR/shared_at_bottom.rs:78:9
    |
 LL | /             println!("Hello World");
 LL | |         }
@@ -67,7 +67,7 @@ LL +         println!("Hello World");
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:93:5
+  --> $DIR/shared_at_bottom.rs:94:5
    |
 LL | /         let later_used_value = "A string value";
 LL | |         println!("{}", later_used_value);
@@ -84,7 +84,7 @@ LL +     println!("{}", later_used_value);
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:106:5
+  --> $DIR/shared_at_bottom.rs:107:5
    |
 LL | /         let simple_examples = "I now identify as a &str :)";
 LL | |         println!("This is the new simple_example: {}", simple_examples);
@@ -100,7 +100,7 @@ LL +     println!("This is the new simple_example: {}", simple_examples);
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:171:5
+  --> $DIR/shared_at_bottom.rs:172:5
    |
 LL | /         x << 2
 LL | |     };
@@ -114,7 +114,7 @@ LL ~     x << 2;
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:178:5
+  --> $DIR/shared_at_bottom.rs:179:5
    |
 LL | /         x * 4
 LL | |     }
@@ -128,7 +128,7 @@ LL +     x * 4
    |
 
 error: all if blocks contain the same code at the end
-  --> $DIR/shared_at_bottom.rs:190:44
+  --> $DIR/shared_at_bottom.rs:191:44
    |
 LL |     if x == 17 { b = 1; a = 0x99; } else { a = 0x99; }
    |                                            ^^^^^^^^^^^

--- a/tests/ui/branches_sharing_code/shared_at_top.rs
+++ b/tests/ui/branches_sharing_code/shared_at_top.rs
@@ -1,5 +1,6 @@
-#![allow(dead_code, clippy::mixed_read_write_in_expression)]
-#![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
+#![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
+#![allow(dead_code)]
+#![allow(clippy::mixed_read_write_in_expression, clippy::uninlined_format_args)]
 
 // This tests the branches_sharing_code lint at the start of blocks
 

--- a/tests/ui/branches_sharing_code/shared_at_top.stderr
+++ b/tests/ui/branches_sharing_code/shared_at_top.stderr
@@ -1,15 +1,15 @@
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:10:5
+  --> $DIR/shared_at_top.rs:11:5
    |
 LL | /     if true {
 LL | |         println!("Hello World!");
    | |_________________________________^
    |
 note: the lint level is defined here
-  --> $DIR/shared_at_top.rs:2:36
+  --> $DIR/shared_at_top.rs:1:9
    |
-LL | #![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider moving these statements before the if
    |
 LL ~     println!("Hello World!");
@@ -17,7 +17,7 @@ LL +     if true {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:19:5
+  --> $DIR/shared_at_top.rs:20:5
    |
 LL | /     if x == 0 {
 LL | |         let y = 9;
@@ -35,7 +35,7 @@ LL +     if x == 0 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:40:5
+  --> $DIR/shared_at_top.rs:41:5
    |
 LL | /     let _ = if x == 7 {
 LL | |         let y = 16;
@@ -48,7 +48,7 @@ LL +     let _ = if x == 7 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:58:5
+  --> $DIR/shared_at_top.rs:59:5
    |
 LL | /     if x == 10 {
 LL | |         let used_value_name = "Different type";
@@ -64,7 +64,7 @@ LL +     if x == 10 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:72:5
+  --> $DIR/shared_at_top.rs:73:5
    |
 LL | /     if x == 11 {
 LL | |         let can_be_overridden = "Move me";
@@ -80,7 +80,7 @@ LL +     if x == 11 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:88:5
+  --> $DIR/shared_at_top.rs:89:5
    |
 LL | /     if x == 2020 {
 LL | |         println!("This should trigger the `SHARED_CODE_IN_IF_BLOCKS` lint.");
@@ -95,7 +95,7 @@ LL +     if x == 2020 {
    |
 
 error: this `if` has identical blocks
-  --> $DIR/shared_at_top.rs:96:18
+  --> $DIR/shared_at_top.rs:97:18
    |
 LL |       if x == 2019 {
    |  __________________^
@@ -104,12 +104,12 @@ LL | |     } else {
    | |_____^
    |
 note: the lint level is defined here
-  --> $DIR/shared_at_top.rs:2:9
+  --> $DIR/shared_at_top.rs:1:40
    |
-LL | #![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: same as this
-  --> $DIR/shared_at_top.rs:98:12
+  --> $DIR/shared_at_top.rs:99:12
    |
 LL |       } else {
    |  ____________^

--- a/tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs
+++ b/tests/ui/branches_sharing_code/shared_at_top_and_bottom.rs
@@ -1,5 +1,6 @@
+#![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
 #![allow(dead_code)]
-#![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
+#![allow(clippy::uninlined_format_args)]
 
 // branches_sharing_code at the top and bottom of the if blocks
 

--- a/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
+++ b/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
@@ -1,5 +1,5 @@
 error: all if blocks contain the same code at both the start and the end
-  --> $DIR/shared_at_top_and_bottom.rs:16:5
+  --> $DIR/shared_at_top_and_bottom.rs:17:5
    |
 LL | /     if x == 7 {
 LL | |         let t = 7;
@@ -8,12 +8,12 @@ LL | |         let _overlap_end = 2 * t;
    | |_________________________________^
    |
 note: the lint level is defined here
-  --> $DIR/shared_at_top_and_bottom.rs:2:36
+  --> $DIR/shared_at_top_and_bottom.rs:1:9
    |
-LL | #![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: this code is shared at the end
-  --> $DIR/shared_at_top_and_bottom.rs:28:5
+  --> $DIR/shared_at_top_and_bottom.rs:29:5
    |
 LL | /         let _u = 9;
 LL | |     }
@@ -32,7 +32,7 @@ LL +     let _u = 9;
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> $DIR/shared_at_top_and_bottom.rs:32:5
+  --> $DIR/shared_at_top_and_bottom.rs:33:5
    |
 LL | /     if x == 99 {
 LL | |         let r = 7;
@@ -41,7 +41,7 @@ LL | |         let _overlap_middle = r * r;
    | |____________________________________^
    |
 note: this code is shared at the end
-  --> $DIR/shared_at_top_and_bottom.rs:43:5
+  --> $DIR/shared_at_top_and_bottom.rs:44:5
    |
 LL | /         let _overlap_end = r * r * r;
 LL | |         let z = "end";
@@ -63,7 +63,7 @@ LL +     let z = "end";
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> $DIR/shared_at_top_and_bottom.rs:61:5
+  --> $DIR/shared_at_top_and_bottom.rs:62:5
    |
 LL | /     if (x > 7 && y < 13) || (x + y) % 2 == 1 {
 LL | |         let a = 0xcafe;
@@ -72,7 +72,7 @@ LL | |         let e_id = gen_id(a, b);
    | |________________________________^
    |
 note: this code is shared at the end
-  --> $DIR/shared_at_top_and_bottom.rs:81:5
+  --> $DIR/shared_at_top_and_bottom.rs:82:5
    |
 LL | /         let pack = DataPack {
 LL | |             id: e_id,
@@ -102,14 +102,14 @@ LL +     process_data(pack);
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> $DIR/shared_at_top_and_bottom.rs:94:5
+  --> $DIR/shared_at_top_and_bottom.rs:95:5
    |
 LL | /     let _ = if x == 7 {
 LL | |         let _ = 19;
    | |___________________^
    |
 note: this code is shared at the end
-  --> $DIR/shared_at_top_and_bottom.rs:103:5
+  --> $DIR/shared_at_top_and_bottom.rs:104:5
    |
 LL | /         x << 2
 LL | |     };
@@ -127,14 +127,14 @@ LL ~     x << 2;
    |
 
 error: all if blocks contain the same code at both the start and the end
-  --> $DIR/shared_at_top_and_bottom.rs:106:5
+  --> $DIR/shared_at_top_and_bottom.rs:107:5
    |
 LL | /     if x == 9 {
 LL | |         let _ = 17;
    | |___________________^
    |
 note: this code is shared at the end
-  --> $DIR/shared_at_top_and_bottom.rs:115:5
+  --> $DIR/shared_at_top_and_bottom.rs:116:5
    |
 LL | /         x * 4
 LL | |     }

--- a/tests/ui/branches_sharing_code/valid_if_blocks.rs
+++ b/tests/ui/branches_sharing_code/valid_if_blocks.rs
@@ -1,5 +1,6 @@
-#![allow(dead_code, clippy::mixed_read_write_in_expression)]
-#![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
+#![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
+#![allow(dead_code)]
+#![allow(clippy::mixed_read_write_in_expression, clippy::uninlined_format_args)]
 
 // This tests valid if blocks that shouldn't trigger the lint
 

--- a/tests/ui/branches_sharing_code/valid_if_blocks.stderr
+++ b/tests/ui/branches_sharing_code/valid_if_blocks.stderr
@@ -1,5 +1,5 @@
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:104:14
+  --> $DIR/valid_if_blocks.rs:105:14
    |
 LL |       if false {
    |  ______________^
@@ -7,12 +7,12 @@ LL | |     } else {
    | |_____^
    |
 note: the lint level is defined here
-  --> $DIR/valid_if_blocks.rs:2:9
+  --> $DIR/valid_if_blocks.rs:1:40
    |
-LL | #![deny(clippy::if_same_then_else, clippy::branches_sharing_code)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: same as this
-  --> $DIR/valid_if_blocks.rs:105:12
+  --> $DIR/valid_if_blocks.rs:106:12
    |
 LL |       } else {
    |  ____________^
@@ -20,7 +20,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:115:15
+  --> $DIR/valid_if_blocks.rs:116:15
    |
 LL |       if x == 0 {
    |  _______________^
@@ -31,7 +31,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:119:12
+  --> $DIR/valid_if_blocks.rs:120:12
    |
 LL |       } else {
    |  ____________^
@@ -42,19 +42,19 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:126:23
+  --> $DIR/valid_if_blocks.rs:127:23
    |
 LL |     let _ = if x == 6 { 7 } else { 7 };
    |                       ^^^^^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:126:34
+  --> $DIR/valid_if_blocks.rs:127:34
    |
 LL |     let _ = if x == 6 { 7 } else { 7 };
    |                                  ^^^^^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:132:23
+  --> $DIR/valid_if_blocks.rs:133:23
    |
 LL |       } else if x == 68 {
    |  _______________________^
@@ -66,7 +66,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:137:12
+  --> $DIR/valid_if_blocks.rs:138:12
    |
 LL |       } else {
    |  ____________^
@@ -78,7 +78,7 @@ LL | |     };
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:146:23
+  --> $DIR/valid_if_blocks.rs:147:23
    |
 LL |       } else if x == 68 {
    |  _______________________^
@@ -88,7 +88,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:149:12
+  --> $DIR/valid_if_blocks.rs:150:12
    |
 LL |       } else {
    |  ____________^

--- a/tests/ui/cast_abs_to_unsigned.fixed
+++ b/tests/ui/cast_abs_to_unsigned.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::cast_abs_to_unsigned)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let x: i32 = -42;

--- a/tests/ui/cast_abs_to_unsigned.rs
+++ b/tests/ui/cast_abs_to_unsigned.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::cast_abs_to_unsigned)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let x: i32 = -42;

--- a/tests/ui/cast_abs_to_unsigned.stderr
+++ b/tests/ui/cast_abs_to_unsigned.stderr
@@ -1,5 +1,5 @@
 error: casting the result of `i32::abs()` to u32
-  --> $DIR/cast_abs_to_unsigned.rs:6:18
+  --> $DIR/cast_abs_to_unsigned.rs:7:18
    |
 LL |     let y: u32 = x.abs() as u32;
    |                  ^^^^^^^^^^^^^^ help: replace with: `x.unsigned_abs()`
@@ -7,97 +7,97 @@ LL |     let y: u32 = x.abs() as u32;
    = note: `-D clippy::cast-abs-to-unsigned` implied by `-D warnings`
 
 error: casting the result of `i32::abs()` to usize
-  --> $DIR/cast_abs_to_unsigned.rs:10:20
+  --> $DIR/cast_abs_to_unsigned.rs:11:20
    |
 LL |     let _: usize = a.abs() as usize;
    |                    ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i32::abs()` to usize
-  --> $DIR/cast_abs_to_unsigned.rs:11:20
+  --> $DIR/cast_abs_to_unsigned.rs:12:20
    |
 LL |     let _: usize = a.abs() as _;
    |                    ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i32::abs()` to usize
-  --> $DIR/cast_abs_to_unsigned.rs:12:13
+  --> $DIR/cast_abs_to_unsigned.rs:13:13
    |
 LL |     let _ = a.abs() as usize;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i64::abs()` to usize
-  --> $DIR/cast_abs_to_unsigned.rs:15:13
+  --> $DIR/cast_abs_to_unsigned.rs:16:13
    |
 LL |     let _ = a.abs() as usize;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i64::abs()` to u8
-  --> $DIR/cast_abs_to_unsigned.rs:16:13
+  --> $DIR/cast_abs_to_unsigned.rs:17:13
    |
 LL |     let _ = a.abs() as u8;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i64::abs()` to u16
-  --> $DIR/cast_abs_to_unsigned.rs:17:13
+  --> $DIR/cast_abs_to_unsigned.rs:18:13
    |
 LL |     let _ = a.abs() as u16;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i64::abs()` to u32
-  --> $DIR/cast_abs_to_unsigned.rs:18:13
+  --> $DIR/cast_abs_to_unsigned.rs:19:13
    |
 LL |     let _ = a.abs() as u32;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i64::abs()` to u64
-  --> $DIR/cast_abs_to_unsigned.rs:19:13
+  --> $DIR/cast_abs_to_unsigned.rs:20:13
    |
 LL |     let _ = a.abs() as u64;
    |             ^^^^^^^^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i64::abs()` to u128
-  --> $DIR/cast_abs_to_unsigned.rs:20:13
+  --> $DIR/cast_abs_to_unsigned.rs:21:13
    |
 LL |     let _ = a.abs() as u128;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `isize::abs()` to usize
-  --> $DIR/cast_abs_to_unsigned.rs:23:13
+  --> $DIR/cast_abs_to_unsigned.rs:24:13
    |
 LL |     let _ = a.abs() as usize;
    |             ^^^^^^^^^^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `isize::abs()` to u8
-  --> $DIR/cast_abs_to_unsigned.rs:24:13
+  --> $DIR/cast_abs_to_unsigned.rs:25:13
    |
 LL |     let _ = a.abs() as u8;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `isize::abs()` to u16
-  --> $DIR/cast_abs_to_unsigned.rs:25:13
+  --> $DIR/cast_abs_to_unsigned.rs:26:13
    |
 LL |     let _ = a.abs() as u16;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `isize::abs()` to u32
-  --> $DIR/cast_abs_to_unsigned.rs:26:13
+  --> $DIR/cast_abs_to_unsigned.rs:27:13
    |
 LL |     let _ = a.abs() as u32;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `isize::abs()` to u64
-  --> $DIR/cast_abs_to_unsigned.rs:27:13
+  --> $DIR/cast_abs_to_unsigned.rs:28:13
    |
 LL |     let _ = a.abs() as u64;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `isize::abs()` to u128
-  --> $DIR/cast_abs_to_unsigned.rs:28:13
+  --> $DIR/cast_abs_to_unsigned.rs:29:13
    |
 LL |     let _ = a.abs() as u128;
    |             ^^^^^^^ help: replace with: `a.unsigned_abs()`
 
 error: casting the result of `i64::abs()` to u32
-  --> $DIR/cast_abs_to_unsigned.rs:30:13
+  --> $DIR/cast_abs_to_unsigned.rs:31:13
    |
 LL |     let _ = (x as i64 - y as i64).abs() as u32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `(x as i64 - y as i64).unsigned_abs()`

--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -1,9 +1,10 @@
 #![warn(clippy::collapsible_match)]
 #![allow(
+    clippy::equatable_if_let,
     clippy::needless_return,
     clippy::no_effect,
     clippy::single_match,
-    clippy::equatable_if_let
+    clippy::uninlined_format_args
 )]
 
 fn lint_cases(opt_opt: Option<Option<u32>>, res_opt: Result<Option<u32>, String>) {

--- a/tests/ui/collapsible_match.stderr
+++ b/tests/ui/collapsible_match.stderr
@@ -1,5 +1,5 @@
 error: this `match` can be collapsed into the outer `match`
-  --> $DIR/collapsible_match.rs:12:20
+  --> $DIR/collapsible_match.rs:13:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -10,7 +10,7 @@ LL | |         },
    |
    = note: `-D clippy::collapsible-match` implied by `-D warnings`
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:12:12
+  --> $DIR/collapsible_match.rs:13:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -18,7 +18,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> $DIR/collapsible_match.rs:21:20
+  --> $DIR/collapsible_match.rs:22:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -28,7 +28,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:21:12
+  --> $DIR/collapsible_match.rs:22:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -36,7 +36,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> $DIR/collapsible_match.rs:30:9
+  --> $DIR/collapsible_match.rs:31:9
    |
 LL | /         if let Some(n) = val {
 LL | |             take(n);
@@ -44,7 +44,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:29:15
+  --> $DIR/collapsible_match.rs:30:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -52,7 +52,7 @@ LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> $DIR/collapsible_match.rs:37:9
+  --> $DIR/collapsible_match.rs:38:9
    |
 LL | /         if let Some(n) = val {
 LL | |             take(n);
@@ -62,7 +62,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:36:15
+  --> $DIR/collapsible_match.rs:37:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -70,7 +70,7 @@ LL |         if let Some(n) = val {
    |                ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> $DIR/collapsible_match.rs:48:9
+  --> $DIR/collapsible_match.rs:49:9
    |
 LL | /         match val {
 LL | |             Some(n) => foo(n),
@@ -79,7 +79,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:47:15
+  --> $DIR/collapsible_match.rs:48:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -88,7 +88,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `match`
-  --> $DIR/collapsible_match.rs:57:13
+  --> $DIR/collapsible_match.rs:58:13
    |
 LL | /             if let Some(n) = val {
 LL | |                 take(n);
@@ -96,7 +96,7 @@ LL | |             }
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:56:12
+  --> $DIR/collapsible_match.rs:57:12
    |
 LL |         Ok(val) => {
    |            ^^^ replace this binding
@@ -104,7 +104,7 @@ LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `if let`
-  --> $DIR/collapsible_match.rs:66:9
+  --> $DIR/collapsible_match.rs:67:9
    |
 LL | /         match val {
 LL | |             Some(n) => foo(n),
@@ -113,7 +113,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:65:15
+  --> $DIR/collapsible_match.rs:66:15
    |
 LL |     if let Ok(val) = res_opt {
    |               ^^^ replace this binding
@@ -122,7 +122,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `match`
-  --> $DIR/collapsible_match.rs:77:13
+  --> $DIR/collapsible_match.rs:78:13
    |
 LL | /             if let Some(n) = val {
 LL | |                 take(n);
@@ -132,7 +132,7 @@ LL | |             }
    | |_____________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:76:12
+  --> $DIR/collapsible_match.rs:77:12
    |
 LL |         Ok(val) => {
    |            ^^^ replace this binding
@@ -140,7 +140,7 @@ LL |             if let Some(n) = val {
    |                    ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> $DIR/collapsible_match.rs:88:20
+  --> $DIR/collapsible_match.rs:89:20
    |
 LL |           Ok(val) => match val {
    |  ____________________^
@@ -150,7 +150,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:88:12
+  --> $DIR/collapsible_match.rs:89:12
    |
 LL |         Ok(val) => match val {
    |            ^^^ replace this binding
@@ -158,7 +158,7 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> $DIR/collapsible_match.rs:97:22
+  --> $DIR/collapsible_match.rs:98:22
    |
 LL |           Some(val) => match val {
    |  ______________________^
@@ -168,7 +168,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> $DIR/collapsible_match.rs:97:14
+  --> $DIR/collapsible_match.rs:98:14
    |
 LL |         Some(val) => match val {
    |              ^^^ replace this binding

--- a/tests/ui/crashes/ice-4775.rs
+++ b/tests/ui/crashes/ice-4775.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+
 pub struct ArrayWrapper<const N: usize>([usize; N]);
 
 impl<const N: usize> ArrayWrapper<{ N }> {

--- a/tests/ui/crashes/regressions.rs
+++ b/tests/ui/crashes/regressions.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_names)]
+#![allow(clippy::disallowed_names, clippy::uninlined_format_args)]
 
 pub fn foo(bar: *const u8) {
     println!("{:#p}", bar);

--- a/tests/ui/default_trait_access.fixed
+++ b/tests/ui/default_trait_access.fixed
@@ -1,8 +1,8 @@
 // run-rustfix
 // aux-build: proc_macro_with_span.rs
-
-#![allow(unused_imports, dead_code)]
 #![deny(clippy::default_trait_access)]
+#![allow(dead_code, unused_imports)]
+#![allow(clippy::uninlined_format_args)]
 
 extern crate proc_macro_with_span;
 

--- a/tests/ui/default_trait_access.rs
+++ b/tests/ui/default_trait_access.rs
@@ -1,8 +1,8 @@
 // run-rustfix
 // aux-build: proc_macro_with_span.rs
-
-#![allow(unused_imports, dead_code)]
 #![deny(clippy::default_trait_access)]
+#![allow(dead_code, unused_imports)]
+#![allow(clippy::uninlined_format_args)]
 
 extern crate proc_macro_with_span;
 

--- a/tests/ui/default_trait_access.stderr
+++ b/tests/ui/default_trait_access.stderr
@@ -5,7 +5,7 @@ LL |     let s1: String = Default::default();
    |                      ^^^^^^^^^^^^^^^^^^ help: try: `std::string::String::default()`
    |
 note: the lint level is defined here
-  --> $DIR/default_trait_access.rs:5:9
+  --> $DIR/default_trait_access.rs:3:9
    |
 LL | #![deny(clippy::default_trait_access)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -1,14 +1,14 @@
 // run-rustfix
-
-#![allow(
-    unused,
-    clippy::no_effect,
-    clippy::redundant_closure_call,
-    clippy::needless_pass_by_value,
-    clippy::option_map_unit_fn,
-    clippy::needless_borrow
-)]
 #![warn(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+#![allow(unused)]
+#![allow(
+    clippy::needless_borrow,
+    clippy::needless_pass_by_value,
+    clippy::no_effect,
+    clippy::option_map_unit_fn,
+    clippy::redundant_closure_call,
+    clippy::uninlined_format_args
+)]
 
 use std::path::{Path, PathBuf};
 

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -1,14 +1,14 @@
 // run-rustfix
-
-#![allow(
-    unused,
-    clippy::no_effect,
-    clippy::redundant_closure_call,
-    clippy::needless_pass_by_value,
-    clippy::option_map_unit_fn,
-    clippy::needless_borrow
-)]
 #![warn(clippy::redundant_closure, clippy::redundant_closure_for_method_calls)]
+#![allow(unused)]
+#![allow(
+    clippy::needless_borrow,
+    clippy::needless_pass_by_value,
+    clippy::no_effect,
+    clippy::option_map_unit_fn,
+    clippy::redundant_closure_call,
+    clippy::uninlined_format_args
+)]
 
 use std::path::{Path, PathBuf};
 

--- a/tests/ui/expect_fun_call.fixed
+++ b/tests/ui/expect_fun_call.fixed
@@ -1,7 +1,6 @@
 // run-rustfix
-
 #![warn(clippy::expect_fun_call)]
-#![allow(clippy::to_string_in_format_args)]
+#![allow(clippy::to_string_in_format_args, clippy::uninlined_format_args)]
 
 /// Checks implementation of the `EXPECT_FUN_CALL` lint
 

--- a/tests/ui/expect_fun_call.rs
+++ b/tests/ui/expect_fun_call.rs
@@ -1,7 +1,6 @@
 // run-rustfix
-
 #![warn(clippy::expect_fun_call)]
-#![allow(clippy::to_string_in_format_args)]
+#![allow(clippy::to_string_in_format_args, clippy::uninlined_format_args)]
 
 /// Checks implementation of the `EXPECT_FUN_CALL` lint
 

--- a/tests/ui/expect_fun_call.stderr
+++ b/tests/ui/expect_fun_call.stderr
@@ -1,5 +1,5 @@
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:35:26
+  --> $DIR/expect_fun_call.rs:34:26
    |
 LL |     with_none_and_format.expect(&format!("Error {}: fake error", error_code));
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
@@ -7,73 +7,73 @@ LL |     with_none_and_format.expect(&format!("Error {}: fake error", error_code
    = note: `-D clippy::expect-fun-call` implied by `-D warnings`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:38:26
+  --> $DIR/expect_fun_call.rs:37:26
    |
 LL |     with_none_and_as_str.expect(format!("Error {}: fake error", error_code).as_str());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:41:37
+  --> $DIR/expect_fun_call.rs:40:37
    |
 LL |     with_none_and_format_with_macro.expect(format!("Error {}: fake error", one!()).as_str());
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("Error {}: fake error", one!()))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:51:25
+  --> $DIR/expect_fun_call.rs:50:25
    |
 LL |     with_err_and_format.expect(&format!("Error {}: fake error", error_code));
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:54:25
+  --> $DIR/expect_fun_call.rs:53:25
    |
 LL |     with_err_and_as_str.expect(format!("Error {}: fake error", error_code).as_str());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:66:17
+  --> $DIR/expect_fun_call.rs:65:17
    |
 LL |     Some("foo").expect(format!("{} {}", 1, 2).as_ref());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("{} {}", 1, 2))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:87:21
+  --> $DIR/expect_fun_call.rs:86:21
    |
 LL |         Some("foo").expect(&get_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:88:21
+  --> $DIR/expect_fun_call.rs:87:21
    |
 LL |         Some("foo").expect(get_string().as_ref());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:89:21
+  --> $DIR/expect_fun_call.rs:88:21
    |
 LL |         Some("foo").expect(get_string().as_str());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:91:21
+  --> $DIR/expect_fun_call.rs:90:21
    |
 LL |         Some("foo").expect(get_static_str());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_static_str()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:92:21
+  --> $DIR/expect_fun_call.rs:91:21
    |
 LL |         Some("foo").expect(get_non_static_str(&0));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_non_static_str(&0).to_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:96:16
+  --> $DIR/expect_fun_call.rs:95:16
    |
 LL |     Some(true).expect(&format!("key {}, {}", 1, 2));
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("key {}, {}", 1, 2))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:102:17
+  --> $DIR/expect_fun_call.rs:101:17
    |
 LL |         opt_ref.expect(&format!("{:?}", opt_ref));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("{:?}", opt_ref))`

--- a/tests/ui/explicit_counter_loop.rs
+++ b/tests/ui/explicit_counter_loop.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::explicit_counter_loop)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let mut vec = vec![1, 2, 3, 4];

--- a/tests/ui/explicit_counter_loop.stderr
+++ b/tests/ui/explicit_counter_loop.stderr
@@ -1,5 +1,5 @@
 error: the variable `_index` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:6:5
+  --> $DIR/explicit_counter_loop.rs:7:5
    |
 LL |     for _v in &vec {
    |     ^^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
@@ -7,49 +7,49 @@ LL |     for _v in &vec {
    = note: `-D clippy::explicit-counter-loop` implied by `-D warnings`
 
 error: the variable `_index` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:12:5
+  --> $DIR/explicit_counter_loop.rs:13:5
    |
 LL |     for _v in &vec {
    |     ^^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter().enumerate()`
 
 error: the variable `_index` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:17:5
+  --> $DIR/explicit_counter_loop.rs:18:5
    |
 LL |     for _v in &mut vec {
    |     ^^^^^^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.iter_mut().enumerate()`
 
 error: the variable `_index` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:22:5
+  --> $DIR/explicit_counter_loop.rs:23:5
    |
 LL |     for _v in vec {
    |     ^^^^^^^^^^^^^ help: consider using: `for (_index, _v) in vec.into_iter().enumerate()`
 
 error: the variable `count` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:61:9
+  --> $DIR/explicit_counter_loop.rs:62:9
    |
 LL |         for ch in text.chars() {
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
 
 error: the variable `count` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:72:9
+  --> $DIR/explicit_counter_loop.rs:73:9
    |
 LL |         for ch in text.chars() {
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `for (count, ch) in text.chars().enumerate()`
 
 error: the variable `count` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:130:9
+  --> $DIR/explicit_counter_loop.rs:131:9
    |
 LL |         for _i in 3..10 {
    |         ^^^^^^^^^^^^^^^ help: consider using: `for (count, _i) in (3..10).enumerate()`
 
 error: the variable `idx_usize` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:170:9
+  --> $DIR/explicit_counter_loop.rs:171:9
    |
 LL |         for _item in slice {
    |         ^^^^^^^^^^^^^^^^^^ help: consider using: `for (idx_usize, _item) in slice.iter().enumerate()`
 
 error: the variable `idx_u32` is used as a loop counter
-  --> $DIR/explicit_counter_loop.rs:182:9
+  --> $DIR/explicit_counter_loop.rs:183:9
    |
 LL |         for _item in slice {
    |         ^^^^^^^^^^^^^^^^^^ help: consider using: `for (idx_u32, _item) in (0_u32..).zip(slice.iter())`

--- a/tests/ui/explicit_deref_methods.fixed
+++ b/tests/ui/explicit_deref_methods.fixed
@@ -1,13 +1,13 @@
 // run-rustfix
-
-#![allow(
-    unused_variables,
-    clippy::clone_double_ref,
-    clippy::needless_borrow,
-    clippy::borrow_deref_ref,
-    clippy::explicit_auto_deref
-)]
 #![warn(clippy::explicit_deref_methods)]
+#![allow(unused_variables)]
+#![allow(
+    clippy::borrow_deref_ref,
+    clippy::clone_double_ref,
+    clippy::explicit_auto_deref,
+    clippy::needless_borrow,
+    clippy::uninlined_format_args
+)]
 
 use std::ops::{Deref, DerefMut};
 

--- a/tests/ui/explicit_deref_methods.rs
+++ b/tests/ui/explicit_deref_methods.rs
@@ -1,13 +1,13 @@
 // run-rustfix
-
-#![allow(
-    unused_variables,
-    clippy::clone_double_ref,
-    clippy::needless_borrow,
-    clippy::borrow_deref_ref,
-    clippy::explicit_auto_deref
-)]
 #![warn(clippy::explicit_deref_methods)]
+#![allow(unused_variables)]
+#![allow(
+    clippy::borrow_deref_ref,
+    clippy::clone_double_ref,
+    clippy::explicit_auto_deref,
+    clippy::needless_borrow,
+    clippy::uninlined_format_args
+)]
 
 use std::ops::{Deref, DerefMut};
 

--- a/tests/ui/explicit_write.fixed
+++ b/tests/ui/explicit_write.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
-#![allow(unused_imports)]
 #![warn(clippy::explicit_write)]
+#![allow(unused_imports)]
+#![allow(clippy::uninlined_format_args)]
 
 fn stdout() -> String {
     String::new()

--- a/tests/ui/explicit_write.rs
+++ b/tests/ui/explicit_write.rs
@@ -1,6 +1,7 @@
 // run-rustfix
-#![allow(unused_imports)]
 #![warn(clippy::explicit_write)]
+#![allow(unused_imports)]
+#![allow(clippy::uninlined_format_args)]
 
 fn stdout() -> String {
     String::new()

--- a/tests/ui/explicit_write.stderr
+++ b/tests/ui/explicit_write.stderr
@@ -1,5 +1,5 @@
 error: use of `write!(stdout(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:23:9
+  --> $DIR/explicit_write.rs:24:9
    |
 LL |         write!(std::io::stdout(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `print!("test")`
@@ -7,73 +7,73 @@ LL |         write!(std::io::stdout(), "test").unwrap();
    = note: `-D clippy::explicit-write` implied by `-D warnings`
 
 error: use of `write!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:24:9
+  --> $DIR/explicit_write.rs:25:9
    |
 LL |         write!(std::io::stderr(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprint!("test")`
 
 error: use of `writeln!(stdout(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:25:9
+  --> $DIR/explicit_write.rs:26:9
    |
 LL |         writeln!(std::io::stdout(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `println!("test")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:26:9
+  --> $DIR/explicit_write.rs:27:9
    |
 LL |         writeln!(std::io::stderr(), "test").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("test")`
 
 error: use of `stdout().write_fmt(...).unwrap()`
-  --> $DIR/explicit_write.rs:27:9
+  --> $DIR/explicit_write.rs:28:9
    |
 LL |         std::io::stdout().write_fmt(format_args!("test")).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `print!("test")`
 
 error: use of `stderr().write_fmt(...).unwrap()`
-  --> $DIR/explicit_write.rs:28:9
+  --> $DIR/explicit_write.rs:29:9
    |
 LL |         std::io::stderr().write_fmt(format_args!("test")).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprint!("test")`
 
 error: use of `writeln!(stdout(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:31:9
+  --> $DIR/explicit_write.rs:32:9
    |
 LL |         writeln!(std::io::stdout(), "test/ntest").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `println!("test/ntest")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:32:9
+  --> $DIR/explicit_write.rs:33:9
    |
 LL |         writeln!(std::io::stderr(), "test/ntest").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("test/ntest")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:35:9
+  --> $DIR/explicit_write.rs:36:9
    |
 LL |         writeln!(std::io::stderr(), "with {}", value).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("with {}", value)`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:36:9
+  --> $DIR/explicit_write.rs:37:9
    |
 LL |         writeln!(std::io::stderr(), "with {} {}", 2, value).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("with {} {}", 2, value)`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:37:9
+  --> $DIR/explicit_write.rs:38:9
    |
 LL |         writeln!(std::io::stderr(), "with {value}").unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("with {value}")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:38:9
+  --> $DIR/explicit_write.rs:39:9
    |
 LL |         writeln!(std::io::stderr(), "macro arg {}", one!()).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("macro arg {}", one!())`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
-  --> $DIR/explicit_write.rs:40:9
+  --> $DIR/explicit_write.rs:41:9
    |
 LL |         writeln!(std::io::stderr(), "{:w$}", value, w = width).unwrap();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("{:w$}", value, w = width)`

--- a/tests/ui/fallible_impl_from.rs
+++ b/tests/ui/fallible_impl_from.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::fallible_impl_from)]
+#![allow(clippy::uninlined_format_args)]
 
 // docs example
 struct Foo(i32);

--- a/tests/ui/fallible_impl_from.stderr
+++ b/tests/ui/fallible_impl_from.stderr
@@ -1,5 +1,5 @@
 error: consider implementing `TryFrom` instead
-  --> $DIR/fallible_impl_from.rs:5:1
+  --> $DIR/fallible_impl_from.rs:6:1
    |
 LL | / impl From<String> for Foo {
 LL | |     fn from(s: String) -> Self {
@@ -15,13 +15,13 @@ LL | #![deny(clippy::fallible_impl_from)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> $DIR/fallible_impl_from.rs:7:13
+  --> $DIR/fallible_impl_from.rs:8:13
    |
 LL |         Foo(s.parse().unwrap())
    |             ^^^^^^^^^^^^^^^^^^
 
 error: consider implementing `TryFrom` instead
-  --> $DIR/fallible_impl_from.rs:26:1
+  --> $DIR/fallible_impl_from.rs:27:1
    |
 LL | / impl From<usize> for Invalid {
 LL | |     fn from(i: usize) -> Invalid {
@@ -34,14 +34,14 @@ LL | | }
    |
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> $DIR/fallible_impl_from.rs:29:13
+  --> $DIR/fallible_impl_from.rs:30:13
    |
 LL |             panic!();
    |             ^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
-  --> $DIR/fallible_impl_from.rs:35:1
+  --> $DIR/fallible_impl_from.rs:36:1
    |
 LL | / impl From<Option<String>> for Invalid {
 LL | |     fn from(s: Option<String>) -> Invalid {
@@ -54,7 +54,7 @@ LL | | }
    |
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> $DIR/fallible_impl_from.rs:37:17
+  --> $DIR/fallible_impl_from.rs:38:17
    |
 LL |         let s = s.unwrap();
    |                 ^^^^^^^^^^
@@ -68,7 +68,7 @@ LL |             panic!("{:?}", s);
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
-  --> $DIR/fallible_impl_from.rs:53:1
+  --> $DIR/fallible_impl_from.rs:54:1
    |
 LL | / impl<'a> From<&'a mut <Box<u32> as ProjStrTrait>::ProjString> for Invalid {
 LL | |     fn from(s: &'a mut <Box<u32> as ProjStrTrait>::ProjString) -> Invalid {
@@ -81,7 +81,7 @@ LL | | }
    |
    = help: `From` is intended for infallible conversions only. Use `TryFrom` if there's a possibility for the conversion to fail
 note: potential failure(s)
-  --> $DIR/fallible_impl_from.rs:55:12
+  --> $DIR/fallible_impl_from.rs:56:12
    |
 LL |         if s.parse::<u32>().ok().unwrap() != 42 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/for_loop_fixable.fixed
+++ b/tests/ui/for_loop_fixable.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
-
 #![allow(dead_code, unused)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::collections::*;
 

--- a/tests/ui/for_loop_fixable.rs
+++ b/tests/ui/for_loop_fixable.rs
@@ -1,6 +1,6 @@
 // run-rustfix
-
 #![allow(dead_code, unused)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::collections::*;
 

--- a/tests/ui/for_loops_over_fallibles.rs
+++ b/tests/ui/for_loops_over_fallibles.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::for_loops_over_fallibles)]
+#![allow(clippy::uninlined_format_args)]
 
 fn for_loops_over_fallibles() {
     let option = Some(1);

--- a/tests/ui/for_loops_over_fallibles.stderr
+++ b/tests/ui/for_loops_over_fallibles.stderr
@@ -1,5 +1,5 @@
 error: for loop over `option`, which is an `Option`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:9:14
+  --> $DIR/for_loops_over_fallibles.rs:10:14
    |
 LL |     for x in option {
    |              ^^^^^^
@@ -8,7 +8,7 @@ LL |     for x in option {
    = help: consider replacing `for x in option` with `if let Some(x) = option`
 
 error: for loop over `option`, which is an `Option`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:14:14
+  --> $DIR/for_loops_over_fallibles.rs:15:14
    |
 LL |     for x in option.iter() {
    |              ^^^^^^
@@ -16,7 +16,7 @@ LL |     for x in option.iter() {
    = help: consider replacing `for x in option.iter()` with `if let Some(x) = option`
 
 error: for loop over `result`, which is a `Result`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:19:14
+  --> $DIR/for_loops_over_fallibles.rs:20:14
    |
 LL |     for x in result {
    |              ^^^^^^
@@ -24,7 +24,7 @@ LL |     for x in result {
    = help: consider replacing `for x in result` with `if let Ok(x) = result`
 
 error: for loop over `result`, which is a `Result`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:24:14
+  --> $DIR/for_loops_over_fallibles.rs:25:14
    |
 LL |     for x in result.iter_mut() {
    |              ^^^^^^
@@ -32,7 +32,7 @@ LL |     for x in result.iter_mut() {
    = help: consider replacing `for x in result.iter_mut()` with `if let Ok(x) = result`
 
 error: for loop over `result`, which is a `Result`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:29:14
+  --> $DIR/for_loops_over_fallibles.rs:30:14
    |
 LL |     for x in result.into_iter() {
    |              ^^^^^^
@@ -40,7 +40,7 @@ LL |     for x in result.into_iter() {
    = help: consider replacing `for x in result.into_iter()` with `if let Ok(x) = result`
 
 error: for loop over `option.ok_or("x not found")`, which is a `Result`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:33:14
+  --> $DIR/for_loops_over_fallibles.rs:34:14
    |
 LL |     for x in option.ok_or("x not found") {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     for x in option.ok_or("x not found") {
    = help: consider replacing `for x in option.ok_or("x not found")` with `if let Ok(x) = option.ok_or("x not found")`
 
 error: you are iterating over `Iterator::next()` which is an Option; this will compile but is probably not what you want
-  --> $DIR/for_loops_over_fallibles.rs:39:14
+  --> $DIR/for_loops_over_fallibles.rs:40:14
    |
 LL |     for x in v.iter().next() {
    |              ^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     for x in v.iter().next() {
    = note: `#[deny(clippy::iter_next_loop)]` on by default
 
 error: for loop over `v.iter().next().and(Some(0))`, which is an `Option`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:44:14
+  --> $DIR/for_loops_over_fallibles.rs:45:14
    |
 LL |     for x in v.iter().next().and(Some(0)) {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |     for x in v.iter().next().and(Some(0)) {
    = help: consider replacing `for x in v.iter().next().and(Some(0))` with `if let Some(x) = v.iter().next().and(Some(0))`
 
 error: for loop over `v.iter().next().ok_or("x not found")`, which is a `Result`. This is more readably written as an `if let` statement
-  --> $DIR/for_loops_over_fallibles.rs:48:14
+  --> $DIR/for_loops_over_fallibles.rs:49:14
    |
 LL |     for x in v.iter().next().ok_or("x not found") {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     for x in v.iter().next().ok_or("x not found") {
    = help: consider replacing `for x in v.iter().next().ok_or("x not found")` with `if let Ok(x) = v.iter().next().ok_or("x not found")`
 
 error: this loop never actually loops
-  --> $DIR/for_loops_over_fallibles.rs:60:5
+  --> $DIR/for_loops_over_fallibles.rs:61:5
    |
 LL | /     while let Some(x) = option {
 LL | |         println!("{}", x);
@@ -83,7 +83,7 @@ LL | |     }
    = note: `#[deny(clippy::never_loop)]` on by default
 
 error: this loop never actually loops
-  --> $DIR/for_loops_over_fallibles.rs:66:5
+  --> $DIR/for_loops_over_fallibles.rs:67:5
    |
 LL | /     while let Ok(x) = result {
 LL | |         println!("{}", x);

--- a/tests/ui/format.fixed
+++ b/tests/ui/format.fixed
@@ -1,13 +1,13 @@
 // run-rustfix
-
+#![warn(clippy::useless_format)]
 #![allow(
     unused_tuple_struct_fields,
     clippy::print_literal,
     clippy::redundant_clone,
     clippy::to_string_in_format_args,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::uninlined_format_args
 )]
-#![warn(clippy::useless_format)]
 
 struct Foo(pub String);
 

--- a/tests/ui/format.rs
+++ b/tests/ui/format.rs
@@ -1,13 +1,13 @@
 // run-rustfix
-
+#![warn(clippy::useless_format)]
 #![allow(
     unused_tuple_struct_fields,
     clippy::print_literal,
     clippy::redundant_clone,
     clippy::to_string_in_format_args,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::uninlined_format_args
 )]
-#![warn(clippy::useless_format)]
 
 struct Foo(pub String);
 

--- a/tests/ui/format_args.fixed
+++ b/tests/ui/format_args.fixed
@@ -1,10 +1,12 @@
 // run-rustfix
-
-#![allow(unused)]
-#![allow(clippy::assertions_on_constants)]
-#![allow(clippy::eq_op)]
-#![allow(clippy::print_literal)]
 #![warn(clippy::to_string_in_format_args)]
+#![allow(unused)]
+#![allow(
+    clippy::assertions_on_constants,
+    clippy::eq_op,
+    clippy::print_literal,
+    clippy::uninlined_format_args
+)]
 
 use std::io::{stdout, Write};
 use std::ops::Deref;

--- a/tests/ui/format_args.rs
+++ b/tests/ui/format_args.rs
@@ -1,10 +1,12 @@
 // run-rustfix
-
-#![allow(unused)]
-#![allow(clippy::assertions_on_constants)]
-#![allow(clippy::eq_op)]
-#![allow(clippy::print_literal)]
 #![warn(clippy::to_string_in_format_args)]
+#![allow(unused)]
+#![allow(
+    clippy::assertions_on_constants,
+    clippy::eq_op,
+    clippy::print_literal,
+    clippy::uninlined_format_args
+)]
 
 use std::io::{stdout, Write};
 use std::ops::Deref;

--- a/tests/ui/format_args.stderr
+++ b/tests/ui/format_args.stderr
@@ -1,5 +1,5 @@
 error: `to_string` applied to a type that implements `Display` in `format!` args
-  --> $DIR/format_args.rs:74:72
+  --> $DIR/format_args.rs:76:72
    |
 LL |     let _ = format!("error: something failed at {}", Location::caller().to_string());
    |                                                                        ^^^^^^^^^^^^ help: remove this
@@ -7,133 +7,133 @@ LL |     let _ = format!("error: something failed at {}", Location::caller().to_
    = note: `-D clippy::to-string-in-format-args` implied by `-D warnings`
 
 error: `to_string` applied to a type that implements `Display` in `write!` args
-  --> $DIR/format_args.rs:78:27
+  --> $DIR/format_args.rs:80:27
    |
 LL |         Location::caller().to_string()
    |                           ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `writeln!` args
-  --> $DIR/format_args.rs:83:27
+  --> $DIR/format_args.rs:85:27
    |
 LL |         Location::caller().to_string()
    |                           ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `print!` args
-  --> $DIR/format_args.rs:85:63
+  --> $DIR/format_args.rs:87:63
    |
 LL |     print!("error: something failed at {}", Location::caller().to_string());
    |                                                               ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:86:65
+  --> $DIR/format_args.rs:88:65
    |
 LL |     println!("error: something failed at {}", Location::caller().to_string());
    |                                                                 ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `eprint!` args
-  --> $DIR/format_args.rs:87:64
+  --> $DIR/format_args.rs:89:64
    |
 LL |     eprint!("error: something failed at {}", Location::caller().to_string());
    |                                                                ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `eprintln!` args
-  --> $DIR/format_args.rs:88:66
+  --> $DIR/format_args.rs:90:66
    |
 LL |     eprintln!("error: something failed at {}", Location::caller().to_string());
    |                                                                  ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `format_args!` args
-  --> $DIR/format_args.rs:89:77
+  --> $DIR/format_args.rs:91:77
    |
 LL |     let _ = format_args!("error: something failed at {}", Location::caller().to_string());
    |                                                                             ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `assert!` args
-  --> $DIR/format_args.rs:90:70
+  --> $DIR/format_args.rs:92:70
    |
 LL |     assert!(true, "error: something failed at {}", Location::caller().to_string());
    |                                                                      ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `assert_eq!` args
-  --> $DIR/format_args.rs:91:73
+  --> $DIR/format_args.rs:93:73
    |
 LL |     assert_eq!(0, 0, "error: something failed at {}", Location::caller().to_string());
    |                                                                         ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `assert_ne!` args
-  --> $DIR/format_args.rs:92:73
+  --> $DIR/format_args.rs:94:73
    |
 LL |     assert_ne!(0, 0, "error: something failed at {}", Location::caller().to_string());
    |                                                                         ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `panic!` args
-  --> $DIR/format_args.rs:93:63
+  --> $DIR/format_args.rs:95:63
    |
 LL |     panic!("error: something failed at {}", Location::caller().to_string());
    |                                                               ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:94:20
+  --> $DIR/format_args.rs:96:20
    |
 LL |     println!("{}", X(1).to_string());
    |                    ^^^^^^^^^^^^^^^^ help: use this: `*X(1)`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:95:20
+  --> $DIR/format_args.rs:97:20
    |
 LL |     println!("{}", Y(&X(1)).to_string());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: use this: `***Y(&X(1))`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:96:24
+  --> $DIR/format_args.rs:98:24
    |
 LL |     println!("{}", Z(1).to_string());
    |                        ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:97:20
+  --> $DIR/format_args.rs:99:20
    |
 LL |     println!("{}", x.to_string());
    |                    ^^^^^^^^^^^^^ help: use this: `**x`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:98:20
+  --> $DIR/format_args.rs:100:20
    |
 LL |     println!("{}", x_ref.to_string());
    |                    ^^^^^^^^^^^^^^^^^ help: use this: `***x_ref`
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:100:39
+  --> $DIR/format_args.rs:102:39
    |
 LL |     println!("{foo}{bar}", foo = "foo".to_string(), bar = "bar");
    |                                       ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:101:52
+  --> $DIR/format_args.rs:103:52
    |
 LL |     println!("{foo}{bar}", foo = "foo", bar = "bar".to_string());
    |                                                    ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:102:39
+  --> $DIR/format_args.rs:104:39
    |
 LL |     println!("{foo}{bar}", bar = "bar".to_string(), foo = "foo");
    |                                       ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:103:52
+  --> $DIR/format_args.rs:105:52
    |
 LL |     println!("{foo}{bar}", bar = "bar", foo = "foo".to_string());
    |                                                    ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `format!` args
-  --> $DIR/format_args.rs:142:38
+  --> $DIR/format_args.rs:144:38
    |
 LL |         let x = format!("{} {}", a, b.to_string());
    |                                      ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> $DIR/format_args.rs:156:24
+  --> $DIR/format_args.rs:158:24
    |
 LL |         println!("{}", original[..10].to_string());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use this: `&original[..10]`

--- a/tests/ui/format_args_unfixable.rs
+++ b/tests/ui/format_args_unfixable.rs
@@ -1,7 +1,5 @@
-#![allow(clippy::assertions_on_constants)]
-#![allow(clippy::eq_op)]
-#![warn(clippy::format_in_format_args)]
-#![warn(clippy::to_string_in_format_args)]
+#![warn(clippy::format_in_format_args, clippy::to_string_in_format_args)]
+#![allow(clippy::assertions_on_constants, clippy::eq_op, clippy::uninlined_format_args)]
 
 use std::io::{stdout, Error, ErrorKind, Write};
 use std::ops::Deref;

--- a/tests/ui/format_args_unfixable.stderr
+++ b/tests/ui/format_args_unfixable.stderr
@@ -1,5 +1,5 @@
 error: `format!` in `println!` args
-  --> $DIR/format_args_unfixable.rs:27:5
+  --> $DIR/format_args_unfixable.rs:25:5
    |
 LL |     println!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     println!("error: {}", format!("something failed at {}", Location::calle
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> $DIR/format_args_unfixable.rs:28:5
+  --> $DIR/format_args_unfixable.rs:26:5
    |
 LL |     println!("{}: {}", error, format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL |     println!("{}: {}", error, format!("something failed at {}", Location::c
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> $DIR/format_args_unfixable.rs:29:5
+  --> $DIR/format_args_unfixable.rs:27:5
    |
 LL |     println!("{:?}: {}", error, format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     println!("{:?}: {}", error, format!("something failed at {}", Location:
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> $DIR/format_args_unfixable.rs:30:5
+  --> $DIR/format_args_unfixable.rs:28:5
    |
 LL |     println!("{{}}: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     println!("{{}}: {}", format!("something failed at {}", Location::caller
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> $DIR/format_args_unfixable.rs:31:5
+  --> $DIR/format_args_unfixable.rs:29:5
    |
 LL |     println!(r#"error: "{}""#, format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     println!(r#"error: "{}""#, format!("something failed at {}", Location::
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> $DIR/format_args_unfixable.rs:32:5
+  --> $DIR/format_args_unfixable.rs:30:5
    |
 LL |     println!("error: {}", format!(r#"something failed at "{}""#, Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,7 +54,7 @@ LL |     println!("error: {}", format!(r#"something failed at "{}""#, Location::
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `println!` args
-  --> $DIR/format_args_unfixable.rs:33:5
+  --> $DIR/format_args_unfixable.rs:31:5
    |
 LL |     println!("error: {}", format!("something failed at {} {0}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     println!("error: {}", format!("something failed at {} {0}", Location::c
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `format!` args
-  --> $DIR/format_args_unfixable.rs:34:13
+  --> $DIR/format_args_unfixable.rs:32:13
    |
 LL |     let _ = format!("error: {}", format!("something failed at {}", Location::caller()));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     let _ = format!("error: {}", format!("something failed at {}", Location
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `write!` args
-  --> $DIR/format_args_unfixable.rs:35:13
+  --> $DIR/format_args_unfixable.rs:33:13
    |
 LL |       let _ = write!(
    |  _____________^
@@ -86,7 +86,7 @@ LL | |     );
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `writeln!` args
-  --> $DIR/format_args_unfixable.rs:40:13
+  --> $DIR/format_args_unfixable.rs:38:13
    |
 LL |       let _ = writeln!(
    |  _____________^
@@ -100,7 +100,7 @@ LL | |     );
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `print!` args
-  --> $DIR/format_args_unfixable.rs:45:5
+  --> $DIR/format_args_unfixable.rs:43:5
    |
 LL |     print!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     print!("error: {}", format!("something failed at {}", Location::caller(
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `eprint!` args
-  --> $DIR/format_args_unfixable.rs:46:5
+  --> $DIR/format_args_unfixable.rs:44:5
    |
 LL |     eprint!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL |     eprint!("error: {}", format!("something failed at {}", Location::caller
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `eprintln!` args
-  --> $DIR/format_args_unfixable.rs:47:5
+  --> $DIR/format_args_unfixable.rs:45:5
    |
 LL |     eprintln!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |     eprintln!("error: {}", format!("something failed at {}", Location::call
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `format_args!` args
-  --> $DIR/format_args_unfixable.rs:48:13
+  --> $DIR/format_args_unfixable.rs:46:13
    |
 LL |     let _ = format_args!("error: {}", format!("something failed at {}", Location::caller()));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +136,7 @@ LL |     let _ = format_args!("error: {}", format!("something failed at {}", Loc
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `assert!` args
-  --> $DIR/format_args_unfixable.rs:49:5
+  --> $DIR/format_args_unfixable.rs:47:5
    |
 LL |     assert!(true, "error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL |     assert!(true, "error: {}", format!("something failed at {}", Location::
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `assert_eq!` args
-  --> $DIR/format_args_unfixable.rs:50:5
+  --> $DIR/format_args_unfixable.rs:48:5
    |
 LL |     assert_eq!(0, 0, "error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,7 +154,7 @@ LL |     assert_eq!(0, 0, "error: {}", format!("something failed at {}", Locatio
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `assert_ne!` args
-  --> $DIR/format_args_unfixable.rs:51:5
+  --> $DIR/format_args_unfixable.rs:49:5
    |
 LL |     assert_ne!(0, 0, "error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +163,7 @@ LL |     assert_ne!(0, 0, "error: {}", format!("something failed at {}", Locatio
    = help: or consider changing `format!` to `format_args!`
 
 error: `format!` in `panic!` args
-  --> $DIR/format_args_unfixable.rs:52:5
+  --> $DIR/format_args_unfixable.rs:50:5
    |
 LL |     panic!("error: {}", format!("something failed at {}", Location::caller()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/functions.rs
+++ b/tests/ui/functions.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::all)]
-#![allow(dead_code)]
-#![allow(unused_unsafe, clippy::missing_safety_doc)]
+#![allow(dead_code, unused_unsafe)]
+#![allow(clippy::missing_safety_doc, clippy::uninlined_format_args)]
 
 // TOO_MANY_ARGUMENTS
 fn good(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f32, _seven: bool) {}

--- a/tests/ui/identity_op.fixed
+++ b/tests/ui/identity_op.fixed
@@ -1,13 +1,13 @@
 // run-rustfix
-
 #![warn(clippy::identity_op)]
+#![allow(unused)]
 #![allow(
     clippy::eq_op,
     clippy::no_effect,
     clippy::unnecessary_operation,
     clippy::op_ref,
     clippy::double_parens,
-    unused
+    clippy::uninlined_format_args
 )]
 
 use std::fmt::Write as _;

--- a/tests/ui/identity_op.rs
+++ b/tests/ui/identity_op.rs
@@ -1,13 +1,13 @@
 // run-rustfix
-
 #![warn(clippy::identity_op)]
+#![allow(unused)]
 #![allow(
     clippy::eq_op,
     clippy::no_effect,
     clippy::unnecessary_operation,
     clippy::op_ref,
     clippy::double_parens,
-    unused
+    clippy::uninlined_format_args
 )]
 
 use std::fmt::Write as _;

--- a/tests/ui/index_refutable_slice/if_let_slice_binding.rs
+++ b/tests/ui/index_refutable_slice/if_let_slice_binding.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
+#![allow(clippy::uninlined_format_args)]
 
 enum SomeEnum<T> {
     One(T),

--- a/tests/ui/index_refutable_slice/if_let_slice_binding.stderr
+++ b/tests/ui/index_refutable_slice/if_let_slice_binding.stderr
@@ -1,5 +1,5 @@
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:13:17
+  --> $DIR/if_let_slice_binding.rs:14:17
    |
 LL |     if let Some(slice) = slice {
    |                 ^^^^^
@@ -19,7 +19,7 @@ LL |         println!("{}", slice_0);
    |                        ~~~~~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:19:17
+  --> $DIR/if_let_slice_binding.rs:20:17
    |
 LL |     if let Some(slice) = slice {
    |                 ^^^^^
@@ -34,7 +34,7 @@ LL |         println!("{}", slice_0);
    |                        ~~~~~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:25:17
+  --> $DIR/if_let_slice_binding.rs:26:17
    |
 LL |     if let Some(slice) = slice {
    |                 ^^^^^
@@ -50,7 +50,7 @@ LL ~         println!("{}", slice_0);
    |
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:32:26
+  --> $DIR/if_let_slice_binding.rs:33:26
    |
 LL |     if let SomeEnum::One(slice) | SomeEnum::Three(slice) = slice_wrapped {
    |                          ^^^^^
@@ -65,7 +65,7 @@ LL |         println!("{}", slice_0);
    |                        ~~~~~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:39:29
+  --> $DIR/if_let_slice_binding.rs:40:29
    |
 LL |     if let (SomeEnum::Three(a), Some(b)) = (a_wrapped, b_wrapped) {
    |                             ^
@@ -80,7 +80,7 @@ LL |         println!("{} -> {}", a_2, b[1]);
    |                              ~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:39:38
+  --> $DIR/if_let_slice_binding.rs:40:38
    |
 LL |     if let (SomeEnum::Three(a), Some(b)) = (a_wrapped, b_wrapped) {
    |                                      ^
@@ -95,7 +95,7 @@ LL |         println!("{} -> {}", a[2], b_1);
    |                                    ~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:46:21
+  --> $DIR/if_let_slice_binding.rs:47:21
    |
 LL |     if let Some(ref slice) = slice {
    |                     ^^^^^
@@ -110,7 +110,7 @@ LL |         println!("{:?}", slice_1);
    |                          ~~~~~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:54:17
+  --> $DIR/if_let_slice_binding.rs:55:17
    |
 LL |     if let Some(slice) = &slice {
    |                 ^^^^^
@@ -125,7 +125,7 @@ LL |         println!("{:?}", slice_0);
    |                          ~~~~~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:123:17
+  --> $DIR/if_let_slice_binding.rs:124:17
    |
 LL |     if let Some(slice) = wrap.inner {
    |                 ^^^^^
@@ -140,7 +140,7 @@ LL |             println!("This is awesome! {}", slice_0);
    |                                             ~~~~~~~
 
 error: this binding can be a slice pattern to avoid indexing
-  --> $DIR/if_let_slice_binding.rs:130:17
+  --> $DIR/if_let_slice_binding.rs:131:17
    |
 LL |     if let Some(slice) = wrap.inner {
    |                 ^^^^^

--- a/tests/ui/infinite_iter.rs
+++ b/tests/ui/infinite_iter.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+
 use std::iter::repeat;
 fn square_is_lower_64(x: &u32) -> bool {
     x * x < 64

--- a/tests/ui/infinite_iter.stderr
+++ b/tests/ui/infinite_iter.stderr
@@ -1,29 +1,29 @@
 error: infinite iteration detected
-  --> $DIR/infinite_iter.rs:9:5
+  --> $DIR/infinite_iter.rs:11:5
    |
 LL |     repeat(0_u8).collect::<Vec<_>>(); // infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/infinite_iter.rs:7:8
+  --> $DIR/infinite_iter.rs:9:8
    |
 LL | #[deny(clippy::infinite_iter)]
    |        ^^^^^^^^^^^^^^^^^^^^^
 
 error: infinite iteration detected
-  --> $DIR/infinite_iter.rs:10:5
+  --> $DIR/infinite_iter.rs:12:5
    |
 LL |     (0..8_u32).take_while(square_is_lower_64).cycle().count(); // infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: infinite iteration detected
-  --> $DIR/infinite_iter.rs:11:5
+  --> $DIR/infinite_iter.rs:13:5
    |
 LL |     (0..8_u64).chain(0..).max(); // infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: infinite iteration detected
-  --> $DIR/infinite_iter.rs:16:5
+  --> $DIR/infinite_iter.rs:18:5
    |
 LL | /     (0..8_u32)
 LL | |         .rev()
@@ -33,37 +33,37 @@ LL | |         .for_each(|x| println!("{}", x)); // infinite iter
    | |________________________________________^
 
 error: infinite iteration detected
-  --> $DIR/infinite_iter.rs:22:5
+  --> $DIR/infinite_iter.rs:24:5
    |
 LL |     (0_usize..).flat_map(|x| 0..x).product::<usize>(); // infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: infinite iteration detected
-  --> $DIR/infinite_iter.rs:23:5
+  --> $DIR/infinite_iter.rs:25:5
    |
 LL |     (0_u64..).filter(|x| x % 2 == 0).last(); // infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: possible infinite iteration detected
-  --> $DIR/infinite_iter.rs:30:5
+  --> $DIR/infinite_iter.rs:32:5
    |
 LL |     (0..).zip((0..).take_while(square_is_lower_64)).count(); // maybe infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/infinite_iter.rs:28:8
+  --> $DIR/infinite_iter.rs:30:8
    |
 LL | #[deny(clippy::maybe_infinite_iter)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: possible infinite iteration detected
-  --> $DIR/infinite_iter.rs:31:5
+  --> $DIR/infinite_iter.rs:33:5
    |
 LL |     repeat(42).take_while(|x| *x == 42).chain(0..42).max(); // maybe infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: possible infinite iteration detected
-  --> $DIR/infinite_iter.rs:32:5
+  --> $DIR/infinite_iter.rs:34:5
    |
 LL | /     (1..)
 LL | |         .scan(0, |state, x| {
@@ -74,31 +74,31 @@ LL | |         .min(); // maybe infinite iter
    | |______________^
 
 error: possible infinite iteration detected
-  --> $DIR/infinite_iter.rs:38:5
+  --> $DIR/infinite_iter.rs:40:5
    |
 LL |     (0..).find(|x| *x == 24); // maybe infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: possible infinite iteration detected
-  --> $DIR/infinite_iter.rs:39:5
+  --> $DIR/infinite_iter.rs:41:5
    |
 LL |     (0..).position(|x| x == 24); // maybe infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: possible infinite iteration detected
-  --> $DIR/infinite_iter.rs:40:5
+  --> $DIR/infinite_iter.rs:42:5
    |
 LL |     (0..).any(|x| x == 24); // maybe infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: possible infinite iteration detected
-  --> $DIR/infinite_iter.rs:41:5
+  --> $DIR/infinite_iter.rs:43:5
    |
 LL |     (0..).all(|x| x == 24); // maybe infinite iter
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: infinite iteration detected
-  --> $DIR/infinite_iter.rs:63:31
+  --> $DIR/infinite_iter.rs:65:31
    |
 LL |         let _: HashSet<i32> = (0..).collect(); // Infinite iter
    |                               ^^^^^^^^^^^^^^^

--- a/tests/ui/issue_2356.fixed
+++ b/tests/ui/issue_2356.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
 #![deny(clippy::while_let_on_iterator)]
 #![allow(unused_mut)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::iter::Iterator;
 

--- a/tests/ui/issue_2356.rs
+++ b/tests/ui/issue_2356.rs
@@ -1,6 +1,7 @@
 // run-rustfix
 #![deny(clippy::while_let_on_iterator)]
 #![allow(unused_mut)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::iter::Iterator;
 

--- a/tests/ui/issue_2356.stderr
+++ b/tests/ui/issue_2356.stderr
@@ -1,5 +1,5 @@
 error: this loop could be written as a `for` loop
-  --> $DIR/issue_2356.rs:17:9
+  --> $DIR/issue_2356.rs:18:9
    |
 LL |         while let Some(e) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for e in it`

--- a/tests/ui/issue_4266.rs
+++ b/tests/ui/issue_4266.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(clippy::uninlined_format_args)]
 
 async fn sink1<'a>(_: &'a str) {} // lint
 async fn sink1_elided(_: &str) {} // ok

--- a/tests/ui/issue_4266.stderr
+++ b/tests/ui/issue_4266.stderr
@@ -1,5 +1,5 @@
 error: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
-  --> $DIR/issue_4266.rs:3:1
+  --> $DIR/issue_4266.rs:4:1
    |
 LL | async fn sink1<'a>(_: &'a str) {} // lint
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL | async fn sink1<'a>(_: &'a str) {} // lint
    = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
 
 error: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
-  --> $DIR/issue_4266.rs:7:1
+  --> $DIR/issue_4266.rs:8:1
    |
 LL | async fn one_to_one<'a>(s: &'a str) -> &'a str {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: methods called `new` usually take no `self`
-  --> $DIR/issue_4266.rs:27:22
+  --> $DIR/issue_4266.rs:28:22
    |
 LL |     pub async fn new(&mut self) -> Self {
    |                      ^^^^^^^^^

--- a/tests/ui/item_after_statement.rs
+++ b/tests/ui/item_after_statement.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::items_after_statements)]
+#![allow(clippy::uninlined_format_args)]
 
 fn ok() {
     fn foo() {

--- a/tests/ui/item_after_statement.stderr
+++ b/tests/ui/item_after_statement.stderr
@@ -1,5 +1,5 @@
 error: adding items after statements is confusing, since items exist from the start of the scope
-  --> $DIR/item_after_statement.rs:12:5
+  --> $DIR/item_after_statement.rs:13:5
    |
 LL | /     fn foo() {
 LL | |         println!("foo");
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::items-after-statements` implied by `-D warnings`
 
 error: adding items after statements is confusing, since items exist from the start of the scope
-  --> $DIR/item_after_statement.rs:19:5
+  --> $DIR/item_after_statement.rs:20:5
    |
 LL | /     fn foo() {
 LL | |         println!("foo");
@@ -17,7 +17,7 @@ LL | |     }
    | |_____^
 
 error: adding items after statements is confusing, since items exist from the start of the scope
-  --> $DIR/item_after_statement.rs:32:13
+  --> $DIR/item_after_statement.rs:33:13
    |
 LL | /             fn say_something() {
 LL | |                 println!("something");

--- a/tests/ui/manual_assert.edition2018.fixed
+++ b/tests/ui/manual_assert.edition2018.fixed
@@ -4,7 +4,8 @@
 // run-rustfix
 
 #![warn(clippy::manual_assert)]
-#![allow(dead_code, unused_doc_comments, clippy::nonminimal_bool)]
+#![allow(dead_code, unused_doc_comments)]
+#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args)]
 
 macro_rules! one {
     () => {

--- a/tests/ui/manual_assert.edition2018.stderr
+++ b/tests/ui/manual_assert.edition2018.stderr
@@ -1,5 +1,5 @@
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:30:5
+  --> $DIR/manual_assert.rs:31:5
    |
 LL | /     if !a.is_empty() {
 LL | |         panic!("qaqaq{:?}", a);
@@ -13,7 +13,7 @@ LL |     assert!(a.is_empty(), "qaqaq{:?}", a);
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:33:5
+  --> $DIR/manual_assert.rs:34:5
    |
 LL | /     if !a.is_empty() {
 LL | |         panic!("qwqwq");
@@ -26,7 +26,7 @@ LL |     assert!(a.is_empty(), "qwqwq");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:50:5
+  --> $DIR/manual_assert.rs:51:5
    |
 LL | /     if b.is_empty() {
 LL | |         panic!("panic1");
@@ -39,7 +39,7 @@ LL |     assert!(!b.is_empty(), "panic1");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:53:5
+  --> $DIR/manual_assert.rs:54:5
    |
 LL | /     if b.is_empty() && a.is_empty() {
 LL | |         panic!("panic2");
@@ -52,7 +52,7 @@ LL |     assert!(!(b.is_empty() && a.is_empty()), "panic2");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:56:5
+  --> $DIR/manual_assert.rs:57:5
    |
 LL | /     if a.is_empty() && !b.is_empty() {
 LL | |         panic!("panic3");
@@ -65,7 +65,7 @@ LL |     assert!(!(a.is_empty() && !b.is_empty()), "panic3");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:59:5
+  --> $DIR/manual_assert.rs:60:5
    |
 LL | /     if b.is_empty() || a.is_empty() {
 LL | |         panic!("panic4");
@@ -78,7 +78,7 @@ LL |     assert!(!(b.is_empty() || a.is_empty()), "panic4");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:62:5
+  --> $DIR/manual_assert.rs:63:5
    |
 LL | /     if a.is_empty() || !b.is_empty() {
 LL | |         panic!("panic5");
@@ -91,7 +91,7 @@ LL |     assert!(!(a.is_empty() || !b.is_empty()), "panic5");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:65:5
+  --> $DIR/manual_assert.rs:66:5
    |
 LL | /     if a.is_empty() {
 LL | |         panic!("with expansion {}", one!())
@@ -104,7 +104,7 @@ LL |     assert!(!a.is_empty(), "with expansion {}", one!());
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:72:5
+  --> $DIR/manual_assert.rs:73:5
    |
 LL | /     if a > 2 {
 LL | |         // comment

--- a/tests/ui/manual_assert.edition2021.fixed
+++ b/tests/ui/manual_assert.edition2021.fixed
@@ -4,7 +4,8 @@
 // run-rustfix
 
 #![warn(clippy::manual_assert)]
-#![allow(dead_code, unused_doc_comments, clippy::nonminimal_bool)]
+#![allow(dead_code, unused_doc_comments)]
+#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args)]
 
 macro_rules! one {
     () => {

--- a/tests/ui/manual_assert.edition2021.stderr
+++ b/tests/ui/manual_assert.edition2021.stderr
@@ -1,5 +1,5 @@
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:30:5
+  --> $DIR/manual_assert.rs:31:5
    |
 LL | /     if !a.is_empty() {
 LL | |         panic!("qaqaq{:?}", a);
@@ -13,7 +13,7 @@ LL |     assert!(a.is_empty(), "qaqaq{:?}", a);
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:33:5
+  --> $DIR/manual_assert.rs:34:5
    |
 LL | /     if !a.is_empty() {
 LL | |         panic!("qwqwq");
@@ -26,7 +26,7 @@ LL |     assert!(a.is_empty(), "qwqwq");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:50:5
+  --> $DIR/manual_assert.rs:51:5
    |
 LL | /     if b.is_empty() {
 LL | |         panic!("panic1");
@@ -39,7 +39,7 @@ LL |     assert!(!b.is_empty(), "panic1");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:53:5
+  --> $DIR/manual_assert.rs:54:5
    |
 LL | /     if b.is_empty() && a.is_empty() {
 LL | |         panic!("panic2");
@@ -52,7 +52,7 @@ LL |     assert!(!(b.is_empty() && a.is_empty()), "panic2");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:56:5
+  --> $DIR/manual_assert.rs:57:5
    |
 LL | /     if a.is_empty() && !b.is_empty() {
 LL | |         panic!("panic3");
@@ -65,7 +65,7 @@ LL |     assert!(!(a.is_empty() && !b.is_empty()), "panic3");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:59:5
+  --> $DIR/manual_assert.rs:60:5
    |
 LL | /     if b.is_empty() || a.is_empty() {
 LL | |         panic!("panic4");
@@ -78,7 +78,7 @@ LL |     assert!(!(b.is_empty() || a.is_empty()), "panic4");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:62:5
+  --> $DIR/manual_assert.rs:63:5
    |
 LL | /     if a.is_empty() || !b.is_empty() {
 LL | |         panic!("panic5");
@@ -91,7 +91,7 @@ LL |     assert!(!(a.is_empty() || !b.is_empty()), "panic5");
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:65:5
+  --> $DIR/manual_assert.rs:66:5
    |
 LL | /     if a.is_empty() {
 LL | |         panic!("with expansion {}", one!())
@@ -104,7 +104,7 @@ LL |     assert!(!a.is_empty(), "with expansion {}", one!());
    |
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:72:5
+  --> $DIR/manual_assert.rs:73:5
    |
 LL | /     if a > 2 {
 LL | |         // comment

--- a/tests/ui/manual_assert.rs
+++ b/tests/ui/manual_assert.rs
@@ -4,7 +4,8 @@
 // run-rustfix
 
 #![warn(clippy::manual_assert)]
-#![allow(dead_code, unused_doc_comments, clippy::nonminimal_bool)]
+#![allow(dead_code, unused_doc_comments)]
+#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args)]
 
 macro_rules! one {
     () => {

--- a/tests/ui/manual_find_fixable.fixed
+++ b/tests/ui/manual_find_fixable.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
-
-#![allow(unused, clippy::needless_return)]
 #![warn(clippy::manual_find)]
+#![allow(unused)]
+#![allow(clippy::needless_return, clippy::uninlined_format_args)]
 
 use std::collections::HashMap;
 

--- a/tests/ui/manual_find_fixable.rs
+++ b/tests/ui/manual_find_fixable.rs
@@ -1,7 +1,7 @@
 // run-rustfix
-
-#![allow(unused, clippy::needless_return)]
 #![warn(clippy::manual_find)]
+#![allow(unused)]
+#![allow(clippy::needless_return, clippy::uninlined_format_args)]
 
 use std::collections::HashMap;
 

--- a/tests/ui/manual_flatten.rs
+++ b/tests/ui/manual_flatten.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_flatten)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::uninlined_format_args)]
 
 fn main() {
     // Test for loop over implicitly adjusted `Iterator` with `if let` expression

--- a/tests/ui/map_unwrap_or.rs
+++ b/tests/ui/map_unwrap_or.rs
@@ -1,6 +1,6 @@
 // aux-build:option_helpers.rs
-
 #![warn(clippy::map_unwrap_or)]
+#![allow(clippy::uninlined_format_args)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/match_ref_pats.fixed
+++ b/tests/ui/match_ref_pats.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
 #![warn(clippy::match_ref_pats)]
-#![allow(dead_code, unused_variables, clippy::equatable_if_let, clippy::enum_variant_names)]
+#![allow(dead_code, unused_variables)]
+#![allow(clippy::enum_variant_names, clippy::equatable_if_let, clippy::uninlined_format_args)]
 
 fn ref_pats() {
     {

--- a/tests/ui/match_ref_pats.rs
+++ b/tests/ui/match_ref_pats.rs
@@ -1,6 +1,7 @@
 // run-rustfix
 #![warn(clippy::match_ref_pats)]
-#![allow(dead_code, unused_variables, clippy::equatable_if_let, clippy::enum_variant_names)]
+#![allow(dead_code, unused_variables)]
+#![allow(clippy::enum_variant_names, clippy::equatable_if_let, clippy::uninlined_format_args)]
 
 fn ref_pats() {
     {

--- a/tests/ui/match_ref_pats.stderr
+++ b/tests/ui/match_ref_pats.stderr
@@ -1,5 +1,5 @@
 error: you don't need to add `&` to all patterns
-  --> $DIR/match_ref_pats.rs:8:9
+  --> $DIR/match_ref_pats.rs:9:9
    |
 LL | /         match v {
 LL | |             &Some(v) => println!("{:?}", v),
@@ -16,7 +16,7 @@ LL ~             None => println!("none"),
    |
 
 error: you don't need to add `&` to both the expression and the patterns
-  --> $DIR/match_ref_pats.rs:25:5
+  --> $DIR/match_ref_pats.rs:26:5
    |
 LL | /     match &w {
 LL | |         &Some(v) => println!("{:?}", v),
@@ -32,7 +32,7 @@ LL ~         None => println!("none"),
    |
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/match_ref_pats.rs:37:12
+  --> $DIR/match_ref_pats.rs:38:12
    |
 LL |     if let &None = a {
    |     -------^^^^^---- help: try this: `if a.is_none()`
@@ -40,13 +40,13 @@ LL |     if let &None = a {
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/match_ref_pats.rs:42:12
+  --> $DIR/match_ref_pats.rs:43:12
    |
 LL |     if let &None = &b {
    |     -------^^^^^----- help: try this: `if b.is_none()`
 
 error: you don't need to add `&` to all patterns
-  --> $DIR/match_ref_pats.rs:102:9
+  --> $DIR/match_ref_pats.rs:103:9
    |
 LL | /         match foobar_variant!(0) {
 LL | |             &FooBar::Foo => println!("Foo"),

--- a/tests/ui/match_result_ok.fixed
+++ b/tests/ui/match_result_ok.fixed
@@ -1,8 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::match_result_ok)]
-#![allow(clippy::boxed_local)]
 #![allow(dead_code)]
+#![allow(clippy::boxed_local, clippy::uninlined_format_args)]
 
 // Checking `if` cases
 

--- a/tests/ui/match_result_ok.rs
+++ b/tests/ui/match_result_ok.rs
@@ -1,8 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::match_result_ok)]
-#![allow(clippy::boxed_local)]
 #![allow(dead_code)]
+#![allow(clippy::boxed_local, clippy::uninlined_format_args)]
 
 // Checking `if` cases
 

--- a/tests/ui/match_result_ok.stderr
+++ b/tests/ui/match_result_ok.stderr
@@ -1,5 +1,5 @@
 error: matching on `Some` with `ok()` is redundant
-  --> $DIR/match_result_ok.rs:10:5
+  --> $DIR/match_result_ok.rs:9:5
    |
 LL |     if let Some(y) = x.parse().ok() { y } else { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     if let Ok(y) = x.parse() { y } else { 0 }
    |     ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: matching on `Some` with `ok()` is redundant
-  --> $DIR/match_result_ok.rs:20:9
+  --> $DIR/match_result_ok.rs:19:9
    |
 LL |         if let Some(y) = x   .   parse()   .   ok   ()    {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |         if let Ok(y) = x   .   parse()       {
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: matching on `Some` with `ok()` is redundant
-  --> $DIR/match_result_ok.rs:46:5
+  --> $DIR/match_result_ok.rs:45:5
    |
 LL |     while let Some(a) = wat.next().ok() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/match_same_arms2.rs
+++ b/tests/ui/match_same_arms2.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::match_same_arms)]
-#![allow(clippy::disallowed_names, clippy::diverging_sub_expression)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::diverging_sub_expression,
+    clippy::uninlined_format_args
+)]
 
 fn bar<T>(_: T) {}
 fn foo() -> bool {

--- a/tests/ui/match_same_arms2.stderr
+++ b/tests/ui/match_same_arms2.stderr
@@ -1,5 +1,5 @@
 error: this match arm has an identical body to the `_` wildcard arm
-  --> $DIR/match_same_arms2.rs:11:9
+  --> $DIR/match_same_arms2.rs:15:9
    |
 LL | /         42 => {
 LL | |             foo();
@@ -13,7 +13,7 @@ LL | |         },
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
    = help: or try changing either arm body
 note: `_` wildcard arm here
-  --> $DIR/match_same_arms2.rs:20:9
+  --> $DIR/match_same_arms2.rs:24:9
    |
 LL | /         _ => {
 LL | |             //~ ERROR match arms have same body
@@ -25,7 +25,7 @@ LL | |         },
    | |_________^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:34:9
+  --> $DIR/match_same_arms2.rs:38:9
    |
 LL |         51 => foo(), //~ ERROR match arms have same body
    |         --^^^^^^^^^
@@ -34,13 +34,13 @@ LL |         51 => foo(), //~ ERROR match arms have same body
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:33:9
+  --> $DIR/match_same_arms2.rs:37:9
    |
 LL |         42 => foo(),
    |         ^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:40:9
+  --> $DIR/match_same_arms2.rs:44:9
    |
 LL |         None => 24, //~ ERROR match arms have same body
    |         ----^^^^^^
@@ -49,13 +49,13 @@ LL |         None => 24, //~ ERROR match arms have same body
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:39:9
+  --> $DIR/match_same_arms2.rs:43:9
    |
 LL |         Some(_) => 24,
    |         ^^^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:62:9
+  --> $DIR/match_same_arms2.rs:66:9
    |
 LL |         (None, Some(a)) => bar(a), //~ ERROR match arms have same body
    |         ---------------^^^^^^^^^^
@@ -64,13 +64,13 @@ LL |         (None, Some(a)) => bar(a), //~ ERROR match arms have same body
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:61:9
+  --> $DIR/match_same_arms2.rs:65:9
    |
 LL |         (Some(a), None) => bar(a),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:67:9
+  --> $DIR/match_same_arms2.rs:71:9
    |
 LL |         (Some(a), ..) => bar(a),
    |         -------------^^^^^^^^^^
@@ -79,13 +79,13 @@ LL |         (Some(a), ..) => bar(a),
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:68:9
+  --> $DIR/match_same_arms2.rs:72:9
    |
 LL |         (.., Some(a)) => bar(a), //~ ERROR match arms have same body
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:101:9
+  --> $DIR/match_same_arms2.rs:105:9
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
    |         ----------------^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,13 +94,13 @@ LL |         (Ok(x), Some(_)) => println!("ok {}", x),
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:102:9
+  --> $DIR/match_same_arms2.rs:106:9
    |
 LL |         (Ok(_), Some(x)) => println!("ok {}", x),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:117:9
+  --> $DIR/match_same_arms2.rs:121:9
    |
 LL |         Ok(_) => println!("ok"),
    |         -----^^^^^^^^^^^^^^^^^^
@@ -109,13 +109,13 @@ LL |         Ok(_) => println!("ok"),
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:116:9
+  --> $DIR/match_same_arms2.rs:120:9
    |
 LL |         Ok(3) => println!("ok"),
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:144:9
+  --> $DIR/match_same_arms2.rs:148:9
    |
 LL |           1 => {
    |           ^ help: try merging the arm patterns: `1 | 0`
@@ -127,7 +127,7 @@ LL | |         },
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:141:9
+  --> $DIR/match_same_arms2.rs:145:9
    |
 LL | /         0 => {
 LL | |             empty!(0);
@@ -135,7 +135,7 @@ LL | |         },
    | |_________^
 
 error: match expression looks like `matches!` macro
-  --> $DIR/match_same_arms2.rs:162:16
+  --> $DIR/match_same_arms2.rs:166:16
    |
 LL |       let _ans = match x {
    |  ________________^
@@ -148,7 +148,7 @@ LL | |     };
    = note: `-D clippy::match-like-matches-macro` implied by `-D warnings`
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:194:9
+  --> $DIR/match_same_arms2.rs:198:9
    |
 LL |         Foo::X(0) => 1,
    |         ---------^^^^^
@@ -157,13 +157,13 @@ LL |         Foo::X(0) => 1,
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:196:9
+  --> $DIR/match_same_arms2.rs:200:9
    |
 LL |         Foo::Z(_) => 1,
    |         ^^^^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:204:9
+  --> $DIR/match_same_arms2.rs:208:9
    |
 LL |         Foo::Z(_) => 1,
    |         ---------^^^^^
@@ -172,13 +172,13 @@ LL |         Foo::Z(_) => 1,
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:202:9
+  --> $DIR/match_same_arms2.rs:206:9
    |
 LL |         Foo::X(0) => 1,
    |         ^^^^^^^^^^^^^^
 
 error: this match arm has an identical body to another arm
-  --> $DIR/match_same_arms2.rs:227:9
+  --> $DIR/match_same_arms2.rs:231:9
    |
 LL |         Some(Bar { y: 0, x: 5, .. }) => 1,
    |         ----------------------------^^^^^
@@ -187,7 +187,7 @@ LL |         Some(Bar { y: 0, x: 5, .. }) => 1,
    |
    = help: or try changing either arm body
 note: other arm here
-  --> $DIR/match_same_arms2.rs:224:9
+  --> $DIR/match_same_arms2.rs:228:9
    |
 LL |         Some(Bar { x: 0, y: 5, .. }) => 1,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/match_single_binding.fixed
+++ b/tests/ui/match_single_binding.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::match_single_binding)]
-#![allow(unused_variables, clippy::toplevel_ref_arg)]
+#![allow(unused_variables)]
+#![allow(clippy::toplevel_ref_arg, clippy::uninlined_format_args)]
 
 struct Point {
     x: i32,

--- a/tests/ui/match_single_binding.rs
+++ b/tests/ui/match_single_binding.rs
@@ -1,7 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::match_single_binding)]
-#![allow(unused_variables, clippy::toplevel_ref_arg)]
+#![allow(unused_variables)]
+#![allow(clippy::toplevel_ref_arg, clippy::uninlined_format_args)]
 
 struct Point {
     x: i32,

--- a/tests/ui/match_single_binding2.fixed
+++ b/tests/ui/match_single_binding2.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::match_single_binding)]
 #![allow(unused_variables)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     // Lint (additional curly braces needed, see #6572)

--- a/tests/ui/match_single_binding2.rs
+++ b/tests/ui/match_single_binding2.rs
@@ -1,7 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::match_single_binding)]
 #![allow(unused_variables)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     // Lint (additional curly braces needed, see #6572)

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -1,7 +1,7 @@
 // aux-build:macro_rules.rs
-
-#![allow(unused, clippy::no_effect, clippy::unnecessary_operation)]
 #![warn(clippy::mut_mut)]
+#![allow(unused)]
+#![allow(clippy::no_effect, clippy::uninlined_format_args, clippy::unnecessary_operation)]
 
 #[macro_use]
 extern crate macro_rules;

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -1,9 +1,9 @@
 // run-rustfix
-
 #![feature(custom_inner_attributes, lint_reasons)]
 
 #[warn(clippy::all, clippy::needless_borrow)]
-#[allow(unused_variables, clippy::unnecessary_mut_passed)]
+#[allow(unused_variables)]
+#[allow(clippy::uninlined_format_args, clippy::unnecessary_mut_passed)]
 fn main() {
     let a = 5;
     let ref_a = &a;

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -1,9 +1,9 @@
 // run-rustfix
-
 #![feature(custom_inner_attributes, lint_reasons)]
 
 #[warn(clippy::all, clippy::needless_borrow)]
-#[allow(unused_variables, clippy::unnecessary_mut_passed)]
+#[allow(unused_variables)]
+#[allow(clippy::uninlined_format_args, clippy::unnecessary_mut_passed)]
 fn main() {
     let a = 5;
     let ref_a = &a;

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+
 use std::collections::{BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 
 fn main() {

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -1,5 +1,5 @@
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:5:39
+  --> $DIR/needless_collect_indirect.rs:7:39
    |
 LL |     let indirect_iter = sample.iter().collect::<Vec<_>>();
    |                                       ^^^^^^^
@@ -14,7 +14,7 @@ LL ~     sample.iter().map(|x| (x, x + 1)).collect::<HashMap<_, _>>();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:7:38
+  --> $DIR/needless_collect_indirect.rs:9:38
    |
 LL |     let indirect_len = sample.iter().collect::<VecDeque<_>>();
    |                                      ^^^^^^^
@@ -28,7 +28,7 @@ LL ~     sample.iter().count();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:9:40
+  --> $DIR/needless_collect_indirect.rs:11:40
    |
 LL |     let indirect_empty = sample.iter().collect::<VecDeque<_>>();
    |                                        ^^^^^^^
@@ -42,7 +42,7 @@ LL ~     sample.iter().next().is_none();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:11:43
+  --> $DIR/needless_collect_indirect.rs:13:43
    |
 LL |     let indirect_contains = sample.iter().collect::<VecDeque<_>>();
    |                                           ^^^^^^^
@@ -56,7 +56,7 @@ LL ~     sample.iter().any(|x| x == &5);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:23:48
+  --> $DIR/needless_collect_indirect.rs:25:48
    |
 LL |     let non_copy_contains = sample.into_iter().collect::<Vec<_>>();
    |                                                ^^^^^^^
@@ -70,7 +70,7 @@ LL ~     sample.into_iter().any(|x| x == a);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:52:51
+  --> $DIR/needless_collect_indirect.rs:54:51
    |
 LL |         let buffer: Vec<&str> = string.split('/').collect();
    |                                                   ^^^^^^^
@@ -84,7 +84,7 @@ LL ~         string.split('/').count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:57:55
+  --> $DIR/needless_collect_indirect.rs:59:55
    |
 LL |         let indirect_len: VecDeque<_> = sample.iter().collect();
    |                                                       ^^^^^^^
@@ -98,7 +98,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:62:57
+  --> $DIR/needless_collect_indirect.rs:64:57
    |
 LL |         let indirect_len: LinkedList<_> = sample.iter().collect();
    |                                                         ^^^^^^^
@@ -112,7 +112,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:67:57
+  --> $DIR/needless_collect_indirect.rs:69:57
    |
 LL |         let indirect_len: BinaryHeap<_> = sample.iter().collect();
    |                                                         ^^^^^^^
@@ -126,7 +126,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:127:59
+  --> $DIR/needless_collect_indirect.rs:129:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -143,7 +143,7 @@ LL ~             vec.iter().map(|k| k * k).any(|x| x == i);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:152:59
+  --> $DIR/needless_collect_indirect.rs:154:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -160,7 +160,7 @@ LL ~             vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:181:63
+  --> $DIR/needless_collect_indirect.rs:183:63
    |
 LL |                 let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                               ^^^^^^^
@@ -177,7 +177,7 @@ LL ~                 vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:217:59
+  --> $DIR/needless_collect_indirect.rs:219:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -195,7 +195,7 @@ LL ~                 vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:242:26
+  --> $DIR/needless_collect_indirect.rs:244:26
    |
 LL |         let w = v.iter().collect::<Vec<_>>();
    |                          ^^^^^^^
@@ -211,7 +211,7 @@ LL ~         for _ in 0..v.iter().count() {
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:264:30
+  --> $DIR/needless_collect_indirect.rs:266:30
    |
 LL |         let mut w = v.iter().collect::<Vec<_>>();
    |                              ^^^^^^^
@@ -227,7 +227,7 @@ LL ~         while 1 == v.iter().count() {
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:286:30
+  --> $DIR/needless_collect_indirect.rs:288:30
    |
 LL |         let mut w = v.iter().collect::<Vec<_>>();
    |                              ^^^^^^^

--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::needless_continue)]
+#![allow(clippy::uninlined_format_args)]
 
 macro_rules! zero {
     ($x:expr) => {

--- a/tests/ui/needless_continue.stderr
+++ b/tests/ui/needless_continue.stderr
@@ -1,5 +1,5 @@
 error: this `else` block is redundant
-  --> $DIR/needless_continue.rs:29:16
+  --> $DIR/needless_continue.rs:30:16
    |
 LL |           } else {
    |  ________________^
@@ -35,7 +35,7 @@ LL | |         }
                    }
 
 error: there is no need for an explicit `else` block for this `if` expression
-  --> $DIR/needless_continue.rs:44:9
+  --> $DIR/needless_continue.rs:45:9
    |
 LL | /         if (zero!(i % 2) || nonzero!(i % 5)) && i % 3 != 0 {
 LL | |             continue;
@@ -55,7 +55,7 @@ LL | |         }
                    }
 
 error: this `continue` expression is redundant
-  --> $DIR/needless_continue.rs:57:9
+  --> $DIR/needless_continue.rs:58:9
    |
 LL |         continue; // should lint here
    |         ^^^^^^^^^
@@ -63,7 +63,7 @@ LL |         continue; // should lint here
    = help: consider dropping the `continue` expression
 
 error: this `continue` expression is redundant
-  --> $DIR/needless_continue.rs:64:9
+  --> $DIR/needless_continue.rs:65:9
    |
 LL |         continue; // should lint here
    |         ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |         continue; // should lint here
    = help: consider dropping the `continue` expression
 
 error: this `continue` expression is redundant
-  --> $DIR/needless_continue.rs:71:9
+  --> $DIR/needless_continue.rs:72:9
    |
 LL |         continue // should lint here
    |         ^^^^^^^^
@@ -79,7 +79,7 @@ LL |         continue // should lint here
    = help: consider dropping the `continue` expression
 
 error: this `continue` expression is redundant
-  --> $DIR/needless_continue.rs:79:9
+  --> $DIR/needless_continue.rs:80:9
    |
 LL |         continue // should lint here
    |         ^^^^^^^^
@@ -87,7 +87,7 @@ LL |         continue // should lint here
    = help: consider dropping the `continue` expression
 
 error: this `else` block is redundant
-  --> $DIR/needless_continue.rs:129:24
+  --> $DIR/needless_continue.rs:130:24
    |
 LL |                   } else {
    |  ________________________^
@@ -110,7 +110,7 @@ LL | |                 }
                            }
 
 error: there is no need for an explicit `else` block for this `if` expression
-  --> $DIR/needless_continue.rs:135:17
+  --> $DIR/needless_continue.rs:136:17
    |
 LL | /                 if condition() {
 LL | |                     continue; // should lint here

--- a/tests/ui/needless_for_each_fixable.fixed
+++ b/tests/ui/needless_for_each_fixable.fixed
@@ -1,10 +1,11 @@
 // run-rustfix
 #![warn(clippy::needless_for_each)]
+#![allow(unused)]
 #![allow(
-    unused,
-    clippy::needless_return,
+    clippy::let_unit_value,
     clippy::match_single_binding,
-    clippy::let_unit_value
+    clippy::needless_return,
+    clippy::uninlined_format_args
 )]
 
 use std::collections::HashMap;

--- a/tests/ui/needless_for_each_fixable.rs
+++ b/tests/ui/needless_for_each_fixable.rs
@@ -1,10 +1,11 @@
 // run-rustfix
 #![warn(clippy::needless_for_each)]
+#![allow(unused)]
 #![allow(
-    unused,
-    clippy::needless_return,
+    clippy::let_unit_value,
     clippy::match_single_binding,
-    clippy::let_unit_value
+    clippy::needless_return,
+    clippy::uninlined_format_args
 )]
 
 use std::collections::HashMap;

--- a/tests/ui/needless_for_each_fixable.stderr
+++ b/tests/ui/needless_for_each_fixable.stderr
@@ -1,5 +1,5 @@
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:15:5
+  --> $DIR/needless_for_each_fixable.rs:16:5
    |
 LL | /     v.iter().for_each(|elem| {
 LL | |         acc += elem;
@@ -15,7 +15,7 @@ LL +     }
    |
 
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:18:5
+  --> $DIR/needless_for_each_fixable.rs:19:5
    |
 LL | /     v.into_iter().for_each(|elem| {
 LL | |         acc += elem;
@@ -30,7 +30,7 @@ LL +     }
    |
 
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:22:5
+  --> $DIR/needless_for_each_fixable.rs:23:5
    |
 LL | /     [1, 2, 3].iter().for_each(|elem| {
 LL | |         acc += elem;
@@ -45,7 +45,7 @@ LL +     }
    |
 
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:27:5
+  --> $DIR/needless_for_each_fixable.rs:28:5
    |
 LL | /     hash_map.iter().for_each(|(k, v)| {
 LL | |         acc += k + v;
@@ -60,7 +60,7 @@ LL +     }
    |
 
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:30:5
+  --> $DIR/needless_for_each_fixable.rs:31:5
    |
 LL | /     hash_map.iter_mut().for_each(|(k, v)| {
 LL | |         acc += *k + *v;
@@ -75,7 +75,7 @@ LL +     }
    |
 
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:33:5
+  --> $DIR/needless_for_each_fixable.rs:34:5
    |
 LL | /     hash_map.keys().for_each(|k| {
 LL | |         acc += k;
@@ -90,7 +90,7 @@ LL +     }
    |
 
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:36:5
+  --> $DIR/needless_for_each_fixable.rs:37:5
    |
 LL | /     hash_map.values().for_each(|v| {
 LL | |         acc += v;
@@ -105,7 +105,7 @@ LL +     }
    |
 
 error: needless use of `for_each`
-  --> $DIR/needless_for_each_fixable.rs:43:5
+  --> $DIR/needless_for_each_fixable.rs:44:5
    |
 LL | /     my_vec().iter().for_each(|elem| {
 LL | |         acc += elem;

--- a/tests/ui/needless_for_each_unfixable.rs
+++ b/tests/ui/needless_for_each_unfixable.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::needless_for_each)]
-#![allow(clippy::needless_return)]
+#![allow(clippy::needless_return, clippy::uninlined_format_args)]
 
 fn main() {
     let v: Vec<i32> = Vec::new();

--- a/tests/ui/needless_late_init.fixed
+++ b/tests/ui/needless_late_init.fixed
@@ -1,12 +1,13 @@
 // run-rustfix
 #![feature(let_chains)]
+#![allow(unused)]
 #![allow(
-    unused,
     clippy::assign_op_pattern,
     clippy::blocks_in_if_conditions,
     clippy::let_and_return,
     clippy::let_unit_value,
-    clippy::nonminimal_bool
+    clippy::nonminimal_bool,
+    clippy::uninlined_format_args
 )]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};

--- a/tests/ui/needless_late_init.rs
+++ b/tests/ui/needless_late_init.rs
@@ -1,12 +1,13 @@
 // run-rustfix
 #![feature(let_chains)]
+#![allow(unused)]
 #![allow(
-    unused,
     clippy::assign_op_pattern,
     clippy::blocks_in_if_conditions,
     clippy::let_and_return,
     clippy::let_unit_value,
-    clippy::nonminimal_bool
+    clippy::nonminimal_bool,
+    clippy::uninlined_format_args
 )]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};

--- a/tests/ui/needless_late_init.stderr
+++ b/tests/ui/needless_late_init.stderr
@@ -1,5 +1,5 @@
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:23:5
+  --> $DIR/needless_late_init.rs:24:5
    |
 LL |     let a;
    |     ^^^^^^ created here
@@ -13,7 +13,7 @@ LL |     let a = "zero";
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:26:5
+  --> $DIR/needless_late_init.rs:27:5
    |
 LL |     let b;
    |     ^^^^^^ created here
@@ -27,7 +27,7 @@ LL |     let b = 1;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:27:5
+  --> $DIR/needless_late_init.rs:28:5
    |
 LL |     let c;
    |     ^^^^^^ created here
@@ -41,7 +41,7 @@ LL |     let c = 2;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:31:5
+  --> $DIR/needless_late_init.rs:32:5
    |
 LL |     let d: usize;
    |     ^^^^^^^^^^^^^ created here
@@ -54,7 +54,7 @@ LL |     let d: usize = 1;
    |     ~~~~~~~~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:34:5
+  --> $DIR/needless_late_init.rs:35:5
    |
 LL |     let e;
    |     ^^^^^^ created here
@@ -67,7 +67,7 @@ LL |     let e = format!("{}", d);
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:39:5
+  --> $DIR/needless_late_init.rs:40:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -88,7 +88,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:48:5
+  --> $DIR/needless_late_init.rs:49:5
    |
 LL |     let b;
    |     ^^^^^^
@@ -109,7 +109,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:55:5
+  --> $DIR/needless_late_init.rs:56:5
    |
 LL |     let d;
    |     ^^^^^^
@@ -130,7 +130,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:63:5
+  --> $DIR/needless_late_init.rs:64:5
    |
 LL |     let e;
    |     ^^^^^^
@@ -151,7 +151,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:70:5
+  --> $DIR/needless_late_init.rs:71:5
    |
 LL |     let f;
    |     ^^^^^^
@@ -167,7 +167,7 @@ LL +         1 => "three",
    |
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:76:5
+  --> $DIR/needless_late_init.rs:77:5
    |
 LL |     let g: usize;
    |     ^^^^^^^^^^^^^
@@ -187,7 +187,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:84:5
+  --> $DIR/needless_late_init.rs:85:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -201,7 +201,7 @@ LL |     let x = 1;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:88:5
+  --> $DIR/needless_late_init.rs:89:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -215,7 +215,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:92:5
+  --> $DIR/needless_late_init.rs:93:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -229,7 +229,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:111:5
+  --> $DIR/needless_late_init.rs:112:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -250,7 +250,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:128:5
+  --> $DIR/needless_late_init.rs:129:5
    |
 LL |     let a;
    |     ^^^^^^

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -1,10 +1,11 @@
 #![warn(clippy::needless_pass_by_value)]
+#![allow(dead_code)]
 #![allow(
-    dead_code,
-    clippy::single_match,
-    clippy::redundant_pattern_matching,
     clippy::option_option,
-    clippy::redundant_clone
+    clippy::redundant_clone,
+    clippy::redundant_pattern_matching,
+    clippy::single_match,
+    clippy::uninlined_format_args
 )]
 
 use std::borrow::Borrow;

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -1,5 +1,5 @@
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:17:23
+  --> $DIR/needless_pass_by_value.rs:18:23
    |
 LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T> {
    |                       ^^^^^^ help: consider changing the type to: `&[T]`
@@ -7,55 +7,55 @@ LL | fn foo<T: Default>(v: Vec<T>, w: Vec<T>, mut x: Vec<T>, y: Vec<T>) -> Vec<T
    = note: `-D clippy::needless-pass-by-value` implied by `-D warnings`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:31:11
+  --> $DIR/needless_pass_by_value.rs:32:11
    |
 LL | fn bar(x: String, y: Wrapper) {
    |           ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:31:22
+  --> $DIR/needless_pass_by_value.rs:32:22
    |
 LL | fn bar(x: String, y: Wrapper) {
    |                      ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:37:71
+  --> $DIR/needless_pass_by_value.rs:38:71
    |
 LL | fn test_borrow_trait<T: Borrow<str>, U: AsRef<str>, V>(t: T, u: U, v: V) {
    |                                                                       ^ help: consider taking a reference instead: `&V`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:49:18
+  --> $DIR/needless_pass_by_value.rs:50:18
    |
 LL | fn test_match(x: Option<Option<String>>, y: Option<Option<String>>) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&Option<Option<String>>`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:62:24
+  --> $DIR/needless_pass_by_value.rs:63:24
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                        ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:62:36
+  --> $DIR/needless_pass_by_value.rs:63:36
    |
 LL | fn test_destructure(x: Wrapper, y: Wrapper, z: Wrapper) {
    |                                    ^^^^^^^ help: consider taking a reference instead: `&Wrapper`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:78:49
+  --> $DIR/needless_pass_by_value.rs:79:49
    |
 LL | fn test_blanket_ref<T: Foo, S: Serialize>(_foo: T, _serializable: S) {}
    |                                                 ^ help: consider taking a reference instead: `&T`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:80:18
+  --> $DIR/needless_pass_by_value.rs:81:18
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                  ^^^^^^ help: consider taking a reference instead: `&String`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:80:29
+  --> $DIR/needless_pass_by_value.rs:81:29
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                             ^^^^^^
@@ -70,13 +70,13 @@ LL |     let _ = t.to_string();
    |             ~~~~~~~~~~~~~
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:80:40
+  --> $DIR/needless_pass_by_value.rs:81:40
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                        ^^^^^^^^ help: consider taking a reference instead: `&Vec<i32>`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:80:53
+  --> $DIR/needless_pass_by_value.rs:81:53
    |
 LL | fn issue_2114(s: String, t: String, u: Vec<i32>, v: Vec<i32>) {
    |                                                     ^^^^^^^^
@@ -91,85 +91,85 @@ LL |     let _ = v.to_owned();
    |             ~~~~~~~~~~~~
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:93:12
+  --> $DIR/needless_pass_by_value.rs:94:12
    |
 LL |         s: String,
    |            ^^^^^^ help: consider changing the type to: `&str`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:94:12
+  --> $DIR/needless_pass_by_value.rs:95:12
    |
 LL |         t: String,
    |            ^^^^^^ help: consider taking a reference instead: `&String`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:103:23
+  --> $DIR/needless_pass_by_value.rs:104:23
    |
 LL |     fn baz(&self, _u: U, _s: Self) {}
    |                       ^ help: consider taking a reference instead: `&U`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:103:30
+  --> $DIR/needless_pass_by_value.rs:104:30
    |
 LL |     fn baz(&self, _u: U, _s: Self) {}
    |                              ^^^^ help: consider taking a reference instead: `&Self`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:125:24
+  --> $DIR/needless_pass_by_value.rs:126:24
    |
 LL | fn bar_copy(x: u32, y: CopyWrapper) {
    |                        ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:123:1
+  --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:131:29
+  --> $DIR/needless_pass_by_value.rs:132:29
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:123:1
+  --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:131:45
+  --> $DIR/needless_pass_by_value.rs:132:45
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:123:1
+  --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:131:61
+  --> $DIR/needless_pass_by_value.rs:132:61
    |
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
 help: consider marking this type as `Copy`
-  --> $DIR/needless_pass_by_value.rs:123:1
+  --> $DIR/needless_pass_by_value.rs:124:1
    |
 LL | struct CopyWrapper(u32);
    | ^^^^^^^^^^^^^^^^^^
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:143:40
+  --> $DIR/needless_pass_by_value.rs:144:40
    |
 LL | fn some_fun<'b, S: Bar<'b, ()>>(_item: S) {}
    |                                        ^ help: consider taking a reference instead: `&S`
 
 error: this argument is passed by value, but not consumed in the function body
-  --> $DIR/needless_pass_by_value.rs:148:20
+  --> $DIR/needless_pass_by_value.rs:149:20
    |
 LL | fn more_fun(_item: impl Club<'static, i32>) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&impl Club<'static, i32>`

--- a/tests/ui/needless_range_loop.rs
+++ b/tests/ui/needless_range_loop.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::needless_range_loop)]
+#![allow(clippy::uninlined_format_args)]
 
 static STATIC: [usize; 4] = [0, 1, 8, 16];
 const CONST: [usize; 4] = [0, 1, 8, 16];

--- a/tests/ui/needless_range_loop.stderr
+++ b/tests/ui/needless_range_loop.stderr
@@ -1,5 +1,5 @@
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop.rs:10:14
+  --> $DIR/needless_range_loop.rs:11:14
    |
 LL |     for i in 0..vec.len() {
    |              ^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     for <item> in &vec {
    |         ~~~~~~    ~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop.rs:19:14
+  --> $DIR/needless_range_loop.rs:20:14
    |
 LL |     for i in 0..vec.len() {
    |              ^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |     for <item> in &vec {
    |         ~~~~~~    ~~~~
 
 error: the loop variable `j` is only used to index `STATIC`
-  --> $DIR/needless_range_loop.rs:24:14
+  --> $DIR/needless_range_loop.rs:25:14
    |
 LL |     for j in 0..4 {
    |              ^^^^
@@ -33,7 +33,7 @@ LL |     for <item> in &STATIC {
    |         ~~~~~~    ~~~~~~~
 
 error: the loop variable `j` is only used to index `CONST`
-  --> $DIR/needless_range_loop.rs:28:14
+  --> $DIR/needless_range_loop.rs:29:14
    |
 LL |     for j in 0..4 {
    |              ^^^^
@@ -44,7 +44,7 @@ LL |     for <item> in &CONST {
    |         ~~~~~~    ~~~~~~
 
 error: the loop variable `i` is used to index `vec`
-  --> $DIR/needless_range_loop.rs:32:14
+  --> $DIR/needless_range_loop.rs:33:14
    |
 LL |     for i in 0..vec.len() {
    |              ^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     for (i, <item>) in vec.iter().enumerate() {
    |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `vec2`
-  --> $DIR/needless_range_loop.rs:40:14
+  --> $DIR/needless_range_loop.rs:41:14
    |
 LL |     for i in 0..vec.len() {
    |              ^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |     for <item> in vec2.iter().take(vec.len()) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop.rs:44:14
+  --> $DIR/needless_range_loop.rs:45:14
    |
 LL |     for i in 5..vec.len() {
    |              ^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     for <item> in vec.iter().skip(5) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop.rs:48:14
+  --> $DIR/needless_range_loop.rs:49:14
    |
 LL |     for i in 0..MAX_LEN {
    |              ^^^^^^^^^^
@@ -88,7 +88,7 @@ LL |     for <item> in vec.iter().take(MAX_LEN) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop.rs:52:14
+  --> $DIR/needless_range_loop.rs:53:14
    |
 LL |     for i in 0..=MAX_LEN {
    |              ^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     for <item> in vec.iter().take(MAX_LEN + 1) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop.rs:56:14
+  --> $DIR/needless_range_loop.rs:57:14
    |
 LL |     for i in 5..10 {
    |              ^^^^^
@@ -110,7 +110,7 @@ LL |     for <item> in vec.iter().take(10).skip(5) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop.rs:60:14
+  --> $DIR/needless_range_loop.rs:61:14
    |
 LL |     for i in 5..=10 {
    |              ^^^^^^
@@ -121,7 +121,7 @@ LL |     for <item> in vec.iter().take(10 + 1).skip(5) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is used to index `vec`
-  --> $DIR/needless_range_loop.rs:64:14
+  --> $DIR/needless_range_loop.rs:65:14
    |
 LL |     for i in 5..vec.len() {
    |              ^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL |     for (i, <item>) in vec.iter().enumerate().skip(5) {
    |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is used to index `vec`
-  --> $DIR/needless_range_loop.rs:68:14
+  --> $DIR/needless_range_loop.rs:69:14
    |
 LL |     for i in 5..10 {
    |              ^^^^^
@@ -143,7 +143,7 @@ LL |     for (i, <item>) in vec.iter().enumerate().take(10).skip(5) {
    |         ~~~~~~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is used to index `vec`
-  --> $DIR/needless_range_loop.rs:73:14
+  --> $DIR/needless_range_loop.rs:74:14
    |
 LL |     for i in 0..vec.len() {
    |              ^^^^^^^^^^^^

--- a/tests/ui/no_effect.rs
+++ b/tests/ui/no_effect.rs
@@ -1,9 +1,7 @@
 #![feature(box_syntax, fn_traits, unboxed_closures)]
 #![warn(clippy::no_effect_underscore_binding)]
-#![allow(dead_code)]
-#![allow(path_statements)]
-#![allow(clippy::deref_addrof)]
-#![allow(clippy::redundant_field_names)]
+#![allow(dead_code, path_statements)]
+#![allow(clippy::deref_addrof, clippy::redundant_field_names, clippy::uninlined_format_args)]
 
 struct Unit;
 struct Tuple(i32);

--- a/tests/ui/no_effect.stderr
+++ b/tests/ui/no_effect.stderr
@@ -1,5 +1,5 @@
 error: statement with no effect
-  --> $DIR/no_effect.rs:94:5
+  --> $DIR/no_effect.rs:92:5
    |
 LL |     0;
    |     ^^
@@ -7,157 +7,157 @@ LL |     0;
    = note: `-D clippy::no-effect` implied by `-D warnings`
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:95:5
+  --> $DIR/no_effect.rs:93:5
    |
 LL |     s2;
    |     ^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:96:5
+  --> $DIR/no_effect.rs:94:5
    |
 LL |     Unit;
    |     ^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:97:5
+  --> $DIR/no_effect.rs:95:5
    |
 LL |     Tuple(0);
    |     ^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:98:5
+  --> $DIR/no_effect.rs:96:5
    |
 LL |     Struct { field: 0 };
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:99:5
+  --> $DIR/no_effect.rs:97:5
    |
 LL |     Struct { ..s };
    |     ^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:100:5
+  --> $DIR/no_effect.rs:98:5
    |
 LL |     Union { a: 0 };
    |     ^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:101:5
+  --> $DIR/no_effect.rs:99:5
    |
 LL |     Enum::Tuple(0);
    |     ^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:102:5
+  --> $DIR/no_effect.rs:100:5
    |
 LL |     Enum::Struct { field: 0 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:103:5
+  --> $DIR/no_effect.rs:101:5
    |
 LL |     5 + 6;
    |     ^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:104:5
+  --> $DIR/no_effect.rs:102:5
    |
 LL |     *&42;
    |     ^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:105:5
+  --> $DIR/no_effect.rs:103:5
    |
 LL |     &6;
    |     ^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:106:5
+  --> $DIR/no_effect.rs:104:5
    |
 LL |     (5, 6, 7);
    |     ^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:107:5
+  --> $DIR/no_effect.rs:105:5
    |
 LL |     box 42;
    |     ^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:108:5
+  --> $DIR/no_effect.rs:106:5
    |
 LL |     ..;
    |     ^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:109:5
+  --> $DIR/no_effect.rs:107:5
    |
 LL |     5..;
    |     ^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:110:5
+  --> $DIR/no_effect.rs:108:5
    |
 LL |     ..5;
    |     ^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:111:5
+  --> $DIR/no_effect.rs:109:5
    |
 LL |     5..6;
    |     ^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:112:5
+  --> $DIR/no_effect.rs:110:5
    |
 LL |     5..=6;
    |     ^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:113:5
+  --> $DIR/no_effect.rs:111:5
    |
 LL |     [42, 55];
    |     ^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:114:5
+  --> $DIR/no_effect.rs:112:5
    |
 LL |     [42, 55][1];
    |     ^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:115:5
+  --> $DIR/no_effect.rs:113:5
    |
 LL |     (42, 55).1;
    |     ^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:116:5
+  --> $DIR/no_effect.rs:114:5
    |
 LL |     [42; 55];
    |     ^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:117:5
+  --> $DIR/no_effect.rs:115:5
    |
 LL |     [42; 55][13];
    |     ^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:119:5
+  --> $DIR/no_effect.rs:117:5
    |
 LL |     || x += 5;
    |     ^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:121:5
+  --> $DIR/no_effect.rs:119:5
    |
 LL |     FooString { s: s };
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:122:5
+  --> $DIR/no_effect.rs:120:5
    |
 LL |     let _unused = 1;
    |     ^^^^^^^^^^^^^^^^
@@ -165,19 +165,19 @@ LL |     let _unused = 1;
    = note: `-D clippy::no-effect-underscore-binding` implied by `-D warnings`
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:123:5
+  --> $DIR/no_effect.rs:121:5
    |
 LL |     let _penguin = || println!("Some helpful closure");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:124:5
+  --> $DIR/no_effect.rs:122:5
    |
 LL |     let _duck = Struct { field: 0 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:125:5
+  --> $DIR/no_effect.rs:123:5
    |
 LL |     let _cat = [2, 4, 6, 8][2];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/option_map_unit_fn_fixable.fixed
+++ b/tests/ui/option_map_unit_fn_fixable.fixed
@@ -1,8 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::option_map_unit_fn)]
 #![allow(unused)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::uninlined_format_args, clippy::unnecessary_wraps)]
 
 fn do_nothing<T>(_: T) {}
 

--- a/tests/ui/option_map_unit_fn_fixable.rs
+++ b/tests/ui/option_map_unit_fn_fixable.rs
@@ -1,8 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::option_map_unit_fn)]
 #![allow(unused)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::uninlined_format_args, clippy::unnecessary_wraps)]
 
 fn do_nothing<T>(_: T) {}
 

--- a/tests/ui/option_map_unit_fn_fixable.stderr
+++ b/tests/ui/option_map_unit_fn_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:39:5
+  --> $DIR/option_map_unit_fn_fixable.rs:38:5
    |
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
@@ -9,7 +9,7 @@ LL |     x.field.map(do_nothing);
    = note: `-D clippy::option-map-unit-fn` implied by `-D warnings`
 
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:41:5
+  --> $DIR/option_map_unit_fn_fixable.rs:40:5
    |
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
@@ -17,7 +17,7 @@ LL |     x.field.map(do_nothing);
    |     help: try this: `if let Some(x_field) = x.field { do_nothing(x_field) }`
 
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:43:5
+  --> $DIR/option_map_unit_fn_fixable.rs:42:5
    |
 LL |     x.field.map(diverge);
    |     ^^^^^^^^^^^^^^^^^^^^-
@@ -25,7 +25,7 @@ LL |     x.field.map(diverge);
    |     help: try this: `if let Some(x_field) = x.field { diverge(x_field) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:49:5
+  --> $DIR/option_map_unit_fn_fixable.rs:48:5
    |
 LL |     x.field.map(|value| x.do_option_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -33,7 +33,7 @@ LL |     x.field.map(|value| x.do_option_nothing(value + captured));
    |     help: try this: `if let Some(value) = x.field { x.do_option_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:51:5
+  --> $DIR/option_map_unit_fn_fixable.rs:50:5
    |
 LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -41,7 +41,7 @@ LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
    |     help: try this: `if let Some(value) = x.field { x.do_option_plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:54:5
+  --> $DIR/option_map_unit_fn_fixable.rs:53:5
    |
 LL |     x.field.map(|value| do_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -49,7 +49,7 @@ LL |     x.field.map(|value| do_nothing(value + captured));
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:56:5
+  --> $DIR/option_map_unit_fn_fixable.rs:55:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -57,7 +57,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:58:5
+  --> $DIR/option_map_unit_fn_fixable.rs:57:5
    |
 LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -65,7 +65,7 @@ LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:60:5
+  --> $DIR/option_map_unit_fn_fixable.rs:59:5
    |
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -73,7 +73,7 @@ LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:63:5
+  --> $DIR/option_map_unit_fn_fixable.rs:62:5
    |
 LL |     x.field.map(|value| diverge(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -81,7 +81,7 @@ LL |     x.field.map(|value| diverge(value + captured));
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:65:5
+  --> $DIR/option_map_unit_fn_fixable.rs:64:5
    |
 LL |     x.field.map(|value| { diverge(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -89,7 +89,7 @@ LL |     x.field.map(|value| { diverge(value + captured) });
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:67:5
+  --> $DIR/option_map_unit_fn_fixable.rs:66:5
    |
 LL |     x.field.map(|value| { diverge(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -97,7 +97,7 @@ LL |     x.field.map(|value| { diverge(value + captured); });
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:69:5
+  --> $DIR/option_map_unit_fn_fixable.rs:68:5
    |
 LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -105,7 +105,7 @@ LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:74:5
+  --> $DIR/option_map_unit_fn_fixable.rs:73:5
    |
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -113,7 +113,7 @@ LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     help: try this: `if let Some(value) = x.field { let y = plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:76:5
+  --> $DIR/option_map_unit_fn_fixable.rs:75:5
    |
 LL |     x.field.map(|value| { plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -121,7 +121,7 @@ LL |     x.field.map(|value| { plus_one(value + captured); });
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:78:5
+  --> $DIR/option_map_unit_fn_fixable.rs:77:5
    |
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -129,7 +129,7 @@ LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:81:5
+  --> $DIR/option_map_unit_fn_fixable.rs:80:5
    |
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -137,7 +137,7 @@ LL |     x.field.map(|ref value| { do_nothing(value + captured) });
    |     help: try this: `if let Some(ref value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:83:5
+  --> $DIR/option_map_unit_fn_fixable.rs:82:5
    |
 LL |     option().map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -145,7 +145,7 @@ LL |     option().map(do_nothing);
    |     help: try this: `if let Some(a) = option() { do_nothing(a) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
-  --> $DIR/option_map_unit_fn_fixable.rs:85:5
+  --> $DIR/option_map_unit_fn_fixable.rs:84:5
    |
 LL |     option().map(|value| println!("{:?}", value));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -1,8 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::or_fun_call)]
 #![allow(dead_code)]
-#![allow(clippy::unnecessary_wraps, clippy::borrow_as_ptr)]
+#![allow(clippy::borrow_as_ptr, clippy::uninlined_format_args, clippy::unnecessary_wraps)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -1,8 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::or_fun_call)]
 #![allow(dead_code)]
-#![allow(clippy::unnecessary_wraps, clippy::borrow_as_ptr)]
+#![allow(clippy::borrow_as_ptr, clippy::uninlined_format_args, clippy::unnecessary_wraps)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -1,5 +1,5 @@
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:49:22
+  --> $DIR/or_fun_call.rs:48:22
    |
 LL |     with_constructor.unwrap_or(make());
    |                      ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(make)`
@@ -7,151 +7,151 @@ LL |     with_constructor.unwrap_or(make());
    = note: `-D clippy::or-fun-call` implied by `-D warnings`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:52:14
+  --> $DIR/or_fun_call.rs:51:14
    |
 LL |     with_new.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:55:21
+  --> $DIR/or_fun_call.rs:54:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:58:14
+  --> $DIR/or_fun_call.rs:57:14
    |
 LL |     with_err.unwrap_or(make());
    |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| make())`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:61:19
+  --> $DIR/or_fun_call.rs:60:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/or_fun_call.rs:64:24
+  --> $DIR/or_fun_call.rs:63:24
    |
 LL |     with_default_trait.unwrap_or(Default::default());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/or_fun_call.rs:67:23
+  --> $DIR/or_fun_call.rs:66:23
    |
 LL |     with_default_type.unwrap_or(u64::default());
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:70:18
+  --> $DIR/or_fun_call.rs:69:18
    |
 LL |     self_default.unwrap_or(<FakeDefault>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(<FakeDefault>::default)`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/or_fun_call.rs:73:18
+  --> $DIR/or_fun_call.rs:72:18
    |
 LL |     real_default.unwrap_or(<FakeDefault as Default>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:76:14
+  --> $DIR/or_fun_call.rs:75:14
    |
 LL |     with_vec.unwrap_or(vec![]);
    |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:79:21
+  --> $DIR/or_fun_call.rs:78:21
    |
 LL |     without_default.unwrap_or(Foo::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:82:19
+  --> $DIR/or_fun_call.rs:81:19
    |
 LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:85:23
+  --> $DIR/or_fun_call.rs:84:23
    |
 LL |     map_vec.entry(42).or_insert(vec![]);
    |                       ^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:88:21
+  --> $DIR/or_fun_call.rs:87:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:91:25
+  --> $DIR/or_fun_call.rs:90:25
    |
 LL |     btree_vec.entry(42).or_insert(vec![]);
    |                         ^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:94:21
+  --> $DIR/or_fun_call.rs:93:21
    |
 LL |     let _ = stringy.unwrap_or(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:102:21
+  --> $DIR/or_fun_call.rs:101:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:104:21
+  --> $DIR/or_fun_call.rs:103:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
 
 error: use of `or` followed by a function call
-  --> $DIR/or_fun_call.rs:128:35
+  --> $DIR/or_fun_call.rs:127:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some("b".to_string()))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:167:14
+  --> $DIR/or_fun_call.rs:166:14
    |
 LL |         None.unwrap_or(ptr_to_ref(s));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:173:14
+  --> $DIR/or_fun_call.rs:172:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:175:14
+  --> $DIR/or_fun_call.rs:174:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:189:14
+  --> $DIR/or_fun_call.rs:188:14
    |
 LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:202:14
+  --> $DIR/or_fun_call.rs:201:14
    |
 LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:214:14
+  --> $DIR/or_fun_call.rs:213:14
    |
 LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:225:10
+  --> $DIR/or_fun_call.rs:224:10
    |
 LL |         .unwrap_or(String::new());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`

--- a/tests/ui/panic_in_result_fn_assertions.rs
+++ b/tests/ui/panic_in_result_fn_assertions.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::panic_in_result_fn)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::uninlined_format_args, clippy::unnecessary_wraps)]
 
 struct A;
 

--- a/tests/ui/panic_in_result_fn_debug_assertions.rs
+++ b/tests/ui/panic_in_result_fn_debug_assertions.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::panic_in_result_fn)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::uninlined_format_args, clippy::unnecessary_wraps)]
 
 // debug_assert should never trigger the `panic_in_result_fn` lint
 

--- a/tests/ui/patterns.fixed
+++ b/tests/ui/patterns.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
-#![allow(unused)]
 #![warn(clippy::all)]
+#![allow(unused)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let v = Some(true);

--- a/tests/ui/patterns.rs
+++ b/tests/ui/patterns.rs
@@ -1,6 +1,7 @@
 // run-rustfix
-#![allow(unused)]
 #![warn(clippy::all)]
+#![allow(unused)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let v = Some(true);

--- a/tests/ui/patterns.stderr
+++ b/tests/ui/patterns.stderr
@@ -1,5 +1,5 @@
 error: the `y @ _` pattern can be written as just `y`
-  --> $DIR/patterns.rs:10:9
+  --> $DIR/patterns.rs:11:9
    |
 LL |         y @ _ => (),
    |         ^^^^^ help: try: `y`
@@ -7,13 +7,13 @@ LL |         y @ _ => (),
    = note: `-D clippy::redundant-pattern` implied by `-D warnings`
 
 error: the `x @ _` pattern can be written as just `x`
-  --> $DIR/patterns.rs:25:9
+  --> $DIR/patterns.rs:26:9
    |
 LL |         ref mut x @ _ => {
    |         ^^^^^^^^^^^^^ help: try: `ref mut x`
 
 error: the `x @ _` pattern can be written as just `x`
-  --> $DIR/patterns.rs:33:9
+  --> $DIR/patterns.rs:34:9
    |
 LL |         ref x @ _ => println!("vec: {:?}", x),
    |         ^^^^^^^^^ help: try: `ref x`

--- a/tests/ui/print_literal.rs
+++ b/tests/ui/print_literal.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::print_literal)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     // these should be fine

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -1,5 +1,5 @@
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:26:24
+  --> $DIR/print_literal.rs:27:24
    |
 LL |     print!("Hello {}", "world");
    |                        ^^^^^^^
@@ -12,7 +12,7 @@ LL +     print!("Hello world");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:27:36
+  --> $DIR/print_literal.rs:28:36
    |
 LL |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
@@ -24,7 +24,7 @@ LL +     println!("Hello {} world", world);
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:28:26
+  --> $DIR/print_literal.rs:29:26
    |
 LL |     println!("Hello {}", "world");
    |                          ^^^^^^^
@@ -36,7 +36,7 @@ LL +     println!("Hello world");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:29:26
+  --> $DIR/print_literal.rs:30:26
    |
 LL |     println!("{} {:.4}", "a literal", 5);
    |                          ^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL +     println!("a literal {:.4}", 5);
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:34:25
+  --> $DIR/print_literal.rs:35:25
    |
 LL |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^
@@ -60,7 +60,7 @@ LL +     println!("hello {1}", "world");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:34:34
+  --> $DIR/print_literal.rs:35:34
    |
 LL |     println!("{0} {1}", "hello", "world");
    |                                  ^^^^^^^
@@ -72,7 +72,7 @@ LL +     println!("{0} world", "hello");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:35:34
+  --> $DIR/print_literal.rs:36:34
    |
 LL |     println!("{1} {0}", "hello", "world");
    |                                  ^^^^^^^
@@ -84,7 +84,7 @@ LL +     println!("world {0}", "hello");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:35:25
+  --> $DIR/print_literal.rs:36:25
    |
 LL |     println!("{1} {0}", "hello", "world");
    |                         ^^^^^^^
@@ -96,7 +96,7 @@ LL +     println!("{1} hello", "world");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:38:35
+  --> $DIR/print_literal.rs:39:35
    |
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                   ^^^^^^^
@@ -108,7 +108,7 @@ LL +     println!("hello {bar}", bar = "world");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:38:50
+  --> $DIR/print_literal.rs:39:50
    |
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^
@@ -120,7 +120,7 @@ LL +     println!("{foo} world", foo = "hello");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:39:50
+  --> $DIR/print_literal.rs:40:50
    |
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^
@@ -132,7 +132,7 @@ LL +     println!("world {foo}", foo = "hello");
    |
 
 error: literal with an empty format string
-  --> $DIR/print_literal.rs:39:35
+  --> $DIR/print_literal.rs:40:35
    |
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                   ^^^^^^^

--- a/tests/ui/recursive_format_impl.rs
+++ b/tests/ui/recursive_format_impl.rs
@@ -1,9 +1,10 @@
 #![warn(clippy::recursive_format_impl)]
 #![allow(
+    clippy::borrow_deref_ref,
+    clippy::deref_addrof,
     clippy::inherent_to_string_shadow_display,
     clippy::to_string_in_format_args,
-    clippy::deref_addrof,
-    clippy::borrow_deref_ref
+    clippy::uninlined_format_args
 )]
 
 use std::fmt;

--- a/tests/ui/recursive_format_impl.stderr
+++ b/tests/ui/recursive_format_impl.stderr
@@ -1,5 +1,5 @@
 error: using `self.to_string` in `fmt::Display` implementation will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:30:25
+  --> $DIR/recursive_format_impl.rs:31:25
    |
 LL |         write!(f, "{}", self.to_string())
    |                         ^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |         write!(f, "{}", self.to_string())
    = note: `-D clippy::recursive-format-impl` implied by `-D warnings`
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:74:9
+  --> $DIR/recursive_format_impl.rs:75:9
    |
 LL |         write!(f, "{}", self)
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |         write!(f, "{}", self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:83:9
+  --> $DIR/recursive_format_impl.rs:84:9
    |
 LL |         write!(f, "{}", &self)
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |         write!(f, "{}", &self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Debug` in `impl Debug` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:89:9
+  --> $DIR/recursive_format_impl.rs:90:9
    |
 LL |         write!(f, "{:?}", &self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |         write!(f, "{:?}", &self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:98:9
+  --> $DIR/recursive_format_impl.rs:99:9
    |
 LL |         write!(f, "{}", &&&self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |         write!(f, "{}", &&&self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:172:9
+  --> $DIR/recursive_format_impl.rs:173:9
    |
 LL |         write!(f, "{}", &*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL |         write!(f, "{}", &*self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Debug` in `impl Debug` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:178:9
+  --> $DIR/recursive_format_impl.rs:179:9
    |
 LL |         write!(f, "{:?}", &*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL |         write!(f, "{:?}", &*self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:194:9
+  --> $DIR/recursive_format_impl.rs:195:9
    |
 LL |         write!(f, "{}", *self)
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |         write!(f, "{}", *self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:210:9
+  --> $DIR/recursive_format_impl.rs:211:9
    |
 LL |         write!(f, "{}", **&&*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |         write!(f, "{}", **&&*self)
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: using `self` as `Display` in `impl Display` will cause infinite recursion
-  --> $DIR/recursive_format_impl.rs:226:9
+  --> $DIR/recursive_format_impl.rs:227:9
    |
 LL |         write!(f, "{}", &&**&&*self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -1,8 +1,8 @@
 // run-rustfix
 // rustfix-only-machine-applicable
-
 #![feature(lint_reasons)]
-#![allow(clippy::implicit_clone, clippy::drop_non_drop)]
+#![allow(clippy::drop_non_drop, clippy::implicit_clone, clippy::uninlined_format_args)]
+
 use std::ffi::OsString;
 use std::path::Path;
 

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -1,8 +1,8 @@
 // run-rustfix
 // rustfix-only-machine-applicable
-
 #![feature(lint_reasons)]
-#![allow(clippy::implicit_clone, clippy::drop_non_drop)]
+#![allow(clippy::drop_non_drop, clippy::implicit_clone, clippy::uninlined_format_args)]
+
 use std::ffi::OsString;
 use std::path::Path;
 

--- a/tests/ui/redundant_pattern_matching_ipaddr.fixed
+++ b/tests/ui/redundant_pattern_matching_ipaddr.fixed
@@ -1,8 +1,11 @@
 // run-rustfix
-
-#![warn(clippy::all)]
-#![warn(clippy::redundant_pattern_matching)]
-#![allow(unused_must_use, clippy::needless_bool, clippy::match_like_matches_macro)]
+#![warn(clippy::all, clippy::redundant_pattern_matching)]
+#![allow(unused_must_use)]
+#![allow(
+    clippy::match_like_matches_macro,
+    clippy::needless_bool,
+    clippy::uninlined_format_args
+)]
 
 use std::net::{
     IpAddr::{self, V4, V6},

--- a/tests/ui/redundant_pattern_matching_ipaddr.rs
+++ b/tests/ui/redundant_pattern_matching_ipaddr.rs
@@ -1,8 +1,11 @@
 // run-rustfix
-
-#![warn(clippy::all)]
-#![warn(clippy::redundant_pattern_matching)]
-#![allow(unused_must_use, clippy::needless_bool, clippy::match_like_matches_macro)]
+#![warn(clippy::all, clippy::redundant_pattern_matching)]
+#![allow(unused_must_use)]
+#![allow(
+    clippy::match_like_matches_macro,
+    clippy::needless_bool,
+    clippy::uninlined_format_args
+)]
 
 use std::net::{
     IpAddr::{self, V4, V6},

--- a/tests/ui/redundant_pattern_matching_ipaddr.stderr
+++ b/tests/ui/redundant_pattern_matching_ipaddr.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:14:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:17:12
    |
 LL |     if let V4(_) = &ipaddr {}
    |     -------^^^^^---------- help: try this: `if ipaddr.is_ipv4()`
@@ -7,31 +7,31 @@ LL |     if let V4(_) = &ipaddr {}
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:16:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:19:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:18:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:21:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:20:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:23:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:22:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:25:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:32:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:35:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => true,
@@ -40,7 +40,7 @@ LL | |     };
    | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:37:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:40:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => false,
@@ -49,7 +49,7 @@ LL | |     };
    | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:42:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:45:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => false,
@@ -58,7 +58,7 @@ LL | |     };
    | |_____^ help: try this: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:47:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:50:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => true,
@@ -67,49 +67,49 @@ LL | |     };
    | |_____^ help: try this: `V6(Ipv6Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:52:20
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:55:20
    |
 LL |     let _ = if let V4(_) = V4(Ipv4Addr::LOCALHOST) {
    |             -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:60:20
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:63:20
    |
 LL |     let _ = if let V4(_) = gen_ipaddr() {
    |             -------^^^^^--------------- help: try this: `if gen_ipaddr().is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:62:19
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:65:19
    |
 LL |     } else if let V6(_) = gen_ipaddr() {
    |            -------^^^^^--------------- help: try this: `if gen_ipaddr().is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:74:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:77:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:76:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:79:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:78:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:81:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:80:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:83:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:82:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:85:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => true,
@@ -118,7 +118,7 @@ LL | |     };
    | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:87:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:90:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => false,

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -1,14 +1,13 @@
 // run-rustfix
-
 #![warn(clippy::all)]
 #![warn(clippy::redundant_pattern_matching)]
+#![allow(deprecated, unused_must_use)]
 #![allow(
-    unused_must_use,
-    clippy::needless_bool,
+    clippy::if_same_then_else,
     clippy::match_like_matches_macro,
-    clippy::unnecessary_wraps,
-    deprecated,
-    clippy::if_same_then_else
+    clippy::needless_bool,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_wraps
 )]
 
 fn main() {

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -1,14 +1,13 @@
 // run-rustfix
-
 #![warn(clippy::all)]
 #![warn(clippy::redundant_pattern_matching)]
+#![allow(deprecated, unused_must_use)]
 #![allow(
-    unused_must_use,
-    clippy::needless_bool,
+    clippy::if_same_then_else,
     clippy::match_like_matches_macro,
-    clippy::unnecessary_wraps,
-    deprecated,
-    clippy::if_same_then_else
+    clippy::needless_bool,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_wraps
 )]
 
 fn main() {

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:16:12
+  --> $DIR/redundant_pattern_matching_result.rs:15:12
    |
 LL |     if let Ok(_) = &result {}
    |     -------^^^^^---------- help: try this: `if result.is_ok()`
@@ -7,31 +7,31 @@ LL |     if let Ok(_) = &result {}
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:18:12
+  --> $DIR/redundant_pattern_matching_result.rs:17:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try this: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:20:12
+  --> $DIR/redundant_pattern_matching_result.rs:19:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try this: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:22:15
+  --> $DIR/redundant_pattern_matching_result.rs:21:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:24:15
+  --> $DIR/redundant_pattern_matching_result.rs:23:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:34:5
+  --> $DIR/redundant_pattern_matching_result.rs:33:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => true,
@@ -40,7 +40,7 @@ LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:39:5
+  --> $DIR/redundant_pattern_matching_result.rs:38:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => false,
@@ -49,7 +49,7 @@ LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:44:5
+  --> $DIR/redundant_pattern_matching_result.rs:43:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => false,
@@ -58,7 +58,7 @@ LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:49:5
+  --> $DIR/redundant_pattern_matching_result.rs:48:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => true,
@@ -67,73 +67,73 @@ LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:54:20
+  --> $DIR/redundant_pattern_matching_result.rs:53:20
    |
 LL |     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
    |             -------^^^^^--------------------- help: try this: `if Ok::<usize, ()>(4).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:60:20
+  --> $DIR/redundant_pattern_matching_result.rs:59:20
    |
 LL |     let _ = if let Ok(_) = gen_res() {
    |             -------^^^^^------------ help: try this: `if gen_res().is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:62:19
+  --> $DIR/redundant_pattern_matching_result.rs:61:19
    |
 LL |     } else if let Err(_) = gen_res() {
    |            -------^^^^^^------------ help: try this: `if gen_res().is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:85:19
+  --> $DIR/redundant_pattern_matching_result.rs:84:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
    |         ----------^^^^^^^----------------------- help: try this: `while (r#try!(result_opt())).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:86:16
+  --> $DIR/redundant_pattern_matching_result.rs:85:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
    |         -------^^^^^^^----------------------- help: try this: `if (r#try!(result_opt())).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:92:12
+  --> $DIR/redundant_pattern_matching_result.rs:91:12
    |
 LL |     if let Some(_) = m!() {}
    |     -------^^^^^^^------- help: try this: `if m!().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:93:15
+  --> $DIR/redundant_pattern_matching_result.rs:92:15
    |
 LL |     while let Some(_) = m!() {}
    |     ----------^^^^^^^------- help: try this: `while m!().is_some()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:111:12
+  --> $DIR/redundant_pattern_matching_result.rs:110:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try this: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:113:12
+  --> $DIR/redundant_pattern_matching_result.rs:112:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try this: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:115:15
+  --> $DIR/redundant_pattern_matching_result.rs:114:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:117:15
+  --> $DIR/redundant_pattern_matching_result.rs:116:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:119:5
+  --> $DIR/redundant_pattern_matching_result.rs:118:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => true,
@@ -142,7 +142,7 @@ LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:124:5
+  --> $DIR/redundant_pattern_matching_result.rs:123:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => false,

--- a/tests/ui/result_map_unit_fn_fixable.fixed
+++ b/tests/ui/result_map_unit_fn_fixable.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::result_map_unit_fn)]
 #![allow(unused)]
+#![allow(clippy::uninlined_format_args)]
 
 fn do_nothing<T>(_: T) {}
 

--- a/tests/ui/result_map_unit_fn_fixable.rs
+++ b/tests/ui/result_map_unit_fn_fixable.rs
@@ -1,7 +1,7 @@
 // run-rustfix
-
 #![warn(clippy::result_map_unit_fn)]
 #![allow(unused)]
+#![allow(clippy::uninlined_format_args)]
 
 fn do_nothing<T>(_: T) {}
 

--- a/tests/ui/reversed_empty_ranges_fixable.fixed
+++ b/tests/ui/reversed_empty_ranges_fixable.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::reversed_empty_ranges)]
+#![allow(clippy::uninlined_format_args)]
 
 const ANSWER: i32 = 42;
 

--- a/tests/ui/reversed_empty_ranges_fixable.rs
+++ b/tests/ui/reversed_empty_ranges_fixable.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::reversed_empty_ranges)]
+#![allow(clippy::uninlined_format_args)]
 
 const ANSWER: i32 = 42;
 

--- a/tests/ui/reversed_empty_ranges_fixable.stderr
+++ b/tests/ui/reversed_empty_ranges_fixable.stderr
@@ -1,5 +1,5 @@
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:9:5
+  --> $DIR/reversed_empty_ranges_fixable.rs:10:5
    |
 LL |     (42..=21).for_each(|x| println!("{}", x));
    |     ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     (21..=42).rev().for_each(|x| println!("{}", x));
    |     ~~~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:10:13
+  --> $DIR/reversed_empty_ranges_fixable.rs:11:13
    |
 LL |     let _ = (ANSWER..21).filter(|x| x % 2 == 0).take(10).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |     let _ = (21..ANSWER).rev().filter(|x| x % 2 == 0).take(10).collect::<Ve
    |             ~~~~~~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:12:14
+  --> $DIR/reversed_empty_ranges_fixable.rs:13:14
    |
 LL |     for _ in -21..=-42 {}
    |              ^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     for _ in (-42..=-21).rev() {}
    |              ~~~~~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_fixable.rs:13:14
+  --> $DIR/reversed_empty_ranges_fixable.rs:14:14
    |
 LL |     for _ in 42u32..21u32 {}
    |              ^^^^^^^^^^^^

--- a/tests/ui/reversed_empty_ranges_loops_fixable.fixed
+++ b/tests/ui/reversed_empty_ranges_loops_fixable.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::reversed_empty_ranges)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     const MAX_LEN: usize = 42;

--- a/tests/ui/reversed_empty_ranges_loops_fixable.rs
+++ b/tests/ui/reversed_empty_ranges_loops_fixable.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::reversed_empty_ranges)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     const MAX_LEN: usize = 42;

--- a/tests/ui/reversed_empty_ranges_loops_fixable.stderr
+++ b/tests/ui/reversed_empty_ranges_loops_fixable.stderr
@@ -1,5 +1,5 @@
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_fixable.rs:7:14
+  --> $DIR/reversed_empty_ranges_loops_fixable.rs:8:14
    |
 LL |     for i in 10..0 {
    |              ^^^^^
@@ -11,7 +11,7 @@ LL |     for i in (0..10).rev() {
    |              ~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_fixable.rs:11:14
+  --> $DIR/reversed_empty_ranges_loops_fixable.rs:12:14
    |
 LL |     for i in 10..=0 {
    |              ^^^^^^
@@ -22,7 +22,7 @@ LL |     for i in (0..=10).rev() {
    |              ~~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_fixable.rs:15:14
+  --> $DIR/reversed_empty_ranges_loops_fixable.rs:16:14
    |
 LL |     for i in MAX_LEN..0 {
    |              ^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     for i in (0..MAX_LEN).rev() {
    |              ~~~~~~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_fixable.rs:34:14
+  --> $DIR/reversed_empty_ranges_loops_fixable.rs:35:14
    |
 LL |     for i in (10..0).map(|x| x * 2) {
    |              ^^^^^^^
@@ -44,7 +44,7 @@ LL |     for i in (0..10).rev().map(|x| x * 2) {
    |              ~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_fixable.rs:39:14
+  --> $DIR/reversed_empty_ranges_loops_fixable.rs:40:14
    |
 LL |     for i in 10..5 + 4 {
    |              ^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     for i in (5 + 4..10).rev() {
    |              ~~~~~~~~~~~~~~~~~
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_fixable.rs:43:14
+  --> $DIR/reversed_empty_ranges_loops_fixable.rs:44:14
    |
 LL |     for i in (5 + 2)..(3 - 1) {
    |              ^^^^^^^^^^^^^^^^

--- a/tests/ui/reversed_empty_ranges_loops_unfixable.rs
+++ b/tests/ui/reversed_empty_ranges_loops_unfixable.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::reversed_empty_ranges)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     for i in 5..5 {

--- a/tests/ui/reversed_empty_ranges_loops_unfixable.stderr
+++ b/tests/ui/reversed_empty_ranges_loops_unfixable.stderr
@@ -1,5 +1,5 @@
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_unfixable.rs:4:14
+  --> $DIR/reversed_empty_ranges_loops_unfixable.rs:5:14
    |
 LL |     for i in 5..5 {
    |              ^^^^
@@ -7,7 +7,7 @@ LL |     for i in 5..5 {
    = note: `-D clippy::reversed-empty-ranges` implied by `-D warnings`
 
 error: this range is empty so it will yield no values
-  --> $DIR/reversed_empty_ranges_loops_unfixable.rs:8:14
+  --> $DIR/reversed_empty_ranges_loops_unfixable.rs:9:14
    |
 LL |     for i in (5 + 2)..(8 - 1) {
    |              ^^^^^^^^^^^^^^^^

--- a/tests/ui/same_functions_in_if_condition.rs
+++ b/tests/ui/same_functions_in_if_condition.rs
@@ -1,8 +1,14 @@
 #![feature(adt_const_params)]
-#![allow(incomplete_features)]
 #![warn(clippy::same_functions_in_if_condition)]
-#![allow(clippy::ifs_same_cond)] // This warning is different from `ifs_same_cond`.
-#![allow(clippy::if_same_then_else, clippy::comparison_chain)] // all empty blocks
+// ifs_same_cond warning is different from `ifs_same_cond`.
+// clippy::if_same_then_else, clippy::comparison_chain -- all empty blocks
+#![allow(incomplete_features)]
+#![allow(
+    clippy::comparison_chain,
+    clippy::if_same_then_else,
+    clippy::ifs_same_cond,
+    clippy::uninlined_format_args
+)]
 
 fn function() -> bool {
     true

--- a/tests/ui/same_functions_in_if_condition.stderr
+++ b/tests/ui/same_functions_in_if_condition.stderr
@@ -1,72 +1,72 @@
 error: this `if` has the same function call as a previous `if`
-  --> $DIR/same_functions_in_if_condition.rs:31:15
+  --> $DIR/same_functions_in_if_condition.rs:37:15
    |
 LL |     } else if function() {
    |               ^^^^^^^^^^
    |
    = note: `-D clippy::same-functions-in-if-condition` implied by `-D warnings`
 note: same as this
-  --> $DIR/same_functions_in_if_condition.rs:30:8
+  --> $DIR/same_functions_in_if_condition.rs:36:8
    |
 LL |     if function() {
    |        ^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> $DIR/same_functions_in_if_condition.rs:36:15
+  --> $DIR/same_functions_in_if_condition.rs:42:15
    |
 LL |     } else if fn_arg(a) {
    |               ^^^^^^^^^
    |
 note: same as this
-  --> $DIR/same_functions_in_if_condition.rs:35:8
+  --> $DIR/same_functions_in_if_condition.rs:41:8
    |
 LL |     if fn_arg(a) {
    |        ^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> $DIR/same_functions_in_if_condition.rs:41:15
+  --> $DIR/same_functions_in_if_condition.rs:47:15
    |
 LL |     } else if obj.method() {
    |               ^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/same_functions_in_if_condition.rs:40:8
+  --> $DIR/same_functions_in_if_condition.rs:46:8
    |
 LL |     if obj.method() {
    |        ^^^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> $DIR/same_functions_in_if_condition.rs:46:15
+  --> $DIR/same_functions_in_if_condition.rs:52:15
    |
 LL |     } else if obj.method_arg(a) {
    |               ^^^^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/same_functions_in_if_condition.rs:45:8
+  --> $DIR/same_functions_in_if_condition.rs:51:8
    |
 LL |     if obj.method_arg(a) {
    |        ^^^^^^^^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> $DIR/same_functions_in_if_condition.rs:53:15
+  --> $DIR/same_functions_in_if_condition.rs:59:15
    |
 LL |     } else if v.pop().is_none() {
    |               ^^^^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/same_functions_in_if_condition.rs:51:8
+  --> $DIR/same_functions_in_if_condition.rs:57:8
    |
 LL |     if v.pop().is_none() {
    |        ^^^^^^^^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> $DIR/same_functions_in_if_condition.rs:58:15
+  --> $DIR/same_functions_in_if_condition.rs:64:15
    |
 LL |     } else if v.len() == 42 {
    |               ^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/same_functions_in_if_condition.rs:56:8
+  --> $DIR/same_functions_in_if_condition.rs:62:8
    |
 LL |     if v.len() == 42 {
    |        ^^^^^^^^^^^^^

--- a/tests/ui/semicolon_if_nothing_returned.rs
+++ b/tests/ui/semicolon_if_nothing_returned.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::semicolon_if_nothing_returned)]
-#![allow(clippy::redundant_closure)]
+#![allow(clippy::redundant_closure, clippy::uninlined_format_args)]
 
 fn get_unit() {}
 

--- a/tests/ui/significant_drop_in_scrutinee.rs
+++ b/tests/ui/significant_drop_in_scrutinee.rs
@@ -1,11 +1,8 @@
 // FIXME: Ideally these suggestions would be fixed via rustfix. Blocked by rust-lang/rust#53934
 // // run-rustfix
-
 #![warn(clippy::significant_drop_in_scrutinee)]
-#![allow(clippy::single_match)]
-#![allow(clippy::match_single_binding)]
-#![allow(unused_assignments)]
-#![allow(dead_code)]
+#![allow(dead_code, unused_assignments)]
+#![allow(clippy::match_single_binding, clippy::single_match, clippy::uninlined_format_args)]
 
 use std::num::ParseIntError;
 use std::ops::Deref;

--- a/tests/ui/significant_drop_in_scrutinee.stderr
+++ b/tests/ui/significant_drop_in_scrutinee.stderr
@@ -1,5 +1,5 @@
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:59:11
+  --> $DIR/significant_drop_in_scrutinee.rs:56:11
    |
 LL |     match mutex.lock().unwrap().foo() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:145:11
+  --> $DIR/significant_drop_in_scrutinee.rs:142:11
    |
 LL |     match s.lock_m().get_the_value() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:166:11
+  --> $DIR/significant_drop_in_scrutinee.rs:163:11
    |
 LL |     match s.lock_m_m().get_the_value() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:214:11
+  --> $DIR/significant_drop_in_scrutinee.rs:211:11
    |
 LL |     match counter.temp_increment().len() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:237:16
+  --> $DIR/significant_drop_in_scrutinee.rs:234:16
    |
 LL |         match (mutex1.lock().unwrap().s.len(), true) {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL ~         match (value, true) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:246:22
+  --> $DIR/significant_drop_in_scrutinee.rs:243:22
    |
 LL |         match (true, mutex1.lock().unwrap().s.len(), true) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL ~         match (true, value, true) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:256:16
+  --> $DIR/significant_drop_in_scrutinee.rs:253:16
    |
 LL |         match (mutex1.lock().unwrap().s.len(), true, mutex2.lock().unwrap().s.len()) {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL ~         match (value, true, mutex2.lock().unwrap().s.len()) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:256:54
+  --> $DIR/significant_drop_in_scrutinee.rs:253:54
    |
 LL |         match (mutex1.lock().unwrap().s.len(), true, mutex2.lock().unwrap().s.len()) {
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,7 +153,7 @@ LL ~         match (mutex1.lock().unwrap().s.len(), true, value) {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:267:15
+  --> $DIR/significant_drop_in_scrutinee.rs:264:15
    |
 LL |         match mutex3.lock().unwrap().s.as_str() {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ LL |         };
    = note: this might lead to deadlocks or other unexpected behavior
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:277:22
+  --> $DIR/significant_drop_in_scrutinee.rs:274:22
    |
 LL |         match (true, mutex3.lock().unwrap().s.as_str()) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL |         };
    = note: this might lead to deadlocks or other unexpected behavior
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:296:11
+  --> $DIR/significant_drop_in_scrutinee.rs:293:11
    |
 LL |     match mutex.lock().unwrap().s.len() > 1 {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:303:11
+  --> $DIR/significant_drop_in_scrutinee.rs:300:11
    |
 LL |     match 1 < mutex.lock().unwrap().s.len() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -223,7 +223,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:321:11
+  --> $DIR/significant_drop_in_scrutinee.rs:318:11
    |
 LL |     match mutex1.lock().unwrap().s.len() < mutex2.lock().unwrap().s.len() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,7 +244,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:332:11
+  --> $DIR/significant_drop_in_scrutinee.rs:329:11
    |
 LL |     match mutex1.lock().unwrap().s.len() >= mutex2.lock().unwrap().s.len() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -265,7 +265,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:367:11
+  --> $DIR/significant_drop_in_scrutinee.rs:364:11
    |
 LL |     match get_mutex_guard().s.len() > 1 {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -284,7 +284,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:384:11
+  --> $DIR/significant_drop_in_scrutinee.rs:381:11
    |
 LL |       match match i {
    |  ___________^
@@ -316,7 +316,7 @@ LL ~     match value
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:410:11
+  --> $DIR/significant_drop_in_scrutinee.rs:407:11
    |
 LL |       match if i > 1 {
    |  ___________^
@@ -349,7 +349,7 @@ LL ~     match value
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:464:11
+  --> $DIR/significant_drop_in_scrutinee.rs:461:11
    |
 LL |     match s.lock().deref().deref() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -367,7 +367,7 @@ LL ~     match value {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:492:11
+  --> $DIR/significant_drop_in_scrutinee.rs:489:11
    |
 LL |     match s.lock().deref().deref() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -380,7 +380,7 @@ LL |     };
    = note: this might lead to deadlocks or other unexpected behavior
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:511:11
+  --> $DIR/significant_drop_in_scrutinee.rs:508:11
    |
 LL |     match mutex.lock().unwrap().i = i {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -399,7 +399,7 @@ LL ~     match () {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:517:11
+  --> $DIR/significant_drop_in_scrutinee.rs:514:11
    |
 LL |     match i = mutex.lock().unwrap().i {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -418,7 +418,7 @@ LL ~     match () {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:523:11
+  --> $DIR/significant_drop_in_scrutinee.rs:520:11
    |
 LL |     match mutex.lock().unwrap().i += 1 {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -437,7 +437,7 @@ LL ~     match () {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:529:11
+  --> $DIR/significant_drop_in_scrutinee.rs:526:11
    |
 LL |     match i += mutex.lock().unwrap().i {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -456,7 +456,7 @@ LL ~     match () {
    |
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:592:11
+  --> $DIR/significant_drop_in_scrutinee.rs:589:11
    |
 LL |     match rwlock.read().unwrap().to_number() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -467,7 +467,7 @@ LL |     };
    = note: this might lead to deadlocks or other unexpected behavior
 
 error: temporary with significant `Drop` in `for` loop condition will live until the end of the `for` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:602:14
+  --> $DIR/significant_drop_in_scrutinee.rs:599:14
    |
 LL |     for s in rwlock.read().unwrap().iter() {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ LL |     }
    = note: this might lead to deadlocks or other unexpected behavior
 
 error: temporary with significant `Drop` in `match` scrutinee will live until the end of the `match` expression
-  --> $DIR/significant_drop_in_scrutinee.rs:617:11
+  --> $DIR/significant_drop_in_scrutinee.rs:614:11
    |
 LL |     match mutex.lock().unwrap().foo() {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::single_match)]
+#![allow(clippy::uninlined_format_args)]
 
 fn dummy() {}
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:8:5
+  --> $DIR/single_match.rs:9:5
    |
 LL | /     match x {
 LL | |         Some(y) => {
@@ -18,7 +18,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:16:5
+  --> $DIR/single_match.rs:17:5
    |
 LL | /     match x {
 LL | |         // Note the missing block braces.
@@ -30,7 +30,7 @@ LL | |     }
    | |_____^ help: try this: `if let Some(y) = x { println!("{:?}", y) }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:25:5
+  --> $DIR/single_match.rs:26:5
    |
 LL | /     match z {
 LL | |         (2..=3, 7..=9) => dummy(),
@@ -39,7 +39,7 @@ LL | |     };
    | |_____^ help: try this: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:54:5
+  --> $DIR/single_match.rs:55:5
    |
 LL | /     match x {
 LL | |         Some(y) => dummy(),
@@ -48,7 +48,7 @@ LL | |     };
    | |_____^ help: try this: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:59:5
+  --> $DIR/single_match.rs:60:5
    |
 LL | /     match y {
 LL | |         Ok(y) => dummy(),
@@ -57,7 +57,7 @@ LL | |     };
    | |_____^ help: try this: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:66:5
+  --> $DIR/single_match.rs:67:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try this: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:87:5
+  --> $DIR/single_match.rs:88:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -75,7 +75,7 @@ LL | |     }
    | |_____^ help: try this: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:100:5
+  --> $DIR/single_match.rs:101:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -84,7 +84,7 @@ LL | |     }
    | |_____^ help: try this: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:106:5
+  --> $DIR/single_match.rs:107:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -93,7 +93,7 @@ LL | |     }
    | |_____^ help: try this: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:111:5
+  --> $DIR/single_match.rs:112:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -102,7 +102,7 @@ LL | |     }
    | |_____^ help: try this: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:117:5
+  --> $DIR/single_match.rs:118:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -111,7 +111,7 @@ LL | |     }
    | |_____^ help: try this: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:134:5
+  --> $DIR/single_match.rs:135:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -120,7 +120,7 @@ LL | |     }
    | |_____^ help: try this: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:142:5
+  --> $DIR/single_match.rs:143:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -129,7 +129,7 @@ LL | |     };
    | |_____^ help: try this: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:164:5
+  --> $DIR/single_match.rs:165:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -138,7 +138,7 @@ LL | |     }
    | |_____^ help: try this: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:170:5
+  --> $DIR/single_match.rs:171:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -147,7 +147,7 @@ LL | |     }
    | |_____^ help: try this: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:176:5
+  --> $DIR/single_match.rs:177:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},

--- a/tests/ui/single_match_else.rs
+++ b/tests/ui/single_match_else.rs
@@ -1,8 +1,6 @@
 // aux-build: proc_macro_with_span.rs
-
 #![warn(clippy::single_match_else)]
-#![allow(clippy::needless_return)]
-#![allow(clippy::no_effect)]
+#![allow(clippy::needless_return, clippy::no_effect, clippy::uninlined_format_args)]
 
 extern crate proc_macro_with_span;
 use proc_macro_with_span::with_span;

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:19:13
+  --> $DIR/single_match_else.rs:17:13
    |
 LL |       let _ = match ExprNode::Butterflies {
    |  _____________^
@@ -21,7 +21,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:84:5
+  --> $DIR/single_match_else.rs:82:5
    |
 LL | /     match Some(1) {
 LL | |         Some(a) => println!("${:?}", a),
@@ -41,7 +41,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:93:5
+  --> $DIR/single_match_else.rs:91:5
    |
 LL | /     match Some(1) {
 LL | |         Some(a) => println!("${:?}", a),
@@ -61,7 +61,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:103:5
+  --> $DIR/single_match_else.rs:101:5
    |
 LL | /     match Result::<i32, Infallible>::Ok(1) {
 LL | |         Ok(a) => println!("${:?}", a),
@@ -81,7 +81,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:112:5
+  --> $DIR/single_match_else.rs:110:5
    |
 LL | /     match Cow::from("moo") {
 LL | |         Cow::Owned(a) => println!("${:?}", a),

--- a/tests/ui/toplevel_ref_arg.fixed
+++ b/tests/ui/toplevel_ref_arg.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // aux-build:macro_rules.rs
-
 #![warn(clippy::toplevel_ref_arg)]
+#![allow(clippy::uninlined_format_args)]
 
 #[macro_use]
 extern crate macro_rules;

--- a/tests/ui/toplevel_ref_arg.rs
+++ b/tests/ui/toplevel_ref_arg.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 // aux-build:macro_rules.rs
-
 #![warn(clippy::toplevel_ref_arg)]
+#![allow(clippy::uninlined_format_args)]
 
 #[macro_use]
 extern crate macro_rules;

--- a/tests/ui/trivially_copy_pass_by_ref.rs
+++ b/tests/ui/trivially_copy_pass_by_ref.rs
@@ -1,8 +1,11 @@
 // normalize-stderr-test "\(\d+ byte\)" -> "(N byte)"
 // normalize-stderr-test "\(limit: \d+ byte\)" -> "(limit: N byte)"
-
 #![deny(clippy::trivially_copy_pass_by_ref)]
-#![allow(clippy::disallowed_names, clippy::redundant_field_names)]
+#![allow(
+    clippy::disallowed_names,
+    clippy::redundant_field_names,
+    clippy::uninlined_format_args
+)]
 
 #[derive(Copy, Clone)]
 struct Foo(u32);

--- a/tests/ui/trivially_copy_pass_by_ref.stderr
+++ b/tests/ui/trivially_copy_pass_by_ref.stderr
@@ -1,113 +1,113 @@
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:47:11
+  --> $DIR/trivially_copy_pass_by_ref.rs:50:11
    |
 LL | fn bad(x: &u32, y: &Foo, z: &Baz) {}
    |           ^^^^ help: consider passing by value instead: `u32`
    |
 note: the lint level is defined here
-  --> $DIR/trivially_copy_pass_by_ref.rs:4:9
+  --> $DIR/trivially_copy_pass_by_ref.rs:3:9
    |
 LL | #![deny(clippy::trivially_copy_pass_by_ref)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:47:20
+  --> $DIR/trivially_copy_pass_by_ref.rs:50:20
    |
 LL | fn bad(x: &u32, y: &Foo, z: &Baz) {}
    |                    ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:47:29
+  --> $DIR/trivially_copy_pass_by_ref.rs:50:29
    |
 LL | fn bad(x: &u32, y: &Foo, z: &Baz) {}
    |                             ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:54:12
+  --> $DIR/trivially_copy_pass_by_ref.rs:57:12
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |            ^^^^^ help: consider passing by value instead: `self`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:54:22
+  --> $DIR/trivially_copy_pass_by_ref.rs:57:22
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |                      ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:54:31
+  --> $DIR/trivially_copy_pass_by_ref.rs:57:31
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |                               ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:54:40
+  --> $DIR/trivially_copy_pass_by_ref.rs:57:40
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |                                        ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:56:16
+  --> $DIR/trivially_copy_pass_by_ref.rs:59:16
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:56:25
+  --> $DIR/trivially_copy_pass_by_ref.rs:59:25
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                         ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:56:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:59:34
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                                  ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:58:35
+  --> $DIR/trivially_copy_pass_by_ref.rs:61:35
    |
 LL |     fn bad_issue7518(self, other: &Self) {}
    |                                   ^^^^^ help: consider passing by value instead: `Self`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:70:16
+  --> $DIR/trivially_copy_pass_by_ref.rs:73:16
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:70:25
+  --> $DIR/trivially_copy_pass_by_ref.rs:73:25
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                         ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:70:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:73:34
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                                  ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:74:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:77:34
    |
 LL |     fn trait_method(&self, _foo: &Foo);
    |                                  ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:106:21
+  --> $DIR/trivially_copy_pass_by_ref.rs:109:21
    |
 LL |     fn foo_never(x: &i32) {
    |                     ^^^^ help: consider passing by value instead: `i32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:111:15
+  --> $DIR/trivially_copy_pass_by_ref.rs:114:15
    |
 LL |     fn foo(x: &i32) {
    |               ^^^^ help: consider passing by value instead: `i32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:138:37
+  --> $DIR/trivially_copy_pass_by_ref.rs:141:37
    |
 LL | fn _unrelated_lifetimes<'a, 'b>(_x: &'a u32, y: &'b u32) -> &'b u32 {
    |                                     ^^^^^^^ help: consider passing by value instead: `u32`

--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -1,12 +1,8 @@
 // run-rustfix
-
-#![allow(clippy::eq_op)]
-#![allow(clippy::format_in_format_args)]
-#![allow(clippy::print_literal)]
-#![allow(named_arguments_used_positionally)]
-#![allow(unused_variables, unused_imports, unused_macros)]
-#![warn(clippy::uninlined_format_args)]
 #![feature(custom_inner_attributes)]
+#![warn(clippy::uninlined_format_args)]
+#![allow(named_arguments_used_positionally, unused_imports, unused_macros, unused_variables)]
+#![allow(clippy::eq_op, clippy::format_in_format_args, clippy::print_literal)]
 
 macro_rules! no_param_str {
     () => {

--- a/tests/ui/uninlined_format_args.rs
+++ b/tests/ui/uninlined_format_args.rs
@@ -1,12 +1,8 @@
 // run-rustfix
-
-#![allow(clippy::eq_op)]
-#![allow(clippy::format_in_format_args)]
-#![allow(clippy::print_literal)]
-#![allow(named_arguments_used_positionally)]
-#![allow(unused_variables, unused_imports, unused_macros)]
-#![warn(clippy::uninlined_format_args)]
 #![feature(custom_inner_attributes)]
+#![warn(clippy::uninlined_format_args)]
+#![allow(named_arguments_used_positionally, unused_imports, unused_macros, unused_variables)]
+#![allow(clippy::eq_op, clippy::format_in_format_args, clippy::print_literal)]
 
 macro_rules! no_param_str {
     () => {

--- a/tests/ui/uninlined_format_args.stderr
+++ b/tests/ui/uninlined_format_args.stderr
@@ -1,5 +1,5 @@
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:47:5
+  --> $DIR/uninlined_format_args.rs:43:5
    |
 LL |     println!("val='{}'", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL +     println!("val='{local_i32}'");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:48:5
+  --> $DIR/uninlined_format_args.rs:44:5
    |
 LL |     println!("val='{   }'", local_i32); // 3 spaces
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL +     println!("val='{local_i32}'"); // 3 spaces
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:49:5
+  --> $DIR/uninlined_format_args.rs:45:5
    |
 LL |     println!("val='{    }'", local_i32); // tab
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL +     println!("val='{local_i32}'"); // tab
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:50:5
+  --> $DIR/uninlined_format_args.rs:46:5
    |
 LL |     println!("val='{     }'", local_i32); // space+tab
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL +     println!("val='{local_i32}'"); // space+tab
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:51:5
+  --> $DIR/uninlined_format_args.rs:47:5
    |
 LL |     println!("val='{     }'", local_i32); // tab+space
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL +     println!("val='{local_i32}'"); // tab+space
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:52:5
+  --> $DIR/uninlined_format_args.rs:48:5
    |
 LL | /     println!(
 LL | |         "val='{
@@ -76,7 +76,7 @@ LL +         "val='{local_i32}'"
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:57:5
+  --> $DIR/uninlined_format_args.rs:53:5
    |
 LL |     println!("{}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL +     println!("{local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:58:5
+  --> $DIR/uninlined_format_args.rs:54:5
    |
 LL |     println!("{}", fn_arg);
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ LL +     println!("{fn_arg}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:59:5
+  --> $DIR/uninlined_format_args.rs:55:5
    |
 LL |     println!("{:?}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL +     println!("{local_i32:?}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:60:5
+  --> $DIR/uninlined_format_args.rs:56:5
    |
 LL |     println!("{:#?}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,7 +124,7 @@ LL +     println!("{local_i32:#?}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:61:5
+  --> $DIR/uninlined_format_args.rs:57:5
    |
 LL |     println!("{:4}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +136,7 @@ LL +     println!("{local_i32:4}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:62:5
+  --> $DIR/uninlined_format_args.rs:58:5
    |
 LL |     println!("{:04}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -148,7 +148,7 @@ LL +     println!("{local_i32:04}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:63:5
+  --> $DIR/uninlined_format_args.rs:59:5
    |
 LL |     println!("{:<3}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL +     println!("{local_i32:<3}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:64:5
+  --> $DIR/uninlined_format_args.rs:60:5
    |
 LL |     println!("{:#010x}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL +     println!("{local_i32:#010x}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:65:5
+  --> $DIR/uninlined_format_args.rs:61:5
    |
 LL |     println!("{:.1}", local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +184,7 @@ LL +     println!("{local_f64:.1}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:66:5
+  --> $DIR/uninlined_format_args.rs:62:5
    |
 LL |     println!("Hello {} is {:.*}", "x", local_i32, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -196,7 +196,7 @@ LL +     println!("Hello {} is {local_f64:.local_i32$}", "x");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:67:5
+  --> $DIR/uninlined_format_args.rs:63:5
    |
 LL |     println!("Hello {} is {:.*}", local_i32, 5, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +208,7 @@ LL +     println!("Hello {local_i32} is {local_f64:.*}", 5);
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:68:5
+  --> $DIR/uninlined_format_args.rs:64:5
    |
 LL |     println!("Hello {} is {2:.*}", local_i32, 5, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +220,7 @@ LL +     println!("Hello {local_i32} is {local_f64:.*}", 5);
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:69:5
+  --> $DIR/uninlined_format_args.rs:65:5
    |
 LL |     println!("{} {}", local_i32, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -232,7 +232,7 @@ LL +     println!("{local_i32} {local_f64}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:70:5
+  --> $DIR/uninlined_format_args.rs:66:5
    |
 LL |     println!("{}, {}", local_i32, local_opt.unwrap());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,7 +244,7 @@ LL +     println!("{local_i32}, {}", local_opt.unwrap());
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:71:5
+  --> $DIR/uninlined_format_args.rs:67:5
    |
 LL |     println!("{}", val);
    |     ^^^^^^^^^^^^^^^^^^^
@@ -256,7 +256,7 @@ LL +     println!("{val}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:72:5
+  --> $DIR/uninlined_format_args.rs:68:5
    |
 LL |     println!("{}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -268,7 +268,7 @@ LL +     println!("{val}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:74:5
+  --> $DIR/uninlined_format_args.rs:70:5
    |
 LL |     println!("val='{/t }'", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -280,7 +280,7 @@ LL +     println!("val='{local_i32}'");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:75:5
+  --> $DIR/uninlined_format_args.rs:71:5
    |
 LL |     println!("val='{/n }'", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -292,7 +292,7 @@ LL +     println!("val='{local_i32}'");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:76:5
+  --> $DIR/uninlined_format_args.rs:72:5
    |
 LL |     println!("val='{local_i32}'", local_i32 = local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -304,7 +304,7 @@ LL +     println!("val='{local_i32}'");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:77:5
+  --> $DIR/uninlined_format_args.rs:73:5
    |
 LL |     println!("val='{local_i32}'", local_i32 = fn_arg);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -316,7 +316,7 @@ LL +     println!("val='{fn_arg}'");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:78:5
+  --> $DIR/uninlined_format_args.rs:74:5
    |
 LL |     println!("{0}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -328,7 +328,7 @@ LL +     println!("{local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:79:5
+  --> $DIR/uninlined_format_args.rs:75:5
    |
 LL |     println!("{0:?}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -340,7 +340,7 @@ LL +     println!("{local_i32:?}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:80:5
+  --> $DIR/uninlined_format_args.rs:76:5
    |
 LL |     println!("{0:#?}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -352,7 +352,7 @@ LL +     println!("{local_i32:#?}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:81:5
+  --> $DIR/uninlined_format_args.rs:77:5
    |
 LL |     println!("{0:04}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -364,7 +364,7 @@ LL +     println!("{local_i32:04}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:82:5
+  --> $DIR/uninlined_format_args.rs:78:5
    |
 LL |     println!("{0:<3}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -376,7 +376,7 @@ LL +     println!("{local_i32:<3}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:83:5
+  --> $DIR/uninlined_format_args.rs:79:5
    |
 LL |     println!("{0:#010x}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -388,7 +388,7 @@ LL +     println!("{local_i32:#010x}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:84:5
+  --> $DIR/uninlined_format_args.rs:80:5
    |
 LL |     println!("{0:.1}", local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -400,7 +400,7 @@ LL +     println!("{local_f64:.1}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:85:5
+  --> $DIR/uninlined_format_args.rs:81:5
    |
 LL |     println!("{0} {0}", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -412,7 +412,7 @@ LL +     println!("{local_i32} {local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:86:5
+  --> $DIR/uninlined_format_args.rs:82:5
    |
 LL |     println!("{1} {} {0} {}", local_i32, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -424,7 +424,7 @@ LL +     println!("{local_f64} {local_i32} {local_i32} {local_f64}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:87:5
+  --> $DIR/uninlined_format_args.rs:83:5
    |
 LL |     println!("{0} {1}", local_i32, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -436,7 +436,7 @@ LL +     println!("{local_i32} {local_f64}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:88:5
+  --> $DIR/uninlined_format_args.rs:84:5
    |
 LL |     println!("{1} {0}", local_i32, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -448,7 +448,7 @@ LL +     println!("{local_f64} {local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:89:5
+  --> $DIR/uninlined_format_args.rs:85:5
    |
 LL |     println!("{1} {0} {1} {0}", local_i32, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -460,7 +460,7 @@ LL +     println!("{local_f64} {local_i32} {local_f64} {local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:91:5
+  --> $DIR/uninlined_format_args.rs:87:5
    |
 LL |     println!("{v}", v = local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -472,7 +472,7 @@ LL +     println!("{local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:92:5
+  --> $DIR/uninlined_format_args.rs:88:5
    |
 LL |     println!("{local_i32:0$}", width);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -484,7 +484,7 @@ LL +     println!("{local_i32:width$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:93:5
+  --> $DIR/uninlined_format_args.rs:89:5
    |
 LL |     println!("{local_i32:w$}", w = width);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -496,7 +496,7 @@ LL +     println!("{local_i32:width$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:94:5
+  --> $DIR/uninlined_format_args.rs:90:5
    |
 LL |     println!("{local_i32:.0$}", prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -508,7 +508,7 @@ LL +     println!("{local_i32:.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:95:5
+  --> $DIR/uninlined_format_args.rs:91:5
    |
 LL |     println!("{local_i32:.p$}", p = prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -520,7 +520,7 @@ LL +     println!("{local_i32:.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:96:5
+  --> $DIR/uninlined_format_args.rs:92:5
    |
 LL |     println!("{:0$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -532,7 +532,7 @@ LL +     println!("{val:val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:97:5
+  --> $DIR/uninlined_format_args.rs:93:5
    |
 LL |     println!("{0:0$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -544,7 +544,7 @@ LL +     println!("{val:val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:98:5
+  --> $DIR/uninlined_format_args.rs:94:5
    |
 LL |     println!("{:0$.0$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -556,7 +556,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:99:5
+  --> $DIR/uninlined_format_args.rs:95:5
    |
 LL |     println!("{0:0$.0$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -568,7 +568,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:100:5
+  --> $DIR/uninlined_format_args.rs:96:5
    |
 LL |     println!("{0:0$.v$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -580,7 +580,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:101:5
+  --> $DIR/uninlined_format_args.rs:97:5
    |
 LL |     println!("{0:v$.0$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -592,7 +592,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:102:5
+  --> $DIR/uninlined_format_args.rs:98:5
    |
 LL |     println!("{v:0$.0$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -604,7 +604,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:103:5
+  --> $DIR/uninlined_format_args.rs:99:5
    |
 LL |     println!("{v:v$.0$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -616,7 +616,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:104:5
+  --> $DIR/uninlined_format_args.rs:100:5
    |
 LL |     println!("{v:0$.v$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -628,7 +628,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:105:5
+  --> $DIR/uninlined_format_args.rs:101:5
    |
 LL |     println!("{v:v$.v$}", v = val);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -640,7 +640,7 @@ LL +     println!("{val:val$.val$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:106:5
+  --> $DIR/uninlined_format_args.rs:102:5
    |
 LL |     println!("{:0$}", width);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -652,7 +652,7 @@ LL +     println!("{width:width$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:107:5
+  --> $DIR/uninlined_format_args.rs:103:5
    |
 LL |     println!("{:1$}", local_i32, width);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -664,7 +664,7 @@ LL +     println!("{local_i32:width$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:108:5
+  --> $DIR/uninlined_format_args.rs:104:5
    |
 LL |     println!("{:w$}", w = width);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -676,7 +676,7 @@ LL +     println!("{width:width$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:109:5
+  --> $DIR/uninlined_format_args.rs:105:5
    |
 LL |     println!("{:w$}", local_i32, w = width);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -688,7 +688,7 @@ LL +     println!("{local_i32:width$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:110:5
+  --> $DIR/uninlined_format_args.rs:106:5
    |
 LL |     println!("{:.0$}", prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -700,7 +700,7 @@ LL +     println!("{prec:.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:111:5
+  --> $DIR/uninlined_format_args.rs:107:5
    |
 LL |     println!("{:.1$}", local_i32, prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -712,7 +712,7 @@ LL +     println!("{local_i32:.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:112:5
+  --> $DIR/uninlined_format_args.rs:108:5
    |
 LL |     println!("{:.p$}", p = prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -724,7 +724,7 @@ LL +     println!("{prec:.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:113:5
+  --> $DIR/uninlined_format_args.rs:109:5
    |
 LL |     println!("{:.p$}", local_i32, p = prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -736,7 +736,7 @@ LL +     println!("{local_i32:.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:114:5
+  --> $DIR/uninlined_format_args.rs:110:5
    |
 LL |     println!("{:0$.1$}", width, prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -748,7 +748,7 @@ LL +     println!("{width:width$.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:115:5
+  --> $DIR/uninlined_format_args.rs:111:5
    |
 LL |     println!("{:0$.w$}", width, w = prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -760,7 +760,7 @@ LL +     println!("{width:width$.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:116:5
+  --> $DIR/uninlined_format_args.rs:112:5
    |
 LL |     println!("{:1$.2$}", local_f64, width, prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -772,7 +772,7 @@ LL +     println!("{local_f64:width$.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:117:5
+  --> $DIR/uninlined_format_args.rs:113:5
    |
 LL |     println!("{:1$.2$} {0} {1} {2}", local_f64, width, prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -784,7 +784,7 @@ LL +     println!("{local_f64:width$.prec$} {local_f64} {width} {prec}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:118:5
+  --> $DIR/uninlined_format_args.rs:114:5
    |
 LL | /     println!(
 LL | |         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}",
@@ -803,7 +803,7 @@ LL ~         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}",
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:129:5
+  --> $DIR/uninlined_format_args.rs:125:5
    |
 LL |     println!("Width = {}, value with width = {:0$}", local_i32, local_f64);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -815,7 +815,7 @@ LL +     println!("Width = {local_i32}, value with width = {local_f64:local_i32$
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:130:5
+  --> $DIR/uninlined_format_args.rs:126:5
    |
 LL |     println!("{:w$.p$}", local_i32, w = width, p = prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -827,7 +827,7 @@ LL +     println!("{local_i32:width$.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:131:5
+  --> $DIR/uninlined_format_args.rs:127:5
    |
 LL |     println!("{:w$.p$}", w = width, p = prec);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -839,7 +839,7 @@ LL +     println!("{width:width$.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:132:20
+  --> $DIR/uninlined_format_args.rs:128:20
    |
 LL |     println!("{}", format!("{}", local_i32));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -851,7 +851,7 @@ LL +     println!("{}", format!("{local_i32}"));
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:170:5
+  --> $DIR/uninlined_format_args.rs:166:5
    |
 LL |     println!("expand='{}'", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unit_arg.rs
+++ b/tests/ui/unit_arg.rs
@@ -1,17 +1,16 @@
 // aux-build: proc_macro_with_span.rs
-
 #![warn(clippy::unit_arg)]
+#![allow(unused_must_use, unused_variables)]
 #![allow(
-    clippy::no_effect,
-    unused_must_use,
-    unused_variables,
-    clippy::unused_unit,
-    clippy::unnecessary_wraps,
-    clippy::or_fun_call,
-    clippy::needless_question_mark,
-    clippy::self_named_constructors,
     clippy::let_unit_value,
-    clippy::never_loop
+    clippy::needless_question_mark,
+    clippy::never_loop,
+    clippy::no_effect,
+    clippy::or_fun_call,
+    clippy::self_named_constructors,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_wraps,
+    clippy::unused_unit
 )]
 
 extern crate proc_macro_with_span;

--- a/tests/ui/unit_arg.stderr
+++ b/tests/ui/unit_arg.stderr
@@ -1,5 +1,5 @@
 error: passing a unit value to a function
-  --> $DIR/unit_arg.rs:63:5
+  --> $DIR/unit_arg.rs:62:5
    |
 LL | /     foo({
 LL | |         1;
@@ -20,7 +20,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> $DIR/unit_arg.rs:66:5
+  --> $DIR/unit_arg.rs:65:5
    |
 LL |     foo(foo(1));
    |     ^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> $DIR/unit_arg.rs:67:5
+  --> $DIR/unit_arg.rs:66:5
    |
 LL | /     foo({
 LL | |         foo(1);
@@ -54,7 +54,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> $DIR/unit_arg.rs:72:5
+  --> $DIR/unit_arg.rs:71:5
    |
 LL | /     b.bar({
 LL | |         1;
@@ -74,7 +74,7 @@ LL ~     b.bar(());
    |
 
 error: passing unit values to a function
-  --> $DIR/unit_arg.rs:75:5
+  --> $DIR/unit_arg.rs:74:5
    |
 LL |     taking_multiple_units(foo(0), foo(1));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -87,7 +87,7 @@ LL ~     taking_multiple_units((), ());
    |
 
 error: passing unit values to a function
-  --> $DIR/unit_arg.rs:76:5
+  --> $DIR/unit_arg.rs:75:5
    |
 LL | /     taking_multiple_units(foo(0), {
 LL | |         foo(1);
@@ -110,7 +110,7 @@ LL ~     taking_multiple_units((), ());
    |
 
 error: passing unit values to a function
-  --> $DIR/unit_arg.rs:80:5
+  --> $DIR/unit_arg.rs:79:5
    |
 LL | /     taking_multiple_units(
 LL | |         {
@@ -146,7 +146,7 @@ LL ~     );
    |
 
 error: passing a unit value to a function
-  --> $DIR/unit_arg.rs:91:13
+  --> $DIR/unit_arg.rs:90:13
    |
 LL |     None.or(Some(foo(2)));
    |             ^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL ~     });
    |
 
 error: passing a unit value to a function
-  --> $DIR/unit_arg.rs:94:5
+  --> $DIR/unit_arg.rs:93:5
    |
 LL |     foo(foo(()));
    |     ^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL ~     foo(());
    |
 
 error: passing a unit value to a function
-  --> $DIR/unit_arg.rs:131:5
+  --> $DIR/unit_arg.rs:130:5
    |
 LL |     Some(foo(1))
    |     ^^^^^^^^^^^^

--- a/tests/ui/unit_arg_empty_blocks.fixed
+++ b/tests/ui/unit_arg_empty_blocks.fixed
@@ -1,6 +1,7 @@
 // run-rustfix
 #![warn(clippy::unit_arg)]
-#![allow(clippy::no_effect, unused_must_use, unused_variables)]
+#![allow(unused_must_use, unused_variables)]
+#![allow(clippy::no_effect, clippy::uninlined_format_args)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/unit_arg_empty_blocks.rs
+++ b/tests/ui/unit_arg_empty_blocks.rs
@@ -1,6 +1,7 @@
 // run-rustfix
 #![warn(clippy::unit_arg)]
-#![allow(clippy::no_effect, unused_must_use, unused_variables)]
+#![allow(unused_must_use, unused_variables)]
+#![allow(clippy::no_effect, clippy::uninlined_format_args)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/unit_arg_empty_blocks.stderr
+++ b/tests/ui/unit_arg_empty_blocks.stderr
@@ -1,5 +1,5 @@
 error: passing a unit value to a function
-  --> $DIR/unit_arg_empty_blocks.rs:16:5
+  --> $DIR/unit_arg_empty_blocks.rs:17:5
    |
 LL |     foo({});
    |     ^^^^--^
@@ -9,7 +9,7 @@ LL |     foo({});
    = note: `-D clippy::unit-arg` implied by `-D warnings`
 
 error: passing a unit value to a function
-  --> $DIR/unit_arg_empty_blocks.rs:17:5
+  --> $DIR/unit_arg_empty_blocks.rs:18:5
    |
 LL |     foo3({}, 2, 2);
    |     ^^^^^--^^^^^^^
@@ -17,7 +17,7 @@ LL |     foo3({}, 2, 2);
    |          help: use a unit literal instead: `()`
 
 error: passing unit values to a function
-  --> $DIR/unit_arg_empty_blocks.rs:18:5
+  --> $DIR/unit_arg_empty_blocks.rs:19:5
    |
 LL |     taking_two_units({}, foo(0));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL ~     taking_two_units((), ());
    |
 
 error: passing unit values to a function
-  --> $DIR/unit_arg_empty_blocks.rs:19:5
+  --> $DIR/unit_arg_empty_blocks.rs:20:5
    |
 LL |     taking_three_units({}, foo(0), foo(1));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unnecessary_clone.rs
+++ b/tests/ui/unnecessary_clone.rs
@@ -1,7 +1,7 @@
 // does not test any rustfixable lints
-
 #![warn(clippy::clone_on_ref_ptr)]
-#![allow(unused, clippy::redundant_clone, clippy::unnecessary_wraps)]
+#![allow(unused)]
+#![allow(clippy::redundant_clone, clippy::uninlined_format_args, clippy::unnecessary_wraps)]
 
 use std::cell::RefCell;
 use std::rc::{self, Rc};

--- a/tests/ui/unnecessary_join.fixed
+++ b/tests/ui/unnecessary_join.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
-
 #![warn(clippy::unnecessary_join)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     // should be linted

--- a/tests/ui/unnecessary_join.rs
+++ b/tests/ui/unnecessary_join.rs
@@ -1,6 +1,6 @@
 // run-rustfix
-
 #![warn(clippy::unnecessary_join)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     // should be linted

--- a/tests/ui/used_underscore_binding.rs
+++ b/tests/ui/used_underscore_binding.rs
@@ -1,9 +1,8 @@
 // aux-build:proc_macro_derive.rs
-
 #![feature(rustc_private)]
 #![warn(clippy::all)]
-#![allow(clippy::disallowed_names, clippy::eq_op)]
 #![warn(clippy::used_underscore_binding)]
+#![allow(clippy::disallowed_names, clippy::eq_op, clippy::uninlined_format_args)]
 
 #[macro_use]
 extern crate proc_macro_derive;

--- a/tests/ui/used_underscore_binding.stderr
+++ b/tests/ui/used_underscore_binding.stderr
@@ -1,5 +1,5 @@
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
-  --> $DIR/used_underscore_binding.rs:25:5
+  --> $DIR/used_underscore_binding.rs:24:5
    |
 LL |     _foo + 1
    |     ^^^^
@@ -7,31 +7,31 @@ LL |     _foo + 1
    = note: `-D clippy::used-underscore-binding` implied by `-D warnings`
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
-  --> $DIR/used_underscore_binding.rs:30:20
+  --> $DIR/used_underscore_binding.rs:29:20
    |
 LL |     println!("{}", _foo);
    |                    ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
-  --> $DIR/used_underscore_binding.rs:31:16
+  --> $DIR/used_underscore_binding.rs:30:16
    |
 LL |     assert_eq!(_foo, _foo);
    |                ^^^^
 
 error: used binding `_foo` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
-  --> $DIR/used_underscore_binding.rs:31:22
+  --> $DIR/used_underscore_binding.rs:30:22
    |
 LL |     assert_eq!(_foo, _foo);
    |                      ^^^^
 
 error: used binding `_underscore_field` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
-  --> $DIR/used_underscore_binding.rs:44:5
+  --> $DIR/used_underscore_binding.rs:43:5
    |
 LL |     s._underscore_field += 1;
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: used binding `_i` which is prefixed with an underscore. A leading underscore signals that a binding will not be used
-  --> $DIR/used_underscore_binding.rs:105:16
+  --> $DIR/used_underscore_binding.rs:104:16
    |
 LL |         uses_i(_i);
    |                ^^

--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -1,7 +1,6 @@
 // run-rustfix
-
 #![deny(clippy::useless_asref)]
-#![allow(clippy::explicit_auto_deref)]
+#![allow(clippy::explicit_auto_deref, clippy::uninlined_format_args)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -1,7 +1,6 @@
 // run-rustfix
-
 #![deny(clippy::useless_asref)]
-#![allow(clippy::explicit_auto_deref)]
+#![allow(clippy::explicit_auto_deref, clippy::uninlined_format_args)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/useless_asref.stderr
+++ b/tests/ui/useless_asref.stderr
@@ -1,71 +1,71 @@
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:44:18
+  --> $DIR/useless_asref.rs:43:18
    |
 LL |         foo_rstr(rstr.as_ref());
    |                  ^^^^^^^^^^^^^ help: try this: `rstr`
    |
 note: the lint level is defined here
-  --> $DIR/useless_asref.rs:3:9
+  --> $DIR/useless_asref.rs:2:9
    |
 LL | #![deny(clippy::useless_asref)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:46:20
+  --> $DIR/useless_asref.rs:45:20
    |
 LL |         foo_rslice(rslice.as_ref());
    |                    ^^^^^^^^^^^^^^^ help: try this: `rslice`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:50:21
+  --> $DIR/useless_asref.rs:49:21
    |
 LL |         foo_mrslice(mrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:52:20
+  --> $DIR/useless_asref.rs:51:20
    |
 LL |         foo_rslice(mrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:59:20
+  --> $DIR/useless_asref.rs:58:20
    |
 LL |         foo_rslice(rrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^ help: try this: `rrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:61:18
+  --> $DIR/useless_asref.rs:60:18
    |
 LL |         foo_rstr(rrrrrstr.as_ref());
    |                  ^^^^^^^^^^^^^^^^^ help: try this: `rrrrrstr`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:66:21
+  --> $DIR/useless_asref.rs:65:21
    |
 LL |         foo_mrslice(mrrrrrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:68:20
+  --> $DIR/useless_asref.rs:67:20
    |
 LL |         foo_rslice(mrrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:72:16
+  --> $DIR/useless_asref.rs:71:16
    |
 LL |     foo_rrrrmr((&&&&MoreRef).as_ref());
    |                ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(&&&&MoreRef)`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:122:13
+  --> $DIR/useless_asref.rs:121:13
    |
 LL |     foo_mrt(mrt.as_mut());
    |             ^^^^^^^^^^^^ help: try this: `mrt`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:124:12
+  --> $DIR/useless_asref.rs:123:12
    |
 LL |     foo_rt(mrt.as_ref());
    |            ^^^^^^^^^^^^ help: try this: `mrt`

--- a/tests/ui/vec.fixed
+++ b/tests/ui/vec.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
-#![allow(clippy::nonstandard_macro_braces)]
 #![warn(clippy::useless_vec)]
+#![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args)]
 
 #[derive(Debug)]
 struct NonCopy;

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -1,6 +1,6 @@
 // run-rustfix
-#![allow(clippy::nonstandard_macro_braces)]
 #![warn(clippy::useless_vec)]
+#![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args)]
 
 #[derive(Debug)]
 struct NonCopy;

--- a/tests/ui/while_let_loop.rs
+++ b/tests/ui/while_let_loop.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::while_let_loop)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let y = Some(true);

--- a/tests/ui/while_let_loop.stderr
+++ b/tests/ui/while_let_loop.stderr
@@ -1,5 +1,5 @@
 error: this loop could be written as a `while let` loop
-  --> $DIR/while_let_loop.rs:5:5
+  --> $DIR/while_let_loop.rs:6:5
    |
 LL | /     loop {
 LL | |         if let Some(_x) = y {
@@ -13,7 +13,7 @@ LL | |     }
    = note: `-D clippy::while-let-loop` implied by `-D warnings`
 
 error: this loop could be written as a `while let` loop
-  --> $DIR/while_let_loop.rs:22:5
+  --> $DIR/while_let_loop.rs:23:5
    |
 LL | /     loop {
 LL | |         match y {
@@ -24,7 +24,7 @@ LL | |     }
    | |_____^ help: try: `while let Some(_x) = y { .. }`
 
 error: this loop could be written as a `while let` loop
-  --> $DIR/while_let_loop.rs:29:5
+  --> $DIR/while_let_loop.rs:30:5
    |
 LL | /     loop {
 LL | |         let x = match y {
@@ -36,7 +36,7 @@ LL | |     }
    | |_____^ help: try: `while let Some(x) = y { .. }`
 
 error: this loop could be written as a `while let` loop
-  --> $DIR/while_let_loop.rs:38:5
+  --> $DIR/while_let_loop.rs:39:5
    |
 LL | /     loop {
 LL | |         let x = match y {
@@ -48,7 +48,7 @@ LL | |     }
    | |_____^ help: try: `while let Some(x) = y { .. }`
 
 error: this loop could be written as a `while let` loop
-  --> $DIR/while_let_loop.rs:68:5
+  --> $DIR/while_let_loop.rs:69:5
    |
 LL | /     loop {
 LL | |         let (e, l) = match "".split_whitespace().next() {

--- a/tests/ui/while_let_on_iterator.fixed
+++ b/tests/ui/while_let_on_iterator.fixed
@@ -1,14 +1,12 @@
 // run-rustfix
-
 #![warn(clippy::while_let_on_iterator)]
+#![allow(dead_code, unreachable_code, unused_mut)]
 #![allow(
-    clippy::never_loop,
-    unreachable_code,
-    unused_mut,
-    dead_code,
     clippy::equatable_if_let,
     clippy::manual_find,
-    clippy::redundant_closure_call
+    clippy::never_loop,
+    clippy::redundant_closure_call,
+    clippy::uninlined_format_args
 )]
 
 fn base() {

--- a/tests/ui/while_let_on_iterator.rs
+++ b/tests/ui/while_let_on_iterator.rs
@@ -1,14 +1,12 @@
 // run-rustfix
-
 #![warn(clippy::while_let_on_iterator)]
+#![allow(dead_code, unreachable_code, unused_mut)]
 #![allow(
-    clippy::never_loop,
-    unreachable_code,
-    unused_mut,
-    dead_code,
     clippy::equatable_if_let,
     clippy::manual_find,
-    clippy::redundant_closure_call
+    clippy::never_loop,
+    clippy::redundant_closure_call,
+    clippy::uninlined_format_args
 )]
 
 fn base() {

--- a/tests/ui/while_let_on_iterator.stderr
+++ b/tests/ui/while_let_on_iterator.stderr
@@ -1,5 +1,5 @@
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:16:5
+  --> $DIR/while_let_on_iterator.rs:14:5
    |
 LL |     while let Option::Some(x) = iter.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in iter`
@@ -7,151 +7,151 @@ LL |     while let Option::Some(x) = iter.next() {
    = note: `-D clippy::while-let-on-iterator` implied by `-D warnings`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:21:5
+  --> $DIR/while_let_on_iterator.rs:19:5
    |
 LL |     while let Some(x) = iter.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in iter`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:26:5
+  --> $DIR/while_let_on_iterator.rs:24:5
    |
 LL |     while let Some(_) = iter.next() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in iter`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:102:9
+  --> $DIR/while_let_on_iterator.rs:100:9
    |
 LL |         while let Some([..]) = it.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for [..] in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:109:9
+  --> $DIR/while_let_on_iterator.rs:107:9
    |
 LL |         while let Some([_x]) = it.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for [_x] in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:122:9
+  --> $DIR/while_let_on_iterator.rs:120:9
    |
 LL |         while let Some(x @ [_]) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x @ [_] in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:142:9
+  --> $DIR/while_let_on_iterator.rs:140:9
    |
 LL |         while let Some(_) = y.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in y`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:199:9
+  --> $DIR/while_let_on_iterator.rs:197:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:210:5
+  --> $DIR/while_let_on_iterator.rs:208:5
    |
 LL |     while let Some(n) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for n in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:212:9
+  --> $DIR/while_let_on_iterator.rs:210:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:221:9
+  --> $DIR/while_let_on_iterator.rs:219:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:230:9
+  --> $DIR/while_let_on_iterator.rs:228:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:247:9
+  --> $DIR/while_let_on_iterator.rs:245:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:262:13
+  --> $DIR/while_let_on_iterator.rs:260:13
    |
 LL |             while let Some(i) = self.0.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for i in self.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:294:13
+  --> $DIR/while_let_on_iterator.rs:292:13
    |
 LL |             while let Some(i) = self.0.0.0.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for i in self.0.0.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:323:5
+  --> $DIR/while_let_on_iterator.rs:321:5
    |
 LL |     while let Some(n) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for n in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:335:9
+  --> $DIR/while_let_on_iterator.rs:333:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:349:5
+  --> $DIR/while_let_on_iterator.rs:347:5
    |
 LL |     while let Some(x) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:360:5
+  --> $DIR/while_let_on_iterator.rs:358:5
    |
 LL |     while let Some(x) = it.0.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:395:5
+  --> $DIR/while_let_on_iterator.rs:393:5
    |
 LL |     while let Some(x) = s.x.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in s.x.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:402:5
+  --> $DIR/while_let_on_iterator.rs:400:5
    |
 LL |     while let Some(x) = x[0].next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in x[0].by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:410:9
+  --> $DIR/while_let_on_iterator.rs:408:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:420:9
+  --> $DIR/while_let_on_iterator.rs:418:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:430:9
+  --> $DIR/while_let_on_iterator.rs:428:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:440:9
+  --> $DIR/while_let_on_iterator.rs:438:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:450:5
+  --> $DIR/while_let_on_iterator.rs:448:5
    |
 LL |     while let Some(..) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in it`

--- a/tests/ui/wildcard_enum_match_arm.fixed
+++ b/tests/ui/wildcard_enum_match_arm.fixed
@@ -1,15 +1,13 @@
 // run-rustfix
 // aux-build:non-exhaustive-enum.rs
-
 #![deny(clippy::wildcard_enum_match_arm)]
+#![allow(dead_code, unreachable_code, unused_variables)]
 #![allow(
-    unreachable_code,
-    unused_variables,
-    dead_code,
+    clippy::diverging_sub_expression,
     clippy::single_match,
-    clippy::wildcard_in_or_patterns,
+    clippy::uninlined_format_args,
     clippy::unnested_or_patterns,
-    clippy::diverging_sub_expression
+    clippy::wildcard_in_or_patterns
 )]
 
 extern crate non_exhaustive_enum;

--- a/tests/ui/wildcard_enum_match_arm.rs
+++ b/tests/ui/wildcard_enum_match_arm.rs
@@ -1,15 +1,13 @@
 // run-rustfix
 // aux-build:non-exhaustive-enum.rs
-
 #![deny(clippy::wildcard_enum_match_arm)]
+#![allow(dead_code, unreachable_code, unused_variables)]
 #![allow(
-    unreachable_code,
-    unused_variables,
-    dead_code,
+    clippy::diverging_sub_expression,
     clippy::single_match,
-    clippy::wildcard_in_or_patterns,
+    clippy::uninlined_format_args,
     clippy::unnested_or_patterns,
-    clippy::diverging_sub_expression
+    clippy::wildcard_in_or_patterns
 )]
 
 extern crate non_exhaustive_enum;

--- a/tests/ui/wildcard_enum_match_arm.stderr
+++ b/tests/ui/wildcard_enum_match_arm.stderr
@@ -1,41 +1,41 @@
 error: wildcard match will also match any future added variants
-  --> $DIR/wildcard_enum_match_arm.rs:42:9
+  --> $DIR/wildcard_enum_match_arm.rs:40:9
    |
 LL |         _ => eprintln!("Not red"),
    |         ^ help: try this: `Color::Green | Color::Blue | Color::Rgb(..) | Color::Cyan`
    |
 note: the lint level is defined here
-  --> $DIR/wildcard_enum_match_arm.rs:4:9
+  --> $DIR/wildcard_enum_match_arm.rs:3:9
    |
 LL | #![deny(clippy::wildcard_enum_match_arm)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: wildcard match will also match any future added variants
-  --> $DIR/wildcard_enum_match_arm.rs:46:9
+  --> $DIR/wildcard_enum_match_arm.rs:44:9
    |
 LL |         _not_red => eprintln!("Not red"),
    |         ^^^^^^^^ help: try this: `_not_red @ Color::Green | _not_red @ Color::Blue | _not_red @ Color::Rgb(..) | _not_red @ Color::Cyan`
 
 error: wildcard match will also match any future added variants
-  --> $DIR/wildcard_enum_match_arm.rs:50:9
+  --> $DIR/wildcard_enum_match_arm.rs:48:9
    |
 LL |         not_red => format!("{:?}", not_red),
    |         ^^^^^^^ help: try this: `not_red @ Color::Green | not_red @ Color::Blue | not_red @ Color::Rgb(..) | not_red @ Color::Cyan`
 
 error: wildcard match will also match any future added variants
-  --> $DIR/wildcard_enum_match_arm.rs:66:9
+  --> $DIR/wildcard_enum_match_arm.rs:64:9
    |
 LL |         _ => "No red",
    |         ^ help: try this: `Color::Red | Color::Green | Color::Blue | Color::Rgb(..) | Color::Cyan`
 
 error: wildcard matches known variants and will also match future added variants
-  --> $DIR/wildcard_enum_match_arm.rs:83:9
+  --> $DIR/wildcard_enum_match_arm.rs:81:9
    |
 LL |         _ => {},
    |         ^ help: try this: `ErrorKind::PermissionDenied | _`
 
 error: wildcard matches known variants and will also match future added variants
-  --> $DIR/wildcard_enum_match_arm.rs:101:13
+  --> $DIR/wildcard_enum_match_arm.rs:99:13
    |
 LL |             _ => (),
    |             ^ help: try this: `Enum::B | _`

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -1,5 +1,5 @@
-#![allow(unused_must_use)]
 #![warn(clippy::write_literal)]
+#![allow(clippy::uninlined_format_args, unused_must_use)]
 
 use std::io::Write;
 


### PR DESCRIPTION
In order to switch `clippy::uninlined_format_args` from pedantic to style, all existing tests must not raise a warning. I did not want to change the actual tests, so this is a relatively minor change that:

* add `#![allow(clippy::uninlined_format_args)]` where needed
* normalizes all allow/deny/warn attributes
   * all allow attributes are grouped together
   * sorted alphabetically
   * the `clippy::*` attributes are listed separate from the other ones.
   * deny and warn attributes are listed before the allowed ones

See also https://github.com/rust-lang/rust-clippy/pull/9233, https://github.com/rust-lang/rust-clippy/pull/9525, https://github.com/rust-lang/rust-clippy/pull/9527

cc: @llogiq @Alexendoo

changelog: none
