### PR TITLE
Fix typo in `unused_self` diagnostic message

### DIFF
--- a/clippy_lints/src/unused_self.rs
+++ b/clippy_lints/src/unused_self.rs
@@ -72,7 +72,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedSelf {
                     self_param.span,
                     "unused `self` argument",
                     None,
-                    "consider refactoring to a associated function",
+                    "consider refactoring to an associated function",
                 );
             }
         }

--- a/tests/ui/unused_self.stderr
+++ b/tests/ui/unused_self.stderr
@@ -4,7 +4,7 @@ error: unused `self` argument
 LL |         fn unused_self_move(self) {}
    |                             ^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
    = note: `-D clippy::unused-self` implied by `-D warnings`
 
 error: unused `self` argument
@@ -13,7 +13,7 @@ error: unused `self` argument
 LL |         fn unused_self_ref(&self) {}
    |                            ^^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: unused `self` argument
   --> $DIR/unused_self.rs:13:32
@@ -21,7 +21,7 @@ error: unused `self` argument
 LL |         fn unused_self_mut_ref(&mut self) {}
    |                                ^^^^^^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: unused `self` argument
   --> $DIR/unused_self.rs:14:32
@@ -29,7 +29,7 @@ error: unused `self` argument
 LL |         fn unused_self_pin_ref(self: Pin<&Self>) {}
    |                                ^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: unused `self` argument
   --> $DIR/unused_self.rs:15:36
@@ -37,7 +37,7 @@ error: unused `self` argument
 LL |         fn unused_self_pin_mut_ref(self: Pin<&mut Self>) {}
    |                                    ^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: unused `self` argument
   --> $DIR/unused_self.rs:16:35
@@ -45,7 +45,7 @@ error: unused `self` argument
 LL |         fn unused_self_pin_nested(self: Pin<Arc<Self>>) {}
    |                                   ^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: unused `self` argument
   --> $DIR/unused_self.rs:17:28
@@ -53,7 +53,7 @@ error: unused `self` argument
 LL |         fn unused_self_box(self: Box<Self>) {}
    |                            ^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: unused `self` argument
   --> $DIR/unused_self.rs:18:40
@@ -61,7 +61,7 @@ error: unused `self` argument
 LL |         fn unused_with_other_used_args(&self, x: u8, y: u8) -> u8 {
    |                                        ^^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: unused `self` argument
   --> $DIR/unused_self.rs:21:37
@@ -69,7 +69,7 @@ error: unused `self` argument
 LL |         fn unused_self_class_method(&self) {
    |                                     ^^^^^
    |
-   = help: consider refactoring to a associated function
+   = help: consider refactoring to an associated function
 
 error: aborting due to 9 previous errors
 


### PR DESCRIPTION
changelog: Msg: [`unused_self`]: The message now correctly uses *an*
[#10138](https://github.com/rust-lang/rust-clippy/pull/10138)
<!-- changelog_checked -->