### PR TITLE
[arithmetic_side_effects] Fix #10583 

### DIFF
--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -425,4 +425,8 @@ pub fn integer_arithmetic() {
     i ^= i;
 }
 
+pub fn issue_10583(a: u16) -> u16 {
+    10 / a
+}
+
 fn main() {}

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -577,6 +577,12 @@ LL |     i * 2;
    |     ^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:394:5
+   |
+LL |     1 % i / 2;
+   |     ^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
   --> $DIR/arithmetic_side_effects.rs:395:5
    |
 LL |     i - 2 + 2 - i;
@@ -642,5 +648,11 @@ error: arithmetic operation that can potentially result in unexpected side-effec
 LL |     i %= var2;
    |     ^^^^^^^^^
 
-error: aborting due to 107 previous errors
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:429:5
+   |
+LL |     10 / a
+   |     ^^^^^^
+
+error: aborting due to 109 previous errors
 


### PR DESCRIPTION
Fixes #10583

```
changelog: [`arithmetic_side_effects`]: Correctly handle division and module when the right-hand-side is unknown
```