### PR TITLE
Add machine applicable suggestion for `bool_assert_comparison`

### DIFF
--- a/tests/ui/bool_assert_comparison.fixed
+++ b/tests/ui/bool_assert_comparison.fixed
@@ -86,66 +86,66 @@ fn main() {
     let b = ImplNotTraitWithBool;
 
     assert_eq!("a".len(), 1);
-    assert_eq!("a".is_empty(), false);
-    assert_eq!("".is_empty(), true);
-    assert_eq!(true, "".is_empty());
+    assert!("a".is_empty());
+    assert!("".is_empty());
+    assert!("".is_empty());
     assert_eq!(a!(), b!());
     assert_eq!(a!(), "".is_empty());
     assert_eq!("".is_empty(), b!());
     assert_eq!(a, true);
-    assert_eq!(b, true);
+    assert!(b);
 
     assert_ne!("a".len(), 1);
-    assert_ne!("a".is_empty(), false);
-    assert_ne!("".is_empty(), true);
-    assert_ne!(true, "".is_empty());
+    assert!("a".is_empty());
+    assert!("".is_empty());
+    assert!("".is_empty());
     assert_ne!(a!(), b!());
     assert_ne!(a!(), "".is_empty());
     assert_ne!("".is_empty(), b!());
     assert_ne!(a, true);
-    assert_ne!(b, true);
+    assert!(b);
 
     debug_assert_eq!("a".len(), 1);
-    debug_assert_eq!("a".is_empty(), false);
-    debug_assert_eq!("".is_empty(), true);
-    debug_assert_eq!(true, "".is_empty());
+    debug_assert!("a".is_empty());
+    debug_assert!("".is_empty());
+    debug_assert!("".is_empty());
     debug_assert_eq!(a!(), b!());
     debug_assert_eq!(a!(), "".is_empty());
     debug_assert_eq!("".is_empty(), b!());
     debug_assert_eq!(a, true);
-    debug_assert_eq!(b, true);
+    debug_assert!(b);
 
     debug_assert_ne!("a".len(), 1);
-    debug_assert_ne!("a".is_empty(), false);
-    debug_assert_ne!("".is_empty(), true);
-    debug_assert_ne!(true, "".is_empty());
+    debug_assert!("a".is_empty());
+    debug_assert!("".is_empty());
+    debug_assert!("".is_empty());
     debug_assert_ne!(a!(), b!());
     debug_assert_ne!(a!(), "".is_empty());
     debug_assert_ne!("".is_empty(), b!());
     debug_assert_ne!(a, true);
-    debug_assert_ne!(b, true);
+    debug_assert!(b);
 
     // assert with error messages
     assert_eq!("a".len(), 1, "tadam {}", 1);
     assert_eq!("a".len(), 1, "tadam {}", true);
-    assert_eq!("a".is_empty(), false, "tadam {}", 1);
-    assert_eq!("a".is_empty(), false, "tadam {}", true);
-    assert_eq!(false, "a".is_empty(), "tadam {}", true);
+    assert!("a".is_empty(), "tadam {}", 1);
+    assert!("a".is_empty(), "tadam {}", true);
+    assert!("a".is_empty(), "tadam {}", true);
     assert_eq!(a, true, "tadam {}", false);
 
     debug_assert_eq!("a".len(), 1, "tadam {}", 1);
     debug_assert_eq!("a".len(), 1, "tadam {}", true);
-    debug_assert_eq!("a".is_empty(), false, "tadam {}", 1);
-    debug_assert_eq!("a".is_empty(), false, "tadam {}", true);
-    debug_assert_eq!(false, "a".is_empty(), "tadam {}", true);
+    debug_assert!("a".is_empty(), "tadam {}", 1);
+    debug_assert!("a".is_empty(), "tadam {}", true);
+    debug_assert!("a".is_empty(), "tadam {}", true);
     debug_assert_eq!(a, true, "tadam {}", false);
 
-    assert_eq!(a!(), true);
-    assert_eq!(true, b!());
+    assert!(a!());
+    assert!(b!());
 
     use debug_assert_eq as renamed;
     renamed!(a, true);
-    renamed!(b, true);
+    debug_assert!(b);
 
     let non_copy = NonCopy;
     assert_eq!(non_copy, true);

--- a/tests/ui/bool_assert_comparison.stderr
+++ b/tests/ui/bool_assert_comparison.stderr
@@ -1,136 +1,303 @@
 error: used `assert_eq!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:69:5
-   |
-LL |     assert_eq!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-   |
-   = note: `-D clippy::bool-assert-comparison` implied by `-D warnings`
-
-error: used `assert_eq!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:70:5
-   |
-LL |     assert_eq!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_eq!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:71:5
-   |
-LL |     assert_eq!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_eq!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:76:5
-   |
-LL |     assert_eq!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_ne!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:79:5
-   |
-LL |     assert_ne!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_ne!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:80:5
-   |
-LL |     assert_ne!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_ne!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:81:5
-   |
-LL |     assert_ne!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_ne!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:86:5
-   |
-LL |     assert_ne!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:89:5
    |
-LL |     debug_assert_eq!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_eq!("a".is_empty(), false);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::bool-assert-comparison` implied by `-D warnings`
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!("a".is_empty(), false);
+LL +     assert!("a".is_empty());
+   |
 
-error: used `debug_assert_eq!` with a literal bool
+error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:90:5
    |
-LL |     debug_assert_eq!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_eq!("".is_empty(), true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!("".is_empty(), true);
+LL +     assert!("".is_empty());
+   |
 
-error: used `debug_assert_eq!` with a literal bool
+error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:91:5
    |
-LL |     debug_assert_eq!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_eq!(true, "".is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!(true, "".is_empty());
+LL +     assert!("".is_empty());
+   |
 
-error: used `debug_assert_eq!` with a literal bool
+error: used `assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:96:5
    |
-LL |     debug_assert_eq!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_eq!(b, true);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!(b, true);
+LL +     assert!(b);
+   |
 
-error: used `debug_assert_ne!` with a literal bool
+error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:99:5
    |
-LL |     debug_assert_ne!("a".is_empty(), false);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_ne!("a".is_empty(), false);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_ne!("a".is_empty(), false);
+LL +     assert!("a".is_empty());
+   |
 
-error: used `debug_assert_ne!` with a literal bool
+error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:100:5
    |
-LL |     debug_assert_ne!("".is_empty(), true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_ne!("".is_empty(), true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_ne!("".is_empty(), true);
+LL +     assert!("".is_empty());
+   |
 
-error: used `debug_assert_ne!` with a literal bool
+error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:101:5
    |
-LL |     debug_assert_ne!(true, "".is_empty());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_ne!(true, "".is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_ne!(true, "".is_empty());
+LL +     assert!("".is_empty());
+   |
 
-error: used `debug_assert_ne!` with a literal bool
+error: used `assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:106:5
    |
-LL |     debug_assert_ne!(b, true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     assert_ne!(b, true);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_ne!(b, true);
+LL +     assert!(b);
+   |
 
-error: used `assert_eq!` with a literal bool
+error: used `debug_assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:109:5
+   |
+LL |     debug_assert_eq!("a".is_empty(), false);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_eq!("a".is_empty(), false);
+LL +     debug_assert!("a".is_empty());
+   |
+
+error: used `debug_assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:110:5
+   |
+LL |     debug_assert_eq!("".is_empty(), true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_eq!("".is_empty(), true);
+LL +     debug_assert!("".is_empty());
+   |
+
+error: used `debug_assert_eq!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:111:5
    |
-LL |     assert_eq!("a".is_empty(), false, "tadam {}", 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_eq!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:112:5
+LL |     debug_assert_eq!(true, "".is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-LL |     assert_eq!("a".is_empty(), false, "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
-
-error: used `assert_eq!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:113:5
+help: replace it with `debug_assert!(..)`
    |
-LL |     assert_eq!(false, "a".is_empty(), "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
+LL -     debug_assert_eq!(true, "".is_empty());
+LL +     debug_assert!("".is_empty());
+   |
 
 error: used `debug_assert_eq!` with a literal bool
-  --> $DIR/bool_assert_comparison.rs:118:5
+  --> $DIR/bool_assert_comparison.rs:116:5
    |
-LL |     debug_assert_eq!("a".is_empty(), false, "tadam {}", 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     debug_assert_eq!(b, true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_eq!(b, true);
+LL +     debug_assert!(b);
+   |
 
-error: used `debug_assert_eq!` with a literal bool
+error: used `debug_assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:119:5
    |
-LL |     debug_assert_eq!("a".is_empty(), false, "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     debug_assert_ne!("a".is_empty(), false);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_ne!("a".is_empty(), false);
+LL +     debug_assert!("a".is_empty());
+   |
 
-error: used `debug_assert_eq!` with a literal bool
+error: used `debug_assert_ne!` with a literal bool
   --> $DIR/bool_assert_comparison.rs:120:5
    |
-LL |     debug_assert_eq!(false, "a".is_empty(), "tadam {}", true);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `debug_assert!(..)`
+LL |     debug_assert_ne!("".is_empty(), true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_ne!("".is_empty(), true);
+LL +     debug_assert!("".is_empty());
+   |
 
-error: aborting due to 22 previous errors
+error: used `debug_assert_ne!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:121:5
+   |
+LL |     debug_assert_ne!(true, "".is_empty());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_ne!(true, "".is_empty());
+LL +     debug_assert!("".is_empty());
+   |
+
+error: used `debug_assert_ne!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:126:5
+   |
+LL |     debug_assert_ne!(b, true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_ne!(b, true);
+LL +     debug_assert!(b);
+   |
+
+error: used `assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:131:5
+   |
+LL |     assert_eq!("a".is_empty(), false, "tadam {}", 1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!("a".is_empty(), false, "tadam {}", 1);
+LL +     assert!("a".is_empty(), "tadam {}", 1);
+   |
+
+error: used `assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:132:5
+   |
+LL |     assert_eq!("a".is_empty(), false, "tadam {}", true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!("a".is_empty(), false, "tadam {}", true);
+LL +     assert!("a".is_empty(), "tadam {}", true);
+   |
+
+error: used `assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:133:5
+   |
+LL |     assert_eq!(false, "a".is_empty(), "tadam {}", true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!(false, "a".is_empty(), "tadam {}", true);
+LL +     assert!("a".is_empty(), "tadam {}", true);
+   |
+
+error: used `debug_assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:138:5
+   |
+LL |     debug_assert_eq!("a".is_empty(), false, "tadam {}", 1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_eq!("a".is_empty(), false, "tadam {}", 1);
+LL +     debug_assert!("a".is_empty(), "tadam {}", 1);
+   |
+
+error: used `debug_assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:139:5
+   |
+LL |     debug_assert_eq!("a".is_empty(), false, "tadam {}", true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_eq!("a".is_empty(), false, "tadam {}", true);
+LL +     debug_assert!("a".is_empty(), "tadam {}", true);
+   |
+
+error: used `debug_assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:140:5
+   |
+LL |     debug_assert_eq!(false, "a".is_empty(), "tadam {}", true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     debug_assert_eq!(false, "a".is_empty(), "tadam {}", true);
+LL +     debug_assert!("a".is_empty(), "tadam {}", true);
+   |
+
+error: used `assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:143:5
+   |
+LL |     assert_eq!(a!(), true);
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!(a!(), true);
+LL +     assert!(a!());
+   |
+
+error: used `assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:144:5
+   |
+LL |     assert_eq!(true, b!());
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `assert!(..)`
+   |
+LL -     assert_eq!(true, b!());
+LL +     assert!(b!());
+   |
+
+error: used `debug_assert_eq!` with a literal bool
+  --> $DIR/bool_assert_comparison.rs:148:5
+   |
+LL |     renamed!(b, true);
+   |     ^^^^^^^^^^^^^^^^^
+   |
+help: replace it with `debug_assert!(..)`
+   |
+LL -     renamed!(b, true);
+LL +     debug_assert!(b);
+   |
+
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
Fixes #7598
Also closes #8118, it had already been fixed by an earlier change but I've added a test for it

changelog: [`bool_assert_comparison`] The suggestion is now machine applicable