### PR TITLE
Fixing `invalid_regex` with invalid UTF8. Also, adding more test cases

### DIFF
--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -177,7 +177,7 @@ fn check_set<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, utf8: bool) {
 }
 
 fn check_regex<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, utf8: bool) {
-    let mut parser = regex_syntax::ParserBuilder::new().unicode(true).utf8(!utf8).build();
+    let mut parser = regex_syntax::ParserBuilder::new().unicode(true).utf8(utf8).build();
 
     if let ExprKind::Lit(lit) = expr.kind {
         if let LitKind::Str(ref r, style) = lit.node {

--- a/tests/ui/regex.rs
+++ b/tests/ui/regex.rs
@@ -42,6 +42,11 @@ fn syntax_error() {
     let escaped_string_span = Regex::new("\\b\\c");
 
     let aux_span = Regex::new("(?ixi)");
+
+    let should_not_lint = Regex::new("(?u).");
+    let should_not_lint = BRegex::new("(?u).");
+    let invalid_utf8_should_not_lint = BRegex::new("(?-u).");
+    let invalid_utf8_should_lint = Regex::new("(?-u).");
 }
 
 fn trivial_regex() {
@@ -71,6 +76,8 @@ fn trivial_regex() {
     // non-trivial regexes
     let non_trivial_dot = Regex::new("a.b");
     let non_trivial_dot_builder = RegexBuilder::new("a.b");
+    let non_trivial_dot = Regex::new(".");
+    let non_trivial_dot = BRegex::new(".");
     let non_trivial_eq = Regex::new("^foo|bar$");
     let non_trivial_starts_with = Regex::new("^foo|bar");
     let non_trivial_ends_with = Regex::new("^foo|bar");

--- a/tests/ui/regex.stderr
+++ b/tests/ui/regex.stderr
@@ -99,8 +99,14 @@ error: regex syntax error: duplicate flag
 LL |     let aux_span = Regex::new("(?ixi)");
    |                                  ^ ^
 
+error: regex syntax error: pattern can match invalid UTF-8
+  --> $DIR/regex.rs:49:53
+   |
+LL |     let invalid_utf8_should_lint = Regex::new("(?-u).");
+   |                                                     ^
+
 error: trivial regex
-  --> $DIR/regex.rs:48:33
+  --> $DIR/regex.rs:53:33
    |
 LL |     let trivial_eq = Regex::new("^foobar$");
    |                                 ^^^^^^^^^^
@@ -108,7 +114,7 @@ LL |     let trivial_eq = Regex::new("^foobar$");
    = help: consider using `==` on `str`s
 
 error: trivial regex
-  --> $DIR/regex.rs:50:48
+  --> $DIR/regex.rs:55:48
    |
 LL |     let trivial_eq_builder = RegexBuilder::new("^foobar$");
    |                                                ^^^^^^^^^^
@@ -116,7 +122,7 @@ LL |     let trivial_eq_builder = RegexBuilder::new("^foobar$");
    = help: consider using `==` on `str`s
 
 error: trivial regex
-  --> $DIR/regex.rs:52:42
+  --> $DIR/regex.rs:57:42
    |
 LL |     let trivial_starts_with = Regex::new("^foobar");
    |                                          ^^^^^^^^^
@@ -124,7 +130,7 @@ LL |     let trivial_starts_with = Regex::new("^foobar");
    = help: consider using `str::starts_with`
 
 error: trivial regex
-  --> $DIR/regex.rs:54:40
+  --> $DIR/regex.rs:59:40
    |
 LL |     let trivial_ends_with = Regex::new("foobar$");
    |                                        ^^^^^^^^^
@@ -132,7 +138,7 @@ LL |     let trivial_ends_with = Regex::new("foobar$");
    = help: consider using `str::ends_with`
 
 error: trivial regex
-  --> $DIR/regex.rs:56:39
+  --> $DIR/regex.rs:61:39
    |
 LL |     let trivial_contains = Regex::new("foobar");
    |                                       ^^^^^^^^
@@ -140,7 +146,7 @@ LL |     let trivial_contains = Regex::new("foobar");
    = help: consider using `str::contains`
 
 error: trivial regex
-  --> $DIR/regex.rs:58:39
+  --> $DIR/regex.rs:63:39
    |
 LL |     let trivial_contains = Regex::new(NOT_A_REAL_REGEX);
    |                                       ^^^^^^^^^^^^^^^^
@@ -148,7 +154,7 @@ LL |     let trivial_contains = Regex::new(NOT_A_REAL_REGEX);
    = help: consider using `str::contains`
 
 error: trivial regex
-  --> $DIR/regex.rs:60:40
+  --> $DIR/regex.rs:65:40
    |
 LL |     let trivial_backslash = Regex::new("a/.b");
    |                                        ^^^^^^^
@@ -156,7 +162,7 @@ LL |     let trivial_backslash = Regex::new("a/.b");
    = help: consider using `str::contains`
 
 error: trivial regex
-  --> $DIR/regex.rs:63:36
+  --> $DIR/regex.rs:68:36
    |
 LL |     let trivial_empty = Regex::new("");
    |                                    ^^
@@ -164,7 +170,7 @@ LL |     let trivial_empty = Regex::new("");
    = help: the regex is unlikely to be useful as it is
 
 error: trivial regex
-  --> $DIR/regex.rs:65:36
+  --> $DIR/regex.rs:70:36
    |
 LL |     let trivial_empty = Regex::new("^");
    |                                    ^^^
@@ -172,7 +178,7 @@ LL |     let trivial_empty = Regex::new("^");
    = help: the regex is unlikely to be useful as it is
 
 error: trivial regex
-  --> $DIR/regex.rs:67:36
+  --> $DIR/regex.rs:72:36
    |
 LL |     let trivial_empty = Regex::new("^$");
    |                                    ^^^^
@@ -180,12 +186,12 @@ LL |     let trivial_empty = Regex::new("^$");
    = help: consider using `str::is_empty`
 
 error: trivial regex
-  --> $DIR/regex.rs:69:44
+  --> $DIR/regex.rs:74:44
    |
 LL |     let binary_trivial_empty = BRegex::new("^$");
    |                                            ^^^^
    |
    = help: consider using `str::is_empty`
 
-error: aborting due to 23 previous errors
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Fixing false positive and false negative when dealing with regex that could match invalid UTF8.

This PR fixes https://github.com/rust-lang/rust-clippy/issues/10825

changelog: [`invalid_regex`]: Fixing false positive and false negative when dealing with regex that could match invalid UTF8