### PR TITLE
Remove `snippet_with_macro_callsite`

### DIFF
--- a/clippy_lints/src/if_then_some_else_none.rs
+++ b/clippy_lints/src/if_then_some_else_none.rs
@@ -1,8 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::eager_or_lazy::switch_to_eager_eval;
 use clippy_utils::msrvs::{self, Msrv};
-use clippy_utils::source::snippet_with_macro_callsite;
+use clippy_utils::source::snippet_with_context;
+use clippy_utils::sugg::Sugg;
 use clippy_utils::{contains_return, higher, is_else_clause, is_res_lang_ctor, path_res, peel_blocks};
+use rustc_errors::Applicability;
 use rustc_hir::LangItem::{OptionNone, OptionSome};
 use rustc_hir::{Expr, ExprKind, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
@@ -72,21 +74,20 @@ impl<'tcx> LateLintPass<'tcx> for IfThenSomeElseNone {
             return;
         }
 
+        let ctxt = expr.span.ctxt();
+
         if let Some(higher::If { cond, then, r#else: Some(els) }) = higher::If::hir(expr)
             && let ExprKind::Block(then_block, _) = then.kind
             && let Some(then_expr) = then_block.expr
             && let ExprKind::Call(then_call, [then_arg]) = then_expr.kind
+            && then_expr.span.ctxt() == ctxt
             && is_res_lang_ctor(cx, path_res(cx, then_call), OptionSome)
             && is_res_lang_ctor(cx, path_res(cx, peel_blocks(els)), OptionNone)
             && !stmts_contains_early_return(then_block.stmts)
         {
-            let cond_snip = snippet_with_macro_callsite(cx, cond.span, "[condition]");
-            let cond_snip = if matches!(cond.kind, ExprKind::Unary(_, _) | ExprKind::Binary(_, _, _)) {
-                format!("({cond_snip})")
-            } else {
-                cond_snip.into_owned()
-            };
-            let arg_snip = snippet_with_macro_callsite(cx, then_arg.span, "");
+            let mut app = Applicability::Unspecified;
+            let cond_snip = Sugg::hir_with_context(cx, cond, expr.span.ctxt(), "[condition]", &mut app).maybe_par().to_string();
+            let arg_snip = snippet_with_context(cx, then_arg.span, ctxt, "[body]", &mut app).0;
             let mut method_body = if then_block.stmts.is_empty() {
                 arg_snip.into_owned()
             } else {

--- a/clippy_lints/src/matches/match_single_binding.rs
+++ b/clippy_lints/src/matches/match_single_binding.rs
@@ -1,7 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::macros::HirNode;
-use clippy_utils::source::{indent_of, snippet, snippet_block, snippet_with_applicability};
-use clippy_utils::sugg::Sugg;
+use clippy_utils::source::{indent_of, snippet, snippet_block_with_context, snippet_with_applicability};
 use clippy_utils::{get_parent_expr, is_refutable, peel_blocks};
 use rustc_errors::Applicability;
 use rustc_hir::{Arm, Expr, ExprKind, Node, PatKind};
@@ -24,21 +23,25 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
     let matched_vars = ex.span;
     let bind_names = arms[0].pat.span;
     let match_body = peel_blocks(arms[0].body);
-    let mut snippet_body = if match_body.span.from_expansion() {
-        Sugg::hir_with_macro_callsite(cx, match_body, "..").to_string()
-    } else {
-        snippet_block(cx, match_body.span, "..", Some(expr.span)).to_string()
-    };
+    let mut app = Applicability::MaybeIncorrect;
+    let (snippet_body, from_macro) = snippet_block_with_context(
+        cx,
+        match_body.span,
+        arms[0].span.ctxt(),
+        "..",
+        Some(expr.span),
+        &mut app,
+    );
+    let mut snippet_body = snippet_body.to_string();
 
     // Do we need to add ';' to suggestion ?
-    if let ExprKind::Block(block, _) = match_body.kind {
+    if matches!(match_body.kind, ExprKind::Block(..)) {
         // macro + expr_ty(body) == ()
-        if block.span.from_expansion() && cx.typeck_results().expr_ty(match_body).is_unit() {
+        if from_macro && cx.typeck_results().expr_ty(match_body).is_unit() {
             snippet_body.push(';');
         }
     }
 
-    let mut applicability = Applicability::MaybeIncorrect;
     match arms[0].pat.kind {
         PatKind::Binding(..) | PatKind::Tuple(_, _) | PatKind::Struct(..) => {
             let (target_span, sugg) = match opt_parent_assign_span(cx, ex) {
@@ -48,7 +51,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                         (ex, expr),
                         (bind_names, matched_vars),
                         &snippet_body,
-                        &mut applicability,
+                        &mut app,
                         Some(span),
                         true,
                     );
@@ -60,7 +63,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                         "this assignment could be simplified",
                         "consider removing the `match` expression",
                         sugg,
-                        applicability,
+                        app,
                     );
 
                     return;
@@ -69,10 +72,10 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                     span,
                     format!(
                         "let {} = {};\n{}let {} = {snippet_body};",
-                        snippet_with_applicability(cx, bind_names, "..", &mut applicability),
-                        snippet_with_applicability(cx, matched_vars, "..", &mut applicability),
+                        snippet_with_applicability(cx, bind_names, "..", &mut app),
+                        snippet_with_applicability(cx, matched_vars, "..", &mut app),
                         " ".repeat(indent_of(cx, expr.span).unwrap_or(0)),
-                        snippet_with_applicability(cx, pat_span, "..", &mut applicability)
+                        snippet_with_applicability(cx, pat_span, "..", &mut app)
                     ),
                 ),
                 None => {
@@ -81,7 +84,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                         (ex, expr),
                         (bind_names, matched_vars),
                         &snippet_body,
-                        &mut applicability,
+                        &mut app,
                         None,
                         true,
                     );
@@ -96,7 +99,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                 "this match could be written as a `let` statement",
                 "consider using a `let` statement",
                 sugg,
-                applicability,
+                app,
             );
         },
         PatKind::Wild => {
@@ -106,7 +109,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                     (ex, expr),
                     (bind_names, matched_vars),
                     &snippet_body,
-                    &mut applicability,
+                    &mut app,
                     None,
                     false,
                 );
@@ -118,7 +121,7 @@ pub(crate) fn check<'a>(cx: &LateContext<'a>, ex: &Expr<'a>, arms: &[Arm<'_>], e
                     "this match could be replaced by its scrutinee and body",
                     "consider using the scrutinee and body instead",
                     sugg,
-                    applicability,
+                    app,
                 );
             } else {
                 span_lint_and_sugg(

--- a/clippy_lints/src/methods/bind_instead_of_map.rs
+++ b/clippy_lints/src/methods/bind_instead_of_map.rs
@@ -1,6 +1,6 @@
 use super::{contains_return, BIND_INSTEAD_OF_MAP};
 use clippy_utils::diagnostics::{multispan_sugg_with_applicability, span_lint_and_sugg, span_lint_and_then};
-use clippy_utils::source::{snippet, snippet_with_macro_callsite};
+use clippy_utils::source::{snippet, snippet_with_context};
 use clippy_utils::{peel_blocks, visitors::find_all_ret_expressions};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
@@ -77,11 +77,8 @@ pub(crate) trait BindInsteadOfMap {
             if !contains_return(inner_expr);
             if let Some(msg) = Self::lint_msg(cx);
             then {
-                let some_inner_snip = if inner_expr.span.from_expansion() {
-                    snippet_with_macro_callsite(cx, inner_expr.span, "_")
-                } else {
-                    snippet(cx, inner_expr.span, "_")
-                };
+                let mut app = Applicability::MachineApplicable;
+                let some_inner_snip = snippet_with_context(cx, inner_expr.span, closure_expr.span.ctxt(), "_", &mut app).0;
 
                 let closure_args_snip = snippet(cx, closure_args_span, "..");
                 let option_snip = snippet(cx, recv.span, "..");
@@ -93,7 +90,7 @@ pub(crate) trait BindInsteadOfMap {
                     &msg,
                     "try this",
                     note,
-                    Applicability::MachineApplicable,
+                    app,
                 );
                 true
             } else {

--- a/clippy_lints/src/methods/clone_on_ref_ptr.rs
+++ b/clippy_lints/src/methods/clone_on_ref_ptr.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::paths;
-use clippy_utils::source::snippet_with_macro_callsite;
+use clippy_utils::source::snippet_with_context;
 use clippy_utils::ty::{is_type_diagnostic_item, match_type};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -33,7 +33,9 @@ pub(super) fn check(
             return;
         };
 
-        let snippet = snippet_with_macro_callsite(cx, receiver.span, "..");
+        // Sometimes unnecessary ::<_> after Rc/Arc/Weak
+        let mut app = Applicability::Unspecified;
+        let snippet = snippet_with_context(cx, receiver.span, expr.span.ctxt(), "..", &mut app).0;
 
         span_lint_and_sugg(
             cx,
@@ -42,7 +44,7 @@ pub(super) fn check(
             "using `.clone()` on a ref-counted pointer",
             "try this",
             format!("{caller_type}::<{}>::clone(&{snippet})", subst.type_at(0)),
-            Applicability::Unspecified, // Sometimes unnecessary ::<_> after Rc/Arc/Weak
+            app,
         );
     }
 }

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -340,18 +340,11 @@ fn suggest_bool_comparison<'a, 'tcx>(
     cx: &LateContext<'tcx>,
     e: &'tcx Expr<'_>,
     expr: &Expr<'_>,
-    mut applicability: Applicability,
+    mut app: Applicability,
     message: &str,
     conv_hint: impl FnOnce(Sugg<'a>) -> Sugg<'a>,
 ) {
-    let hint = if expr.span.from_expansion() {
-        if applicability != Applicability::Unspecified {
-            applicability = Applicability::MaybeIncorrect;
-        }
-        Sugg::hir_with_macro_callsite(cx, expr, "..")
-    } else {
-        Sugg::hir_with_applicability(cx, expr, "..", &mut applicability)
-    };
+    let hint = Sugg::hir_with_context(cx, expr, e.span.ctxt(), "..", &mut app);
     span_lint_and_sugg(
         cx,
         BOOL_COMPARISON,
@@ -359,7 +352,7 @@ fn suggest_bool_comparison<'a, 'tcx>(
         message,
         "try simplifying it as shown",
         conv_hint(hint).to_string(),
-        applicability,
+        app,
     );
 }
 

--- a/clippy_lints/src/semicolon_if_nothing_returned.rs
+++ b/clippy_lints/src/semicolon_if_nothing_returned.rs
@@ -1,7 +1,6 @@
 use crate::rustc_lint::LintContext;
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::snippet_with_macro_callsite;
-use clippy_utils::sugg;
+use clippy_utils::source::snippet_with_context;
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::{Block, ExprKind};
@@ -44,7 +43,8 @@ impl<'tcx> LateLintPass<'tcx> for SemicolonIfNothingReturned {
             if let Some(expr) = block.expr;
             let t_expr = cx.typeck_results().expr_ty(expr);
             if t_expr.is_unit();
-            if let snippet = snippet_with_macro_callsite(cx, expr.span, "}");
+            let mut app = Applicability::MaybeIncorrect;
+            if let snippet = snippet_with_context(cx, expr.span, block.span.ctxt(), "}", &mut app).0;
             if !snippet.ends_with('}') && !snippet.ends_with(';');
             if cx.sess().source_map().is_multiline(block.span);
             then {
@@ -52,17 +52,14 @@ impl<'tcx> LateLintPass<'tcx> for SemicolonIfNothingReturned {
                 if let ExprKind::DropTemps(..) = &expr.kind {
                     return;
                 }
-
-                let sugg = sugg::Sugg::hir_with_macro_callsite(cx, expr, "..");
-                let suggestion = format!("{sugg};");
                 span_lint_and_sugg(
                     cx,
                     SEMICOLON_IF_NOTHING_RETURNED,
                     expr.span.source_callsite(),
                     "consider adding a `;` to the last statement for consistent formatting",
                     "add a `;` here",
-                    suggestion,
-                    Applicability::MaybeIncorrect,
+                    format!("{snippet};"),
+                    app,
                 );
             }
         }

--- a/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/clippy_lints/src/unit_types/let_unit_value.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::get_parent_node;
-use clippy_utils::source::snippet_with_macro_callsite;
+use clippy_utils::source::snippet_with_context;
 use clippy_utils::visitors::{for_each_local_assignment, for_each_value_source};
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
@@ -48,12 +48,13 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, local: &'tcx Local<'_>) {
                 "this let-binding has unit value",
                 |diag| {
                     if let Some(expr) = &local.init {
-                        let snip = snippet_with_macro_callsite(cx, expr.span, "()");
+                        let mut app = Applicability::MachineApplicable;
+                        let snip = snippet_with_context(cx, expr.span, local.span.ctxt(), "()", &mut app).0;
                         diag.span_suggestion(
                             local.span,
                             "omit the `let` binding",
                             format!("{snip};"),
-                            Applicability::MachineApplicable, // snippet
+                            app,
                         );
                     }
                 },

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -1,9 +1,7 @@
 //! Contains utility functions to generate suggestions.
 #![deny(clippy::missing_docs_in_private_items)]
 
-use crate::source::{
-    snippet, snippet_opt, snippet_with_applicability, snippet_with_context, snippet_with_macro_callsite,
-};
+use crate::source::{snippet, snippet_opt, snippet_with_applicability, snippet_with_context};
 use crate::ty::expr_sig;
 use crate::{get_parent_expr_for_hir, higher};
 use rustc_ast::util::parser::AssocOp;
@@ -87,12 +85,6 @@ impl<'a> Sugg<'a> {
             }
             Sugg::NonParen(Cow::Borrowed(default))
         })
-    }
-
-    /// Same as `hir`, but will use the pre expansion span if the `expr` was in a macro.
-    pub fn hir_with_macro_callsite(cx: &LateContext<'_>, expr: &hir::Expr<'_>, default: &'a str) -> Self {
-        let get_snippet = |span| snippet_with_macro_callsite(cx, span, default);
-        Self::hir_from_snippet(expr, get_snippet)
     }
 
     /// Same as `hir`, but first walks the span up to the given context. This will result in the

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -69,8 +69,8 @@ fn issue5504() {
     }
 
     fn try_result_opt() -> Result<i32, i32> {
-        while (r#try!(result_opt())).is_some() {}
-        if (r#try!(result_opt())).is_some() {}
+        while r#try!(result_opt()).is_some() {}
+        if r#try!(result_opt()).is_some() {}
         Ok(42)
     }
 

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -88,13 +88,13 @@ error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:84:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
-   |         ----------^^^^^^^----------------------- help: try this: `while (r#try!(result_opt())).is_some()`
+   |         ----------^^^^^^^----------------------- help: try this: `while r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:85:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
-   |         -------^^^^^^^----------------------- help: try this: `if (r#try!(result_opt())).is_some()`
+   |         -------^^^^^^^----------------------- help: try this: `if r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:91:12


### PR DESCRIPTION
`snippet_with_context` is used instead to support nested macro calls.

changelog: None
