### PR TITLE
Move manual_clamp to nursery

### DIFF
--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -35,6 +35,9 @@ declare_clippy_lint! {
     /// Some may consider panicking in these situations to be desirable, but it also may
     /// introduce panicking where there wasn't any before.
     ///
+    /// See also [the discussion in the
+    /// PR](https://github.com/rust-lang/rust-clippy/pull/9484#issuecomment-1278922613).
+    ///
     /// ### Examples
     /// ```rust
     /// # let (input, min, max) = (0, -2, 1);
@@ -78,7 +81,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.66.0"]
     pub MANUAL_CLAMP,
-    complexity,
+    nursery,
     "using a clamp pattern instead of the clamp function"
 }
 impl_lint_pass!(ManualClamp => [MANUAL_CLAMP]);


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust-clippy/pull/9484#issuecomment-1278922613 and decided in the [Zulip meeting](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Meeting.202022-12-13/near/315626226)

changelog: Moved [`manual_clamp`] to `nursery` (Now allow-by-default)
[#10101](https://github.com/rust-lang/rust-clippy/pull/10101)
<!-- changelog_checked -->