### PR TITLE
Add a test that checks for old style test headers

### DIFF
--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,0 +1,29 @@
+use regex::Regex;
+use std::fs;
+use walkdir::WalkDir;
+
+#[test]
+fn old_test_headers() {
+    let old_headers = Regex::new(
+        r"^//( ?\[\w+\])? ?((check|build|run|ignore|aux|only|needs|rustc|unset|no|normalize|run|compile)-|edition|incremental|revisions).*",
+    )
+    .unwrap();
+    let mut failed = false;
+
+    for entry in WalkDir::new("tests") {
+        let entry = entry.unwrap();
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let file = fs::read_to_string(entry.path()).unwrap();
+
+        if let Some(header) = old_headers.find(&file) {
+            println!("Found header `{}` in {}", header.as_str(), entry.path().display());
+
+            failed = true;
+        }
+    }
+
+    assert!(!failed, "use `//@foo` style test headers instead");
+}

--- a/tests/ui/crashes/ice-10645.rs
+++ b/tests/ui/crashes/ice-10645.rs
@@ -1,4 +1,4 @@
-// compile-flags: --cap-lints=warn
+//@compile-flags: --cap-lints=warn
 // https://github.com/rust-lang/rust-clippy/issues/10645
 
 #![warn(clippy::future_not_send)]

--- a/tests/ui/crashes/ice-10645.stderr
+++ b/tests/ui/crashes/ice-10645.stderr
@@ -1,4 +1,4 @@
-error: future cannot be sent between threads safely
+warning: future cannot be sent between threads safely
   --> $DIR/ice-10645.rs:5:35
    |
 LL | pub async fn bar<'a, T: 'a>(_: T) {}
@@ -12,5 +12,5 @@ LL | pub async fn bar<'a, T: 'a>(_: T) {}
    = note: `T` doesn't implement `std::marker::Send`
    = note: `-D clippy::future-not-send` implied by `-D warnings`
 
-error: aborting due to previous error
+warning: 1 warning emitted
 

--- a/tests/ui/crashes/ice-4968.rs
+++ b/tests/ui/crashes/ice-4968.rs
@@ -1,5 +1,3 @@
-//@check-pass
-
 // Test for https://github.com/rust-lang/rust-clippy/issues/4968
 
 #![warn(clippy::unsound_collection_transmute)]

--- a/tests/ui/expect_tool_lint_rfc_2383.rs
+++ b/tests/ui/expect_tool_lint_rfc_2383.rs
@@ -1,4 +1,3 @@
-// check-pass
 #![feature(lint_reasons)]
 //! This file tests the `#[expect]` attribute implementation for tool lints. The same
 //! file is used to test clippy and rustdoc. Any changes to this file should be synced

--- a/tests/ui/expect_tool_lint_rfc_2383.stderr
+++ b/tests/ui/expect_tool_lint_rfc_2383.stderr
@@ -1,5 +1,5 @@
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:35:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:34:14
    |
 LL |     #[expect(dead_code)]
    |              ^^^^^^^^^
@@ -7,31 +7,31 @@ LL |     #[expect(dead_code)]
    = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:39:18
+  --> $DIR/expect_tool_lint_rfc_2383.rs:38:18
    |
 LL |         #[expect(illegal_floating_point_literal_pattern)]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:113:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:112:14
    |
 LL |     #[expect(clippy::almost_swapped)]
    |              ^^^^^^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:120:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:119:14
    |
 LL |     #[expect(clippy::bytes_nth)]
    |              ^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:125:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:124:14
    |
 LL |     #[expect(clippy::if_same_then_else)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:130:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:129:14
    |
 LL |     #[expect(clippy::overly_complex_bool_expr)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Follow up to #10669, we're pretty used to them so they're easy to slip through

changelog: none
