### PR TITLE
Preserve `ref` on `infallible_destructuring_match` suggestion

### DIFF
--- a/tests/ui/infallible_destructuring_match.fixed
+++ b/tests/ui/infallible_destructuring_match.fixed
@@ -9,6 +9,9 @@ enum SingleVariantEnum {
 
 struct TupleStruct(i32);
 
+struct NonCopy;
+struct TupleStructWithNonCopy(NonCopy);
+
 enum EmptyEnum {}
 
 macro_rules! match_enum {
@@ -69,6 +72,15 @@ fn infallible_destructuring_match_struct() {
     };
 
     let TupleStruct(data) = wrapper;
+}
+
+fn infallible_destructuring_match_struct_with_noncopy() {
+    let wrapper = TupleStructWithNonCopy(NonCopy);
+
+    // This should lint! (keeping `ref` in the suggestion)
+    let TupleStructWithNonCopy(ref data) = wrapper;
+
+    let TupleStructWithNonCopy(ref data) = wrapper;
 }
 
 macro_rules! match_never_enum {

--- a/tests/ui/infallible_destructuring_match.rs
+++ b/tests/ui/infallible_destructuring_match.rs
@@ -9,6 +9,9 @@ enum SingleVariantEnum {
 
 struct TupleStruct(i32);
 
+struct NonCopy;
+struct TupleStructWithNonCopy(NonCopy);
+
 enum EmptyEnum {}
 
 macro_rules! match_enum {
@@ -73,6 +76,17 @@ fn infallible_destructuring_match_struct() {
     };
 
     let TupleStruct(data) = wrapper;
+}
+
+fn infallible_destructuring_match_struct_with_noncopy() {
+    let wrapper = TupleStructWithNonCopy(NonCopy);
+
+    // This should lint! (keeping `ref` in the suggestion)
+    let data = match wrapper {
+        TupleStructWithNonCopy(ref n) => n,
+    };
+
+    let TupleStructWithNonCopy(ref data) = wrapper;
 }
 
 macro_rules! match_never_enum {

--- a/tests/ui/infallible_destructuring_match.stderr
+++ b/tests/ui/infallible_destructuring_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
-  --> $DIR/infallible_destructuring_match.rs:26:5
+  --> $DIR/infallible_destructuring_match.rs:29:5
    |
 LL | /     let data = match wrapper {
 LL | |         SingleVariantEnum::Variant(i) => i,
@@ -9,7 +9,7 @@ LL | |     };
    = note: `-D clippy::infallible-destructuring-match` implied by `-D warnings`
 
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
-  --> $DIR/infallible_destructuring_match.rs:58:5
+  --> $DIR/infallible_destructuring_match.rs:61:5
    |
 LL | /     let data = match wrapper {
 LL | |         TupleStruct(i) => i,
@@ -17,12 +17,20 @@ LL | |     };
    | |______^ help: try this: `let TupleStruct(data) = wrapper;`
 
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
-  --> $DIR/infallible_destructuring_match.rs:90:5
+  --> $DIR/infallible_destructuring_match.rs:85:5
+   |
+LL | /     let data = match wrapper {
+LL | |         TupleStructWithNonCopy(ref n) => n,
+LL | |     };
+   | |______^ help: try this: `let TupleStructWithNonCopy(ref data) = wrapper;`
+
+error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
+  --> $DIR/infallible_destructuring_match.rs:104:5
    |
 LL | /     let data = match wrapper {
 LL | |         Ok(i) => i,
 LL | |     };
    | |______^ help: try this: `let Ok(data) = wrapper;`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/7499

changelog: [`infallible_destructuring_match`]: Preserve `ref` on suggestion