### PR TITLE
remove unusued `#![feature(drain_filter)]`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(array_windows)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(box_patterns)]
-#![feature(drain_filter)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]


### PR DESCRIPTION
The unstable feature does not appear to be used and its presence blocks work in https://github.com/rust-lang/rust/pull/104455

changelog: none
