### PR TITLE
Disable `type_complexity` lint by default

### DIFF
--- a/clippy_lints/src/types/mod.rs
+++ b/clippy_lints/src/types/mod.rs
@@ -266,7 +266,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub TYPE_COMPLEXITY,
-    complexity,
+    pedantic,
     "usage of very complex types that might be better factored into `type` definitions"
 }
 


### PR DESCRIPTION
```
changelog: [`type_complexity`]: disabled by default by moving from the `complexity` group to the `pedantic` group
```

The `type_complexity` lint is currently the [most globally ignored](https://github.com/dtolnay/noisy-clippy#results-updated-february-2023) lint. Across whole ecosystems (Bevy, Diesel and more), it simply must be turned off by every user and every crate in the ecosystem: clear and idiomatic use of type-heavy frameworks constantly triggers this lint.

In these cases, it encourages replacing straightforward dependency injection code with type definitions that are only used once,  misleading beginners into masking complexity with indirection.

**Feedback requested:** I'm new to contributing to clippy, and I wasn't sure of the best way to disable this by default. Should this be pedantic? Style? It's clearly a "complexity" lint still, but it doesn't appear that we can configure it to be off-by-default without moving it out of the group.