### PR TITLE
Ensure new_ret_no_self is not fired if impl Trait<Self> is returned.

### DIFF
--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -350,3 +350,53 @@ impl RetOtherSelf<T> {
         RetOtherSelf(RetOtherSelfWrapper(t))
     }
 }
+
+mod issue7344 {
+    struct RetImplTraitSelf<T>(T);
+
+    impl<T> RetImplTraitSelf<T> {
+        // should not trigger lint
+        fn new(t: T) -> impl Into<Self> {
+            Self(t)
+        }
+    }
+
+    struct RetImplTraitNoSelf<T>(T);
+
+    impl<T> RetImplTraitNoSelf<T> {
+        // should trigger lint
+        fn new(t: T) -> impl Into<i32> {
+            1
+        }
+    }
+
+    trait Trait2<T, U> {}
+    impl<T, U> Trait2<T, U> for () {}
+
+    struct RetImplTraitSelf2<T>(T);
+
+    impl<T> RetImplTraitSelf2<T> {
+        // should not trigger lint
+        fn new(t: T) -> impl Trait2<(), Self> {
+            unimplemented!()
+        }
+    }
+
+    struct RetImplTraitNoSelf2<T>(T);
+
+    impl<T> RetImplTraitNoSelf2<T> {
+        // should trigger lint
+        fn new(t: T) -> impl Trait2<(), i32> {
+            unimplemented!()
+        }
+    }
+
+    struct RetImplTraitSelfAdt<'a>(&'a str);
+
+    impl<'a> RetImplTraitSelfAdt<'a> {
+        // should not trigger lint
+        fn new<'b: 'a>(s: &'b str) -> impl Into<RetImplTraitSelfAdt<'b>> {
+            RetImplTraitSelfAdt(s)
+        }
+    }
+}

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -76,5 +76,21 @@ LL | |             unimplemented!();
 LL | |         }
    | |_________^
 
-error: aborting due to 10 previous errors
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self.rs:368:9
+   |
+LL | /         fn new(t: T) -> impl Into<i32> {
+LL | |             1
+LL | |         }
+   | |_________^
+
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self.rs:389:9
+   |
+LL | /         fn new(t: T) -> impl Trait2<(), i32> {
+LL | |             unimplemented!()
+LL | |         }
+   | |_________^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Fix #7344: ensure new_ret_no_self is not fired if `impl Trait<Self>` is returned.

changelog: [`new_ret_no_self`]: No longer lints when `impl Trait<Self>` is returned
