### PR TITLE
 Fix [match_single_binding] suggestion introduced an extra semicolon

### DIFF
--- a/clippy_lints/src/matches/match_single_binding.rs
+++ b/clippy_lints/src/matches/match_single_binding.rs
@@ -31,19 +31,11 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
     };
 
     // Do we need to add ';' to suggestion ?
-    match match_body.kind {
-        ExprKind::Block(block, _) => {
-            // macro + expr_ty(body) == ()
-            if block.span.from_expansion() && cx.typeck_results().expr_ty(match_body).is_unit() {
-                snippet_body.push(';');
-            }
-        },
-        _ => {
-            // expr_ty(body) == ()
-            if cx.typeck_results().expr_ty(match_body).is_unit() {
-                snippet_body.push(';');
-            }
-        },
+    if let ExprKind::Block(block, _) = match_body.kind {
+        // macro + expr_ty(body) == ()
+        if block.span.from_expansion() && cx.typeck_results().expr_ty(match_body).is_unit() {
+            snippet_body.push(';');
+        }
     }
 
     let mut applicability = Applicability::MaybeIncorrect;

--- a/tests/ui/match_single_binding.fixed
+++ b/tests/ui/match_single_binding.fixed
@@ -133,3 +133,16 @@ fn issue_9575() {
         println!("Needs curlies");
     };
 }
+
+#[allow(dead_code)]
+fn issue_9725(r: Option<u32>) {
+    let x = r;
+    match x {
+        Some(_) => {
+            println!("Some");
+        },
+        None => {
+            println!("None");
+        },
+    };
+}

--- a/tests/ui/match_single_binding.rs
+++ b/tests/ui/match_single_binding.rs
@@ -148,3 +148,17 @@ fn issue_9575() {
         _ => println!("Needs curlies"),
     };
 }
+
+#[allow(dead_code)]
+fn issue_9725(r: Option<u32>) {
+    match r {
+        x => match x {
+            Some(_) => {
+                println!("Some");
+            },
+            None => {
+                println!("None");
+            },
+        },
+    };
+}

--- a/tests/ui/match_single_binding.stderr
+++ b/tests/ui/match_single_binding.stderr
@@ -213,5 +213,30 @@ LL +         println!("Needs curlies");
 LL ~     };
    |
 
-error: aborting due to 14 previous errors
+error: this match could be written as a `let` statement
+  --> $DIR/match_single_binding.rs:154:5
+   |
+LL | /     match r {
+LL | |         x => match x {
+LL | |             Some(_) => {
+LL | |                 println!("Some");
+...  |
+LL | |         },
+LL | |     };
+   | |_____^
+   |
+help: consider using a `let` statement
+   |
+LL ~     let x = r;
+LL +     match x {
+LL +         Some(_) => {
+LL +             println!("Some");
+LL +         },
+LL +         None => {
+LL +             println!("None");
+LL +         },
+LL ~     };
+   |
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Fix #9725

---

changelog: [`match_single_binding`]: suggestion no longer introduces unneeded semicolons
[#10060](https://github.com/rust-lang/rust-clippy/pull/10060)
<!-- changelog_checked -->