### PR TITLE
Emit `unnecessary_cast` on raw pointers as well

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -175,8 +175,8 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for casts to the same type, casts of int literals to integer types
-    /// and casts of float literals to float types.
+    /// Checks for casts to the same type, casts of int literals to integer types, casts of float
+    /// literals to float types and casts between raw pointers without changing type or constness.
     ///
     /// ### Why is this bad?
     /// It's just unnecessary.

--- a/tests/ui/as_ptr_cast_mut.rs
+++ b/tests/ui/as_ptr_cast_mut.rs
@@ -1,3 +1,4 @@
+//@run-rustfix
 #![allow(unused)]
 #![warn(clippy::as_ptr_cast_mut)]
 #![allow(clippy::wrong_self_convention)]

--- a/tests/ui/as_ptr_cast_mut.rs
+++ b/tests/ui/as_ptr_cast_mut.rs
@@ -1,7 +1,6 @@
-//@run-rustfix
 #![allow(unused)]
 #![warn(clippy::as_ptr_cast_mut)]
-#![allow(clippy::wrong_self_convention)]
+#![allow(clippy::wrong_self_convention, clippy::unnecessary_cast)]
 
 struct MutPtrWrapper(Vec<u8>);
 impl MutPtrWrapper {

--- a/tests/ui/as_ptr_cast_mut.stderr
+++ b/tests/ui/as_ptr_cast_mut.stderr
@@ -12,5 +12,19 @@ error: casting the result of `as_ptr` to *mut i8
 LL |     let _: *mut i8 = string.as_ptr() as *mut _;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `string.as_mut_ptr()`
 
-error: aborting due to 2 previous errors
+error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
+  --> $DIR/as_ptr_cast_mut.rs:25:13
+   |
+LL |     let _ = string.as_mut_ptr() as *mut u8;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.as_mut_ptr()`
+   |
+   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
+
+error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
+  --> $DIR/as_ptr_cast_mut.rs:29:13
+   |
+LL |     let _ = nn.as_ptr() as *mut u8;
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `nn.as_ptr()`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/as_ptr_cast_mut.stderr
+++ b/tests/ui/as_ptr_cast_mut.stderr
@@ -12,19 +12,5 @@ error: casting the result of `as_ptr` to *mut i8
 LL |     let _: *mut i8 = string.as_ptr() as *mut _;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `string.as_mut_ptr()`
 
-error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
-  --> $DIR/as_ptr_cast_mut.rs:25:13
-   |
-LL |     let _ = string.as_mut_ptr() as *mut u8;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.as_mut_ptr()`
-   |
-   = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
-
-error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
-  --> $DIR/as_ptr_cast_mut.rs:29:13
-   |
-LL |     let _ = nn.as_ptr() as *mut u8;
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `nn.as_ptr()`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/cast_slice_different_sizes.rs
+++ b/tests/ui/cast_slice_different_sizes.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::let_unit_value)]
+#![allow(clippy::let_unit_value, clippy::unnecessary_cast)]
 
 fn main() {
     let x: [i32; 3] = [1_i32, 2, 3];

--- a/tests/ui/crashes/ice-1782.rs
+++ b/tests/ui/crashes/ice-1782.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, unused_variables)]
+#![allow(clippy::unnecessary_cast)]
 
 /// Should not trigger an ICE in `SpanlessEq` / `consts::constant`
 ///

--- a/tests/ui/from_raw_with_void_ptr.rs
+++ b/tests/ui/from_raw_with_void_ptr.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::from_raw_with_void_ptr)]
+#![allow(clippy::unnecessary_cast)]
 
 use std::ffi::c_void;
 use std::rc::Rc;

--- a/tests/ui/from_raw_with_void_ptr.stderr
+++ b/tests/ui/from_raw_with_void_ptr.stderr
@@ -1,60 +1,60 @@
 error: creating a `Box` from a void raw pointer
-  --> $DIR/from_raw_with_void_ptr.rs:10:22
+  --> $DIR/from_raw_with_void_ptr.rs:11:22
    |
 LL |     let _ = unsafe { Box::from_raw(ptr) };
    |                      ^^^^^^^^^^^^^^^^^^
    |
 help: cast this to a pointer of the appropriate type
