### PR TITLE
fix `box-default` ignoring trait objects' types

### DIFF
--- a/clippy_lints/src/box_default.rs
+++ b/clippy_lints/src/box_default.rs
@@ -88,7 +88,7 @@ struct InferVisitor(bool);
 
 impl<'tcx> Visitor<'tcx> for InferVisitor {
     fn visit_ty(&mut self, t: &rustc_hir::Ty<'_>) {
-        self.0 |= matches!(t.kind, TyKind::Infer);
+        self.0 |= matches!(t.kind, TyKind::Infer | TyKind::OpaqueDef(..) | TyKind::TraitObject(..));
         if !self.0 {
             walk_ty(self, t);
         }

--- a/tests/ui/box_default.fixed
+++ b/tests/ui/box_default.fixed
@@ -40,4 +40,18 @@ fn ret_ty_fn() -> Box<bool> {
 }
 
 #[allow(clippy::boxed_local)]
-fn call_ty_fn(_b: Box<u8>) {}
+fn call_ty_fn(_b: Box<u8>) {
+    issue_9621_dyn_trait();
+}
+
+use std::io::{Read, Result};
+
+impl Read for ImplementsDefault {
+    fn read(&mut self, _: &mut [u8]) -> Result<usize> {
+        Ok(0)
+    }
+}
+
+fn issue_9621_dyn_trait() {
+    let _: Box<dyn Read> = Box::<ImplementsDefault>::default();
+}

--- a/tests/ui/box_default.rs
+++ b/tests/ui/box_default.rs
@@ -40,4 +40,18 @@ fn ret_ty_fn() -> Box<bool> {
 }
 
 #[allow(clippy::boxed_local)]
-fn call_ty_fn(_b: Box<u8>) {}
+fn call_ty_fn(_b: Box<u8>) {
+    issue_9621_dyn_trait();
+}
+
+use std::io::{Read, Result};
+
+impl Read for ImplementsDefault {
+    fn read(&mut self, _: &mut [u8]) -> Result<usize> {
+        Ok(0)
+    }
+}
+
+fn issue_9621_dyn_trait() {
+    let _: Box<dyn Read> = Box::new(ImplementsDefault::default());
+}

--- a/tests/ui/box_default.stderr
+++ b/tests/ui/box_default.stderr
@@ -78,5 +78,11 @@ error: `Box::new(_)` of default value
 LL |     Box::new(bool::default())
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::<bool>::default()`
 
-error: aborting due to 13 previous errors
+error: `Box::new(_)` of default value
+  --> $DIR/box_default.rs:56:28
+   |
+LL |     let _: Box<dyn Read> = Box::new(ImplementsDefault::default());
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::<ImplementsDefault>::default()`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
This avoids removing the turbofish when the `Box` type is a `dyn` or `impl _`.

This fixes #9621.

---

changelog: none
