### PR TITLE
make `as_underscore` lint on _ as the type of a ptr cast

### DIFF
--- a/tests/ui/as_underscore.fixed
+++ b/tests/ui/as_underscore.fixed
@@ -4,10 +4,31 @@
 
 fn foo(_n: usize) {}
 
+fn use_ptr(_: *const *const ()) {}
+
+#[allow(dead_code)]
+struct UwU;
+
+impl UwU {
+    #[allow(dead_code)]
+    fn as_ptr(&self) -> *const u8 {
+        &self as *const &UwU as *const u8
+    }
+}
+
 fn main() {
     let n: u16 = 256;
     foo(n as usize);
 
     let n = 0_u128;
     let _n: u8 = n as u8;
+
+    let x = 1 as *const ();
+    use_ptr(x as *const *const ());
+    let x2 = x as *const *const ();
+    use_ptr(x2);
+
+    let _x3: *mut i32 = x as *mut i32;
+
+    let _x4: *const () = x as *const ();
 }

--- a/tests/ui/as_underscore.rs
+++ b/tests/ui/as_underscore.rs
@@ -4,10 +4,31 @@
 
 fn foo(_n: usize) {}
 
+fn use_ptr(_: *const *const ()) {}
+
+#[allow(dead_code)]
+struct UwU;
+
+impl UwU {
+    #[allow(dead_code)]
+    fn as_ptr(&self) -> *const u8 {
+        &self as *const _ as *const u8
+    }
+}
+
 fn main() {
     let n: u16 = 256;
     foo(n as _);
 
     let n = 0_u128;
     let _n: u8 = n as _;
+
+    let x = 1 as *const ();
+    use_ptr(x as *const _);
+    let x2 = x as *const _;
+    use_ptr(x2);
+
+    let _x3: *mut i32 = x as *mut _;
+
+    let _x4: *const () = x as _;
 }

--- a/tests/ui/as_underscore.stderr
+++ b/tests/ui/as_underscore.stderr
@@ -1,20 +1,60 @@
 error: using `as _` conversion
-  --> $DIR/as_underscore.rs:9:9
+  --> $DIR/as_underscore.rs:15:9
+   |
+LL |         &self as *const _ as *const u8
+   |         ^^^^^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const &UwU`
+   |
+   = note: `-D clippy::as-underscore` implied by `-D warnings`
+
+error: using `as _` conversion
+  --> $DIR/as_underscore.rs:21:9
    |
 LL |     foo(n as _);
    |         ^^^^^-
    |              |
    |              help: consider giving the type explicitly: `usize`
-   |
-   = note: `-D clippy::as-underscore` implied by `-D warnings`
 
 error: using `as _` conversion
-  --> $DIR/as_underscore.rs:12:18
+  --> $DIR/as_underscore.rs:24:18
    |
 LL |     let _n: u8 = n as _;
    |                  ^^^^^-
    |                       |
    |                       help: consider giving the type explicitly: `u8`
 
-error: aborting due to 2 previous errors
+error: using `as _` conversion
+  --> $DIR/as_underscore.rs:27:13
+   |
+LL |     use_ptr(x as *const _);
+   |             ^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const *const ()`
+
+error: using `as _` conversion
+  --> $DIR/as_underscore.rs:28:14
+   |
+LL |     let x2 = x as *const _;
+   |              ^^^^^--------
+   |                   |
+   |                   help: consider giving the type explicitly: `*const *const ()`
+
+error: using `as _` conversion
+  --> $DIR/as_underscore.rs:31:25
+   |
+LL |     let _x3: *mut i32 = x as *mut _;
+   |                         ^^^^^------
+   |                              |
+   |                              help: consider giving the type explicitly: `*mut i32`
+
+error: using `as _` conversion
+  --> $DIR/as_underscore.rs:33:26
+   |
+LL |     let _x4: *const () = x as _;
+   |                          ^^^^^-
+   |                               |
+   |                               help: consider giving the type explicitly: `*const ()`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This makes `as_underscore` lint on cases where the type of a raw pointer `as` cast is inferred.  This can be very dangerous, such as the following code:
```rust
fn as_ptr(&self) -> *const u8 {
    &self as *const _ as *const u8
}
```
which now shows ``help: consider giving the type explicitly: `*const &UwU` ``, and should hopefully help the programmer notice that they've incorrectly turned a double pointer into a single pointer.

changelog: `as_underscore` now lints on cases where the type of a raw pointer `as` cast is an underscore, such as `x as *const _`.
