### PR TITLE
[`allow_attributes`, `allow_attributes_without_reason`]: Ignore attributes from procedural macros

### DIFF
--- a/clippy_lints/src/allow_attributes.rs
+++ b/clippy_lints/src/allow_attributes.rs
@@ -1,4 +1,4 @@
-use ast::AttrStyle;
+use ast::{AttrStyle, Attribute};
 use clippy_utils::{diagnostics::span_lint_and_sugg, is_from_proc_macro};
 use rustc_ast as ast;
 use rustc_errors::Applicability;
@@ -50,14 +50,14 @@ declare_lint_pass!(AllowAttribute => [ALLOW_ATTRIBUTES]);
 
 impl LateLintPass<'_> for AllowAttribute {
     // Separate each crate's features.
-    fn check_attribute(&mut self, cx: &LateContext<'_>, attr: &ast::Attribute) {
+    fn check_attribute<'cx>(&mut self, cx: &LateContext<'cx>, attr: &'cx Attribute) {
         if_chain! {
             if !in_external_macro(cx.sess(), attr.span);
             if cx.tcx.features().lint_reasons;
             if let AttrStyle::Outer = attr.style;
             if let Some(ident) = attr.ident();
             if ident.name == rustc_span::symbol::sym::allow;
-            if !is_from_proc_macro(cx, &(attr, cx));
+            if !is_from_proc_macro(cx, &attr);
             then {
                 span_lint_and_sugg(
                     cx,

--- a/clippy_lints/src/allow_attributes.rs
+++ b/clippy_lints/src/allow_attributes.rs
@@ -1,5 +1,5 @@
 use ast::AttrStyle;
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::{diagnostics::span_lint_and_sugg, is_from_proc_macro};
 use rustc_ast as ast;
 use rustc_errors::Applicability;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
@@ -57,6 +57,7 @@ impl LateLintPass<'_> for AllowAttribute {
             if let AttrStyle::Outer = attr.style;
             if let Some(ident) = attr.ident();
             if ident.name == rustc_span::symbol::sym::allow;
+            if !is_from_proc_macro(cx, &(attr, cx));
             then {
                 span_lint_and_sugg(
                     cx,

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -1,9 +1,12 @@
 //! checks for attributes
 
-use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::macros::{is_panic, macro_backtrace};
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::{first_line_of_span, is_present_in_source, snippet_opt, without_block_comments};
+use clippy_utils::{
+    diagnostics::{span_lint, span_lint_and_help, span_lint_and_sugg, span_lint_and_then},
+    is_from_proc_macro,
+};
 use if_chain::if_chain;
 use rustc_ast::{AttrKind, AttrStyle, Attribute, LitKind, MetaItemKind, MetaItemLit, NestedMetaItem};
 use rustc_errors::Applicability;
@@ -540,7 +543,7 @@ fn check_clippy_lint_names(cx: &LateContext<'_>, name: Symbol, items: &[NestedMe
     }
 }
 
-fn check_lint_reason(cx: &LateContext<'_>, name: Symbol, items: &[NestedMetaItem], attr: &'_ Attribute) {
+fn check_lint_reason(cx: &LateContext<'_>, name: Symbol, items: &[NestedMetaItem], attr: &Attribute) {
     // Check for the feature
     if !cx.tcx.features().lint_reasons {
         return;
@@ -555,7 +558,7 @@ fn check_lint_reason(cx: &LateContext<'_>, name: Symbol, items: &[NestedMetaItem
     }
 
     // Check if the attribute is in an external macro and therefore out of the developer's control
-    if in_external_macro(cx.sess(), attr.span) {
+    if in_external_macro(cx.sess(), attr.span) || is_from_proc_macro(cx, &(attr, cx)) {
         return;
     }
 

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -543,7 +543,7 @@ fn check_clippy_lint_names(cx: &LateContext<'_>, name: Symbol, items: &[NestedMe
     }
 }
 
-fn check_lint_reason(cx: &LateContext<'_>, name: Symbol, items: &[NestedMetaItem], attr: &Attribute) {
+fn check_lint_reason<'cx>(cx: &LateContext<'cx>, name: Symbol, items: &[NestedMetaItem], attr: &'cx Attribute) {
     // Check for the feature
     if !cx.tcx.features().lint_reasons {
         return;
@@ -558,7 +558,7 @@ fn check_lint_reason(cx: &LateContext<'_>, name: Symbol, items: &[NestedMetaItem
     }
 
     // Check if the attribute is in an external macro and therefore out of the developer's control
-    if in_external_macro(cx.sess(), attr.span) || is_from_proc_macro(cx, &(attr, cx)) {
+    if in_external_macro(cx.sess(), attr.span) || is_from_proc_macro(cx, &attr) {
         return;
     }
 

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -358,15 +358,16 @@ impl<'cx> WithSearchPat for (&FnKind<'cx>, &Body<'cx>, HirId, Span) {
     }
 }
 
-impl<'cx> WithSearchPat for (&Attribute, &LateContext<'cx>) {
+// `Attribute` does not have the `hir` associated lifetime, so we cannot use the macro
+impl<'cx> WithSearchPat for &'cx Attribute {
     type Context = LateContext<'cx>;
 
     fn search_pat(&self, _cx: &Self::Context) -> (Pat, Pat) {
-        attr_search_pat(self.0)
+        attr_search_pat(self)
     }
 
     fn span(&self) -> Span {
-        self.0.span
+        self.span
     }
 }
 

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -344,7 +344,7 @@ impl<'cx> WithSearchPat for (&Attribute, &LateContext<'cx>) {
     type Context = LateContext<'cx>;
 
     fn search_pat(&self, _cx: &Self::Context) -> (Pat, Pat) {
-        attr_search_pat(&self.0)
+        attr_search_pat(self.0)
     }
 
     fn span(&self) -> Span {

--- a/tests/ui/allow_attributes.fixed
+++ b/tests/ui/allow_attributes.fixed
@@ -25,7 +25,7 @@ struct CfgT;
 
 fn ignore_external() {
     external! {
-        #[allow(clippy::needless_borrow)]
+        #[allow(clippy::needless_borrow)] // Should not lint
         fn a() {}
     }
 }

--- a/tests/ui/allow_attributes.fixed
+++ b/tests/ui/allow_attributes.fixed
@@ -1,9 +1,12 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs
 #![allow(unused)]
 #![warn(clippy::allow_attributes)]
 #![feature(lint_reasons)]
+#![no_main]
 
-fn main() {}
+extern crate proc_macros;
+use proc_macros::{external, with_span};
 
 // Using clippy::needless_borrow just as a placeholder, it isn't relevant.
 
@@ -17,8 +20,23 @@ struct T3;
 #[warn(clippy::needless_borrow)] // Should not lint
 struct T4;
 // `panic = "unwind"` should always be true
-#[cfg_attr(panic = "unwind", expect(dead_code))]
+#[cfg_attr(panic = "unwind", allow(dead_code))]
 struct CfgT;
+
+fn ignore_external() {
+    external! {
+        #[allow(clippy::needless_borrow)]
+        fn a() {}
+    }
+}
+
+fn ignore_proc_macro() {
+    with_span! {
+        span
+        #[allow(clippy::needless_borrow)] // Should not lint
+        fn a() {}
+    }
+}
 
 fn ignore_inner_attr() {
     #![allow(unused)] // Should not lint

--- a/tests/ui/allow_attributes.fixed
+++ b/tests/ui/allow_attributes.fixed
@@ -20,7 +20,7 @@ struct T3;
 #[warn(clippy::needless_borrow)] // Should not lint
 struct T4;
 // `panic = "unwind"` should always be true
-#[cfg_attr(panic = "unwind", allow(dead_code))]
+#[cfg_attr(panic = "unwind", expect(dead_code))]
 struct CfgT;
 
 fn ignore_external() {

--- a/tests/ui/allow_attributes.rs
+++ b/tests/ui/allow_attributes.rs
@@ -1,9 +1,12 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs
 #![allow(unused)]
 #![warn(clippy::allow_attributes)]
 #![feature(lint_reasons)]
+#![no_main]
 
-fn main() {}
+extern crate proc_macros;
+use proc_macros::{external, with_span};
 
 // Using clippy::needless_borrow just as a placeholder, it isn't relevant.
 
@@ -19,6 +22,21 @@ struct T4;
 // `panic = "unwind"` should always be true
 #[cfg_attr(panic = "unwind", allow(dead_code))]
 struct CfgT;
+
+fn ignore_external() {
+    external! {
+        #[allow(clippy::needless_borrow)] // Should not lint
+        fn a() {}
+    }
+}
+
+fn ignore_proc_macro() {
+    with_span! {
+        span
+        #[allow(clippy::needless_borrow)] // Should not lint
+        fn a() {}
+    }
+}
 
 fn ignore_inner_attr() {
     #![allow(unused)] // Should not lint

--- a/tests/ui/allow_attributes.stderr
+++ b/tests/ui/allow_attributes.stderr
@@ -6,5 +6,11 @@ LL | #[allow(dead_code)]
    |
    = note: `-D clippy::allow-attributes` implied by `-D warnings`
 
-error: aborting due to previous error
+error: #[allow] attribute found
+  --> $DIR/allow_attributes.rs:23:30
+   |
+LL | #[cfg_attr(panic = "unwind", allow(dead_code))]
+   |                              ^^^^^ help: replace it with: `expect`
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/allow_attributes.stderr
+++ b/tests/ui/allow_attributes.stderr
@@ -1,16 +1,10 @@
 error: #[allow] attribute found
-  --> $DIR/allow_attributes.rs:11:3
+  --> $DIR/allow_attributes.rs:14:3
    |
 LL | #[allow(dead_code)]
    |   ^^^^^ help: replace it with: `expect`
    |
    = note: `-D clippy::allow-attributes` implied by `-D warnings`
 
-error: #[allow] attribute found
-  --> $DIR/allow_attributes.rs:20:30
-   |
-LL | #[cfg_attr(panic = "unwind", allow(dead_code))]
-   |                              ^^^^^ help: replace it with: `expect`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/tests/ui/allow_attributes_false_positive.rs
+++ b/tests/ui/allow_attributes_false_positive.rs
@@ -1,5 +1,0 @@
-#![warn(clippy::allow_attributes)]
-#![feature(lint_reasons)]
-#![crate_type = "proc-macro"]
-
-fn main() {}

--- a/tests/ui/allow_attributes_without_reason.rs
+++ b/tests/ui/allow_attributes_without_reason.rs
@@ -28,3 +28,17 @@ fn main() {
         fn b() {}
     }
 }
+
+// Make sure this is not triggered on `?` desugaring
+
+pub fn trigger_fp_option() -> Option<()>{
+    Some(())?;
+    None?;
+    Some(())
+}
+
+pub fn trigger_fp_result() -> Result<(), &'static str> {
+    Ok(())?;
+    Err("asdf")?;
+    Ok(())
+}

--- a/tests/ui/allow_attributes_without_reason.rs
+++ b/tests/ui/allow_attributes_without_reason.rs
@@ -1,9 +1,15 @@
+//@aux-build:proc_macros.rs
 #![feature(lint_reasons)]
 #![deny(clippy::allow_attributes_without_reason)]
+#![allow(unfulfilled_lint_expectations)]
+
+extern crate proc_macros;
+use proc_macros::{external, with_span};
 
 // These should trigger the lint
 #[allow(dead_code)]
 #[allow(dead_code, deprecated)]
+#[expect(dead_code)]
 // These should be fine
 #[allow(dead_code, reason = "This should be allowed")]
 #[warn(dyn_drop, reason = "Warnings can also have reasons")]
@@ -11,4 +17,14 @@
 #[deny(deref_nullptr)]
 #[forbid(deref_nullptr)]
 
-fn main() {}
+fn main() {
+    external! {
+        #[allow(dead_code)]
+        fn a() {}
+    }
+    with_span! {
+        span
+        #[allow(dead_code)]
+        fn b() {}
+    }
+}

--- a/tests/ui/allow_attributes_without_reason.rs
+++ b/tests/ui/allow_attributes_without_reason.rs
@@ -31,7 +31,7 @@ fn main() {
 
 // Make sure this is not triggered on `?` desugaring
 
-pub fn trigger_fp_option() -> Option<()>{
+pub fn trigger_fp_option() -> Option<()> {
     Some(())?;
     None?;
     Some(())

--- a/tests/ui/allow_attributes_without_reason.stderr
+++ b/tests/ui/allow_attributes_without_reason.stderr
@@ -1,23 +1,39 @@
 error: `allow` attribute without specifying a reason
-  --> $DIR/allow_attributes_without_reason.rs:5:1
+  --> $DIR/allow_attributes_without_reason.rs:4:1
    |
-LL | #[allow(dead_code)]
-   | ^^^^^^^^^^^^^^^^^^^
+LL | #![allow(unfulfilled_lint_expectations)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try adding a reason at the end with `, reason = ".."`
 note: the lint level is defined here
-  --> $DIR/allow_attributes_without_reason.rs:2:9
+  --> $DIR/allow_attributes_without_reason.rs:3:9
    |
 LL | #![deny(clippy::allow_attributes_without_reason)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `allow` attribute without specifying a reason
-  --> $DIR/allow_attributes_without_reason.rs:6:1
+  --> $DIR/allow_attributes_without_reason.rs:10:1
+   |
+LL | #[allow(dead_code)]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a reason at the end with `, reason = ".."`
+
+error: `allow` attribute without specifying a reason
+  --> $DIR/allow_attributes_without_reason.rs:11:1
    |
 LL | #[allow(dead_code, deprecated)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try adding a reason at the end with `, reason = ".."`
 
-error: aborting due to 2 previous errors
+error: `expect` attribute without specifying a reason
+  --> $DIR/allow_attributes_without_reason.rs:12:1
+   |
+LL | #[expect(dead_code)]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a reason at the end with `, reason = ".."`
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
I use `lint_reasons` and `clap`, which is a bit overzealous when it comes to preventing warnings in its macros; it uses a ton of allow attributes on everything to, as ironic as it is, silence warnings. These two now ignore anything from procedural macros.

PS, I think `allow_attributes.rs` should be merged with `attrs.rs` in the future.

fixes #10377 

changelog: [`allow_attributes`, `allow_attributes_without_reason`]: Ignore attributes from procedural macros
