### PR TITLE
Don't suggest keeping borrows in `identity_op`

### DIFF
--- a/tests/ui/identity_op.fixed
+++ b/tests/ui/identity_op.fixed
@@ -65,7 +65,7 @@ fn main() {
     42;
     1;
     42;
-    &x;
+    x;
     x;
 
     let mut a = A(String::new());
@@ -112,6 +112,10 @@ fn main() {
     2 * { a };
     (({ a } + 4));
     1;
+
+    // Issue #9904
+    let x = 0i32;
+    let _: i32 = x;
 }
 
 pub fn decide(a: bool, b: bool) -> u32 {

--- a/tests/ui/identity_op.rs
+++ b/tests/ui/identity_op.rs
@@ -112,6 +112,10 @@ fn main() {
     2 * (0 + { a });
     1 * ({ a } + 4);
     1 * 1;
+
+    // Issue #9904
+    let x = 0i32;
+    let _: i32 = &x + 0;
 }
 
 pub fn decide(a: bool, b: bool) -> u32 {

--- a/tests/ui/identity_op.stderr
+++ b/tests/ui/identity_op.stderr
@@ -70,7 +70,7 @@ error: this operation has no effect
   --> $DIR/identity_op.rs:68:5
    |
 LL |     &x >> 0;
-   |     ^^^^^^^ help: consider reducing it to: `&x`
+   |     ^^^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
   --> $DIR/identity_op.rs:69:5
@@ -229,10 +229,16 @@ LL |     1 * 1;
    |     ^^^^^ help: consider reducing it to: `1`
 
 error: this operation has no effect
-  --> $DIR/identity_op.rs:118:5
+  --> $DIR/identity_op.rs:118:18
+   |
+LL |     let _: i32 = &x + 0;
+   |                  ^^^^^^ help: consider reducing it to: `x`
+
+error: this operation has no effect
+  --> $DIR/identity_op.rs:122:5
    |
 LL |     0 + if a { 1 } else { 2 } + if b { 3 } else { 5 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if a { 1 } else { 2 })`
 
-error: aborting due to 39 previous errors
+error: aborting due to 40 previous errors
 


### PR DESCRIPTION
fixes #9904
changelog: `identity_op`: Don't suggest keeping borrows
