### PR TITLE
new lint: `drain_collect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4737,6 +4737,7 @@ Released 2018-09-13
 [`double_must_use`]: https://rust-lang.github.io/rust-clippy/master/index.html#double_must_use
 [`double_neg`]: https://rust-lang.github.io/rust-clippy/master/index.html#double_neg
 [`double_parens`]: https://rust-lang.github.io/rust-clippy/master/index.html#double_parens
+[`drain_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#drain_collect
 [`drop_bounds`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_bounds
 [`drop_copy`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_copy
 [`drop_non_drop`]: https://rust-lang.github.io/rust-clippy/master/index.html#drop_non_drop

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -324,6 +324,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::CLONE_ON_COPY_INFO,
     crate::methods::CLONE_ON_REF_PTR_INFO,
     crate::methods::COLLAPSIBLE_STR_REPLACE_INFO,
+    crate::methods::DRAIN_COLLECT_INFO,
     crate::methods::ERR_EXPECT_INFO,
     crate::methods::EXPECT_FUN_CALL_INFO,
     crate::methods::EXPECT_USED_INFO,

--- a/clippy_lints/src/methods/drain_collect.rs
+++ b/clippy_lints/src/methods/drain_collect.rs
@@ -1,0 +1,77 @@
+use crate::methods::DRAIN_COLLECT;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_range_full;
+use clippy_utils::source::snippet;
+use clippy_utils::ty::is_type_lang_item;
+use rustc_errors::Applicability;
+use rustc_hir::Expr;
+use rustc_hir::ExprKind;
+use rustc_hir::LangItem;
+use rustc_hir::Path;
+use rustc_hir::QPath;
+use rustc_lint::LateContext;
+use rustc_middle::query::Key;
+use rustc_middle::ty::Ty;
+use rustc_span::sym;
+use rustc_span::Symbol;
+
+/// Checks if both types match the given diagnostic item, e.g.:
+///
+/// `vec![1,2].drain(..).collect::<Vec<_>>()`
+///  ^^^^^^^^^                     ^^^^^^   true
+/// `vec![1,2].drain(..).collect::<HashSet<_>>()`
+///  ^^^^^^^^^                     ^^^^^^^^^^  false
+fn types_match_diagnostic_item(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>, sym: Symbol) -> bool {
+    if let Some(expr_adt_did) = expr.ty_adt_id()
+        && let Some(recv_adt_did) = recv.ty_adt_id()
+    {
+        cx.tcx.is_diagnostic_item(sym, expr_adt_did) && cx.tcx.is_diagnostic_item(sym, recv_adt_did)
+    } else {
+        false
+    }
+}
+
+/// Checks `std::{vec::Vec, collections::VecDeque}`.
+fn check_vec(cx: &LateContext<'_>, args: &[Expr<'_>], expr: Ty<'_>, recv: Ty<'_>, recv_path: &Path<'_>) -> bool {
+    (types_match_diagnostic_item(cx, expr, recv, sym::Vec)
+        || types_match_diagnostic_item(cx, expr, recv, sym::VecDeque))
+        && matches!(args, [arg] if is_range_full(cx, arg, Some(recv_path)))
+}
+
+/// Checks `std::string::String`
+fn check_string(cx: &LateContext<'_>, args: &[Expr<'_>], expr: Ty<'_>, recv: Ty<'_>, recv_path: &Path<'_>) -> bool {
+    is_type_lang_item(cx, expr, LangItem::String)
+        && is_type_lang_item(cx, recv, LangItem::String)
+        && matches!(args, [arg] if is_range_full(cx, arg, Some(recv_path)))
+}
+
+/// Checks `std::collections::{HashSet, HashMap, BinaryHeap}`.
+fn check_collections(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>) -> Option<&'static str> {
+    types_match_diagnostic_item(cx, expr, recv, sym::HashSet)
+        .then_some("HashSet")
+        .or_else(|| types_match_diagnostic_item(cx, expr, recv, sym::HashMap).then_some("HashMap"))
+        .or_else(|| types_match_diagnostic_item(cx, expr, recv, sym::BinaryHeap).then_some("BinaryHeap"))
+}
+
+pub(super) fn check(cx: &LateContext<'_>, args: &[Expr<'_>], expr: &Expr<'_>, recv: &Expr<'_>) {
+    let expr_ty = cx.typeck_results().expr_ty(expr);
+    let recv_ty = cx.typeck_results().expr_ty(recv).peel_refs();
+
+    if let ExprKind::Path(QPath::Resolved(_, recv_path)) = recv.kind
+        && let Some(typename) = check_vec(cx, args, expr_ty, recv_ty, recv_path)
+            .then_some("Vec")
+            .or_else(|| check_string(cx, args, expr_ty, recv_ty, recv_path).then_some("String"))
+            .or_else(|| check_collections(cx, expr_ty, recv_ty))
+    {
+        let recv = snippet(cx, recv.span, "<expr>");
+        span_lint_and_sugg(
+            cx,
+            DRAIN_COLLECT,
+            expr.span,
+            &format!("you seem to be trying to move all elements into a new `{typename}`"),
+            "consider using `mem::take`",
+            format!("std::mem::take(&mut {recv})"),
+            Applicability::MachineApplicable,
+        );
+    }
+}

