### PR TITLE
fix codeblocks in the document

### DIFF
--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -558,8 +558,8 @@ impl fmt::Display for ClippyConfiguration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "* `{}`: `{}`: {} (defaults to `{}`)",
-            self.name, self.config_type, self.doc, self.default
+            "* `{}`: `{}`(defaults to `{}`): {}",
+            self.name, self.config_type, self.default, self.doc
         )
     }
 }


### PR DESCRIPTION
While I've looked into https://github.com/rust-lang/rust-clippy/issues/9990, I found broken code blocks in the document.

This patch not only improves visibility, but also fixes a potential bug. When a lint description ends with code block, the string will have three backquotes at the end.
Since the current implementation prints the default value immediately after that, the markdown renderer is unable to properly close the code block.

e.g. `arithmetic_side_effects`, we can see code block is not rendered properly, and (I think) it's bit hard to understand what ``"defaults to `[]`"`` is meant.

![2022-12-26_01-51](https://user-images.githubusercontent.com/14945055/209476342-4d0b2e18-44b6-4c74-8c3c-4f4f0904e8ca.png)

In this PR, it will be rendered as:

![image](https://user-images.githubusercontent.com/14945055/209476353-07587b86-1100-445f-946d-41f62f741e51.png)

changelog: none

r? @xFrednet
