### PR TITLE
Add `unused_enumerate_index` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5561,6 +5561,7 @@ Released 2018-09-13
 [`unstable_as_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#unstable_as_slice
 [`unused_async`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_async
 [`unused_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_collect
+[`unused_enumerate_index`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
 [`unused_format_specs`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_format_specs
 [`unused_io_amount`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
 [`unused_label`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_label

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -274,6 +274,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::loops::NEVER_LOOP_INFO,
     crate::loops::SAME_ITEM_PUSH_INFO,
     crate::loops::SINGLE_ELEMENT_LOOP_INFO,
+    crate::loops::UNUSED_ENUMERATE_INDEX_INFO,
     crate::loops::WHILE_IMMUTABLE_CONDITION_INFO,
     crate::loops::WHILE_LET_LOOP_INFO,
     crate::loops::WHILE_LET_ON_ITERATOR_INFO,

--- a/clippy_lints/src/loops/for_kv_map.rs
+++ b/clippy_lints/src/loops/for_kv_map.rs
@@ -1,9 +1,8 @@
 use super::FOR_KV_MAP;
 use clippy_utils::diagnostics::{multispan_sugg, span_lint_and_then};
 use clippy_utils::source::snippet;
-use clippy_utils::sugg;
 use clippy_utils::ty::is_type_diagnostic_item;
-use clippy_utils::visitors::is_local_used;
+use clippy_utils::{pat_is_wild, sugg};
 use rustc_hir::{BorrowKind, Expr, ExprKind, Mutability, Pat, PatKind};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
@@ -53,14 +52,5 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>, arg: &'tcx
                 );
             }
         }
-    }
-}
-
-/// Returns `true` if the pattern is a `PatWild` or an ident prefixed with `_`.
-fn pat_is_wild<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx PatKind<'_>, body: &'tcx Expr<'_>) -> bool {
-    match *pat {
-        PatKind::Wild => true,
-        PatKind::Binding(_, id, ident, None) if ident.as_str().starts_with('_') => !is_local_used(cx, body, id),
-        _ => false,
     }
 }

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -580,7 +580,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for `for (_, v) in a.iter().enumerate()`
+    /// Checks for uses of the `enumerate` method where the index is unused (`_`)
     ///
     /// ### Why is this bad?
     /// The index from `.enumerate()` is immediately dropped.
@@ -589,20 +589,20 @@ declare_clippy_lint! {
     /// ```rust
     /// let v = vec![1, 2, 3, 4];
     /// for (_, x) in v.iter().enumerate() {
-    ///     print!("{x}")
+    ///     println!("{x}");
     /// }
     /// ```
     /// Use instead:
     /// ```rust
     /// let v = vec![1, 2, 3, 4];
     /// for x in v.iter() {
-    ///     print!("{x}")
+    ///     println!("{x}");
     /// }
     /// ```
-    #[clippy::version = "1.69.0"]
+    #[clippy::version = "1.75.0"]
     pub UNUSED_ENUMERATE_INDEX,
     style,
-    "using .enumerate() and immediately dropping the index"
+    "using `.enumerate()` and immediately dropping the index"
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/loops/unused_enumerate_index.rs
+++ b/clippy_lints/src/loops/unused_enumerate_index.rs
@@ -1,8 +1,7 @@
 use super::UNUSED_ENUMERATE_INDEX;
 use clippy_utils::diagnostics::{multispan_sugg, span_lint_and_then};
 use clippy_utils::source::snippet;
-use clippy_utils::sugg;
-use clippy_utils::visitors::is_local_used;
+use clippy_utils::{pat_is_wild, sugg};
 use rustc_hir::def::DefKind;
 use rustc_hir::{Expr, ExprKind, Pat, PatKind};
 use rustc_lint::LateContext;
@@ -60,13 +59,4 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>, arg: &'tcx
             );
         },
     );
-}
-
-/// Returns `true` if the pattern is a `PatWild` or an ident prefixed with `_`.
-fn pat_is_wild<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx PatKind<'_>, body: &'tcx Expr<'_>) -> bool {
-    match *pat {
-        PatKind::Wild => true,
-        PatKind::Binding(_, id, ident, None) if ident.as_str().starts_with('_') => !is_local_used(cx, body, id),
-        _ => false,
-    }
 }

