### PR TITLE
help: refer to `cargo check --help`

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -176,7 +176,7 @@ Common options:
         --rustc              Pass all args to rustc
     -V, --version            Print version info and exit
 
-Other options are the same as `cargo check`.
+For the other options see `cargo check --help`.
 
 To allow or deny a lint from the command line you can use `cargo clippy --`
 with:

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ Common options:
     -V, --version            Print version info and exit
     --explain LINT           Print the documentation for a given lint
 
-Other options are the same as `cargo check`.
+For the other options see `cargo check --help`.
 
 To allow or deny a lint from the command line you can use `cargo clippy --`
 with:


### PR DESCRIPTION
Fixes #10436 

changelog: none
