### PR TITLE
wildcard_enum_match_arm lint takes the enum origin into account

### DIFF
--- a/tests/ui/match_wildcard_for_single_variants.fixed
+++ b/tests/ui/match_wildcard_for_single_variants.fixed
@@ -123,7 +123,7 @@ fn main() {
             Enum::A => (),
             Enum::B => (),
             Enum::C => (),
-            _ => (),
+            Enum::__Private => (),
         }
         match Enum::A {
             Enum::A => (),

--- a/tests/ui/match_wildcard_for_single_variants.stderr
+++ b/tests/ui/match_wildcard_for_single_variants.stderr
@@ -49,10 +49,16 @@ LL |         _ => (),
    |         ^ help: try this: `Color::Blue`
 
 error: wildcard matches only a single variant and will also match any future added variants
+  --> $DIR/match_wildcard_for_single_variants.rs:126:13
+   |
+LL |             _ => (),
+   |             ^ help: try this: `Enum::__Private`
+
+error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:153:13
    |
 LL |             _ => 2,
    |             ^ help: try this: `Foo::B`
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 

--- a/tests/ui/wildcard_enum_match_arm.fixed
+++ b/tests/ui/wildcard_enum_match_arm.fixed
@@ -96,7 +96,7 @@ fn main() {
         }
         match Enum::A {
             Enum::A => (),
-            Enum::B | _ => (),
+            Enum::B | Enum::__Private => (),
         }
     }
 }

--- a/tests/ui/wildcard_enum_match_arm.stderr
+++ b/tests/ui/wildcard_enum_match_arm.stderr
@@ -34,11 +34,11 @@ error: wildcard matches known variants and will also match future added variants
 LL |         _ => {},
    |         ^ help: try this: `ErrorKind::PermissionDenied | _`
 
-error: wildcard matches known variants and will also match future added variants
+error: wildcard match will also match any future added variants
   --> $DIR/wildcard_enum_match_arm.rs:99:13
    |
 LL |             _ => (),
-   |             ^ help: try this: `Enum::B | _`
+   |             ^ help: try this: `Enum::B | Enum::__Private`
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes #7419 

---

changelog: Enhancement: [`wildcard_enum_match_arm`]: Now lints missing private variants, for local enums
[#10250](https://github.com/rust-lang/rust-clippy/pull/10250)
<!-- changelog_checked -->