### PR TITLE
Fix error caused by recursion into Self.

### DIFF
--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -90,6 +90,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
                                 .substs
                                 .types()
                                 .skip(1) // Skip the implicit `Self` generic parameter
+                                .filter(|inner_ty| *inner_ty != ty) // Skip any other `Self` generic parameters
                                 .any(|ty| contains_ty_adt_constructor_opaque(cx, ty, needle))
                             {
                                 return true;

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -400,3 +400,14 @@ mod issue7344 {
         }
     }
 }
+
+mod issue10041 {
+    struct Bomb;
+
+    impl Bomb {
+        // Hidden <Rhs = Self> default generic paramter.
+        pub fn explode(&self) -> impl PartialOrd {
+            0i32
+        }
+    }
+}


### PR DESCRIPTION
fixes #10041

Prevent recursion into Self when it's a generic parameter. Added regression test from example in #10041.

- \[x] Followed [lint naming conventions][lint_naming] - **N/A**
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints` - **N/A**
- \[x] Added lint documentation - **N/A**
- \[x] Run `cargo dev fmt`

changelog: [`new-ret-no-self`] Fix segmentation fault caused when generic parameter defaults to `Self` and is unspecified. For example, `fn uh_oh(&self) -> impl PartialOrd { ... }` has a hidden `Rhs=Self` as the generic parameter for `PartialOrd`.
