### PR TITLE
[significant_drop_tightening] Ignore inexpensive statements

### DIFF
--- a/tests/ui/significant_drop_tightening.fixed
+++ b/tests/ui/significant_drop_tightening.fixed
@@ -4,6 +4,14 @@
 
 use std::sync::Mutex;
 
+pub fn post_bindings_can_be_ignored() {
+    let mutex = Mutex::new(1);
+    let lock = mutex.lock().unwrap();
+    let rslt = *lock;
+    let another = rslt;
+    let _ = another;
+}
+
 pub fn unnecessary_contention_with_multiple_owned_results() {
     {
         let mutex = Mutex::new(1i32);

--- a/tests/ui/significant_drop_tightening.rs
+++ b/tests/ui/significant_drop_tightening.rs
@@ -4,6 +4,14 @@
 
 use std::sync::Mutex;
 
+pub fn post_bindings_can_be_ignored() {
+    let mutex = Mutex::new(1);
+    let lock = mutex.lock().unwrap();
+    let rslt = *lock;
+    let another = rslt;
+    let _ = another;
+}
+
 pub fn unnecessary_contention_with_multiple_owned_results() {
     {
         let mutex = Mutex::new(1i32);

--- a/tests/ui/significant_drop_tightening.stderr
+++ b/tests/ui/significant_drop_tightening.stderr
@@ -1,5 +1,5 @@
 error: temporary with significant `Drop` can be early dropped
-  --> $DIR/significant_drop_tightening.rs:17:13
+  --> $DIR/significant_drop_tightening.rs:25:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -20,7 +20,7 @@ LL +         drop(lock);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> $DIR/significant_drop_tightening.rs:38:13
+  --> $DIR/significant_drop_tightening.rs:46:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -44,7 +44,7 @@ LL +
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> $DIR/significant_drop_tightening.rs:44:17
+  --> $DIR/significant_drop_tightening.rs:52:17
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(vec![1i32]);


### PR DESCRIPTION
Not all statements that follow the last use of a lock guard are expensive and can therefore be ignored by the lint. 

```rust
pub fn foo() -> i32 {
    let mutex = Mutex::new(1);
    let lock = mutex.lock().unwrap();
    let rslt = *lock;
    let another = rslt;
   another
}
```

---

changelog: [`significant_drop_tightening`]: No longer lints for inexpensive statements after the lock guard
[#10363](https://github.com/rust-lang/rust-clippy/pull/10363)
<!-- changelog_checked -->