### PR TITLE
Add `needless_if` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5008,6 +5008,7 @@ Released 2018-09-13
 [`needless_doctest_main`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main
 [`needless_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_else
 [`needless_for_each`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each
+[`needless_if`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_if
 [`needless_late_init`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
 [`needless_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
 [`needless_match`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_match

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -459,6 +459,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::needless_continue::NEEDLESS_CONTINUE_INFO,
     crate::needless_else::NEEDLESS_ELSE_INFO,
     crate::needless_for_each::NEEDLESS_FOR_EACH_INFO,
+    crate::needless_if::NEEDLESS_IF_INFO,
     crate::needless_late_init::NEEDLESS_LATE_INIT_INFO,
     crate::needless_parens_on_range_literals::NEEDLESS_PARENS_ON_RANGE_LITERALS_INFO,
     crate::needless_pass_by_value::NEEDLESS_PASS_BY_VALUE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -223,6 +223,7 @@ mod needless_borrowed_ref;
 mod needless_continue;
 mod needless_else;
 mod needless_for_each;
+mod needless_if;
 mod needless_late_init;
 mod needless_parens_on_range_literals;
 mod needless_pass_by_value;
@@ -1029,6 +1030,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|_| Box::new(endian_bytes::EndianBytes));
     store.register_late_pass(|_| Box::new(redundant_type_annotations::RedundantTypeAnnotations));
     store.register_late_pass(|_| Box::new(arc_with_non_send_sync::ArcWithNonSendSync));
+    store.register_late_pass(|_| Box::new(needless_if::NeedlessIf));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/needless_if.rs
+++ b/clippy_lints/src/needless_if.rs
@@ -1,0 +1,66 @@
+use clippy_utils::{diagnostics::span_lint_and_sugg, is_from_proc_macro, source::snippet_with_applicability};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, Node};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::lint::in_external_macro;
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// ### Why is this bad?
+    ///
+    /// ### Example
+    /// ```rust
+    /// // example code where clippy issues a warning
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// // example code which does not raise clippy warning
+    /// ```
+    #[clippy::version = "1.72.0"]
+    pub NEEDLESS_IF,
+    complexity,
+    "checks for empty if branches"
+}
+declare_lint_pass!(NeedlessIf => [NEEDLESS_IF]);
+
+impl LateLintPass<'_> for NeedlessIf {
+    fn check_expr<'tcx>(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        if let ExprKind::If(if_expr, block, else_expr) = &expr.kind
+            && let ExprKind::Block(block, ..) = block.kind
+            && block.stmts.is_empty()
+            && block.expr.is_none()
+            && else_expr.is_none()
+            && !in_external_macro(cx.sess(), expr.span)
+        {
+            let mut app = Applicability::MachineApplicable;
+            let snippet = snippet_with_applicability(cx, if_expr.span, "{ ... }", &mut app);
+
+            // Ignore `else if`
+            if let Some(parent_id) = cx.tcx.hir().opt_parent_id(expr.hir_id)
+                && let Some(Node::Expr(Expr {
+                    kind: ExprKind::If(_, _, Some(else_expr)),
+                    ..
+                })) = cx.tcx.hir().find(parent_id)
+                && else_expr.hir_id == expr.hir_id
+            {
+                return;
+            }
+
+            if is_from_proc_macro(cx, expr) {
+                return;
+            }
+
+            span_lint_and_sugg(
+                cx,
+                NEEDLESS_IF,
+                expr.span,
+                "this if branch is empty",
+                "you can remove it",
+                format!("{snippet};"),
+                Applicability::MachineApplicable,
+            );
+        }
+    }
+}

--- a/clippy_lints/src/needless_if.rs
+++ b/clippy_lints/src/needless_if.rs
@@ -7,16 +7,24 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for empty `if` statements with no else branch.
     ///
     /// ### Why is this bad?
+    /// It can be entirely omitted, and often the condition too.
+    ///
+    /// ### Known issues
+    /// This will only suggest to remove the `if` statement, not the condition. Other lints such as
+    /// `no_effect` will take care of removing the condition if it's unnecessary.
     ///
     /// ### Example
-    /// ```rust
-    /// // example code where clippy issues a warning
+    /// ```rust,ignore
+    /// if really_expensive_condition(&i) {}
+    /// if really_expensive_condition_with_side_effects(&mut i) {}
     /// ```
     /// Use instead:
-    /// ```rust
-    /// // example code which does not raise clippy warning
+    /// ```rust,ignore
+    /// // <omitted>
+    /// really_expensive_condition_with_side_effects(&mut i);
     /// ```
     #[clippy::version = "1.72.0"]
     pub NEEDLESS_IF,

--- a/clippy_lints/src/needless_if.rs
+++ b/clippy_lints/src/needless_if.rs
@@ -1,20 +1,23 @@
 use clippy_utils::{diagnostics::span_lint_and_sugg, is_from_proc_macro, source::snippet_with_applicability};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, Node};
+use rustc_hir::{
+    intravisit::{walk_expr, Visitor},
+    Expr, ExprKind, Node,
+};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for empty `if` statements with no else branch.
+    /// Checks for empty `if` branches with no else branch.
     ///
     /// ### Why is this bad?
     /// It can be entirely omitted, and often the condition too.
     ///
     /// ### Known issues
-    /// This will only suggest to remove the `if` statement, not the condition. Other lints such as
-    /// `no_effect` will take care of removing the condition if it's unnecessary.
+    /// This will usually only suggest to remove the `if` statement, not the condition. Other lints
+    /// such as `no_effect` will take care of removing the condition if it's unnecessary.
     ///
     /// ### Example
     /// ```rust,ignore
@@ -42,9 +45,6 @@ impl LateLintPass<'_> for NeedlessIf {
             && else_expr.is_none()
             && !in_external_macro(cx.sess(), expr.span)
         {
-            let mut app = Applicability::MachineApplicable;
-            let snippet = snippet_with_applicability(cx, if_expr.span, "{ ... }", &mut app);
-
             // Ignore `else if`
             if let Some(parent_id) = cx.tcx.hir().opt_parent_id(expr.hir_id)
                 && let Some(Node::Expr(Expr {
@@ -56,19 +56,48 @@ impl LateLintPass<'_> for NeedlessIf {
                 return;
             }
 
-            if is_from_proc_macro(cx, expr) {
+            if is_any_if_let(if_expr) || is_from_proc_macro(cx, expr) {
                 return;
             }
+
+            let mut app = Applicability::MachineApplicable;
+            let snippet = snippet_with_applicability(cx, if_expr.span, "{ ... }", &mut app);
 
             span_lint_and_sugg(
                 cx,
                 NEEDLESS_IF,
                 expr.span,
-                "this if branch is empty",
+                "this `if` branch is empty",
                 "you can remove it",
-                format!("{snippet};"),
-                Applicability::MachineApplicable,
+                if if_expr.can_have_side_effects() {
+                    format!("{snippet};")
+                } else {
+                    String::new()
+                },
+                app,
             );
         }
+    }
+}
+
+/// Returns true if any `Expr` contained within this `Expr` is a `Let`, else false.
+///
+/// Really wish `Expr` had a `walk` method...
+fn is_any_if_let(expr: &Expr<'_>) -> bool {
+    let mut v = IsAnyLetVisitor(false);
+
+    v.visit_expr(expr);
+    v.0
+}
+
+struct IsAnyLetVisitor(bool);
+
+impl Visitor<'_> for IsAnyLetVisitor {
+    fn visit_expr(&mut self, expr: &Expr<'_>) {
+        if matches!(expr.kind, ExprKind::Let(..)) {
+            self.0 = true;
+        }
+
+        walk_expr(self, expr);
     }
 }

--- a/clippy_lints/src/needless_if.rs
+++ b/clippy_lints/src/needless_if.rs
@@ -96,8 +96,8 @@ impl Visitor<'_> for IsAnyLetVisitor {
     fn visit_expr(&mut self, expr: &Expr<'_>) {
         if matches!(expr.kind, ExprKind::Let(..)) {
             self.0 = true;
+        } else {
+            walk_expr(self, expr);
         }
-
-        walk_expr(self, expr);
     }
 }

--- a/lintcheck/lintcheck_crates.toml
+++ b/lintcheck/lintcheck_crates.toml
@@ -1,7 +1,38 @@
 [crates]
 # some of these are from cargotest
-bevy = {name = "bevy", versions = ['0.10.1']}
-deno = {name = "deno", versions = ['1.34.2']}
+cargo = {name = "cargo", versions = ['0.64.0']}
+iron = {name = "iron", versions = ['0.6.1']}
+ripgrep = {name = "ripgrep", versions = ['12.1.1']}
+xsv = {name = "xsv", versions = ['0.13.0']}
+# commented out because of 173K clippy::match_same_arms msgs in language_type.rs
+#tokei = { name = "tokei", versions = ['12.0.4']}
+rayon = {name = "rayon", versions = ['1.5.0']}
+serde = {name = "serde", versions = ['1.0.118']}
+# top 10 crates.io dls
+bitflags = {name = "bitflags", versions = ['1.2.1']}
+# crash = {name = "clippy_crash", path = "/tmp/clippy_crash"}
+libc = {name = "libc", versions = ['0.2.81']}
+log = {name = "log", versions = ['0.4.11']}
+proc-macro2 = {name = "proc-macro2", versions = ['1.0.24']}
+quote = {name = "quote", versions = ['1.0.7']}
+rand = {name = "rand", versions = ['0.7.3']}
+rand_core = {name = "rand_core", versions = ['0.6.0']}
+regex = {name = "regex", versions = ['1.3.2']}
+syn = {name = "syn", versions = ['1.0.54']}
+unicode-xid = {name = "unicode-xid", versions = ['0.2.1']}
+# some more of dtolnays crates
+anyhow = {name = "anyhow", versions = ['1.0.38']}
+async-trait = {name = "async-trait", versions = ['0.1.42']}
+cxx = {name = "cxx", versions = ['1.0.32']}
+ryu = {name = "ryu", versions = ['1.0.5']}
+serde_yaml = {name = "serde_yaml", versions = ['0.8.17']}
+thiserror = {name = "thiserror", versions = ['1.0.24']}
+# some embark crates, there are other interesting crates but
+# unfortunately adding them increases lintcheck runtime drastically
+cfg-expr = {name = "cfg-expr", versions = ['0.7.1']}
+puffin = {name = "puffin", git_url = "https://github.com/EmbarkStudios/puffin", git_hash = "02dd4a3"}
+rpmalloc = {name = "rpmalloc", versions = ['0.2.0']}
+tame-oidc = {name = "tame-oidc", versions = ['0.1.0']}
 
 [recursive]
 ignore = [

--- a/lintcheck/lintcheck_crates.toml
+++ b/lintcheck/lintcheck_crates.toml
@@ -1,38 +1,7 @@
 [crates]
 # some of these are from cargotest
-cargo = {name = "cargo", versions = ['0.64.0']}
-iron = {name = "iron", versions = ['0.6.1']}
-ripgrep = {name = "ripgrep", versions = ['12.1.1']}
-xsv = {name = "xsv", versions = ['0.13.0']}
-# commented out because of 173K clippy::match_same_arms msgs in language_type.rs
-#tokei = { name = "tokei", versions = ['12.0.4']}
-rayon = {name = "rayon", versions = ['1.5.0']}
-serde = {name = "serde", versions = ['1.0.118']}
-# top 10 crates.io dls
-bitflags = {name = "bitflags", versions = ['1.2.1']}
-# crash = {name = "clippy_crash", path = "/tmp/clippy_crash"}
-libc = {name = "libc", versions = ['0.2.81']}
-log = {name = "log", versions = ['0.4.11']}
-proc-macro2 = {name = "proc-macro2", versions = ['1.0.24']}
-quote = {name = "quote", versions = ['1.0.7']}
-rand = {name = "rand", versions = ['0.7.3']}
-rand_core = {name = "rand_core", versions = ['0.6.0']}
-regex = {name = "regex", versions = ['1.3.2']}
-syn = {name = "syn", versions = ['1.0.54']}
-unicode-xid = {name = "unicode-xid", versions = ['0.2.1']}
-# some more of dtolnays crates
-anyhow = {name = "anyhow", versions = ['1.0.38']}
-async-trait = {name = "async-trait", versions = ['0.1.42']}
-cxx = {name = "cxx", versions = ['1.0.32']}
-ryu = {name = "ryu", versions = ['1.0.5']}
-serde_yaml = {name = "serde_yaml", versions = ['0.8.17']}
-thiserror = {name = "thiserror", versions = ['1.0.24']}
-# some embark crates, there are other interesting crates but
-# unfortunately adding them increases lintcheck runtime drastically
-cfg-expr = {name = "cfg-expr", versions = ['0.7.1']}
-puffin = {name = "puffin", git_url = "https://github.com/EmbarkStudios/puffin", git_hash = "02dd4a3"}
-rpmalloc = {name = "rpmalloc", versions = ['0.2.0']}
-tame-oidc = {name = "tame-oidc", versions = ['0.1.0']}
+bevy = {name = "bevy", versions = ['0.10.1']}
+deno = {name = "deno", versions = ['1.34.2']}
 
 [recursive]
 ignore = [

--- a/tests/ui-internal/if_chain_style.rs
+++ b/tests/ui-internal/if_chain_style.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::if_chain_style)]
-#![allow(clippy::no_effect, clippy::nonminimal_bool, clippy::missing_clippy_version_attribute)]
+#![allow(
+    clippy::needless_if,
+    clippy::no_effect,
+    clippy::nonminimal_bool,
+    clippy::missing_clippy_version_attribute
+)]
 
 extern crate if_chain;
 

--- a/tests/ui-internal/if_chain_style.stderr
+++ b/tests/ui-internal/if_chain_style.stderr
@@ -1,5 +1,5 @@
 error: this `if` can be part of the inner `if_chain!`
-  --> $DIR/if_chain_style.rs:9:5
+  --> $DIR/if_chain_style.rs:14:5
    |
 LL | /     if true {
 LL | |         let x = "";
@@ -11,14 +11,14 @@ LL | |     }
    | |_____^
    |
 help: this `let` statement can also be in the `if_chain!`
-  --> $DIR/if_chain_style.rs:10:9
+  --> $DIR/if_chain_style.rs:15:9
    |
 LL |         let x = "";
    |         ^^^^^^^^^^^
    = note: `-D clippy::if-chain-style` implied by `-D warnings`
 
 error: `if a && b;` should be `if a; if b;`
-  --> $DIR/if_chain_style.rs:19:12
+  --> $DIR/if_chain_style.rs:24:12
    |
 LL |           if true
    |  ____________^
@@ -27,25 +27,25 @@ LL | |             && false;
    | |____________________^
 
 error: `let` expression should be inside `then { .. }`
-  --> $DIR/if_chain_style.rs:24:9
+  --> $DIR/if_chain_style.rs:29:9
    |
 LL |         let x = "";
    |         ^^^^^^^^^^^
 
 error: this `if` can be part of the outer `if_chain!`
-  --> $DIR/if_chain_style.rs:35:13
+  --> $DIR/if_chain_style.rs:40:13
    |
 LL |             if true {}
    |             ^^^^^^^^^^
    |
 help: this `let` statement can also be in the `if_chain!`
-  --> $DIR/if_chain_style.rs:33:13
+  --> $DIR/if_chain_style.rs:38:13
    |
 LL |             let x = "";
    |             ^^^^^^^^^^^
 
 error: `if_chain!` only has one `if`
-  --> $DIR/if_chain_style.rs:29:5
+  --> $DIR/if_chain_style.rs:34:5
    |
 LL | /     if_chain! {
 LL | |         // single `if` condition
@@ -59,13 +59,13 @@ LL | |     }
    = note: this error originates in the macro `__if_chain` which comes from the expansion of the macro `if_chain` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `let` expression should be above the `if_chain!`
-  --> $DIR/if_chain_style.rs:40:9
+  --> $DIR/if_chain_style.rs:45:9
    |
 LL |         let x = "";
    |         ^^^^^^^^^^^
 
 error: this `if_chain!` can be merged with the outer `if_chain!`
-  --> $DIR/if_chain_style.rs:46:13
+  --> $DIR/if_chain_style.rs:51:13
    |
 LL | /             if_chain! {
 LL | |                 if true;
@@ -75,7 +75,7 @@ LL | |             }
    | |_____________^
    |
 help: these `let` statements can also be in the `if_chain!`
-  --> $DIR/if_chain_style.rs:43:13
+  --> $DIR/if_chain_style.rs:48:13
    |
 LL | /             let x = "";
 LL | |             let x = "";

--- a/tests/ui-toml/excessive_nesting/excessive_nesting.rs
+++ b/tests/ui-toml/excessive_nesting/excessive_nesting.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::no_effect)]
 #![allow(clippy::unnecessary_operation)]
 #![allow(clippy::never_loop)]
+#![allow(clippy::needless_if)]
 #![warn(clippy::excessive_nesting)]
 #![allow(clippy::collapsible_if)]
 

--- a/tests/ui-toml/excessive_nesting/excessive_nesting.stderr
+++ b/tests/ui-toml/excessive_nesting/excessive_nesting.stderr
@@ -1,5 +1,5 @@
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:20:25
+  --> $DIR/excessive_nesting.rs:21:25
    |
 LL |                 let w = { 3 };
    |                         ^^^^^
@@ -8,7 +8,7 @@ LL |                 let w = { 3 };
    = note: `-D clippy::excessive-nesting` implied by `-D warnings`
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:66:17
+  --> $DIR/excessive_nesting.rs:67:17
    |
 LL | /                 impl C {
 LL | |                     pub fn c() {}
@@ -18,7 +18,7 @@ LL | |                 }
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:80:25
+  --> $DIR/excessive_nesting.rs:81:25
    |
 LL |                 let x = { 1 }; // not a warning, but cc is
    |                         ^^^^^
@@ -26,7 +26,7 @@ LL |                 let x = { 1 }; // not a warning, but cc is
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:97:17
+  --> $DIR/excessive_nesting.rs:98:17
    |
 LL | /                 pub mod e {
 LL | |                     pub mod f {}
@@ -36,7 +36,7 @@ LL | |                 } // not here
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:110:18
+  --> $DIR/excessive_nesting.rs:111:18
    |
 LL |     a_but_not({{{{{{{{0}}}}}}}});
    |                  ^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     a_but_not({{{{{{{{0}}}}}}}});
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:111:12
+  --> $DIR/excessive_nesting.rs:112:12
    |
 LL |     a.a({{{{{{{{{0}}}}}}}}});
    |            ^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |     a.a({{{{{{{{{0}}}}}}}}});
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:112:12
+  --> $DIR/excessive_nesting.rs:113:12
    |
 LL |     (0, {{{{{{{1}}}}}}});
    |            ^^^^^^^^^
