### PR TITLE
Fix #9544

### DIFF
--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -12,6 +12,31 @@
 
 use core::num::{Saturating, Wrapping};
 
+pub struct Custom;
+
+macro_rules! impl_arith {
+    ( $( $_trait:ident, $ty:ty, $method:ident; )* ) => {
+        $(
+            impl core::ops::$_trait<$ty> for Custom {
+                type Output = Self;
+                fn $method(self, _: $ty) -> Self::Output { Self }
+            }
+        )*
+    }
+}
+
+impl_arith!(
+    Add, i32, add;
+    Div, i32, div;
+    Mul, i32, mul;
+    Sub, i32, sub;
+
+    Add, f64, add;
+    Div, f64, div;
+    Mul, f64, mul;
+    Sub, f64, sub;
+);
+
 pub fn association_with_structures_should_not_trigger_the_lint() {
     enum Foo {
         Bar = -2,
@@ -130,7 +155,7 @@ pub fn non_overflowing_ops_or_ops_already_handled_by_the_compiler_should_not_tri
     _n = -(-1);
 }
 
-pub fn overflowing_runtime_ops() {
+pub fn runtime_ops() {
     let mut _n = i32::MAX;
 
     // Assign
@@ -162,6 +187,32 @@ pub fn overflowing_runtime_ops() {
     _n = _n * &2;
     _n = 2 * _n;
     _n = &2 * _n;
+
+    // Custom
+    let _ = Custom + 0;
+    let _ = Custom + 1;
+    let _ = Custom + 2;
+    let _ = Custom + 0.0;
+    let _ = Custom + 1.0;
+    let _ = Custom + 2.0;
+    let _ = Custom - 0;
+    let _ = Custom - 1;
+    let _ = Custom - 2;
+    let _ = Custom - 0.0;
+    let _ = Custom - 1.0;
+    let _ = Custom - 2.0;
+    let _ = Custom / 0;
+    let _ = Custom / 1;
+    let _ = Custom / 2;
+    let _ = Custom / 0.0;
+    let _ = Custom / 1.0;
+    let _ = Custom / 2.0;
+    let _ = Custom * 0;
+    let _ = Custom * 1;
+    let _ = Custom * 2;
+    let _ = Custom * 0.0;
+    let _ = Custom * 1.0;
+    let _ = Custom * 2.0;
 
     // Unary
     _n = -_n;

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -1,10 +1,28 @@
 error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:78:13
+   |
+LL |     let _ = String::new() + "";
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::arithmetic-side-effects` implied by `-D warnings`
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:86:27
+   |
+LL |     let inferred_string = string + "";
+   |                           ^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:90:13
+   |
+LL |     let _ = inferred_string + "";
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
   --> $DIR/arithmetic_side_effects.rs:162:5
    |
 LL |     _n += 1;
    |     ^^^^^^^
-   |
-   = note: `-D clippy::arithmetic-side-effects` implied by `-D warnings`
 
 error: arithmetic operation that can potentially result in unexpected side-effects
   --> $DIR/arithmetic_side_effects.rs:163:5
@@ -312,5 +330,5 @@ error: arithmetic operation that can potentially result in unexpected side-effec
 LL |     _n = -&_n;
    |          ^^^^
 
-error: aborting due to 52 previous errors
+error: aborting due to 55 previous errors
 

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -1,5 +1,5 @@
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:137:5
+  --> $DIR/arithmetic_side_effects.rs:162:5
    |
 LL |     _n += 1;
    |     ^^^^^^^
@@ -7,166 +7,310 @@ LL |     _n += 1;
    = note: `-D clippy::arithmetic-side-effects` implied by `-D warnings`
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:138:5
+  --> $DIR/arithmetic_side_effects.rs:163:5
    |
 LL |     _n += &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:139:5
+  --> $DIR/arithmetic_side_effects.rs:164:5
    |
 LL |     _n -= 1;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:140:5
+  --> $DIR/arithmetic_side_effects.rs:165:5
    |
 LL |     _n -= &1;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:141:5
+  --> $DIR/arithmetic_side_effects.rs:166:5
    |
 LL |     _n /= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:142:5
+  --> $DIR/arithmetic_side_effects.rs:167:5
    |
 LL |     _n /= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:143:5
+  --> $DIR/arithmetic_side_effects.rs:168:5
    |
 LL |     _n %= 0;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:144:5
+  --> $DIR/arithmetic_side_effects.rs:169:5
    |
 LL |     _n %= &0;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:145:5
+  --> $DIR/arithmetic_side_effects.rs:170:5
    |
 LL |     _n *= 2;
    |     ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:146:5
+  --> $DIR/arithmetic_side_effects.rs:171:5
    |
 LL |     _n *= &2;
    |     ^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:149:10
+  --> $DIR/arithmetic_side_effects.rs:174:10
    |
 LL |     _n = _n + 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:150:10
+  --> $DIR/arithmetic_side_effects.rs:175:10
    |
 LL |     _n = _n + &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:151:10
+  --> $DIR/arithmetic_side_effects.rs:176:10
    |
 LL |     _n = 1 + _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:152:10
+  --> $DIR/arithmetic_side_effects.rs:177:10
    |
 LL |     _n = &1 + _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:153:10
+  --> $DIR/arithmetic_side_effects.rs:178:10
    |
 LL |     _n = _n - 1;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:154:10
+  --> $DIR/arithmetic_side_effects.rs:179:10
    |
 LL |     _n = _n - &1;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:155:10
+  --> $DIR/arithmetic_side_effects.rs:180:10
    |
 LL |     _n = 1 - _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:156:10
+  --> $DIR/arithmetic_side_effects.rs:181:10
    |
 LL |     _n = &1 - _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:157:10
+  --> $DIR/arithmetic_side_effects.rs:182:10
    |
 LL |     _n = _n / 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:158:10
+  --> $DIR/arithmetic_side_effects.rs:183:10
    |
 LL |     _n = _n / &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:159:10
+  --> $DIR/arithmetic_side_effects.rs:184:10
    |
 LL |     _n = _n % 0;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:160:10
+  --> $DIR/arithmetic_side_effects.rs:185:10
    |
 LL |     _n = _n % &0;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:161:10
+  --> $DIR/arithmetic_side_effects.rs:186:10
    |
 LL |     _n = _n * 2;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:162:10
+  --> $DIR/arithmetic_side_effects.rs:187:10
    |
 LL |     _n = _n * &2;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:163:10
+  --> $DIR/arithmetic_side_effects.rs:188:10
    |
 LL |     _n = 2 * _n;
    |          ^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:164:10
+  --> $DIR/arithmetic_side_effects.rs:189:10
    |
 LL |     _n = &2 * _n;
    |          ^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:167:10
+  --> $DIR/arithmetic_side_effects.rs:192:13
+   |
+LL |     let _ = Custom + 0;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:193:13
+   |
+LL |     let _ = Custom + 1;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:194:13
+   |
+LL |     let _ = Custom + 2;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:195:13
+   |
+LL |     let _ = Custom + 0.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:196:13
+   |
+LL |     let _ = Custom + 1.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:197:13
+   |
+LL |     let _ = Custom + 2.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:198:13
+   |
+LL |     let _ = Custom - 0;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:199:13
+   |
+LL |     let _ = Custom - 1;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:200:13
+   |
+LL |     let _ = Custom - 2;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:201:13
+   |
+LL |     let _ = Custom - 0.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:202:13
+   |
+LL |     let _ = Custom - 1.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:203:13
+   |
+LL |     let _ = Custom - 2.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:204:13
+   |
+LL |     let _ = Custom / 0;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:205:13
+   |
+LL |     let _ = Custom / 1;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:206:13
+   |
+LL |     let _ = Custom / 2;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:207:13
+   |
+LL |     let _ = Custom / 0.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:208:13
+   |
+LL |     let _ = Custom / 1.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:209:13
+   |
+LL |     let _ = Custom / 2.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:210:13
+   |
+LL |     let _ = Custom * 0;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:211:13
+   |
+LL |     let _ = Custom * 1;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:212:13
+   |
+LL |     let _ = Custom * 2;
+   |             ^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:213:13
+   |
+LL |     let _ = Custom * 0.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:214:13
+   |
+LL |     let _ = Custom * 1.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:215:13
+   |
+LL |     let _ = Custom * 2.0;
+   |             ^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:218:10
    |
 LL |     _n = -_n;
    |          ^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> $DIR/arithmetic_side_effects.rs:168:10
+  --> $DIR/arithmetic_side_effects.rs:219:10
    |
 LL |     _n = -&_n;
    |          ^^^^
 
-error: aborting due to 28 previous errors
+error: aborting due to 52 previous errors
 


### PR DESCRIPTION
Fix #9544

r? @Alexendoo 

changelog: [`arithmetic_side_effects`]: Fix false negative for `CustomType / usize`, `CustomType * float` and similar