### PR TITLE
[`unnecessary_cast`] add parenthesis when negative number uses a method

### DIFF
--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -97,4 +97,10 @@ mod fixable {
 
         let _ = -(1 + 1) as i64;
     }
+
+    fn issue_9563() {
+        let _: f64 = (-8.0_f64).exp();
+        #[allow(clippy::precedence)]
+        let _: f64 = -8.0_f64.exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
+    }
 }

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -97,4 +97,10 @@ mod fixable {
 
         let _ = -(1 + 1) as i64;
     }
+
+    fn issue_9563() {
+        let _: f64 = (-8.0 as f64).exp();
+        #[allow(clippy::precedence)]
+        let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
+    }
 }

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -162,5 +162,17 @@ error: casting integer literal to `i64` is unnecessary
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
-error: aborting due to 27 previous errors
+error: casting float literal to `f64` is unnecessary
+  --> $DIR/unnecessary_cast.rs:102:22
+   |
+LL |         let _: f64 = (-8.0 as f64).exp();
+   |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
+
+error: casting float literal to `f64` is unnecessary
+  --> $DIR/unnecessary_cast.rs:104:23
+   |
+LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
+   |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
+
+error: aborting due to 29 previous errors
 


### PR DESCRIPTION
fix #9563

The issue was probably introduced by 90fe3bea52dd6ebd0cb02785ba523f182ff761e6

changelog: [`unnecessary_cast`] add parenthesis when negative number uses a method


r? llogiq