### PR TITLE
Don't lint manual_let_else in cases where ? would work

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -662,7 +662,6 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     });
     store.register_late_pass(move |_| Box::new(matches::Matches::new(msrv())));
     let matches_for_let_else = conf.matches_for_let_else;
-    store.register_late_pass(move |_| Box::new(manual_let_else::ManualLetElse::new(msrv(), matches_for_let_else)));
     store.register_early_pass(move || Box::new(manual_non_exhaustive::ManualNonExhaustiveStruct::new(msrv())));
     store.register_late_pass(move |_| Box::new(manual_non_exhaustive::ManualNonExhaustiveEnum::new(msrv())));
     store.register_late_pass(move |_| Box::new(manual_strip::ManualStrip::new(msrv())));
@@ -771,7 +770,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(|_| Box::<useless_conversion::UselessConversion>::default());
     store.register_late_pass(|_| Box::new(implicit_hasher::ImplicitHasher));
     store.register_late_pass(|_| Box::new(fallible_impl_from::FallibleImplFrom));
-    store.register_late_pass(|_| Box::<question_mark::QuestionMark>::default());
+    store.register_late_pass(move |_| Box::new(question_mark::QuestionMark::new(msrv(), matches_for_let_else)));
     store.register_late_pass(|_| Box::new(question_mark_used::QuestionMarkUsed));
     store.register_early_pass(|| Box::new(suspicious_operation_groupings::SuspiciousOperationGroupings));
     store.register_late_pass(|_| Box::new(suspicious_trait_impl::SuspiciousImpl));

--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -1,10 +1,10 @@
-use crate::question_mark::{pat_and_expr_can_be_question_mark, QuestionMark, QUESTION_MARK};
+use crate::question_mark::{QuestionMark, QUESTION_MARK};
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::higher::IfLetOrMatch;
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::ty::is_type_diagnostic_item;
 use clippy_utils::visitors::{Descend, Visitable};
-use clippy_utils::{is_lint_allowed, msrvs, peel_blocks};
+use clippy_utils::{is_lint_allowed, msrvs, pat_and_expr_can_be_question_mark, peel_blocks};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::Applicability;
 use rustc_hir::intravisit::{walk_expr, Visitor};

--- a/clippy_lints/src/manual_rem_euclid.rs
+++ b/clippy_lints/src/manual_rem_euclid.rs
@@ -119,7 +119,7 @@ fn check_for_either_unsigned_int_constant<'a>(
 }
 
 fn check_for_unsigned_int_constant<'a>(cx: &'a LateContext<'_>, expr: &'a Expr<'_>) -> Option<u128> {
