### PR TITLE
reword dbg_macro labels

### DIFF
--- a/clippy_lints/src/dbg_macro.rs
+++ b/clippy_lints/src/dbg_macro.rs
@@ -10,11 +10,11 @@ use rustc_span::sym;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of dbg!() macro.
+    /// Checks for usage of the [`dbg!`](https://doc.rust-lang.org/std/macro.dbg.html) macro.
     ///
     /// ### Why is this bad?
-    /// `dbg!` macro is intended as a debugging tool. It
-    /// should not be in version control.
+    /// The `dbg!` macro is intended as a debugging tool. It should not be present in released
+    /// software or committed to a version control system.
     ///
     /// ### Example
     /// ```rust,ignore
@@ -91,8 +91,8 @@ impl LateLintPass<'_> for DbgMacro {
                 cx,
                 DBG_MACRO,
                 macro_call.span,
-                "`dbg!` macro is intended as a debugging tool",
-                "ensure to avoid having uses of it in version control",
+                "the `dbg!` macro is intended as a debugging tool",
+                "remove the invocation before committing it to a version control system",
                 suggestion,
                 applicability,
             );

--- a/tests/ui-toml/dbg_macro/dbg_macro.stderr
+++ b/tests/ui-toml/dbg_macro/dbg_macro.stderr
@@ -1,99 +1,99 @@
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:5:22
    |
 LL |     if let Some(n) = dbg!(n.checked_sub(4)) { n } else { n }
    |                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::dbg-macro` implied by `-D warnings`
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     if let Some(n) = n.checked_sub(4) { n } else { n }
    |                      ~~~~~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:9:8
    |
 LL |     if dbg!(n <= 1) {
    |        ^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     if n <= 1 {
    |        ~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:10:9
    |
 LL |         dbg!(1)
    |         ^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |         1
    |
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:12:9
    |
 LL |         dbg!(n * factorial(n - 1))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |         n * factorial(n - 1)
    |
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:17:5
    |
 LL |     dbg!(42);
    |     ^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     42;
    |     ~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:18:5
    |
 LL |     dbg!(dbg!(dbg!(42)));
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     dbg!(dbg!(42));
    |     ~~~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:19:14
    |
 LL |     foo(3) + dbg!(factorial(4));
    |              ^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     foo(3) + factorial(4);
    |              ~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:20:5
    |
 LL |     dbg!(1, 2, dbg!(3, 4));
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     (1, 2, dbg!(3, 4));
    |     ~~~~~~~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:21:5
    |
 LL |     dbg!(1, 2, 3, 4, 5);
    |     ^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     (1, 2, 3, 4, 5);
    |     ~~~~~~~~~~~~~~~

--- a/tests/ui/dbg_macro.stderr
+++ b/tests/ui/dbg_macro.stderr
@@ -1,143 +1,143 @@
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:5:22
    |
 LL |     if let Some(n) = dbg!(n.checked_sub(4)) { n } else { n }
    |                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::dbg-macro` implied by `-D warnings`
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     if let Some(n) = n.checked_sub(4) { n } else { n }
    |                      ~~~~~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:9:8
    |
 LL |     if dbg!(n <= 1) {
    |        ^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     if n <= 1 {
    |        ~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:10:9
    |
 LL |         dbg!(1)
    |         ^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |         1
    |
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:12:9
    |
 LL |         dbg!(n * factorial(n - 1))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |         n * factorial(n - 1)
    |
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:17:5
    |
 LL |     dbg!(42);
    |     ^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     42;
    |     ~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:18:5
    |
 LL |     dbg!(dbg!(dbg!(42)));
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     dbg!(dbg!(42));
    |     ~~~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:19:14
    |
 LL |     foo(3) + dbg!(factorial(4));
    |              ^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     foo(3) + factorial(4);
    |              ~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:20:5
    |
 LL |     dbg!(1, 2, dbg!(3, 4));
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     (1, 2, dbg!(3, 4));
    |     ~~~~~~~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:21:5
    |
 LL |     dbg!(1, 2, 3, 4, 5);
    |     ^^^^^^^^^^^^^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     (1, 2, 3, 4, 5);
    |     ~~~~~~~~~~~~~~~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:41:9
    |
 LL |         dbg!(2);
    |         ^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |         2;
    |         ~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:47:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     1;
    |     ~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:52:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |     1;
    |     ~
 
-error: `dbg!` macro is intended as a debugging tool
+error: the `dbg!` macro is intended as a debugging tool
   --> $DIR/dbg_macro.rs:58:9
    |
 LL |         dbg!(1);
    |         ^^^^^^^
    |
-help: ensure to avoid having uses of it in version control
+help: remove the invocation before committing it to a version control system
    |
 LL |         1;
    |         ~


### PR DESCRIPTION
---

This change rewords the `dbg_macro` lint labels to be clearer.

changelog: none
<!-- changelog_checked -->
