### PR TITLE
Display the `needless_return` suggestion

### DIFF
--- a/tests/ui/needless_return.stderr
+++ b/tests/ui/needless_return.stderr
@@ -5,7 +5,11 @@ LL |     return true;
    |     ^^^^^^^^^^^
    |
    = note: `-D clippy::needless-return` implied by `-D warnings`
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return true;
+LL +     true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:32:5
@@ -13,7 +17,11 @@ error: unneeded `return` statement
 LL |     return true;
    |     ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return true;
+LL +     true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:37:5
@@ -21,7 +29,11 @@ error: unneeded `return` statement
 LL |     return true;;;
    |     ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return true;;;
+LL +     true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:42:5
@@ -29,7 +41,11 @@ error: unneeded `return` statement
 LL |     return true;; ; ;
    |     ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return true;; ; ;
+LL +     true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:47:9
@@ -37,7 +53,11 @@ error: unneeded `return` statement
 LL |         return true;
    |         ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return true;
+LL +         true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:49:9
@@ -45,7 +65,11 @@ error: unneeded `return` statement
 LL |         return false;
    |         ^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return false;
+LL +         false
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:55:17
@@ -53,7 +77,10 @@ error: unneeded `return` statement
 LL |         true => return false,
    |                 ^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL |         true => false,
+   |                 ~~~~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:57:13
@@ -61,7 +88,11 @@ error: unneeded `return` statement
 LL |             return true;
    |             ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -             return true;
+LL +             true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:64:9
@@ -69,7 +100,11 @@ error: unneeded `return` statement
 LL |         return true;
    |         ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return true;
+LL +         true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:66:16
@@ -77,7 +112,10 @@ error: unneeded `return` statement
 LL |     let _ = || return true;
    |                ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL |     let _ = || true;
