### PR TITLE
Fix version declared for semicolon_inside_block and semicolon_outside…

### DIFF
--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     /// # let x = 0;
     /// unsafe { f(x); }
     /// ```
-    #[clippy::version = "1.66.0"]
+    #[clippy::version = "1.68.0"]
     pub SEMICOLON_INSIDE_BLOCK,
     restriction,
     "add a semicolon inside the block"
@@ -59,7 +59,7 @@ declare_clippy_lint! {
     /// # let x = 0;
     /// unsafe { f(x) };
     /// ```
-    #[clippy::version = "1.66.0"]
+    #[clippy::version = "1.68.0"]
     pub SEMICOLON_OUTSIDE_BLOCK,
     restriction,
     "add a semicolon outside the block"


### PR DESCRIPTION
As per Issue #10244, the lint were documentated
as being part of 1.66.0 but will actually be
released 1.68.0 .

changelog: [`semicolon_inside_block`]: Documentation fix
Fixes #10244
