### PR TITLE
`invalid_regex`: Show full error when string value doesn't match source

### DIFF
--- a/tests/ui/regex.rs
+++ b/tests/ui/regex.rs
@@ -36,6 +36,10 @@ fn syntax_error() {
 
     let raw_string_error = Regex::new(r"[...\/...]");
     let raw_string_error = Regex::new(r#"[...\/...]"#);
+
+    let escaped_string_span = Regex::new("\\b\\c");
+
+    let aux_span = Regex::new("(?ixi)");
 }
 
 fn trivial_regex() {

--- a/tests/ui/regex.stderr
+++ b/tests/ui/regex.stderr
@@ -29,7 +29,10 @@ error: regex syntax error: invalid character class range, the start must be <= t
 LL |     let some_unicode = Regex::new("[é-è]");
    |                                     ^^^
 
-error: regex syntax error on position 0: unclosed group
+error: regex parse error:
+           (
+           ^
+       error: unclosed group
   --> $DIR/regex.rs:18:33
    |
 LL |     let some_regex = Regex::new(OPENING_PAREN);
@@ -43,25 +46,37 @@ LL |     let binary_pipe_in_wrong_position = BRegex::new("|");
    |
    = help: the regex is unlikely to be useful as it is
 
-error: regex syntax error on position 0: unclosed group
+error: regex parse error:
+           (
+           ^
+       error: unclosed group
   --> $DIR/regex.rs:21:41
    |
 LL |     let some_binary_regex = BRegex::new(OPENING_PAREN);
    |                                         ^^^^^^^^^^^^^
 
-error: regex syntax error on position 0: unclosed group
+error: regex parse error:
+           (
+           ^
+       error: unclosed group
   --> $DIR/regex.rs:22:56
    |
 LL |     let some_binary_regex_builder = BRegexBuilder::new(OPENING_PAREN);
    |                                                        ^^^^^^^^^^^^^
 
-error: regex syntax error on position 0: unclosed group
+error: regex parse error:
+           (
+           ^
+       error: unclosed group
   --> $DIR/regex.rs:34:37
    |
 LL |     let set_error = RegexSet::new(&[OPENING_PAREN, r"[a-z]+/.(com|org|net)"]);
    |                                     ^^^^^^^^^^^^^
 
-error: regex syntax error on position 0: unclosed group
+error: regex parse error:
+           (
+           ^
+       error: unclosed group
   --> $DIR/regex.rs:35:39
    |
 LL |     let bset_error = BRegexSet::new(&[OPENING_PAREN, r"[a-z]+/.(com|org|net)"]);
@@ -79,8 +94,25 @@ error: regex syntax error: unrecognized escape sequence
 LL |     let raw_string_error = Regex::new(r#"[...//...]"#);
    |                                              ^^
 
+error: regex parse error:
+           /b/c
+             ^^
+       error: unrecognized escape sequence
+  --> $DIR/regex.rs:40:42
+   |
+LL |     let escaped_string_span = Regex::new("/b/c");
+   |                                          ^^^^^^^^
+   |
+   = help: consider using a raw string literal: `r".."`
+
+error: regex syntax error: duplicate flag
+  --> $DIR/regex.rs:42:34
+   |
+LL |     let aux_span = Regex::new("(?ixi)");
+   |                                  ^ ^
+
 error: trivial regex
-  --> $DIR/regex.rs:42:33
+  --> $DIR/regex.rs:46:33
    |
 LL |     let trivial_eq = Regex::new("^foobar$");
    |                                 ^^^^^^^^^^
@@ -88,7 +120,7 @@ LL |     let trivial_eq = Regex::new("^foobar$");
    = help: consider using `==` on `str`s
 
 error: trivial regex
-  --> $DIR/regex.rs:44:48
+  --> $DIR/regex.rs:48:48
    |
 LL |     let trivial_eq_builder = RegexBuilder::new("^foobar$");
    |                                                ^^^^^^^^^^
@@ -96,7 +128,7 @@ LL |     let trivial_eq_builder = RegexBuilder::new("^foobar$");
    = help: consider using `==` on `str`s
 
 error: trivial regex
-  --> $DIR/regex.rs:46:42
+  --> $DIR/regex.rs:50:42
    |
 LL |     let trivial_starts_with = Regex::new("^foobar");
    |                                          ^^^^^^^^^
@@ -104,7 +136,7 @@ LL |     let trivial_starts_with = Regex::new("^foobar");
    = help: consider using `str::starts_with`
 
 error: trivial regex
-  --> $DIR/regex.rs:48:40
+  --> $DIR/regex.rs:52:40
    |
 LL |     let trivial_ends_with = Regex::new("foobar$");
    |                                        ^^^^^^^^^
@@ -112,7 +144,7 @@ LL |     let trivial_ends_with = Regex::new("foobar$");
    = help: consider using `str::ends_with`
 
 error: trivial regex
-  --> $DIR/regex.rs:50:39
+  --> $DIR/regex.rs:54:39
    |
 LL |     let trivial_contains = Regex::new("foobar");
    |                                       ^^^^^^^^
@@ -120,7 +152,7 @@ LL |     let trivial_contains = Regex::new("foobar");
    = help: consider using `str::contains`
 
 error: trivial regex
-  --> $DIR/regex.rs:52:39
+  --> $DIR/regex.rs:56:39
    |
 LL |     let trivial_contains = Regex::new(NOT_A_REAL_REGEX);
    |                                       ^^^^^^^^^^^^^^^^
@@ -128,7 +160,7 @@ LL |     let trivial_contains = Regex::new(NOT_A_REAL_REGEX);
    = help: consider using `str::contains`
 
 error: trivial regex
-  --> $DIR/regex.rs:54:40
+  --> $DIR/regex.rs:58:40
    |
 LL |     let trivial_backslash = Regex::new("a/.b");
    |                                        ^^^^^^^
@@ -136,7 +168,7 @@ LL |     let trivial_backslash = Regex::new("a/.b");
    = help: consider using `str::contains`
 
 error: trivial regex
-  --> $DIR/regex.rs:57:36
+  --> $DIR/regex.rs:61:36
    |
 LL |     let trivial_empty = Regex::new("");
    |                                    ^^
@@ -144,7 +176,7 @@ LL |     let trivial_empty = Regex::new("");
    = help: the regex is unlikely to be useful as it is
 
 error: trivial regex
-  --> $DIR/regex.rs:59:36
+  --> $DIR/regex.rs:63:36
    |
 LL |     let trivial_empty = Regex::new("^");
    |                                    ^^^
@@ -152,7 +184,7 @@ LL |     let trivial_empty = Regex::new("^");
    = help: the regex is unlikely to be useful as it is
 
 error: trivial regex
-  --> $DIR/regex.rs:61:36
+  --> $DIR/regex.rs:65:36
    |
 LL |     let trivial_empty = Regex::new("^$");
    |                                    ^^^^
@@ -160,12 +192,12 @@ LL |     let trivial_empty = Regex::new("^$");
    = help: consider using `str::is_empty`
 
 error: trivial regex
-  --> $DIR/regex.rs:63:44
+  --> $DIR/regex.rs:67:44
    |
 LL |     let binary_trivial_empty = BRegex::new("^$");
    |                                            ^^^^
    |
    = help: consider using `str::is_empty`
 
-error: aborting due to 23 previous errors
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
changelog: [`invalid_regex`]: Show full error when parsing non-literals or regular strings containing escape sequences

Fixes #4170, the escape sequence there causes the span to be incorrect which will have caused most of the confusion