### PR TITLE
Don't apply `no_effect_underscore_binding` on `__`

### DIFF
--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -98,6 +98,7 @@ fn check_no_effect(cx: &LateContext<'_>, stmt: &Stmt<'_>) -> bool {
             if has_no_effect(cx, init);
             if let PatKind::Binding(_, _, ident, _) = local.pat.kind;
             if ident.name.to_ident_string().starts_with('_');
+            if !ident.name.to_ident_string().starts_with("__");
             then {
                 span_lint_hir(
                     cx,


### PR DESCRIPTION
`__` is sometimes used to indicate "this is an implementation detail, don't use this", but this lint is incorrectly triggered on such code.

changelog: [`no_effect_underscore_binding`]: Don't apply if there are 2 or more leading underscores
