### PR TITLE
Update lint example for `collapsible_str_replace`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -159,7 +159,7 @@ declare_clippy_lint! {
     /// ```
     /// Use instead:
     /// ```rust
-    /// let hello = "hesuo worpd".replace(&['s', 'u', 'p'], "l");
+    /// let hello = "hesuo worpd".replace(['s', 'u', 'p'], "l");
     /// ```
     #[clippy::version = "1.65.0"]
     pub COLLAPSIBLE_STR_REPLACE,


### PR DESCRIPTION
To fix this warning:
```
warning: the borrowed expression implements the required traits
  --> src/fixes/quote_character.rs:16:43
   |
16 |         let hello = "hesuo worpd".replace(&['s', 'u', 'p'], "l");
   |                                           ^^^^^^^^^^^^^^^^ help: change this to: `['s', 'u', 'p']`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none