-    let Some(int_const) = constant_full_int(cx, cx.typeck_results(), expr) else { return None };
+    let int_const = constant_full_int(cx, cx.typeck_results(), expr)?;
     match int_const {
         FullInt::S(s) => s.try_into().ok(),
         FullInt::U(u) => Some(u),

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -87,6 +87,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
 use rustc_hir::hir_id::{HirIdMap, HirIdSet};
 use rustc_hir::intravisit::{walk_expr, FnKind, Visitor};
+use rustc_hir::LangItem::OptionSome;
 use rustc_hir::LangItem::{OptionNone, ResultErr, ResultOk};
 use rustc_hir::{
     self as hir, def, Arm, ArrayLen, BindingAnnotation, Block, BlockCheckMode, Body, Closure, Destination, Expr,
@@ -2540,6 +2541,50 @@ pub fn span_extract_comment(sm: &SourceMap, span: Span) -> String {
 
 pub fn span_find_starting_semi(sm: &SourceMap, span: Span) -> Span {
     sm.span_take_while(span, |&ch| ch == ' ' || ch == ';')
+}
+
+/// Returns whether the given let pattern and else body can be turned into a question mark
+///
+/// For this example:
+/// ```ignore
+/// let FooBar { a, b } = if let Some(a) = ex { a } else { return None };
+/// ```
+/// We get as parameters:
+/// ```ignore
+/// pat: Some(a)
+/// else_body: return None
+/// ```
+
+/// And for this example:
+/// ```ignore
+/// let Some(FooBar { a, b }) = ex else { return None };
+/// ```
+/// We get as parameters:
+/// ```ignore
+/// pat: Some(FooBar { a, b })
+/// else_body: return None
+/// ```
+
+/// We output `Some(a)` in the first instance, and `Some(FooBar { a, b })` in the second, because
+/// the question mark operator is applicable here. Callers have to check whether we are in a
+/// constant or not.
+pub fn pat_and_expr_can_be_question_mark<'a, 'hir>(
+    cx: &LateContext<'_>,
+    pat: &'a Pat<'hir>,
+    else_body: &Expr<'_>,
+) -> Option<&'a Pat<'hir>> {
+    if let PatKind::TupleStruct(pat_path, [inner_pat], _) = pat.kind &&
+        is_res_lang_ctor(cx, cx.qpath_res(&pat_path, pat.hir_id), OptionSome) &&
+        !is_refutable(cx, inner_pat) &&
+        let else_body = peel_blocks(else_body) &&
+        let ExprKind::Ret(Some(ret_val)) = else_body.kind &&
+        let ExprKind::Path(ret_path) = ret_val.kind &&
+        is_res_lang_ctor(cx, cx.qpath_res(&ret_path, ret_val.hir_id), OptionNone)
+    {
+        Some(inner_pat)
+    } else {
+        None
+    }
 }
 
 macro_rules! op_utils {

--- a/tests/ui/manual_let_else_question_mark.fixed
+++ b/tests/ui/manual_let_else_question_mark.fixed
@@ -52,5 +52,12 @@ fn foo() -> Option<()> {
         let Some(v) = g() else { return None };
     }
 
+    // This is a copy of the case above where we'd fire the question_mark lint, but here we have allowed
+    // it. Make sure that manual_let_else is fired as the fallback.
+    #[allow(clippy::question_mark)]
+    {
+        let Some(v) = g() else { return None };
+    }
+
     Some(())
 }

--- a/tests/ui/manual_let_else_question_mark.fixed
+++ b/tests/ui/manual_let_else_question_mark.fixed
@@ -1,0 +1,56 @@
+//@run-rustfix
+#![allow(unused_braces, unused_variables, dead_code)]
+#![allow(
+    clippy::collapsible_else_if,
+    clippy::unused_unit,
+    clippy::let_unit_value,
+    clippy::match_single_binding,
+    clippy::never_loop
+)]
+#![warn(clippy::manual_let_else, clippy::question_mark)]
+
+enum Variant {
+    A(usize, usize),
+    B(usize),
+    C,
+}
+
+fn g() -> Option<(u8, u8)> {
+    None
+}
+
+fn e() -> Variant {
+    Variant::A(0, 0)
+}
+
+fn main() {}
+
+fn foo() -> Option<()> {
+    // Fire here, normal case
+    let v = g()?;
+
+    // Don't fire here, the pattern is refutable
+    let Variant::A(v, w) = e() else { return None };
+
+    // Fire here, the pattern is irrefutable
+    let (v, w) = g()?;
+
+    // Don't fire manual_let_else in this instance: question mark can be used instead.
+    let v = g()?;
+
+    // Do fire manual_let_else in this instance: question mark cannot be used here due to the return
+    // body.
+    let Some(v) = g() else {
+        return Some(());
+    };
+
+    // Here we could also fire the question_mark lint, but we don't (as it's a match and not an if let).
+    // So we still emit manual_let_else here. For the *resulting* code, we *do* emit the question_mark
+    // lint, so for rustfix reasons, we allow the question_mark lint here.
+    #[allow(clippy::question_mark)]
+    {
+        let Some(v) = g() else { return None };
+    }
+
+    Some(())
+}

--- a/tests/ui/manual_let_else_question_mark.rs
+++ b/tests/ui/manual_let_else_question_mark.rs
@@ -57,5 +57,12 @@ fn foo() -> Option<()> {
         };
     }
 
+    // This is a copy of the case above where we'd fire the question_mark lint, but here we have allowed
+    // it. Make sure that manual_let_else is fired as the fallback.
+    #[allow(clippy::question_mark)]
+    {
+        let v = if let Some(v_some) = g() { v_some } else { return None };
+    }
+
     Some(())
 }

