### PR TITLE
Fix bug with getting parent directories in `lookup_conf_file`

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -478,7 +478,8 @@ pub fn lookup_conf_file() -> io::Result<(Option<PathBuf>, Vec<String>)> {
     // If neither of those exist, use ".".
     let mut current = env::var_os("CLIPPY_CONF_DIR")
         .or_else(|| env::var_os("CARGO_MANIFEST_DIR"))
-        .map_or_else(|| PathBuf::from("."), PathBuf::from);
+        .map_or_else(|| PathBuf::from("."), PathBuf::from)
+        .canonicalize()?;
 
     let mut found_config: Option<PathBuf> = None;
     let mut warnings = vec![];


### PR DESCRIPTION
Currently `lookup_conf_file` doesn't canonicalize the configuration directory before using [`PathBuf::pop`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.pop) to get the parent directory. This isn't usually an issue when clippy is invoked via `cargo clippy` as `CARGO_MANIFEST_DIR` is already canonicalized. However, this currently causes `clippy-driver` to ignore any `clippy.toml` in any parent directories when  `CARGO_MANIFEST_DIR` and `CLIPPY_CONF_DIR` are not set.

changelog: Fix a bug that would cause parent directories not to be searched for `clippy.toml` when using `clippy-driver` directly.