### PR TITLE
Fix `almost_swapped` false positive (`let mut a = b; a = a`)

### DIFF
--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -190,6 +190,7 @@ fn check_suspicious_swap(cx: &LateContext<'_>, block: &Block<'_>) {
             && first.span.eq_ctxt(second.span)
             && is_same(cx, lhs0, rhs1)
             && is_same(cx, lhs1, rhs0)
+			&& !is_same(cx, lhs1, rhs1) // Ignore a = b; a = a (#10421)
             && let Some(lhs_sugg) = match &lhs0 {
                 ExprOrIdent::Expr(expr) => Sugg::hir_opt(cx, expr),
                 ExprOrIdent::Ident(ident) => Some(Sugg::NonParen(ident.as_str().into())),

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -186,3 +186,11 @@ const fn issue_9864(mut u: u32) -> u32 {
     v = temp;
     u + v
 }
+
+#[allow(clippy::let_and_return)]
+const fn issue_10421(x: u32) -> u32 {
+    let a = x;
+    let a = a;
+    let a = a;
+    a
+}

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -215,3 +215,11 @@ const fn issue_9864(mut u: u32) -> u32 {
     v = temp;
     u + v
 }
+
+#[allow(clippy::let_and_return)]
+const fn issue_10421(x: u32) -> u32 {
+    let a = x;
+    let a = a;
+    let a = a;
+    a
+}


### PR DESCRIPTION
Fixes `2` in #10421 
changelog: [`almost_swapped`]: Fix false positive when a variable is changed to itself. (`a = a`)
