### PR TITLE
fix the `string-extend-chars` suggestion on slice

### DIFF
--- a/clippy_lints/src/methods/string_extend_chars.rs
+++ b/clippy_lints/src/methods/string_extend_chars.rs
@@ -19,7 +19,11 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr
         let target = &arglists[0].0;
         let self_ty = cx.typeck_results().expr_ty(target).peel_refs();
         let ref_str = if *self_ty.kind() == ty::Str {
-            ""
+            if matches!(target.kind, hir::ExprKind::Index(..)) {
+                "&"
+            } else {
+                ""
+            }
         } else if is_type_diagnostic_item(cx, self_ty, sym::String) {
             "&"
         } else {

--- a/tests/ui/string_extend.fixed
+++ b/tests/ui/string_extend.fixed
@@ -29,4 +29,7 @@ fn main() {
 
     let f = HasChars;
     s.extend(f.chars());
+
+    // issue #9735
+    s.push_str(&abc[0..2]);
 }

--- a/tests/ui/string_extend.rs
+++ b/tests/ui/string_extend.rs
@@ -29,4 +29,7 @@ fn main() {
 
     let f = HasChars;
     s.extend(f.chars());
+
+    // issue #9735
+    s.extend(abc[0..2].chars());
 }

--- a/tests/ui/string_extend.stderr
+++ b/tests/ui/string_extend.stderr
@@ -18,5 +18,11 @@ error: calling `.extend(_.chars())`
 LL |     s.extend(def.chars());
    |     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.push_str(&def)`
 
-error: aborting due to 3 previous errors
+error: calling `.extend(_.chars())`
+  --> $DIR/string_extend.rs:34:5
+   |
+LL |     s.extend(abc[0..2].chars());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.push_str(&abc[0..2])`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This adds the missing `&` to the suggestion if the target is a `str` slice (e.g. extending with `"foo"[..].chars()`).

This closes #9735.

---

changelog: fix the `string-extend-chars` suggestion for `str` slices
