### PR TITLE
Fix allow_attributes_without_reason applying to external crate macros

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -464,6 +464,11 @@ fn check_lint_reason(cx: &LateContext<'_>, name: Symbol, items: &[NestedMetaItem
         return;
     }
 
+    // Check if the attribute is in an external macro and therefore out of the developer's control
+    if in_external_macro(cx.sess(), attr.span) {
+        return;
+    }
+
     span_lint_and_help(
         cx,
         ALLOW_ATTRIBUTES_WITHOUT_REASON,


### PR DESCRIPTION
Previously the `clippy::allow_attributes_without_reason` lint would apply to external crate macros. Many macros in the Rust ecosystem include these `allow` attributes without adding a reason, making this lint pretty much unusable in any sizable Rust project.

This commit fixes that by adding a check to the lint if the attribute is from an external crate macro and returning early.

```
changelog: [`allow_attributes_without_reason`]: allow_attributes_without_reason no longer applies to external crate macros
```
