### PR TITLE
Mark uninlined_format_args as pedantic

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -125,7 +125,7 @@ declare_clippy_lint! {
     /// nothing will be suggested, e.g. `println!("{0}={1}", var, 1+2)`.
     #[clippy::version = "1.66.0"]
     pub UNINLINED_FORMAT_ARGS,
-    style,
+    pedantic,
     "using non-inlined variables in `format!` calls"
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/10087

We should restore this when rust-analyzer support gets better. Worth filing an issue to track.

changelog: Mark [`uninlined_format_args`] as `pedantic`