### PR TITLE
[`useless_vec`]: lint `vec!` invocations when a slice or an array would do

### DIFF
--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -1,16 +1,21 @@
+use std::ops::ControlFlow;
+
 use clippy_utils::consts::{constant, Constant};
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::higher;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::is_copy;
+use clippy_utils::visitors::for_each_local_use_after_expr;
+use clippy_utils::{get_parent_expr, higher, is_trait_method};
 use if_chain::if_chain;
+use rustc_ast::BindingAnnotation;
 use rustc_errors::Applicability;
-use rustc_hir::{BorrowKind, Expr, ExprKind, Mutability};
+use rustc_hir::{BorrowKind, Expr, ExprKind, Mutability, Node, PatKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_middle::ty::{self, Ty};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::source_map::Span;
+use rustc_span::sym;
 
 #[expect(clippy::module_name_repetitions)]
 #[derive(Copy, Clone)]
@@ -20,7 +25,7 @@ pub struct UselessVec {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of `&vec![..]` when using `&[..]` would
+    /// Checks for usage of `vec![..]` when using `[..]` would
     /// be possible.
     ///
     /// ### Why is this bad?
@@ -46,16 +51,70 @@ declare_clippy_lint! {
 
 impl_lint_pass!(UselessVec => [USELESS_VEC]);
 
+fn adjusts_to_slice(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+    if let ty::Ref(_, ty, _) = cx.typeck_results().expr_ty_adjusted(e).kind() {
+        ty.is_slice()
+    } else {
+        false
+    }
+}
+
+/// Checks if the given expression is a method call to a `Vec` method
+/// that also exists on slices. If this returns true, it means that
+/// this expression does not actually require a `Vec` and could just work with an array.
+fn is_allowed_vec_method(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
+    const ALLOWED_METHOD_NAMES: &[&str] = &["len", "as_ptr", "as_slice", "is_empty"];
+
+    if let ExprKind::MethodCall(path, ..) = e.kind {
+        ALLOWED_METHOD_NAMES.contains(&path.ident.name.as_str())
+    } else {
+        is_trait_method(cx, e, sym::IntoIterator)
+    }
+}
+
 impl<'tcx> LateLintPass<'tcx> for UselessVec {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         // search for `&vec![_]` expressions where the adjusted type is `&[_]`
         if_chain! {
-            if let ty::Ref(_, ty, _) = cx.typeck_results().expr_ty_adjusted(expr).kind();
-            if let ty::Slice(..) = ty.kind();
+            if adjusts_to_slice(cx, expr);
             if let ExprKind::AddrOf(BorrowKind::Ref, mutability, addressee) = expr.kind;
             if let Some(vec_args) = higher::VecArgs::hir(cx, addressee);
             then {
-                self.check_vec_macro(cx, &vec_args, mutability, expr.span);
+                self.check_vec_macro(cx, &vec_args, mutability, expr.span, SuggestSlice::Yes);
+            }
+        }
+
+        // search for `let foo = vec![_]` expressions where all uses of `foo`
+        // adjust to slices or call a method that exist on slices (e.g. len)
+        if let Some(vec_args) = higher::VecArgs::hir(cx, expr)
+            && let Node::Local(local) = cx.tcx.hir().get_parent(expr.hir_id)
+            // for now ignore locals with type annotations.
+            // this is to avoid compile errors when doing the suggestion here: let _: Vec<_> = vec![..];
+            && local.ty.is_none()
+            && let PatKind::Binding(BindingAnnotation(_, mutbl), id, ..) = local.pat.kind
+            && is_copy(cx, vec_type(cx.typeck_results().expr_ty_adjusted(expr)))
+        {
+            let only_slice_uses = for_each_local_use_after_expr(cx, id, expr.hir_id, |expr| {
+                // allow indexing into a vec and some set of allowed method calls that exist on slices, too
+                if let Some(parent) = get_parent_expr(cx, expr)
+                    && (adjusts_to_slice(cx, expr)
+                        || matches!(parent.kind, ExprKind::Index(..))
+                        || is_allowed_vec_method(cx, parent))
+                {
+                    ControlFlow::Continue(())
+                } else {
+                    ControlFlow::Break(())
+                }
+            }).is_continue();
+
+            if only_slice_uses {
+                self.check_vec_macro(
+                    cx,
+                    &vec_args,
+                    mutbl,
+                    expr.span.ctxt().outer_expn_data().call_site,
+                    SuggestSlice::No
+                );
             }
         }
 
@@ -67,10 +126,18 @@ impl<'tcx> LateLintPass<'tcx> for UselessVec {
             then {
                 // report the error around the `vec!` not inside `<std macros>:`
                 let span = arg.span.ctxt().outer_expn_data().call_site;
-                self.check_vec_macro(cx, &vec_args, Mutability::Not, span);
+                self.check_vec_macro(cx, &vec_args, Mutability::Not, span, SuggestSlice::Yes);
             }
         }
     }
+}
+
+#[derive(Copy, Clone)]
+enum SuggestSlice {
+    /// Suggest using a slice `&[..]` / `&mut [..]`
+    Yes,
+    /// Suggest using an array: `[..]`
+    No,
 }
 
 impl UselessVec {
@@ -80,8 +147,15 @@ impl UselessVec {
         vec_args: &higher::VecArgs<'tcx>,
         mutability: Mutability,
         span: Span,
+        suggest_slice: SuggestSlice,
     ) {
         let mut applicability = Applicability::MachineApplicable;
+
+        let (borrow_prefix_mut, borrow_prefix) = match suggest_slice {
+            SuggestSlice::Yes => ("&mut ", "&"),
+            SuggestSlice::No => ("", ""),
+        };
+
         let snippet = match *vec_args {
             higher::VecArgs::Repeat(elem, len) => {
                 if let Some(Constant::Int(len_constant)) = constant(cx, cx.typeck_results(), len) {
@@ -93,14 +167,14 @@ impl UselessVec {
                     match mutability {
                         Mutability::Mut => {
                             format!(
-                                "&mut [{}; {}]",
+                                "{borrow_prefix_mut}[{}; {}]",
                                 snippet_with_applicability(cx, elem.span, "elem", &mut applicability),
                                 snippet_with_applicability(cx, len.span, "len", &mut applicability)
                             )
                         },
                         Mutability::Not => {
                             format!(
-                                "&[{}; {}]",
+                                "{borrow_prefix}[{}; {}]",
                                 snippet_with_applicability(cx, elem.span, "elem", &mut applicability),
                                 snippet_with_applicability(cx, len.span, "len", &mut applicability)
                             )
@@ -120,18 +194,21 @@ impl UselessVec {
                     match mutability {
                         Mutability::Mut => {
                             format!(
-                                "&mut [{}]",
+                                "{borrow_prefix_mut}[{}]",
                                 snippet_with_applicability(cx, span, "..", &mut applicability)
                             )
                         },
                         Mutability::Not => {
-                            format!("&[{}]", snippet_with_applicability(cx, span, "..", &mut applicability))
+                            format!(
+                                "{borrow_prefix}[{}]",
+                                snippet_with_applicability(cx, span, "..", &mut applicability)
+                            )
                         },
                     }
                 } else {
                     match mutability {
-                        Mutability::Mut => "&mut []".into(),
-                        Mutability::Not => "&[]".into(),
+                        Mutability::Mut => format!("{borrow_prefix_mut}[]"),
+                        Mutability::Not => format!("{borrow_prefix}[]"),
                     }
                 }
             },
@@ -142,7 +219,13 @@ impl UselessVec {
             USELESS_VEC,
             span,
             "useless use of `vec!`",
-            "you can use a slice directly",
+            &format!(
+                "you can use {} directly",
+                match suggest_slice {
+                    SuggestSlice::Yes => "a slice",
+                    SuggestSlice::No => "an array",
+                }
+            ),
             snippet,
             applicability,
         );

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -63,7 +63,7 @@ fn adjusts_to_slice(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
 /// that also exists on slices. If this returns true, it means that
 /// this expression does not actually require a `Vec` and could just work with an array.
 fn is_allowed_vec_method(cx: &LateContext<'_>, e: &Expr<'_>) -> bool {
-    const ALLOWED_METHOD_NAMES: &[&str] = &["len", "as_ptr", "as_slice", "is_empty"];
+    const ALLOWED_METHOD_NAMES: &[&str] = &["len", "as_ptr", "is_empty"];
 
     if let ExprKind::MethodCall(path, ..) = e.kind {
         ALLOWED_METHOD_NAMES.contains(&path.ident.name.as_str())

--- a/tests/ui-toml/suppress_lint_in_const/test.rs
+++ b/tests/ui-toml/suppress_lint_in_const/test.rs
@@ -3,7 +3,12 @@
 // We also check the out_of_bounds_indexing lint here, because it lints similar things and
 // we want to avoid false positives.
 #![warn(clippy::out_of_bounds_indexing)]
-#![allow(unconditional_panic, clippy::no_effect, clippy::unnecessary_operation)]
+#![allow(
+    unconditional_panic,
+    clippy::no_effect,
+    clippy::unnecessary_operation,
+    clippy::useless_vec
+)]
 
 const ARR: [i32; 2] = [1, 2];
 const REF: &i32 = &ARR[idx()]; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.

--- a/tests/ui-toml/suppress_lint_in_const/test.stderr
+++ b/tests/ui-toml/suppress_lint_in_const/test.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `main::{constant#3}` failed
-  --> $DIR/test.rs:31:14
+  --> $DIR/test.rs:36:14
    |
 LL |     const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
    |              ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
 
 note: erroneous constant used
-  --> $DIR/test.rs:31:5
+  --> $DIR/test.rs:36:5
    |
 LL |     const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: indexing may panic
-  --> $DIR/test.rs:22:5
+  --> $DIR/test.rs:27:5
    |
 LL |     x[index];
    |     ^^^^^^^^
@@ -20,7 +20,7 @@ LL |     x[index];
    = note: `-D clippy::indexing-slicing` implied by `-D warnings`
 
 error: indexing may panic
-  --> $DIR/test.rs:38:5
+  --> $DIR/test.rs:43:5
    |
 LL |     v[0];
    |     ^^^^
@@ -28,7 +28,7 @@ LL |     v[0];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:39:5
+  --> $DIR/test.rs:44:5
    |
 LL |     v[10];
    |     ^^^^^
@@ -36,7 +36,7 @@ LL |     v[10];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:40:5
+  --> $DIR/test.rs:45:5
    |
 LL |     v[1 << 3];
    |     ^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     v[1 << 3];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:46:5
+  --> $DIR/test.rs:51:5
    |
 LL |     v[N];
    |     ^^^^
@@ -52,7 +52,7 @@ LL |     v[N];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:47:5
+  --> $DIR/test.rs:52:5
    |
 LL |     v[M];
    |     ^^^^
@@ -60,7 +60,7 @@ LL |     v[M];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/test.rs:10:24
+  --> $DIR/test.rs:15:24
    |
 LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    |                        ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -1,6 +1,7 @@
 //@compile-flags: --crate-name conf_disallowed_methods
 
 #![warn(clippy::disallowed_methods)]
+#![allow(clippy::useless_vec)]
 
 extern crate futures;
 extern crate regex;

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -1,5 +1,5 @@
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:33:14
+  --> $DIR/conf_disallowed_methods.rs:34:14
    |
 LL |     let re = Regex::new(r"ab.*c").unwrap();
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     let re = Regex::new(r"ab.*c").unwrap();
    = note: `-D clippy::disallowed-methods` implied by `-D warnings`
 
 error: use of a disallowed method `regex::Regex::is_match`
-  --> $DIR/conf_disallowed_methods.rs:34:5
+  --> $DIR/conf_disallowed_methods.rs:35:5
    |
 LL |     re.is_match("abc");
    |     ^^^^^^^^^^^^^^^^^^
@@ -15,73 +15,73 @@ LL |     re.is_match("abc");
    = note: no matching allowed (from clippy.toml)
 
 error: use of a disallowed method `std::iter::Iterator::sum`
-  --> $DIR/conf_disallowed_methods.rs:37:5
+  --> $DIR/conf_disallowed_methods.rs:38:5
    |
 LL |     a.iter().sum::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `slice::sort_unstable`
-  --> $DIR/conf_disallowed_methods.rs:39:5
+  --> $DIR/conf_disallowed_methods.rs:40:5
    |
 LL |     a.sort_unstable();
    |     ^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:41:13
+  --> $DIR/conf_disallowed_methods.rs:42:13
    |
 LL |     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:44:61
+  --> $DIR/conf_disallowed_methods.rs:45:61
    |
 LL |     let indirect: fn(&str) -> Result<Regex, regex::Error> = Regex::new;
    |                                                             ^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:47:28
+  --> $DIR/conf_disallowed_methods.rs:48:28
    |
 LL |     let in_call = Box::new(f32::clamp);
    |                            ^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:48:53
+  --> $DIR/conf_disallowed_methods.rs:49:53
    |
 LL |     let in_method_call = ["^", "$"].into_iter().map(Regex::new);
    |                                                     ^^^^^^^^^^
 
 error: use of a disallowed method `futures::stream::select_all`
-  --> $DIR/conf_disallowed_methods.rs:51:31
+  --> $DIR/conf_disallowed_methods.rs:52:31
    |
 LL |     let same_name_as_module = select_all(vec![empty::<()>()]);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_fn`
-  --> $DIR/conf_disallowed_methods.rs:53:5
+  --> $DIR/conf_disallowed_methods.rs:54:5
    |
 LL |     local_fn();
    |     ^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_mod::f`
-  --> $DIR/conf_disallowed_methods.rs:54:5
+  --> $DIR/conf_disallowed_methods.rs:55:5
    |
 LL |     local_mod::f();
    |     ^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Struct::method`
-  --> $DIR/conf_disallowed_methods.rs:56:5
+  --> $DIR/conf_disallowed_methods.rs:57:5
    |
 LL |     s.method();
    |     ^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::provided_method`
-  --> $DIR/conf_disallowed_methods.rs:57:5
+  --> $DIR/conf_disallowed_methods.rs:58:5
    |
 LL |     s.provided_method();
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::implemented_method`
-  --> $DIR/conf_disallowed_methods.rs:58:5
+  --> $DIR/conf_disallowed_methods.rs:59:5
    |
 LL |     s.implemented_method();
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-toml/unwrap_used/unwrap_used.rs
+++ b/tests/ui-toml/unwrap_used/unwrap_used.rs
@@ -1,6 +1,11 @@
 //@compile-flags: --test
 
-#![allow(unused_mut, clippy::get_first, clippy::from_iter_instead_of_collect)]
+#![allow(
+    unused_mut,
+    clippy::get_first,
+    clippy::from_iter_instead_of_collect,
+    clippy::useless_vec
+)]
 #![warn(clippy::unwrap_used)]
 #![deny(clippy::get_unwrap)]
 

--- a/tests/ui-toml/unwrap_used/unwrap_used.stderr
+++ b/tests/ui-toml/unwrap_used/unwrap_used.stderr
@@ -1,17 +1,17 @@
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:35:17
+  --> $DIR/unwrap_used.rs:40:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
    |
 note: the lint level is defined here
-  --> $DIR/unwrap_used.rs:5:9
+  --> $DIR/unwrap_used.rs:10:9
    |
 LL | #![deny(clippy::get_unwrap)]
    |         ^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:35:17
+  --> $DIR/unwrap_used.rs:40:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,13 +20,13 @@ LL |         let _ = boxed_slice.get(1).unwrap();
    = note: `-D clippy::unwrap-used` implied by `-D warnings`
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:36:17
+  --> $DIR/unwrap_used.rs:41:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:36:17
+  --> $DIR/unwrap_used.rs:41:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +34,13 @@ LL |         let _ = some_slice.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:37:17
+  --> $DIR/unwrap_used.rs:42:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:37:17
+  --> $DIR/unwrap_used.rs:42:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,13 +48,13 @@ LL |         let _ = some_vec.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:38:17
+  --> $DIR/unwrap_used.rs:43:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:38:17
+  --> $DIR/unwrap_used.rs:43:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,13 +62,13 @@ LL |         let _ = some_vecdeque.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:39:17
+  --> $DIR/unwrap_used.rs:44:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:39:17
+  --> $DIR/unwrap_used.rs:44:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,13 +76,13 @@ LL |         let _ = some_hashmap.get(&1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:40:17
+  --> $DIR/unwrap_used.rs:45:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:40:17
+  --> $DIR/unwrap_used.rs:45:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,13 +90,13 @@ LL |         let _ = some_btreemap.get(&1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:44:21
+  --> $DIR/unwrap_used.rs:49:21
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:44:22
+  --> $DIR/unwrap_used.rs:49:22
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,13 +104,13 @@ LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:49:9
+  --> $DIR/unwrap_used.rs:54:9
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:49:10
+  --> $DIR/unwrap_used.rs:54:10
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,13 +118,13 @@ LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:50:9
+  --> $DIR/unwrap_used.rs:55:9
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:50:10
+  --> $DIR/unwrap_used.rs:55:10
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,13 +132,13 @@ LL |         *some_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:51:9
+  --> $DIR/unwrap_used.rs:56:9
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:51:10
+  --> $DIR/unwrap_used.rs:56:10
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -146,13 +146,13 @@ LL |         *some_vec.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:52:9
+  --> $DIR/unwrap_used.rs:57:9
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:52:10
+  --> $DIR/unwrap_used.rs:57:10
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,13 +160,13 @@ LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:64:17
+  --> $DIR/unwrap_used.rs:69:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:64:17
+  --> $DIR/unwrap_used.rs:69:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -174,13 +174,13 @@ LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:65:17
+  --> $DIR/unwrap_used.rs:70:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/unwrap_used.rs:65:17
+  --> $DIR/unwrap_used.rs:70:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -188,13 +188,13 @@ LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:72:13
+  --> $DIR/unwrap_used.rs:77:13
    |
 LL |     let _ = boxed_slice.get(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/unwrap_used.rs:90:17
+  --> $DIR/unwrap_used.rs:95:17
    |
 LL |         let _ = Box::new([0]).get(1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&Box::new([0])[1]`

--- a/tests/ui/assign_ops.fixed
+++ b/tests/ui/assign_ops.fixed
@@ -2,7 +2,7 @@
 
 use core::num::Wrapping;
 
-#[allow(dead_code, unused_assignments)]
+#[allow(dead_code, unused_assignments, clippy::useless_vec)]
 #[warn(clippy::assign_op_pattern)]
 fn main() {
     let mut a = 5;

--- a/tests/ui/assign_ops.rs
+++ b/tests/ui/assign_ops.rs
@@ -2,7 +2,7 @@
 
 use core::num::Wrapping;
 
-#[allow(dead_code, unused_assignments)]
+#[allow(dead_code, unused_assignments, clippy::useless_vec)]
 #[warn(clippy::assign_op_pattern)]
 fn main() {
     let mut a = 5;

--- a/tests/ui/bytecount.rs
+++ b/tests/ui/bytecount.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_borrow)]
+#![allow(clippy::needless_borrow, clippy::useless_vec)]
 
 #[deny(clippy::naive_bytecount)]
 fn main() {

--- a/tests/ui/collection_is_never_read.rs
+++ b/tests/ui/collection_is_never_read.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::useless_vec)]
 #![warn(clippy::collection_is_never_read)]
 
 use std::collections::{HashMap, HashSet};

--- a/tests/ui/comparison_to_empty.fixed
+++ b/tests/ui/comparison_to_empty.fixed
@@ -1,6 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::comparison_to_empty)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // Disallow comparisons to empty

--- a/tests/ui/comparison_to_empty.rs
+++ b/tests/ui/comparison_to_empty.rs
@@ -1,6 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::comparison_to_empty)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // Disallow comparisons to empty

--- a/tests/ui/comparison_to_empty.stderr
+++ b/tests/ui/comparison_to_empty.stderr
@@ -1,5 +1,5 @@
 error: comparison to empty slice
-  --> $DIR/comparison_to_empty.rs:8:13
+  --> $DIR/comparison_to_empty.rs:9:13
    |
 LL |     let _ = s == "";
    |             ^^^^^^^ help: using `is_empty` is clearer and more explicit: `s.is_empty()`
@@ -7,19 +7,19 @@ LL |     let _ = s == "";
    = note: `-D clippy::comparison-to-empty` implied by `-D warnings`
 
 error: comparison to empty slice
-  --> $DIR/comparison_to_empty.rs:9:13
+  --> $DIR/comparison_to_empty.rs:10:13
    |
 LL |     let _ = s != "";
    |             ^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!s.is_empty()`
 
 error: comparison to empty slice
-  --> $DIR/comparison_to_empty.rs:12:13
+  --> $DIR/comparison_to_empty.rs:13:13
    |
 LL |     let _ = v == [];
    |             ^^^^^^^ help: using `is_empty` is clearer and more explicit: `v.is_empty()`
 
 error: comparison to empty slice
-  --> $DIR/comparison_to_empty.rs:13:13
+  --> $DIR/comparison_to_empty.rs:14:13
    |
 LL |     let _ = v != [];
    |             ^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!v.is_empty()`

--- a/tests/ui/deref_addrof.fixed
+++ b/tests/ui/deref_addrof.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
 
-#![allow(clippy::return_self_not_must_use)]
+#![allow(clippy::return_self_not_must_use, clippy::useless_vec)]
 #![warn(clippy::deref_addrof)]
 
 extern crate proc_macros;

--- a/tests/ui/deref_addrof.rs
+++ b/tests/ui/deref_addrof.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
 
-#![allow(clippy::return_self_not_must_use)]
+#![allow(clippy::return_self_not_must_use, clippy::useless_vec)]
 #![warn(clippy::deref_addrof)]
 
 extern crate proc_macros;

--- a/tests/ui/eq_op_macros.rs
+++ b/tests/ui/eq_op_macros.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::eq_op)]
+#![allow(clippy::useless_vec)]
 
 // lint also in macro definition
 macro_rules! assert_in_macro_def {

--- a/tests/ui/eq_op_macros.stderr
+++ b/tests/ui/eq_op_macros.stderr
@@ -1,5 +1,5 @@
 error: identical args used in this `assert_eq!` macro call
-  --> $DIR/eq_op_macros.rs:7:20
+  --> $DIR/eq_op_macros.rs:8:20
    |
 LL |         assert_eq!(a, a);
    |                    ^^^^
@@ -11,7 +11,7 @@ LL |     assert_in_macro_def!();
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `assert_ne!` macro call
-  --> $DIR/eq_op_macros.rs:8:20
+  --> $DIR/eq_op_macros.rs:9:20
    |
 LL |         assert_ne!(a, a);
    |                    ^^^^
@@ -22,7 +22,7 @@ LL |     assert_in_macro_def!();
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `debug_assert_eq!` macro call
-  --> $DIR/eq_op_macros.rs:9:26
+  --> $DIR/eq_op_macros.rs:10:26
    |
 LL |         debug_assert_eq!(a, a);
    |                          ^^^^
@@ -33,7 +33,7 @@ LL |     assert_in_macro_def!();
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `debug_assert_ne!` macro call
-  --> $DIR/eq_op_macros.rs:10:26
+  --> $DIR/eq_op_macros.rs:11:26
    |
 LL |         debug_assert_ne!(a, a);
    |                          ^^^^
@@ -44,49 +44,49 @@ LL |     assert_in_macro_def!();
    = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `assert_eq!` macro call
-  --> $DIR/eq_op_macros.rs:22:16
+  --> $DIR/eq_op_macros.rs:23:16
    |
 LL |     assert_eq!(a, a);
    |                ^^^^
 
 error: identical args used in this `assert_eq!` macro call
-  --> $DIR/eq_op_macros.rs:23:16
+  --> $DIR/eq_op_macros.rs:24:16
    |
 LL |     assert_eq!(a + 1, a + 1);
    |                ^^^^^^^^^^^^
 
 error: identical args used in this `assert_ne!` macro call
-  --> $DIR/eq_op_macros.rs:30:16
+  --> $DIR/eq_op_macros.rs:31:16
    |
 LL |     assert_ne!(a, a);
    |                ^^^^
 
 error: identical args used in this `assert_ne!` macro call
-  --> $DIR/eq_op_macros.rs:31:16
+  --> $DIR/eq_op_macros.rs:32:16
    |
 LL |     assert_ne!(a + 1, a + 1);
    |                ^^^^^^^^^^^^
 
 error: identical args used in this `debug_assert_eq!` macro call
-  --> $DIR/eq_op_macros.rs:38:22
+  --> $DIR/eq_op_macros.rs:39:22
    |
 LL |     debug_assert_eq!(a, a);
    |                      ^^^^
 
 error: identical args used in this `debug_assert_eq!` macro call
-  --> $DIR/eq_op_macros.rs:39:22
+  --> $DIR/eq_op_macros.rs:40:22
    |
 LL |     debug_assert_eq!(a + 1, a + 1);
    |                      ^^^^^^^^^^^^
 
 error: identical args used in this `debug_assert_ne!` macro call
-  --> $DIR/eq_op_macros.rs:46:22
+  --> $DIR/eq_op_macros.rs:47:22
    |
 LL |     debug_assert_ne!(a, a);
    |                      ^^^^
 
 error: identical args used in this `debug_assert_ne!` macro call
-  --> $DIR/eq_op_macros.rs:47:22
+  --> $DIR/eq_op_macros.rs:48:22
    |
 LL |     debug_assert_ne!(a + 1, a + 1);
    |                      ^^^^^^^^^^^^

--- a/tests/ui/excessive_precision.fixed
+++ b/tests/ui/excessive_precision.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::excessive_precision)]
-#![allow(dead_code, unused_variables, clippy::print_literal)]
+#![allow(dead_code, unused_variables, clippy::print_literal, clippy::useless_vec)]
 
 fn main() {
     // Consts

--- a/tests/ui/excessive_precision.rs
+++ b/tests/ui/excessive_precision.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::excessive_precision)]
-#![allow(dead_code, unused_variables, clippy::print_literal)]
+#![allow(dead_code, unused_variables, clippy::print_literal, clippy::useless_vec)]
 
 fn main() {
     // Consts

--- a/tests/ui/explicit_counter_loop.rs
+++ b/tests/ui/explicit_counter_loop.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::explicit_counter_loop)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
 
 fn main() {
     let mut vec = vec![1, 2, 3, 4];

--- a/tests/ui/find_map.rs
+++ b/tests/ui/find_map.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::useless_vec)]
 
 #[derive(Debug, Copy, Clone)]
 enum Flavor {

--- a/tests/ui/for_loop_fixable.fixed
+++ b/tests/ui/for_loop_fixable.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![allow(dead_code, unused)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
 
 use std::collections::*;
 

--- a/tests/ui/for_loop_fixable.rs
+++ b/tests/ui/for_loop_fixable.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![allow(dead_code, unused)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
 
 use std::collections::*;
 

--- a/tests/ui/for_loop_unfixable.rs
+++ b/tests/ui/for_loop_unfixable.rs
@@ -7,7 +7,12 @@
     clippy::iter_next_loop,
     clippy::for_kv_map
 )]
-#[allow(clippy::linkedlist, clippy::unnecessary_mut_passed, clippy::similar_names)]
+#[allow(
+    clippy::linkedlist,
+    clippy::unnecessary_mut_passed,
+    clippy::similar_names,
+    clippy::useless_vec
+)]
 #[allow(for_loops_over_fallibles)]
 fn main() {
     let vec = vec![1, 2, 3, 4];

--- a/tests/ui/for_loop_unfixable.stderr
+++ b/tests/ui/for_loop_unfixable.stderr
@@ -1,5 +1,5 @@
 error: you are iterating over `Iterator::next()` which is an Option; this will compile but is probably not what you want
-  --> $DIR/for_loop_unfixable.rs:15:15
+  --> $DIR/for_loop_unfixable.rs:20:15
    |
 LL |     for _v in vec.iter().next() {}
    |               ^^^^^^^^^^^^^^^^^

--- a/tests/ui/format.fixed
+++ b/tests/ui/format.fixed
@@ -6,7 +6,8 @@
     clippy::redundant_clone,
     clippy::to_string_in_format_args,
     clippy::needless_borrow,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 struct Foo(pub String);

--- a/tests/ui/format.rs
+++ b/tests/ui/format.rs
@@ -6,7 +6,8 @@
     clippy::redundant_clone,
     clippy::to_string_in_format_args,
     clippy::needless_borrow,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 struct Foo(pub String);

--- a/tests/ui/format.stderr
+++ b/tests/ui/format.stderr
@@ -1,5 +1,5 @@
 error: useless use of `format!`
-  --> $DIR/format.rs:19:5
+  --> $DIR/format.rs:20:5
    |
 LL |     format!("foo");
    |     ^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
@@ -7,19 +7,19 @@ LL |     format!("foo");
    = note: `-D clippy::useless-format` implied by `-D warnings`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:20:5
+  --> $DIR/format.rs:21:5
    |
 LL |     format!("{{}}");
    |     ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{}".to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:21:5
+  --> $DIR/format.rs:22:5
    |
 LL |     format!("{{}} abc {{}}");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{} abc {}".to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:22:5
+  --> $DIR/format.rs:23:5
    |
 LL | /     format!(
 LL | |         r##"foo {{}}
@@ -34,67 +34,67 @@ LL ~ " bar"##.to_string();
    |
 
 error: useless use of `format!`
-  --> $DIR/format.rs:27:13
+  --> $DIR/format.rs:28:13
    |
 LL |     let _ = format!("");
    |             ^^^^^^^^^^^ help: consider using `String::new()`: `String::new()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:29:5
+  --> $DIR/format.rs:30:5
    |
 LL |     format!("{}", "foo");
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:37:5
+  --> $DIR/format.rs:38:5
    |
 LL |     format!("{}", arg);
    |     ^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:67:5
+  --> $DIR/format.rs:68:5
    |
 LL |     format!("{}", 42.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `42.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:69:5
+  --> $DIR/format.rs:70:5
    |
 LL |     format!("{}", x.display().to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.display().to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:73:18
+  --> $DIR/format.rs:74:18
    |
 LL |     let _ = Some(format!("{}", a + "bar"));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `a + "bar"`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:77:22
+  --> $DIR/format.rs:78:22
    |
 LL |     let _s: String = format!("{}", &*v.join("/n"));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `(&*v.join("/n")).to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:83:13
+  --> $DIR/format.rs:84:13
    |
 LL |     let _ = format!("{x}");
    |             ^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:85:13
+  --> $DIR/format.rs:86:13
    |
 LL |     let _ = format!("{y}", y = x);
    |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:89:13
+  --> $DIR/format.rs:90:13
    |
 LL |     let _ = format!("{abc}");
    |             ^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `abc.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:91:13
+  --> $DIR/format.rs:92:13
    |
 LL |     let _ = format!("{xx}");
    |             ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `xx.to_string()`

--- a/tests/ui/get_first.fixed
+++ b/tests/ui/get_first.fixed
@@ -1,5 +1,6 @@
 //@run-rustfix
 #![warn(clippy::get_first)]
+#![allow(clippy::useless_vec)]
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::VecDeque;

--- a/tests/ui/get_first.rs
+++ b/tests/ui/get_first.rs
@@ -1,5 +1,6 @@
 //@run-rustfix
 #![warn(clippy::get_first)]
+#![allow(clippy::useless_vec)]
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::VecDeque;

--- a/tests/ui/get_first.stderr
+++ b/tests/ui/get_first.stderr
@@ -1,5 +1,5 @@
 error: accessing first element with `x.get(0)`
-  --> $DIR/get_first.rs:19:13
+  --> $DIR/get_first.rs:20:13
    |
 LL |     let _ = x.get(0); // Use x.first()
    |             ^^^^^^^^ help: try: `x.first()`
@@ -7,13 +7,13 @@ LL |     let _ = x.get(0); // Use x.first()
    = note: `-D clippy::get-first` implied by `-D warnings`
 
 error: accessing first element with `y.get(0)`
-  --> $DIR/get_first.rs:24:13
+  --> $DIR/get_first.rs:25:13
    |
 LL |     let _ = y.get(0); // Use y.first()
    |             ^^^^^^^^ help: try: `y.first()`
 
 error: accessing first element with `z.get(0)`
-  --> $DIR/get_first.rs:29:13
+  --> $DIR/get_first.rs:30:13
    |
 LL |     let _ = z.get(0); // Use z.first()
    |             ^^^^^^^^ help: try: `z.first()`

--- a/tests/ui/get_last_with_len.fixed
+++ b/tests/ui/get_last_with_len.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::get_last_with_len)]
-#![allow(unused)]
+#![allow(unused, clippy::useless_vec)]
 
 use std::collections::VecDeque;
 

--- a/tests/ui/get_last_with_len.rs
+++ b/tests/ui/get_last_with_len.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::get_last_with_len)]
-#![allow(unused)]
+#![allow(unused, clippy::useless_vec)]
 
 use std::collections::VecDeque;
 

