### PR TITLE
fix incorrect suggestion in `suboptimal_flops`

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -324,7 +324,7 @@ fn check_powi(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, args: 
                     let maybe_neg_sugg = |expr, hir_id| {
                         let sugg = Sugg::hir(cx, expr, "..");
                         if matches!(op, BinOpKind::Sub) && hir_id == rhs.hir_id {
-                            format!("-{sugg}")
+                            format!("-{}", sugg.maybe_par())
                         } else {
                             sugg.to_string()
                         }

--- a/tests/ui/floating_point_powi.fixed
+++ b/tests/ui/floating_point_powi.fixed
@@ -14,6 +14,15 @@ fn main() {
     let _ = (y as f32).mul_add(y as f32, x);
     let _ = x.mul_add(x, y).sqrt();
     let _ = y.mul_add(y, x).sqrt();
+
+    let _ = (x - 1.0).mul_add(x - 1.0, -y);
+    let _ = (x - 1.0).mul_add(x - 1.0, -y) + 3.0;
+    let _ = (x - 1.0).mul_add(x - 1.0, -(y + 3.0));
+    let _ = (y + 1.0).mul_add(-(y + 1.0), x);
+    let _ = (3.0 * y).mul_add(-(3.0 * y), x);
+    let _ = (y + 1.0 + x).mul_add(-(y + 1.0 + x), x);
+    let _ = (y + 1.0 + 2.0).mul_add(-(y + 1.0 + 2.0), x);
+
     // Cases where the lint shouldn't be applied
     let _ = x.powi(2);
     let _ = x.powi(1 + 1);

--- a/tests/ui/floating_point_powi.rs
+++ b/tests/ui/floating_point_powi.rs
@@ -14,6 +14,15 @@ fn main() {
     let _ = x + (y as f32).powi(2);
     let _ = (x.powi(2) + y).sqrt();
     let _ = (x + y.powi(2)).sqrt();
+
+    let _ = (x - 1.0).powi(2) - y;
+    let _ = (x - 1.0).powi(2) - y + 3.0;
+    let _ = (x - 1.0).powi(2) - (y + 3.0);
+    let _ = x - (y + 1.0).powi(2);
+    let _ = x - (3.0 * y).powi(2);
+    let _ = x - (y + 1.0 + x).powi(2);
+    let _ = x - (y + 1.0 + 2.0).powi(2);
+
     // Cases where the lint shouldn't be applied
     let _ = x.powi(2);
     let _ = x.powi(1 + 1);

--- a/tests/ui/floating_point_powi.stderr
+++ b/tests/ui/floating_point_powi.stderr
@@ -42,5 +42,47 @@ error: multiply and add expressions can be calculated more efficiently and accur
 LL |     let _ = (x + y.powi(2)).sqrt();
    |             ^^^^^^^^^^^^^^^ help: consider using: `y.mul_add(y, x)`
 
-error: aborting due to 7 previous errors
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:18:13
+   |
+LL |     let _ = (x - 1.0).powi(2) - y;
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x - 1.0).mul_add(x - 1.0, -y)`
+
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:19:13
+   |
+LL |     let _ = (x - 1.0).powi(2) - y + 3.0;
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x - 1.0).mul_add(x - 1.0, -y)`
+
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:20:13
+   |
+LL |     let _ = (x - 1.0).powi(2) - (y + 3.0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(x - 1.0).mul_add(x - 1.0, -(y + 3.0))`
+
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:21:13
+   |
+LL |     let _ = x - (y + 1.0).powi(2);
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(y + 1.0).mul_add(-(y + 1.0), x)`
+
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:22:13
+   |
+LL |     let _ = x - (3.0 * y).powi(2);
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(3.0 * y).mul_add(-(3.0 * y), x)`
+
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:23:13
+   |
+LL |     let _ = x - (y + 1.0 + x).powi(2);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(y + 1.0 + x).mul_add(-(y + 1.0 + x), x)`
+
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_powi.rs:24:13
+   |
+LL |     let _ = x - (y + 1.0 + 2.0).powi(2);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(y + 1.0 + 2.0).mul_add(-(y + 1.0 + 2.0), x)`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
fixes #10003

There was an error when trying to negate an expression like `x - 1.0`. We used to format it as `-x - 1.0` whereas a proper negation would be `-(x - 1.0)`.

Therefore, we add parentheses around the expression when it is `ExprKind::Binary`.

We also add parentheses around multiply and divide expressions, even though this is not strictly necessary.

changelog: [`suboptimal_flops`]: fix incorrect suggestion caused by an incorrect negation of floating point expressions.