### PR TITLE
Correct active members link in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ a [developer guide] and is a good place to start your journey.
 All issues on Clippy are mentored, if you want help simply ask someone from the
 Clippy team directly by mentioning them in the issue or over on [Zulip]. All
 currently active team members can be found
-[here](https://github.com/rust-lang/highfive/blob/master/highfive/configs/rust-lang/rust-clippy.json#L3)
+[here](https://github.com/rust-lang/rust-clippy/blob/master/triagebot.toml#L18)
 
 Some issues are easier than others. The [`good-first-issue`] label can be used to find the easy
 issues. You can use `@rustbot claim` to assign the issue to yourself.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,6 +17,7 @@ contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIB
 
 [assign.owners]
 "/.github" = ["@flip1995"]
+"/util/gh-pages" = ["@xFrednet"]
 "*" = [
     "@flip1995",
     "@Manishearth",


### PR DESCRIPTION
This corrects the link, where to find which members are currently active and can be pinged. It also adds me as the code owner of `gh-pages`. In most cases, I'm asked to review those PRs anyways :)

Otherwise, not much more to day, have a great day!

---

Closes: #10521

changelog: none
<!-- changelog_checked -->