### PR TITLE
Add allow-print-in-tests config

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -876,13 +876,14 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|_| Box::<only_used_in_recursion::OnlyUsedInRecursion>::default());
     let allow_dbg_in_tests = conf.allow_dbg_in_tests;
     store.register_late_pass(move |_| Box::new(dbg_macro::DbgMacro::new(allow_dbg_in_tests)));
+    let allow_print_in_tests = conf.allow_print_in_tests;
+    store.register_late_pass(move |_| Box::new(write::Write::new(allow_print_in_tests)));
     let cargo_ignore_publish = conf.cargo_ignore_publish;
     store.register_late_pass(move |_| {
         Box::new(cargo::Cargo {
             ignore_publish: cargo_ignore_publish,
         })
     });
-    store.register_late_pass(|_| Box::<write::Write>::default());
     store.register_early_pass(|| Box::new(crate_in_macro_def::CrateInMacroDef));
     store.register_early_pass(|| Box::new(empty_structs_with_brackets::EmptyStructsWithBrackets));
     store.register_late_pass(|_| Box::new(unnecessary_owned_empty_strings::UnnecessaryOwnedEmptyStrings));

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -389,6 +389,10 @@ define_Conf! {
     ///
     /// Whether `dbg!` should be allowed in test functions
     (allow_dbg_in_tests: bool = false),
+    /// Lint: PRINT_STDOUT, PRINT_STDERR.
+    ///
+    /// Whether print macros (ex. `println!`) should be allowed in test functions
+    (allow_print_in_tests: bool = false),
     /// Lint: RESULT_LARGE_ERR.
     ///
     /// The maximum size of the `Err`-variant in a `Result` returned from a function

--- a/tests/ui-toml/print_macro/clippy.toml
+++ b/tests/ui-toml/print_macro/clippy.toml
@@ -1,0 +1,1 @@
+allow-print-in-tests = true

--- a/tests/ui-toml/print_macro/print_macro.rs
+++ b/tests/ui-toml/print_macro/print_macro.rs
@@ -1,0 +1,20 @@
+// compile-flags: --test
+#![warn(clippy::print_stdout)]
+#![warn(clippy::print_stderr)]
+
+fn foo(n: u32) {
+    print!("{n}");
+    eprint!("{n}");
+}
+
+#[test]
+pub fn foo1() {
+    print!("{}", 1);
+    eprint!("{}", 1);
+}
+
+#[cfg(test)]
+fn foo3() {
+    print!("{}", 1);
+    eprint!("{}", 1);
+}

--- a/tests/ui-toml/print_macro/print_macro.stderr
+++ b/tests/ui-toml/print_macro/print_macro.stderr
@@ -1,0 +1,18 @@
+error: use of `print!`
+  --> $DIR/print_macro.rs:6:5
+   |
+LL |     print!("{n}");
+   |     ^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::print-stdout` implied by `-D warnings`
+
+error: use of `eprint!`
+  --> $DIR/print_macro.rs:7:5
+   |
+LL |     eprint!("{n}");
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::print-stderr` implied by `-D warnings`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -1,6 +1,7 @@
 error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown field `foobar`, expected one of
            allow-dbg-in-tests
            allow-expect-in-tests
+           allow-print-in-tests
            allow-unwrap-in-tests
            allowed-scripts
            arithmetic-side-effects-allowed


### PR DESCRIPTION
Add a config, allow-print-in-tests, that can be set in clippy.toml which allows the usage of `[e]print[ln]!` macros in tests.

Closes #9795

---

changelog: Enhancement: [print_stdout], [print_stderr]: Can now be enabled in test with the `allow-print-in-tests` config value
