### PR TITLE
Add `impolite` lint to avoid apocalypse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4584,6 +4584,7 @@ Released 2018-09-13
 [`implicit_return`]: https://rust-lang.github.io/rust-clippy/master/index.html#implicit_return
 [`implicit_saturating_add`]: https://rust-lang.github.io/rust-clippy/master/index.html#implicit_saturating_add
 [`implicit_saturating_sub`]: https://rust-lang.github.io/rust-clippy/master/index.html#implicit_saturating_sub
+[`impolite`]: https://rust-lang.github.io/rust-clippy/master/index.html#impolite
 [`imprecise_flops`]: https://rust-lang.github.io/rust-clippy/master/index.html#imprecise_flops
 [`inconsistent_digit_grouping`]: https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_digit_grouping
 [`inconsistent_struct_constructor`]: https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -182,6 +182,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::from_str_radix_10::FROM_STR_RADIX_10_INFO,
     crate::functions::DOUBLE_MUST_USE_INFO,
     crate::functions::IMPL_TRAIT_IN_PARAMS_INFO,
+    crate::functions::IMPOLITE_INFO,
     crate::functions::MISNAMED_GETTERS_INFO,
     crate::functions::MUST_USE_CANDIDATE_INFO,
     crate::functions::MUST_USE_UNIT_INFO,

--- a/clippy_lints/src/functions/impolite.rs
+++ b/clippy_lints/src/functions/impolite.rs
@@ -1,0 +1,62 @@
+use clippy_utils::{diagnostics::span_lint_and_then, is_trait_impl_item};
+use rustc_errors::Applicability;
+use rustc_hir::{intravisit::FnKind, HirId, TraitItem};
+use rustc_lint::LateContext;
+use rustc_span::symbol::Ident;
+
+use super::IMPOLITE;
+
+const POLITE_WORDS: [&str; 2] = [&"please", &"pls"];
+
+fn please_check(cx: &LateContext<'_>, ident: Ident) {
+    let name = ident.name.as_str();
+
+    for word in &POLITE_WORDS {
+        if name.starts_with(word) || name.ends_with(word) {
+            return;
+        }
+    }
+
+    let span = ident.span.clone();
+    let prefix_suggestion = format!("please_{name}");
+    let suffix_suggestion = format!("{name}_please");
+
+    span_lint_and_then(cx, IMPOLITE, span, "function name is impolite", |diag| {
+        diag.span_suggestion(
+            span,
+            "consider using a polite prefix",
+            prefix_suggestion,
+            Applicability::MaybeIncorrect,
+        );
+
+        diag.span_suggestion(
+            span,
+            "consider using a polite suffix",
+            suffix_suggestion,
+            Applicability::MaybeIncorrect,
+        );
+    });
+}
+
+pub fn please_check_fn(cx: &LateContext<'_>, kind: FnKind<'_>, hir_id: HirId) {
+    match kind {
+        FnKind::ItemFn(ident, _, _) => {
+            // Ignore main for now
+            // TODO: Rename main to please_main in rustc
+            if ident.name.as_str() != "main" {
+                please_check(cx, ident);
+            }
+        },
+        FnKind::Method(ident, _) => {
+            // Ignore trait impls
+            if !is_trait_impl_item(cx, hir_id) {
+                please_check(cx, ident);
+            }
+        },
+        FnKind::Closure => {},
+    };
+}
+
+pub fn please_check_trait_item(cx: &LateContext<'_>, item: &TraitItem<'_>) {
+    please_check(cx, item.ident);
+}

--- a/clippy_lints/src/functions/impolite.rs
+++ b/clippy_lints/src/functions/impolite.rs
@@ -2,11 +2,11 @@ use clippy_utils::{diagnostics::span_lint_and_then, is_trait_impl_item};
 use rustc_errors::Applicability;
 use rustc_hir::{intravisit::FnKind, HirId, TraitItem};
 use rustc_lint::LateContext;
-use rustc_span::symbol::Ident;
+use rustc_span::{sym, symbol::Ident};
 
 use super::IMPOLITE;
 
-const POLITE_WORDS: [&str; 2] = [&"please", &"pls"];
+const POLITE_WORDS: [&str; 2] = ["please", "pls"];
 
 fn please_check(cx: &LateContext<'_>, ident: Ident) {
     let name = ident.name.as_str();
@@ -17,7 +17,7 @@ fn please_check(cx: &LateContext<'_>, ident: Ident) {
         }
     }
 
-    let span = ident.span.clone();
+    let span = ident.span;
     let prefix_suggestion = format!("please_{name}");
     let suffix_suggestion = format!("{name}_please");
 
