### PR TITLE
Move `borrow_as_ptr` lint in the `suspicious` category

### DIFF
--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -577,7 +577,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.60.0"]
     pub BORROW_AS_PTR,
-    pedantic,
+    suspicious,
     "borrowing just to cast to a raw pointer"
 }
 

--- a/tests/ui/borrow_as_ptr.fixed
+++ b/tests/ui/borrow_as_ptr.fixed
@@ -4,7 +4,9 @@
 fn main() {
     let val = 1;
     let _p = std::ptr::addr_of!(val);
+    let _p = std::ptr::addr_of!(val) as *const u32;
 
     let mut val_mut = 1;
     let _p_mut = std::ptr::addr_of_mut!(val_mut);
+    let _p_mut = std::ptr::addr_of_mut!(val_mut) as *mut u32;
 }

--- a/tests/ui/borrow_as_ptr.fixed
+++ b/tests/ui/borrow_as_ptr.fixed
@@ -1,5 +1,4 @@
 //@run-rustfix
-#![warn(clippy::borrow_as_ptr)]
 
 fn main() {
     let val = 1;

--- a/tests/ui/borrow_as_ptr.rs
+++ b/tests/ui/borrow_as_ptr.rs
@@ -1,5 +1,4 @@
 //@run-rustfix
-#![warn(clippy::borrow_as_ptr)]
 
 fn main() {
     let val = 1;

--- a/tests/ui/borrow_as_ptr.rs
+++ b/tests/ui/borrow_as_ptr.rs
@@ -4,7 +4,9 @@
 fn main() {
     let val = 1;
     let _p = &val as *const i32;
+    let _p = (&val as *const i32) as *const u32;
 
     let mut val_mut = 1;
     let _p_mut = &mut val_mut as *mut i32;
+    let _p_mut = (&mut val_mut as *mut i32) as *mut u32;
 }

--- a/tests/ui/borrow_as_ptr.stderr
+++ b/tests/ui/borrow_as_ptr.stderr
@@ -1,5 +1,5 @@
 error: borrow as raw pointer
-  --> $DIR/borrow_as_ptr.rs:6:14
+  --> $DIR/borrow_as_ptr.rs:5:14
    |
 LL |     let _p = &val as *const i32;
    |              ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of!(val)`
@@ -7,19 +7,19 @@ LL |     let _p = &val as *const i32;
    = note: `-D clippy::borrow-as-ptr` implied by `-D warnings`
 
 error: borrow as raw pointer
-  --> $DIR/borrow_as_ptr.rs:7:14
+  --> $DIR/borrow_as_ptr.rs:6:14
    |
 LL |     let _p = (&val as *const i32) as *const u32;
    |              ^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of!(val)`
 
 error: borrow as raw pointer
-  --> $DIR/borrow_as_ptr.rs:10:18
+  --> $DIR/borrow_as_ptr.rs:9:18
    |
 LL |     let _p_mut = &mut val_mut as *mut i32;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of_mut!(val_mut)`
 
 error: borrow as raw pointer
-  --> $DIR/borrow_as_ptr.rs:11:18
+  --> $DIR/borrow_as_ptr.rs:10:18
    |
 LL |     let _p_mut = (&mut val_mut as *mut i32) as *mut u32;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of_mut!(val_mut)`

--- a/tests/ui/borrow_as_ptr.stderr
+++ b/tests/ui/borrow_as_ptr.stderr
@@ -7,10 +7,22 @@ LL |     let _p = &val as *const i32;
    = note: `-D clippy::borrow-as-ptr` implied by `-D warnings`
 
 error: borrow as raw pointer
-  --> $DIR/borrow_as_ptr.rs:9:18
+  --> $DIR/borrow_as_ptr.rs:7:14
+   |
+LL |     let _p = (&val as *const i32) as *const u32;
+   |              ^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of!(val)`
+
+error: borrow as raw pointer
+  --> $DIR/borrow_as_ptr.rs:10:18
    |
 LL |     let _p_mut = &mut val_mut as *mut i32;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of_mut!(val_mut)`
 
-error: aborting due to 2 previous errors
+error: borrow as raw pointer
+  --> $DIR/borrow_as_ptr.rs:11:18
+   |
+LL |     let _p_mut = (&mut val_mut as *mut i32) as *mut u32;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of_mut!(val_mut)`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/borrow_deref_ref.fixed
+++ b/tests/ui/borrow_deref_ref.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 //@aux-build: proc_macros.rs
 
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code, unused_variables, clippy::borrow_as_ptr)]
 
 extern crate proc_macros;
 use proc_macros::with_span;

--- a/tests/ui/borrow_deref_ref.rs
+++ b/tests/ui/borrow_deref_ref.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 //@aux-build: proc_macros.rs
 
-#![allow(dead_code, unused_variables)]
+#![allow(dead_code, unused_variables, clippy::borrow_as_ptr)]
 
 extern crate proc_macros;
 use proc_macros::with_span;

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -2,6 +2,7 @@
 #![feature(lint_reasons)]
 #![allow(
     unused,
+    clippy::borrow_as_ptr,
     clippy::uninlined_format_args,
     clippy::unnecessary_mut_passed,
     clippy::unnecessary_to_owned

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -2,6 +2,7 @@
 #![feature(lint_reasons)]
 #![allow(
     unused,
+    clippy::borrow_as_ptr,
     clippy::uninlined_format_args,
     clippy::unnecessary_mut_passed,
     clippy::unnecessary_to_owned

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -1,5 +1,5 @@
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:15:15
+  --> $DIR/needless_borrow.rs:16:15
    |
 LL |     let _ = x(&&a); // warn
    |               ^^^ help: change this to: `&a`
@@ -7,211 +7,211 @@ LL |     let _ = x(&&a); // warn
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:19:13
+  --> $DIR/needless_borrow.rs:20:13
    |
 LL |     mut_ref(&mut &mut b); // warn
    |             ^^^^^^^^^^^ help: change this to: `&mut b`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:31:13
+  --> $DIR/needless_borrow.rs:32:13
    |
 LL |             &&a
    |             ^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:33:15
+  --> $DIR/needless_borrow.rs:34:15
    |
 LL |         46 => &&a,
    |               ^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:39:27
+  --> $DIR/needless_borrow.rs:40:27
    |
 LL |                     break &ref_a;
    |                           ^^^^^^ help: change this to: `ref_a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:46:15
+  --> $DIR/needless_borrow.rs:47:15
    |
 LL |     let _ = x(&&&a);
    |               ^^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:47:15
+  --> $DIR/needless_borrow.rs:48:15
    |
 LL |     let _ = x(&mut &&a);
    |               ^^^^^^^^ help: change this to: `&a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:48:15
+  --> $DIR/needless_borrow.rs:49:15
    |
 LL |     let _ = x(&&&mut b);
    |               ^^^^^^^^ help: change this to: `&mut b`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:49:15
+  --> $DIR/needless_borrow.rs:50:15
    |
 LL |     let _ = x(&&ref_a);
    |               ^^^^^^^ help: change this to: `ref_a`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:52:11
+  --> $DIR/needless_borrow.rs:53:11
    |
 LL |         x(&b);
    |           ^^ help: change this to: `b`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:59:13
+  --> $DIR/needless_borrow.rs:60:13
    |
 LL |     mut_ref(&mut x);
    |             ^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:60:13
+  --> $DIR/needless_borrow.rs:61:13
    |
 LL |     mut_ref(&mut &mut x);
    |             ^^^^^^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:61:23
+  --> $DIR/needless_borrow.rs:62:23
    |
 LL |     let y: &mut i32 = &mut x;
    |                       ^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:62:23
+  --> $DIR/needless_borrow.rs:63:23
    |
 LL |     let y: &mut i32 = &mut &mut x;
    |                       ^^^^^^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:71:14
+  --> $DIR/needless_borrow.rs:72:14
    |
 LL |         0 => &mut x,
    |              ^^^^^^ help: change this to: `x`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:77:14
+  --> $DIR/needless_borrow.rs:78:14
    |
 LL |         0 => &mut x,
    |              ^^^^^^ help: change this to: `x`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:89:13
+  --> $DIR/needless_borrow.rs:90:13
    |
 LL |     let _ = (&x).0;
    |             ^^^^ help: change this to: `x`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:91:22
+  --> $DIR/needless_borrow.rs:92:22
    |
 LL |     let _ = unsafe { (&*x).0 };
    |                      ^^^^^ help: change this to: `(*x)`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:101:5
+  --> $DIR/needless_borrow.rs:102:5
    |
 LL |     (&&()).foo();
    |     ^^^^^^ help: change this to: `(&())`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:110:5
+  --> $DIR/needless_borrow.rs:111:5
    |
 LL |     (&&5).foo();
    |     ^^^^^ help: change this to: `(&5)`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:135:51
+  --> $DIR/needless_borrow.rs:136:51
    |
 LL |     let _ = std::process::Command::new("ls").args(&["-a", "-l"]).status().unwrap();
    |                                                   ^^^^^^^^^^^^^ help: change this to: `["-a", "-l"]`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:136:44
+  --> $DIR/needless_borrow.rs:137:44
    |
 LL |     let _ = std::path::Path::new(".").join(&&".");
    |                                            ^^^^^ help: change this to: `"."`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:137:23
+  --> $DIR/needless_borrow.rs:138:23
    |
 LL |     deref_target_is_x(&X);
    |                       ^^ help: change this to: `X`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:138:26
+  --> $DIR/needless_borrow.rs:139:26
    |
 LL |     multiple_constraints(&[[""]]);
    |                          ^^^^^^^ help: change this to: `[[""]]`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:139:45
+  --> $DIR/needless_borrow.rs:140:45
    |
 LL |     multiple_constraints_normalizes_to_same(&X, X);
    |                                             ^^ help: change this to: `X`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> $DIR/needless_borrow.rs:140:32
+  --> $DIR/needless_borrow.rs:141:32
    |
 LL |     let _ = Some("").unwrap_or(&"");
    |                                ^^^ help: change this to: `""`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:141:33
+  --> $DIR/needless_borrow.rs:142:33
    |
 LL |     let _ = std::fs::write("x", &"".to_string());
    |                                 ^^^^^^^^^^^^^^^ help: change this to: `"".to_string()`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:190:13
+  --> $DIR/needless_borrow.rs:191:13
    |
 LL |             (&self.f)()
    |             ^^^^^^^^^ help: change this to: `(self.f)`
 
 error: this expression borrows a value the compiler would automatically borrow
-  --> $DIR/needless_borrow.rs:199:13
+  --> $DIR/needless_borrow.rs:200:13
    |
 LL |             (&mut self.f)()
    |             ^^^^^^^^^^^^^ help: change this to: `(self.f)`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:283:20
+  --> $DIR/needless_borrow.rs:284:20
    |
 LL |         takes_iter(&mut x)
    |                    ^^^^^^ help: change this to: `x`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:297:55
+  --> $DIR/needless_borrow.rs:298:55
    |
 LL |         let _ = std::process::Command::new("ls").args(&["-a", "-l"]).status().unwrap();
    |                                                       ^^^^^^^^^^^^^ help: change this to: `["-a", "-l"]`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:335:37
+  --> $DIR/needless_borrow.rs:336:37
    |
 LL |         let _ = std::fs::write("x", &arg);
    |                                     ^^^^ help: change this to: `arg`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:336:37
+  --> $DIR/needless_borrow.rs:337:37
    |
 LL |         let _ = std::fs::write("x", &loc);
    |                                     ^^^^ help: change this to: `loc`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:354:15
+  --> $DIR/needless_borrow.rs:355:15
    |
 LL |         debug(&x);
    |               ^^ help: change this to: `x`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:363:15
+  --> $DIR/needless_borrow.rs:364:15
    |
 LL |         use_x(&x);
    |               ^^ help: change this to: `x`
 
 error: the borrowed expression implements the required traits
-  --> $DIR/needless_borrow.rs:457:13
+  --> $DIR/needless_borrow.rs:458:13
    |
 LL |         foo(&a);
    |             ^^ help: change this to: `a`

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -1,6 +1,11 @@
 //@run-rustfix
 #![warn(clippy::single_match)]
-#![allow(unused, clippy::uninlined_format_args, clippy::redundant_pattern_matching)]
+#![allow(
+    unused,
+    clippy::borrow_as_ptr,
+    clippy::uninlined_format_args,
+    clippy::redundant_pattern_matching
+)]
 fn dummy() {}
 
 fn single_match() {

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -1,6 +1,11 @@
 //@run-rustfix
 #![warn(clippy::single_match)]
-#![allow(unused, clippy::uninlined_format_args, clippy::redundant_pattern_matching)]
+#![allow(
+    unused,
+    clippy::borrow_as_ptr,
+    clippy::uninlined_format_args,
+    clippy::redundant_pattern_matching
+)]
 fn dummy() {}
 
 fn single_match() {

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:9:5
+  --> $DIR/single_match.rs:14:5
    |
 LL | /     match x {
 LL | |         Some(y) => {
@@ -18,7 +18,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:17:5
+  --> $DIR/single_match.rs:22:5
    |
 LL | /     match x {
 LL | |         // Note the missing block braces.
@@ -30,7 +30,7 @@ LL | |     }
    | |_____^ help: try this: `if let Some(y) = x { println!("{:?}", y) }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:26:5
+  --> $DIR/single_match.rs:31:5
    |
 LL | /     match z {
 LL | |         (2..=3, 7..=9) => dummy(),
@@ -39,7 +39,7 @@ LL | |     };
    | |_____^ help: try this: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:55:5
+  --> $DIR/single_match.rs:60:5
    |
 LL | /     match x {
 LL | |         Some(y) => dummy(),
@@ -48,7 +48,7 @@ LL | |     };
    | |_____^ help: try this: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:60:5
+  --> $DIR/single_match.rs:65:5
    |
 LL | /     match y {
 LL | |         Ok(y) => dummy(),
@@ -57,7 +57,7 @@ LL | |     };
    | |_____^ help: try this: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:67:5
+  --> $DIR/single_match.rs:72:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try this: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:88:5
+  --> $DIR/single_match.rs:93:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -75,7 +75,7 @@ LL | |     }
    | |_____^ help: try this: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:101:5
+  --> $DIR/single_match.rs:106:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -84,7 +84,7 @@ LL | |     }
    | |_____^ help: try this: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:107:5