-  --> $DIR/from_raw_with_void_ptr.rs:10:36
+  --> $DIR/from_raw_with_void_ptr.rs:11:36
    |
 LL |     let _ = unsafe { Box::from_raw(ptr) };
    |                                    ^^^
    = note: `-D clippy::from-raw-with-void-ptr` implied by `-D warnings`
 
 error: creating a `Rc` from a void raw pointer
-  --> $DIR/from_raw_with_void_ptr.rs:21:22
+  --> $DIR/from_raw_with_void_ptr.rs:22:22
    |
 LL |     let _ = unsafe { Rc::from_raw(ptr) };
    |                      ^^^^^^^^^^^^^^^^^
    |
 help: cast this to a pointer of the appropriate type
-  --> $DIR/from_raw_with_void_ptr.rs:21:35
+  --> $DIR/from_raw_with_void_ptr.rs:22:35
    |
 LL |     let _ = unsafe { Rc::from_raw(ptr) };
    |                                   ^^^
 
 error: creating a `Arc` from a void raw pointer
-  --> $DIR/from_raw_with_void_ptr.rs:25:22
+  --> $DIR/from_raw_with_void_ptr.rs:26:22
    |
 LL |     let _ = unsafe { Arc::from_raw(ptr) };
    |                      ^^^^^^^^^^^^^^^^^^
    |
 help: cast this to a pointer of the appropriate type
-  --> $DIR/from_raw_with_void_ptr.rs:25:36
+  --> $DIR/from_raw_with_void_ptr.rs:26:36
    |
 LL |     let _ = unsafe { Arc::from_raw(ptr) };
    |                                    ^^^
 
 error: creating a `Weak` from a void raw pointer
-  --> $DIR/from_raw_with_void_ptr.rs:29:22
+  --> $DIR/from_raw_with_void_ptr.rs:30:22
    |
 LL |     let _ = unsafe { std::rc::Weak::from_raw(ptr) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: cast this to a pointer of the appropriate type
-  --> $DIR/from_raw_with_void_ptr.rs:29:46
+  --> $DIR/from_raw_with_void_ptr.rs:30:46
    |
 LL |     let _ = unsafe { std::rc::Weak::from_raw(ptr) };
    |                                              ^^^
 
 error: creating a `Weak` from a void raw pointer
-  --> $DIR/from_raw_with_void_ptr.rs:33:22
+  --> $DIR/from_raw_with_void_ptr.rs:34:22
    |
 LL |     let _ = unsafe { std::sync::Weak::from_raw(ptr) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: cast this to a pointer of the appropriate type
-  --> $DIR/from_raw_with_void_ptr.rs:33:48
+  --> $DIR/from_raw_with_void_ptr.rs:34:48
    |
 LL |     let _ = unsafe { std::sync::Weak::from_raw(ptr) };
    |                                                ^^^

--- a/tests/ui/transmute_ptr_to_ref.fixed
+++ b/tests/ui/transmute_ptr_to_ref.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::match_single_binding)]
+#![allow(clippy::match_single_binding, clippy::unnecessary_cast)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = &*p;

--- a/tests/ui/transmute_ptr_to_ref.rs
+++ b/tests/ui/transmute_ptr_to_ref.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::match_single_binding)]
+#![allow(clippy::match_single_binding, clippy::unnecessary_cast)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = std::mem::transmute(p);

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 #![warn(clippy::unnecessary_cast)]
 #![allow(
-    unused_must_use,
+    unused,
     clippy::borrow_as_ptr,
     clippy::no_effect,
     clippy::nonstandard_macro_braces,
@@ -10,6 +10,14 @@
 
 type PtrConstU8 = *const u8;
 type PtrMutU8 = *mut u8;
