### PR TITLE
Add new lint `ptr_cast_constness`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4948,6 +4948,7 @@ Released 2018-09-13
 [`println_empty_string`]: https://rust-lang.github.io/rust-clippy/master/index.html#println_empty_string
 [`ptr_arg`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
 [`ptr_as_ptr`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_as_ptr
+[`ptr_cast_constness`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_cast_constness
 [`ptr_eq`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_eq
 [`ptr_offset_with_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_offset_with_cast
 [`pub_enum_variant_names`]: https://rust-lang.github.io/rust-clippy/master/index.html#pub_enum_variant_names

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -752,7 +752,7 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
                 return;
             }
             cast_slice_from_raw_parts::check(cx, expr, cast_expr, cast_to, &self.msrv);
-            ptr_cast_constness::check(cx, expr, cast_expr, cast_from, cast_to);
+            ptr_cast_constness::check(cx, expr, cast_expr, cast_from, cast_to, &self.msrv);
             as_ptr_cast_mut::check(cx, expr, cast_expr, cast_to);
             fn_to_numeric_cast_any::check(cx, expr, cast_expr, cast_from, cast_to);
             fn_to_numeric_cast::check(cx, expr, cast_expr, cast_from, cast_to);

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -448,7 +448,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.65.0"]
     pub PTR_CAST_CONSTNESS,
     pedantic,
-    "TODO"
+    "casting using `as` from and to raw pointers to change constness when specialized methods apply"
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -18,6 +18,7 @@ mod fn_to_numeric_cast;
 mod fn_to_numeric_cast_any;
 mod fn_to_numeric_cast_with_truncation;
 mod ptr_as_ptr;
+mod ptr_cast_constness;
 mod unnecessary_cast;
 mod utils;
 
@@ -399,7 +400,7 @@ declare_clippy_lint! {
     /// namely `*const T` to `*const U` and `*mut T` to `*mut U`.
     ///
     /// ### Why is this bad?
-    /// Though `as` casts between raw pointers is not terrible, `pointer::cast` is safer because
+    /// Though `as` casts between raw pointers are not terrible, `pointer::cast` is safer because
     /// it cannot accidentally change the pointer's mutability nor cast the pointer to other types like `usize`.
     ///
     /// ### Example
@@ -420,6 +421,34 @@ declare_clippy_lint! {
     pub PTR_AS_PTR,
     pedantic,
     "casting using `as` from and to raw pointers that doesn't change its mutability, where `pointer::cast` could take the place of `as`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for `as` casts between raw pointers which change its constness, namely `*const T` to
+    /// `*mut T` and `*mut T` to `*const T`.
+    ///
+    /// ### Why is this bad?
+    /// Though `as` casts between raw pointers are not terrible, `pointer::cast_mut` and
+    /// `pointer::cast_const` are safer because they cannot accidentally cast the pointer to another
+    /// type.
+    ///
+    /// ### Example
+    /// ```rust
+    /// let ptr: *const u32 = &42_u32;
+    /// let mut_ptr = ptr as *mut u32;
+    /// let ptr = mut_ptr as *const u32;
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// let ptr: *const u32 = &42_u32;
+    /// let mut_ptr = ptr.cast_mut();
+    /// let ptr = mut_ptr.cast_const();
+    /// ```
+    #[clippy::version = "1.65.0"]
+    pub PTR_CAST_CONSTNESS,
+    pedantic,
+    "TODO"
 }
 
 declare_clippy_lint! {
@@ -689,6 +718,7 @@ impl_lint_pass!(Casts => [
     FN_TO_NUMERIC_CAST_WITH_TRUNCATION,
     CHAR_LIT_AS_U8,
     PTR_AS_PTR,
+    PTR_CAST_CONSTNESS,
     CAST_ENUM_TRUNCATION,
     CAST_ENUM_CONSTRUCTOR,
     CAST_ABS_TO_UNSIGNED,
@@ -722,6 +752,7 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
                 return;
             }
             cast_slice_from_raw_parts::check(cx, expr, cast_expr, cast_to, &self.msrv);
+            ptr_cast_constness::check(cx, expr, cast_expr, cast_from, cast_to);
             as_ptr_cast_mut::check(cx, expr, cast_expr, cast_to);
             fn_to_numeric_cast_any::check(cx, expr, cast_expr, cast_from, cast_to);
             fn_to_numeric_cast::check(cx, expr, cast_expr, cast_from, cast_to);

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -445,7 +445,7 @@ declare_clippy_lint! {
     /// let mut_ptr = ptr.cast_mut();
     /// let ptr = mut_ptr.cast_const();
     /// ```
-    #[clippy::version = "1.65.0"]
+    #[clippy::version = "1.71.0"]
     pub PTR_CAST_CONSTNESS,
     pedantic,
     "casting using `as` from and to raw pointers to change constness when specialized methods apply"

--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -1,15 +1,24 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::sugg::Sugg;
+use clippy_utils::{diagnostics::span_lint_and_sugg, msrvs::Msrv};
 use if_chain::if_chain;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, Mutability};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, Ty, TypeAndMut};
+use rustc_semver::RustcVersion;
 
 use super::PTR_CAST_CONSTNESS;
 
-pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>) {
+pub(super) fn check(
+    cx: &LateContext<'_>,
+    expr: &Expr<'_>,
+    cast_expr: &Expr<'_>,
+    cast_from: Ty<'_>,
+    cast_to: Ty<'_>,
+    msrv: &Msrv,
+) {
     if_chain! {
+        if msrv.meets(RustcVersion::new(1,65,0));
         if let ty::RawPtr(TypeAndMut { mutbl: from_mutbl, .. }) = cast_from.kind();
         if let ty::RawPtr(TypeAndMut { mutbl: to_mutbl, .. }) = cast_to.kind();
         if !matches!((from_mutbl, to_mutbl),

--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -1,3 +1,4 @@
+use clippy_utils::msrvs::POINTER_CAST_CONSTNESS;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{diagnostics::span_lint_and_sugg, msrvs::Msrv};
 use if_chain::if_chain;
@@ -5,7 +6,6 @@ use rustc_errors::Applicability;
 use rustc_hir::{Expr, Mutability};
 use rustc_lint::LateContext;
 use rustc_middle::ty::{self, Ty, TypeAndMut};
-use rustc_semver::RustcVersion;
 
 use super::PTR_CAST_CONSTNESS;
 
@@ -18,7 +18,7 @@ pub(super) fn check(
     msrv: &Msrv,
 ) {
     if_chain! {
-        if msrv.meets(RustcVersion::new(1,65,0));
+        if msrv.meets(POINTER_CAST_CONSTNESS);
         if let ty::RawPtr(TypeAndMut { mutbl: from_mutbl, .. }) = cast_from.kind();
         if let ty::RawPtr(TypeAndMut { mutbl: to_mutbl, .. }) = cast_to.kind();
         if matches!((from_mutbl, to_mutbl),

--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -1,0 +1,35 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::sugg::Sugg;
+use if_chain::if_chain;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, Mutability};
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, Ty, TypeAndMut};
+
+use super::PTR_CAST_CONSTNESS;
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>) {
+    if_chain! {
+        if let ty::RawPtr(TypeAndMut { mutbl: from_mutbl, .. }) = cast_from.kind();
+        if let ty::RawPtr(TypeAndMut { mutbl: to_mutbl, .. }) = cast_to.kind();
+        if !matches!((from_mutbl, to_mutbl),
+            (Mutability::Not, Mutability::Not) | (Mutability::Mut, Mutability::Mut));
+        then {
+            let sugg = Sugg::hir(cx, cast_expr, "_");
+            let constness = match *to_mutbl {
+                Mutability::Not => "const",
+                Mutability::Mut => "mut",
+            };
+
+            span_lint_and_sugg(
+                cx,
+                PTR_CAST_CONSTNESS,
+                expr.span,
+                "`as` casting between raw pointers while changing its constness",
+                &format!("try `pointer::cast_{constness}`, a safer alternative"),
+                format!("{}.cast_{constness}()", sugg.maybe_par()),
+                Applicability::MachineApplicable,
+            );
+        }
+    }
+}

--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -21,8 +21,8 @@ pub(super) fn check(
         if msrv.meets(RustcVersion::new(1,65,0));
         if let ty::RawPtr(TypeAndMut { mutbl: from_mutbl, .. }) = cast_from.kind();
         if let ty::RawPtr(TypeAndMut { mutbl: to_mutbl, .. }) = cast_to.kind();
-        if !matches!((from_mutbl, to_mutbl),
-            (Mutability::Not, Mutability::Not) | (Mutability::Mut, Mutability::Mut));
+        if matches!((from_mutbl, to_mutbl),
+            (Mutability::Not, Mutability::Mut) | (Mutability::Mut, Mutability::Not));
         then {
             let sugg = Sugg::hir(cx, cast_expr, "_");
             let constness = match *to_mutbl {

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -89,6 +89,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::casts::FN_TO_NUMERIC_CAST_ANY_INFO,
     crate::casts::FN_TO_NUMERIC_CAST_WITH_TRUNCATION_INFO,
     crate::casts::PTR_AS_PTR_INFO,
+    crate::casts::PTR_CAST_CONSTNESS_INFO,
     crate::casts::UNNECESSARY_CAST_INFO,
     crate::checked_conversions::CHECKED_CONVERSIONS_INFO,
     crate::cognitive_complexity::COGNITIVE_COMPLEXITY_INFO,

--- a/clippy_utils/src/msrvs.rs
+++ b/clippy_utils/src/msrvs.rs
@@ -20,7 +20,7 @@ macro_rules! msrv_aliases {
 // names may refer to stabilized feature flags or library items
 msrv_aliases! {
     1,68,0 { PATH_MAIN_SEPARATOR_STR }
-    1,65,0 { LET_ELSE }
+    1,65,0 { LET_ELSE, POINTER_CAST_CONSTNESS }
     1,62,0 { BOOL_THEN_SOME, DEFAULT_ENUM_ATTRIBUTE }
     1,58,0 { FORMAT_ARGS_CAPTURE, PATTERN_TRAIT_CHAR_ARRAY }
     1,55,0 { SEEK_REWIND }

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -36,7 +36,7 @@ fn main() {
 }
 
 #[clippy::msrv = "1.64"]
-fn _msrv_1_37() {
+fn _msrv_1_64() {
     let ptr: *const u32 = &42_u32;
     let mut_ptr: *mut u32 = &mut 42_u32;
 
@@ -46,7 +46,7 @@ fn _msrv_1_37() {
 }
 
 #[clippy::msrv = "1.65"]
-fn _msrv_1_38() {
+fn _msrv_1_65() {
     let ptr: *const u32 = &42_u32;
     let mut_ptr: *mut u32 = &mut 42_u32;
 

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -41,8 +41,8 @@ fn _msrv_1_37() {
     let mut_ptr: *mut u32 = &mut 42_u32;
 
     // `pointer::cast_const` and `pointer::cast_mut` were stabilized in 1.65. Do not lint this
-    let _ = ptr.cast_mut();
-    let _ = mut_ptr.cast_const();
+    let _ = ptr as *mut i32;
+    let _ = mut_ptr as *const i32;
 }
 
 #[clippy::msrv = "1.65"]

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -1,0 +1,55 @@
+//@run-rustfix
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::ptr_cast_constness)]
+
+extern crate proc_macros;
+use proc_macros::{external, inline_macros};
+
+#[inline_macros]
+fn main() {
+    let ptr: *const u32 = &42_u32;
+    let mut_ptr: *mut u32 = &mut 42_u32;
+
+    let _ = ptr as *const i32;
+    let _ = mut_ptr as *mut i32;
+
+    // Make sure the lint can handle the difference in their operator precedences.
+    unsafe {
+        let ptr_ptr: *const *const u32 = &ptr;
+        let _ = (*ptr_ptr).cast_mut();
+    }
+
+    let _ = ptr.cast_mut();
+    let _ = mut_ptr.cast_const();
+
+    // Lint this, since pointer::cast_mut and pointer::cast_const have ?Sized
+    let ptr_of_array: *const [u32; 4] = &[1, 2, 3, 4];
+    let _ = ptr_of_array as *const [u32];
+    let _ = ptr_of_array as *const dyn std::fmt::Debug;
+
+    // Make sure the lint is triggered inside a macro
+    let _ = inline!($ptr as *const i32);
+
+    // Do not lint inside macros from external crates
+    let _ = external!($ptr as *const i32);
+}
+
+#[clippy::msrv = "1.64"]
+fn _msrv_1_37() {
+    let ptr: *const u32 = &42_u32;
+    let mut_ptr: *mut u32 = &mut 42_u32;
+
+    // `pointer::cast_const` and `pointer::cast_mut` were stabilized in 1.65. Do not lint this
+    let _ = ptr.cast_mut();
+    let _ = mut_ptr.cast_const();
+}
+
+#[clippy::msrv = "1.65"]
+fn _msrv_1_38() {
+    let ptr: *const u32 = &42_u32;
+    let mut_ptr: *mut u32 = &mut 42_u32;
+
+    let _ = ptr.cast_mut();
+    let _ = mut_ptr.cast_const();
+}

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -36,7 +36,7 @@ fn main() {
 }
 
 #[clippy::msrv = "1.64"]
-fn _msrv_1_37() {
+fn _msrv_1_64() {
     let ptr: *const u32 = &42_u32;
     let mut_ptr: *mut u32 = &mut 42_u32;
 
@@ -46,7 +46,7 @@ fn _msrv_1_37() {
 }
 
 #[clippy::msrv = "1.65"]
-fn _msrv_1_38() {
+fn _msrv_1_65() {
     let ptr: *const u32 = &42_u32;
     let mut_ptr: *mut u32 = &mut 42_u32;
 

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -1,0 +1,55 @@
+//@run-rustfix
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::ptr_cast_constness)]
+
+extern crate proc_macros;
+use proc_macros::{external, inline_macros};
+
+#[inline_macros]
+fn main() {
+    let ptr: *const u32 = &42_u32;
+    let mut_ptr: *mut u32 = &mut 42_u32;
+
+    let _ = ptr as *const i32;
+    let _ = mut_ptr as *mut i32;
+
+    // Make sure the lint can handle the difference in their operator precedences.
+    unsafe {
+        let ptr_ptr: *const *const u32 = &ptr;
+        let _ = *ptr_ptr as *mut i32;
+    }
+
+    let _ = ptr as *mut i32;
+    let _ = mut_ptr as *const i32;
+
+    // Lint this, since pointer::cast_mut and pointer::cast_const have ?Sized
+    let ptr_of_array: *const [u32; 4] = &[1, 2, 3, 4];
+    let _ = ptr_of_array as *const [u32];
+    let _ = ptr_of_array as *const dyn std::fmt::Debug;
+
+    // Make sure the lint is triggered inside a macro
+    let _ = inline!($ptr as *const i32);
+
+    // Do not lint inside macros from external crates
+    let _ = external!($ptr as *const i32);
+}
+
+#[clippy::msrv = "1.64"]
+fn _msrv_1_37() {
+    let ptr: *const u32 = &42_u32;
+    let mut_ptr: *mut u32 = &mut 42_u32;
+
+    // `pointer::cast_const` and `pointer::cast_mut` were stabilized in 1.65. Do not lint this
+    let _ = ptr as *mut i32;
+    let _ = mut_ptr as *const i32;
+}
+
+#[clippy::msrv = "1.65"]
+fn _msrv_1_38() {
+    let ptr: *const u32 = &42_u32;
+    let mut_ptr: *mut u32 = &mut 42_u32;
+
+    let _ = ptr as *mut i32;
+    let _ = mut_ptr as *const i32;
+}

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -1,0 +1,46 @@
+error: `as` casting between raw pointers while changing its constness
+  --> $DIR/ptr_cast_constness.rs:20:17
+   |
+LL |         let _ = *ptr_ptr as *mut i32;
+   |                 ^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `(*ptr_ptr).cast_mut()`
+   |
+   = note: `-D clippy::ptr-cast-constness` implied by `-D warnings`
+
+error: `as` casting between raw pointers while changing its constness
+  --> $DIR/ptr_cast_constness.rs:23:13
+   |
+LL |     let _ = ptr as *mut i32;
+   |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
+
+error: `as` casting between raw pointers while changing its constness
+  --> $DIR/ptr_cast_constness.rs:24:13
+   |
+LL |     let _ = mut_ptr as *const i32;
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
+
+error: `as` casting between raw pointers while changing its constness
+  --> $DIR/ptr_cast_constness.rs:44:13
+   |
+LL |     let _ = ptr as *mut i32;
+   |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
+
+error: `as` casting between raw pointers while changing its constness
+  --> $DIR/ptr_cast_constness.rs:45:13
+   |
+LL |     let _ = mut_ptr as *const i32;
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
+
+error: `as` casting between raw pointers while changing its constness
+  --> $DIR/ptr_cast_constness.rs:53:13
+   |
+LL |     let _ = ptr as *mut i32;
+   |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
+
+error: `as` casting between raw pointers while changing its constness
+  --> $DIR/ptr_cast_constness.rs:54:13
+   |
+LL |     let _ = mut_ptr as *const i32;
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
+
+error: aborting due to 7 previous errors
+

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -19,18 +19,6 @@ LL |     let _ = mut_ptr as *const i32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
 error: `as` casting between raw pointers while changing its constness
-  --> $DIR/ptr_cast_constness.rs:44:13
-   |
-LL |     let _ = ptr as *mut i32;
-   |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
-
-error: `as` casting between raw pointers while changing its constness
-  --> $DIR/ptr_cast_constness.rs:45:13
-   |
-LL |     let _ = mut_ptr as *const i32;
-   |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
-
-error: `as` casting between raw pointers while changing its constness
   --> $DIR/ptr_cast_constness.rs:53:13
    |
 LL |     let _ = ptr as *mut i32;
@@ -42,5 +30,5 @@ error: `as` casting between raw pointers while changing its constness
 LL |     let _ = mut_ptr as *const i32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This adds a new lint which functions as the opposite side of the coin to `ptr_as_ptr`. Rather than linting only as casts that don't change constness, this lints only constness; suggesting to use `pointer::cast_const` or `pointer::cast_mut` instead.

changelog: new lint [`ptr_cast_constness`]
