### PR TITLE
Fix FP for `let_unit_value` when `await` used

### DIFF
--- a/clippy_lints/src/unit_types/let_unit_value.rs
+++ b/clippy_lints/src/unit_types/let_unit_value.rs
@@ -5,7 +5,7 @@ use clippy_utils::visitors::{for_each_local_assignment, for_each_value_source};
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::{Expr, ExprKind, HirId, HirIdSet, Local, Node, PatKind, QPath, TyKind};
+use rustc_hir::{Expr, ExprKind, HirId, HirIdSet, Local, MatchSource, Node, PatKind, QPath, TyKind};
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty;
@@ -41,6 +41,10 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, local: &'tcx Local<'_>) {
                 );
             }
         } else {
+            if let ExprKind::Match(_, _, MatchSource::AwaitDesugar) = init.kind {
+                return
+            }
+
             span_lint_and_then(
                 cx,
                 LET_UNIT_VALUE,

--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -175,3 +175,7 @@ fn attributes() {
     #[expect(clippy::let_unit_value)]
     let _ = f();
 }
+
+async fn issue10433() {
+    let _pending: () = std::future::pending().await;
+}

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -175,3 +175,7 @@ fn attributes() {
     #[expect(clippy::let_unit_value)]
     let _ = f();
 }
+
+async fn issue10433() {
+    let _pending: () = std::future::pending().await;
+}


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust-clippy/issues/10433

changelog: Fix FP for `let_unit_value` when `await` used
