### PR TITLE
Allow multiple clippy.tomls and make them inherit from lower priority ones

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,3 @@
-# NOTE: Any changes here must be reversed in `tests/clippy.toml`
+# NOTE: Any changes here must be reversed in `tests/clippy.toml`, expect `workspace`
+workspace = true
 avoid-breaking-exported-api = false

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
+# NOTE: Any changes here must be reversed in `tests/clippy.toml`
 avoid-breaking-exported-api = false

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -119,10 +119,9 @@ struct ClippyCallbacks {
 }
 
 impl rustc_driver::Callbacks for ClippyCallbacks {
-    // JUSTIFICATION: necessary in clippy driver to set `mir_opt_level`
-    #[allow(rustc::bad_opt_access)]
+    #[allow(rustc::bad_opt_access, reason = "necessary in clippy driver to set `mir_opt_level`")]
     fn config(&mut self, config: &mut interface::Config) {
-        let conf_path = clippy_lints::lookup_conf_file();
+        let conf_path = clippy_lints::lookup_conf_files();
         let previous = config.register_lints.take();
         let clippy_args_var = self.clippy_args_var.take();
         config.parse_sess_created = Some(Box::new(move |parse_sess| {

--- a/tests/clippy.toml
+++ b/tests/clippy.toml
@@ -1,1 +1,2 @@
 # default config for tests, overrides clippy.toml at the project root
+avoid-breaking-exported-api = true

--- a/tests/ui-cargo/inherit_config/clippy.toml
+++ b/tests/ui-cargo/inherit_config/clippy.toml
@@ -1,0 +1,2 @@
+too-many-lines-threshold = 1
+single-char-binding-names-threshold = 1

--- a/tests/ui-cargo/inherit_config/inner/Cargo.toml
+++ b/tests/ui-cargo/inherit_config/inner/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "inherit-config"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/ui-cargo/inherit_config/inner/clippy.toml
+++ b/tests/ui-cargo/inherit_config/inner/clippy.toml
@@ -1,2 +1,4 @@
 too-many-lines-threshold = 3
 msrv = "1.1"
+# Will emit an error if uncommented, and revert to default config
+# workspace = true

--- a/tests/ui-cargo/inherit_config/inner/clippy.toml
+++ b/tests/ui-cargo/inherit_config/inner/clippy.toml
@@ -1,0 +1,2 @@
+too-many-lines-threshold = 3
+msrv = "1.1"

--- a/tests/ui-cargo/inherit_config/inner/src/main.rs
+++ b/tests/ui-cargo/inherit_config/inner/src/main.rs
@@ -1,0 +1,11 @@
+//@compile-flags: --crate-name=inherit_config
+#![warn(clippy::many_single_char_names, clippy::too_many_lines)]
+
+fn main() {
+    // Inherited from outer config
+    let (a, b, c) = (1, 2, 3);
+    _ = ();
+    _ = ();
+    _ = ();
+    // Too many lines, not 1 but 3 because of inner config
+}

--- a/tests/ui-cargo/inherit_config/inner/src/main.stderr
+++ b/tests/ui-cargo/inherit_config/inner/src/main.stderr
@@ -1,0 +1,44 @@
+error: 3 bindings with single-character names in scope
+  --> $DIR/main.rs:6:10
+   |
+LL |     let (a, b, c) = (1, 2, 3);
+   |          ^  ^  ^
+   |
+   = note: `-D clippy::many-single-char-names` implied by `-D warnings`
+
+error: this function has too many lines (4/3)
+  --> $DIR/main.rs:4:1
+   |
+LL | / fn main() {
+LL | |     // Inherited from outer config
+LL | |     let (a, b, c) = (1, 2, 3);
+LL | |     _ = ();
+...  |
+LL | |     // Too many lines, not 1 but 3 because of inner config
+LL | | }
+   | |_^
+   |
+   = note: `-D clippy::too-many-lines` implied by `-D warnings`
+
+error: this let-binding has unit value
+  --> $DIR/main.rs:7:5
+   |
+LL |     _ = ();
+   |     ^^^^^^ help: omit the `let` binding: `();`
+   |
+   = note: `-D clippy::let-unit-value` implied by `-D warnings`
+
+error: this let-binding has unit value
+  --> $DIR/main.rs:8:5
+   |
+LL |     _ = ();
+   |     ^^^^^^ help: omit the `let` binding: `();`
+
+error: this let-binding has unit value
+  --> $DIR/main.rs:9:5
+   |
+LL |     _ = ();
+   |     ^^^^^^ help: omit the `let` binding: `();`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -58,6 +58,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            vec-box-size-threshold
            verbose-bit-mask-threshold
            warn-on-all-wildcard-imports
+           workspace
   --> $DIR/clippy.toml:2:1
    |
 LL | foobar = 42
@@ -123,6 +124,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            vec-box-size-threshold
            verbose-bit-mask-threshold
            warn-on-all-wildcard-imports
+           workspace
   --> $DIR/clippy.toml:4:1
    |
 LL | barfoo = 53


### PR DESCRIPTION
This is a bit of a pain to test, but from my own testing it seems to work :slightly_smiling_face:
Just one issue I know currently, see https://github.com/Centri3/rust-clippy/blob/560b6b7122f8de1295c4bfe66c8e7d314ae868b1/clippy_lints/src/utils/conf.rs#L571-L574

Closes #7353

changelog: Enhancement: `clippy.toml` can now be modified on a per-package basis
