### PR TITLE
Now `option_env_unwrap` warns even if a variable isn't set at compiletime

### DIFF
--- a/clippy_lints/src/option_env_unwrap.rs
+++ b/clippy_lints/src/option_env_unwrap.rs
@@ -1,10 +1,9 @@
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::is_direct_expn_of;
-use if_chain::if_chain;
 use rustc_ast::ast::{Expr, ExprKind, MethodCall};
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
-use rustc_span::sym;
+use rustc_span::{sym, Span};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -36,21 +35,24 @@ declare_lint_pass!(OptionEnvUnwrap => [OPTION_ENV_UNWRAP]);
 
 impl EarlyLintPass for OptionEnvUnwrap {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
-        if_chain! {
-            if let ExprKind::MethodCall(box MethodCall { seg, receiver, .. }) = &expr.kind;
-            if matches!(seg.ident.name, sym::expect | sym::unwrap);
-            if let ExprKind::Call(caller, _) = &receiver.kind;
-            if is_direct_expn_of(caller.span, "option_env").is_some();
-            then {
-                span_lint_and_help(
-                    cx,
-                    OPTION_ENV_UNWRAP,
-                    expr.span,
-                    "this will panic at run-time if the environment variable doesn't exist at compile-time",
-                    None,
-                    "consider using the `env!` macro instead"
-                );
-            }
+        fn lint(cx: &EarlyContext<'_>, span: Span) {
+            span_lint_and_help(
+                cx,
+                OPTION_ENV_UNWRAP,
+                span,
+                "this will panic at run-time if the environment variable doesn't exist at compile-time",
+                None,
+                "consider using the `env!` macro instead",
+            );
         }
+
+        if let ExprKind::MethodCall(box MethodCall { seg, receiver, .. }) = &expr.kind &&
+		matches!(seg.ident.name, sym::expect | sym::unwrap) {
+			if let ExprKind::Call(caller, _) = &receiver.kind && is_direct_expn_of(caller.span, "option_env").is_some() {
+				lint(cx, expr.span);
+			} else if let ExprKind::Path(_, caller) = &receiver.kind && is_direct_expn_of(caller.span, "option_env").is_some() {
+				lint(cx, expr.span);
+			}
+		}
     }
 }

--- a/clippy_lints/src/option_env_unwrap.rs
+++ b/clippy_lints/src/option_env_unwrap.rs
@@ -48,9 +48,12 @@ impl EarlyLintPass for OptionEnvUnwrap {
 
         if let ExprKind::MethodCall(box MethodCall { seg, receiver, .. }) = &expr.kind &&
 		matches!(seg.ident.name, sym::expect | sym::unwrap) {
-			if let ExprKind::Call(caller, _) = &receiver.kind && is_direct_expn_of(caller.span, "option_env").is_some() {
+			if let ExprKind::Call(caller, _) = &receiver.kind &&
+            // If it exists, it will be ::core::option::Option::Some("<env var>").unwrap() (A method call in the HIR)
+            is_direct_expn_of(caller.span, "option_env").is_some() {
 				lint(cx, expr.span);
-			} else if let ExprKind::Path(_, caller) = &receiver.kind && is_direct_expn_of(caller.span, "option_env").is_some() {
+			} else if let ExprKind::Path(_, caller) = &receiver.kind && // If it doesn't exist, it will be ::core::option::Option::None::<&'static str>.unwrap() (A path in the HIR)
+            is_direct_expn_of(caller.span, "option_env").is_some() {
 				lint(cx, expr.span);
 			}
 		}

--- a/tests/ui/option_env_unwrap.rs
+++ b/tests/ui/option_env_unwrap.rs
@@ -9,6 +9,7 @@ use proc_macros::{external, inline_macros};
 fn main() {
     let _ = option_env!("PATH").unwrap();
     let _ = option_env!("PATH").expect("environment variable PATH isn't set");
+    let _ = option_env!("__Y__do_not_use").unwrap(); // This test only works if you don't have a __Y__do_not_use env variable in your environment.
     let _ = inline!(option_env!($"PATH").unwrap());
     let _ = inline!(option_env!($"PATH").expect($"environment variable PATH isn't set"));
     let _ = external!(option_env!($"PATH").unwrap());

--- a/tests/ui/option_env_unwrap.stderr
+++ b/tests/ui/option_env_unwrap.stderr
@@ -18,8 +18,8 @@ LL |     let _ = option_env!("PATH").expect("environment variable PATH isn't set
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
   --> $DIR/option_env_unwrap.rs:12:13
    |
-LL |     let _ = option_env!("Y").unwrap(); // This test only works if you don't have a __Y__do_not_use env variable in your environment.
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = option_env!("__Y__do_not_use").unwrap(); // This test only works if you don't have a __Y__do_not_use env variable in your env...
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using the `env!` macro instead
 

--- a/tests/ui/option_env_unwrap.stderr
+++ b/tests/ui/option_env_unwrap.stderr
@@ -16,7 +16,15 @@ LL |     let _ = option_env!("PATH").expect("environment variable PATH isn't set
    = help: consider using the `env!` macro instead
 
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
-  --> $DIR/option_env_unwrap.rs:12:21
+  --> $DIR/option_env_unwrap.rs:12:13
+   |
+LL |     let _ = option_env!("Y").unwrap(); // This test only works if you don't have a __Y__do_not_use env variable in your environment.
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using the `env!` macro instead
+
+error: this will panic at run-time if the environment variable doesn't exist at compile-time
+  --> $DIR/option_env_unwrap.rs:13:21
    |
 LL |     let _ = inline!(option_env!($"PATH").unwrap());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +33,7 @@ LL |     let _ = inline!(option_env!($"PATH").unwrap());
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
-  --> $DIR/option_env_unwrap.rs:13:21
+  --> $DIR/option_env_unwrap.rs:14:21
    |
 LL |     let _ = inline!(option_env!($"PATH").expect($"environment variable PATH isn't set"));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +42,7 @@ LL |     let _ = inline!(option_env!($"PATH").expect($"environment variable PATH
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
-  --> $DIR/option_env_unwrap.rs:14:13
+  --> $DIR/option_env_unwrap.rs:15:13
    |
 LL |     let _ = external!(option_env!($"PATH").unwrap());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,7 +51,7 @@ LL |     let _ = external!(option_env!($"PATH").unwrap());
    = note: this error originates in the macro `external` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
-  --> $DIR/option_env_unwrap.rs:15:13
+  --> $DIR/option_env_unwrap.rs:16:13
    |
 LL |     let _ = external!(option_env!($"PATH").expect($"environment variable PATH isn't set"));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,5 +59,5 @@ LL |     let _ = external!(option_env!($"PATH").expect($"environment variable PA
    = help: consider using the `env!` macro instead
    = note: this error originates in the macro `external` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes #10742
changelog: Fix false negative where `option_env_unwrap` wouldn't warn if the env variable isn't set at compile-time.
