### PR TITLE
Extend `trait_duplication_in_bounds` to cover trait objects

### DIFF
--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -177,6 +177,7 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                         bounds,
                         ..
                     ),
+                    span,
                     ..
                 },
                 ..
@@ -189,6 +190,12 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
 
         let mut seen_def_ids = FxHashSet::default();
 
+        let traits = bounds
+            .iter()
+            .filter_map(|b| snippet_opt(cx, b.span))
+            .collect::<Vec<_>>();
+        let traits = traits.join(" + ");
+
         for bound in bounds.iter() {
             let Some(def_id) = bound.trait_ref.trait_def_id() else { continue; };
 
@@ -198,10 +205,10 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                 span_lint_and_sugg(
                     cx,
                     TRAIT_DUPLICATION_IN_BOUNDS,
-                    bound.span,
+                    *span,
                     "this trait bound is already specified in trait declaration",
                     "consider removing this trait bound",
-                    "".to_string(),
+                    traits.clone(),
                     Applicability::MaybeIncorrect,
                 );
             }

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -206,13 +206,13 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
             }
         }
 
-        let fixed_trait_snippet = fixed_traits
-            .iter()
-            .filter_map(|b| snippet_opt(cx, b.span))
-            .collect::<Vec<_>>()
-            .join(" + ");
-
         if bounds.len() != fixed_traits.len() {
+            let fixed_trait_snippet = fixed_traits
+                .iter()
+                .filter_map(|b| snippet_opt(cx, b.span))
+                .collect::<Vec<_>>()
+                .join(" + ");
+
             span_lint_and_sugg(
                 cx,
                 TRAIT_DUPLICATION_IN_BOUNDS,

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -177,7 +177,6 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                         bounds,
                         ..
                     ),
-                    span,
                     ..
                 },
                 ..
@@ -186,6 +185,12 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
 
         if bounds.len() < 2 {
             return;
+        }
+
+        let mut bounds_span = Span::default();
+
+        for bound in bounds.iter() {
+            bounds_span = bounds_span.to(bound.span);
         }
 
         let mut seen_def_ids = FxHashSet::default();
