### PR TITLE
Don't lint `manual_assert` in `else if`

### DIFF
--- a/tests/ui/manual_assert.edition2018.fixed
+++ b/tests/ui/manual_assert.edition2018.fixed
@@ -62,6 +62,11 @@ fn main() {
         panic!("panic5");
     }
     assert!(!a.is_empty(), "with expansion {}", one!());
+    if a.is_empty() {
+        let _ = 0;
+    } else if a.len() == 1 {
+        panic!("panic6");
+    }
 }
 
 fn issue7730(a: u8) {

--- a/tests/ui/manual_assert.edition2021.fixed
+++ b/tests/ui/manual_assert.edition2021.fixed
@@ -50,6 +50,11 @@ fn main() {
     assert!(!(b.is_empty() || a.is_empty()), "panic4");
     assert!(!(a.is_empty() || !b.is_empty()), "panic5");
     assert!(!a.is_empty(), "with expansion {}", one!());
+    if a.is_empty() {
+        let _ = 0;
+    } else if a.len() == 1 {
+        panic!("panic6");
+    }
 }
 
 fn issue7730(a: u8) {

--- a/tests/ui/manual_assert.edition2021.stderr
+++ b/tests/ui/manual_assert.edition2021.stderr
@@ -65,7 +65,7 @@ LL | |     }
    | |_____^ help: try instead: `assert!(!a.is_empty(), "with expansion {}", one!());`
 
 error: only a `panic!` in `if`-then statement
-  --> $DIR/manual_assert.rs:73:5
+  --> $DIR/manual_assert.rs:78:5
    |
 LL | /     if a > 2 {
 LL | |         // comment

--- a/tests/ui/manual_assert.rs
+++ b/tests/ui/manual_assert.rs
@@ -66,6 +66,11 @@ fn main() {
     if a.is_empty() {
         panic!("with expansion {}", one!())
     }
+    if a.is_empty() {
+        let _ = 0;
+    } else if a.len() == 1 {
+        panic!("panic6");
+    }
 }
 
 fn issue7730(a: u8) {


### PR DESCRIPTION
fixes #9886
changelog: `manual_assert`: Don't lint in `else if`
