### PR TITLE
make [`len_zero`] lint not spanning over parenthesis

### DIFF
--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -168,25 +168,27 @@ impl<'tcx> LateLintPass<'tcx> for LenZero {
         }
 
         if let ExprKind::Binary(Spanned { node: cmp, .. }, left, right) = expr.kind {
+            // expr.span might contains parenthesis, see issue #10529
+            let actual_span = left.span.with_hi(right.span.hi());
             match cmp {
                 BinOpKind::Eq => {
-                    check_cmp(cx, expr.span, left, right, "", 0); // len == 0
-                    check_cmp(cx, expr.span, right, left, "", 0); // 0 == len
+                    check_cmp(cx, actual_span, left, right, "", 0); // len == 0
+                    check_cmp(cx, actual_span, right, left, "", 0); // 0 == len
                 },
                 BinOpKind::Ne => {
-                    check_cmp(cx, expr.span, left, right, "!", 0); // len != 0
-                    check_cmp(cx, expr.span, right, left, "!", 0); // 0 != len
+                    check_cmp(cx, actual_span, left, right, "!", 0); // len != 0
+                    check_cmp(cx, actual_span, right, left, "!", 0); // 0 != len
                 },
                 BinOpKind::Gt => {
-                    check_cmp(cx, expr.span, left, right, "!", 0); // len > 0
-                    check_cmp(cx, expr.span, right, left, "", 1); // 1 > len
+                    check_cmp(cx, actual_span, left, right, "!", 0); // len > 0
+                    check_cmp(cx, actual_span, right, left, "", 1); // 1 > len
                 },
                 BinOpKind::Lt => {
-                    check_cmp(cx, expr.span, left, right, "", 1); // len < 1
-                    check_cmp(cx, expr.span, right, left, "!", 0); // 0 < len
+                    check_cmp(cx, actual_span, left, right, "", 1); // len < 1
+                    check_cmp(cx, actual_span, right, left, "!", 0); // 0 < len
                 },
-                BinOpKind::Ge => check_cmp(cx, expr.span, left, right, "!", 1), // len >= 1
-                BinOpKind::Le => check_cmp(cx, expr.span, right, left, "!", 1), // 1 <= len
+                BinOpKind::Ge => check_cmp(cx, actual_span, left, right, "!", 1), // len >= 1
+                BinOpKind::Le => check_cmp(cx, actual_span, right, left, "!", 1), // 1 <= len
                 _ => (),
             }
         }

--- a/tests/ui/len_zero.fixed
+++ b/tests/ui/len_zero.fixed
@@ -176,6 +176,10 @@ fn main() {
         // No error; `HasWrongIsEmpty` does not have `.is_empty()`.
         println!("Or this!");
     }
+
+    // issue #10529
+    (!has_is_empty.is_empty()).then(|| println!("This can happen."));
+    (has_is_empty.is_empty()).then(|| println!("Or this!"));
 }
 
 fn test_slice(b: &[u8]) {

--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -176,6 +176,10 @@ fn main() {
         // No error; `HasWrongIsEmpty` does not have `.is_empty()`.
         println!("Or this!");
     }
+
+    // issue #10529
+    (has_is_empty.len() > 0).then(|| println!("This can happen."));
+    (has_is_empty.len() == 0).then(|| println!("Or this!"));
 }
 
 fn test_slice(b: &[u8]) {

--- a/tests/ui/len_zero.stderr
+++ b/tests/ui/len_zero.stderr
@@ -123,10 +123,22 @@ LL |     if with_is_empty.len() == 0 {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `with_is_empty.is_empty()`
 
 error: length comparison to zero
-  --> $DIR/len_zero.rs:182:8
+  --> $DIR/len_zero.rs:181:6
+   |
+LL |     (has_is_empty.len() > 0).then(|| println!("This can happen."));
+   |      ^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!has_is_empty.is_empty()`
+
+error: length comparison to zero
+  --> $DIR/len_zero.rs:182:6
+   |
+LL |     (has_is_empty.len() == 0).then(|| println!("Or this!"));
+   |      ^^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `has_is_empty.is_empty()`
+
+error: length comparison to zero
+  --> $DIR/len_zero.rs:186:8
    |
 LL |     if b.len() != 0 {}
    |        ^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!b.is_empty()`
 
-error: aborting due to 21 previous errors
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
sorry it should be a quick fix but I was caught up by other stuffs last couple weeks :man_facepalming: 

---

fixes: #10529 

changelog: make [`len_zero`] lint not spanning over parenthesis
