### PR TITLE
Ignore more pointer types in `unnecessary_cast`

### DIFF
--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -45,6 +45,8 @@ fn main() {
     [1u8, 2].as_mut_ptr() as PtrConstU8;
     let _: *const u8 = [1u8, 2].as_ptr() as _;
     let _: *mut u8 = [1u8, 2].as_mut_ptr() as _;
+    let _: *const u8 = [1u8, 2].as_ptr() as *const _;
+    let _: *mut u8 = [1u8, 2].as_mut_ptr() as *mut _;
 
     owo::<u32>([1u32].as_ptr());
     uwu::<u32, u8>([1u32].as_ptr());
@@ -70,6 +72,17 @@ fn main() {
     // do not lint cast to alias type
     1 as I32Alias;
     &1 as &I32Alias;
+
+    let i8_ptr: *const i8 = &1;
+    let u8_ptr: *const u8 = &1;
+
+    // cfg dependant pointees
+    i8_ptr as *const std::os::raw::c_char;
+    u8_ptr as *const std::os::raw::c_char;
+
+    // type aliased pointees
+    i8_ptr as *const std::ffi::c_char;
+    u8_ptr as *const std::ffi::c_char;
 
     // issue #9960
     macro_rules! bind_var {

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -45,6 +45,8 @@ fn main() {
     [1u8, 2].as_mut_ptr() as PtrConstU8;
     let _: *const u8 = [1u8, 2].as_ptr() as _;
     let _: *mut u8 = [1u8, 2].as_mut_ptr() as _;
+    let _: *const u8 = [1u8, 2].as_ptr() as *const _;
+    let _: *mut u8 = [1u8, 2].as_mut_ptr() as *mut _;
 
     owo::<u32>([1u32].as_ptr()) as *const u32;
     uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
@@ -70,6 +72,17 @@ fn main() {
     // do not lint cast to alias type
     1 as I32Alias;
     &1 as &I32Alias;
+
+    let i8_ptr: *const i8 = &1;
+    let u8_ptr: *const u8 = &1;
+
+    // cfg dependant pointees
+    i8_ptr as *const std::os::raw::c_char;
+    u8_ptr as *const std::os::raw::c_char;
+
+    // type aliased pointees
+    i8_ptr as *const std::ffi::c_char;
+    u8_ptr as *const std::ffi::c_char;
 
     // issue #9960
     macro_rules! bind_var {

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -73,157 +73,157 @@ LL |     [1u8, 2].as_mut_ptr() as *mut u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_mut_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
-  --> $DIR/unnecessary_cast.rs:49:5
+  --> $DIR/unnecessary_cast.rs:51:5
    |
 LL |     owo::<u32>([1u32].as_ptr()) as *const u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `owo::<u32>([1u32].as_ptr())`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> $DIR/unnecessary_cast.rs:50:5
+  --> $DIR/unnecessary_cast.rs:52:5
    |
 LL |     uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u8>([1u32].as_ptr())`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
-  --> $DIR/unnecessary_cast.rs:52:5
+  --> $DIR/unnecessary_cast.rs:54:5
    |
 LL |     uwu::<u32, u32>([1u32].as_ptr()) as *const u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u32>([1u32].as_ptr())`
 
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:93:9
+  --> $DIR/unnecessary_cast.rs:106:9
    |
 LL |         100 as f32;
    |         ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:94:9
+  --> $DIR/unnecessary_cast.rs:107:9
    |
 LL |         100 as f64;
    |         ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:95:9
+  --> $DIR/unnecessary_cast.rs:108:9
    |
 LL |         100_i32 as f64;
    |         ^^^^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:96:17
+  --> $DIR/unnecessary_cast.rs:109:17
    |
 LL |         let _ = -100 as f32;
    |                 ^^^^^^^^^^^ help: try: `-100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:97:17
+  --> $DIR/unnecessary_cast.rs:110:17
    |
 LL |         let _ = -100 as f64;
    |                 ^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:98:17
+  --> $DIR/unnecessary_cast.rs:111:17
    |
 LL |         let _ = -100_i32 as f64;
    |                 ^^^^^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:99:9
+  --> $DIR/unnecessary_cast.rs:112:9
    |
 LL |         100. as f32;
    |         ^^^^^^^^^^^ help: try: `100_f32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:100:9
+  --> $DIR/unnecessary_cast.rs:113:9
    |
 LL |         100. as f64;
    |         ^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:112:9
+  --> $DIR/unnecessary_cast.rs:125:9
    |
 LL |         1 as u32;
    |         ^^^^^^^^ help: try: `1_u32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:113:9
+  --> $DIR/unnecessary_cast.rs:126:9
    |
 LL |         0x10 as i32;
    |         ^^^^^^^^^^^ help: try: `0x10_i32`
 
 error: casting integer literal to `usize` is unnecessary
-  --> $DIR/unnecessary_cast.rs:114:9
+  --> $DIR/unnecessary_cast.rs:127:9
    |
 LL |         0b10 as usize;
    |         ^^^^^^^^^^^^^ help: try: `0b10_usize`
 
 error: casting integer literal to `u16` is unnecessary
-  --> $DIR/unnecessary_cast.rs:115:9
+  --> $DIR/unnecessary_cast.rs:128:9
    |
 LL |         0o73 as u16;
    |         ^^^^^^^^^^^ help: try: `0o73_u16`
 
 error: casting integer literal to `u32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:116:9
+  --> $DIR/unnecessary_cast.rs:129:9
    |
 LL |         1_000_000_000 as u32;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `1_000_000_000_u32`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:118:9
+  --> $DIR/unnecessary_cast.rs:131:9
    |
 LL |         1.0 as f64;
    |         ^^^^^^^^^^ help: try: `1.0_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:119:9
+  --> $DIR/unnecessary_cast.rs:132:9
    |
 LL |         0.5 as f32;
    |         ^^^^^^^^^^ help: try: `0.5_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:123:17
+  --> $DIR/unnecessary_cast.rs:136:17
    |
 LL |         let _ = -1 as i32;
    |                 ^^^^^^^^^ help: try: `-1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:124:17
+  --> $DIR/unnecessary_cast.rs:137:17
    |
 LL |         let _ = -1.0 as f32;
    |                 ^^^^^^^^^^^ help: try: `-1.0_f32`
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> $DIR/unnecessary_cast.rs:130:18
+  --> $DIR/unnecessary_cast.rs:143:18
    |
 LL |         let _ = &(x as i32);
    |                  ^^^^^^^^^^ help: try: `{ x }`
 
 error: casting integer literal to `i32` is unnecessary
-  --> $DIR/unnecessary_cast.rs:136:22
+  --> $DIR/unnecessary_cast.rs:149:22
    |
 LL |         let _: i32 = -(1) as i32;
    |                      ^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:138:22
+  --> $DIR/unnecessary_cast.rs:151:22
    |
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:145:22
+  --> $DIR/unnecessary_cast.rs:158:22
    |
 LL |         let _: f64 = (-8.0 as f64).exp();
    |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
 
 error: casting float literal to `f64` is unnecessary
-  --> $DIR/unnecessary_cast.rs:147:23
+  --> $DIR/unnecessary_cast.rs:160:23
    |
 LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
    |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> $DIR/unnecessary_cast.rs:155:20
+  --> $DIR/unnecessary_cast.rs:168:20
    |
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`


### PR DESCRIPTION
Spotted this because

https://github.com/rust-lang/rust-clippy/blob/e2c655b4c07c912ef749be316aeea8453cb9d840/tests/ui/suspicious_to_owned.rs#L9-L10

currently fails on `aarch64-unknown-linux-gnu` as `c_char` is `u8` there

The current implementation checks for `as alias`, `as _`. This adds things like
- `as *const alias`
- `as *const cfg_dependant`
- `as *const _`

changelog: none
