### PR TITLE
Add `manual_slice_size_calculation` applicable suggestion

### DIFF
--- a/clippy_lints/src/manual_slice_size_calculation.rs
+++ b/clippy_lints/src/manual_slice_size_calculation.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_context;
-use clippy_utils::{expr_or_init, in_constant};
+use clippy_utils::{expr_or_init, in_constant, std_or_core};
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -50,6 +50,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualSliceSizeCalculation {
             let ctxt = expr.span.ctxt();
             let mut app = Applicability::MachineApplicable;
             let val_name = snippet_with_context(cx, receiver.span, ctxt, "slice", &mut app).0;
+            let Some(sugg) = std_or_core(cx) else { return };
 
             span_lint_and_sugg(
                 cx,
@@ -57,7 +58,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualSliceSizeCalculation {
                     expr.span,
                     "manual slice size calculation",
                     "try",
-                    format!("std::mem::size_of_val({val_name})"),
+                    format!("{sugg}::mem::size_of_val({val_name})"),
                     Applicability::MachineApplicable,
                 );
         }

--- a/clippy_lints/src/manual_slice_size_calculation.rs
+++ b/clippy_lints/src/manual_slice_size_calculation.rs
@@ -1,3 +1,4 @@
+// run-rustfix
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::{expr_or_init, in_constant};

--- a/tests/ui/manual_slice_size_calculation.fixed
+++ b/tests/ui/manual_slice_size_calculation.fixed
@@ -9,15 +9,15 @@ fn main() {
     let s_i32 = v_i32.as_slice();
 
     // True positives:
-    let _ = s_i32.len() * size_of::<i32>(); // WARNING
-    let _ = size_of::<i32>() * s_i32.len(); // WARNING
-    let _ = size_of::<i32>() * s_i32.len() * 5; // WARNING
+    let _ = std::mem::size_of_val(s_i32); // WARNING
+    let _ = std::mem::size_of_val(s_i32); // WARNING
+    let _ = std::mem::size_of_val(s_i32) * 5; // WARNING
 
     let len = s_i32.len();
     let size = size_of::<i32>();
-    let _ = len * size_of::<i32>(); // WARNING
-    let _ = s_i32.len() * size; // WARNING
-    let _ = len * size; // WARNING
+    let _ = std::mem::size_of_val(s_i32); // WARNING
+    let _ = std::mem::size_of_val(s_i32); // WARNING
+    let _ = std::mem::size_of_val(s_i32); // WARNING
 
     // True negatives:
     let _ = size_of::<i32>() + s_i32.len(); // Ok, not a multiplication

--- a/tests/ui/manual_slice_size_calculation.stderr
+++ b/tests/ui/manual_slice_size_calculation.stderr
@@ -1,5 +1,5 @@
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:11:13
+  --> $DIR/manual_slice_size_calculation.rs:12:13
    |
 LL |     let _ = s_i32.len() * size_of::<i32>(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
@@ -7,31 +7,31 @@ LL |     let _ = s_i32.len() * size_of::<i32>(); // WARNING
    = note: `-D clippy::manual-slice-size-calculation` implied by `-D warnings`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:12:13
+  --> $DIR/manual_slice_size_calculation.rs:13:13
    |
 LL |     let _ = size_of::<i32>() * s_i32.len(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:13:13
+  --> $DIR/manual_slice_size_calculation.rs:14:13
    |
 LL |     let _ = size_of::<i32>() * s_i32.len() * 5; // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:17:13
+  --> $DIR/manual_slice_size_calculation.rs:18:13
    |
 LL |     let _ = len * size_of::<i32>(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:18:13
+  --> $DIR/manual_slice_size_calculation.rs:19:13
    |
 LL |     let _ = s_i32.len() * size; // WARNING
    |             ^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:19:13
+  --> $DIR/manual_slice_size_calculation.rs:20:13
    |
 LL |     let _ = len * size; // WARNING
    |             ^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`

--- a/tests/ui/manual_slice_size_calculation.stderr
+++ b/tests/ui/manual_slice_size_calculation.stderr
@@ -2,50 +2,39 @@ error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:11:13
    |
 LL |     let _ = s_i32.len() * size_of::<i32>(); // WARNING
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
    |
-   = help: consider using std::mem::size_of_val instead
    = note: `-D clippy::manual-slice-size-calculation` implied by `-D warnings`
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:12:13
    |
 LL |     let _ = size_of::<i32>() * s_i32.len(); // WARNING
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using std::mem::size_of_val instead
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:13:13
    |
 LL |     let _ = size_of::<i32>() * s_i32.len() * 5; // WARNING
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using std::mem::size_of_val instead
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:17:13
    |
 LL |     let _ = len * size_of::<i32>(); // WARNING
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using std::mem::size_of_val instead
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:18:13
    |
 LL |     let _ = s_i32.len() * size; // WARNING
-   |             ^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using std::mem::size_of_val instead
+   |             ^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
   --> $DIR/manual_slice_size_calculation.rs:19:13
    |
 LL |     let _ = len * size; // WARNING
-   |             ^^^^^^^^^^
-   |
-   = help: consider using std::mem::size_of_val instead
+   |             ^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rust-clippy/pull/10659#issuecomment-1511688869.

This adds applicable suggestions to the `manual_slice_size_calculation` lint:

```
error: manual slice size calculation
  --> $DIR/manual_slice_size_calculation.rs:11:13
   |
LL |     let _ = s_i32.len() * size_of::<i32>(); // WARNING
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
   |
   = note: `-D clippy::manual-slice-size-calculation` implied by `-D warnings`
```

changelog: [`manual_slice_size_calculation`]: add machine applicable suggestion
