### PR TITLE
[bool_comparison] Deal with multiple false-like options

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -595,7 +595,9 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|_| Box::new(float_literal::FloatLiteral));
     store.register_late_pass(|_| Box::new(ptr::Ptr));
     store.register_late_pass(|_| Box::new(needless_bool::NeedlessBool));
-    store.register_late_pass(|_| Box::new(needless_bool::BoolComparison));
+    let bool_comparison_false_ty = conf.bool_comparison_false_ty.clone();
+    store
+        .register_late_pass(move |_| Box::new(needless_bool::BoolComparison::new(bool_comparison_false_ty.as_deref())));
     store.register_late_pass(|_| Box::new(needless_for_each::NeedlessForEach));
     store.register_late_pass(|_| Box::<misc::LintPass>::default());
     store.register_late_pass(|_| Box::new(eta_reduction::EtaReduction));

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -252,6 +252,13 @@ define_Conf! {
     ///
     /// Suppress lints whenever the suggested change would cause breakage for other crates.
     (avoid_breaking_exported_api: bool = true),
+    /// Lint: BOOL_COMPARISON.
+    ///
+    /// There are two possible attributes:
+    ///
+    /// 1. `equal`: Recommends equity checks in favor of negations. For example `if !bool { .. }` becomes `if bool == false { .. }`.
+    /// 2. `exclamation-mark`: Recommends the negation of booleans using `!` instead of equity checks like `bool == false` (default).
+    (bool_comparison_false_ty: Option<String> = None),
     /// Lint: MANUAL_SPLIT_ONCE, MANUAL_STR_REPEAT, CLONED_INSTEAD_OF_COPIED, REDUNDANT_FIELD_NAMES, REDUNDANT_STATIC_LIFETIMES, FILTER_MAP_NEXT, CHECKED_CONVERSIONS, MANUAL_RANGE_CONTAINS, USE_SELF, MEM_REPLACE_WITH_DEFAULT, MANUAL_NON_EXHAUSTIVE, OPTION_AS_REF_DEREF, MAP_UNWRAP_OR, MATCH_LIKE_MATCHES_MACRO, MANUAL_STRIP, MISSING_CONST_FOR_FN, UNNESTED_OR_PATTERNS, FROM_OVER_INTO, PTR_AS_PTR, IF_THEN_SOME_ELSE_NONE, APPROX_CONSTANT, DEPRECATED_CFG_ATTR, INDEX_REFUTABLE_SLICE, MAP_CLONE, BORROW_AS_PTR, MANUAL_BITS, ERR_EXPECT, CAST_ABS_TO_UNSIGNED, UNINLINED_FORMAT_ARGS, MANUAL_CLAMP, MANUAL_LET_ELSE, UNCHECKED_DURATION_SUBTRACTION, COLLAPSIBLE_STR_REPLACE, SEEK_FROM_CURRENT, SEEK_REWIND, UNNECESSARY_LAZY_EVALUATIONS, TRANSMUTE_PTR_TO_REF, ALMOST_COMPLETE_RANGE, NEEDLESS_BORROW, DERIVABLE_IMPLS, MANUAL_IS_ASCII_CHECK, MANUAL_REM_EUCLID, MANUAL_RETAIN.
     ///
     /// The minimum rust version that the project supports

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -514,6 +514,11 @@ impl<T: Display> Display for ParenHelper<T> {
     }
 }
 
