### PR TITLE
move `UNINLINED_FORMAT_ARGS` to pedantic

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -115,7 +115,7 @@ declare_clippy_lint! {
     /// nothing will be suggested, e.g. `println!("{0}={1}", var, 1+2)`.
     #[clippy::version = "1.65.0"]
     pub UNINLINED_FORMAT_ARGS,
-    style,
+    pedantic,
     "using non-inlined variables in `format!` calls"
 }
 


### PR DESCRIPTION
As discussed in zulip, we are moving this lint to pedantic to be backported

changelog: [`UNINLINED_FORMAT_ARGS`]: move to pedantic
