### PR TITLE
fix empty_structs_with_brackets suggestion errors

### DIFF
--- a/clippy_lints/src/empty_structs_with_brackets.rs
+++ b/clippy_lints/src/empty_structs_with_brackets.rs
@@ -45,7 +45,7 @@ impl EarlyLintPass for EmptyStructsWithBrackets {
                         span_after_ident,
                         "remove the brackets",
                         ";",
-                        Applicability::MachineApplicable);
+                        Applicability::Unspecified);
                     },
             );
         }


### PR DESCRIPTION
fixes #9887

I refer to [my comment](https://github.com/rust-lang/rust-clippy/issues/9887#issuecomment-1368495395) to explain this PR.

---

changelog: Sugg: [`empty_structs_with_brackets`]: The suggestion is no longer machine applicable, to avoid errors when accessing struct fields
[#10141](https://github.com/rust-lang/rust-clippy/pull/10141)
<!-- changelog_checked -->