### PR TITLE
Add S-waiting-on-review autolabel.

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -9,6 +9,9 @@ allow-unauthenticated = [
 # See https://github.com/rust-lang/triagebot/wiki/Shortcuts
 [shortcut]
 
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
 


### PR DESCRIPTION
This adds the S-waiting-on-review autolabel feature for new PRs.  This was previously handled by highfive, but I neglected to include it in #9963.

changelog: none
