### PR TITLE
Fix false positive in `allow_attributes`

### DIFF
--- a/clippy_lints/src/allow_attributes.rs
+++ b/clippy_lints/src/allow_attributes.rs
@@ -2,7 +2,8 @@ use ast::AttrStyle;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast as ast;
 use rustc_errors::Applicability;
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::lint::in_external_macro;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
@@ -51,6 +52,7 @@ impl LateLintPass<'_> for AllowAttribute {
     // Separate each crate's features.
     fn check_attribute(&mut self, cx: &LateContext<'_>, attr: &ast::Attribute) {
         if_chain! {
+            if !in_external_macro(cx.sess(), attr.span);
             if cx.tcx.features().lint_reasons;
             if let AttrStyle::Outer = attr.style;
             if let Some(ident) = attr.ident();

--- a/tests/ui/allow_attributes_false_positive.rs
+++ b/tests/ui/allow_attributes_false_positive.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 #![warn(clippy::allow_attributes)]
 #![feature(lint_reasons)]
 #![crate_type = "proc-macro"]

--- a/tests/ui/allow_attributes_false_positive.rs
+++ b/tests/ui/allow_attributes_false_positive.rs
@@ -1,0 +1,6 @@
+#![allow(unused)]
+#![warn(clippy::allow_attributes)]
+#![feature(lint_reasons)]
+#![crate_type = "proc-macro"]
+
+fn main() {}


### PR DESCRIPTION
This would emit a warning if used in a proc-macro with the feature `lint_reasons` enabled. This is now fixed.

changelog: [`allow_attributes`]: Don't lint if in external macro