+  --> $DIR/single_match.rs:112:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -93,7 +93,7 @@ LL | |     }
    | |_____^ help: try this: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:112:5
+  --> $DIR/single_match.rs:117:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -102,7 +102,7 @@ LL | |     }
    | |_____^ help: try this: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:118:5
+  --> $DIR/single_match.rs:123:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -111,7 +111,7 @@ LL | |     }
    | |_____^ help: try this: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:135:5
+  --> $DIR/single_match.rs:140:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -120,7 +120,7 @@ LL | |     }
    | |_____^ help: try this: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:143:5
+  --> $DIR/single_match.rs:148:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -129,7 +129,7 @@ LL | |     };
    | |_____^ help: try this: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:165:5
+  --> $DIR/single_match.rs:170:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -138,7 +138,7 @@ LL | |     }
    | |_____^ help: try this: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:171:5
+  --> $DIR/single_match.rs:176:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -147,7 +147,7 @@ LL | |     }
    | |_____^ help: try this: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:177:5
+  --> $DIR/single_match.rs:182:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
@@ -156,7 +156,7 @@ LL | |     }
    | |_____^ help: try this: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:249:5
+  --> $DIR/single_match.rs:254:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -176,7 +176,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:257:5
+  --> $DIR/single_match.rs:262:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]

