### PR TITLE
Clarify `let_underscore` documentation

### DIFF
--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -122,7 +122,7 @@ declare_clippy_lint! {
     /// }
     /// // Either provide a type annotation:
     /// let _: Result<u32, ()> = foo();
-    /// // …or drop the let keyword:
+    /// // …or drop the `let` keyword to allow this anyway.
     /// _ = foo();
     /// ```
     #[clippy::version = "1.69.0"]


### PR DESCRIPTION
Fixes #10867
changelog: [`let_underscore`]: Clarify its documentation