### PR TITLE
(Small) Fix broken links for Rust merge

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -24,7 +24,7 @@ because that's clearly a non-descriptive name.
   - [Lint passes](#lint-passes)
   - [Emitting a lint](#emitting-a-lint)
   - [Adding the lint logic](#adding-the-lint-logic)
-  - [Specifying the lint's minimum supported Rust version (MSRV)](#specifying-the-lints-minimum-supported-rust-version--msrv-)
+  - [Specifying the lint's minimum supported Rust version (MSRV)](#specifying-the-lints-minimum-supported-rust-version-msrv)
   - [Author lint](#author-lint)
   - [Print HIR lint](#print-hir-lint)
   - [Documentation](#documentation)

--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -148,4 +148,4 @@ clippy-driver --edition 2018 -Cpanic=abort foo.rs
 > that are not optimized as expected, for example.
 
 [Installation]: installation.md
-[CI]: continuous_integration/index.md
+[CI]: continuous_integration/README.md


### PR DESCRIPTION
rust-lang/rust#110003's CI is [currently broken](https://github.com/rust-lang/rust/actions/runs/4628510374/jobs/8187672234?pr=110003) because of broken links. This PR fixes that.
It was tested against `lintcheck` and found another broken link in `usage.md` (apart from CI's broken links)

changelog:Fix broken links in the book
Sorry for putting more work on you, but you're the one doing the Rust PR
r? @flip1995 