### PR TITLE
Fix ICE in `result_large_err` with uninhabited enums

### DIFF
--- a/tests/ui/result_large_err.rs
+++ b/tests/ui/result_large_err.rs
@@ -108,4 +108,10 @@ pub fn array_error<T, U>() -> Result<(), ArrayError<(i32, T), U>> {
     Ok(())
 }
 
+// Issue #10005
+enum Empty {}
+fn _empty_error() -> Result<(), Empty> {
+    Ok(())
+}
+
 fn main() {}


### PR DESCRIPTION
fixes #10005
changelog: `result_large_err`: Fix ICE with uninhabited enums
