### PR TITLE
Move `index_refutable_slice` to `pedantic`

### DIFF
--- a/clippy_lints/src/index_refutable_slice.rs
+++ b/clippy_lints/src/index_refutable_slice.rs
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.59.0"]
     pub INDEX_REFUTABLE_SLICE,
-    nursery,
+    pedantic,
     "avoid indexing on slices which could be destructed"
 }
 


### PR DESCRIPTION
During the creation, I out this lint into the nursery group to let it run in the wild before moving it to a commonly used group. This move never happened until now, though. It should be safe, as Clippy and I have been using it for months and there are no open issues for is :)

---

changelog: Move `index_refutable_slice` to `pedantic` (Now warn-by-default)
[#9975](https://github.com/rust-lang/rust-clippy/pull/9975)
