### PR TITLE
needless_else: new lint to check for empty `else` clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4874,6 +4874,7 @@ Released 2018-09-13
 [`needless_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_collect
 [`needless_continue`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
 [`needless_doctest_main`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main
+[`needless_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_else
 [`needless_for_each`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each
 [`needless_late_init`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
 [`needless_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -449,6 +449,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::needless_bool::NEEDLESS_BOOL_ASSIGN_INFO,
     crate::needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE_INFO,
     crate::needless_continue::NEEDLESS_CONTINUE_INFO,
+    crate::needless_else::NEEDLESS_ELSE_INFO,
     crate::needless_for_each::NEEDLESS_FOR_EACH_INFO,
     crate::needless_late_init::NEEDLESS_LATE_INIT_INFO,
     crate::needless_parens_on_range_literals::NEEDLESS_PARENS_ON_RANGE_LITERALS_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -218,6 +218,7 @@ mod needless_arbitrary_self_type;
 mod needless_bool;
 mod needless_borrowed_ref;
 mod needless_continue;
+mod needless_else;
 mod needless_for_each;
 mod needless_late_init;
 mod needless_parens_on_range_literals;
@@ -992,6 +993,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|_| Box::new(items_after_test_module::ItemsAfterTestModule));
     store.register_early_pass(|| Box::new(ref_patterns::RefPatterns));
     store.register_late_pass(|_| Box::new(default_constructed_unit_structs::DefaultConstructedUnitStructs));
+    store.register_early_pass(|| Box::new(needless_else::NeedlessElse));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/needless_else.rs
+++ b/clippy_lints/src/needless_else.rs
@@ -1,0 +1,57 @@
+use clippy_utils::{diagnostics::span_lint_and_sugg, source::trim_span, span_extract_comment};
+use rustc_ast::ast::{Expr, ExprKind};
+use rustc_errors::Applicability;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for empty `else` branches.
+    ///
+    /// ### Why is this bad?
+    /// An empty else branch does nothing and can be removed.
+    ///
+    /// ### Example
+    /// ```rust
+    ///# fn check() -> bool { true }
+    /// if check() {
+    ///     println!("Check successful!");
+    /// } else {
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    ///# fn check() -> bool { true }
+    /// if check() {
+    ///     println!("Check successful!");
+    /// }
+    /// ```
+    #[clippy::version = "1.71.0"]
+    pub NEEDLESS_ELSE,
+    style,
+    "empty else branch"
+}
+declare_lint_pass!(NeedlessElse => [NEEDLESS_ELSE]);
+
+impl EarlyLintPass for NeedlessElse {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if let ExprKind::If(_, then_block, Some(else_clause)) = &expr.kind &&
+            let ExprKind::Block(block, _) = &else_clause.kind &&
+            !expr.span.from_expansion() &&
+            !else_clause.span.from_expansion() &&
+            block.stmts.is_empty() {
+                let span = trim_span(cx.sess().source_map(), expr.span.trim_start(then_block.span).unwrap());
+                if span_extract_comment(cx.sess().source_map(), span).is_empty() {
+                    span_lint_and_sugg(
+                        cx,
+                        NEEDLESS_ELSE,
+                        span,
+                        "this else branch is empty",
+                        "you can remove it",
+                        String::new(),
+                        Applicability::MachineApplicable,
+                    );
+                }
+            }
+    }
+}

--- a/tests/ui-toml/ifs_same_cond/ifs_same_cond.rs
+++ b/tests/ui-toml/ifs_same_cond/ifs_same_cond.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::ifs_same_cond)]
-#![allow(clippy::if_same_then_else, clippy::comparison_chain)]
+#![allow(clippy::if_same_then_else, clippy::comparison_chain, clippy::needless_else)]
 
 fn main() {}
 

--- a/tests/ui/branches_sharing_code/valid_if_blocks.rs
+++ b/tests/ui/branches_sharing_code/valid_if_blocks.rs
@@ -1,6 +1,10 @@
 #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
 #![allow(dead_code)]
