### PR TITLE
docs fix: unknown field `allowed-locales`

### DIFF
--- a/clippy_lints/src/disallowed_script_idents.rs
+++ b/clippy_lints/src/disallowed_script_idents.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// ### Example
     /// ```rust
     /// // Assuming that `clippy.toml` contains the following line:
-    /// // allowed-locales = ["Latin", "Cyrillic"]
+    /// // allowed-scripts = ["Latin", "Cyrillic"]
     /// let counter = 10; // OK, latin is allowed.
     /// let счётчик = 10; // OK, cyrillic is allowed.
     /// let zähler = 10; // OK, it's still latin.


### PR DESCRIPTION
changelog: [`DISALLOWED_SCRIPT_IDENTS`]: Replace the nonexistent `allowed-locales` in the docs with `allowed-scripts`.
