### PR TITLE
Fix FN in `needless_return`

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -210,22 +210,25 @@ fn check_final_expr<'tcx>(
             // if desugar of `do yeet`, don't lint
             if let Some(inner_expr) = inner
                 && let ExprKind::Call(path_expr, _) = inner_expr.kind
-                && let ExprKind::Path(QPath::LangItem(LangItem::TryTraitFromYeet, _, _)) = path_expr.kind {
-                    return;
+                && let ExprKind::Path(QPath::LangItem(LangItem::TryTraitFromYeet, _, _)) = path_expr.kind
+            {
+                return;
             }
-            if cx.tcx.hir().attrs(expr.hir_id).is_empty() {
-                let borrows = inner.map_or(false, |inner| last_statement_borrows(cx, inner));
-                if !borrows {
-                    // check if expr return nothing
-                    let ret_span = if inner.is_none() && replacement == RetReplacement::Empty {
-                        extend_span_to_previous_non_ws(cx, peeled_drop_expr.span)
-                    } else {
-                        peeled_drop_expr.span
-                    };
+            if !cx.tcx.hir().attrs(expr.hir_id).is_empty() {
+                return;
+            }
+            let borrows = inner.map_or(false, |inner| last_statement_borrows(cx, inner));
+            if borrows {
+                return;
+            }
+            // check if expr return nothing
+            let ret_span = if inner.is_none() && replacement == RetReplacement::Empty {
+                extend_span_to_previous_non_ws(cx, peeled_drop_expr.span)
+            } else {
+                peeled_drop_expr.span
+            };
 
-                    emit_return_lint(cx, ret_span, semi_spans, inner.as_ref().map(|i| i.span), replacement);
-                }
-            }
+            emit_return_lint(cx, ret_span, semi_spans, inner.as_ref().map(|i| i.span), replacement);
         },
         ExprKind::If(_, then, else_clause_opt) => {
             check_block_return(cx, &then.kind, semi_spans.clone());

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -295,7 +295,7 @@ fn last_statement_borrows<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) 
         {
             ControlFlow::Break(())
         } else {
-            ControlFlow::Continue(Descend::from(!expr.span.from_expansion()))
+            ControlFlow::Continue(Descend::from(!e.span.from_expansion()))
         }
     })
     .is_some()

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -277,4 +277,14 @@ fn issue9947() -> Result<(), String> {
     do yeet "hello";
 }
 
+// without anyhow, but triggers the same bug I believe
+#[expect(clippy::useless_format)]
+fn issue10051() -> Result<String, String> {
+    if true {
+        Ok(format!("ok!"))
+    } else {
+        Err(format!("err!"))
+    }
+}
+
 fn main() {}

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -287,4 +287,14 @@ fn issue9947() -> Result<(), String> {
     do yeet "hello";
 }
 
+// without anyhow, but triggers the same bug I believe
+#[expect(clippy::useless_format)]
+fn issue10051() -> Result<String, String> {
+    if true {
+        return Ok(format!("ok!"));
+    } else {
+        return Err(format!("err!"));
+    }
+}
+
 fn main() {}

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -386,5 +386,21 @@ LL |         let _ = 42; return;
    |
    = help: remove `return`
 
-error: aborting due to 46 previous errors
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:294:9
+   |
+LL |         return Ok(format!("ok!"));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: unneeded `return` statement
+  --> $DIR/needless_return.rs:296:9
+   |
+LL |         return Err(format!("err!"));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `return`
+
+error: aborting due to 48 previous errors
 


### PR DESCRIPTION
Fixes #10051

changelog: Enhancement: [`needless_return`]: Now detects more cases for returns of owned values
[#10110](https://github.com/rust-lang/rust-clippy/pull/10110)
<!-- changelog_checked -->