### PR TITLE
Add configuration to lint missing docs of `pub(crate)` items

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -542,7 +542,8 @@ if no suggestion can be made.
 
 
 ### missing-docs-in-crate-items
-Whether to **only** check for missing documentation in `pub(crate)` items.
+Whether to **only** check for missing documentation in items visible within the current
+crate. For example, `pub(crate)` items.
 
 **Default Value:** `false` (`bool`)
 

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -53,6 +53,7 @@ Please use that command to update the file and do not edit it by hand.
 | [ignore-interior-mutability](#ignore-interior-mutability) | `["bytes::Bytes"]` |
 | [allow-mixed-uninlined-format-args](#allow-mixed-uninlined-format-args) | `true` |
 | [suppress-restriction-lint-in-const](#suppress-restriction-lint-in-const) | `false` |
+| [missing-docs-in-crate-items](#missing-docs-in-crate-items) | `false` |
 
 ### arithmetic-side-effects-allowed
 Suppress checking of the passed type names in all types of operations.
@@ -538,6 +539,14 @@ if no suggestion can be made.
 **Default Value:** `false` (`bool`)
 
 * [indexing_slicing](https://rust-lang.github.io/rust-clippy/master/index.html#indexing_slicing)
+
+
+### missing-docs-in-crate-items
+Whether to **only** check for missing documentation in `pub(crate)` items.
+
+**Default Value:** `false` (`bool`)
+
+* [missing_docs_in_private_items](https://rust-lang.github.io/rust-clippy/master/index.html#missing_docs_in_private_items)
 
 
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -665,12 +665,13 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         ))
     });
     let doc_valid_idents = conf.doc_valid_idents.iter().cloned().collect::<FxHashSet<_>>();
+    let only_check_missing_docs_in_crate_items = conf.only_check_missing_docs_in_crate_items;
     store.register_late_pass(move |_| Box::new(doc::DocMarkdown::new(doc_valid_idents.clone())));
     store.register_late_pass(|_| Box::new(neg_multiply::NegMultiply));
     store.register_late_pass(|_| Box::new(mem_forget::MemForget));
     store.register_late_pass(|_| Box::new(let_if_seq::LetIfSeq));
     store.register_late_pass(|_| Box::new(mixed_read_write_in_expression::EvalOrderDependence));
-    store.register_late_pass(|_| Box::new(missing_doc::MissingDoc::new()));
+    store.register_late_pass(move |_| Box::new(missing_doc::MissingDoc::new(only_check_missing_docs_in_crate_items)));
     store.register_late_pass(|_| Box::new(missing_inline::MissingInline));
     store.register_late_pass(move |_| Box::new(exhaustive_items::ExhaustiveItems));
     store.register_late_pass(|_| Box::new(match_result_ok::MatchResultOk));

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -665,13 +665,13 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
         ))
     });
     let doc_valid_idents = conf.doc_valid_idents.iter().cloned().collect::<FxHashSet<_>>();
-    let only_check_missing_docs_in_crate_items = conf.only_check_missing_docs_in_crate_items;
+    let missing_docs_in_crate_items = conf.missing_docs_in_crate_items;
     store.register_late_pass(move |_| Box::new(doc::DocMarkdown::new(doc_valid_idents.clone())));
     store.register_late_pass(|_| Box::new(neg_multiply::NegMultiply));
     store.register_late_pass(|_| Box::new(mem_forget::MemForget));
     store.register_late_pass(|_| Box::new(let_if_seq::LetIfSeq));
     store.register_late_pass(|_| Box::new(mixed_read_write_in_expression::EvalOrderDependence));
