### PR TITLE
Bugfix: Ignore `impl Trait`(s) @ `let_underscore_untyped`

### DIFF
--- a/tests/ui/let_underscore_untyped.rs
+++ b/tests/ui/let_underscore_untyped.rs
@@ -28,6 +28,10 @@ fn f() -> Box<dyn Display> {
     Box::new(1)
 }
 
+fn g() -> impl Fn() {
+    || {}
+}
+
 fn main() {
     let _ = a();
     let _ = b(1);
@@ -35,6 +39,7 @@ fn main() {
     let _ = d(&1);
     let _ = e();
     let _ = f();
+    let _ = g();
 
     _ = a();
     _ = b(1);

--- a/tests/ui/let_underscore_untyped.stderr
+++ b/tests/ui/let_underscore_untyped.stderr
@@ -1,5 +1,5 @@
 error: non-binding `let` without a type annotation
-  --> $DIR/let_underscore_untyped.rs:32:5
+  --> $DIR/let_underscore_untyped.rs:36:5
    |
 LL |     let _ = a();
    |     ^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let _ = a();
    = note: `-D clippy::let-underscore-untyped` implied by `-D warnings`
 
 error: non-binding `let` without a type annotation
-  --> $DIR/let_underscore_untyped.rs:33:5
+  --> $DIR/let_underscore_untyped.rs:37:5
    |
 LL |     let _ = b(1);
    |     ^^^^^^^^^^^^^
@@ -16,15 +16,7 @@ LL |     let _ = b(1);
    = help: consider adding a type annotation or removing the `let` keyword
 
 error: non-binding `let` without a type annotation
-  --> $DIR/let_underscore_untyped.rs:34:5
-   |
-LL |     let _ = c();
-   |     ^^^^^^^^^^^^
-   |
-   = help: consider adding a type annotation or removing the `let` keyword
-
-error: non-binding `let` without a type annotation
-  --> $DIR/let_underscore_untyped.rs:35:5
+  --> $DIR/let_underscore_untyped.rs:39:5
    |
 LL |     let _ = d(&1);
    |     ^^^^^^^^^^^^^^
@@ -32,7 +24,7 @@ LL |     let _ = d(&1);
    = help: consider adding a type annotation or removing the `let` keyword
 
 error: non-binding `let` without a type annotation
-  --> $DIR/let_underscore_untyped.rs:36:5
+  --> $DIR/let_underscore_untyped.rs:40:5
    |
 LL |     let _ = e();
    |     ^^^^^^^^^^^^
@@ -40,12 +32,12 @@ LL |     let _ = e();
    = help: consider adding a type annotation or removing the `let` keyword
 
 error: non-binding `let` without a type annotation
-  --> $DIR/let_underscore_untyped.rs:37:5
+  --> $DIR/let_underscore_untyped.rs:41:5
    |
 LL |     let _ = f();
    |     ^^^^^^^^^^^^
    |
    = help: consider adding a type annotation or removing the `let` keyword
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes #10411

changelog:[`let_underscore_untyped`]: Ignore `impl Trait`(s) that caused false positives.