### PR TITLE
add tests in `implicit_saturating_sub` lint

### DIFF
--- a/clippy_lints/src/implicit_saturating_sub.rs
+++ b/clippy_lints/src/implicit_saturating_sub.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.44.0"]
     pub IMPLICIT_SATURATING_SUB,
-    pedantic,
+    style,
     "Perform saturating subtraction instead of implicitly checking lower bound of data type"
 }
 

--- a/clippy_lints/src/lib.register_all.rs
+++ b/clippy_lints/src/lib.register_all.rs
@@ -86,6 +86,7 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(functions::TOO_MANY_ARGUMENTS),
     LintId::of(if_let_mutex::IF_LET_MUTEX),
     LintId::of(implicit_saturating_add::IMPLICIT_SATURATING_ADD),
+    LintId::of(implicit_saturating_sub::IMPLICIT_SATURATING_SUB),
     LintId::of(indexing_slicing::OUT_OF_BOUNDS_INDEXING),
     LintId::of(infinite_iter::INFINITE_ITER),
     LintId::of(inherent_to_string::INHERENT_TO_STRING),

--- a/clippy_lints/src/lib.register_pedantic.rs
+++ b/clippy_lints/src/lib.register_pedantic.rs
@@ -34,7 +34,6 @@ store.register_group(true, "clippy::pedantic", Some("clippy_pedantic"), vec![
     LintId::of(functions::TOO_MANY_LINES),
     LintId::of(if_not_else::IF_NOT_ELSE),
     LintId::of(implicit_hasher::IMPLICIT_HASHER),
-    LintId::of(implicit_saturating_sub::IMPLICIT_SATURATING_SUB),
     LintId::of(inconsistent_struct_constructor::INCONSISTENT_STRUCT_CONSTRUCTOR),
     LintId::of(infinite_iter::MAYBE_INFINITE_ITER),
     LintId::of(invalid_upcast_comparisons::INVALID_UPCAST_COMPARISONS),

--- a/clippy_lints/src/lib.register_style.rs
+++ b/clippy_lints/src/lib.register_style.rs
@@ -30,6 +30,7 @@ store.register_group(true, "clippy::style", Some("clippy_style"), vec![
     LintId::of(functions::MUST_USE_UNIT),
     LintId::of(functions::RESULT_UNIT_ERR),
     LintId::of(implicit_saturating_add::IMPLICIT_SATURATING_ADD),
+    LintId::of(implicit_saturating_sub::IMPLICIT_SATURATING_SUB),
     LintId::of(inherent_to_string::INHERENT_TO_STRING),
     LintId::of(init_numbered_fields::INIT_NUMBERED_FIELDS),
     LintId::of(len_zero::COMPARISON_TO_EMPTY),

--- a/tests/ui/implicit_saturating_sub.fixed
+++ b/tests/ui/implicit_saturating_sub.fixed
@@ -2,6 +2,21 @@
 #![allow(unused_assignments, unused_mut, clippy::assign_op_pattern)]
 #![warn(clippy::implicit_saturating_sub)]
 
+use std::cmp::PartialEq;
+use std::ops::SubAssign;
+// Mock type
+struct Mock;
+
+impl PartialEq<u32> for Mock {
+    fn eq(&self, _: &u32) -> bool {
+        true
+    }
+}
+
+impl SubAssign<u32> for Mock {
+    fn sub_assign(&mut self, _: u32) {}
+}
+
 fn main() {
     // Tests for unsigned integers
 
@@ -164,5 +179,40 @@ fn main() {
         u_32 -= 1;
     } else {
         println!("side effect");
+    }
+
+    // Extended tests
+    let mut m = Mock;
+    let mut u_32 = 3000;
+    let a = 200;
+    let mut _b = 8;
+
+    if m != 0 {
+        m -= 1;
+    }
+
+    if a > 0 {
+        _b -= 1;
+    }
+
+    if 0 > a {
+        _b -= 1;
+    }
+
+    if u_32 > 0 {
+        u_32 -= 1;
+    } else {
+        println!("don't lint this");
+    }
+
+    if u_32 > 0 {
+        println!("don't lint this");
+        u_32 -= 1;
+    }
+
+    if u_32 > 42 {
+        println!("brace yourself!");
+    } else if u_32 > 0 {
+        u_32 -= 1;
     }
 }

--- a/tests/ui/implicit_saturating_sub.rs
+++ b/tests/ui/implicit_saturating_sub.rs
@@ -2,6 +2,21 @@
 #![allow(unused_assignments, unused_mut, clippy::assign_op_pattern)]
 #![warn(clippy::implicit_saturating_sub)]
 
+use std::cmp::PartialEq;
+use std::ops::SubAssign;
+// Mock type
+struct Mock;
+
+impl PartialEq<u32> for Mock {
+    fn eq(&self, _: &u32) -> bool {
+        true
+    }
+}
+
+impl SubAssign<u32> for Mock {
+    fn sub_assign(&mut self, _: u32) {}
+}
+
 fn main() {
     // Tests for unsigned integers
 
@@ -210,5 +225,40 @@ fn main() {
         u_32 -= 1;
     } else {
         println!("side effect");
+    }
+
+    // Extended tests
+    let mut m = Mock;
+    let mut u_32 = 3000;
+    let a = 200;
+    let mut _b = 8;
+
+    if m != 0 {
+        m -= 1;
+    }
+
+    if a > 0 {
+        _b -= 1;
+    }
+
+    if 0 > a {
+        _b -= 1;
+    }
+
+    if u_32 > 0 {
+        u_32 -= 1;
+    } else {
+        println!("don't lint this");
+    }
+
+    if u_32 > 0 {
+        println!("don't lint this");
+        u_32 -= 1;
+    }
+
+    if u_32 > 42 {
+        println!("brace yourself!");
+    } else if u_32 > 0 {
+        u_32 -= 1;
     }
 }

--- a/tests/ui/implicit_saturating_sub.stderr
+++ b/tests/ui/implicit_saturating_sub.stderr
@@ -1,5 +1,5 @@
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:13:5
+  --> $DIR/implicit_saturating_sub.rs:28:5
    |
 LL | /     if u_8 > 0 {
 LL | |         u_8 = u_8 - 1;
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::implicit-saturating-sub` implied by `-D warnings`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:20:13
+  --> $DIR/implicit_saturating_sub.rs:35:13
    |
 LL | /             if u_8 > 0 {
 LL | |                 u_8 -= 1;
@@ -17,7 +17,7 @@ LL | |             }
    | |_____________^ help: try: `u_8 = u_8.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:34:5
+  --> $DIR/implicit_saturating_sub.rs:49:5
    |
 LL | /     if u_16 > 0 {
 LL | |         u_16 -= 1;
@@ -25,7 +25,7 @@ LL | |     }
    | |_____^ help: try: `u_16 = u_16.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:44:5
+  --> $DIR/implicit_saturating_sub.rs:59:5
    |
 LL | /     if u_32 != 0 {
 LL | |         u_32 -= 1;
@@ -33,7 +33,7 @@ LL | |     }
    | |_____^ help: try: `u_32 = u_32.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:65:5
+  --> $DIR/implicit_saturating_sub.rs:80:5
    |
 LL | /     if u_64 > 0 {
 LL | |         u_64 -= 1;
@@ -41,7 +41,7 @@ LL | |     }
    | |_____^ help: try: `u_64 = u_64.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:70:5
+  --> $DIR/implicit_saturating_sub.rs:85:5
    |
 LL | /     if 0 < u_64 {
 LL | |         u_64 -= 1;
@@ -49,7 +49,7 @@ LL | |     }
    | |_____^ help: try: `u_64 = u_64.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:75:5
+  --> $DIR/implicit_saturating_sub.rs:90:5
    |
 LL | /     if 0 != u_64 {
 LL | |         u_64 -= 1;
@@ -57,7 +57,7 @@ LL | |     }
    | |_____^ help: try: `u_64 = u_64.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:96:5
+  --> $DIR/implicit_saturating_sub.rs:111:5
    |
 LL | /     if u_usize > 0 {
 LL | |         u_usize -= 1;
@@ -65,33 +65,17 @@ LL | |     }
    | |_____^ help: try: `u_usize = u_usize.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:108:5
-   |
-LL | /     if i_8 > i8::MIN {
-LL | |         i_8 -= 1;
-LL | |     }
-   | |_____^ help: try: `i_8 = i_8.saturating_sub(1);`
-
-error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:113:5
-   |
-LL | /     if i_8 > i8::MIN {
-LL | |         i_8 -= 1;
-LL | |     }
-   | |_____^ help: try: `i_8 = i_8.saturating_sub(1);`
-
-error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:118:5
-   |
-LL | /     if i_8 != i8::MIN {
-LL | |         i_8 -= 1;
-LL | |     }
-   | |_____^ help: try: `i_8 = i_8.saturating_sub(1);`
-
-error: implicitly performing saturating subtraction
   --> $DIR/implicit_saturating_sub.rs:123:5
    |
-LL | /     if i_8 != i8::MIN {
+LL | /     if i_8 > i8::MIN {
+LL | |         i_8 -= 1;
+LL | |     }
+   | |_____^ help: try: `i_8 = i_8.saturating_sub(1);`
+
+error: implicitly performing saturating subtraction
+  --> $DIR/implicit_saturating_sub.rs:128:5
+   |
+LL | /     if i_8 > i8::MIN {
 LL | |         i_8 -= 1;
 LL | |     }
    | |_____^ help: try: `i_8 = i_8.saturating_sub(1);`
@@ -99,31 +83,31 @@ LL | |     }
 error: implicitly performing saturating subtraction
   --> $DIR/implicit_saturating_sub.rs:133:5
    |
-LL | /     if i_16 > i16::MIN {
-LL | |         i_16 -= 1;
+LL | /     if i_8 != i8::MIN {
+LL | |         i_8 -= 1;
 LL | |     }
-   | |_____^ help: try: `i_16 = i_16.saturating_sub(1);`
+   | |_____^ help: try: `i_8 = i_8.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
   --> $DIR/implicit_saturating_sub.rs:138:5
    |
+LL | /     if i_8 != i8::MIN {
+LL | |         i_8 -= 1;
+LL | |     }
+   | |_____^ help: try: `i_8 = i_8.saturating_sub(1);`
+
+error: implicitly performing saturating subtraction
+  --> $DIR/implicit_saturating_sub.rs:148:5
+   |
 LL | /     if i_16 > i16::MIN {
 LL | |         i_16 -= 1;
 LL | |     }
    | |_____^ help: try: `i_16 = i_16.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:143:5
+  --> $DIR/implicit_saturating_sub.rs:153:5
    |
-LL | /     if i_16 != i16::MIN {
-LL | |         i_16 -= 1;
-LL | |     }
-   | |_____^ help: try: `i_16 = i_16.saturating_sub(1);`
-
-error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:148:5
-   |
-LL | /     if i_16 != i16::MIN {
+LL | /     if i_16 > i16::MIN {
 LL | |         i_16 -= 1;
 LL | |     }
    | |_____^ help: try: `i_16 = i_16.saturating_sub(1);`
@@ -131,31 +115,31 @@ LL | |     }
 error: implicitly performing saturating subtraction
   --> $DIR/implicit_saturating_sub.rs:158:5
    |
-LL | /     if i_32 > i32::MIN {
-LL | |         i_32 -= 1;
+LL | /     if i_16 != i16::MIN {
+LL | |         i_16 -= 1;
 LL | |     }
-   | |_____^ help: try: `i_32 = i_32.saturating_sub(1);`
+   | |_____^ help: try: `i_16 = i_16.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
   --> $DIR/implicit_saturating_sub.rs:163:5
    |
+LL | /     if i_16 != i16::MIN {
+LL | |         i_16 -= 1;
+LL | |     }
+   | |_____^ help: try: `i_16 = i_16.saturating_sub(1);`
+
+error: implicitly performing saturating subtraction
+  --> $DIR/implicit_saturating_sub.rs:173:5
+   |
 LL | /     if i_32 > i32::MIN {
 LL | |         i_32 -= 1;
 LL | |     }
    | |_____^ help: try: `i_32 = i_32.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:168:5
+  --> $DIR/implicit_saturating_sub.rs:178:5
    |
-LL | /     if i_32 != i32::MIN {
-LL | |         i_32 -= 1;
-LL | |     }
-   | |_____^ help: try: `i_32 = i_32.saturating_sub(1);`
-
-error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:173:5
-   |
-LL | /     if i_32 != i32::MIN {
+LL | /     if i_32 > i32::MIN {
 LL | |         i_32 -= 1;
 LL | |     }
    | |_____^ help: try: `i_32 = i_32.saturating_sub(1);`
@@ -163,13 +147,29 @@ LL | |     }
 error: implicitly performing saturating subtraction
   --> $DIR/implicit_saturating_sub.rs:183:5
    |
+LL | /     if i_32 != i32::MIN {
+LL | |         i_32 -= 1;
+LL | |     }
+   | |_____^ help: try: `i_32 = i_32.saturating_sub(1);`
+
+error: implicitly performing saturating subtraction
+  --> $DIR/implicit_saturating_sub.rs:188:5
+   |
+LL | /     if i_32 != i32::MIN {
+LL | |         i_32 -= 1;
+LL | |     }
+   | |_____^ help: try: `i_32 = i_32.saturating_sub(1);`
+
+error: implicitly performing saturating subtraction
+  --> $DIR/implicit_saturating_sub.rs:198:5
+   |
 LL | /     if i64::MIN < i_64 {
 LL | |         i_64 -= 1;
 LL | |     }
    | |_____^ help: try: `i_64 = i_64.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:188:5
+  --> $DIR/implicit_saturating_sub.rs:203:5
    |
 LL | /     if i64::MIN != i_64 {
 LL | |         i_64 -= 1;
@@ -177,7 +177,7 @@ LL | |     }
    | |_____^ help: try: `i_64 = i_64.saturating_sub(1);`
 
 error: implicitly performing saturating subtraction
-  --> $DIR/implicit_saturating_sub.rs:193:5
+  --> $DIR/implicit_saturating_sub.rs:208:5
    |
 LL | /     if i64::MIN < i_64 {
 LL | |         i_64 -= 1;


### PR DESCRIPTION
This adds more tests to the `implicit_saturating_sub` lint to rule out certain false positives that have appeared in the past.

Now with those false positives out of the equation, we can move the lint to `style`.

---

changelog: promote [`implicit-saturating-sub`] to the `style` category
