### PR TITLE
Add Default to Clippy Lints Lint groups

### DIFF
--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -448,6 +448,12 @@ Otherwise, have a great day =^.^=
                                         None
                                     </label>
                                 </li>
+                                <li class="checkbox">
+                                    <label ng-click="resetGroupsToDefault()">
+                                        <input type="checkbox" class="invisible" />
+                                        Default
+                                    </label>
+                                </li>
                                 <li role="separator" class="divider"></li>
                                 <li class="checkbox" ng-repeat="(group, enabled) in groups">
                                     <label class="text-capitalize">

--- a/util/gh-pages/index.html
+++ b/util/gh-pages/index.html
@@ -443,15 +443,15 @@ Otherwise, have a great day =^.^=
                                     </label>
                                 </li>
                                 <li class="checkbox">
-                                    <label ng-click="toggleGroups(false)">
-                                        <input type="checkbox" class="invisible" />
-                                        None
-                                    </label>
-                                </li>
-                                <li class="checkbox">
                                     <label ng-click="resetGroupsToDefault()">
                                         <input type="checkbox" class="invisible" />
                                         Default
+                                    </label>
+                                </li>
+                                <li class="checkbox">
+                                    <label ng-click="toggleGroups(false)">
+                                        <input type="checkbox" class="invisible" />
+                                        None
                                     </label>
                                 </li>
                                 <li role="separator" class="divider"></li>

--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -171,9 +171,7 @@
             $scope.resetGroupsToDefault = function () {
                 const groups = $scope.groups;
                 for (const [key, value] of Object.entries(GROUPS_FILTER_DEFAULT)) {
-                    if (groups.hasOwnProperty(key)) {
-                        groups[key] = value;
-                    }
+                    groups[key] = value;
                 }
             };
 

--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -114,7 +114,7 @@
                 return $scope.levels[lint.level];
             };
 
-            var GROUPS_FILTER_DEFAULT = {
+            const GROUPS_FILTER_DEFAULT = {
                 cargo: true,
                 complexity: true,
                 correctness: true,
@@ -125,8 +125,12 @@
                 restriction: true,
                 style: true,
                 suspicious: true,
+            }
+
+            $scope.groups = {
+                ...GROUPS_FILTER_DEFAULT
             };
-            $scope.groups = GROUPS_FILTER_DEFAULT;
+
             const THEMES_DEFAULT = {
                 light: "Light",
                 rust: "Rust",
@@ -158,6 +162,15 @@
             $scope.toggleGroups = function (value) {
                 const groups = $scope.groups;
                 for (const key in groups) {
+                    if (groups.hasOwnProperty(key)) {
+                        groups[key] = value;
+                    }
+                }
+            };
+
+            $scope.resetGroupsToDefault = function () {
+                const groups = $scope.groups;
+                for (const [key, value] of Object.entries(GROUPS_FILTER_DEFAULT)) {
                     if (groups.hasOwnProperty(key)) {
                         groups[key] = value;
                     }


### PR DESCRIPTION
- related to #7958

This PR adds a default (reset) button to Clippy Lints Lint groups. (change for website)
[The page](https://rust-lang.github.io/rust-clippy/master/index.html) sets only `Deprecated` to false by default.
Certainly it is easy to set only `deprecated` to false, but it may be a bit lazy for beginners.



https://user-images.githubusercontent.com/38400669/194831117-3ade7e0d-c4de-4189-9daf-3be8ea3cdd18.mov



changelog: none
