### PR TITLE
Suggest `std::mem::size_of_val` instead of `std::mem::size_of_value`

### DIFF
--- a/clippy_lints/src/manual_slice_size_calculation.rs
+++ b/clippy_lints/src/manual_slice_size_calculation.rs
@@ -38,7 +38,7 @@ declare_lint_pass!(ManualSliceSizeCalculation => [MANUAL_SLICE_SIZE_CALCULATION]
 
 impl<'tcx> LateLintPass<'tcx> for ManualSliceSizeCalculation {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        // Does not apply inside const because size_of_value is not cost in stable.
+        // Does not apply inside const because size_of_val is not cost in stable.
         if !in_constant(cx, expr.hir_id)
             && let ExprKind::Binary(ref op, left, right) = expr.kind
             && BinOpKind::Mul == op.node
@@ -50,7 +50,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualSliceSizeCalculation {
                 expr.span,
                 "manual slice size calculation",
                 None,
-                "consider using std::mem::size_of_value instead");
+                "consider using std::mem::size_of_val instead");
         }
     }
 }

--- a/tests/ui/manual_slice_size_calculation.stderr
+++ b/tests/ui/manual_slice_size_calculation.stderr
@@ -4,7 +4,7 @@ error: manual slice size calculation
 LL |     let _ = s_i32.len() * size_of::<i32>(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider using std::mem::size_of_value instead
+   = help: consider using std::mem::size_of_val instead
    = note: `-D clippy::manual-slice-size-calculation` implied by `-D warnings`
 
 error: manual slice size calculation
@@ -13,7 +13,7 @@ error: manual slice size calculation
 LL |     let _ = size_of::<i32>() * s_i32.len(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider using std::mem::size_of_value instead
+   = help: consider using std::mem::size_of_val instead
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:13:13
@@ -21,7 +21,7 @@ error: manual slice size calculation
 LL |     let _ = size_of::<i32>() * s_i32.len() * 5; // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider using std::mem::size_of_value instead
+   = help: consider using std::mem::size_of_val instead
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:17:13
@@ -29,7 +29,7 @@ error: manual slice size calculation
 LL |     let _ = len * size_of::<i32>(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: consider using std::mem::size_of_value instead
+   = help: consider using std::mem::size_of_val instead
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:18:13
@@ -37,7 +37,7 @@ error: manual slice size calculation
 LL |     let _ = s_i32.len() * size; // WARNING
    |             ^^^^^^^^^^^^^^^^^^
    |
-   = help: consider using std::mem::size_of_value instead
+   = help: consider using std::mem::size_of_val instead
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:19:13
@@ -45,7 +45,7 @@ error: manual slice size calculation
 LL |     let _ = len * size; // WARNING
    |             ^^^^^^^^^^
    |
-   = help: consider using std::mem::size_of_value instead
+   = help: consider using std::mem::size_of_val instead
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
This fixes the incorrect suggestion to use `std::mem::size_of_value`. It should be [`std::mem::size_of_val`](https://doc.rust-lang.org/std/mem/fn.size_of_val.html).

changelog: [`manual_slice_size_calculation`]: suggest `std::mem::size_of_val` rather than `std::mem::size_of_value`
