### PR TITLE
clippy: drop unused semver crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/driver.rs"
 
 [dependencies]
 clippy_lints = { path = "clippy_lints" }
-semver = "1.0"
 rustc_tools_util = "0.3.0"
 tempfile = { version = "3.2", optional = true }
 termize = "0.1"


### PR DESCRIPTION
Drop unused `semver` crate dependency.

changelog: none