### PR TITLE
Lint unnecessary safety comments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4451,6 +4451,7 @@ Released 2018-09-13
 [`unnecessary_mut_passed`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_mut_passed
 [`unnecessary_operation`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_operation
 [`unnecessary_owned_empty_strings`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_owned_empty_strings
+[`unnecessary_safety_comment`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_safety_comment
 [`unnecessary_safety_doc`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_safety_doc
 [`unnecessary_self_imports`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_self_imports
 [`unnecessary_sort_by`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -584,6 +584,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::types::TYPE_COMPLEXITY_INFO,
     crate::types::VEC_BOX_INFO,
     crate::undocumented_unsafe_blocks::UNDOCUMENTED_UNSAFE_BLOCKS_INFO,
+    crate::undocumented_unsafe_blocks::UNNECESSARY_SAFETY_COMMENT_INFO,
     crate::unicode::INVISIBLE_CHARACTERS_INFO,
     crate::unicode::NON_ASCII_LITERAL_INFO,
     crate::unicode::UNICODE_NOT_NFC_INFO,

--- a/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -89,7 +89,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.67.0"]
     pub UNNECESSARY_SAFETY_COMMENT,
     restriction,
-    "creating an unsafe block without explaining why it is safe"
+    "annotating safe code with a safety comment"
 }
 
 declare_lint_pass!(UndocumentedUnsafeBlocks => [UNDOCUMENTED_UNSAFE_BLOCKS, UNNECESSARY_SAFETY_COMMENT]);
@@ -138,12 +138,11 @@ impl<'tcx> LateLintPass<'tcx> for UndocumentedUnsafeBlocks {
     }
 
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &hir::Stmt<'tcx>) {
-        let expr = match stmt.kind {
+        let (
             hir::StmtKind::Local(&hir::Local { init: Some(expr), .. })
             | hir::StmtKind::Expr(expr)
-            | hir::StmtKind::Semi(expr) => expr,
-            _ => return,
-        };
+            | hir::StmtKind::Semi(expr)
+        ) = stmt.kind else { return };
         if !is_lint_allowed(cx, UNNECESSARY_SAFETY_COMMENT, stmt.hir_id)
             && !in_external_macro(cx.tcx.sess, stmt.span)
             && let HasSafetyComment::Yes(pos) = stmt_has_safety_comment(cx, stmt.span, stmt.hir_id)

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -170,22 +170,22 @@ where
         cb: F,
     }
 
-    struct WithStmtGuarg<'a, F> {
+    struct WithStmtGuard<'a, F> {
         val: &'a mut RetFinder<F>,
         prev_in_stmt: bool,
     }
 
     impl<F> RetFinder<F> {
-        fn inside_stmt(&mut self, in_stmt: bool) -> WithStmtGuarg<'_, F> {
+        fn inside_stmt(&mut self, in_stmt: bool) -> WithStmtGuard<'_, F> {
             let prev_in_stmt = std::mem::replace(&mut self.in_stmt, in_stmt);
-            WithStmtGuarg {
+            WithStmtGuard {
                 val: self,
                 prev_in_stmt,
             }
         }
     }
 
-    impl<F> std::ops::Deref for WithStmtGuarg<'_, F> {
+    impl<F> std::ops::Deref for WithStmtGuard<'_, F> {
         type Target = RetFinder<F>;
 
         fn deref(&self) -> &Self::Target {
@@ -193,13 +193,13 @@ where
         }
     }
 
-    impl<F> std::ops::DerefMut for WithStmtGuarg<'_, F> {
+    impl<F> std::ops::DerefMut for WithStmtGuard<'_, F> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             self.val
         }
     }
 
-    impl<F> Drop for WithStmtGuarg<'_, F> {
+    impl<F> Drop for WithStmtGuard<'_, F> {
         fn drop(&mut self) {
             self.val.in_stmt = self.prev_in_stmt;
         }

--- a/tests/ui/undocumented_unsafe_blocks.rs
+++ b/tests/ui/undocumented_unsafe_blocks.rs
@@ -472,6 +472,19 @@ mod unsafe_impl_invalid_comment {
     unsafe impl Interference for () {}
 }
 
+mod unsafe_items_invalid_comment {
+    // SAFETY:
+    const CONST: u32 = 0;
+    // SAFETY:
+    static STATIC: u32 = 0;
+    // SAFETY:
+    struct Struct;
+    // SAFETY:
+    enum Enum {}
+    // SAFETY:
+    mod module {}
+}
+
 unsafe trait ImplInFn {}
 
 fn impl_in_fn() {

--- a/tests/ui/undocumented_unsafe_blocks.rs
+++ b/tests/ui/undocumented_unsafe_blocks.rs
@@ -1,6 +1,6 @@
 // aux-build:proc_macro_unsafe.rs
 
-#![warn(clippy::undocumented_unsafe_blocks)]
+#![warn(clippy::undocumented_unsafe_blocks, clippy::unnecessary_safety_comment)]
 #![allow(clippy::let_unit_value, clippy::missing_safety_doc)]
 
 extern crate proc_macro_unsafe;

--- a/tests/ui/undocumented_unsafe_blocks.rs
+++ b/tests/ui/undocumented_unsafe_blocks.rs
@@ -472,19 +472,6 @@ mod unsafe_impl_invalid_comment {
     unsafe impl Interference for () {}
 }
 
-mod unsafe_items_invalid_comment {
-    // SAFETY:
-    const CONST: u32 = 0;
-    // SAFETY:
-    static STATIC: u32 = 0;
-    // SAFETY:
-    struct Struct;
-    // SAFETY:
-    enum Enum {}
-    // SAFETY:
-    mod module {}
-}
-
 unsafe trait ImplInFn {}
 
 fn impl_in_fn() {
@@ -520,37 +507,6 @@ fn issue_9142() {
             bar
         }
     };
-}
-
-mod unnecessary_from_macro {
-    trait T {}
-
-    macro_rules! no_safety_comment {
-        ($t:ty) => {
-            impl T for $t {}
-        };
-    }
-
-    // FIXME: This is not caught
-    // Safety: unnecessary
-    no_safety_comment!(());
-
-    macro_rules! with_safety_comment {
-        ($t:ty) => {
-            // Safety: unnecessary
-            impl T for $t {}
-        };
-    }
-
-    with_safety_comment!(i32);
-}
-
-fn unnecessary_on_stmt_and_expr() -> u32 {
-    // SAFETY: unnecessary
-    let num = 42;
-
-    // SAFETY: unnecessary
-    24
 }
 
 fn main() {}

--- a/tests/ui/undocumented_unsafe_blocks.rs
+++ b/tests/ui/undocumented_unsafe_blocks.rs
@@ -522,4 +522,35 @@ fn issue_9142() {
     };
 }
 
