### PR TITLE
fix: adjust return type

### DIFF
--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -171,7 +171,7 @@ pub(super) fn check<'tcx>(
             _,
         ) = arg.kind
         {
-            expr
+            *expr
         } else {
             arg
         }


### PR DESCRIPTION
This PR fixes type mismatch in `extract_inner_arg` lambda, `&&Expr` and `&Expr`.
actually they will be dereferenced in compilation so is valid, but rust-analyzer reports it.

![2022-10-30_15-03](https://user-images.githubusercontent.com/14945055/198865224-4cc672ae-0de0-4703-bffc-35975f118c32.png)


changelog: none

