### PR TITLE
Fix allow attribute, items from macros in `items_after_statements`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -747,7 +747,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_early_pass(|| Box::new(unused_unit::UnusedUnit));
     store.register_late_pass(|_| Box::new(returns::Return));
     store.register_early_pass(|| Box::new(collapsible_if::CollapsibleIf));
-    store.register_early_pass(|| Box::new(items_after_statements::ItemsAfterStatements));
+    store.register_late_pass(|_| Box::new(items_after_statements::ItemsAfterStatements));
     store.register_early_pass(|| Box::new(precedence::Precedence));
     store.register_late_pass(|_| Box::new(needless_parens_on_range_literals::NeedlessParensOnRangeLiterals));
     store.register_early_pass(|| Box::new(needless_continue::NeedlessContinue));

--- a/tests/ui/items_after_statement.rs
+++ b/tests/ui/items_after_statement.rs
@@ -51,3 +51,20 @@ fn semicolon() {
 
     let _ = S::new(3);
 }
+
+fn item_from_macro() {
+    macro_rules! static_assert_size {
+        ($ty:ty, $size:expr) => {
+            const _: [(); $size] = [(); ::std::mem::size_of::<$ty>()];
+        };
+    }
+
+    let _ = 1;
+    static_assert_size!(u32, 4);
+}
+
+fn allow_attribute() {
+    let _ = 1;
+    #[allow(clippy::items_after_statements)]
+    const _: usize = 1;
+}

--- a/tests/ui/items_after_statement.stderr
+++ b/tests/ui/items_after_statement.stderr
@@ -1,5 +1,5 @@
 error: adding items after statements is confusing, since items exist from the start of the scope
-  --> $DIR/item_after_statement.rs:13:5
+  --> $DIR/items_after_statement.rs:13:5
    |
 LL | /     fn foo() {
 LL | |         println!("foo");
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::items-after-statements` implied by `-D warnings`
 
 error: adding items after statements is confusing, since items exist from the start of the scope
-  --> $DIR/item_after_statement.rs:20:5
+  --> $DIR/items_after_statement.rs:20:5
    |
 LL | /     fn foo() {
 LL | |         println!("foo");
@@ -17,7 +17,7 @@ LL | |     }
    | |_____^
 
 error: adding items after statements is confusing, since items exist from the start of the scope
-  --> $DIR/item_after_statement.rs:33:13
+  --> $DIR/items_after_statement.rs:33:13
    |
 LL | /             fn say_something() {
 LL | |                 println!("something");


### PR DESCRIPTION
Fixes #10540

changelog: [`items_after_statements`]: Fixes `#[allow(clippy::items_after_statements)]` when applied to an item, and ignores items after statements from different macro contexts