### PR TITLE
Fix FP of single-element-loop

### DIFF
--- a/clippy_lints/src/loops/single_element_loop.rs
+++ b/clippy_lints/src/loops/single_element_loop.rs
@@ -1,7 +1,7 @@
 use super::SINGLE_ELEMENT_LOOP;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::{indent_of, snippet_with_applicability};
-use clippy_utils::visitors::for_each_expr;
+use clippy_utils::visitors::contains_break_or_continue;
 use if_chain::if_chain;
 use rustc_ast::util::parser::PREC_PREFIX;
 use rustc_ast::Mutability;
@@ -9,18 +9,6 @@ use rustc_errors::Applicability;
 use rustc_hir::{is_range_literal, BorrowKind, Expr, ExprKind, Pat};
 use rustc_lint::LateContext;
 use rustc_span::edition::Edition;
-use std::ops::ControlFlow;
-
-fn contains_break_or_continue(expr: &Expr<'_>) -> bool {
-    for_each_expr(expr, |e| {
-        if matches!(e.kind, ExprKind::Break(..) | ExprKind::Continue(..)) {
-            ControlFlow::Break(())
-        } else {
-            ControlFlow::Continue(())
-        }
-    })
-    .is_some()
-}
 
 pub(super) fn check<'tcx>(
     cx: &LateContext<'tcx>,

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -724,3 +724,14 @@ pub fn for_each_local_assignment<'tcx, B>(
         ControlFlow::Continue(())
     }
 }
+
+pub fn contains_break_or_continue(expr: &Expr<'_>) -> bool {
+    for_each_expr(expr, |e| {
+        if matches!(e.kind, ExprKind::Break(..) | ExprKind::Continue(..)) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .is_some()
+}

--- a/tests/ui/single_element_loop.fixed
+++ b/tests/ui/single_element_loop.fixed
@@ -33,4 +33,31 @@ fn main() {
         let item = 0..5;
         dbg!(item);
     }
+
+    // should not lint (issue #10018)
+    for e in [42] {
+        if e > 0 {
+            continue;
+        }
+    }
+
+    // should not lint (issue #10018)
+    for e in [42] {
+        if e > 0 {
+            break;
+        }
+    }
+
+    // should lint (issue #10018)
+    {
+        let _ = 42;
+        let _f = |n: u32| {
+            for i in 0..n {
+                if i > 10 {
+                    dbg!(i);
+                    break;
+                }
+            }
+        };
+    }
 }

--- a/tests/ui/single_element_loop.rs
+++ b/tests/ui/single_element_loop.rs
@@ -27,4 +27,30 @@ fn main() {
     for item in [0..5].into_iter() {
         dbg!(item);
     }
+
+    // should not lint (issue #10018)
+    for e in [42] {
+        if e > 0 {
+            continue;
+        }
+    }
+
+    // should not lint (issue #10018)
+    for e in [42] {
+        if e > 0 {
+            break;
+        }
+    }
+
+    // should lint (issue #10018)
+    for _ in [42] {
+        let _f = |n: u32| {
+            for i in 0..n {
+                if i > 10 {
+                    dbg!(i);
+                    break;
+                }
+            }
+        };
+    }
 }

--- a/tests/ui/single_element_loop.stderr
+++ b/tests/ui/single_element_loop.stderr
@@ -95,5 +95,32 @@ LL +         dbg!(item);
 LL +     }
    |
 
-error: aborting due to 6 previous errors
+error: for loop over a single element
+  --> $DIR/single_element_loop.rs:46:5
+   |
+LL | /     for _ in [42] {
+LL | |         let _f = |n: u32| {
+LL | |             for i in 0..n {
+LL | |                 if i > 10 {
+...  |
+LL | |         };
+LL | |     }
+   | |_____^
+   |
+help: try
+   |
+LL ~     {
+LL +         let _ = 42;
+LL +         let _f = |n: u32| {
+LL +             for i in 0..n {
+LL +                 if i > 10 {
+LL +                     dbg!(i);
+LL +                     break;
+LL +                 }
+LL +             }
+LL +         };
+LL +     }
+   |
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
closes #10018

---

changelog: [`single_element_loop`]: No longer lints, if the loop contains a `break` or `continue`
[#10162](https://github.com/rust-lang/rust-clippy/pull/10162)
<!-- changelog_checked -->