--- a/tests/ui/get_unwrap.fixed
+++ b/tests/ui/get_unwrap.fixed
@@ -1,6 +1,11 @@
 //@run-rustfix
 
-#![allow(unused_mut, clippy::from_iter_instead_of_collect, clippy::get_first)]
+#![allow(
+    unused_mut,
+    clippy::from_iter_instead_of_collect,
+    clippy::get_first,
+    clippy::useless_vec
+)]
 #![warn(clippy::unwrap_used)]
 #![deny(clippy::get_unwrap)]
 

--- a/tests/ui/get_unwrap.rs
+++ b/tests/ui/get_unwrap.rs
@@ -1,6 +1,11 @@
 //@run-rustfix
 
-#![allow(unused_mut, clippy::from_iter_instead_of_collect, clippy::get_first)]
+#![allow(
+    unused_mut,
+    clippy::from_iter_instead_of_collect,
+    clippy::get_first,
+    clippy::useless_vec
+)]
 #![warn(clippy::unwrap_used)]
 #![deny(clippy::get_unwrap)]
 

--- a/tests/ui/get_unwrap.stderr
+++ b/tests/ui/get_unwrap.stderr
@@ -1,17 +1,17 @@
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:35:17
+  --> $DIR/get_unwrap.rs:40:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
    |
 note: the lint level is defined here
-  --> $DIR/get_unwrap.rs:5:9
+  --> $DIR/get_unwrap.rs:10:9
    |
 LL | #![deny(clippy::get_unwrap)]
    |         ^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:35:17
+  --> $DIR/get_unwrap.rs:40:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,13 +20,13 @@ LL |         let _ = boxed_slice.get(1).unwrap();
    = note: `-D clippy::unwrap-used` implied by `-D warnings`
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:36:17
+  --> $DIR/get_unwrap.rs:41:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:36:17
+  --> $DIR/get_unwrap.rs:41:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +34,13 @@ LL |         let _ = some_slice.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:37:17
+  --> $DIR/get_unwrap.rs:42:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:37:17
+  --> $DIR/get_unwrap.rs:42:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,13 +48,13 @@ LL |         let _ = some_vec.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:38:17
+  --> $DIR/get_unwrap.rs:43:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:38:17
+  --> $DIR/get_unwrap.rs:43:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,13 +62,13 @@ LL |         let _ = some_vecdeque.get(0).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:39:17
+  --> $DIR/get_unwrap.rs:44:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:39:17
+  --> $DIR/get_unwrap.rs:44:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,13 +76,13 @@ LL |         let _ = some_hashmap.get(&1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:40:17
+  --> $DIR/get_unwrap.rs:45:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:40:17
+  --> $DIR/get_unwrap.rs:45:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,13 +90,13 @@ LL |         let _ = some_btreemap.get(&1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:44:21
+  --> $DIR/get_unwrap.rs:49:21
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:44:22
+  --> $DIR/get_unwrap.rs:49:22
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,13 +104,13 @@ LL |         let _: u8 = *boxed_slice.get(1).unwrap();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:49:9
+  --> $DIR/get_unwrap.rs:54:9
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:49:10
+  --> $DIR/get_unwrap.rs:54:10
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,13 +118,13 @@ LL |         *boxed_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:50:9
+  --> $DIR/get_unwrap.rs:55:9
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:50:10
+  --> $DIR/get_unwrap.rs:55:10
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,13 +132,13 @@ LL |         *some_slice.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:51:9
+  --> $DIR/get_unwrap.rs:56:9
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:51:10
+  --> $DIR/get_unwrap.rs:56:10
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -146,13 +146,13 @@ LL |         *some_vec.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:52:9
+  --> $DIR/get_unwrap.rs:57:9
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:52:10
+  --> $DIR/get_unwrap.rs:57:10
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,13 +160,13 @@ LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:64:17
+  --> $DIR/get_unwrap.rs:69:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:64:17
+  --> $DIR/get_unwrap.rs:69:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -174,13 +174,13 @@ LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
    = help: if you don't want to handle the `None` case gracefully, consider using `expect()` to provide a better panic message
 
 error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more concise
-  --> $DIR/get_unwrap.rs:65:17
+  --> $DIR/get_unwrap.rs:70:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
-  --> $DIR/get_unwrap.rs:65:17
+  --> $DIR/get_unwrap.rs:70:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/indexing_slicing_index.rs
+++ b/tests/ui/indexing_slicing_index.rs
@@ -3,7 +3,12 @@
 // We also check the out_of_bounds_indexing lint here, because it lints similar things and
 // we want to avoid false positives.
 #![warn(clippy::out_of_bounds_indexing)]
-#![allow(unconditional_panic, clippy::no_effect, clippy::unnecessary_operation)]
+#![allow(
+    unconditional_panic,
+    clippy::no_effect,
+    clippy::unnecessary_operation,
+    clippy::useless_vec
+)]
 
 const ARR: [i32; 2] = [1, 2];
 const REF: &i32 = &ARR[idx()]; // This should be linted, since `suppress-restriction-lint-in-const` default is false.