--- a/tests/ui/single_match_else.fixed
+++ b/tests/ui/single_match_else.fixed
@@ -1,7 +1,13 @@
 //@run-rustfix
 //@aux-build: proc_macros.rs
 #![warn(clippy::single_match_else)]
-#![allow(unused, clippy::needless_return, clippy::no_effect, clippy::uninlined_format_args)]
+#![allow(
+    unused,
+    clippy::borrow_as_ptr,
+    clippy::needless_return,
+    clippy::no_effect,
+    clippy::uninlined_format_args
+)]
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/single_match_else.rs
+++ b/tests/ui/single_match_else.rs
@@ -1,7 +1,13 @@
 //@run-rustfix
 //@aux-build: proc_macros.rs
 #![warn(clippy::single_match_else)]
-#![allow(unused, clippy::needless_return, clippy::no_effect, clippy::uninlined_format_args)]
+#![allow(
+    unused,
+    clippy::borrow_as_ptr,
+    clippy::needless_return,
+    clippy::no_effect,
+    clippy::uninlined_format_args
+)]
 extern crate proc_macros;
 use proc_macros::with_span;
 

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:17:13
+  --> $DIR/single_match_else.rs:23:13
    |
 LL |       let _ = match ExprNode::Butterflies {
    |  _____________^
@@ -21,7 +21,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:82:5
+  --> $DIR/single_match_else.rs:88:5
    |
 LL | /     match Some(1) {
 LL | |         Some(a) => println!("${:?}", a),
@@ -41,7 +41,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:91:5
+  --> $DIR/single_match_else.rs:97:5
    |
 LL | /     match Some(1) {
 LL | |         Some(a) => println!("${:?}", a),
@@ -61,7 +61,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:101:5
+  --> $DIR/single_match_else.rs:107:5
    |
 LL | /     match Result::<i32, Infallible>::Ok(1) {
 LL | |         Ok(a) => println!("${:?}", a),
@@ -81,7 +81,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:110:5
+  --> $DIR/single_match_else.rs:116:5
    |
 LL | /     match Cow::from("moo") {
 LL | |         Cow::Owned(a) => println!("${:?}", a),
@@ -101,7 +101,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:120:5
+  --> $DIR/single_match_else.rs:126:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -124,7 +124,7 @@ LL +     }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:131:5
+  --> $DIR/single_match_else.rs:137:5
    |
 LL | /     match bar {
 LL | |         Some(v) => {
@@ -148,7 +148,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:143:5
+  --> $DIR/single_match_else.rs:149:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -172,7 +172,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match_else.rs:155:5
+  --> $DIR/single_match_else.rs:161:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]

--- a/tests/ui/unnecessary_struct_initialization.fixed
+++ b/tests/ui/unnecessary_struct_initialization.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(unused)]
+#![allow(unused, clippy::borrow_as_ptr)]
 #![warn(clippy::unnecessary_struct_initialization)]
 
 struct S {

--- a/tests/ui/unnecessary_struct_initialization.rs
+++ b/tests/ui/unnecessary_struct_initialization.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(unused)]
+#![allow(unused, clippy::borrow_as_ptr)]
 #![warn(clippy::unnecessary_struct_initialization)]
 
 struct S {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust-clippy/issues/10872.

This lint should warn by default as it actually allows to uncover potentially problematic reference to pointer conversions. To do so, I moved it into the `suspicious` category. I also used this opportunity to extend its tests.

The second issue described in the issue doesn't seem to be covered by the current lint implementation though.