### PR TITLE
deps: drop serde feature from url, drop rustc-workspace-hack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,6 @@ walkdir = "2.3"
 # This is used by the `collect-metadata` alias.
 filetime = "0.2"
 
-# A noop dependency that changes in the Rust repository, it's a bit of a hack.
-# See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
-# for more information.
-rustc-workspace-hack = "1.0"
-
 # UI test dependencies
 clap = { version = "4.1.4", features = ["derive"] }
 clippy_utils = { path = "clippy_utils" }

--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -26,9 +26,7 @@ unicode-normalization = "0.1"
 unicode-script = { version = "0.5", default-features = false }
 semver = "1.0"
 rustc-semver = "1.1"
-# NOTE: cargo requires serde feat in its url dep
-# see <https://github.com/rust-lang/rust/pull/63587#issuecomment-522343864>
-url = { version = "2.2", features = ["serde"] }
+url = "2.2"
 
 [features]
 deny-warnings = ["clippy_utils/deny-warnings"]


### PR DESCRIPTION
Cargo now have it's own workspace and rustc dropped [`rustc-workspace-hack`](https://github.com/rust-lang/rust/pull/109133), so no need to unify features here; drop rustc-workspace-hack.

changelog: none
