### PR TITLE
Show multiple clippy.toml warnings with `sess.warn` instead of `eprintln!`

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -130,7 +130,7 @@ impl rustc_driver::Callbacks for ClippyCallbacks {
     #[allow(rustc::bad_opt_access)]
     fn config(&mut self, config: &mut interface::Config) {
         let conf_path = clippy_lints::lookup_conf_file();
-        let conf_path_string = if let Ok(Some(path)) = &conf_path {
+        let conf_path_string = if let Ok((Some(path), _)) = &conf_path {
             path.to_str().map(String::from)
         } else {
             None

--- a/tests/ui-cargo/multiple_config_files/warn/src/main.stderr
+++ b/tests/ui-cargo/multiple_config_files/warn/src/main.stderr
@@ -1,2 +1,4 @@
-Using config file `$SRC_DIR/.clippy.toml`
-Warning: `$SRC_DIR/clippy.toml` will be ignored.
+warning: using config file `$SRC_DIR/.clippy.toml`, `$SRC_DIR/clippy.toml` will be ignored
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Use `sess.warn` to display the multiple clippy.toml warning instead of `eprintln!`.

changelog: none