### PR TITLE
Remove unnecessary `clone` from `needless_collect` example

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3133,8 +3133,11 @@ declare_clippy_lint! {
     /// ### Example
     /// ```rust
     /// # let iterator = vec![1].into_iter();
-    /// let len = iterator.clone().collect::<Vec<_>>().len();
-    /// // should be
+    /// let len = iterator.collect::<Vec<_>>().len();
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// # let iterator = vec![1].into_iter();
     /// let len = iterator.count();
     /// ```
     #[clippy::version = "1.30.0"]


### PR DESCRIPTION
The example for [clippy::needless_collect](https://rust-lang.github.io/rust-clippy/master/#needless_collect) is written as follows:

```rust
let len = iterator.clone().collect::<Vec<_>>().len();
// should be
let len = iterator.count();
```

With this change, the unnecessary `clone()` is removed and the the standard

    ### Example
    ```rust
    // original
    ```
    Use instead:
    ```rust
    // improved
    ```

structure is followed.

Discussion: https://github.com/rust-lang/rust-clippy/discussions/10784#discussion-5198885

changelog: [`needless_collect`]: Cleaned up the example in the lint documentation.
