### PR TITLE
Fix UB in `as_ptr_cast_mut` documentation

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -625,14 +625,14 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
-    /// let string = String::with_capacity(1);
-    /// let ptr = string.as_ptr() as *mut u8;
+    /// let mut vec = Vec::<u8>::with_capacity(1);
+    /// let ptr = vec.as_ptr() as *mut u8;
     /// unsafe { ptr.write(4) }; // UNDEFINED BEHAVIOUR
     /// ```
     /// Use instead:
     /// ```rust
-    /// let mut string = String::with_capacity(1);
-    /// let ptr = string.as_mut_ptr();
+    /// let mut vec = Vec::<u8>::with_capacity(1);
+    /// let ptr = vec.as_mut_ptr();
     /// unsafe { ptr.write(4) };
     /// ```
     #[clippy::version = "1.66.0"]


### PR DESCRIPTION
changelog: none

Fixes #10628

There's no `String::as_mut_ptr` surprisingly, so the example is actually calling `str::as_mut_ptr` on an empty `str`