### PR TITLE
Enable ptr_as_ptr by default

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -402,7 +402,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.51.0"]
     pub PTR_AS_PTR,
-    pedantic,
+    style,
     "casting using `as` from and to raw pointers that doesn't change its mutability, where `pointer::cast` could take the place of `as`"
 }
 

--- a/tests/ui/as_ptr_cast_mut.rs
+++ b/tests/ui/as_ptr_cast_mut.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 #![warn(clippy::as_ptr_cast_mut)]
-#![allow(clippy::wrong_self_convention)]
+#![allow(clippy::wrong_self_convention, clippy::ptr_as_ptr)]
 
 struct MutPtrWrapper(Vec<u8>);
 impl MutPtrWrapper {

--- a/tests/ui/cast_alignment.rs
+++ b/tests/ui/cast_alignment.rs
@@ -9,7 +9,8 @@ extern crate libc;
     clippy::no_effect,
     clippy::unnecessary_operation,
     clippy::cast_lossless,
-    clippy::borrow_as_ptr
+    clippy::borrow_as_ptr,
+    clippy::ptr_as_ptr
 )]
 
 fn main() {

--- a/tests/ui/cast_alignment.stderr
+++ b/tests/ui/cast_alignment.stderr
@@ -1,5 +1,5 @@
 error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
-  --> $DIR/cast_alignment.rs:19:5
+  --> $DIR/cast_alignment.rs:20:5
    |
 LL |     (&1u8 as *const u8) as *const u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,19 +7,19 @@ LL |     (&1u8 as *const u8) as *const u16;
    = note: `-D clippy::cast-ptr-alignment` implied by `-D warnings`
 
 error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`) (1 < 2 bytes)
-  --> $DIR/cast_alignment.rs:20:5
+  --> $DIR/cast_alignment.rs:21:5
    |
 LL |     (&mut 1u8 as *mut u8) as *mut u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting from `*const u8` to a more-strictly-aligned pointer (`*const u16`) (1 < 2 bytes)
-  --> $DIR/cast_alignment.rs:23:5
+  --> $DIR/cast_alignment.rs:24:5
    |
 LL |     (&1u8 as *const u8).cast::<u16>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting from `*mut u8` to a more-strictly-aligned pointer (`*mut u16`) (1 < 2 bytes)
-  --> $DIR/cast_alignment.rs:24:5
+  --> $DIR/cast_alignment.rs:25:5
    |
 LL |     (&mut 1u8 as *mut u8).cast::<u16>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cast_ref_to_mut.rs
+++ b/tests/ui/cast_ref_to_mut.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::cast_ref_to_mut)]
-#![allow(clippy::no_effect, clippy::borrow_as_ptr)]
+#![allow(clippy::no_effect, clippy::borrow_as_ptr, clippy::ptr_as_ptr)]
 
 extern "C" {
     // N.B., mutability can be easily incorrect in FFI calls -- as

--- a/tests/ui/crashes/ice-1782.rs
+++ b/tests/ui/crashes/ice-1782.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code, unused_variables, clippy::ptr_as_ptr)]
 
 /// Should not trigger an ICE in `SpanlessEq` / `consts::constant`
 ///

--- a/tests/ui/crashes/ice-4579.rs
+++ b/tests/ui/crashes/ice-4579.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::single_match)]
+#![allow(clippy::single_match, clippy::ptr_as_ptr)]
 
 use std::ptr;
 

--- a/tests/ui/from_raw_with_void_ptr.rs
+++ b/tests/ui/from_raw_with_void_ptr.rs
@@ -6,29 +6,29 @@ use std::sync::Arc;
 
 fn main() {
     // must lint
-    let ptr = Box::into_raw(Box::new(42usize)) as *mut c_void;
+    let ptr = Box::into_raw(Box::new(42usize)).cast::<c_void>();
     let _ = unsafe { Box::from_raw(ptr) };
 
     // shouldn't be linted
-    let _ = unsafe { Box::from_raw(ptr as *mut usize) };
+    let _ = unsafe { Box::from_raw(ptr.cast::<usize>()) };
 
     // shouldn't be linted
-    let should_not_lint_ptr = Box::into_raw(Box::new(12u8)) as *mut u8;
-    let _ = unsafe { Box::from_raw(should_not_lint_ptr as *mut u8) };
+    let should_not_lint_ptr = Box::into_raw(Box::new(12u8)).cast::<u8>();
+    let _ = unsafe { Box::from_raw(should_not_lint_ptr.cast::<u8>()) };
 
     // must lint
-    let ptr = Rc::into_raw(Rc::new(42usize)) as *mut c_void;
+    let ptr = Rc::into_raw(Rc::new(42usize)).cast::<c_void>();
     let _ = unsafe { Rc::from_raw(ptr) };
 
     // must lint
-    let ptr = Arc::into_raw(Arc::new(42usize)) as *mut c_void;
+    let ptr = Arc::into_raw(Arc::new(42usize)).cast::<c_void>();
     let _ = unsafe { Arc::from_raw(ptr) };
 
     // must lint
-    let ptr = std::rc::Weak::into_raw(Rc::downgrade(&Rc::new(42usize))) as *mut c_void;
+    let ptr = std::rc::Weak::into_raw(Rc::downgrade(&Rc::new(42usize))).cast::<c_void>();
     let _ = unsafe { std::rc::Weak::from_raw(ptr) };
 
     // must lint
-    let ptr = std::sync::Weak::into_raw(Arc::downgrade(&Arc::new(42usize))) as *mut c_void;
+    let ptr = std::sync::Weak::into_raw(Arc::downgrade(&Arc::new(42usize))).cast::<c_void>();
     let _ = unsafe { std::sync::Weak::from_raw(ptr) };
 }

--- a/tests/ui/missing_const_for_fn/cant_be_const.rs
+++ b/tests/ui/missing_const_for_fn/cant_be_const.rs
@@ -104,6 +104,7 @@ fn const_generic_params<T, const N: usize>(t: &[T; N]) -> &[T; N] {
     t
 }
 
+#[allow(clippy::ptr_as_ptr)]
 fn const_generic_return<T, const N: usize>(t: &[T]) -> &[T; N] {
     let p = t.as_ptr() as *const [T; N];
 

--- a/tests/ui/ptr_eq.fixed
+++ b/tests/ui/ptr_eq.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::ptr_eq)]
+#![allow(clippy::ptr_as_ptr)]
 
 macro_rules! mac {
     ($a:expr, $b:expr) => {

--- a/tests/ui/ptr_eq.rs
+++ b/tests/ui/ptr_eq.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 #![warn(clippy::ptr_eq)]
+#![allow(clippy::ptr_as_ptr)]
 
 macro_rules! mac {
     ($a:expr, $b:expr) => {

--- a/tests/ui/ptr_eq.stderr
+++ b/tests/ui/ptr_eq.stderr
@@ -1,5 +1,5 @@
 error: use `std::ptr::eq` when comparing raw pointers
-  --> $DIR/ptr_eq.rs:20:13
+  --> $DIR/ptr_eq.rs:21:13
    |
 LL |     let _ = a as *const _ as usize == b as *const _ as usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::eq(a, b)`
@@ -7,7 +7,7 @@ LL |     let _ = a as *const _ as usize == b as *const _ as usize;
    = note: `-D clippy::ptr-eq` implied by `-D warnings`
 
 error: use `std::ptr::eq` when comparing raw pointers
-  --> $DIR/ptr_eq.rs:21:13
+  --> $DIR/ptr_eq.rs:22:13
    |
 LL |     let _ = a as *const _ == b as *const _;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::eq(a, b)`

--- a/tests/ui/suspicious_to_owned.rs
+++ b/tests/ui/suspicious_to_owned.rs
@@ -7,7 +7,7 @@ use std::ffi::{c_char, CStr};
 fn main() {
     let moo = "Moooo";
     let c_moo = b"Moooo\0";
-    let c_moo_ptr = c_moo.as_ptr() as *const c_char;
+    let c_moo_ptr = c_moo.as_ptr().cast::<c_char>();
     let moos = ['M', 'o', 'o'];
     let moos_vec = moos.to_vec();
 

--- a/tests/ui/transmute_ptr_to_ptr.rs
+++ b/tests/ui/transmute_ptr_to_ptr.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::borrow_as_ptr, clippy::ptr_as_ptr)]
 
 // Make sure we can modify lifetimes, which is one of the recommended uses
 // of transmute

--- a/tests/ui/transmute_ptr_to_ref.fixed
+++ b/tests/ui/transmute_ptr_to_ref.fixed
@@ -2,7 +2,7 @@
 
 #![feature(custom_inner_attributes)]
 #![warn(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::match_single_binding)]
+#![allow(clippy::match_single_binding, clippy::ptr_as_ptr)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = &*p;

--- a/tests/ui/transmute_ptr_to_ref.rs
+++ b/tests/ui/transmute_ptr_to_ref.rs
@@ -2,7 +2,7 @@
 
 #![feature(custom_inner_attributes)]
 #![warn(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::match_single_binding)]
+#![allow(clippy::match_single_binding, clippy::ptr_as_ptr)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = std::mem::transmute(p);

--- a/tests/ui/transmutes_expressible_as_ptr_casts.fixed
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.fixed
@@ -4,7 +4,7 @@
 // would otherwise be responsible for
 #![warn(clippy::useless_transmute)]
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(dead_code, unused_unsafe, clippy::borrow_as_ptr)]
+#![allow(dead_code, unused_unsafe, clippy::borrow_as_ptr, clippy::ptr_as_ptr)]
 
 use std::mem::{size_of, transmute};
 

--- a/tests/ui/transmutes_expressible_as_ptr_casts.rs
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.rs
@@ -4,7 +4,7 @@
 // would otherwise be responsible for
 #![warn(clippy::useless_transmute)]
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(dead_code, unused_unsafe, clippy::borrow_as_ptr)]
+#![allow(dead_code, unused_unsafe, clippy::borrow_as_ptr, clippy::ptr_as_ptr)]
 
 use std::mem::{size_of, transmute};
 


### PR DESCRIPTION
Under the assumption that the `as` keyword is a mistake, we should be encouraging users to move away from it where possible.

changelog: [`ptr_as_ptr`]: warn by default