### PR TITLE
`multiple_unsafe_ops_per_block`: Don't lint in external macros

### DIFF
--- a/clippy_lints/src/multiple_unsafe_ops_per_block.rs
+++ b/clippy_lints/src/multiple_unsafe_ops_per_block.rs
@@ -10,6 +10,7 @@ use hir::{
 use rustc_ast::Mutability;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::lint::in_external_macro;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::Span;
 
@@ -66,7 +67,7 @@ declare_lint_pass!(MultipleUnsafeOpsPerBlock => [MULTIPLE_UNSAFE_OPS_PER_BLOCK])
 
 impl<'tcx> LateLintPass<'tcx> for MultipleUnsafeOpsPerBlock {
     fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx hir::Block<'_>) {
-        if !matches!(block.rules, BlockCheckMode::UnsafeBlock(_)) {
+        if !matches!(block.rules, BlockCheckMode::UnsafeBlock(_)) || in_external_macro(cx.tcx.sess, block.span) {
             return;
         }
         let mut unsafe_ops = vec![];

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -149,3 +149,13 @@ macro_rules! almost_complete_range {
         let _ = '0'..'9';
     };
 }
+
+#[macro_export]
+macro_rules! unsafe_macro {
+    () => {
+        unsafe {
+            *core::ptr::null::<()>();
+            *core::ptr::null::<()>();
+        }
+    };
+}

--- a/tests/ui/multiple_unsafe_ops_per_block.rs
+++ b/tests/ui/multiple_unsafe_ops_per_block.rs
@@ -1,8 +1,12 @@
+// aux-build:macro_rules.rs
 #![allow(unused)]
 #![allow(deref_nullptr)]
 #![allow(clippy::unnecessary_operation)]
 #![allow(clippy::drop_copy)]
 #![warn(clippy::multiple_unsafe_ops_per_block)]
+
+#[macro_use]
+extern crate macro_rules;
 
 use core::arch::asm;
 
@@ -105,6 +109,11 @@ unsafe fn read_char_bad(ptr: *const u8) -> char {
 unsafe fn read_char_good(ptr: *const u8) -> char {
     let int_value = unsafe { *ptr.cast::<u32>() };
     unsafe { core::char::from_u32_unchecked(int_value) }
+}
+
+// no lint
+fn issue10259() {
+    unsafe_macro!();
 }
 
 fn main() {}

--- a/tests/ui/multiple_unsafe_ops_per_block.stderr
+++ b/tests/ui/multiple_unsafe_ops_per_block.stderr
@@ -1,5 +1,5 @@
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> $DIR/multiple_unsafe_ops_per_block.rs:32:5
+  --> $DIR/multiple_unsafe_ops_per_block.rs:36:5
    |
 LL | /     unsafe {
 LL | |         STATIC += 1;
@@ -8,19 +8,19 @@ LL | |     }
    | |_____^
    |
 note: modification of a mutable static occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:33:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:37:9
    |
 LL |         STATIC += 1;
    |         ^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:34:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:38:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
    = note: `-D clippy::multiple-unsafe-ops-per-block` implied by `-D warnings`
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> $DIR/multiple_unsafe_ops_per_block.rs:41:5
+  --> $DIR/multiple_unsafe_ops_per_block.rs:45:5
    |
 LL | /     unsafe {
 LL | |         drop(u.u);
@@ -29,18 +29,18 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:42:14
+  --> $DIR/multiple_unsafe_ops_per_block.rs:46:14
    |
 LL |         drop(u.u);
    |              ^^^
 note: raw pointer dereference occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:43:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:47:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 
 error: this `unsafe` block contains 3 unsafe operations, expected only one
-  --> $DIR/multiple_unsafe_ops_per_block.rs:48:5
+  --> $DIR/multiple_unsafe_ops_per_block.rs:52:5
    |
 LL | /     unsafe {
 LL | |         asm!("nop");
@@ -50,23 +50,23 @@ LL | |     }
    | |_____^
    |
 note: inline assembly used here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:49:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:53:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 note: unsafe method call occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:50:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:54:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 note: modification of a mutable static occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:51:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:55:9
    |
 LL |         STATIC = 0;
    |         ^^^^^^^^^^
 
 error: this `unsafe` block contains 6 unsafe operations, expected only one
-  --> $DIR/multiple_unsafe_ops_per_block.rs:57:5
+  --> $DIR/multiple_unsafe_ops_per_block.rs:61:5
    |
 LL | /     unsafe {
 LL | |         drop(u.u);
@@ -78,49 +78,49 @@ LL | |     }
    | |_____^
    |
 note: union field access occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:58:14
+  --> $DIR/multiple_unsafe_ops_per_block.rs:62:14
    |
 LL |         drop(u.u);
    |              ^^^
 note: access of a mutable static occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:59:14
+  --> $DIR/multiple_unsafe_ops_per_block.rs:63:14
    |
 LL |         drop(STATIC);
    |              ^^^^^^
 note: unsafe method call occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:60:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:64:9
    |
 LL |         sample.not_very_safe();
    |         ^^^^^^^^^^^^^^^^^^^^^^
 note: unsafe function call occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:61:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:65:9
    |
 LL |         not_very_safe();
    |         ^^^^^^^^^^^^^^^
 note: raw pointer dereference occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:62:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:66:9
    |
 LL |         *raw_ptr();
    |         ^^^^^^^^^^
 note: inline assembly used here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:63:9
+  --> $DIR/multiple_unsafe_ops_per_block.rs:67:9
    |
 LL |         asm!("nop");
    |         ^^^^^^^^^^^
 
 error: this `unsafe` block contains 2 unsafe operations, expected only one
-  --> $DIR/multiple_unsafe_ops_per_block.rs:101:5
+  --> $DIR/multiple_unsafe_ops_per_block.rs:105:5
    |
 LL |     unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: unsafe function call occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:101:14
+  --> $DIR/multiple_unsafe_ops_per_block.rs:105:14
    |
 LL |     unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: raw pointer dereference occurs here
-  --> $DIR/multiple_unsafe_ops_per_block.rs:101:39
+  --> $DIR/multiple_unsafe_ops_per_block.rs:105:39
    |
 LL |     unsafe { char::from_u32_unchecked(*ptr.cast::<u32>()) }
    |                                       ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #10259

changelog: FP: [`multiple_unsafe_ops_per_block`]: No longer lints in external macros
[#10260](https://github.com/rust-lang/rust-clippy/pull/10260)
<!-- changelog_none -->