+mod unnecessary_from_macro {
+    trait T {}
+
+    macro_rules! no_safety_comment {
+        ($t:ty) => {
+            impl T for $t {}
+        };
+    }
+
+    // FIXME: This is not caught
+    // Safety: unnecessary
+    no_safety_comment!(());
+
+    macro_rules! with_safety_comment {
+        ($t:ty) => {
+            // Safety: unnecessary
+            impl T for $t {}
+        };
+    }
+
+    with_safety_comment!(i32);
+}
+
+fn unnecessary_on_stmt_and_expr() -> u32 {
+    // SAFETY: unnecessary
+    let num = 42;
+
+    // SAFETY: unnecessary
+    24
+}
+
 fn main() {}

--- a/tests/ui/undocumented_unsafe_blocks.stderr
+++ b/tests/ui/undocumented_unsafe_blocks.stderr
@@ -344,6 +344,24 @@ LL |         unsafe {};
    |
    = help: consider adding a safety comment on the preceding line
 
+error: statement has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:514:5
+   |
+LL | /     let _ = {
+LL | |         if unsafe { true } {
+LL | |             todo!();
+LL | |         } else {
+...  |
+LL | |         }
+LL | |     };
+   | |______^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:513:5
+   |
+LL |     // SAFETY: this is more than one level away, so it should warn
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: unsafe block missing a safety comment
   --> $DIR/undocumented_unsafe_blocks.rs:515:12
    |
