### PR TITLE
Add `MINIMAL_CFG_CONDITION` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4899,6 +4899,7 @@ Released 2018-09-13
 [`no_effect_underscore_binding`]: https://rust-lang.github.io/rust-clippy/master/index.html#no_effect_underscore_binding
 [`no_mangle_with_rust_abi`]: https://rust-lang.github.io/rust-clippy/master/index.html#no_mangle_with_rust_abi
 [`non_ascii_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_ascii_literal
+[`non_minimal_cfg`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_minimal_cfg
 [`non_octal_unix_permissions`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_octal_unix_permissions
 [`non_send_fields_in_send_ty`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_send_fields_in_send_ty
 [`nonminimal_bool`]: https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -796,6 +796,14 @@ fn check_nested_cfg(cx: &EarlyContext<'_>, items: &[NestedMetaItem]) {
                             }
                         },
                     );
+                } else if list.is_empty() && meta.has_name(sym::all) {
+                    span_lint_and_then(
+                        cx,
+                        NON_MINIMAL_CFG,
+                        meta.span,
+                        "unneeded sub `cfg` when there is no condition",
+                        |_| {},
+                    );
                 }
             }
         }

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -52,6 +52,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::attrs::EMPTY_LINE_AFTER_OUTER_ATTR_INFO,
     crate::attrs::INLINE_ALWAYS_INFO,
     crate::attrs::MISMATCHED_TARGET_OS_INFO,
+    crate::attrs::NON_MINIMAL_CFG_INFO,
     crate::attrs::USELESS_ATTRIBUTE_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_INVALID_TYPE_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_LOCK_INFO,

--- a/tests/ui/non_minimal_cfg.fixed
+++ b/tests/ui/non_minimal_cfg.fixed
@@ -1,0 +1,14 @@
+//@run-rustfix
+
+#![allow(unused)]
+
+#[cfg(windows)]
+fn hermit() {}
+
+#[cfg(windows)]
+fn wasi() {}
+
+#[cfg(all(unix, not(windows)))]
+fn the_end() {}
+
+fn main() {}

--- a/tests/ui/non_minimal_cfg.fixed
+++ b/tests/ui/non_minimal_cfg.fixed
@@ -11,4 +11,7 @@ fn wasi() {}
 #[cfg(all(unix, not(windows)))]
 fn the_end() {}
 
+#[cfg(any())]
+fn any() {}
+
 fn main() {}

--- a/tests/ui/non_minimal_cfg.rs
+++ b/tests/ui/non_minimal_cfg.rs
@@ -11,4 +11,7 @@ fn wasi() {}
 #[cfg(all(any(unix), all(not(windows))))]
 fn the_end() {}
 
+#[cfg(any())]
+fn any() {}
+
 fn main() {}

--- a/tests/ui/non_minimal_cfg.rs
+++ b/tests/ui/non_minimal_cfg.rs
@@ -1,0 +1,14 @@
+//@run-rustfix
+
+#![allow(unused)]
+
+#[cfg(all(windows))]
+fn hermit() {}
+
+#[cfg(any(windows))]
+fn wasi() {}
+
+#[cfg(all(any(unix), all(not(windows))))]
+fn the_end() {}
+
+fn main() {}

--- a/tests/ui/non_minimal_cfg.stderr
+++ b/tests/ui/non_minimal_cfg.stderr
@@ -1,0 +1,28 @@
+error: unneeded sub `cfg` when there is only one condition
+  --> $DIR/non_minimal_cfg.rs:5:7
+   |
+LL | #[cfg(all(windows))]
+   |       ^^^^^^^^^^^^ help: try: `windows`
+   |
+   = note: `-D clippy::non-minimal-cfg` implied by `-D warnings`
+
+error: unneeded sub `cfg` when there is only one condition
+  --> $DIR/non_minimal_cfg.rs:8:7
+   |
+LL | #[cfg(any(windows))]
+   |       ^^^^^^^^^^^^ help: try: `windows`
+
+error: unneeded sub `cfg` when there is only one condition
+  --> $DIR/non_minimal_cfg.rs:11:11
+   |
+LL | #[cfg(all(any(unix), all(not(windows))))]
+   |           ^^^^^^^^^ help: try: `unix`
+
+error: unneeded sub `cfg` when there is only one condition
+  --> $DIR/non_minimal_cfg.rs:11:22
+   |
+LL | #[cfg(all(any(unix), all(not(windows))))]
+   |                      ^^^^^^^^^^^^^^^^^ help: try: `not(windows)`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/non_minimal_cfg2.rs
+++ b/tests/ui/non_minimal_cfg2.rs
@@ -1,0 +1,6 @@
+#![allow(unused)]
+
+#[cfg(all())]
+fn all() {}
+
+fn main() {}

--- a/tests/ui/non_minimal_cfg2.stderr
+++ b/tests/ui/non_minimal_cfg2.stderr
@@ -1,0 +1,10 @@
+error: unneeded sub `cfg` when there is no condition
+  --> $DIR/non_minimal_cfg2.rs:3:7
+   |
+LL | #[cfg(all())]
+   |       ^^^^^
+   |
+   = note: `-D clippy::non-minimal-cfg` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
I encountered a few cases where some code had:

```rust
#[cfg(any(unix))]
```

In this case, the `any` is useless. This lint checks this and also for the `all` condition.

```
changelog: [`non_minimal_cfg`]: Add new `non_minimal_cfg` lint
```