### PR TITLE
Fix `vec-box-size-threshold` off-by-one error

### DIFF
--- a/clippy_lints/src/types/vec_box.rs
+++ b/clippy_lints/src/types/vec_box.rs
@@ -42,7 +42,7 @@ pub(super) fn check(
             if !ty_ty.has_escaping_bound_vars();
             if ty_ty.is_sized(cx.tcx.at(ty.span), cx.param_env);
             if let Ok(ty_ty_size) = cx.layout_of(ty_ty).map(|l| l.size.bytes());
-            if ty_ty_size <= box_size_threshold;
+            if ty_ty_size < box_size_threshold;
             then {
                 span_lint_and_sugg(
                     cx,

--- a/tests/ui-toml/vec_box_sized/test.rs
+++ b/tests/ui-toml/vec_box_sized/test.rs
@@ -7,8 +7,9 @@ struct C {
 }
 
 struct Foo(Vec<Box<u8>>);
-struct Bar(Vec<Box<u32>>);
-struct Baz(Vec<Box<(u32, u32)>>);
+struct Bar(Vec<Box<u16>>);
+struct Quux(Vec<Box<u32>>);
+struct Baz(Vec<Box<(u16, u16)>>);
 struct BarBaz(Vec<Box<S>>);
 struct FooBarBaz(Vec<Box<C>>);
 

--- a/tests/ui-toml/vec_box_sized/test.stderr
+++ b/tests/ui-toml/vec_box_sized/test.stderr
@@ -9,11 +9,11 @@ LL | struct Foo(Vec<Box<u8>>);
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
   --> $DIR/test.rs:10:12
    |
-LL | struct Bar(Vec<Box<u32>>);
-   |            ^^^^^^^^^^^^^ help: try: `Vec<u32>`
+LL | struct Bar(Vec<Box<u16>>);
+   |            ^^^^^^^^^^^^^ help: try: `Vec<u16>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> $DIR/test.rs:13:18
+  --> $DIR/test.rs:14:18
    |
 LL | struct FooBarBaz(Vec<Box<C>>);
    |                  ^^^^^^^^^^^ help: try: `Vec<C>`


### PR DESCRIPTION
The docs for `vec-box-size-threshold` say "The size of the boxed type in bytes, where boxing in a `Vec` is allowed", but previously a boxed type of exactly that size wasn't allowed in `Vec`.

changelog: [`vec_box`]: Fix off-by-one error for `vec-box-size-threshold` configuration.