### PR TITLE
Don't apply `string_lit_as_bytes` if in macro expansion

### DIFF
--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -253,6 +253,10 @@ impl<'tcx> LateLintPass<'tcx> for StringLitAsBytes {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
         use rustc_ast::LitKind;
 
+        if e.span.from_expansion() {
+            return;
+        }
+
         if_chain! {
             // Find std::str::converts::from_utf8
             if let Some(args) = match_function_call(cx, e, &paths::STR_FROM_UTF8);

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -253,10 +253,6 @@ impl<'tcx> LateLintPass<'tcx> for StringLitAsBytes {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
         use rustc_ast::LitKind;
 
-        if e.span.from_expansion() {
-            return;
-        }
-
         if_chain! {
             // Find std::str::converts::from_utf8
             if let Some(args) = match_function_call(cx, e, &paths::STR_FROM_UTF8);
@@ -296,6 +292,7 @@ impl<'tcx> LateLintPass<'tcx> for StringLitAsBytes {
         }
 
         if_chain! {
+            if !in_external_macro(cx.sess(), e.span);
             if let ExprKind::MethodCall(path, receiver, ..) = &e.kind;
             if path.ident.name == sym!(as_bytes);
             if let ExprKind::Lit(lit) = &receiver.kind;

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -22,6 +22,13 @@ macro_rules! string_add {
 }
 
 #[macro_export]
+macro_rules! string_lit_as_bytes {
+    ($s:literal) => {
+        const C: &[u8] = $s.as_bytes();
+    };
+}
+
+#[macro_export]
 macro_rules! mut_mut {
     () => {
         let mut_mut_ty: &mut &mut u32 = &mut &mut 1u32;

--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -3,6 +3,12 @@
 #![allow(dead_code, unused_variables)]
 #![warn(clippy::string_lit_as_bytes)]
 
+macro_rules! b {
+    ($b:literal) => {
+        const C: &[u8] = $b.as_bytes();
+    }
+}
+
 fn str_lit_as_bytes() {
     let bs = b"hello there";
 
@@ -10,6 +16,8 @@ fn str_lit_as_bytes() {
 
     let bs = b"lit to string".to_vec();
     let bs = b"lit to owned".to_vec();
+
+    b!("aaa");
 
     // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();

--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -1,11 +1,15 @@
 //@run-rustfix
+//@aux-build:macro_rules.rs
 
 #![allow(dead_code, unused_variables)]
 #![warn(clippy::string_lit_as_bytes)]
 
+#[macro_use]
+extern crate macro_rules;
+
 macro_rules! b {
     ($b:literal) => {
-        const C: &[u8] = $b.as_bytes();
+        const B: &[u8] = b"warning";
     };
 }
 
@@ -17,7 +21,9 @@ fn str_lit_as_bytes() {
     let bs = b"lit to string".to_vec();
     let bs = b"lit to owned".to_vec();
 
-    b!("aaa");
+    b!("warning");
+
+    string_lit_as_bytes!("no warning");
 
     // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();

--- a/tests/ui/string_lit_as_bytes.fixed
+++ b/tests/ui/string_lit_as_bytes.fixed
@@ -6,7 +6,7 @@
 macro_rules! b {
     ($b:literal) => {
         const C: &[u8] = $b.as_bytes();
-    }
+    };
 }
 
 fn str_lit_as_bytes() {

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -6,7 +6,7 @@
 macro_rules! b {
     ($b:literal) => {
         const C: &[u8] = $b.as_bytes();
-    }
+    };
 }
 
 fn str_lit_as_bytes() {

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -1,11 +1,15 @@
 //@run-rustfix
+//@aux-build:macro_rules.rs
 
 #![allow(dead_code, unused_variables)]
 #![warn(clippy::string_lit_as_bytes)]
 
+#[macro_use]
+extern crate macro_rules;
+
 macro_rules! b {
     ($b:literal) => {
-        const C: &[u8] = $b.as_bytes();
+        const B: &[u8] = $b.as_bytes();
     };
 }
 
@@ -17,7 +21,9 @@ fn str_lit_as_bytes() {
     let bs = "lit to string".to_string().into_bytes();
     let bs = "lit to owned".to_owned().into_bytes();
 
-    b!("aaa");
+    b!("warning");
+
+    string_lit_as_bytes!("no warning");
 
     // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();

--- a/tests/ui/string_lit_as_bytes.rs
+++ b/tests/ui/string_lit_as_bytes.rs
@@ -3,6 +3,12 @@
 #![allow(dead_code, unused_variables)]
 #![warn(clippy::string_lit_as_bytes)]
 
+macro_rules! b {
+    ($b:literal) => {
+        const C: &[u8] = $b.as_bytes();
+    }
+}
+
 fn str_lit_as_bytes() {
     let bs = "hello there".as_bytes();
 
@@ -10,6 +16,8 @@ fn str_lit_as_bytes() {
 
     let bs = "lit to string".to_string().into_bytes();
     let bs = "lit to owned".to_owned().into_bytes();
+
+    b!("aaa");
 
     // no warning, because these cannot be written as byte string literals:
     let ubs = "☃".as_bytes();

--- a/tests/ui/string_lit_as_bytes.stderr
+++ b/tests/ui/string_lit_as_bytes.stderr
@@ -1,5 +1,5 @@
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:13:14
+  --> $DIR/string_lit_as_bytes.rs:17:14
    |
 LL |     let bs = "hello there".as_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"hello there"`
@@ -7,34 +7,45 @@ LL |     let bs = "hello there".as_bytes();
    = note: `-D clippy::string-lit-as-bytes` implied by `-D warnings`
 
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:15:14
+  --> $DIR/string_lit_as_bytes.rs:19:14
    |
 LL |     let bs = r###"raw string with 3# plus " ""###.as_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with 3# plus " ""###`
 
 error: calling `into_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:17:14
+  --> $DIR/string_lit_as_bytes.rs:21:14
    |
 LL |     let bs = "lit to string".to_string().into_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"lit to string".to_vec()`
 
 error: calling `into_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:18:14
+  --> $DIR/string_lit_as_bytes.rs:22:14
    |
 LL |     let bs = "lit to owned".to_owned().into_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"lit to owned".to_vec()`
 
+error: calling `as_bytes()` on a string literal
+  --> $DIR/string_lit_as_bytes.rs:12:26
+   |
+LL |         const B: &[u8] = $b.as_bytes();
+   |                          ^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"warning"`
+...
+LL |     b!("warning");
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: calling `as_bytes()` on `include_str!(..)`
-  --> $DIR/string_lit_as_bytes.rs:33:22
+  --> $DIR/string_lit_as_bytes.rs:39:22
    |
 LL |     let includestr = include_str!("string_lit_as_bytes.rs").as_bytes();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("string_lit_as_bytes.rs")`
 
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:35:13
+  --> $DIR/string_lit_as_bytes.rs:41:13
    |
 LL |     let _ = "string with newline/t/n".as_bytes();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"string with newline/t/n"`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/string_lit_as_bytes.stderr
+++ b/tests/ui/string_lit_as_bytes.stderr
@@ -1,5 +1,5 @@
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:7:14
+  --> $DIR/string_lit_as_bytes.rs:13:14
    |
 LL |     let bs = "hello there".as_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"hello there"`
@@ -7,31 +7,31 @@ LL |     let bs = "hello there".as_bytes();
    = note: `-D clippy::string-lit-as-bytes` implied by `-D warnings`
 
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:9:14
+  --> $DIR/string_lit_as_bytes.rs:15:14
    |
 LL |     let bs = r###"raw string with 3# plus " ""###.as_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `br###"raw string with 3# plus " ""###`
 
 error: calling `into_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:11:14
+  --> $DIR/string_lit_as_bytes.rs:17:14
    |
 LL |     let bs = "lit to string".to_string().into_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"lit to string".to_vec()`
 
 error: calling `into_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:12:14
+  --> $DIR/string_lit_as_bytes.rs:18:14
    |
 LL |     let bs = "lit to owned".to_owned().into_bytes();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"lit to owned".to_vec()`
 
 error: calling `as_bytes()` on `include_str!(..)`
-  --> $DIR/string_lit_as_bytes.rs:25:22
+  --> $DIR/string_lit_as_bytes.rs:33:22
    |
 LL |     let includestr = include_str!("string_lit_as_bytes.rs").as_bytes();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `include_bytes!(..)` instead: `include_bytes!("string_lit_as_bytes.rs")`
 
 error: calling `as_bytes()` on a string literal
-  --> $DIR/string_lit_as_bytes.rs:27:13
+  --> $DIR/string_lit_as_bytes.rs:35:13
    |
 LL |     let _ = "string with newline/t/n".as_bytes();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using a byte string literal instead: `b"string with newline/t/n"`


### PR DESCRIPTION
The following code will emit a warning on both w! and h!, despite there being nothing the user (or library author) could do about it:
```rust
#![warn(clippy::string_lit_as_bytes)]

use windows::w;
use windows::h;

fn main() {
    let _w = w!("example");
    let _h = h!("example");
}
```
This is because windows-rs will create a binding `const INPUT: &[u8] = $s.as_bytes()`, and changing this to b"$s" is, well, suboptimal. I don't know enough about Rust to know if this is something that can be detected though if it can be I'm happy with closing this in favor of implementing that.

I'm not sure whether this is how it should be done though, as this simply tells clippy to not invoke this even if it's applicable (this also affects the other string lints, but didn't cause any tests to fail).

changelog: [`string_lit_as_bytes`]: Don't lint if in external macro
