### PR TITLE
lintcheck: fix clap panic

### DIFF
--- a/lintcheck/src/config.rs
+++ b/lintcheck/src/config.rs
@@ -35,7 +35,7 @@ fn get_clap_config() -> ArgMatches {
                 .long("markdown")
                 .help("Change the reports table to use markdown links"),
             Arg::new("recursive")
-                .long("--recursive")
+                .long("recursive")
                 .help("Run clippy on the dependencies of crates specified in crates-toml")
                 .conflicts_with("threads")
                 .conflicts_with("fix"),


### PR DESCRIPTION
clap 4.1.4 panics if `-` is used at the start of an argument:

```
$ cargo lintcheck
[…]
thread 'main' panicked at 'Argument recursive: long "--recursive" must not start with a `-`, that will be handled by the parser', /home/sam/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.4/src/builder/debug_asserts.rs:82:13
```

changelog: none
<!-- changelog_checked -->