### PR TITLE
Don't suggest moving tuple structs with a significant drop to late evaluation

### DIFF
--- a/clippy_utils/src/eager_or_lazy.rs
+++ b/clippy_utils/src/eager_or_lazy.rs
@@ -120,7 +120,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                             .expr_ty(e)
                             .has_significant_drop(self.cx.tcx, self.cx.param_env)
                         {
-                            self.eagerness = Lazy;
+                            self.eagerness = ForceNoChange;
                             return;
                         }
                     },

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -225,4 +225,15 @@ mod issue8239 {
     }
 }
 
+mod issue9608 {
+    fn sig_drop() {
+        enum X {
+            X(std::fs::File),
+            Y(u32),
+        }
+
+        let _ = None.unwrap_or(X::Y(0));
+    }
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -225,4 +225,15 @@ mod issue8239 {
     }
 }
 
+mod issue9608 {
+    fn sig_drop() {
+        enum X {
+            X(std::fs::File),
+            Y(u32),
+        }
+
+        let _ = None.unwrap_or(X::Y(0));
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fixes #9608

changelog: Don't suggest moving tuple structs with a significant drop to late evaluation