--- a/clippy_lints/src/methods/drain_collect.rs
+++ b/clippy_lints/src/methods/drain_collect.rs
@@ -66,17 +66,19 @@ pub(super) fn check(cx: &LateContext<'_>, args: &[Expr<'_>], expr: &Expr<'_>, re
             .or_else(|| check_collections(cx, expr_ty, recv_ty_no_refs))
     {
         let recv = snippet(cx, recv.span, "<expr>");
+        let sugg = if let ty::Ref(..) = recv_ty.kind() {
+            format!("std::mem::take({recv})")
+        } else {
+            format!("std::mem::take(&mut {recv})")
+        };
+
         span_lint_and_sugg(
             cx,
             DRAIN_COLLECT,
             expr.span,
             &format!("you seem to be trying to move all elements into a new `{typename}`"),
             "consider using `mem::take`",
-            if let ty::Ref(..) = recv_ty.kind() {
-                format!("std::mem::take({recv})")
-            } else {
-                format!("std::mem::take(&mut {recv})")
-            },
+            sugg,
             Applicability::MachineApplicable,
         );
     }

--- a/clippy_lints/src/methods/drain_collect.rs
+++ b/clippy_lints/src/methods/drain_collect.rs
@@ -11,7 +11,7 @@ use rustc_hir::Path;
 use rustc_hir::QPath;
 use rustc_lint::LateContext;
 use rustc_middle::query::Key;
-use rustc_middle::ty::Ty;
+use rustc_middle::ty;
 use rustc_span::sym;
 use rustc_span::Symbol;
 
@@ -21,7 +21,7 @@ use rustc_span::Symbol;
 ///  ^^^^^^^^^                     ^^^^^^   true
 /// `vec![1,2].drain(..).collect::<HashSet<_>>()`
 ///  ^^^^^^^^^                     ^^^^^^^^^^  false
