### PR TITLE
Make `[clippy::dump]` support trait items

### DIFF
--- a/clippy_lints/src/utils/dump_hir.rs
+++ b/clippy_lints/src/utils/dump_hir.rs
@@ -1,4 +1,5 @@
 use clippy_utils::get_attr;
+use hir::TraitItem;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
@@ -45,6 +46,18 @@ impl<'tcx> LateLintPass<'tcx> for DumpHir {
         }
         if has_attr(cx, stmt.hir_id) {
             println!("{stmt:#?}");
+        }
+    }
+
+    fn check_trait_item(&mut self, cx: &LateContext<'_>, item: &TraitItem<'_>) {
+        if has_attr(cx, item.hir_id()) {
+            println!("{item:#?}");
+        }
+    }
+
+    fn check_impl_item(&mut self, cx: &LateContext<'_>, item: &hir::ImplItem<'_>) {
+        if has_attr(cx, item.hir_id()) {
+            println!("{item:#?}");
         }
     }
 }


### PR DESCRIPTION
Roses are red,
violets are blue,
trait items are rare,
`[clippy::dump]` is too

---

Let's just ignore the horrible poem... anyways. While working on Marker I noticed, that `[clippy::dump]` doesn't work on trait item (See [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e2d9791ffa2872e7c09a9dfbd470350c)). This simply adds support for that. `[clippy::dump]` doesn't have UI tests, to make it more resistant to changes in the AST. I tested it locally and the dump works after these changes.

---

changelog: none
