### PR TITLE
chore: add simple comment for `get_enclosing_block`

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1304,6 +1304,7 @@ pub fn get_parent_expr_for_hir<'tcx>(cx: &LateContext<'tcx>, hir_id: hir::HirId)
     }
 }
 
+/// Gets the enclosing block, if any.
 pub fn get_enclosing_block<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<&'tcx Block<'tcx>> {
     let map = &cx.tcx.hir();
     let enclosing_node = map


### PR DESCRIPTION
I was reading the code of `clippy_utils/src/lib.rs` and thought that adding comment on `get_closing_block` would be helpful to first time visitor.

---

changelog: none
<!-- changelog_checked -->