### PR TITLE
Fix ICE in `redundant_allocation`

### DIFF
--- a/clippy_lints/src/types/redundant_allocation.rs
+++ b/clippy_lints/src/types/redundant_allocation.rs
@@ -5,6 +5,7 @@ use rustc_errors::Applicability;
 use rustc_hir::{self as hir, def_id::DefId, QPath, TyKind};
 use rustc_hir_analysis::hir_ty_to_ty;
 use rustc_lint::LateContext;
+use rustc_middle::ty::TypeVisitable;
 use rustc_span::symbol::sym;
 
 use super::{utils, REDUNDANT_ALLOCATION};
@@ -51,14 +52,15 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, qpath: &QPath<'_
         return false
     };
     let inner_span = match qpath_generic_tys(inner_qpath).next() {
-        Some(ty) => {
+        Some(hir_ty) => {
             // Reallocation of a fat pointer causes it to become thin. `hir_ty_to_ty` is safe to use
             // here because `mod.rs` guarantees this lint is only run on types outside of bodies and
             // is not run on locals.
-            if !hir_ty_to_ty(cx.tcx, ty).is_sized(cx.tcx.at(ty.span), cx.param_env) {
+            let ty = hir_ty_to_ty(cx.tcx, hir_ty);
+            if ty.has_escaping_bound_vars() || !ty.is_sized(cx.tcx.at(hir_ty.span), cx.param_env) {
                 return false;
             }
-            ty.span
+            hir_ty.span
         },
         None => return false,
     };

--- a/tests/ui/crashes/ice-9746.rs
+++ b/tests/ui/crashes/ice-9746.rs
@@ -1,0 +1,15 @@
+//! <https://github.com/rust-lang/rust-clippy/issues/9746#issuecomment-1297132880>
+
+trait Trait {}
+
+struct Struct<'a> {
+    _inner: &'a Struct<'a>,
+}
+
+impl Trait for Struct<'_> {}
+
+fn example<'a>(s: &'a Struct) -> Box<Box<dyn Trait + 'a>> {
+    Box::new(Box::new(Struct { _inner: s }))
+}
+
+fn main() {}


### PR DESCRIPTION
changelog: Fix ICE in `redundant_allocation`

Closes #9746, the original issue was fixed already, this gets the one in https://github.com/rust-lang/rust-clippy/issues/9746#issuecomment-1297132880