### PR TITLE
fix(suspicious_to_owned): use span_suggestions to suggest both intents

### DIFF
--- a/clippy_lints/src/methods/suspicious_to_owned.rs
+++ b/clippy_lints/src/methods/suspicious_to_owned.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_diag_trait_item;
 use clippy_utils::source::snippet_with_context;
 use if_chain::if_chain;
@@ -17,19 +17,25 @@ pub fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr<'_>) -
         let input_type = cx.typeck_results().expr_ty(expr);
         if let ty::Adt(adt, _) = cx.typeck_results().expr_ty(expr).kind();
         if cx.tcx.is_diagnostic_item(sym::Cow, adt.did());
+
         then {
             let mut app = Applicability::MaybeIncorrect;
             let recv_snip = snippet_with_context(cx, recv.span, expr.span.ctxt(), "..", &mut app).0;
-            span_lint_and_sugg(
+            span_lint_and_then(
                 cx,
                 SUSPICIOUS_TO_OWNED,
                 expr.span,
                 &with_forced_trimmed_paths!(format!(
                     "this `to_owned` call clones the {input_type} itself and does not cause the {input_type} contents to become owned"
                 )),
-                "consider using, depending on intent",
-                format!("{recv_snip}.clone()` or `{recv_snip}.into_owned()"),
-                app,
+                |diag| {
+                    diag.span_suggestions(
+                        expr.span,
+                        "depending on intent, either make the Cow an Owned variant or clone the Cow itself",
+                        [format!("{recv_snip}.into_owned()"), format!("{recv_snip}.clone()")],
+                        Applicability::Unspecified
+                    );
+                }
             );
             return true;
         }

--- a/clippy_lints/src/methods/suspicious_to_owned.rs
+++ b/clippy_lints/src/methods/suspicious_to_owned.rs
@@ -33,7 +33,7 @@ pub fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr<'_>) -
                         expr.span,
                         "depending on intent, either make the Cow an Owned variant or clone the Cow itself",
                         [format!("{recv_snip}.into_owned()"), format!("{recv_snip}.clone()")],
-                        Applicability::Unspecified
+                        app
                     );
                 }
             );

