### PR TITLE
Bring up Rust lang #37612 as a known problem for let_and_return

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -25,6 +25,12 @@ declare_clippy_lint! {
     /// It is just extraneous code. Remove it to make your code
     /// more rusty.
     ///
+    /// ### Known problems
+    /// In the case of some temporaries, e.g. locks, eliding the variable binding could lead
+    /// to deadlocks. See [rust-lang issue 37612](https://github.com/rust-lang/rust/issues/37612).
+    /// This could become relevant if the code is later changed to use the code that would have been
+    /// bound without first assigning it to a let-binding.
+    ///
     /// ### Example
     /// ```rust
     /// fn foo() -> String {

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     ///
     /// ### Known problems
     /// In the case of some temporaries, e.g. locks, eliding the variable binding could lead
-    /// to deadlocks. See [rust-lang issue 37612](https://github.com/rust-lang/rust/issues/37612).
+    /// to deadlocks. See [this issue](https://github.com/rust-lang/rust/issues/37612).
     /// This could become relevant if the code is later changed to use the code that would have been
     /// bound without first assigning it to a let-binding.
     ///


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/4182.

I don't think conforming to this lint could trigger the issue immediately, only if subsequent code-changes go wrong, but I may be mistaken. 

Since the lint can't trigger it by itself, just closing this issue might be reasonable, if not maybe this PR fixes it.

changelog: Update docs for `let_and_return`, mention rust-lang #37612
