### PR TITLE
uninlined_format_args: do not inline argument with generic parameters

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -340,6 +340,7 @@ fn check_one_arg(
     if matches!(param.kind, Implicit | Starred | Named(_) | Numbered)
         && let ExprKind::Path(QPath::Resolved(None, path)) = param.value.kind
         && let [segment] = path.segments
+        && segment.args.is_none()
         && let Some(arg_span) = args.value_with_prev_comma_span(param.value.hir_id)
     {
         let replacement = match param.usage {

--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -174,3 +174,7 @@ fn _meets_msrv() {
     let local_i32 = 1;
     println!("expand='{local_i32}'");
 }
+
+fn _do_not_fire() {
+    println!("{:?}", None::<()>);
+}

--- a/tests/ui/uninlined_format_args.rs
+++ b/tests/ui/uninlined_format_args.rs
@@ -179,3 +179,7 @@ fn _meets_msrv() {
     let local_i32 = 1;
     println!("expand='{}'", local_i32);
 }
+
+fn _do_not_fire() {
+    println!("{:?}", None::<()>);
+}


### PR DESCRIPTION
Fix #10339

---

changelog: FP: [`uninlined_format_args`]: No longer lints for arguments with generic parameters
[#10343](https://github.com/rust-lang/rust-clippy/pull/10343)
<!-- changelog_checked -->
