### PR TITLE
Move `unnecessary_unsafety_doc` to `pedantic`

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -253,7 +253,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.66.0"]
     pub UNNECESSARY_SAFETY_DOC,
-    style,
+    restriction,
     "`pub fn` or `pub trait` with `# Safety` docs"
 }
 

--- a/tests/ui/unnecessary_unsafety_doc.rs
+++ b/tests/ui/unnecessary_unsafety_doc.rs
@@ -1,6 +1,7 @@
 // aux-build:doc_unsafe_macros.rs
 
 #![allow(clippy::let_unit_value)]
+#![warn(clippy::unnecessary_safety_doc)]
 
 #[macro_use]
 extern crate doc_unsafe_macros;

--- a/tests/ui/unnecessary_unsafety_doc.stderr
+++ b/tests/ui/unnecessary_unsafety_doc.stderr
@@ -1,5 +1,5 @@
 error: safe function's docs have unnecessary `# Safety` section
-  --> $DIR/doc_unnecessary_unsafe.rs:18:1
+  --> $DIR/unnecessary_unsafety_doc.rs:19:1
    |
 LL | pub fn apocalypse(universe: &mut ()) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,31 +7,31 @@ LL | pub fn apocalypse(universe: &mut ()) {
    = note: `-D clippy::unnecessary-safety-doc` implied by `-D warnings`
 
 error: safe function's docs have unnecessary `# Safety` section
-  --> $DIR/doc_unnecessary_unsafe.rs:44:5
+  --> $DIR/unnecessary_unsafety_doc.rs:45:5
    |
 LL |     pub fn republished() {
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: safe function's docs have unnecessary `# Safety` section
-  --> $DIR/doc_unnecessary_unsafe.rs:57:5
+  --> $DIR/unnecessary_unsafety_doc.rs:58:5
    |
 LL |     fn documented(self);
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: docs for safe trait have unnecessary `# Safety` section
-  --> $DIR/doc_unnecessary_unsafe.rs:67:1
+  --> $DIR/unnecessary_unsafety_doc.rs:68:1
    |
 LL | pub trait DocumentedSafeTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: safe function's docs have unnecessary `# Safety` section
-  --> $DIR/doc_unnecessary_unsafe.rs:95:5
+  --> $DIR/unnecessary_unsafety_doc.rs:96:5
    |
 LL |     pub fn documented() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: safe function's docs have unnecessary `# Safety` section
-  --> $DIR/doc_unnecessary_unsafe.rs:122:9
+  --> $DIR/unnecessary_unsafety_doc.rs:123:9
    |
 LL |         pub fn drive() {
    |         ^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL | very_safe!();
    = note: this error originates in the macro `very_safe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: docs for safe trait have unnecessary `# Safety` section
-  --> $DIR/doc_unnecessary_unsafe.rs:146:1
+  --> $DIR/unnecessary_unsafety_doc.rs:147:1
    |
 LL | pub trait DocumentedSafeTraitWithImplementationHeader {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This lint was added in #9822. I like the idea, but also agree with #9986 as well. I think it should at least not be warn-by-default. This is one of these cases, where I'd like a group between pedantic and restriction. But I believe that users using `#![warn(clippy::pedantic)]` will know how to enable the lint if they disagree with it.


---

Since the lint is new:

changelog: none

r? @flip1995 since I'd suggest back porting this, the original PR was merged 16 days ago.

Closes: #9986 (While it doesn't address everything, I believe that this is the best compromise)
