### PR TITLE
add [`permissions_set_readonly_false`] #9702

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4142,6 +4142,7 @@ Released 2018-09-13
 [`partialeq_to_none`]: https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none
 [`path_buf_push_overwrite`]: https://rust-lang.github.io/rust-clippy/master/index.html#path_buf_push_overwrite
 [`pattern_type_mismatch`]: https://rust-lang.github.io/rust-clippy/master/index.html#pattern_type_mismatch
+[`permissions_set_readonly_false`]: https://rust-lang.github.io/rust-clippy/master/index.html#permissions_set_readonly_false
 [`positional_named_format_parameters`]: https://rust-lang.github.io/rust-clippy/master/index.html#positional_named_format_parameters
 [`possible_missing_comma`]: https://rust-lang.github.io/rust-clippy/master/index.html#possible_missing_comma
 [`precedence`]: https://rust-lang.github.io/rust-clippy/master/index.html#precedence

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -489,6 +489,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::pass_by_ref_or_value::LARGE_TYPES_PASSED_BY_VALUE_INFO,
     crate::pass_by_ref_or_value::TRIVIALLY_COPY_PASS_BY_REF_INFO,
     crate::pattern_type_mismatch::PATTERN_TYPE_MISMATCH_INFO,
+    crate::permissions_set_readonly_false::PERMISSIONS_SET_READONLY_FALSE_INFO,
     crate::precedence::PRECEDENCE_INFO,
     crate::ptr::CMP_NULL_INFO,
     crate::ptr::INVALID_NULL_PTR_USAGE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -234,6 +234,7 @@ mod partialeq_ne_impl;
 mod partialeq_to_none;
 mod pass_by_ref_or_value;
 mod pattern_type_mismatch;
+mod permissions_set_readonly_false;
 mod precedence;
 mod ptr;
 mod ptr_offset_with_cast;
@@ -916,6 +917,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_early_pass(|| Box::new(partial_pub_fields::PartialPubFields));
     store.register_late_pass(|_| Box::new(missing_trait_methods::MissingTraitMethods));
     store.register_late_pass(|_| Box::new(from_raw_with_void_ptr::FromRawWithVoidPtr));
+    store.register_late_pass(|_| Box::new(permissions_set_readonly_false::PermissionsSetReadonlyFalse));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/permissions_set_readonly_false.rs
+++ b/clippy_lints/src/permissions_set_readonly_false.rs
@@ -1,0 +1,54 @@
+use clippy_utils::diagnostics::span_lint_and_note;
+use clippy_utils::paths;
+use clippy_utils::ty::match_type;
+use rustc_ast::ast::LitKind;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for calls to `std::fs::Permissions.set_readonly` with argument `false`
+    ///
+    /// ### Why is this bad?
+    /// On Unix platforms this results in the file being world writable
+    ///
+    /// ### Example
+    /// ```rust
+    /// let f = File::create("foo.txt").unwrap();
+    /// let metadata = f.metadata().unwrap();
+    /// let mut permissions = metadata.permissions();
+    /// permissions.set_readonly(false);
+    /// ```
+    #[clippy::version = "1.66.0"]
+    pub PERMISSIONS_SET_READONLY_FALSE,
+    suspicious,
+    "Checks for calls to `std::fs::Permissions.set_readonly` with argument `false`"
+}
+declare_lint_pass!(PermissionsSetReadonlyFalse => [PERMISSIONS_SET_READONLY_FALSE]);
+
+impl<'tcx> LateLintPass<'tcx> for PermissionsSetReadonlyFalse {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        if let ExprKind::MethodCall(path, receiver, args, _) = &expr.kind {
+            if_chain! {
+                if match_type(cx, cx.typeck_results().expr_ty(receiver), &paths::PERMISSIONS);
+                if path.ident.name == sym!(set_readonly);
+                if args.len() == 1;
+                then {
+                    if let ExprKind::Lit(lit) = &args[0].kind {
+                        if LitKind::Bool(false) == lit.node {
+                            span_lint_and_note(
+                                cx,
+                                PERMISSIONS_SET_READONLY_FALSE,
+                                expr.span,
+                                "call to `set_readonly` with argument `false`",
+                                None,
+                                "on Unix platforms this results in the file being world writable",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/clippy_lints/src/permissions_set_readonly_false.rs
+++ b/clippy_lints/src/permissions_set_readonly_false.rs
@@ -15,6 +15,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
+    /// use std::fs::File;
     /// let f = File::create("foo.txt").unwrap();
     /// let metadata = f.metadata().unwrap();
     /// let mut permissions = metadata.permissions();

--- a/tests/ui/permissions_set_readonly_false.rs
+++ b/tests/ui/permissions_set_readonly_false.rs
@@ -1,0 +1,29 @@
+#![allow(unused)]
+#![warn(clippy::permissions_set_readonly_false)]
+
+use std::fs::File;
+
+struct A;
+
+impl A {
+    pub fn set_readonly(&mut self, b: bool) {}
+}
+
+fn set_readonly(b: bool) {}
+
+fn main() {
+    let f = File::create("foo.txt").unwrap();
+    let metadata = f.metadata().unwrap();
+    let mut permissions = metadata.permissions();
+    // lint here
+    permissions.set_readonly(false);
+    // no lint
+    permissions.set_readonly(true);
+
+    let mut a = A;
+    // no lint here - a is not of type std::fs::Permissions
+    a.set_readonly(false);
+
+    // no lint here - plain function
+    set_readonly(false);
+}

--- a/tests/ui/permissions_set_readonly_false.stderr
+++ b/tests/ui/permissions_set_readonly_false.stderr
@@ -1,0 +1,11 @@
+error: call to `set_readonly` with argument `false`
+  --> $DIR/permissions_set_readonly_false.rs:19:5
+   |
+LL |     permissions.set_readonly(false);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: on Unix platforms this results in the file being world writable
+   = note: `-D clippy::permissions-set-readonly-false` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #9702

---

changelog: New lint [`permissions_set_readonly_false`]
[#9744](https://github.com/rust-lang/rust-clippy/pull/9744)
<!-- chnagelog_checked -->
