### PR TITLE
Ignore `manual_slice_size_calculation` in code from macro expansions

### DIFF
--- a/tests/ui/manual_slice_size_calculation.fixed
+++ b/tests/ui/manual_slice_size_calculation.fixed
@@ -1,8 +1,12 @@
 // run-rustfix
+// aux-build:proc_macros.rs
 #![allow(unused)]
 #![warn(clippy::manual_slice_size_calculation)]
 
+extern crate proc_macros;
+
 use core::mem::{align_of, size_of};
+use proc_macros::external;
 
 fn main() {
     let v_i32 = Vec::<i32>::new();
@@ -19,12 +23,17 @@ fn main() {
     let _ = std::mem::size_of_val(s_i32); // WARNING
     let _ = std::mem::size_of_val(s_i32); // WARNING
 
+    let _ = std::mem::size_of_val(external!(&[1u64][..]));
+
     // True negatives:
     let _ = size_of::<i32>() + s_i32.len(); // Ok, not a multiplication
     let _ = size_of::<i32>() * s_i32.partition_point(|_| true); // Ok, not len()
     let _ = size_of::<i32>() * v_i32.len(); // Ok, not a slice
     let _ = align_of::<i32>() * s_i32.len(); // Ok, not size_of()
     let _ = size_of::<u32>() * s_i32.len(); // Ok, different types
+
+    let _ = external!($s_i32.len() * size_of::<i32>());
+    let _ = external!($s_i32.len()) * size_of::<i32>();
 
     // False negatives:
     let _ = 5 * size_of::<i32>() * s_i32.len(); // Ok (MISSED OPPORTUNITY)

--- a/tests/ui/manual_slice_size_calculation.rs
+++ b/tests/ui/manual_slice_size_calculation.rs
@@ -1,8 +1,12 @@
 // run-rustfix
+// aux-build:proc_macros.rs
 #![allow(unused)]
 #![warn(clippy::manual_slice_size_calculation)]
 
+extern crate proc_macros;
+
 use core::mem::{align_of, size_of};
+use proc_macros::external;
 
 fn main() {
     let v_i32 = Vec::<i32>::new();
@@ -19,12 +23,17 @@ fn main() {
     let _ = s_i32.len() * size; // WARNING
     let _ = len * size; // WARNING
 
+    let _ = external!(&[1u64][..]).len() * size_of::<u64>();
+
     // True negatives:
     let _ = size_of::<i32>() + s_i32.len(); // Ok, not a multiplication
     let _ = size_of::<i32>() * s_i32.partition_point(|_| true); // Ok, not len()
     let _ = size_of::<i32>() * v_i32.len(); // Ok, not a slice
     let _ = align_of::<i32>() * s_i32.len(); // Ok, not size_of()
     let _ = size_of::<u32>() * s_i32.len(); // Ok, different types
+
+    let _ = external!($s_i32.len() * size_of::<i32>());
+    let _ = external!($s_i32.len()) * size_of::<i32>();
 
     // False negatives:
     let _ = 5 * size_of::<i32>() * s_i32.len(); // Ok (MISSED OPPORTUNITY)

--- a/tests/ui/manual_slice_size_calculation.stderr
+++ b/tests/ui/manual_slice_size_calculation.stderr
@@ -1,5 +1,5 @@
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:12:13
+  --> $DIR/manual_slice_size_calculation.rs:16:13
    |
 LL |     let _ = s_i32.len() * size_of::<i32>(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
@@ -7,34 +7,40 @@ LL |     let _ = s_i32.len() * size_of::<i32>(); // WARNING
    = note: `-D clippy::manual-slice-size-calculation` implied by `-D warnings`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:13:13
+  --> $DIR/manual_slice_size_calculation.rs:17:13
    |
 LL |     let _ = size_of::<i32>() * s_i32.len(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:14:13
+  --> $DIR/manual_slice_size_calculation.rs:18:13
    |
 LL |     let _ = size_of::<i32>() * s_i32.len() * 5; // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:18:13
+  --> $DIR/manual_slice_size_calculation.rs:22:13
    |
 LL |     let _ = len * size_of::<i32>(); // WARNING
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:19:13
+  --> $DIR/manual_slice_size_calculation.rs:23:13
    |
 LL |     let _ = s_i32.len() * size; // WARNING
    |             ^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
 error: manual slice size calculation
-  --> $DIR/manual_slice_size_calculation.rs:20:13
+  --> $DIR/manual_slice_size_calculation.rs:24:13
    |
 LL |     let _ = len * size; // WARNING
    |             ^^^^^^^^^^ help: try: `std::mem::size_of_val(s_i32)`
 
-error: aborting due to 6 previous errors
+error: manual slice size calculation
+  --> $DIR/manual_slice_size_calculation.rs:26:13
+   |
+LL |     let _ = external!(&[1u64][..]).len() * size_of::<u64>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::mem::size_of_val(external!(&[1u64][..]))`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
changelog: none, assuming same release as #10659