-fn types_match_diagnostic_item(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>, sym: Symbol) -> bool {
+fn types_match_diagnostic_item(cx: &LateContext<'_>, expr: ty::Ty<'_>, recv: ty::Ty<'_>, sym: Symbol) -> bool {
     if let Some(expr_adt_did) = expr.ty_adt_id()
         && let Some(recv_adt_did) = recv.ty_adt_id()
     {
@@ -32,21 +32,33 @@ fn types_match_diagnostic_item(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>,
 }
 
 /// Checks `std::{vec::Vec, collections::VecDeque}`.
-fn check_vec(cx: &LateContext<'_>, args: &[Expr<'_>], expr: Ty<'_>, recv: Ty<'_>, recv_path: &Path<'_>) -> bool {
+fn check_vec(
+    cx: &LateContext<'_>,
+    args: &[Expr<'_>],
+    expr: ty::Ty<'_>,
+    recv: ty::Ty<'_>,
+    recv_path: &Path<'_>,
+) -> bool {
     (types_match_diagnostic_item(cx, expr, recv, sym::Vec)
         || types_match_diagnostic_item(cx, expr, recv, sym::VecDeque))
         && matches!(args, [arg] if is_range_full(cx, arg, Some(recv_path)))
 }
 
 /// Checks `std::string::String`
-fn check_string(cx: &LateContext<'_>, args: &[Expr<'_>], expr: Ty<'_>, recv: Ty<'_>, recv_path: &Path<'_>) -> bool {
+fn check_string(
+    cx: &LateContext<'_>,
+    args: &[Expr<'_>],
+    expr: ty::Ty<'_>,
+    recv: ty::Ty<'_>,
+    recv_path: &Path<'_>,
+) -> bool {
     is_type_lang_item(cx, expr, LangItem::String)
         && is_type_lang_item(cx, recv, LangItem::String)
         && matches!(args, [arg] if is_range_full(cx, arg, Some(recv_path)))
 }
 
 /// Checks `std::collections::{HashSet, HashMap, BinaryHeap}`.
-fn check_collections(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>) -> Option<&'static str> {
+fn check_collections(cx: &LateContext<'_>, expr: ty::Ty<'_>, recv: ty::Ty<'_>) -> Option<&'static str> {
     types_match_diagnostic_item(cx, expr, recv, sym::HashSet)
         .then_some("HashSet")
         .or_else(|| types_match_diagnostic_item(cx, expr, recv, sym::HashMap).then_some("HashMap"))
@@ -55,13 +67,14 @@ fn check_collections(cx: &LateContext<'_>, expr: Ty<'_>, recv: Ty<'_>) -> Option
 
 pub(super) fn check(cx: &LateContext<'_>, args: &[Expr<'_>], expr: &Expr<'_>, recv: &Expr<'_>) {
     let expr_ty = cx.typeck_results().expr_ty(expr);
-    let recv_ty = cx.typeck_results().expr_ty(recv).peel_refs();
+    let recv_ty = cx.typeck_results().expr_ty(recv);
+    let recv_ty_no_refs = recv_ty.peel_refs();
 
     if let ExprKind::Path(QPath::Resolved(_, recv_path)) = recv.kind
-        && let Some(typename) = check_vec(cx, args, expr_ty, recv_ty, recv_path)
+        && let Some(typename) = check_vec(cx, args, expr_ty, recv_ty_no_refs, recv_path)
             .then_some("Vec")
-            .or_else(|| check_string(cx, args, expr_ty, recv_ty, recv_path).then_some("String"))
-            .or_else(|| check_collections(cx, expr_ty, recv_ty))
+            .or_else(|| check_string(cx, args, expr_ty, recv_ty_no_refs, recv_path).then_some("String"))
+            .or_else(|| check_collections(cx, expr_ty, recv_ty_no_refs))
     {
         let recv = snippet(cx, recv.span, "<expr>");
         span_lint_and_sugg(
@@ -70,7 +83,10 @@ pub(super) fn check(cx: &LateContext<'_>, args: &[Expr<'_>], expr: &Expr<'_>, re
             expr.span,
             &format!("you seem to be trying to move all elements into a new `{typename}`"),
             "consider using `mem::take`",
-            format!("std::mem::take(&mut {recv})"),
+            match recv_ty.kind() {
+                ty::Ref(..) => format!("std::mem::take({recv})"),
+                _ => format!("std::mem::take(&mut {recv})"),
+            },
             Applicability::MachineApplicable,
         );
     }

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3260,7 +3260,7 @@ declare_clippy_lint! {
     /// When using `mem::take`, the old collection is replaced with an empty one and ownership of
     /// the old collection is returned.
     ///
-    /// ### Drawback
+    /// ### Known issues
     /// `mem::take(&mut vec)` is almost equivalent to `vec.drain(..).collect()`, except that
     /// it also moves the **capacity**. The user might have explicitly written it this way
     /// to keep the capacity on the original `Vec`.

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3281,7 +3281,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.71.0"]
     pub DRAIN_COLLECT,
     perf,
-    "description"
+    "calling `.drain(..).collect()` to move all elements into a new collection"
 }
 
 pub struct Methods {

--- a/tests/ui/drain_collect.fixed
+++ b/tests/ui/drain_collect.fixed
@@ -6,7 +6,7 @@
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 
 fn binaryheap(b: &mut BinaryHeap<i32>) -> BinaryHeap<i32> {
-    b.drain().collect()
+    std::mem::take(b)
 }
 
 fn binaryheap_dont_lint(b: &mut BinaryHeap<i32>) -> HashSet<i32> {
@@ -14,7 +14,7 @@ fn binaryheap_dont_lint(b: &mut BinaryHeap<i32>) -> HashSet<i32> {
 }
 
 fn hashmap(b: &mut HashMap<i32, i32>) -> HashMap<i32, i32> {
-    b.drain().collect()
+    std::mem::take(b)
 }
 
 fn hashmap_dont_lint(b: &mut HashMap<i32, i32>) -> Vec<(i32, i32)> {
@@ -22,7 +22,7 @@ fn hashmap_dont_lint(b: &mut HashMap<i32, i32>) -> Vec<(i32, i32)> {
 }
 
 fn hashset(b: &mut HashSet<i32>) -> HashSet<i32> {
-    b.drain().collect()
+    std::mem::take(b)
 }
 
 fn hashset_dont_lint(b: &mut HashSet<i32>) -> Vec<i32> {
@@ -30,7 +30,7 @@ fn hashset_dont_lint(b: &mut HashSet<i32>) -> Vec<i32> {
 }
 
 fn vecdeque(b: &mut VecDeque<i32>) -> VecDeque<i32> {
-    b.drain(..).collect()
+    std::mem::take(b)
 }
 
 fn vecdeque_dont_lint(b: &mut VecDeque<i32>) -> HashSet<i32> {
@@ -38,24 +38,24 @@ fn vecdeque_dont_lint(b: &mut VecDeque<i32>) -> HashSet<i32> {
 }
 
 fn vec(b: &mut Vec<i32>) -> Vec<i32> {
-    b.drain(..).collect()
+    std::mem::take(b)
 }
 
 fn vec2(b: &mut Vec<i32>) -> Vec<i32> {
-    b.drain(0..).collect()
+    std::mem::take(b)
 }
 
 fn vec3(b: &mut Vec<i32>) -> Vec<i32> {
-    b.drain(..b.len()).collect()
+    std::mem::take(b)
 }
 
 fn vec4(b: &mut Vec<i32>) -> Vec<i32> {
-    b.drain(0..b.len()).collect()
+    std::mem::take(b)
 }
 
 fn vec_no_reborrow() -> Vec<i32> {
     let mut b = vec![1, 2, 3];
-    b.drain(..).collect()
+    std::mem::take(&mut b)
 }
 
 fn vec_dont_lint(b: &mut Vec<i32>) -> HashSet<i32> {
@@ -63,7 +63,7 @@ fn vec_dont_lint(b: &mut Vec<i32>) -> HashSet<i32> {
 }
 
 fn string(b: &mut String) -> String {
-    b.drain(..).collect()
+    std::mem::take(b)
 }
 
 fn string_dont_lint(b: &mut String) -> HashSet<char> {

--- a/tests/ui/drain_collect.fixed
+++ b/tests/ui/drain_collect.fixed
@@ -70,4 +70,8 @@ fn string_dont_lint(b: &mut String) -> HashSet<char> {
     b.drain(..).collect()
 }
 
+fn not_whole_length(v: &mut Vec<i32>) -> Vec<i32> {
+    v.drain(1..).collect()
+}
+
 fn main() {}

--- a/tests/ui/drain_collect.rs
+++ b/tests/ui/drain_collect.rs
@@ -70,4 +70,8 @@ fn string_dont_lint(b: &mut String) -> HashSet<char> {
     b.drain(..).collect()
 }
 
+fn not_whole_length(v: &mut Vec<i32>) -> Vec<i32> {
+    v.drain(1..).collect()
+}
+
 fn main() {}

--- a/tests/ui/drain_collect.rs
+++ b/tests/ui/drain_collect.rs
@@ -1,0 +1,65 @@
+#![deny(clippy::drain_collect)]
+
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
+
+fn binaryheap(b: &mut BinaryHeap<i32>) -> BinaryHeap<i32> {
+    b.drain().collect()
+}
+
+fn binaryheap_dont_lint(b: &mut BinaryHeap<i32>) -> HashSet<i32> {
+    b.drain().collect()
+}
+
+fn hashmap(b: &mut HashMap<i32, i32>) -> HashMap<i32, i32> {
+    b.drain().collect()
+}
+
+fn hashmap_dont_lint(b: &mut HashMap<i32, i32>) -> Vec<(i32, i32)> {
+    b.drain().collect()
+}
+
+fn hashset(b: &mut HashSet<i32>) -> HashSet<i32> {
+    b.drain().collect()
+}
+
+fn hashset_dont_lint(b: &mut HashSet<i32>) -> Vec<i32> {
+    b.drain().collect()
+}
+
+fn vecdeque(b: &mut VecDeque<i32>) -> VecDeque<i32> {
+    b.drain(..).collect()
+}
+
+fn vecdeque_dont_lint(b: &mut VecDeque<i32>) -> HashSet<i32> {
+    b.drain(..).collect()
+}
+
+fn vec(b: &mut Vec<i32>) -> Vec<i32> {
+    b.drain(..).collect()
+}
+
+fn vec2(b: &mut Vec<i32>) -> Vec<i32> {
+    b.drain(0..).collect()
+}
+
+fn vec3(b: &mut Vec<i32>) -> Vec<i32> {
+    b.drain(..b.len()).collect()
+}
+
+fn vec4(b: &mut Vec<i32>) -> Vec<i32> {
+    b.drain(0..b.len()).collect()
+}
+
+fn vec_dont_lint(b: &mut Vec<i32>) -> HashSet<i32> {
+    b.drain(..).collect()
+}
+
+fn string(b: &mut String) -> String {
+    b.drain(..).collect()
+}
+
+fn string_dont_lint(b: &mut String) -> HashSet<char> {
+    b.drain(..).collect()
+}
+
+fn main() {}

--- a/tests/ui/drain_collect.stderr
+++ b/tests/ui/drain_collect.stderr
@@ -1,62 +1,68 @@
 error: you seem to be trying to move all elements into a new `BinaryHeap`
-  --> $DIR/drain_collect.rs:6:5
+  --> $DIR/drain_collect.rs:9:5
    |
 LL |     b.drain().collect()
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
    |
 note: the lint level is defined here
-  --> $DIR/drain_collect.rs:1:9
+  --> $DIR/drain_collect.rs:3:9
    |
 LL | #![deny(clippy::drain_collect)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: you seem to be trying to move all elements into a new `HashMap`
-  --> $DIR/drain_collect.rs:14:5
+  --> $DIR/drain_collect.rs:17:5
    |
 LL |     b.drain().collect()
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
 
 error: you seem to be trying to move all elements into a new `HashSet`
-  --> $DIR/drain_collect.rs:22:5
+  --> $DIR/drain_collect.rs:25:5
    |
 LL |     b.drain().collect()
-   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
 
 error: you seem to be trying to move all elements into a new `Vec`
-  --> $DIR/drain_collect.rs:30:5
+  --> $DIR/drain_collect.rs:33:5
    |
 LL |     b.drain(..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
 
 error: you seem to be trying to move all elements into a new `Vec`
-  --> $DIR/drain_collect.rs:38:5
+  --> $DIR/drain_collect.rs:41:5
    |
 LL |     b.drain(..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
 
 error: you seem to be trying to move all elements into a new `Vec`
-  --> $DIR/drain_collect.rs:42:5
+  --> $DIR/drain_collect.rs:45:5
    |
 LL |     b.drain(0..).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
 
 error: you seem to be trying to move all elements into a new `Vec`
-  --> $DIR/drain_collect.rs:46:5
+  --> $DIR/drain_collect.rs:49:5
    |
 LL |     b.drain(..b.len()).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
 
 error: you seem to be trying to move all elements into a new `Vec`
-  --> $DIR/drain_collect.rs:50:5
+  --> $DIR/drain_collect.rs:53:5
    |
 LL |     b.drain(0..b.len()).collect()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
 
-error: you seem to be trying to move all elements into a new `String`
+error: you seem to be trying to move all elements into a new `Vec`
   --> $DIR/drain_collect.rs:58:5
    |
 LL |     b.drain(..).collect()
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
 
-error: aborting due to 9 previous errors
+error: you seem to be trying to move all elements into a new `String`
+  --> $DIR/drain_collect.rs:66:5
+   |
+LL |     b.drain(..).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(b)`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/drain_collect.stderr
+++ b/tests/ui/drain_collect.stderr
@@ -1,0 +1,62 @@
+error: you seem to be trying to move all elements into a new `BinaryHeap`
+  --> $DIR/drain_collect.rs:6:5
+   |
+LL |     b.drain().collect()
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+   |
+note: the lint level is defined here
+  --> $DIR/drain_collect.rs:1:9
+   |
+LL | #![deny(clippy::drain_collect)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
+error: you seem to be trying to move all elements into a new `HashMap`
+  --> $DIR/drain_collect.rs:14:5
+   |
+LL |     b.drain().collect()
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: you seem to be trying to move all elements into a new `HashSet`
+  --> $DIR/drain_collect.rs:22:5
+   |
+LL |     b.drain().collect()
+   |     ^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: you seem to be trying to move all elements into a new `Vec`
+  --> $DIR/drain_collect.rs:30:5
+   |
+LL |     b.drain(..).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: you seem to be trying to move all elements into a new `Vec`
+  --> $DIR/drain_collect.rs:38:5
+   |
+LL |     b.drain(..).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: you seem to be trying to move all elements into a new `Vec`
+  --> $DIR/drain_collect.rs:42:5
+   |
+LL |     b.drain(0..).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: you seem to be trying to move all elements into a new `Vec`
+  --> $DIR/drain_collect.rs:46:5
+   |
+LL |     b.drain(..b.len()).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: you seem to be trying to move all elements into a new `Vec`
+  --> $DIR/drain_collect.rs:50:5
+   |
+LL |     b.drain(0..b.len()).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: you seem to be trying to move all elements into a new `String`
+  --> $DIR/drain_collect.rs:58:5
+   |
+LL |     b.drain(..).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `std::mem::take(&mut b)`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/iter_with_drain.fixed
+++ b/tests/ui/iter_with_drain.fixed
@@ -2,7 +2,7 @@
 // will emits unused mut warnings after fixing
 #![allow(unused_mut)]
 // will emits needless collect warnings after fixing
-#![allow(clippy::needless_collect)]
+#![allow(clippy::needless_collect, clippy::drain_collect)]
 #![warn(clippy::iter_with_drain)]
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 

--- a/tests/ui/iter_with_drain.rs
+++ b/tests/ui/iter_with_drain.rs
@@ -2,7 +2,7 @@
 // will emits unused mut warnings after fixing
 #![allow(unused_mut)]
 // will emits needless collect warnings after fixing
-#![allow(clippy::needless_collect)]
+#![allow(clippy::needless_collect, clippy::drain_collect)]
 #![warn(clippy::iter_with_drain)]
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 


### PR DESCRIPTION
Closes #10818.

This adds a new lint that looks for `.drain(..).collect()` and suggests replacing it with `mem::take`.

changelog: [`drain_collect`]: new lint
