### PR TITLE
Warn if unresolved disallowed types/macros/methods are used in clippy.toml for disallowed_* macros

### DIFF
--- a/tests/ui-toml/disallowed_macros/clippy.toml
+++ b/tests/ui-toml/disallowed_macros/clippy.toml
@@ -8,4 +8,6 @@ disallowed-macros = [
     "macros::ty",
     "macros::pat",
     "macros::item",
+    # Macros which don't exist will lint
+    "disallowed_macros::does_not_exist",
 ]

--- a/tests/ui-toml/disallowed_macros/disallowed_macros.rs
+++ b/tests/ui-toml/disallowed_macros/disallowed_macros.rs
@@ -1,4 +1,4 @@
-// aux-build:macros.rs
+// --crate-name disallowed_macros aux-build:macros.rs
 
 #![allow(unused)]
 

--- a/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
+++ b/tests/ui-toml/disallowed_macros/disallowed_macros.stderr
@@ -1,10 +1,12 @@
+error: Could not resolve disallowed macro: `disallowed_macros::does_not_exist`
+   |
+   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
+
 error: use of a disallowed macro `std::println`
   --> $DIR/disallowed_macros.rs:10:5
    |
 LL |     println!("one");
    |     ^^^^^^^^^^^^^^^
-   |
-   = note: `-D clippy::disallowed-macros` implied by `-D warnings`
 
 error: use of a disallowed macro `std::println`
   --> $DIR/disallowed_macros.rs:11:5
@@ -80,5 +82,5 @@ error: use of a disallowed macro `macros::item`
 LL |     macros::item!();
    |     ^^^^^^^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 14 previous errors
 

--- a/tests/ui-toml/toml_disallowed_methods/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_methods/clippy.toml
@@ -14,4 +14,6 @@ disallowed-methods = [
     "conf_disallowed_methods::Struct::method",
     "conf_disallowed_methods::Trait::provided_method",
     "conf_disallowed_methods::Trait::implemented_method",
+    # Methods which don't exist will lint
+    "conf_disallowed_methods::does_not_exist",
 ]

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -1,10 +1,12 @@
+error: Could not resolve disallowed method: `conf_disallowed_methods::does_not_exist`
+   |
+   = note: `-D clippy::disallowed-methods` implied by `-D warnings`
+
 error: use of a disallowed method `regex::Regex::new`
   --> $DIR/conf_disallowed_methods.rs:33:14
    |
 LL |     let re = Regex::new(r"ab.*c").unwrap();
    |              ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `-D clippy::disallowed-methods` implied by `-D warnings`
 
 error: use of a disallowed method `regex::Regex::is_match`
   --> $DIR/conf_disallowed_methods.rs:34:5