@@ -205,7 +210,7 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                 span_lint_and_sugg(
                     cx,
                     TRAIT_DUPLICATION_IN_BOUNDS,
-                    *span,
+                    bounds_span,
                     "this trait bound is already specified in trait declaration",
                     "consider removing this trait bound",
                     traits.clone(),

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -195,13 +195,14 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
             let already_seen = !seen_def_ids.insert(def_id);
 
             if already_seen {
-                span_lint_and_help(
+                span_lint_and_sugg(
                     cx,
                     TRAIT_DUPLICATION_IN_BOUNDS,
                     bound.span,
                     "this trait bound is already specified in trait declaration",
-                    None,
                     "consider removing this trait bound",
+                    "".to_string(),
+                    Applicability::MaybeIncorrect,
                 );
             }
         }

--- a/tests/ui/trait_duplication_in_bounds.fixed
+++ b/tests/ui/trait_duplication_in_bounds.fixed
@@ -2,6 +2,8 @@
 #![deny(clippy::trait_duplication_in_bounds)]
 #![allow(unused)]
 
+use std::any::Any;
+
 fn bad_foo<T: Clone + Copy, U: Clone + Copy>(arg0: T, argo1: U) {
     unimplemented!();
 }
@@ -106,6 +108,14 @@ mod foo {
 }
 
 fn qualified_path<T: std::clone::Clone + foo::Clone>(arg0: T) {
+    unimplemented!();
+}
+
+fn good_trait_object(arg0: &(dyn Any + Send)) {
+    unimplemented!();
+}
+
+fn bad_trait_object(arg0: &(dyn Any + Send)) {
     unimplemented!();
 }
 

--- a/tests/ui/trait_duplication_in_bounds.rs
+++ b/tests/ui/trait_duplication_in_bounds.rs
@@ -2,6 +2,8 @@
 #![deny(clippy::trait_duplication_in_bounds)]
 #![allow(unused)]
 
+use std::any::Any;
+
 fn bad_foo<T: Clone + Clone + Clone + Copy, U: Clone + Copy>(arg0: T, argo1: U) {
     unimplemented!();
 }

--- a/tests/ui/trait_duplication_in_bounds.rs
+++ b/tests/ui/trait_duplication_in_bounds.rs
@@ -109,4 +109,12 @@ fn qualified_path<T: std::clone::Clone + Clone + foo::Clone>(arg0: T) {
     unimplemented!();
 }
 
+fn good_trait_object(arg0: &(dyn Any + Send)) {
+    unimplemented!();
+}
+
+fn bad_trait_object(arg0: &(dyn Any + Send + Send)) {
+    unimplemented!();
+}
+
 fn main() {}

--- a/tests/ui/trait_duplication_in_bounds.stderr
+++ b/tests/ui/trait_duplication_in_bounds.stderr
@@ -53,11 +53,10 @@ LL | fn qualified_path<T: std::clone::Clone + Clone + foo::Clone>(arg0: T) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::clone::Clone + foo::Clone`
 
 error: this trait bound is already specified in trait declaration
-  --> $DIR/trait_duplication_in_bounds.rs:118:46
+  --> $DIR/trait_duplication_in_bounds.rs:118:33
    |
 LL | fn bad_trait_object(arg0: &(dyn Any + Send + Send)) {
-   |                                              ^^^^ help: consider removing this trait bound
-   |
+   |                                 ^^^^^^^^^^^^^^^^^ help: try: `Any + Send`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/trait_duplication_in_bounds.stderr
+++ b/tests/ui/trait_duplication_in_bounds.stderr
@@ -1,5 +1,5 @@
 error: these bounds contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:5:15
+  --> $DIR/trait_duplication_in_bounds.rs:7:15
    |
 LL | fn bad_foo<T: Clone + Clone + Clone + Copy, U: Clone + Copy>(arg0: T, argo1: U) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
@@ -11,46 +11,53 @@ LL | #![deny(clippy::trait_duplication_in_bounds)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: these where clauses contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:11:8
+  --> $DIR/trait_duplication_in_bounds.rs:13:8
    |
 LL |     T: Clone + Clone + Clone + Copy,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
 
 error: these bounds contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:39:26
+  --> $DIR/trait_duplication_in_bounds.rs:41:26
    |
 LL | trait BadSelfTraitBound: Clone + Clone + Clone {
    |                          ^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone`
 
 error: these where clauses contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:46:15
+  --> $DIR/trait_duplication_in_bounds.rs:48:15
    |
 LL |         Self: Clone + Clone + Clone;
    |               ^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone`
 
 error: these bounds contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:60:24
+  --> $DIR/trait_duplication_in_bounds.rs:62:24
    |
 LL | trait BadTraitBound<T: Clone + Clone + Clone + Copy, U: Clone + Copy> {
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
 
 error: these where clauses contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:67:12
+  --> $DIR/trait_duplication_in_bounds.rs:69:12
    |
 LL |         T: Clone + Clone + Clone + Copy,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Clone + Copy`
 
 error: these bounds contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:100:19
+  --> $DIR/trait_duplication_in_bounds.rs:102:19
    |
 LL | fn bad_generic<T: GenericTrait<u64> + GenericTrait<u32> + GenericTrait<u64>>(arg0: T) {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `GenericTrait<u64> + GenericTrait<u32>`
 
 error: these bounds contain repeated elements
-  --> $DIR/trait_duplication_in_bounds.rs:108:22
+  --> $DIR/trait_duplication_in_bounds.rs:110:22
    |
 LL | fn qualified_path<T: std::clone::Clone + Clone + foo::Clone>(arg0: T) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::clone::Clone + foo::Clone`
 
-error: aborting due to 8 previous errors
+error: this trait bound is already specified in trait declaration
+  --> $DIR/trait_duplication_in_bounds.rs:118:46
+   |
+LL | fn bad_trait_object(arg0: &(dyn Any + Send + Send)) {
+   |                                              ^^^^ help: consider removing this trait bound
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
This PR extends `trait_duplication_in_bounds` to cover trait objects.

Currently,
```rs
fn foo(_a: &(dyn Any + Send + Send)) {}
```

generates no warnings. With this PR, it will complain about a duplicate trait and can remove it

Moved from rust-lang/rust#110991

changelog: [`trait_duplication_in_bounds`]: warn on duplicate trait object constraints
