### PR TITLE
Use `split-debuginfo = "unpacked"` for debug builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,6 @@ target-dir = "target"
 
 [unstable]
 binary-dep-depinfo = true
+
+[profile.dev]
+split-debuginfo = "unpacked"

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -180,6 +180,8 @@ jobs:
 
     # Run
     - name: Build Integration Test
+      env:
+        CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: off
       run: cargo test --test integration --features integration --no-run
 
     # Upload


### PR DESCRIPTION
On Windows this has no effect as it's unsupported. On macOS the default set by cargo is already unpacked so no effect there either

For Linux it shaves a bit off the rebuild time, for me in the case of a simple `touch` + `cargo build` it goes from 12s to 10s

It saves a good amount of disk space too, on `aarch64-unknown-linux-gnu` it saves 1.2GB for a plain `cargo build`, 3GB when also running `cargo dev` and `cargo test --no-run -F internal`

r? @flip1995

changelog: none