-#![allow(clippy::mixed_read_write_in_expression, clippy::uninlined_format_args)]
+#![allow(
+    clippy::mixed_read_write_in_expression,
+    clippy::uninlined_format_args,
+    clippy::needless_else
+)]
 
 // This tests valid if blocks that shouldn't trigger the lint
 

--- a/tests/ui/branches_sharing_code/valid_if_blocks.stderr
+++ b/tests/ui/branches_sharing_code/valid_if_blocks.stderr
@@ -1,5 +1,5 @@
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:105:14
+  --> $DIR/valid_if_blocks.rs:109:14
    |
 LL |       if false {
    |  ______________^
@@ -7,7 +7,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:106:12
+  --> $DIR/valid_if_blocks.rs:110:12
    |
 LL |       } else {
    |  ____________^
@@ -20,7 +20,7 @@ LL | #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:116:15
+  --> $DIR/valid_if_blocks.rs:120:15
    |
 LL |       if x == 0 {
    |  _______________^
@@ -31,7 +31,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:120:12
+  --> $DIR/valid_if_blocks.rs:124:12
    |
 LL |       } else {
    |  ____________^
@@ -42,19 +42,19 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:127:23
+  --> $DIR/valid_if_blocks.rs:131:23
    |
 LL |     let _ = if x == 6 { 7 } else { 7 };
    |                       ^^^^^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:127:34
+  --> $DIR/valid_if_blocks.rs:131:34
    |
 LL |     let _ = if x == 6 { 7 } else { 7 };
    |                                  ^^^^^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:133:23
+  --> $DIR/valid_if_blocks.rs:137:23
    |
 LL |       } else if x == 68 {
    |  _______________________^
@@ -66,7 +66,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:138:12
+  --> $DIR/valid_if_blocks.rs:142:12
    |
 LL |       } else {
    |  ____________^
@@ -78,7 +78,7 @@ LL | |     };
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/valid_if_blocks.rs:147:23
+  --> $DIR/valid_if_blocks.rs:151:23
    |
 LL |       } else if x == 68 {
    |  _______________________^
@@ -88,7 +88,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/valid_if_blocks.rs:150:12
+  --> $DIR/valid_if_blocks.rs:154:12
    |
 LL |       } else {
    |  ____________^

--- a/tests/ui/crashes/ice-7410.rs
+++ b/tests/ui/crashes/ice-7410.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::redundant_pattern_matching)]
+#![allow(clippy::needless_else)]
 
 use core::panic::PanicInfo;
 

--- a/tests/ui/ifs_same_cond.rs
+++ b/tests/ui/ifs_same_cond.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::ifs_same_cond)]
-#![allow(clippy::if_same_then_else, clippy::comparison_chain)] // all empty blocks
+#![allow(clippy::if_same_then_else, clippy::comparison_chain, clippy::needless_else)] // all empty blocks
 
 fn ifs_same_cond() {
     let a = 0;

--- a/tests/ui/needless_else.fixed
+++ b/tests/ui/needless_else.fixed
@@ -1,0 +1,40 @@
+//@run-rustfix
+#![allow(unused)]
+#![warn(clippy::needless_else)]
+#![allow(clippy::suspicious_else_formatting)]
+
+macro_rules! mac {
+    ($test:expr) => {
+        if $test {
+            println!("Test successful!");
+        } else {
+        }
+    };
+}
+
+fn main() {
+    let b = std::hint::black_box(true);
+
+    if b {
+        println!("Foobar");
+    } 
+
+    if b {
+        println!("Foobar");
+    } else {
+        // Do not lint because this comment might be important
+    }
+
+    if b {
+        println!("Foobar");
+    } else
+    /* Do not lint because this comment might be important */
+    {
+    }
+
+    // Do not lint because of the expression
+    let _ = if b { 1 } else { 2 };
+
+    // Do not lint because inside a macro
+    mac!(b);
+}

--- a/tests/ui/needless_else.rs
+++ b/tests/ui/needless_else.rs
@@ -1,0 +1,41 @@
+//@run-rustfix
+#![allow(unused)]
+#![warn(clippy::needless_else)]
+#![allow(clippy::suspicious_else_formatting)]
+
+macro_rules! mac {
+    ($test:expr) => {
+        if $test {
+            println!("Test successful!");
+        } else {
+        }
+    };
+}
+
+fn main() {
+    let b = std::hint::black_box(true);
+
+    if b {
+        println!("Foobar");
+    } else {
+    }
+
+    if b {
+        println!("Foobar");
+    } else {
+        // Do not lint because this comment might be important
+    }
+
+    if b {
+        println!("Foobar");
+    } else
+    /* Do not lint because this comment might be important */
+    {
+    }
+
+    // Do not lint because of the expression
+    let _ = if b { 1 } else { 2 };
+
+    // Do not lint because inside a macro
+    mac!(b);
+}

--- a/tests/ui/needless_else.stderr
+++ b/tests/ui/needless_else.stderr
@@ -1,0 +1,12 @@
+error: this else branch is empty
+  --> $DIR/needless_else.rs:20:7
+   |
+LL |       } else {
+   |  _______^
+LL | |     }
+   | |_____^ help: you can remove it
+   |
+   = note: `-D clippy::needless-else` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -7,7 +7,8 @@
     clippy::if_same_then_else,
     clippy::single_match,
     clippy::needless_bool,
