### PR TITLE
Fix typo in `expect_used` and `unwrap_used` warning messages

### DIFF
--- a/clippy_lints/src/methods/expect_used.rs
+++ b/clippy_lints/src/methods/expect_used.rs
@@ -18,9 +18,9 @@ pub(super) fn check(
     let obj_ty = cx.typeck_results().expr_ty(recv).peel_refs();
 
     let mess = if is_type_diagnostic_item(cx, obj_ty, sym::Option) && !is_err {
-        Some((EXPECT_USED, "an Option", "None", ""))
+        Some((EXPECT_USED, "an `Option`", "None", ""))
     } else if is_type_diagnostic_item(cx, obj_ty, sym::Result) {
-        Some((EXPECT_USED, "a Result", if is_err { "Ok" } else { "Err" }, "an "))
+        Some((EXPECT_USED, "a `Result`", if is_err { "Ok" } else { "Err" }, "an "))
     } else {
         None
     };
@@ -36,7 +36,7 @@ pub(super) fn check(
             cx,
             lint,
             expr.span,
-            &format!("used `{method}()` on `{kind}` value"),
+            &format!("used `{method}()` on {kind} value"),
             None,
             &format!("if this value is {none_prefix}`{none_value}`, it will panic"),
         );

--- a/clippy_lints/src/methods/unwrap_used.rs
+++ b/clippy_lints/src/methods/unwrap_used.rs
@@ -18,9 +18,9 @@ pub(super) fn check(
     let obj_ty = cx.typeck_results().expr_ty(recv).peel_refs();
 
     let mess = if is_type_diagnostic_item(cx, obj_ty, sym::Option) && !is_err {
-        Some((UNWRAP_USED, "an Option", "None", ""))
+        Some((UNWRAP_USED, "an `Option`", "None", ""))
     } else if is_type_diagnostic_item(cx, obj_ty, sym::Result) {
-        Some((UNWRAP_USED, "a Result", if is_err { "Ok" } else { "Err" }, "an "))
+        Some((UNWRAP_USED, "a `Result`", if is_err { "Ok" } else { "Err" }, "an "))
     } else {
         None
     };
@@ -45,7 +45,7 @@ pub(super) fn check(
             cx,
             lint,
             expr.span,
-            &format!("used `unwrap{method_suffix}()` on `{kind}` value"),
+            &format!("used `unwrap{method_suffix}()` on {kind} value"),
             None,
             &help,
         );

--- a/tests/ui-toml/expect_used/expect_used.stderr
+++ b/tests/ui-toml/expect_used/expect_used.stderr
@@ -1,4 +1,4 @@
-error: used `expect()` on `an Option` value
+error: used `expect()` on an `Option` value
   --> $DIR/expect_used.rs:6:13
    |
 LL |     let _ = opt.expect("");
@@ -7,7 +7,7 @@ LL |     let _ = opt.expect("");
    = help: if this value is `None`, it will panic
    = note: `-D clippy::expect-used` implied by `-D warnings`
 
-error: used `expect()` on `a Result` value
+error: used `expect()` on a `Result` value
   --> $DIR/expect_used.rs:11:13
    |
 LL |     let _ = res.expect("");

--- a/tests/ui-toml/unwrap_used/unwrap_used.stderr
+++ b/tests/ui-toml/unwrap_used/unwrap_used.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(clippy::get_unwrap)]
    |         ^^^^^^^^^^^^^^^^^^
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:35:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
@@ -25,7 +25,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:36:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
@@ -39,7 +39,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:37:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
@@ -53,7 +53,7 @@ error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:38:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
@@ -67,7 +67,7 @@ error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more 
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:39:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
@@ -81,7 +81,7 @@ error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:40:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
@@ -95,7 +95,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:44:22
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
@@ -109,7 +109,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:49:10
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
@@ -123,7 +123,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:50:10
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
@@ -137,7 +137,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:51:10
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
@@ -151,7 +151,7 @@ error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and 
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:52:10
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
@@ -165,7 +165,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:64:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
@@ -179,7 +179,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:65:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();

--- a/tests/ui/expect.stderr
+++ b/tests/ui/expect.stderr
@@ -1,4 +1,4 @@
-error: used `expect()` on `an Option` value
+error: used `expect()` on an `Option` value
   --> $DIR/expect.rs:5:13
    |
 LL |     let _ = opt.expect("");
@@ -7,7 +7,7 @@ LL |     let _ = opt.expect("");
    = help: if this value is `None`, it will panic
    = note: `-D clippy::expect-used` implied by `-D warnings`
 
-error: used `expect()` on `a Result` value
+error: used `expect()` on a `Result` value
   --> $DIR/expect.rs:10:13
    |
 LL |     let _ = res.expect("");
@@ -15,7 +15,7 @@ LL |     let _ = res.expect("");
    |
    = help: if this value is an `Err`, it will panic
 
-error: used `expect_err()` on `a Result` value
+error: used `expect_err()` on a `Result` value
   --> $DIR/expect.rs:11:13
    |
 LL |     let _ = res.expect_err("");

--- a/tests/ui/get_unwrap.stderr
+++ b/tests/ui/get_unwrap.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(clippy::get_unwrap)]
    |         ^^^^^^^^^^^^^^^^^^
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:35:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
@@ -25,7 +25,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:36:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
@@ -39,7 +39,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:37:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
@@ -53,7 +53,7 @@ error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:38:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
@@ -67,7 +67,7 @@ error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more 
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:39:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
@@ -81,7 +81,7 @@ error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:40:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
@@ -95,7 +95,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:44:22
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
@@ -109,7 +109,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:49:10
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
@@ -123,7 +123,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:50:10
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
@@ -137,7 +137,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:51:10
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
@@ -151,7 +151,7 @@ error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and 
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:52:10
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
@@ -165,7 +165,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:64:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
@@ -179,7 +179,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:65:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();

