### PR TITLE
fix `almost_swapped`: Ignore external macros

### DIFF
--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -76,9 +76,7 @@ declare_lint_pass!(Swap => [MANUAL_SWAP, ALMOST_SWAPPED]);
 impl<'tcx> LateLintPass<'tcx> for Swap {
     fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'_>) {
         check_manual_swap(cx, block);
-        if !in_external_macro(cx.sess(), block.span) {
-            check_suspicious_swap(cx, block);
-        }
+        check_suspicious_swap(cx, block);
         check_xor_swap(cx, block);
     }
 }
@@ -191,6 +189,7 @@ fn check_suspicious_swap(cx: &LateContext<'_>, block: &Block<'_>) {
         if let Some((lhs0, rhs0)) = parse(first)
             && let Some((lhs1, rhs1)) = parse(second)
             && first.span.eq_ctxt(second.span)
+			&& !in_external_macro(&cx.sess(), first.span)
             && is_same(cx, lhs0, rhs1)
             && is_same(cx, lhs1, rhs0)
 			&& !is_same(cx, lhs1, rhs1) // Ignore a = b; a = a (#10421)

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -6,7 +6,8 @@ use clippy_utils::{can_mut_borrow_both, eq_expr_value, in_constant, std_or_core}
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Block, Expr, ExprKind, PatKind, QPath, Stmt, StmtKind};
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Spanned;
@@ -75,7 +76,9 @@ declare_lint_pass!(Swap => [MANUAL_SWAP, ALMOST_SWAPPED]);
 impl<'tcx> LateLintPass<'tcx> for Swap {
     fn check_block(&mut self, cx: &LateContext<'tcx>, block: &'tcx Block<'_>) {
         check_manual_swap(cx, block);
-        check_suspicious_swap(cx, block);
+        if !in_external_macro(cx.sess(), block.span) {
+            check_suspicious_swap(cx, block);
+        }
         check_xor_swap(cx, block);
     }
 }

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -27,3 +27,13 @@ macro_rules! mut_mut {
         let mut_mut_ty: &mut &mut u32 = &mut &mut 1u32;
     };
 }
+
+#[macro_export]
+macro_rules! issue_10421 {
+    () => {
+        let mut a = 1;
+        let mut b = 2;
+        a = b;
+        b = a;
+    };
+}

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -8,7 +8,8 @@
     redundant_semicolons,
     dead_code,
     unused_assignments,
-    unused_variables
+    unused_variables,
+    clippy::let_and_return
 )]
 
 struct Foo(u32);
@@ -187,8 +188,16 @@ const fn issue_9864(mut u: u32) -> u32 {
     u + v
 }
 
