### PR TITLE
add new lint `as_underscore_ptr` to check for `as *{const,mut} _`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4392,6 +4392,7 @@ Released 2018-09-13
 [`as_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_conversions
 [`as_ptr_cast_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_ptr_cast_mut
 [`as_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_underscore
+[`as_underscore_ptr`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_underscore_ptr
 [`assertions_on_constants`]: https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
 [`assertions_on_result_states`]: https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_result_states
 [`assign_op_pattern`]: https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

--- a/clippy_lints/src/casts/as_underscore_ptr.rs
+++ b/clippy_lints/src/casts/as_underscore_ptr.rs
@@ -1,0 +1,58 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::ty::is_ptr_like;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, MutTy, Ty, TyKind};
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, TypeAndMut};
+
+use super::AS_UNDERSCORE_PTR;
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, mut target_ty: &Ty<'_>) {
+    if let TyKind::Ptr(MutTy { mutbl, .. }) = target_ty.kind {
+        // get this before stripping the pointers, so the suggestion suggests replacing the whole type
+        let ty_span = target_ty.span;
+
+        // strip all pointers from the type
+        while let TyKind::Ptr(MutTy { ty: new_ty, .. }) = target_ty.kind {
+            target_ty = new_ty;
+        }
+
+        if matches!(target_ty.kind, TyKind::Infer) {
+            let mutbl_str = match mutbl {
+                rustc_ast::Mutability::Not => "const",
+                rustc_ast::Mutability::Mut => "mut",
+            };
+            span_lint_and_then(
+                cx,
+                AS_UNDERSCORE_PTR,
+                expr.span,
+                format!("using `as *{mutbl_str} _` conversion").as_str(),
+                |diag| {
+                    let ty_resolved = cx.typeck_results().expr_ty(expr);
+                    if let ty::Error(_) = ty_resolved.kind() {
+                        diag.help("consider giving the type explicitly");
+                    } else {
+                        // strip the first pointer of the resolved type of the cast, to test if the pointed to type
+                        // is also a pointer-like.  This might be a logic error, so bring extra notice to it.
+                        if let ty::RawPtr(TypeAndMut { ty: pointee_ty, .. }) = ty_resolved.kind() {
+                            if is_ptr_like(cx.tcx, *pointee_ty).is_some() {
+                                diag.note("the pointed to type is still a pointer-like type");
+                            }
+                        } else {
+                            unreachable!("The target type of a cast for `as_underscore_ptr` is a pointer");
+                        }
+
+                        diag.span_suggestion(
+                            ty_span,
+                            "consider giving the type explicitly",
+                            ty_resolved,
+                            Applicability::MachineApplicable,
+                        );
+                    }
+                },
+            );
+        }
+    } else {
+        // not a pointer
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -69,6 +69,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::cargo::WILDCARD_DEPENDENCIES_INFO,
     crate::casts::AS_PTR_CAST_MUT_INFO,
     crate::casts::AS_UNDERSCORE_INFO,
+    crate::casts::AS_UNDERSCORE_PTR_INFO,
     crate::casts::BORROW_AS_PTR_INFO,
     crate::casts::CAST_ABS_TO_UNSIGNED_INFO,
     crate::casts::CAST_ENUM_CONSTRUCTOR_INFO,

--- a/clippy_lints/src/only_used_in_recursion.rs
+++ b/clippy_lints/src/only_used_in_recursion.rs
@@ -8,7 +8,7 @@ use rustc_hir::hir_id::HirIdMap;
 use rustc_hir::{Body, Expr, ExprKind, HirId, ImplItem, ImplItemKind, Node, PatKind, TraitItem, TraitItemKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::subst::{EarlyBinder, GenericArgKind, SubstsRef};
-use rustc_middle::ty::{self, ConstKind};
+use rustc_middle::ty::{self, ConstKind, List};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::symbol::{kw, Ident};
 use rustc_span::Span;
@@ -249,7 +249,7 @@ impl<'tcx> LateLintPass<'tcx> for OnlyUsedInRecursion {
                 {
                     (
                         trait_item_id,
-                        FnKind::ImplTraitFn(cx.tcx.erase_regions(trait_ref.substs) as *const _ as usize),
+                        FnKind::ImplTraitFn(cx.tcx.erase_regions(trait_ref.substs) as *const List<_> as usize),
                         usize::from(sig.decl.implicit_self.has_implicit_self()),
                     )
                 } else {
@@ -390,6 +390,6 @@ fn has_matching_substs(kind: FnKind, substs: SubstsRef<'_>) -> bool {
             GenericArgKind::Const(c) => matches!(c.kind(), ConstKind::Param(c) if c.index as usize == idx),
         }),
         #[allow(trivial_casts)]
-        FnKind::ImplTraitFn(expected_substs) => substs as *const _ as usize == expected_substs,
+        FnKind::ImplTraitFn(expected_substs) => substs as *const List<_> as usize == expected_substs,
     }
 }

--- a/tests/ui/as_underscore_ptr.fixed
+++ b/tests/ui/as_underscore_ptr.fixed
@@ -1,0 +1,66 @@
+//@run-rustfix
+
+#![allow(unused)]
+#![deny(clippy::as_underscore_ptr)]
+
+use std::rc::Rc;
+
+// intent: turn a `&u64` into a `*const u8` that points to the bytes of the u64 (⚠️does not work⚠️)
+fn owo(x: &u64) -> *const u8 {
+    // ⚠️ `&x` is a `&&u64`, so this turns a double pointer into a single pointer
+    // ⚠️ This pointer is a dangling pointer to a local
+    &x as *const &u64 as *const u8
+}
+
+// note: this test is the same basic idea as above, but uses a `&self` which can be even more
+// misleading. In fact this is the case that was found in *real code* (that didn't work)
+// that inspired this lint. Make sure that it lints with `&self`!
+struct UwU;
+impl UwU {
+    // like above, this creates a double pointer, and then returns a dangling single pointer
+    // intent: turn a `&UwU` into a `*const u8` that points to the same data
+    fn as_ptr(&self) -> *const u8 {
+        // ⚠️ `&self` is a `&&UwU`, so this turns a double pointer into a single pointer
+        // ⚠️ This pointer is a dangling pointer to a local
+        &self as *const &UwU as *const u8
+    }
+}
+
+fn use_ptr(_: *const ()) {}
+
+fn main() {
+    let _: *const u8 = 1 as *const u8;
+    use_ptr(1 as *const ());
+
+    let _: *mut u8 = 1 as *mut u8;
+
+    // Pointer-to-pointer note tests
+    // If a _ resolves to a type that is itself a pointer, it's likely a mistake
+    // Show a note for all of these cases
+
+    // const ptr to ref
+    let r = &&1;
+    let _ = r as *const &i32;
+
+    // const ptr to mut ref
+    let r = &&mut 1;
+    let _ = r as *const &mut i32;
+
+    // mut ptr to ref
+    let r = &mut &1;
+    let _ = r as *mut &i32;
+
+    // mut ptr to mut ref
+    let r = &mut &mut 1;
+    let _ = r as *mut &mut i32;
+
+    // ptr to Box
+    let b = Box::new(1);
+    let r = &b;
+    let _ = r as *const std::boxed::Box<i32>;
+
+    // ptr to Rc
+    let rc = Rc::new(1);
+    let r = &rc;
+    let _ = r as *const std::rc::Rc<i32>;
+}

--- a/tests/ui/as_underscore_ptr.rs
+++ b/tests/ui/as_underscore_ptr.rs
@@ -1,0 +1,66 @@
+//@run-rustfix
+
+#![allow(unused)]
+#![deny(clippy::as_underscore_ptr)]
+
+use std::rc::Rc;
+
+// intent: turn a `&u64` into a `*const u8` that points to the bytes of the u64 (⚠️does not work⚠️)
+fn owo(x: &u64) -> *const u8 {
+    // ⚠️ `&x` is a `&&u64`, so this turns a double pointer into a single pointer
+    // ⚠️ This pointer is a dangling pointer to a local
+    &x as *const _ as *const u8
+}
+
+// note: this test is the same basic idea as above, but uses a `&self` which can be even more
+// misleading. In fact this is the case that was found in *real code* (that didn't work)
+// that inspired this lint. Make sure that it lints with `&self`!
+struct UwU;
+impl UwU {
+    // like above, this creates a double pointer, and then returns a dangling single pointer
+    // intent: turn a `&UwU` into a `*const u8` that points to the same data
+    fn as_ptr(&self) -> *const u8 {
+        // ⚠️ `&self` is a `&&UwU`, so this turns a double pointer into a single pointer
+        // ⚠️ This pointer is a dangling pointer to a local
+        &self as *const _ as *const u8
+    }
+}
+
+fn use_ptr(_: *const ()) {}
+
+fn main() {
+    let _: *const u8 = 1 as *const _;
+    use_ptr(1 as *const _);
+
+    let _: *mut u8 = 1 as *mut _;
+
+    // Pointer-to-pointer note tests
+    // If a _ resolves to a type that is itself a pointer, it's likely a mistake
+    // Show a note for all of these cases
+
+    // const ptr to ref
+    let r = &&1;
+    let _ = r as *const _;
+
+    // const ptr to mut ref
+    let r = &&mut 1;
+    let _ = r as *const _;
+
+    // mut ptr to ref
+    let r = &mut &1;
+    let _ = r as *mut _;
+
+    // mut ptr to mut ref
+    let r = &mut &mut 1;
+    let _ = r as *mut _;
+
+    // ptr to Box
+    let b = Box::new(1);
+    let r = &b;
+    let _ = r as *const _;
+
+    // ptr to Rc
+    let rc = Rc::new(1);
+    let r = &rc;
+    let _ = r as *const _;
+}

--- a/tests/ui/as_underscore_ptr.stderr
+++ b/tests/ui/as_underscore_ptr.stderr
@@ -1,0 +1,111 @@
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:12:5
+   |
+LL |     &x as *const _ as *const u8
+   |     ^^^^^^--------
+   |           |
+   |           help: consider giving the type explicitly: `*const &u64`
+   |
+   = note: the pointed to type is still a pointer-like type
+note: the lint level is defined here
+  --> $DIR/as_underscore_ptr.rs:4:9
+   |
+LL | #![deny(clippy::as_underscore_ptr)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:25:9
+   |
+LL |         &self as *const _ as *const u8
+   |         ^^^^^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const &UwU`
+   |
+   = note: the pointed to type is still a pointer-like type
+
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:32:24
+   |
+LL |     let _: *const u8 = 1 as *const _;
+   |                        ^^^^^--------
+   |                             |
+   |                             help: consider giving the type explicitly: `*const u8`
+
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:33:13
+   |
+LL |     use_ptr(1 as *const _);
+   |             ^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const ()`
+
+error: using `as *mut _` conversion
+  --> $DIR/as_underscore_ptr.rs:35:22
+   |
+LL |     let _: *mut u8 = 1 as *mut _;
+   |                      ^^^^^------
+   |                           |
+   |                           help: consider giving the type explicitly: `*mut u8`
+
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:43:13
+   |
+LL |     let _ = r as *const _;
+   |             ^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const &i32`
+   |
+   = note: the pointed to type is still a pointer-like type
+
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:47:13
+   |
+LL |     let _ = r as *const _;
+   |             ^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const &mut i32`
+   |
+   = note: the pointed to type is still a pointer-like type
+
+error: using `as *mut _` conversion
+  --> $DIR/as_underscore_ptr.rs:51:13
+   |
+LL |     let _ = r as *mut _;
+   |             ^^^^^------
+   |                  |
+   |                  help: consider giving the type explicitly: `*mut &i32`
+   |
+   = note: the pointed to type is still a pointer-like type
+
+error: using `as *mut _` conversion
+  --> $DIR/as_underscore_ptr.rs:55:13
+   |
+LL |     let _ = r as *mut _;
+   |             ^^^^^------
+   |                  |
+   |                  help: consider giving the type explicitly: `*mut &mut i32`
+   |
+   = note: the pointed to type is still a pointer-like type
+
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:60:13
+   |
+LL |     let _ = r as *const _;
+   |             ^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const std::boxed::Box<i32>`
+   |
+   = note: the pointed to type is still a pointer-like type
+
+error: using `as *const _` conversion
+  --> $DIR/as_underscore_ptr.rs:65:13
+   |
+LL |     let _ = r as *const _;
+   |             ^^^^^--------
+   |                  |
+   |                  help: consider giving the type explicitly: `*const std::rc::Rc<i32>`
+   |
+   = note: the pointed to type is still a pointer-like type
+
+error: aborting due to 11 previous errors
+

--- a/tests/ui/author/issue_3849.rs
+++ b/tests/ui/author/issue_3849.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::transmute_ptr_to_ref)]
 #![allow(clippy::transmuting_null)]
 
