### PR TITLE
Fix is_async_fn to check FnKind::Method

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1901,7 +1901,11 @@ pub fn if_sequence<'tcx>(mut expr: &'tcx Expr<'tcx>) -> (Vec<&'tcx Expr<'tcx>>, 
 
 /// Checks if the given function kind is an async function.
 pub fn is_async_fn(kind: FnKind<'_>) -> bool {
-    matches!(kind, FnKind::ItemFn(_, _, header) if header.asyncness == IsAsync::Async)
+    match kind {
+        FnKind::ItemFn(_, _, header) => header.asyncness == IsAsync::Async,
+        FnKind::Method(_, sig) => sig.header.asyncness == IsAsync::Async,
+        FnKind::Closure => false,
+    }
 }
 
 /// Peels away all the compiler generated code surrounding the body of an async function,

--- a/tests/ui/cognitive_complexity.rs
+++ b/tests/ui/cognitive_complexity.rs
@@ -400,4 +400,12 @@ mod issue9300 {
         let a = 0;
         if a == 0 {}
     }
+
+    pub struct S;
+    impl S {
+        pub async fn async_method() {
+            let a = 0;
+            if a == 0 {}
+        }
+    }
 }

--- a/tests/ui/cognitive_complexity.stderr
+++ b/tests/ui/cognitive_complexity.stderr
@@ -143,5 +143,13 @@ LL |     async fn a() {
    |
    = help: you could split it up into multiple smaller functions
 
-error: aborting due to 18 previous errors
+error: the function has a cognitive complexity of (2/1)
+  --> $DIR/cognitive_complexity.rs:406:22
+   |
+LL |         pub async fn async_method() {
+   |                      ^^^^^^^^^^^^
+   |
+   = help: you could split it up into multiple smaller functions
+
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
This is a follow-up PR of https://github.com/rust-lang/rust-clippy/pull/9828 to support also async methods.

changelog: [`cognitive_complexity`] support async method


r? @Alexendoo 