### PR TITLE
Add `max_line_length` to `.editorconfig`, matching `rustfmt.toml`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+max_line_length = 120
 
 [*.md]
 # double whitespace at end of line


### PR DESCRIPTION
Add `max_line_length` to `.editorconfig` to match the `max_width` in `rustfmt.toml`.

changelog: none