### PR TITLE
Use `HybridBitSet`s in `possible_borrower`

### DIFF
--- a/tests/ui/possible_borrower.rs
+++ b/tests/ui/possible_borrower.rs
@@ -1,0 +1,15 @@
+fn meow(_s: impl AsRef<str>) {}
+
+macro_rules! quad {
+    ($x:stmt) => {
+        $x
+        $x
+        $x
+        $x
+    };
+}
+
+fn main() {
+    let i = 0;
+    quad!(quad!(quad!(quad!(quad!(meow(format!("abc{i}")))))));
+}


### PR DESCRIPTION
This is an attempt to address #10134.

r? @Jarcho

---

changelog: Enhancement: [`redundant_clone`]: Improved performance and memory usage
[#10144](https://github.com/rust-lang/rust-clippy/pull/10144)
<!-- changelog_checked -->