--- a/clippy_lints/src/methods/suspicious_to_owned.rs
+++ b/clippy_lints/src/methods/suspicious_to_owned.rs
@@ -29,10 +29,16 @@ pub fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr<'_>) -
                     "this `to_owned` call clones the {input_type} itself and does not cause the {input_type} contents to become owned"
                 )),
                 |diag| {
-                    diag.span_suggestions(
+                    diag.span_suggestion(
                         expr.span,
-                        "depending on intent, either make the Cow an Owned variant or clone the Cow itself",
-                        [format!("{recv_snip}.into_owned()"), format!("{recv_snip}.clone()")],
+                        "depending on intent, either make the Cow an Owned variant",
+                        format!("{recv_snip}.into_owned()"),
+                        app
+                    );
+                    diag.span_suggestion(
+                        expr.span,
+                        "or clone the Cow itself",
+                        format!("{recv_snip}.clone()"),
                         app
                     );
                 }

--- a/tests/ui/suspicious_to_owned.stderr
+++ b/tests/ui/suspicious_to_owned.stderr
@@ -5,12 +5,14 @@ LL |     let _ = cow.to_owned();
    |             ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::suspicious-to-owned` implied by `-D warnings`
-help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+help: depending on intent, either make the Cow an Owned variant
+   |
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
+help: or clone the Cow itself
    |
 LL |     let _ = cow.clone();
    |             ~~~~~~~~~~~
-LL |     let _ = cow.into_owned();
-   |             ~~~~~~~~~~~~~~~~
 
 error: this `to_owned` call clones the Cow<'_, [char; 3]> itself and does not cause the Cow<'_, [char; 3]> contents to become owned
   --> $DIR/suspicious_to_owned.rs:26:13
@@ -18,12 +20,14 @@ error: this `to_owned` call clones the Cow<'_, [char; 3]> itself and does not ca
 LL |     let _ = cow.to_owned();
    |             ^^^^^^^^^^^^^^
    |
-help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+help: depending on intent, either make the Cow an Owned variant
+   |
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
+help: or clone the Cow itself
    |
 LL |     let _ = cow.clone();
    |             ~~~~~~~~~~~
-LL |     let _ = cow.into_owned();
-   |             ~~~~~~~~~~~~~~~~
 
 error: this `to_owned` call clones the Cow<'_, Vec<char>> itself and does not cause the Cow<'_, Vec<char>> contents to become owned
   --> $DIR/suspicious_to_owned.rs:36:13
@@ -31,12 +35,14 @@ error: this `to_owned` call clones the Cow<'_, Vec<char>> itself and does not ca
 LL |     let _ = cow.to_owned();
    |             ^^^^^^^^^^^^^^
    |
-help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+help: depending on intent, either make the Cow an Owned variant
+   |
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
+help: or clone the Cow itself
    |
 LL |     let _ = cow.clone();
    |             ~~~~~~~~~~~
-LL |     let _ = cow.into_owned();
-   |             ~~~~~~~~~~~~~~~~
 
 error: this `to_owned` call clones the Cow<'_, str> itself and does not cause the Cow<'_, str> contents to become owned
   --> $DIR/suspicious_to_owned.rs:46:13
@@ -44,12 +50,14 @@ error: this `to_owned` call clones the Cow<'_, str> itself and does not cause th
 LL |     let _ = cow.to_owned();
    |             ^^^^^^^^^^^^^^
    |
-help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+help: depending on intent, either make the Cow an Owned variant
+   |
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
+help: or clone the Cow itself
    |
 LL |     let _ = cow.clone();
    |             ~~~~~~~~~~~
-LL |     let _ = cow.into_owned();
-   |             ~~~~~~~~~~~~~~~~
 
 error: implicitly cloning a `String` by calling `to_owned` on its dereferenced type
   --> $DIR/suspicious_to_owned.rs:60:13

--- a/tests/ui/suspicious_to_owned.stderr
+++ b/tests/ui/suspicious_to_owned.stderr
@@ -2,27 +2,54 @@ error: this `to_owned` call clones the Cow<'_, str> itself and does not cause th
   --> $DIR/suspicious_to_owned.rs:16:13
    |
 LL |     let _ = cow.to_owned();
-   |             ^^^^^^^^^^^^^^ help: consider using, depending on intent: `cow.clone()` or `cow.into_owned()`
+   |             ^^^^^^^^^^^^^^
    |
    = note: `-D clippy::suspicious-to-owned` implied by `-D warnings`
+help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+   |
+LL |     let _ = cow.clone();
+   |             ~~~~~~~~~~~
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
 
 error: this `to_owned` call clones the Cow<'_, [char; 3]> itself and does not cause the Cow<'_, [char; 3]> contents to become owned
   --> $DIR/suspicious_to_owned.rs:26:13
    |
 LL |     let _ = cow.to_owned();
-   |             ^^^^^^^^^^^^^^ help: consider using, depending on intent: `cow.clone()` or `cow.into_owned()`
+   |             ^^^^^^^^^^^^^^
+   |
+help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+   |
+LL |     let _ = cow.clone();
+   |             ~~~~~~~~~~~
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
 
 error: this `to_owned` call clones the Cow<'_, Vec<char>> itself and does not cause the Cow<'_, Vec<char>> contents to become owned
   --> $DIR/suspicious_to_owned.rs:36:13
    |
 LL |     let _ = cow.to_owned();
-   |             ^^^^^^^^^^^^^^ help: consider using, depending on intent: `cow.clone()` or `cow.into_owned()`
+   |             ^^^^^^^^^^^^^^
+   |
+help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+   |
+LL |     let _ = cow.clone();
+   |             ~~~~~~~~~~~
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
 
 error: this `to_owned` call clones the Cow<'_, str> itself and does not cause the Cow<'_, str> contents to become owned
   --> $DIR/suspicious_to_owned.rs:46:13
    |
 LL |     let _ = cow.to_owned();
-   |             ^^^^^^^^^^^^^^ help: consider using, depending on intent: `cow.clone()` or `cow.into_owned()`
+   |             ^^^^^^^^^^^^^^
+   |
+help: depending on intent, either make the Cow an Owned variant or clone the Cow itself
+   |
+LL |     let _ = cow.clone();
+   |             ~~~~~~~~~~~
+LL |     let _ = cow.into_owned();
+   |             ~~~~~~~~~~~~~~~~
 
 error: implicitly cloning a `String` by calling `to_owned` on its dereferenced type
   --> $DIR/suspicious_to_owned.rs:60:13


### PR DESCRIPTION
fixes #10294

changelog: [`suspicious_to_owned`]: suggestions now produce valid Rust code
