### PR TITLE
Move `let_underscore_drop` to restriction

### DIFF
--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -62,8 +62,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for `let _ = <expr>`
-    /// where expr has a type that implements `Drop`
+    /// Checks for `let _ = <expr>` where expr has a type that implements `Drop`
     ///
     /// ### Why is this bad?
     /// This statement immediately drops the initializer
@@ -94,7 +93,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.50.0"]
     pub LET_UNDERSCORE_DROP,
-    pedantic,
+    restriction,
     "non-binding let on a type that implements `Drop`"
 }
 

--- a/clippy_lints/src/lib.register_pedantic.rs
+++ b/clippy_lints/src/lib.register_pedantic.rs
@@ -39,7 +39,6 @@ store.register_group(true, "clippy::pedantic", Some("clippy_pedantic"), vec![
     LintId::of(items_after_statements::ITEMS_AFTER_STATEMENTS),
     LintId::of(iter_not_returning_iterator::ITER_NOT_RETURNING_ITERATOR),
     LintId::of(large_stack_arrays::LARGE_STACK_ARRAYS),
-    LintId::of(let_underscore::LET_UNDERSCORE_DROP),
     LintId::of(literal_representation::LARGE_DIGIT_GROUPS),
     LintId::of(literal_representation::UNREADABLE_LITERAL),
     LintId::of(loops::EXPLICIT_INTO_ITER_LOOP),

--- a/clippy_lints/src/lib.register_restriction.rs
+++ b/clippy_lints/src/lib.register_restriction.rs
@@ -28,6 +28,7 @@ store.register_group(true, "clippy::restriction", Some("clippy_restriction"), ve
     LintId::of(indexing_slicing::INDEXING_SLICING),
     LintId::of(inherent_impl::MULTIPLE_INHERENT_IMPL),
     LintId::of(large_include_file::LARGE_INCLUDE_FILE),
+    LintId::of(let_underscore::LET_UNDERSCORE_DROP),
     LintId::of(let_underscore::LET_UNDERSCORE_MUST_USE),
     LintId::of(literal_representation::DECIMAL_LITERAL_REPRESENTATION),
     LintId::of(matches::REST_PAT_IN_FULLY_BOUND_STRUCTS),

--- a/lintcheck/src/main.rs
+++ b/lintcheck/src/main.rs
@@ -678,7 +678,7 @@ fn main() {
         .unwrap();
 
     let server = config.recursive.then(|| {
-        fs::remove_dir_all("target/lintcheck/shared_target_dir/recursive").unwrap_or_default();
+        let _ = fs::remove_dir_all("target/lintcheck/shared_target_dir/recursive");
 
         LintcheckServer::spawn(recursive_options)
     });

--- a/src/docs/let_underscore_drop.txt
+++ b/src/docs/let_underscore_drop.txt
@@ -1,6 +1,5 @@
 ### What it does
-Checks for `let _ = <expr>`
-where expr has a type that implements `Drop`
+Checks for `let _ = <expr>` where expr has a type that implements `Drop`
 
 ### Why is this bad?
 This statement immediately drops the initializer


### PR DESCRIPTION
Because of things like #9314. `let _` is considered the idiomatic way to ignore `must_use`: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute

changelog: [`let_underscore_drop`]: move to restriction

r? @flip1995 