### PR TITLE
Improve span for module_name_repetitions

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -277,7 +277,7 @@ impl LateLintPass<'_> for EnumVariantNames {
                                 Some(c) if is_word_beginning(c) => span_lint(
                                     cx,
                                     MODULE_NAME_REPETITIONS,
-                                    item.span,
+                                    item.ident.span,
                                     "item name starts with its containing module's name",
                                 ),
                                 _ => (),
@@ -287,7 +287,7 @@ impl LateLintPass<'_> for EnumVariantNames {
                             span_lint(
                                 cx,
                                 MODULE_NAME_REPETITIONS,
-                                item.span,
+                                item.ident.span,
                                 "item name ends with its containing module's name",
                             );
                         }

--- a/tests/ui/module_name_repetitions.stderr
+++ b/tests/ui/module_name_repetitions.stderr
@@ -1,34 +1,34 @@
 error: item name starts with its containing module's name
-  --> $DIR/module_name_repetitions.rs:8:5
+  --> $DIR/module_name_repetitions.rs:8:12
    |
 LL |     pub fn foo_bar() {}
-   |     ^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^
    |
    = note: `-D clippy::module-name-repetitions` implied by `-D warnings`
 
 error: item name ends with its containing module's name
-  --> $DIR/module_name_repetitions.rs:9:5
+  --> $DIR/module_name_repetitions.rs:9:12
    |
 LL |     pub fn bar_foo() {}
-   |     ^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^
 
 error: item name starts with its containing module's name
-  --> $DIR/module_name_repetitions.rs:10:5
+  --> $DIR/module_name_repetitions.rs:10:16
    |
 LL |     pub struct FooCake;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^
 
 error: item name ends with its containing module's name
-  --> $DIR/module_name_repetitions.rs:11:5
+  --> $DIR/module_name_repetitions.rs:11:14
    |
 LL |     pub enum CakeFoo {}
-   |     ^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^
 
 error: item name starts with its containing module's name
-  --> $DIR/module_name_repetitions.rs:12:5
+  --> $DIR/module_name_repetitions.rs:12:16
    |
 LL |     pub struct Foo7Bar;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
changelog: [`module_name_repetitions`]: Narrowed span to the identifier