@@ -86,5 +88,5 @@ error: use of a disallowed method `conf_disallowed_methods::Trait::implemented_m
 LL |     s.implemented_method();
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: aborting due to 15 previous errors
 

--- a/tests/ui-toml/toml_disallowed_types/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_types/clippy.toml
@@ -12,4 +12,6 @@ disallowed-types = [
     { path = "std::net::Ipv4Addr", reason = "no IPv4 allowed" },
     # can use an inline table but omit reason
     { path = "std::net::TcpListener" },
+    # Types which don't exist will lint
+    "conf_disallowed_types::DoesNotExist",
 ]

--- a/tests/ui-toml/toml_disallowed_types/conf_disallowed_types.rs
+++ b/tests/ui-toml/toml_disallowed_types/conf_disallowed_types.rs
@@ -1,3 +1,5 @@
+// compile-flags: --crate-name conf_disallowed_types
+
 #![warn(clippy::disallowed_types)]
 
 extern crate quote;

--- a/tests/ui-toml/toml_disallowed_types/conf_disallowed_types.stderr
+++ b/tests/ui-toml/toml_disallowed_types/conf_disallowed_types.stderr
@@ -1,67 +1,69 @@
-error: `std::sync::atomic::AtomicU32` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:7:1
-   |
-LL | use std::sync::atomic::AtomicU32;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+error: Could not resolve disallowed type: `conf_disallowed_types::DoesNotExist`
    |
    = note: `-D clippy::disallowed-types` implied by `-D warnings`
 
+error: `std::sync::atomic::AtomicU32` is not allowed according to config
+  --> $DIR/conf_disallowed_types.rs:9:1
+   |
+LL | use std::sync::atomic::AtomicU32;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: `std::time::Instant` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:8:1
+  --> $DIR/conf_disallowed_types.rs:10:1
    |
 LL | use std::time::Instant as Sneaky;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `std::time::Instant` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:12:33
+  --> $DIR/conf_disallowed_types.rs:14:33
    |
 LL | fn bad_return_type() -> fn() -> Sneaky {
    |                                 ^^^^^^
 
 error: `std::time::Instant` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:16:28
+  --> $DIR/conf_disallowed_types.rs:18:28
    |
 LL | fn bad_arg_type(_: impl Fn(Sneaky) -> foo::atomic::AtomicU32) {}
    |                            ^^^^^^
 
 error: `std::sync::atomic::AtomicU32` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:16:39
+  --> $DIR/conf_disallowed_types.rs:18:39
    |
 LL | fn bad_arg_type(_: impl Fn(Sneaky) -> foo::atomic::AtomicU32) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `std::io::Read` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:18:22
+  --> $DIR/conf_disallowed_types.rs:20:22
    |
 LL | fn trait_obj(_: &dyn std::io::Read) {}
    |                      ^^^^^^^^^^^^^
 
 error: `usize` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:20:33
+  --> $DIR/conf_disallowed_types.rs:22:33
    |
 LL | fn full_and_single_path_prim(_: usize, _: bool) {}
    |                                 ^^^^^
 
 error: `bool` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:20:43
+  --> $DIR/conf_disallowed_types.rs:22:43
    |
 LL | fn full_and_single_path_prim(_: usize, _: bool) {}
    |                                           ^^^^
 
 error: `usize` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:22:28
+  --> $DIR/conf_disallowed_types.rs:24:28
    |
 LL | fn const_generics<const C: usize>() {}
    |                            ^^^^^
 
 error: `usize` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:24:24
+  --> $DIR/conf_disallowed_types.rs:26:24
    |
 LL | struct GenArg<const U: usize>([u8; U]);
    |                        ^^^^^
 
 error: `std::net::Ipv4Addr` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:28:10
+  --> $DIR/conf_disallowed_types.rs:30:10
    |
 LL | fn ip(_: std::net::Ipv4Addr) {}
    |          ^^^^^^^^^^^^^^^^^^
@@ -69,64 +71,64 @@ LL | fn ip(_: std::net::Ipv4Addr) {}
    = note: no IPv4 allowed (from clippy.toml)
 
 error: `std::net::TcpListener` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:30:16
+  --> $DIR/conf_disallowed_types.rs:32:16
    |
 LL | fn listener(_: std::net::TcpListener) {}
    |                ^^^^^^^^^^^^^^^^^^^^^
 
 error: `std::collections::HashMap` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:34:48
+  --> $DIR/conf_disallowed_types.rs:36:48
    |
 LL |     let _: std::collections::HashMap<(), ()> = std::collections::HashMap::new();
    |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `std::collections::HashMap` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:34:12
+  --> $DIR/conf_disallowed_types.rs:36:12
    |
 LL |     let _: std::collections::HashMap<(), ()> = std::collections::HashMap::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `std::time::Instant` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:35:13
+  --> $DIR/conf_disallowed_types.rs:37:13
    |
 LL |     let _ = Sneaky::now();
    |             ^^^^^^
 
 error: `std::sync::atomic::AtomicU32` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:36:13
+  --> $DIR/conf_disallowed_types.rs:38:13
    |
 LL |     let _ = foo::atomic::AtomicU32::new(0);
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `std::sync::atomic::AtomicU32` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:37:17
+  --> $DIR/conf_disallowed_types.rs:39:17
    |
 LL |     static FOO: std::sync::atomic::AtomicU32 = foo::atomic::AtomicU32::new(1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `std::sync::atomic::AtomicU32` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:37:48
+  --> $DIR/conf_disallowed_types.rs:39:48
    |
 LL |     static FOO: std::sync::atomic::AtomicU32 = foo::atomic::AtomicU32::new(1);
    |                                                ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `syn::TypePath` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:38:43
+  --> $DIR/conf_disallowed_types.rs:40:43
    |
 LL |     let _: std::collections::BTreeMap<(), syn::TypePath> = Default::default();
    |                                           ^^^^^^^^^^^^^
 
 error: `syn::Ident` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:39:13
+  --> $DIR/conf_disallowed_types.rs:41:13
    |
 LL |     let _ = syn::Ident::new("", todo!());
    |             ^^^^^^^^^^
 
 error: `usize` is not allowed according to config
-  --> $DIR/conf_disallowed_types.rs:41:12
+  --> $DIR/conf_disallowed_types.rs:43:12
    |
 LL |     let _: usize = 64_usize;
    |            ^^^^^
 
-error: aborting due to 21 previous errors
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
I am unsure if this is the right level of abstraction to work at for this feature. There doesn't seem to be an easy way to get a span of the config file to point to what directly was unresolved. This does note what entry is unresolved though so the user can see what may have been removed or is invalid for disallowed macros, types and methods.

changelog: [`disallowed_macros`]:  warn if unresolved macro is disallowed, [`disallowed_types`]:  warn if unresolved type is disallowed, [`disallowed_methods`]: warn if unresolved method is disallowed
