### PR TITLE
[`check_result_unit_err`]: Disable on `no_std`

### DIFF
--- a/clippy_lints/src/functions/result.rs
+++ b/clippy_lints/src/functions/result.rs
@@ -6,8 +6,8 @@ use rustc_middle::ty::{self, Ty};
 use rustc_span::{sym, Span};
 
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
-use clippy_utils::trait_ref_of_method;
 use clippy_utils::ty::{approx_ty_size, is_type_diagnostic_item};
+use clippy_utils::{is_no_std_crate, trait_ref_of_method};
 
 use super::{RESULT_LARGE_ERR, RESULT_UNIT_ERR};
 
@@ -71,7 +71,7 @@ pub(super) fn check_trait_item<'tcx>(cx: &LateContext<'tcx>, item: &hir::TraitIt
 }
 
 fn check_result_unit_err(cx: &LateContext<'_>, err_ty: Ty<'_>, fn_header_span: Span) {
-    if err_ty.is_unit() {
+    if err_ty.is_unit() && !is_no_std_crate(cx) {
         span_lint_and_help(
             cx,
             RESULT_UNIT_ERR,


### PR DESCRIPTION
This lint suggests returning a type implementing the trait `std::error::Error` ([doc](https://doc.rust-lang.org/std/error/trait.Error.html)) for the `Result`, but this trait is not available in `no_std` crates, so it's not possible for them to fix this lint.

This is my first time working in Clippy's codebase, so I may have missed something. Please let me know and I'll fix it.

## Example:
Running Clippy on a project with the following `lib.rs`:
```rust
#![no_std]

use core::result::Result;

pub fn ret_err() -> Result<(),()> {
    if true { Ok(()) } else { Err(()) }
}
```
will yield the following warning:
```
warning: this returns a `Result<_, ()>`
 --> src/lib.rs:6:1
  |
6 | pub fn ret_err() -> Result<(),()> {
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: use a custom `Error` type instead
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err
  = note: `#[warn(clippy::result_unit_err)]` on by default
```

After the fix, Clippy passes.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`check_result_unit_err`]: No longer warns on `no_std` projects
