### PR TITLE
[`unwrap_used`], [`expect_used`] do not lint in `test` cfg

### DIFF
--- a/clippy_lints/src/methods/expect_used.rs
+++ b/clippy_lints/src/methods/expect_used.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::is_in_test_function;
+use clippy_utils::is_in_cfg_test;
 use clippy_utils::ty::is_type_diagnostic_item;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
@@ -27,7 +27,7 @@ pub(super) fn check(
 
     let method = if is_err { "expect_err" } else { "expect" };
 
-    if allow_expect_in_tests && is_in_test_function(cx.tcx, expr.hir_id) {
+    if allow_expect_in_tests && is_in_cfg_test(cx.tcx, expr.hir_id) {
         return;
     }
 

--- a/clippy_lints/src/methods/unwrap_used.rs
+++ b/clippy_lints/src/methods/unwrap_used.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::ty::is_type_diagnostic_item;
-use clippy_utils::{is_in_test_function, is_lint_allowed};
+use clippy_utils::{is_in_cfg_test, is_lint_allowed};
 use rustc_hir as hir;
 use rustc_lint::LateContext;
 use rustc_span::sym;
@@ -27,7 +27,7 @@ pub(super) fn check(
 
     let method_suffix = if is_err { "_err" } else { "" };
 
-    if allow_unwrap_in_tests && is_in_test_function(cx.tcx, expr.hir_id) {
+    if allow_unwrap_in_tests && is_in_cfg_test(cx.tcx, expr.hir_id) {
         return;
     }
 

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -373,7 +373,7 @@ define_Conf! {
     (max_include_file_size: u64 = 1_000_000),
     /// Lint: EXPECT_USED.
     ///
-    /// Whether `expect` should be allowed in test cfg
+    /// Whether `expect` should be allowed within `#[cfg(test)]`
     (allow_expect_in_tests: bool = false),
     /// Lint: UNWRAP_USED.
     ///

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -373,11 +373,11 @@ define_Conf! {
     (max_include_file_size: u64 = 1_000_000),
     /// Lint: EXPECT_USED.
     ///
-    /// Whether `expect` should be allowed in test functions
+    /// Whether `expect` should be allowed in test cfg
     (allow_expect_in_tests: bool = false),
     /// Lint: UNWRAP_USED.
     ///
-    /// Whether `unwrap` should be allowed in test functions
+    /// Whether `unwrap` should be allowed in test cfg
     (allow_unwrap_in_tests: bool = false),
     /// Lint: DBG_MACRO.
     ///

--- a/tests/ui-toml/expect_used/expect_used.rs
+++ b/tests/ui-toml/expect_used/expect_used.rs
@@ -16,14 +16,19 @@ fn main() {
     expect_result();
 }
 
-#[test]
-fn test_expect_option() {
-    let opt = Some(0);
-    let _ = opt.expect("");
-}
+#[cfg(test)]
+mod issue9612 {
+    // should not lint in `#[cfg(test)]` modules
+    #[test]
+    fn test_fn() {
+        let _a: u8 = 2.try_into().unwrap();
+        let _a: u8 = 3.try_into().expect("");
 
-#[test]
-fn test_expect_result() {
-    let res: Result<u8, ()> = Ok(0);
-    let _ = res.expect("");
+        util();
+    }
+
+    fn util() {
+        let _a: u8 = 4.try_into().unwrap();
+        let _a: u8 = 5.try_into().expect("");
+    }
 }

--- a/tests/ui-toml/unwrap_used/unwrap_used.rs
+++ b/tests/ui-toml/unwrap_used/unwrap_used.rs
@@ -66,8 +66,21 @@ fn main() {
     }
 }
 
-#[test]
-fn test() {
-    let boxed_slice: Box<[u8]> = Box::new([0, 1, 2, 3]);
-    let _ = boxed_slice.get(1).unwrap();
+#[cfg(test)]
+mod issue9612 {
+    // should not lint in `#[cfg(test)]` modules
+    #[test]
+    fn test_fn() {
+        let _a: u8 = 2.try_into().unwrap();
+        let _a: u8 = 3.try_into().expect("");
+
+        util();
+    }
+
+    fn util() {
+        let _a: u8 = 4.try_into().unwrap();
+        let _a: u8 = 5.try_into().expect("");
+        // should still warn
+        let _ = Box::new([0]).get(1).unwrap();
+    }
 }

--- a/tests/ui-toml/unwrap_used/unwrap_used.stderr
+++ b/tests/ui-toml/unwrap_used/unwrap_used.stderr
@@ -188,10 +188,10 @@ LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:72:13
+  --> $DIR/unwrap_used.rs:84:17
    |
-LL |     let _ = boxed_slice.get(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
+LL |         let _ = Box::new([0]).get(1).unwrap();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&Box::new([0])[1]`
 
 error: aborting due to 27 previous errors
 


### PR DESCRIPTION
changelog: [`unwrap_used`], [`expect_used`] do not lint in `test` cfg

fix https://github.com/rust-lang/rust-clippy/issues/9612

I've updated the doc and used `cfg` acronym, not sure if `conditional compiler flag` would have been better