### PR TITLE
[`ptr_cast_constness`]: Only lint on casts which don't change type

### DIFF
--- a/clippy_lints/src/casts/ptr_cast_constness.rs
+++ b/clippy_lints/src/casts/ptr_cast_constness.rs
@@ -9,20 +9,21 @@ use rustc_middle::ty::{self, Ty, TypeAndMut};
 
 use super::PTR_CAST_CONSTNESS;
 
-pub(super) fn check(
+pub(super) fn check<'tcx>(
     cx: &LateContext<'_>,
     expr: &Expr<'_>,
     cast_expr: &Expr<'_>,
-    cast_from: Ty<'_>,
-    cast_to: Ty<'_>,
+    cast_from: Ty<'tcx>,
+    cast_to: Ty<'tcx>,
     msrv: &Msrv,
 ) {
     if_chain! {
         if msrv.meets(POINTER_CAST_CONSTNESS);
-        if let ty::RawPtr(TypeAndMut { mutbl: from_mutbl, .. }) = cast_from.kind();
-        if let ty::RawPtr(TypeAndMut { mutbl: to_mutbl, .. }) = cast_to.kind();
+        if let ty::RawPtr(TypeAndMut { mutbl: from_mutbl, ty: from_ty }) = cast_from.kind();
+        if let ty::RawPtr(TypeAndMut { mutbl: to_mutbl, ty: to_ty }) = cast_to.kind();
         if matches!((from_mutbl, to_mutbl),
             (Mutability::Not, Mutability::Mut) | (Mutability::Mut, Mutability::Not));
+        if from_ty == to_ty;
         then {
             let sugg = Sugg::hir(cx, cast_expr, "_");
             let constness = match *to_mutbl {
@@ -34,7 +35,7 @@ pub(super) fn check(
                 cx,
                 PTR_CAST_CONSTNESS,
                 expr.span,
-                "`as` casting between raw pointers while changing its constness",
+                "`as` casting between raw pointers while changing only its constness",
                 &format!("try `pointer::cast_{constness}`, a safer alternative"),
                 format!("{}.cast_{constness}()", sugg.maybe_par()),
                 Applicability::MachineApplicable,

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -2,17 +2,24 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::ptr_cast_constness)]
+#![allow(clippy::transmute_ptr_to_ref, unused)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};
+
+unsafe fn ptr_to_ref<T, U>(p: *const T, om: *mut U) {
+    let _: &mut T = std::mem::transmute(p.cast_mut());
+    let _ = &mut *p.cast_mut();
+    let _: &T = &*(om as *const T);
+}
 
 #[inline_macros]
 fn main() {
     let ptr: *const u32 = &42_u32;
     let mut_ptr: *mut u32 = &mut 42_u32;
 
-    let _ = ptr as *const i32;
-    let _ = mut_ptr as *mut i32;
+    let _ = ptr as *const u32;
+    let _ = mut_ptr as *mut u32;
 
     // Make sure the lint can handle the difference in their operator precedences.
     unsafe {
@@ -29,10 +36,10 @@ fn main() {
     let _ = ptr_of_array as *const dyn std::fmt::Debug;
 
     // Make sure the lint is triggered inside a macro
-    let _ = inline!($ptr as *const i32);
+    let _ = inline!($ptr as *const u32);
 
     // Do not lint inside macros from external crates
-    let _ = external!($ptr as *const i32);
+    let _ = external!($ptr as *const u32);
 }
 
 #[clippy::msrv = "1.64"]
@@ -41,8 +48,8 @@ fn _msrv_1_64() {
     let mut_ptr: *mut u32 = &mut 42_u32;
 
     // `pointer::cast_const` and `pointer::cast_mut` were stabilized in 1.65. Do not lint this
-    let _ = ptr as *mut i32;
-    let _ = mut_ptr as *const i32;
+    let _ = ptr as *mut u32;
+    let _ = mut_ptr as *const u32;
 }
 
 #[clippy::msrv = "1.65"]

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -2,7 +2,7 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::ptr_cast_constness)]
-#![allow(clippy::transmute_ptr_to_ref, unused)]
+#![allow(clippy::transmute_ptr_to_ref, clippy::unnecessary_cast, unused)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -2,7 +2,7 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::ptr_cast_constness)]
-#![allow(clippy::transmute_ptr_to_ref, unused)]
+#![allow(clippy::transmute_ptr_to_ref, clippy::unnecessary_cast, unused)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -2,26 +2,33 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::ptr_cast_constness)]
+#![allow(clippy::transmute_ptr_to_ref, unused)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};
+
+unsafe fn ptr_to_ref<T, U>(p: *const T, om: *mut U) {
+    let _: &mut T = std::mem::transmute(p as *mut T);
+    let _ = &mut *(p as *mut T);
+    let _: &T = &*(om as *const T);
+}
 
 #[inline_macros]
 fn main() {
     let ptr: *const u32 = &42_u32;
     let mut_ptr: *mut u32 = &mut 42_u32;
 
-    let _ = ptr as *const i32;
-    let _ = mut_ptr as *mut i32;
+    let _ = ptr as *const u32;
+    let _ = mut_ptr as *mut u32;
 
     // Make sure the lint can handle the difference in their operator precedences.
     unsafe {
         let ptr_ptr: *const *const u32 = &ptr;
-        let _ = *ptr_ptr as *mut i32;
+        let _ = *ptr_ptr as *mut u32;
     }
 
-    let _ = ptr as *mut i32;
-    let _ = mut_ptr as *const i32;
+    let _ = ptr as *mut u32;
+    let _ = mut_ptr as *const u32;
 
     // Lint this, since pointer::cast_mut and pointer::cast_const have ?Sized
     let ptr_of_array: *const [u32; 4] = &[1, 2, 3, 4];
@@ -29,10 +36,10 @@ fn main() {
     let _ = ptr_of_array as *const dyn std::fmt::Debug;
 
     // Make sure the lint is triggered inside a macro
-    let _ = inline!($ptr as *const i32);
+    let _ = inline!($ptr as *const u32);
 
     // Do not lint inside macros from external crates
-    let _ = external!($ptr as *const i32);
+    let _ = external!($ptr as *const u32);
 }
 
 #[clippy::msrv = "1.64"]
@@ -41,8 +48,8 @@ fn _msrv_1_64() {
     let mut_ptr: *mut u32 = &mut 42_u32;
 
     // `pointer::cast_const` and `pointer::cast_mut` were stabilized in 1.65. Do not lint this
-    let _ = ptr as *mut i32;
-    let _ = mut_ptr as *const i32;
+    let _ = ptr as *mut u32;
+    let _ = mut_ptr as *const u32;
 }
 
 #[clippy::msrv = "1.65"]
@@ -50,6 +57,6 @@ fn _msrv_1_65() {
     let ptr: *const u32 = &42_u32;
     let mut_ptr: *mut u32 = &mut 42_u32;
 
-    let _ = ptr as *mut i32;
-    let _ = mut_ptr as *const i32;
+    let _ = ptr as *mut u32;
+    let _ = mut_ptr as *const u32;
 }

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -1,34 +1,46 @@
-error: `as` casting between raw pointers while changing its constness
-  --> $DIR/ptr_cast_constness.rs:20:17
+error: `as` casting between raw pointers while changing only its constness
+  --> $DIR/ptr_cast_constness.rs:11:41
    |
-LL |         let _ = *ptr_ptr as *mut i32;
-   |                 ^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `(*ptr_ptr).cast_mut()`
+LL |     let _: &mut T = std::mem::transmute(p as *mut T);
+   |                                         ^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
    |
    = note: `-D clippy::ptr-cast-constness` implied by `-D warnings`
 
-error: `as` casting between raw pointers while changing its constness
-  --> $DIR/ptr_cast_constness.rs:23:13
+error: `as` casting between raw pointers while changing only its constness
+  --> $DIR/ptr_cast_constness.rs:12:19
    |
-LL |     let _ = ptr as *mut i32;
+LL |     let _ = &mut *(p as *mut T);
+   |                   ^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
+
+error: `as` casting between raw pointers while changing only its constness
+  --> $DIR/ptr_cast_constness.rs:27:17
+   |
+LL |         let _ = *ptr_ptr as *mut u32;
+   |                 ^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `(*ptr_ptr).cast_mut()`
+
+error: `as` casting between raw pointers while changing only its constness
+  --> $DIR/ptr_cast_constness.rs:30:13
+   |
+LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
-error: `as` casting between raw pointers while changing its constness
-  --> $DIR/ptr_cast_constness.rs:24:13
+error: `as` casting between raw pointers while changing only its constness
+  --> $DIR/ptr_cast_constness.rs:31:13
    |
-LL |     let _ = mut_ptr as *const i32;
+LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
-error: `as` casting between raw pointers while changing its constness
-  --> $DIR/ptr_cast_constness.rs:53:13
+error: `as` casting between raw pointers while changing only its constness
+  --> $DIR/ptr_cast_constness.rs:60:13
    |
-LL |     let _ = ptr as *mut i32;
+LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
-error: `as` casting between raw pointers while changing its constness
-  --> $DIR/ptr_cast_constness.rs:54:13
+error: `as` casting between raw pointers while changing only its constness
+  --> $DIR/ptr_cast_constness.rs:61:13
    |
-LL |     let _ = mut_ptr as *const i32;
+LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
fixes #10874

changelog: [`ptr_cast_constness`]: Only lint on casts which don't change type