### PR TITLE
Add `transmute_slice_to_larger_element_type` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4794,6 +4794,7 @@ Released 2018-09-13
 [`transmute_num_to_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_num_to_bytes
 [`transmute_ptr_to_ptr`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ptr
 [`transmute_ptr_to_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ref
+[`transmute_slice_to_larger_element_type`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_slice_to_larger_element_type
 [`transmute_undefined_repr`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmute_undefined_repr
 [`transmutes_expressible_as_ptr_casts`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmutes_expressible_as_ptr_casts
 [`transmuting_null`]: https://rust-lang.github.io/rust-clippy/master/index.html#transmuting_null

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -577,6 +577,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::transmute::TRANSMUTE_NUM_TO_BYTES_INFO,
     crate::transmute::TRANSMUTE_PTR_TO_PTR_INFO,
     crate::transmute::TRANSMUTE_PTR_TO_REF_INFO,
+    crate::transmute::TRANSMUTE_SLICE_TO_LARGER_ELEMENT_TYPE_INFO,
     crate::transmute::TRANSMUTE_UNDEFINED_REPR_INFO,
     crate::transmute::TRANSMUTING_NULL_INFO,
     crate::transmute::UNSOUND_COLLECTION_TRANSMUTE_INFO,

--- a/clippy_lints/src/transmute/mod.rs
+++ b/clippy_lints/src/transmute/mod.rs
@@ -8,6 +8,7 @@ mod transmute_num_to_bytes;
 mod transmute_ptr_to_ptr;
 mod transmute_ptr_to_ref;
 mod transmute_ref_to_ref;
+mod transmute_slice_to_larger_element_type;
 mod transmute_undefined_repr;
 mod transmutes_expressible_as_ptr_casts;
 mod transmuting_null;
@@ -438,6 +439,25 @@ declare_clippy_lint! {
     "transmute results in a null function pointer, which is undefined behavior"
 }
 
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// ### Why is this bad?
+    ///
+    /// ### Example
+    /// ```rust
+    /// // example code where clippy issues a warning
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// // example code which does not raise clippy warning
+    /// ```
+    #[clippy::version = "1.69.0"]
+    pub TRANSMUTE_SLICE_TO_LARGER_ELEMENT_TYPE,
+    correctness,
+    "default lint description"
+}
+
 pub struct Transmute {
     msrv: Msrv,
 }
@@ -458,6 +478,7 @@ impl_lint_pass!(Transmute => [
     TRANSMUTE_UNDEFINED_REPR,
     TRANSMUTING_NULL,
     TRANSMUTE_NULL_TO_FN,
+    TRANSMUTE_SLICE_TO_LARGER_ELEMENT_TYPE,
 ]);
 impl Transmute {
     #[must_use]
@@ -503,6 +524,7 @@ impl<'tcx> LateLintPass<'tcx> for Transmute {
                     | transmute_int_to_float::check(cx, e, from_ty, to_ty, arg, const_context)
                     | transmute_float_to_int::check(cx, e, from_ty, to_ty, arg, const_context)
                     | transmute_num_to_bytes::check(cx, e, from_ty, to_ty, arg, const_context)
+                    | transmute_slice_to_larger_element_type::check(cx, e, from_ty, to_ty, arg)
                     | (
                         unsound_collection_transmute::check(cx, e, from_ty, to_ty)
                         || transmute_undefined_repr::check(cx, e, from_ty, to_ty)

--- a/clippy_lints/src/transmute/mod.rs
+++ b/clippy_lints/src/transmute/mod.rs
@@ -441,21 +441,32 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for slice creation which has larger element before transmute.
     ///
     /// ### Why is this bad?
+    /// Creating those slices leads to out-of-bounds read, considered Undefined Behavior.
     ///
     /// ### Example
     /// ```rust
-    /// // example code where clippy issues a warning
+    /// let i8_slice: &[i8] = &[1i8, 2, 3, 4];
+    //  let i32_slice: &[i32] = unsafe { std::mem::transmute(i8_slice) };
     /// ```
+    ///
     /// Use instead:
+    ///
     /// ```rust
-    /// // example code which does not raise clippy warning
+    /// let i32_slice: &[i32] = i8_slice.iter().map(|item| unsafe { std::mem::transmute(item) }).collect::<Vec<_>>().to_slice();
+    /// ```
+    ///
+    /// or, alternatively:
+    ///
+    /// ```rust
+    /// let i32_slice: &[i32] = std::slice::align_to::<i32>(i8_slice).1;
     /// ```
     #[clippy::version = "1.69.0"]
     pub TRANSMUTE_SLICE_TO_LARGER_ELEMENT_TYPE,
     correctness,
-    "default lint description"
+    "transmute leads out-of-bounds read, which is undefined behavior"
 }
 
 pub struct Transmute {

--- a/clippy_lints/src/transmute/mod.rs
+++ b/clippy_lints/src/transmute/mod.rs
@@ -449,19 +449,21 @@ declare_clippy_lint! {
     /// ### Example
     /// ```rust
     /// let i8_slice: &[i8] = &[1i8, 2, 3, 4];
-    //  let i32_slice: &[i32] = unsafe { std::mem::transmute(i8_slice) };
+    /// let i32_slice: &[i32] = unsafe { std::mem::transmute(i8_slice) };
     /// ```
     ///
     /// Use instead:
     ///
     /// ```rust
+    /// let i8_slice: &[i8] = &[1i8, 2, 3, 4];
     /// let i32_slice: &[i32] = i8_slice.iter().map(|item| unsafe { std::mem::transmute(item) }).collect::<Vec<_>>().to_slice();
     /// ```
     ///
     /// or, alternatively:
     ///
     /// ```rust
-    /// let i32_slice: &[i32] = std::slice::align_to::<i32>(i8_slice).1;
+    /// let i8_slice: &[i8] = &[1i8, 2, 3, 4];
+    /// let i32_slice: &[i32] = unsafe { i8_slice.align_to::<i32>().1 };
     /// ```
     #[clippy::version = "1.69.0"]
     pub TRANSMUTE_SLICE_TO_LARGER_ELEMENT_TYPE,

--- a/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
+++ b/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
@@ -36,7 +36,7 @@ pub(super) fn check<'tcx>(
                             .iter()\
                             .map(|item| unsafe {{ std::mem::transmute(item) }})\
                             .collect::<Vec<_>>()\
-                            .to_slice()"
+                            .as_slice()"
                         );
                         let sugg_reallocate = Cow::from(sugg_reallocate);
                         let sugg_align_to = format!("({transmute_arg}).align_to::<{ty_elem_to}>().1");

--- a/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
+++ b/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
@@ -9,7 +9,6 @@ use rustc_lint::LateContext;
 use rustc_middle::ty::{self, Ty};
 use std::borrow::Cow;
 
-// TODO: Adjust the parameters as necessary
 pub(super) fn check<'tcx>(
     cx: &LateContext<'tcx>,
     call_to_transmute: &'tcx Expr<'_>,

--- a/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
+++ b/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
@@ -40,7 +40,7 @@ pub(super) fn check<'tcx>(
                             .to_slice()"
                         );
                         let sugg_reallocate = Cow::from(sugg_reallocate);
-                        let sugg_align_to = format!("std::slice::align_to::<{ty_elem_to}>({transmute_arg}).1");
+                        let sugg_align_to = format!("({transmute_arg}).align_to::<{ty_elem_to}>().1");
                         let sugg_align_to = Cow::from(sugg_align_to);
                         diag.note("this transmute leads out-of-bounds read");
                         diag.span_suggestions(

--- a/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
+++ b/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
@@ -31,6 +31,7 @@ pub(super) fn check<'tcx>(
                         let transmute_arg = sugg::Sugg::hir(cx, transmute_arg, "..");
                         // TODO: In this case, outer unsafe block is not needed anymore. It should be removed in
                         // suggestion.
+                        // FIXME: this do not compile, because temporal Vec dropped at end of outer unsafe block.
                         let sugg_reallocate = format!(
                             "{transmute_arg}\
                             .iter()\

--- a/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
+++ b/clippy_lints/src/transmute/transmute_slice_to_larger_element_type.rs
@@ -1,0 +1,71 @@
+use super::TRANSMUTE_SLICE_TO_LARGER_ELEMENT_TYPE;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::reindent_multiline;
+use clippy_utils::sugg;
+use clippy_utils::ty::approx_ty_size;
+use rustc_errors::Applicability;
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, Ty};
+use std::borrow::Cow;
+
+// TODO: Adjust the parameters as necessary
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    call_to_transmute: &'tcx Expr<'_>,
+    from_ty: Ty<'tcx>,
+    to_ty: Ty<'tcx>,
+    transmute_arg: &'tcx Expr<'_>,
+) -> bool {
+    if let (ty::Ref(_, ty_from, _), ty::Ref(_, ty_to, _)) = (&from_ty.kind(), &to_ty.kind()) {
+        if let (&ty::Slice(ty_elem_from), &ty::Slice(ty_elem_to)) = (&ty_from.kind(), &ty_to.kind()) {
+            let ty_eleme_from_size = approx_ty_size(cx, *ty_elem_from);
+            let ty_elem_to_size = approx_ty_size(cx, *ty_elem_to);
+            if ty_eleme_from_size < ty_elem_to_size {
+                // this is UB!!
+                span_lint_and_then(
+                    cx,
+                    TRANSMUTE_SLICE_TO_LARGER_ELEMENT_TYPE,
+                    call_to_transmute.span,
+                    &format!("transmute from `&[{ty_elem_from}]` to `&[{ty_elem_to}]` results in undefined behavior"),
+                    |diag| {
+                        let transmute_arg = sugg::Sugg::hir(cx, transmute_arg, "..");
+                        // TODO: In this case, outer unsafe block is not needed anymore. It should be removed in
+                        // suggestion.
+                        let sugg_reallocate = format!(
+                            "{transmute_arg}\
+                            .iter()\
+                            .map(|item| unsafe {{ std::mem::transmute(item) }})\
+                            .collect::<Vec<_>>()\
+                            .to_slice()"
+                        );
+                        let sugg_reallocate = Cow::from(sugg_reallocate);
+                        let sugg_align_to = format!("std::slice::align_to::<{ty_elem_to}>({transmute_arg}).1");
+                        let sugg_align_to = Cow::from(sugg_align_to);
+                        diag.note("this transmute leads out-of-bounds read");
+                        diag.span_suggestions(
+                            call_to_transmute.span,
+                            "try",
+                            [
+                                reindent_multiline(sugg_reallocate, true, None).to_string(),
+                                // TODO: this suggestion does not check if there's prefix and postfix.
+                                // NOTE: this is not what user want to do if ty_elem_to is ZST; however,
+                                // this lint will not fire in such case anyway (ZSTs cannot be larger than any type).
+                                reindent_multiline(sugg_align_to, true, None).to_string(),
+                            ],
+                            Applicability::Unspecified,
+                        );
+                    },
+                );
+
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    }
+}

--- a/tests/ui/transmute_slice_to_larger_element_type.rs
+++ b/tests/ui/transmute_slice_to_larger_element_type.rs
@@ -1,0 +1,9 @@
+#![allow(unused)]
+#![warn(clippy::transmute_slice_to_larger_element_type)]
+
+fn i8_slice_to_i32_slice() {
+    let i8_slice: &[i8] = &[1i8, 2, 3, 4];
+    let i32_slice: &[i32] = unsafe { std::mem::transmute(i8_slice) };
+}
+
+fn main() {}

--- a/tests/ui/transmute_slice_to_larger_element_type.stderr
+++ b/tests/ui/transmute_slice_to_larger_element_type.stderr
@@ -1,0 +1,17 @@
+error: transmute from `&[i8]` to `&[i32]` results in undefined behavior
+  --> $DIR/transmute_slice_to_larger_element_type.rs:6:38
+   |
+LL |     let i32_slice: &[i32] = unsafe { std::mem::transmute(i8_slice) };
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this transmute leads out-of-bounds read
+   = note: `-D clippy::transmute-slice-to-larger-element-type` implied by `-D warnings`
+help: try
+   |
+LL |     let i32_slice: &[i32] = unsafe { i8_slice.iter().map(|item| unsafe { std::mem::transmute(item) }).collect::<Vec<_>>().to_slice() };
+   |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     let i32_slice: &[i32] = unsafe { std::slice::align_to::<i32>(i8_slice).1 };
+   |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+

--- a/tests/ui/transmute_slice_to_larger_element_type.stderr
+++ b/tests/ui/transmute_slice_to_larger_element_type.stderr
@@ -10,7 +10,7 @@ help: try
    |
 LL |     let i32_slice: &[i32] = unsafe { i8_slice.iter().map(|item| unsafe { std::mem::transmute(item) }).collect::<Vec<_>>().to_slice() };
    |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-LL |     let i32_slice: &[i32] = unsafe { std::slice::align_to::<i32>(i8_slice).1 };
+LL |     let i32_slice: &[i32] = unsafe { i8_slice.align_to::<i32>().1 };
    |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error

--- a/tests/ui/transmute_slice_to_larger_element_type.stderr
+++ b/tests/ui/transmute_slice_to_larger_element_type.stderr
@@ -8,10 +8,10 @@ LL |     let i32_slice: &[i32] = unsafe { std::mem::transmute(i8_slice) };
    = note: `-D clippy::transmute-slice-to-larger-element-type` implied by `-D warnings`
 help: try
    |
+LL |     let i32_slice: &[i32] = unsafe { (i8_slice).align_to::<i32>().1 };
+   |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     let i32_slice: &[i32] = unsafe { i8_slice.iter().map(|item| unsafe { std::mem::transmute(item) }).collect::<Vec<_>>().to_slice() };
    |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-LL |     let i32_slice: &[i32] = unsafe { i8_slice.align_to::<i32>().1 };
-   |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
<!--
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.
-->

- [x] Followed [lint naming conventions][lint_naming]
- [x] Added passing UI tests (including committed `.stderr` file)
- [ ] `cargo test` passes locally
  - [ ] except `fmt` check
- [x] Executed `cargo dev update_lints`
- [x] Added lint documentation
- [ ] Run `cargo dev fmt`
  - This was not possible, because running `cargo dev fmt` somehow implied `cargo dev fmt --check`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

<!--
Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*
-->

close #10285 

---

changelog: New lint: [`transmute_slice_to_larger_element_type`]
[#10312](https://github.com/rust-lang/rust-clippy/pull/10312)
<!-- changelog_checked -->