### PR TITLE
Add `lintcheck` to packages linted by `dogfood` test

### DIFF
--- a/lintcheck/src/config.rs
+++ b/lintcheck/src/config.rs
@@ -97,7 +97,7 @@ impl LintcheckConfig {
             Some(&0) => {
                 // automatic choice
                 // Rayon seems to return thread count so half that for core count
-                (rayon::current_num_threads() / 2) as usize
+                rayon::current_num_threads() / 2
             },
             Some(&threads) => threads,
             // no -j passed, use a single thread

--- a/lintcheck/src/config.rs
+++ b/lintcheck/src/config.rs
@@ -73,8 +73,7 @@ impl LintcheckConfig {
         let sources_toml = env::var("LINTCHECK_TOML").unwrap_or_else(|_| {
             clap_config
                 .get_one::<String>("crates-toml")
-                .map(|s| &**s)
-                .unwrap_or("lintcheck/lintcheck_crates.toml")
+                .map_or("lintcheck/lintcheck_crates.toml", |s| &**s)
                 .into()
         });
 

--- a/lintcheck/src/driver.rs
+++ b/lintcheck/src/driver.rs
@@ -5,7 +5,7 @@ use std::net::TcpStream;
 use std::process::{self, Command, Stdio};
 use std::{env, mem};
 
-/// 1. Sends [DriverInfo] to the [crate::recursive::LintcheckServer] running on `addr`
+/// 1. Sends [`DriverInfo`] to the [`crate::recursive::LintcheckServer`] running on `addr`
 /// 2. Receives [bool] from the server, if `false` returns `None`
 /// 3. Otherwise sends the stderr of running `clippy-driver` to the server
 fn run_clippy(addr: &str) -> Option<i32> {

--- a/lintcheck/src/recursive.rs
+++ b/lintcheck/src/recursive.rs
@@ -1,7 +1,7 @@
 //! In `--recursive` mode we set the `lintcheck` binary as the `RUSTC_WRAPPER` of `cargo check`,
-//! this allows [crate::driver] to be run for every dependency. The driver connects to
-//! [LintcheckServer] to ask if it should be skipped, and if not sends the stderr of running clippy
-//! on the crate to the server
+//! this allows [`crate::driver`] to be run for every dependency. The driver connects to
+//! [`LintcheckServer`] to ask if it should be skipped, and if not sends the stderr of running
+//! clippy on the crate to the server
 
 use crate::ClippyWarning;
 use crate::RecursiveOptions;
@@ -109,8 +109,8 @@ impl LintcheckServer {
 
         Self {
             local_addr,
-            sender,
             receiver,
+            sender,
         }
     }
 

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -20,7 +20,14 @@ fn dogfood_clippy() {
     }
 
     // "" is the root package
-    for package in &["", "clippy_dev", "clippy_lints", "clippy_utils", "rustc_tools_util"] {
+    for package in &[
+        "",
+        "clippy_dev",
+        "clippy_lints",
+        "clippy_utils",
+        "lintcheck",
+        "rustc_tools_util",
+    ] {
         run_clippy_for_package(package, &["-D", "clippy::all", "-D", "clippy::pedantic"]);
     }
 }


### PR DESCRIPTION
Currently, `lintcheck` is not checked by the `dogfood` test. I assume that is not intentional. If it is intentional, then this PR can be ignored.

changelog: Add `lintcheck` to packages linted by `dogfood` test
