### PR TITLE
Replace manual let else patterns with let else

### DIFF
--- a/clippy_dev/src/setup/intellij.rs
+++ b/clippy_dev/src/setup/intellij.rs
@@ -36,9 +36,8 @@ impl ClippyProjectInfo {
 }
 
 pub fn setup_rustc_src(rustc_path: &str) {
-    let rustc_source_dir = match check_and_get_rustc_dir(rustc_path) {
-        Ok(path) => path,
-        Err(_) => return,
+    let Ok(rustc_source_dir) = check_and_get_rustc_dir(rustc_path) else {
+        return
     };
 
     for project in CLIPPY_PROJECTS {
@@ -172,14 +171,10 @@ pub fn remove_rustc_src() {
 }
 
 fn remove_rustc_src_from_project(project: &ClippyProjectInfo) -> bool {
-    let mut cargo_content = if let Ok(content) = read_project_file(project.cargo_file) {
-        content
-    } else {
+    let Ok(mut cargo_content) = read_project_file(project.cargo_file) else {
         return false;
     };
-    let section_start = if let Some(section_start) = cargo_content.find(RUSTC_PATH_SECTION) {
-        section_start
-    } else {
+    let Some(section_start) = cargo_content.find(RUSTC_PATH_SECTION) else {
         println!(
             "info: dependencies could not be found in `{}` for {}, skipping file",
             project.cargo_file, project.name
@@ -187,9 +182,7 @@ fn remove_rustc_src_from_project(project: &ClippyProjectInfo) -> bool {
         return true;
     };
 
-    let end_point = if let Some(end_point) = cargo_content.find(DEPENDENCIES_SECTION) {
-        end_point
-    } else {
+    let Some(end_point) = cargo_content.find(DEPENDENCIES_SECTION) else {
         eprintln!(
             "error: the end of the rustc dependencies section could not be found in `{}`",
             project.cargo_file

--- a/clippy_dev/src/update_lints.rs
+++ b/clippy_dev/src/update_lints.rs
@@ -869,13 +869,11 @@ fn clippy_lints_src_files() -> impl Iterator<Item = (PathBuf, DirEntry)> {
 macro_rules! match_tokens {
     ($iter:ident, $($token:ident $({$($fields:tt)*})? $(($capture:ident))?)*) => {
          {
-            $($(let $capture =)? if let Some(LintDeclSearchResult {
+            $(#[allow(clippy::redundant_pattern)] let Some(LintDeclSearchResult {
                     token_kind: TokenKind::$token $({$($fields)*})?,
-                    content: _x,
+                    content: $($capture @)? _,
                     ..
-            }) = $iter.next() {
-                _x
-            } else {
+            }) = $iter.next() else {
                 continue;
             };)*
             #[allow(clippy::unused_unit)]

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -339,10 +339,7 @@ fn check_copy_clone<'tcx>(cx: &LateContext<'tcx>, item: &Item<'_>, trait_ref: &h
         Some(id) if trait_ref.trait_def_id() == Some(id) => id,
         _ => return,
     };
-    let copy_id = match cx.tcx.lang_items().copy_trait() {
-        Some(id) => id,
-        None => return,
-    };
+    let Some(copy_id) = cx.tcx.lang_items().copy_trait() else { return };
     let (ty_adt, ty_subs) = match *ty.kind() {
         // Unions can't derive clone.
         ty::Adt(adt, subs) if !adt.is_union() => (adt, subs),

--- a/clippy_lints/src/disallowed_methods.rs
+++ b/clippy_lints/src/disallowed_methods.rs
@@ -94,9 +94,8 @@ impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
         } else {
             path_def_id(cx, expr)
         };
-        let def_id = match uncalled_path.or_else(|| fn_def_id(cx, expr)) {
-            Some(def_id) => def_id,
-            None => return,
+        let Some(def_id) = uncalled_path.or_else(|| fn_def_id(cx, expr)) else {
+            return
         };
         let conf = match self.disallowed.get(&def_id) {
             Some(&index) => &self.conf_disallowed[index],

--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -213,9 +213,8 @@ fn check_sig<'tcx>(cx: &LateContext<'tcx>, closure_ty: Ty<'tcx>, call_ty: Ty<'tc
     if !closure_ty.has_late_bound_regions() {
         return true;
     }
-    let substs = match closure_ty.kind() {
-        ty::Closure(_, substs) => substs,
-        _ => return false,
+    let ty::Closure(_, substs) = closure_ty.kind() else {
+        return false;
     };
     let closure_sig = cx.tcx.signature_unclosure(substs.as_closure().sig(), Unsafety::Normal);
     cx.tcx.erase_late_bound_regions(closure_sig) == cx.tcx.erase_late_bound_regions(call_sig)

--- a/clippy_lints/src/functions/too_many_lines.rs
+++ b/clippy_lints/src/functions/too_many_lines.rs
@@ -22,9 +22,8 @@ pub(super) fn check_fn(
         return;
     }
 
-    let code_snippet = match snippet_opt(cx, body.value.span) {
-        Some(s) => s,
-        _ => return,
+    let Some(code_snippet) = snippet_opt(cx, body.value.span) else {
+        return
     };
     let mut line_count: u64 = 0;
     let mut in_comment = false;

--- a/clippy_lints/src/invalid_upcast_comparisons.rs
+++ b/clippy_lints/src/invalid_upcast_comparisons.rs
@@ -145,9 +145,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidUpcastComparisons {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if let ExprKind::Binary(ref cmp, lhs, rhs) = expr.kind {
             let normalized = comparisons::normalize_comparison(cmp.node, lhs, rhs);
-            let (rel, normalized_lhs, normalized_rhs) = if let Some(val) = normalized {
-                val
-            } else {
+            let Some((rel, normalized_lhs, normalized_rhs)) = normalized else {
                 return;
             };
 

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -124,9 +124,8 @@ impl<'tcx> LateLintPass<'tcx> for LargeEnumVariant {
         }
         if let ItemKind::Enum(ref def, _) = item.kind {
             let ty = cx.tcx.type_of(item.def_id);
-            let (adt, subst) = match ty.kind() {
-                Adt(adt, subst) => (adt, subst),
-                _ => panic!("already checked whether this is an enum"),
+            let Adt(adt, subst) = ty.kind() else {
+                panic!("already checked whether this is an enum")
             };
             if adt.variants().len() <= 1 {
                 return;

--- a/clippy_lints/src/loops/while_let_on_iterator.rs
+++ b/clippy_lints/src/loops/while_let_on_iterator.rs
@@ -331,9 +331,8 @@ fn needs_mutable_borrow(cx: &LateContext<'_>, iter_expr: &IterExpr, loop_expr: &
     }
 
     if let Some(e) = get_enclosing_loop_or_multi_call_closure(cx, loop_expr) {
-        let local_id = match iter_expr.path {
-            Res::Local(id) => id,
-            _ => return true,
+        let Res::Local(local_id) = iter_expr.path else {
+            return true
         };
         let mut v = NestedLoopVisitor {
             cx,

--- a/clippy_lints/src/matches/manual_utils.rs
+++ b/clippy_lints/src/matches/manual_utils.rs
@@ -60,9 +60,8 @@ where
         return None;
     }
 
-    let some_expr = match get_some_expr_fn(cx, some_pat, some_expr, expr_ctxt) {
-        Some(expr) => expr,
-        None => return None,
+    let Some(some_expr) = get_some_expr_fn(cx, some_pat, some_expr, expr_ctxt) else {
+        return None;
     };
 
     // These two lints will go back and forth with each other.

--- a/clippy_lints/src/matches/match_same_arms.rs
+++ b/clippy_lints/src/matches/match_same_arms.rs
@@ -221,7 +221,6 @@ fn iter_matching_struct_fields<'a>(
 
 #[expect(clippy::similar_names)]
 impl<'a> NormalizedPat<'a> {
-    #[expect(clippy::too_many_lines)]
     fn from_pat(cx: &LateContext<'_>, arena: &'a DroplessArena, pat: &'a Pat<'_>) -> Self {
         match pat.kind {
             PatKind::Wild | PatKind::Binding(.., None) => Self::Wild,
@@ -235,9 +234,8 @@ impl<'a> NormalizedPat<'a> {
                 Self::Struct(cx.qpath_res(path, pat.hir_id).opt_def_id(), fields)
             },
             PatKind::TupleStruct(ref path, pats, wild_idx) => {
-                let adt = match cx.typeck_results().pat_ty(pat).ty_adt_def() {
-                    Some(x) => x,
-                    None => return Self::Wild,
+                let Some(adt) = cx.typeck_results().pat_ty(pat).ty_adt_def() else {
+                    return Self::Wild
                 };
                 let (var_id, variant) = if adt.is_enum() {
                     match cx.qpath_res(path, pat.hir_id).opt_def_id() {

--- a/clippy_lints/src/methods/into_iter_on_ref.rs
+++ b/clippy_lints/src/methods/into_iter_on_ref.rs
@@ -42,9 +42,8 @@ pub(super) fn check(
 
 fn ty_has_iter_method(cx: &LateContext<'_>, self_ref_ty: Ty<'_>) -> Option<(Symbol, &'static str)> {
     has_iter_method(cx, self_ref_ty).map(|ty_name| {
-        let mutbl = match self_ref_ty.kind() {
-            ty::Ref(_, _, mutbl) => mutbl,
-            _ => unreachable!(),
+        let ty::Ref(_, _, mutbl) = self_ref_ty.kind() else {
+            unreachable!()
         };
         let method_name = match mutbl {
             hir::Mutability::Not => "iter",

--- a/clippy_lints/src/methods/manual_saturating_arithmetic.rs
+++ b/clippy_lints/src/methods/manual_saturating_arithmetic.rs
@@ -21,11 +21,7 @@ pub fn check(
         return;
     }
 
-    let mm = if let Some(mm) = is_min_or_max(cx, unwrap_arg) {
-        mm
-    } else {
-        return;
-    };
+    let Some(mm) = is_min_or_max(cx, unwrap_arg) else { return };
 
     if ty.is_signed() {
         use self::{
@@ -33,9 +29,7 @@ pub fn check(
             Sign::{Neg, Pos},
         };
 
-        let sign = if let Some(sign) = lit_sign(arith_rhs) {
-            sign
-        } else {
+        let Some(sign) = lit_sign(arith_rhs) else {
             return;
         };
 

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3851,9 +3851,8 @@ impl SelfKind {
                 hir::Mutability::Mut => &paths::ASMUT_TRAIT,
             };
 
-            let trait_def_id = match get_trait_def_id(cx, trait_path) {
-                Some(did) => did,
-                None => return false,
+            let Some(trait_def_id) = get_trait_def_id(cx, trait_path) else {
+                return false
             };
             implements_trait(cx, ty, trait_def_id, &[parent_ty.into()])
         }

--- a/clippy_lints/src/methods/str_splitn.rs
+++ b/clippy_lints/src/methods/str_splitn.rs
@@ -289,9 +289,7 @@ fn parse_iter_usage<'tcx>(
 ) -> Option<IterUsage> {
     let (kind, span) = match iter.next() {
         Some((_, Node::Expr(e))) if e.span.ctxt() == ctxt => {
-            let (name, args) = if let ExprKind::MethodCall(name, _, [args @ ..], _) = e.kind {
-                (name, args)
-            } else {
+            let ExprKind::MethodCall(name, _, [args @ ..], _) = e.kind else {
                 return None;
             };
             let did = cx.typeck_results().type_dependent_def_id(e.hir_id)?;

--- a/clippy_lints/src/misc_early/literal_suffix.rs
+++ b/clippy_lints/src/misc_early/literal_suffix.rs
@@ -6,9 +6,7 @@ use rustc_lint::EarlyContext;
 use super::{SEPARATED_LITERAL_SUFFIX, UNSEPARATED_LITERAL_SUFFIX};
 
 pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, lit_snip: &str, suffix: &str, sugg_type: &str) {
-    let maybe_last_sep_idx = if let Some(val) = lit_snip.len().checked_sub(suffix.len() + 1) {
-        val
-    } else {
+    let Some(maybe_last_sep_idx) = lit_snip.len().checked_sub(suffix.len() + 1) else {
         return; // It's useless so shouldn't lint.
     };
     // Do not lint when literal is unsuffixed.

--- a/clippy_lints/src/misc_early/mixed_case_hex_literals.rs
+++ b/clippy_lints/src/misc_early/mixed_case_hex_literals.rs
@@ -5,9 +5,7 @@ use rustc_lint::EarlyContext;
 use super::MIXED_CASE_HEX_LITERALS;
 
 pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, suffix: &str, lit_snip: &str) {
-    let maybe_last_sep_idx = if let Some(val) = lit_snip.len().checked_sub(suffix.len() + 1) {
-        val
-    } else {
+    let Some(maybe_last_sep_idx) = lit_snip.len().checked_sub(suffix.len() + 1) else {
         return; // It's useless so shouldn't lint.
     };
     if maybe_last_sep_idx <= 2 {

--- a/clippy_lints/src/mismatching_type_param_order.rs
+++ b/clippy_lints/src/mismatching_type_param_order.rs
@@ -70,9 +70,8 @@ impl<'tcx> LateLintPass<'tcx> for TypeParamMismatch {
 
                 // find the type that the Impl is for
                 // only lint on struct/enum/union for now
-                let defid = match path.res {
-                    Res::Def(DefKind::Struct | DefKind::Enum | DefKind::Union, defid) => defid,
-                    _ => return,
+                let Res::Def(DefKind::Struct | DefKind::Enum | DefKind::Union, defid) = path.res else {
+                    return
                 };
 
                 // get the names of the generic parameters in the type

--- a/clippy_lints/src/mixed_read_write_in_expression.rs
+++ b/clippy_lints/src/mixed_read_write_in_expression.rs
@@ -190,10 +190,7 @@ fn check_for_unsequenced_reads(vis: &mut ReadVisitor<'_, '_>) {
         if parent_id == cur_id {
             break;
         }
-        let parent_node = match map.find(parent_id) {
-            Some(parent) => parent,
-            None => break,
-        };
+        let Some(parent_node) = map.find(parent_id) else { break };
 
         let stop_early = match parent_node {
             Node::Expr(expr) => check_expr(vis, expr),

--- a/clippy_lints/src/needless_for_each.rs
+++ b/clippy_lints/src/needless_for_each.rs
@@ -49,9 +49,8 @@ declare_lint_pass!(NeedlessForEach => [NEEDLESS_FOR_EACH]);
 
 impl<'tcx> LateLintPass<'tcx> for NeedlessForEach {
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
-        let expr = match stmt.kind {
-            StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr,
-            _ => return,
+        let (StmtKind::Expr(expr) | StmtKind::Semi(expr)) = stmt.kind else {
+             return
         };
 
         if_chain! {

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -357,9 +357,8 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst {
             }
 
             // Make sure it is a const item.
-            let item_def_id = match cx.qpath_res(qpath, expr.hir_id) {
-                Res::Def(DefKind::Const | DefKind::AssocConst, did) => did,
-                _ => return,
+            let Res::Def(DefKind::Const | DefKind::AssocConst, item_def_id) = cx.qpath_res(qpath, expr.hir_id) else {
+                return
             };
 
             // Climb up to resolve any field access and explicit referencing.

--- a/clippy_lints/src/non_octal_unix_permissions.rs
+++ b/clippy_lints/src/non_octal_unix_permissions.rs
@@ -55,9 +55,8 @@ impl<'tcx> LateLintPass<'tcx> for NonOctalUnixPermissions {
                     if let ExprKind::Lit(_) = param.kind;
 
                     then {
-                        let snip = match snippet_opt(cx, param.span) {
-                            Some(s) => s,
-                            _ => return,
+                        let Some(snip) = snippet_opt(cx, param.span) else {
+                            return
                         };
 
                         if !snip.starts_with("0o") {
@@ -72,16 +71,10 @@ impl<'tcx> LateLintPass<'tcx> for NonOctalUnixPermissions {
                     if let Some(def_id) = cx.qpath_res(path, func.hir_id).opt_def_id();
                     if match_def_path(cx, def_id, &paths::PERMISSIONS_FROM_MODE);
                     if let ExprKind::Lit(_) = param.kind;
-
+                    if let Some(snip) = snippet_opt(cx, param.span);
+                    if !snip.starts_with("0o");
                     then {
-                        let snip = match snippet_opt(cx, param.span) {
-                            Some(s) => s,
-                            _ => return,
-                        };
-
-                        if !snip.starts_with("0o") {
-                            show_error(cx, param);
-                        }
+                        show_error(cx, param);
                     }
                 }
             },

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -552,9 +552,8 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'_>, args:
             }
 
             // Check if this is local we care about
-            let args_idx = match path_to_local(e).and_then(|id| self.bindings.get(&id)) {
-                Some(&i) => i,
-                None => return walk_expr(self, e),
+            let Some(&args_idx) = path_to_local(e).and_then(|id| self.bindings.get(&id)) else {
+                return walk_expr(self, e);
             };
             let args = &self.args[args_idx];
             let result = &mut self.results[args_idx];
@@ -609,9 +608,7 @@ fn check_ptr_arg_usage<'tcx>(cx: &LateContext<'tcx>, body: &'tcx Body<'_>, args:
                             }
                         }
 
-                        let id = if let Some(x) = self.cx.typeck_results().type_dependent_def_id(e.hir_id) {
-                            x
-                        } else {
+                        let Some(id) = self.cx.typeck_results().type_dependent_def_id(e.hir_id) else {
                             set_skip_flag();
                             return;
                         };

--- a/clippy_lints/src/ptr_offset_with_cast.rs
+++ b/clippy_lints/src/ptr_offset_with_cast.rs
@@ -49,15 +49,13 @@ declare_lint_pass!(PtrOffsetWithCast => [PTR_OFFSET_WITH_CAST]);
 impl<'tcx> LateLintPass<'tcx> for PtrOffsetWithCast {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         // Check if the expressions is a ptr.offset or ptr.wrapping_offset method call
-        let (receiver_expr, arg_expr, method) = match expr_as_ptr_offset_call(cx, expr) {
-            Some(call_arg) => call_arg,
-            None => return,
+        let Some((receiver_expr, arg_expr, method)) = expr_as_ptr_offset_call(cx, expr) else {
+            return
         };
 
         // Check if the argument to the method call is a cast from usize
-        let cast_lhs_expr = match expr_as_cast_from_usize(cx, arg_expr) {
-            Some(cast_lhs_expr) => cast_lhs_expr,
-            None => return,
+        let Some(cast_lhs_expr) = expr_as_cast_from_usize(cx, arg_expr) else {
+            return
         };
 
         let msg = format!("use of `{method}` with a `usize` casted to an `isize`");

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -106,10 +106,7 @@ impl_lint_pass!(Shadow => [SHADOW_SAME, SHADOW_REUSE, SHADOW_UNRELATED]);
 
 impl<'tcx> LateLintPass<'tcx> for Shadow {
     fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>) {
-        let (id, ident) = match pat.kind {
-            PatKind::Binding(_, hir_id, ident, _) => (hir_id, ident),
-            _ => return,
-        };
+        let PatKind::Binding(_, id, ident, _) = pat.kind else { return };
 
         if pat.span.desugaring_kind().is_some() {
             return;

--- a/clippy_lints/src/types/rc_buffer.rs
+++ b/clippy_lints/src/types/rc_buffer.rs
@@ -26,10 +26,7 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
             if !cx.tcx.is_diagnostic_item(sym::Vec, id) {
                 return false;
             }
-            let qpath = match &ty.kind {
-                TyKind::Path(qpath) => qpath,
-                _ => return false,
-            };
+            let TyKind::Path(qpath) = &ty.kind else { return false };
             let inner_span = match qpath_generic_tys(qpath).next() {
                 Some(ty) => ty.span,
                 None => return false,
@@ -65,10 +62,7 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
             if !cx.tcx.is_diagnostic_item(sym::Vec, id) {
                 return false;
             }
-            let qpath = match &ty.kind {
-                TyKind::Path(qpath) => qpath,
-                _ => return false,
-            };
+            let TyKind::Path(qpath) = &ty.kind else { return false };
             let inner_span = match qpath_generic_tys(qpath).next() {
                 Some(ty) => ty.span,
                 None => return false,

--- a/clippy_lints/src/types/redundant_allocation.rs
+++ b/clippy_lints/src/types/redundant_allocation.rs
@@ -47,9 +47,8 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
         _ => return false,
     };
 
-    let inner_qpath = match &ty.kind {
-        TyKind::Path(inner_qpath) => inner_qpath,
-        _ => return false,
+    let TyKind::Path(inner_qpath) = &ty.kind else {
+        return false
     };
     let inner_span = match qpath_generic_tys(inner_qpath).next() {
         Some(ty) => {

--- a/clippy_lints/src/unnested_or_patterns.rs
+++ b/clippy_lints/src/unnested_or_patterns.rs
@@ -163,9 +163,8 @@ fn unnest_or_patterns(pat: &mut P<Pat>) -> bool {
             noop_visit_pat(p, self);
 
             // Don't have an or-pattern? Just quit early on.
-            let alternatives = match &mut p.kind {
-                Or(ps) => ps,
-                _ => return,
+            let Or(alternatives) = &mut p.kind else {
+                return
             };
 
             // Collapse or-patterns directly nested in or-patterns.

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -47,9 +47,8 @@ declare_lint_pass!(UnusedIoAmount => [UNUSED_IO_AMOUNT]);
 
 impl<'tcx> LateLintPass<'tcx> for UnusedIoAmount {
     fn check_stmt(&mut self, cx: &LateContext<'_>, s: &hir::Stmt<'_>) {
-        let expr = match s.kind {
-            hir::StmtKind::Semi(expr) | hir::StmtKind::Expr(expr) => expr,
-            _ => return,
+        let (hir::StmtKind::Semi(expr) | hir::StmtKind::Expr(expr)) = s.kind else {
+            return
         };
 
         match expr.kind {

--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -55,9 +55,8 @@ impl<'tcx> LateLintPass<'tcx> for UselessConversion {
 
         match e.kind {
             ExprKind::Match(_, arms, MatchSource::TryDesugar) => {
-                let e = match arms[0].body.kind {
-                    ExprKind::Ret(Some(e)) | ExprKind::Break(_, Some(e)) => e,
-                    _ => return,
+                let (ExprKind::Ret(Some(e)) | ExprKind::Break(_, Some(e))) = arms[0].body.kind else {
+                     return
                 };
                 if let ExprKind::Call(_, [arg, ..]) = e.kind {
                     self.try_desugar_arm.push(arg.hir_id);

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1402,18 +1402,12 @@ impl<'tcx> LateLintPass<'tcx> for IfChainStyle {
         } else {
             return;
         };
-        let then_block = match then.kind {
-            ExprKind::Block(block, _) => block,
-            _ => return,
-        };
+        let ExprKind::Block(then_block, _) = then.kind else { return };
         let if_chain_span = is_expn_of(expr.span, "if_chain");
         if !els {
             check_nested_if_chains(cx, expr, then_block, if_chain_span);
         }
-        let if_chain_span = match if_chain_span {
-            None => return,
-            Some(span) => span,
-        };
+        let Some(if_chain_span) = if_chain_span else { return };
         // check for `if a && b;`
         if_chain! {
             if let ExprKind::Binary(op, _, _) = cond.kind;


### PR DESCRIPTION
Clears the codebase from places where the lint added by #8437 is firing, by adopting let else.

changelog: none