--- a/clippy_lints/src/loops/unused_enumerate_index.rs
+++ b/clippy_lints/src/loops/unused_enumerate_index.rs
@@ -1,0 +1,75 @@
+use super::UNUSED_ENUMERATE_INDEX;
+use clippy_utils::diagnostics::{multispan_sugg, span_lint_and_then};
+use clippy_utils::source::snippet;
+use clippy_utils::sugg;
+use clippy_utils::visitors::is_local_used;
+use rustc_hir::{Expr, ExprKind, Pat, PatKind};
+use rustc_lint::LateContext;
+use rustc_middle::ty;
+
+/// Checks for the `UNUSED_ENUMERATE_INDEX` lint.
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>, arg: &'tcx Expr<'_>, body: &'tcx Expr<'_>) {
+    let pat_span = pat.span;
+
+    let PatKind::Tuple(pat, _) = pat.kind else {
+        return;
+    };
+
+    if pat.len() != 2 {
+        return;
+    }
+
+    let arg_span = arg.span;
+
+    let ExprKind::MethodCall(method, self_arg, [], _) = arg.kind else {
+        return;
+    };
+
+    if method.ident.as_str() != "enumerate" {
+        return;
+    }
+
+    let ty = cx.typeck_results().expr_ty(arg);
+
+    if !pat_is_wild(cx, &pat[0].kind, body) {
+        return;
+    }
+
+    let new_pat_span = pat[1].span;
+
+    let name = match *ty.kind() {
+        ty::Adt(base, _substs) => cx.tcx.def_path_str(base.did()),
+        _ => return,
+    };
+
+    if name != "std::iter::Enumerate" && name != "core::iter::Enumerate" {
+        return;
+    }
+
+    span_lint_and_then(
+        cx,
+        UNUSED_ENUMERATE_INDEX,
+        arg_span,
+        "you seem to use `.enumerate()` and immediately discard the index",
+        |diag| {
+            let base_iter = sugg::Sugg::hir(cx, self_arg, "base iter");
+            multispan_sugg(
+                diag,
+                "remove the `.enumerate()` call",
+                vec![
+                    (pat_span, snippet(cx, new_pat_span, "value").into_owned()),
+                    (arg_span, base_iter.to_string()),
+                ],
+            );
+        },
+    );
+}
+
+/// Returns `true` if the pattern is a `PatWild` or an ident prefixed with `_`.
+fn pat_is_wild<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx PatKind<'_>, body: &'tcx Expr<'_>) -> bool {
+    match *pat {
+        PatKind::Wild => true,
+        PatKind::Binding(_, id, ident, None) if ident.as_str().starts_with('_') => !is_local_used(cx, body, id),
+        _ => false,
+    }
+}

--- a/clippy_lints/src/methods/iter_kv_map.rs
+++ b/clippy_lints/src/methods/iter_kv_map.rs
@@ -3,9 +3,8 @@
 use super::ITER_KV_MAP;
 use clippy_utils::diagnostics::{multispan_sugg, span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::{snippet, snippet_with_applicability};
-use clippy_utils::sugg;
 use clippy_utils::ty::is_type_diagnostic_item;
-use clippy_utils::visitors::is_local_used;
+use clippy_utils::{pat_is_wild, sugg};
 use rustc_hir::{BindingAnnotation, Body, BorrowKind, ByRef, Expr, ExprKind, Mutability, Pat, PatKind};
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty;
@@ -82,15 +81,5 @@ pub(super) fn check<'tcx>(
                 }
             }
         }
-    }
-}
-
-/// Returns `true` if the pattern is a `PatWild`, or is an ident prefixed with `_`
-/// that is not locally used.
-fn pat_is_wild<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx PatKind<'_>, body: &'tcx Expr<'_>) -> bool {
-    match *pat {
-        PatKind::Wild => true,
-        PatKind::Binding(_, id, ident, None) if ident.as_str().starts_with('_') => !is_local_used(cx, body, id),
-        _ => false,
     }
 }

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2960,3 +2960,15 @@ op_utils! {
     Shl    ShlAssign
     Shr    ShrAssign
 }
+
+/// Returns `true` if the pattern is a `PatWild`, or is an ident prefixed with `_`
+/// that is not locally used.
+pub fn pat_is_wild<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx PatKind<'_>, body: impl Visitable<'tcx>) -> bool {
+    match *pat {
+        PatKind::Wild => true,
+        PatKind::Binding(_, id, ident, None) if ident.as_str().starts_with('_') => {
+            !visitors::is_local_used(cx, body, id)
+        },
+        _ => false,
+    }
+}

--- a/tests/ui/unused_enumerate_index.fixed
+++ b/tests/ui/unused_enumerate_index.fixed
@@ -1,10 +1,58 @@
-// run-rustfix
 #![allow(unused)]
 #![warn(clippy::unused_enumerate_index)]
+
+use std::iter::Enumerate;
 
 fn main() {
     let v = [1, 2, 3];
     for x in v.iter() {
-        print!("{x}");
+        println!("{x}");
+    }
+
+    struct Dummy1;
+    impl Dummy1 {
+        fn enumerate(self) -> Vec<usize> {
+            vec![]
+        }
+    }
+    let dummy = Dummy1;
+    for x in dummy.enumerate() {
+        println!("{x}");
+    }
+
+    struct Dummy2;
+    impl Dummy2 {
+        fn enumerate(self) -> Enumerate<std::vec::IntoIter<usize>> {
+            vec![1, 2].into_iter().enumerate()
+        }
+    }
+    let dummy = Dummy2;
+    for (_, x) in dummy.enumerate() {
+        println!("{x}");
+    }
+
+    let mut with_used_iterator = [1, 2, 3].into_iter().enumerate();
+    with_used_iterator.next();
+    for (_, x) in with_used_iterator {
+        println!("{x}");
+    }
+
+    struct Dummy3(std::vec::IntoIter<usize>);
+
+    impl Iterator for Dummy3 {
+        type Item = usize;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.0.size_hint()
+        }
+    }
+
+    let dummy = Dummy3(vec![1, 2, 3].into_iter());
+    for x in dummy {
+        println!("{x}");
     }
 }

