### PR TITLE
[missing_const_for_fn] fix #7121

### DIFF
--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -41,6 +41,7 @@ declare_clippy_lint! {
     /// can't be const as it calls a non-const function. Making `a` const and running Clippy again,
     /// will suggest to make `b` const, too.
     ///
+    /// If you are marking public function with const, doing opposite will break API compatibility.
     /// ### Example
     /// ```rust
     /// # struct Foo {

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -41,7 +41,7 @@ declare_clippy_lint! {
     /// can't be const as it calls a non-const function. Making `a` const and running Clippy again,
     /// will suggest to make `b` const, too.
     ///
-    /// If you are marking public function with const, doing opposite will break API compatibility.
+    /// If you are marking a public function with `const`, removing it again will break API compatibility.
     /// ### Example
     /// ```rust
     /// # struct Foo {


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`missing_const_for_fn`] note about removing const may break compatibility

fix #7121 
