### PR TITLE
Allow implementing`Hash` with derived `PartialEq` (`derive_hash_xor_eq`

### DIFF
--- a/tests/ui/derive_hash_xor_eq.rs
+++ b/tests/ui/derive_hash_xor_eq.rs
@@ -34,23 +34,4 @@ impl std::hash::Hash for Bah {
     fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
 }
 
-#[derive(PartialEq)]
-struct Foo2;
-
-trait Hash {}
-
-// We don't want to lint on user-defined traits called `Hash`
-impl Hash for Foo2 {}
-
-mod use_hash {
-    use std::hash::{Hash, Hasher};
-
-    #[derive(PartialEq)]
-    struct Foo3;
-
-    impl Hash for Foo3 {
-        fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
-    }
-}
-
 fn main() {}

--- a/tests/ui/derive_hash_xor_eq.stderr
+++ b/tests/ui/derive_hash_xor_eq.stderr
@@ -25,35 +25,5 @@ LL | impl PartialEq<Baz> for Baz {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: you are implementing `Hash` explicitly but have derived `PartialEq`
-  --> $DIR/derive_hash_xor_eq.rs:33:1
-   |
-LL | / impl std::hash::Hash for Bah {
-LL | |     fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
-LL | | }
-   | |_^
-   |
-note: `PartialEq` implemented here
-  --> $DIR/derive_hash_xor_eq.rs:30:10
-   |
-LL | #[derive(PartialEq)]
-   |          ^^^^^^^^^
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: you are implementing `Hash` explicitly but have derived `PartialEq`
-  --> $DIR/derive_hash_xor_eq.rs:51:5
-   |
-LL | /     impl Hash for Foo3 {
-LL | |         fn hash<H: std::hash::Hasher>(&self, _: &mut H) {}
-LL | |     }
-   | |_____^
-   |
-note: `PartialEq` implemented here
-  --> $DIR/derive_hash_xor_eq.rs:48:14
-   |
-LL |     #[derive(PartialEq)]
-   |              ^^^^^^^^^
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This is a common pattern and is totally allowed by the `Hash` trait.

Fixes #2627

changelog: [`derive_hash_xor_eq `]: allow implementing `Hash` with derived `PartialEq`
