### PR TITLE
Fix suggestion on fully qualified syntax

### DIFF
--- a/tests/ui/explicit_deref_methods.fixed
+++ b/tests/ui/explicit_deref_methods.fixed
@@ -1,11 +1,12 @@
 //@run-rustfix
 #![warn(clippy::explicit_deref_methods)]
-#![allow(unused_variables)]
+#![allow(unused_variables, unused_must_use)]
 #![allow(
     clippy::borrow_deref_ref,
     suspicious_double_ref_op,
     clippy::explicit_auto_deref,
     clippy::needless_borrow,
+    clippy::no_effect,
     clippy::uninlined_format_args
 )]
 
@@ -25,6 +26,22 @@ impl Deref for CustomVec {
 
     fn deref(&self) -> &Vec<u8> {
         &self.0
+    }
+}
+
+struct Aaa;
+
+impl Deref for Aaa {
+    type Target = ();
+
+    fn deref(&self) -> &Self::Target {
+        todo!();
+    }
+}
+
+impl DerefMut for Aaa {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        todo!();
     }
 }
 
@@ -57,6 +74,16 @@ fn main() {
 
     let opt_a = Some(a.clone());
     let b = &*opt_a.unwrap();
+
+    // make sure `Aaa::deref` instead of `aaa.deref()` works as well as fully qualified syntax
+
+    &*Aaa;
+    &mut *Aaa;
+    &*Aaa;
+    &mut *Aaa;
+    let mut aaa = Aaa;
+    &*aaa;
+    &mut *aaa;
 
     // following should not require linting
 

--- a/tests/ui/explicit_deref_methods.fixed
+++ b/tests/ui/explicit_deref_methods.fixed
@@ -75,15 +75,16 @@ fn main() {
     let opt_a = Some(a.clone());
     let b = &*opt_a.unwrap();
 
-    // make sure `Aaa::deref` instead of `aaa.deref()` works as well as fully qualified syntax
+    // make sure `Aaa::deref` instead of `aaa.deref()` is not linted, as well as fully qualified
+    // syntax
 
-    &*Aaa;
-    &mut *Aaa;
-    &*Aaa;
-    &mut *Aaa;
+    Aaa::deref(&Aaa);
+    Aaa::deref_mut(&mut Aaa);
+    <Aaa as Deref>::deref(&Aaa);
+    <Aaa as DerefMut>::deref_mut(&mut Aaa);
     let mut aaa = Aaa;
-    &*aaa;
-    &mut *aaa;
+    Aaa::deref(&aaa);
+    Aaa::deref_mut(&mut aaa);
 
     // following should not require linting
 

--- a/tests/ui/explicit_deref_methods.rs
+++ b/tests/ui/explicit_deref_methods.rs
@@ -75,7 +75,8 @@ fn main() {
     let opt_a = Some(a.clone());
     let b = opt_a.unwrap().deref();
 
-    // make sure `Aaa::deref` instead of `aaa.deref()` works as well as fully qualified syntax
+    // make sure `Aaa::deref` instead of `aaa.deref()` is not linted, as well as fully qualified
+    // syntax
 
     Aaa::deref(&Aaa);
     Aaa::deref_mut(&mut Aaa);

--- a/tests/ui/explicit_deref_methods.rs
+++ b/tests/ui/explicit_deref_methods.rs
@@ -1,11 +1,12 @@
 //@run-rustfix
 #![warn(clippy::explicit_deref_methods)]
-#![allow(unused_variables)]
+#![allow(unused_variables, unused_must_use)]
 #![allow(
     clippy::borrow_deref_ref,
     suspicious_double_ref_op,
     clippy::explicit_auto_deref,
     clippy::needless_borrow,
+    clippy::no_effect,
     clippy::uninlined_format_args
 )]
 
@@ -25,6 +26,22 @@ impl Deref for CustomVec {
 
     fn deref(&self) -> &Vec<u8> {
         &self.0
+    }
+}
+
+struct Aaa;
+
+impl Deref for Aaa {
+    type Target = ();
+
+    fn deref(&self) -> &Self::Target {
+        todo!();
+    }
+}
+
+impl DerefMut for Aaa {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        todo!();
     }
 }
 
