### PR TITLE
Avoid linting unsized mutable reference

### DIFF
--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -68,13 +68,15 @@ impl<'a, 'tcx> intravisit::Visitor<'tcx> for MutVisitor<'a, 'tcx> {
                     expr.span,
                     "generally you want to avoid `&mut &mut _` if possible",
                 );
-            } else if let ty::Ref(_, _, hir::Mutability::Mut) = self.cx.typeck_results().expr_ty(e).kind() {
-                span_lint(
-                    self.cx,
-                    MUT_MUT,
-                    expr.span,
-                    "this expression mutably borrows a mutable reference. Consider reborrowing",
-                );
+            } else if let ty::Ref(_, ty, hir::Mutability::Mut) = self.cx.typeck_results().expr_ty(e).kind() {
+                if ty.peel_refs().is_sized(self.cx.tcx.at(expr.span), self.cx.param_env) {
+                    span_lint(
+                        self.cx,
+                        MUT_MUT,
+                        expr.span,
+                        "this expression mutably borrows a mutable reference. Consider reborrowing",
+                    );
+                }
             }
         }
     }

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -57,3 +57,20 @@ fn issue6922() {
     // do not lint from an external macro
     mut_mut!();
 }
+
+mod issue9035 {
+    use std::fmt::Display;
+
+    struct Foo<'a> {
+        inner: &'a mut dyn Display,
+    }
+
+    impl Foo<'_> {
+        fn foo(&mut self) {
+            let hlp = &mut self.inner;
+            bar(hlp);
+        }
+    }
+
+    fn bar(_: &mut impl Display) {}
+}


### PR DESCRIPTION
fix https://github.com/rust-lang/rust-clippy/issues/9035

changelog: [`mut_mut`] avoid suggesting to reborrow unsized mutable reference
