### PR TITLE
Ignore `#[cfg]`'d out code in `needless_else`

### DIFF
--- a/tests/ui/needless_else.fixed
+++ b/tests/ui/needless_else.fixed
@@ -12,6 +12,10 @@ macro_rules! mac {
     };
 }
 
+macro_rules! empty_expansion {
+    () => {};
+}
+
 fn main() {
     let b = std::hint::black_box(true);
 
@@ -37,4 +41,17 @@ fn main() {
 
     // Do not lint because inside a macro
     mac!(b);
+
+    if b {
+        println!("Foobar");
+    } else {
+        #[cfg(foo)]
+        "Do not lint cfg'd out code"
+    }
+
+    if b {
+        println!("Foobar");
+    } else {
+        empty_expansion!();
+    }
 }

--- a/tests/ui/needless_else.rs
+++ b/tests/ui/needless_else.rs
@@ -12,6 +12,10 @@ macro_rules! mac {
     };
 }
 
+macro_rules! empty_expansion {
+    () => {};
+}
+
 fn main() {
     let b = std::hint::black_box(true);
 
@@ -38,4 +42,17 @@ fn main() {
 
     // Do not lint because inside a macro
     mac!(b);
+
+    if b {
+        println!("Foobar");
+    } else {
+        #[cfg(foo)]
+        "Do not lint cfg'd out code"
+    }
+
+    if b {
+        println!("Foobar");
+    } else {
+        empty_expansion!();
+    }
 }

--- a/tests/ui/needless_else.stderr
+++ b/tests/ui/needless_else.stderr
@@ -1,5 +1,5 @@
 error: this else branch is empty
-  --> $DIR/needless_else.rs:20:7
+  --> $DIR/needless_else.rs:24:7
    |
 LL |       } else {
    |  _______^


### PR DESCRIPTION
changelog: none (same release as #10810)

`#[cfg]` making things fun once more

This lead me to think about macro calls that expand to nothing as well, but apparently they produce an empty stmt in the AST so are already handled, added a test for that

r? @llogiq