### PR TITLE
Fix FP in `unnecessary_safety_comment`

### DIFF
--- a/tests/ui/unnecessary_safety_comment.rs
+++ b/tests/ui/unnecessary_safety_comment.rs
@@ -48,4 +48,21 @@ fn unnecessary_on_stmt_and_expr() -> u32 {
     24
 }
 
+mod issue_10084 {
+    unsafe fn bar() -> i32 {
+        42
+    }
+
+    macro_rules! foo {
+        () => {
+            // SAFETY: This is necessary
+            unsafe { bar() }
+        };
+    }
+
+    fn main() {
+        foo!();
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust-clippy/issues/10084

changelog: FP: [`unnecessary_safety_comment`]: No longer lints code inside macros
[#10106](https://github.com/rust-lang/rust-clippy/pull/10106)
<!-- changelog_checked -->