### PR TITLE
Treat custom enum discriminant values as constants

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -196,7 +196,7 @@ pub fn in_constant(cx: &LateContext<'_>, id: HirId) -> bool {
     let parent_id = cx.tcx.hir().get_parent_item(id).def_id;
     match cx.tcx.hir().get_by_def_id(parent_id) {
         Node::Item(&Item {
-            kind: ItemKind::Const(..) | ItemKind::Static(..),
+            kind: ItemKind::Const(..) | ItemKind::Static(..) | ItemKind::Enum(..),
             ..
         })
         | Node::TraitItem(&TraitItem {

--- a/tests/ui/cast_lossless_integer.fixed
+++ b/tests/ui/cast_lossless_integer.fixed
@@ -45,3 +45,9 @@ mod cast_lossless_in_impl {
         }
     }
 }
+
+#[derive(PartialEq, Debug)]
+#[repr(i64)]
+enum Test {
+    A = u32::MAX as i64 + 1,
+}

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -45,3 +45,9 @@ mod cast_lossless_in_impl {
         }
     }
 }
+
+#[derive(PartialEq, Debug)]
+#[repr(i64)]
+enum Test {
+    A = u32::MAX as i64 + 1,
+}


### PR DESCRIPTION
fixes #9882
changelog: All lints: Don't lint in enum discriminant values when the suggestion won't work in a const context