@@ -60,7 +60,7 @@ LL |     (0, {{{{{{{1}}}}}}});
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:117:25
+  --> $DIR/excessive_nesting.rs:118:25
    |
 LL |                   if true {
    |  _________________________^
@@ -73,7 +73,7 @@ LL | |                 }
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:129:29
+  --> $DIR/excessive_nesting.rs:130:29
    |
 LL |                   let z = (|| {
    |  _____________________________^
@@ -85,7 +85,7 @@ LL | |                 })();
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:148:13
+  --> $DIR/excessive_nesting.rs:149:13
    |
 LL |     y += {{{{{5}}}}};
    |             ^^^^^
@@ -93,7 +93,7 @@ LL |     y += {{{{{5}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:149:20
+  --> $DIR/excessive_nesting.rs:150:20
    |
 LL |     let z = y + {{{{{{{{{5}}}}}}}}};
    |                    ^^^^^^^^^^^^^
@@ -101,7 +101,7 @@ LL |     let z = y + {{{{{{{{{5}}}}}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:150:12
+  --> $DIR/excessive_nesting.rs:151:12
    |
 LL |     [0, {{{{{{{{{{0}}}}}}}}}}];
    |            ^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     [0, {{{{{{{{{{0}}}}}}}}}}];
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:151:25
+  --> $DIR/excessive_nesting.rs:152:25
    |
 LL |     let mut xx = [0; {{{{{{{{100}}}}}}}}];
    |                         ^^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     let mut xx = [0; {{{{{{{{100}}}}}}}}];
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:152:11
+  --> $DIR/excessive_nesting.rs:153:11
    |
 LL |     xx[{{{{{{{{{{{{{{{{{{{{{{{{3}}}}}}}}}}}}}}}}}}}}}}}}];
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     xx[{{{{{{{{{{{{{{{{{{{{{{{{3}}}}}}}}}}}}}}}}}}}}}}}}];
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:153:13
+  --> $DIR/excessive_nesting.rs:154:13
    |
 LL |     &mut {{{{{{{{{{y}}}}}}}}}};
    |             ^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL |     &mut {{{{{{{{{{y}}}}}}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:155:17
+  --> $DIR/excessive_nesting.rs:156:17
    |
 LL |     for i in {{{{xx}}}} {{{{{{{{}}}}}}}}
    |                 ^^^^
@@ -141,7 +141,7 @@ LL |     for i in {{{{xx}}}} {{{{{{{{}}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:155:28
+  --> $DIR/excessive_nesting.rs:156:28
    |
 LL |     for i in {{{{xx}}}} {{{{{{{{}}}}}}}}
    |                            ^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     for i in {{{{xx}}}} {{{{{{{{}}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:157:28
+  --> $DIR/excessive_nesting.rs:158:28
    |
 LL |     while let Some(i) = {{{{{{Some(1)}}}}}} {{{{{{{}}}}}}}
    |                            ^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL |     while let Some(i) = {{{{{{Some(1)}}}}}} {{{{{{{}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:157:48
+  --> $DIR/excessive_nesting.rs:158:48
    |
 LL |     while let Some(i) = {{{{{{Some(1)}}}}}} {{{{{{{}}}}}}}
    |                                                ^^^^^^^^
@@ -165,7 +165,7 @@ LL |     while let Some(i) = {{{{{{Some(1)}}}}}} {{{{{{{}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:159:14
+  --> $DIR/excessive_nesting.rs:160:14
    |
 LL |     while {{{{{{{{true}}}}}}}} {{{{{{{{{}}}}}}}}}
    |              ^^^^^^^^^^^^^^
@@ -173,7 +173,7 @@ LL |     while {{{{{{{{true}}}}}}}} {{{{{{{{{}}}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:159:35
+  --> $DIR/excessive_nesting.rs:160:35
    |
 LL |     while {{{{{{{{true}}}}}}}} {{{{{{{{{}}}}}}}}}
    |                                   ^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL |     while {{{{{{{{true}}}}}}}} {{{{{{{{{}}}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:161:23
+  --> $DIR/excessive_nesting.rs:162:23
    |
 LL |     let d = D { d: {{{{{{{{{{{{{{{{{{{{{{{3}}}}}}}}}}}}}}}}}}}}}}} };
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -189,7 +189,7 @@ LL |     let d = D { d: {{{{{{{{{{{{{{{{{{{{{{{3}}}}}}}}}}}}}}}}}}}}}}} };
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:163:8
+  --> $DIR/excessive_nesting.rs:164:8
    |
 LL |     {{{{1;}}}}..{{{{{{3}}}}}};
    |        ^^^^
@@ -197,7 +197,7 @@ LL |     {{{{1;}}}}..{{{{{{3}}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:163:20
+  --> $DIR/excessive_nesting.rs:164:20
    |
 LL |     {{{{1;}}}}..{{{{{{3}}}}}};
    |                    ^^^^^^^
@@ -205,7 +205,7 @@ LL |     {{{{1;}}}}..{{{{{{3}}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:164:8
+  --> $DIR/excessive_nesting.rs:165:8
    |
 LL |     {{{{1;}}}}..={{{{{{{{{{{{{{{{{{{{{{{{{{6}}}}}}}}}}}}}}}}}}}}}}}}}};
    |        ^^^^
@@ -213,7 +213,7 @@ LL |     {{{{1;}}}}..={{{{{{{{{{{{{{{{{{{{{{{{{{6}}}}}}}}}}}}}}}}}}}}}}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:164:21
+  --> $DIR/excessive_nesting.rs:165:21
    |
 LL |     {{{{1;}}}}..={{{{{{{{{{{{{{{{{{{{{{{{{{6}}}}}}}}}}}}}}}}}}}}}}}}}};
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +221,7 @@ LL |     {{{{1;}}}}..={{{{{{{{{{{{{{{{{{{{{{{{{{6}}}}}}}}}}}}}}}}}}}}}}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:165:10
+  --> $DIR/excessive_nesting.rs:166:10
    |
 LL |     ..{{{{{{{5}}}}}}};
    |          ^^^^^^^^^
@@ -229,7 +229,7 @@ LL |     ..{{{{{{{5}}}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:166:11
+  --> $DIR/excessive_nesting.rs:167:11
    |
 LL |     ..={{{{{3}}}}};
    |           ^^^^^
@@ -237,7 +237,7 @@ LL |     ..={{{{{3}}}}};
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:167:8
+  --> $DIR/excessive_nesting.rs:168:8
    |
 LL |     {{{{{1;}}}}}..;
    |        ^^^^^^
@@ -245,7 +245,7 @@ LL |     {{{{{1;}}}}}..;
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:169:20
+  --> $DIR/excessive_nesting.rs:170:20
    |
 LL |     loop { break {{{{1}}}} };
    |                    ^^^^^
@@ -253,7 +253,7 @@ LL |     loop { break {{{{1}}}} };
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:170:13
+  --> $DIR/excessive_nesting.rs:171:13
    |
 LL |     loop {{{{{{}}}}}}
    |             ^^^^^^
@@ -261,7 +261,7 @@ LL |     loop {{{{{{}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:172:14
+  --> $DIR/excessive_nesting.rs:173:14
    |
 LL |     match {{{{{{true}}}}}} {
    |              ^^^^^^^^^^
@@ -269,7 +269,7 @@ LL |     match {{{{{{true}}}}}} {
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:173:20
+  --> $DIR/excessive_nesting.rs:174:20
    |
 LL |         true => {{{{}}}},
    |                    ^^
@@ -277,7 +277,7 @@ LL |         true => {{{{}}}},
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:174:21
+  --> $DIR/excessive_nesting.rs:175:21
    |
 LL |         false => {{{{}}}},
    |                     ^^
@@ -285,7 +285,7 @@ LL |         false => {{{{}}}},
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:180:17
+  --> $DIR/excessive_nesting.rs:181:17
    |
 LL | /                 {
 LL | |                     println!("warning! :)");
@@ -295,7 +295,7 @@ LL | |                 }
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:189:28
+  --> $DIR/excessive_nesting.rs:190:28
    |
 LL |     async fn c() -> u32 {{{{{{{0}}}}}}}
    |                            ^^^^^^^^^
@@ -303,7 +303,7 @@ LL |     async fn c() -> u32 {{{{{{{0}}}}}}}
    = help: try refactoring your code to minimize nesting
 
 error: this block is too nested
-  --> $DIR/excessive_nesting.rs:195:8
+  --> $DIR/excessive_nesting.rs:196:8
    |
 LL |     {{{{b().await}}}};
    |        ^^^^^^^^^^^

--- a/tests/ui/auxiliary/proc_macros.rs
+++ b/tests/ui/auxiliary/proc_macros.rs
@@ -4,7 +4,7 @@
 #![crate_type = "proc-macro"]
 #![feature(let_chains)]
 #![feature(proc_macro_span)]
-#![allow(dead_code)]
+#![allow(clippy::needless_if, dead_code)]
 
 extern crate proc_macro;
 

--- a/tests/ui/blocks_in_if_conditions.fixed
+++ b/tests/ui/blocks_in_if_conditions.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::blocks_in_if_conditions)]
-#![allow(unused, clippy::let_and_return)]
+#![allow(unused, clippy::let_and_return, clippy::needless_if)]
 #![warn(clippy::nonminimal_bool)]
 
 macro_rules! blocky {

--- a/tests/ui/blocks_in_if_conditions.rs
+++ b/tests/ui/blocks_in_if_conditions.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::blocks_in_if_conditions)]
-#![allow(unused, clippy::let_and_return)]
+#![allow(unused, clippy::let_and_return, clippy::needless_if)]
 #![warn(clippy::nonminimal_bool)]
 
 macro_rules! blocky {

--- a/tests/ui/blocks_in_if_conditions_closure.rs
+++ b/tests/ui/blocks_in_if_conditions_closure.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::blocks_in_if_conditions)]
-#![allow(unused, clippy::let_and_return)]
+#![allow(unused, clippy::let_and_return, clippy::needless_if)]
 
 fn predicate<F: FnOnce(T) -> bool, T>(pfn: F, val: T) -> bool {
     pfn(val)

--- a/tests/ui/bool_comparison.fixed
+++ b/tests/ui/bool_comparison.fixed
@@ -1,5 +1,6 @@
 //@run-rustfix
 
+#![allow(clippy::needless_if)]
 #![warn(clippy::bool_comparison)]
 
 fn main() {

--- a/tests/ui/bool_comparison.rs
+++ b/tests/ui/bool_comparison.rs
@@ -1,5 +1,6 @@
 //@run-rustfix
 
+#![allow(clippy::needless_if)]
 #![warn(clippy::bool_comparison)]
 
 fn main() {

--- a/tests/ui/bool_comparison.stderr
+++ b/tests/ui/bool_comparison.stderr
@@ -1,5 +1,5 @@
 error: equality checks against true are unnecessary
-  --> $DIR/bool_comparison.rs:7:8
+  --> $DIR/bool_comparison.rs:8:8
    |
 LL |     if x == true {
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
@@ -7,127 +7,127 @@ LL |     if x == true {
    = note: `-D clippy::bool-comparison` implied by `-D warnings`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/bool_comparison.rs:12:8
+  --> $DIR/bool_comparison.rs:13:8
    |
 LL |     if x == false {
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: equality checks against true are unnecessary
-  --> $DIR/bool_comparison.rs:17:8
+  --> $DIR/bool_comparison.rs:18:8
    |
 LL |     if true == x {
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/bool_comparison.rs:22:8
+  --> $DIR/bool_comparison.rs:23:8
    |
 LL |     if false == x {
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: inequality checks against true can be replaced by a negation
-  --> $DIR/bool_comparison.rs:27:8
+  --> $DIR/bool_comparison.rs:28:8
    |
 LL |     if x != true {
    |        ^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: inequality checks against false are unnecessary
-  --> $DIR/bool_comparison.rs:32:8
+  --> $DIR/bool_comparison.rs:33:8
    |
 LL |     if x != false {
    |        ^^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: inequality checks against true can be replaced by a negation
-  --> $DIR/bool_comparison.rs:37:8
+  --> $DIR/bool_comparison.rs:38:8
    |
 LL |     if true != x {
    |        ^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: inequality checks against false are unnecessary
-  --> $DIR/bool_comparison.rs:42:8
+  --> $DIR/bool_comparison.rs:43:8
    |
 LL |     if false != x {
    |        ^^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: less than comparison against true can be replaced by a negation
-  --> $DIR/bool_comparison.rs:47:8
+  --> $DIR/bool_comparison.rs:48:8
    |
 LL |     if x < true {
    |        ^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: greater than checks against false are unnecessary
-  --> $DIR/bool_comparison.rs:52:8
+  --> $DIR/bool_comparison.rs:53:8
    |
 LL |     if false < x {
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: greater than checks against false are unnecessary
-  --> $DIR/bool_comparison.rs:57:8
+  --> $DIR/bool_comparison.rs:58:8
    |
 LL |     if x > false {
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: less than comparison against true can be replaced by a negation
-  --> $DIR/bool_comparison.rs:62:8
+  --> $DIR/bool_comparison.rs:63:8
    |
 LL |     if true > x {
    |        ^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: order comparisons between booleans can be simplified
-  --> $DIR/bool_comparison.rs:68:8
+  --> $DIR/bool_comparison.rs:69:8
    |
 LL |     if x < y {
    |        ^^^^^ help: try simplifying it as shown: `!x & y`
 
 error: order comparisons between booleans can be simplified
-  --> $DIR/bool_comparison.rs:73:8
+  --> $DIR/bool_comparison.rs:74:8
    |
 LL |     if x > y {
    |        ^^^^^ help: try simplifying it as shown: `x & !y`
 
 error: this comparison might be written more concisely
-  --> $DIR/bool_comparison.rs:121:8
+  --> $DIR/bool_comparison.rs:122:8
    |
 LL |     if a == !b {};
    |        ^^^^^^^ help: try simplifying it as shown: `a != b`
 
 error: this comparison might be written more concisely
-  --> $DIR/bool_comparison.rs:122:8
+  --> $DIR/bool_comparison.rs:123:8
    |
 LL |     if !a == b {};
    |        ^^^^^^^ help: try simplifying it as shown: `a != b`
 
 error: this comparison might be written more concisely
-  --> $DIR/bool_comparison.rs:126:8
+  --> $DIR/bool_comparison.rs:127:8
    |
 LL |     if b == !a {};
    |        ^^^^^^^ help: try simplifying it as shown: `b != a`
 
 error: this comparison might be written more concisely
-  --> $DIR/bool_comparison.rs:127:8
+  --> $DIR/bool_comparison.rs:128:8
    |
 LL |     if !b == a {};
    |        ^^^^^^^ help: try simplifying it as shown: `b != a`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/bool_comparison.rs:151:8
+  --> $DIR/bool_comparison.rs:152:8
    |
 LL |     if false == m!(func) {}
    |        ^^^^^^^^^^^^^^^^^ help: try simplifying it as shown: `!m!(func)`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/bool_comparison.rs:152:8
+  --> $DIR/bool_comparison.rs:153:8
    |
 LL |     if m!(func) == false {}
    |        ^^^^^^^^^^^^^^^^^ help: try simplifying it as shown: `!m!(func)`
 
 error: equality checks against true are unnecessary
-  --> $DIR/bool_comparison.rs:153:8
+  --> $DIR/bool_comparison.rs:154:8
    |
 LL |     if true == m!(func) {}
    |        ^^^^^^^^^^^^^^^^ help: try simplifying it as shown: `m!(func)`
 
 error: equality checks against true are unnecessary
-  --> $DIR/bool_comparison.rs:154:8
+  --> $DIR/bool_comparison.rs:155:8
    |
 LL |     if m!(func) == true {}
    |        ^^^^^^^^^^^^^^^^ help: try simplifying it as shown: `m!(func)`

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.fixed
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.fixed
@@ -1,5 +1,10 @@
 //@run-rustfix
-#![allow(unused, clippy::redundant_clone, clippy::derive_partial_eq_without_eq)] // See #5700
+#![allow(
+    unused,
+    clippy::needless_if,
+    clippy::redundant_clone,
+    clippy::derive_partial_eq_without_eq
+)] // See #5700
 
 // Define the types in each module to avoid trait impls leaking between modules.
 macro_rules! impl_types {

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.rs
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.rs
@@ -1,5 +1,10 @@
 //@run-rustfix
-#![allow(unused, clippy::redundant_clone, clippy::derive_partial_eq_without_eq)] // See #5700
+#![allow(
+    unused,
+    clippy::needless_if,
+    clippy::redundant_clone,
+    clippy::derive_partial_eq_without_eq
+)] // See #5700
 
 // Define the types in each module to avoid trait impls leaking between modules.
 macro_rules! impl_types {

--- a/tests/ui/cmp_owned/asymmetric_partial_eq.stderr
+++ b/tests/ui/cmp_owned/asymmetric_partial_eq.stderr
@@ -1,5 +1,5 @@
 error: this creates an owned instance just for comparison
-  --> $DIR/asymmetric_partial_eq.rs:42:12
+  --> $DIR/asymmetric_partial_eq.rs:47:12
    |
 LL |         if borrowed.to_owned() == owned {}
    |            ^^^^^^^^^^^^^^^^^^^ help: try: `borrowed`
@@ -7,7 +7,7 @@ LL |         if borrowed.to_owned() == owned {}
    = note: `-D clippy::cmp-owned` implied by `-D warnings`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/asymmetric_partial_eq.rs:43:21
+  --> $DIR/asymmetric_partial_eq.rs:48:21
    |
 LL |         if owned == borrowed.to_owned() {}
    |            ---------^^^^^^^^^^^^^^^^^^^
@@ -15,13 +15,13 @@ LL |         if owned == borrowed.to_owned() {}
    |            help: try: `borrowed == owned`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/asymmetric_partial_eq.rs:61:21
+  --> $DIR/asymmetric_partial_eq.rs:66:21
    |
 LL |         if owned == borrowed.to_owned() {}
    |                     ^^^^^^^^^^^^^^^^^^^ help: try: `borrowed`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/asymmetric_partial_eq.rs:62:12
+  --> $DIR/asymmetric_partial_eq.rs:67:12
    |
 LL |         if borrowed.to_owned() == owned {}
    |            ^^^^^^^^^^^^^^^^^^^---------
@@ -29,7 +29,7 @@ LL |         if borrowed.to_owned() == owned {}
    |            help: try: `owned == borrowed`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/asymmetric_partial_eq.rs:88:20
+  --> $DIR/asymmetric_partial_eq.rs:93:20
    |
 LL |         if "Hi" == borrowed.to_string() {}
    |            --------^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL |         if "Hi" == borrowed.to_string() {}
    |            help: try: `borrowed == "Hi"`
 
 error: this creates an owned instance just for comparison
-  --> $DIR/asymmetric_partial_eq.rs:89:12
+  --> $DIR/asymmetric_partial_eq.rs:94:12
    |
 LL |         if borrowed.to_string() == "Hi" {}
    |            ^^^^^^^^^^^^^^^^^^^^ help: try: `borrowed`

--- a/tests/ui/collapsible_else_if.fixed
+++ b/tests/ui/collapsible_else_if.fixed
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(clippy::assertions_on_constants, clippy::equatable_if_let)]
+#![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_if)]
 
 #[rustfmt::skip]
 #[warn(clippy::collapsible_if)]

--- a/tests/ui/collapsible_else_if.rs
+++ b/tests/ui/collapsible_else_if.rs
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(clippy::assertions_on_constants, clippy::equatable_if_let)]
+#![allow(clippy::assertions_on_constants, clippy::equatable_if_let, clippy::needless_if)]
 
 #[rustfmt::skip]
 #[warn(clippy::collapsible_if)]

--- a/tests/ui/collapsible_if.fixed
+++ b/tests/ui/collapsible_if.fixed
@@ -2,6 +2,7 @@
 #![allow(
     clippy::assertions_on_constants,
     clippy::equatable_if_let,
+    clippy::needless_if,
     clippy::nonminimal_bool,
     clippy::eq_op
 )]

--- a/tests/ui/collapsible_if.rs
+++ b/tests/ui/collapsible_if.rs
@@ -2,6 +2,7 @@
 #![allow(
     clippy::assertions_on_constants,
     clippy::equatable_if_let,
+    clippy::needless_if,
     clippy::nonminimal_bool,
     clippy::eq_op
 )]

--- a/tests/ui/collapsible_if.stderr
+++ b/tests/ui/collapsible_if.stderr
@@ -1,5 +1,5 @@
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:14:5
+  --> $DIR/collapsible_if.rs:15:5
    |
 LL | /     if x == "hello" {
 LL | |         if y == "world" {
@@ -17,7 +17,7 @@ LL +     }
    |
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:20:5
+  --> $DIR/collapsible_if.rs:21:5
    |
 LL | /     if x == "hello" || x == "world" {
 LL | |         if y == "world" || y == "hello" {
@@ -34,7 +34,7 @@ LL +     }
    |
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:26:5
+  --> $DIR/collapsible_if.rs:27:5
    |
 LL | /     if x == "hello" && x == "world" {
 LL | |         if y == "world" || y == "hello" {
@@ -51,7 +51,7 @@ LL +     }
    |
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:32:5
+  --> $DIR/collapsible_if.rs:33:5
    |
 LL | /     if x == "hello" || x == "world" {
 LL | |         if y == "world" && y == "hello" {
@@ -68,7 +68,7 @@ LL +     }
    |
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:38:5
+  --> $DIR/collapsible_if.rs:39:5
    |
 LL | /     if x == "hello" && x == "world" {
 LL | |         if y == "world" && y == "hello" {
@@ -85,7 +85,7 @@ LL +     }
    |
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:44:5
+  --> $DIR/collapsible_if.rs:45:5
    |
 LL | /     if 42 == 1337 {
 LL | |         if 'a' != 'A' {
@@ -102,7 +102,7 @@ LL +     }
    |
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:100:5
+  --> $DIR/collapsible_if.rs:101:5
    |
 LL | /     if x == "hello" {
 LL | |         if y == "world" { // Collapsible
@@ -119,7 +119,7 @@ LL +     }
    |
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:159:5
+  --> $DIR/collapsible_if.rs:160:5
    |
 LL | /     if matches!(true, true) {
 LL | |         if matches!(true, true) {}
@@ -127,7 +127,7 @@ LL | |     }
    | |_____^ help: collapse nested if block: `if matches!(true, true) && matches!(true, true) {}`
 
 error: this `if` statement can be collapsed
-  --> $DIR/collapsible_if.rs:164:5
+  --> $DIR/collapsible_if.rs:165:5
    |
 LL | /     if matches!(true, true) && truth() {
 LL | |         if matches!(true, true) {}

--- a/tests/ui/crashes/ice-3462.rs
+++ b/tests/ui/crashes/ice-3462.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::all)]
-#![allow(clippy::disallowed_names, clippy::equatable_if_let)]
+#![allow(clippy::disallowed_names, clippy::equatable_if_let, clippy::needless_if)]
 #![allow(unused)]
 
 /// Test for https://github.com/rust-lang/rust-clippy/issues/3462

--- a/tests/ui/crashes/ice-7169.rs
+++ b/tests/ui/crashes/ice-7169.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_if)]
+
 #[derive(Default)]
 struct A<T> {
     a: Vec<A<T>>,

--- a/tests/ui/crashes/ice-7169.stderr
+++ b/tests/ui/crashes/ice-7169.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/ice-7169.rs:8:12
+  --> $DIR/ice-7169.rs:10:12
    |
 LL |     if let Ok(_) = Ok::<_, ()>(A::<String>::default()) {}
    |     -------^^^^^-------------------------------------- help: try this: `if Ok::<_, ()>(A::<String>::default()).is_ok()`

--- a/tests/ui/disallowed_names.rs
+++ b/tests/ui/disallowed_names.rs
@@ -1,5 +1,6 @@
 #![allow(
     dead_code,
+    clippy::needless_if,
     clippy::similar_names,
     clippy::single_match,
     clippy::toplevel_ref_arg,

--- a/tests/ui/disallowed_names.stderr
+++ b/tests/ui/disallowed_names.stderr
@@ -1,5 +1,5 @@
 error: use of a disallowed/placeholder name `foo`
-  --> $DIR/disallowed_names.rs:11:9
+  --> $DIR/disallowed_names.rs:12:9
    |
 LL | fn test(foo: ()) {}
    |         ^^^
@@ -7,79 +7,79 @@ LL | fn test(foo: ()) {}
    = note: `-D clippy::disallowed-names` implied by `-D warnings`
 
 error: use of a disallowed/placeholder name `foo`
-  --> $DIR/disallowed_names.rs:14:9
+  --> $DIR/disallowed_names.rs:15:9
    |
 LL |     let foo = 42;
    |         ^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> $DIR/disallowed_names.rs:15:9
+  --> $DIR/disallowed_names.rs:16:9
    |
 LL |     let baz = 42;
    |         ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> $DIR/disallowed_names.rs:16:9
+  --> $DIR/disallowed_names.rs:17:9
    |
 LL |     let quux = 42;
    |         ^^^^
 
 error: use of a disallowed/placeholder name `foo`
-  --> $DIR/disallowed_names.rs:27:10
+  --> $DIR/disallowed_names.rs:28:10
    |
 LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |          ^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> $DIR/disallowed_names.rs:27:20
+  --> $DIR/disallowed_names.rs:28:20
    |
 LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |                    ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> $DIR/disallowed_names.rs:27:26
+  --> $DIR/disallowed_names.rs:28:26
    |
 LL |         (foo, Some(baz), quux @ Some(_)) => (),
    |                          ^^^^
 
 error: use of a disallowed/placeholder name `foo`
-  --> $DIR/disallowed_names.rs:32:19
+  --> $DIR/disallowed_names.rs:33:19
    |
 LL | fn issue_1647(mut foo: u8) {
    |                   ^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> $DIR/disallowed_names.rs:33:13
+  --> $DIR/disallowed_names.rs:34:13
    |
 LL |     let mut baz = 0;
    |             ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> $DIR/disallowed_names.rs:34:21
+  --> $DIR/disallowed_names.rs:35:21
    |
 LL |     if let Some(mut quux) = Some(42) {}
    |                     ^^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> $DIR/disallowed_names.rs:38:13
+  --> $DIR/disallowed_names.rs:39:13
    |
 LL |     let ref baz = 0;
    |             ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> $DIR/disallowed_names.rs:39:21
+  --> $DIR/disallowed_names.rs:40:21
    |
 LL |     if let Some(ref quux) = Some(42) {}
    |                     ^^^^
 
 error: use of a disallowed/placeholder name `baz`
-  --> $DIR/disallowed_names.rs:43:17
+  --> $DIR/disallowed_names.rs:44:17
    |
 LL |     let ref mut baz = 0;
    |                 ^^^
 
 error: use of a disallowed/placeholder name `quux`
-  --> $DIR/disallowed_names.rs:44:25
+  --> $DIR/disallowed_names.rs:45:25
    |
 LL |     if let Some(ref mut quux) = Some(42) {}
    |                         ^^^^

--- a/tests/ui/double_comparison.fixed
+++ b/tests/ui/double_comparison.fixed
@@ -1,4 +1,5 @@
 //@run-rustfix
+#![allow(clippy::needless_if)]
 
 fn main() {
     let x = 1;

--- a/tests/ui/double_comparison.rs
+++ b/tests/ui/double_comparison.rs
@@ -1,4 +1,5 @@
 //@run-rustfix
+#![allow(clippy::needless_if)]
 
 fn main() {
     let x = 1;

--- a/tests/ui/double_comparison.stderr
+++ b/tests/ui/double_comparison.stderr
@@ -1,5 +1,5 @@
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:6:8
+  --> $DIR/double_comparison.rs:7:8
    |
 LL |     if x == y || x < y {
    |        ^^^^^^^^^^^^^^^ help: try: `x <= y`
@@ -7,43 +7,43 @@ LL |     if x == y || x < y {
    = note: `-D clippy::double-comparisons` implied by `-D warnings`
 
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:9:8
+  --> $DIR/double_comparison.rs:10:8
    |
 LL |     if x < y || x == y {
    |        ^^^^^^^^^^^^^^^ help: try: `x <= y`
 
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:12:8
+  --> $DIR/double_comparison.rs:13:8
    |
 LL |     if x == y || x > y {
    |        ^^^^^^^^^^^^^^^ help: try: `x >= y`
 
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:15:8
+  --> $DIR/double_comparison.rs:16:8
    |
 LL |     if x > y || x == y {
    |        ^^^^^^^^^^^^^^^ help: try: `x >= y`
 
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:18:8
+  --> $DIR/double_comparison.rs:19:8
    |
 LL |     if x < y || x > y {
    |        ^^^^^^^^^^^^^^ help: try: `x != y`
 
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:21:8
+  --> $DIR/double_comparison.rs:22:8
    |
 LL |     if x > y || x < y {
    |        ^^^^^^^^^^^^^^ help: try: `x != y`
 
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:24:8
+  --> $DIR/double_comparison.rs:25:8
    |
 LL |     if x <= y && x >= y {
    |        ^^^^^^^^^^^^^^^^ help: try: `x == y`
 
 error: this binary expression can be simplified
-  --> $DIR/double_comparison.rs:27:8
+  --> $DIR/double_comparison.rs:28:8
    |
 LL |     if x >= y && x <= y {
    |        ^^^^^^^^^^^^^^^^ help: try: `x == y`

--- a/tests/ui/equatable_if_let.fixed
+++ b/tests/ui/equatable_if_let.fixed
@@ -1,7 +1,12 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
 
-#![allow(unused_variables, dead_code, clippy::derive_partial_eq_without_eq)]
+#![allow(
+    unused_variables,
+    dead_code,
+    clippy::derive_partial_eq_without_eq,
+    clippy::needless_if
+)]
 #![warn(clippy::equatable_if_let)]
 
 extern crate proc_macros;

--- a/tests/ui/equatable_if_let.rs
+++ b/tests/ui/equatable_if_let.rs
@@ -1,7 +1,12 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
 
-#![allow(unused_variables, dead_code, clippy::derive_partial_eq_without_eq)]
+#![allow(
+    unused_variables,
+    dead_code,
+    clippy::derive_partial_eq_without_eq,
+    clippy::needless_if
+)]
 #![warn(clippy::equatable_if_let)]
 
 extern crate proc_macros;

--- a/tests/ui/equatable_if_let.stderr
+++ b/tests/ui/equatable_if_let.stderr
@@ -1,5 +1,5 @@
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:60:8
+  --> $DIR/equatable_if_let.rs:65:8
    |
 LL |     if let 2 = a {}
    |        ^^^^^^^^^ help: try: `a == 2`
@@ -7,79 +7,79 @@ LL |     if let 2 = a {}
    = note: `-D clippy::equatable-if-let` implied by `-D warnings`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:61:8
+  --> $DIR/equatable_if_let.rs:66:8
    |
 LL |     if let Ordering::Greater = a.cmp(&b) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.cmp(&b) == Ordering::Greater`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:62:8
+  --> $DIR/equatable_if_let.rs:67:8
    |
 LL |     if let Some(2) = c {}
    |        ^^^^^^^^^^^^^^^ help: try: `c == Some(2)`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:63:8
+  --> $DIR/equatable_if_let.rs:68:8
    |
 LL |     if let Struct { a: 2, b: false } = d {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `d == (Struct { a: 2, b: false })`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:64:8
+  --> $DIR/equatable_if_let.rs:69:8
    |
 LL |     if let Enum::TupleVariant(32, 64) = e {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `e == Enum::TupleVariant(32, 64)`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:65:8
+  --> $DIR/equatable_if_let.rs:70:8
    |
 LL |     if let Enum::RecordVariant { a: 64, b: 32 } = e {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `e == (Enum::RecordVariant { a: 64, b: 32 })`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:66:8
+  --> $DIR/equatable_if_let.rs:71:8
    |
 LL |     if let Enum::UnitVariant = e {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `e == Enum::UnitVariant`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:67:8
+  --> $DIR/equatable_if_let.rs:72:8
    |
 LL |     if let (Enum::UnitVariant, &Struct { a: 2, b: false }) = (e, &d) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(e, &d) == (Enum::UnitVariant, &Struct { a: 2, b: false })`
 
 error: this pattern matching can be expressed using `matches!`
-  --> $DIR/equatable_if_let.rs:76:8
+  --> $DIR/equatable_if_let.rs:81:8
    |
 LL |     if let NotPartialEq::A = f {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(f, NotPartialEq::A)`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:77:8
+  --> $DIR/equatable_if_let.rs:82:8
    |
 LL |     if let NotStructuralEq::A = g {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `g == NotStructuralEq::A`
 
 error: this pattern matching can be expressed using `matches!`
-  --> $DIR/equatable_if_let.rs:78:8
+  --> $DIR/equatable_if_let.rs:83:8
    |
 LL |     if let Some(NotPartialEq::A) = Some(f) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(Some(f), Some(NotPartialEq::A))`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:79:8
+  --> $DIR/equatable_if_let.rs:84:8
    |
 LL |     if let Some(NotStructuralEq::A) = Some(g) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(g) == Some(NotStructuralEq::A)`
 
 error: this pattern matching can be expressed using `matches!`
-  --> $DIR/equatable_if_let.rs:80:8
+  --> $DIR/equatable_if_let.rs:85:8
    |
 LL |     if let NoPartialEqStruct { a: 2, b: false } = h {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(h, NoPartialEqStruct { a: 2, b: false })`
 
 error: this pattern matching can be expressed using equality
-  --> $DIR/equatable_if_let.rs:82:8
+  --> $DIR/equatable_if_let.rs:87:8
    |
 LL |     if let inline!("abc") = "abc" {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"abc" == inline!("abc")`

--- a/tests/ui/expect_tool_lint_rfc_2383.rs
+++ b/tests/ui/expect_tool_lint_rfc_2383.rs
@@ -11,6 +11,7 @@
 //! This test can't cover every lint from Clippy, rustdoc and potentially other
 //! tools that will be developed. This therefore only tests a small subset of lints
 #![expect(rustdoc::missing_crate_level_docs)]
+#![allow(clippy::needless_if)]
 
 mod rustc_ok {
     //! See <https://doc.rust-lang.org/rustc/lints/index.html>

--- a/tests/ui/expect_tool_lint_rfc_2383.stderr
+++ b/tests/ui/expect_tool_lint_rfc_2383.stderr
@@ -1,5 +1,5 @@
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:34:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:35:14
    |
 LL |     #[expect(dead_code)]
    |              ^^^^^^^^^
@@ -7,31 +7,31 @@ LL |     #[expect(dead_code)]
    = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:38:18
+  --> $DIR/expect_tool_lint_rfc_2383.rs:39:18
    |
 LL |         #[expect(illegal_floating_point_literal_pattern)]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:112:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:113:14
    |
 LL |     #[expect(clippy::almost_swapped)]
    |              ^^^^^^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:119:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:120:14
    |
 LL |     #[expect(clippy::bytes_nth)]
    |              ^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:124:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:125:14
    |
 LL |     #[expect(clippy::if_same_then_else)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
-  --> $DIR/expect_tool_lint_rfc_2383.rs:129:14
+  --> $DIR/expect_tool_lint_rfc_2383.rs:130:14
    |
 LL |     #[expect(clippy::overly_complex_bool_expr)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/filetype_is_file.rs
+++ b/tests/ui/filetype_is_file.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_if)]
 #![warn(clippy::filetype_is_file)]
 
 fn main() -> std::io::Result<()> {

--- a/tests/ui/filetype_is_file.stderr
+++ b/tests/ui/filetype_is_file.stderr
@@ -1,5 +1,5 @@
 error: `FileType::is_file()` only covers regular files
-  --> $DIR/filetype_is_file.rs:8:8
+  --> $DIR/filetype_is_file.rs:9:8
    |
 LL |     if fs::metadata("foo.txt")?.file_type().is_file() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     if fs::metadata("foo.txt")?.file_type().is_file() {
    = note: `-D clippy::filetype-is-file` implied by `-D warnings`
 
 error: `!FileType::is_file()` only denies regular files
-  --> $DIR/filetype_is_file.rs:13:8
+  --> $DIR/filetype_is_file.rs:14:8
    |
 LL |     if !fs::metadata("foo.txt")?.file_type().is_file() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     if !fs::metadata("foo.txt")?.file_type().is_file() {
    = help: use `FileType::is_dir()` instead
 
 error: `FileType::is_file()` only covers regular files
-  --> $DIR/filetype_is_file.rs:18:9
+  --> $DIR/filetype_is_file.rs:19:9
    |
 LL |     if !fs::metadata("foo.txt")?.file_type().is_file().bitor(true) {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/fn_null_check.rs
+++ b/tests/ui/fn_null_check.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 #![warn(clippy::fn_null_check)]
 #![allow(clippy::cmp_null)]
+#![allow(clippy::needless_if)]
 #![allow(clippy::ptr_eq)]
 #![allow(clippy::zero_ptr)]
 

--- a/tests/ui/fn_null_check.stderr
+++ b/tests/ui/fn_null_check.stderr
@@ -1,5 +1,5 @@
 error: function pointer assumed to be nullable, even though it isn't
-  --> $DIR/fn_null_check.rs:13:8
+  --> $DIR/fn_null_check.rs:14:8
    |
 LL |     if (fn_ptr as *mut ()).is_null() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     if (fn_ptr as *mut ()).is_null() {}
    = note: `-D clippy::fn-null-check` implied by `-D warnings`
 
 error: function pointer assumed to be nullable, even though it isn't
-  --> $DIR/fn_null_check.rs:14:8
+  --> $DIR/fn_null_check.rs:15:8
    |
 LL |     if (fn_ptr as *const u8).is_null() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     if (fn_ptr as *const u8).is_null() {}
    = help: try wrapping your function pointer type in `Option<T>` instead, and using `is_none` to check for null pointer value
 
 error: function pointer assumed to be nullable, even though it isn't
-  --> $DIR/fn_null_check.rs:15:8
+  --> $DIR/fn_null_check.rs:16:8
    |
 LL |     if (fn_ptr as *const ()) == std::ptr::null() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     if (fn_ptr as *const ()) == std::ptr::null() {}
    = help: try wrapping your function pointer type in `Option<T>` instead, and using `is_none` to check for null pointer value
 
 error: function pointer assumed to be nullable, even though it isn't
-  --> $DIR/fn_null_check.rs:16:8
+  --> $DIR/fn_null_check.rs:17:8
    |
 LL |     if (fn_ptr as *const ()) == (0 as *const ()) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     if (fn_ptr as *const ()) == (0 as *const ()) {}
    = help: try wrapping your function pointer type in `Option<T>` instead, and using `is_none` to check for null pointer value
 
 error: function pointer assumed to be nullable, even though it isn't
-  --> $DIR/fn_null_check.rs:17:8
+  --> $DIR/fn_null_check.rs:18:8
    |
 LL |     if (fn_ptr as *const ()) == ZPTR {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/if_same_then_else2.rs
+++ b/tests/ui/if_same_then_else2.rs
@@ -5,6 +5,7 @@
     clippy::equatable_if_let,
     clippy::collapsible_if,
     clippy::ifs_same_cond,
+    clippy::needless_if,
     clippy::needless_return,
     clippy::single_element_loop,
     clippy::branches_sharing_code

--- a/tests/ui/if_same_then_else2.stderr
+++ b/tests/ui/if_same_then_else2.stderr
@@ -1,5 +1,5 @@
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else2.rs:14:13
+  --> $DIR/if_same_then_else2.rs:15:13
    |
 LL |       if true {
    |  _____________^
@@ -12,7 +12,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else2.rs:23:12
+  --> $DIR/if_same_then_else2.rs:24:12
    |
 LL |       } else {
    |  ____________^
@@ -26,7 +26,7 @@ LL | |     }
    = note: `-D clippy::if-same-then-else` implied by `-D warnings`
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else2.rs:35:13
+  --> $DIR/if_same_then_else2.rs:36:13
    |
 LL |       if true {
    |  _____________^
@@ -35,7 +35,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else2.rs:37:12
+  --> $DIR/if_same_then_else2.rs:38:12
    |
 LL |       } else {
    |  ____________^
@@ -45,7 +45,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else2.rs:42:13
+  --> $DIR/if_same_then_else2.rs:43:13
    |
 LL |       if true {
    |  _____________^
@@ -54,7 +54,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else2.rs:44:12
+  --> $DIR/if_same_then_else2.rs:45:12
    |
 LL |       } else {
    |  ____________^
@@ -64,7 +64,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else2.rs:92:21
+  --> $DIR/if_same_then_else2.rs:93:21
    |
 LL |       let _ = if true {
    |  _____________________^
@@ -73,7 +73,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else2.rs:94:12
+  --> $DIR/if_same_then_else2.rs:95:12
    |
 LL |       } else {
    |  ____________^
@@ -83,7 +83,7 @@ LL | |     };
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else2.rs:99:13
+  --> $DIR/if_same_then_else2.rs:100:13
    |
 LL |       if true {
    |  _____________^
@@ -92,7 +92,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else2.rs:101:12
+  --> $DIR/if_same_then_else2.rs:102:12
    |
 LL |       } else {
    |  ____________^
@@ -102,7 +102,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> $DIR/if_same_then_else2.rs:123:20
+  --> $DIR/if_same_then_else2.rs:124:20
    |
 LL |       } else if true {
    |  ____________________^
@@ -112,7 +112,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/if_same_then_else2.rs:126:12
+  --> $DIR/if_same_then_else2.rs:127:12
    |
 LL |       } else {
    |  ____________^

--- a/tests/ui/ifs_same_cond.rs
+++ b/tests/ui/ifs_same_cond.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::ifs_same_cond)]
-#![allow(clippy::if_same_then_else, clippy::comparison_chain, clippy::needless_else)] // all empty blocks
+#![allow(
+    clippy::if_same_then_else,
+    clippy::comparison_chain,
+    clippy::needless_if,
+    clippy::needless_else
+)] // all empty blocks
 
 fn ifs_same_cond() {
     let a = 0;

--- a/tests/ui/ifs_same_cond.stderr
+++ b/tests/ui/ifs_same_cond.stderr
@@ -1,48 +1,48 @@
 error: this `if` has the same condition as a previous `if`
-  --> $DIR/ifs_same_cond.rs:9:15
+  --> $DIR/ifs_same_cond.rs:14:15
    |
 LL |     } else if b {
    |               ^
    |
 note: same as this
-  --> $DIR/ifs_same_cond.rs:8:8
+  --> $DIR/ifs_same_cond.rs:13:8
    |
 LL |     if b {
    |        ^
    = note: `-D clippy::ifs-same-cond` implied by `-D warnings`
 
 error: this `if` has the same condition as a previous `if`
-  --> $DIR/ifs_same_cond.rs:14:15
+  --> $DIR/ifs_same_cond.rs:19:15
    |
 LL |     } else if a == 1 {
    |               ^^^^^^
    |
 note: same as this
-  --> $DIR/ifs_same_cond.rs:13:8
+  --> $DIR/ifs_same_cond.rs:18:8
    |
 LL |     if a == 1 {
    |        ^^^^^^
 
 error: this `if` has the same condition as a previous `if`
-  --> $DIR/ifs_same_cond.rs:20:15
+  --> $DIR/ifs_same_cond.rs:25:15
    |
 LL |     } else if 2 * a == 1 {
    |               ^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/ifs_same_cond.rs:18:8
+  --> $DIR/ifs_same_cond.rs:23:8
    |
 LL |     if 2 * a == 1 {
    |        ^^^^^^^^^^
 
 error: this `if` has the same condition as a previous `if`
-  --> $DIR/ifs_same_cond.rs:49:15
+  --> $DIR/ifs_same_cond.rs:54:15
    |
 LL |     } else if a.contains("ah") {
    |               ^^^^^^^^^^^^^^^^
    |
 note: same as this
-  --> $DIR/ifs_same_cond.rs:48:8
+  --> $DIR/ifs_same_cond.rs:53:8
    |
 LL |     if a.contains("ah") {
    |        ^^^^^^^^^^^^^^^^

--- a/tests/ui/len_zero.fixed
+++ b/tests/ui/len_zero.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::len_zero)]
-#![allow(dead_code, unused, clippy::len_without_is_empty)]
+#![allow(dead_code, unused, clippy::needless_if, clippy::len_without_is_empty)]
 
 extern crate core;
 use core::ops::Deref;

--- a/tests/ui/len_zero.rs
+++ b/tests/ui/len_zero.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![warn(clippy::len_zero)]
-#![allow(dead_code, unused, clippy::len_without_is_empty)]
+#![allow(dead_code, unused, clippy::needless_if, clippy::len_without_is_empty)]
 
 extern crate core;
 use core::ops::Deref;

--- a/tests/ui/manual_let_else.rs
+++ b/tests/ui/manual_let_else.rs
@@ -4,7 +4,8 @@
     clippy::unused_unit,
     clippy::let_unit_value,
     clippy::match_single_binding,
-    clippy::never_loop
+    clippy::never_loop,
+    clippy::needless_if
 )]
 #![warn(clippy::manual_let_else)]
 

--- a/tests/ui/manual_let_else.stderr
+++ b/tests/ui/manual_let_else.stderr
@@ -1,5 +1,5 @@
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:24:5
+  --> $DIR/manual_let_else.rs:25:5
    |
 LL |     let v = if let Some(v_some) = g() { v_some } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { return };`
@@ -7,7 +7,7 @@ LL |     let v = if let Some(v_some) = g() { v_some } else { return };
    = note: `-D clippy::manual-let-else` implied by `-D warnings`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:25:5
+  --> $DIR/manual_let_else.rs:26:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -24,7 +24,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:31:5
+  --> $DIR/manual_let_else.rs:32:5
    |
 LL | /     let v = if let Some(v) = g() {
 LL | |         // Blocks around the identity should have no impact
@@ -45,25 +45,25 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:44:9
+  --> $DIR/manual_let_else.rs:45:9
    |
 LL |         let v = if let Some(v_some) = g() { v_some } else { continue };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { continue };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:45:9
+  --> $DIR/manual_let_else.rs:46:9
    |
 LL |         let v = if let Some(v_some) = g() { v_some } else { break };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { break };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:49:5
+  --> $DIR/manual_let_else.rs:50:5
    |
 LL |     let v = if let Some(v_some) = g() { v_some } else { panic!() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { panic!() };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:52:5
+  --> $DIR/manual_let_else.rs:53:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -80,7 +80,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:59:5
+  --> $DIR/manual_let_else.rs:60:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -97,7 +97,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:66:5
+  --> $DIR/manual_let_else.rs:67:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -116,7 +116,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:76:5
+  --> $DIR/manual_let_else.rs:77:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -138,13 +138,13 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:86:5
+  --> $DIR/manual_let_else.rs:87:5
    |
 LL |     let v = if let Some(v_some) = g() { v_some } else { if panic!() {} };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { if panic!() {} };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:89:5
+  --> $DIR/manual_let_else.rs:90:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -165,7 +165,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:98:5
+  --> $DIR/manual_let_else.rs:99:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -186,7 +186,7 @@ LL +     } };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:107:5
+  --> $DIR/manual_let_else.rs:108:5
    |
 LL | /     let v = if let Some(v_some) = g() {
 LL | |         v_some
@@ -215,7 +215,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:124:5
+  --> $DIR/manual_let_else.rs:125:5
    |
 LL | /     let (v, w) = if let Some(v_some) = g().map(|v| (v, 42)) {
 LL | |         v_some
@@ -232,7 +232,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:131:5
+  --> $DIR/manual_let_else.rs:132:5
    |
 LL | /     let (w, S { v }) = if let (Some(v_some), w_some) = (g().map(|_| S { v: 0 }), 0) {
 LL | |         (w_some, v_some)
@@ -249,7 +249,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:140:13
+  --> $DIR/manual_let_else.rs:141:13
    |
 LL |             let $n = if let Some(v) = $e { v } else { return };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some($n) = g() else { return };`
@@ -260,19 +260,19 @@ LL |     create_binding_if_some!(w, g());
    = note: this error originates in the macro `create_binding_if_some` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:149:5
+  --> $DIR/manual_let_else.rs:150:5
    |
 LL |     let v = if let Variant::A(a, 0) = e() { a } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Variant::A(v, 0) = e() else { return };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:152:5
+  --> $DIR/manual_let_else.rs:153:5
    |
 LL |     let mut v = if let Variant::B(b) = e() { b } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Variant::B(mut v) = e() else { return };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:156:5
+  --> $DIR/manual_let_else.rs:157:5
    |
 LL | /     let v = if let Ok(Some(Variant::B(b))) | Err(Some(Variant::A(b, _))) = nested {
 LL | |         b
@@ -289,19 +289,19 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:162:5
+  --> $DIR/manual_let_else.rs:163:5
    |
 LL |     let v = if let Variant::A(.., a) = e() { a } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Variant::A(.., v) = e() else { return };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:165:5
+  --> $DIR/manual_let_else.rs:166:5
    |
 LL |     let w = if let (Some(v), ()) = (g(), ()) { v } else { return };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let (Some(w), ()) = (g(), ()) else { return };`
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:168:5
+  --> $DIR/manual_let_else.rs:169:5
    |
 LL | /     let w = if let Some(S { v: x }) = Some(S { v: 0 }) {
 LL | |         x
@@ -318,7 +318,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:175:5
+  --> $DIR/manual_let_else.rs:176:5
    |
 LL | /     let v = if let Some(S { v: x }) = Some(S { v: 0 }) {
 LL | |         x
@@ -335,7 +335,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:182:5
+  --> $DIR/manual_let_else.rs:183:5
    |
 LL | /     let (x, S { v }, w) = if let Some(U { v, w, x }) = None::<U<S<()>>> {
 LL | |         (x, v, w)
@@ -352,7 +352,7 @@ LL +     };
    |
 
 error: this could be rewritten as `let...else`
-  --> $DIR/manual_let_else.rs:296:5
+  --> $DIR/manual_let_else.rs:297:5
    |
 LL | /     let _ = match ff {
 LL | |         Some(value) => value,

--- a/tests/ui/match_overlapping_arm.rs
+++ b/tests/ui/match_overlapping_arm.rs
@@ -1,7 +1,7 @@
 #![feature(exclusive_range_pattern)]
 #![warn(clippy::match_overlapping_arm)]
 #![allow(clippy::redundant_pattern_matching)]
-#![allow(clippy::if_same_then_else, clippy::equatable_if_let)]
+#![allow(clippy::if_same_then_else, clippy::equatable_if_let, clippy::needless_if)]
 
 /// Tests for match_overlapping_arm
 

--- a/tests/ui/needless_bool/fixable.fixed
+++ b/tests/ui/needless_bool/fixable.fixed
@@ -7,6 +7,7 @@
     clippy::no_effect,
     clippy::if_same_then_else,
     clippy::equatable_if_let,
+    clippy::needless_if,
     clippy::needless_return,
     clippy::self_named_constructors
 )]

--- a/tests/ui/needless_bool/fixable.rs
+++ b/tests/ui/needless_bool/fixable.rs
@@ -7,6 +7,7 @@
     clippy::no_effect,
     clippy::if_same_then_else,
     clippy::equatable_if_let,
+    clippy::needless_if,
     clippy::needless_return,
     clippy::self_named_constructors
 )]

--- a/tests/ui/needless_bool/fixable.stderr
+++ b/tests/ui/needless_bool/fixable.stderr
@@ -1,5 +1,5 @@
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:41:5
+  --> $DIR/fixable.rs:42:5
    |
 LL | /     if x {
 LL | |         true
@@ -11,7 +11,7 @@ LL | |     };
    = note: `-D clippy::needless-bool` implied by `-D warnings`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:46:5
+  --> $DIR/fixable.rs:47:5
    |
 LL | /     if x {
 LL | |         false
@@ -21,7 +21,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `!x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:51:5
+  --> $DIR/fixable.rs:52:5
    |
 LL | /     if x && y {
 LL | |         false
@@ -31,7 +31,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `!(x && y)`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:59:5
+  --> $DIR/fixable.rs:60:5
    |
 LL | /     if a == b {
 LL | |         false
@@ -41,7 +41,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a != b`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:64:5
+  --> $DIR/fixable.rs:65:5
    |
 LL | /     if a != b {
 LL | |         false
@@ -51,7 +51,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a == b`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:69:5
+  --> $DIR/fixable.rs:70:5
    |
 LL | /     if a < b {
 LL | |         false
@@ -61,7 +61,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a >= b`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:74:5
+  --> $DIR/fixable.rs:75:5
    |
 LL | /     if a <= b {
 LL | |         false
@@ -71,7 +71,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a > b`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:79:5
+  --> $DIR/fixable.rs:80:5
    |
 LL | /     if a > b {
 LL | |         false
@@ -81,7 +81,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a <= b`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:84:5
+  --> $DIR/fixable.rs:85:5
    |
 LL | /     if a >= b {
 LL | |         false
@@ -91,7 +91,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `a < b`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:112:5
+  --> $DIR/fixable.rs:113:5
    |
 LL | /     if x {
 LL | |         return true;
@@ -101,7 +101,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:120:5
+  --> $DIR/fixable.rs:121:5
    |
 LL | /     if x {
 LL | |         return false;
@@ -111,7 +111,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return !x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:128:5
+  --> $DIR/fixable.rs:129:5
    |
 LL | /     if x && y {
 LL | |         return true;
@@ -121,7 +121,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return x && y`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:136:5
+  --> $DIR/fixable.rs:137:5
    |
 LL | /     if x && y {
 LL | |         return false;
@@ -131,7 +131,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `return !(x && y)`
 
 error: equality checks against true are unnecessary
-  --> $DIR/fixable.rs:144:8
+  --> $DIR/fixable.rs:145:8
    |
 LL |     if x == true {};
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
@@ -139,25 +139,25 @@ LL |     if x == true {};
    = note: `-D clippy::bool-comparison` implied by `-D warnings`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/fixable.rs:148:8
+  --> $DIR/fixable.rs:149:8
    |
 LL |     if x == false {};
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: equality checks against true are unnecessary
-  --> $DIR/fixable.rs:158:8
+  --> $DIR/fixable.rs:159:8
    |
 LL |     if x == true {};
    |        ^^^^^^^^^ help: try simplifying it as shown: `x`
 
 error: equality checks against false can be replaced by a negation
-  --> $DIR/fixable.rs:159:8
+  --> $DIR/fixable.rs:160:8
    |
 LL |     if x == false {};
    |        ^^^^^^^^^^ help: try simplifying it as shown: `!x`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:168:12
+  --> $DIR/fixable.rs:169:12
    |
 LL |       } else if returns_bool() {
    |  ____________^
@@ -168,7 +168,7 @@ LL | |     };
    | |_____^ help: you can reduce it to: `{ !returns_bool() }`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:181:5
+  --> $DIR/fixable.rs:182:5
    |
 LL | /     if unsafe { no(4) } & 1 != 0 {
 LL | |         true
@@ -178,13 +178,13 @@ LL | |     };
    | |_____^ help: you can reduce it to: `(unsafe { no(4) } & 1 != 0)`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:186:30
+  --> $DIR/fixable.rs:187:30
    |
 LL |     let _brackets_unneeded = if unsafe { no(4) } & 1 != 0 { true } else { false };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `unsafe { no(4) } & 1 != 0`
 
 error: this if-then-else expression returns a bool literal
-  --> $DIR/fixable.rs:189:9
+  --> $DIR/fixable.rs:190:9
    |
 LL |         if unsafe { no(4) } & 1 != 0 { true } else { false }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `(unsafe { no(4) } & 1 != 0)`

--- a/tests/ui/needless_borrowed_ref.fixed
+++ b/tests/ui/needless_borrowed_ref.fixed
@@ -5,7 +5,8 @@
     unused,
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::needless_if
 )]
 
 fn main() {}

--- a/tests/ui/needless_borrowed_ref.rs
+++ b/tests/ui/needless_borrowed_ref.rs
@@ -5,7 +5,8 @@
     unused,
     irrefutable_let_patterns,
     non_shorthand_field_patterns,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::needless_if
 )]
 
 fn main() {}

--- a/tests/ui/needless_borrowed_ref.stderr
+++ b/tests/ui/needless_borrowed_ref.stderr
@@ -1,5 +1,5 @@
 error: this pattern takes a reference on something that is being dereferenced
-  --> $DIR/needless_borrowed_ref.rs:31:34
+  --> $DIR/needless_borrowed_ref.rs:32:34
    |
 LL |     let _ = v.iter_mut().filter(|&ref a| a.is_empty());
    |                                  ^^^^^^
@@ -12,7 +12,7 @@ LL +     let _ = v.iter_mut().filter(|a| a.is_empty());
    |
 
 error: this pattern takes a reference on something that is being dereferenced
-  --> $DIR/needless_borrowed_ref.rs:35:17
+  --> $DIR/needless_borrowed_ref.rs:36:17
    |
 LL |     if let Some(&ref v) = thingy {}
    |                 ^^^^^^
@@ -24,7 +24,7 @@ LL +     if let Some(v) = thingy {}
    |
 
 error: this pattern takes a reference on something that is being dereferenced
-  --> $DIR/needless_borrowed_ref.rs:37:14
+  --> $DIR/needless_borrowed_ref.rs:38:14
    |
 LL |     if let &[&ref a, ref b] = slice_of_refs {}
    |              ^^^^^^
@@ -36,7 +36,7 @@ LL +     if let &[a, ref b] = slice_of_refs {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:39:9
+  --> $DIR/needless_borrowed_ref.rs:40:9
    |
 LL |     let &[ref a, ..] = &array;
    |         ^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL +     let [a, ..] = &array;
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:40:9
+  --> $DIR/needless_borrowed_ref.rs:41:9
    |
 LL |     let &[ref a, ref b, ..] = &array;
    |         ^^^^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL +     let [a, b, ..] = &array;
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:42:12
+  --> $DIR/needless_borrowed_ref.rs:43:12
    |
 LL |     if let &[ref a, ref b] = slice {}
    |            ^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL +     if let [a, b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:43:12
+  --> $DIR/needless_borrowed_ref.rs:44:12
    |
 LL |     if let &[ref a, ref b] = &vec[..] {}
    |            ^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL +     if let [a, b] = &vec[..] {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:45:12
+  --> $DIR/needless_borrowed_ref.rs:46:12
    |
 LL |     if let &[ref a, ref b, ..] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL +     if let [a, b, ..] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:46:12
+  --> $DIR/needless_borrowed_ref.rs:47:12
    |
 LL |     if let &[ref a, .., ref b] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL +     if let [a, .., b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:47:12
+  --> $DIR/needless_borrowed_ref.rs:48:12
    |
 LL |     if let &[.., ref a, ref b] = slice {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -120,7 +120,7 @@ LL +     if let [.., a, b] = slice {}
    |
 
 error: dereferencing a slice pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:49:12
+  --> $DIR/needless_borrowed_ref.rs:50:12
    |
 LL |     if let &[ref a, _] = slice {}
    |            ^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL +     if let [a, _] = slice {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:51:12
+  --> $DIR/needless_borrowed_ref.rs:52:12
    |
 LL |     if let &(ref a, ref b, ref c) = &tuple {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL +     if let (a, b, c) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:52:12
+  --> $DIR/needless_borrowed_ref.rs:53:12
    |
 LL |     if let &(ref a, _, ref c) = &tuple {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -156,7 +156,7 @@ LL +     if let (a, _, c) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:53:12
+  --> $DIR/needless_borrowed_ref.rs:54:12
    |
 LL |     if let &(ref a, ..) = &tuple {}
    |            ^^^^^^^^^^^^
@@ -168,7 +168,7 @@ LL +     if let (a, ..) = &tuple {}
    |
 
 error: dereferencing a tuple pattern where every element takes a reference
-  --> $DIR/needless_borrowed_ref.rs:55:12
+  --> $DIR/needless_borrowed_ref.rs:56:12
    |
 LL |     if let &TupleStruct(ref a, ..) = &tuple_struct {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^
@@ -180,7 +180,7 @@ LL +     if let TupleStruct(a, ..) = &tuple_struct {}
    |
 
 error: dereferencing a struct pattern where every field's pattern takes a reference
-  --> $DIR/needless_borrowed_ref.rs:57:12
+  --> $DIR/needless_borrowed_ref.rs:58:12
    |
 LL |       if let &Struct {
    |  ____________^
@@ -199,7 +199,7 @@ LL ~         c: renamed,
    |
 
 error: dereferencing a struct pattern where every field's pattern takes a reference
-  --> $DIR/needless_borrowed_ref.rs:64:12
+  --> $DIR/needless_borrowed_ref.rs:65:12
    |
 LL |     if let &Struct { ref a, b: _, .. } = &s {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/needless_collect.fixed
+++ b/tests/ui/needless_collect.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(unused, clippy::suspicious_map, clippy::iter_count)]
+#![allow(unused, clippy::needless_if, clippy::suspicious_map, clippy::iter_count)]
 
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList};
 

--- a/tests/ui/needless_collect.rs
+++ b/tests/ui/needless_collect.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 
-#![allow(unused, clippy::suspicious_map, clippy::iter_count)]
+#![allow(unused, clippy::needless_if, clippy::suspicious_map, clippy::iter_count)]
 
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList};
 

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::uninlined_format_args, clippy::useless_vec)]
+#![allow(clippy::needless_if, clippy::uninlined_format_args)]
 #![warn(clippy::needless_collect)]
 
 use std::collections::{BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -1,5 +1,5 @@
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:8:39
+  --> $DIR/needless_collect_indirect.rs:9:39
    |
 LL |     let indirect_iter = sample.iter().collect::<Vec<_>>();
    |                                       ^^^^^^^
@@ -14,7 +14,7 @@ LL ~     sample.iter().map(|x| (x, x + 1)).collect::<HashMap<_, _>>();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:10:38
+  --> $DIR/needless_collect_indirect.rs:11:38
    |
 LL |     let indirect_len = sample.iter().collect::<VecDeque<_>>();
    |                                      ^^^^^^^
@@ -28,7 +28,7 @@ LL ~     sample.iter().count();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:12:40
+  --> $DIR/needless_collect_indirect.rs:13:40
    |
 LL |     let indirect_empty = sample.iter().collect::<VecDeque<_>>();
    |                                        ^^^^^^^
@@ -42,7 +42,7 @@ LL ~     sample.iter().next().is_none();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:14:43
+  --> $DIR/needless_collect_indirect.rs:15:43
    |
 LL |     let indirect_contains = sample.iter().collect::<VecDeque<_>>();
    |                                           ^^^^^^^
@@ -56,7 +56,7 @@ LL ~     sample.iter().any(|x| x == &5);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:26:48
+  --> $DIR/needless_collect_indirect.rs:27:48
    |
 LL |     let non_copy_contains = sample.into_iter().collect::<Vec<_>>();
    |                                                ^^^^^^^
@@ -70,7 +70,7 @@ LL ~     sample.into_iter().any(|x| x == a);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:55:51
+  --> $DIR/needless_collect_indirect.rs:56:51
    |
 LL |         let buffer: Vec<&str> = string.split('/').collect();
    |                                                   ^^^^^^^
@@ -84,7 +84,7 @@ LL ~         string.split('/').count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:60:55
+  --> $DIR/needless_collect_indirect.rs:61:55
    |
 LL |         let indirect_len: VecDeque<_> = sample.iter().collect();
    |                                                       ^^^^^^^
@@ -98,7 +98,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:65:57
+  --> $DIR/needless_collect_indirect.rs:66:57
    |
 LL |         let indirect_len: LinkedList<_> = sample.iter().collect();
    |                                                         ^^^^^^^
@@ -112,7 +112,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:70:57
+  --> $DIR/needless_collect_indirect.rs:71:57
    |
 LL |         let indirect_len: BinaryHeap<_> = sample.iter().collect();
    |                                                         ^^^^^^^
@@ -126,7 +126,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:130:59
+  --> $DIR/needless_collect_indirect.rs:131:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -143,7 +143,7 @@ LL ~             vec.iter().map(|k| k * k).any(|x| x == i);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:155:59
+  --> $DIR/needless_collect_indirect.rs:156:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -160,7 +160,7 @@ LL ~             vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:184:63
+  --> $DIR/needless_collect_indirect.rs:185:63
    |
 LL |                 let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                               ^^^^^^^
@@ -177,7 +177,7 @@ LL ~                 vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:220:59
+  --> $DIR/needless_collect_indirect.rs:221:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -195,7 +195,7 @@ LL ~                 vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:245:26
+  --> $DIR/needless_collect_indirect.rs:246:26
    |
 LL |         let w = v.iter().collect::<Vec<_>>();
    |                          ^^^^^^^
@@ -211,7 +211,7 @@ LL ~         for _ in 0..v.iter().count() {
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:267:30
+  --> $DIR/needless_collect_indirect.rs:268:30
    |
 LL |         let mut w = v.iter().collect::<Vec<_>>();
    |                              ^^^^^^^
@@ -227,7 +227,7 @@ LL ~         while 1 == v.iter().count() {
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:289:30
+  --> $DIR/needless_collect_indirect.rs:290:30
    |
 LL |         let mut w = v.iter().collect::<Vec<_>>();
    |                              ^^^^^^^

--- a/tests/ui/needless_if.fixed
+++ b/tests/ui/needless_if.fixed
@@ -48,7 +48,10 @@ fn main() {
     if let true = true {}
     if let true = true && true {}
     if true && let true = true {}
-    if { if let true = true && true { true } else { false } } && true {}
+    if {
+        if let true = true && true { true } else { false }
+    } && true
+    {}
     external! { if (true) {} }
     with_span! {
         span

--- a/tests/ui/needless_if.fixed
+++ b/tests/ui/needless_if.fixed
@@ -1,11 +1,13 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
+#![feature(let_chains)]
 #![allow(
     clippy::blocks_in_if_conditions,
     clippy::if_same_then_else,
     clippy::ifs_same_cond,
     clippy::needless_else,
     clippy::no_effect,
+    clippy::nonminimal_bool,
     unused
 )]
 #![warn(clippy::needless_if)]
@@ -14,21 +16,39 @@ extern crate proc_macros;
 use proc_macros::external;
 use proc_macros::with_span;
 
+fn no_side_effects() -> bool {
+    true
+}
+
+fn has_side_effects(a: &mut u32) -> bool {
+    *a = 1;
+    true
+}
+
 fn main() {
     // Lint
-    (true);
+    
+    // Do not remove the condition
+    no_side_effects();
+    let mut x = 0;
+    has_side_effects(&mut x);
+    assert_eq!(x, 1);
     // Do not lint
     if (true) {
     } else {
     }
+    {
+        return;
+    };
     // Do not lint if `else if` is present
     if (true) {
     } else if (true) {
     }
-    // Ensure clippy does not bork this up, other cases should be added
-    {
-        return;
-    };
+    // Do not lint if any `let` is present
+    if let true = true {}
+    if let true = true && true {}
+    if true && let true = true {}
+    if { if let true = true && true { true } else { false } } && true {}
     external! { if (true) {} }
     with_span! {
         span

--- a/tests/ui/needless_if.fixed
+++ b/tests/ui/needless_if.fixed
@@ -1,0 +1,37 @@
+//@run-rustfix
+//@aux-build:proc_macros.rs
+#![allow(
+    clippy::blocks_in_if_conditions,
+    clippy::if_same_then_else,
+    clippy::ifs_same_cond,
+    clippy::needless_else,
+    clippy::no_effect,
+    unused
+)]
+#![warn(clippy::needless_if)]
+
+extern crate proc_macros;
+use proc_macros::external;
+use proc_macros::with_span;
+
+fn main() {
+    // Lint
+    (true);
+    // Do not lint
+    if (true) {
+    } else {
+    }
+    // Do not lint if `else if` is present
+    if (true) {
+    } else if (true) {
+    }
+    // Ensure clippy does not bork this up, other cases should be added
+    {
+        return;
+    };
+    external! { if (true) {} }
+    with_span! {
+        span
+        if (true) {}
+    }
+}

--- a/tests/ui/needless_if.rs
+++ b/tests/ui/needless_if.rs
@@ -1,0 +1,37 @@
+//@run-rustfix
+//@aux-build:proc_macros.rs
+#![allow(
+    clippy::blocks_in_if_conditions,
+    clippy::if_same_then_else,
+    clippy::ifs_same_cond,
+    clippy::needless_else,
+    clippy::no_effect,
+    unused
+)]
+#![warn(clippy::needless_if)]
+
+extern crate proc_macros;
+use proc_macros::external;
+use proc_macros::with_span;
+
+fn main() {
+    // Lint
+    if (true) {}
+    // Do not lint
+    if (true) {
+    } else {
+    }
+    // Do not lint if `else if` is present
+    if (true) {
+    } else if (true) {
+    }
+    // Ensure clippy does not bork this up, other cases should be added
+    if {
+        return;
+    } {}
+    external! { if (true) {} }
+    with_span! {
+        span
+        if (true) {}
+    }
+}

--- a/tests/ui/needless_if.rs
+++ b/tests/ui/needless_if.rs
@@ -1,11 +1,13 @@
 //@run-rustfix
 //@aux-build:proc_macros.rs
+#![feature(let_chains)]
 #![allow(
     clippy::blocks_in_if_conditions,
     clippy::if_same_then_else,
     clippy::ifs_same_cond,
     clippy::needless_else,
     clippy::no_effect,
+    clippy::nonminimal_bool,
     unused
 )]
 #![warn(clippy::needless_if)]
@@ -14,21 +16,42 @@ extern crate proc_macros;
 use proc_macros::external;
 use proc_macros::with_span;
 
+fn no_side_effects() -> bool {
+    true
+}
+
+fn has_side_effects(a: &mut u32) -> bool {
+    *a = 1;
+    true
+}
+
 fn main() {
     // Lint
     if (true) {}
+    // Do not remove the condition
+    if no_side_effects() {}
+    let mut x = 0;
+    if has_side_effects(&mut x) {}
+    assert_eq!(x, 1);
     // Do not lint
     if (true) {
     } else {
     }
+    if {
+        return;
+    } {}
     // Do not lint if `else if` is present
     if (true) {
     } else if (true) {
     }
-    // Ensure clippy does not bork this up, other cases should be added
+    // Do not lint if any `let` is present
+    if let true = true {}
+    if let true = true && true {}
+    if true && let true = true {}
     if {
-        return;
-    } {}
+        if let true = true && true { true } else { false }
+    } && true
+    {}
     external! { if (true) {} }
     with_span! {
         span

--- a/tests/ui/needless_if.stderr
+++ b/tests/ui/needless_if.stderr
@@ -1,13 +1,25 @@
-error: this if branch is empty
-  --> $DIR/needless_if.rs:19:5
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:30:5
    |
 LL |     if (true) {}
-   |     ^^^^^^^^^^^^ help: you can remove it: `(true);`
+   |     ^^^^^^^^^^^^ help: you can remove it
    |
    = note: `-D clippy::needless-if` implied by `-D warnings`
 
-error: this if branch is empty
-  --> $DIR/needless_if.rs:29:5
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:32:5
+   |
+LL |     if no_side_effects() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `no_side_effects();`
+
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:34:5
+   |
+LL |     if has_side_effects(&mut x) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `has_side_effects(&mut x);`
+
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:40:5
    |
 LL | /     if {
 LL | |         return;
@@ -21,5 +33,5 @@ LL +         return;
 LL +     };
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/needless_if.stderr
+++ b/tests/ui/needless_if.stderr
@@ -1,0 +1,25 @@
+error: this if branch is empty
+  --> $DIR/needless_if.rs:19:5
+   |
+LL |     if (true) {}
+   |     ^^^^^^^^^^^^ help: you can remove it: `(true);`
+   |
+   = note: `-D clippy::needless-if` implied by `-D warnings`
+
+error: this if branch is empty
+  --> $DIR/needless_if.rs:29:5
+   |
+LL | /     if {
+LL | |         return;
+LL | |     } {}
+   | |________^
+   |
+help: you can remove it
+   |
+LL ~     {
+LL +         return;
+LL +     };
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/nonminimal_bool.rs
+++ b/tests/ui/nonminimal_bool.rs
@@ -1,5 +1,5 @@
 #![feature(lint_reasons)]
-#![allow(unused, clippy::diverging_sub_expression)]
+#![allow(unused, clippy::diverging_sub_expression, clippy::needless_if)]
 #![warn(clippy::nonminimal_bool)]
 #![allow(clippy::useless_vec)]
 

--- a/tests/ui/nonminimal_bool_methods.fixed
+++ b/tests/ui/nonminimal_bool_methods.fixed
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(unused, clippy::diverging_sub_expression)]
+#![allow(unused, clippy::diverging_sub_expression, clippy::needless_if)]
 #![warn(clippy::nonminimal_bool)]
 
 fn methods_with_negation() {

--- a/tests/ui/nonminimal_bool_methods.rs
+++ b/tests/ui/nonminimal_bool_methods.rs
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(unused, clippy::diverging_sub_expression)]
+#![allow(unused, clippy::diverging_sub_expression, clippy::needless_if)]
 #![warn(clippy::nonminimal_bool)]
 
 fn methods_with_negation() {

--- a/tests/ui/overflow_check_conditional.rs
+++ b/tests/ui/overflow_check_conditional.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::overflow_check_conditional)]
+#![allow(clippy::needless_if)]
 
 fn test(a: u32, b: u32, c: u32) {
     if a + b < a {}

--- a/tests/ui/overflow_check_conditional.stderr
+++ b/tests/ui/overflow_check_conditional.stderr
@@ -1,5 +1,5 @@
 error: you are trying to use classic C overflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:4:8
+  --> $DIR/overflow_check_conditional.rs:5:8
    |
 LL |     if a + b < a {}
    |        ^^^^^^^^^
@@ -7,43 +7,43 @@ LL |     if a + b < a {}
    = note: `-D clippy::overflow-check-conditional` implied by `-D warnings`
 
 error: you are trying to use classic C overflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:5:8
+  --> $DIR/overflow_check_conditional.rs:6:8
    |
 LL |     if a > a + b {}
    |        ^^^^^^^^^
 
 error: you are trying to use classic C overflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:6:8
+  --> $DIR/overflow_check_conditional.rs:7:8
    |
 LL |     if a + b < b {}
    |        ^^^^^^^^^
 
 error: you are trying to use classic C overflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:7:8
+  --> $DIR/overflow_check_conditional.rs:8:8
    |
 LL |     if b > a + b {}
    |        ^^^^^^^^^
 
 error: you are trying to use classic C underflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:8:8
+  --> $DIR/overflow_check_conditional.rs:9:8
    |
 LL |     if a - b > b {}
    |        ^^^^^^^^^
 
 error: you are trying to use classic C underflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:9:8
+  --> $DIR/overflow_check_conditional.rs:10:8
    |
 LL |     if b < a - b {}
    |        ^^^^^^^^^
 
 error: you are trying to use classic C underflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:10:8
+  --> $DIR/overflow_check_conditional.rs:11:8
    |
 LL |     if a - b > a {}
    |        ^^^^^^^^^
 
 error: you are trying to use classic C underflow conditions that will fail in Rust
-  --> $DIR/overflow_check_conditional.rs:11:8
+  --> $DIR/overflow_check_conditional.rs:12:8
    |
 LL |     if a < a - b {}
    |        ^^^^^^^^^

--- a/tests/ui/partialeq_to_none.fixed
+++ b/tests/ui/partialeq_to_none.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op)]
+#![allow(clippy::eq_op, clippy::needless_if)]
 
 struct Foobar;
 

--- a/tests/ui/partialeq_to_none.rs
+++ b/tests/ui/partialeq_to_none.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op)]
+#![allow(clippy::eq_op, clippy::needless_if)]
 
 struct Foobar;
 

--- a/tests/ui/redundant_pattern_matching_drop_order.fixed
+++ b/tests/ui/redundant_pattern_matching_drop_order.fixed
@@ -2,7 +2,12 @@
 
 // Issue #5746
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(clippy::if_same_then_else, clippy::equatable_if_let, clippy::needless_else)]
+#![allow(
+    clippy::if_same_then_else,
+    clippy::equatable_if_let,
+    clippy::needless_if,
+    clippy::needless_else
+)]
 use std::task::Poll::{Pending, Ready};
 
 fn main() {

--- a/tests/ui/redundant_pattern_matching_drop_order.rs
+++ b/tests/ui/redundant_pattern_matching_drop_order.rs
@@ -2,7 +2,12 @@
 
 // Issue #5746
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(clippy::if_same_then_else, clippy::equatable_if_let, clippy::needless_else)]
+#![allow(
+    clippy::if_same_then_else,
+    clippy::equatable_if_let,
+    clippy::needless_if,
+    clippy::needless_else
+)]
 use std::task::Poll::{Pending, Ready};
 
 fn main() {

--- a/tests/ui/redundant_pattern_matching_drop_order.stderr
+++ b/tests/ui/redundant_pattern_matching_drop_order.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:12:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:17:12
    |
 LL |     if let Ok(_) = m.lock() {}
    |     -------^^^^^----------- help: try this: `if m.lock().is_ok()`
@@ -9,7 +9,7 @@ LL |     if let Ok(_) = m.lock() {}
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:13:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:18:12
    |
 LL |     if let Err(_) = Err::<(), _>(m.lock().unwrap().0) {}
    |     -------^^^^^^------------------------------------ help: try this: `if Err::<(), _>(m.lock().unwrap().0).is_err()`
@@ -18,7 +18,7 @@ LL |     if let Err(_) = Err::<(), _>(m.lock().unwrap().0) {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:16:16
+  --> $DIR/redundant_pattern_matching_drop_order.rs:21:16
    |
 LL |         if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
    |         -------^^^^^----------------------------------------- help: try this: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
@@ -27,7 +27,7 @@ LL |         if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:18:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:23:12
    |
 LL |     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {
    |     -------^^^^^----------------------------------------- help: try this: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
@@ -36,31 +36,31 @@ LL |     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:21:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:26:12
    |
 LL |     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
    |     -------^^^^^----------------------------------------- help: try this: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:22:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:27:12
    |
 LL |     if let Err(_) = Err::<std::sync::MutexGuard<()>, _>(()) {}
    |     -------^^^^^^------------------------------------------ help: try this: `if Err::<std::sync::MutexGuard<()>, _>(()).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:24:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:29:12
    |
 LL |     if let Ok(_) = Ok::<_, ()>(String::new()) {}
    |     -------^^^^^----------------------------- help: try this: `if Ok::<_, ()>(String::new()).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:25:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:30:12
    |
 LL |     if let Err(_) = Err::<(), _>((String::new(), ())) {}
    |     -------^^^^^^------------------------------------ help: try this: `if Err::<(), _>((String::new(), ())).is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:28:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:33:12
    |
 LL |     if let Some(_) = Some(m.lock()) {}
    |     -------^^^^^^^----------------- help: try this: `if Some(m.lock()).is_some()`
@@ -69,7 +69,7 @@ LL |     if let Some(_) = Some(m.lock()) {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:29:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:34:12
    |
 LL |     if let Some(_) = Some(m.lock().unwrap().0) {}
    |     -------^^^^^^^---------------------------- help: try this: `if Some(m.lock().unwrap().0).is_some()`
@@ -78,7 +78,7 @@ LL |     if let Some(_) = Some(m.lock().unwrap().0) {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:32:16
+  --> $DIR/redundant_pattern_matching_drop_order.rs:37:16
    |
 LL |         if let None = None::<std::sync::MutexGuard<()>> {}
    |         -------^^^^------------------------------------ help: try this: `if None::<std::sync::MutexGuard<()>>.is_none()`
@@ -87,7 +87,7 @@ LL |         if let None = None::<std::sync::MutexGuard<()>> {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:34:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:39:12
    |
 LL |     if let None = None::<std::sync::MutexGuard<()>> {
    |     -------^^^^------------------------------------ help: try this: `if None::<std::sync::MutexGuard<()>>.is_none()`
@@ -96,25 +96,25 @@ LL |     if let None = None::<std::sync::MutexGuard<()>> {
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:38:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:43:12
    |
 LL |     if let None = None::<std::sync::MutexGuard<()>> {}
    |     -------^^^^------------------------------------ help: try this: `if None::<std::sync::MutexGuard<()>>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:40:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:45:12
    |
 LL |     if let Some(_) = Some(String::new()) {}
    |     -------^^^^^^^---------------------- help: try this: `if Some(String::new()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:41:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:46:12
    |
 LL |     if let Some(_) = Some((String::new(), ())) {}
    |     -------^^^^^^^---------------------------- help: try this: `if Some((String::new(), ())).is_some()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:44:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:49:12
    |
 LL |     if let Ready(_) = Ready(m.lock()) {}
    |     -------^^^^^^^^------------------ help: try this: `if Ready(m.lock()).is_ready()`
@@ -123,7 +123,7 @@ LL |     if let Ready(_) = Ready(m.lock()) {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:45:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:50:12
    |
 LL |     if let Ready(_) = Ready(m.lock().unwrap().0) {}
    |     -------^^^^^^^^----------------------------- help: try this: `if Ready(m.lock().unwrap().0).is_ready()`
@@ -132,7 +132,7 @@ LL |     if let Ready(_) = Ready(m.lock().unwrap().0) {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:48:16
+  --> $DIR/redundant_pattern_matching_drop_order.rs:53:16
    |
 LL |         if let Pending = Pending::<std::sync::MutexGuard<()>> {}
    |         -------^^^^^^^--------------------------------------- help: try this: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
@@ -141,7 +141,7 @@ LL |         if let Pending = Pending::<std::sync::MutexGuard<()>> {}
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:50:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:55:12
    |
 LL |     if let Pending = Pending::<std::sync::MutexGuard<()>> {
    |     -------^^^^^^^--------------------------------------- help: try this: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
@@ -150,19 +150,19 @@ LL |     if let Pending = Pending::<std::sync::MutexGuard<()>> {
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:54:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:59:12
    |
 LL |     if let Pending = Pending::<std::sync::MutexGuard<()>> {}
    |     -------^^^^^^^--------------------------------------- help: try this: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:56:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:61:12
    |
 LL |     if let Ready(_) = Ready(String::new()) {}
    |     -------^^^^^^^^----------------------- help: try this: `if Ready(String::new()).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_drop_order.rs:57:12
+  --> $DIR/redundant_pattern_matching_drop_order.rs:62:12
    |
 LL |     if let Ready(_) = Ready((String::new(), ())) {}
    |     -------^^^^^^^^----------------------------- help: try this: `if Ready((String::new(), ())).is_ready()`

--- a/tests/ui/redundant_pattern_matching_ipaddr.fixed
+++ b/tests/ui/redundant_pattern_matching_ipaddr.fixed
@@ -4,6 +4,7 @@
 #![allow(
     clippy::match_like_matches_macro,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::uninlined_format_args
 )]
 

--- a/tests/ui/redundant_pattern_matching_ipaddr.rs
+++ b/tests/ui/redundant_pattern_matching_ipaddr.rs
@@ -4,6 +4,7 @@
 #![allow(
     clippy::match_like_matches_macro,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::uninlined_format_args
 )]
 

--- a/tests/ui/redundant_pattern_matching_ipaddr.stderr
+++ b/tests/ui/redundant_pattern_matching_ipaddr.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:17:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:18:12
    |
 LL |     if let V4(_) = &ipaddr {}
    |     -------^^^^^---------- help: try this: `if ipaddr.is_ipv4()`
@@ -7,31 +7,31 @@ LL |     if let V4(_) = &ipaddr {}
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:19:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:20:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:21:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:22:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:23:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:24:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:25:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:26:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:35:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:36:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => true,
@@ -40,7 +40,7 @@ LL | |     };
    | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:40:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:41:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => false,
@@ -49,7 +49,7 @@ LL | |     };
    | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:45:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:46:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => false,
@@ -58,7 +58,7 @@ LL | |     };
    | |_____^ help: try this: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:50:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:51:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => true,
@@ -67,49 +67,49 @@ LL | |     };
    | |_____^ help: try this: `V6(Ipv6Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:55:20
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:56:20
    |
 LL |     let _ = if let V4(_) = V4(Ipv4Addr::LOCALHOST) {
    |             -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:63:20
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:64:20
    |
 LL |     let _ = if let V4(_) = gen_ipaddr() {
    |             -------^^^^^--------------- help: try this: `if gen_ipaddr().is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:65:19
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:66:19
    |
 LL |     } else if let V6(_) = gen_ipaddr() {
    |            -------^^^^^--------------- help: try this: `if gen_ipaddr().is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:77:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:78:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:79:12
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:80:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try this: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:81:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:82:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:83:15
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:84:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try this: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:85:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:86:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => true,
@@ -118,7 +118,7 @@ LL | |     };
    | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> $DIR/redundant_pattern_matching_ipaddr.rs:90:5
+  --> $DIR/redundant_pattern_matching_ipaddr.rs:91:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => false,

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -5,6 +5,7 @@
 #![allow(
     unused_must_use,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -5,6 +5,7 @@
 #![allow(
     unused_must_use,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:14:12
+  --> $DIR/redundant_pattern_matching_option.rs:15:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try this: `if None::<()>.is_none()`
@@ -7,43 +7,43 @@ LL |     if let None = None::<()> {}
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:16:12
+  --> $DIR/redundant_pattern_matching_option.rs:17:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try this: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:18:12
+  --> $DIR/redundant_pattern_matching_option.rs:19:12
    |
 LL |     if let Some(_) = Some(42) {
    |     -------^^^^^^^----------- help: try this: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:24:15
+  --> $DIR/redundant_pattern_matching_option.rs:25:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try this: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:26:15
+  --> $DIR/redundant_pattern_matching_option.rs:27:15
    |
 LL |     while let None = Some(42) {}
    |     ----------^^^^----------- help: try this: `while Some(42).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:28:15
+  --> $DIR/redundant_pattern_matching_option.rs:29:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try this: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:31:15
+  --> $DIR/redundant_pattern_matching_option.rs:32:15
    |
 LL |     while let Some(_) = v.pop() {
    |     ----------^^^^^^^---------- help: try this: `while v.pop().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:39:5
+  --> $DIR/redundant_pattern_matching_option.rs:40:5
    |
 LL | /     match Some(42) {
 LL | |         Some(_) => true,
@@ -52,7 +52,7 @@ LL | |     };
    | |_____^ help: try this: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:44:5
+  --> $DIR/redundant_pattern_matching_option.rs:45:5
    |
 LL | /     match None::<()> {
 LL | |         Some(_) => false,
@@ -61,7 +61,7 @@ LL | |     };
    | |_____^ help: try this: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:49:13
+  --> $DIR/redundant_pattern_matching_option.rs:50:13
    |
 LL |       let _ = match None::<()> {
    |  _____________^
@@ -71,55 +71,55 @@ LL | |     };
    | |_____^ help: try this: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:55:20
+  --> $DIR/redundant_pattern_matching_option.rs:56:20
    |
 LL |     let _ = if let Some(_) = opt { true } else { false };
    |             -------^^^^^^^------ help: try this: `if opt.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:61:20
+  --> $DIR/redundant_pattern_matching_option.rs:62:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
    |             -------^^^^^^^------------ help: try this: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:63:19
+  --> $DIR/redundant_pattern_matching_option.rs:64:19
    |
 LL |     } else if let None = gen_opt() {
    |            -------^^^^------------ help: try this: `if gen_opt().is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:69:12
+  --> $DIR/redundant_pattern_matching_option.rs:70:12
    |
 LL |     if let Some(..) = gen_opt() {}
    |     -------^^^^^^^^------------ help: try this: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:84:12
+  --> $DIR/redundant_pattern_matching_option.rs:85:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try this: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:86:12
+  --> $DIR/redundant_pattern_matching_option.rs:87:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try this: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:88:15
+  --> $DIR/redundant_pattern_matching_option.rs:89:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try this: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:90:15
+  --> $DIR/redundant_pattern_matching_option.rs:91:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try this: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:92:5
+  --> $DIR/redundant_pattern_matching_option.rs:93:5
    |
 LL | /     match Some(42) {
 LL | |         Some(_) => true,
@@ -128,7 +128,7 @@ LL | |     };
    | |_____^ help: try this: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:97:5
+  --> $DIR/redundant_pattern_matching_option.rs:98:5
    |
 LL | /     match None::<()> {
 LL | |         Some(_) => false,
@@ -137,19 +137,19 @@ LL | |     };
    | |_____^ help: try this: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:105:12
+  --> $DIR/redundant_pattern_matching_option.rs:106:12
    |
 LL |     if let None = *(&None::<()>) {}
    |     -------^^^^----------------- help: try this: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:106:12
+  --> $DIR/redundant_pattern_matching_option.rs:107:12
    |
 LL |     if let None = *&None::<()> {}
    |     -------^^^^--------------- help: try this: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:112:5
+  --> $DIR/redundant_pattern_matching_option.rs:113:5
    |
 LL | /     match x {
 LL | |         Some(_) => true,
@@ -158,7 +158,7 @@ LL | |     };
    | |_____^ help: try this: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:117:5
+  --> $DIR/redundant_pattern_matching_option.rs:118:5
    |
 LL | /     match x {
 LL | |         None => true,
@@ -167,7 +167,7 @@ LL | |     };
    | |_____^ help: try this: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:122:5
+  --> $DIR/redundant_pattern_matching_option.rs:123:5
    |
 LL | /     match x {
 LL | |         Some(_) => false,
@@ -176,7 +176,7 @@ LL | |     };
    | |_____^ help: try this: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:127:5
+  --> $DIR/redundant_pattern_matching_option.rs:128:5
    |
 LL | /     match x {
 LL | |         None => false,
@@ -185,13 +185,13 @@ LL | |     };
    | |_____^ help: try this: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_option.rs:142:13
+  --> $DIR/redundant_pattern_matching_option.rs:143:13
    |
 LL |     let _ = matches!(x, Some(_));
    |             ^^^^^^^^^^^^^^^^^^^^ help: try this: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> $DIR/redundant_pattern_matching_option.rs:144:13
+  --> $DIR/redundant_pattern_matching_option.rs:145:13
    |
 LL |     let _ = matches!(x, None);
    |             ^^^^^^^^^^^^^^^^^ help: try this: `x.is_none()`

--- a/tests/ui/redundant_pattern_matching_poll.fixed
+++ b/tests/ui/redundant_pattern_matching_poll.fixed
@@ -5,6 +5,7 @@
 #![allow(
     unused_must_use,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_poll.rs
+++ b/tests/ui/redundant_pattern_matching_poll.rs
@@ -5,6 +5,7 @@
 #![allow(
     unused_must_use,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else

--- a/tests/ui/redundant_pattern_matching_poll.stderr
+++ b/tests/ui/redundant_pattern_matching_poll.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:16:12
+  --> $DIR/redundant_pattern_matching_poll.rs:17:12
    |
 LL |     if let Pending = Pending::<()> {}
    |     -------^^^^^^^---------------- help: try this: `if Pending::<()>.is_pending()`
@@ -7,37 +7,37 @@ LL |     if let Pending = Pending::<()> {}
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:18:12
+  --> $DIR/redundant_pattern_matching_poll.rs:19:12
    |
 LL |     if let Ready(_) = Ready(42) {}
    |     -------^^^^^^^^------------ help: try this: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:20:12
+  --> $DIR/redundant_pattern_matching_poll.rs:21:12
    |
 LL |     if let Ready(_) = Ready(42) {
    |     -------^^^^^^^^------------ help: try this: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:26:15
+  --> $DIR/redundant_pattern_matching_poll.rs:27:15
    |
 LL |     while let Ready(_) = Ready(42) {}
    |     ----------^^^^^^^^------------ help: try this: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:28:15
+  --> $DIR/redundant_pattern_matching_poll.rs:29:15
    |
 LL |     while let Pending = Ready(42) {}
    |     ----------^^^^^^^------------ help: try this: `while Ready(42).is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:30:15
+  --> $DIR/redundant_pattern_matching_poll.rs:31:15
    |
 LL |     while let Pending = Pending::<()> {}
    |     ----------^^^^^^^---------------- help: try this: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:36:5
+  --> $DIR/redundant_pattern_matching_poll.rs:37:5
    |
 LL | /     match Ready(42) {
 LL | |         Ready(_) => true,
@@ -46,7 +46,7 @@ LL | |     };
    | |_____^ help: try this: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:41:5
+  --> $DIR/redundant_pattern_matching_poll.rs:42:5
    |
 LL | /     match Pending::<()> {
 LL | |         Ready(_) => false,
@@ -55,7 +55,7 @@ LL | |     };
    | |_____^ help: try this: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:46:13
+  --> $DIR/redundant_pattern_matching_poll.rs:47:13
    |
 LL |       let _ = match Pending::<()> {
    |  _____________^
@@ -65,49 +65,49 @@ LL | |     };
    | |_____^ help: try this: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:52:20
+  --> $DIR/redundant_pattern_matching_poll.rs:53:20
    |
 LL |     let _ = if let Ready(_) = poll { true } else { false };
    |             -------^^^^^^^^------- help: try this: `if poll.is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:56:20
+  --> $DIR/redundant_pattern_matching_poll.rs:57:20
    |
 LL |     let _ = if let Ready(_) = gen_poll() {
    |             -------^^^^^^^^------------- help: try this: `if gen_poll().is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:58:19
+  --> $DIR/redundant_pattern_matching_poll.rs:59:19
    |
 LL |     } else if let Pending = gen_poll() {
    |            -------^^^^^^^------------- help: try this: `if gen_poll().is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:74:12
+  --> $DIR/redundant_pattern_matching_poll.rs:75:12
    |
 LL |     if let Ready(_) = Ready(42) {}
    |     -------^^^^^^^^------------ help: try this: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:76:12
+  --> $DIR/redundant_pattern_matching_poll.rs:77:12
    |
 LL |     if let Pending = Pending::<()> {}
    |     -------^^^^^^^---------------- help: try this: `if Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:78:15
+  --> $DIR/redundant_pattern_matching_poll.rs:79:15
    |
 LL |     while let Ready(_) = Ready(42) {}
    |     ----------^^^^^^^^------------ help: try this: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:80:15
+  --> $DIR/redundant_pattern_matching_poll.rs:81:15
    |
 LL |     while let Pending = Pending::<()> {}
    |     ----------^^^^^^^---------------- help: try this: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> $DIR/redundant_pattern_matching_poll.rs:82:5
+  --> $DIR/redundant_pattern_matching_poll.rs:83:5
    |
 LL | /     match Ready(42) {
 LL | |         Ready(_) => true,
@@ -116,7 +116,7 @@ LL | |     };
    | |_____^ help: try this: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> $DIR/redundant_pattern_matching_poll.rs:87:5
+  --> $DIR/redundant_pattern_matching_poll.rs:88:5
    |
 LL | /     match Pending::<()> {
 LL | |         Ready(_) => false,

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -6,6 +6,7 @@
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps
 )]

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -6,6 +6,7 @@
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,
     clippy::needless_bool,
+    clippy::needless_if,
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps
 )]

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:15:12
+  --> $DIR/redundant_pattern_matching_result.rs:16:12
    |
 LL |     if let Ok(_) = &result {}
    |     -------^^^^^---------- help: try this: `if result.is_ok()`
@@ -7,31 +7,31 @@ LL |     if let Ok(_) = &result {}
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:17:12
+  --> $DIR/redundant_pattern_matching_result.rs:18:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try this: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:19:12
+  --> $DIR/redundant_pattern_matching_result.rs:20:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try this: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:21:15
+  --> $DIR/redundant_pattern_matching_result.rs:22:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:23:15
+  --> $DIR/redundant_pattern_matching_result.rs:24:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:33:5
+  --> $DIR/redundant_pattern_matching_result.rs:34:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => true,
@@ -40,7 +40,7 @@ LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:38:5
+  --> $DIR/redundant_pattern_matching_result.rs:39:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => false,
@@ -49,7 +49,7 @@ LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:43:5
+  --> $DIR/redundant_pattern_matching_result.rs:44:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => false,
@@ -58,7 +58,7 @@ LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:48:5
+  --> $DIR/redundant_pattern_matching_result.rs:49:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => true,
@@ -67,73 +67,73 @@ LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:53:20
+  --> $DIR/redundant_pattern_matching_result.rs:54:20
    |
 LL |     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
    |             -------^^^^^--------------------- help: try this: `if Ok::<usize, ()>(4).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:61:20
+  --> $DIR/redundant_pattern_matching_result.rs:62:20
    |
 LL |     let _ = if let Ok(_) = gen_res() {
    |             -------^^^^^------------ help: try this: `if gen_res().is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:63:19
+  --> $DIR/redundant_pattern_matching_result.rs:64:19
    |
 LL |     } else if let Err(_) = gen_res() {
    |            -------^^^^^^------------ help: try this: `if gen_res().is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:86:19
+  --> $DIR/redundant_pattern_matching_result.rs:87:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
    |         ----------^^^^^^^----------------------- help: try this: `while r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:87:16
+  --> $DIR/redundant_pattern_matching_result.rs:88:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
    |         -------^^^^^^^----------------------- help: try this: `if r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:93:12
+  --> $DIR/redundant_pattern_matching_result.rs:94:12
    |
 LL |     if let Some(_) = m!() {}
    |     -------^^^^^^^------- help: try this: `if m!().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> $DIR/redundant_pattern_matching_result.rs:94:15
+  --> $DIR/redundant_pattern_matching_result.rs:95:15
    |
 LL |     while let Some(_) = m!() {}
    |     ----------^^^^^^^------- help: try this: `while m!().is_some()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:112:12
+  --> $DIR/redundant_pattern_matching_result.rs:113:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try this: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:114:12
+  --> $DIR/redundant_pattern_matching_result.rs:115:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try this: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:116:15
+  --> $DIR/redundant_pattern_matching_result.rs:117:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:118:15
+  --> $DIR/redundant_pattern_matching_result.rs:119:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:120:5
+  --> $DIR/redundant_pattern_matching_result.rs:121:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => true,
@@ -142,7 +142,7 @@ LL | |     };
    | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:125:5
+  --> $DIR/redundant_pattern_matching_result.rs:126:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => false,
@@ -151,7 +151,7 @@ LL | |     };
    | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:135:5
+  --> $DIR/redundant_pattern_matching_result.rs:136:5
    |
 LL | /     match x {
 LL | |         Ok(_) => true,
@@ -160,7 +160,7 @@ LL | |     };
    | |_____^ help: try this: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:140:5
+  --> $DIR/redundant_pattern_matching_result.rs:141:5
    |
 LL | /     match x {
 LL | |         Ok(_) => false,
@@ -169,7 +169,7 @@ LL | |     };
    | |_____^ help: try this: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:145:5
+  --> $DIR/redundant_pattern_matching_result.rs:146:5
    |
 LL | /     match x {
 LL | |         Err(_) => true,
@@ -178,7 +178,7 @@ LL | |     };
    | |_____^ help: try this: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:150:5
+  --> $DIR/redundant_pattern_matching_result.rs:151:5
    |
 LL | /     match x {
 LL | |         Err(_) => false,
@@ -187,13 +187,13 @@ LL | |     };
    | |_____^ help: try this: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> $DIR/redundant_pattern_matching_result.rs:171:13
+  --> $DIR/redundant_pattern_matching_result.rs:172:13
    |
 LL |     let _ = matches!(x, Ok(_));
    |             ^^^^^^^^^^^^^^^^^^ help: try this: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> $DIR/redundant_pattern_matching_result.rs:173:13
+  --> $DIR/redundant_pattern_matching_result.rs:174:13
    |
 LL |     let _ = matches!(x, Err(_));
    |             ^^^^^^^^^^^^^^^^^^^ help: try this: `x.is_err()`

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -1,7 +1,7 @@
 //@aux-build:proc_macro_derive.rs
 
 #![warn(clippy::shadow_same, clippy::shadow_reuse, clippy::shadow_unrelated)]
-#![allow(clippy::let_unit_value)]
+#![allow(clippy::let_unit_value, clippy::needless_if)]
 
 extern crate proc_macro_derive;
 

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -1,6 +1,11 @@
 //@run-rustfix
 #![warn(clippy::single_match)]
-#![allow(unused, clippy::uninlined_format_args, clippy::redundant_pattern_matching)]
+#![allow(
+    unused,
+    clippy::uninlined_format_args,
+    clippy::needless_if,
+    clippy::redundant_pattern_matching
+)]
 fn dummy() {}
 
 fn single_match() {

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -1,6 +1,11 @@
 //@run-rustfix
 #![warn(clippy::single_match)]
-#![allow(unused, clippy::uninlined_format_args, clippy::redundant_pattern_matching)]
+#![allow(
+    unused,
+    clippy::uninlined_format_args,
+    clippy::needless_if,
+    clippy::redundant_pattern_matching
+)]
 fn dummy() {}
 
 fn single_match() {

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:9:5
+  --> $DIR/single_match.rs:14:5
    |
 LL | /     match x {
 LL | |         Some(y) => {
@@ -18,7 +18,7 @@ LL ~     };
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:17:5
+  --> $DIR/single_match.rs:22:5
    |
 LL | /     match x {
 LL | |         // Note the missing block braces.
@@ -30,7 +30,7 @@ LL | |     }
    | |_____^ help: try this: `if let Some(y) = x { println!("{:?}", y) }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:26:5
+  --> $DIR/single_match.rs:31:5
    |
 LL | /     match z {
 LL | |         (2..=3, 7..=9) => dummy(),
@@ -39,7 +39,7 @@ LL | |     };
    | |_____^ help: try this: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:55:5
+  --> $DIR/single_match.rs:60:5
    |
 LL | /     match x {
 LL | |         Some(y) => dummy(),
@@ -48,7 +48,7 @@ LL | |     };
    | |_____^ help: try this: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:60:5
+  --> $DIR/single_match.rs:65:5
    |
 LL | /     match y {
 LL | |         Ok(y) => dummy(),
@@ -57,7 +57,7 @@ LL | |     };
    | |_____^ help: try this: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:67:5
+  --> $DIR/single_match.rs:72:5
    |
 LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try this: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:88:5
+  --> $DIR/single_match.rs:93:5
    |
 LL | /     match x {
 LL | |         "test" => println!(),
@@ -75,7 +75,7 @@ LL | |     }
    | |_____^ help: try this: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:101:5
+  --> $DIR/single_match.rs:106:5
    |
 LL | /     match x {
 LL | |         Foo::A => println!(),
@@ -84,7 +84,7 @@ LL | |     }
    | |_____^ help: try this: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:107:5
+  --> $DIR/single_match.rs:112:5
    |
 LL | /     match x {
 LL | |         FOO_C => println!(),
@@ -93,7 +93,7 @@ LL | |     }
    | |_____^ help: try this: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:112:5
+  --> $DIR/single_match.rs:117:5
    |
 LL | /     match &&x {
 LL | |         Foo::A => println!(),
@@ -102,7 +102,7 @@ LL | |     }
    | |_____^ help: try this: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
-  --> $DIR/single_match.rs:118:5
+  --> $DIR/single_match.rs:123:5
    |
 LL | /     match &x {
 LL | |         Foo::A => println!(),
@@ -111,7 +111,7 @@ LL | |     }
    | |_____^ help: try this: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:135:5
+  --> $DIR/single_match.rs:140:5
    |
 LL | /     match x {
 LL | |         Bar::A => println!(),
@@ -120,7 +120,7 @@ LL | |     }
    | |_____^ help: try this: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:143:5
+  --> $DIR/single_match.rs:148:5
    |
 LL | /     match x {
 LL | |         None => println!(),
@@ -129,7 +129,7 @@ LL | |     };
    | |_____^ help: try this: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:165:5
+  --> $DIR/single_match.rs:170:5
    |
 LL | /     match x {
 LL | |         (Some(_), _) => {},
@@ -138,7 +138,7 @@ LL | |     }
    | |_____^ help: try this: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:171:5
+  --> $DIR/single_match.rs:176:5
    |
 LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
@@ -147,7 +147,7 @@ LL | |     }
    | |_____^ help: try this: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:177:5
+  --> $DIR/single_match.rs:182:5
    |
 LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
@@ -156,7 +156,7 @@ LL | |     }
    | |_____^ help: try this: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:249:5
+  --> $DIR/single_match.rs:254:5
    |
 LL | /     match bar {
 LL | |         Some(v) => unsafe {
@@ -176,7 +176,7 @@ LL +     } }
    |
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
-  --> $DIR/single_match.rs:257:5
+  --> $DIR/single_match.rs:262:5
    |
 LL | /     match bar {
 LL | |         #[rustfmt::skip]

--- a/tests/ui/starts_ends_with.fixed
+++ b/tests/ui/starts_ends_with.fixed
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(dead_code, unused_must_use)]
+#![allow(clippy::needless_if, dead_code, unused_must_use)]
 
 fn main() {}
 

--- a/tests/ui/starts_ends_with.rs
+++ b/tests/ui/starts_ends_with.rs
@@ -1,5 +1,5 @@
 //@run-rustfix
-#![allow(dead_code, unused_must_use)]
+#![allow(clippy::needless_if, dead_code, unused_must_use)]
 
 fn main() {}
 

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -1,7 +1,12 @@
 //@aux-build:proc_macro_suspicious_else_formatting.rs
 
 #![warn(clippy::suspicious_else_formatting)]
-#![allow(clippy::if_same_then_else, clippy::let_unit_value, clippy::needless_else)]
+#![allow(
+    clippy::if_same_then_else,
+    clippy::let_unit_value,
+    clippy::needless_if,
+    clippy::needless_else
+)]
 
 extern crate proc_macro_suspicious_else_formatting;
 use proc_macro_suspicious_else_formatting::DeriveBadSpan;

--- a/tests/ui/suspicious_else_formatting.stderr
+++ b/tests/ui/suspicious_else_formatting.stderr
@@ -1,5 +1,5 @@
 error: this looks like an `else {..}` but the `else` is missing
-  --> $DIR/suspicious_else_formatting.rs:17:6
+  --> $DIR/suspicious_else_formatting.rs:22:6
    |
 LL |     } {
    |      ^
@@ -8,7 +8,7 @@ LL |     } {
    = note: `-D clippy::suspicious-else-formatting` implied by `-D warnings`
 
 error: this looks like an `else if` but the `else` is missing
-  --> $DIR/suspicious_else_formatting.rs:21:6
+  --> $DIR/suspicious_else_formatting.rs:26:6
    |
 LL |     } if foo() {
    |      ^
@@ -16,7 +16,7 @@ LL |     } if foo() {
    = note: to remove this lint, add the missing `else` or add a new line before the second `if`
 
 error: this looks like an `else if` but the `else` is missing
-  --> $DIR/suspicious_else_formatting.rs:28:10
+  --> $DIR/suspicious_else_formatting.rs:33:10
    |
 LL |         } if foo() {
    |          ^
@@ -24,7 +24,7 @@ LL |         } if foo() {
    = note: to remove this lint, add the missing `else` or add a new line before the second `if`
 
 error: this looks like an `else if` but the `else` is missing
-  --> $DIR/suspicious_else_formatting.rs:36:10
+  --> $DIR/suspicious_else_formatting.rs:41:10
    |
 LL |         } if foo() {
    |          ^
@@ -32,7 +32,7 @@ LL |         } if foo() {
    = note: to remove this lint, add the missing `else` or add a new line before the second `if`
 
 error: this is an `else {..}` but the formatting might hide it
-  --> $DIR/suspicious_else_formatting.rs:45:6
+  --> $DIR/suspicious_else_formatting.rs:50:6
    |
 LL |       } else
    |  ______^
@@ -42,7 +42,7 @@ LL | |     {
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
 
 error: this is an `else if` but the formatting might hide it
-  --> $DIR/suspicious_else_formatting.rs:57:6
+  --> $DIR/suspicious_else_formatting.rs:62:6
    |
 LL |       } else
    |  ______^
@@ -52,7 +52,7 @@ LL | |     if foo() { // the span of the above error should continue here
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
 
 error: this is an `else if` but the formatting might hide it
-  --> $DIR/suspicious_else_formatting.rs:62:6
+  --> $DIR/suspicious_else_formatting.rs:67:6
    |
 LL |       }
    |  ______^
@@ -63,7 +63,7 @@ LL | |     if foo() { // the span of the above error should continue here
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `if`
 
 error: this is an `else {..}` but the formatting might hide it
-  --> $DIR/suspicious_else_formatting.rs:89:6
+  --> $DIR/suspicious_else_formatting.rs:94:6
    |
 LL |       }
    |  ______^
@@ -75,7 +75,7 @@ LL | |     {
    = note: to remove this lint, remove the `else` or remove the new line between `else` and `{..}`
 
 error: this is an `else {..}` but the formatting might hide it
-  --> $DIR/suspicious_else_formatting.rs:97:6
+  --> $DIR/suspicious_else_formatting.rs:102:6
    |
 LL |       }
    |  ______^

--- a/tests/ui/suspicious_unary_op_formatting.rs
+++ b/tests/ui/suspicious_unary_op_formatting.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::suspicious_unary_op_formatting)]
+#![allow(clippy::needless_if)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui/suspicious_unary_op_formatting.stderr
+++ b/tests/ui/suspicious_unary_op_formatting.stderr
@@ -1,5 +1,5 @@
 error: by not having a space between `>` and `-` it looks like `>-` is a single operator
-  --> $DIR/suspicious_unary_op_formatting.rs:8:9
+  --> $DIR/suspicious_unary_op_formatting.rs:9:9
    |
 LL |     if a >- 30 {}
    |         ^^^^
@@ -8,7 +8,7 @@ LL |     if a >- 30 {}
    = note: `-D clippy::suspicious-unary-op-formatting` implied by `-D warnings`
 
 error: by not having a space between `>=` and `-` it looks like `>=-` is a single operator
-  --> $DIR/suspicious_unary_op_formatting.rs:9:9
+  --> $DIR/suspicious_unary_op_formatting.rs:10:9
    |
 LL |     if a >=- 30 {}
    |         ^^^^^
@@ -16,7 +16,7 @@ LL |     if a >=- 30 {}
    = help: put a space between `>=` and `-` and remove the space after `-`
 
 error: by not having a space between `&&` and `!` it looks like `&&!` is a single operator
-  --> $DIR/suspicious_unary_op_formatting.rs:14:9
+  --> $DIR/suspicious_unary_op_formatting.rs:15:9
    |
 LL |     if b &&! c {}
    |         ^^^^^
@@ -24,7 +24,7 @@ LL |     if b &&! c {}
    = help: put a space between `&&` and `!` and remove the space after `!`
 
 error: by not having a space between `>` and `-` it looks like `>-` is a single operator
-  --> $DIR/suspicious_unary_op_formatting.rs:16:9
+  --> $DIR/suspicious_unary_op_formatting.rs:17:9
    |
 LL |     if a >-   30 {}
    |         ^^^^^^

--- a/tests/ui/unit_cmp.rs
+++ b/tests/ui/unit_cmp.rs
@@ -2,7 +2,8 @@
 #![allow(
     clippy::no_effect,
     clippy::unnecessary_operation,
-    clippy::derive_partial_eq_without_eq
+    clippy::derive_partial_eq_without_eq,
+    clippy::needless_if
 )]
 
 #[derive(PartialEq)]

--- a/tests/ui/unit_cmp.stderr
+++ b/tests/ui/unit_cmp.stderr
@@ -1,5 +1,5 @@
 error: ==-comparison of unit values detected. This will always be true
-  --> $DIR/unit_cmp.rs:16:8
+  --> $DIR/unit_cmp.rs:17:8
    |
 LL |       if {
    |  ________^
@@ -12,7 +12,7 @@ LL | |     } {}
    = note: `-D clippy::unit-cmp` implied by `-D warnings`
 
 error: >-comparison of unit values detected. This will always be false
-  --> $DIR/unit_cmp.rs:22:8
+  --> $DIR/unit_cmp.rs:23:8
    |
 LL |       if {
    |  ________^
@@ -23,7 +23,7 @@ LL | |     } {}
    | |_____^
 
 error: `assert_eq` of unit values detected. This will always succeed
-  --> $DIR/unit_cmp.rs:28:5
+  --> $DIR/unit_cmp.rs:29:5
    |
 LL | /     assert_eq!(
 LL | |         {
@@ -35,7 +35,7 @@ LL | |     );
    | |_____^
 
 error: `debug_assert_eq` of unit values detected. This will always succeed
-  --> $DIR/unit_cmp.rs:36:5
+  --> $DIR/unit_cmp.rs:37:5
    |
 LL | /     debug_assert_eq!(
 LL | |         {
@@ -47,7 +47,7 @@ LL | |     );
    | |_____^
 
 error: `assert_ne` of unit values detected. This will always fail
-  --> $DIR/unit_cmp.rs:45:5
+  --> $DIR/unit_cmp.rs:46:5
    |
 LL | /     assert_ne!(
 LL | |         {
@@ -59,7 +59,7 @@ LL | |     );
    | |_____^
 
 error: `debug_assert_ne` of unit values detected. This will always fail
-  --> $DIR/unit_cmp.rs:53:5
+  --> $DIR/unit_cmp.rs:54:5
    |
 LL | /     debug_assert_ne!(
 LL | |         {

--- a/tests/ui/unnecessary_safety_comment.rs
+++ b/tests/ui/unnecessary_safety_comment.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::undocumented_unsafe_blocks, clippy::unnecessary_safety_comment)]
-#![allow(clippy::let_unit_value, clippy::missing_safety_doc)]
+#![allow(clippy::let_unit_value, clippy::missing_safety_doc, clippy::needless_if)]
 
 mod unsafe_items_invalid_comment {
     // SAFETY:

--- a/tests/ui/unneeded_wildcard_pattern.fixed
+++ b/tests/ui/unneeded_wildcard_pattern.fixed
@@ -1,6 +1,7 @@
 //@run-rustfix
 #![feature(stmt_expr_attributes)]
 #![deny(clippy::unneeded_wildcard_pattern)]
+#![allow(clippy::needless_if)]
 
 fn main() {
     let t = (0, 1, 2, 3);

--- a/tests/ui/unneeded_wildcard_pattern.rs
+++ b/tests/ui/unneeded_wildcard_pattern.rs
@@ -1,6 +1,7 @@
 //@run-rustfix
 #![feature(stmt_expr_attributes)]
 #![deny(clippy::unneeded_wildcard_pattern)]
+#![allow(clippy::needless_if)]
 
 fn main() {
     let t = (0, 1, 2, 3);

--- a/tests/ui/unneeded_wildcard_pattern.stderr
+++ b/tests/ui/unneeded_wildcard_pattern.stderr
@@ -1,5 +1,5 @@
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:8:18
+  --> $DIR/unneeded_wildcard_pattern.rs:9:18
    |
 LL |     if let (0, .., _) = t {};
    |                  ^^^ help: remove it
@@ -11,79 +11,79 @@ LL | #![deny(clippy::unneeded_wildcard_pattern)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:9:16
+  --> $DIR/unneeded_wildcard_pattern.rs:10:16
    |
 LL |     if let (0, _, ..) = t {};
    |                ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:10:13
+  --> $DIR/unneeded_wildcard_pattern.rs:11:13
    |
 LL |     if let (_, .., 0) = t {};
    |             ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:11:15
+  --> $DIR/unneeded_wildcard_pattern.rs:12:15
    |
 LL |     if let (.., _, 0) = t {};
    |               ^^^ help: remove it
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:12:16
+  --> $DIR/unneeded_wildcard_pattern.rs:13:16
    |
 LL |     if let (0, _, _, ..) = t {};
    |                ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:13:18
+  --> $DIR/unneeded_wildcard_pattern.rs:14:18
    |
 LL |     if let (0, .., _, _) = t {};
    |                  ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:22:22
+  --> $DIR/unneeded_wildcard_pattern.rs:23:22
    |
 LL |         if let (0, .., _, _,) = t {};
    |                      ^^^^^^ help: remove them
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:29:19
+  --> $DIR/unneeded_wildcard_pattern.rs:30:19
    |
 LL |     if let S(0, .., _) = s {};
    |                   ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:30:17
+  --> $DIR/unneeded_wildcard_pattern.rs:31:17
    |
 LL |     if let S(0, _, ..) = s {};
    |                 ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:31:14
+  --> $DIR/unneeded_wildcard_pattern.rs:32:14
    |
 LL |     if let S(_, .., 0) = s {};
    |              ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:32:16
+  --> $DIR/unneeded_wildcard_pattern.rs:33:16
    |
 LL |     if let S(.., _, 0) = s {};
    |                ^^^ help: remove it
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:33:17
+  --> $DIR/unneeded_wildcard_pattern.rs:34:17
    |
 LL |     if let S(0, _, _, ..) = s {};
    |                 ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:34:19
+  --> $DIR/unneeded_wildcard_pattern.rs:35:19
    |
 LL |     if let S(0, .., _, _) = s {};
    |                   ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:43:23
+  --> $DIR/unneeded_wildcard_pattern.rs:44:23
    |
 LL |         if let S(0, .., _, _,) = s {};
    |                       ^^^^^^ help: remove them

--- a/tests/ui/unnested_or_patterns.fixed
+++ b/tests/ui/unnested_or_patterns.fixed
@@ -2,7 +2,12 @@
 
 #![feature(box_patterns)]
 #![warn(clippy::unnested_or_patterns)]
-#![allow(clippy::cognitive_complexity, clippy::match_ref_pats, clippy::upper_case_acronyms)]
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::match_ref_pats,
+    clippy::upper_case_acronyms,
+    clippy::needless_if
+)]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused)]
 
 fn main() {

--- a/tests/ui/unnested_or_patterns.rs
+++ b/tests/ui/unnested_or_patterns.rs
@@ -2,7 +2,12 @@
 
 #![feature(box_patterns)]
 #![warn(clippy::unnested_or_patterns)]
-#![allow(clippy::cognitive_complexity, clippy::match_ref_pats, clippy::upper_case_acronyms)]
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::match_ref_pats,
+    clippy::upper_case_acronyms,
+    clippy::needless_if
+)]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused)]
 
 fn main() {

--- a/tests/ui/unnested_or_patterns.stderr
+++ b/tests/ui/unnested_or_patterns.stderr
@@ -1,5 +1,5 @@
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:12:12
+  --> $DIR/unnested_or_patterns.rs:17:12
    |
 LL |     if let box 0 | box 2 = Box::new(0) {}
    |            ^^^^^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     if let box (0 | 2) = Box::new(0) {}
    |            ~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:13:12
+  --> $DIR/unnested_or_patterns.rs:18:12
    |
 LL |     if let box ((0 | 1)) | box (2 | 3) | box 4 = Box::new(0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |     if let box (0 | 1 | 2 | 3 | 4) = Box::new(0) {}
    |            ~~~~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:15:12
+  --> $DIR/unnested_or_patterns.rs:20:12
    |
 LL |     if let Some(1) | C0 | Some(2) = None {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     if let Some(1 | 2) | C0 = None {}
    |            ~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:16:12
+  --> $DIR/unnested_or_patterns.rs:21:12
    |
 LL |     if let &mut 0 | &mut 2 = &mut 0 {}
    |            ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     if let &mut (0 | 2) = &mut 0 {}
    |            ~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:17:12
+  --> $DIR/unnested_or_patterns.rs:22:12
    |
 LL |     if let x @ 0 | x @ 2 = 0 {}
    |            ^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     if let x @ (0 | 2) = 0 {}
    |            ~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:18:12
+  --> $DIR/unnested_or_patterns.rs:23:12
    |
 LL |     if let (0, 1) | (0, 2) | (0, 3) = (0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |     if let (0, 1 | 2 | 3) = (0, 0) {}
    |            ~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:19:12
+  --> $DIR/unnested_or_patterns.rs:24:12
    |
 LL |     if let (1, 0) | (2, 0) | (3, 0) = (0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     if let (1 | 2 | 3, 0) = (0, 0) {}
    |            ~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:20:12
+  --> $DIR/unnested_or_patterns.rs:25:12
    |
 LL |     if let (x, ..) | (x, 1) | (x, 2) = (0, 1) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL |     if let (x, ..) | (x, 1 | 2) = (0, 1) {}
    |            ~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:21:12
+  --> $DIR/unnested_or_patterns.rs:26:12
    |
 LL |     if let [0] | [1] = [0] {}
    |            ^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     if let [0 | 1] = [0] {}
    |            ~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:22:12
+  --> $DIR/unnested_or_patterns.rs:27:12
    |
 LL |     if let [x, 0] | [x, 1] = [0, 1] {}
    |            ^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ LL |     if let [x, 0 | 1] = [0, 1] {}
    |            ~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:23:12
+  --> $DIR/unnested_or_patterns.rs:28:12
    |
 LL |     if let [x, 0] | [x, 1] | [x, 2] = [0, 1] {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     if let [x, 0 | 1 | 2] = [0, 1] {}
    |            ~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:24:12
+  --> $DIR/unnested_or_patterns.rs:29:12
    |
 LL |     if let [x, ..] | [x, 1] | [x, 2] = [0, 1] {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL |     if let [x, ..] | [x, 1 | 2] = [0, 1] {}
    |            ~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:26:12
+  --> $DIR/unnested_or_patterns.rs:31:12
    |
 LL |     if let TS(0, x) | TS(1, x) = TS(0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     if let TS(0 | 1, x) = TS(0, 0) {}
    |            ~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:27:12
+  --> $DIR/unnested_or_patterns.rs:32:12
    |
 LL |     if let TS(1, 0) | TS(2, 0) | TS(3, 0) = TS(0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,7 +154,7 @@ LL |     if let TS(1 | 2 | 3, 0) = TS(0, 0) {}
    |            ~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:28:12
+  --> $DIR/unnested_or_patterns.rs:33:12
    |
 LL |     if let TS(x, ..) | TS(x, 1) | TS(x, 2) = TS(0, 0) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL |     if let TS(x, ..) | TS(x, 1 | 2) = TS(0, 0) {}
    |            ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:33:12
+  --> $DIR/unnested_or_patterns.rs:38:12
    |
 LL |     if let S { x: 0, y } | S { y, x: 1 } = (S { x: 0, y: 1 }) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +176,7 @@ LL |     if let S { x: 0 | 1, y } = (S { x: 0, y: 1 }) {}
    |            ~~~~~~~~~~~~~~~~~
 
 error: unnested or-patterns
-  --> $DIR/unnested_or_patterns.rs:44:12
+  --> $DIR/unnested_or_patterns.rs:49:12
    |
 LL |     if let [1] | [53] = [0] {}
    |            ^^^^^^^^^^

--- a/tests/ui/unnested_or_patterns2.fixed
+++ b/tests/ui/unnested_or_patterns2.fixed
@@ -2,7 +2,7 @@
 
 #![feature(box_patterns)]
 #![warn(clippy::unnested_or_patterns)]
-#![allow(clippy::cognitive_complexity, clippy::match_ref_pats)]
+#![allow(clippy::cognitive_complexity, clippy::match_ref_pats, clippy::needless_if)]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused_variables)]
 
 fn main() {

--- a/tests/ui/unnested_or_patterns2.rs
+++ b/tests/ui/unnested_or_patterns2.rs
@@ -2,7 +2,7 @@
 
 #![feature(box_patterns)]
 #![warn(clippy::unnested_or_patterns)]
-#![allow(clippy::cognitive_complexity, clippy::match_ref_pats)]
+#![allow(clippy::cognitive_complexity, clippy::match_ref_pats, clippy::needless_if)]
 #![allow(unreachable_patterns, irrefutable_let_patterns, unused_variables)]
 
 fn main() {

--- a/tests/ui/useless_conversion.fixed
+++ b/tests/ui/useless_conversion.fixed
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![deny(clippy::useless_conversion)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::needless_if, clippy::unnecessary_wraps)]
 
 fn test_generic<T: Copy>(val: T) -> T {
     let _ = val;

--- a/tests/ui/useless_conversion.rs
+++ b/tests/ui/useless_conversion.rs
@@ -1,7 +1,7 @@
 //@run-rustfix
 
 #![deny(clippy::useless_conversion)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::needless_if, clippy::unnecessary_wraps)]
 
 fn test_generic<T: Copy>(val: T) -> T {
     let _ = T::from(val);

--- a/tests/ui/useless_conversion_try.rs
+++ b/tests/ui/useless_conversion_try.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::useless_conversion)]
+#![allow(clippy::needless_if)]
 
 fn test_generic<T: Copy>(val: T) -> T {
     let _ = T::try_from(val).unwrap();

--- a/tests/ui/useless_conversion_try.stderr
+++ b/tests/ui/useless_conversion_try.stderr
@@ -1,5 +1,5 @@
 error: useless conversion to the same type: `T`
-  --> $DIR/useless_conversion_try.rs:4:13
+  --> $DIR/useless_conversion_try.rs:5:13
    |
 LL |     let _ = T::try_from(val).unwrap();
    |             ^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | #![deny(clippy::useless_conversion)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: useless conversion to the same type: `T`
-  --> $DIR/useless_conversion_try.rs:5:5
+  --> $DIR/useless_conversion_try.rs:6:5
    |
 LL |     val.try_into().unwrap()
    |     ^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |     val.try_into().unwrap()
    = help: consider removing `.try_into()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> $DIR/useless_conversion_try.rs:27:21
+  --> $DIR/useless_conversion_try.rs:28:21
    |
 LL |     let _: String = "foo".to_string().try_into().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |     let _: String = "foo".to_string().try_into().unwrap();
    = help: consider removing `.try_into()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> $DIR/useless_conversion_try.rs:28:21
+  --> $DIR/useless_conversion_try.rs:29:21
    |
 LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     let _: String = TryFrom::try_from("foo".to_string()).unwrap();
    = help: consider removing `TryFrom::try_from()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> $DIR/useless_conversion_try.rs:29:13
+  --> $DIR/useless_conversion_try.rs:30:13
    |
 LL |     let _ = String::try_from("foo".to_string()).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     let _ = String::try_from("foo".to_string()).unwrap();
    = help: consider removing `String::try_from()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> $DIR/useless_conversion_try.rs:30:13
+  --> $DIR/useless_conversion_try.rs:31:13
    |
 LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |     let _ = String::try_from(format!("A: {:04}", 123)).unwrap();
    = help: consider removing `String::try_from()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> $DIR/useless_conversion_try.rs:31:21
+  --> $DIR/useless_conversion_try.rs:32:21
    |
 LL |     let _: String = format!("Hello {}", "world").try_into().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL |     let _: String = format!("Hello {}", "world").try_into().unwrap();
    = help: consider removing `.try_into()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> $DIR/useless_conversion_try.rs:32:21
+  --> $DIR/useless_conversion_try.rs:33:21
    |
 LL |     let _: String = String::new().try_into().unwrap();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL |     let _: String = String::new().try_into().unwrap();
    = help: consider removing `.try_into()`
 
 error: useless conversion to the same type: `std::string::String`
-  --> $DIR/useless_conversion_try.rs:33:27
+  --> $DIR/useless_conversion_try.rs:34:27
    |
 LL |     let _: String = match String::from("_").try_into() {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
first off: Sorry about the large diff. Seems a ton of tests do this (understandably so).

this is basically everything I wanted in #10868, while it doesn't lint *all* unnecessary empty blocks, it lints needless if statements; which are basically the crux of the issue (for me) anyway. I've committed code that includes this far too many times :sweat_smile: hopefully clippy can help me out soon

closes #10868

changelog: New lint [`needless_if`]
