### PR TITLE
improve `manual_is_ascii_check ` check

### DIFF
--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -1,5 +1,6 @@
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::{diagnostics::span_lint_and_sugg, higher, in_constant, macros::root_macro_call, source::snippet};
+use rustc_ast::ast::RangeLimits;
 use rustc_ast::LitKind::{Byte, Char};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, PatKind, RangeEnd};
@@ -83,7 +84,8 @@ impl<'tcx> LateLintPass<'tcx> for ManualIsAsciiCheck {
             }
         } else if let ExprKind::MethodCall(path, receiver, [arg], ..) = expr.kind
             && path.ident.name == sym!(contains)
-            && let Some(higher::Range { start: Some(start), end: Some(end), .. }) = higher::Range::hir(receiver) {
+            && let Some(higher::Range { start: Some(start), end: Some(end), limits: RangeLimits::Closed })
+            = higher::Range::hir(receiver) {
                 let range = check_range(start, end);
                 check_is_ascii(cx, expr.span, arg, &range);
         }

--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -24,6 +24,14 @@ declare_clippy_lint! {
     ///     assert!(matches!(b'X', b'A'..=b'Z'));
     ///     assert!(matches!('2', '0'..='9'));
     ///     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
+    ///
+    ///     assert!((b'0'..=b'9').contains(&b'0'));
+    ///     assert!((b'a'..=b'z').contains(&b'a'));
+    ///     assert!((b'A'..=b'Z').contains(&b'A'));
+    ///
+    ///     assert!(('0'..='9').contains(&'0'));
+    ///     assert!(('a'..='z').contains(&'a'));
+    ///     assert!(('A'..='Z').contains(&'A'));
     /// }
     /// ```
     /// Use instead:
@@ -33,6 +41,14 @@ declare_clippy_lint! {
     ///     assert!(b'X'.is_ascii_uppercase());
     ///     assert!('2'.is_ascii_digit());
     ///     assert!('x'.is_ascii_alphabetic());
+    ///
+    ///     assert!(b'0'.is_ascii_digit());
+    ///     assert!(b'a'.is_ascii_lowercase());
+    ///     assert!(b'A'.is_ascii_uppercase());
+    ///
+    ///     assert!('0'.is_ascii_digit());
+    ///     assert!('a'.is_ascii_lowercase());
+    ///     assert!('A'.is_ascii_uppercase());
     /// }
     /// ```
     #[clippy::version = "1.66.0"]

--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -25,13 +25,9 @@ declare_clippy_lint! {
     ///     assert!(matches!('2', '0'..='9'));
     ///     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
     ///
-    ///     assert!((b'0'..=b'9').contains(&b'0'));
-    ///     assert!((b'a'..=b'z').contains(&b'a'));
-    ///     assert!((b'A'..=b'Z').contains(&b'A'));
-    ///
-    ///     assert!(('0'..='9').contains(&'0'));
-    ///     assert!(('a'..='z').contains(&'a'));
-    ///     assert!(('A'..='Z').contains(&'A'));
+    ///     ('0'..='9').contains(&'0');
+    ///     ('a'..='z').contains(&'a');
+    ///     ('A'..='Z').contains(&'A');
     /// }
     /// ```
     /// Use instead:
@@ -42,13 +38,9 @@ declare_clippy_lint! {
     ///     assert!('2'.is_ascii_digit());
     ///     assert!('x'.is_ascii_alphabetic());
     ///
-    ///     assert!(b'0'.is_ascii_digit());
-    ///     assert!(b'a'.is_ascii_lowercase());
-    ///     assert!(b'A'.is_ascii_uppercase());
-    ///
-    ///     assert!('0'.is_ascii_digit());
-    ///     assert!('a'.is_ascii_lowercase());
-    ///     assert!('A'.is_ascii_uppercase());
+    ///     '0'.is_ascii_digit();
+    ///     'a'.is_ascii_lowercase();
+    ///     'A'.is_ascii_uppercase();
     /// }
     /// ```
     #[clippy::version = "1.66.0"]

--- a/tests/ui/manual_is_ascii_check.fixed
+++ b/tests/ui/manual_is_ascii_check.fixed
@@ -16,13 +16,13 @@ fn main() {
 
     assert!(matches!('x', 'A'..='Z' | 'a'..='z' | '_'));
 
-    assert!(&b'0'.is_ascii_digit());
-    assert!(&b'a'.is_ascii_lowercase());
-    assert!(&b'A'.is_ascii_uppercase());
+    assert!(b'0'.is_ascii_digit());
+    assert!(b'a'.is_ascii_lowercase());
+    assert!(b'A'.is_ascii_uppercase());
 
-    assert!(&'0'.is_ascii_digit());
-    assert!(&'a'.is_ascii_lowercase());
-    assert!(&'A'.is_ascii_uppercase());
+    assert!('0'.is_ascii_digit());
+    assert!('a'.is_ascii_lowercase());
+    assert!('A'.is_ascii_uppercase());
 }
 
 #[clippy::msrv = "1.23"]

--- a/tests/ui/manual_is_ascii_check.fixed
+++ b/tests/ui/manual_is_ascii_check.fixed
@@ -15,7 +15,14 @@ fn main() {
     assert!('x'.is_ascii_alphabetic());
 
     assert!(matches!('x', 'A'..='Z' | 'a'..='z' | '_'));
+
     assert!(&b'0'.is_ascii_digit());
+    assert!(&b'a'.is_ascii_lowercase());
+    assert!(&b'A'.is_ascii_uppercase());
+
+    assert!(&'0'.is_ascii_digit());
+    assert!(&'a'.is_ascii_lowercase());
+    assert!(&'A'.is_ascii_uppercase());
 }
 
 #[clippy::msrv = "1.23"]

--- a/tests/ui/manual_is_ascii_check.fixed
+++ b/tests/ui/manual_is_ascii_check.fixed
@@ -15,6 +15,7 @@ fn main() {
     assert!('x'.is_ascii_alphabetic());
 
     assert!(matches!('x', 'A'..='Z' | 'a'..='z' | '_'));
+    assert!(&b'0'.is_ascii_digit());
 }
 
 #[clippy::msrv = "1.23"]

--- a/tests/ui/manual_is_ascii_check.fixed
+++ b/tests/ui/manual_is_ascii_check.fixed
@@ -16,13 +16,18 @@ fn main() {
 
     assert!(matches!('x', 'A'..='Z' | 'a'..='z' | '_'));
 
-    assert!(b'0'.is_ascii_digit());
-    assert!(b'a'.is_ascii_lowercase());
-    assert!(b'A'.is_ascii_uppercase());
+    b'0'.is_ascii_digit();
+    b'a'.is_ascii_lowercase();
+    b'A'.is_ascii_uppercase();
 
-    assert!('0'.is_ascii_digit());
-    assert!('a'.is_ascii_lowercase());
-    assert!('A'.is_ascii_uppercase());
+    '0'.is_ascii_digit();
+    'a'.is_ascii_lowercase();
+    'A'.is_ascii_uppercase();
+
+    let cool_letter = &'g';
+    cool_letter.is_ascii_digit();
+    cool_letter.is_ascii_lowercase();
+    cool_letter.is_ascii_uppercase();
 }
 
 #[clippy::msrv = "1.23"]

--- a/tests/ui/manual_is_ascii_check.rs
+++ b/tests/ui/manual_is_ascii_check.rs
@@ -15,6 +15,7 @@ fn main() {
     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
 
     assert!(matches!('x', 'A'..='Z' | 'a'..='z' | '_'));
+    assert!((b'0'..=b'9').contains(&b'0'));
 }
 
 #[clippy::msrv = "1.23"]

--- a/tests/ui/manual_is_ascii_check.rs
+++ b/tests/ui/manual_is_ascii_check.rs
@@ -16,13 +16,18 @@ fn main() {
 
     assert!(matches!('x', 'A'..='Z' | 'a'..='z' | '_'));
 
-    assert!((b'0'..=b'9').contains(&b'0'));
-    assert!((b'a'..=b'z').contains(&b'a'));
-    assert!((b'A'..=b'Z').contains(&b'A'));
+    (b'0'..=b'9').contains(&b'0');
+    (b'a'..=b'z').contains(&b'a');
+    (b'A'..=b'Z').contains(&b'A');
 
-    assert!(('0'..='9').contains(&'0'));
-    assert!(('a'..='z').contains(&'a'));
-    assert!(('A'..='Z').contains(&'A'));
+    ('0'..='9').contains(&'0');
+    ('a'..='z').contains(&'a');
+    ('A'..='Z').contains(&'A');
+
+    let cool_letter = &'g';
+    ('0'..='9').contains(cool_letter);
+    ('a'..='z').contains(cool_letter);
+    ('A'..='Z').contains(cool_letter);
 }
 
 #[clippy::msrv = "1.23"]

--- a/tests/ui/manual_is_ascii_check.rs
+++ b/tests/ui/manual_is_ascii_check.rs
@@ -15,7 +15,14 @@ fn main() {
     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
 
     assert!(matches!('x', 'A'..='Z' | 'a'..='z' | '_'));
+
     assert!((b'0'..=b'9').contains(&b'0'));
+    assert!((b'a'..=b'z').contains(&b'a'));
+    assert!((b'A'..=b'Z').contains(&b'A'));
+
+    assert!(('0'..='9').contains(&'0'));
+    assert!(('a'..='z').contains(&'a'));
+    assert!(('A'..='Z').contains(&'A'));
 }
 
 #[clippy::msrv = "1.23"]

--- a/tests/ui/manual_is_ascii_check.stderr
+++ b/tests/ui/manual_is_ascii_check.stderr
@@ -43,64 +43,82 @@ LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:19:13
+  --> $DIR/manual_is_ascii_check.rs:19:5
    |
-LL |     assert!((b'0'..=b'9').contains(&b'0'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'0'.is_ascii_digit()`
+LL |     (b'0'..=b'9').contains(&b'0');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'0'.is_ascii_digit()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:20:13
+  --> $DIR/manual_is_ascii_check.rs:20:5
    |
-LL |     assert!((b'a'..=b'z').contains(&b'a'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'a'.is_ascii_lowercase()`
+LL |     (b'a'..=b'z').contains(&b'a');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'a'.is_ascii_lowercase()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:21:13
+  --> $DIR/manual_is_ascii_check.rs:21:5
    |
-LL |     assert!((b'A'..=b'Z').contains(&b'A'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'A'.is_ascii_uppercase()`
+LL |     (b'A'..=b'Z').contains(&b'A');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'A'.is_ascii_uppercase()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:23:13
+  --> $DIR/manual_is_ascii_check.rs:23:5
    |
-LL |     assert!(('0'..='9').contains(&'0'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'0'.is_ascii_digit()`
+LL |     ('0'..='9').contains(&'0');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'0'.is_ascii_digit()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:24:13
+  --> $DIR/manual_is_ascii_check.rs:24:5
    |
-LL |     assert!(('a'..='z').contains(&'a'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'a'.is_ascii_lowercase()`
+LL |     ('a'..='z').contains(&'a');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'a'.is_ascii_lowercase()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:25:13
+  --> $DIR/manual_is_ascii_check.rs:25:5
    |
-LL |     assert!(('A'..='Z').contains(&'A'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'A'.is_ascii_uppercase()`
+LL |     ('A'..='Z').contains(&'A');
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'A'.is_ascii_uppercase()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:37:13
+  --> $DIR/manual_is_ascii_check.rs:28:5
+   |
+LL |     ('0'..='9').contains(cool_letter);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_digit()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:29:5
+   |
+LL |     ('a'..='z').contains(cool_letter);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_lowercase()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:30:5
+   |
+LL |     ('A'..='Z').contains(cool_letter);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cool_letter.is_ascii_uppercase()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:42:13
    |
 LL |     assert!(matches!(b'1', b'0'..=b'9'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'1'.is_ascii_digit()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:38:13
+  --> $DIR/manual_is_ascii_check.rs:43:13
    |
 LL |     assert!(matches!('X', 'A'..='Z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'X'.is_ascii_uppercase()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:39:13
+  --> $DIR/manual_is_ascii_check.rs:44:13
    |
 LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:49:23
+  --> $DIR/manual_is_ascii_check.rs:54:23
    |
 LL |     const FOO: bool = matches!('x', '0'..='9');
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_digit()`
 
-error: aborting due to 17 previous errors
+error: aborting due to 20 previous errors
 

--- a/tests/ui/manual_is_ascii_check.stderr
+++ b/tests/ui/manual_is_ascii_check.stderr
@@ -43,34 +43,64 @@ LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:18:13
+  --> $DIR/manual_is_ascii_check.rs:19:13
    |
 LL |     assert!((b'0'..=b'9').contains(&b'0'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&b'0'.is_ascii_digit()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:30:13
+  --> $DIR/manual_is_ascii_check.rs:20:13
+   |
+LL |     assert!((b'a'..=b'z').contains(&b'a'));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&b'a'.is_ascii_lowercase()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:21:13
+   |
+LL |     assert!((b'A'..=b'Z').contains(&b'A'));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&b'A'.is_ascii_uppercase()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:23:13
+   |
+LL |     assert!(('0'..='9').contains(&'0'));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'0'.is_ascii_digit()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:24:13
+   |
+LL |     assert!(('a'..='z').contains(&'a'));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a'.is_ascii_lowercase()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:25:13
+   |
+LL |     assert!(('A'..='Z').contains(&'A'));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'A'.is_ascii_uppercase()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:37:13
    |
 LL |     assert!(matches!(b'1', b'0'..=b'9'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'1'.is_ascii_digit()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:31:13
+  --> $DIR/manual_is_ascii_check.rs:38:13
    |
 LL |     assert!(matches!('X', 'A'..='Z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'X'.is_ascii_uppercase()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:32:13
+  --> $DIR/manual_is_ascii_check.rs:39:13
    |
 LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:42:23
+  --> $DIR/manual_is_ascii_check.rs:49:23
    |
 LL |     const FOO: bool = matches!('x', '0'..='9');
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_digit()`
 
-error: aborting due to 12 previous errors
+error: aborting due to 17 previous errors
 

--- a/tests/ui/manual_is_ascii_check.stderr
+++ b/tests/ui/manual_is_ascii_check.stderr
@@ -46,37 +46,37 @@ error: manual check for common ascii range
   --> $DIR/manual_is_ascii_check.rs:19:13
    |
 LL |     assert!((b'0'..=b'9').contains(&b'0'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&b'0'.is_ascii_digit()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'0'.is_ascii_digit()`
 
 error: manual check for common ascii range
   --> $DIR/manual_is_ascii_check.rs:20:13
    |
 LL |     assert!((b'a'..=b'z').contains(&b'a'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&b'a'.is_ascii_lowercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'a'.is_ascii_lowercase()`
 
 error: manual check for common ascii range
   --> $DIR/manual_is_ascii_check.rs:21:13
    |
 LL |     assert!((b'A'..=b'Z').contains(&b'A'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&b'A'.is_ascii_uppercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'A'.is_ascii_uppercase()`
 
 error: manual check for common ascii range
   --> $DIR/manual_is_ascii_check.rs:23:13
    |
 LL |     assert!(('0'..='9').contains(&'0'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'0'.is_ascii_digit()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'0'.is_ascii_digit()`
 
 error: manual check for common ascii range
   --> $DIR/manual_is_ascii_check.rs:24:13
    |
 LL |     assert!(('a'..='z').contains(&'a'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a'.is_ascii_lowercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'a'.is_ascii_lowercase()`
 
 error: manual check for common ascii range
   --> $DIR/manual_is_ascii_check.rs:25:13
    |
 LL |     assert!(('A'..='Z').contains(&'A'));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'A'.is_ascii_uppercase()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'A'.is_ascii_uppercase()`
 
 error: manual check for common ascii range
   --> $DIR/manual_is_ascii_check.rs:37:13

--- a/tests/ui/manual_is_ascii_check.stderr
+++ b/tests/ui/manual_is_ascii_check.stderr
@@ -43,28 +43,34 @@ LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:29:13
+  --> $DIR/manual_is_ascii_check.rs:18:13
+   |
+LL |     assert!((b'0'..=b'9').contains(&b'0'));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&b'0'.is_ascii_digit()`
+
+error: manual check for common ascii range
+  --> $DIR/manual_is_ascii_check.rs:30:13
    |
 LL |     assert!(matches!(b'1', b'0'..=b'9'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b'1'.is_ascii_digit()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:30:13
+  --> $DIR/manual_is_ascii_check.rs:31:13
    |
 LL |     assert!(matches!('X', 'A'..='Z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'X'.is_ascii_uppercase()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:31:13
+  --> $DIR/manual_is_ascii_check.rs:32:13
    |
 LL |     assert!(matches!('x', 'A'..='Z' | 'a'..='z'));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_alphabetic()`
 
 error: manual check for common ascii range
-  --> $DIR/manual_is_ascii_check.rs:41:23
+  --> $DIR/manual_is_ascii_check.rs:42:23
    |
 LL |     const FOO: bool = matches!('x', '0'..='9');
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `'x'.is_ascii_digit()`
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Sorry, not familiar the api, i can only check the method name of expression `<expr-1>.contains(<expr-2>)` after read clippy book and hints from #9933 . i dont know how to check
1.  if <expr-1> is a specific range
2. <expr-2> is a character

r? @xFrednet could you please provide some more hints? 😝️

---

changelog: Enhancement: [`manual_is_ascii_check`]: Now detects ranges with `.contains()` calls
[#10053](https://github.com/rust-lang/rust-clippy/pull/10053)
<!-- changelog_checked -->