### PR TITLE
[`unused_io_amount`]: Lint with `is_ok` and `is_err`

### DIFF
--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -65,7 +65,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedIoAmount {
                 }
             },
             hir::ExprKind::MethodCall(path, arg_0, ..) => match path.ident.as_str() {
-                "expect" | "unwrap" | "unwrap_or" | "unwrap_or_else" => {
+                "expect" | "unwrap" | "unwrap_or" | "unwrap_or_else" | "is_ok" | "is_err" => {
                     check_map_error(cx, arg_0, expr);
                 },
                 _ => (),

--- a/tests/ui/unused_io_amount.rs
+++ b/tests/ui/unused_io_amount.rs
@@ -63,6 +63,14 @@ fn combine_or(file: &str) -> Result<(), Error> {
     Ok(())
 }
 
+fn is_ok_err<T: io::Read + io::Write>(s: &mut T) {
+    s.write(b"ok").is_ok();
+    s.write(b"err").is_err();
+    let mut buf = [0u8; 0];
+    s.read(&mut buf).is_ok();
+    s.read(&mut buf).is_err();
+}
+
 async fn bad_async_write<W: AsyncWrite + Unpin>(w: &mut W) {
     w.write(b"hello world").await.unwrap();
 }

--- a/tests/ui/unused_io_amount.stderr
+++ b/tests/ui/unused_io_amount.stderr
@@ -82,13 +82,45 @@ LL | |         .expect("error");
 error: written amount is not handled
   --> $DIR/unused_io_amount.rs:67:5
    |
+LL |     s.write(b"ok").is_ok();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `Write::write_all` instead, or handle partial writes
+
+error: written amount is not handled
+  --> $DIR/unused_io_amount.rs:68:5
+   |
+LL |     s.write(b"err").is_err();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `Write::write_all` instead, or handle partial writes
+
+error: read amount is not handled
+  --> $DIR/unused_io_amount.rs:70:5
+   |
+LL |     s.read(&mut buf).is_ok();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `Read::read_exact` instead, or handle partial reads
+
+error: read amount is not handled
+  --> $DIR/unused_io_amount.rs:71:5
+   |
+LL |     s.read(&mut buf).is_err();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use `Read::read_exact` instead, or handle partial reads
+
+error: written amount is not handled
+  --> $DIR/unused_io_amount.rs:75:5
+   |
 LL |     w.write(b"hello world").await.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `AsyncWriteExt::write_all` instead, or handle partial writes
 
 error: read amount is not handled
-  --> $DIR/unused_io_amount.rs:72:5
+  --> $DIR/unused_io_amount.rs:80:5
    |
 LL |     r.read(&mut buf[..]).await.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -96,7 +128,7 @@ LL |     r.read(&mut buf[..]).await.unwrap();
    = help: use `AsyncReadExt::read_exact` instead, or handle partial reads
 
 error: written amount is not handled
-  --> $DIR/unused_io_amount.rs:85:9
+  --> $DIR/unused_io_amount.rs:93:9
    |
 LL |         w.write(b"hello world").await?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +136,7 @@ LL |         w.write(b"hello world").await?;
    = help: use `AsyncWriteExt::write_all` instead, or handle partial writes
 
 error: read amount is not handled
-  --> $DIR/unused_io_amount.rs:93:9
+  --> $DIR/unused_io_amount.rs:101:9
    |
 LL |         r.read(&mut buf[..]).await.or(Err(Error::Kind))?;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +144,7 @@ LL |         r.read(&mut buf[..]).await.or(Err(Error::Kind))?;
    = help: use `AsyncReadExt::read_exact` instead, or handle partial reads
 
 error: written amount is not handled
-  --> $DIR/unused_io_amount.rs:101:5
+  --> $DIR/unused_io_amount.rs:109:5
    |
 LL |     w.write(b"hello world").await.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,12 +152,12 @@ LL |     w.write(b"hello world").await.unwrap();
    = help: use `AsyncWriteExt::write_all` instead, or handle partial writes
 
 error: read amount is not handled
-  --> $DIR/unused_io_amount.rs:106:5
+  --> $DIR/unused_io_amount.rs:114:5
    |
 LL |     r.read(&mut buf[..]).await.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `AsyncReadExt::read_exact` instead, or handle partial reads
 
-error: aborting due to 16 previous errors
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
Fixes #10132

changelog: Apply [`unused_io_amount`] lint to `is_ok` and `is_err` without checking read/write amount
