### PR TITLE
[`zero_prefixed_literal`] Do not advise to use octal form if not possible

### DIFF
--- a/clippy_lints/src/misc_early/zero_prefixed_literal.rs
+++ b/clippy_lints/src/misc_early/zero_prefixed_literal.rs
@@ -6,6 +6,7 @@ use rustc_lint::EarlyContext;
 use super::ZERO_PREFIXED_LITERAL;
 
 pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, lit_snip: &str) {
+    let trimmed_lit_snip = lit_snip.trim_start_matches(|c| c == '_' || c == '0');
     span_lint_and_then(
         cx,
         ZERO_PREFIXED_LITERAL,
@@ -15,15 +16,18 @@ pub(super) fn check(cx: &EarlyContext<'_>, lit: &Lit, lit_snip: &str) {
             diag.span_suggestion(
                 lit.span,
                 "if you mean to use a decimal constant, remove the `0` to avoid confusion",
-                lit_snip.trim_start_matches(|c| c == '_' || c == '0').to_string(),
+                trimmed_lit_snip.to_string(),
                 Applicability::MaybeIncorrect,
             );
-            diag.span_suggestion(
-                lit.span,
-                "if you mean to use an octal constant, use `0o`",
-                format!("0o{}", lit_snip.trim_start_matches(|c| c == '_' || c == '0')),
-                Applicability::MaybeIncorrect,
-            );
+            // do not advise to use octal form if the literal cannot be expressed in base 8.
+            if !lit_snip.contains(|c| c == '8' || c == '9') {
+                diag.span_suggestion(
+                    lit.span,
+                    "if you mean to use an octal constant, use `0o`",
+                    format!("0o{trimmed_lit_snip}"),
+                    Applicability::MaybeIncorrect,
+                );
+            }
         },
     );
 }

--- a/tests/ui/literals.rs
+++ b/tests/ui/literals.rs
@@ -40,3 +40,10 @@ fn main() {
     let ok26 = 0x6_A0_BF;
     let ok27 = 0b1_0010_0101;
 }
+
+fn issue9651() {
+    // lint but octal form is not possible here
+    let _ = 08;
+    let _ = 09;
+    let _ = 089;
+}

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -135,5 +135,38 @@ error: digits of hex or binary literal not grouped by four
 LL |     let fail25 = 0b01_100_101;
    |                  ^^^^^^^^^^^^ help: consider: `0b0110_0101`
 
-error: aborting due to 18 previous errors
+error: this is a decimal constant
+  --> $DIR/literals.rs:46:13
+   |
+LL |     let _ = 08;
+   |             ^^
+   |
+help: if you mean to use a decimal constant, remove the `0` to avoid confusion
+   |
+LL |     let _ = 8;
+   |             ~
+
+error: this is a decimal constant
+  --> $DIR/literals.rs:47:13
+   |
+LL |     let _ = 09;
+   |             ^^
+   |
+help: if you mean to use a decimal constant, remove the `0` to avoid confusion
+   |
+LL |     let _ = 9;
+   |             ~
+
+error: this is a decimal constant
+  --> $DIR/literals.rs:48:13
+   |
+LL |     let _ = 089;
+   |             ^^^
+   |
+help: if you mean to use a decimal constant, remove the `0` to avoid confusion
+   |
+LL |     let _ = 89;
+   |             ~~
+
+error: aborting due to 21 previous errors
 


### PR DESCRIPTION
fix https://github.com/rust-lang/rust-clippy/issues/9651

changelog: [`zero_prefixed_literal`] Do not advise to use octal form if not possible