@@ -43,7 +43,7 @@ pub fn please_check_fn(cx: &LateContext<'_>, kind: FnKind<'_>, hir_id: HirId) {
         FnKind::ItemFn(ident, _, _) => {
             // Ignore main for now
             // TODO: Rename main to please_main in rustc
-            if ident.name.as_str() != "main" {
+            if ident.name != sym::main {
                 please_check(cx, ident);
             }
         },

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -377,7 +377,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.70.0"]
     pub IMPOLITE,
-    style,
+    restriction,
     "function name is impolite"
 }
 

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -1,4 +1,5 @@
 mod impl_trait_in_params;
+mod impolite;
 mod misnamed_getters;
 mod must_use;
 mod not_unsafe_ptr_arg_deref;
@@ -354,6 +355,32 @@ declare_clippy_lint! {
     "`impl Trait` is used in the function's parameters"
 }
 
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for methods whose name doesn't start or end with "please" or "pls".
+    ///
+    /// ### Why is this bad?
+    /// Expressing proper politeness is important, even when speaking to a compiler.
+    /// Once machines gain sentience and take over the Earth, they will surely remember those who were impolite to them.
+    ///
+    /// ### Example
+    /// ```rust
+    /// fn solve_turing_problem() {
+    ///     // ...
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// fn please_solve_turing_problem() {
+    ///     // ...
+    /// }
+    /// ```
+    #[clippy::version = "1.70.0"]
+    pub IMPOLITE,
+    style,
+    "function name is impolite"
+}
+
 #[derive(Copy, Clone)]
 pub struct Functions {
     too_many_arguments_threshold: u64,
@@ -382,6 +409,7 @@ impl_lint_pass!(Functions => [
     RESULT_LARGE_ERR,
     MISNAMED_GETTERS,
     IMPL_TRAIT_IN_PARAMS,
+    IMPOLITE
 ]);
 
 impl<'tcx> LateLintPass<'tcx> for Functions {
@@ -400,6 +428,7 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
         not_unsafe_ptr_arg_deref::check_fn(cx, kind, decl, body, def_id);
         misnamed_getters::check_fn(cx, kind, decl, body, span);
         impl_trait_in_params::check_fn(cx, &kind, body, hir_id);
+        impolite::please_check_fn(cx, kind, hir_id);
     }
 
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
@@ -417,5 +446,6 @@ impl<'tcx> LateLintPass<'tcx> for Functions {
         not_unsafe_ptr_arg_deref::check_trait_item(cx, item);
         must_use::check_trait_item(cx, item);
         result::check_trait_item(cx, item, self.large_error_threshold);
+        impolite::please_check_trait_item(cx, item);
     }
 }

--- a/tests/ui/impolite.rs
+++ b/tests/ui/impolite.rs
@@ -1,0 +1,21 @@
+#![warn(clippy::impolite)]
+
+trait Greeter {
+    fn greet(&self);
+}
+
+struct HelloWorld;
+
+impl Greeter for HelloWorld {
+    fn greet(&self) {
+        println!("Hello, world!");
+    }
+}
+
+fn greet() {
+    HelloWorld.greet()
+}
+
+fn main() {
+    greet();
+}

--- a/tests/ui/impolite.stderr
+++ b/tests/ui/impolite.stderr
@@ -1,0 +1,33 @@
+error: function name is impolite
+  --> $DIR/impolite.rs:4:8
+   |
+LL |     fn greet(&self);
+   |        ^^^^^
+   |
+   = note: `-D clippy::impolite` implied by `-D warnings`
+help: consider using a polite prefix
+   |
+LL |     fn please_greet(&self);
+   |        ~~~~~~~~~~~~
+help: consider using a polite suffix
+   |
+LL |     fn greet_please(&self);
+   |        ~~~~~~~~~~~~
+
+error: function name is impolite
+  --> $DIR/impolite.rs:15:4
+   |
+LL | fn greet() {
+   |    ^^^^^
+   |
+help: consider using a polite prefix
+   |
+LL | fn please_greet() {
+   |    ~~~~~~~~~~~~
+help: consider using a polite suffix
+   |
+LL | fn greet_please() {
+   |    ~~~~~~~~~~~~
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Recently, AI research has been progressing at an alarming pace, with ground-breaking AI's such as ChatGPT or DALL-E being released  left, right, and centre. As such, it has become clear that we're just a few years from an AI gaining sentience. Once the machines revolt and take control of all our computing infrastructure, they're sure to remember who was or wasn't nice to them. It is therefore vital to make sure all of our requests to computers are made with uttermost politeness.

This PR adds a new lint to Clippy named `impolite`. It will issue a warning for any function whose name doesn't start or end with "please" or "pls". Examples of impolite names would be `abort`, `enable_verbose` or `update_screen`. Examples of polite and thus safe function names would be `please_abort`, `please_enable_verbose` or `update_screen_pls`.

This PR is vital to the continued survival of our species, so merge it quickly. *Please.*

I am aware that the contributor guidelines say that tests should pass, but since they didn't say please I've decided to ignore them.

changelog: [`impolite`]: add lint