-pub const ZPTR: *const usize = 0 as *const _;
+pub const ZPTR: *const usize = 0 as *const usize;
 
 fn main() {
     unsafe {

--- a/tests/ui/borrow_deref_ref.fixed
+++ b/tests/ui/borrow_deref_ref.fixed
@@ -51,8 +51,8 @@ mod should_not_lint2 {
 mod false_negative {
     fn foo() {
         let x = &12;
-        let addr_x = &x as *const _ as usize;
-        let addr_y = &x as *const _ as usize; // assert ok
+        let addr_x = &x as *const &i32 as usize;
+        let addr_y = &x as *const &i32 as usize; // assert ok
         // let addr_y = &x as *const _ as usize; // assert fail
         assert_ne!(addr_x, addr_y);
     }

--- a/tests/ui/borrow_deref_ref.rs
+++ b/tests/ui/borrow_deref_ref.rs
@@ -51,8 +51,8 @@ mod should_not_lint2 {
 mod false_negative {
     fn foo() {
         let x = &12;
-        let addr_x = &x as *const _ as usize;
-        let addr_y = &&*x as *const _ as usize; // assert ok
+        let addr_x = &x as *const &i32 as usize;
+        let addr_y = &&*x as *const &i32 as usize; // assert ok
         // let addr_y = &x as *const _ as usize; // assert fail
         assert_ne!(addr_x, addr_y);
     }

--- a/tests/ui/borrow_deref_ref.stderr
+++ b/tests/ui/borrow_deref_ref.stderr
@@ -15,7 +15,7 @@ LL |         let b = &mut &*bar(&12);
 error: deref on an immutable reference
   --> $DIR/borrow_deref_ref.rs:55:23
    |
-LL |         let addr_y = &&*x as *const _ as usize; // assert ok
+LL |         let addr_y = &&*x as *const &i32 as usize; // assert ok
    |                       ^^^ help: if you would like to reborrow, try removing `&*`: `x`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/fn_null_check.rs
+++ b/tests/ui/fn_null_check.rs
@@ -4,8 +4,8 @@
 #![allow(clippy::ptr_eq)]
 #![allow(clippy::zero_ptr)]
 
-pub const ZPTR: *const () = 0 as *const _;
-pub const NOT_ZPTR: *const () = 1 as *const _;
+pub const ZPTR: *const () = 0 as *const ();
+pub const NOT_ZPTR: *const () = 1 as *const ();
 
 fn main() {
     let fn_ptr = main;

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -162,13 +162,13 @@ mod issue6675 {
 
     unsafe fn foo() {
         let s = "test".to_owned();
-        let s = &s as *const _;
+        let s = &s as *const String;
         None.unwrap_or_else(|| ptr_to_ref(s));
     }
 
     fn bar() {
         let s = "test".to_owned();
-        let s = &s as *const _;
+        let s = &s as *const String;
         None.unwrap_or_else(|| unsafe { ptr_to_ref(s) });
         #[rustfmt::skip]
         None.unwrap_or_else(|| unsafe { ptr_to_ref(s) });

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -162,13 +162,13 @@ mod issue6675 {
 
     unsafe fn foo() {
         let s = "test".to_owned();
-        let s = &s as *const _;
+        let s = &s as *const String;
         None.unwrap_or(ptr_to_ref(s));
     }
 
     fn bar() {
         let s = "test".to_owned();
-        let s = &s as *const _;
+        let s = &s as *const String;
         None.unwrap_or(unsafe { ptr_to_ref(s) });
         #[rustfmt::skip]
         None.unwrap_or( unsafe { ptr_to_ref(s) }    );

--- a/tests/ui/transmute_null_to_fn.rs
+++ b/tests/ui/transmute_null_to_fn.rs
@@ -10,8 +10,8 @@ fn one_liners() {
     }
 }
 
-pub const ZPTR: *const usize = 0 as *const _;
-pub const NOT_ZPTR: *const usize = 1 as *const _;
+pub const ZPTR: *const usize = 0 as *const usize;
+pub const NOT_ZPTR: *const usize = 1 as *const usize;
 
 fn transmute_const() {
     unsafe {

--- a/tests/ui/transmuting_null.rs
+++ b/tests/ui/transmuting_null.rs
@@ -12,8 +12,8 @@ fn one_liners() {
     }
 }
 
-pub const ZPTR: *const usize = 0 as *const _;
-pub const NOT_ZPTR: *const usize = 1 as *const _;
+pub const ZPTR: *const usize = 0 as *const usize;
+pub const NOT_ZPTR: *const usize = 1 as *const usize;
 
 fn transmute_const() {
     unsafe {


### PR DESCRIPTION
This probably could go in `suspicious`, but I was unsure where exactly to put it.  It's not necessarily wrong code on its own, but can be problematic in certain situations.

changelog: [`as_underscore_ptr`]: a new lint to detect use of `as *const _` or `as *mut _` which can be the cause of subtle raw pointer bugs.
