### PR TITLE
flip1995: Stepping down from the reviewer rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,9 +17,9 @@ contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIB
 
 [assign.owners]
 "/.github" = ["@flip1995"]
+"/book" = ["@flip1995"]
 "/util/gh-pages" = ["@xFrednet"]
 "*" = [
-    "@flip1995",
     "@Manishearth",
     "@llogiq",
     "@giraffate",


### PR DESCRIPTION
A step I was trying to avoid for way too long, but sadly necessary now. I hope I can come back stronger in a few months.

More explanation on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Stepping.20back.20from.20review.20rotation/near/358384096)

changelog: none
