### PR TITLE
Return multiple resolutions from `def_path_res`

### DIFF
--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -1,7 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::{match_def_path, paths};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_hir::def::{Namespace, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{AsyncGeneratorKind, Body, BodyId, GeneratorKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -189,7 +188,7 @@ impl LateLintPass<'_> for AwaitHolding {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
         for conf in &self.conf_invalid_types {
             let segs: Vec<_> = conf.path().split("::").collect();
-            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, Some(Namespace::TypeNS)) {
+            for id in clippy_utils::def_path_def_ids(cx, &segs) {
                 self.def_ids.insert(id, conf.clone());
             }
         }

--- a/clippy_lints/src/disallowed_macros.rs
+++ b/clippy_lints/src/disallowed_macros.rs
@@ -1,7 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::macros::macro_backtrace;
 use rustc_data_structures::fx::FxHashSet;
-use rustc_hir::def::{Namespace, Res};
 use rustc_hir::def_id::DefIdMap;
 use rustc_hir::{Expr, ForeignItem, HirId, ImplItem, Item, Pat, Path, Stmt, TraitItem, Ty};
 use rustc_lint::{LateContext, LateLintPass};
@@ -89,7 +88,7 @@ impl DisallowedMacros {
                     &format!("use of a disallowed macro `{}`", conf.path()),
                     |diag| {
                         if let Some(reason) = conf.reason() {
-                            diag.note(&format!("{reason} (from clippy.toml)"));
+                            diag.note(reason);
                         }
                     },
                 );
@@ -104,7 +103,7 @@ impl LateLintPass<'_> for DisallowedMacros {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
         for (index, conf) in self.conf_disallowed.iter().enumerate() {
             let segs: Vec<_> = conf.path().split("::").collect();
-            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, Some(Namespace::MacroNS)) {
+            for id in clippy_utils::def_path_def_ids(cx, &segs) {
                 self.disallowed.insert(id, index);
             }
         }

--- a/clippy_lints/src/disallowed_methods.rs
+++ b/clippy_lints/src/disallowed_methods.rs
@@ -1,7 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::{fn_def_id, get_parent_expr, path_def_id};
 
-use rustc_hir::def::{Namespace, Res};
 use rustc_hir::def_id::DefIdMap;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -79,7 +78,7 @@ impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
         for (index, conf) in self.conf_disallowed.iter().enumerate() {
             let segs: Vec<_> = conf.path().split("::").collect();
-            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, Some(Namespace::ValueNS)) {
+            for id in clippy_utils::def_path_def_ids(cx, &segs) {
                 self.disallowed.insert(id, index);
             }
         }
@@ -104,7 +103,7 @@ impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
         let msg = format!("use of a disallowed method `{}`", conf.path());
         span_lint_and_then(cx, DISALLOWED_METHODS, expr.span, &msg, |diag| {
             if let Some(reason) = conf.reason() {
-                diag.note(&format!("{reason} (from clippy.toml)"));
+                diag.note(reason);
             }
         });
     }

--- a/clippy_lints/src/disallowed_types.rs
+++ b/clippy_lints/src/disallowed_types.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_hir::def::{Namespace, Res};
+use rustc_hir::def::Res;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Item, ItemKind, PolyTraitRef, PrimTy, Ty, TyKind, UseKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -53,8 +53,8 @@ declare_clippy_lint! {
 #[derive(Clone, Debug)]
 pub struct DisallowedTypes {
     conf_disallowed: Vec<conf::DisallowedPath>,
-    def_ids: FxHashMap<DefId, Option<String>>,
-    prim_tys: FxHashMap<PrimTy, Option<String>>,
+    def_ids: FxHashMap<DefId, usize>,
+    prim_tys: FxHashMap<PrimTy, usize>,
 }
 
 impl DisallowedTypes {
@@ -69,13 +69,13 @@ impl DisallowedTypes {
     fn check_res_emit(&self, cx: &LateContext<'_>, res: &Res, span: Span) {
         match res {
             Res::Def(_, did) => {
-                if let Some(reason) = self.def_ids.get(did) {
-                    emit(cx, &cx.tcx.def_path_str(*did), span, reason.as_deref());
+                if let Some(&index) = self.def_ids.get(did) {
+                    emit(cx, &cx.tcx.def_path_str(*did), span, &self.conf_disallowed[index]);
                 }
             },
             Res::PrimTy(prim) => {
-                if let Some(reason) = self.prim_tys.get(prim) {
-                    emit(cx, prim.name_str(), span, reason.as_deref());
+                if let Some(&index) = self.prim_tys.get(prim) {
+                    emit(cx, prim.name_str(), span, &self.conf_disallowed[index]);
                 }
             },
             _ => {},
@@ -87,17 +87,19 @@ impl_lint_pass!(DisallowedTypes => [DISALLOWED_TYPES]);
 
 impl<'tcx> LateLintPass<'tcx> for DisallowedTypes {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
-        for conf in &self.conf_disallowed {
+        for (index, conf) in self.conf_disallowed.iter().enumerate() {
             let segs: Vec<_> = conf.path().split("::").collect();
-            let reason = conf.reason().map(|reason| format!("{reason} (from clippy.toml)"));
-            match clippy_utils::def_path_res(cx, &segs, Some(Namespace::TypeNS)) {
-                Res::Def(_, id) => {
-                    self.def_ids.insert(id, reason);
-                },
-                Res::PrimTy(ty) => {
-                    self.prim_tys.insert(ty, reason);
-                },
-                _ => {},
+
+            for res in clippy_utils::def_path_res(cx, &segs) {
+                match res {
+                    Res::Def(_, id) => {
+                        self.def_ids.insert(id, index);
+                    },
+                    Res::PrimTy(ty) => {
+                        self.prim_tys.insert(ty, index);
+                    },
+                    _ => {},
+                }
             }
         }
     }
@@ -119,14 +121,14 @@ impl<'tcx> LateLintPass<'tcx> for DisallowedTypes {
     }
 }
 
-fn emit(cx: &LateContext<'_>, name: &str, span: Span, reason: Option<&str>) {
+fn emit(cx: &LateContext<'_>, name: &str, span: Span, conf: &conf::DisallowedPath) {
     span_lint_and_then(
         cx,
         DISALLOWED_TYPES,
         span,
         &format!("`{name}` is not allowed according to config"),
         |diag| {
-            if let Some(reason) = reason {
+            if let Some(reason) = conf.reason() {
                 diag.note(reason);
             }
         },

--- a/clippy_lints/src/missing_enforced_import_rename.rs
+++ b/clippy_lints/src/missing_enforced_import_rename.rs
@@ -59,7 +59,7 @@ impl LateLintPass<'_> for ImportRename {
     fn check_crate(&mut self, cx: &LateContext<'_>) {
         for Rename { path, rename } in &self.conf_renames {
             let segs = path.split("::").collect::<Vec<_>>();
-            if let Res::Def(_, id) = clippy_utils::def_path_res(cx, &segs, None) {
+            for id in clippy_utils::def_path_def_ids(cx, &segs) {
                 self.renames.insert(id, Symbol::intern(rename));
             }
         }

--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -1,8 +1,7 @@
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::{def_path_res, trait_ref_of_method};
+use clippy_utils::{def_path_def_ids, trait_ref_of_method};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
-use rustc_hir::def::Namespace;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TypeVisitable;
 use rustc_middle::ty::{Adt, Array, Ref, Slice, Tuple, Ty};
@@ -94,7 +93,7 @@ impl<'tcx> LateLintPass<'tcx> for MutableKeyType {
         let mut path = Vec::new();
         for ty in &self.ignore_interior_mutability {
             path.extend(ty.split("::"));
-            if let Some(id) = def_path_res(cx, &path[..], Some(Namespace::TypeNS)).opt_def_id() {
+            for id in def_path_def_ids(cx, &path[..]) {
                 self.ignore_mut_def_ids.insert(id);
             }
             path.clear();

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -53,11 +53,11 @@ impl DisallowedPath {
         path
     }
 
-    pub fn reason(&self) -> Option<&str> {
+    pub fn reason(&self) -> Option<String> {
         match self {
             Self::WithReason {
                 reason: Some(reason), ..
-            } => Some(reason),
+            } => Some(format!("{reason} (from clippy.toml)")),
             _ => None,
         }
     }

--- a/clippy_lints/src/utils/internal_lints/interning_defined_symbol.rs
+++ b/clippy_lints/src/utils/internal_lints/interning_defined_symbol.rs
@@ -2,7 +2,7 @@ use clippy_utils::consts::{constant_simple, Constant};
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet;
 use clippy_utils::ty::match_type;
-use clippy_utils::{def_path_res, is_expn_of, match_def_path, paths};
+use clippy_utils::{def_path_def_ids, is_expn_of, match_def_path, paths};
 use if_chain::if_chain;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::Applicability;
@@ -74,7 +74,7 @@ impl<'tcx> LateLintPass<'tcx> for InterningDefinedSymbol {
         }
 
         for &module in &[&paths::KW_MODULE, &paths::SYM_MODULE] {
-            if let Some(def_id) = def_path_res(cx, module, None).opt_def_id() {
+            for def_id in def_path_def_ids(cx, module) {
                 for item in cx.tcx.module_children(def_id).iter() {
                     if_chain! {
                         if let Res::Def(DefKind::Const, item_def_id) = item.res;

--- a/clippy_lints/src/utils/internal_lints/invalid_paths.rs
+++ b/clippy_lints/src/utils/internal_lints/invalid_paths.rs
@@ -3,7 +3,7 @@ use clippy_utils::def_path_res;
 use clippy_utils::diagnostics::span_lint;
 use if_chain::if_chain;
 use rustc_hir as hir;
-use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def::DefKind;
 use rustc_hir::Item;
 use rustc_hir_analysis::hir_ty_to_ty;
 use rustc_lint::{LateContext, LateLintPass};
@@ -63,7 +63,7 @@ impl<'tcx> LateLintPass<'tcx> for InvalidPaths {
 // This is not a complete resolver for paths. It works on all the paths currently used in the paths
 // module.  That's all it does and all it needs to do.
 pub fn check_path(cx: &LateContext<'_>, path: &[&str]) -> bool {
-    if def_path_res(cx, path, None) != Res::Err {
+    if !def_path_res(cx, path).is_empty() {
         return true;
     }
 

--- a/clippy_lints/src/utils/internal_lints/unnecessary_def_path.rs
+++ b/clippy_lints/src/utils/internal_lints/unnecessary_def_path.rs
@@ -1,19 +1,19 @@
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::source::snippet_with_applicability;
-use clippy_utils::{def_path_res, is_lint_allowed, match_any_def_paths, peel_hir_expr_refs};
+use clippy_utils::{def_path_def_ids, is_lint_allowed, match_any_def_paths, peel_hir_expr_refs};
 use if_chain::if_chain;
 use rustc_ast::ast::LitKind;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
-use rustc_hir::def::{DefKind, Namespace, Res};
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Expr, ExprKind, Local, Mutability, Node};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::mir::interpret::{Allocation, ConstValue, GlobalAlloc};
-use rustc_middle::ty::{self, AssocKind, DefIdTree, Ty};
+use rustc_middle::ty::{self, DefIdTree, Ty};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::symbol::{Ident, Symbol};
+use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 
 use std::str;
@@ -110,7 +110,7 @@ impl UnnecessaryDefPath {
             // Extract the path to the matched type
             if let Some(segments) = path_to_matched_type(cx, item_arg);
             let segments: Vec<&str> = segments.iter().map(|sym| &**sym).collect();
-            if let Some(def_id) = inherent_def_path_res(cx, &segments[..]);
+            if let Some(def_id) = def_path_def_ids(cx, &segments[..]).next();
             then {
                 // Check if the target item is a diagnostic item or LangItem.
                 #[rustfmt::skip]
@@ -209,7 +209,7 @@ impl UnnecessaryDefPath {
     fn check_array(&mut self, cx: &LateContext<'_>, elements: &[Expr<'_>], span: Span) {
         let Some(path) = path_from_array(elements) else { return };
 
-        if let Some(def_id) = inherent_def_path_res(cx, &path.iter().map(AsRef::as_ref).collect::<Vec<_>>()) {
+        for def_id in def_path_def_ids(cx, &path.iter().map(AsRef::as_ref).collect::<Vec<_>>()) {
             self.array_def_ids.insert((def_id, span));
         }
     }
@@ -293,41 +293,11 @@ fn path_from_array(exprs: &[Expr<'_>]) -> Option<Vec<String>> {
         .collect()
 }
 
-// def_path_res will match field names before anything else, but for this we want to match
-// inherent functions first.
-fn inherent_def_path_res(cx: &LateContext<'_>, segments: &[&str]) -> Option<DefId> {
-    def_path_res(cx, segments, None).opt_def_id().map(|def_id| {
-        if cx.tcx.def_kind(def_id) == DefKind::Field {
-            let method_name = *segments.last().unwrap();
-            cx.tcx
-                .def_key(def_id)
-                .parent
-                .and_then(|parent_idx| {
-                    cx.tcx
-                        .inherent_impls(DefId {
-                            index: parent_idx,
-                            krate: def_id.krate,
-                        })
-                        .iter()
-                        .find_map(|impl_id| {
-                            cx.tcx.associated_items(*impl_id).find_by_name_and_kind(
-                                cx.tcx,
-                                Ident::from_str(method_name),
-                                AssocKind::Fn,
-                                *impl_id,
-                            )
-                        })
-                })
-                .map_or(def_id, |item| item.def_id)
-        } else {
-            def_id
-        }
-    })
-}
-
 fn get_lang_item_name(cx: &LateContext<'_>, def_id: DefId) -> Option<Symbol> {
     if let Some(lang_item) = cx.tcx.lang_items().items().iter().position(|id| *id == Some(def_id)) {
-        let lang_items = def_path_res(cx, &["rustc_hir", "lang_items", "LangItem"], Some(Namespace::TypeNS)).def_id();
+        let lang_items = def_path_def_ids(cx, &["rustc_hir", "lang_items", "LangItem"])
+            .next()
+            .unwrap();
         let item_name = cx
             .tcx
             .adt_def(lang_items)

--- a/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.stderr
+++ b/tests/ui-toml/await_holding_invalid_type/await_holding_invalid_type.stderr
@@ -4,7 +4,7 @@ error: `std::string::String` may not be held across an `await` point per `clippy
 LL |     let _x = String::from("hello");
    |         ^^
    |
-   = note: strings are bad
+   = note: strings are bad (from clippy.toml)
    = note: `-D clippy::await-holding-invalid-type` implied by `-D warnings`
 
 error: `std::net::Ipv4Addr` may not be held across an `await` point per `clippy.toml`
@@ -19,7 +19,7 @@ error: `std::string::String` may not be held across an `await` point per `clippy
 LL |         let _x = String::from("hi!");
    |             ^^
    |
-   = note: strings are bad
+   = note: strings are bad (from clippy.toml)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui-toml/toml_disallowed_methods/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_methods/clippy.toml
@@ -8,4 +8,10 @@ disallowed-methods = [
     { path = "regex::Regex::is_match", reason = "no matching allowed" },
     # can use an inline table but omit reason
     { path = "regex::Regex::new" },
+    # local paths
+    "conf_disallowed_methods::local_fn",
+    "conf_disallowed_methods::local_mod::f",
+    "conf_disallowed_methods::Struct::method",
+    "conf_disallowed_methods::Trait::provided_method",
+    "conf_disallowed_methods::Trait::implemented_method",
 ]

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -1,3 +1,5 @@
+// compile-flags: --crate-name conf_disallowed_methods
+
 #![warn(clippy::disallowed_methods)]
 
 extern crate futures;
@@ -5,6 +7,27 @@ extern crate regex;
 
 use futures::stream::{empty, select_all};
 use regex::Regex;
+
+fn local_fn() {}
+
+struct Struct;
+
+impl Struct {
+    fn method(&self) {}
+}
+
+trait Trait {
+    fn provided_method(&self) {}
+    fn implemented_method(&self);
+}
+
+impl Trait for Struct {
+    fn implemented_method(&self) {}
+}
+
+mod local_mod {
+    pub fn f() {}
+}
 
 fn main() {
     let re = Regex::new(r"ab.*c").unwrap();
@@ -26,4 +49,11 @@ fn main() {
 
     // resolve ambiguity between `futures::stream::select_all` the module and the function
     let same_name_as_module = select_all(vec![empty::<()>()]);
+
+    local_fn();
+    local_mod::f();
+    let s = Struct;
+    s.method();
+    s.provided_method();
+    s.implemented_method();
 }

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -1,5 +1,5 @@
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:10:14
+  --> $DIR/conf_disallowed_methods.rs:33:14
    |
 LL |     let re = Regex::new(r"ab.*c").unwrap();
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     let re = Regex::new(r"ab.*c").unwrap();
    = note: `-D clippy::disallowed-methods` implied by `-D warnings`
 
 error: use of a disallowed method `regex::Regex::is_match`
-  --> $DIR/conf_disallowed_methods.rs:11:5
+  --> $DIR/conf_disallowed_methods.rs:34:5
    |
 LL |     re.is_match("abc");
    |     ^^^^^^^^^^^^^^^^^^
@@ -15,46 +15,76 @@ LL |     re.is_match("abc");
    = note: no matching allowed (from clippy.toml)
 
 error: use of a disallowed method `std::iter::Iterator::sum`
-  --> $DIR/conf_disallowed_methods.rs:14:5
+  --> $DIR/conf_disallowed_methods.rs:37:5
    |
 LL |     a.iter().sum::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `slice::sort_unstable`
-  --> $DIR/conf_disallowed_methods.rs:16:5
+  --> $DIR/conf_disallowed_methods.rs:39:5
    |
 LL |     a.sort_unstable();
    |     ^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:18:13
+  --> $DIR/conf_disallowed_methods.rs:41:13
    |
 LL |     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:21:61
+  --> $DIR/conf_disallowed_methods.rs:44:61
    |
 LL |     let indirect: fn(&str) -> Result<Regex, regex::Error> = Regex::new;
    |                                                             ^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:24:28
+  --> $DIR/conf_disallowed_methods.rs:47:28
    |
 LL |     let in_call = Box::new(f32::clamp);
    |                            ^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:25:53
+  --> $DIR/conf_disallowed_methods.rs:48:53
    |
 LL |     let in_method_call = ["^", "$"].into_iter().map(Regex::new);
    |                                                     ^^^^^^^^^^
 
 error: use of a disallowed method `futures::stream::select_all`
-  --> $DIR/conf_disallowed_methods.rs:28:31
+  --> $DIR/conf_disallowed_methods.rs:51:31
    |
 LL |     let same_name_as_module = select_all(vec![empty::<()>()]);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: use of a disallowed method `conf_disallowed_methods::local_fn`
+  --> $DIR/conf_disallowed_methods.rs:53:5
+   |
+LL |     local_fn();
+   |     ^^^^^^^^^^
+
+error: use of a disallowed method `conf_disallowed_methods::local_mod::f`
+  --> $DIR/conf_disallowed_methods.rs:54:5
+   |
+LL |     local_mod::f();
+   |     ^^^^^^^^^^^^^^
+
+error: use of a disallowed method `conf_disallowed_methods::Struct::method`
+  --> $DIR/conf_disallowed_methods.rs:56:5
+   |
+LL |     s.method();
+   |     ^^^^^^^^^^
+
+error: use of a disallowed method `conf_disallowed_methods::Trait::provided_method`
+  --> $DIR/conf_disallowed_methods.rs:57:5
+   |
+LL |     s.provided_method();
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: use of a disallowed method `conf_disallowed_methods::Trait::implemented_method`
+  --> $DIR/conf_disallowed_methods.rs:58:5
+   |
+LL |     s.implemented_method();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Changes `def_path_res` to return all the resolutions matching the path rather than the first one (with a namespace hint that covered some cases).  This would fix any issues that come up with multiple versions of the same crate being present as they all have the same crate name

It also adds resolution of `impl _ {}` items for local items, and removes struct field resolution as it didn't seem to be used anywhere

I tested it on a local crate and it worked for the multiple crate issue, but I couldn't come up with a test that worked well with `// aux-build`, maybe `// aux-crate` after https://github.com/rust-lang/rust/pull/103266 could work but I'm not sure on that either

changelog: [`disallowed_methods`], [`disallowed_types`], [`disallowed_macros`]: fix path resolution with multiple versions of the same crate
changelog: [`disallowed_methods`]: Resolve methods in `impl`s in the current crate