--- a/tests/ui/manual_let_else_question_mark.rs
+++ b/tests/ui/manual_let_else_question_mark.rs
@@ -1,0 +1,61 @@
+//@run-rustfix
+#![allow(unused_braces, unused_variables, dead_code)]
+#![allow(
+    clippy::collapsible_else_if,
+    clippy::unused_unit,
+    clippy::let_unit_value,
+    clippy::match_single_binding,
+    clippy::never_loop
+)]
+#![warn(clippy::manual_let_else, clippy::question_mark)]
+
+enum Variant {
+    A(usize, usize),
+    B(usize),
+    C,
+}
+
+fn g() -> Option<(u8, u8)> {
+    None
+}
+
+fn e() -> Variant {
+    Variant::A(0, 0)
+}
+
+fn main() {}
+
+fn foo() -> Option<()> {
+    // Fire here, normal case
+    let Some(v) = g() else { return None };
+
+    // Don't fire here, the pattern is refutable
+    let Variant::A(v, w) = e() else { return None };
+
+    // Fire here, the pattern is irrefutable
+    let Some((v, w)) = g() else { return None };
+
+    // Don't fire manual_let_else in this instance: question mark can be used instead.
+    let v = if let Some(v_some) = g() { v_some } else { return None };
+
+    // Do fire manual_let_else in this instance: question mark cannot be used here due to the return
+    // body.
+    let v = if let Some(v_some) = g() {
+        v_some
+    } else {
+        return Some(());
+    };
+
+    // Here we could also fire the question_mark lint, but we don't (as it's a match and not an if let).
+    // So we still emit manual_let_else here. For the *resulting* code, we *do* emit the question_mark
+    // lint, so for rustfix reasons, we allow the question_mark lint here.
+    #[allow(clippy::question_mark)]
+    {
+        let v = match g() {
+            Some(v_some) => v_some,
+            _ => return None,
+        };
+    }
+
+    Some(())
+}

--- a/tests/ui/manual_let_else_question_mark.stderr
+++ b/tests/ui/manual_let_else_question_mark.stderr
@@ -45,5 +45,11 @@ LL | |             _ => return None,
 LL | |         };
    | |__________^ help: consider writing: `let Some(v) = g() else { return None };`
 
-error: aborting due to 5 previous errors
+error: this could be rewritten as `let...else`
+  --> $DIR/manual_let_else_question_mark.rs:64:9
+   |
+LL |         let v = if let Some(v_some) = g() { v_some } else { return None };
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider writing: `let Some(v) = g() else { return None };`
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/manual_let_else_question_mark.stderr
+++ b/tests/ui/manual_let_else_question_mark.stderr
@@ -1,0 +1,49 @@
+error: this `let...else` may be rewritten with the `?` operator
+  --> $DIR/manual_let_else_question_mark.rs:30:5
+   |
+LL |     let Some(v) = g() else { return None };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `let v = g()?;`
+   |
+   = note: `-D clippy::question-mark` implied by `-D warnings`
+
+error: this `let...else` may be rewritten with the `?` operator
+  --> $DIR/manual_let_else_question_mark.rs:36:5
+   |
+LL |     let Some((v, w)) = g() else { return None };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `let (v, w) = g()?;`
+
+error: this block may be rewritten with the `?` operator
+  --> $DIR/manual_let_else_question_mark.rs:39:13
+   |
+LL |     let v = if let Some(v_some) = g() { v_some } else { return None };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `g()?`
+
+error: this could be rewritten as `let...else`
+  --> $DIR/manual_let_else_question_mark.rs:43:5
+   |
+LL | /     let v = if let Some(v_some) = g() {
+LL | |         v_some
+LL | |     } else {
+LL | |         return Some(());
+LL | |     };
+   | |______^
+   |
+   = note: `-D clippy::manual-let-else` implied by `-D warnings`
+help: consider writing
+   |
+LL ~     let Some(v) = g() else {
+LL +         return Some(());
+LL +     };
+   |
+
+error: this could be rewritten as `let...else`
+  --> $DIR/manual_let_else_question_mark.rs:54:9
+   |
+LL | /         let v = match g() {
+LL | |             Some(v_some) => v_some,
+LL | |             _ => return None,
+LL | |         };
+   | |__________^ help: consider writing: `let Some(v) = g() else { return None };`
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Don't lint `manual_let_else` where the question mark operator `?` would be sufficient, that is, mostly in cases like:

```Rust
let v = if let Some(v) = ex { v } else { return None };
```

Also, this PR emits the `question_mark` lint for `let...else` patterns that could be written with `?` (also, only `return None` like cases).

```
changelog: [`manual_let_else`]: don't lint in cases where question_mark already lints
changelog: [`question_mark`]: lint for `let Some(...) = ex else { return None };`
```

Fixes  #8755