### PR TITLE
Fix documentation for `derived_hash_with_manual_eq`

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -24,8 +24,8 @@ use rustc_span::sym;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for deriving `Hash` but implementing `PartialEq`
-    /// explicitly or vice versa.
+    /// Lints against manual `PartialEq` implementations for types with a derived `Hash`
+    /// implementation.
     ///
     /// ### Why is this bad?
     /// The implementation of these traits must agree (for
@@ -54,8 +54,8 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for deriving `Ord` but implementing `PartialOrd`
-    /// explicitly or vice versa.
+    /// Lints against manual `PartialOrd` and `Ord` implementations for types with a derived `Ord`
+    /// or `PartialOrd` implementation.
     ///
     /// ### Why is this bad?
     /// The implementation of these traits must agree (for


### PR DESCRIPTION
changelog: fix documentation for `derived_hash_with_manual_eq`

The documentation retained "vice versa" from the previous incarnation of the lint but the lint itself no longer lints against manual `Hash` implementations with a derived `PartialEq`.

I also adjusted the documentation for `PartialOrd`-`Ord` lint as "vice versa" seemed a little confusing to me there (as to what it was refering to exactly.)