### PR TITLE
Add a temporary workaround for  multiline formart arg inlining

### DIFF
--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -44,7 +44,9 @@ fn tester(fn_arg: i32) {
     println!("val='{local_i32}'"); // space+tab
     println!("val='{local_i32}'"); // tab+space
     println!(
-        "val='{local_i32}'"
+        "val='{
+    }'",
+        local_i32
     );
     println!("{local_i32}");
     println!("{fn_arg}");
@@ -108,7 +110,8 @@ fn tester(fn_arg: i32) {
     println!("{local_f64:width$.prec$}");
     println!("{local_f64:width$.prec$} {local_f64} {width} {prec}");
     println!(
-        "{local_i32:width$.prec$} {local_i32:prec$.width$} {width:local_i32$.prec$} {width:prec$.local_i32$} {prec:local_i32$.width$} {prec:width$.local_i32$}",
+        "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}",
+        local_i32, width, prec,
     );
     println!(
         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$} {3}",
@@ -139,7 +142,9 @@ fn tester(fn_arg: i32) {
     println!(no_param_str!(), local_i32);
 
     println!(
-        "{val}",
+        "{}",
+        // comment with a comma , in it
+        val,
     );
     println!("{val}");
 

--- a/tests/ui/uninlined_format_args.stderr
+++ b/tests/ui/uninlined_format_args.stderr
@@ -60,22 +60,6 @@ LL +     println!("val='{local_i32}'"); // tab+space
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:46:5
-   |
-LL | /     println!(
-LL | |         "val='{
-LL | |     }'",
-LL | |         local_i32
-LL | |     );
-   | |_____^
-   |
-help: change this to
-   |
-LL -         "val='{
-LL +         "val='{local_i32}'"
-   |
-
-error: variables can be used directly in the `format!` string
   --> $DIR/uninlined_format_args.rs:51:5
    |
 LL |     println!("{}", local_i32);
@@ -784,25 +768,6 @@ LL +     println!("{local_f64:width$.prec$} {local_f64} {width} {prec}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:112:5
-   |
-LL | /     println!(
-LL | |         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}",
-LL | |         local_i32, width, prec,
-LL | |     );
-   | |_____^
-   |
-help: change this to
-   |
-LL ~         "{local_i32:width$.prec$} {local_i32:prec$.width$} {width:local_i32$.prec$} {width:prec$.local_i32$} {prec:local_i32$.width$} {prec:width$.local_i32$}", width, prec,
-LL ~         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}", width, prec,
-LL ~         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}", width, prec,
-LL ~         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}", width, prec,
-LL ~         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}", width, prec,
-LL ~         "{0:1$.2$} {0:2$.1$} {1:0$.2$} {1:2$.0$} {2:0$.1$} {2:1$.0$}",
-   |
-
-error: variables can be used directly in the `format!` string
   --> $DIR/uninlined_format_args.rs:123:5
    |
 LL |     println!("Width = {}, value with width = {:0$}", local_i32, local_f64);
@@ -851,22 +816,6 @@ LL +     println!("{}", format!("{local_i32}"));
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:144:5
-   |
-LL | /     println!(
-LL | |         "{}",
-LL | |         // comment with a comma , in it
-LL | |         val,
-LL | |     );
-   | |_____^
-   |
-help: change this to
-   |
-LL -         "{}",
-LL +         "{val}",
-   |
-
-error: variables can be used directly in the `format!` string
   --> $DIR/uninlined_format_args.rs:149:5
    |
 LL |     println!("{}", /* comment with a comma , in it */ val);
@@ -890,5 +839,5 @@ LL -     println!("expand='{}'", local_i32);
 LL +     println!("expand='{local_i32}'");
    |
 
-error: aborting due to 73 previous errors
+error: aborting due to 70 previous errors
 


### PR DESCRIPTION
per suggestion in
https://github.com/rust-lang/rust/pull/102729#discussion_r988990080

workaround for an internal crash when handling multi-line format argument inlining.

changelog: none

(no point for changelog because it is still a new lint being introduced)