### PR TITLE
let `upper_case_acronyms` check the enum name

### DIFF
--- a/clippy_lints/src/upper_case_acronyms.rs
+++ b/clippy_lints/src/upper_case_acronyms.rs
@@ -114,6 +114,7 @@ impl LateLintPass<'_> for UpperCaseAcronyms {
                 check_ident(cx, &it.ident, self.upper_case_acronyms_aggressive);
             },
             ItemKind::Enum(ref enumdef, _) => {
+                check_ident(cx, &it.ident, self.upper_case_acronyms_aggressive);
                 // check enum variants separately because again we only want to lint on private enums and
                 // the fn check_variant does not know about the vis of the enum of its variants
                 enumdef

--- a/tests/ui/upper_case_acronyms.rs
+++ b/tests/ui/upper_case_acronyms.rs
@@ -38,4 +38,13 @@ enum ParseErrorPrivate<T> {
     Parse(T, String),
 }
 
+// do lint here
+struct JSON;
+
+// do lint here
+enum YAML {
+    Num(u32),
+    Str(String),
+}
+
 fn main() {}

--- a/tests/ui/upper_case_acronyms.stderr
+++ b/tests/ui/upper_case_acronyms.stderr
@@ -54,5 +54,17 @@ error: name `WASD` contains a capitalized acronym
 LL |     WASD(u8),
    |     ^^^^ help: consider making the acronym lowercase, except the initial letter: `Wasd`
 
-error: aborting due to 9 previous errors
+error: name `JSON` contains a capitalized acronym
+  --> $DIR/upper_case_acronyms.rs:42:8
+   |
+LL | struct JSON;
+   |        ^^^^ help: consider making the acronym lowercase, except the initial letter: `Json`
+
+error: name `YAML` contains a capitalized acronym
+  --> $DIR/upper_case_acronyms.rs:45:6
+   |
+LL | enum YAML {
+   |      ^^^^ help: consider making the acronym lowercase, except the initial letter: `Yaml`
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

Fix #9579

changelog: [`upper_case_acronyms`]: check the enum name
