### PR TITLE
`suspicious_else_formatting`: Don't warn if there is a comment between else and curly bracket

### DIFF
--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -236,6 +236,12 @@ fn check_else(cx: &EarlyContext<'_>, expr: &Expr) {
                 }
             }
 
+            // Don't warn if the only thing inside post_else_post_eol is a comment block.
+            let trimmed_post_else_post_eol = post_else_post_eol.trim();
+            if trimmed_post_else_post_eol.starts_with("/*") && trimmed_post_else_post_eol.ends_with("*/") {
+                return
+            }
+
             let else_desc = if is_if(else_) { "if" } else { "{..}" };
             span_lint_and_note(
                 cx,

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -108,6 +108,13 @@ fn main() {
     else
     {
     }
+
+    //#10273 This is fine. Don't warn
+    if foo() {
+    } else
+    /* whelp */
+    {
+    }
 }
 
 // #7650 - Don't lint. Proc-macro using bad spans for `if` expressions.


### PR DESCRIPTION
This PR fixes https://github.com/rust-lang/rust-clippy/issues/10273

The idea is that if the only thing after `else` and before `{` is a comment, we will not warn because, probably, the line break was "made" by rustfmt.

changelog: [`suspicious_else_formatting`]: Don't warn if the only thing between `else` and curly bracket is a comment