### PR TITLE
Direct towards late passes in `cargo dev new_lint`

### DIFF
--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
         },
         Some(("new_lint", matches)) => {
             match new_lint::create(
-                matches.get_one::<String>("pass"),
+                matches.get_one::<String>("pass").unwrap(),
                 matches.get_one::<String>("name"),
                 matches.get_one::<String>("category").map(String::as_str),
                 matches.get_one::<String>("type").map(String::as_str),
@@ -176,7 +176,7 @@ fn get_clap_config() -> ArgMatches {
                         .help("Specify whether the lint runs during the early or late pass")
                         .value_parser(["early", "late"])
                         .conflicts_with("type")
-                        .required_unless_present("type"),
+                        .default_value("late"),
                     Arg::new("name")
                         .short('n')
                         .long("name")

--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -37,7 +37,7 @@ impl<T> Context for io::Result<T> {
 ///
 /// This function errors out if the files couldn't be created or written to.
 pub fn create(
-    pass: Option<&String>,
+    pass: &String,
     lint_name: Option<&String>,
     category: Option<&str>,
     mut ty: Option<&str>,
@@ -49,7 +49,7 @@ pub fn create(
     }
 
     let lint = LintData {
-        pass: pass.map_or("", String::as_str),
+        pass,
         name: lint_name.expect("`name` argument is validated by clap"),
         category: category.expect("`category` argument is validated by clap"),
         ty,
@@ -61,6 +61,14 @@ pub fn create(
 
     if lint.ty.is_none() {
         add_lint(&lint, msrv).context("Unable to add lint to clippy_lints/src/lib.rs")?;
+    }
+
+    if pass == "early" {
+        println!(
+            "\n\
+            NOTE: Use a late pass unless you need something specific from\
+            an early pass, as they lack many features and utilities"
+        );
     }
 
     Ok(())


### PR DESCRIPTION
changelog: none

This would be the tooling part of #9311

- `--pass late` is now the default
- It prints a message recommending the use of a late pass if you choose `--pass early`