### PR TITLE
lint::unsafe_removed_from_name: fix false positive result when allowed

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -357,7 +357,8 @@ impl<'tcx> LateLintPass<'tcx> for Attributes {
                                                     "wildcard_imports"
                                                         | "enum_glob_use"
                                                         | "redundant_pub_crate"
-                                                        | "macro_use_imports",
+                                                        | "macro_use_imports"
+                                                        | "unsafe_removed_from_name",
                                                 )
                                             })
                                         {

--- a/tests/ui/unsafe_removed_from_name.rs
+++ b/tests/ui/unsafe_removed_from_name.rs
@@ -24,4 +24,7 @@ use mod_with_some_unsafe_things::Unsafe as LieAboutModSafety;
 use mod_with_some_unsafe_things::Safe as IPromiseItsSafeThisTime;
 use mod_with_some_unsafe_things::Unsafe as SuperUnsafeModThing;
 
+#[allow(clippy::unsafe_removed_from_name)]
+use mod_with_some_unsafe_things::Unsafe as SuperSafeThing;
+
 fn main() {}


### PR DESCRIPTION
changelog: [`unsafe_removed_from_name`] Fix allowing on imports produces a false positive on `useless_attribute`.

Fixes: #9197

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>
