### PR TITLE
fix manual_filter false positive

### DIFF
--- a/tests/ui/manual_filter.fixed
+++ b/tests/ui/manual_filter.fixed
@@ -139,6 +139,20 @@ fn main() {
     } else {
         None
     };
+
+    let allowed_integers = vec![3, 4, 5, 6];
+    // Don't lint, since there's a side effect in the else branch
+    match Some(21) {
+        Some(x) => {
+            if allowed_integers.contains(&x) {
+                Some(x)
+            } else {
+                println!("Invalid integer: {x:?}");
+                None
+            }
+        },
+        None => None,
+    };
 }
 
 fn maybe_some() -> Option<u32> {

--- a/tests/ui/manual_filter.fixed
+++ b/tests/ui/manual_filter.fixed
@@ -116,4 +116,31 @@ fn main() {
         },
         None => None,
     };
+
+    match Some(20) {
+        // Don't Lint, because `Some(3*x)` is not `None`
+        None => None,
+        Some(x) => {
+            if x > 0 {
+                Some(3 * x)
+            } else {
+                Some(x)
+            }
+        },
+    };
+
+    // Don't lint: https://github.com/rust-lang/rust-clippy/issues/10088
+    let result = if let Some(a) = maybe_some() {
+        if let Some(b) = maybe_some() {
+            Some(a + b)
+        } else {
+            Some(a)
+        }
+    } else {
+        None
+    };
+}
+
+fn maybe_some() -> Option<u32> {
+    Some(0)
 }

--- a/tests/ui/manual_filter.rs
+++ b/tests/ui/manual_filter.rs
@@ -240,4 +240,31 @@ fn main() {
         },
         None => None,
     };
+
+    match Some(20) {
+        // Don't Lint, because `Some(3*x)` is not `None`
+        None => None,
+        Some(x) => {
+            if x > 0 {
+                Some(3 * x)
+            } else {
+                Some(x)
+            }
+        },
+    };
+
+    // Don't lint: https://github.com/rust-lang/rust-clippy/issues/10088
+    let result = if let Some(a) = maybe_some() {
+        if let Some(b) = maybe_some() {
+            Some(a + b)
+        } else {
+            Some(a)
+        }
+    } else {
+        None
+    };
+}
+
+fn maybe_some() -> Option<u32> {
+    Some(0)
 }

--- a/tests/ui/manual_filter.rs
+++ b/tests/ui/manual_filter.rs
@@ -263,6 +263,20 @@ fn main() {
     } else {
         None
     };
+
+    let allowed_integers = vec![3, 4, 5, 6];
+    // Don't lint, since there's a side effect in the else branch
+    match Some(21) {
+        Some(x) => {
+            if allowed_integers.contains(&x) {
+                Some(x)
+            } else {
+                println!("Invalid integer: {x:?}");
+                None
+            }
+        },
+        None => None,
+    };
 }
 
 fn maybe_some() -> Option<u32> {


### PR DESCRIPTION
fixes #10088 
fixes #9766

changelog: FP: [`manual_filter`]: Now ignores if expressions where the else branch has side effects or doesn't return `None`
[#10091](https://github.com/rust-lang/rust-clippy/pull/10091)
<!-- changelog_checked -->