--- a/tests/ui/unused_enumerate_index.fixed
+++ b/tests/ui/unused_enumerate_index.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+#![allow(unused)]
+#![warn(clippy::unused_enumerate_index)]
+
+fn main() {
+    let v = [1, 2, 3];
+    for x in v.iter() {
+        print!("{x}");
+    }
+}

--- a/tests/ui/unused_enumerate_index.rs
+++ b/tests/ui/unused_enumerate_index.rs
@@ -1,10 +1,58 @@
-// run-rustfix
 #![allow(unused)]
 #![warn(clippy::unused_enumerate_index)]
+
+use std::iter::Enumerate;
 
 fn main() {
     let v = [1, 2, 3];
     for (_, x) in v.iter().enumerate() {
-        print!("{x}");
+        println!("{x}");
+    }
+
+    struct Dummy1;
+    impl Dummy1 {
+        fn enumerate(self) -> Vec<usize> {
+            vec![]
+        }
+    }
+    let dummy = Dummy1;
+    for x in dummy.enumerate() {
+        println!("{x}");
+    }
+
+    struct Dummy2;
+    impl Dummy2 {
+        fn enumerate(self) -> Enumerate<std::vec::IntoIter<usize>> {
+            vec![1, 2].into_iter().enumerate()
+        }
+    }
+    let dummy = Dummy2;
+    for (_, x) in dummy.enumerate() {
+        println!("{x}");
+    }
+
+    let mut with_used_iterator = [1, 2, 3].into_iter().enumerate();
+    with_used_iterator.next();
+    for (_, x) in with_used_iterator {
+        println!("{x}");
+    }
+
+    struct Dummy3(std::vec::IntoIter<usize>);
+
+    impl Iterator for Dummy3 {
+        type Item = usize;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            self.0.size_hint()
+        }
+    }
+
+    let dummy = Dummy3(vec![1, 2, 3].into_iter());
+    for (_, x) in dummy.enumerate() {
+        println!("{x}");
     }
 }

--- a/tests/ui/unused_enumerate_index.rs
+++ b/tests/ui/unused_enumerate_index.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+#![allow(unused)]
+#![warn(clippy::unused_enumerate_index)]
+
+fn main() {
+    let v = [1, 2, 3];
+    for (_, x) in v.iter().enumerate() {
+        print!("{x}");
+    }
+}

--- a/tests/ui/unused_enumerate_index.stderr
+++ b/tests/ui/unused_enumerate_index.stderr
@@ -1,5 +1,5 @@
 error: you seem to use `.enumerate()` and immediately discard the index
-  --> $DIR/unused_enumerate_index.rs:7:19
+  --> $DIR/unused_enumerate_index.rs:8:19
    |
 LL |     for (_, x) in v.iter().enumerate() {
    |                   ^^^^^^^^^^^^^^^^^^^^
@@ -11,5 +11,16 @@ help: remove the `.enumerate()` call
 LL |     for x in v.iter() {
    |         ~    ~~~~~~~~
 
-error: aborting due to previous error
+error: you seem to use `.enumerate()` and immediately discard the index
+  --> $DIR/unused_enumerate_index.rs:55:19
+   |
+LL |     for (_, x) in dummy.enumerate() {
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+help: remove the `.enumerate()` call
+   |
+LL |     for x in dummy {
+   |         ~    ~~~~~
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/unused_enumerate_index.stderr
+++ b/tests/ui/unused_enumerate_index.stderr
@@ -1,0 +1,15 @@
+error: you seem to use `.enumerate()` and immediately discard the index
+  --> $DIR/unused_enumerate_index.rs:7:19
+   |
+LL |     for (_, x) in v.iter().enumerate() {
+   |                   ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::unused-enumerate-index` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_enumerate_index)]`
+help: remove the `.enumerate()` call
+   |
+LL |     for x in v.iter() {
+   |         ~    ~~~~~~~~
+
+error: aborting due to previous error
+


### PR DESCRIPTION
A lint for unused `.enumerate()` indexes (`for (_, x) in iter.enumerate()`).

I wasn't able to find a `rustc_span::sym::Enumerate`, so the code for checking that it's the correct `Enumerate` iterator is a bit weird.

---

changelog: New lint: [`unused_enumerate_index`]: A new lint for checking that the indexes from `.enumerate()` calls are used.
[#10404](https://github.com/rust-lang/rust-clippy/pull/10404)
<!-- changelog_checked -->
