### PR TITLE
Fix `explicit_auto_deref` fp

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -1362,6 +1362,7 @@ fn ty_auto_deref_stability<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, precedenc
                 continue;
             },
             ty::Param(_) => TyPosition::new_deref_stable_for_result(precedence, ty),
+            ty::Projection(_) if ty.has_non_region_param() => TyPosition::new_deref_stable_for_result(precedence, ty),
             ty::Infer(_) | ty::Error(_) | ty::Bound(..) | ty::Opaque(..) | ty::Placeholder(_) | ty::Dynamic(..) => {
                 Position::ReborrowStable(precedence).into()
             },

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -266,4 +266,15 @@ fn main() {
         }
         x
     };
+
+    trait WithAssoc {
+        type Assoc: ?Sized;
+    }
+    impl WithAssoc for String {
+        type Assoc = str;
+    }
+    fn takes_assoc<T: WithAssoc>(_: &T::Assoc) -> T {
+        unimplemented!()
+    }
+    let _: String = takes_assoc(&*String::new());
 }

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -266,4 +266,15 @@ fn main() {
         }
         *x
     };
+
+    trait WithAssoc {
+        type Assoc: ?Sized;
+    }
+    impl WithAssoc for String {
+        type Assoc = str;
+    }
+    fn takes_assoc<T: WithAssoc>(_: &T::Assoc) -> T {
+        unimplemented!()
+    }
+    let _: String = takes_assoc(&*String::new());
 }


### PR DESCRIPTION
fixes #9763
fixes #9811

changelog: `explicit_auto_deref`: Don't lint when the target type is a projection with generic arguments
