### PR TITLE
redundant_pattern_matching

### DIFF
--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -185,7 +185,7 @@ fn is_some(path_kind: PatKind<'_>) -> bool {
     match path_kind {
         PatKind::TupleStruct(QPath::Resolved(_, path), patterns, _) if is_wild(&patterns[0]) => {
             let name = path.segments[0].ident;
-            if name.as_str() == "Some" {
+            if name.name == rustc_span::sym::Some {
                 return true;
             }
             false

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -183,15 +183,12 @@ fn find_bool_lit(ex: &ExprKind<'_>) -> Option<bool> {
 
 fn is_some(path_kind: PatKind<'_>) -> bool {
     match path_kind {
-        PatKind::TupleStruct(ref path_left, patterns, _) if is_wild(&patterns[0]) => match path_left {
-            QPath::Resolved(_, path) => {
-                let name = path.segments[0].ident;
-                if name.as_str() == "Some" {
-                    return true;
-                }
-                return false;
-            },
-            _ => false,
+        PatKind::TupleStruct(QPath::Resolved(_, path), patterns, _) if is_wild(&patterns[0]) => {
+            let name = path.segments[0].ident;
+            if name.as_str() == "Some" {
+                return true;
+            }
+            false
         },
         _ => false,
     }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -1,10 +1,12 @@
+use super::REDUNDANT_PATTERN_MATCHING;
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_lint_allowed;
 use clippy_utils::is_wild;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::span_contains_comment;
 use rustc_ast::{Attribute, LitKind};
 use rustc_errors::Applicability;
-use rustc_hir::{Arm, BorrowKind, Expr, ExprKind, Guard, Pat};
+use rustc_hir::{Arm, BorrowKind, Expr, ExprKind, Guard, Pat, PatKind, QPath};
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty;
 use rustc_span::source_map::Spanned;
@@ -99,6 +101,14 @@ where
                 }
             }
 
+            for arm in iter_without_last.clone() {
+                if let Some(pat) = arm.1 {
+                    if !is_lint_allowed(cx, REDUNDANT_PATTERN_MATCHING, pat.hir_id) && is_some(pat.kind) {
+                        return false;
+                    }
+                }
+            }
+
             // The suggestion may be incorrect, because some arms can have `cfg` attributes
             // evaluated into `false` and so such arms will be stripped before.
             let mut applicability = Applicability::MaybeIncorrect;
@@ -168,5 +178,21 @@ fn find_bool_lit(ex: &ExprKind<'_>) -> Option<bool> {
             }
         },
         _ => None,
+    }
+}
+
+fn is_some(path_kind: PatKind<'_>) -> bool {
+    match path_kind {
+        PatKind::TupleStruct(ref path_left, patterns, _) if is_wild(&patterns[0]) => match path_left {
+            QPath::Resolved(_, path) => {
+                let name = path.segments[0].ident;
+                if name.as_str() == "Some" {
+                    return true;
+                }
+                return false;
+            },
+            _ => false,
+        },
+        _ => false,
     }
 }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -183,12 +183,9 @@ fn find_bool_lit(ex: &ExprKind<'_>) -> Option<bool> {
 
 fn is_some(path_kind: PatKind<'_>) -> bool {
     match path_kind {
-        PatKind::TupleStruct(QPath::Resolved(_, path), patterns, _) if is_wild(&patterns[0]) => {
+        PatKind::TupleStruct(QPath::Resolved(_, path), [first, ..], _) if is_wild(first) => {
             let name = path.segments[0].ident;
-            if name.name == rustc_span::sym::Some {
-                return true;
-            }
-            false
+            name.name == rustc_span::sym::Some
         },
         _ => false,
     }

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -188,9 +188,8 @@ fn find_sugg_for_if_let<'tcx>(
 pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op: &Expr<'_>, arms: &[Arm<'_>]) {
     if arms.len() == 2 {
         let node_pair = (&arms[0].pat.kind, &arms[1].pat.kind);
-        let found_good_method = found_good_method(cx, arms, node_pair);
 
-        if let Some(good_method) = found_good_method {
+        if let Some(good_method) = found_good_method(cx, arms, node_pair) {
             let span = expr.span.to(op.span);
             let result_expr = match &op.kind {
                 ExprKind::AddrOf(_, _, borrowed) => borrowed,
@@ -309,6 +308,9 @@ fn get_good_method<'a>(cx: &LateContext<'_>, arms: &[Arm<'_>], path_left: &QPath
         return match name.as_str() {
             "Ok" => {
                 find_good_method_for_matches_macro(cx, arms, path_left, Item::Lang(ResultOk), "is_ok()", "is_err()")
+            },
+            "Err" => {
+                find_good_method_for_matches_macro(cx, arms, path_left, Item::Lang(ResultErr), "is_err()", "is_ok()")
             },
             "Some" => find_good_method_for_matches_macro(
                 cx,

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -186,7 +186,6 @@ fn find_sugg_for_if_let<'tcx>(
 }
 
 pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op: &Expr<'_>, arms: &[Arm<'_>]) {
-    //eprintln!("{:#?}", expr);
     if arms.len() == 2 {
         let node_pair = (&arms[0].pat.kind, &arms[1].pat.kind);
         let found_good_method = match node_pair {

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -289,23 +289,7 @@ fn found_good_method<'a>(
                 None
             }
         },
-        (PatKind::Path(ref path_left), PatKind::Wild) => {
-            if let Some(name) = get_ident(path_left) {
-                match name.as_str() {
-                    "None" => find_good_method_for_matches_macro(
-                        cx,
-                        arms,
-                        path_left,
-                        Item::Lang(OptionNone),
-                        "is_none()",
-                        "is_some()",
-                    ),
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        },
+        (PatKind::Path(ref path_left), PatKind::Wild) => get_good_method(cx, arms, path_left),
         _ => None,
     }
 }
@@ -333,6 +317,14 @@ fn get_good_method<'a>(cx: &LateContext<'_>, arms: &[Arm<'_>], path_left: &QPath
                 Item::Lang(OptionSome),
                 "is_some()",
                 "is_none()",
+            ),
+            "None" => find_good_method_for_matches_macro(
+                cx,
+                arms,
+                path_left,
+                Item::Lang(OptionNone),
+                "is_none()",
+                "is_some()",
             ),
             _ => None,
         };

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -312,8 +312,7 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
                 } else {
                     None
                 }
-                
-            }
+            },
             _ => None,
         };
 

--- a/tests/ui/match_expr_like_matches_macro.fixed
+++ b/tests/ui/match_expr_like_matches_macro.fixed
@@ -15,7 +15,7 @@ fn main() {
     let _y = matches!(x, Some(0));
 
     // Lint
-    let _w = matches!(x, Some(_));
+    let _w = x.is_some();
 
     // Turn into is_none
     let _z = x.is_none();

--- a/tests/ui/match_expr_like_matches_macro.stderr
+++ b/tests/ui/match_expr_like_matches_macro.stderr
@@ -10,7 +10,7 @@ LL | |     };
    |
    = note: `-D clippy::match-like-matches-macro` implied by `-D warnings`
 
-error: match expression looks like `matches!` macro
+error: redundant pattern matching, consider using `is_some()`
   --> $DIR/match_expr_like_matches_macro.rs:21:14
    |
 LL |       let _w = match x {
@@ -18,7 +18,9 @@ LL |       let _w = match x {
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `matches!(x, Some(_))`
+   | |_____^ help: try this: `x.is_some()`
+   |
+   = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/match_expr_like_matches_macro.rs:27:14
@@ -29,8 +31,6 @@ LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
    | |_____^ help: try this: `x.is_none()`
-   |
-   = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:33:15

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -95,15 +95,12 @@ fn issue10726() {
 
     Some(42).is_none();
 
-    Some(42).is_none();
-
-    Some(42).is_some();
-
-    None::<()>.is_none();
-
-    None::<()>.is_none();
-
-    None::<()>.is_none();
-
     None::<()>.is_some();
+
+    None::<()>.is_none();
+
+    match Some(42) {
+        Some(21) => true,
+        _ => false,
+    };
 }

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -46,6 +46,7 @@ fn main() {
     let _ = if opt.is_some() { true } else { false };
 
     issue6067();
+    issue10726();
 
     let _ = if gen_opt().is_some() {
         1
@@ -87,4 +88,22 @@ const fn issue6067() {
 fn issue7921() {
     if (&None::<()>).is_none() {}
     if (&None::<()>).is_none() {}
+}
+
+fn issue10726() {
+    Some(42).is_some();
+
+    Some(42).is_none();
+
+    Some(42).is_none();
+
+    Some(42).is_some();
+
+    None::<()>.is_none();
+
+    None::<()>.is_none();
+
+    None::<()>.is_none();
+
+    None::<()>.is_some();
 }

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -92,15 +92,14 @@ fn issue7921() {
 
 fn issue10726() {
     let x = Some(42);
-    let y = None::<()>;
 
     x.is_some();
 
     x.is_none();
 
-    y.is_some();
+    x.is_none();
 
-    y.is_none();
+    x.is_some();
 
     // Don't lint
     match x {

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -91,15 +91,19 @@ fn issue7921() {
 }
 
 fn issue10726() {
-    Some(42).is_some();
+    let x = Some(42);
+    let y = None::<()>;
 
-    Some(42).is_none();
+    x.is_some();
 
-    None::<()>.is_some();
+    x.is_none();
 
-    None::<()>.is_none();
+    y.is_some();
 
-    match Some(42) {
+    y.is_none();
+
+    // Don't lint
+    match x {
         Some(21) => true,
         _ => false,
     };

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -55,6 +55,7 @@ fn main() {
     let _ = if let Some(_) = opt { true } else { false };
 
     issue6067();
+    issue10726();
 
     let _ = if let Some(_) = gen_opt() {
         1
@@ -102,4 +103,46 @@ const fn issue6067() {
 fn issue7921() {
     if let None = *(&None::<()>) {}
     if let None = *&None::<()> {}
+}
+
+fn issue10726() {
+    match Some(42) {
+        Some(_) => true,
+        _ => false,
+    };
+
+    match Some(42) {
+        Some(_) => false,
+        _ => true,
+    };
+
+    match Some(42) {
+        None => true,
+        _ => false,
+    };
+
+    match Some(42) {
+        None => false,
+        _ => true,
+    };
+
+    match None::<()> {
+        Some(_) => false,
+        _ => true,
+    };
+
+    match None::<()> {
+        Some(_) => false,
+        _ => true,
+    };
+
+    match None::<()> {
+        None => true,
+        _ => false,
+    };
+
+    match None::<()> {
+        None => false,
+        _ => true,
+    };
 }

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -112,28 +112,13 @@ fn issue10726() {
     };
 
     match Some(42) {
-        Some(_) => false,
-        _ => true,
-    };
-
-    match Some(42) {
         None => true,
         _ => false,
     };
 
-    match Some(42) {
-        None => false,
-        _ => true,
-    };
-
     match None::<()> {
-        Some(_) => false,
-        _ => true,
-    };
-
-    match None::<()> {
-        Some(_) => false,
-        _ => true,
+        Some(_) => true,
+        _ => false,
     };
 
     match None::<()> {
@@ -141,8 +126,8 @@ fn issue10726() {
         _ => false,
     };
 
-    match None::<()> {
-        None => false,
-        _ => true,
+    match Some(42) {
+        Some(21) => true,
+        _ => false,
     };
 }

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -106,27 +106,31 @@ fn issue7921() {
 }
 
 fn issue10726() {
-    match Some(42) {
+    let x = Some(42);
+    let y = None::<()>;
+
+    match x {
         Some(_) => true,
         _ => false,
     };
 
-    match Some(42) {
+    match x {
         None => true,
         _ => false,
     };
 
-    match None::<()> {
+    match y {
         Some(_) => true,
         _ => false,
     };
 
-    match None::<()> {
+    match y {
         None => true,
         _ => false,
     };
 
-    match Some(42) {
+    // Don't lint
+    match x {
         Some(21) => true,
         _ => false,
     };

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -107,7 +107,6 @@ fn issue7921() {
 
 fn issue10726() {
     let x = Some(42);
-    let y = None::<()>;
 
     match x {
         Some(_) => true,
@@ -119,14 +118,14 @@ fn issue10726() {
         _ => false,
     };
 
-    match y {
-        Some(_) => true,
-        _ => false,
+    match x {
+        Some(_) => false,
+        _ => true,
     };
 
-    match y {
-        None => true,
-        _ => false,
+    match x {
+        None => false,
+        _ => true,
     };
 
     // Don't lint

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -161,64 +161,28 @@ error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:114:5
    |
 LL | /     match Some(42) {
-LL | |         Some(_) => false,
-LL | |         _ => true,
+LL | |         None => true,
+LL | |         _ => false,
 LL | |     };
    | |_____^ help: try this: `Some(42).is_none()`
 
-error: redundant pattern matching, consider using `is_none()`
+error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:119:5
    |
-LL | /     match Some(42) {
-LL | |         None => true,
+LL | /     match None::<()> {
+LL | |         Some(_) => true,
 LL | |         _ => false,
-LL | |     };
-   | |_____^ help: try this: `Some(42).is_none()`
-
-error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:124:5
-   |
-LL | /     match Some(42) {
-LL | |         None => false,
-LL | |         _ => true,
-LL | |     };
-   | |_____^ help: try this: `Some(42).is_some()`
-
-error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:129:5
-   |
-LL | /     match None::<()> {
-LL | |         Some(_) => false,
-LL | |         _ => true,
-LL | |     };
-   | |_____^ help: try this: `None::<()>.is_none()`
-
-error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:134:5
-   |
-LL | /     match None::<()> {
-LL | |         Some(_) => false,
-LL | |         _ => true,
-LL | |     };
-   | |_____^ help: try this: `None::<()>.is_none()`
-
-error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:139:5
-   |
-LL | /     match None::<()> {
-LL | |         None => true,
-LL | |         _ => false,
-LL | |     };
-   | |_____^ help: try this: `None::<()>.is_none()`
-
-error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:144:5
-   |
-LL | /     match None::<()> {
-LL | |         None => false,
-LL | |         _ => true,
 LL | |     };
    | |_____^ help: try this: `None::<()>.is_some()`
 
-error: aborting due to 30 previous errors
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:124:5
+   |
+LL | /     match None::<()> {
+LL | |         None => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `None::<()>.is_none()`
+
+error: aborting due to 26 previous errors
 

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -77,49 +77,49 @@ LL |     let _ = if let Some(_) = opt { true } else { false };
    |             -------^^^^^^^------ help: try this: `if opt.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:59:20
+  --> $DIR/redundant_pattern_matching_option.rs:60:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
    |             -------^^^^^^^------------ help: try this: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:61:19
+  --> $DIR/redundant_pattern_matching_option.rs:62:19
    |
 LL |     } else if let None = gen_opt() {
    |            -------^^^^------------ help: try this: `if gen_opt().is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:67:12
+  --> $DIR/redundant_pattern_matching_option.rs:68:12
    |
 LL |     if let Some(..) = gen_opt() {}
    |     -------^^^^^^^^------------ help: try this: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:82:12
+  --> $DIR/redundant_pattern_matching_option.rs:83:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try this: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:84:12
+  --> $DIR/redundant_pattern_matching_option.rs:85:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try this: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:86:15
+  --> $DIR/redundant_pattern_matching_option.rs:87:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try this: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:88:15
+  --> $DIR/redundant_pattern_matching_option.rs:89:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try this: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:90:5
+  --> $DIR/redundant_pattern_matching_option.rs:91:5
    |
 LL | /     match Some(42) {
 LL | |         Some(_) => true,
@@ -128,7 +128,7 @@ LL | |     };
    | |_____^ help: try this: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:95:5
+  --> $DIR/redundant_pattern_matching_option.rs:96:5
    |
 LL | /     match None::<()> {
 LL | |         Some(_) => false,
@@ -137,16 +137,88 @@ LL | |     };
    | |_____^ help: try this: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:103:12
+  --> $DIR/redundant_pattern_matching_option.rs:104:12
    |
 LL |     if let None = *(&None::<()>) {}
    |     -------^^^^----------------- help: try this: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:104:12
+  --> $DIR/redundant_pattern_matching_option.rs:105:12
    |
 LL |     if let None = *&None::<()> {}
    |     -------^^^^--------------- help: try this: `if (&None::<()>).is_none()`
 
-error: aborting due to 22 previous errors
+error: redundant pattern matching, consider using `is_some()`
+  --> $DIR/redundant_pattern_matching_option.rs:109:5
+   |
+LL | /     match Some(42) {
+LL | |         Some(_) => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `Some(42).is_some()`
+
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:114:5
+   |
+LL | /     match Some(42) {
+LL | |         Some(_) => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `Some(42).is_none()`
+
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:119:5
+   |
+LL | /     match Some(42) {
+LL | |         None => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `Some(42).is_none()`
+
+error: redundant pattern matching, consider using `is_some()`
+  --> $DIR/redundant_pattern_matching_option.rs:124:5
+   |
+LL | /     match Some(42) {
+LL | |         None => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `Some(42).is_some()`
+
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:129:5
+   |
+LL | /     match None::<()> {
+LL | |         Some(_) => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `None::<()>.is_none()`
+
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:134:5
+   |
+LL | /     match None::<()> {
+LL | |         Some(_) => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `None::<()>.is_none()`
+
+error: redundant pattern matching, consider using `is_none()`
+  --> $DIR/redundant_pattern_matching_option.rs:139:5
+   |
+LL | /     match None::<()> {
+LL | |         None => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `None::<()>.is_none()`
+
+error: redundant pattern matching, consider using `is_some()`
+  --> $DIR/redundant_pattern_matching_option.rs:144:5
+   |
+LL | /     match None::<()> {
+LL | |         None => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `None::<()>.is_some()`
+
+error: aborting due to 30 previous errors
 

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -149,7 +149,7 @@ LL |     if let None = *&None::<()> {}
    |     -------^^^^--------------- help: try this: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:112:5
+  --> $DIR/redundant_pattern_matching_option.rs:111:5
    |
 LL | /     match x {
 LL | |         Some(_) => true,
@@ -158,7 +158,7 @@ LL | |     };
    | |_____^ help: try this: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:117:5
+  --> $DIR/redundant_pattern_matching_option.rs:116:5
    |
 LL | /     match x {
 LL | |         None => true,
@@ -166,23 +166,23 @@ LL | |         _ => false,
 LL | |     };
    | |_____^ help: try this: `x.is_none()`
 
-error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:122:5
-   |
-LL | /     match y {
-LL | |         Some(_) => true,
-LL | |         _ => false,
-LL | |     };
-   | |_____^ help: try this: `y.is_some()`
-
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:127:5
+  --> $DIR/redundant_pattern_matching_option.rs:121:5
    |
-LL | /     match y {
-LL | |         None => true,
-LL | |         _ => false,
+LL | /     match x {
+LL | |         Some(_) => false,
+LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `y.is_none()`
+   | |_____^ help: try this: `x.is_none()`
+
+error: redundant pattern matching, consider using `is_some()`
+  --> $DIR/redundant_pattern_matching_option.rs:126:5
+   |
+LL | /     match x {
+LL | |         None => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `x.is_some()`
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -149,40 +149,40 @@ LL |     if let None = *&None::<()> {}
    |     -------^^^^--------------- help: try this: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:109:5
+  --> $DIR/redundant_pattern_matching_option.rs:112:5
    |
-LL | /     match Some(42) {
+LL | /     match x {
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `Some(42).is_some()`
+   | |_____^ help: try this: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:114:5
+  --> $DIR/redundant_pattern_matching_option.rs:117:5
    |
-LL | /     match Some(42) {
+LL | /     match x {
 LL | |         None => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `Some(42).is_none()`
+   | |_____^ help: try this: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:119:5
+  --> $DIR/redundant_pattern_matching_option.rs:122:5
    |
-LL | /     match None::<()> {
+LL | /     match y {
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `None::<()>.is_some()`
+   | |_____^ help: try this: `y.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:124:5
+  --> $DIR/redundant_pattern_matching_option.rs:127:5
    |
-LL | /     match None::<()> {
+LL | /     match y {
 LL | |         None => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `None::<()>.is_none()`
+   | |_____^ help: try this: `y.is_none()`
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -114,7 +114,12 @@ fn issue10726() {
 
     Ok::<i32, i32>(42).is_err();
 
+    Err::<i32, i32>(42).is_ok();
+
     Err::<i32, i32>(42).is_err();
 
-    Err::<i32, i32>(42).is_ok();
+    match Ok::<i32, i32>(42) {
+        Ok(21) => true,
+        _ => false,
+    };
 }

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -43,6 +43,7 @@ fn main() {
     issue5504();
     issue6067();
     issue6065();
+    issue10726();
 
     let _ = if gen_res().is_ok() {
         1
@@ -106,4 +107,14 @@ const fn issue6067() {
     Ok::<i32, i32>(42).is_ok();
 
     Err::<i32, i32>(42).is_err();
+}
+
+fn issue10726() {
+    Ok::<i32, i32>(42).is_ok();
+
+    Ok::<i32, i32>(42).is_err();
+
+    Err::<i32, i32>(42).is_err();
+
+    Err::<i32, i32>(42).is_ok();
 }

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -110,16 +110,26 @@ const fn issue6067() {
 }
 
 fn issue10726() {
-    Ok::<i32, i32>(42).is_ok();
+    // This is optional, but it makes the examples easier
+    let x: Result<i32, i32> = Ok(42);
 
-    Ok::<i32, i32>(42).is_err();
+    x.is_ok();
 
-    Err::<i32, i32>(42).is_ok();
+    x.is_err();
 
-    Err::<i32, i32>(42).is_err();
+    x.is_err();
 
-    match Ok::<i32, i32>(42) {
-        Ok(21) => true,
-        _ => false,
+    x.is_ok();
+
+    // Don't lint
+    match x {
+        Err(16) => false,
+        _ => true,
+    };
+
+    // Don't lint
+    match x {
+        Ok(16) => false,
+        _ => true,
     };
 }

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -55,6 +55,7 @@ fn main() {
     issue5504();
     issue6067();
     issue6065();
+    issue10726();
 
     let _ = if let Ok(_) = gen_res() {
         1
@@ -123,5 +124,27 @@ const fn issue6067() {
     match Err::<i32, i32>(42) {
         Ok(_) => false,
         Err(_) => true,
+    };
+}
+
+fn issue10726() {
+    match Ok::<i32, i32>(42) {
+        Ok(_) => true,
+        _ => false,
+    };
+
+    match Ok::<i32, i32>(42) {
+        Ok(_) => false,
+        _ => true,
+    };
+
+    match Err::<i32, i32>(42) {
+        Ok(_) => false,
+        _ => true,
+    };
+
+    match Err::<i32, i32>(42) {
+        Ok(_) => true,
+        _ => false,
     };
 }

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -134,17 +134,22 @@ fn issue10726() {
     };
 
     match Ok::<i32, i32>(42) {
-        Ok(_) => false,
-        _ => true,
-    };
-
-    match Err::<i32, i32>(42) {
-        Ok(_) => false,
-        _ => true,
+        Err(_) => true,
+        _ => false,
     };
 
     match Err::<i32, i32>(42) {
         Ok(_) => true,
+        _ => false,
+    };
+
+    match Err::<i32, i32>(42) {
+        Err(_) => true,
+        _ => false,
+    };
+
+    match Ok::<i32, i32>(42) {
+        Ok(21) => true,
         _ => false,
     };
 }

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -128,28 +128,38 @@ const fn issue6067() {
 }
 
 fn issue10726() {
-    match Ok::<i32, i32>(42) {
+    // This is optional, but it makes the examples easier
+    let x: Result<i32, i32> = Ok(42);
+
+    match x {
         Ok(_) => true,
         _ => false,
     };
 
-    match Ok::<i32, i32>(42) {
+    match x {
+        Ok(_) => false,
+        _ => true,
+    };
+
+    match x {
         Err(_) => true,
         _ => false,
     };
 
-    match Err::<i32, i32>(42) {
-        Ok(_) => true,
-        _ => false,
+    match x {
+        Err(_) => false,
+        _ => true,
     };
 
-    match Err::<i32, i32>(42) {
-        Err(_) => true,
-        _ => false,
+    // Don't lint
+    match x {
+        Err(16) => false,
+        _ => true,
     };
 
-    match Ok::<i32, i32>(42) {
-        Ok(21) => true,
-        _ => false,
+    // Don't lint
+    match x {
+        Ok(16) => false,
+        _ => true,
     };
 }

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -73,67 +73,67 @@ LL |     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
    |             -------^^^^^--------------------- help: try this: `if Ok::<usize, ()>(4).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:59:20
+  --> $DIR/redundant_pattern_matching_result.rs:60:20
    |
 LL |     let _ = if let Ok(_) = gen_res() {
    |             -------^^^^^------------ help: try this: `if gen_res().is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:61:19
+  --> $DIR/redundant_pattern_matching_result.rs:62:19
    |
 LL |     } else if let Err(_) = gen_res() {
    |            -------^^^^^^------------ help: try this: `if gen_res().is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:84:19
+  --> $DIR/redundant_pattern_matching_result.rs:85:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
    |         ----------^^^^^^^----------------------- help: try this: `while r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:85:16
+  --> $DIR/redundant_pattern_matching_result.rs:86:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
    |         -------^^^^^^^----------------------- help: try this: `if r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:91:12
+  --> $DIR/redundant_pattern_matching_result.rs:92:12
    |
 LL |     if let Some(_) = m!() {}
    |     -------^^^^^^^------- help: try this: `if m!().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:92:15
+  --> $DIR/redundant_pattern_matching_result.rs:93:15
    |
 LL |     while let Some(_) = m!() {}
    |     ----------^^^^^^^------- help: try this: `while m!().is_some()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:110:12
+  --> $DIR/redundant_pattern_matching_result.rs:111:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try this: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:112:12
+  --> $DIR/redundant_pattern_matching_result.rs:113:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try this: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:114:15
+  --> $DIR/redundant_pattern_matching_result.rs:115:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:116:15
+  --> $DIR/redundant_pattern_matching_result.rs:117:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:118:5
+  --> $DIR/redundant_pattern_matching_result.rs:119:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => true,
@@ -142,7 +142,7 @@ LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:123:5
+  --> $DIR/redundant_pattern_matching_result.rs:124:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => false,
@@ -150,5 +150,41 @@ LL | |         Err(_) => true,
 LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
 
-error: aborting due to 22 previous errors
+error: redundant pattern matching, consider using `is_ok()`
+  --> $DIR/redundant_pattern_matching_result.rs:131:5
+   |
+LL | /     match Ok::<i32, i32>(42) {
+LL | |         Ok(_) => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
+
+error: redundant pattern matching, consider using `is_err()`
+  --> $DIR/redundant_pattern_matching_result.rs:136:5
+   |
+LL | /     match Ok::<i32, i32>(42) {
+LL | |         Ok(_) => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `Ok::<i32, i32>(42).is_err()`
+
+error: redundant pattern matching, consider using `is_err()`
+  --> $DIR/redundant_pattern_matching_result.rs:141:5
+   |
+LL | /     match Err::<i32, i32>(42) {
+LL | |         Ok(_) => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
+
+error: redundant pattern matching, consider using `is_ok()`
+  --> $DIR/redundant_pattern_matching_result.rs:146:5
+   |
+LL | /     match Err::<i32, i32>(42) {
+LL | |         Ok(_) => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `Err::<i32, i32>(42).is_ok()`
+
+error: aborting due to 26 previous errors
 

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -163,28 +163,28 @@ error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:136:5
    |
 LL | /     match Ok::<i32, i32>(42) {
-LL | |         Ok(_) => false,
-LL | |         _ => true,
+LL | |         Err(_) => true,
+LL | |         _ => false,
 LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_err()`
 
-error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:141:5
-   |
-LL | /     match Err::<i32, i32>(42) {
-LL | |         Ok(_) => false,
-LL | |         _ => true,
-LL | |     };
-   | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
-
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:146:5
+  --> $DIR/redundant_pattern_matching_result.rs:141:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => true,
 LL | |         _ => false,
 LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_ok()`
+
+error: redundant pattern matching, consider using `is_err()`
+  --> $DIR/redundant_pattern_matching_result.rs:146:5
+   |
+LL | /     match Err::<i32, i32>(42) {
+LL | |         Err(_) => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -151,40 +151,40 @@ LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:131:5
+  --> $DIR/redundant_pattern_matching_result.rs:134:5
    |
-LL | /     match Ok::<i32, i32>(42) {
+LL | /     match x {
 LL | |         Ok(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
+   | |_____^ help: try this: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:136:5
+  --> $DIR/redundant_pattern_matching_result.rs:139:5
    |
-LL | /     match Ok::<i32, i32>(42) {
+LL | /     match x {
+LL | |         Ok(_) => false,
+LL | |         _ => true,
+LL | |     };
+   | |_____^ help: try this: `x.is_err()`
+
+error: redundant pattern matching, consider using `is_err()`
+  --> $DIR/redundant_pattern_matching_result.rs:144:5
+   |
+LL | /     match x {
 LL | |         Err(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `Ok::<i32, i32>(42).is_err()`
+   | |_____^ help: try this: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:141:5
+  --> $DIR/redundant_pattern_matching_result.rs:149:5
    |
-LL | /     match Err::<i32, i32>(42) {
-LL | |         Ok(_) => true,
-LL | |         _ => false,
+LL | /     match x {
+LL | |         Err(_) => false,
+LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `Err::<i32, i32>(42).is_ok()`
-
-error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:146:5
-   |
-LL | /     match Err::<i32, i32>(42) {
-LL | |         Err(_) => true,
-LL | |         _ => false,
-LL | |     };
-   | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
+   | |_____^ help: try this: `x.is_ok()`
 
 error: aborting due to 26 previous errors
 


### PR DESCRIPTION
This PR try to solve this issue https://github.com/rust-lang/rust-clippy/pull/10726, 
but it enter in conflict with another test.

changelog: none

Try to test this:
```
let _w = match x {
     Some(_) => true,
     _ => false,
};
```

this happen:
```
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:21:14
    |
 LL |       let _w = match x {
    |  ______________^
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
    | |_____^ help: try this: `matches!(x, Some(_))`
 
+error: redundant pattern matching, consider using `is_some()`
+  --> $DIR/match_expr_like_matches_macro.rs:21:14
+   |
+LL |       let _w = match x {
+   |  ______________^
+LL | |         Some(_) => true,
+LL | |         _ => false,
+LL | |     };
+   | |_____^ help: try this: `x.is_some()`
+   |
+   = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
+
```
I need some help to fix this. Thanks