-    clippy::equatable_if_let
+    clippy::equatable_if_let,
+    clippy::needless_else
 )]
 #![warn(clippy::needless_return)]
 

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -7,7 +7,8 @@
     clippy::if_same_then_else,
     clippy::single_match,
     clippy::needless_bool,
-    clippy::equatable_if_let
+    clippy::equatable_if_let,
+    clippy::needless_else
 )]
 #![warn(clippy::needless_return)]
 

--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -1,5 +1,5 @@
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:27:5
+  --> $DIR/needless_return.rs:28:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:31:5
+  --> $DIR/needless_return.rs:32:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:36:5
+  --> $DIR/needless_return.rs:37:5
    |
 LL |     return true;;;
    |     ^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     return true;;;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:41:5
+  --> $DIR/needless_return.rs:42:5
    |
 LL |     return true;; ; ;
    |     ^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     return true;; ; ;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:46:9
+  --> $DIR/needless_return.rs:47:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:48:9
+  --> $DIR/needless_return.rs:49:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |         return false;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:54:17
+  --> $DIR/needless_return.rs:55:17
    |
 LL |         true => return false,
    |                 ^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |         true => return false,
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:56:13
+  --> $DIR/needless_return.rs:57:13
    |
 LL |             return true;
    |             ^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |             return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:63:9
+  --> $DIR/needless_return.rs:64:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |         return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:65:16
+  --> $DIR/needless_return.rs:66:16
    |
 LL |     let _ = || return true;
    |                ^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     let _ = || return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:69:5