+/// Builds the string for `<expr> == false` adding parenthesis when necessary.
+pub fn make_eq_false(expr: Sugg<'_>) -> Sugg<'static> {
+    Sugg::MaybeParen(format!("{} == false", expr.maybe_par()).into())
+}
+
 /// Builds the string for `<op><expr>` adding parenthesis when necessary.
 ///
 /// For convenience, the operator is taken as a string because all unary

--- a/tests/ui-toml/bool_comparison_equal/bool_comparison_equal.rs
+++ b/tests/ui-toml/bool_comparison_equal/bool_comparison_equal.rs
@@ -1,0 +1,16 @@
+#![warn(clippy::bool_comparison)]
+
+fn main() {
+    let x = true;
+    let _ = x == false;
+    let _ = false == x;
+    let _ = x != true;
+    let _ = true != x;
+    let _ = x < true;
+    let _ = true > x;
+
+    let y = true;
+    let _ = x < y;
+    let _ = x > y;
+    let _ = x > y && !x && y == false;
+}

--- a/tests/ui-toml/bool_comparison_equal/bool_comparison_equal.stderr
+++ b/tests/ui-toml/bool_comparison_equal/bool_comparison_equal.stderr
@@ -1,0 +1,52 @@
+error: inequality checks against true can be replaced with a comparison against `false`
+  --> $DIR/bool_comparison_equal.rs:7:13
+   |
+LL |     let _ = x != true;
+   |             ^^^^^^^^^ help: try simplifying it as shown: `x == false`
+   |
+   = note: `-D clippy::bool-comparison` implied by `-D warnings`
+
+error: inequality checks against true can be replaced with a comparison against `false`
+  --> $DIR/bool_comparison_equal.rs:8:13
+   |
+LL |     let _ = true != x;
+   |             ^^^^^^^^^ help: try simplifying it as shown: `x == false`
+
+error: less than comparison against true can be replaced with a comparison against `false`
+  --> $DIR/bool_comparison_equal.rs:9:13
+   |
+LL |     let _ = x < true;
+   |             ^^^^^^^^ help: try simplifying it as shown: `x == false`
+
+error: less than comparison against true can be replaced with a comparison against `false`
+  --> $DIR/bool_comparison_equal.rs:10:13
+   |
+LL |     let _ = true > x;
+   |             ^^^^^^^^ help: try simplifying it as shown: `x == false`
+
+error: order comparisons between booleans can be simplified
+  --> $DIR/bool_comparison_equal.rs:13:13
+   |
+LL |     let _ = x < y;
+   |             ^^^^^ help: try simplifying it as shown: `x == false & y`
+
+error: order comparisons between booleans can be simplified
+  --> $DIR/bool_comparison_equal.rs:14:13
+   |
+LL |     let _ = x > y;
+   |             ^^^^^ help: try simplifying it as shown: `x & y == false`
+
+error: order comparisons between booleans can be simplified
+  --> $DIR/bool_comparison_equal.rs:15:13
+   |
+LL |     let _ = x > y && !x && y == false;
+   |             ^^^^^ help: try simplifying it as shown: `x & y == false`
+
+error: negation (`!`) is hard to see and can lead to possible misunderstandings
+  --> $DIR/bool_comparison_equal.rs:15:22
+   |
+LL |     let _ = x > y && !x && y == false;
+   |                      ^^ help: try replacing it with a comparison against `false`: `x == false`
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui-toml/bool_comparison_equal/clippy.toml
+++ b/tests/ui-toml/bool_comparison_equal/clippy.toml
@@ -1,0 +1,1 @@
+bool-comparison-false-ty = "equals"

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -12,6 +12,7 @@ error: error reading Clippy's configuration file `$DIR/clippy.toml`: unknown fie
            avoid-breaking-exported-api
            await-holding-invalid-types
            blacklisted-names
+           bool-comparison-false-ty
            cargo-ignore-publish
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold


### PR DESCRIPTION
Fix #10796

In face of the feedback provided in https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/.E2.9C.94.20New.20possible.20lint.20to.20deal.20with.20.60!bool.60 and in #10796, the most natural solution to maintain the current behaviour, avoid potential conflicts with a new theoretical lint and enable the possibility of specify different behaviours was, IMO, the addition of a new configuration parameter for `bool_comparison` as well as the incorporation of unary checks.

```
changelog: [`bool_comparison`]: Add a new `bool-comparison-false-ty` parameter to specify different false-like behaviours
```