### PR TITLE
[#10167] Clarify that the lint only works if x eq. y in a `for` loop.

### DIFF
--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -103,7 +103,7 @@ declare_clippy_lint! {
 declare_clippy_lint! {
     /// ### What it does
     /// Checks for range expressions `x..y` where both `x` and `y`
-    /// are constant and `x` is greater or equal to `y`.
+    /// are constant and `x` is greater to `y`. Also triggers if `x` is equal to `y` when they are conditions to a `for` loop.
     ///
     /// ### Why is this bad?
     /// Empty ranges yield no values so iterating them is a no-op.


### PR DESCRIPTION
Reading the documentation for the lint, one could expect that the lint works in all cases that `X == Y`. This is false.

While the lint was updated, the documentation wasn't.

More information about the `N..N` problem in #5689 and #5628

---

Fixes #10167 
changelog: [`reversed_empty_ranges`]: Update and clarify documentation