### PR TITLE
Don't lint `string_lit_as_bytes` in match scrutinees

### DIFF
--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -25,6 +25,12 @@ fn str_lit_as_bytes() {
     let includestr = include_bytes!("string_lit_as_bytes.rs");
 
     let _ = b"string with newline\t\n";
+
+    let _ = match "x".as_bytes() {
+        b"xx" => 0,
+        [b'x', ..] => 1,
+        _ => 2,
+    };
 }
 
 fn main() {}

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -25,6 +25,12 @@ fn str_lit_as_bytes() {
     let includestr = include_str!("string_lit_as_bytes.rs").as_bytes();
 
     let _ = "string with newline\t\n".as_bytes();
+
+    let _ = match "x".as_bytes() {
+        b"xx" => 0,
+        [b'x', ..] => 1,
+        _ => 2,
+    };
 }
 
 fn main() {}


### PR DESCRIPTION
fixes #9885
changelog: `string_lit_as_bytes`: Don't lint in match scrutinees
