### PR TITLE
[`collapsible_match`] specify field name when destructuring structs

### DIFF
--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -253,6 +253,27 @@ fn negative_cases(res_opt: Result<Option<u32>, String>, res_res: Result<Result<u
     };
 }
 
+pub enum Issue9647 {
+    A { a: Option<Option<u8>>, b: () },
+    B,
+}
+
+pub fn test_1(x: Issue9647) {
+    if let Issue9647::A { a, .. } = x {
+        if let Some(u) = a {
+            println!("{u:?}")
+        }
+    }
+}
+
+pub fn test_2(x: Issue9647) {
+    if let Issue9647::A { a: Some(a), .. } = x {
+        if let Some(u) = a {
+            println!("{u}")
+        }
+    }
+}
+
 fn make<T>() -> T {
     unimplemented!()
 }

--- a/tests/ui/collapsible_match.stderr
+++ b/tests/ui/collapsible_match.stderr
@@ -175,5 +175,37 @@ LL |         Some(val) => match val {
 LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
-error: aborting due to 10 previous errors
+error: this `if let` can be collapsed into the outer `if let`
+  --> $DIR/collapsible_match.rs:263:9
+   |
+LL | /         if let Some(u) = a {
+LL | |             println!("{u:?}")
+LL | |         }
+   | |_________^
+   |
+help: the outer pattern can be modified to include the inner pattern
+  --> $DIR/collapsible_match.rs:262:27
+   |
+LL |     if let Issue9647::A { a, .. } = x {
+   |                           ^ replace this binding
+LL |         if let Some(u) = a {
+   |                ^^^^^^^ with this pattern, prefixed by a:
+
+error: this `if let` can be collapsed into the outer `if let`
+  --> $DIR/collapsible_match.rs:271:9
+   |
+LL | /         if let Some(u) = a {
+LL | |             println!("{u}")
+LL | |         }
+   | |_________^
+   |
+help: the outer pattern can be modified to include the inner pattern
+  --> $DIR/collapsible_match.rs:270:35
+   |
+LL |     if let Issue9647::A { a: Some(a), .. } = x {
+   |                                   ^ replace this binding
+LL |         if let Some(u) = a {
+   |                ^^^^^^^ with this pattern
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
changelog: [`collapsible_match`] specify field name when destructuring structs

fix https://github.com/rust-lang/rust-clippy/issues/9647

I wasn't the sure about the best way to convey the message in the lint message since it does not use suggestion. Because I liked the former output highlighting both spans, I've left it as before, only modifying the span label.