### PR TITLE
validate lint name in `clippy_dev`

### DIFF
--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -182,7 +182,7 @@ fn get_clap_config() -> ArgMatches {
                         .long("name")
                         .help("Name of the new lint in snake case, ex: fn_too_long")
                         .required(true)
-                        .value_parser(|name: &str| Ok::<_, Infallible>(name.replace("-", "_"))),
+                        .value_parser(|name: &str| Ok::<_, Infallible>(name.replace('-', "_"))),
                     Arg::new("category")
                         .short('c')
                         .long("category")

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -180,7 +180,14 @@ fn get_clap_config() -> ArgMatches {
                         .short('n')
                         .long("name")
                         .help("Name of the new lint in snake case, ex: fn_too_long")
-                        .required(true),
+                        .required(true)
+                        .value_parser(|name: &str| {
+                            if name.contains('-') {
+                                Err("Lint name cannot contain `-`, use `_` instead.")
+                            } else {
+                                Ok(name.to_owned())
+                            }
+                        }),
                     Arg::new("category")
                         .short('c')
                         .long("category")

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -5,6 +5,7 @@
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use clippy_dev::{bless, dogfood, fmt, lint, new_lint, serve, setup, update_lints};
 use indoc::indoc;
+use std::convert::Infallible;
 
 fn main() {
     let matches = get_clap_config();
@@ -181,13 +182,7 @@ fn get_clap_config() -> ArgMatches {
                         .long("name")
                         .help("Name of the new lint in snake case, ex: fn_too_long")
                         .required(true)
-                        .value_parser(|name: &str| {
-                            if name.contains('-') {
-                                Err("Lint name cannot contain `-`, use `_` instead.")
-                            } else {
-                                Ok(name.to_owned())
-                            }
-                        }),
+                        .value_parser(|name: &str| Ok::<_, Infallible>(name.replace("-", "_"))),
                     Arg::new("category")
                         .short('c')
                         .long("category")


### PR DESCRIPTION
This PR adds a little bit of validation to `cargo dev new_lint`. I've had it happen a few times where I wanted to add a new lint, but forgot that lint names cannot contain `-`. If you try to do it anyway, `clippy_dev` will generate illegal syntax (like adding `mod test-lint;` to clippy_lints/src/lib.rs for the module declaration). Maybe having it error out early would be helpful to others too.

changelog: none