+  --> $DIR/needless_return.rs:70:5
    |
 LL |     return the_answer!();
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL |     return the_answer!();
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:72:21
+  --> $DIR/needless_return.rs:73:21
    |
 LL |   fn test_void_fun() {
    |  _____________________^
@@ -98,7 +98,7 @@ LL | |     return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:77:11
+  --> $DIR/needless_return.rs:78:11
    |
 LL |       if b {
    |  ___________^
@@ -108,7 +108,7 @@ LL | |         return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:79:13
+  --> $DIR/needless_return.rs:80:13
    |
 LL |       } else {
    |  _____________^
@@ -118,7 +118,7 @@ LL | |         return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:87:14
+  --> $DIR/needless_return.rs:88:14
    |
 LL |         _ => return,
    |              ^^^^^^
@@ -126,7 +126,7 @@ LL |         _ => return,
    = help: replace `return` with a unit value
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:95:24
+  --> $DIR/needless_return.rs:96:24
    |
 LL |               let _ = 42;
    |  ________________________^
@@ -136,7 +136,7 @@ LL | |             return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:98:14
+  --> $DIR/needless_return.rs:99:14
    |
 LL |         _ => return,
    |              ^^^^^^
@@ -144,7 +144,7 @@ LL |         _ => return,
    = help: replace `return` with a unit value
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:111:9
+  --> $DIR/needless_return.rs:112:9
    |
 LL |         return String::from("test");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -152,7 +152,7 @@ LL |         return String::from("test");
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:113:9
+  --> $DIR/needless_return.rs:114:9
    |
 LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -160,7 +160,7 @@ LL |         return String::new();
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:135:32
+  --> $DIR/needless_return.rs:136:32
    |
 LL |         bar.unwrap_or_else(|_| return)
    |                                ^^^^^^
@@ -168,7 +168,7 @@ LL |         bar.unwrap_or_else(|_| return)
    = help: replace `return` with an empty block
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:139:21
+  --> $DIR/needless_return.rs:140:21
    |
 LL |           let _ = || {
    |  _____________________^
@@ -178,7 +178,7 @@ LL | |             return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:142:20
+  --> $DIR/needless_return.rs:143:20
    |
 LL |         let _ = || return;
    |                    ^^^^^^
@@ -186,7 +186,7 @@ LL |         let _ = || return;
    = help: replace `return` with an empty block
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:148:32
+  --> $DIR/needless_return.rs:149:32
    |
 LL |         res.unwrap_or_else(|_| return Foo)
    |                                ^^^^^^^^^^
@@ -194,7 +194,7 @@ LL |         res.unwrap_or_else(|_| return Foo)
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:157:5
+  --> $DIR/needless_return.rs:158:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -202,7 +202,7 @@ LL |     return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:161:5
+  --> $DIR/needless_return.rs:162:5
    |
 LL |     return true;
    |     ^^^^^^^^^^^
@@ -210,7 +210,7 @@ LL |     return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:166:9
+  --> $DIR/needless_return.rs:167:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -218,7 +218,7 @@ LL |         return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:168:9
+  --> $DIR/needless_return.rs:169:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
@@ -226,7 +226,7 @@ LL |         return false;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:174:17
+  --> $DIR/needless_return.rs:175:17
    |
 LL |         true => return false,
    |                 ^^^^^^^^^^^^
@@ -234,7 +234,7 @@ LL |         true => return false,
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:176:13
+  --> $DIR/needless_return.rs:177:13
    |
 LL |             return true;
    |             ^^^^^^^^^^^
@@ -242,7 +242,7 @@ LL |             return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:183:9
+  --> $DIR/needless_return.rs:184:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -250,7 +250,7 @@ LL |         return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:185:16
+  --> $DIR/needless_return.rs:186:16
    |
 LL |     let _ = || return true;
    |                ^^^^^^^^^^^
@@ -258,7 +258,7 @@ LL |     let _ = || return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:189:5
+  --> $DIR/needless_return.rs:190:5
    |
 LL |     return the_answer!();
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -266,7 +266,7 @@ LL |     return the_answer!();
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:192:33
+  --> $DIR/needless_return.rs:193:33
    |
 LL |   async fn async_test_void_fun() {
    |  _________________________________^
@@ -276,7 +276,7 @@ LL | |     return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:197:11
+  --> $DIR/needless_return.rs:198:11
    |
 LL |       if b {
    |  ___________^
@@ -286,7 +286,7 @@ LL | |         return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:199:13
+  --> $DIR/needless_return.rs:200:13
    |
 LL |       } else {
    |  _____________^
@@ -296,7 +296,7 @@ LL | |         return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:207:14
+  --> $DIR/needless_return.rs:208:14
    |
 LL |         _ => return,
    |              ^^^^^^
@@ -304,7 +304,7 @@ LL |         _ => return,
    = help: replace `return` with a unit value
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:220:9
+  --> $DIR/needless_return.rs:221:9
    |
 LL |         return String::from("test");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -312,7 +312,7 @@ LL |         return String::from("test");
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:222:9
+  --> $DIR/needless_return.rs:223:9
    |
 LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -320,7 +320,7 @@ LL |         return String::new();
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:238:5
+  --> $DIR/needless_return.rs:239:5
    |
 LL |     return format!("Hello {}", "world!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -328,7 +328,7 @@ LL |     return format!("Hello {}", "world!");
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:250:9
+  --> $DIR/needless_return.rs:251:9
    |
 LL |         return true;
    |         ^^^^^^^^^^^
@@ -336,7 +336,7 @@ LL |         return true;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:252:9
+  --> $DIR/needless_return.rs:253:9
    |
 LL |         return false;
    |         ^^^^^^^^^^^^
@@ -344,7 +344,7 @@ LL |         return false;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:259:13
+  --> $DIR/needless_return.rs:260:13
    |
 LL |             return 10;
    |             ^^^^^^^^^
@@ -352,7 +352,7 @@ LL |             return 10;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:262:13
+  --> $DIR/needless_return.rs:263:13
    |
 LL |             return 100;
    |             ^^^^^^^^^^
@@ -360,7 +360,7 @@ LL |             return 100;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:270:9
+  --> $DIR/needless_return.rs:271:9
    |
 LL |         return 0;
    |         ^^^^^^^^
@@ -368,7 +368,7 @@ LL |         return 0;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:277:13
+  --> $DIR/needless_return.rs:278:13
    |
 LL |             return *(x as *const isize);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -376,7 +376,7 @@ LL |             return *(x as *const isize);
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:279:13
+  --> $DIR/needless_return.rs:280:13
    |
 LL |             return !*(x as *const isize);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -384,7 +384,7 @@ LL |             return !*(x as *const isize);
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:286:20
+  --> $DIR/needless_return.rs:287:20
    |
 LL |           let _ = 42;
    |  ____________________^
@@ -395,7 +395,7 @@ LL | |         return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:293:20
+  --> $DIR/needless_return.rs:294:20
    |
 LL |         let _ = 42; return;
    |                    ^^^^^^^
@@ -403,7 +403,7 @@ LL |         let _ = 42; return;
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:305:9
+  --> $DIR/needless_return.rs:306:9
    |
 LL |         return Ok(format!("ok!"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -411,7 +411,7 @@ LL |         return Ok(format!("ok!"));
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:307:9
+  --> $DIR/needless_return.rs:308:9
    |
 LL |         return Err(format!("err!"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -419,7 +419,7 @@ LL |         return Err(format!("err!"));
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:313:9
+  --> $DIR/needless_return.rs:314:9
    |
 LL |         return if true { 1 } else { 2 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -427,7 +427,7 @@ LL |         return if true { 1 } else { 2 };
    = help: remove `return`
 
 error: unneeded `return` statement
-  --> $DIR/needless_return.rs:317:9
+  --> $DIR/needless_return.rs:318:9
    |
 LL |         return if b1 { 0 } else { 1 } | if b2 { 2 } else { 3 } | if b3 { 4 } else { 5 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/redundant_pattern_matching_drop_order.fixed
+++ b/tests/ui/redundant_pattern_matching_drop_order.fixed
@@ -2,7 +2,7 @@
 
 // Issue #5746
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(clippy::if_same_then_else, clippy::equatable_if_let)]
+#![allow(clippy::if_same_then_else, clippy::equatable_if_let, clippy::needless_else)]
 use std::task::Poll::{Pending, Ready};
 
 fn main() {

--- a/tests/ui/redundant_pattern_matching_drop_order.rs
+++ b/tests/ui/redundant_pattern_matching_drop_order.rs
@@ -2,7 +2,7 @@
 
 // Issue #5746
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(clippy::if_same_then_else, clippy::equatable_if_let)]
+#![allow(clippy::if_same_then_else, clippy::equatable_if_let, clippy::needless_else)]
 use std::task::Poll::{Pending, Ready};
 
 fn main() {

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macro_suspicious_else_formatting.rs
 
 #![warn(clippy::suspicious_else_formatting)]
-#![allow(clippy::if_same_then_else, clippy::let_unit_value)]
+#![allow(clippy::if_same_then_else, clippy::let_unit_value, clippy::needless_else)]
 
 extern crate proc_macro_suspicious_else_formatting;
 use proc_macro_suspicious_else_formatting::DeriveBadSpan;


### PR DESCRIPTION
Empty `else` clauses are useless. They happen in the wild and are not linted yet: https://github.com/uutils/coreutils/pull/4880/files

`else` clauses containing or preceded by comments are not linted as the comments might be important.

changelog: [`needless_else`]: new lint