### PR TITLE
Fix styling in documentation for `suspicious_xor_used_as_pow` lint

### DIFF
--- a/clippy_lints/src/suspicious_xor_used_as_pow.rs
+++ b/clippy_lints/src/suspicious_xor_used_as_pow.rs
@@ -9,7 +9,7 @@ declare_clippy_lint! {
     /// ### What it does
     /// Warns for a Bitwise XOR (`^`) operator being probably confused as a powering. It will not trigger if any of the numbers are not in decimal.
     /// ### Why is this bad?
-    ///	It's most probably a typo and may lead to unexpected behaviours.
+    /// It's most probably a typo and may lead to unexpected behaviours.
     /// ### Example
     /// ```rust
     /// let x = 3_i32 ^ 4_i32;


### PR DESCRIPTION
There was a tab after the three leading slashes which caused the contents of the "Why is this bad?" section to be rendered as a code block.

**Before:**

<img width="626" alt="master" src="https://user-images.githubusercontent.com/4869194/214985546-4433d211-9fd3-450c-8ff7-2c0a47fccdc0.png">

**After:**

<img width="520" alt="fixed" src="https://user-images.githubusercontent.com/4869194/214985561-87255196-008c-4a1c-8cc8-c54b337d22a2.png">

The file still contains a lot of tabs but they don't affect the documentation.

---

changelog: [`suspicious_xor_used_as_pow`]: Fix styling in documentation
