### PR TITLE
fix never_loop false positive

### DIFF
--- a/clippy_lints/src/loops/never_loop.rs
+++ b/clippy_lints/src/loops/never_loop.rs
@@ -169,7 +169,8 @@ fn never_loop_expr(expr: &Expr<'_>, main_loop_id: HirId) -> NeverLoopResult {
                 combine_seq(e, arms)
             }
         },
-        ExprKind::Block(b, _) => never_loop_block(b, main_loop_id),
+        ExprKind::Block(b, None) => never_loop_block(b, main_loop_id),
+        ExprKind::Block(b, Some(_label)) => absorb_break(never_loop_block(b, main_loop_id)),
         ExprKind::Continue(d) => {
             let id = d
                 .target_id

--- a/tests/ui/never_loop.rs
+++ b/tests/ui/never_loop.rs
@@ -229,6 +229,18 @@ pub fn test18() {
     };
 }
 
+// Issue #9831: unconditional break to internal labeled block
+pub fn test19() {
+    fn thing(iter: impl Iterator) {
+        for _ in iter {
+            'b: {
+                // error goes away if we just have the block's value be ().
+                break 'b;
+            }
+        }
+    }
+}
+
 fn main() {
     test1();
     test2();


### PR DESCRIPTION
fixes #9831

changelog: [`never_loop`]: fixed false positive on unconditional break in internal labeled block
