### PR TITLE
[`new_without_default`]: Now emits on const fns

### DIFF
--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -75,10 +75,6 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                     if let hir::ImplItemKind::Fn(ref sig, _) = impl_item.kind {
                         let name = impl_item.ident.name;
                         let id = impl_item.owner_id;
-                        if sig.header.constness == hir::Constness::Const {
-                            // can't be implemented by default
-                            return;
-                        }
                         if sig.header.unsafety == hir::Unsafety::Unsafe {
                             // can't be implemented for unsafe new
                             return;

--- a/tests/ui/new_without_default.fixed
+++ b/tests/ui/new_without_default.fixed
@@ -132,12 +132,18 @@ impl PrivateItem {
     } // We don't lint private items on public structs
 }
 
-struct Const;
+pub struct Const;
+
+impl Default for Const {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Const {
     pub const fn new() -> Const {
         Const
-    } // const fns can't be implemented via Default
+    } // While Default is not const, it can still call const functions, so we should lint this
 }
 
 pub struct IgnoreGenericNew;

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -114,12 +114,12 @@ impl PrivateItem {
     } // We don't lint private items on public structs
 }
 
-struct Const;
+pub struct Const;
 
 impl Const {
     pub const fn new() -> Const {
         Const
-    } // const fns can't be implemented via Default
+    } // While Default is not const, it can still call const functions, so we should lint this
 }
 
 pub struct IgnoreGenericNew;

--- a/tests/ui/new_without_default.stderr
+++ b/tests/ui/new_without_default.stderr
@@ -55,6 +55,23 @@ LL +     }
 LL + }
    |
 
+error: you should consider adding a `Default` implementation for `Const`
+  --> $DIR/new_without_default.rs:120:5
+   |
+LL | /     pub const fn new() -> Const {
+LL | |         Const
+LL | |     } // While Default is not const, it can still call const functions, so we should lint this
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl Default for Const {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
 error: you should consider adding a `Default` implementation for `NewNotEqualToDerive`
   --> $DIR/new_without_default.rs:180:5
    |
@@ -149,5 +166,5 @@ LL +     }
 LL + }
    |
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
While `Default::default` is not const, it can still call `const new`; there's no reason this shouldn't be linted as well.

fixes #10877

changelog: [`new_without_default`]: Now emits on const fns
