### PR TITLE
WIP format literal arg inlining

### DIFF
--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -594,7 +594,7 @@ fn positional_arg_piece_span(piece: &FormatArgsPiece) -> Option<(Span, usize)> {
 /// `r#"a"#` -> (`a`, true)
 ///
 /// `"b"` -> (`b`, false)
-fn extract_str_literal(literal: &str) -> Option<(String, bool)> {
+pub fn extract_str_literal(literal: &str) -> Option<(String, bool)> {
     let (literal, raw) = match literal.strip_prefix('r') {
         Some(stripped) => (stripped.trim_matches('#'), true),
         None => (literal, false),

--- a/tests/ui-toml/allow_mixed_uninlined_format_args/uninlined_format_args.stderr
+++ b/tests/ui-toml/allow_mixed_uninlined_format_args/uninlined_format_args.stderr
@@ -21,7 +21,7 @@ LL |     println!("Hello {} is {:.*}", "x", local_i32, local_f64);
 help: change this to
    |
 LL -     println!("Hello {} is {:.*}", "x", local_i32, local_f64);
-LL +     println!("Hello {} is {local_f64:.local_i32$}", "x");
+LL +     println!("Hello x is {local_f64:.local_i32$}");
    |
 
 error: literal with an empty format string

--- a/tests/ui/uninlined_format_args.fixed
+++ b/tests/ui/uninlined_format_args.fixed
@@ -59,7 +59,7 @@ fn tester(fn_arg: i32) {
     println!("{local_i32:<3}");
     println!("{local_i32:#010x}");
     println!("{local_f64:.1}");
-    println!("Hello {} is {:.*}", "x", local_i32, local_f64);
+    println!("Hello x is {local_f64:.local_i32$}");
     println!("Hello {} is {:.*}", local_i32, 5, local_f64);
     println!("Hello {} is {2:.*}", local_i32, 5, local_f64);
     println!("{local_i32} {local_f64}");
@@ -83,12 +83,12 @@ fn tester(fn_arg: i32) {
     println!("{local_i32} {local_f64}");
     println!("{local_f64} {local_i32}");
     println!("{local_f64} {local_i32} {local_f64} {local_i32}");
-    println!("{1} {0}", "str", local_i32);
+    println!("{local_i32} str");
     println!("{local_i32}");
-    println!("{local_i32:width$}");
-    println!("{local_i32:width$}");
-    println!("{local_i32:.prec$}");
-    println!("{local_i32:.prec$}");
+    println!("{local_i32:0$}", width);
+    println!("{local_i32:w$}", w = width);
+    println!("{local_i32:.0$}", prec);
+    println!("{local_i32:.p$}", p = prec);
     println!("{val:val$}");
     println!("{val:val$}");
     println!("{val:val$.val$}");
@@ -266,4 +266,18 @@ fn tester2() {
         small = "small value: {}",
         local_i32,
     };
+}
+
+fn literals() {
+    let var = 5;
+    println!("foo");
+    println!("foo");
+    println!("{:var$}", "foo");
+    println!("foo");
+    println!("{0:1$}", "foo", 5);
+    println!("var {var} lit foo");
+    println!("var {var} lit foo");
+    println!("var foo lit foo");
+    println!("var foo lit foo {var},");
+    println!("var {0} lit {} {},", "foo", 5);
 }

--- a/tests/ui/uninlined_format_args.rs
+++ b/tests/ui/uninlined_format_args.rs
@@ -272,3 +272,17 @@ fn tester2() {
         local_i32,
     };
 }
+
+fn literals() {
+    let var = 5;
+    println!("{}", "foo");
+    println!("{:5}", "foo");
+    println!("{:var$}", "foo");
+    println!("{:-5}", "foo");
+    println!("{0:1$}", "foo", 5);
+    println!("var {} lit {}", var, "foo");
+    println!("var {1} lit {0}", "foo", var);
+    println!("var {} lit {0}", "foo");
+    println!("var {0} lit {} {},", "foo", var);
+    println!("var {0} lit {} {},", "foo", 5);
+}

--- a/tests/ui/uninlined_format_args.stderr
+++ b/tests/ui/uninlined_format_args.stderr
@@ -179,6 +179,18 @@ LL +     println!("{local_f64:.1}");
    |
 
 error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:64:5
+   |
+LL |     println!("Hello {} is {:.*}", "x", local_i32, local_f64);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("Hello {} is {:.*}", "x", local_i32, local_f64);
+LL +     println!("Hello x is {local_f64:.local_i32$}");
+   |
+
+error: variables can be used directly in the `format!` string
   --> $DIR/uninlined_format_args.rs:67:5
    |
 LL |     println!("{} {}", local_i32, local_f64);
@@ -407,6 +419,18 @@ LL +     println!("{local_f64} {local_i32} {local_f64} {local_i32}");
    |
 
 error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:88:5
+   |
+LL |     println!("{1} {0}", "str", local_i32);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("{1} {0}", "str", local_i32);
+LL +     println!("{local_i32} str");
+   |
+
+error: variables can be used directly in the `format!` string
   --> $DIR/uninlined_format_args.rs:89:5
    |
 LL |     println!("{v}", v = local_i32);
@@ -416,54 +440,6 @@ help: change this to
    |
 LL -     println!("{v}", v = local_i32);
 LL +     println!("{local_i32}");
-   |
-
-error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:90:5
-   |
-LL |     println!("{local_i32:0$}", width);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: change this to
-   |
-LL -     println!("{local_i32:0$}", width);
-LL +     println!("{local_i32:width$}");
-   |
-
-error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:91:5
-   |
-LL |     println!("{local_i32:w$}", w = width);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: change this to
-   |
-LL -     println!("{local_i32:w$}", w = width);
-LL +     println!("{local_i32:width$}");
-   |
-
-error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:92:5
-   |
-LL |     println!("{local_i32:.0$}", prec);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: change this to
-   |
-LL -     println!("{local_i32:.0$}", prec);
-LL +     println!("{local_i32:.prec$}");
-   |
-
-error: variables can be used directly in the `format!` string
-  --> $DIR/uninlined_format_args.rs:93:5
-   |
-LL |     println!("{local_i32:.p$}", p = prec);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: change this to
-   |
-LL -     println!("{local_i32:.p$}", p = prec);
-LL +     println!("{local_i32:.prec$}");
    |
 
 error: variables can be used directly in the `format!` string
@@ -845,5 +821,89 @@ LL -     println!("expand='{}'", local_i32);
 LL +     println!("expand='{local_i32}'");
    |
 
-error: aborting due to 71 previous errors
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:278:5
+   |
+LL |     println!("{}", "foo");
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("{}", "foo");
+LL +     println!("foo");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:279:5
+   |
+LL |     println!("{:5}", "foo");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("{:5}", "foo");
+LL +     println!("foo");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:281:5
+   |
+LL |     println!("{:-5}", "foo");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("{:-5}", "foo");
+LL +     println!("foo");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:283:5
+   |
+LL |     println!("var {} lit {}", var, "foo");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("var {} lit {}", var, "foo");
+LL +     println!("var {var} lit foo");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:284:5
+   |
+LL |     println!("var {1} lit {0}", "foo", var);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("var {1} lit {0}", "foo", var);
+LL +     println!("var {var} lit foo");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:285:5
+   |
+LL |     println!("var {} lit {0}", "foo");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("var {} lit {0}", "foo");
+LL +     println!("var foo lit foo");
+   |
+
+error: variables can be used directly in the `format!` string
+  --> $DIR/uninlined_format_args.rs:286:5
+   |
+LL |     println!("var {0} lit {} {},", "foo", var);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: change this to
+   |
+LL -     println!("var {0} lit {} {},", "foo", var);
+LL +     println!("var foo lit foo {var},");
+   |
+
+error: aborting due to 76 previous errors
 


### PR DESCRIPTION
A rough draft of #10739 implementation. The goal is to allow any kind of literal string arguments to be inlined automatically.

```rust
format!("hello {}", "world")
// is replaced with
format!("hello world")
```

```
changelog: [`uninlined_format_args`]: support for inlining string literals
```
