### PR TITLE
Don't lint non-statement/faux empty `needless_if`s

### DIFF
--- a/tests/ui/needless_if.fixed
+++ b/tests/ui/needless_if.fixed
@@ -5,9 +5,12 @@
     clippy::blocks_in_if_conditions,
     clippy::if_same_then_else,
     clippy::ifs_same_cond,
+    clippy::let_unit_value,
     clippy::needless_else,
     clippy::no_effect,
     clippy::nonminimal_bool,
+    clippy::short_circuit_statement,
+    clippy::unnecessary_operation,
     unused
 )]
 #![warn(clippy::needless_if)]
@@ -16,12 +19,7 @@ extern crate proc_macros;
 use proc_macros::external;
 use proc_macros::with_span;
 
-fn no_side_effects() -> bool {
-    true
-}
-
-fn has_side_effects(a: &mut u32) -> bool {
-    *a = 1;
+fn maybe_side_effect() -> bool {
     true
 }
 
@@ -29,32 +27,67 @@ fn main() {
     // Lint
     
     // Do not remove the condition
-    no_side_effects();
-    let mut x = 0;
-    has_side_effects(&mut x);
-    assert_eq!(x, 1);
+    maybe_side_effect();
     // Do not lint
     if (true) {
     } else {
     }
-    {
+    ({
         return;
-    };
+    });
     // Do not lint if `else if` is present
     if (true) {
     } else if (true) {
     }
-    // Do not lint if any `let` is present
+    // Do not lint `if let` or let chains
     if let true = true {}
     if let true = true && true {}
     if true && let true = true {}
-    if {
+    // Can lint nested `if let`s
+    ({
         if let true = true && true { true } else { false }
-    } && true
-    {}
+    } && true);
     external! { if (true) {} }
     with_span! {
         span
         if (true) {}
     }
+
+    if true {
+        // comment
+    }
+
+    if true {
+        #[cfg(any())]
+        foo;
+    }
+
+    macro_rules! empty_expansion {
+        () => {};
+    }
+
+    if true {
+        empty_expansion!();
+    }
+
+    macro_rules! empty_repetition {
+        ($($t:tt)*) => {
+            if true {
+                $($t)*
+            }
+        }
+    }
+
+    empty_repetition!();
+
+    // Must be placed into an expression context to not be interpreted as a block
+    ({ maybe_side_effect() });
+    // Would be a block followed by `&&true` - a double reference to `true`
+    ({ maybe_side_effect() } && true);
+
+    // Don't leave trailing attributes
+    #[allow(unused)]
+    true;
+
+    let () = if maybe_side_effect() {};
 }

--- a/tests/ui/needless_if.stderr
+++ b/tests/ui/needless_if.stderr
@@ -1,5 +1,5 @@
 error: this `if` branch is empty
-  --> $DIR/needless_if.rs:30:5
+  --> $DIR/needless_if.rs:28:5
    |
 LL |     if (true) {}
    |     ^^^^^^^^^^^^ help: you can remove it
@@ -7,19 +7,13 @@ LL |     if (true) {}
    = note: `-D clippy::needless-if` implied by `-D warnings`
 
 error: this `if` branch is empty
-  --> $DIR/needless_if.rs:32:5
+  --> $DIR/needless_if.rs:30:5
    |
-LL |     if no_side_effects() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `no_side_effects();`
+LL |     if maybe_side_effect() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `maybe_side_effect();`
 
 error: this `if` branch is empty
-  --> $DIR/needless_if.rs:34:5
-   |
-LL |     if has_side_effects(&mut x) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `has_side_effects(&mut x);`
-
-error: this `if` branch is empty
-  --> $DIR/needless_if.rs:40:5
+  --> $DIR/needless_if.rs:35:5
    |
 LL | /     if {
 LL | |         return;
@@ -28,10 +22,44 @@ LL | |     } {}
    |
 help: you can remove it
    |
-LL ~     {
+LL ~     ({
 LL +         return;
-LL +     };
+LL +     });
    |
 
-error: aborting due to 4 previous errors
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:47:5
+   |
+LL | /     if {
+LL | |         if let true = true && true { true } else { false }
+LL | |     } && true
+LL | |     {}
+   | |______^
+   |
+help: you can remove it
+   |
+LL ~     ({
+LL +         if let true = true && true { true } else { false }
+LL +     } && true);
+   |
+
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:85:5
+   |
+LL |     if { maybe_side_effect() } {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() });`
+
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:87:5
+   |
+LL |     if { maybe_side_effect() } && true {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can remove it: `({ maybe_side_effect() } && true);`
+
+error: this `if` branch is empty
+  --> $DIR/needless_if.rs:91:5
+   |
+LL |     if true {}
+   |     ^^^^^^^^^^ help: you can remove it: `true;`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Also has a basic fall-back for `if` statements that have attributes applied to them and incorporates https://github.com/rust-lang/rust-clippy/pull/10921#pullrequestreview-1474008780 while I was there

r? @Manishearth

changelog: none