### PR TITLE
Mini-fix `double_must_use` for async functions

### DIFF
--- a/clippy_lints/src/functions/must_use.rs
+++ b/clippy_lints/src/functions/must_use.rs
@@ -23,7 +23,8 @@ use super::{DOUBLE_MUST_USE, MUST_USE_CANDIDATE, MUST_USE_UNIT};
 pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {
     let attrs = cx.tcx.hir().attrs(item.hir_id());
     let attr = cx.tcx.get_attr(item.owner_id, sym::must_use);
-    if let hir::ItemKind::Fn(ref sig, _generics, ref body_id) = item.kind {
+    if let hir::ItemKind::Fn(ref sig, _generics, ref body_id) = item.kind && !sig.header.is_async() /* (#10486) */ {
+
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
         if let Some(attr) = attr {
@@ -43,7 +44,7 @@ pub(super) fn check_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>
 }
 
 pub(super) fn check_impl_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'_>) {
-    if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind {
+    if let hir::ImplItemKind::Fn(ref sig, ref body_id) = item.kind && !sig.header.is_async() /* (#10486) */ {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
         let attrs = cx.tcx.hir().attrs(item.hir_id());
@@ -65,7 +66,7 @@ pub(super) fn check_impl_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::Imp
 }
 
 pub(super) fn check_trait_item<'tcx>(cx: &LateContext<'tcx>, item: &'tcx hir::TraitItem<'_>) {
-    if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind {
+    if let hir::TraitItemKind::Fn(ref sig, ref eid) = item.kind && !sig.header.is_async() /* (#10486) */ {
         let is_public = cx.effective_visibilities.is_exported(item.owner_id.def_id);
         let fn_header_span = item.span.with_hi(sig.decl.output.span().hi());
 

--- a/tests/ui/double_must_use.rs
+++ b/tests/ui/double_must_use.rs
@@ -21,6 +21,12 @@ pub fn must_use_with_note() -> Result<(), ()> {
     unimplemented!();
 }
 
+// vvvv Should not lint (#10486)
+#[must_use]
+async fn async_must_use() -> usize {
+    unimplemented!();
+}
+
 fn main() {
     must_use_result();
     must_use_tuple();


### PR DESCRIPTION
From Rust 1.67 onwards, the `#[must_use]` attribute also applies to the `Future::Output` (rust-lang/rust#100633). So the lint `double_must_use` was linting all async functions. This PR changes the `double_must_use` lint so it ignores `async` functions. 

---

Closes #10486 
changelog:
