### PR TITLE
Make dogfood tests run in `release` mode

### DIFF
--- a/clippy_dev/src/dogfood.rs
+++ b/clippy_dev/src/dogfood.rs
@@ -10,8 +10,14 @@ use std::{
 pub fn dogfood(fix: bool, allow_dirty: bool, allow_staged: bool) {
     let mut cmd = Command::new("cargo");
 
+    #[cfg(not(target_os = "windows"))]
     cmd.current_dir(clippy_project_root())
         .args(["test", "-r", "--test", "dogfood"])
+        .args(["--features", "internal"])
+        .args(["--", "dogfood_clippy"]);
+    #[cfg(target_os = "windows")]
+    cmd.current_dir(clippy_project_root())
+        .args(["test", "--test", "dogfood"])
         .args(["--features", "internal"])
         .args(["--", "dogfood_clippy"]);
 


### PR DESCRIPTION
The old PR was about creating a new alias in `.cargo/config.toml`. After some extra testing we noticed that the speedup wasn't that critical and @flip1995 created a new patch to actually make `dogfood` tests run with a `--release` argument.

Ignore any conversation before [this comment](https://github.com/rust-lang/rust-clippy/pull/10576#issuecomment-1492002622), as the PR has been re-done.

changelog:none