--- a/tests/ui/indexing_slicing_index.stderr
+++ b/tests/ui/indexing_slicing_index.stderr
@@ -1,5 +1,5 @@
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:9:20
+  --> $DIR/indexing_slicing_index.rs:14:20
    |
 LL | const REF: &i32 = &ARR[idx()]; // This should be linted, since `suppress-restriction-lint-in-const` default is false.
    |                    ^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | const REF: &i32 = &ARR[idx()]; // This should be linted, since `suppress-re
    = note: `-D clippy::indexing-slicing` implied by `-D warnings`
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:10:24
+  --> $DIR/indexing_slicing_index.rs:15:24
    |
 LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    |                        ^^^^^^^^^^^
@@ -18,19 +18,19 @@ LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    = note: the suggestion might not be applicable in constant blocks
 
 error[E0080]: evaluation of `main::{constant#3}` failed
-  --> $DIR/indexing_slicing_index.rs:31:14
+  --> $DIR/indexing_slicing_index.rs:36:14
    |
 LL |     const { &ARR[idx4()] }; // This should be linted, since `suppress-restriction-lint-in-const` default is false.
    |              ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
 
 note: erroneous constant used
-  --> $DIR/indexing_slicing_index.rs:31:5
+  --> $DIR/indexing_slicing_index.rs:36:5
    |
 LL |     const { &ARR[idx4()] }; // This should be linted, since `suppress-restriction-lint-in-const` default is false.
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:22:5
+  --> $DIR/indexing_slicing_index.rs:27:5
    |
 LL |     x[index];
    |     ^^^^^^^^
@@ -38,7 +38,7 @@ LL |     x[index];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:30:14
+  --> $DIR/indexing_slicing_index.rs:35:14
    |
 LL |     const { &ARR[idx()] }; // This should be linted, since `suppress-restriction-lint-in-const` default is false.
    |              ^^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     const { &ARR[idx()] }; // This should be linted, since `suppress-restri
    = note: the suggestion might not be applicable in constant blocks
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:31:14
+  --> $DIR/indexing_slicing_index.rs:36:14
    |
 LL |     const { &ARR[idx4()] }; // This should be linted, since `suppress-restriction-lint-in-const` default is false.
    |              ^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     const { &ARR[idx4()] }; // This should be linted, since `suppress-restr
    = note: the suggestion might not be applicable in constant blocks
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:38:5
+  --> $DIR/indexing_slicing_index.rs:43:5
    |
 LL |     v[0];
    |     ^^^^
@@ -64,7 +64,7 @@ LL |     v[0];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:39:5
+  --> $DIR/indexing_slicing_index.rs:44:5
    |
 LL |     v[10];
    |     ^^^^^
@@ -72,7 +72,7 @@ LL |     v[10];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:40:5
+  --> $DIR/indexing_slicing_index.rs:45:5
    |
 LL |     v[1 << 3];
    |     ^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     v[1 << 3];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:46:5
+  --> $DIR/indexing_slicing_index.rs:51:5
    |
 LL |     v[N];
    |     ^^^^
@@ -88,7 +88,7 @@ LL |     v[N];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:47:5
+  --> $DIR/indexing_slicing_index.rs:52:5
    |
 LL |     v[M];
    |     ^^^^
@@ -96,7 +96,7 @@ LL |     v[M];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/indexing_slicing_index.rs:10:24
+  --> $DIR/indexing_slicing_index.rs:15:24
    |
 LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    |                        ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4

--- a/tests/ui/indexing_slicing_slice.rs
+++ b/tests/ui/indexing_slicing_slice.rs
@@ -2,7 +2,7 @@
 // We also check the out_of_bounds_indexing lint here, because it lints similar things and
 // we want to avoid false positives.
 #![warn(clippy::out_of_bounds_indexing)]
-#![allow(clippy::no_effect, clippy::unnecessary_operation)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::useless_vec)]
 
 fn main() {
     let x = [1, 2, 3, 4];

--- a/tests/ui/iter_count.fixed
+++ b/tests/ui/iter_count.fixed
@@ -7,7 +7,8 @@
     array_into_iter,
     unused_mut,
     clippy::into_iter_on_ref,
-    clippy::unnecessary_operation
+    clippy::unnecessary_operation,
+    clippy::useless_vec
 )]
 
 extern crate option_helpers;

--- a/tests/ui/iter_count.rs
+++ b/tests/ui/iter_count.rs
@@ -7,7 +7,8 @@
     array_into_iter,
     unused_mut,
     clippy::into_iter_on_ref,
-    clippy::unnecessary_operation
+    clippy::unnecessary_operation,
+    clippy::useless_vec
 )]
 
 extern crate option_helpers;

--- a/tests/ui/iter_count.stderr
+++ b/tests/ui/iter_count.stderr
@@ -1,5 +1,5 @@
 error: called `.iter().count()` on a `slice`
-  --> $DIR/iter_count.rs:54:6
+  --> $DIR/iter_count.rs:55:6
    |
 LL |     &vec[..].iter().count();
    |      ^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec[..].len()`
@@ -7,145 +7,145 @@ LL |     &vec[..].iter().count();
    = note: `-D clippy::iter-count` implied by `-D warnings`
 
 error: called `.iter().count()` on a `Vec`
-  --> $DIR/iter_count.rs:55:5
+  --> $DIR/iter_count.rs:56:5
    |
 LL |     vec.iter().count();
    |     ^^^^^^^^^^^^^^^^^^ help: try: `vec.len()`
 
 error: called `.iter().count()` on a `slice`
-  --> $DIR/iter_count.rs:56:5
+  --> $DIR/iter_count.rs:57:5
    |
 LL |     boxed_slice.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `boxed_slice.len()`
 
 error: called `.iter().count()` on a `VecDeque`
-  --> $DIR/iter_count.rs:57:5
+  --> $DIR/iter_count.rs:58:5
    |
 LL |     vec_deque.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec_deque.len()`
 
 error: called `.iter().count()` on a `HashSet`
-  --> $DIR/iter_count.rs:58:5
+  --> $DIR/iter_count.rs:59:5
    |
 LL |     hash_set.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_set.len()`
 
 error: called `.iter().count()` on a `HashMap`
-  --> $DIR/iter_count.rs:59:5
+  --> $DIR/iter_count.rs:60:5
    |
 LL |     hash_map.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_map.len()`
 
 error: called `.iter().count()` on a `BTreeMap`
-  --> $DIR/iter_count.rs:60:5
+  --> $DIR/iter_count.rs:61:5
    |
 LL |     b_tree_map.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_map.len()`
 
 error: called `.iter().count()` on a `BTreeSet`
-  --> $DIR/iter_count.rs:61:5
+  --> $DIR/iter_count.rs:62:5
    |
 LL |     b_tree_set.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_set.len()`
 
 error: called `.iter().count()` on a `LinkedList`
-  --> $DIR/iter_count.rs:62:5
+  --> $DIR/iter_count.rs:63:5
    |
 LL |     linked_list.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `linked_list.len()`
 
 error: called `.iter().count()` on a `BinaryHeap`
-  --> $DIR/iter_count.rs:63:5
+  --> $DIR/iter_count.rs:64:5
    |
 LL |     binary_heap.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `binary_heap.len()`
 
 error: called `.iter_mut().count()` on a `Vec`
-  --> $DIR/iter_count.rs:65:5
+  --> $DIR/iter_count.rs:66:5
    |
 LL |     vec.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.len()`
 
 error: called `.iter_mut().count()` on a `slice`
-  --> $DIR/iter_count.rs:66:6
+  --> $DIR/iter_count.rs:67:6
    |
 LL |     &vec[..].iter_mut().count();
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec[..].len()`
 
 error: called `.iter_mut().count()` on a `VecDeque`
-  --> $DIR/iter_count.rs:67:5
+  --> $DIR/iter_count.rs:68:5
    |
 LL |     vec_deque.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec_deque.len()`
 
 error: called `.iter_mut().count()` on a `HashMap`
-  --> $DIR/iter_count.rs:68:5
+  --> $DIR/iter_count.rs:69:5
    |
 LL |     hash_map.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_map.len()`
 
 error: called `.iter_mut().count()` on a `BTreeMap`
-  --> $DIR/iter_count.rs:69:5
+  --> $DIR/iter_count.rs:70:5
    |
 LL |     b_tree_map.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_map.len()`
 
 error: called `.iter_mut().count()` on a `LinkedList`
-  --> $DIR/iter_count.rs:70:5
+  --> $DIR/iter_count.rs:71:5
    |
 LL |     linked_list.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `linked_list.len()`
 
 error: called `.into_iter().count()` on a `slice`
-  --> $DIR/iter_count.rs:72:6
+  --> $DIR/iter_count.rs:73:6
    |
 LL |     &vec[..].into_iter().count();
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec[..].len()`
 
 error: called `.into_iter().count()` on a `Vec`
-  --> $DIR/iter_count.rs:73:5
+  --> $DIR/iter_count.rs:74:5
    |
 LL |     vec.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.len()`
 
 error: called `.into_iter().count()` on a `VecDeque`
-  --> $DIR/iter_count.rs:74:5
+  --> $DIR/iter_count.rs:75:5
    |
 LL |     vec_deque.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec_deque.len()`
 
 error: called `.into_iter().count()` on a `HashSet`
-  --> $DIR/iter_count.rs:75:5
+  --> $DIR/iter_count.rs:76:5
    |
 LL |     hash_set.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_set.len()`
 
 error: called `.into_iter().count()` on a `HashMap`
-  --> $DIR/iter_count.rs:76:5
+  --> $DIR/iter_count.rs:77:5
    |
 LL |     hash_map.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_map.len()`
 
 error: called `.into_iter().count()` on a `BTreeMap`
-  --> $DIR/iter_count.rs:77:5
+  --> $DIR/iter_count.rs:78:5
    |
 LL |     b_tree_map.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_map.len()`
 
 error: called `.into_iter().count()` on a `BTreeSet`
-  --> $DIR/iter_count.rs:78:5
+  --> $DIR/iter_count.rs:79:5
    |
 LL |     b_tree_set.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_set.len()`
 
 error: called `.into_iter().count()` on a `LinkedList`
-  --> $DIR/iter_count.rs:79:5
+  --> $DIR/iter_count.rs:80:5
    |
 LL |     linked_list.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `linked_list.len()`
 
 error: called `.into_iter().count()` on a `BinaryHeap`
-  --> $DIR/iter_count.rs:80:5
+  --> $DIR/iter_count.rs:81:5
    |
 LL |     binary_heap.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `binary_heap.len()`

--- a/tests/ui/iter_next_slice.fixed
+++ b/tests/ui/iter_next_slice.fixed
@@ -1,5 +1,6 @@
 //@run-rustfix
 #![warn(clippy::iter_next_slice)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // test code goes here

--- a/tests/ui/iter_next_slice.rs
+++ b/tests/ui/iter_next_slice.rs
@@ -1,5 +1,6 @@
 //@run-rustfix
 #![warn(clippy::iter_next_slice)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // test code goes here

--- a/tests/ui/iter_next_slice.stderr
+++ b/tests/ui/iter_next_slice.stderr
@@ -1,5 +1,5 @@
 error: using `.iter().next()` on an array
-  --> $DIR/iter_next_slice.rs:9:13
+  --> $DIR/iter_next_slice.rs:10:13
    |
 LL |     let _ = s.iter().next();
    |             ^^^^^^^^^^^^^^^ help: try calling: `s.first()`
@@ -7,19 +7,19 @@ LL |     let _ = s.iter().next();
    = note: `-D clippy::iter-next-slice` implied by `-D warnings`
 
 error: using `.iter().next()` on a Slice without end index
-  --> $DIR/iter_next_slice.rs:12:13
+  --> $DIR/iter_next_slice.rs:13:13
    |
 LL |     let _ = s[2..].iter().next();
    |             ^^^^^^^^^^^^^^^^^^^^ help: try calling: `s.get(2)`
 
 error: using `.iter().next()` on a Slice without end index
-  --> $DIR/iter_next_slice.rs:15:13
+  --> $DIR/iter_next_slice.rs:16:13
    |
 LL |     let _ = v[5..].iter().next();
    |             ^^^^^^^^^^^^^^^^^^^^ help: try calling: `v.get(5)`
 
 error: using `.iter().next()` on an array
-  --> $DIR/iter_next_slice.rs:18:13
+  --> $DIR/iter_next_slice.rs:19:13
    |
 LL |     let _ = v.iter().next();
    |             ^^^^^^^^^^^^^^^ help: try calling: `v.first()`

--- a/tests/ui/iter_nth.rs
+++ b/tests/ui/iter_nth.rs
@@ -1,6 +1,7 @@
 //@aux-build:option_helpers.rs
 
 #![warn(clippy::iter_nth)]
+#![allow(clippy::useless_vec)]
 
 #[macro_use]
 extern crate option_helpers;

--- a/tests/ui/iter_nth.stderr
+++ b/tests/ui/iter_nth.stderr
@@ -1,5 +1,5 @@
 error: called `.iter().nth()` on a Vec
-  --> $DIR/iter_nth.rs:33:23
+  --> $DIR/iter_nth.rs:34:23
    |
 LL |         let bad_vec = some_vec.iter().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |         let bad_vec = some_vec.iter().nth(3);
    = note: `-D clippy::iter-nth` implied by `-D warnings`
 
 error: called `.iter().nth()` on a slice
-  --> $DIR/iter_nth.rs:34:26
+  --> $DIR/iter_nth.rs:35:26
    |
 LL |         let bad_slice = &some_vec[..].iter().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |         let bad_slice = &some_vec[..].iter().nth(3);
    = help: calling `.get()` is both faster and more readable
 
 error: called `.iter().nth()` on a slice
-  --> $DIR/iter_nth.rs:35:31
+  --> $DIR/iter_nth.rs:36:31
    |
 LL |         let bad_boxed_slice = boxed_slice.iter().nth(3);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         let bad_boxed_slice = boxed_slice.iter().nth(3);
    = help: calling `.get()` is both faster and more readable
 
 error: called `.iter().nth()` on a VecDeque
-  --> $DIR/iter_nth.rs:36:29
+  --> $DIR/iter_nth.rs:37:29
    |
 LL |         let bad_vec_deque = some_vec_deque.iter().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         let bad_vec_deque = some_vec_deque.iter().nth(3);
    = help: calling `.get()` is both faster and more readable
 
 error: called `.iter_mut().nth()` on a Vec
-  --> $DIR/iter_nth.rs:41:23
+  --> $DIR/iter_nth.rs:42:23
    |
 LL |         let bad_vec = some_vec.iter_mut().nth(3);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         let bad_vec = some_vec.iter_mut().nth(3);
    = help: calling `.get_mut()` is both faster and more readable
 
 error: called `.iter_mut().nth()` on a slice
-  --> $DIR/iter_nth.rs:44:26
+  --> $DIR/iter_nth.rs:45:26
    |
 LL |         let bad_slice = &some_vec[..].iter_mut().nth(3);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |         let bad_slice = &some_vec[..].iter_mut().nth(3);
    = help: calling `.get_mut()` is both faster and more readable
 
 error: called `.iter_mut().nth()` on a VecDeque
