### PR TITLE
Remove lint name and category fields from the new lint issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_lint.yml
+++ b/.github/ISSUE_TEMPLATE/new_lint.yml
@@ -12,29 +12,6 @@ body:
       description: What does this lint do?
     validations:
       required: true
-  - type: input
-    id: lint-name
-    attributes:
-      label: Lint Name
-      description: Please provide the lint name.
-  - type: dropdown
-    id: category
-    attributes:
-      label: Category
-      description: >
-        What category should this lint go into? If you're unsure you can select
-        multiple categories. You can find a category description in the
-        `README`.
-      multiple: true
-      options:
-        - correctness
-        - suspicious
-        - style
-        - complexity
-        - perf
-        - pedantic
-        - restriction
-        - cargo
   - type: textarea
     id: advantage
     attributes:


### PR DESCRIPTION
changelog: none

Picking a name/category is something the implementers/reviewers tend to cover anyway, I think asking people to come up with it at the time of their suggestion is more of a barrier than it's worth

Inspired by the mention in #10849