@@ -360,5 +378,45 @@ LL |             let bar = unsafe {};
    |
    = help: consider adding a safety comment on the preceding line
 
-error: aborting due to 40 previous errors
+error: impl has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:541:13
+   |
+LL |             impl T for $t {}
+   |             ^^^^^^^^^^^^^^^^
+...
+LL |     with_safety_comment!(i32);
+   |     ------------------------- in this macro invocation
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:540:13
+   |
+LL |             // Safety: unnecessary
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `with_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expression has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:553:5
+   |
+LL |     24
+   |     ^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:552:5
+   |
+LL |     // SAFETY: unnecessary
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: statement has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:550:5
+   |
+LL |     let num = 42;
+   |     ^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:549:5
+   |
+LL |     // SAFETY: unnecessary
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 44 previous errors
 

--- a/tests/ui/undocumented_unsafe_blocks.stderr
+++ b/tests/ui/undocumented_unsafe_blocks.stderr
@@ -239,6 +239,19 @@ LL |     unsafe impl TrailingComment for () {} // SAFETY:
    |
    = help: consider adding a safety comment on the preceding line
 
+error: constant item has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:471:5
+   |
+LL |     const BIG_NUMBER: i32 = 1000000;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:470:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+   = note: `-D clippy::unnecessary-safety-comment` implied by `-D warnings`
+
 error: unsafe impl missing a safety comment
   --> $DIR/undocumented_unsafe_blocks.rs:472:5
    |
@@ -287,5 +300,5 @@ LL |             let bar = unsafe {};
    |
    = help: consider adding a safety comment on the preceding line
 
-error: aborting due to 34 previous errors
+error: aborting due to 35 previous errors
 

--- a/tests/ui/undocumented_unsafe_blocks.stderr
+++ b/tests/ui/undocumented_unsafe_blocks.stderr
@@ -260,8 +260,68 @@ LL |     unsafe impl Interference for () {}
    |
    = help: consider adding a safety comment on the preceding line
 
-error: unsafe impl missing a safety comment
+error: constant item has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:477:5
+   |
+LL |     const CONST: u32 = 0;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:476:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: static item has unnecessary safety comment
   --> $DIR/undocumented_unsafe_blocks.rs:479:5
+   |
+LL |     static STATIC: u32 = 0;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:478:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: struct has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:481:5
+   |
+LL |     struct Struct;
+   |     ^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:480:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: enum has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:483:5
+   |
+LL |     enum Enum {}
+   |     ^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:482:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: module has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:485:5
+   |
+LL |     mod module {}
+   |     ^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:484:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: unsafe impl missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:492:5
    |
 LL |     unsafe impl ImplInFn for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -269,7 +329,7 @@ LL |     unsafe impl ImplInFn for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:488:1
+  --> $DIR/undocumented_unsafe_blocks.rs:501:1
    |
 LL | unsafe impl CrateRoot for () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,7 +337,7 @@ LL | unsafe impl CrateRoot for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:498:9
+  --> $DIR/undocumented_unsafe_blocks.rs:511:9
    |
 LL |         unsafe {};
    |         ^^^^^^^^^
@@ -285,7 +345,7 @@ LL |         unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:502:12
+  --> $DIR/undocumented_unsafe_blocks.rs:515:12
    |
 LL |         if unsafe { true } {
    |            ^^^^^^^^^^^^^^^
@@ -293,12 +353,12 @@ LL |         if unsafe { true } {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:505:23
+  --> $DIR/undocumented_unsafe_blocks.rs:518:23
    |
 LL |             let bar = unsafe {};
    |                       ^^^^^^^^^
    |
    = help: consider adding a safety comment on the preceding line
 
-error: aborting due to 35 previous errors
+error: aborting due to 40 previous errors
 

--- a/tests/ui/undocumented_unsafe_blocks.stderr
+++ b/tests/ui/undocumented_unsafe_blocks.stderr
@@ -260,68 +260,8 @@ LL |     unsafe impl Interference for () {}
    |
    = help: consider adding a safety comment on the preceding line
 
-error: constant item has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:477:5
-   |
-LL |     const CONST: u32 = 0;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:476:5
-   |
-LL |     // SAFETY:
-   |     ^^^^^^^^^^
-
-error: static item has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:479:5
-   |
-LL |     static STATIC: u32 = 0;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:478:5
-   |
-LL |     // SAFETY:
-   |     ^^^^^^^^^^
-
-error: struct has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:481:5
-   |
-LL |     struct Struct;
-   |     ^^^^^^^^^^^^^^
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:480:5
-   |
-LL |     // SAFETY:
-   |     ^^^^^^^^^^
-
-error: enum has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:483:5
-   |
-LL |     enum Enum {}
-   |     ^^^^^^^^^^^^
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:482:5
-   |
-LL |     // SAFETY:
-   |     ^^^^^^^^^^
-
-error: module has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:485:5
-   |
-LL |     mod module {}
-   |     ^^^^^^^^^^^^^
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:484:5
-   |
-LL |     // SAFETY:
-   |     ^^^^^^^^^^
-
 error: unsafe impl missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:492:5
+  --> $DIR/undocumented_unsafe_blocks.rs:479:5
    |
 LL |     unsafe impl ImplInFn for () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -329,7 +269,7 @@ LL |     unsafe impl ImplInFn for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe impl missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:501:1
+  --> $DIR/undocumented_unsafe_blocks.rs:488:1
    |
 LL | unsafe impl CrateRoot for () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -337,7 +277,7 @@ LL | unsafe impl CrateRoot for () {}
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:511:9
+  --> $DIR/undocumented_unsafe_blocks.rs:498:9
    |
 LL |         unsafe {};
    |         ^^^^^^^^^
@@ -345,7 +285,7 @@ LL |         unsafe {};
    = help: consider adding a safety comment on the preceding line
 
 error: statement has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:514:5
+  --> $DIR/undocumented_unsafe_blocks.rs:501:5
    |
 LL | /     let _ = {
 LL | |         if unsafe { true } {
@@ -357,13 +297,13 @@ LL | |     };
    | |______^
    |
 help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:513:5
+  --> $DIR/undocumented_unsafe_blocks.rs:500:5
    |
 LL |     // SAFETY: this is more than one level away, so it should warn
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe block missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:515:12
+  --> $DIR/undocumented_unsafe_blocks.rs:502:12
    |
 LL |         if unsafe { true } {
    |            ^^^^^^^^^^^^^^^
@@ -371,52 +311,12 @@ LL |         if unsafe { true } {
    = help: consider adding a safety comment on the preceding line
 
 error: unsafe block missing a safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:518:23
+  --> $DIR/undocumented_unsafe_blocks.rs:505:23
    |
 LL |             let bar = unsafe {};
    |                       ^^^^^^^^^
    |
    = help: consider adding a safety comment on the preceding line
 
-error: impl has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:541:13
-   |
-LL |             impl T for $t {}
-   |             ^^^^^^^^^^^^^^^^
-...
-LL |     with_safety_comment!(i32);
-   |     ------------------------- in this macro invocation
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:540:13
-   |
-LL |             // Safety: unnecessary
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `with_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: expression has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:553:5
-   |
-LL |     24
-   |     ^^
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:552:5
-   |
-LL |     // SAFETY: unnecessary
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
-error: statement has unnecessary safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:550:5
-   |
-LL |     let num = 42;
-   |     ^^^^^^^^^^^^^
-   |
-help: consider removing the safety comment
-  --> $DIR/undocumented_unsafe_blocks.rs:549:5
-   |
-LL |     // SAFETY: unnecessary
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 44 previous errors
+error: aborting due to 36 previous errors
 

