### PR TITLE
Downgrade items_after_test_module to nursery

### DIFF
--- a/clippy_lints/src/items_after_test_module.rs
+++ b/clippy_lints/src/items_after_test_module.rs
@@ -34,7 +34,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.70.0"]
     pub ITEMS_AFTER_TEST_MODULE,
-    style,
+    nursery,
     "An item was found after the testing module `tests`"
 }
 


### PR DESCRIPTION
I think this lint shouldn't be enabled by default while we reconcile #10713.

changelog: [`items_after_test_module`]: remove from default set of enabled lints