### PR TITLE
Add `safe_unchecked` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4871,6 +4871,7 @@ Released 2018-09-13
 [`result_unwrap_used`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_unwrap_used
 [`return_self_not_must_use`]: https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use
 [`reversed_empty_ranges`]: https://rust-lang.github.io/rust-clippy/master/index.html#reversed_empty_ranges
+[`safe_unchecked`]: https://rust-lang.github.io/rust-clippy/master/index.html#safe_unchecked
 [`same_functions_in_if_condition`]: https://rust-lang.github.io/rust-clippy/master/index.html#same_functions_in_if_condition
 [`same_item_push`]: https://rust-lang.github.io/rust-clippy/master/index.html#same_item_push
 [`same_name_method`]: https://rust-lang.github.io/rust-clippy/master/index.html#same_name_method

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -188,6 +188,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::functions::NOT_UNSAFE_PTR_ARG_DEREF_INFO,
     crate::functions::RESULT_LARGE_ERR_INFO,
     crate::functions::RESULT_UNIT_ERR_INFO,
+    crate::functions::SAFE_UNCHECKED_INFO,
     crate::functions::TOO_MANY_ARGUMENTS_INFO,
     crate::functions::TOO_MANY_LINES_INFO,
     crate::future_not_send::FUTURE_NOT_SEND_INFO,

--- a/clippy_lints/src/functions/safe_unchecked.rs
+++ b/clippy_lints/src/functions/safe_unchecked.rs
@@ -1,0 +1,42 @@
+use clippy_utils::{diagnostics::span_lint_and_then, is_trait_impl_item};
+use rustc_errors::Applicability;
+use rustc_hir::{intravisit::FnKind, HirId};
+use rustc_lint::LateContext;
+use rustc_span::{symbol::Ident, Span};
+
+use super::SAFE_UNCHECKED;
+
+pub(super) fn check_fn(cx: &LateContext<'_>, kind: &FnKind<'_>, sp: Span, hir_id: HirId) {
+    fn lint_if_name_ends_with_unchecked(cx: &LateContext<'_>, item_span: Span, ident: &Ident) {
+        if ident.as_str().ends_with("_unchecked") {
+            span_lint_and_then(
+                cx,
+                SAFE_UNCHECKED,
+                ident.span,
+                "this function ending with `_unchecked` isn't marked with `unsafe`",
+                |diag| {
+                    diag.span_suggestion_verbose(
+                        item_span.shrink_to_lo().with_lo(item_span.lo()),
+                        "add an unsafe marker",
+                        "unsafe ",
+                        Applicability::MaybeIncorrect,
+                    );
+                },
+            );
+        }
+    }
+
+    match kind {
+        FnKind::ItemFn(ident, _, header) => {
+            if !header.is_unsafe() {
+                lint_if_name_ends_with_unchecked(cx, sp, ident);
+            }
+        },
+        FnKind::Method(ident, sig) => {
+            if !sig.header.is_unsafe() && !is_trait_impl_item(cx, hir_id) {
+                lint_if_name_ends_with_unchecked(cx, sp, ident);
+            }
+        },
+        FnKind::Closure => (),
+    }
+}

--- a/tests/ui/safe_unchecked.fixed
+++ b/tests/ui/safe_unchecked.fixed
@@ -1,0 +1,17 @@
+// run-rustfix
+#![allow(unused)]
+#![warn(clippy::safe_unchecked)]
+
+unsafe fn should_lint_unchecked() {}
+fn should_not_lint() {} // Name doesn't end with "_unchecked"
+unsafe fn should_not_lint_unchecked() {} // It's an unsafe function
+
+trait SomeTrait {
+    fn method_should_not_lint_unchecked();
+}
+
+impl SomeTrait for usize {
+    fn method_should_not_lint_unchecked() {}
+}
+
+fn main() {}

--- a/tests/ui/safe_unchecked.rs
+++ b/tests/ui/safe_unchecked.rs
@@ -1,0 +1,17 @@
+// run-rustfix
+#![allow(unused)]
+#![warn(clippy::safe_unchecked)]
+
+fn should_lint_unchecked() {}
+fn should_not_lint() {} // Name doesn't end with "_unchecked"
+unsafe fn should_not_lint_unchecked() {} // It's an unsafe function
+
+trait SomeTrait {
+    fn method_should_not_lint_unchecked();
+}
+
+impl SomeTrait for usize {
+    fn method_should_not_lint_unchecked() {}
+}
+
+fn main() {}

--- a/tests/ui/safe_unchecked.stderr
+++ b/tests/ui/safe_unchecked.stderr
@@ -1,0 +1,14 @@
+error: this function ending with `_unchecked` isn't marked with `unsafe`
+  --> $DIR/safe_unchecked.rs:5:4
+   |
+LL | fn should_lint_unchecked() {}
+   |    ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::safe-unchecked` implied by `-D warnings`
+help: add an unsafe marker
+   |
+LL | unsafe fn should_lint_unchecked() {}
+   | ++++++
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Adds the lint `safe_unchecked`, that triggers when a function which name ends with "_unchecked" isn't marked as unsafe

Resolves #9438 
changelog:[`safe_unchecked`]: The lint was added
