### PR TITLE
Stack overflow fix

### DIFF
--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -90,6 +90,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
                                 .substs
                                 .types()
                                 .skip(1) // Skip the implicit `Self` generic parameter
+                                .filter(|inner_ty| *inner_ty != ty) // Skip any other `Self` generic parameters
                                 .any(|ty| contains_ty_adt_constructor_opaque(cx, ty, needle))
                             {
                                 return true;

--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -91,7 +91,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
                                 .types()
                                 .skip(1) // Skip the implicit `Self` generic parameter
                                 .filter(|inner_ty| *inner_ty != ty) // Skip any other `Self` generic parameters
-                                .any(|ty| contains_ty_adt_constructor_opaque(cx, ty, needle))
+                                .any(|ty| ty == needle || ty.ty_adt_def() == needle.ty_adt_def())
                             {
                                 return true;
                             }
@@ -100,7 +100,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
                         // so we check the term for `U`.
                         ty::PredicateKind::Clause(ty::Clause::Projection(projection_predicate)) => {
                             if let ty::TermKind::Ty(ty) = projection_predicate.term.unpack() {
-                                if contains_ty_adt_constructor_opaque(cx, ty, needle) {
+                                if ty == needle || ty.ty_adt_def() == needle.ty_adt_def() {
                                     return true;
                                 }
                             };

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -1,12 +1,20 @@
 error: methods called `new` usually return `Self`
+  --> $DIR/methods.rs:96:5
+   |
+LL | /     async fn new() -> Option<Self> {
+LL | |         None
+LL | |     }
+   | |_____^
+   |
+   = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
+
+error: methods called `new` usually return `Self`
   --> $DIR/methods.rs:104:5
    |
 LL | /     fn new() -> i32 {
 LL | |         0
 LL | |     }
    | |_____^
-   |
-   = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(..)` instead
   --> $DIR/methods.rs:125:13
@@ -20,5 +28,5 @@ LL | |                    ).next();
    |
    = note: `-D clippy::filter-next` implied by `-D warnings`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -400,3 +400,14 @@ mod issue7344 {
         }
     }
 }
+
+mod issue10041 {
+    struct Bomb;
+
+    impl Bomb {
+        // Hidden <Rhs = Self> default generic paramter.
+        pub fn explode(&self) -> impl PartialOrd {
+            0i32
+        }
+    }
+}

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -413,14 +413,14 @@ mod issue10041 {
     }
 }
 
-mod issue10041_TAIT {
+mod issue10041_tait {
     type X = impl std::ops::Add<Output = X>;
 
     struct Foo;
 
     impl Foo {
         fn new() -> X {
-            return 1;
+            1
         }
     }
 }

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -1,3 +1,4 @@
+#![feature(type_alias_impl_trait)]
 #![warn(clippy::new_ret_no_self)]
 #![allow(dead_code)]
 
@@ -408,6 +409,18 @@ mod issue10041 {
         // Hidden <Rhs = Self> default generic paramter.
         pub fn explode(&self) -> impl PartialOrd {
             0i32
+        }
+    }
+}
+
+mod issue10041_TAIT {
+    type X = impl std::ops::Add<Output = X>;
+
+    struct Foo;
+
+    impl Foo {
+        fn new() -> X {
+            return 1;
         }
     }
 }

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -1,5 +1,5 @@
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:49:5
+  --> $DIR/new_ret_no_self.rs:50:5
    |
 LL | /     pub fn new(_: String) -> impl R<Item = u32> {
 LL | |         S3
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:81:5
+  --> $DIR/new_ret_no_self.rs:82:5
    |
 LL | /     pub fn new() -> u32 {
 LL | |         unimplemented!();
@@ -17,7 +17,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:90:5
+  --> $DIR/new_ret_no_self.rs:91:5
    |
 LL | /     pub fn new(_: String) -> u32 {
 LL | |         unimplemented!();
@@ -25,7 +25,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:126:5
+  --> $DIR/new_ret_no_self.rs:127:5
    |
 LL | /     pub fn new() -> (u32, u32) {
 LL | |         unimplemented!();
@@ -33,7 +33,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:153:5
+  --> $DIR/new_ret_no_self.rs:154:5
    |
 LL | /     pub fn new() -> *mut V {
 LL | |         unimplemented!();
@@ -41,7 +41,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:171:5
+  --> $DIR/new_ret_no_self.rs:172:5
    |
 LL | /     pub fn new() -> Option<u32> {
 LL | |         unimplemented!();
@@ -49,19 +49,19 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:224:9
+  --> $DIR/new_ret_no_self.rs:225:9
    |
 LL |         fn new() -> String;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:236:9
+  --> $DIR/new_ret_no_self.rs:237:9
    |
 LL |         fn new(_: String) -> String;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:271:9
+  --> $DIR/new_ret_no_self.rs:272:9
    |
 LL | /         fn new() -> (u32, u32) {
 LL | |             unimplemented!();
@@ -69,7 +69,7 @@ LL | |         }
    | |_________^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:298:9
+  --> $DIR/new_ret_no_self.rs:299:9
    |
 LL | /         fn new() -> *mut V {
 LL | |             unimplemented!();
@@ -77,7 +77,7 @@ LL | |         }
    | |_________^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:368:9
+  --> $DIR/new_ret_no_self.rs:369:9
    |
 LL | /         fn new(t: T) -> impl Into<i32> {
 LL | |             1
@@ -85,12 +85,10 @@ LL | |         }
    | |_________^
 
 error: methods called `new` usually return `Self`
-  --> $DIR/new_ret_no_self.rs:389:9
+  --> $DIR/new_ret_no_self.rs:390:9
    |
 LL | /         fn new(t: T) -> impl Trait2<(), i32> {
 LL | |             unimplemented!()
 LL | |         }
    | |_________^
-
-error: aborting due to 12 previous errors
 

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -92,3 +92,13 @@ LL | |             unimplemented!()
 LL | |         }
    | |_________^
 
+error: methods called `new` usually return `Self`
+  --> $DIR/new_ret_no_self.rs:422:9
+   |
+LL | /         fn new() -> X {
+LL | |             1
+LL | |         }
+   | |_________^
+
+error: aborting due to 13 previous errors
+


### PR DESCRIPTION
See https://github.com/rust-lang/rust-clippy/pull/10068#issuecomment-1352528391 for details

-- original PR description of #10068 --

fixes #10041

Prevent recursion into Self when it's a generic parameter. Added regression test from example in #10041.

- \[x] Followed [lint naming conventions][lint_naming] - **N/A**
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints` - **N/A**
- \[x] Added lint documentation - **N/A**
- \[x] Run `cargo dev fmt`

changelog: [`new-ret-no-self`] Fix segmentation fault caused when generic parameter defaults to `Self` and is unspecified. For example, `fn uh_oh(&self)>