+   |                ~~~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:70:5
@@ -85,7 +123,11 @@ error: unneeded `return` statement
 LL |     return the_answer!();
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return the_answer!();
+LL +     the_answer!()
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:73:21
@@ -95,7 +137,12 @@ LL |   fn test_void_fun() {
 LL | |     return;
    | |__________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL - fn test_void_fun() {
+LL -     return;
+LL + fn test_void_fun() {
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:78:11
@@ -105,7 +152,12 @@ LL |       if b {
 LL | |         return;
    | |______________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     if b {
+LL -         return;
+LL +     if b {
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:80:13
@@ -115,7 +167,12 @@ LL |       } else {
 LL | |         return;
    | |______________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     } else {
+LL -         return;
+LL +     } else {
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:88:14
@@ -123,7 +180,10 @@ error: unneeded `return` statement
 LL |         _ => return,
    |              ^^^^^^
    |
-   = help: replace `return` with a unit value
+help: replace `return` with a unit value
+   |
+LL |         _ => (),
+   |              ~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:96:24
@@ -133,7 +193,12 @@ LL |               let _ = 42;
 LL | |             return;
    | |__________________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -             let _ = 42;
+LL -             return;
+LL +             let _ = 42;
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:99:14
@@ -141,7 +206,10 @@ error: unneeded `return` statement
 LL |         _ => return,
    |              ^^^^^^
    |
-   = help: replace `return` with a unit value
+help: replace `return` with a unit value
+   |
+LL |         _ => (),
+   |              ~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:112:9
@@ -149,7 +217,11 @@ error: unneeded `return` statement
 LL |         return String::from("test");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return String::from("test");
+LL +         String::from("test")
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:114:9
@@ -157,7 +229,11 @@ error: unneeded `return` statement
 LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return String::new();
+LL +         String::new()
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:136:32
@@ -165,7 +241,10 @@ error: unneeded `return` statement
 LL |         bar.unwrap_or_else(|_| return)
    |                                ^^^^^^
    |
-   = help: replace `return` with an empty block
+help: replace `return` with an empty block
+   |
+LL |         bar.unwrap_or_else(|_| {})
+   |                                ~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:140:21
@@ -175,7 +254,12 @@ LL |           let _ = || {
 LL | |             return;
    | |__________________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         let _ = || {
+LL -             return;
+LL +         let _ = || {
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:143:20
@@ -183,7 +267,10 @@ error: unneeded `return` statement
 LL |         let _ = || return;
    |                    ^^^^^^
    |
-   = help: replace `return` with an empty block
+help: replace `return` with an empty block
+   |
+LL |         let _ = || {};
+   |                    ~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:149:32
@@ -191,7 +278,10 @@ error: unneeded `return` statement
 LL |         res.unwrap_or_else(|_| return Foo)
    |                                ^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL |         res.unwrap_or_else(|_| Foo)
+   |                                ~~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:158:5
@@ -199,7 +289,11 @@ error: unneeded `return` statement
 LL |     return true;
    |     ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return true;
+LL +     true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:162:5
@@ -207,7 +301,11 @@ error: unneeded `return` statement
 LL |     return true;
    |     ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return true;
+LL +     true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:167:9
@@ -215,7 +313,11 @@ error: unneeded `return` statement
 LL |         return true;
    |         ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return true;
+LL +         true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:169:9
@@ -223,7 +325,11 @@ error: unneeded `return` statement
 LL |         return false;
    |         ^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return false;
+LL +         false
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:175:17
@@ -231,7 +337,10 @@ error: unneeded `return` statement
 LL |         true => return false,
    |                 ^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL |         true => false,
+   |                 ~~~~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:177:13
@@ -239,7 +348,11 @@ error: unneeded `return` statement
 LL |             return true;
    |             ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -             return true;
+LL +             true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:184:9
@@ -247,7 +360,11 @@ error: unneeded `return` statement
 LL |         return true;
    |         ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return true;
+LL +         true
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:186:16
@@ -255,7 +372,10 @@ error: unneeded `return` statement
 LL |     let _ = || return true;
    |                ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL |     let _ = || true;
+   |                ~~~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:190:5
@@ -263,7 +383,11 @@ error: unneeded `return` statement
 LL |     return the_answer!();
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return the_answer!();
+LL +     the_answer!()
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:193:33
@@ -273,7 +397,12 @@ LL |   async fn async_test_void_fun() {
 LL | |     return;
    | |__________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL - async fn async_test_void_fun() {
+LL -     return;
+LL + async fn async_test_void_fun() {
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:198:11
@@ -283,7 +412,12 @@ LL |       if b {
 LL | |         return;
    | |______________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     if b {
+LL -         return;
+LL +     if b {
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:200:13
@@ -293,7 +427,12 @@ LL |       } else {
 LL | |         return;
    | |______________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     } else {
+LL -         return;
+LL +     } else {
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:208:14
@@ -301,7 +440,10 @@ error: unneeded `return` statement
 LL |         _ => return,
    |              ^^^^^^
    |
-   = help: replace `return` with a unit value
+help: replace `return` with a unit value
+   |
+LL |         _ => (),
+   |              ~~
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:221:9
@@ -309,7 +451,11 @@ error: unneeded `return` statement
 LL |         return String::from("test");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return String::from("test");
+LL +         String::from("test")
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:223:9
@@ -317,7 +463,11 @@ error: unneeded `return` statement
 LL |         return String::new();
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return String::new();
+LL +         String::new()
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:239:5
@@ -325,7 +475,11 @@ error: unneeded `return` statement
 LL |     return format!("Hello {}", "world!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -     return format!("Hello {}", "world!");
+LL +     format!("Hello {}", "world!")
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:251:9
@@ -333,7 +487,13 @@ error: unneeded `return` statement
 LL |         return true;
    |         ^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL ~         true
+LL |     } else {
+LL |         return false;
+LL ~     }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:253:9
@@ -341,7 +501,11 @@ error: unneeded `return` statement
 LL |         return false;
    |         ^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL ~         false
+LL ~     }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:260:13
@@ -349,7 +513,14 @@ error: unneeded `return` statement
 LL |             return 10;
    |             ^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL ~             10
+LL |         },
+ ...
+LL |         },
+LL ~     }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:263:13
@@ -357,7 +528,12 @@ error: unneeded `return` statement
 LL |             return 100;
    |             ^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL ~             100
+LL |         },
+LL ~     }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:271:9
@@ -365,7 +541,11 @@ error: unneeded `return` statement
 LL |         return 0;
    |         ^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL ~         0
+LL ~     }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:278:13
@@ -373,7 +553,14 @@ error: unneeded `return` statement
 LL |             return *(x as *const isize);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL ~             *(x as *const isize)
+LL |         } else {
+LL |             return !*(x as *const isize);
+LL ~         }
+LL ~     }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:280:13
@@ -381,7 +568,12 @@ error: unneeded `return` statement
 LL |             return !*(x as *const isize);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL ~             !*(x as *const isize)
+LL ~         }
+LL ~     }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:287:20
@@ -392,7 +584,13 @@ LL | |
 LL | |         return;
    | |______________^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         let _ = 42;
+LL - 
+LL -         return;
+LL +         let _ = 42;
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:294:20
@@ -400,7 +598,11 @@ error: unneeded `return` statement
 LL |         let _ = 42; return;
    |                    ^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         let _ = 42; return;
+LL +         let _ = 42;
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:306:9
@@ -408,7 +610,11 @@ error: unneeded `return` statement
 LL |         return Ok(format!("ok!"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return Ok(format!("ok!"));
+LL +         Ok(format!("ok!"))
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:308:9
@@ -416,7 +622,11 @@ error: unneeded `return` statement
 LL |         return Err(format!("err!"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return Err(format!("err!"));
+LL +         Err(format!("err!"))
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:314:9
@@ -424,7 +634,11 @@ error: unneeded `return` statement
 LL |         return if true { 1 } else { 2 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return`
+help: remove `return`
+   |
+LL -         return if true { 1 } else { 2 };
+LL +         if true { 1 } else { 2 }
+   |
 
 error: unneeded `return` statement
   --> $DIR/needless_return.rs:318:9
@@ -432,7 +646,11 @@ error: unneeded `return` statement
 LL |         return if b1 { 0 } else { 1 } | if b2 { 2 } else { 3 } | if b3 { 4 } else { 5 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: remove `return` and wrap the sequence with parentheses
+help: remove `return` and wrap the sequence with parentheses
+   |
+LL -         return if b1 { 0 } else { 1 } | if b2 { 2 } else { 3 } | if b3 { 4 } else { 5 };
+LL +         (if b1 { 0 } else { 1 } | if b2 { 2 } else { 3 } | if b3 { 4 } else { 5 })
+   |
 
 error: aborting due to 52 previous errors
 


### PR DESCRIPTION
Fixes #10816

Makes it a multipart suggestion so it can be displayed in a single frame which also fixes https://github.com/rust-lang/rust-clippy/issues/10816#issuecomment-1559784868

changelog: [`needless_return`]: Display the suggested change
