### PR TITLE
Add beta-nominated label to triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,7 +1,7 @@
 [relabel]
 allow-unauthenticated = [
     "A-*", "C-*", "E-*", "I-*", "L-*", "P-*", "S-*", "T-*",
-    "good-first-issue"
+    "good-first-issue", "beta-nominated"
 ]
 
 # Allows shortcuts like `@rustbot ready`


### PR DESCRIPTION
Also non-maintainers should be able to label PRs with `beta-nominated`.

changelog: none
