### PR TITLE
fix: support `map_or` for `or_fun_call` lint

### DIFF
--- a/tests/ui/manual_ok_or.fixed
+++ b/tests/ui/manual_ok_or.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::manual_ok_or)]
+#![allow(clippy::or_fun_call)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::redundant_closure)]
 #![allow(dead_code)]

--- a/tests/ui/manual_ok_or.rs
+++ b/tests/ui/manual_ok_or.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::manual_ok_or)]
+#![allow(clippy::or_fun_call)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::redundant_closure)]
 #![allow(dead_code)]

--- a/tests/ui/manual_ok_or.stderr
+++ b/tests/ui/manual_ok_or.stderr
@@ -1,5 +1,5 @@
 error: this pattern reimplements `Option::ok_or`
-  --> $DIR/manual_ok_or.rs:11:5
+  --> $DIR/manual_ok_or.rs:12:5
    |
 LL |     foo.map_or(Err("error"), |v| Ok(v));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `foo.ok_or("error")`
@@ -7,19 +7,19 @@ LL |     foo.map_or(Err("error"), |v| Ok(v));
    = note: `-D clippy::manual-ok-or` implied by `-D warnings`
 
 error: this pattern reimplements `Option::ok_or`
-  --> $DIR/manual_ok_or.rs:14:5
+  --> $DIR/manual_ok_or.rs:15:5
    |
 LL |     foo.map_or(Err("error"), Ok);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `foo.ok_or("error")`
 
 error: this pattern reimplements `Option::ok_or`
-  --> $DIR/manual_ok_or.rs:17:5
+  --> $DIR/manual_ok_or.rs:18:5
    |
 LL |     None::<i32>.map_or(Err("error"), |v| Ok(v));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `None::<i32>.ok_or("error")`
 
 error: this pattern reimplements `Option::ok_or`
-  --> $DIR/manual_ok_or.rs:21:5
+  --> $DIR/manual_ok_or.rs:22:5
    |
 LL | /     foo.map_or(Err::<i32, &str>(
 LL | |         &format!(

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -236,4 +236,20 @@ mod issue9608 {
     }
 }
 
+mod issue8993 {
+    fn g() -> i32 {
+        3
+    }
+
+    fn f(n: i32) -> i32 {
+        n
+    }
+
+    fn test_map_or() {
+        let _ = Some(4).map_or_else(g, |v| v);
+        let _ = Some(4).map_or_else(g, f);
+        let _ = Some(4).map_or(0, f);
+    }
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -236,4 +236,20 @@ mod issue9608 {
     }
 }
 
+mod issue8993 {
+    fn g() -> i32 {
+        3
+    }
+
+    fn f(n: i32) -> i32 {
+        n
+    }
+
+    fn test_map_or() {
+        let _ = Some(4).map_or(g(), |v| v);
+        let _ = Some(4).map_or(g(), f);
+        let _ = Some(4).map_or(0, f);
+    }
+}
+
 fn main() {}

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -156,5 +156,17 @@ error: use of `unwrap_or` followed by a call to `new`
 LL |         .unwrap_or(String::new());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
-error: aborting due to 26 previous errors
+error: use of `map_or` followed by a function call
+  --> $DIR/or_fun_call.rs:249:25
+   |
+LL |         let _ = Some(4).map_or(g(), |v| v);
+   |                         ^^^^^^^^^^^^^^^^^^ help: try this: `map_or_else(g, |v| v)`
+
+error: use of `map_or` followed by a function call
+  --> $DIR/or_fun_call.rs:250:25
+   |
+LL |         let _ = Some(4).map_or(g(), f);
+   |                         ^^^^^^^^^^^^^^ help: try this: `map_or_else(g, f)`
+
+error: aborting due to 28 previous errors
 


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust-clippy/issues/8993

The methods defined in `KNOW_TYPES`, except for `map_or`, accepts only one argument, so the matching `if let [arg] = args` works only for these methods.
This PR adds `rest_arg` argument to `check_general_case` method and handling of cases with two arguments to support `map_or`.

changelog: `or_fun_call` support `map_or`

* add `rest_arg` to pass second argument from `map_or(U, F)`
* extract some procedures into closure

