### PR TITLE
[`unnecessary_cast`] Do not lint negative hexadecimal literals when cast as floats

### DIFF
--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -59,9 +59,6 @@ pub(super) fn check<'tcx>(
                 lint_unnecessary_cast(cx, expr, literal_str, cast_from, cast_to);
                 return false;
             },
-            LitKind::Int(_, LitIntType::Unsuffixed) | LitKind::Float(_, LitFloatType::Unsuffixed) => {
-                return false;
-            },
             LitKind::Int(_, LitIntType::Signed(_) | LitIntType::Unsigned(_))
             | LitKind::Float(_, LitFloatType::Suffixed(_))
                 if cast_from.kind() == cast_to.kind() =>

--- a/clippy_utils/src/numeric_literal.rs
+++ b/clippy_utils/src/numeric_literal.rs
@@ -69,12 +69,13 @@ impl<'a> NumericLiteral<'a> {
 
     #[must_use]
     pub fn new(lit: &'a str, suffix: Option<&'a str>, float: bool) -> Self {
+        let unsigned_lit = lit.trim_start_matches('-');
         // Determine delimiter for radix prefix, if present, and radix.
-        let radix = if lit.starts_with("0x") {
+        let radix = if unsigned_lit.starts_with("0x") {
             Radix::Hexadecimal
-        } else if lit.starts_with("0b") {
+        } else if unsigned_lit.starts_with("0b") {
             Radix::Binary
-        } else if lit.starts_with("0o") {
+        } else if unsigned_lit.starts_with("0o") {
             Radix::Octal
         } else {
             Radix::Decimal

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -111,4 +111,8 @@ mod fixable {
 
         let _num = foo();
     }
+
+    fn issue_9603() {
+        let _: f32 = -0x400 as f32;
+    }
 }

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -111,4 +111,8 @@ mod fixable {
 
         let _num = foo() as f32;
     }
+
+    fn issue_9603() {
+        let _: f32 = -0x400 as f32;
+    }
 }


### PR DESCRIPTION
fix https://github.com/rust-lang/rust-clippy/issues/9603

changelog: [`unnecessary_cast`] Do not lint negative hexadecimal literals when cast as floats