### PR TITLE
Fix missing block for unsafe code

### DIFF
--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -73,7 +73,6 @@ pub fn expr_block<T: LintContext>(
     let (code, from_macro) = snippet_block_with_context(cx, expr.span, outer, default, indent_relative_to, app);
     if !from_macro &&
         let ExprKind::Block(block, _) = expr.kind &&
-        // TODO: Is this enough UnsafeSource::UserProvided, or should CompilerGenerated be also included?
         block.rules != BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
     {
         format!("{code}")

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -4,7 +4,7 @@
 
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{BlockCheckMode, Expr, ExprKind, UnsafeSource};
 use rustc_lint::{LateContext, LintContext};
 use rustc_session::Session;
 use rustc_span::source_map::{original_sp, SourceMap};
@@ -71,11 +71,17 @@ pub fn expr_block<T: LintContext>(
     app: &mut Applicability,
 ) -> String {
     let (code, from_macro) = snippet_block_with_context(cx, expr.span, outer, default, indent_relative_to, app);
-    if from_macro {
-        format!("{{ {code} }}")
-    } else if let ExprKind::Block(_, _) = expr.kind {
+    if !from_macro &&
+        let ExprKind::Block(block, _) = expr.kind &&
+        // TODO: Is this enough UnsafeSource::UserProvided, or should CompilerGenerated be also included?
+        block.rules != BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
+    {
         format!("{code}")
     } else {
+        // FIXME: add extra indent for the unsafe blocks:
+        //     original code:   unsafe { ... }
+        //     result code:     { unsafe { ... } }
+        //     desired code:    {\n  unsafe { ... }\n}
         format!("{{ {code} }}")
     }
 }

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -6,27 +6,15 @@ fn dummy() {}
 fn single_match() {
     let x = Some(1u8);
 
-    match x {
-        Some(y) => {
-            println!("{:?}", y);
-        },
-        _ => (),
+    if let Some(y) = x {
+        println!("{:?}", y);
     };
 
     let x = Some(1u8);
-    match x {
-        // Note the missing block braces.
-        // We suggest `if let Some(y) = x { .. }` because the macro
-        // is expanded before we can do anything.
-        Some(y) => println!("{:?}", y),
-        _ => (),
-    }
+    if let Some(y) = x { println!("{:?}", y) }
 
     let z = (1u8, 1u8);
-    match z {
-        (2..=3, 7..=9) => dummy(),
-        _ => {},
-    };
+    if let (2..=3, 7..=9) = z { dummy() };
 
     // Not linted (pattern guards used)
     match x {
@@ -52,22 +40,13 @@ fn single_match_know_enum() {
     let x = Some(1u8);
     let y: Result<_, i8> = Ok(1i8);
 
-    match x {
-        Some(y) => dummy(),
-        None => (),
-    };
+    if let Some(y) = x { dummy() };
 
-    match y {
-        Ok(y) => dummy(),
-        Err(..) => (),
-    };
+    if let Ok(y) = y { dummy() };
 
     let c = Cow::Borrowed("");
 
-    match c {
-        Cow::Borrowed(..) => dummy(),
-        Cow::Owned(..) => (),
-    };
+    if let Cow::Borrowed(..) = c { dummy() };
 
     let z = Foo::Bar;
     // no warning
@@ -85,10 +64,7 @@ fn single_match_know_enum() {
 // issue #173
 fn if_suggestion() {
     let x = "test";
-    match x {
-        "test" => println!(),
-        _ => (),
-    }
+    if x == "test" { println!() }
 
     #[derive(PartialEq, Eq)]
     enum Foo {
@@ -98,27 +74,15 @@ fn if_suggestion() {
     }
 
     let x = Foo::A;
-    match x {
-        Foo::A => println!(),
-        _ => (),
-    }
+    if x == Foo::A { println!() }
 
     const FOO_C: Foo = Foo::C(0);
-    match x {
-        FOO_C => println!(),
-        _ => (),
-    }
+    if x == FOO_C { println!() }
 
-    match &&x {
-        Foo::A => println!(),
-        _ => (),
-    }
+    if x == Foo::A { println!() }
 
     let x = &x;
-    match &x {
-        Foo::A => println!(),
-        _ => (),
-    }
+    if x == &Foo::A { println!() }
 
     enum Bar {
         A,
@@ -132,18 +96,12 @@ fn if_suggestion() {
     impl Eq for Bar {}
 
     let x = Bar::A;
-    match x {
-        Bar::A => println!(),
-        _ => (),
-    }
+    if let Bar::A = x { println!() }
 
     // issue #7038
     struct X;
     let x = Some(X);
-    match x {
-        None => println!(),
-        _ => (),
-    };
+    if let None = x { println!() };
 }
 
 // See: issue #8282
@@ -162,22 +120,13 @@ fn ranges() {
     }
 
     // lint
-    match x {
-        (Some(_), _) => {},
-        (None, _) => {},
-    }
+    if let (Some(_), _) = x {}
 
     // lint
-    match x {
-        (Some(E::V), _) => todo!(),
-        (_, _) => {},
-    }
+    if let (Some(E::V), _) = x { todo!() }
 
     // lint
-    match (Some(42), Some(E::V), Some(42)) {
-        (.., Some(E::V), _) => {},
-        (..) => {},
-    }
+    if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}
 
     // Don't lint, see above.
     match (Some(E::V), Some(E::V), Some(E::V)) {
@@ -246,22 +195,15 @@ fn main() {
 }
 
 fn issue_10808(bar: Option<i32>) {
-    match bar {
-        Some(v) => unsafe {
+    if let Some(v) = bar { unsafe {
+        let r = &v as *const i32;
+        println!("{}", *r);
+    } }
+
+    if let Some(v) = bar {
+        unsafe {
             let r = &v as *const i32;
             println!("{}", *r);
-        },
-        _ => {},
-    }
-
-    match bar {
-        #[rustfmt::skip]
-        Some(v) => {
-            unsafe {
-                let r = &v as *const i32;
-                println!("{}", *r);
-            }
-        },
-        _ => {},
+        }
     }
 }

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::single_match)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(unused, clippy::uninlined_format_args)]
 
 fn dummy() {}
 
@@ -243,4 +243,25 @@ fn main() {
         Some(x) => x,
         _ => 0,
     };
+}
+
+fn issue_10808(bar: Option<i32>) {
+    match bar {
+        Some(v) => unsafe {
+            let r = &v as *const i32;
+            println!("{}", *r);
+        },
+        _ => {},
+    }
+
+    match bar {
+        Some(v) => {
+            // this comment prevents rustfmt from collapsing the block
+            unsafe {
+                let r = &v as *const i32;
+                println!("{}", *r);
+            }
+        },
+        _ => {},
+    }
 }

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -255,8 +255,8 @@ fn issue_10808(bar: Option<i32>) {
     }
 
     match bar {
+        #[rustfmt::skip]
         Some(v) => {
-            // this comment prevents rustfmt from collapsing the block
             unsafe {
                 let r = &v as *const i32;
                 println!("{}", *r);

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -155,5 +155,48 @@ LL | |         (..) => {},
 LL | |     }
    | |_____^ help: try this: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
-error: aborting due to 16 previous errors
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:249:5
+   |
+LL | /     match bar {
+LL | |         Some(v) => unsafe {
+LL | |             let r = &v as *const i32;
+LL | |             println!("{}", *r);
+LL | |         },
+LL | |         _ => {},
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(v) = bar { unsafe {
+LL +         let r = &v as *const i32;
+LL +         println!("{}", *r);
+LL +     } }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match.rs:257:5
+   |
+LL | /     match bar {
+LL | |         Some(v) => {
+LL | |             // this comment prevents rustfmt from collapsing the block
+LL | |             unsafe {
+...  |
+LL | |         _ => {},
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(v) = bar {
+LL +         // this comment prevents rustfmt from collapsing the block
+LL +         unsafe {
+LL +             let r = &v as *const i32;
+LL +             println!("{}", *r);
+LL +         }
+LL +     }
+   |
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -179,8 +179,8 @@ error: you seem to be trying to use `match` for destructuring a single pattern. 
   --> $DIR/single_match.rs:257:5
    |
 LL | /     match bar {
+LL | |         #[rustfmt::skip]
 LL | |         Some(v) => {
-LL | |             // this comment prevents rustfmt from collapsing the block
 LL | |             unsafe {
 ...  |
 LL | |         _ => {},
@@ -190,7 +190,6 @@ LL | |     }
 help: try this
    |
 LL ~     if let Some(v) = bar {
-LL +         // this comment prevents rustfmt from collapsing the block
 LL +         unsafe {
 LL +             let r = &v as *const i32;
 LL +             println!("{}", *r);

--- a/tests/ui/single_match_else.fixed
+++ b/tests/ui/single_match_else.fixed
@@ -14,12 +14,9 @@ enum ExprNode {
 static NODE: ExprNode = ExprNode::Unicorns;
 
 fn unwrap_addr() -> Option<&'static ExprNode> {
-    let _ = match ExprNode::Butterflies {
-        ExprNode::ExprAddrOf => Some(&NODE),
-        _ => {
-            let x = 5;
-            None
-        },
+    let _ = if let ExprNode::ExprAddrOf = ExprNode::Butterflies { Some(&NODE) } else {
+        let x = 5;
+        None
     };
 
     // Don't lint
@@ -79,91 +76,66 @@ fn main() {
     //
 
     // lint here
-    match Some(1) {
-        Some(a) => println!("${:?}", a),
-        None => {
-            println!("else block");
-            return
-        },
+    if let Some(a) = Some(1) { println!("${:?}", a) } else {
+        println!("else block");
+        return
     }
 
     // lint here
-    match Some(1) {
-        Some(a) => println!("${:?}", a),
-        None => {
-            println!("else block");
-            return;
-        },
+    if let Some(a) = Some(1) { println!("${:?}", a) } else {
+        println!("else block");
+        return;
     }
 
     // lint here
     use std::convert::Infallible;
-    match Result::<i32, Infallible>::Ok(1) {
-        Ok(a) => println!("${:?}", a),
-        Err(_) => {
-            println!("else block");
-            return;
-        }
+    if let Ok(a) = Result::<i32, Infallible>::Ok(1) { println!("${:?}", a) } else {
+        println!("else block");
+        return;
     }
 
     use std::borrow::Cow;
-    match Cow::from("moo") {
-        Cow::Owned(a) => println!("${:?}", a),
-        Cow::Borrowed(_) => {
-            println!("else block");
-            return;
-        }
+    if let Cow::Owned(a) = Cow::from("moo") { println!("${:?}", a) } else {
+        println!("else block");
+        return;
     }
 }
 
 fn issue_10808(bar: Option<i32>) {
-    match bar {
-        Some(v) => unsafe {
-            let r = &v as *const i32;
-            println!("{}", *r);
-        },
-        None => {
-            println!("None1");
-            println!("None2");
-        },
+    if let Some(v) = bar { unsafe {
+        let r = &v as *const i32;
+        println!("{}", *r);
+    } } else {
+        println!("None1");
+        println!("None2");
     }
 
-    match bar {
-        Some(v) => {
-            println!("Some");
-            println!("{v}");
-        },
-        None => unsafe {
-            let v = 0;
-            let r = &v as *const i32;
-            println!("{}", *r);
-        },
-    }
+    if let Some(v) = bar {
+        println!("Some");
+        println!("{v}");
+    } else { unsafe {
+        let v = 0;
+        let r = &v as *const i32;
+        println!("{}", *r);
+    } }
 
-    match bar {
-        Some(v) => unsafe {
-            let r = &v as *const i32;
-            println!("{}", *r);
-        },
-        None => unsafe {
-            let v = 0;
-            let r = &v as *const i32;
-            println!("{}", *r);
-        },
-    }
+    if let Some(v) = bar { unsafe {
+        let r = &v as *const i32;
+        println!("{}", *r);
+    } } else { unsafe {
+        let v = 0;
+        let r = &v as *const i32;
+        println!("{}", *r);
+    } }
 
-    match bar {
-        #[rustfmt::skip]
-        Some(v) => {
-            unsafe {
-                let r = &v as *const i32;
-                println!("{}", *r);
-            }
-        },
-        None => {
-            println!("None");
-            println!("None");
-        },
+    if let Some(v) = bar {
+        unsafe {
+            let r = &v as *const i32;
+            println!("{}", *r);
+        }
+    } else {
+        println!("None");
+        println!("None");
     }
 
     match bar {

--- a/tests/ui/single_match_else.rs
+++ b/tests/ui/single_match_else.rs
@@ -153,8 +153,8 @@ fn issue_10808(bar: Option<i32>) {
     }
 
     match bar {
+        #[rustfmt::skip]
         Some(v) => {
-            // this comment prevents rustfmt from collapsing the block
             unsafe {
                 let r = &v as *const i32;
                 println!("{}", *r);
@@ -171,8 +171,8 @@ fn issue_10808(bar: Option<i32>) {
             println!("Some");
             println!("{v}");
         },
+        #[rustfmt::skip]
         None => {
-            // this comment prevents rustfmt from collapsing the block
             unsafe {
                 let v = 0;
                 let r = &v as *const i32;
@@ -182,15 +182,15 @@ fn issue_10808(bar: Option<i32>) {
     }
 
     match bar {
+        #[rustfmt::skip]
         Some(v) => {
-            // this comment prevents rustfmt from collapsing the block
             unsafe {
                 let r = &v as *const i32;
                 println!("{}", *r);
             }
         },
+        #[rustfmt::skip]
         None => {
-            // this comment prevents rustfmt from collapsing the block
             unsafe {
                 let v = 0;
                 let r = &v as *const i32;

--- a/tests/ui/single_match_else.rs
+++ b/tests/ui/single_match_else.rs
@@ -1,6 +1,6 @@
 //@aux-build: proc_macros.rs
 #![warn(clippy::single_match_else)]
-#![allow(clippy::needless_return, clippy::no_effect, clippy::uninlined_format_args)]
+#![allow(unused, clippy::needless_return, clippy::no_effect, clippy::uninlined_format_args)]
 
 extern crate proc_macros;
 use proc_macros::with_span;
@@ -113,5 +113,89 @@ fn main() {
             println!("else block");
             return;
         }
+    }
+}
+
+fn issue_10808(bar: Option<i32>) {
+    match bar {
+        Some(v) => unsafe {
+            let r = &v as *const i32;
+            println!("{}", *r);
+        },
+        None => {
+            println!("None1");
+            println!("None2");
+        },
+    }
+
+    match bar {
+        Some(v) => {
+            println!("Some");
+            println!("{v}");
+        },
+        None => unsafe {
+            let v = 0;
+            let r = &v as *const i32;
+            println!("{}", *r);
+        },
+    }
+
+    match bar {
+        Some(v) => unsafe {
+            let r = &v as *const i32;
+            println!("{}", *r);
+        },
+        None => unsafe {
+            let v = 0;
+            let r = &v as *const i32;
+            println!("{}", *r);
+        },
+    }
+
+    match bar {
+        Some(v) => {
+            // this comment prevents rustfmt from collapsing the block
+            unsafe {
+                let r = &v as *const i32;
+                println!("{}", *r);
+            }
+        },
+        None => {
+            println!("None");
+            println!("None");
+        },
+    }
+
+    match bar {
+        Some(v) => {
+            println!("Some");
+            println!("{v}");
+        },
+        None => {
+            // this comment prevents rustfmt from collapsing the block
+            unsafe {
+                let v = 0;
+                let r = &v as *const i32;
+                println!("{}", *r);
+            }
+        },
+    }
+
+    match bar {
+        Some(v) => {
+            // this comment prevents rustfmt from collapsing the block
+            unsafe {
+                let r = &v as *const i32;
+                println!("{}", *r);
+            }
+        },
+        None => {
+            // this comment prevents rustfmt from collapsing the block
+            unsafe {
+                let v = 0;
+                let r = &v as *const i32;
+                println!("{}", *r);
+            }
+        },
     }
 }

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -175,8 +175,8 @@ error: you seem to be trying to use `match` for destructuring a single pattern. 
   --> $DIR/single_match_else.rs:155:5
    |
 LL | /     match bar {
+LL | |         #[rustfmt::skip]
 LL | |         Some(v) => {
-LL | |             // this comment prevents rustfmt from collapsing the block
 LL | |             unsafe {
 ...  |
 LL | |         },
@@ -186,7 +186,6 @@ LL | |     }
 help: try this
    |
 LL ~     if let Some(v) = bar {
-LL +         // this comment prevents rustfmt from collapsing the block
 LL +         unsafe {
 LL +             let r = &v as *const i32;
 LL +             println!("{}", *r);

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -100,5 +100,102 @@ LL +         return;
 LL +     }
    |
 
-error: aborting due to 5 previous errors
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:120:5
+   |
+LL | /     match bar {
+LL | |         Some(v) => unsafe {
+LL | |             let r = &v as *const i32;
+LL | |             println!("{}", *r);
+...  |
+LL | |         },
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(v) = bar { unsafe {
+LL +         let r = &v as *const i32;
+LL +         println!("{}", *r);
+LL +     } } else {
+LL +         println!("None1");
+LL +         println!("None2");
+LL +     }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:131:5
+   |
+LL | /     match bar {
+LL | |         Some(v) => {
+LL | |             println!("Some");
+LL | |             println!("{v}");
+...  |
+LL | |         },
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(v) = bar {
+LL +         println!("Some");
+LL +         println!("{v}");
+LL +     } else { unsafe {
+LL +         let v = 0;
+LL +         let r = &v as *const i32;
+LL +         println!("{}", *r);
+LL +     } }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:143:5
+   |
+LL | /     match bar {
+LL | |         Some(v) => unsafe {
+LL | |             let r = &v as *const i32;
+LL | |             println!("{}", *r);
+...  |
+LL | |         },
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(v) = bar { unsafe {
+LL +         let r = &v as *const i32;
+LL +         println!("{}", *r);
+LL +     } } else { unsafe {
+LL +         let v = 0;
+LL +         let r = &v as *const i32;
+LL +         println!("{}", *r);
+LL +     } }
+   |
+
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> $DIR/single_match_else.rs:155:5
+   |
+LL | /     match bar {
+LL | |         Some(v) => {
+LL | |             // this comment prevents rustfmt from collapsing the block
+LL | |             unsafe {
+...  |
+LL | |         },
+LL | |     }
+   | |_____^
+   |
+help: try this
+   |
+LL ~     if let Some(v) = bar {
+LL +         // this comment prevents rustfmt from collapsing the block
+LL +         unsafe {
+LL +             let r = &v as *const i32;
+LL +             println!("{}", *r);
+LL +         }
+LL +     } else {
+LL +         println!("None");
+LL +         println!("None");
+LL +     }
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
If a block is declared as unsafe, it needs an extra layer of curly braces around it.

Fixes #10808

This code adds handling for `UnsafeSource::UserProvided` block, i.e. `unsafe { ... }`. Note that we do not handle the `UnsafeSource::CompilerGenerated` as it seems to not be possible to generate that with the user code (?), or at least doesn't seem to be needed to be handled explicitly.

There is an issue with this code: it does not add an extra indentation for the unsafe blocks. I think this is a relatively minor concern for such an edge case, and should probably be done by a separate PR (fixing compile bug is more important than getting styling perfect especially when `rustfmt` will fix it anyway)

```rust
// original code
unsafe {
  ...
}

// code that is now generated by this PR
{ unsafe {
  ...
} }

// what we would ideally like to get
{
  unsafe {
    ...
  }
}
```

changelog: [`single_match`](https://rust-lang.github.io/rust-clippy/master/#single_match): Fix suggestion for `unsafe` blocks
