### PR TITLE
Avoid `match_wildcard_for_single_variants` on guarded wild matches

### DIFF
--- a/clippy_lints/src/matches/match_wild_enum.rs
+++ b/clippy_lints/src/matches/match_wild_enum.rs
@@ -30,7 +30,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>]) {
     let mut has_non_wild = false;
     for arm in arms {
         match peel_hir_pat_refs(arm.pat).0.kind {
-            PatKind::Wild => wildcard_span = Some(arm.pat.span),
+            PatKind::Wild if arm.guard.is_none() => wildcard_span = Some(arm.pat.span),
             PatKind::Binding(_, _, ident, None) => {
                 wildcard_span = Some(arm.pat.span);
                 wildcard_ident = Some(ident);

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -185,7 +185,6 @@ impl<'a> Sugg<'a> {
     ) -> Self {
         use rustc_ast::ast::RangeLimits;
 
-        #[expect(clippy::match_wildcard_for_single_variants)]
         match expr.kind {
             _ if expr.span.ctxt() != ctxt => Sugg::NonParen(snippet_with_context(cx, expr.span, ctxt, default, app).0),
             ast::ExprKind::AddrOf(..)

--- a/tests/ui/match_wildcard_for_single_variants.fixed
+++ b/tests/ui/match_wildcard_for_single_variants.fixed
@@ -132,3 +132,19 @@ fn main() {
         }
     }
 }
+
+mod issue9993 {
+    enum Foo {
+        A(bool),
+        B,
+    }
+
+    fn test() {
+        let _ = match Foo::A(true) {
+            _ if false => 0,
+            Foo::A(true) => 1,
+            Foo::A(false) => 2,
+            Foo::B => 3,
+        };
+    }
+}

--- a/tests/ui/match_wildcard_for_single_variants.fixed
+++ b/tests/ui/match_wildcard_for_single_variants.fixed
@@ -146,5 +146,11 @@ mod issue9993 {
             Foo::A(false) => 2,
             Foo::B => 3,
         };
+
+        let _ = match Foo::B {
+            _ if false => 0,
+            Foo::A(_) => 1,
+            Foo::B => 2,
+        };
     }
 }

--- a/tests/ui/match_wildcard_for_single_variants.rs
+++ b/tests/ui/match_wildcard_for_single_variants.rs
@@ -132,3 +132,19 @@ fn main() {
         }
     }
 }
+
+mod issue9993 {
+    enum Foo {
+        A(bool),
+        B,
+    }
+
+    fn test() {
+        let _ = match Foo::A(true) {
+            _ if false => 0,
+            Foo::A(true) => 1,
+            Foo::A(false) => 2,
+            Foo::B => 3,
+        };
+    }
+}

--- a/tests/ui/match_wildcard_for_single_variants.rs
+++ b/tests/ui/match_wildcard_for_single_variants.rs
@@ -146,5 +146,11 @@ mod issue9993 {
             Foo::A(false) => 2,
             Foo::B => 3,
         };
+
+        let _ = match Foo::B {
+            _ if false => 0,
+            Foo::A(_) => 1,
+            _ => 2,
+        };
     }
 }

--- a/tests/ui/match_wildcard_for_single_variants.stderr
+++ b/tests/ui/match_wildcard_for_single_variants.stderr
@@ -48,5 +48,11 @@ error: wildcard matches only a single variant and will also match any future add
 LL |         _ => (),
    |         ^ help: try this: `Color::Blue`
 
-error: aborting due to 8 previous errors
+error: wildcard matches only a single variant and will also match any future added variants
+  --> $DIR/match_wildcard_for_single_variants.rs:153:13
+   |
+LL |             _ => 2,
+   |             ^ help: try this: `Foo::B`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
fix #9993

changelog: FP: [`match_wildcard_for_single_variants`]: No longer lints on wildcards with a guard
[#10056](https://github.com/rust-lang/rust-clippy/pull/10056)
<!-- changelog_checked -->

r? @Jarcho 