### PR TITLE
fix `single_component_path_imports` FP on `self::<import>::..`

### DIFF
--- a/tests/ui/single_component_path_imports.fixed
+++ b/tests/ui/single_component_path_imports.fixed
@@ -2,9 +2,11 @@
 #![warn(clippy::single_component_path_imports)]
 #![allow(unused_imports)]
 
+use core;
 
 use serde as edres;
 pub use serde;
+use std;
 
 macro_rules! m {
     () => {
@@ -17,6 +19,10 @@ fn main() {
 
     // False positive #5154, shouldn't trigger lint.
     m!();
+
+    // False positive #10549
+    let _ = self::std::io::stdout();
+    let _ = 0 as self::core::ffi::c_uint;
 }
 
 mod hello_mod {

--- a/tests/ui/single_component_path_imports.rs
+++ b/tests/ui/single_component_path_imports.rs
@@ -2,9 +2,11 @@
 #![warn(clippy::single_component_path_imports)]
 #![allow(unused_imports)]
 
+use core;
 use regex;
 use serde as edres;
 pub use serde;
+use std;
 
 macro_rules! m {
     () => {
@@ -17,6 +19,10 @@ fn main() {
 
     // False positive #5154, shouldn't trigger lint.
     m!();
+
+    // False positive #10549
+    let _ = self::std::io::stdout();
+    let _ = 0 as self::core::ffi::c_uint;
 }
 
 mod hello_mod {

--- a/tests/ui/single_component_path_imports.stderr
+++ b/tests/ui/single_component_path_imports.stderr
@@ -1,5 +1,5 @@
 error: this import is redundant
-  --> $DIR/single_component_path_imports.rs:5:1
+  --> $DIR/single_component_path_imports.rs:6:1
    |
 LL | use regex;
    | ^^^^^^^^^^ help: remove it entirely
@@ -7,7 +7,7 @@ LL | use regex;
    = note: `-D clippy::single-component-path-imports` implied by `-D warnings`
 
 error: this import is redundant
-  --> $DIR/single_component_path_imports.rs:23:5
+  --> $DIR/single_component_path_imports.rs:29:5
    |
 LL |     use regex;
    |     ^^^^^^^^^^ help: remove it entirely


### PR DESCRIPTION
fixes #10549

I noticed that a couple functions in the file I was working on took `cx` as a parameter but didn't use them, so I removed that. Can revert if desired because it isn't related to my changes.

changelog: [`single_component_path_imports`] don't suggest removing import when it is used as `self::<import>::..`
