### PR TITLE
Add `needless_pass_by_ref_mut` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5047,6 +5047,7 @@ Released 2018-09-13
 [`needless_option_as_deref`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_option_as_deref
 [`needless_option_take`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_option_take
 [`needless_parens_on_range_literals`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_parens_on_range_literals
+[`needless_pass_by_ref_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
 [`needless_pass_by_value`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value
 [`needless_pub_self`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_pub_self
 [`needless_question_mark`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -470,6 +470,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::needless_if::NEEDLESS_IF_INFO,
     crate::needless_late_init::NEEDLESS_LATE_INIT_INFO,
     crate::needless_parens_on_range_literals::NEEDLESS_PARENS_ON_RANGE_LITERALS_INFO,
+    crate::needless_pass_by_ref_mut::NEEDLESS_PASS_BY_REF_MUT_INFO,
     crate::needless_pass_by_value::NEEDLESS_PASS_BY_VALUE_INFO,
     crate::needless_question_mark::NEEDLESS_QUESTION_MARK_INFO,
     crate::needless_update::NEEDLESS_UPDATE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1058,7 +1058,11 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     let stack_size_threshold = conf.stack_size_threshold;
     store.register_late_pass(move |_| Box::new(large_stack_frames::LargeStackFrames::new(stack_size_threshold)));
     store.register_late_pass(|_| Box::new(single_range_in_vec_init::SingleRangeInVecInit));
-    store.register_late_pass(|_| Box::new(needless_pass_by_ref_mut::NeedlessPassByRefMut));
+    store.register_late_pass(move |_| {
+        Box::new(needless_pass_by_ref_mut::NeedlessPassByRefMut::new(
+            avoid_breaking_exported_api,
+        ))
+    });
     store.register_late_pass(|_| Box::new(incorrect_impls::IncorrectImpls));
     store.register_late_pass(move |_| {
         Box::new(single_call_fn::SingleCallFn {

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -229,6 +229,7 @@ mod needless_for_each;
 mod needless_if;
 mod needless_late_init;
 mod needless_parens_on_range_literals;
+mod needless_pass_by_ref_mut;
 mod needless_pass_by_value;
 mod needless_question_mark;
 mod needless_update;
@@ -1057,6 +1058,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     let stack_size_threshold = conf.stack_size_threshold;
     store.register_late_pass(move |_| Box::new(large_stack_frames::LargeStackFrames::new(stack_size_threshold)));
     store.register_late_pass(|_| Box::new(single_range_in_vec_init::SingleRangeInVecInit));
+    store.register_late_pass(|_| Box::new(needless_pass_by_ref_mut::NeedlessPassByRefMut));
     store.register_late_pass(|_| Box::new(incorrect_impls::IncorrectImpls));
     store.register_late_pass(move |_| {
         Box::new(single_call_fn::SingleCallFn {

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -264,7 +264,7 @@ impl LiteralDigitGrouping {
                     return;
                 }
 
-                if Self::is_literal_uuid_formatted(&mut num_lit) {
+                if Self::is_literal_uuid_formatted(&num_lit) {
                     return;
                 }
 
@@ -376,7 +376,7 @@ impl LiteralDigitGrouping {
     ///
     /// Returns `true` if the radix is hexadecimal, and the groups match the
     /// UUID format of 8-4-4-4-12.
-    fn is_literal_uuid_formatted(num_lit: &mut NumericLiteral<'_>) -> bool {
+    fn is_literal_uuid_formatted(num_lit: &NumericLiteral<'_>) -> bool {
         if num_lit.radix != Radix::Hexadecimal {
             return false;
         }

--- a/clippy_lints/src/needless_pass_by_ref_mut.rs
+++ b/clippy_lints/src/needless_pass_by_ref_mut.rs
@@ -1,0 +1,238 @@
+use super::needless_pass_by_value::requires_exact_signature;
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet;
+use clippy_utils::{is_from_proc_macro, is_self};
+use if_chain::if_chain;
+use rustc_errors::Applicability;
+use rustc_hir::intravisit::FnKind;
+use rustc_hir::{Body, FnDecl, HirId, Impl, ItemKind, Mutability, Node, PatKind};
+use rustc_hir::{HirIdMap, HirIdSet};
+use rustc_hir_typeck::expr_use_visitor as euv;
+use rustc_infer::infer::TyCtxtInferExt;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::mir::FakeReadCause;
+use rustc_middle::ty::{self, Ty};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_span::def_id::LocalDefId;
+use rustc_span::symbol::kw;
+use rustc_span::Span;
+use rustc_target::spec::abi::Abi;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Check if a `&mut` function argument is actually used mutably.
+    ///
+    /// ### Why is this bad?
+    /// Less `mut` means less fights with the borrow checker. It can also lead to more
+    /// opportunities for parallelization.
+    ///
+    /// ### Example
+    /// ```rust
+    /// fn foo(y: &mut i32) -> i32 {
+    ///     12 + *y
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// fn foo(y: &i32) -> i32 {
+    ///     12 + *y
+    /// }
+    /// ```
+    #[clippy::version = "1.72.0"]
+    pub NEEDLESS_PASS_BY_REF_MUT,
+    suspicious,
+    "using a `&mut` argument when it's not mutated"
+}
+declare_lint_pass!(NeedlessPassByRefMut => [NEEDLESS_PASS_BY_REF_MUT]);
+
+fn should_skip<'tcx>(
+    cx: &LateContext<'tcx>,
+    input: rustc_hir::Ty<'tcx>,
+    ty: Ty<'_>,
+    arg: &rustc_hir::Param<'_>,
+) -> bool {
+    // We check if this a `&mut`. `ref_mutability` returns `None` if it's not a reference.
+    if !matches!(ty.ref_mutability(), Some(Mutability::Mut)) {
+        return true;
+    }
+
+    if is_self(arg) {
+        return true;
+    }
+
+    if let PatKind::Binding(.., name, _) = arg.pat.kind {
+        // If it's a potentially unused variable, we don't check it.
+        if name.name == kw::Underscore || name.as_str().starts_with('_') {
+            return true;
+        }
+    }
+
+    // All spans generated from a proc-macro invocation are the same...
+    is_from_proc_macro(cx, &input)
+}
+
+impl<'tcx> LateLintPass<'tcx> for NeedlessPassByRefMut {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        kind: FnKind<'tcx>,
+        decl: &'tcx FnDecl<'_>,
+        body: &'tcx Body<'_>,
+        span: Span,
+        fn_def_id: LocalDefId,
+    ) {
+        if span.from_expansion() {
+            return;
+        }
+
+        let hir_id = cx.tcx.hir().local_def_id_to_hir_id(fn_def_id);
+
+        match kind {
+            FnKind::ItemFn(.., header) => {
+                let attrs = cx.tcx.hir().attrs(hir_id);
+                if header.abi != Abi::Rust || requires_exact_signature(attrs) {
+                    return;
+                }
+            },
+            FnKind::Method(..) => (),
+            FnKind::Closure => return,
+        }
+
+        // Exclude non-inherent impls
+        if let Some(Node::Item(item)) = cx.tcx.hir().find_parent(hir_id) {
+            if matches!(
+                item.kind,
+                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait(..)
+            ) {
+                return;
+            }
+        }
+
+        let fn_sig = cx.tcx.fn_sig(fn_def_id).subst_identity();
+        let fn_sig = cx.tcx.liberate_late_bound_regions(fn_def_id.to_def_id(), fn_sig);
+
+        // If there are no `&mut` argument, no need to go any further.
+        if !decl
+            .inputs
+            .iter()
+            .zip(fn_sig.inputs())
+            .zip(body.params)
+            .any(|((&input, &ty), arg)| !should_skip(cx, input, ty, arg))
+        {
+            return;
+        }
+
+        // Collect variables mutably used and spans which will need dereferencings from the
+        // function body.
+        let MutablyUsedVariablesCtxt { mutably_used_vars, .. } = {
+            let mut ctx = MutablyUsedVariablesCtxt::default();
+            let infcx = cx.tcx.infer_ctxt().build();
+            euv::ExprUseVisitor::new(&mut ctx, &infcx, fn_def_id, cx.param_env, cx.typeck_results()).consume_body(body);
+            ctx
+        };
+
+        for ((&input, &ty), arg) in decl.inputs.iter().zip(fn_sig.inputs()).zip(body.params) {
+            if should_skip(cx, input, ty, arg) {
+                continue;
+            }
+
+            // Only take `&mut` arguments.
+            if_chain! {
+                if let PatKind::Binding(_, canonical_id, ..) = arg.pat.kind;
+                if !mutably_used_vars.contains(&canonical_id);
+                if let rustc_hir::TyKind::Ref(_, inner_ty) = input.kind;
+                then {
+                    // If the argument is never used mutably, we emit the error.
+                    span_lint_and_sugg(
+                        cx,
+                        NEEDLESS_PASS_BY_REF_MUT,
+                        input.span,
+                        "this argument is a mutable reference, but not used mutably",
+                        "consider changing to",
+                        format!("&{}", snippet(cx, cx.tcx.hir().span(inner_ty.ty.hir_id), "_")),
+                        Applicability::Unspecified,
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct MutablyUsedVariablesCtxt {
+    mutably_used_vars: HirIdSet,
+    prev_bind: Option<HirId>,
+    aliases: HirIdMap<HirId>,
+}
+
+impl MutablyUsedVariablesCtxt {
+    fn add_mutably_used_var(&mut self, mut used_id: HirId) {
+        while let Some(id) = self.aliases.get(&used_id) {
+            self.mutably_used_vars.insert(used_id);
+            used_id = *id;
+        }
+        self.mutably_used_vars.insert(used_id);
+    }
+}
+
+impl<'tcx> euv::Delegate<'tcx> for MutablyUsedVariablesCtxt {
+    fn consume(&mut self, cmt: &euv::PlaceWithHirId<'tcx>, _id: HirId) {
+        if let euv::Place {
+            base: euv::PlaceBase::Local(vid),
+            base_ty,
+            ..
+        } = &cmt.place
+        {
+            if let Some(bind_id) = self.prev_bind.take() {
+                self.aliases.insert(bind_id, *vid);
+            } else if matches!(base_ty.ref_mutability(), Some(Mutability::Mut)) {
+                self.add_mutably_used_var(*vid);
+            }
+        }
+    }
+
+    fn borrow(&mut self, cmt: &euv::PlaceWithHirId<'tcx>, _id: HirId, borrow: ty::BorrowKind) {
+        self.prev_bind = None;
+        if let euv::Place {
+            base: euv::PlaceBase::Local(vid),
+            base_ty,
+            ..
+        } = &cmt.place
+        {
+            // If this is a mutable borrow, it was obviously used mutably so we add it. However
+            // for `UniqueImmBorrow`, it's interesting because if you do: `array[0] = value` inside
+            // a closure, it'll return this variant whereas if you have just an index access, it'll
+            // return `ImmBorrow`. So if there is "Unique" and it's a mutable reference, we add it
+            // to the mutably used variables set.
+            if borrow == ty::BorrowKind::MutBorrow
+                || (borrow == ty::BorrowKind::UniqueImmBorrow && base_ty.ref_mutability() == Some(Mutability::Mut))
+            {
+                self.add_mutably_used_var(*vid);
+            }
+        }
+    }
+
+    fn mutate(&mut self, cmt: &euv::PlaceWithHirId<'tcx>, _id: HirId) {
+        self.prev_bind = None;
+        if let euv::Place {
+            projections,
+            base: euv::PlaceBase::Local(vid),
+            ..
+        } = &cmt.place
+        {
+            if !projections.is_empty() {
+                self.add_mutably_used_var(*vid);
+            }
+        }
+    }
+
+    fn copy(&mut self, _cmt: &euv::PlaceWithHirId<'tcx>, _id: HirId) {
+        self.prev_bind = None;
+    }
+
+    fn fake_read(&mut self, _: &rustc_hir_typeck::expr_use_visitor::PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {}
+
+    fn bind(&mut self, _cmt: &euv::PlaceWithHirId<'tcx>, id: HirId) {
+        self.prev_bind = Some(id);
+    }
+}

--- a/clippy_lints/src/needless_pass_by_ref_mut.rs
+++ b/clippy_lints/src/needless_pass_by_ref_mut.rs
@@ -22,6 +22,9 @@ declare_clippy_lint! {
     /// ### What it does
     /// Check if a `&mut` function argument is actually used mutably.
     ///
+    /// Be careful if the function is publically reexported as it would break compatibility with
+    /// users of this function.
+    ///
     /// ### Why is this bad?
     /// Less `mut` means less fights with the borrow checker. It can also lead to more
     /// opportunities for parallelization.

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -289,7 +289,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
 }
 
 /// Functions marked with these attributes must have the exact signature.
-fn requires_exact_signature(attrs: &[Attribute]) -> bool {
+pub(crate) fn requires_exact_signature(attrs: &[Attribute]) -> bool {
     attrs.iter().any(|attr| {
         [sym::proc_macro, sym::proc_macro_attribute, sym::proc_macro_derive]
             .iter()

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -91,7 +91,7 @@ struct ExistingName {
 struct SimilarNamesLocalVisitor<'a, 'tcx> {
     names: Vec<ExistingName>,
     cx: &'a EarlyContext<'tcx>,
-    lint: &'a NonExpressiveNames,
+    lint: NonExpressiveNames,
 
     /// A stack of scopes containing the single-character bindings in each scope.
     single_char_names: Vec<Vec<Ident>>,
@@ -365,7 +365,7 @@ impl EarlyLintPass for NonExpressiveNames {
             ..
         }) = item.kind
         {
-            do_check(self, cx, &item.attrs, &sig.decl, blk);
+            do_check(*self, cx, &item.attrs, &sig.decl, blk);
         }
     }
 
@@ -380,12 +380,12 @@ impl EarlyLintPass for NonExpressiveNames {
             ..
         }) = item.kind
         {
-            do_check(self, cx, &item.attrs, &sig.decl, blk);
+            do_check(*self, cx, &item.attrs, &sig.decl, blk);
         }
     }
 }
 
-fn do_check(lint: &mut NonExpressiveNames, cx: &EarlyContext<'_>, attrs: &[Attribute], decl: &FnDecl, blk: &Block) {
+fn do_check(lint: NonExpressiveNames, cx: &EarlyContext<'_>, attrs: &[Attribute], decl: &FnDecl, blk: &Block) {
     if !attrs.iter().any(|attr| attr.has_name(sym::test)) {
         let mut visitor = SimilarNamesLocalVisitor {
             names: Vec::new(),

--- a/tests/ui-toml/toml_trivially_copy/test.rs
+++ b/tests/ui-toml/toml_trivially_copy/test.rs
@@ -2,6 +2,7 @@
 //@normalize-stderr-test: "\(limit: \d+ byte\)" -> "(limit: N byte)"
 
 #![warn(clippy::trivially_copy_pass_by_ref)]
+#![allow(clippy::needless_pass_by_ref_mut)]
 
 #[derive(Copy, Clone)]
 struct Foo(u8);

--- a/tests/ui-toml/toml_trivially_copy/test.stderr
+++ b/tests/ui-toml/toml_trivially_copy/test.stderr
@@ -1,5 +1,5 @@
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/test.rs:14:11
+  --> $DIR/test.rs:15:11
    |
 LL | fn bad(x: &u16, y: &Foo) {}
    |           ^^^^ help: consider passing by value instead: `u16`
@@ -7,7 +7,7 @@ LL | fn bad(x: &u16, y: &Foo) {}
    = note: `-D clippy::trivially-copy-pass-by-ref` implied by `-D warnings`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/test.rs:14:20
+  --> $DIR/test.rs:15:20
    |
 LL | fn bad(x: &u16, y: &Foo) {}
    |                    ^^^^ help: consider passing by value instead: `Foo`

--- a/tests/ui/borrow_box.rs
+++ b/tests/ui/borrow_box.rs
@@ -1,6 +1,10 @@
 #![deny(clippy::borrowed_box)]
 #![allow(dead_code, unused_variables)]
-#![allow(clippy::uninlined_format_args, clippy::disallowed_names)]
+#![allow(
+    clippy::uninlined_format_args,
+    clippy::disallowed_names,
+    clippy::needless_pass_by_ref_mut
+)]
 
 use std::fmt::Display;
 

--- a/tests/ui/borrow_box.stderr
+++ b/tests/ui/borrow_box.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:20:14
+  --> $DIR/borrow_box.rs:24:14
    |
 LL |     let foo: &Box<bool>;
    |              ^^^^^^^^^^ help: try: `&bool`
@@ -11,55 +11,55 @@ LL | #![deny(clippy::borrowed_box)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:24:10
+  --> $DIR/borrow_box.rs:28:10
    |
 LL |     foo: &'a Box<bool>,
    |          ^^^^^^^^^^^^^ help: try: `&'a bool`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:28:17
+  --> $DIR/borrow_box.rs:32:17
    |
 LL |     fn test4(a: &Box<bool>);
    |                 ^^^^^^^^^^ help: try: `&bool`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:94:25
+  --> $DIR/borrow_box.rs:98:25
    |
 LL | pub fn test14(_display: &Box<dyn Display>) {}
    |                         ^^^^^^^^^^^^^^^^^ help: try: `&dyn Display`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:95:25
+  --> $DIR/borrow_box.rs:99:25
    |
 LL | pub fn test15(_display: &Box<dyn Display + Send>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(dyn Display + Send)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:96:29
+  --> $DIR/borrow_box.rs:100:29
    |
 LL | pub fn test16<'a>(_display: &'a Box<dyn Display + 'a>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a (dyn Display + 'a)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:98:25
+  --> $DIR/borrow_box.rs:102:25
    |
 LL | pub fn test17(_display: &Box<impl Display>) {}
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `&impl Display`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:99:25
+  --> $DIR/borrow_box.rs:103:25
    |
 LL | pub fn test18(_display: &Box<impl Display + Send>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(impl Display + Send)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:100:29
+  --> $DIR/borrow_box.rs:104:29
    |
 LL | pub fn test19<'a>(_display: &'a Box<impl Display + 'a>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a (impl Display + 'a)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> $DIR/borrow_box.rs:105:25
+  --> $DIR/borrow_box.rs:109:25
    |
 LL | pub fn test20(_display: &Box<(dyn Display + Send)>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(dyn Display + Send)`

--- a/tests/ui/infinite_loop.stderr
+++ b/tests/ui/infinite_loop.stderr
@@ -1,3 +1,11 @@
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/infinite_loop.rs:7:17
+   |
+LL | fn fn_mutref(i: &mut i32) {
+   |                 ^^^^^^^^ help: consider changing to: `&i32`
+   |
+   = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
+
 error: variables in the condition are not mutated in the loop body
   --> $DIR/infinite_loop.rs:20:11
    |
@@ -91,5 +99,5 @@ LL |     while y < 10 {
    = note: this loop contains `return`s or `break`s
    = help: rewrite it as `if cond { loop { } }`
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 

--- a/tests/ui/let_underscore_future.stderr
+++ b/tests/ui/let_underscore_future.stderr
@@ -1,3 +1,11 @@
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/let_underscore_future.rs:11:35
+   |
+LL | fn do_something_to_future(future: &mut impl Future<Output = ()>) {}
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&impl Future<Output = ()>`
+   |
+   = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
+
 error: non-binding `let` on a future
   --> $DIR/let_underscore_future.rs:14:5
    |
@@ -23,5 +31,5 @@ LL |     let _ = future;
    |
    = help: consider awaiting the future or dropping explicitly with `std::mem::drop`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/must_use_candidates.fixed
+++ b/tests/ui/must_use_candidates.fixed
@@ -1,6 +1,11 @@
 //@run-rustfix
 #![feature(never_type)]
-#![allow(unused_mut, unused_tuple_struct_fields, clippy::redundant_allocation)]
+#![allow(
+    unused_mut,
+    unused_tuple_struct_fields,
+    clippy::redundant_allocation,
+    clippy::needless_pass_by_ref_mut
+)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/tests/ui/must_use_candidates.rs
+++ b/tests/ui/must_use_candidates.rs
@@ -1,6 +1,11 @@
 //@run-rustfix
 #![feature(never_type)]
-#![allow(unused_mut, unused_tuple_struct_fields, clippy::redundant_allocation)]
+#![allow(
+    unused_mut,
+    unused_tuple_struct_fields,
+    clippy::redundant_allocation,
+    clippy::needless_pass_by_ref_mut
+)]
 #![warn(clippy::must_use_candidate)]
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/tests/ui/must_use_candidates.stderr
+++ b/tests/ui/must_use_candidates.stderr
@@ -1,5 +1,5 @@
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:12:1
+  --> $DIR/must_use_candidates.rs:17:1
    |
 LL | pub fn pure(i: u8) -> u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn pure(i: u8) -> u8`
@@ -7,25 +7,25 @@ LL | pub fn pure(i: u8) -> u8 {
    = note: `-D clippy::must-use-candidate` implied by `-D warnings`
 
 error: this method could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:17:5
+  --> $DIR/must_use_candidates.rs:22:5
    |
 LL |     pub fn inherent_pure(&self) -> u8 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn inherent_pure(&self) -> u8`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:48:1
+  --> $DIR/must_use_candidates.rs:53:1
    |
 LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:60:1
+  --> $DIR/must_use_candidates.rs:65:1
    |
 LL | pub fn rcd(_x: Rc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn rcd(_x: Rc<u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:68:1
+  --> $DIR/must_use_candidates.rs:73:1
    |
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn arcd(_x: Arc<u32>) -> bool`

--- a/tests/ui/mut_from_ref.rs
+++ b/tests/ui/mut_from_ref.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::needless_lifetimes)]
+#![allow(unused, clippy::needless_lifetimes, clippy::needless_pass_by_ref_mut)]
 #![warn(clippy::mut_from_ref)]
 
 struct Foo;

--- a/tests/ui/mut_key.stderr
+++ b/tests/ui/mut_key.stderr
@@ -12,6 +12,14 @@ error: mutable key type
 LL | fn should_not_take_this_arg(m: &mut HashMap<Key, usize>, _n: usize) -> HashSet<Key> {
    |                                                                        ^^^^^^^^^^^^
 
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/mut_key.rs:30:32
+   |
+LL | fn should_not_take_this_arg(m: &mut HashMap<Key, usize>, _n: usize) -> HashSet<Key> {
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&HashMap<Key, usize>`
+   |
+   = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
+
 error: mutable key type
   --> $DIR/mut_key.rs:31:5
    |
@@ -102,5 +110,5 @@ error: mutable key type
 LL |     let _map = HashMap::<Arc<Cell<usize>>, usize>::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 17 previous errors
+error: aborting due to 18 previous errors
 

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -1,7 +1,12 @@
 //@aux-build:proc_macros.rs:proc-macro
 #![warn(clippy::mut_mut)]
 #![allow(unused)]
-#![allow(clippy::no_effect, clippy::uninlined_format_args, clippy::unnecessary_operation)]
+#![allow(
+    clippy::no_effect,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_operation,
+    clippy::needless_pass_by_ref_mut
+)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -1,5 +1,5 @@
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:9:11
+  --> $DIR/mut_mut.rs:14:11
    |
 LL | fn fun(x: &mut &mut u32) -> bool {
    |           ^^^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL | fn fun(x: &mut &mut u32) -> bool {
    = note: `-D clippy::mut-mut` implied by `-D warnings`
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:26:17
+  --> $DIR/mut_mut.rs:31:17
    |
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:41:25
+  --> $DIR/mut_mut.rs:46:25
    |
 LL |     let mut z = inline!(&mut $(&mut 3u32));
    |                         ^
@@ -21,37 +21,37 @@ LL |     let mut z = inline!(&mut $(&mut 3u32));
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this expression mutably borrows a mutable reference. Consider reborrowing
-  --> $DIR/mut_mut.rs:28:21
+  --> $DIR/mut_mut.rs:33:21
    |
 LL |         let mut y = &mut x;
    |                     ^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:32:32
+  --> $DIR/mut_mut.rs:37:32
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                                ^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:32:16
+  --> $DIR/mut_mut.rs:37:16
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                ^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:37:37
+  --> $DIR/mut_mut.rs:42:37
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                                     ^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:37:16
+  --> $DIR/mut_mut.rs:42:16
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                ^^^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:37:21
+  --> $DIR/mut_mut.rs:42:21
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                     ^^^^^^^^^^^^^

--- a/tests/ui/mut_reference.stderr
+++ b/tests/ui/mut_reference.stderr
@@ -1,3 +1,17 @@
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/mut_reference.rs:4:33
+   |
+LL | fn takes_a_mutable_reference(a: &mut i32) {}
+   |                                 ^^^^^^^^ help: consider changing to: `&i32`
+   |
+   = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
+
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/mut_reference.rs:11:44
+   |
+LL |     fn takes_a_mutable_reference(&self, a: &mut i32) {}
+   |                                            ^^^^^^^^ help: consider changing to: `&i32`
+
 error: the function `takes_an_immutable_reference` doesn't need a mutable reference
   --> $DIR/mut_reference.rs:17:34
    |
@@ -18,5 +32,5 @@ error: the method `takes_an_immutable_reference` doesn't need a mutable referenc
 LL |     my_struct.takes_an_immutable_reference(&mut 42);
    |                                            ^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/needless_pass_by_ref_mut.rs
+++ b/tests/ui/needless_pass_by_ref_mut.rs
@@ -1,0 +1,105 @@
+#![allow(unused)]
+
+use std::ptr::NonNull;
+
+// Should only warn for `s`.
+fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
+    *x += *b + s.len() as u32;
+}
+
+// Should not warn.
+fn foo2(s: &mut Vec<u32>) {
+    s.push(8);
+}
+
+// Should not warn because we return it.
+fn foo3(s: &mut Vec<u32>) -> &mut Vec<u32> {
+    s
+}
+
+// Should not warn because `s` is used as mutable.
+fn foo4(s: &mut Vec<u32>) {
+    Vec::push(s, 4);
+}
+
+// Should not warn.
+fn foo5(s: &mut Vec<u32>) {
+    foo2(s);
+}
+
+// Should warn.
+fn foo6(s: &mut Vec<u32>) {
+    non_mut_ref(s);
+}
+
+fn non_mut_ref(_: &Vec<u32>) {}
+
+struct Bar;
+
+impl Bar {
+    // Should not warn on `&mut self`.
+    fn bar(&mut self) {}
+
+    // Should warn about `vec`
+    fn mushroom(&self, vec: &mut Vec<i32>) -> usize {
+        vec.len()
+    }
+
+    // Should warn about `vec` (and not `self`).
+    fn badger(&mut self, vec: &mut Vec<i32>) -> usize {
+        vec.len()
+    }
+}
+
+trait Babar {
+    // Should not warn here since it's a trait method.
+    fn method(arg: &mut u32);
+}
+
+impl Babar for Bar {
+    // Should not warn here since it's a trait method.
+    fn method(a: &mut u32) {}
+}
+
+// Should not warn (checking variable aliasing).
+fn alias_check(s: &mut Vec<u32>) {
+    let mut alias = s;
+    let mut alias2 = alias;
+    let mut alias3 = alias2;
+    alias3.push(0);
+}
+
+// Should not warn (checking variable aliasing).
+fn alias_check2(mut s: &mut Vec<u32>) {
+    let mut alias = &mut s;
+    alias.push(0);
+}
+
+struct Mut<T> {
+    ptr: NonNull<T>,
+}
+
+impl<T> Mut<T> {
+    // Should not warn because `NonNull::from` also accepts `&mut`.
+    fn new(ptr: &mut T) -> Self {
+        Mut {
+            ptr: NonNull::from(ptr),
+        }
+    }
+}
+
+// Should not warn.
+fn unused(_: &mut u32, _b: &mut u8) {}
+
+fn main() {
+    let mut u = 0;
+    let mut v = vec![0];
+    foo(&mut v, &0, &mut u);
+    foo2(&mut v);
+    foo3(&mut v);
+    foo4(&mut v);
+    foo5(&mut v);
+    alias_check(&mut v);
+    alias_check2(&mut v);
+    println!("{u}");
+}

--- a/tests/ui/needless_pass_by_ref_mut.stderr
+++ b/tests/ui/needless_pass_by_ref_mut.stderr
@@ -1,0 +1,28 @@
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/needless_pass_by_ref_mut.rs:6:11
+   |
+LL | fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
+   |           ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
+   |
+   = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
+
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/needless_pass_by_ref_mut.rs:31:12
+   |
+LL | fn foo6(s: &mut Vec<u32>) {
+   |            ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
+
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/needless_pass_by_ref_mut.rs:44:29
+   |
+LL |     fn mushroom(&self, vec: &mut Vec<i32>) -> usize {
+   |                             ^^^^^^^^^^^^^ help: consider changing to: `&Vec<i32>`
+
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/needless_pass_by_ref_mut.rs:49:31
+   |
+LL |     fn badger(&mut self, vec: &mut Vec<i32>) -> usize {
+   |                               ^^^^^^^^^^^^^ help: consider changing to: `&Vec<i32>`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -3,7 +3,8 @@
     unused,
     clippy::many_single_char_names,
     clippy::needless_lifetimes,
-    clippy::redundant_clone
+    clippy::redundant_clone,
+    clippy::needless_pass_by_ref_mut
 )]
 #![warn(clippy::ptr_arg)]
 

--- a/tests/ui/ptr_arg.stderr
+++ b/tests/ui/ptr_arg.stderr
@@ -1,5 +1,5 @@
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:13:14
+  --> $DIR/ptr_arg.rs:14:14
    |
 LL | fn do_vec(x: &Vec<i64>) {
    |              ^^^^^^^^^ help: change this to: `&[i64]`
@@ -7,43 +7,43 @@ LL | fn do_vec(x: &Vec<i64>) {
    = note: `-D clippy::ptr-arg` implied by `-D warnings`
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:17:18
+  --> $DIR/ptr_arg.rs:18:18
    |
 LL | fn do_vec_mut(x: &mut Vec<i64>) {
    |                  ^^^^^^^^^^^^^ help: change this to: `&mut [i64]`
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:21:14
+  --> $DIR/ptr_arg.rs:22:14
    |
 LL | fn do_str(x: &String) {
    |              ^^^^^^^ help: change this to: `&str`
 
 error: writing `&mut String` instead of `&mut str` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:25:18
+  --> $DIR/ptr_arg.rs:26:18
    |
 LL | fn do_str_mut(x: &mut String) {
    |                  ^^^^^^^^^^^ help: change this to: `&mut str`
 
 error: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:29:15
+  --> $DIR/ptr_arg.rs:30:15
    |
 LL | fn do_path(x: &PathBuf) {
    |               ^^^^^^^^ help: change this to: `&Path`
 
 error: writing `&mut PathBuf` instead of `&mut Path` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:33:19
+  --> $DIR/ptr_arg.rs:34:19
    |
 LL | fn do_path_mut(x: &mut PathBuf) {
    |                   ^^^^^^^^^^^^ help: change this to: `&mut Path`
 
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:41:18
+  --> $DIR/ptr_arg.rs:42:18
    |
 LL |     fn do_vec(x: &Vec<i64>);
    |                  ^^^^^^^^^ help: change this to: `&[i64]`
 
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:54:14
+  --> $DIR/ptr_arg.rs:55:14
    |
 LL | fn cloned(x: &Vec<u8>) -> Vec<u8> {
    |              ^^^^^^^^
@@ -60,7 +60,7 @@ LL ~     x.to_owned()
    |
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:63:18
+  --> $DIR/ptr_arg.rs:64:18
    |
 LL | fn str_cloned(x: &String) -> String {
    |                  ^^^^^^^
@@ -76,7 +76,7 @@ LL ~     x.to_owned()
    |
 
 error: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:71:19
+  --> $DIR/ptr_arg.rs:72:19
    |
 LL | fn path_cloned(x: &PathBuf) -> PathBuf {
    |                   ^^^^^^^^
@@ -92,7 +92,7 @@ LL ~     x.to_path_buf()
    |
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:79:44
+  --> $DIR/ptr_arg.rs:80:44
    |
 LL | fn false_positive_capacity(x: &Vec<u8>, y: &String) {
    |                                            ^^^^^^^
@@ -106,19 +106,19 @@ LL ~     let c = y;
    |
 
 error: using a reference to `Cow` is not recommended
-  --> $DIR/ptr_arg.rs:93:25
+  --> $DIR/ptr_arg.rs:94:25
    |
 LL | fn test_cow_with_ref(c: &Cow<[i32]>) {}
    |                         ^^^^^^^^^^^ help: change this to: `&[i32]`
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:122:66
+  --> $DIR/ptr_arg.rs:123:66
    |
 LL |     fn some_allowed(#[allow(clippy::ptr_arg)] _v: &Vec<u32>, _s: &String) {}
    |                                                                  ^^^^^^^ help: change this to: `&str`
 
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:151:21
+  --> $DIR/ptr_arg.rs:152:21
    |
 LL |     fn foo_vec(vec: &Vec<u8>) {
    |                     ^^^^^^^^
@@ -131,7 +131,7 @@ LL ~         let _ = vec.to_owned().clone();
    |
 
 error: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:156:23
+  --> $DIR/ptr_arg.rs:157:23
    |
 LL |     fn foo_path(path: &PathBuf) {
    |                       ^^^^^^^^
@@ -144,7 +144,7 @@ LL ~         let _ = path.to_path_buf().clone();
    |
 
 error: writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:161:21
+  --> $DIR/ptr_arg.rs:162:21
    |
 LL |     fn foo_str(str: &PathBuf) {
    |                     ^^^^^^^^
@@ -157,43 +157,43 @@ LL ~         let _ = str.to_path_buf().clone();
    |
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:167:29
+  --> $DIR/ptr_arg.rs:168:29
    |
 LL | fn mut_vec_slice_methods(v: &mut Vec<u32>) {
    |                             ^^^^^^^^^^^^^ help: change this to: `&mut [u32]`
 
 error: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:229:17
+  --> $DIR/ptr_arg.rs:230:17
    |
 LL | fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
    |                 ^^^^^^^^^^^^^ help: change this to: `&mut [u32]`
 
 error: writing `&mut String` instead of `&mut str` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:229:35
+  --> $DIR/ptr_arg.rs:230:35
    |
 LL | fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
    |                                   ^^^^^^^^^^^ help: change this to: `&mut str`
 
 error: writing `&mut PathBuf` instead of `&mut Path` involves a new object where a slice will do
-  --> $DIR/ptr_arg.rs:229:51
+  --> $DIR/ptr_arg.rs:230:51
    |
 LL | fn dyn_trait(a: &mut Vec<u32>, b: &mut String, c: &mut PathBuf) {
    |                                                   ^^^^^^^^^^^^ help: change this to: `&mut Path`
 
 error: using a reference to `Cow` is not recommended
-  --> $DIR/ptr_arg.rs:252:39
+  --> $DIR/ptr_arg.rs:253:39
    |
 LL |     fn cow_elided_lifetime<'a>(input: &'a Cow<str>) -> &'a str {
    |                                       ^^^^^^^^^^^^ help: change this to: `&str`
 
 error: using a reference to `Cow` is not recommended
-  --> $DIR/ptr_arg.rs:257:36
+  --> $DIR/ptr_arg.rs:258:36
    |
 LL |     fn cow_bad_ret_ty_1<'a>(input: &'a Cow<'a, str>) -> &'static str {
    |                                    ^^^^^^^^^^^^^^^^ help: change this to: `&str`
 
 error: using a reference to `Cow` is not recommended
-  --> $DIR/ptr_arg.rs:260:40
+  --> $DIR/ptr_arg.rs:261:40
    |
 LL |     fn cow_bad_ret_ty_2<'a, 'b>(input: &'a Cow<'a, str>) -> &'b str {
    |                                        ^^^^^^^^^^^^^^^^ help: change this to: `&str`

--- a/tests/ui/read_zero_byte_vec.rs
+++ b/tests/ui/read_zero_byte_vec.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::read_zero_byte_vec)]
-#![allow(clippy::unused_io_amount)]
+#![allow(clippy::unused_io_amount, clippy::needless_pass_by_ref_mut)]
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;

--- a/tests/ui/self_assignment.rs
+++ b/tests/ui/self_assignment.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::self_assignment)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::needless_pass_by_ref_mut)]
 
 pub struct S<'a> {
     a: i32,

--- a/tests/ui/should_impl_trait/method_list_2.stderr
+++ b/tests/ui/should_impl_trait/method_list_2.stderr
@@ -39,6 +39,14 @@ LL | |     }
    |
    = help: consider implementing the trait `std::hash::Hash` or choosing a less ambiguous method name
 
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/method_list_2.rs:38:31
+   |
+LL |     pub fn hash(&self, state: &mut T) {
+   |                               ^^^^^^ help: consider changing to: `&T`
+   |
+   = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
+
 error: method `index` can be confused for the standard trait method `std::ops::Index::index`
   --> $DIR/method_list_2.rs:42:5
    |
@@ -149,5 +157,5 @@ LL | |     }
    |
    = help: consider implementing the trait `std::ops::Sub` or choosing a less ambiguous method name
 
-error: aborting due to 15 previous errors
+error: aborting due to 16 previous errors
 

--- a/tests/ui/should_impl_trait/method_list_2.stderr
+++ b/tests/ui/should_impl_trait/method_list_2.stderr
@@ -45,6 +45,7 @@ error: this argument is a mutable reference, but not used mutably
 LL |     pub fn hash(&self, state: &mut T) {
    |                               ^^^^^^ help: consider changing to: `&T`
    |
+   = warning: changing this function will impact semver compatibility
    = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
 
 error: method `index` can be confused for the standard trait method `std::ops::Index::index`

--- a/tests/ui/slow_vector_initialization.stderr
+++ b/tests/ui/slow_vector_initialization.stderr
@@ -72,5 +72,13 @@ LL |     vec1 = Vec::with_capacity(10);
 LL |     vec1.resize(10, 0);
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: this argument is a mutable reference, but not used mutably
+  --> $DIR/slow_vector_initialization.rs:62:18
+   |
+LL | fn do_stuff(vec: &mut [u8]) {}
+   |                  ^^^^^^^^^ help: consider changing to: `&[u8]`
+   |
+   = note: `-D clippy::needless-pass-by-ref-mut` implied by `-D warnings`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/trivially_copy_pass_by_ref.rs
+++ b/tests/ui/trivially_copy_pass_by_ref.rs
@@ -5,7 +5,8 @@
     clippy::disallowed_names,
     clippy::needless_lifetimes,
     clippy::redundant_field_names,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::needless_pass_by_ref_mut
 )]
 
 #[derive(Copy, Clone)]

--- a/tests/ui/trivially_copy_pass_by_ref.stderr
+++ b/tests/ui/trivially_copy_pass_by_ref.stderr
@@ -1,5 +1,5 @@
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:51:11
+  --> $DIR/trivially_copy_pass_by_ref.rs:52:11
    |
 LL | fn bad(x: &u32, y: &Foo, z: &Baz) {}
    |           ^^^^ help: consider passing by value instead: `u32`
@@ -11,103 +11,103 @@ LL | #![deny(clippy::trivially_copy_pass_by_ref)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:51:20
+  --> $DIR/trivially_copy_pass_by_ref.rs:52:20
    |
 LL | fn bad(x: &u32, y: &Foo, z: &Baz) {}
    |                    ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:51:29
+  --> $DIR/trivially_copy_pass_by_ref.rs:52:29
    |
 LL | fn bad(x: &u32, y: &Foo, z: &Baz) {}
    |                             ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:58:12
+  --> $DIR/trivially_copy_pass_by_ref.rs:59:12
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |            ^^^^^ help: consider passing by value instead: `self`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:58:22
+  --> $DIR/trivially_copy_pass_by_ref.rs:59:22
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |                      ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:58:31
+  --> $DIR/trivially_copy_pass_by_ref.rs:59:31
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |                               ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:58:40
+  --> $DIR/trivially_copy_pass_by_ref.rs:59:40
    |
 LL |     fn bad(&self, x: &u32, y: &Foo, z: &Baz) {}
    |                                        ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:60:16
+  --> $DIR/trivially_copy_pass_by_ref.rs:61:16
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:60:25
+  --> $DIR/trivially_copy_pass_by_ref.rs:61:25
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                         ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:60:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:61:34
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                                  ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:62:35
+  --> $DIR/trivially_copy_pass_by_ref.rs:63:35
    |
 LL |     fn bad_issue7518(self, other: &Self) {}
    |                                   ^^^^^ help: consider passing by value instead: `Self`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:74:16
+  --> $DIR/trivially_copy_pass_by_ref.rs:75:16
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                ^^^^ help: consider passing by value instead: `u32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:74:25
+  --> $DIR/trivially_copy_pass_by_ref.rs:75:25
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                         ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:74:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:75:34
    |
 LL |     fn bad2(x: &u32, y: &Foo, z: &Baz) {}
    |                                  ^^^^ help: consider passing by value instead: `Baz`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:78:34
+  --> $DIR/trivially_copy_pass_by_ref.rs:79:34
    |
 LL |     fn trait_method(&self, _foo: &Foo);
    |                                  ^^^^ help: consider passing by value instead: `Foo`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:110:21
+  --> $DIR/trivially_copy_pass_by_ref.rs:111:21
    |
 LL |     fn foo_never(x: &i32) {
    |                     ^^^^ help: consider passing by value instead: `i32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:115:15
+  --> $DIR/trivially_copy_pass_by_ref.rs:116:15
    |
 LL |     fn foo(x: &i32) {
    |               ^^^^ help: consider passing by value instead: `i32`
 
 error: this argument (N byte) is passed by reference, but would be more efficient if passed by value (limit: N byte)
-  --> $DIR/trivially_copy_pass_by_ref.rs:142:37
+  --> $DIR/trivially_copy_pass_by_ref.rs:143:37
    |
 LL | fn _unrelated_lifetimes<'a, 'b>(_x: &'a u32, y: &'b u32) -> &'b u32 {
    |                                     ^^^^^^^ help: consider passing by value instead: `u32`

--- a/tests/ui/unused_io_amount.rs
+++ b/tests/ui/unused_io_amount.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, clippy::needless_pass_by_ref_mut)]
 #![warn(clippy::unused_io_amount)]
 
 extern crate futures;

--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -1,6 +1,10 @@
 //@run-rustfix
 #![deny(clippy::useless_asref)]
-#![allow(clippy::explicit_auto_deref, clippy::uninlined_format_args)]
+#![allow(
+    clippy::explicit_auto_deref,
+    clippy::uninlined_format_args,
+    clippy::needless_pass_by_ref_mut
+)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -1,6 +1,10 @@
 //@run-rustfix
 #![deny(clippy::useless_asref)]
-#![allow(clippy::explicit_auto_deref, clippy::uninlined_format_args)]
+#![allow(
+    clippy::explicit_auto_deref,
+    clippy::uninlined_format_args,
+    clippy::needless_pass_by_ref_mut
+)]
 
 use std::fmt::Debug;
 

--- a/tests/ui/useless_asref.stderr
+++ b/tests/ui/useless_asref.stderr
@@ -1,5 +1,5 @@
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:43:18
+  --> $DIR/useless_asref.rs:47:18
    |
 LL |         foo_rstr(rstr.as_ref());
    |                  ^^^^^^^^^^^^^ help: try this: `rstr`
@@ -11,61 +11,61 @@ LL | #![deny(clippy::useless_asref)]
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:45:20
+  --> $DIR/useless_asref.rs:49:20
    |
 LL |         foo_rslice(rslice.as_ref());
    |                    ^^^^^^^^^^^^^^^ help: try this: `rslice`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:49:21
+  --> $DIR/useless_asref.rs:53:21
    |
 LL |         foo_mrslice(mrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:51:20
+  --> $DIR/useless_asref.rs:55:20
    |
 LL |         foo_rslice(mrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:58:20
+  --> $DIR/useless_asref.rs:62:20
    |
 LL |         foo_rslice(rrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^ help: try this: `rrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:60:18
+  --> $DIR/useless_asref.rs:64:18
    |
 LL |         foo_rstr(rrrrrstr.as_ref());
    |                  ^^^^^^^^^^^^^^^^^ help: try this: `rrrrrstr`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:65:21
+  --> $DIR/useless_asref.rs:69:21
    |
 LL |         foo_mrslice(mrrrrrslice.as_mut());
    |                     ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:67:20
+  --> $DIR/useless_asref.rs:71:20
    |
 LL |         foo_rslice(mrrrrrslice.as_ref());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:71:16
+  --> $DIR/useless_asref.rs:75:16
    |
 LL |     foo_rrrrmr((&&&&MoreRef).as_ref());
    |                ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(&&&&MoreRef)`
 
 error: this call to `as_mut` does nothing
-  --> $DIR/useless_asref.rs:121:13
+  --> $DIR/useless_asref.rs:125:13
    |
 LL |     foo_mrt(mrt.as_mut());
    |             ^^^^^^^^^^^^ help: try this: `mrt`
 
 error: this call to `as_ref` does nothing
-  --> $DIR/useless_asref.rs:123:12
+  --> $DIR/useless_asref.rs:127:12
    |
 LL |     foo_rt(mrt.as_ref());
    |            ^^^^^^^^^^^^ help: try this: `mrt`


### PR DESCRIPTION
changelog: [`needless_pass_by_ref_mut`]: This PR add a new lint `needless_pass_by_ref_mut` which emits a warning in case a `&mut` function argument isn't used mutably. It doesn't warn on trait and trait impls functions.

Fixes #8863.