### PR TITLE
expl_impl_clone_on_copy: ignore packed structs with type/const params

### DIFF
--- a/tests/ui/derive.rs
+++ b/tests/ui/derive.rs
@@ -85,4 +85,15 @@ impl<T: Clone, U> Clone for GenericRef<'_, T, U> {
     }
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/10188
+#[repr(packed)]
+#[derive(Copy)]
+struct Packed<T>(T);
+
+impl<T: Copy> Clone for Packed<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
changelog: [`expl_impl_clone_on_copy`]: Ignore `#[repr(packed)]` structs with type or const paramaters

Fixes #10188

A more involved solution that checks if any bound on the trait impl aren't present on the struct definition would be ideal, but I couldn't see a nice way to go about that