### PR TITLE
[`default_constructed_unit_structs`]: do not lint on type alias paths

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -287,7 +287,7 @@ pub fn is_wild(pat: &Pat<'_>) -> bool {
 /// Checks if the given `QPath` belongs to a type alias.
 pub fn is_ty_alias(qpath: &QPath<'_>) -> bool {
     match *qpath {
-        QPath::Resolved(_, path) => matches!(path.res, Res::Def(DefKind::TyAlias, ..)),
+        QPath::Resolved(_, path) => matches!(path.res, Res::Def(DefKind::TyAlias | DefKind::AssocTy, ..)),
         QPath::TypeRelative(ty, _) if let TyKind::Path(qpath) = ty.kind => { is_ty_alias(&qpath) },
         _ => false,
     }

--- a/tests/ui/default_constructed_unit_structs.fixed
+++ b/tests/ui/default_constructed_unit_structs.fixed
@@ -101,6 +101,28 @@ struct EmptyStruct {}
 #[non_exhaustive]
 struct NonExhaustiveStruct;
 
+mod issue_10755 {
+    struct Sqlite {}
+
+    trait HasArguments<'q> {
+        type Arguments;
+    }
+
+    impl<'q> HasArguments<'q> for Sqlite {
+        type Arguments = std::marker::PhantomData<&'q ()>;
+    }
+
+    type SqliteArguments<'q> = <Sqlite as HasArguments<'q>>::Arguments;
+
+    fn foo() {
+        // should not lint
+        // type alias cannot be used as a constructor
+        let _ = <Sqlite as HasArguments>::Arguments::default();
+
+        let _ = SqliteArguments::default();
+    }
+}
+
 fn main() {
     // should lint
     let _ = PhantomData::<usize>;

--- a/tests/ui/default_constructed_unit_structs.rs
+++ b/tests/ui/default_constructed_unit_structs.rs
@@ -101,6 +101,28 @@ struct EmptyStruct {}
 #[non_exhaustive]
 struct NonExhaustiveStruct;
 
+mod issue_10755 {
+    struct Sqlite {}
+
+    trait HasArguments<'q> {
+        type Arguments;
+    }
+
+    impl<'q> HasArguments<'q> for Sqlite {
+        type Arguments = std::marker::PhantomData<&'q ()>;
+    }
+
+    type SqliteArguments<'q> = <Sqlite as HasArguments<'q>>::Arguments;
+
+    fn foo() {
+        // should not lint
+        // type alias cannot be used as a constructor
+        let _ = <Sqlite as HasArguments>::Arguments::default();
+
+        let _ = SqliteArguments::default();
+    }
+}
+
 fn main() {
     // should lint
     let _ = PhantomData::<usize>::default();

--- a/tests/ui/default_constructed_unit_structs.stderr
+++ b/tests/ui/default_constructed_unit_structs.stderr
@@ -13,25 +13,25 @@ LL |             inner: PhantomData::default(),
    |                               ^^^^^^^^^^^ help: remove this call to `default`
 
 error: use of `default` to create a unit struct
-  --> $DIR/default_constructed_unit_structs.rs:106:33
+  --> $DIR/default_constructed_unit_structs.rs:128:33
    |
 LL |     let _ = PhantomData::<usize>::default();
    |                                 ^^^^^^^^^^^ help: remove this call to `default`
 
 error: use of `default` to create a unit struct
-  --> $DIR/default_constructed_unit_structs.rs:107:42
+  --> $DIR/default_constructed_unit_structs.rs:129:42
    |
 LL |     let _: PhantomData<i32> = PhantomData::default();
    |                                          ^^^^^^^^^^^ help: remove this call to `default`
 
 error: use of `default` to create a unit struct
-  --> $DIR/default_constructed_unit_structs.rs:108:55
+  --> $DIR/default_constructed_unit_structs.rs:130:55
    |
 LL |     let _: PhantomData<i32> = std::marker::PhantomData::default();
    |                                                       ^^^^^^^^^^^ help: remove this call to `default`
 
 error: use of `default` to create a unit struct
-  --> $DIR/default_constructed_unit_structs.rs:109:23
+  --> $DIR/default_constructed_unit_structs.rs:131:23
    |
 LL |     let _ = UnitStruct::default();
    |                       ^^^^^^^^^^^ help: remove this call to `default`


### PR DESCRIPTION
Fixes #10755.

Type aliases cannot be used as a constructor, so this lint should not trigger in those cases.
I also changed `clippy_utils::is_ty_alias` to also consider associated types since [they kinda are type aliases too](https://github.com/rust-lang/rust/blob/48ec50ae39d0ca0baa0e78f56c395dcc6d7ebd65/compiler/rustc_resolve/src/late/diagnostics.rs#L1520).

changelog: [`default_constructed_unit_structs`]: do not lint on type alias paths