-#[allow(clippy::let_and_return)]
+macro_rules! issue_10421 {
+    () => {
+        let a = 1;
+        let b = a;
+        let b = b;
+    };
+}
+
 const fn issue_10421(x: u32) -> u32 {
+    issue_10421!();
     let a = x;
     let a = a;
     let a = a;

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+// aux-build: macro_rules.rs
 
 #![warn(clippy::all)]
 #![allow(
@@ -188,13 +189,8 @@ const fn issue_9864(mut u: u32) -> u32 {
     u + v
 }
 
-macro_rules! issue_10421 {
-    () => {
-        let a = 1;
-        let b = a;
-        let b = b;
-    };
-}
+#[macro_use]
+extern crate macro_rules;
 
 const fn issue_10421(x: u32) -> u32 {
     issue_10421!();

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+// aux-build: macro_rules.rs
 
 #![warn(clippy::all)]
 #![allow(
@@ -217,13 +218,8 @@ const fn issue_9864(mut u: u32) -> u32 {
     u + v
 }
 
-macro_rules! issue_10421 {
-    () => {
-        let a = 1;
-        let b = a;
-        let b = b;
-    };
-}
+#[macro_use]
+extern crate macro_rules;
 
 const fn issue_10421(x: u32) -> u32 {
     issue_10421!();

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -8,7 +8,8 @@
     redundant_semicolons,
     dead_code,
     unused_assignments,
-    unused_variables
+    unused_variables,
+    clippy::let_and_return
 )]
 
 struct Foo(u32);
@@ -216,8 +217,16 @@ const fn issue_9864(mut u: u32) -> u32 {
     u + v
 }
 
-#[allow(clippy::let_and_return)]
+macro_rules! issue_10421 {
+    () => {
+        let a = 1;
+        let b = a;
+        let b = b;
+    };
+}
+
 const fn issue_10421(x: u32) -> u32 {
+    issue_10421!();
     let a = x;
     let a = a;
     let a = a;

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:25:5
+  --> $DIR/swap.rs:26:5
    |
 LL | /     let temp = bar.a;
 LL | |     bar.a = bar.b;
@@ -10,7 +10,7 @@ LL | |     bar.b = temp;
    = note: `-D clippy::manual-swap` implied by `-D warnings`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:37:5
+  --> $DIR/swap.rs:38:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -18,7 +18,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:46:5
+  --> $DIR/swap.rs:47:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -26,7 +26,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:65:5
+  --> $DIR/swap.rs:66:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -34,7 +34,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:76:5
+  --> $DIR/swap.rs:77:5
    |
 LL | /     a ^= b;
 LL | |     b ^= a;
@@ -42,7 +42,7 @@ LL | |     a ^= b;
    | |___________^ help: try: `std::mem::swap(&mut a, &mut b);`
 
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:84:5
+  --> $DIR/swap.rs:85:5
    |
 LL | /     bar.a ^= bar.b;
 LL | |     bar.b ^= bar.a;
@@ -50,7 +50,7 @@ LL | |     bar.a ^= bar.b;
    | |___________________^ help: try: `std::mem::swap(&mut bar.a, &mut bar.b);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:92:5
+  --> $DIR/swap.rs:93:5
    |
 LL | /     foo[0] ^= foo[1];
 LL | |     foo[1] ^= foo[0];
@@ -58,7 +58,7 @@ LL | |     foo[0] ^= foo[1];
    | |_____________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `foo[0][1]` and `bar[1][0]` manually
-  --> $DIR/swap.rs:121:5
+  --> $DIR/swap.rs:122:5
    |
 LL | /     let temp = foo[0][1];
 LL | |     foo[0][1] = bar[1][0];
@@ -68,7 +68,7 @@ LL | |     bar[1][0] = temp;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:135:7
+  --> $DIR/swap.rs:136:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -79,7 +79,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:144:7
+  --> $DIR/swap.rs:145:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -90,7 +90,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `b` and `a` manually
-  --> $DIR/swap.rs:170:5
+  --> $DIR/swap.rs:171:5
    |
 LL | /     let t = b;
 LL | |     b = a;
@@ -100,7 +100,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:132:5
+  --> $DIR/swap.rs:133:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -110,7 +110,7 @@ LL | |     b = a;
    = note: `-D clippy::almost-swapped` implied by `-D warnings`
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:141:5
+  --> $DIR/swap.rs:142:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;
@@ -119,7 +119,7 @@ LL | |     a = c.0;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:148:5
+  --> $DIR/swap.rs:149:5
    |
 LL | /     let a = b;
 LL | |     let b = a;
@@ -128,7 +128,7 @@ LL | |     let b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `d` and `c`
-  --> $DIR/swap.rs:153:5
+  --> $DIR/swap.rs:154:5
    |
 LL | /     d = c;
 LL | |     c = d;
@@ -137,7 +137,7 @@ LL | |     c = d;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:157:5
+  --> $DIR/swap.rs:158:5
    |
 LL | /     let a = b;
 LL | |     b = a;
@@ -146,7 +146,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `s.0.x` and `s.0.y` manually
-  --> $DIR/swap.rs:205:5
+  --> $DIR/swap.rs:206:5
    |
 LL | /     let t = s.0.x;
 LL | |     s.0.x = s.0.y;

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:26:5
+  --> $DIR/swap.rs:27:5
    |
 LL | /     let temp = bar.a;
 LL | |     bar.a = bar.b;
@@ -10,7 +10,7 @@ LL | |     bar.b = temp;
    = note: `-D clippy::manual-swap` implied by `-D warnings`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:38:5
+  --> $DIR/swap.rs:39:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -18,7 +18,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:47:5
+  --> $DIR/swap.rs:48:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -26,7 +26,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:66:5
+  --> $DIR/swap.rs:67:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -34,7 +34,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:77:5
+  --> $DIR/swap.rs:78:5
    |
 LL | /     a ^= b;
 LL | |     b ^= a;
@@ -42,7 +42,7 @@ LL | |     a ^= b;
    | |___________^ help: try: `std::mem::swap(&mut a, &mut b);`
 
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:85:5
+  --> $DIR/swap.rs:86:5
    |
 LL | /     bar.a ^= bar.b;
 LL | |     bar.b ^= bar.a;
@@ -50,7 +50,7 @@ LL | |     bar.a ^= bar.b;
    | |___________________^ help: try: `std::mem::swap(&mut bar.a, &mut bar.b);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:93:5
+  --> $DIR/swap.rs:94:5
    |
 LL | /     foo[0] ^= foo[1];
 LL | |     foo[1] ^= foo[0];
@@ -58,7 +58,7 @@ LL | |     foo[0] ^= foo[1];
    | |_____________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `foo[0][1]` and `bar[1][0]` manually
-  --> $DIR/swap.rs:122:5
+  --> $DIR/swap.rs:123:5
    |
 LL | /     let temp = foo[0][1];
 LL | |     foo[0][1] = bar[1][0];
@@ -68,7 +68,7 @@ LL | |     bar[1][0] = temp;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:136:7
+  --> $DIR/swap.rs:137:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -79,7 +79,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:145:7
+  --> $DIR/swap.rs:146:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -90,7 +90,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `b` and `a` manually
-  --> $DIR/swap.rs:171:5
+  --> $DIR/swap.rs:172:5
    |
 LL | /     let t = b;
 LL | |     b = a;
@@ -100,7 +100,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:133:5
+  --> $DIR/swap.rs:134:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -110,7 +110,7 @@ LL | |     b = a;
    = note: `-D clippy::almost-swapped` implied by `-D warnings`
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:142:5
+  --> $DIR/swap.rs:143:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;
@@ -119,7 +119,7 @@ LL | |     a = c.0;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:149:5
+  --> $DIR/swap.rs:150:5
    |
 LL | /     let a = b;
 LL | |     let b = a;
@@ -128,7 +128,7 @@ LL | |     let b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `d` and `c`
-  --> $DIR/swap.rs:154:5
+  --> $DIR/swap.rs:155:5
    |
 LL | /     d = c;
 LL | |     c = d;
@@ -137,7 +137,7 @@ LL | |     c = d;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:158:5
+  --> $DIR/swap.rs:159:5
    |
 LL | /     let a = b;
 LL | |     b = a;
@@ -146,7 +146,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `s.0.x` and `s.0.y` manually
-  --> $DIR/swap.rs:206:5
+  --> $DIR/swap.rs:207:5
    |
 LL | /     let t = s.0.x;
 LL | |     s.0.x = s.0.y;


### PR DESCRIPTION
Fixes #10421 ; Related to #10499 (Fixing points *1* and *3* from #10421)
changelog: [`almost_swapped`]: Add a check to ignore external macros
