### PR TITLE
fix `box-default` linting `no_std` non-boxes

### DIFF
--- a/clippy_lints/src/box_default.rs
+++ b/clippy_lints/src/box_default.rs
@@ -46,7 +46,7 @@ impl LateLintPass<'_> for BoxDefault {
             && !in_external_macro(cx.sess(), expr.span)
             && (expr.span.eq_ctxt(arg.span) || is_vec_expn(cx, arg))
             && seg.ident.name == sym::new
-            && path_def_id(cx, ty) == cx.tcx.lang_items().owned_box()
+            && path_def_id(cx, ty).map_or(false, |id| Some(id) == cx.tcx.lang_items().owned_box())
             && is_default_equivalent(cx, arg)
         {
             let arg_ty = cx.typeck_results().expr_ty(arg);

--- a/tests/ui/box_default_no_std.rs
+++ b/tests/ui/box_default_no_std.rs
@@ -1,0 +1,33 @@
+#![feature(lang_items, start, libc)]
+#![warn(clippy::box_default)]
+#![no_std]
+
+pub struct NotBox<T> {
+    _value: T,
+}
+
+impl<T> NotBox<T> {
+    pub fn new(value: T) -> Self {
+        Self { _value: value }
+    }
+}
+
+impl<T: Default> Default for NotBox<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+#[start]
+fn main(_argc: isize, _argv: *const *const u8) -> isize {
+    let _p = NotBox::new(isize::default());
+    0
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}


### PR DESCRIPTION
This fixes #9653 by doing the check against the `Box` type correctly even if `Box` isn't there, as in `no_std` code. Thanks to @lukas-code for opening the issue and supplying a reproducer!

---

changelog: none
