### PR TITLE
In uninit checking, add fallback for polymorphic types

### DIFF
--- a/tests/ui/uninit.rs
+++ b/tests/ui/uninit.rs
@@ -1,7 +1,7 @@
 #![feature(stmt_expr_attributes)]
 #![allow(clippy::let_unit_value, invalid_value)]
 
-use std::mem::{self, MaybeUninit};
+use std::mem::MaybeUninit;
 
 union MyOwnMaybeUninit {
     value: u8,
@@ -30,12 +30,24 @@ fn main() {
     let _: [u8; 0] = unsafe { MaybeUninit::uninit().assume_init() };
 
     // Was a false negative.
-    let _: usize = unsafe { mem::MaybeUninit::uninit().assume_init() };
+    let _: usize = unsafe { MaybeUninit::uninit().assume_init() };
 
     polymorphic::<()>();
+    polymorphic_maybe_uninit_array::<10>();
+    polymorphic_maybe_uninit::<u8>();
 
     fn polymorphic<T>() {
         // We are conservative around polymorphic types.
-        let _: T = unsafe { mem::MaybeUninit::uninit().assume_init() };
+        let _: T = unsafe { MaybeUninit::uninit().assume_init() };
+    }
+
+    fn polymorphic_maybe_uninit_array<const N: usize>() {
+        // While the type is polymorphic, MaybeUninit<u8> is not.
+        let _: [MaybeUninit<u8>; N] = unsafe { MaybeUninit::uninit().assume_init() };
+    }
+
+    fn polymorphic_maybe_uninit<T>() {
+        // The entire type is polymorphic, but it's wrapped in a MaybeUninit.
+        let _: MaybeUninit<T> = unsafe { MaybeUninit::uninit().assume_init() };
     }
 }

--- a/tests/ui/uninit.stderr
+++ b/tests/ui/uninit.stderr
@@ -9,14 +9,14 @@ LL |     let _: usize = unsafe { MaybeUninit::uninit().assume_init() };
 error: this call for this type may be undefined behavior
   --> $DIR/uninit.rs:33:29
    |
-LL |     let _: usize = unsafe { mem::MaybeUninit::uninit().assume_init() };
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _: usize = unsafe { MaybeUninit::uninit().assume_init() };
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this call for this type may be undefined behavior
-  --> $DIR/uninit.rs:39:29
+  --> $DIR/uninit.rs:41:29
    |
-LL |         let _: T = unsafe { mem::MaybeUninit::uninit().assume_init() };
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _: T = unsafe { MaybeUninit::uninit().assume_init() };
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/uninit_vec.rs
+++ b/tests/ui/uninit_vec.rs
@@ -124,4 +124,12 @@ fn main() {
             vec.set_len(10);
         }
     }
+
+    fn poly_maybe_uninit<T>() {
+        // We are conservative around polymorphic types.
+        let mut vec: Vec<MaybeUninit<T>> = Vec::with_capacity(1000);
+        unsafe {
+            vec.set_len(10);
+        }
+    }
 }


### PR DESCRIPTION
After #10520, we always assumed that polymorphic types do not allow to be left uninitialized. But we can do better, by peeking into polymorphic types and adding a few special cases for going through tuples, arrays (because the length may be polymorphic) and blanket allowing all unions (like MaybeUninit).

fixes #10551

changelog: [uninit_vec]: fix false positive for polymorphic types
changelog: [uninit_assumed_init]: fix false positive for polymorphic types