@@ -57,6 +74,16 @@ fn main() {
 
     let opt_a = Some(a.clone());
     let b = opt_a.unwrap().deref();
+
+    // make sure `Aaa::deref` instead of `aaa.deref()` works as well as fully qualified syntax
+
+    Aaa::deref(&Aaa);
+    Aaa::deref_mut(&mut Aaa);
+    <Aaa as Deref>::deref(&Aaa);
+    <Aaa as DerefMut>::deref_mut(&mut Aaa);
+    let mut aaa = Aaa;
+    Aaa::deref(&aaa);
+    Aaa::deref_mut(&mut aaa);
 
     // following should not require linting
 

--- a/tests/ui/explicit_deref_methods.stderr
+++ b/tests/ui/explicit_deref_methods.stderr
@@ -67,46 +67,10 @@ LL |     let b = opt_a.unwrap().deref();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&*opt_a.unwrap()`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:80:5
-   |
-LL |     Aaa::deref(&Aaa);
-   |     ^^^^^^^^^^^^^^^^ help: try this: `&*Aaa`
-
-error: explicit `deref_mut` method call
-  --> $DIR/explicit_deref_methods.rs:81:5
-   |
-LL |     Aaa::deref_mut(&mut Aaa);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut *Aaa`
-
-error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:82:5
-   |
-LL |     <Aaa as Deref>::deref(&Aaa);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&*Aaa`
-
-error: explicit `deref_mut` method call
-  --> $DIR/explicit_deref_methods.rs:83:5
-   |
-LL |     <Aaa as DerefMut>::deref_mut(&mut Aaa);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut *Aaa`
-
-error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:85:5
-   |
-LL |     Aaa::deref(&aaa);
-   |     ^^^^^^^^^^^^^^^^ help: try this: `&*aaa`
-
-error: explicit `deref_mut` method call
-  --> $DIR/explicit_deref_methods.rs:86:5
-   |
-LL |     Aaa::deref_mut(&mut aaa);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut *aaa`
-
-error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:112:31
+  --> $DIR/explicit_deref_methods.rs:113:31
    |
 LL |     let b: &str = expr_deref!(a.deref());
    |                               ^^^^^^^^^ help: try this: `&*a`
 
-error: aborting due to 18 previous errors
+error: aborting due to 12 previous errors
 

--- a/tests/ui/explicit_deref_methods.stderr
+++ b/tests/ui/explicit_deref_methods.stderr
@@ -1,5 +1,5 @@
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:36:19
+  --> $DIR/explicit_deref_methods.rs:53:19
    |
 LL |     let b: &str = a.deref();
    |                   ^^^^^^^^^ help: try this: `&*a`
@@ -7,70 +7,106 @@ LL |     let b: &str = a.deref();
    = note: `-D clippy::explicit-deref-methods` implied by `-D warnings`
 
 error: explicit `deref_mut` method call
-  --> $DIR/explicit_deref_methods.rs:38:23
+  --> $DIR/explicit_deref_methods.rs:55:23
    |
 LL |     let b: &mut str = a.deref_mut();
    |                       ^^^^^^^^^^^^^ help: try this: `&mut **a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:41:39
+  --> $DIR/explicit_deref_methods.rs:58:39
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
    |                                       ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:41:50
+  --> $DIR/explicit_deref_methods.rs:58:50
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
    |                                                  ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:43:20
+  --> $DIR/explicit_deref_methods.rs:60:20
    |
 LL |     println!("{}", a.deref());
    |                    ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:46:11
+  --> $DIR/explicit_deref_methods.rs:63:11
    |
 LL |     match a.deref() {
    |           ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:50:28
+  --> $DIR/explicit_deref_methods.rs:67:28
    |
 LL |     let b: String = concat(a.deref());
    |                            ^^^^^^^^^ help: try this: `&*a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:52:13
+  --> $DIR/explicit_deref_methods.rs:69:13
    |
 LL |     let b = just_return(a).deref();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `just_return(a)`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:54:28
+  --> $DIR/explicit_deref_methods.rs:71:28
    |
 LL |     let b: String = concat(just_return(a).deref());
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `just_return(a)`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:56:19
+  --> $DIR/explicit_deref_methods.rs:73:19
    |
 LL |     let b: &str = a.deref().deref();
    |                   ^^^^^^^^^^^^^^^^^ help: try this: `&**a`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:59:13
+  --> $DIR/explicit_deref_methods.rs:76:13
    |
 LL |     let b = opt_a.unwrap().deref();
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&*opt_a.unwrap()`
 
 error: explicit `deref` method call
-  --> $DIR/explicit_deref_methods.rs:85:31
+  --> $DIR/explicit_deref_methods.rs:80:5
+   |
+LL |     Aaa::deref(&Aaa);
+   |     ^^^^^^^^^^^^^^^^ help: try this: `&*Aaa`
+
+error: explicit `deref_mut` method call
+  --> $DIR/explicit_deref_methods.rs:81:5
+   |
+LL |     Aaa::deref_mut(&mut Aaa);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut *Aaa`
+
+error: explicit `deref` method call
+  --> $DIR/explicit_deref_methods.rs:82:5
+   |
+LL |     <Aaa as Deref>::deref(&Aaa);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&*Aaa`
+
+error: explicit `deref_mut` method call
+  --> $DIR/explicit_deref_methods.rs:83:5
+   |
+LL |     <Aaa as DerefMut>::deref_mut(&mut Aaa);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut *Aaa`
+
+error: explicit `deref` method call
+  --> $DIR/explicit_deref_methods.rs:85:5
+   |
+LL |     Aaa::deref(&aaa);
+   |     ^^^^^^^^^^^^^^^^ help: try this: `&*aaa`
+
+error: explicit `deref_mut` method call
+  --> $DIR/explicit_deref_methods.rs:86:5
+   |
+LL |     Aaa::deref_mut(&mut aaa);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut *aaa`
+
+error: explicit `deref` method call
+  --> $DIR/explicit_deref_methods.rs:112:31
    |
 LL |     let b: &str = expr_deref!(a.deref());
    |                               ^^^^^^^^^ help: try this: `&*a`
 
-error: aborting due to 12 previous errors
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
fixes #10850

changelog: [`explicit_deref_methods`]: Fix malformed suggestion on `Foo::deref(&foo)`
