### PR TITLE
Fix `#[allow(clippy::enum_variant_names)]` directly on variants

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -1,6 +1,6 @@
 //! lint on enum variants that are prefixed or suffixed by the same characters
 
-use clippy_utils::diagnostics::{span_lint, span_lint_and_help};
+use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_hir};
 use clippy_utils::source::is_present_in_source;
 use clippy_utils::str_utils::{camel_case_split, count_match_end, count_match_start};
 use rustc_hir::{EnumDef, Item, ItemKind, Variant};
@@ -135,9 +135,10 @@ fn check_enum_start(cx: &LateContext<'_>, item_name: &str, variant: &Variant<'_>
         && name.chars().nth(item_name_chars).map_or(false, |c| !c.is_lowercase())
         && name.chars().nth(item_name_chars + 1).map_or(false, |c| !c.is_numeric())
     {
-        span_lint(
+        span_lint_hir(
             cx,
             ENUM_VARIANT_NAMES,
+            variant.hir_id,
             variant.span,
             "variant name starts with the enum's name",
         );
@@ -149,9 +150,10 @@ fn check_enum_end(cx: &LateContext<'_>, item_name: &str, variant: &Variant<'_>) 
     let item_name_chars = item_name.chars().count();
 
     if count_match_end(item_name, name).char_count == item_name_chars {
-        span_lint(
+        span_lint_hir(
             cx,
             ENUM_VARIANT_NAMES,
+            variant.hir_id,
             variant.span,
             "variant name ends with the enum's name",
         );

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -179,4 +179,14 @@ mod issue9018 {
     }
 }
 
+mod allow_attributes_on_variants {
+    enum Enum {
+        #[allow(clippy::enum_variant_names)]
+        EnumStartsWith,
+        #[allow(clippy::enum_variant_names)]
+        EndsWithEnum,
+        Foo,
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
changelog: [`enum_variant_names`]: Fix `#[allow]` attributes applied directly to the enum variant

Fixes #10695