### PR TITLE
Adapt versions.html file to cleaned up gh-pages

### DIFF
--- a/util/gh-pages/versions.html
+++ b/util/gh-pages/versions.html
@@ -36,7 +36,7 @@
                 <ul class="list-group">
                     <a class="list-group-item" ng-repeat="version in data | orderBy:versionOrder:true"
                        href="./{{version}}/index.html">
-                        {{normalizeVersionDisplay(version)}}
+                        {{version}}
                     </a>
                 </ul>
             </article>
@@ -54,18 +54,15 @@
         .controller('docVersions', function ($scope, $http) {
             $scope.loading = true;
 
-            $scope.normalizeVersionDisplay = function(v) {
-                return v.replace(/^v/, '');
-            };
-
             $scope.normalizeVersion = function(v) {
-                return v.replace(/^v/, '').replace(/^rust-/, '');
+                return v.replace(/^rust-/, '');
             };
 
             $scope.versionOrder = function(v) {
                 if (v === 'master') { return Infinity; }
                 if (v === 'stable') { return Number.MAX_VALUE; }
                 if (v === 'beta') { return Number.MAX_VALUE - 1; }
+                if (v === 'pre-1.29.0') { return Number.MIN_VALUE; }
 
                 return $scope.normalizeVersion(v)
                     .split('.')


### PR DESCRIPTION
Companion PR to #10875

changelog: Remove legacy v0.0.* versions from Clippy repository and documentation. 

Must be merged together with #10875 (best with a closed tree)

r? @Alexendoo (because you were randomly selected on the other PR :P)