### PR TITLE
`question_mark` don't lint on `if let Err` with `else`

### DIFF
--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -189,6 +189,7 @@ fn is_early_return(smbl: Symbol, cx: &LateContext<'_>, if_block: &IfBlockType<'_
                             && expr_return_none_or_err(smbl, cx, if_else.unwrap(), let_expr, Some(let_pat_sym)))
                             || is_res_lang_ctor(cx, res, ResultErr)
                                 && expr_return_none_or_err(smbl, cx, if_then, let_expr, Some(let_pat_sym))
+                                && if_else.is_none()
                     },
                     _ => false,
                 }

--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -134,6 +134,9 @@ fn result_func(x: Result<i32, i32>) -> Result<i32, i32> {
         return func_returning_result();
     }
 
+    // no warning
+    let _ = if let Err(e) = x { Err(e) } else { Ok(0) };
+
     Ok(y)
 }
 

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -166,6 +166,9 @@ fn result_func(x: Result<i32, i32>) -> Result<i32, i32> {
         return func_returning_result();
     }
 
+    // no warning
+    let _ = if let Err(e) = x { Err(e) } else { Ok(0) };
+
     Ok(y)
 }
 

--- a/tests/ui/question_mark.stderr
+++ b/tests/ui/question_mark.stderr
@@ -115,7 +115,7 @@ LL | |     }
    | |_____^ help: replace it with: `x?;`
 
 error: this block may be rewritten with the `?` operator
-  --> $DIR/question_mark.rs:193:5
+  --> $DIR/question_mark.rs:196:5
    |
 LL | /     if let Err(err) = func_returning_result() {
 LL | |         return Err(err);
@@ -123,7 +123,7 @@ LL | |     }
    | |_____^ help: replace it with: `func_returning_result()?;`
 
 error: this block may be rewritten with the `?` operator
-  --> $DIR/question_mark.rs:200:5
+  --> $DIR/question_mark.rs:203:5
    |
 LL | /     if let Err(err) = func_returning_result() {
 LL | |         return Err(err);


### PR DESCRIPTION
cc #9518

AFAICT the only time this would be a valid suggestion is the rather esoteric

```rust
let _ = if let Err(e) = x {
    return Err(e);
} else {
    // no side effects
    x.unwrap()
}
```

which doesn't seem worth checking to me. Please correct me if I'm missing something.

changelog: [`question_mark`] don't lint on `if let Err` with `else`
