### PR TITLE
handle exponent without digits in `numeric_literal`

### DIFF
--- a/clippy_utils/src/numeric_literal.rs
+++ b/clippy_utils/src/numeric_literal.rs
@@ -161,7 +161,7 @@ impl<'a> NumericLiteral<'a> {
         }
 
         if let Some((separator, exponent)) = self.exponent {
-            if exponent != "0" {
+            if !exponent.is_empty() && exponent != "0" {
                 output.push_str(separator);
                 Self::group_digits(&mut output, exponent, group_size, true, false);
             }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,3 +5,4 @@ wrap_comments = true
 edition = "2021"
 error_on_line_overflow = true
 version = "Two"
+ignore = ["tests/ui/crashes/ice-10912.rs"]

--- a/tests/ui/crashes/ice-10912.rs
+++ b/tests/ui/crashes/ice-10912.rs
@@ -1,0 +1,4 @@
+#![warn(clippy::unreadable_literal)]
+fn f2() -> impl Sized { && 3.14159265358979323846E }
+
+fn main() {}

--- a/tests/ui/crashes/ice-10912.stderr
+++ b/tests/ui/crashes/ice-10912.stderr
@@ -1,0 +1,16 @@
+error: expected at least one digit in exponent
+  --> $DIR/ice-10912.rs:2:28
+   |
+LL | fn f2() -> impl Sized { && 3.14159265358979323846E }
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: long literal lacking separators
+  --> $DIR/ice-10912.rs:2:28
+   |
+LL | fn f2() -> impl Sized { && 3.14159265358979323846E }
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^ help: consider: `3.141_592_653_589_793_238_46`
+   |
+   = note: `-D clippy::unreadable-literal` implied by `-D warnings`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #10912 

The numeric literal util module didn't check for exponents with no digits.
So:
https://github.com/rust-lang/rust-clippy/blob/384cf376120f09df7710d2ff39c986144a7b1517/clippy_utils/src/numeric_literal.rs#L163-L168

`exponent` here would be the empty string, which passed the `!= "0"` check (when it shouldn't have, it should probably be treated as if the user wrote `E0`), then later fails when counting the digits and subtracting one (0 - 1 = overflow).

Also, interestingly I can't even write a test for this because exponents with no digits is some kind of error by itself and `cargo dev fmt` fails on it.

changelog: [`unreadable_literal`]: don't (debug) ICE on numeric literal with empty exponent