### PR TITLE
Suggest using Path for comparing extensions

### DIFF
--- a/clippy_lints/src/methods/case_sensitive_file_extension_comparisons.rs
+++ b/clippy_lints/src/methods/case_sensitive_file_extension_comparisons.rs
@@ -1,7 +1,9 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::is_type_lang_item;
 use if_chain::if_chain;
 use rustc_ast::ast::LitKind;
+use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, LangItem};
 use rustc_lint::LateContext;
 use rustc_span::{source_map::Spanned, Span};
@@ -28,13 +30,39 @@ pub(super) fn check<'tcx>(
         let recv_ty = cx.typeck_results().expr_ty(recv).peel_refs();
         if recv_ty.is_str() || is_type_lang_item(cx, recv_ty, LangItem::String);
         then {
-            span_lint_and_help(
+            span_lint_and_then(
                 cx,
                 CASE_SENSITIVE_FILE_EXTENSION_COMPARISONS,
-                call_span,
+                recv.span.to(call_span),
                 "case-sensitive file extension comparison",
-                None,
-                "consider using a case-insensitive comparison instead",
+                |diag| {
+                    diag.help("consider using a case-insensitive comparison instead");
+                    let mut recv_str = Sugg::hir(cx, recv, "").to_string();
+
+                    if is_type_lang_item(cx, recv_ty, LangItem::String) {
+                        recv_str = format!("&{recv_str}");
+                    }
+
+                    if recv_str.contains(".to_lowercase()") {
+                        diag.note("to_lowercase allocates memory, this can be avoided by using Path");
+                        recv_str = recv_str.replace(".to_lowercase()", "");
+                    }
+
+                    if recv_str.contains(".to_uppercase()") {
+                        diag.note("to_uppercase allocates memory, this can be avoided by using Path");
+                        recv_str = recv_str.replace(".to_uppercase()", "");
+                    }
+
+                    diag.span_suggestion(
+                        recv.span.to(call_span),
+                        "use std::path::Path",
+                        format!("std::path::Path::new({})
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case(\"{}\"))", 
+                            recv_str, ext_str.strip_prefix('.').unwrap()),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
             );
         }
     }

--- a/tests/ui/case_sensitive_file_extension_comparisons.fixed
+++ b/tests/ui/case_sensitive_file_extension_comparisons.fixed
@@ -11,24 +11,38 @@ impl TestStruct {
 
 #[allow(dead_code)]
 fn is_rust_file(filename: &str) -> bool {
-    filename.ends_with(".rs")
+    std::path::Path::new(filename)
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("rs"))
 }
 
 fn main() {
     // std::string::String and &str should trigger the lint failure with .ext12
-    let _ = String::new().ends_with(".ext12");
-    let _ = "str".ends_with(".ext12");
+    let _ = std::path::Path::new(&String::new())
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+    let _ = std::path::Path::new("str")
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
 
     // The test struct should not trigger the lint failure with .ext12
     TestStruct {}.ends_with(".ext12");
 
     // std::string::String and &str should trigger the lint failure with .EXT12
-    let _ = String::new().ends_with(".EXT12");
-    let _ = "str".ends_with(".EXT12");
+    let _ = std::path::Path::new(&String::new())
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+    let _ = std::path::Path::new("str")
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
 
     // This should print a note about how to_lowercase and to_uppercase allocates
-    let _ = String::new().to_lowercase().ends_with(".EXT12");
-    let _ = String::new().to_uppercase().ends_with(".EXT12");
+    let _ = std::path::Path::new(&String::new())
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+    let _ = std::path::Path::new(&String::new())
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
 
     // The test struct should not trigger the lint failure with .EXT12
     TestStruct {}.ends_with(".EXT12");

--- a/tests/ui/case_sensitive_file_extension_comparisons.fixed
+++ b/tests/ui/case_sensitive_file_extension_comparisons.fixed
@@ -36,13 +36,9 @@ fn main() {
         .extension()
         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
 
-    // This should print a note about how to_lowercase and to_uppercase allocates
-    let _ = std::path::Path::new(&String::new())
-        .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
-    let _ = std::path::Path::new(&String::new())
-        .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+    // Should not trigger the lint failure because of the calls to to_lowercase and to_uppercase
+    let _ = String::new().to_lowercase().ends_with(".EXT12");
+    let _ = String::new().to_uppercase().ends_with(".EXT12");
 
     // The test struct should not trigger the lint failure with .EXT12
     TestStruct {}.ends_with(".EXT12");

--- a/tests/ui/case_sensitive_file_extension_comparisons.fixed
+++ b/tests/ui/case_sensitive_file_extension_comparisons.fixed
@@ -25,6 +25,13 @@ fn main() {
         .extension()
         .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
 
+    // The fixup should preserve the indentation level
+    {
+        let _ = std::path::Path::new("str")
+            .extension()
+            .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+    }
+
     // The test struct should not trigger the lint failure with .ext12
     TestStruct {}.ends_with(".ext12");
 

--- a/tests/ui/case_sensitive_file_extension_comparisons.rs
+++ b/tests/ui/case_sensitive_file_extension_comparisons.rs
@@ -19,6 +19,11 @@ fn main() {
     let _ = String::new().ends_with(".ext12");
     let _ = "str".ends_with(".ext12");
 
+    // The fixup should preserve the indentation level
+    {
+        let _ = "str".ends_with(".ext12");
+    }
+
     // The test struct should not trigger the lint failure with .ext12
     TestStruct {}.ends_with(".ext12");
 

--- a/tests/ui/case_sensitive_file_extension_comparisons.rs
+++ b/tests/ui/case_sensitive_file_extension_comparisons.rs
@@ -26,7 +26,7 @@ fn main() {
     let _ = String::new().ends_with(".EXT12");
     let _ = "str".ends_with(".EXT12");
 
-    // This should print a note about how to_lowercase and to_uppercase allocates
+    // Should not trigger the lint failure because of the calls to to_lowercase and to_uppercase
     let _ = String::new().to_lowercase().ends_with(".EXT12");
     let _ = String::new().to_uppercase().ends_with(".EXT12");
 

--- a/tests/ui/case_sensitive_file_extension_comparisons.stderr
+++ b/tests/ui/case_sensitive_file_extension_comparisons.stderr
@@ -1,43 +1,103 @@
 error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:12:14
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:14:5
    |
 LL |     filename.ends_with(".rs")
-   |              ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a case-insensitive comparison instead
    = note: `-D clippy::case-sensitive-file-extension-comparisons` implied by `-D warnings`
+help: use std::path::Path
+   |
+LL ~     std::path::Path::new(filename)
+LL +         .extension()
+LL +         .map_or(false, |ext| ext.eq_ignore_ascii_case("rs"))
+   |
 
 error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:17:27
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:19:13
    |
 LL |     let _ = String::new().ends_with(".ext12");
-   |                           ^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new(&String::new())
+LL +         .extension()
+LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+   |
 
 error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:18:19
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:20:13
    |
 LL |     let _ = "str".ends_with(".ext12");
-   |                   ^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new("str")
+LL +         .extension()
+LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+   |
 
 error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:24:27
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:26:13
    |
 LL |     let _ = String::new().ends_with(".EXT12");
-   |                           ^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new(&String::new())
+LL +         .extension()
+LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+   |
 
 error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:25:19
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:27:13
    |
 LL |     let _ = "str".ends_with(".EXT12");
-   |                   ^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new("str")
+LL +         .extension()
+LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+   |
 
-error: aborting due to 5 previous errors
+error: case-sensitive file extension comparison
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:30:13
+   |
+LL |     let _ = String::new().to_lowercase().ends_with(".EXT12");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+   = note: to_lowercase allocates memory, this can be avoided by using Path
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new(&String::new())
+LL +         .extension()
+LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+   |
+
+error: case-sensitive file extension comparison
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:31:13
+   |
+LL |     let _ = String::new().to_uppercase().ends_with(".EXT12");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+   = note: to_uppercase allocates memory, this can be avoided by using Path
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new(&String::new())
+LL +         .extension()
+LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+   |
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/case_sensitive_file_extension_comparisons.stderr
+++ b/tests/ui/case_sensitive_file_extension_comparisons.stderr
@@ -69,35 +69,5 @@ LL +         .extension()
 LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
    |
 
-error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:30:13
-   |
-LL |     let _ = String::new().to_lowercase().ends_with(".EXT12");
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using a case-insensitive comparison instead
-   = note: to_lowercase allocates memory, this can be avoided by using Path
-help: use std::path::Path
-   |
-LL ~     let _ = std::path::Path::new(&String::new())
-LL +         .extension()
-LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
-   |
-
-error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:31:13
-   |
-LL |     let _ = String::new().to_uppercase().ends_with(".EXT12");
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using a case-insensitive comparison instead
-   = note: to_uppercase allocates memory, this can be avoided by using Path
-help: use std::path::Path
-   |
-LL ~     let _ = std::path::Path::new(&String::new())
-LL +         .extension()
-LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
-   |
-
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/case_sensitive_file_extension_comparisons.stderr
+++ b/tests/ui/case_sensitive_file_extension_comparisons.stderr
@@ -42,7 +42,21 @@ LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
    |
 
 error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:26:13
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:24:17
+   |
+LL |         let _ = "str".ends_with(".ext12");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~         let _ = std::path::Path::new("str")
+LL +             .extension()
+LL ~             .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+   |
+
+error: case-sensitive file extension comparison
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:31:13
    |
 LL |     let _ = String::new().ends_with(".EXT12");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +70,7 @@ LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
    |
 
 error: case-sensitive file extension comparison
-  --> $DIR/case_sensitive_file_extension_comparisons.rs:27:13
+  --> $DIR/case_sensitive_file_extension_comparisons.rs:32:13
    |
 LL |     let _ = "str".ends_with(".EXT12");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,5 +83,5 @@ LL +         .extension()
 LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
    |
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes #10042 

changelog: Sugg: [`case_sensitive_file_extension_comparisons`]: Now displays a suggestion with `Path`
[#10107](https://github.com/rust-lang/rust-clippy/pull/10107)
<!-- changelog_checked -->