-    store.register_late_pass(move |_| Box::new(missing_doc::MissingDoc::new(only_check_missing_docs_in_crate_items)));
+    store.register_late_pass(move |_| Box::new(missing_doc::MissingDoc::new(missing_docs_in_crate_items)));
     store.register_late_pass(|_| Box::new(missing_inline::MissingInline));
     store.register_late_pass(move |_| Box::new(exhaustive_items::ExhaustiveItems));
     store.register_late_pass(|_| Box::new(match_result_ok::MatchResultOk));

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -8,6 +8,7 @@
 use clippy_utils::attrs::is_doc_hidden;
 use clippy_utils::diagnostics::span_lint;
 use clippy_utils::is_from_proc_macro;
+use hir::def_id::LocalDefId;
 use if_chain::if_chain;
 use rustc_ast::ast::{self, MetaItem, MetaItemKind};
 use rustc_hir as hir;
@@ -35,7 +36,7 @@ declare_clippy_lint! {
 }
 
 pub struct MissingDoc {
-    /// FIXME: docs
+    /// Whether to only check for missing docs in `pub(crate)` items.
     crate_items_only: bool,
     /// Stack of whether #[doc(hidden)] is set
     /// at each level which has lint attributes.
@@ -79,6 +80,7 @@ impl MissingDoc {
     fn check_missing_docs_attrs(
         &self,
         cx: &LateContext<'_>,
+        def_id: LocalDefId,
         attrs: &[ast::Attribute],
         sp: Span,
         article: &'static str,
@@ -97,6 +99,13 @@ impl MissingDoc {
 
         if sp.from_expansion() {
             return;
+        }
+
+        if self.crate_items_only && def_id != CRATE_DEF_ID {
+            let vis = cx.tcx.visibility(def_id);
+            if vis != Visibility::Public && vis != Visibility::Restricted(CRATE_DEF_ID.into()) {
+                return;
+            }
         }
 
         let has_doc = attrs
@@ -127,17 +136,10 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
     fn check_crate(&mut self, cx: &LateContext<'tcx>) {
         let attrs = cx.tcx.hir().attrs(hir::CRATE_HIR_ID);
-        self.check_missing_docs_attrs(cx, attrs, cx.tcx.def_span(CRATE_DEF_ID), "the", "crate");
+        self.check_missing_docs_attrs(cx, CRATE_DEF_ID, attrs, cx.tcx.def_span(CRATE_DEF_ID), "the", "crate");
     }
 
     fn check_item(&mut self, cx: &LateContext<'tcx>, it: &'tcx hir::Item<'_>) {
-        if self.crate_items_only {
-            let vis = cx.tcx.visibility(it.owner_id.to_def_id());
-            if vis != Visibility::Public && vis != Visibility::Restricted(CRATE_DEF_ID.into()) {
-                return;
-            }
-        }
-
         match it.kind {
             hir::ItemKind::Fn(..) => {
                 // ignore main()
@@ -170,7 +172,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
         let attrs = cx.tcx.hir().attrs(it.hir_id());
         if !is_from_proc_macro(cx, it) {
-            self.check_missing_docs_attrs(cx, attrs, it.span, article, desc);
+            self.check_missing_docs_attrs(cx, it.owner_id.def_id, attrs, it.span, article, desc);
         }
     }
 
@@ -179,7 +181,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
         let attrs = cx.tcx.hir().attrs(trait_item.hir_id());
         if !is_from_proc_macro(cx, trait_item) {
-            self.check_missing_docs_attrs(cx, attrs, trait_item.span, article, desc);
+            self.check_missing_docs_attrs(cx, trait_item.owner_id.def_id, attrs, trait_item.span, article, desc);
         }
     }
 
@@ -196,7 +198,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
         let (article, desc) = cx.tcx.article_and_description(impl_item.owner_id.to_def_id());
         let attrs = cx.tcx.hir().attrs(impl_item.hir_id());
         if !is_from_proc_macro(cx, impl_item) {
-            self.check_missing_docs_attrs(cx, attrs, impl_item.span, article, desc);
+            self.check_missing_docs_attrs(cx, impl_item.owner_id.def_id, attrs, impl_item.span, article, desc);
         }
     }
 
@@ -204,7 +206,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
         if !sf.is_positional() {
             let attrs = cx.tcx.hir().attrs(sf.hir_id);
             if !is_from_proc_macro(cx, sf) {
-                self.check_missing_docs_attrs(cx, attrs, sf.span, "a", "struct field");
+                self.check_missing_docs_attrs(cx, sf.def_id, attrs, sf.span, "a", "struct field");
             }
         }
     }
@@ -212,7 +214,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
     fn check_variant(&mut self, cx: &LateContext<'tcx>, v: &'tcx hir::Variant<'_>) {
         let attrs = cx.tcx.hir().attrs(v.hir_id);
         if !is_from_proc_macro(cx, v) {
-            self.check_missing_docs_attrs(cx, attrs, v.span, "a", "variant");
+            self.check_missing_docs_attrs(cx, v.def_id, attrs, v.span, "a", "variant");
         }
     }
 }

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -103,7 +103,7 @@ impl MissingDoc {
 
         if self.crate_items_only && def_id != CRATE_DEF_ID {
             let vis = cx.tcx.visibility(def_id);
-            if vis != Visibility::Public && vis != Visibility::Restricted(CRATE_DEF_ID.into()) {
+            if vis == Visibility::Public || vis != Visibility::Restricted(CRATE_DEF_ID.into()) {
                 return;
             }
         }

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -36,7 +36,8 @@ declare_clippy_lint! {
 }
 
 pub struct MissingDoc {
-    /// Whether to only check for missing docs in `pub(crate)` items.
+    /// Whether to **only** check for missing documentation in items visible within the current
+    /// crate. For example, `pub(crate)` items.
     crate_items_only: bool,
     /// Stack of whether #[doc(hidden)] is set
     /// at each level which has lint attributes.

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -456,7 +456,7 @@ define_Conf! {
     (suppress_restriction_lint_in_const: bool = false),
     /// Lint: MISSING_DOCS_IN_PRIVATE_ITEMS.
     ///
-    /// Whether to **only** check for missing docmuentation in `pub(crate)` items.
+    /// Whether to **only** check for missing documentation in `pub(crate)` items.
     (missing_docs_in_crate_items: bool = false),
 }
 

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -456,8 +456,8 @@ define_Conf! {
     (suppress_restriction_lint_in_const: bool = false),
     /// Lint: MISSING_DOCS_IN_PRIVATE_ITEMS.
     ///
-    /// FIXME: docs
-    (only_check_missing_docs_in_crate_items: bool = false),
+    /// Whether to **only** check for missing docmuentation in `pub(crate)` items.
+    (missing_docs_in_crate_items: bool = false),
 }
 
 /// Search for the configuration file.

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -454,6 +454,10 @@ define_Conf! {
     /// configuration will cause restriction lints to trigger even
     /// if no suggestion can be made.
     (suppress_restriction_lint_in_const: bool = false),
+    /// Lint: MISSING_DOCS_IN_PRIVATE_ITEMS.
+    ///
+    /// FIXME: docs
+    (only_check_missing_docs_in_crate_items: bool = false),
 }
 
 /// Search for the configuration file.

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -456,7 +456,8 @@ define_Conf! {
     (suppress_restriction_lint_in_const: bool = false),
     /// Lint: MISSING_DOCS_IN_PRIVATE_ITEMS.
     ///
-    /// Whether to **only** check for missing documentation in `pub(crate)` items.
+    /// Whether to **only** check for missing documentation in items visible within the current
+    /// crate. For example, `pub(crate)` items.
     (missing_docs_in_crate_items: bool = false),
 }
 

--- a/tests/ui-toml/pub_crate_missing_docs/clippy.toml
+++ b/tests/ui-toml/pub_crate_missing_docs/clippy.toml
@@ -1,0 +1,1 @@
+only-check-missing-docs-in-crate-items = true

--- a/tests/ui-toml/pub_crate_missing_docs/clippy.toml
+++ b/tests/ui-toml/pub_crate_missing_docs/clippy.toml
@@ -1,1 +1,1 @@
-only-check-missing-docs-in-crate-items = true
+missing-docs-in-crate-items = true

--- a/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.rs
+++ b/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.rs
@@ -1,4 +1,5 @@
 //! this is crate
+#![allow(missing_docs)]
 #![warn(clippy::missing_docs_in_private_items)]
 
 /// this is mod
@@ -44,6 +45,13 @@ mod my_mod {
         priv_field_no_docs: (),
     }
 }
+
+/// some docs
+type CrateTypedefWithDocs = String;
+type CrateTypedefNoDocs = String;
+/// some docs
+pub type PubTypedefWithDocs = String;
+pub type PubTypedefNoDocs = String;
 
 fn main() {
     my_mod::crate_with_docs();

--- a/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.rs
+++ b/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.rs
@@ -1,0 +1,32 @@
+//! this is crate
+#![warn(clippy::missing_docs_in_private_items)]
+
+/// this is mod
+mod my_mod {
+    /// some docs
+    fn priv_with_docs() {}
+    fn priv_no_docs() {}
+    /// some docs
+    pub(crate) fn crate_with_docs() {}
+    pub(crate) fn crate_no_docs() {}
+    /// some docs
+    pub(super) fn super_with_docs() {}
+    pub(super) fn super_no_docs() {}
+
+    mod my_sub {
+        /// some docs
+        fn sub_priv_with_docs() {}
+        fn sub_priv_no_docs() {}
+        /// some docs
+        pub(crate) fn sub_crate_with_docs() {}
+        pub(crate) fn sub_crate_no_docs() {}
+        /// some docs
+        pub(super) fn sub_super_with_docs() {}
+        pub(super) fn sub_super_no_docs() {}
+    }
+}
+
+fn main() {
+    my_mod::crate_with_docs();
+    my_mod::crate_no_docs();
+}

--- a/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.rs
+++ b/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.rs
@@ -24,6 +24,25 @@ mod my_mod {
         pub(super) fn sub_super_with_docs() {}
         pub(super) fn sub_super_no_docs() {}
     }
+
+    /// some docs
+    pub(crate) struct CrateStructWithDocs {
+        /// some docs
+        pub(crate) crate_field_with_docs: (),
+        pub(crate) crate_field_no_docs: (),
+        /// some docs
+        priv_field_with_docs: (),
+        priv_field_no_docs: (),
+    }
+
+    pub(crate) struct CrateStructNoDocs {
+        /// some docs
+        pub(crate) crate_field_with_docs: (),
+        pub(crate) crate_field_no_docs: (),
+        /// some docs
+        priv_field_with_docs: (),
+        priv_field_no_docs: (),
+    }
 }
 
 fn main() {

--- a/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.stderr
+++ b/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.stderr
@@ -1,5 +1,5 @@
 error: missing documentation for a function
-  --> $DIR/pub_crate_missing_doc.rs:11:5
+  --> $DIR/pub_crate_missing_doc.rs:12:5
    |
 LL |     pub(crate) fn crate_no_docs() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,25 +7,25 @@ LL |     pub(crate) fn crate_no_docs() {}
    = note: `-D clippy::missing-docs-in-private-items` implied by `-D warnings`
 
 error: missing documentation for a function
-  --> $DIR/pub_crate_missing_doc.rs:14:5
+  --> $DIR/pub_crate_missing_doc.rs:15:5
    |
 LL |     pub(super) fn super_no_docs() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a function
-  --> $DIR/pub_crate_missing_doc.rs:22:9
+  --> $DIR/pub_crate_missing_doc.rs:23:9
    |
 LL |         pub(crate) fn sub_crate_no_docs() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a struct field
-  --> $DIR/pub_crate_missing_doc.rs:32:9
+  --> $DIR/pub_crate_missing_doc.rs:33:9
    |
 LL |         pub(crate) crate_field_no_docs: (),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing documentation for a struct
-  --> $DIR/pub_crate_missing_doc.rs:38:5
+  --> $DIR/pub_crate_missing_doc.rs:39:5
    |
 LL | /     pub(crate) struct CrateStructNoDocs {
 LL | |         /// some docs
@@ -37,10 +37,16 @@ LL | |     }
    | |_____^
 
 error: missing documentation for a struct field
-  --> $DIR/pub_crate_missing_doc.rs:41:9
+  --> $DIR/pub_crate_missing_doc.rs:42:9
    |
 LL |         pub(crate) crate_field_no_docs: (),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: missing documentation for a type alias
+  --> $DIR/pub_crate_missing_doc.rs:51:1
+   |
+LL | type CrateTypedefNoDocs = String;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.stderr
+++ b/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.stderr
@@ -18,5 +18,29 @@ error: missing documentation for a function
 LL |         pub(crate) fn sub_crate_no_docs() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: missing documentation for a struct field
+  --> $DIR/pub_crate_missing_doc.rs:32:9
+   |
+LL |         pub(crate) crate_field_no_docs: (),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: missing documentation for a struct
+  --> $DIR/pub_crate_missing_doc.rs:38:5
+   |
+LL | /     pub(crate) struct CrateStructNoDocs {
+LL | |         /// some docs
+LL | |         pub(crate) crate_field_with_docs: (),
+LL | |         pub(crate) crate_field_no_docs: (),
+...  |
+LL | |         priv_field_no_docs: (),
+LL | |     }
+   | |_____^
+
+error: missing documentation for a struct field
+  --> $DIR/pub_crate_missing_doc.rs:41:9
+   |
+LL |         pub(crate) crate_field_no_docs: (),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.stderr
+++ b/tests/ui-toml/pub_crate_missing_docs/pub_crate_missing_doc.stderr
@@ -1,0 +1,22 @@
+error: missing documentation for a function
+  --> $DIR/pub_crate_missing_doc.rs:11:5
+   |
+LL |     pub(crate) fn crate_no_docs() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::missing-docs-in-private-items` implied by `-D warnings`
+
+error: missing documentation for a function
+  --> $DIR/pub_crate_missing_doc.rs:14:5
+   |
+LL |     pub(super) fn super_no_docs() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: missing documentation for a function
+  --> $DIR/pub_crate_missing_doc.rs:22:9
+   |
+LL |         pub(crate) fn sub_crate_no_docs() {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -33,8 +33,8 @@ error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown fie
            max-struct-bools
            max-suggested-slice-pattern-length
            max-trait-bounds
+           missing-docs-in-crate-items
            msrv
-           only-check-missing-docs-in-crate-items
            pass-by-value-size-limit
            single-char-binding-names-threshold
            standard-macro-braces

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -34,6 +34,7 @@ error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown fie
            max-suggested-slice-pattern-length
            max-trait-bounds
            msrv
+           only-check-missing-docs-in-crate-items
            pass-by-value-size-limit
            single-char-binding-names-threshold
            standard-macro-braces


### PR DESCRIPTION
Fixes this: https://github.com/rust-lang/rust-clippy/issues/5736#issuecomment-1412442404

TODO:
- [x] Needs docs
- [x] Needs better names
- [x] Should `pub` items be checked to when this new option is enabled? I'm saying no because `missing_docs` already exists

@flip1995 I'd like to get some input from you :) 

---

changelog: Enhancement: [`missing_docs_in_private_items`]: Added new configuration `missing-docs-in-crate-items` to lint on items visible within the current crate. For example, `pub(crate)` items.
[#10303](https://github.com/rust-lang/rust-clippy/pull/10303)
<!-- changelog_checked -->
