### PR TITLE
Move `mutex_atomic` to `restriction`

### DIFF
--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub MUTEX_ATOMIC,
-    nursery,
+    restriction,
     "using a mutex where an atomic value could be used instead"
 }
 

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -1,6 +1,6 @@
 //! Checks for uses of mutex where an atomic value could be used
 //!
-//! This lint is **warn** by default
+//! This lint is **allow** by default
 
 use clippy_utils::diagnostics::span_lint;
 use clippy_utils::ty::is_type_diagnostic_item;
@@ -19,6 +19,10 @@ declare_clippy_lint! {
     /// reference sequential is shooting flies with cannons.
     /// `std::sync::atomic::AtomicBool` and `std::sync::atomic::AtomicPtr` are leaner and
     /// faster.
+    ///
+    /// On the other hand, `Mutex`es are, in general, easier to
+    /// verify correctness. An atomic does not behave the same as
+    /// an equivalent mutex. See [this issue](https://github.com/rust-lang/rust-clippy/issues/4295)'s commentary for more details.
     ///
     /// ### Known problems
     /// This lint cannot detect if the mutex is actually used
@@ -40,7 +44,7 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub MUTEX_ATOMIC,
     restriction,
-    "using a mutex where an atomic value could be used instead"
+    "using a mutex where an atomic value could be used instead."
 }
 
 declare_clippy_lint! {


### PR DESCRIPTION
By #4295, the general consensus seems to be that `mutex_atomic` is not a useful lint in most cases. If anything, it could be useful as a restriction on code that for whatever reason can't use atomics. Keeping it in `clippy::nursery` is harmful to people attempting to use clippy for soundness.

---

changelog: Moved [`mutex_atomic`] to `restriction`
[#10115](https://github.com/rust-lang/rust-clippy/pull/10115)
<!-- chnagelog_checked -->