### PR TITLE
Fix manual_let_else produces a wrong suggestion with or-patterns

### DIFF
--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -151,7 +151,12 @@ fn emit_manual_let_else(cx: &LateContext<'_>, span: Span, expr: &Expr<'_>, pat: 
             } else {
                 format!("{{ {sn_else} }}")
             };
-            let sugg = format!("let {sn_pat} = {sn_expr} else {else_bl};");
+            let sn_bl = if matches!(pat.kind, PatKind::Or(..)) {
+                format!("({sn_pat})")
+            } else {
+                sn_pat.into_owned()
+            };
+            let sugg = format!("let {sn_bl} = {sn_expr} else {else_bl};");
             diag.span_suggestion(span, "consider writing", sugg, app);
         },
     );

--- a/tests/ui/manual_let_else_match.rs
+++ b/tests/ui/manual_let_else_match.rs
@@ -64,6 +64,13 @@ fn fire() {
         Ok(v) => v,
         Err(()) => return,
     };
+
+    let f = Variant::Bar(1);
+
+    let _value = match f {
+        Variant::Bar(_) | Variant::Baz(_) => (),
+        _ => return,
+    };
 }
 
 fn not_fire() {

--- a/tests/ui/manual_let_else_match.stderr
+++ b/tests/ui/manual_let_else_match.stderr
@@ -25,7 +25,7 @@ LL | /         let v = match h() {
 LL | |             (Some(_), Some(_)) | (None, None) => continue,
 LL | |             (Some(v), None) | (None, Some(v)) => v,
 LL | |         };
-   | |__________^ help: consider writing: `let (Some(v), None) | (None, Some(v)) = h() else { continue };`
+   | |__________^ help: consider writing: `let ((Some(v), None) | (None, Some(v))) = h() else { continue };`
 
 error: this could be rewritten as `let...else`
   --> $DIR/manual_let_else_match.rs:49:9
@@ -34,7 +34,7 @@ LL | /         let v = match build_enum() {
 LL | |             _ => continue,
 LL | |             Variant::Bar(v) | Variant::Baz(v) => v,
 LL | |         };
-   | |__________^ help: consider writing: `let Variant::Bar(v) | Variant::Baz(v) = build_enum() else { continue };`
+   | |__________^ help: consider writing: `let (Variant::Bar(v) | Variant::Baz(v)) = build_enum() else { continue };`
 
 error: this could be rewritten as `let...else`
   --> $DIR/manual_let_else_match.rs:57:5
@@ -54,5 +54,14 @@ LL | |         Err(()) => return,
 LL | |     };
    | |______^ help: consider writing: `let Ok(v) = f().map_err(|_| ()) else { return };`
 
-error: aborting due to 6 previous errors
+error: this could be rewritten as `let...else`
+  --> $DIR/manual_let_else_match.rs:70:5
+   |
+LL | /     let _value = match f {
+LL | |         Variant::Bar(_) | Variant::Baz(_) => (),
+LL | |         _ => return,
+LL | |     };
+   | |______^ help: consider writing: `let (Variant::Bar(_) | Variant::Baz(_)) = f else { return };`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fix #9938
changelog: Sugg: [`manual_let_else`]: Suggestions for or-patterns now include required brackets.
[#9966](https://github.com/rust-lang/rust-clippy/pull/9966)
