### PR TITLE
[`useless_conversion`]: pluralize if there are multiple `.into_iter()` calls

### DIFF
--- a/tests/ui/useless_conversion.stderr
+++ b/tests/ui/useless_conversion.stderr
@@ -122,7 +122,7 @@ error: explicit call to `.into_iter()` in function argument accepting `IntoItera
   --> $DIR/useless_conversion.rs:171:7
    |
 LL |     b(vec![1, 2].into_iter());
-   |       ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2]`
+   |       ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing the `.into_iter()`: `vec![1, 2]`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> $DIR/useless_conversion.rs:161:13
@@ -134,7 +134,7 @@ error: explicit call to `.into_iter()` in function argument accepting `IntoItera
   --> $DIR/useless_conversion.rs:172:7
    |
 LL |     c(vec![1, 2].into_iter());
-   |       ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2]`
+   |       ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing the `.into_iter()`: `vec![1, 2]`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> $DIR/useless_conversion.rs:162:18
@@ -146,7 +146,7 @@ error: explicit call to `.into_iter()` in function argument accepting `IntoItera
   --> $DIR/useless_conversion.rs:173:7
    |
 LL |     d(vec![1, 2].into_iter());
-   |       ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2]`
+   |       ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing the `.into_iter()`: `vec![1, 2]`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> $DIR/useless_conversion.rs:165:12
@@ -158,7 +158,7 @@ error: explicit call to `.into_iter()` in function argument accepting `IntoItera
   --> $DIR/useless_conversion.rs:176:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter());
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2]`
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing the `.into_iter()`s: `vec![1, 2]`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> $DIR/useless_conversion.rs:161:13
@@ -170,7 +170,7 @@ error: explicit call to `.into_iter()` in function argument accepting `IntoItera
   --> $DIR/useless_conversion.rs:177:7
    |
 LL |     b(vec![1, 2].into_iter().into_iter().into_iter());
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into_iter()`: `vec![1, 2]`
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing the `.into_iter()`s: `vec![1, 2]`
    |
 note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> $DIR/useless_conversion.rs:161:13


### PR DESCRIPTION
context: https://github.com/rust-lang/rust-clippy/pull/10814#issuecomment-1575036086

changelog: [`useless_conversion`]: pluralize if there are multiple `.into_iter()` calls in the chain

r? @llogiq