### PR TITLE
Update actions/setup-node

### DIFF
--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup Node.js
-      uses: actions/setup-node@v1.4.4
+      uses: actions/setup-node@v3
       with:
         node-version: '14.x'
 


### PR DESCRIPTION
Follow up of https://github.com/rust-lang/rust-clippy/pull/10771. One warning remains: https://github.com/rust-lang/rust-clippy/actions/runs/4959567213

changelog: none
