### PR TITLE
cast_possible_truncation: issue proper help message

### DIFF
--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -168,7 +168,7 @@ pub(super) fn check(
     let suggestion = format!("{cast_to_snip}::try_from({name_of_cast_from})");
 
     span_lint_and_then(cx, CAST_POSSIBLE_TRUNCATION, expr.span, &msg, |diag| {
-        diag.help("if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...");
+        diag.help("if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...");
         diag.span_suggestion_with_style(
             expr.span,
             "... or use `try_from` and handle the error accordingly",

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -42,7 +42,7 @@ error: casting `f32` to `i32` may truncate the value
 LL |     1f32 as i32;
    |     ^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
 help: ... or use `try_from` and handle the error accordingly
    |
@@ -55,7 +55,7 @@ error: casting `f32` to `u32` may truncate the value
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     u32::try_from(1f32);
@@ -75,7 +75,7 @@ error: casting `f64` to `f32` may truncate the value
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     f32::try_from(1f64);
@@ -87,7 +87,7 @@ error: casting `i32` to `i8` may truncate the value
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     i8::try_from(1i32);
@@ -99,7 +99,7 @@ error: casting `i32` to `u8` may truncate the value
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     u8::try_from(1i32);
@@ -111,7 +111,7 @@ error: casting `f64` to `isize` may truncate the value
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     isize::try_from(1f64);
@@ -123,7 +123,7 @@ error: casting `f64` to `usize` may truncate the value
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     usize::try_from(1f64);
@@ -141,7 +141,7 @@ error: casting `u32` to `u16` may truncate the value
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     u16::try_from(1f32 as u32);
@@ -153,7 +153,7 @@ error: casting `f32` to `u32` may truncate the value
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     u32::try_from(1f32) as u16;
@@ -215,7 +215,7 @@ error: casting `i64` to `i8` may truncate the value
 LL |     (-99999999999i64).min(1) as i8; // should be linted because signed
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     i8::try_from((-99999999999i64).min(1)); // should be linted because signed
@@ -227,7 +227,7 @@ error: casting `u64` to `u8` may truncate the value
 LL |     999999u64.clamp(0, 256) as u8; // should still be linted
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     u8::try_from(999999u64.clamp(0, 256)); // should still be linted
@@ -239,7 +239,7 @@ error: casting `main::E2` to `u8` may truncate the value
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |             let _ = u8::try_from(self);
@@ -259,7 +259,7 @@ error: casting `main::E5` to `i8` may truncate the value
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |             let _ = i8::try_from(self);
@@ -277,7 +277,7 @@ error: casting `main::E6` to `i16` may truncate the value
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |             let _ = i16::try_from(self);
@@ -289,7 +289,7 @@ error: casting `main::E7` to `usize` may truncate the value on targets with 32-b
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |             let _ = usize::try_from(self);
@@ -301,7 +301,7 @@ error: casting `main::E10` to `u16` may truncate the value
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |             let _ = u16::try_from(self);
@@ -313,7 +313,7 @@ error: casting `u32` to `u8` may truncate the value
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     let c = u8::try_from((q >> 16));
@@ -325,7 +325,7 @@ error: casting `u32` to `u8` may truncate the value
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     let c = u8::try_from((q / 1000));

--- a/tests/ui/cast_size.stderr
+++ b/tests/ui/cast_size.stderr
@@ -4,7 +4,7 @@ error: casting `isize` to `i8` may truncate the value
 LL |     1isize as i8;
    |     ^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
    = note: `-D clippy::cast-possible-truncation` implied by `-D warnings`
 help: ... or use `try_from` and handle the error accordingly
    |
@@ -43,7 +43,7 @@ error: casting `isize` to `i32` may truncate the value on targets with 64-bit wi
 LL |     1isize as i32;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     i32::try_from(1isize);
@@ -55,7 +55,7 @@ error: casting `isize` to `u32` may truncate the value on targets with 64-bit wi
 LL |     1isize as u32;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     u32::try_from(1isize);
@@ -67,7 +67,7 @@ error: casting `usize` to `u32` may truncate the value on targets with 64-bit wi
 LL |     1usize as u32;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     u32::try_from(1usize);
@@ -79,7 +79,7 @@ error: casting `usize` to `i32` may truncate the value on targets with 64-bit wi
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     i32::try_from(1usize);
@@ -99,7 +99,7 @@ error: casting `i64` to `isize` may truncate the value on targets with 32-bit wi
 LL |     1i64 as isize;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     isize::try_from(1i64);
@@ -111,7 +111,7 @@ error: casting `i64` to `usize` may truncate the value on targets with 32-bit wi
 LL |     1i64 as usize;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     usize::try_from(1i64);
@@ -123,7 +123,7 @@ error: casting `u64` to `isize` may truncate the value on targets with 32-bit wi
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     isize::try_from(1u64);
@@ -141,7 +141,7 @@ error: casting `u64` to `usize` may truncate the value on targets with 32-bit wi
 LL |     1u64 as usize;
    |     ^^^^^^^^^^^^^
    |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_precision_loss)]` ...
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 help: ... or use `try_from` and handle the error accordingly
    |
 LL |     usize::try_from(1u64);


### PR DESCRIPTION
Fixes #10325 

---

changelog: Sugg: [`cast_possible_truncation`]: Corrected the lint name in help message
[#10330](https://github.com/rust-lang/rust-clippy/pull/10330)
<!-- changelog_checked-->