### PR TITLE
rustc_tools_util: bump version in anticipation of a new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio = { version = "1", features = ["io-util"] }
 rustc-semver = "1.1"
 
 [build-dependencies]
-rustc_tools_util = { version = "0.2", path = "rustc_tools_util" }
+rustc_tools_util = { version = "0.2.1", path = "rustc_tools_util" }
 
 [features]
 deny-warnings = ["clippy_lints/deny-warnings"]

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_tools_util"
-version = "0.2.0"
+version = "0.2.1"
 description = "small helper to generate version information for git packages"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"

--- a/rustc_tools_util/README.md
+++ b/rustc_tools_util/README.md
@@ -6,12 +6,12 @@ for packages installed from a git repo
 ## Usage
 
 Add a `build.rs` file to your repo and list it in `Cargo.toml`
-````
+````toml
 build = "build.rs"
 ````
 
 List rustc_tools_util as regular AND build dependency.
-````
+````toml
 [dependencies]
 rustc_tools_util = "0.1"
 

--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -137,7 +137,7 @@ mod test {
         let vi = get_version_info!();
         assert_eq!(vi.major, 0);
         assert_eq!(vi.minor, 2);
-        assert_eq!(vi.patch, 0);
+        assert_eq!(vi.patch, 1);
         assert_eq!(vi.crate_name, "rustc_tools_util");
         // hard to make positive tests for these since they will always change
         assert!(vi.commit_hash.is_none());
@@ -147,7 +147,7 @@ mod test {
     #[test]
     fn test_display_local() {
         let vi = get_version_info!();
-        assert_eq!(vi.to_string(), "rustc_tools_util 0.2.0");
+        assert_eq!(vi.to_string(), "rustc_tools_util 0.2.1");
     }
 
     #[test]
@@ -156,7 +156,7 @@ mod test {
         let s = format!("{vi:?}");
         assert_eq!(
             s,
-            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 2, patch: 0 }"
+            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 2, patch: 1 }"
         );
     }
 }


### PR DESCRIPTION
cc https://github.com/rust-lang/rust-clippy/issues/9553

After this is merged, I will publish the 0.2.1 version to crates.io, and make another PR that switches clippy to use the dependency from crates.io.
The source can still be kept in the clippy repo though imo.


This will allow miri and clippy to "share" the crate in the rustc repo once they both depend on it.

changelog: release `rustc_tools_util` on `Crates.io`.