### PR TITLE
from_over_into: Show suggestions for non-Self expanded paths

### DIFF
--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -134,9 +134,10 @@ impl<'a, 'tcx> Visitor<'tcx> for SelfFinder<'a, 'tcx> {
                 kw::SelfUpper => self.upper.push(segment.ident.span),
                 _ => continue,
             }
+
+            self.invalid |= segment.ident.span.from_expansion();
         }
 
-        self.invalid |= path.span.from_expansion();
         if !self.invalid {
             walk_path(self, path);
         }

--- a/tests/ui/from_over_into.fixed
+++ b/tests/ui/from_over_into.fixed
@@ -60,6 +60,15 @@ impl From<String> for A {
     }
 }
 
+struct PathInExpansion;
+
+impl From<PathInExpansion> for String {
+    fn from(val: PathInExpansion) -> Self {
+        // non self/Self paths in expansions are fine
+        panic!()
+    }
+}
+
 #[clippy::msrv = "1.40"]
 fn msrv_1_40() {
     struct FromOverInto<T>(Vec<T>);

--- a/tests/ui/from_over_into.rs
+++ b/tests/ui/from_over_into.rs
@@ -60,6 +60,15 @@ impl From<String> for A {
     }
 }
 
+struct PathInExpansion;
+
+impl Into<String> for PathInExpansion {
+    fn into(self) -> String {
+        // non self/Self paths in expansions are fine
+        panic!()
+    }
+}
+
 #[clippy::msrv = "1.40"]
 fn msrv_1_40() {
     struct FromOverInto<T>(Vec<T>);

--- a/tests/ui/from_over_into.stderr
+++ b/tests/ui/from_over_into.stderr
@@ -59,7 +59,21 @@ LL ~         val.0
    |
 
 error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
-  --> $DIR/from_over_into.rs:78:5
+  --> $DIR/from_over_into.rs:65:1
+   |
+LL | impl Into<String> for PathInExpansion {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `impl From<Local> for Foreign` is allowed by the orphan rules, for more information see
+           https://doc.rust-lang.org/reference/items/implementations.html#trait-implementation-coherence
+help: replace the `Into` implementation with `From<PathInExpansion>`
+   |
+LL ~ impl From<PathInExpansion> for String {
+LL ~     fn from(val: PathInExpansion) -> Self {
+   |
+
+error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
+  --> $DIR/from_over_into.rs:87:5
    |
 LL |     impl<T> Into<FromOverInto<T>> for Vec<T> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,5 +85,5 @@ LL ~         fn from(val: Vec<T>) -> Self {
 LL ~             FromOverInto(val)
    |
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/from_over_into_unfixable.rs
+++ b/tests/ui/from_over_into_unfixable.rs
@@ -3,14 +3,14 @@
 struct InMacro(String);
 
 macro_rules! in_macro {
-    ($e:ident) => {
-        $e
+    () => {
+        Self::new()
     };
 }
 
 impl Into<InMacro> for String {
     fn into(self) -> InMacro {
-        InMacro(in_macro!(self))
+        InMacro(in_macro!())
     }
 }
 


### PR DESCRIPTION
changelog: [`from_over_into`]: Show suggestions when the body contains macros not expanding to `Self`

Currently any path in a macro expansion causes the suggestion to be hidden, meaning most macro calls cause it to be hidden

Now it's only hidden if the expansion contains `Self`