### PR TITLE
Ignore synthetic type parameters for `extra_unused_type_parameters`

### DIFF
--- a/clippy_lints/src/extra_unused_type_parameters.rs
+++ b/clippy_lints/src/extra_unused_type_parameters.rs
@@ -23,7 +23,6 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
-    /// // unused type parameters
     /// fn unused_ty<T>(x: u8) {
     ///     // ..
     /// }
@@ -45,7 +44,7 @@ declare_lint_pass!(ExtraUnusedTypeParameters => [EXTRA_UNUSED_TYPE_PARAMETERS]);
 /// trait bounds those parameters have.
 struct TypeWalker<'cx, 'tcx> {
     cx: &'cx LateContext<'tcx>,
-    /// Collection of all the type parameters and their spans.
+    /// Collection of all the function's type parameters.
     ty_params: FxHashMap<DefId, Span>,
     /// Collection of any (inline) trait bounds corresponding to each type parameter.
     bounds: FxHashMap<DefId, Span>,
@@ -69,8 +68,8 @@ impl<'cx, 'tcx> TypeWalker<'cx, 'tcx> {
             .params
             .iter()
             .filter_map(|param| {
-                if let GenericParamKind::Type { .. } = param.kind {
-                    Some((param.def_id.into(), param.span))
+                if let GenericParamKind::Type { synthetic, .. } = param.kind {
+                    (!synthetic).then_some((param.def_id.into(), param.span))
                 } else {
                     if !param.is_elided_lifetime() {
                         all_params_unused = false;

--- a/tests/ui/extra_unused_type_parameters.rs
+++ b/tests/ui/extra_unused_type_parameters.rs
@@ -71,6 +71,8 @@ where
         .filter_map(move |(i, a)| if i == index { None } else { Some(a) })
 }
 
+fn unused_opaque<A, B>(dummy: impl Default) {}
+
 mod issue10319 {
     fn assert_send<T: Send>() {}
 

--- a/tests/ui/extra_unused_type_parameters.stderr
+++ b/tests/ui/extra_unused_type_parameters.stderr
@@ -55,5 +55,13 @@ LL |     fn unused_ty_impl<T>(&self) {}
    |
    = help: consider removing the parameter
 
-error: aborting due to 7 previous errors
+error: type parameters go unused in function definition
+  --> $DIR/extra_unused_type_parameters.rs:74:17
+   |
+LL | fn unused_opaque<A, B>(dummy: impl Default) {}
+   |                 ^^^^^^
+   |
+   = help: consider removing the parameters
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
There was a minor bug around calculating spans when forming the help message. An example:

```rust
fn unused_opaque<A, B>(dummy: impl Default) {}
//               ^^ ^
```

In this case, the entire list of generics should be highlighted, instead of each individual parameter. The culprit is the `impl Default`, which registers as a type parameter but doesn't live within the `<...>`. Because synthetic parameters can't ever be manually created, we just ignore them for this lint.

r? @flip1995 
changelog: none
<!-- changelog_checked -->