### PR TITLE
Fix rust-lang/rust#107877, etc.

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -1357,10 +1357,10 @@ fn replace_types<'tcx>(
                     && let Some(term_ty) = projection_predicate.term.ty()
                     && let ty::Param(term_param_ty) = term_ty.kind()
                 {
-                    let item_def_id = projection_predicate.projection_ty.def_id;
-                    let assoc_item = cx.tcx.associated_item(item_def_id);
-                    let projection = cx.tcx
-                        .mk_projection(assoc_item.def_id, cx.tcx.mk_substs_trait(new_ty, []));
+                    let projection = cx.tcx.mk_ty(ty::Alias(
+                        ty::Projection,
+                        projection_predicate.projection_ty.with_self_ty(cx.tcx, new_ty),
+                    ));
 
                     if let Ok(projected_ty) = cx.tcx.try_normalize_erasing_regions(cx.param_env, projection)
                         && substs[term_param_ty.index as usize] != ty::GenericArg::from(projected_ty)

--- a/tests/ui/crashes/ice-rust-107877.rs
+++ b/tests/ui/crashes/ice-rust-107877.rs
@@ -1,0 +1,17 @@
+#![allow(dead_code)]
+
+struct Foo;
+
+impl<'a> std::convert::TryFrom<&'a String> for Foo {
+    type Error = std::convert::Infallible;
+
+    fn try_from(_: &'a String) -> Result<Self, Self::Error> {
+        Ok(Foo)
+    }
+}
+
+fn find<E>(_: impl std::convert::TryInto<Foo, Error = E>) {}
+
+fn main() {
+    find(&String::new());
+}


### PR DESCRIPTION
Fix #10009
Fix #10387
Fix https://github.com/rust-lang/rust/issues/107877

The fix is to verify that the associated item's trait is implemented before trying to project the item's type.

r? @Jarcho

---

changelog: ICE: [`needless_borrow`]: No longer panics on ambiguous projections
[#10403](https://github.com/rust-lang/rust-clippy/pull/10403)
<!-- changelog_checked -->