-  --> $DIR/iter_nth.rs:47:29
+  --> $DIR/iter_nth.rs:48:29
    |
 LL |         let bad_vec_deque = some_vec_deque.iter_mut().nth(3);
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/iter_overeager_cloned.fixed
+++ b/tests/ui/iter_overeager_cloned.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::iter_overeager_cloned, clippy::redundant_clone, clippy::filter_next)]
-#![allow(dead_code, clippy::let_unit_value)]
+#![allow(dead_code, clippy::let_unit_value, clippy::useless_vec)]
 
 fn main() {
     let vec = vec!["1".to_string(), "2".to_string(), "3".to_string()];

--- a/tests/ui/iter_overeager_cloned.rs
+++ b/tests/ui/iter_overeager_cloned.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::iter_overeager_cloned, clippy::redundant_clone, clippy::filter_next)]
-#![allow(dead_code, clippy::let_unit_value)]
+#![allow(dead_code, clippy::let_unit_value, clippy::useless_vec)]
 
 fn main() {
     let vec = vec!["1".to_string(), "2".to_string(), "3".to_string()];

--- a/tests/ui/iter_skip_next.fixed
+++ b/tests/ui/iter_skip_next.fixed
@@ -4,6 +4,7 @@
 #![warn(clippy::iter_skip_next)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::iter_nth)]
+#![allow(clippy::useless_vec)]
 #![allow(unused_mut, dead_code)]
 
 extern crate option_helpers;

--- a/tests/ui/iter_skip_next.rs
+++ b/tests/ui/iter_skip_next.rs
@@ -4,6 +4,7 @@
 #![warn(clippy::iter_skip_next)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::iter_nth)]
+#![allow(clippy::useless_vec)]
 #![allow(unused_mut, dead_code)]
 
 extern crate option_helpers;

--- a/tests/ui/iter_skip_next.stderr
+++ b/tests/ui/iter_skip_next.stderr
@@ -1,5 +1,5 @@
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:16:28
+  --> $DIR/iter_skip_next.rs:17:28
    |
 LL |     let _ = some_vec.iter().skip(42).next();
    |                            ^^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(42)`
@@ -7,37 +7,37 @@ LL |     let _ = some_vec.iter().skip(42).next();
    = note: `-D clippy::iter-skip-next` implied by `-D warnings`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:17:36
+  --> $DIR/iter_skip_next.rs:18:36
    |
 LL |     let _ = some_vec.iter().cycle().skip(42).next();
    |                                    ^^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(42)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:18:20
+  --> $DIR/iter_skip_next.rs:19:20
    |
 LL |     let _ = (1..10).skip(10).next();
    |                    ^^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(10)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:19:33
+  --> $DIR/iter_skip_next.rs:20:33
    |
 LL |     let _ = &some_vec[..].iter().skip(3).next();
    |                                 ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(3)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:27:26
+  --> $DIR/iter_skip_next.rs:28:26
    |
 LL |     let _: Vec<&str> = sp.skip(1).next().unwrap().split(' ').collect();
    |                          ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(1)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:29:29
+  --> $DIR/iter_skip_next.rs:30:29
    |
 LL |         let _: Vec<&str> = s.skip(1).next().unwrap().split(' ').collect();
    |                             ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(1)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:35:29
+  --> $DIR/iter_skip_next.rs:36:29
    |
 LL |         let _: Vec<&str> = s.skip(1).next().unwrap().split(' ').collect();
    |                             ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(1)`

--- a/tests/ui/iterator_step_by_zero.rs
+++ b/tests/ui/iterator_step_by_zero.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::useless_vec)]
 #[warn(clippy::iterator_step_by_zero)]
 fn main() {
     let _ = vec!["A", "B", "B"].iter().step_by(0);

--- a/tests/ui/iterator_step_by_zero.stderr
+++ b/tests/ui/iterator_step_by_zero.stderr
@@ -1,5 +1,5 @@
 error: `Iterator::step_by(0)` will panic at runtime
-  --> $DIR/iterator_step_by_zero.rs:3:13
+  --> $DIR/iterator_step_by_zero.rs:4:13
    |
 LL |     let _ = vec!["A", "B", "B"].iter().step_by(0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,37 +7,37 @@ LL |     let _ = vec!["A", "B", "B"].iter().step_by(0);
    = note: `-D clippy::iterator-step-by-zero` implied by `-D warnings`
 
 error: `Iterator::step_by(0)` will panic at runtime
-  --> $DIR/iterator_step_by_zero.rs:4:13
+  --> $DIR/iterator_step_by_zero.rs:5:13
    |
 LL |     let _ = "XXX".chars().step_by(0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `Iterator::step_by(0)` will panic at runtime
-  --> $DIR/iterator_step_by_zero.rs:5:13
+  --> $DIR/iterator_step_by_zero.rs:6:13
    |
 LL |     let _ = (0..1).step_by(0);
    |             ^^^^^^^^^^^^^^^^^
 
 error: `Iterator::step_by(0)` will panic at runtime
-  --> $DIR/iterator_step_by_zero.rs:14:13
+  --> $DIR/iterator_step_by_zero.rs:15:13
    |
 LL |     let _ = (1..).step_by(0);
    |             ^^^^^^^^^^^^^^^^
 
 error: `Iterator::step_by(0)` will panic at runtime
-  --> $DIR/iterator_step_by_zero.rs:15:13
+  --> $DIR/iterator_step_by_zero.rs:16:13
    |
 LL |     let _ = (1..=2).step_by(0);
    |             ^^^^^^^^^^^^^^^^^^
 
 error: `Iterator::step_by(0)` will panic at runtime
-  --> $DIR/iterator_step_by_zero.rs:18:13
+  --> $DIR/iterator_step_by_zero.rs:19:13
    |
 LL |     let _ = x.step_by(0);
    |             ^^^^^^^^^^^^
 
 error: `Iterator::step_by(0)` will panic at runtime
-  --> $DIR/iterator_step_by_zero.rs:22:13
+  --> $DIR/iterator_step_by_zero.rs:23:13
    |
 LL |     let _ = v1.iter().step_by(2 / 3);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/manual_assert.edition2018.fixed
+++ b/tests/ui/manual_assert.edition2018.fixed
@@ -5,7 +5,7 @@
 
 #![warn(clippy::manual_assert)]
 #![allow(dead_code, unused_doc_comments)]
-#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args)]
+#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args, clippy::useless_vec)]
 
 macro_rules! one {
     () => {

--- a/tests/ui/manual_assert.edition2021.fixed
+++ b/tests/ui/manual_assert.edition2021.fixed
@@ -5,7 +5,7 @@
 
 #![warn(clippy::manual_assert)]
 #![allow(dead_code, unused_doc_comments)]
-#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args)]
+#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args, clippy::useless_vec)]
 
 macro_rules! one {
     () => {

--- a/tests/ui/manual_assert.rs
+++ b/tests/ui/manual_assert.rs
@@ -5,7 +5,7 @@
 
 #![warn(clippy::manual_assert)]
 #![allow(dead_code, unused_doc_comments)]
-#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args)]
+#![allow(clippy::nonminimal_bool, clippy::uninlined_format_args, clippy::useless_vec)]
 
 macro_rules! one {
     () => {

--- a/tests/ui/manual_filter.fixed
+++ b/tests/ui/manual_filter.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::manual_filter)]
-#![allow(unused_variables, dead_code)]
+#![allow(unused_variables, dead_code, clippy::useless_vec)]
 
 fn main() {
     Some(0).filter(|&x| x <= 0);

--- a/tests/ui/manual_filter.rs
+++ b/tests/ui/manual_filter.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::manual_filter)]
-#![allow(unused_variables, dead_code)]
+#![allow(unused_variables, dead_code, clippy::useless_vec)]
 
 fn main() {
     match Some(0) {

--- a/tests/ui/manual_filter_map.fixed
+++ b/tests/ui/manual_filter_map.fixed
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![warn(clippy::manual_filter_map)]
 #![allow(clippy::redundant_closure)] // FIXME suggestion may have redundant closure
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // is_some(), unwrap()

--- a/tests/ui/manual_filter_map.rs
+++ b/tests/ui/manual_filter_map.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![warn(clippy::manual_filter_map)]
 #![allow(clippy::redundant_closure)] // FIXME suggestion may have redundant closure
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // is_some(), unwrap()

--- a/tests/ui/manual_filter_map.stderr
+++ b/tests/ui/manual_filter_map.stderr
@@ -1,5 +1,5 @@
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:8:19
+  --> $DIR/manual_filter_map.rs:9:19
    |
 LL |     let _ = (0..).filter(|n| to_opt(*n).is_some()).map(|a| to_opt(a).unwrap());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter_map(|a| to_opt(a))`
@@ -7,19 +7,19 @@ LL |     let _ = (0..).filter(|n| to_opt(*n).is_some()).map(|a| to_opt(a).unwrap
    = note: `-D clippy::manual-filter-map` implied by `-D warnings`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:11:19
+  --> $DIR/manual_filter_map.rs:12:19
    |
 LL |     let _ = (0..).filter(|&n| to_opt(n).is_some()).map(|a| to_opt(a).expect("hi"));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter_map(|a| to_opt(a))`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:14:19
+  --> $DIR/manual_filter_map.rs:15:19
    |
 LL |     let _ = (0..).filter(|&n| to_res(n).is_ok()).map(|a| to_res(a).unwrap_or(1));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `filter_map(|a| to_res(a).ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:17:10
+  --> $DIR/manual_filter_map.rs:18:10
    |
 LL |           .filter(|&x| to_ref(to_opt(x)).is_some())
    |  __________^
@@ -27,7 +27,7 @@ LL | |         .map(|y| to_ref(to_opt(y)).unwrap());
    | |____________________________________________^ help: try: `filter_map(|y| *to_ref(to_opt(y)))`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:20:10
+  --> $DIR/manual_filter_map.rs:21:10
    |
 LL |           .filter(|x| to_ref(to_opt(*x)).is_some())
    |  __________^
@@ -35,7 +35,7 @@ LL | |         .map(|y| to_ref(to_opt(y)).unwrap());
    | |____________________________________________^ help: try: `filter_map(|y| *to_ref(to_opt(y)))`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:24:10
+  --> $DIR/manual_filter_map.rs:25:10
    |
 LL |           .filter(|&x| to_ref(to_res(x)).is_ok())
    |  __________^
@@ -43,7 +43,7 @@ LL | |         .map(|y| to_ref(to_res(y)).unwrap());
    | |____________________________________________^ help: try: `filter_map(|y| to_ref(to_res(y)).ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:27:10
+  --> $DIR/manual_filter_map.rs:28:10
    |
 LL |           .filter(|x| to_ref(to_res(*x)).is_ok())
    |  __________^
@@ -51,7 +51,7 @@ LL | |         .map(|y| to_ref(to_res(y)).unwrap());
    | |____________________________________________^ help: try: `filter_map(|y| to_ref(to_res(y)).ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:33:27
+  --> $DIR/manual_filter_map.rs:34:27
    |
 LL |     iter::<Option<&u8>>().find(|x| x.is_some()).map(|x| x.cloned().unwrap());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned())`
@@ -59,67 +59,67 @@ LL |     iter::<Option<&u8>>().find(|x| x.is_some()).map(|x| x.cloned().unwrap()
    = note: `-D clippy::manual-find-map` implied by `-D warnings`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:34:28
+  --> $DIR/manual_filter_map.rs:35:28
    |
 LL |     iter::<&Option<&u8>>().find(|x| x.is_some()).map(|x| x.cloned().unwrap());
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:35:31
+  --> $DIR/manual_filter_map.rs:36:31
    |
 LL |     iter::<&Option<String>>().find(|x| x.is_some()).map(|x| x.as_deref().unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.as_deref())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:36:31
+  --> $DIR/manual_filter_map.rs:37:31
    |
 LL |     iter::<Option<&String>>().find(|&x| to_ref(x).is_some()).map(|y| to_ref(y).cloned().unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|y| to_ref(y).cloned())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:38:30
+  --> $DIR/manual_filter_map.rs:39:30
    |
 LL |     iter::<Result<u8, ()>>().find(|x| x.is_ok()).map(|x| x.unwrap());
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:39:31
+  --> $DIR/manual_filter_map.rs:40:31
    |
 LL |     iter::<&Result<u8, ()>>().find(|x| x.is_ok()).map(|x| x.unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:40:32
+  --> $DIR/manual_filter_map.rs:41:32
    |
 LL |     iter::<&&Result<u8, ()>>().find(|x| x.is_ok()).map(|x| x.unwrap());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:41:31
+  --> $DIR/manual_filter_map.rs:42:31
    |
 LL |     iter::<Result<&u8, ()>>().find(|x| x.is_ok()).map(|x| x.cloned().unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:42:32
+  --> $DIR/manual_filter_map.rs:43:32
    |
 LL |     iter::<&Result<&u8, ()>>().find(|x| x.is_ok()).map(|x| x.cloned().unwrap());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:43:35
+  --> $DIR/manual_filter_map.rs:44:35
    |
 LL |     iter::<&Result<String, ()>>().find(|x| x.is_ok()).map(|x| x.as_deref().unwrap());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.as_deref().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_filter_map.rs:44:35
+  --> $DIR/manual_filter_map.rs:45:35
    |
 LL |     iter::<Result<&String, ()>>().find(|&x| to_ref(x).is_ok()).map(|y| to_ref(y).cloned().unwrap());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|y| to_ref(y).cloned().ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:92:10
+  --> $DIR/manual_filter_map.rs:93:10
    |
 LL |           .filter(|f| f.option_field.is_some())
    |  __________^
@@ -127,7 +127,7 @@ LL | |         .map(|f| f.option_field.clone().unwrap());
    | |_________________________________________________^ help: try: `filter_map(|f| f.option_field.clone())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:97:10
+  --> $DIR/manual_filter_map.rs:98:10
    |
 LL |           .filter(|f| f.ref_field.is_some())
    |  __________^
@@ -135,7 +135,7 @@ LL | |         .map(|f| f.ref_field.cloned().unwrap());
    | |_______________________________________________^ help: try: `filter_map(|f| f.ref_field.cloned())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:102:10
+  --> $DIR/manual_filter_map.rs:103:10
    |
 LL |           .filter(|f| f.ref_field.is_some())
    |  __________^
@@ -143,7 +143,7 @@ LL | |         .map(|f| f.ref_field.copied().unwrap());
    | |_______________________________________________^ help: try: `filter_map(|f| f.ref_field.copied())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:107:10
+  --> $DIR/manual_filter_map.rs:108:10
    |
 LL |           .filter(|f| f.result_field.is_ok())
    |  __________^
@@ -151,7 +151,7 @@ LL | |         .map(|f| f.result_field.clone().unwrap());
    | |_________________________________________________^ help: try: `filter_map(|f| f.result_field.clone().ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:112:10
+  --> $DIR/manual_filter_map.rs:113:10
    |
 LL |           .filter(|f| f.result_field.is_ok())
    |  __________^
@@ -159,7 +159,7 @@ LL | |         .map(|f| f.result_field.as_ref().unwrap());
    | |__________________________________________________^ help: try: `filter_map(|f| f.result_field.as_ref().ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:117:10
+  --> $DIR/manual_filter_map.rs:118:10
    |
 LL |           .filter(|f| f.result_field.is_ok())
    |  __________^
@@ -167,7 +167,7 @@ LL | |         .map(|f| f.result_field.as_deref().unwrap());
    | |____________________________________________________^ help: try: `filter_map(|f| f.result_field.as_deref().ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:122:10
+  --> $DIR/manual_filter_map.rs:123:10
    |
 LL |           .filter(|f| f.result_field.is_ok())
    |  __________^
@@ -175,7 +175,7 @@ LL | |         .map(|f| f.result_field.as_mut().unwrap());
    | |__________________________________________________^ help: try: `filter_map(|f| f.result_field.as_mut().ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:127:10
+  --> $DIR/manual_filter_map.rs:128:10
    |
 LL |           .filter(|f| f.result_field.is_ok())
    |  __________^
@@ -183,7 +183,7 @@ LL | |         .map(|f| f.result_field.as_deref_mut().unwrap());
    | |________________________________________________________^ help: try: `filter_map(|f| f.result_field.as_deref_mut().ok())`
 
 error: `filter(..).map(..)` can be simplified as `filter_map(..)`
-  --> $DIR/manual_filter_map.rs:132:10
+  --> $DIR/manual_filter_map.rs:133:10
    |
 LL |           .filter(|f| f.result_field.is_ok())
    |  __________^

--- a/tests/ui/manual_find_map.fixed
+++ b/tests/ui/manual_find_map.fixed
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![warn(clippy::manual_find_map)]
 #![allow(clippy::redundant_closure)] // FIXME suggestion may have redundant closure
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // is_some(), unwrap()

--- a/tests/ui/manual_find_map.rs
+++ b/tests/ui/manual_find_map.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![warn(clippy::manual_find_map)]
 #![allow(clippy::redundant_closure)] // FIXME suggestion may have redundant closure
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // is_some(), unwrap()

--- a/tests/ui/manual_find_map.stderr
+++ b/tests/ui/manual_find_map.stderr
@@ -1,5 +1,5 @@
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:8:19
+  --> $DIR/manual_find_map.rs:9:19
    |
 LL |     let _ = (0..).find(|n| to_opt(*n).is_some()).map(|a| to_opt(a).unwrap());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|a| to_opt(a))`
@@ -7,19 +7,19 @@ LL |     let _ = (0..).find(|n| to_opt(*n).is_some()).map(|a| to_opt(a).unwrap()
    = note: `-D clippy::manual-find-map` implied by `-D warnings`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:11:19
+  --> $DIR/manual_find_map.rs:12:19
    |
 LL |     let _ = (0..).find(|&n| to_opt(n).is_some()).map(|a| to_opt(a).expect("hi"));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|a| to_opt(a))`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:14:19
+  --> $DIR/manual_find_map.rs:15:19
    |
 LL |     let _ = (0..).find(|&n| to_res(n).is_ok()).map(|a| to_res(a).unwrap_or(1));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|a| to_res(a).ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:17:10
+  --> $DIR/manual_find_map.rs:18:10
    |
 LL |           .find(|&x| to_ref(to_opt(x)).is_some())
    |  __________^
@@ -27,7 +27,7 @@ LL | |         .map(|y| to_ref(to_opt(y)).unwrap());
    | |____________________________________________^ help: try: `find_map(|y| *to_ref(to_opt(y)))`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:20:10
+  --> $DIR/manual_find_map.rs:21:10
    |
 LL |           .find(|x| to_ref(to_opt(*x)).is_some())
    |  __________^
@@ -35,7 +35,7 @@ LL | |         .map(|y| to_ref(to_opt(y)).unwrap());
    | |____________________________________________^ help: try: `find_map(|y| *to_ref(to_opt(y)))`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:24:10
+  --> $DIR/manual_find_map.rs:25:10
    |
 LL |           .find(|&x| to_ref(to_res(x)).is_ok())
    |  __________^
@@ -43,7 +43,7 @@ LL | |         .map(|y| to_ref(to_res(y)).unwrap());
    | |____________________________________________^ help: try: `find_map(|y| to_ref(to_res(y)).ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:27:10
+  --> $DIR/manual_find_map.rs:28:10
    |
 LL |           .find(|x| to_ref(to_res(*x)).is_ok())
    |  __________^
@@ -51,91 +51,91 @@ LL | |         .map(|y| to_ref(to_res(y)).unwrap());
    | |____________________________________________^ help: try: `find_map(|y| to_ref(to_res(y)).ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:33:26
+  --> $DIR/manual_find_map.rs:34:26
    |
 LL |     iter::<Option<u8>>().find(|x| x.is_some()).map(|x| x.unwrap());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x)`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:34:27
+  --> $DIR/manual_find_map.rs:35:27
    |
 LL |     iter::<&Option<u8>>().find(|x| x.is_some()).map(|x| x.unwrap());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| *x)`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:35:28
+  --> $DIR/manual_find_map.rs:36:28
    |
 LL |     iter::<&&Option<u8>>().find(|x| x.is_some()).map(|x| x.unwrap());
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| **x)`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:36:27
+  --> $DIR/manual_find_map.rs:37:27
    |
 LL |     iter::<Option<&u8>>().find(|x| x.is_some()).map(|x| x.cloned().unwrap());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:37:28
+  --> $DIR/manual_find_map.rs:38:28
    |
 LL |     iter::<&Option<&u8>>().find(|x| x.is_some()).map(|x| x.cloned().unwrap());
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:38:31
+  --> $DIR/manual_find_map.rs:39:31
    |
 LL |     iter::<&Option<String>>().find(|x| x.is_some()).map(|x| x.as_deref().unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.as_deref())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:39:31
+  --> $DIR/manual_find_map.rs:40:31
    |
 LL |     iter::<Option<&String>>().find(|&x| to_ref(x).is_some()).map(|y| to_ref(y).cloned().unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|y| to_ref(y).cloned())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:41:30
+  --> $DIR/manual_find_map.rs:42:30
    |
 LL |     iter::<Result<u8, ()>>().find(|x| x.is_ok()).map(|x| x.unwrap());
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:42:31
+  --> $DIR/manual_find_map.rs:43:31
    |
 LL |     iter::<&Result<u8, ()>>().find(|x| x.is_ok()).map(|x| x.unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:43:32
+  --> $DIR/manual_find_map.rs:44:32
    |
 LL |     iter::<&&Result<u8, ()>>().find(|x| x.is_ok()).map(|x| x.unwrap());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:44:31
+  --> $DIR/manual_find_map.rs:45:31
    |
 LL |     iter::<Result<&u8, ()>>().find(|x| x.is_ok()).map(|x| x.cloned().unwrap());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:45:32
+  --> $DIR/manual_find_map.rs:46:32
    |
 LL |     iter::<&Result<&u8, ()>>().find(|x| x.is_ok()).map(|x| x.cloned().unwrap());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.cloned().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:46:35
+  --> $DIR/manual_find_map.rs:47:35
    |
 LL |     iter::<&Result<String, ()>>().find(|x| x.is_ok()).map(|x| x.as_deref().unwrap());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|x| x.as_deref().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:47:35
+  --> $DIR/manual_find_map.rs:48:35
    |
 LL |     iter::<Result<&String, ()>>().find(|&x| to_ref(x).is_ok()).map(|y| to_ref(y).cloned().unwrap());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `find_map(|y| to_ref(y).cloned().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:95:10
+  --> $DIR/manual_find_map.rs:96:10
    |
 LL |           .find(|f| f.option_field.is_some())
    |  __________^
@@ -143,7 +143,7 @@ LL | |         .map(|f| f.option_field.clone().unwrap());
    | |_________________________________________________^ help: try: `find_map(|f| f.option_field.clone())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:100:10
+  --> $DIR/manual_find_map.rs:101:10
    |
 LL |           .find(|f| f.ref_field.is_some())
    |  __________^
@@ -151,7 +151,7 @@ LL | |         .map(|f| f.ref_field.cloned().unwrap());
    | |_______________________________________________^ help: try: `find_map(|f| f.ref_field.cloned())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:105:10
+  --> $DIR/manual_find_map.rs:106:10
    |
 LL |           .find(|f| f.ref_field.is_some())
    |  __________^
@@ -159,7 +159,7 @@ LL | |         .map(|f| f.ref_field.copied().unwrap());
    | |_______________________________________________^ help: try: `find_map(|f| f.ref_field.copied())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:110:10
+  --> $DIR/manual_find_map.rs:111:10
    |
 LL |           .find(|f| f.result_field.is_ok())
    |  __________^
@@ -167,7 +167,7 @@ LL | |         .map(|f| f.result_field.clone().unwrap());
    | |_________________________________________________^ help: try: `find_map(|f| f.result_field.clone().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:115:10
+  --> $DIR/manual_find_map.rs:116:10
    |
 LL |           .find(|f| f.result_field.is_ok())
    |  __________^
@@ -175,7 +175,7 @@ LL | |         .map(|f| f.result_field.as_ref().unwrap());
    | |__________________________________________________^ help: try: `find_map(|f| f.result_field.as_ref().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:120:10
+  --> $DIR/manual_find_map.rs:121:10
    |
 LL |           .find(|f| f.result_field.is_ok())
    |  __________^
@@ -183,7 +183,7 @@ LL | |         .map(|f| f.result_field.as_deref().unwrap());
    | |____________________________________________________^ help: try: `find_map(|f| f.result_field.as_deref().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:125:10
+  --> $DIR/manual_find_map.rs:126:10
    |
 LL |           .find(|f| f.result_field.is_ok())
    |  __________^
@@ -191,7 +191,7 @@ LL | |         .map(|f| f.result_field.as_mut().unwrap());
    | |__________________________________________________^ help: try: `find_map(|f| f.result_field.as_mut().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:130:10
+  --> $DIR/manual_find_map.rs:131:10
    |
 LL |           .find(|f| f.result_field.is_ok())
    |  __________^
@@ -199,7 +199,7 @@ LL | |         .map(|f| f.result_field.as_deref_mut().unwrap());
    | |________________________________________________________^ help: try: `find_map(|f| f.result_field.as_deref_mut().ok())`
 
 error: `find(..).map(..)` can be simplified as `find_map(..)`
-  --> $DIR/manual_find_map.rs:135:10
+  --> $DIR/manual_find_map.rs:136:10
    |
 LL |           .find(|f| f.result_field.is_ok())
    |  __________^

--- a/tests/ui/manual_memcpy/without_loop_counters.rs
+++ b/tests/ui/manual_memcpy/without_loop_counters.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::needless_range_loop, clippy::manual_memcpy)]
+#![allow(clippy::useless_vec)]
 
 const LOOP_OFFSET: usize = 5000;
 

--- a/tests/ui/manual_memcpy/without_loop_counters.stderr
+++ b/tests/ui/manual_memcpy/without_loop_counters.stderr
@@ -1,5 +1,5 @@
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:7:5
+  --> $DIR/without_loop_counters.rs:8:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i] = src[i];
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::manual-memcpy` implied by `-D warnings`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:12:5
+  --> $DIR/without_loop_counters.rs:13:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i + 10] = src[i];
@@ -17,7 +17,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[10..(src.len() + 10)].copy_from_slice(&src[..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:17:5
+  --> $DIR/without_loop_counters.rs:18:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i] = src[i + 10];
@@ -25,7 +25,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..src.len()].copy_from_slice(&src[10..(src.len() + 10)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:22:5
+  --> $DIR/without_loop_counters.rs:23:5
    |
 LL | /     for i in 11..src.len() {
 LL | |         dst[i] = src[i - 10];
@@ -33,7 +33,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[11..src.len()].copy_from_slice(&src[(11 - 10)..(src.len() - 10)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:27:5
+  --> $DIR/without_loop_counters.rs:28:5
    |
 LL | /     for i in 0..dst.len() {
 LL | |         dst[i] = src[i];
@@ -41,7 +41,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst.copy_from_slice(&src[..dst.len()]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:40:5
+  --> $DIR/without_loop_counters.rs:41:5
    |
 LL | /     for i in 10..256 {
 LL | |         dst[i] = src[i - 5];
@@ -56,7 +56,7 @@ LL +     dst2[(10 + 500)..(256 + 500)].copy_from_slice(&src[10..256]);
    |
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:52:5
+  --> $DIR/without_loop_counters.rs:53:5
    |
 LL | /     for i in 10..LOOP_OFFSET {
 LL | |         dst[i + LOOP_OFFSET] = src[i - some_var];
@@ -64,7 +64,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[(10 + LOOP_OFFSET)..(LOOP_OFFSET + LOOP_OFFSET)].copy_from_slice(&src[(10 - some_var)..(LOOP_OFFSET - some_var)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:65:5
+  --> $DIR/without_loop_counters.rs:66:5
    |
 LL | /     for i in 0..src_vec.len() {
 LL | |         dst_vec[i] = src_vec[i];
@@ -72,7 +72,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst_vec[..src_vec.len()].copy_from_slice(&src_vec[..]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:94:5
+  --> $DIR/without_loop_counters.rs:95:5
    |
 LL | /     for i in from..from + src.len() {
 LL | |         dst[i] = src[i - from];
@@ -80,7 +80,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[from..(from + src.len())].copy_from_slice(&src[..(from + src.len() - from)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:98:5
+  --> $DIR/without_loop_counters.rs:99:5
    |
 LL | /     for i in from..from + 3 {
 LL | |         dst[i] = src[i - from];
@@ -88,7 +88,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[from..(from + 3)].copy_from_slice(&src[..(from + 3 - from)]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:103:5
+  --> $DIR/without_loop_counters.rs:104:5
    |
 LL | /     for i in 0..5 {
 LL | |         dst[i - 0] = src[i];
@@ -96,7 +96,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..5].copy_from_slice(&src[..5]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:108:5
+  --> $DIR/without_loop_counters.rs:109:5
    |
 LL | /     for i in 0..0 {
 LL | |         dst[i] = src[i];
@@ -104,7 +104,7 @@ LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..0].copy_from_slice(&src[..0]);`
 
 error: it looks like you're manually copying between slices
-  --> $DIR/without_loop_counters.rs:131:5
+  --> $DIR/without_loop_counters.rs:132:5
    |
 LL | /     for i in 0..src.len() {
 LL | |         dst[i] = src[i].clone();

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -4,7 +4,8 @@
     clippy::clone_on_copy,
     clippy::iter_cloned_collect,
     clippy::many_single_char_names,
-    clippy::redundant_clone
+    clippy::redundant_clone,
+    clippy::useless_vec
 )]
 
 fn main() {

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -4,7 +4,8 @@
     clippy::clone_on_copy,
     clippy::iter_cloned_collect,
     clippy::many_single_char_names,
-    clippy::redundant_clone
+    clippy::redundant_clone,
+    clippy::useless_vec
 )]
 
 fn main() {

--- a/tests/ui/map_clone.stderr
+++ b/tests/ui/map_clone.stderr
@@ -1,5 +1,5 @@
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:11:22
+  --> $DIR/map_clone.rs:12:22
    |
 LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `vec![5_i8; 6].iter().copied()`
@@ -7,31 +7,31 @@ LL |     let _: Vec<i8> = vec![5_i8; 6].iter().map(|x| *x).collect();
    = note: `-D clippy::map-clone` implied by `-D warnings`
 
 error: you are using an explicit closure for cloning elements
-  --> $DIR/map_clone.rs:12:26
+  --> $DIR/map_clone.rs:13:26
    |
 LL |     let _: Vec<String> = vec![String::new()].iter().map(|x| x.clone()).collect();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `cloned` method: `vec![String::new()].iter().cloned()`
 
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:13:23
+  --> $DIR/map_clone.rs:14:23
    |
 LL |     let _: Vec<u32> = vec![42, 43].iter().map(|&x| x).collect();
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `vec![42, 43].iter().copied()`
 
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:15:26
+  --> $DIR/map_clone.rs:16:26
    |
 LL |     let _: Option<u64> = Some(&16).map(|b| *b);
    |                          ^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `Some(&16).copied()`
 
 error: you are using an explicit closure for copying elements
-  --> $DIR/map_clone.rs:16:25
+  --> $DIR/map_clone.rs:17:25
    |
 LL |     let _: Option<u8> = Some(&1).map(|x| x.clone());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `Some(&1).copied()`
 
 error: you are needlessly cloning iterator elements
-  --> $DIR/map_clone.rs:27:29
+  --> $DIR/map_clone.rs:28:29
    |
 LL |     let _ = std::env::args().map(|v| v.clone());
    |                             ^^^^^^^^^^^^^^^^^^^ help: remove the `map` call

--- a/tests/ui/match_on_vec_items.rs
+++ b/tests/ui/match_on_vec_items.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::match_on_vec_items)]
+#![allow(clippy::useless_vec)]
 
 fn match_with_wildcard() {
     let arr = vec![0, 1, 2, 3];

--- a/tests/ui/match_on_vec_items.stderr
+++ b/tests/ui/match_on_vec_items.stderr
@@ -1,5 +1,5 @@
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:9:11
+  --> $DIR/match_on_vec_items.rs:10:11
    |
 LL |     match arr[idx] {
    |           ^^^^^^^^ help: try this: `arr.get(idx)`
@@ -7,43 +7,43 @@ LL |     match arr[idx] {
    = note: `-D clippy::match-on-vec-items` implied by `-D warnings`
 
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:16:11
+  --> $DIR/match_on_vec_items.rs:17:11
    |
 LL |     match arr[range] {
    |           ^^^^^^^^^^ help: try this: `arr.get(range)`
 
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:29:11
+  --> $DIR/match_on_vec_items.rs:30:11
    |
 LL |     match arr[idx] {
    |           ^^^^^^^^ help: try this: `arr.get(idx)`
 
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:36:11
+  --> $DIR/match_on_vec_items.rs:37:11
    |
 LL |     match arr[range] {
    |           ^^^^^^^^^^ help: try this: `arr.get(range)`
 
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:49:11
+  --> $DIR/match_on_vec_items.rs:50:11
    |
 LL |     match arr[idx] {
    |           ^^^^^^^^ help: try this: `arr.get(idx)`
 
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:56:11
+  --> $DIR/match_on_vec_items.rs:57:11
    |
 LL |     match arr[range] {
    |           ^^^^^^^^^^ help: try this: `arr.get(range)`
 
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:69:11
+  --> $DIR/match_on_vec_items.rs:70:11
    |
 LL |     match arr[idx] {
    |           ^^^^^^^^ help: try this: `arr.get(idx)`
 
 error: indexing into a vector may panic
-  --> $DIR/match_on_vec_items.rs:76:11
+  --> $DIR/match_on_vec_items.rs:77:11
    |
 LL |     match arr[range] {
    |           ^^^^^^^^^^ help: try this: `arr.get(range)`

--- a/tests/ui/match_single_binding.fixed
+++ b/tests/ui/match_single_binding.fixed
@@ -5,7 +5,8 @@
     clippy::let_unit_value,
     clippy::no_effect,
     clippy::toplevel_ref_arg,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 struct Point {

--- a/tests/ui/match_single_binding.rs
+++ b/tests/ui/match_single_binding.rs
@@ -5,7 +5,8 @@
     clippy::let_unit_value,
     clippy::no_effect,
     clippy::toplevel_ref_arg,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 struct Point {

--- a/tests/ui/match_single_binding.stderr
+++ b/tests/ui/match_single_binding.stderr
@@ -1,5 +1,5 @@
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:33:5
+  --> $DIR/match_single_binding.rs:34:5
    |
 LL | /     match (a, b, c) {
 LL | |         (x, y, z) => {
@@ -18,7 +18,7 @@ LL +     }
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:39:5
+  --> $DIR/match_single_binding.rs:40:5
    |
 LL | /     match (a, b, c) {
 LL | |         (x, y, z) => println!("{} {} {}", x, y, z),
@@ -32,7 +32,7 @@ LL +     println!("{} {} {}", x, y, z);
    |
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:56:5
+  --> $DIR/match_single_binding.rs:57:5
    |
 LL | /     match a {
 LL | |         _ => println!("whatever"),
@@ -40,7 +40,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `println!("whatever");`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:60:5
+  --> $DIR/match_single_binding.rs:61:5
    |
 LL | /     match a {
 LL | |         _ => {
@@ -59,7 +59,7 @@ LL +     }
    |
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:67:5
+  --> $DIR/match_single_binding.rs:68:5
    |
 LL | /     match a {
 LL | |         _ => {
@@ -81,7 +81,7 @@ LL +     }
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:77:5
+  --> $DIR/match_single_binding.rs:78:5
    |
 LL | /     match p {
 LL | |         Point { x, y } => println!("Coords: ({}, {})", x, y),
@@ -95,7 +95,7 @@ LL +     println!("Coords: ({}, {})", x, y);
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:81:5
+  --> $DIR/match_single_binding.rs:82:5
    |
 LL | /     match p {
 LL | |         Point { x: x1, y: y1 } => println!("Coords: ({}, {})", x1, y1),
@@ -109,7 +109,7 @@ LL +     println!("Coords: ({}, {})", x1, y1);
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:86:5
+  --> $DIR/match_single_binding.rs:87:5
    |
 LL | /     match x {
 LL | |         ref r => println!("Got a reference to {}", r),
@@ -123,7 +123,7 @@ LL +     println!("Got a reference to {}", r);
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:91:5
+  --> $DIR/match_single_binding.rs:92:5
    |
 LL | /     match x {
 LL | |         ref mut mr => println!("Got a mutable reference to {}", mr),
@@ -137,7 +137,7 @@ LL +     println!("Got a mutable reference to {}", mr);
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:95:5
+  --> $DIR/match_single_binding.rs:96:5
    |
 LL | /     let product = match coords() {
 LL | |         Point { x, y } => x * y,
@@ -151,7 +151,7 @@ LL +     let product = x * y;
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:103:18
+  --> $DIR/match_single_binding.rs:104:18
    |
 LL |           .map(|i| match i.unwrap() {
    |  __________________^
@@ -168,7 +168,7 @@ LL ~         })
    |
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:129:5
+  --> $DIR/match_single_binding.rs:130:5
    |
 LL | /     match x {
 LL | |         // =>
@@ -177,7 +177,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `println!("Not an array index start")`
 
 error: this assignment could be simplified
-  --> $DIR/match_single_binding.rs:138:5
+  --> $DIR/match_single_binding.rs:139:5
    |
 LL | /     val = match val.split_at(idx) {
 LL | |         (pre, suf) => {
@@ -197,7 +197,7 @@ LL ~     };
    |
 
 error: this match could be replaced by its scrutinee and body
-  --> $DIR/match_single_binding.rs:151:16
+  --> $DIR/match_single_binding.rs:152:16
    |
 LL |       let _ = || match side_effects() {
    |  ________________^
@@ -214,7 +214,7 @@ LL ~     };
    |
 
 error: this match could be written as a `let` statement
-  --> $DIR/match_single_binding.rs:157:5
+  --> $DIR/match_single_binding.rs:158:5
    |
 LL | /     match r {
 LL | |         x => match x {
@@ -239,7 +239,7 @@ LL ~     };
    |
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:170:5
+  --> $DIR/match_single_binding.rs:171:5
    |
 LL | /     match 1 {
 LL | |         _ => (),
@@ -247,7 +247,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `();`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:174:13
+  --> $DIR/match_single_binding.rs:175:13
    |
 LL |       let a = match 1 {
    |  _____________^
@@ -256,7 +256,7 @@ LL | |     };
    | |_____^ help: consider using the match body instead: `()`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:178:5
+  --> $DIR/match_single_binding.rs:179:5
    |
 LL | /     match 1 {
 LL | |         _ => side_effects(),
@@ -264,7 +264,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `side_effects();`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:182:13
+  --> $DIR/match_single_binding.rs:183:13
    |
 LL |       let b = match 1 {
    |  _____________^
@@ -273,7 +273,7 @@ LL | |     };
    | |_____^ help: consider using the match body instead: `side_effects()`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:186:5
+  --> $DIR/match_single_binding.rs:187:5
    |
 LL | /     match 1 {
 LL | |         _ => println!("1"),
@@ -281,7 +281,7 @@ LL | |     }
    | |_____^ help: consider using the match body instead: `println!("1");`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:190:13
+  --> $DIR/match_single_binding.rs:191:13
    |
 LL |       let c = match 1 {
    |  _____________^
@@ -290,7 +290,7 @@ LL | |     };
    | |_____^ help: consider using the match body instead: `println!("1")`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:195:9
+  --> $DIR/match_single_binding.rs:196:9
    |
 LL | /         match 1 {
 LL | |             _ => (),
@@ -298,7 +298,7 @@ LL | |         },
    | |_________^ help: consider using the match body instead: `()`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:198:9
+  --> $DIR/match_single_binding.rs:199:9
    |
 LL | /         match 1 {
 LL | |             _ => side_effects(),
@@ -306,7 +306,7 @@ LL | |         },
    | |_________^ help: consider using the match body instead: `side_effects()`
 
 error: this match could be replaced by its body itself
-  --> $DIR/match_single_binding.rs:201:9
+  --> $DIR/match_single_binding.rs:202:9
    |
 LL | /         match 1 {
 LL | |             _ => println!("1"),

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -18,6 +18,7 @@
     clippy::wrong_self_convention,
     clippy::unused_async,
     clippy::unused_self,
+    clippy::useless_vec,
     unused
 )]
 

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -1,5 +1,5 @@
 error: methods called `new` usually return `Self`
-  --> $DIR/methods.rs:105:5
+  --> $DIR/methods.rs:106:5
    |
 LL | /     fn new() -> i32 {
 LL | |         0
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::new-ret-no-self` implied by `-D warnings`
 
 error: called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(..)` instead
-  --> $DIR/methods.rs:126:13
+  --> $DIR/methods.rs:127:13
    |
 LL |       let _ = v.iter().filter(|&x| {
    |  _____________^

--- a/tests/ui/methods_fixable.fixed
+++ b/tests/ui/methods_fixable.fixed
@@ -1,6 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::filter_next)]
+#![allow(clippy::useless_vec)]
 
 /// Checks implementation of `FILTER_NEXT` lint.
 fn main() {

--- a/tests/ui/methods_fixable.rs
+++ b/tests/ui/methods_fixable.rs
@@ -1,6 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::filter_next)]
+#![allow(clippy::useless_vec)]
 
 /// Checks implementation of `FILTER_NEXT` lint.
 fn main() {

--- a/tests/ui/methods_fixable.stderr
+++ b/tests/ui/methods_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(..)` instead
-  --> $DIR/methods_fixable.rs:10:13
+  --> $DIR/methods_fixable.rs:11:13
    |
 LL |     let _ = v.iter().filter(|&x| *x < 0).next();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `v.iter().find(|&x| *x < 0)`

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
 #![warn(clippy::needless_collect)]
 
 use std::collections::{BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};

--- a/tests/ui/needless_late_init.fixed
+++ b/tests/ui/needless_late_init.fixed
@@ -8,7 +8,8 @@
     clippy::let_and_return,
     clippy::let_unit_value,
     clippy::nonminimal_bool,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 extern crate proc_macros;

--- a/tests/ui/needless_late_init.rs
+++ b/tests/ui/needless_late_init.rs
@@ -8,7 +8,8 @@
     clippy::let_and_return,
     clippy::let_unit_value,
     clippy::nonminimal_bool,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 extern crate proc_macros;

--- a/tests/ui/needless_late_init.stderr
+++ b/tests/ui/needless_late_init.stderr
@@ -1,5 +1,5 @@
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:27:5
+  --> $DIR/needless_late_init.rs:28:5
    |
 LL |     let a;
    |     ^^^^^^ created here
@@ -13,7 +13,7 @@ LL |     let a = "zero";
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:30:5
+  --> $DIR/needless_late_init.rs:31:5
    |
 LL |     let b;
    |     ^^^^^^ created here
@@ -27,7 +27,7 @@ LL |     let b = 1;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:31:5
+  --> $DIR/needless_late_init.rs:32:5
    |
 LL |     let c;
    |     ^^^^^^ created here
@@ -41,7 +41,7 @@ LL |     let c = 2;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:35:5
+  --> $DIR/needless_late_init.rs:36:5
    |
 LL |     let d: usize;
    |     ^^^^^^^^^^^^^ created here
@@ -54,7 +54,7 @@ LL |     let d: usize = 1;
    |     ~~~~~~~~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:38:5
+  --> $DIR/needless_late_init.rs:39:5
    |
 LL |     let e;
    |     ^^^^^^ created here
@@ -67,7 +67,7 @@ LL |     let e = format!("{}", d);
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:43:5
+  --> $DIR/needless_late_init.rs:44:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -88,7 +88,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:52:5
+  --> $DIR/needless_late_init.rs:53:5
    |
 LL |     let b;
    |     ^^^^^^
@@ -109,7 +109,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:59:5
+  --> $DIR/needless_late_init.rs:60:5
    |
 LL |     let d;
    |     ^^^^^^
@@ -130,7 +130,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:67:5
+  --> $DIR/needless_late_init.rs:68:5
    |
 LL |     let e;
    |     ^^^^^^
@@ -151,7 +151,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:74:5
+  --> $DIR/needless_late_init.rs:75:5
    |
 LL |     let f;
    |     ^^^^^^
@@ -167,7 +167,7 @@ LL +         1 => "three",
    |
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:80:5
+  --> $DIR/needless_late_init.rs:81:5
    |
 LL |     let g: usize;
    |     ^^^^^^^^^^^^^
@@ -187,7 +187,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:88:5
+  --> $DIR/needless_late_init.rs:89:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -201,7 +201,7 @@ LL |     let x = 1;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:92:5
+  --> $DIR/needless_late_init.rs:93:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -215,7 +215,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:96:5
+  --> $DIR/needless_late_init.rs:97:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -229,7 +229,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:115:5
+  --> $DIR/needless_late_init.rs:116:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -250,7 +250,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:132:5
+  --> $DIR/needless_late_init.rs:133:5
    |
 LL |     let a;
    |     ^^^^^^

--- a/tests/ui/needless_option_as_deref.fixed
+++ b/tests/ui/needless_option_as_deref.fixed
@@ -2,6 +2,7 @@
 
 #![allow(unused)]
 #![warn(clippy::needless_option_as_deref)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // should lint

--- a/tests/ui/needless_option_as_deref.rs
+++ b/tests/ui/needless_option_as_deref.rs
@@ -2,6 +2,7 @@
 
 #![allow(unused)]
 #![warn(clippy::needless_option_as_deref)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // should lint

--- a/tests/ui/needless_option_as_deref.stderr
+++ b/tests/ui/needless_option_as_deref.stderr
@@ -1,5 +1,5 @@
 error: derefed type is same as origin
-  --> $DIR/needless_option_as_deref.rs:8:29
+  --> $DIR/needless_option_as_deref.rs:9:29
    |
 LL |     let _: Option<&usize> = Some(&1).as_deref();
    |                             ^^^^^^^^^^^^^^^^^^^ help: try this: `Some(&1)`
@@ -7,13 +7,13 @@ LL |     let _: Option<&usize> = Some(&1).as_deref();
    = note: `-D clippy::needless-option-as-deref` implied by `-D warnings`
 
 error: derefed type is same as origin
-  --> $DIR/needless_option_as_deref.rs:9:33
+  --> $DIR/needless_option_as_deref.rs:10:33
    |
 LL |     let _: Option<&mut usize> = Some(&mut 1).as_deref_mut();
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `Some(&mut 1)`
 
 error: derefed type is same as origin
-  --> $DIR/needless_option_as_deref.rs:13:13
+  --> $DIR/needless_option_as_deref.rs:14:13
    |
 LL |     let _ = x.as_deref_mut();
    |             ^^^^^^^^^^^^^^^^ help: try this: `x`

--- a/tests/ui/needless_range_loop.rs
+++ b/tests/ui/needless_range_loop.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::needless_range_loop)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
 
 static STATIC: [usize; 4] = [0, 1, 8, 16];
 const CONST: [usize; 4] = [0, 1, 8, 16];

--- a/tests/ui/needless_range_loop2.rs
+++ b/tests/ui/needless_range_loop2.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::needless_range_loop)]
+#![allow(clippy::useless_vec)]
 
 fn calc_idx(i: usize) -> usize {
     (i + i + 20) % 4

--- a/tests/ui/needless_range_loop2.stderr
+++ b/tests/ui/needless_range_loop2.stderr
@@ -1,5 +1,5 @@
 error: the loop variable `i` is only used to index `ns`
-  --> $DIR/needless_range_loop2.rs:10:14
+  --> $DIR/needless_range_loop2.rs:11:14
    |
 LL |     for i in 3..10 {
    |              ^^^^^
@@ -11,7 +11,7 @@ LL |     for <item> in ns.iter().take(10).skip(3) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `ms`
-  --> $DIR/needless_range_loop2.rs:31:14
+  --> $DIR/needless_range_loop2.rs:32:14
    |
 LL |     for i in 0..ms.len() {
    |              ^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |     for <item> in &mut ms {
    |         ~~~~~~    ~~~~~~~
 
 error: the loop variable `i` is only used to index `ms`
-  --> $DIR/needless_range_loop2.rs:37:14
+  --> $DIR/needless_range_loop2.rs:38:14
    |
 LL |     for i in 0..ms.len() {
    |              ^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     for <item> in &mut ms {
    |         ~~~~~~    ~~~~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop2.rs:61:14
+  --> $DIR/needless_range_loop2.rs:62:14
    |
 LL |     for i in x..x + 4 {
    |              ^^^^^^^^
@@ -44,7 +44,7 @@ LL |     for <item> in vec.iter_mut().skip(x).take(4) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `vec`
-  --> $DIR/needless_range_loop2.rs:68:14
+  --> $DIR/needless_range_loop2.rs:69:14
    |
 LL |     for i in x..=x + 4 {
    |              ^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     for <item> in vec.iter_mut().skip(x).take(4 + 1) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `arr`
-  --> $DIR/needless_range_loop2.rs:74:14
+  --> $DIR/needless_range_loop2.rs:75:14
    |
 LL |     for i in 0..3 {
    |              ^^^^
@@ -66,7 +66,7 @@ LL |     for <item> in &arr {
    |         ~~~~~~    ~~~~
 
 error: the loop variable `i` is only used to index `arr`
-  --> $DIR/needless_range_loop2.rs:78:14
+  --> $DIR/needless_range_loop2.rs:79:14
    |
 LL |     for i in 0..2 {
    |              ^^^^
@@ -77,7 +77,7 @@ LL |     for <item> in arr.iter().take(2) {
    |         ~~~~~~    ~~~~~~~~~~~~~~~~~~
 
 error: the loop variable `i` is only used to index `arr`
-  --> $DIR/needless_range_loop2.rs:82:14
+  --> $DIR/needless_range_loop2.rs:83:14
    |
 LL |     for i in 1..3 {
    |              ^^^^

--- a/tests/ui/no_effect.rs
+++ b/tests/ui/no_effect.rs
@@ -5,7 +5,8 @@
     clippy::deref_addrof,
     clippy::redundant_field_names,
     clippy::uninlined_format_args,
-    clippy::unnecessary_struct_initialization
+    clippy::unnecessary_struct_initialization,
+    clippy::useless_vec
 )]
 
 struct Unit;

--- a/tests/ui/no_effect.stderr
+++ b/tests/ui/no_effect.stderr
@@ -1,5 +1,5 @@
 error: statement with no effect
-  --> $DIR/no_effect.rs:97:5
+  --> $DIR/no_effect.rs:98:5
    |
 LL |     0;
    |     ^^
@@ -7,151 +7,151 @@ LL |     0;
    = note: `-D clippy::no-effect` implied by `-D warnings`
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:98:5
+  --> $DIR/no_effect.rs:99:5
    |
 LL |     s2;
    |     ^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:99:5
+  --> $DIR/no_effect.rs:100:5
    |
 LL |     Unit;
    |     ^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:100:5
+  --> $DIR/no_effect.rs:101:5
    |
 LL |     Tuple(0);
    |     ^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:101:5
+  --> $DIR/no_effect.rs:102:5
    |
 LL |     Struct { field: 0 };
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:102:5
+  --> $DIR/no_effect.rs:103:5
    |
 LL |     Struct { ..s };
    |     ^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:103:5
+  --> $DIR/no_effect.rs:104:5
    |
 LL |     Union { a: 0 };
    |     ^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:104:5
+  --> $DIR/no_effect.rs:105:5
    |
 LL |     Enum::Tuple(0);
    |     ^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:105:5
+  --> $DIR/no_effect.rs:106:5
    |
 LL |     Enum::Struct { field: 0 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:106:5
+  --> $DIR/no_effect.rs:107:5
    |
 LL |     5 + 6;
    |     ^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:107:5
+  --> $DIR/no_effect.rs:108:5
    |
 LL |     *&42;
    |     ^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:108:5
+  --> $DIR/no_effect.rs:109:5
    |
 LL |     &6;
    |     ^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:109:5
+  --> $DIR/no_effect.rs:110:5
    |
 LL |     (5, 6, 7);
    |     ^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:110:5
+  --> $DIR/no_effect.rs:111:5
    |
 LL |     ..;
    |     ^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:111:5
+  --> $DIR/no_effect.rs:112:5
    |
 LL |     5..;
    |     ^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:112:5
+  --> $DIR/no_effect.rs:113:5
    |
 LL |     ..5;
    |     ^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:113:5
+  --> $DIR/no_effect.rs:114:5
    |
 LL |     5..6;
    |     ^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:114:5
+  --> $DIR/no_effect.rs:115:5
    |
 LL |     5..=6;
    |     ^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:115:5
+  --> $DIR/no_effect.rs:116:5
    |
 LL |     [42, 55];
    |     ^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:116:5
+  --> $DIR/no_effect.rs:117:5
    |
 LL |     [42, 55][1];
    |     ^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:117:5
+  --> $DIR/no_effect.rs:118:5
    |
 LL |     (42, 55).1;
    |     ^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:118:5
+  --> $DIR/no_effect.rs:119:5
    |
 LL |     [42; 55];
    |     ^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:119:5
+  --> $DIR/no_effect.rs:120:5
    |
 LL |     [42; 55][13];
    |     ^^^^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:121:5
+  --> $DIR/no_effect.rs:122:5
    |
 LL |     || x += 5;
    |     ^^^^^^^^^^
 
 error: statement with no effect
-  --> $DIR/no_effect.rs:123:5
+  --> $DIR/no_effect.rs:124:5
    |
 LL |     FooString { s: s };
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:124:5
+  --> $DIR/no_effect.rs:125:5
    |
 LL |     let _unused = 1;
    |     ^^^^^^^^^^^^^^^^
@@ -159,19 +159,19 @@ LL |     let _unused = 1;
    = note: `-D clippy::no-effect-underscore-binding` implied by `-D warnings`
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:125:5
+  --> $DIR/no_effect.rs:126:5
    |
 LL |     let _penguin = || println!("Some helpful closure");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:126:5
+  --> $DIR/no_effect.rs:127:5
    |
 LL |     let _duck = Struct { field: 0 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:127:5
+  --> $DIR/no_effect.rs:128:5
    |
 LL |     let _cat = [2, 4, 6, 8][2];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/nonminimal_bool.rs
+++ b/tests/ui/nonminimal_bool.rs
@@ -1,6 +1,7 @@
 #![feature(lint_reasons)]
 #![allow(unused, clippy::diverging_sub_expression)]
 #![warn(clippy::nonminimal_bool)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     let a: bool = unimplemented!();

--- a/tests/ui/nonminimal_bool.stderr
+++ b/tests/ui/nonminimal_bool.stderr
@@ -1,5 +1,5 @@
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:11:13
+  --> $DIR/nonminimal_bool.rs:12:13
    |
 LL |     let _ = !true;
    |             ^^^^^ help: try: `false`
@@ -7,43 +7,43 @@ LL |     let _ = !true;
    = note: `-D clippy::nonminimal-bool` implied by `-D warnings`
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:12:13
+  --> $DIR/nonminimal_bool.rs:13:13
    |
 LL |     let _ = !false;
    |             ^^^^^^ help: try: `true`
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:13:13
+  --> $DIR/nonminimal_bool.rs:14:13
    |
 LL |     let _ = !!a;
    |             ^^^ help: try: `a`
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:14:13
+  --> $DIR/nonminimal_bool.rs:15:13
    |
 LL |     let _ = false || a;
    |             ^^^^^^^^^^ help: try: `a`
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:18:13
+  --> $DIR/nonminimal_bool.rs:19:13
    |
 LL |     let _ = !(!a && b);
    |             ^^^^^^^^^^ help: try: `a || !b`
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:19:13
+  --> $DIR/nonminimal_bool.rs:20:13
    |
 LL |     let _ = !(!a || b);
    |             ^^^^^^^^^^ help: try: `a && !b`
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:20:13
+  --> $DIR/nonminimal_bool.rs:21:13
    |
 LL |     let _ = !a && !(b && c);
    |             ^^^^^^^^^^^^^^^ help: try: `!(a || b && c)`
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:28:13
+  --> $DIR/nonminimal_bool.rs:29:13
    |
 LL |     let _ = a == b && c == 5 && a == b;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     let _ = a == b && c == 5;
    |             ~~~~~~~~~~~~~~~~
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:29:13
+  --> $DIR/nonminimal_bool.rs:30:13
    |
 LL |     let _ = a == b || c == 5 || a == b;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |     let _ = a == b || c == 5;
    |             ~~~~~~~~~~~~~~~~
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:30:13
+  --> $DIR/nonminimal_bool.rs:31:13
    |
 LL |     let _ = a == b && c == 5 && b == a;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -82,7 +82,7 @@ LL |     let _ = a == b && c == 5;
    |             ~~~~~~~~~~~~~~~~
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:31:13
+  --> $DIR/nonminimal_bool.rs:32:13
    |
 LL |     let _ = a != b || !(a != b || c == d);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     let _ = a != b || c != d;
    |             ~~~~~~~~~~~~~~~~
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:32:13
+  --> $DIR/nonminimal_bool.rs:33:13
    |
 LL |     let _ = a != b && !(a != b && c == d);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL |     let _ = a != b && c != d;
    |             ~~~~~~~~~~~~~~~~
 
 error: this boolean expression can be simplified
-  --> $DIR/nonminimal_bool.rs:62:8
+  --> $DIR/nonminimal_bool.rs:63:8
    |
 LL |     if matches!(true, true) && true {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(true, true)`

--- a/tests/ui/option_as_ref_deref.fixed
+++ b/tests/ui/option_as_ref_deref.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(unused, clippy::redundant_clone)]
+#![allow(unused, clippy::redundant_clone, clippy::useless_vec)]
 #![warn(clippy::option_as_ref_deref)]
 
 use std::ffi::{CString, OsString};

--- a/tests/ui/option_as_ref_deref.rs
+++ b/tests/ui/option_as_ref_deref.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(unused, clippy::redundant_clone)]
+#![allow(unused, clippy::redundant_clone, clippy::useless_vec)]
 #![warn(clippy::option_as_ref_deref)]
 
 use std::ffi::{CString, OsString};

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -1,7 +1,12 @@
 //@run-rustfix
 #![warn(clippy::or_fun_call)]
 #![allow(dead_code)]
-#![allow(clippy::borrow_as_ptr, clippy::uninlined_format_args, clippy::unnecessary_wraps)]
+#![allow(
+    clippy::borrow_as_ptr,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_wraps,
+    clippy::useless_vec
+)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -1,7 +1,12 @@
 //@run-rustfix
 #![warn(clippy::or_fun_call)]
 #![allow(dead_code)]
-#![allow(clippy::borrow_as_ptr, clippy::uninlined_format_args, clippy::unnecessary_wraps)]
+#![allow(
+    clippy::borrow_as_ptr,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_wraps,
+    clippy::useless_vec
+)]
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -1,5 +1,5 @@
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:48:22
+  --> $DIR/or_fun_call.rs:53:22
    |
 LL |     with_constructor.unwrap_or(make());
    |                      ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(make)`
@@ -7,163 +7,163 @@ LL |     with_constructor.unwrap_or(make());
    = note: `-D clippy::or-fun-call` implied by `-D warnings`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:51:14
+  --> $DIR/or_fun_call.rs:56:14
    |
 LL |     with_new.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:54:21
+  --> $DIR/or_fun_call.rs:59:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:57:14
+  --> $DIR/or_fun_call.rs:62:14
    |
 LL |     with_err.unwrap_or(make());
    |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| make())`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:60:19
+  --> $DIR/or_fun_call.rs:65:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/or_fun_call.rs:63:24
+  --> $DIR/or_fun_call.rs:68:24
    |
 LL |     with_default_trait.unwrap_or(Default::default());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/or_fun_call.rs:66:23
+  --> $DIR/or_fun_call.rs:71:23
    |
 LL |     with_default_type.unwrap_or(u64::default());
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:69:18
+  --> $DIR/or_fun_call.rs:74:18
    |
 LL |     self_default.unwrap_or(<FakeDefault>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(<FakeDefault>::default)`
 
 error: use of `unwrap_or` followed by a call to `default`
-  --> $DIR/or_fun_call.rs:72:18
+  --> $DIR/or_fun_call.rs:77:18
    |
 LL |     real_default.unwrap_or(<FakeDefault as Default>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:75:14
+  --> $DIR/or_fun_call.rs:80:14
    |
 LL |     with_vec.unwrap_or(vec![]);
    |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:78:21
+  --> $DIR/or_fun_call.rs:83:21
    |
 LL |     without_default.unwrap_or(Foo::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:81:19
+  --> $DIR/or_fun_call.rs:86:19
    |
 LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:84:23
+  --> $DIR/or_fun_call.rs:89:23
    |
 LL |     map_vec.entry(42).or_insert(vec![]);
    |                       ^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:87:21
+  --> $DIR/or_fun_call.rs:92:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:90:25
+  --> $DIR/or_fun_call.rs:95:25
    |
 LL |     btree_vec.entry(42).or_insert(vec![]);
    |                         ^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:93:21
+  --> $DIR/or_fun_call.rs:98:21
    |
 LL |     let _ = stringy.unwrap_or(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:101:21
+  --> $DIR/or_fun_call.rs:106:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:103:21
+  --> $DIR/or_fun_call.rs:108:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
 
 error: use of `or` followed by a function call
-  --> $DIR/or_fun_call.rs:127:35
+  --> $DIR/or_fun_call.rs:132:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some("b".to_string()))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:166:14
+  --> $DIR/or_fun_call.rs:171:14
    |
 LL |         None.unwrap_or(ptr_to_ref(s));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:172:14
+  --> $DIR/or_fun_call.rs:177:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:174:14
+  --> $DIR/or_fun_call.rs:179:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:188:14
+  --> $DIR/or_fun_call.rs:193:14
    |
 LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:201:14
+  --> $DIR/or_fun_call.rs:206:14
    |
 LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:213:14
+  --> $DIR/or_fun_call.rs:218:14
    |
 LL |             .unwrap_or(String::new());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
-  --> $DIR/or_fun_call.rs:224:10
+  --> $DIR/or_fun_call.rs:229:10
    |
 LL |         .unwrap_or(String::new());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
 
 error: use of `map_or` followed by a function call
-  --> $DIR/or_fun_call.rs:249:25
+  --> $DIR/or_fun_call.rs:254:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
    |                         ^^^^^^^^^^^^^^^^^^ help: try this: `map_or_else(g, |v| v)`
 
 error: use of `map_or` followed by a function call
-  --> $DIR/or_fun_call.rs:250:25
+  --> $DIR/or_fun_call.rs:255:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try this: `map_or_else(g, f)`

--- a/tests/ui/ptr_offset_with_cast.fixed
+++ b/tests/ui/ptr_offset_with_cast.fixed
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::unnecessary_cast, clippy::useless_vec)]
 
 fn main() {
     let vec = vec![b'a', b'b', b'c'];

--- a/tests/ui/ptr_offset_with_cast.rs
+++ b/tests/ui/ptr_offset_with_cast.rs
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::unnecessary_cast, clippy::useless_vec)]
 
 fn main() {
     let vec = vec![b'a', b'b', b'c'];

--- a/tests/ui/range.rs
+++ b/tests/ui/range.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::useless_vec)]
 #[warn(clippy::range_zip_with_len)]
 fn main() {
     let v1 = vec![1, 2, 3];

--- a/tests/ui/range.stderr
+++ b/tests/ui/range.stderr
@@ -1,5 +1,5 @@
 error: it is more idiomatic to use `v1.iter().enumerate()`
-  --> $DIR/range.rs:5:14
+  --> $DIR/range.rs:6:14
    |
 LL |     let _x = v1.iter().zip(0..v1.len());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rc_clone_in_vec_init/arc.rs
+++ b/tests/ui/rc_clone_in_vec_init/arc.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::rc_clone_in_vec_init)]
+#![allow(clippy::useless_vec)]
 use std::sync::{Arc, Mutex};
 
 fn main() {}

--- a/tests/ui/rc_clone_in_vec_init/arc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/arc.stderr
@@ -1,5 +1,5 @@
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/arc.rs:7:13
+  --> $DIR/arc.rs:8:13
    |
 LL |     let v = vec![Arc::new("x".to_string()); 2];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/arc.rs:15:21
+  --> $DIR/arc.rs:16:21
    |
 LL |             let v = vec![Arc::new("x".to_string()); 2];
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ LL ~             };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/arc.rs:21:13
+  --> $DIR/arc.rs:22:13
    |
 LL |       let v = vec![
    |  _____________^
@@ -76,7 +76,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/arc.rs:30:14
+  --> $DIR/arc.rs:31:14
    |
 LL |       let v1 = vec![
    |  ______________^

--- a/tests/ui/rc_clone_in_vec_init/rc.rs
+++ b/tests/ui/rc_clone_in_vec_init/rc.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::rc_clone_in_vec_init)]
+#![allow(clippy::useless_vec)]
 use std::rc::Rc;
 use std::sync::Mutex;
 

--- a/tests/ui/rc_clone_in_vec_init/rc.stderr
+++ b/tests/ui/rc_clone_in_vec_init/rc.stderr
@@ -1,5 +1,5 @@
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/rc.rs:8:13
+  --> $DIR/rc.rs:9:13
    |
 LL |     let v = vec![Rc::new("x".to_string()); 2];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/rc.rs:16:21
+  --> $DIR/rc.rs:17:21
    |
 LL |             let v = vec![Rc::new("x".to_string()); 2];
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ LL ~             };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/rc.rs:22:13
+  --> $DIR/rc.rs:23:13
    |
 LL |       let v = vec![
    |  _____________^
@@ -76,7 +76,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/rc.rs:31:14
+  --> $DIR/rc.rs:32:14
    |
 LL |       let v1 = vec![
    |  ______________^

--- a/tests/ui/rc_clone_in_vec_init/weak.rs
+++ b/tests/ui/rc_clone_in_vec_init/weak.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::rc_clone_in_vec_init)]
+#![allow(clippy::useless_vec)]
 use std::rc::{Rc, Weak as UnSyncWeak};
 use std::sync::{Arc, Mutex, Weak as SyncWeak};
 

--- a/tests/ui/rc_clone_in_vec_init/weak.stderr
+++ b/tests/ui/rc_clone_in_vec_init/weak.stderr
@@ -1,5 +1,5 @@
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:8:13
+  --> $DIR/weak.rs:9:13
    |
 LL |     let v = vec![SyncWeak::<u32>::new(); 2];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:9:14
+  --> $DIR/weak.rs:10:14
    |
 LL |     let v2 = vec![UnSyncWeak::<u32>::new(); 2];
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:11:13
+  --> $DIR/weak.rs:12:13
    |
 LL |     let v = vec![Rc::downgrade(&Rc::new("x".to_string())); 2];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:12:13
+  --> $DIR/weak.rs:13:13
    |
 LL |     let v = vec![Arc::downgrade(&Arc::new("x".to_string())); 2];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:20:21
+  --> $DIR/weak.rs:21:21
    |
 LL |             let v = vec![Arc::downgrade(&Arc::new("x".to_string())); 2];
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,7 +115,7 @@ LL ~             };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:21:22
+  --> $DIR/weak.rs:22:22
    |
 LL |             let v2 = vec![Rc::downgrade(&Rc::new("x".to_string())); 2];
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL ~             };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:27:13
+  --> $DIR/weak.rs:28:13
    |
 LL |       let v = vec![
    |  _____________^
@@ -168,7 +168,7 @@ LL ~     };
    |
 
 error: initializing a reference-counted pointer in `vec![elem; len]`
-  --> $DIR/weak.rs:36:14
+  --> $DIR/weak.rs:37:14
    |
 LL |       let v1 = vec![
    |  ______________^

--- a/tests/ui/search_is_some.rs
+++ b/tests/ui/search_is_some.rs
@@ -1,5 +1,6 @@
 //@aux-build:option_helpers.rs
 #![warn(clippy::search_is_some)]
+#![allow(clippy::useless_vec)]
 #![allow(dead_code)]
 extern crate option_helpers;
 use option_helpers::IteratorFalsePositives;

--- a/tests/ui/search_is_some.stderr
+++ b/tests/ui/search_is_some.stderr
@@ -1,5 +1,5 @@
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> $DIR/search_is_some.rs:14:13
+  --> $DIR/search_is_some.rs:15:13
    |
 LL |       let _ = v.iter().find(|&x| {
    |  _____________^
@@ -12,7 +12,7 @@ LL | |                    ).is_some();
    = note: `-D clippy::search-is-some` implied by `-D warnings`
 
 error: called `is_some()` after searching an `Iterator` with `position`
-  --> $DIR/search_is_some.rs:20:13
+  --> $DIR/search_is_some.rs:21:13
    |
 LL |       let _ = v.iter().position(|&x| {
    |  _____________^
@@ -24,7 +24,7 @@ LL | |                    ).is_some();
    = help: this is more succinctly expressed by calling `any()`
 
 error: called `is_some()` after searching an `Iterator` with `rposition`
-  --> $DIR/search_is_some.rs:26:13
+  --> $DIR/search_is_some.rs:27:13
    |
 LL |       let _ = v.iter().rposition(|&x| {
    |  _____________^
@@ -36,13 +36,13 @@ LL | |                    ).is_some();
    = help: this is more succinctly expressed by calling `any()`
 
 error: called `is_some()` after searching an `Iterator` with `find`
-  --> $DIR/search_is_some.rs:41:20
+  --> $DIR/search_is_some.rs:42:20
    |
 LL |     let _ = (0..1).find(some_closure).is_some();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `any()` instead: `any(some_closure)`
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> $DIR/search_is_some.rs:51:13
+  --> $DIR/search_is_some.rs:52:13
    |
 LL |       let _ = v.iter().find(|&x| {
    |  _____________^
@@ -54,7 +54,7 @@ LL | |                    ).is_none();
    = help: this is more succinctly expressed by calling `any()` with negation
 
 error: called `is_none()` after searching an `Iterator` with `position`
-  --> $DIR/search_is_some.rs:57:13
+  --> $DIR/search_is_some.rs:58:13
    |
 LL |       let _ = v.iter().position(|&x| {
    |  _____________^
@@ -66,7 +66,7 @@ LL | |                    ).is_none();
    = help: this is more succinctly expressed by calling `any()` with negation
 
 error: called `is_none()` after searching an `Iterator` with `rposition`
-  --> $DIR/search_is_some.rs:63:13
+  --> $DIR/search_is_some.rs:64:13
    |
 LL |       let _ = v.iter().rposition(|&x| {
    |  _____________^
@@ -78,7 +78,7 @@ LL | |                    ).is_none();
    = help: this is more succinctly expressed by calling `any()` with negation
 
 error: called `is_none()` after searching an `Iterator` with `find`
-  --> $DIR/search_is_some.rs:78:13
+  --> $DIR/search_is_some.rs:79:13
    |
 LL |     let _ = (0..1).find(some_closure).is_none();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `!_.any()` instead: `!(0..1).any(some_closure)`

--- a/tests/ui/search_is_some_fixable_none.fixed
+++ b/tests/ui/search_is_some_fixable_none.fixed
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(dead_code, clippy::explicit_auto_deref)]
+#![allow(dead_code, clippy::explicit_auto_deref, clippy::useless_vec)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/search_is_some_fixable_none.rs
+++ b/tests/ui/search_is_some_fixable_none.rs
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(dead_code, clippy::explicit_auto_deref)]
+#![allow(dead_code, clippy::explicit_auto_deref, clippy::useless_vec)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/search_is_some_fixable_some.fixed
+++ b/tests/ui/search_is_some_fixable_some.fixed
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(dead_code, clippy::explicit_auto_deref)]
+#![allow(dead_code, clippy::explicit_auto_deref, clippy::useless_vec)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/search_is_some_fixable_some.rs
+++ b/tests/ui/search_is_some_fixable_some.rs
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(dead_code, clippy::explicit_auto_deref)]
+#![allow(dead_code, clippy::explicit_auto_deref, clippy::useless_vec)]
 #![warn(clippy::search_is_some)]
 
 fn main() {

--- a/tests/ui/self_assignment.rs
+++ b/tests/ui/self_assignment.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::self_assignment)]
+#![allow(clippy::useless_vec)]
 
 pub struct S<'a> {
     a: i32,

--- a/tests/ui/self_assignment.stderr
+++ b/tests/ui/self_assignment.stderr
@@ -1,5 +1,5 @@
 error: self-assignment of `a` to `a`
-  --> $DIR/self_assignment.rs:12:5
+  --> $DIR/self_assignment.rs:13:5
    |
 LL |     a = a;
    |     ^^^^^
@@ -7,61 +7,61 @@ LL |     a = a;
    = note: `-D clippy::self-assignment` implied by `-D warnings`
 
 error: self-assignment of `*b` to `*b`
-  --> $DIR/self_assignment.rs:13:5
+  --> $DIR/self_assignment.rs:14:5
    |
 LL |     *b = *b;
    |     ^^^^^^^
 
 error: self-assignment of `s` to `s`
-  --> $DIR/self_assignment.rs:14:5
+  --> $DIR/self_assignment.rs:15:5
    |
 LL |     s = s;
    |     ^^^^^
 
 error: self-assignment of `s.a` to `s.a`
-  --> $DIR/self_assignment.rs:15:5
+  --> $DIR/self_assignment.rs:16:5
    |
 LL |     s.a = s.a;
    |     ^^^^^^^^^
 
 error: self-assignment of `s.b[5 + 5]` to `s.b[10]`
-  --> $DIR/self_assignment.rs:16:5
+  --> $DIR/self_assignment.rs:17:5
    |
 LL |     s.b[10] = s.b[5 + 5];
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: self-assignment of `s.c[0][1]` to `s.c[0][1]`
-  --> $DIR/self_assignment.rs:17:5
+  --> $DIR/self_assignment.rs:18:5
    |
 LL |     s.c[0][1] = s.c[0][1];
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: self-assignment of `s.b[a]` to `s.b[a]`
-  --> $DIR/self_assignment.rs:18:5
+  --> $DIR/self_assignment.rs:19:5
    |
 LL |     s.b[a] = s.b[a];
    |     ^^^^^^^^^^^^^^^
 
 error: self-assignment of `*s.e` to `*s.e`
-  --> $DIR/self_assignment.rs:19:5
+  --> $DIR/self_assignment.rs:20:5
    |
 LL |     *s.e = *s.e;
    |     ^^^^^^^^^^^
 
 error: self-assignment of `s.b[10 + a]` to `s.b[a + 10]`
-  --> $DIR/self_assignment.rs:20:5
+  --> $DIR/self_assignment.rs:21:5
    |
 LL |     s.b[a + 10] = s.b[10 + a];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: self-assignment of `t.1` to `t.1`
-  --> $DIR/self_assignment.rs:23:5
+  --> $DIR/self_assignment.rs:24:5
    |
 LL |     t.1 = t.1;
    |     ^^^^^^^^^
 
 error: self-assignment of `(t.0)` to `t.0`
-  --> $DIR/self_assignment.rs:24:5
+  --> $DIR/self_assignment.rs:25:5
    |
 LL |     t.0 = (t.0);
    |     ^^^^^^^^^^^

--- a/tests/ui/skip_while_next.rs
+++ b/tests/ui/skip_while_next.rs
@@ -1,7 +1,7 @@
 //@aux-build:option_helpers.rs
 
 #![warn(clippy::skip_while_next)]
-#![allow(clippy::disallowed_names)]
+#![allow(clippy::disallowed_names, clippy::useless_vec)]
 
 extern crate option_helpers;
 use option_helpers::IteratorFalsePositives;

--- a/tests/ui/stable_sort_primitive.fixed
+++ b/tests/ui/stable_sort_primitive.fixed
@@ -1,5 +1,6 @@
 //@run-rustfix
 #![warn(clippy::stable_sort_primitive)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // positive examples

--- a/tests/ui/stable_sort_primitive.rs
+++ b/tests/ui/stable_sort_primitive.rs
@@ -1,5 +1,6 @@
 //@run-rustfix
 #![warn(clippy::stable_sort_primitive)]
+#![allow(clippy::useless_vec)]
 
 fn main() {
     // positive examples

--- a/tests/ui/stable_sort_primitive.stderr
+++ b/tests/ui/stable_sort_primitive.stderr
@@ -1,5 +1,5 @@
 error: used `sort` on primitive type `i32`
-  --> $DIR/stable_sort_primitive.rs:7:5
+  --> $DIR/stable_sort_primitive.rs:8:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
@@ -8,7 +8,7 @@ LL |     vec.sort();
    = note: `-D clippy::stable-sort-primitive` implied by `-D warnings`
 
 error: used `sort` on primitive type `bool`
-  --> $DIR/stable_sort_primitive.rs:9:5
+  --> $DIR/stable_sort_primitive.rs:10:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
@@ -16,7 +16,7 @@ LL |     vec.sort();
    = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `char`
-  --> $DIR/stable_sort_primitive.rs:11:5
+  --> $DIR/stable_sort_primitive.rs:12:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
@@ -24,7 +24,7 @@ LL |     vec.sort();
    = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `str`
-  --> $DIR/stable_sort_primitive.rs:13:5
+  --> $DIR/stable_sort_primitive.rs:14:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
@@ -32,7 +32,7 @@ LL |     vec.sort();
    = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `tuple`
-  --> $DIR/stable_sort_primitive.rs:15:5
+  --> $DIR/stable_sort_primitive.rs:16:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
@@ -40,7 +40,7 @@ LL |     vec.sort();
    = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `array`
-  --> $DIR/stable_sort_primitive.rs:17:5
+  --> $DIR/stable_sort_primitive.rs:18:5
    |
 LL |     vec.sort();
    |     ^^^^^^^^^^ help: try: `vec.sort_unstable()`
@@ -48,7 +48,7 @@ LL |     vec.sort();
    = note: an unstable sort typically performs faster without any observable difference for this data type
 
 error: used `sort` on primitive type `i32`
-  --> $DIR/stable_sort_primitive.rs:19:5
+  --> $DIR/stable_sort_primitive.rs:20:5
    |
 LL |     arr.sort();
    |     ^^^^^^^^^^ help: try: `arr.sort_unstable()`

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -10,7 +10,8 @@
     dead_code,
     unused_assignments,
     unused_variables,
-    clippy::let_and_return
+    clippy::let_and_return,
+    clippy::useless_vec
 )]
 
 struct Foo(u32);

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -10,7 +10,8 @@
     dead_code,
     unused_assignments,
     unused_variables,
-    clippy::let_and_return
+    clippy::let_and_return,
+    clippy::useless_vec
 )]
 
 struct Foo(u32);

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:27:5
+  --> $DIR/swap.rs:28:5
    |
 LL | /     let temp = bar.a;
 LL | |     bar.a = bar.b;
@@ -10,7 +10,7 @@ LL | |     bar.b = temp;
    = note: `-D clippy::manual-swap` implied by `-D warnings`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:39:5
+  --> $DIR/swap.rs:40:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -18,7 +18,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:48:5
+  --> $DIR/swap.rs:49:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -26,7 +26,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:67:5
+  --> $DIR/swap.rs:68:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -34,7 +34,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:78:5
+  --> $DIR/swap.rs:79:5
    |
 LL | /     a ^= b;
 LL | |     b ^= a;
@@ -42,7 +42,7 @@ LL | |     a ^= b;
    | |___________^ help: try: `std::mem::swap(&mut a, &mut b);`
 
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:86:5
+  --> $DIR/swap.rs:87:5
    |
 LL | /     bar.a ^= bar.b;
 LL | |     bar.b ^= bar.a;
@@ -50,7 +50,7 @@ LL | |     bar.a ^= bar.b;
    | |___________________^ help: try: `std::mem::swap(&mut bar.a, &mut bar.b);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:94:5
+  --> $DIR/swap.rs:95:5
    |
 LL | /     foo[0] ^= foo[1];
 LL | |     foo[1] ^= foo[0];
@@ -58,7 +58,7 @@ LL | |     foo[0] ^= foo[1];
    | |_____________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `foo[0][1]` and `bar[1][0]` manually
-  --> $DIR/swap.rs:123:5
+  --> $DIR/swap.rs:124:5
    |
 LL | /     let temp = foo[0][1];
 LL | |     foo[0][1] = bar[1][0];
@@ -68,7 +68,7 @@ LL | |     bar[1][0] = temp;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:137:7
+  --> $DIR/swap.rs:138:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -79,7 +79,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:146:7
+  --> $DIR/swap.rs:147:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -90,7 +90,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `b` and `a` manually
-  --> $DIR/swap.rs:172:5
+  --> $DIR/swap.rs:173:5
    |
 LL | /     let t = b;
 LL | |     b = a;
@@ -100,7 +100,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:134:5
+  --> $DIR/swap.rs:135:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -110,7 +110,7 @@ LL | |     b = a;
    = note: `-D clippy::almost-swapped` implied by `-D warnings`
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:143:5
+  --> $DIR/swap.rs:144:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;
@@ -119,7 +119,7 @@ LL | |     a = c.0;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:150:5
+  --> $DIR/swap.rs:151:5
    |
 LL | /     let a = b;
 LL | |     let b = a;
@@ -128,7 +128,7 @@ LL | |     let b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `d` and `c`
-  --> $DIR/swap.rs:155:5
+  --> $DIR/swap.rs:156:5
    |
 LL | /     d = c;
 LL | |     c = d;
@@ -137,7 +137,7 @@ LL | |     c = d;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:159:5
+  --> $DIR/swap.rs:160:5
    |
 LL | /     let a = b;
 LL | |     b = a;
@@ -146,7 +146,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `s.0.x` and `s.0.y` manually
-  --> $DIR/swap.rs:207:5
+  --> $DIR/swap.rs:208:5
    |
 LL | /     let t = s.0.x;
 LL | |     s.0.x = s.0.y;

--- a/tests/ui/toplevel_ref_arg.fixed
+++ b/tests/ui/toplevel_ref_arg.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
 #![warn(clippy::toplevel_ref_arg)]
-#![allow(clippy::uninlined_format_args, unused)]
+#![allow(clippy::uninlined_format_args, unused, clippy::useless_vec)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/toplevel_ref_arg.rs
+++ b/tests/ui/toplevel_ref_arg.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
 #![warn(clippy::toplevel_ref_arg)]
-#![allow(clippy::uninlined_format_args, unused)]
+#![allow(clippy::uninlined_format_args, unused, clippy::useless_vec)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::all)]
-#![allow(unused, clippy::needless_pass_by_value, clippy::vec_box)]
+#![allow(unused, clippy::needless_pass_by_value, clippy::vec_box, clippy::useless_vec)]
 #![feature(associated_type_defaults)]
 
 type Alias = Vec<Vec<Box<(u32, u32, u32, u32)>>>; // no warning here

--- a/tests/ui/unit_return_expecting_ord.rs
+++ b/tests/ui/unit_return_expecting_ord.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::unit_return_expecting_ord)]
 #![allow(clippy::needless_return)]
 #![allow(clippy::unused_unit)]
+#![allow(clippy::useless_vec)]
 #![feature(is_sorted)]
 
 struct Struct {

--- a/tests/ui/unit_return_expecting_ord.stderr
+++ b/tests/ui/unit_return_expecting_ord.stderr
@@ -1,36 +1,36 @@
 error: this closure returns the unit type which also implements Ord
-  --> $DIR/unit_return_expecting_ord.rs:18:25
+  --> $DIR/unit_return_expecting_ord.rs:19:25
    |
 LL |     structs.sort_by_key(|s| {
    |                         ^^^
    |
 help: probably caused by this trailing semicolon
-  --> $DIR/unit_return_expecting_ord.rs:19:24
+  --> $DIR/unit_return_expecting_ord.rs:20:24
    |
 LL |         double(s.field);
    |                        ^
    = note: `-D clippy::unit-return-expecting-ord` implied by `-D warnings`
 
 error: this closure returns the unit type which also implements PartialOrd
-  --> $DIR/unit_return_expecting_ord.rs:22:30
+  --> $DIR/unit_return_expecting_ord.rs:23:30
    |
 LL |     structs.is_sorted_by_key(|s| {
    |                              ^^^
    |
 help: probably caused by this trailing semicolon
-  --> $DIR/unit_return_expecting_ord.rs:23:24
+  --> $DIR/unit_return_expecting_ord.rs:24:24
    |
 LL |         double(s.field);
    |                        ^
 
 error: this closure returns the unit type which also implements PartialOrd
-  --> $DIR/unit_return_expecting_ord.rs:25:30
+  --> $DIR/unit_return_expecting_ord.rs:26:30
    |
 LL |     structs.is_sorted_by_key(|s| {
    |                              ^^^
 
 error: this closure returns the unit type which also implements Ord
-  --> $DIR/unit_return_expecting_ord.rs:35:25
+  --> $DIR/unit_return_expecting_ord.rs:36:25
    |
 LL |     structs.sort_by_key(|s| unit(s.field));
    |                         ^^^

--- a/tests/ui/unnecessary_join.fixed
+++ b/tests/ui/unnecessary_join.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::unnecessary_join)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
 
 fn main() {
     // should be linted

--- a/tests/ui/unnecessary_join.rs
+++ b/tests/ui/unnecessary_join.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::unnecessary_join)]
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
 
 fn main() {
     // should be linted

--- a/tests/ui/unnecessary_sort_by.fixed
+++ b/tests/ui/unnecessary_sort_by.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(clippy::stable_sort_primitive)]
+#![allow(clippy::stable_sort_primitive, clippy::useless_vec)]
 
 use std::cell::Ref;
 

--- a/tests/ui/unnecessary_sort_by.rs
+++ b/tests/ui/unnecessary_sort_by.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(clippy::stable_sort_primitive)]
+#![allow(clippy::stable_sort_primitive, clippy::useless_vec)]
 
 use std::cell::Ref;
 

--- a/tests/ui/vec.fixed
+++ b/tests/ui/vec.fixed
@@ -2,6 +2,12 @@
 #![warn(clippy::useless_vec)]
 #![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args)]
 
+use std::rc::Rc;
+
+struct StructWithVec {
+    _x: Vec<i32>,
+}
+
 #[derive(Debug)]
 struct NonCopy;
 
@@ -75,4 +81,44 @@ fn main() {
     for a in vec![1; 201] {
         println!("{:?}", a);
     }
+
+    // Do lint
+    let mut x = [1, 2, 3];
+    x.fill(123);
+    dbg!(x[0]);
+    dbg!(x.len());
+    dbg!(x.iter().sum::<i32>());
+
+    let _x: &[i32] = &[1, 2, 3];
+
+    for _ in &[1, 2, 3] {}
+
+    // Don't lint
+    let x = vec![1, 2, 3];
+    let _v: Vec<i32> = x;
+
+    let x = vec![1, 2, 3];
+    let _s = StructWithVec { _x: x };
+
+    // Explicit type annotation would make the change to [1, 2, 3]
+    // a compile error.
+    let _x: Vec<i32> = vec![1, 2, 3];
+
+    // Calling a Vec method through a mutable reference
+    let mut x = vec![1, 2, 3];
+    let re = &mut x;
+    re.push(4);
+
+    // Comparing arrays whose length is not equal is a compile error
+    let x = vec![1, 2, 3];
+    let y = vec![1, 2, 3, 4];
+    dbg!(x == y);
+
+    // Non-copy types
+    let _x = vec![String::new(); 10];
+    #[allow(clippy::rc_clone_in_vec_init)]
+    let _x = vec![Rc::new(1); 10];
+
+    // Too large
+    let _x = vec![1; 201];
 }

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -2,6 +2,12 @@
 #![warn(clippy::useless_vec)]
 #![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args)]
 
+use std::rc::Rc;
+
+struct StructWithVec {
+    _x: Vec<i32>,
+}
+
 #[derive(Debug)]
 struct NonCopy;
 
@@ -75,4 +81,44 @@ fn main() {
     for a in vec![1; 201] {
         println!("{:?}", a);
     }
+
+    // Do lint
+    let mut x = vec![1, 2, 3];
+    x.fill(123);
+    dbg!(x[0]);
+    dbg!(x.len());
+    dbg!(x.iter().sum::<i32>());
+
+    let _x: &[i32] = &vec![1, 2, 3];
+
+    for _ in vec![1, 2, 3] {}
+
+    // Don't lint
+    let x = vec![1, 2, 3];
+    let _v: Vec<i32> = x;
+
+    let x = vec![1, 2, 3];
+    let _s = StructWithVec { _x: x };
+
+    // Explicit type annotation would make the change to [1, 2, 3]
+    // a compile error.
+    let _x: Vec<i32> = vec![1, 2, 3];
+
+    // Calling a Vec method through a mutable reference
+    let mut x = vec![1, 2, 3];
+    let re = &mut x;
+    re.push(4);
+
+    // Comparing arrays whose length is not equal is a compile error
+    let x = vec![1, 2, 3];
+    let y = vec![1, 2, 3, 4];
+    dbg!(x == y);
+
+    // Non-copy types
+    let _x = vec![String::new(); 10];
+    #[allow(clippy::rc_clone_in_vec_init)]
+    let _x = vec![Rc::new(1); 10];
+
+    // Too large
+    let _x = vec![1; 201];
 }

--- a/tests/ui/vec.stderr
+++ b/tests/ui/vec.stderr
@@ -1,5 +1,5 @@
 error: useless use of `vec!`
-  --> $DIR/vec.rs:28:14
+  --> $DIR/vec.rs:34:14
    |
 LL |     on_slice(&vec![]);
    |              ^^^^^^^ help: you can use a slice directly: `&[]`
@@ -7,64 +7,82 @@ LL |     on_slice(&vec![]);
    = note: `-D clippy::useless-vec` implied by `-D warnings`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:30:18
+  --> $DIR/vec.rs:36:18
    |
 LL |     on_mut_slice(&mut vec![]);
    |                  ^^^^^^^^^^^ help: you can use a slice directly: `&mut []`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:32:14
+  --> $DIR/vec.rs:38:14
    |
 LL |     on_slice(&vec![1, 2]);
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:34:18
+  --> $DIR/vec.rs:40:18
    |
 LL |     on_mut_slice(&mut vec![1, 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:36:14
+  --> $DIR/vec.rs:42:14
    |
 LL |     on_slice(&vec![1, 2]);
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:38:18
+  --> $DIR/vec.rs:44:18
    |
 LL |     on_mut_slice(&mut vec![1, 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:40:14
+  --> $DIR/vec.rs:46:14
    |
 LL |     on_slice(&vec!(1, 2));
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:42:18
+  --> $DIR/vec.rs:48:18
    |
 LL |     on_mut_slice(&mut vec![1, 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:44:14
+  --> $DIR/vec.rs:50:14
    |
 LL |     on_slice(&vec![1; 2]);
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1; 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:46:18
+  --> $DIR/vec.rs:52:18
    |
 LL |     on_mut_slice(&mut vec![1; 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1; 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:63:14
+  --> $DIR/vec.rs:69:14
    |
 LL |     for a in vec![1, 2, 3] {
    |              ^^^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2, 3]`
 
-error: aborting due to 11 previous errors
+error: useless use of `vec!`
+  --> $DIR/vec.rs:86:17
+   |
+LL |     let mut x = vec![1, 2, 3];
+   |                 ^^^^^^^^^^^^^ help: you can use an array directly: `[1, 2, 3]`
+
+error: useless use of `vec!`
+  --> $DIR/vec.rs:92:22
+   |
+LL |     let _x: &[i32] = &vec![1, 2, 3];
+   |                      ^^^^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2, 3]`
+
+error: useless use of `vec!`
+  --> $DIR/vec.rs:94:14
+   |
+LL |     for _ in vec![1, 2, 3] {}
+   |              ^^^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2, 3]`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/while_let_on_iterator.fixed
+++ b/tests/ui/while_let_on_iterator.fixed
@@ -6,7 +6,8 @@
     clippy::manual_find,
     clippy::never_loop,
     clippy::redundant_closure_call,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 fn base() {

--- a/tests/ui/while_let_on_iterator.rs
+++ b/tests/ui/while_let_on_iterator.rs
@@ -6,7 +6,8 @@
     clippy::manual_find,
     clippy::never_loop,
     clippy::redundant_closure_call,
-    clippy::uninlined_format_args
+    clippy::uninlined_format_args,
+    clippy::useless_vec
 )]
 
 fn base() {

--- a/tests/ui/while_let_on_iterator.stderr
+++ b/tests/ui/while_let_on_iterator.stderr
@@ -1,5 +1,5 @@
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:14:5
+  --> $DIR/while_let_on_iterator.rs:15:5
    |
 LL |     while let Option::Some(x) = iter.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in iter`
@@ -7,151 +7,151 @@ LL |     while let Option::Some(x) = iter.next() {
    = note: `-D clippy::while-let-on-iterator` implied by `-D warnings`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:19:5
+  --> $DIR/while_let_on_iterator.rs:20:5
    |
 LL |     while let Some(x) = iter.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in iter`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:24:5
+  --> $DIR/while_let_on_iterator.rs:25:5
    |
 LL |     while let Some(_) = iter.next() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in iter`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:100:9
+  --> $DIR/while_let_on_iterator.rs:101:9
    |
 LL |         while let Some([..]) = it.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for [..] in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:107:9
+  --> $DIR/while_let_on_iterator.rs:108:9
    |
 LL |         while let Some([_x]) = it.next() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for [_x] in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:120:9
+  --> $DIR/while_let_on_iterator.rs:121:9
    |
 LL |         while let Some(x @ [_]) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x @ [_] in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:140:9
+  --> $DIR/while_let_on_iterator.rs:141:9
    |
 LL |         while let Some(_) = y.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in y`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:197:9
+  --> $DIR/while_let_on_iterator.rs:198:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:208:5
+  --> $DIR/while_let_on_iterator.rs:209:5
    |
 LL |     while let Some(n) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for n in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:210:9
+  --> $DIR/while_let_on_iterator.rs:211:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:219:9
+  --> $DIR/while_let_on_iterator.rs:220:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:228:9
+  --> $DIR/while_let_on_iterator.rs:229:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:245:9
+  --> $DIR/while_let_on_iterator.rs:246:9
    |
 LL |         while let Some(m) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for m in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:260:13
+  --> $DIR/while_let_on_iterator.rs:261:13
    |
 LL |             while let Some(i) = self.0.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for i in self.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:292:13
+  --> $DIR/while_let_on_iterator.rs:293:13
    |
 LL |             while let Some(i) = self.0.0.0.next() {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for i in self.0.0.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:321:5
+  --> $DIR/while_let_on_iterator.rs:322:5
    |
 LL |     while let Some(n) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for n in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:333:9
+  --> $DIR/while_let_on_iterator.rs:334:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:347:5
+  --> $DIR/while_let_on_iterator.rs:348:5
    |
 LL |     while let Some(x) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:358:5
+  --> $DIR/while_let_on_iterator.rs:359:5
    |
 LL |     while let Some(x) = it.0.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.0.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:393:5
+  --> $DIR/while_let_on_iterator.rs:394:5
    |
 LL |     while let Some(x) = s.x.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in s.x.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:400:5
+  --> $DIR/while_let_on_iterator.rs:401:5
    |
 LL |     while let Some(x) = x[0].next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in x[0].by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:408:9
+  --> $DIR/while_let_on_iterator.rs:409:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:418:9
+  --> $DIR/while_let_on_iterator.rs:419:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:428:9
+  --> $DIR/while_let_on_iterator.rs:429:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it.by_ref()`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:438:9
+  --> $DIR/while_let_on_iterator.rs:439:9
    |
 LL |         while let Some(x) = it.next() {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for x in it`
 
 error: this loop could be written as a `for` loop
-  --> $DIR/while_let_on_iterator.rs:448:5
+  --> $DIR/while_let_on_iterator.rs:449:5
    |
 LL |     while let Some(..) = it.next() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `for _ in it`


### PR DESCRIPTION
First off, sorry for that large diff in tests. *A lot* of tests seem to trigger the lint with this new change, so I decided to `#![allow()]` the lint in the affected tests to make reviewing this easier, and also split the commits up so that the first commit is the actual logic of the lint and the second commit contains all the test changes. The stuff that changed in the tests is mostly just line numbers now. So, as large as the diff looks, it's not actually that bad. 😅
I manually went through all of these to find out about edge cases and decided to put them in `tests/ui/vec.rs`.

For more context, I wrote about the idea of this PR here: https://github.com/rust-lang/rust-clippy/issues/2262#issuecomment-1579155257 (that explains the logic)

Basically, it now also considers the case where a `Vec` is put in a local variable and the user only ever does things with it that one could also do with a slice or an array. This should catch a lot more cases, and (at least from looking at the tests) it does.

changelog: [`useless_vec`]: lint `vec!` invocations when a slice or an array would do (also considering local variables now)