### PR TITLE
Really dogfood clippy

### DIFF
--- a/clippy_lints/src/let_with_type_underscore.rs
+++ b/clippy_lints/src/let_with_type_underscore.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_help;
-use rustc_hir::*;
+use rustc_hir::{Local, TyKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::lint::in_external_macro;
 use rustc_session::{declare_lint_pass, declare_tool_lint};

--- a/clippy_lints/src/manual_async_fn.rs
+++ b/clippy_lints/src/manual_async_fn.rs
@@ -77,11 +77,12 @@ impl<'tcx> LateLintPass<'tcx> for ManualAsyncFn {
                             if let Some(ret_pos) = position_before_rarrow(&header_snip);
                             if let Some((ret_sugg, ret_snip)) = suggested_ret(cx, output);
                             then {
-                                let header_snip = if !vis_snip.is_empty() {
-                                    format!("{} async {}", vis_snip, &header_snip[vis_snip.len() + 1..ret_pos])
-                                } else {
+                                let header_snip = if vis_snip.is_empty() {
                                     format!("async {}", &header_snip[..ret_pos])
+                                } else {
+                                    format!("{} async {}", vis_snip, &header_snip[vis_snip.len() + 1..ret_pos])
                                 };
+
                                 let help = format!("make the function `async` and {ret_sugg}");
                                 diag.span_suggestion(
                                     header_span,

--- a/clippy_lints/src/manual_main_separator_str.rs
+++ b/clippy_lints/src/manual_main_separator_str.rs
@@ -3,7 +3,7 @@ use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::{is_trait_method, match_def_path, paths, peel_hir_expr_refs};
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::*;
+use rustc_hir::{Expr, ExprKind, Mutability, QPath};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -69,4 +69,6 @@ impl LateLintPass<'_> for ManualMainSeparatorStr {
                 );
             }
     }
+
+    extract_msrv_attr!(LateContext);
 }

--- a/clippy_lints/src/redundant_async_block.rs
+++ b/clippy_lints/src/redundant_async_block.rs
@@ -1,5 +1,5 @@
 use clippy_utils::{diagnostics::span_lint_and_sugg, source::snippet};
-use rustc_ast::ast::*;
+use rustc_ast::ast::{Expr, ExprKind, Stmt, StmtKind};
 use rustc_ast::visit::Visitor as AstVisitor;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -189,7 +189,7 @@ fn check_suspicious_swap(cx: &LateContext<'_>, block: &Block<'_>) {
         if let Some((lhs0, rhs0)) = parse(first)
             && let Some((lhs1, rhs1)) = parse(second)
             && first.span.eq_ctxt(second.span)
-			&& !in_external_macro(&cx.sess(), first.span)
+			&& !in_external_macro(cx.sess(), first.span)
             && is_same(cx, lhs0, rhs1)
             && is_same(cx, lhs1, rhs0)
 			&& !is_same(cx, lhs1, rhs1) // Ignore a = b; a = a (#10421)
@@ -260,8 +260,8 @@ fn parse<'a, 'hir>(stmt: &'a Stmt<'hir>) -> Option<(ExprOrIdent<'hir>, &'a Expr<
 /// Implementation of the xor case for `MANUAL_SWAP` lint.
 fn check_xor_swap(cx: &LateContext<'_>, block: &Block<'_>) {
     for [s1, s2, s3] in block.stmts.array_windows::<3>() {
+        let ctxt = s1.span.ctxt();
         if_chain! {
-            let ctxt = s1.span.ctxt();
             if let Some((lhs0, rhs0)) = extract_sides_of_xor_assign(s1, ctxt);
             if let Some((lhs1, rhs1)) = extract_sides_of_xor_assign(s2, ctxt);
             if let Some((lhs2, rhs2)) = extract_sides_of_xor_assign(s3, ctxt);

--- a/clippy_lints/src/wildcard_imports.rs
+++ b/clippy_lints/src/wildcard_imports.rs
@@ -158,12 +158,10 @@ impl LateLintPass<'_> for WildcardImports {
                 let mut imports = used_imports.items().map(ToString::to_string).into_sorted_stable_ord(false);
                 let imports_string = if imports.len() == 1 {
                     imports.pop().unwrap()
+                } else if braced_glob {
+                    imports.join(", ")
                 } else {
-                    if braced_glob {
-                        imports.join(", ")
-                    } else {
-                        format!("{{{}}}", imports.join(", "))
-                    }
+                    format!("{{{}}}", imports.join(", "))
                 };
 
                 let sugg = if braced_glob {

--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -37,10 +37,10 @@ fn dogfood_clippy() {
     }
 
     assert!(
-        !failed_packages.is_empty(),
+        failed_packages.is_empty(),
         "Dogfood failed for packages `{}`",
         failed_packages.iter().format(", "),
-    )
+    );
 }
 
 #[test]


### PR DESCRIPTION
The dogfood success condition was inverted in `tests/dogfood.rs`:

```rust
  assert!(!failed_packages.is_empty(), …);
```

while instead the `failed_packages` collection must be empty:

```rust
  assert!(failed_packages.is_empty(), …);
```

And indeed, several clippy lint source files were not clean and had to be fixed in the process.

changelog: none
