### PR TITLE
Move `unchecked_duration_subtraction` to pedantic

### DIFF
--- a/clippy_lints/src/instant_subtraction.rs
+++ b/clippy_lints/src/instant_subtraction.rs
@@ -61,7 +61,7 @@ declare_clippy_lint! {
     /// [`Instant::now()`]: std::time::Instant::now;
     #[clippy::version = "1.65.0"]
     pub UNCHECKED_DURATION_SUBTRACTION,
-    suspicious,
+    pedantic,
     "finds unchecked subtraction of a 'Duration' from an 'Instant'"
 }
 


### PR DESCRIPTION
changelog: [`unchecked_duration_subtraction`]: Move to pedantic

Based on https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Meeting.202023-01-10/near/320488860
