### PR TITLE
`ref_option_ref` do not lint when inner reference is mutable

### DIFF
--- a/clippy_lints/src/ref_option_ref.rs
+++ b/clippy_lints/src/ref_option_ref.rs
@@ -52,7 +52,8 @@ impl<'tcx> LateLintPass<'tcx> for RefOptionRef {
                 GenericArg::Type(inner_ty) => Some(inner_ty),
                 _ => None,
             });
-            if let TyKind::Rptr(_, _) = inner_ty.kind;
+            if let TyKind::Rptr(_, ref inner_mut_ty) = inner_ty.kind;
+            if inner_mut_ty.mutbl == Mutability::Not;
 
             then {
                 span_lint_and_sugg(

--- a/tests/ui/ref_option_ref.rs
+++ b/tests/ui/ref_option_ref.rs
@@ -45,3 +45,8 @@ impl RefOptTrait for u32 {
 fn main() {
     let x: &Option<&u32> = &None;
 }
+
+fn issue9682(arg: &Option<&mut String>) {
+    // Should not lint, as the inner ref is mutable making it non `Copy`
+    println!("{arg:?}");
+}


### PR DESCRIPTION
changelog: [`ref_option_ref`] do not lint when inner reference is mutable

fix https://github.com/rust-lang/rust-clippy/issues/9682