### PR TITLE
`doc_markdown` lint: Whitelist names of popular frame servers

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -29,6 +29,7 @@ const DEFAULT_DOC_VALID_IDENTS: &[&str] = &[
     "TeX", "LaTeX", "BibTeX", "BibLaTeX",
     "MinGW",
     "CamelCase",
+    "AviSynth", "VapourSynth",
 ];
 const DEFAULT_DISALLOWED_NAMES: &[&str] = &["foo", "baz", "quux"];
 

--- a/tests/ui/doc/doc-fixable.rs
+++ b/tests/ui/doc/doc-fixable.rs
@@ -71,6 +71,7 @@ fn test_units() {
 /// TeX LaTeX BibTeX BibLaTeX
 /// MinGW
 /// CamelCase (see also #2395)
+/// AviSynth VapourSynth
 /// be_sure_we_got_to_the_end_of_it
 fn test_allowed() {
 }


### PR DESCRIPTION
changelog: none

Spelling proof:

- https://avs-plus.net/
- https://www.vapoursynth.com/

Popularity proof:

- https://forum.doom9.org/#collapseimg_forumbit_67
- https://en.wikipedia.org/wiki/Doom9

Must the names also be added to these locations?

- https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/doc/doc-fixable.rs#L55
- https://github.com/rust-lang/rust-clippy/blob/master/tests/ui/doc/doc-fixable.fixed#L55
