### PR TITLE
[`no_effect`]: Suggest adding `return` if applicable

### DIFF
--- a/tests/ui/no_effect_return.rs
+++ b/tests/ui/no_effect_return.rs
@@ -1,0 +1,81 @@
+#![allow(clippy::unused_unit, dead_code, unused)]
+#![no_main]
+
+use std::ops::ControlFlow;
+
+fn a() -> u32 {
+    {
+        0u32;
+    }
+    0
+}
+
+async fn b() -> u32 {
+    {
+        0u32;
+    }
+    0
+}
+
+type C = i32;
+async fn c() -> C {
+    {
+        0i32 as C;
+    }
+    0
+}
+
+fn d() -> u128 {
+    {
+        // not last stmt
+        0u128;
+        println!("lol");
+    }
+    0
+}
+
+fn e() -> u32 {
+    {
+        // mismatched types
+        0u16;
+    }
+    0
+}
+
+fn f() -> [u16; 1] {
+    {
+        [1u16];
+    }
+    [1]
+}
+
+fn g() -> ControlFlow<()> {
+    {
+        ControlFlow::Break::<()>(());
+    }
+    ControlFlow::Continue(())
+}
+
+fn h() -> Vec<u16> {
+    {
+        // function call, so this won't trigger `no_effect`. not an issue with this change, but the
+        // lint itself (but also not really.)
+        vec![0u16];
+    }
+    vec![]
+}
+
+fn i() -> () {
+    {
+        ();
+    }
+    ()
+}
+
+fn j() {
+    {
+        // does not suggest on function without explicit return type
+        ();
+    }
+    ()
+}

--- a/tests/ui/no_effect_return.stderr
+++ b/tests/ui/no_effect_return.stderr
@@ -1,0 +1,70 @@
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:8:9
+   |
+LL |         0u32;
+   |         -^^^^
+   |         |
+   |         help: did you mean to return it?: `return`
+   |
+   = note: `-D clippy::no-effect` implied by `-D warnings`
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:15:9
+   |
+LL |         0u32;
+   |         -^^^^
+   |         |
+   |         help: did you mean to return it?: `return`
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:23:9
+   |
+LL |         0i32 as C;
+   |         -^^^^^^^^^
+   |         |
+   |         help: did you mean to return it?: `return`
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:31:9
+   |
+LL |         0u128;
+   |         ^^^^^^
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:40:9
+   |
+LL |         0u16;
+   |         ^^^^^
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:47:9
+   |
+LL |         [1u16];
+   |         -^^^^^^
+   |         |
+   |         help: did you mean to return it?: `return`
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:54:9
+   |
+LL |         ControlFlow::Break::<()>(());
+   |         -^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: did you mean to return it?: `return`
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:70:9
+   |
+LL |         ();
+   |         -^^
+   |         |
+   |         help: did you mean to return it?: `return`
+
+error: statement with no effect
+  --> $DIR/no_effect_return.rs:78:9
+   |
+LL |         ();
+   |         ^^^
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
Closes #10941

Unfortunately doesn't catch anything complex as `no_effect` already wouldn't, but I'm fine with that (it catches `ControlFlow` at least :D)

changelog: [`no_effect`]: Suggest adding `return` if statement has same type as function's return type and is the last statement in a block