--- a/tests/ui/unnecessary_safety_comment.rs
+++ b/tests/ui/unnecessary_safety_comment.rs
@@ -1,0 +1,51 @@
+#![warn(clippy::undocumented_unsafe_blocks, clippy::unnecessary_safety_comment)]
+#![allow(clippy::let_unit_value, clippy::missing_safety_doc)]
+
+mod unsafe_items_invalid_comment {
+    // SAFETY:
+    const CONST: u32 = 0;
+    // SAFETY:
+    static STATIC: u32 = 0;
+    // SAFETY:
+    struct Struct;
+    // SAFETY:
+    enum Enum {}
+    // SAFETY:
+    mod module {}
+}
+
+mod unnecessary_from_macro {
+    trait T {}
+
+    macro_rules! no_safety_comment {
+        ($t:ty) => {
+            impl T for $t {}
+        };
+    }
+
+    // FIXME: This is not caught
+    // Safety: unnecessary
+    no_safety_comment!(());
+
+    macro_rules! with_safety_comment {
+        ($t:ty) => {
+            // Safety: unnecessary
+            impl T for $t {}
+        };
+    }
+
+    with_safety_comment!(i32);
+}
+
+fn unnecessary_on_stmt_and_expr() -> u32 {
+    // SAFETY: unnecessary
+    let num = 42;
+
+    // SAFETY: unnecessary
+    if num > 24 {}
+
+    // SAFETY: unnecessary
+    24
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_safety_comment.stderr
+++ b/tests/ui/unnecessary_safety_comment.stderr
@@ -1,0 +1,115 @@
+error: constant item has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:6:5
+   |
+LL |     const CONST: u32 = 0;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:5:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+   = note: `-D clippy::unnecessary-safety-comment` implied by `-D warnings`
+
+error: static item has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:8:5
+   |
+LL |     static STATIC: u32 = 0;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:7:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: struct has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:10:5
+   |
+LL |     struct Struct;
+   |     ^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:9:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: enum has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:12:5
+   |
+LL |     enum Enum {}
+   |     ^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:11:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: module has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:14:5
+   |
+LL |     mod module {}
+   |     ^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:13:5
+   |
+LL |     // SAFETY:
+   |     ^^^^^^^^^^
+
+error: impl has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:33:13
+   |
+LL |             impl T for $t {}
+   |             ^^^^^^^^^^^^^^^^
+...
+LL |     with_safety_comment!(i32);
+   |     ------------------------- in this macro invocation
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:32:13
+   |
+LL |             // Safety: unnecessary
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `with_safety_comment` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expression has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:48:5
+   |
+LL |     24
+   |     ^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:47:5
+   |
+LL |     // SAFETY: unnecessary
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: statement has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:42:5
+   |
+LL |     let num = 42;
+   |     ^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:41:5
+   |
+LL |     // SAFETY: unnecessary
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: statement has unnecessary safety comment
+  --> $DIR/unnecessary_safety_comment.rs:45:5
+   |
+LL |     if num > 24 {}
+   |     ^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/unnecessary_safety_comment.rs:44:5
+   |
+LL |     // SAFETY: unnecessary
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
changelog: [`unnecessary_safety_comment`]: Add unnecessary safety comment lint

Addresses https://github.com/rust-lang/rust-clippy/issues/7954

This does not necessarily catch all occurences, as doing so would require checking all expressions in the entire source which seems rather expensive. Instead what the lint does is it checks items, statements and the tail expression of blocks for safety comments, then checks if those comments are necessary or not, then linting for the unnecessary ones.

I kept the tests in one file to check that the lints do not clash with each other.