+
+fn owo<T>(ptr: *const T) -> *const T {
+    ptr
+}
+
+fn uwu<T, U>(ptr: *const T) -> *const U {
+    ptr as *const U
+}
 
 #[rustfmt::skip]
 fn main() {
@@ -25,6 +33,8 @@ fn main() {
     1_i32;
     1_f32;
 
+    let _: *mut u8 = [1u8, 2].as_ptr() as *mut u8;
+
     [1u8, 2].as_ptr();
     [1u8, 2].as_ptr() as *mut u8;
     [1u8, 2].as_mut_ptr();
@@ -35,6 +45,9 @@ fn main() {
     [1u8, 2].as_mut_ptr() as PtrConstU8;
     let _: *const u8 = [1u8, 2].as_ptr() as _;
     let _: *mut u8 = [1u8, 2].as_mut_ptr() as _;
+
+    owo::<u32>([1u32].as_ptr());
+    uwu::<u32, u8>([1u32].as_ptr());
 
     // macro version
     macro_rules! foo {

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -8,6 +8,9 @@
     clippy::unnecessary_operation
 )]
 
+type PtrConstU8 = *const u8;
+type PtrMutU8 = *mut u8;
+
 #[rustfmt::skip]
 fn main() {
     // Test cast_unnecessary
@@ -21,6 +24,17 @@ fn main() {
     -1_f32;
     1_i32;
     1_f32;
+
+    [1u8, 2].as_ptr();
+    [1u8, 2].as_ptr() as *mut u8;
+    [1u8, 2].as_mut_ptr();
+    [1u8, 2].as_mut_ptr() as *const u8;
+    [1u8, 2].as_ptr() as PtrConstU8;
+    [1u8, 2].as_ptr() as PtrMutU8;
+    [1u8, 2].as_mut_ptr() as PtrMutU8;
+    [1u8, 2].as_mut_ptr() as PtrConstU8;
+    let _: *const u8 = [1u8, 2].as_ptr() as _;
+    let _: *mut u8 = [1u8, 2].as_mut_ptr() as _;
 
     // macro version
     macro_rules! foo {

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -48,6 +48,8 @@ fn main() {
 
     owo::<u32>([1u32].as_ptr());
     uwu::<u32, u8>([1u32].as_ptr());
+    // this will not lint in the function body even though they have the same type, instead here
+    uwu::<u32, u32>([1u32].as_ptr());
 
     // macro version
     macro_rules! foo {

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 #![warn(clippy::unnecessary_cast)]
 #![allow(
-    unused_must_use,
+    unused,
     clippy::borrow_as_ptr,
     clippy::no_effect,
     clippy::nonstandard_macro_braces,
@@ -10,6 +10,14 @@
 
 type PtrConstU8 = *const u8;
 type PtrMutU8 = *mut u8;
+
+fn owo<T>(ptr: *const T) -> *const T {
+    ptr as *const T
+}
+
+fn uwu<T, U>(ptr: *const T) -> *const U {
+    ptr as *const U
+}
 
 #[rustfmt::skip]
 fn main() {
@@ -25,6 +33,8 @@ fn main() {
     1_i32 as i32;
     1_f32 as f32;
 
+    let _: *mut u8 = [1u8, 2].as_ptr() as *const u8 as *mut u8;
+
     [1u8, 2].as_ptr() as *const u8;
     [1u8, 2].as_ptr() as *mut u8;
     [1u8, 2].as_mut_ptr() as *mut u8;
@@ -35,6 +45,9 @@ fn main() {
     [1u8, 2].as_mut_ptr() as PtrConstU8;
     let _: *const u8 = [1u8, 2].as_ptr() as _;
     let _: *mut u8 = [1u8, 2].as_mut_ptr() as _;
+
+    owo::<u32>([1u32].as_ptr()) as *const u32;
+    uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
 
     // macro version
     macro_rules! foo {

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -8,6 +8,9 @@
     clippy::unnecessary_operation
 )]
 
+type PtrConstU8 = *const u8;
+type PtrMutU8 = *mut u8;
+
 #[rustfmt::skip]
 fn main() {
     // Test cast_unnecessary
@@ -21,6 +24,17 @@ fn main() {
     -1f32 as f32;
     1_i32 as i32;
     1_f32 as f32;
+
+    [1u8, 2].as_ptr() as *const u8;
+    [1u8, 2].as_ptr() as *mut u8;
+    [1u8, 2].as_mut_ptr() as *mut u8;
+    [1u8, 2].as_mut_ptr() as *const u8;
+    [1u8, 2].as_ptr() as PtrConstU8;
+    [1u8, 2].as_ptr() as PtrMutU8;
+    [1u8, 2].as_mut_ptr() as PtrMutU8;
+    [1u8, 2].as_mut_ptr() as PtrConstU8;
+    let _: *const u8 = [1u8, 2].as_ptr() as _;
+    let _: *mut u8 = [1u8, 2].as_mut_ptr() as _;
 
     // macro version
     macro_rules! foo {

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -48,6 +48,8 @@ fn main() {
 
     owo::<u32>([1u32].as_ptr()) as *const u32;
     uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
+    // this will not lint in the function body even though they have the same type, instead here
+    uwu::<u32, u32>([1u32].as_ptr()) as *const u32;
 
     // macro version
     macro_rules! foo {

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -1,5 +1,5 @@
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:14:5
+  --> $DIR/unnecessary_cast.rs:17:5
    |
 LL |     1i32 as i32;
    |     ^^^^^^^^^^^ help: try: `1_i32`
@@ -7,184 +7,196 @@ LL |     1i32 as i32;
    = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:15:5
+  --> $DIR/unnecessary_cast.rs:18:5
    |
 LL |     1f32 as f32;
    |     ^^^^^^^^^^^ help: try: `1_f32`
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/unnecessary_cast.rs:16:5
+  --> $DIR/unnecessary_cast.rs:19:5
    |
 LL |     false as bool;
    |     ^^^^^^^^^^^^^ help: try: `false`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:19:5
+  --> $DIR/unnecessary_cast.rs:22:5
    |
 LL |     -1_i32 as i32;
    |     ^^^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:20:5
+  --> $DIR/unnecessary_cast.rs:23:5
    |
 LL |     - 1_i32 as i32;
    |     ^^^^^^^^^^^^^^ help: try: `- 1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:21:5
+  --> $DIR/unnecessary_cast.rs:24:5
    |
 LL |     -1f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `-1_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:22:5
+  --> $DIR/unnecessary_cast.rs:25:5
    |
 LL |     1_i32 as i32;
    |     ^^^^^^^^^^^^ help: try: `1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:23:5
+  --> $DIR/unnecessary_cast.rs:26:5
    |
 LL |     1_f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `1_f32`
 
+error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
+  --> $DIR/unnecessary_cast.rs:28:5
+   |
+LL |     [1u8, 2].as_ptr() as *const u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_ptr()`
+
+error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
+  --> $DIR/unnecessary_cast.rs:30:5
+   |
+LL |     [1u8, 2].as_mut_ptr() as *mut u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_mut_ptr()`
+
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:64:9
+  --> $DIR/unnecessary_cast.rs:78:9
    |
 LL |         100 as f32;
    |         ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:65:9
+  --> $DIR/unnecessary_cast.rs:79:9
    |
 LL |         100 as f64;
    |         ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:66:9
+  --> $DIR/unnecessary_cast.rs:80:9
    |
 LL |         100_i32 as f64;
    |         ^^^^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:67:17
+  --> $DIR/unnecessary_cast.rs:81:17
    |
 LL |         let _ = -100 as f32;
    |                 ^^^^^^^^^^^ help: try: `-100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:68:17
+  --> $DIR/unnecessary_cast.rs:82:17
    |
 LL |         let _ = -100 as f64;
    |                 ^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:69:17
+  --> $DIR/unnecessary_cast.rs:83:17
    |
 LL |         let _ = -100_i32 as f64;
    |                 ^^^^^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:70:9
+  --> $DIR/unnecessary_cast.rs:84:9
    |
 LL |         100. as f32;
    |         ^^^^^^^^^^^ help: try: `100_f32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:71:9
+  --> $DIR/unnecessary_cast.rs:85:9
    |
 LL |         100. as f64;
    |         ^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:83:9
+  --> $DIR/unnecessary_cast.rs:97:9
    |
 LL |         1 as u32;
    |         ^^^^^^^^ help: try: `1_u32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:84:9
+  --> $DIR/unnecessary_cast.rs:98:9
    |
 LL |         0x10 as i32;
    |         ^^^^^^^^^^^ help: try: `0x10_i32`
 
 error: casting integer literal to `usize` is unnecessary
-  --> $DIR/unnecessary_cast.rs:85:9
+  --> $DIR/unnecessary_cast.rs:99:9
    |
 LL |         0b10 as usize;
    |         ^^^^^^^^^^^^^ help: try: `0b10_usize`
 
 error: casting integer literal to `u16` is unnecessary
-  --> $DIR/unnecessary_cast.rs:86:9
+  --> $DIR/unnecessary_cast.rs:100:9
    |
 LL |         0o73 as u16;
    |         ^^^^^^^^^^^ help: try: `0o73_u16`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:87:9
+  --> $DIR/unnecessary_cast.rs:101:9
    |
 LL |         1_000_000_000 as u32;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `1_000_000_000_u32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:89:9
+  --> $DIR/unnecessary_cast.rs:103:9
    |
 LL |         1.0 as f64;
    |         ^^^^^^^^^^ help: try: `1.0_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:90:9
+  --> $DIR/unnecessary_cast.rs:104:9
    |
 LL |         0.5 as f32;
    |         ^^^^^^^^^^ help: try: `0.5_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:94:17
+  --> $DIR/unnecessary_cast.rs:108:17
    |
 LL |         let _ = -1 as i32;
    |                 ^^^^^^^^^ help: try: `-1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:95:17
+  --> $DIR/unnecessary_cast.rs:109:17
    |
 LL |         let _ = -1.0 as f32;
    |                 ^^^^^^^^^^^ help: try: `-1.0_f32`
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/unnecessary_cast.rs:101:18
+  --> $DIR/unnecessary_cast.rs:115:18
    |
 LL |         let _ = &(x as i32);
    |                  ^^^^^^^^^^ help: try: `{ x }`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:107:22
+  --> $DIR/unnecessary_cast.rs:121:22
    |
 LL |         let _: i32 = -(1) as i32;
    |                      ^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:109:22
+  --> $DIR/unnecessary_cast.rs:123:22
    |
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:116:22
+  --> $DIR/unnecessary_cast.rs:130:22
    |
 LL |         let _: f64 = (-8.0 as f64).exp();
    |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:118:23
+  --> $DIR/unnecessary_cast.rs:132:23
    |
 LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
    |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/unnecessary_cast.rs:126:20
+  --> $DIR/unnecessary_cast.rs:140:20
    |
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`
 
-error: aborting due to 31 previous errors
+error: aborting due to 33 previous errors
 

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -84,143 +84,149 @@ error: casting raw pointers to the same type and constness is unnecessary (`*con
 LL |     uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u8>([1u32].as_ptr())`
 
+error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
+  --> $DIR/unnecessary_cast.rs:52:5
+   |
+LL |     uwu::<u32, u32>([1u32].as_ptr()) as *const u32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u32>([1u32].as_ptr())`
+
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:91:9
+  --> $DIR/unnecessary_cast.rs:93:9
    |
 LL |         100 as f32;
    |         ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:92:9
+  --> $DIR/unnecessary_cast.rs:94:9
    |
 LL |         100 as f64;
    |         ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:93:9
+  --> $DIR/unnecessary_cast.rs:95:9
    |
 LL |         100_i32 as f64;
    |         ^^^^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:94:17
+  --> $DIR/unnecessary_cast.rs:96:17
    |
 LL |         let _ = -100 as f32;
    |                 ^^^^^^^^^^^ help: try: `-100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:95:17
+  --> $DIR/unnecessary_cast.rs:97:17
    |
 LL |         let _ = -100 as f64;
    |                 ^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:96:17
+  --> $DIR/unnecessary_cast.rs:98:17
    |
 LL |         let _ = -100_i32 as f64;
    |                 ^^^^^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:97:9
+  --> $DIR/unnecessary_cast.rs:99:9
    |
 LL |         100. as f32;
    |         ^^^^^^^^^^^ help: try: `100_f32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:98:9
+  --> $DIR/unnecessary_cast.rs:100:9
    |
 LL |         100. as f64;
    |         ^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:110:9
+  --> $DIR/unnecessary_cast.rs:112:9
    |
 LL |         1 as u32;
    |         ^^^^^^^^ help: try: `1_u32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:111:9
+  --> $DIR/unnecessary_cast.rs:113:9
    |
 LL |         0x10 as i32;
    |         ^^^^^^^^^^^ help: try: `0x10_i32`
 
 error: casting integer literal to `usize` is unnecessary
-  --> $DIR/unnecessary_cast.rs:112:9
+  --> $DIR/unnecessary_cast.rs:114:9
    |
 LL |         0b10 as usize;
    |         ^^^^^^^^^^^^^ help: try: `0b10_usize`
 
 error: casting integer literal to `u16` is unnecessary
-  --> $DIR/unnecessary_cast.rs:113:9
+  --> $DIR/unnecessary_cast.rs:115:9
    |
 LL |         0o73 as u16;
    |         ^^^^^^^^^^^ help: try: `0o73_u16`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:114:9
+  --> $DIR/unnecessary_cast.rs:116:9
    |
 LL |         1_000_000_000 as u32;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `1_000_000_000_u32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:116:9
+  --> $DIR/unnecessary_cast.rs:118:9
    |
 LL |         1.0 as f64;
    |         ^^^^^^^^^^ help: try: `1.0_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:117:9
+  --> $DIR/unnecessary_cast.rs:119:9
    |
 LL |         0.5 as f32;
    |         ^^^^^^^^^^ help: try: `0.5_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:121:17
+  --> $DIR/unnecessary_cast.rs:123:17
    |
 LL |         let _ = -1 as i32;
    |                 ^^^^^^^^^ help: try: `-1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:122:17
+  --> $DIR/unnecessary_cast.rs:124:17
    |
 LL |         let _ = -1.0 as f32;
    |                 ^^^^^^^^^^^ help: try: `-1.0_f32`
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/unnecessary_cast.rs:128:18
+  --> $DIR/unnecessary_cast.rs:130:18
    |
 LL |         let _ = &(x as i32);
    |                  ^^^^^^^^^^ help: try: `{ x }`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:134:22
+  --> $DIR/unnecessary_cast.rs:136:22
    |
 LL |         let _: i32 = -(1) as i32;
    |                      ^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:136:22
+  --> $DIR/unnecessary_cast.rs:138:22
    |
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:143:22
+  --> $DIR/unnecessary_cast.rs:145:22
    |
 LL |         let _: f64 = (-8.0 as f64).exp();
    |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:145:23
+  --> $DIR/unnecessary_cast.rs:147:23
    |
 LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
    |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/unnecessary_cast.rs:153:20
+  --> $DIR/unnecessary_cast.rs:155:20
    |
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`
 
-error: aborting due to 37 previous errors
+error: aborting due to 38 previous errors
 

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -1,202 +1,226 @@
-error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:17:5
+error: casting raw pointers to the same type and constness is unnecessary (`*const T` -> `*const T`)
+  --> $DIR/unnecessary_cast.rs:15:5
    |
-LL |     1i32 as i32;
-   |     ^^^^^^^^^^^ help: try: `1_i32`
+LL |     ptr as *const T
+   |     ^^^^^^^^^^^^^^^ help: try: `ptr`
    |
    = note: `-D clippy::unnecessary-cast` implied by `-D warnings`
 
+error: casting integer literal to `i32` is unnecessary
+  --> $DIR/unnecessary_cast.rs:25:5
+   |
+LL |     1i32 as i32;
+   |     ^^^^^^^^^^^ help: try: `1_i32`
+
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:18:5
+  --> $DIR/unnecessary_cast.rs:26:5
    |
 LL |     1f32 as f32;
    |     ^^^^^^^^^^^ help: try: `1_f32`
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> $DIR/unnecessary_cast.rs:19:5
+  --> $DIR/unnecessary_cast.rs:27:5
    |
 LL |     false as bool;
    |     ^^^^^^^^^^^^^ help: try: `false`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:22:5
+  --> $DIR/unnecessary_cast.rs:30:5
    |
 LL |     -1_i32 as i32;
    |     ^^^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:23:5
+  --> $DIR/unnecessary_cast.rs:31:5
    |
 LL |     - 1_i32 as i32;
    |     ^^^^^^^^^^^^^^ help: try: `- 1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:24:5
+  --> $DIR/unnecessary_cast.rs:32:5
    |
 LL |     -1f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `-1_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:25:5
+  --> $DIR/unnecessary_cast.rs:33:5
    |
 LL |     1_i32 as i32;
    |     ^^^^^^^^^^^^ help: try: `1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:26:5
+  --> $DIR/unnecessary_cast.rs:34:5
    |
 LL |     1_f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `1_f32`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> $DIR/unnecessary_cast.rs:28:5
+  --> $DIR/unnecessary_cast.rs:36:22
+   |
+LL |     let _: *mut u8 = [1u8, 2].as_ptr() as *const u8 as *mut u8;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_ptr()`
+
+error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
+  --> $DIR/unnecessary_cast.rs:38:5
    |
 LL |     [1u8, 2].as_ptr() as *const u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
-  --> $DIR/unnecessary_cast.rs:30:5
+  --> $DIR/unnecessary_cast.rs:40:5
    |
 LL |     [1u8, 2].as_mut_ptr() as *mut u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_mut_ptr()`
 
+error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
+  --> $DIR/unnecessary_cast.rs:49:5
+   |
+LL |     owo::<u32>([1u32].as_ptr()) as *const u32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `owo::<u32>([1u32].as_ptr())`
+
+error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
+  --> $DIR/unnecessary_cast.rs:50:5
+   |
+LL |     uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u8>([1u32].as_ptr())`
+
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:78:9
+  --> $DIR/unnecessary_cast.rs:91:9
    |
 LL |         100 as f32;
    |         ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:79:9
+  --> $DIR/unnecessary_cast.rs:92:9
    |
 LL |         100 as f64;
    |         ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:80:9
+  --> $DIR/unnecessary_cast.rs:93:9
    |
 LL |         100_i32 as f64;
    |         ^^^^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:81:17
+  --> $DIR/unnecessary_cast.rs:94:17
    |
 LL |         let _ = -100 as f32;
    |                 ^^^^^^^^^^^ help: try: `-100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:82:17
+  --> $DIR/unnecessary_cast.rs:95:17
    |
 LL |         let _ = -100 as f64;
    |                 ^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:83:17
+  --> $DIR/unnecessary_cast.rs:96:17
    |
 LL |         let _ = -100_i32 as f64;
    |                 ^^^^^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:84:9
+  --> $DIR/unnecessary_cast.rs:97:9
    |
 LL |         100. as f32;
    |         ^^^^^^^^^^^ help: try: `100_f32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:85:9
+  --> $DIR/unnecessary_cast.rs:98:9
    |
 LL |         100. as f64;
    |         ^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:97:9
+  --> $DIR/unnecessary_cast.rs:110:9
    |
 LL |         1 as u32;
    |         ^^^^^^^^ help: try: `1_u32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:98:9
+  --> $DIR/unnecessary_cast.rs:111:9
    |
 LL |         0x10 as i32;
    |         ^^^^^^^^^^^ help: try: `0x10_i32`
 
 error: casting integer literal to `usize` is unnecessary
-  --> $DIR/unnecessary_cast.rs:99:9
+  --> $DIR/unnecessary_cast.rs:112:9
    |
 LL |         0b10 as usize;
    |         ^^^^^^^^^^^^^ help: try: `0b10_usize`
 
 error: casting integer literal to `u16` is unnecessary
-  --> $DIR/unnecessary_cast.rs:100:9
+  --> $DIR/unnecessary_cast.rs:113:9
    |
 LL |         0o73 as u16;
    |         ^^^^^^^^^^^ help: try: `0o73_u16`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:101:9
+  --> $DIR/unnecessary_cast.rs:114:9
    |
 LL |         1_000_000_000 as u32;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `1_000_000_000_u32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:103:9
+  --> $DIR/unnecessary_cast.rs:116:9
    |
 LL |         1.0 as f64;
    |         ^^^^^^^^^^ help: try: `1.0_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:104:9
+  --> $DIR/unnecessary_cast.rs:117:9
    |
 LL |         0.5 as f32;
    |         ^^^^^^^^^^ help: try: `0.5_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:108:17
+  --> $DIR/unnecessary_cast.rs:121:17
    |
 LL |         let _ = -1 as i32;
    |                 ^^^^^^^^^ help: try: `-1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:109:17
+  --> $DIR/unnecessary_cast.rs:122:17
    |
 LL |         let _ = -1.0 as f32;
    |                 ^^^^^^^^^^^ help: try: `-1.0_f32`
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/unnecessary_cast.rs:115:18
+  --> $DIR/unnecessary_cast.rs:128:18
    |
 LL |         let _ = &(x as i32);
    |                  ^^^^^^^^^^ help: try: `{ x }`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:121:22
+  --> $DIR/unnecessary_cast.rs:134:22
    |
 LL |         let _: i32 = -(1) as i32;
    |                      ^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:123:22
+  --> $DIR/unnecessary_cast.rs:136:22
    |
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:130:22
+  --> $DIR/unnecessary_cast.rs:143:22
    |
 LL |         let _: f64 = (-8.0 as f64).exp();
    |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:132:23
+  --> $DIR/unnecessary_cast.rs:145:23
    |
 LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
    |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/unnecessary_cast.rs:140:20
+  --> $DIR/unnecessary_cast.rs:153:20
    |
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`
 
-error: aborting due to 33 previous errors
+error: aborting due to 37 previous errors
 


### PR DESCRIPTION
Supersedes(?) #10782, since this and #10567 will cover the original issue.
Does not lint on type aliases or inferred types.

changelog: [`unnecessary_cast`]: Also emit on casts between raw pointers with the same type and constness
