### PR TITLE
Fix `useless_vec` suggestion in `for _ in vec![..]`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -699,7 +699,12 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     });
     let too_large_for_stack = conf.too_large_for_stack;
     store.register_late_pass(move |_| Box::new(escape::BoxedLocal { too_large_for_stack }));
-    store.register_late_pass(move |_| Box::new(vec::UselessVec { too_large_for_stack }));
+    store.register_late_pass(move |_| {
+        Box::new(vec::UselessVec {
+            too_large_for_stack,
+            msrv: msrv(),
+        })
+    });
     store.register_late_pass(|_| Box::new(panic_unimplemented::PanicUnimplemented));
     store.register_late_pass(|_| Box::new(strings::StringLitAsBytes));
     store.register_late_pass(|_| Box::new(derive::Derive));

--- a/tests/ui/vec.fixed
+++ b/tests/ui/vec.fixed
@@ -1,15 +1,12 @@
 //@run-rustfix
 #![warn(clippy::useless_vec)]
-#![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args)]
+#![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args, unused)]
 
 use std::rc::Rc;
 
 struct StructWithVec {
     _x: Vec<i32>,
 }
-
-#[derive(Debug)]
-struct NonCopy;
 
 fn on_slice(_: &[u8]) {}
 
@@ -66,14 +63,6 @@ fn main() {
     on_mut_slice(&mut vec![2; line.length]);
     on_mut_slice(&mut vec![2; line.length()]);
 
-    for a in &[1, 2, 3] {
-        println!("{:?}", a);
-    }
-
-    for a in vec![NonCopy, NonCopy] {
-        println!("{:?}", a);
-    }
-
     on_vec(&vec![1; 201]); // Ok, size of `vec` higher than `too_large_for_stack`
     on_mut_vec(&mut vec![1; 201]); // Ok, size of `vec` higher than `too_large_for_stack`
 
@@ -91,7 +80,7 @@ fn main() {
 
     let _x: &[i32] = &[1, 2, 3];
 
-    for _ in &[1, 2, 3] {}
+    for _ in [1, 2, 3] {}
 
     // Don't lint
     let x = vec![1, 2, 3];
@@ -121,4 +110,26 @@ fn main() {
 
     // Too large
     let _x = vec![1; 201];
+}
+
+#[clippy::msrv = "1.53"]
+fn above() {
+    for a in [1, 2, 3] {
+        let _: usize = a;
+    }
+
+    for a in [String::new(), String::new()] {
+        let _: String = a;
+    }
+}
+
+#[clippy::msrv = "1.52"]
+fn below() {
+    for a in vec![1, 2, 3] {
+        let _: usize = a;
+    }
+
+    for a in vec![String::new(), String::new()] {
+        let _: String = a;
+    }
 }

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -1,15 +1,12 @@
 //@run-rustfix
 #![warn(clippy::useless_vec)]
-#![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args)]
+#![allow(clippy::nonstandard_macro_braces, clippy::uninlined_format_args, unused)]
 
 use std::rc::Rc;
 
 struct StructWithVec {
     _x: Vec<i32>,
 }
-
-#[derive(Debug)]
-struct NonCopy;
 
 fn on_slice(_: &[u8]) {}
 
@@ -66,14 +63,6 @@ fn main() {
     on_mut_slice(&mut vec![2; line.length]);
     on_mut_slice(&mut vec![2; line.length()]);
 
-    for a in vec![1, 2, 3] {
-        println!("{:?}", a);
-    }
-
-    for a in vec![NonCopy, NonCopy] {
-        println!("{:?}", a);
-    }
-
     on_vec(&vec![1; 201]); // Ok, size of `vec` higher than `too_large_for_stack`
     on_mut_vec(&mut vec![1; 201]); // Ok, size of `vec` higher than `too_large_for_stack`
 
@@ -121,4 +110,26 @@ fn main() {
 
     // Too large
     let _x = vec![1; 201];
+}
+
+#[clippy::msrv = "1.53"]
+fn above() {
+    for a in vec![1, 2, 3] {
+        let _: usize = a;
+    }
+
+    for a in vec![String::new(), String::new()] {
+        let _: String = a;
+    }
+}
+
+#[clippy::msrv = "1.52"]
+fn below() {
+    for a in vec![1, 2, 3] {
+        let _: usize = a;
+    }
+
+    for a in vec![String::new(), String::new()] {
+        let _: String = a;
+    }
 }

--- a/tests/ui/vec.stderr
+++ b/tests/ui/vec.stderr
@@ -1,5 +1,5 @@
 error: useless use of `vec!`
-  --> $DIR/vec.rs:34:14
+  --> $DIR/vec.rs:31:14
    |
 LL |     on_slice(&vec![]);
    |              ^^^^^^^ help: you can use a slice directly: `&[]`
@@ -7,82 +7,88 @@ LL |     on_slice(&vec![]);
    = note: `-D clippy::useless-vec` implied by `-D warnings`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:36:18
+  --> $DIR/vec.rs:33:18
    |
 LL |     on_mut_slice(&mut vec![]);
    |                  ^^^^^^^^^^^ help: you can use a slice directly: `&mut []`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:38:14
+  --> $DIR/vec.rs:35:14
    |
 LL |     on_slice(&vec![1, 2]);
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:40:18
+  --> $DIR/vec.rs:37:18
    |
 LL |     on_mut_slice(&mut vec![1, 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:42:14
+  --> $DIR/vec.rs:39:14
    |
 LL |     on_slice(&vec![1, 2]);
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:44:18
+  --> $DIR/vec.rs:41:18
    |
 LL |     on_mut_slice(&mut vec![1, 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:46:14
+  --> $DIR/vec.rs:43:14
    |
 LL |     on_slice(&vec!(1, 2));
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:48:18
+  --> $DIR/vec.rs:45:18
    |
 LL |     on_mut_slice(&mut vec![1, 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1, 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:50:14
+  --> $DIR/vec.rs:47:14
    |
 LL |     on_slice(&vec![1; 2]);
    |              ^^^^^^^^^^^ help: you can use a slice directly: `&[1; 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:52:18
+  --> $DIR/vec.rs:49:18
    |
 LL |     on_mut_slice(&mut vec![1; 2]);
    |                  ^^^^^^^^^^^^^^^ help: you can use a slice directly: `&mut [1; 2]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:69:14
-   |
-LL |     for a in vec![1, 2, 3] {
-   |              ^^^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2, 3]`
-
-error: useless use of `vec!`
-  --> $DIR/vec.rs:86:17
+  --> $DIR/vec.rs:75:17
    |
 LL |     let mut x = vec![1, 2, 3];
    |                 ^^^^^^^^^^^^^ help: you can use an array directly: `[1, 2, 3]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:92:22
+  --> $DIR/vec.rs:81:22
    |
 LL |     let _x: &[i32] = &vec![1, 2, 3];
    |                      ^^^^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2, 3]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:94:14
+  --> $DIR/vec.rs:83:14
    |
 LL |     for _ in vec![1, 2, 3] {}
-   |              ^^^^^^^^^^^^^ help: you can use a slice directly: `&[1, 2, 3]`
+   |              ^^^^^^^^^^^^^ help: you can use an array directly: `[1, 2, 3]`
 
-error: aborting due to 14 previous errors
+error: useless use of `vec!`
+  --> $DIR/vec.rs:117:14
+   |
+LL |     for a in vec![1, 2, 3] {
+   |              ^^^^^^^^^^^^^ help: you can use an array directly: `[1, 2, 3]`
+
+error: useless use of `vec!`
+  --> $DIR/vec.rs:121:14
+   |
+LL |     for a in vec![String::new(), String::new()] {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly: `[String::new(), String::new()]`
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/111034
Fixes #2256

changelog: [`useless_vec`]: Fix suggestion in `for _ in vec![..]`
