### PR TITLE
fix: uninlined_format_args shouldn't inline panic! before 2021ed

### DIFF
--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -150,6 +150,19 @@ fn tester(fn_arg: i32) {
 
     println!(with_span!("{0} {1}" "{1} {0}"), local_i32, local_f64);
     println!("{}", with_span!(span val));
+
+    if local_i32 > 0 {
+        panic!("p1 {local_i32}");
+    }
+    if local_i32 > 0 {
+        panic!("p2 {local_i32}");
+    }
+    if local_i32 > 0 {
+        panic!("p3 {local_i32}");
+    }
+    if local_i32 > 0 {
+        panic!("p4 {local_i32}");
+    }
 }
 
 fn main() {

--- a/tests/ui/uninlined_format_args.rs
+++ b/tests/ui/uninlined_format_args.rs
@@ -150,6 +150,19 @@ fn tester(fn_arg: i32) {
 
     println!(with_span!("{0} {1}" "{1} {0}"), local_i32, local_f64);
     println!("{}", with_span!(span val));
+
+    if local_i32 > 0 {
+        panic!("p1 {}", local_i32);
+    }
+    if local_i32 > 0 {
+        panic!("p2 {0}", local_i32);
+    }
+    if local_i32 > 0 {
+        panic!("p3 {local_i32}", local_i32 = local_i32);
+    }
+    if local_i32 > 0 {
+        panic!("p4 {local_i32}");
+    }
 }
 
 fn main() {

--- a/tests/ui/uninlined_format_args.stderr
+++ b/tests/ui/uninlined_format_args.stderr
@@ -828,7 +828,43 @@ LL +     println!("{val}");
    |
 
 error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:168:5
+  --> $DIR/uninlined_format_args.rs:155:9
+   |
+LL |         panic!("p1 {}", local_i32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -         panic!("p1 {}", local_i32);
+LL +         panic!("p1 {local_i32}");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:158:9
+   |
+LL |         panic!("p2 {0}", local_i32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -         panic!("p2 {0}", local_i32);
+LL +         panic!("p2 {local_i32}");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:161:9
+   |
+LL |         panic!("p3 {local_i32}", local_i32 = local_i32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -         panic!("p3 {local_i32}", local_i32 = local_i32);
+LL +         panic!("p3 {local_i32}");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:181:5
    |
 LL |     println!("expand='{}'", local_i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -839,5 +875,5 @@ LL -     println!("expand='{}'", local_i32);
 LL +     println!("expand='{local_i32}'");
    |
 
-error: aborting due to 70 previous errors
+error: aborting due to 73 previous errors
 

--- a/tests/ui/uninlined_format_args_2018.fixed
+++ b/tests/ui/uninlined_format_args_2018.fixed
@@ -1,0 +1,27 @@
+// run-rustfix
+// edition:2018
+
+#![warn(clippy::uninlined_format_args)]
+
+fn main() {
+    let var = 1;
+
+    println!("val='{var}'");
+
+    if var > 0 {
+        panic!("p1 {}", var);
+    }
+    if var > 0 {
+        panic!("p2 {0}", var);
+    }
+    if var > 0 {
+        panic!("p3 {var}", var = var);
+    }
+
+    #[allow(non_fmt_panics)]
+    {
+        if var > 0 {
+            panic!("p4 {var}");
+        }
+    }
+}

--- a/tests/ui/uninlined_format_args_2018.rs
+++ b/tests/ui/uninlined_format_args_2018.rs
@@ -1,0 +1,27 @@
+// run-rustfix
+// edition:2018
+
+#![warn(clippy::uninlined_format_args)]
+
+fn main() {
+    let var = 1;
+
+    println!("val='{}'", var);
+
+    if var > 0 {
+        panic!("p1 {}", var);
+    }
+    if var > 0 {
+        panic!("p2 {0}", var);
+    }
+    if var > 0 {
+        panic!("p3 {var}", var = var);
+    }
+
+    #[allow(non_fmt_panics)]
+    {
+        if var > 0 {
+            panic!("p4 {var}");
+        }
+    }
+}

--- a/tests/ui/uninlined_format_args_2018.stderr
+++ b/tests/ui/uninlined_format_args_2018.stderr
@@ -1,0 +1,15 @@
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args_2018.rs:9:5
+   |
+LL |     println!("val='{}'", var);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
+help: change this to
+   |
+LL -     println!("val='{}'", var);
+LL +     println!("val='{var}'");
+   |
+
+error: aborting due to previous error
+

--- a/tests/ui/uninlined_format_args_2021.fixed
+++ b/tests/ui/uninlined_format_args_2021.fixed
@@ -1,0 +1,23 @@
+// run-rustfix
+// edition:2021
+
+#![warn(clippy::uninlined_format_args)]
+
+fn main() {
+    let var = 1;
+
+    println!("val='{var}'");
+
+    if var > 0 {
+        panic!("p1 {var}");
+    }
+    if var > 0 {
+        panic!("p2 {var}");
+    }
+    if var > 0 {
+        panic!("p3 {var}");
+    }
+    if var > 0 {
+        panic!("p4 {var}");
+    }
+}

--- a/tests/ui/uninlined_format_args_2021.rs
+++ b/tests/ui/uninlined_format_args_2021.rs
@@ -1,0 +1,23 @@
+// run-rustfix
+// edition:2021
+
+#![warn(clippy::uninlined_format_args)]
+
+fn main() {
+    let var = 1;
+
+    println!("val='{}'", var);
+
+    if var > 0 {
+        panic!("p1 {}", var);
+    }
+    if var > 0 {
+        panic!("p2 {0}", var);
+    }
+    if var > 0 {
+        panic!("p3 {var}", var = var);
+    }
+    if var > 0 {
+        panic!("p4 {var}");
+    }
+}

--- a/tests/ui/uninlined_format_args_2021.stderr
+++ b/tests/ui/uninlined_format_args_2021.stderr
@@ -1,0 +1,51 @@
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args_2021.rs:9:5
+   |
+LL |     println!("val='{}'", var);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
+help: change this to
+   |
+LL -     println!("val='{}'", var);
+LL +     println!("val='{var}'");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args_2021.rs:12:9
+   |
+LL |         panic!("p1 {}", var);
+   |         ^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -         panic!("p1 {}", var);
+LL +         panic!("p1 {var}");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args_2021.rs:15:9
+   |
+LL |         panic!("p2 {0}", var);
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -         panic!("p2 {0}", var);
+LL +         panic!("p2 {var}");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args_2021.rs:18:9
+   |
+LL |         panic!("p3 {var}", var = var);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -         panic!("p3 {var}", var = var);
+LL +         panic!("p3 {var}");
+   |
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Before 2021 edition, `panic!("...")` was not treated as a format string.
Clippy autofix of `panic!("{}", foo)` into `panic!("{foo}")` is incorrect.

changelog: [`uninlined_format_args`]: Do not inline panic! macros before 2021 edition