### PR TITLE
[`type_repetition_in_bounds`]: Don't lint on derived code

### DIFF
--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
 use clippy_utils::source::{snippet, snippet_opt, snippet_with_applicability};
-use clippy_utils::{SpanlessEq, SpanlessHash};
+use clippy_utils::{is_from_proc_macro, SpanlessEq, SpanlessHash};
 use core::hash::{Hash, Hasher};
 use if_chain::if_chain;
 use itertools::Itertools;
@@ -260,10 +260,7 @@ impl TraitBounds {
                     SpanlessTy { ty: p.bounded_ty, cx },
                     p.bounds.iter().collect::<Vec<_>>()
                 );
-                let bounded_ty = snippet(cx, p.bounded_ty.span, "_");
-                if let TyKind::Path(qpath) = p.bounded_ty.kind;
-                if format!("{}:", rustc_hir_pretty::qpath_to_string(&qpath)) == format!("{bounded_ty}:");
-
+                if !is_from_proc_macro(cx, p.bounded_ty);
                 then {
                     let trait_bounds = v
                         .iter()
@@ -272,7 +269,10 @@ impl TraitBounds {
                         .filter_map(get_trait_info_from_bound)
                         .map(|(_, _, span)| snippet_with_applicability(cx, span, "..", &mut applicability))
                         .join(" + ");
-                    let hint_string = format!("consider combining the bounds: `{bounded_ty}: {trait_bounds}`");
+                    let hint_string = format!(
+                        "consider combining the bounds: `{}: {trait_bounds}`",
+                        snippet(cx, p.bounded_ty.span, "_"),
+                    );
                     span_lint_and_help(
                         cx,
                         TYPE_REPETITION_IN_BOUNDS,

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -260,6 +260,9 @@ impl TraitBounds {
                     SpanlessTy { ty: p.bounded_ty, cx },
                     p.bounds.iter().collect::<Vec<_>>()
                 );
+                if let TyKind::Path(qpath) = p.bounded_ty.kind;
+                if format!("{}:", rustc_hir_pretty::qpath_to_string(&qpath))
+                    == format!("{}:", snippet(cx, p.bounded_ty.span, "_"));
 
                 then {
                     let trait_bounds = v

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -262,7 +262,7 @@ impl TraitBounds {
                 );
                 let bounded_ty = snippet(cx, p.bounded_ty.span, "_");
                 if let TyKind::Path(qpath) = p.bounded_ty.kind;
-                if format!("{}:", rustc_hir_pretty::qpath_to_string(&qpath)) == format!("{}:", bounded_ty);
+                if format!("{}:", rustc_hir_pretty::qpath_to_string(&qpath)) == format!("{bounded_ty}:");
 
                 then {
                     let trait_bounds = v
@@ -272,7 +272,7 @@ impl TraitBounds {
                         .filter_map(get_trait_info_from_bound)
                         .map(|(_, _, span)| snippet_with_applicability(cx, span, "..", &mut applicability))
                         .join(" + ");
-                    let hint_string = format!("consider combining the bounds: `{}: {trait_bounds}`", bounded_ty);
+                    let hint_string = format!("consider combining the bounds: `{bounded_ty}: {trait_bounds}`");
                     span_lint_and_help(
                         cx,
                         TYPE_REPETITION_IN_BOUNDS,

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -260,9 +260,9 @@ impl TraitBounds {
                     SpanlessTy { ty: p.bounded_ty, cx },
                     p.bounds.iter().collect::<Vec<_>>()
                 );
+                let bounded_ty = snippet(cx, p.bounded_ty.span, "_");
                 if let TyKind::Path(qpath) = p.bounded_ty.kind;
-                if format!("{}:", rustc_hir_pretty::qpath_to_string(&qpath))
-                    == format!("{}:", snippet(cx, p.bounded_ty.span, "_"));
+                if format!("{}:", rustc_hir_pretty::qpath_to_string(&qpath)) == format!("{}:", bounded_ty);
 
                 then {
                     let trait_bounds = v
@@ -272,10 +272,7 @@ impl TraitBounds {
                         .filter_map(get_trait_info_from_bound)
                         .map(|(_, _, span)| snippet_with_applicability(cx, span, "..", &mut applicability))
                         .join(" + ");
-                    let hint_string = format!(
-                        "consider combining the bounds: `{}: {trait_bounds}`",
-                        snippet(cx, p.bounded_ty.span, "_"),
-                    );
+                    let hint_string = format!("consider combining the bounds: `{}: {trait_bounds}`", bounded_ty);
                     span_lint_and_help(
                         cx,
                         TYPE_REPETITION_IN_BOUNDS,
@@ -345,7 +342,7 @@ fn check_trait_bound_duplication(cx: &LateContext<'_>, gen: &'_ Generics<'_>) {
                             "this trait bound is already specified in the where clause",
                             None,
                             "consider removing this trait bound",
-                            );
+                        );
                     }
                 }
             }

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -319,19 +319,6 @@ fn attr_search_pat(attr: &Attribute) -> (Pat, Pat) {
     }
 }
 
-// TODO: Waiting on `ty_search_pat`.
-// fn where_pred_search_pat(where_pred: &WherePredicate<'_>) -> (Pat, Pat) {
-//     match where_pred {
-//         WherePredicate::BoundPredicate(bound) => {
-//             todo!();
-//         },
-//         WherePredicate::RegionPredicate(region) => {
-//
-//         },
-//         WherePredicate::EqPredicate(..) => unimplemented!(),
-//     }
-// }
-
 fn ty_search_pat(ty: &Ty<'_>) -> (Pat, Pat) {
     match ty.kind {
         TyKind::Slice(..) | TyKind::Array(..) => (Pat::Str("["), Pat::Str("]")),

--- a/clippy_utils/src/check_proc_macro.rs
+++ b/clippy_utils/src/check_proc_macro.rs
@@ -351,7 +351,8 @@ fn ty_search_pat(ty: &Ty<'_>) -> (Pat, Pat) {
         TyKind::Never => (Pat::Str("!"), Pat::Str("")),
         TyKind::Tup(..) => (Pat::Str("("), Pat::Str(")")),
         TyKind::OpaqueDef(..) => (Pat::Str("impl"), Pat::Str("")),
-        // NOTE: This is missing `TraitObject` and `Path` here. It always return true then.
+        TyKind::Path(qpath) => qpath_search_pat(&qpath),
+        // NOTE: This is missing `TraitObject`. It always return true then.
         _ => (Pat::Str(""), Pat::Str("")),
     }
 }

--- a/tests/ui/type_repetition_in_bounds.rs
+++ b/tests/ui/type_repetition_in_bounds.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::type_repetition_in_bounds)]
 #![allow(clippy::extra_unused_type_parameters)]
 
+use serde::Deserialize;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 
 pub fn foo<T>(_t: T)
@@ -68,6 +69,20 @@ mod issue4326 {
     {
         foo: S,
     }
+}
+
+// Extern macros shouldn't lint, again (see #10504)
+mod issue10504 {
+    use serde::{Deserialize, Serialize};
+    use std::fmt::Debug;
+    use std::hash::Hash;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(bound(
+        serialize = "T: Serialize + Hash + Eq",
+        deserialize = "Box<T>: serde::de::DeserializeOwned + Hash + Eq"
+    ))]
+    struct OpaqueParams<T: ?Sized + Debug>(std::marker::PhantomData<T>);
 }
 
 // Issue #7360

--- a/tests/ui/type_repetition_in_bounds.stderr
+++ b/tests/ui/type_repetition_in_bounds.stderr
@@ -1,5 +1,5 @@
 error: this type has already been used as a bound predicate
-  --> $DIR/type_repetition_in_bounds.rs:9:5
+  --> $DIR/type_repetition_in_bounds.rs:10:5
    |
 LL |     T: Clone,
    |     ^^^^^^^^
@@ -12,7 +12,7 @@ LL | #![deny(clippy::type_repetition_in_bounds)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this type has already been used as a bound predicate
-  --> $DIR/type_repetition_in_bounds.rs:26:5
+  --> $DIR/type_repetition_in_bounds.rs:27:5
    |
 LL |     Self: Copy + Default + Ord,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |     Self: Copy + Default + Ord,
    = help: consider combining the bounds: `Self: Clone + Copy + Default + Ord`
 
 error: this type has already been used as a bound predicate
-  --> $DIR/type_repetition_in_bounds.rs:86:5
+  --> $DIR/type_repetition_in_bounds.rs:101:5
    |
 LL |     T: Clone,
    |     ^^^^^^^^
@@ -28,7 +28,7 @@ LL |     T: Clone,
    = help: consider combining the bounds: `T: ?Sized + Clone`
 
 error: this type has already been used as a bound predicate
-  --> $DIR/type_repetition_in_bounds.rs:91:5
+  --> $DIR/type_repetition_in_bounds.rs:106:5
    |
 LL |     T: ?Sized,
    |     ^^^^^^^^^


### PR DESCRIPTION
fixes #10504.

changelog: [`type_repetition_in_bounds`]: Don't lint on derived code
