### PR TITLE
Shrink `missing_{safety,errors,panics}_doc` spans

### DIFF
--- a/tests/ui/doc_errors.stderr
+++ b/tests/ui/doc_errors.stderr
@@ -1,52 +1,40 @@
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:7:1
    |
-LL | / pub fn pub_fn_missing_errors_header() -> Result<(), ()> {
-LL | |     unimplemented!();
-LL | | }
-   | |_^
+LL | pub fn pub_fn_missing_errors_header() -> Result<(), ()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::missing-errors-doc` implied by `-D warnings`
 
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:11:1
    |
-LL | / pub async fn async_pub_fn_missing_errors_header() -> Result<(), ()> {
-LL | |     unimplemented!();
-LL | | }
-   | |_^
+LL | pub async fn async_pub_fn_missing_errors_header() -> Result<(), ()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:16:1
    |
-LL | / pub fn pub_fn_returning_io_result() -> io::Result<()> {
-LL | |     unimplemented!();
-LL | | }
-   | |_^
+LL | pub fn pub_fn_returning_io_result() -> io::Result<()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:21:1
    |
-LL | / pub async fn async_pub_fn_returning_io_result() -> io::Result<()> {
-LL | |     unimplemented!();
-LL | | }
-   | |_^
+LL | pub async fn async_pub_fn_returning_io_result() -> io::Result<()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:51:5
    |
-LL | /     pub fn pub_method_missing_errors_header() -> Result<(), ()> {
-LL | |         unimplemented!();
-LL | |     }
-   | |_____^
+LL |     pub fn pub_method_missing_errors_header() -> Result<(), ()> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:56:5
    |
-LL | /     pub async fn async_pub_method_missing_errors_header() -> Result<(), ()> {
-LL | |         unimplemented!();
-LL | |     }
-   | |_____^
+LL |     pub async fn async_pub_method_missing_errors_header() -> Result<(), ()> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function returning `Result` missing `# Errors` section
   --> $DIR/doc_errors.rs:85:5

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -1,20 +1,16 @@
 error: unsafe function's docs miss `# Safety` section
   --> $DIR/doc_unsafe.rs:9:1
    |
-LL | / pub unsafe fn destroy_the_planet() {
-LL | |     unimplemented!();
-LL | | }
-   | |_^
+LL | pub unsafe fn destroy_the_planet() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::missing-safety-doc` implied by `-D warnings`
 
 error: unsafe function's docs miss `# Safety` section
   --> $DIR/doc_unsafe.rs:32:5
    |
-LL | /     pub unsafe fn republished() {
-LL | |         unimplemented!();
-LL | |     }
-   | |_____^
+LL |     pub unsafe fn republished() {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs miss `# Safety` section
   --> $DIR/doc_unsafe.rs:40:5
@@ -25,29 +21,23 @@ LL |     unsafe fn woefully_underdocumented(self);
 error: docs for unsafe trait missing `# Safety` section
   --> $DIR/doc_unsafe.rs:46:1
    |
-LL | / pub unsafe trait UnsafeTrait {
-LL | |     fn method();
-LL | | }
-   | |_^
+LL | pub unsafe trait UnsafeTrait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs miss `# Safety` section
   --> $DIR/doc_unsafe.rs:76:5
    |
-LL | /     pub unsafe fn more_undocumented_unsafe() -> Self {
-LL | |         unimplemented!();
-LL | |     }
-   | |_____^
+LL |     pub unsafe fn more_undocumented_unsafe() -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs miss `# Safety` section
   --> $DIR/doc_unsafe.rs:92:9
    |
-LL | /         pub unsafe fn whee() {
-LL | |             unimplemented!()
-LL | |         }
-   | |_________^
+LL |         pub unsafe fn whee() {
+   |         ^^^^^^^^^^^^^^^^^^^^
 ...
-LL |   very_unsafe!();
-   |   -------------- in this macro invocation
+LL | very_unsafe!();
+   | -------------- in this macro invocation
    |
    = note: this error originates in the macro `very_unsafe` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/missing_panics_doc.stderr
+++ b/tests/ui/missing_panics_doc.stderr
@@ -1,11 +1,8 @@
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:6:1
    |
-LL | / pub fn unwrap() {
-LL | |     let result = Err("Hi");
-LL | |     result.unwrap()
-LL | | }
-   | |_^
+LL | pub fn unwrap() {
+   | ^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:8:5
@@ -17,10 +14,8 @@ LL |     result.unwrap()
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:12:1
    |
-LL | / pub fn panic() {
-LL | |     panic!("This function panics")
-LL | | }
-   | |_^
+LL | pub fn panic() {
+   | ^^^^^^^^^^^^^^
    |
 note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:13:5
@@ -31,10 +26,8 @@ LL |     panic!("This function panics")
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:17:1
    |
-LL | / pub fn todo() {
-LL | |     todo!()
-LL | | }
-   | |_^
+LL | pub fn todo() {
+   | ^^^^^^^^^^^^^
    |
 note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:18:5
@@ -45,14 +38,8 @@ LL |     todo!()
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:22:1
    |
-LL | / pub fn inner_body(opt: Option<u32>) {
-LL | |     opt.map(|x| {
-LL | |         if x == 10 {
-LL | |             panic!()
-LL | |         }
-LL | |     });
-LL | | }
-   | |_^
+LL | pub fn inner_body(opt: Option<u32>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:25:13
@@ -63,10 +50,8 @@ LL |             panic!()
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:31:1
    |
-LL | / pub fn unreachable_and_panic() {
-LL | |     if true { unreachable!() } else { panic!() }
-LL | | }
-   | |_^
+LL | pub fn unreachable_and_panic() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:32:39
@@ -77,11 +62,8 @@ LL |     if true { unreachable!() } else { panic!() }
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:36:1
    |
-LL | / pub fn assert_eq() {
-LL | |     let x = 0;
-LL | |     assert_eq!(x, 0);
-LL | | }
-   | |_^
+LL | pub fn assert_eq() {
+   | ^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:38:5
@@ -92,11 +74,8 @@ LL |     assert_eq!(x, 0);
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:42:1
    |
-LL | / pub fn assert_ne() {
-LL | |     let x = 0;
-LL | |     assert_ne!(x, 0);
-LL | | }
-   | |_^
+LL | pub fn assert_ne() {
+   | ^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
   --> $DIR/missing_panics_doc.rs:44:5


### PR DESCRIPTION
Shrink the spans of `clippy::missing_*_doc` to match `missing_docs` and don't cover the entire item anymore. This helps readability in IDEs by not coloring the entire screen yellow, similar to https://github.com/rust-lang/rust/pull/103749 and https://github.com/rust-lang/rust/pull/90761.

before:
![image](https://user-images.githubusercontent.com/26522220/199483288-af0cf0c2-a9e4-47a8-81e3-50ccf380d939.png)

after:
![image](https://user-images.githubusercontent.com/26522220/199483366-445e5ddd-9f71-4de1-85be-43461c9b7d5d.png)

changelog: [`missing_safety_doc`], [`missing_error_doc`], [`missing_panics_doc`]: These lints no longer span the entire item.
