### PR TITLE
run linkcheck in clippy ci

### DIFF
--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -36,6 +36,12 @@ jobs:
     - name: Check *.md files
       run: git ls-files -z '*.md' | xargs -0 -n 1 -I {} ./node_modules/.bin/remark {} -u lint -f > /dev/null
 
+    - name: Linkcheck book
+      run: |
+        rustup toolchain install nightly --component rust-docs
+        curl https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh -o linkcheck.sh
+        sh linkcheck.sh clippy --path ./book
+        
     - name: Build mdbook
       run: mdbook build book
 

--- a/book/src/development/lint_passes.md
+++ b/book/src/development/lint_passes.md
@@ -50,7 +50,7 @@ questions already, but the parser is okay with it. This is what we
 mean when we say `EarlyLintPass` deals with only syntax on the AST level.
 
 Alternatively, think of the `foo_functions` lint we mentioned in
-[define new lints](define_lints.md#name-the-lint) chapter.
+define new lints <!-- FIXME: add link --> chapter.
 
 We want the `foo_functions` lint to detect functions with `foo` as their name.
 Writing a lint that only checks for the name of a function means that we only


### PR DESCRIPTION
fixes #10711

changelog: Run [linkcheck.sh](https://github.com/rust-lang/rust/blob/master/src/tools/linkchecker/linkcheck.sh) from rustc repo in Remark.yml to check Clippy book.