### PR TITLE
prevents `len_without_is_empty` from yielding positive when `len` takes arguments besides `&self`

### DIFF
--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -135,6 +135,7 @@ impl<'tcx> LateLintPass<'tcx> for LenZero {
             if item.ident.name == sym::len;
             if let ImplItemKind::Fn(sig, _) = &item.kind;
             if sig.decl.implicit_self.has_implicit_self();
+            if sig.decl.inputs.len() == 1;
             if cx.effective_visibilities.is_exported(item.owner_id.def_id);
             if matches!(sig.decl.output, FnRetTy::Return(_));
             if let Some(imp) = get_parent_as_impl(cx.tcx, item.hir_id());

--- a/tests/ui/len_without_is_empty.rs
+++ b/tests/ui/len_without_is_empty.rs
@@ -282,4 +282,17 @@ impl AsyncLen {
     }
 }
 
+// issue #9520
+pub struct NonStandardLenAndIsEmptySignature;
+impl NonStandardLenAndIsEmptySignature {
+    // don't lint
+    pub fn len(&self, something: usize) -> usize {
+        something
+    }
+
+    pub fn is_empty(&self, something: usize) -> bool {
+        something == 0
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes #9520
---

changelog: Fix [`len_without_is_empty`] false positive when len has a non-standard method signature
