### PR TITLE
[`match_wild_err_arm`]: do not lint in const contexts

### DIFF
--- a/clippy_lints/src/matches/match_wild_err_arm.rs
+++ b/clippy_lints/src/matches/match_wild_err_arm.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_note;
 use clippy_utils::macros::{is_panic, root_macro_call};
 use clippy_utils::ty::is_type_diagnostic_item;
 use clippy_utils::visitors::is_local_used;
-use clippy_utils::{is_wild, peel_blocks_with_stmt};
+use clippy_utils::{in_constant, is_wild, peel_blocks_with_stmt};
 use rustc_hir::{Arm, Expr, PatKind};
 use rustc_lint::LateContext;
 use rustc_span::symbol::{kw, sym};
@@ -10,6 +10,11 @@ use rustc_span::symbol::{kw, sym};
 use super::MATCH_WILD_ERR_ARM;
 
 pub(crate) fn check<'tcx>(cx: &LateContext<'tcx>, ex: &Expr<'tcx>, arms: &[Arm<'tcx>]) {
+    // `unwrap`/`expect` is not (yet) const, so we want to allow this in const contexts for now
+    if in_constant(cx, ex.hir_id) {
+        return;
+    }
+
     let ex_ty = cx.typeck_results().expr_ty(ex).peel_refs();
     if is_type_diagnostic_item(cx, ex_ty, sym::Result) {
         for arm in arms {

--- a/tests/ui/match_wild_err_arm.rs
+++ b/tests/ui/match_wild_err_arm.rs
@@ -1,6 +1,19 @@
 #![feature(exclusive_range_pattern)]
-#![allow(clippy::match_same_arms)]
+#![allow(clippy::match_same_arms, dead_code)]
 #![warn(clippy::match_wild_err_arm)]
+
+fn issue_10635() {
+    enum Error {
+        A,
+        B,
+    }
+
+    // Don't trigger in const contexts. Const unwrap is not yet stable
+    const X: () = match Ok::<_, Error>(()) {
+        Ok(x) => x,
+        Err(_) => panic!(),
+    };
+}
 
 fn match_wild_err_arm() {
     let x: Result<i32, &str> = Ok(3);

--- a/tests/ui/match_wild_err_arm.stderr
+++ b/tests/ui/match_wild_err_arm.stderr
@@ -1,5 +1,5 @@
 error: `Err(_)` matches all errors
-  --> $DIR/match_wild_err_arm.rs:11:9
+  --> $DIR/match_wild_err_arm.rs:24:9
    |
 LL |         Err(_) => panic!("err"),
    |         ^^^^^^
@@ -8,7 +8,7 @@ LL |         Err(_) => panic!("err"),
    = note: `-D clippy::match-wild-err-arm` implied by `-D warnings`
 
 error: `Err(_)` matches all errors
-  --> $DIR/match_wild_err_arm.rs:17:9
+  --> $DIR/match_wild_err_arm.rs:30:9
    |
 LL |         Err(_) => panic!(),
    |         ^^^^^^
@@ -16,7 +16,7 @@ LL |         Err(_) => panic!(),
    = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_)` matches all errors
-  --> $DIR/match_wild_err_arm.rs:23:9
+  --> $DIR/match_wild_err_arm.rs:36:9
    |
 LL |         Err(_) => {
    |         ^^^^^^
@@ -24,7 +24,7 @@ LL |         Err(_) => {
    = note: match each error separately or use the error output, or use `.expect(msg)` if the error case is unreachable
 
 error: `Err(_e)` matches all errors
-  --> $DIR/match_wild_err_arm.rs:31:9
+  --> $DIR/match_wild_err_arm.rs:44:9
    |
 LL |         Err(_e) => panic!(),
    |         ^^^^^^^


### PR DESCRIPTION
Fixes #10635.

changelog: [`match_wild_err_arm`]: do not lint in const contexts as `Result::{unwrap, expect}` is not const-stable