### PR TITLE
[`let_with_type_underscore`]: Don't emit on locals from procedural macros

### DIFF
--- a/clippy_lints/src/let_with_type_underscore.rs
+++ b/clippy_lints/src/let_with_type_underscore.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::{diagnostics::span_lint_and_help, is_from_proc_macro};
 use rustc_hir::{Local, TyKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::lint::in_external_macro;
@@ -32,7 +32,12 @@ impl LateLintPass<'_> for UnderscoreTyped {
             if let TyKind::Infer = &ty.kind; // that type is '_'
             if local.span.ctxt() == ty.span.ctxt();
             then {
-                span_lint_and_help(cx,
+                if let Some(init) = local.init && is_from_proc_macro(cx, init) {
+                    return;
+                }
+
+                span_lint_and_help(
+                    cx,
                     LET_WITH_TYPE_UNDERSCORE,
                     local.span,
                     "variable declared with type underscore",

--- a/tests/ui/let_with_type_underscore.rs
+++ b/tests/ui/let_with_type_underscore.rs
@@ -1,7 +1,7 @@
 //@aux-build: proc_macros.rs
 #![allow(unused)]
 #![warn(clippy::let_with_type_underscore)]
-#![allow(clippy::let_unit_value)]
+#![allow(clippy::let_unit_value, clippy::needless_late_init)]
 
 extern crate proc_macros;
 
@@ -9,20 +9,34 @@ fn func() -> &'static str {
     ""
 }
 
+#[rustfmt::skip]
 fn main() {
     // Will lint
     let x: _ = 1;
     let _: _ = 2;
     let x: _ = func();
+    let x: _;
+    x = ();
 
     let x = 1; // Will not lint, Rust infers this to an integer before Clippy
     let x = func();
     let x: Vec<_> = Vec::<u32>::new();
     let x: [_; 1] = [1];
+    let x : _ = 1;
 
-    // do not lint from procedural macros
+    // Do not lint from procedural macros
     proc_macros::with_span! {
         span
         let x: _ = ();
+        // Late initialization
+        let x: _;
+        x = ();
+        // Ensure weird formatting will not break it (hopefully)
+        let x : _ = 1;
+        let x
+: _ = 1;
+        let                   x :              
+        _;
+        x = ();
     };
 }

--- a/tests/ui/let_with_type_underscore.rs
+++ b/tests/ui/let_with_type_underscore.rs
@@ -1,6 +1,9 @@
+//@aux-build: proc_macros.rs
 #![allow(unused)]
 #![warn(clippy::let_with_type_underscore)]
 #![allow(clippy::let_unit_value)]
+
+extern crate proc_macros;
 
 fn func() -> &'static str {
     ""
@@ -16,4 +19,10 @@ fn main() {
     let x = func();
     let x: Vec<_> = Vec::<u32>::new();
     let x: [_; 1] = [1];
+
+    // do not lint from procedural macros
+    proc_macros::with_span! {
+        span
+        let x: _ = ();
+    };
 }

--- a/tests/ui/let_with_type_underscore.stderr
+++ b/tests/ui/let_with_type_underscore.stderr
@@ -1,36 +1,36 @@
 error: variable declared with type underscore
-  --> $DIR/let_with_type_underscore.rs:11:5
+  --> $DIR/let_with_type_underscore.rs:14:5
    |
 LL |     let x: _ = 1;
    |     ^^^^^^^^^^^^^
    |
 help: remove the explicit type `_` declaration
-  --> $DIR/let_with_type_underscore.rs:11:10
+  --> $DIR/let_with_type_underscore.rs:14:10
    |
 LL |     let x: _ = 1;
    |          ^^^
    = note: `-D clippy::let-with-type-underscore` implied by `-D warnings`
 
 error: variable declared with type underscore
-  --> $DIR/let_with_type_underscore.rs:12:5
+  --> $DIR/let_with_type_underscore.rs:15:5
    |
 LL |     let _: _ = 2;
    |     ^^^^^^^^^^^^^
    |
 help: remove the explicit type `_` declaration
-  --> $DIR/let_with_type_underscore.rs:12:10
+  --> $DIR/let_with_type_underscore.rs:15:10
    |
 LL |     let _: _ = 2;
    |          ^^^
 
 error: variable declared with type underscore
-  --> $DIR/let_with_type_underscore.rs:13:5
+  --> $DIR/let_with_type_underscore.rs:16:5
    |
 LL |     let x: _ = func();
    |     ^^^^^^^^^^^^^^^^^^
    |
 help: remove the explicit type `_` declaration
-  --> $DIR/let_with_type_underscore.rs:13:10
+  --> $DIR/let_with_type_underscore.rs:16:10
    |
 LL |     let x: _ = func();
    |          ^^^

--- a/tests/ui/let_with_type_underscore.stderr
+++ b/tests/ui/let_with_type_underscore.stderr
@@ -1,39 +1,63 @@
 error: variable declared with type underscore
-  --> $DIR/let_with_type_underscore.rs:14:5
+  --> $DIR/let_with_type_underscore.rs:15:5
    |
 LL |     let x: _ = 1;
    |     ^^^^^^^^^^^^^
    |
 help: remove the explicit type `_` declaration
-  --> $DIR/let_with_type_underscore.rs:14:10
+  --> $DIR/let_with_type_underscore.rs:15:10
    |
 LL |     let x: _ = 1;
    |          ^^^
    = note: `-D clippy::let-with-type-underscore` implied by `-D warnings`
 
 error: variable declared with type underscore
-  --> $DIR/let_with_type_underscore.rs:15:5
+  --> $DIR/let_with_type_underscore.rs:16:5
    |
 LL |     let _: _ = 2;
    |     ^^^^^^^^^^^^^
    |
 help: remove the explicit type `_` declaration
-  --> $DIR/let_with_type_underscore.rs:15:10
+  --> $DIR/let_with_type_underscore.rs:16:10
    |
 LL |     let _: _ = 2;
    |          ^^^
 
 error: variable declared with type underscore
-  --> $DIR/let_with_type_underscore.rs:16:5
+  --> $DIR/let_with_type_underscore.rs:17:5
    |
 LL |     let x: _ = func();
    |     ^^^^^^^^^^^^^^^^^^
    |
 help: remove the explicit type `_` declaration
-  --> $DIR/let_with_type_underscore.rs:16:10
+  --> $DIR/let_with_type_underscore.rs:17:10
    |
 LL |     let x: _ = func();
    |          ^^^
 
-error: aborting due to 3 previous errors
+error: variable declared with type underscore
+  --> $DIR/let_with_type_underscore.rs:18:5
+   |
+LL |     let x: _;
+   |     ^^^^^^^^^
+   |
+help: remove the explicit type `_` declaration
+  --> $DIR/let_with_type_underscore.rs:18:10
+   |
+LL |     let x: _;
+   |          ^^^
+
+error: variable declared with type underscore
+  --> $DIR/let_with_type_underscore.rs:25:5
+   |
+LL |     let x : _ = 1;
+   |     ^^^^^^^^^^^^^^
+   |
+help: remove the explicit type `_` declaration
+  --> $DIR/let_with_type_underscore.rs:25:10
+   |
+LL |     let x : _ = 1;
+   |          ^^^^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
closes #10498

changelog: [`let_with_type_underscore`]: Don't emit on locals from procedural macros
