### PR TITLE
Enable cast_lossless by default

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -152,7 +152,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub CAST_LOSSLESS,
-    pedantic,
+    style,
     "casts using `as` that are known to be lossless, e.g., `x as u64` where `x: u8`"
 }
 


### PR DESCRIPTION
Under the assumption that the `as` keyword is a mistake, we should be encouraging users to move away from it where possible.

Closes https://github.com/rust-lang/rust-clippy/issues/4864

changelog: [`cast_lossless`]: warn by default