### PR TITLE
Update Applicability of `redundant_allocation` lint from `MachineApplicable` to `MaybeIncorrect`

### DIFF
--- a/clippy_lints/src/types/redundant_allocation.rs
+++ b/clippy_lints/src/types/redundant_allocation.rs
@@ -10,6 +10,7 @@ use rustc_span::symbol::sym;
 use super::{utils, REDUNDANT_ALLOCATION};
 
 pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_>, def_id: DefId) -> bool {
+    let mut applicability = Applicability::MaybeIncorrect;
     let outer_sym = if Some(def_id) == cx.tcx.lang_items().owned_box() {
         "Box"
     } else if cx.tcx.is_diagnostic_item(sym::Rc, def_id) {
@@ -21,7 +22,6 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
     };
 
     if let Some(span) = utils::match_borrows_parameter(cx, qpath) {
-        let mut applicability = Applicability::MaybeIncorrect;
         let generic_snippet = snippet_with_applicability(cx, span, "..", &mut applicability);
         span_lint_and_then(
             cx,
@@ -63,7 +63,6 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
         None => return false,
     };
     if inner_sym == outer_sym {
-        let mut applicability = Applicability::MaybeIncorrect;
         let generic_snippet = snippet_with_applicability(cx, inner_span, "..", &mut applicability);
         span_lint_and_then(
             cx,


### PR DESCRIPTION
This changes `redundant_allocation` lint from MachineApplicable to MaybeIncorrect

```
changelog: [`redundant_allocation]: Change Applicability from MachineApplicable to MaybeIncorrect

```

fixes #6243

---
changelog: [`redundant_allocation`]: Change Applicability from MachineApplicable to MaybeIncorrect