--- a/tests/ui/unwrap.stderr
+++ b/tests/ui/unwrap.stderr
@@ -1,4 +1,4 @@
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap.rs:5:13
    |
 LL |     let _ = opt.unwrap();
@@ -7,7 +7,7 @@ LL |     let _ = opt.unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
    = note: `-D clippy::unwrap-used` implied by `-D warnings`
 
-error: used `unwrap()` on `a Result` value
+error: used `unwrap()` on a `Result` value
   --> $DIR/unwrap.rs:10:13
    |
 LL |     let _ = res.unwrap();
@@ -15,7 +15,7 @@ LL |     let _ = res.unwrap();
    |
    = help: if you don't want to handle the `Err` case gracefully, consider using `expect()` to provide a better panic message
 
-error: used `unwrap_err()` on `a Result` value
+error: used `unwrap_err()` on a `Result` value
   --> $DIR/unwrap.rs:11:13
    |
 LL |     let _ = res.unwrap_err();

--- a/tests/ui/unwrap_expect_used.stderr
+++ b/tests/ui/unwrap_expect_used.stderr
@@ -1,4 +1,4 @@
-error: used `unwrap()` on `an Option` value
+error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_expect_used.rs:23:5
    |
 LL |     Some(3).unwrap();
@@ -7,7 +7,7 @@ LL |     Some(3).unwrap();
    = help: if this value is `None`, it will panic
    = note: `-D clippy::unwrap-used` implied by `-D warnings`
 
-error: used `expect()` on `an Option` value
+error: used `expect()` on an `Option` value
   --> $DIR/unwrap_expect_used.rs:24:5
    |
 LL |     Some(3).expect("Hello world!");
@@ -16,7 +16,7 @@ LL |     Some(3).expect("Hello world!");
    = help: if this value is `None`, it will panic
    = note: `-D clippy::expect-used` implied by `-D warnings`
 
-error: used `unwrap()` on `a Result` value
+error: used `unwrap()` on a `Result` value
   --> $DIR/unwrap_expect_used.rs:31:5
    |
 LL |     a.unwrap();
@@ -24,7 +24,7 @@ LL |     a.unwrap();
    |
    = help: if this value is an `Err`, it will panic
 
-error: used `expect()` on `a Result` value
+error: used `expect()` on a `Result` value
   --> $DIR/unwrap_expect_used.rs:32:5
    |
 LL |     a.expect("Hello world!");
@@ -32,7 +32,7 @@ LL |     a.expect("Hello world!");
    |
    = help: if this value is an `Err`, it will panic
 
-error: used `unwrap_err()` on `a Result` value
+error: used `unwrap_err()` on a `Result` value
   --> $DIR/unwrap_expect_used.rs:33:5
    |
 LL |     a.unwrap_err();
@@ -40,7 +40,7 @@ LL |     a.unwrap_err();
    |
    = help: if this value is an `Ok`, it will panic
 
-error: used `expect_err()` on `a Result` value
+error: used `expect_err()` on a `Result` value
   --> $DIR/unwrap_expect_used.rs:34:5
    |
 LL |     a.expect_err("Hello error!");


### PR DESCRIPTION
"\`an Option\`" -> "an \`Option\`" and "\`a Result\`" -> "a \`Result\`".

changelog: fix typo in `expect_used` and `unwrap_used` warning messages