### PR TITLE
[`match_same_arms`]: don't lint if `non_exhaustive_omitted_patterns`

### DIFF
--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -559,6 +559,9 @@ declare_clippy_lint! {
     /// ### What it does
     /// Checks for `match` with identical arm bodies.
     ///
+    /// Note: Does not lint on wildcards if the `non_exhaustive_omitted_patterns_lint` feature is
+    /// enabled and disallowed.
+    ///
     /// ### Why is this bad?
     /// This is probably a copy & paste error. If arm bodies
     /// are the same on purpose, you can factor them

--- a/tests/ui/match_same_arms_non_exhaustive.rs
+++ b/tests/ui/match_same_arms_non_exhaustive.rs
@@ -1,0 +1,58 @@
+#![feature(non_exhaustive_omitted_patterns_lint)]
+#![warn(clippy::match_same_arms)]
+#![no_main]
+
+use std::sync::atomic::Ordering; // #[non_exhaustive] enum
+
+pub fn f(x: Ordering) {
+    match x {
+        Ordering::Relaxed => println!("relaxed"),
+        Ordering::Release => println!("release"),
+        Ordering::Acquire => println!("acquire"),
+        Ordering::AcqRel | Ordering::SeqCst => panic!(),
+        #[deny(non_exhaustive_omitted_patterns)]
+        _ => panic!(),
+    }
+}
+
+mod f {
+    #![deny(non_exhaustive_omitted_patterns)]
+
+    use super::*;
+
+    pub fn f(x: Ordering) {
+        match x {
+            Ordering::Relaxed => println!("relaxed"),
+            Ordering::Release => println!("release"),
+            Ordering::Acquire => println!("acquire"),
+            Ordering::AcqRel | Ordering::SeqCst => panic!(),
+            _ => panic!(),
+        }
+    }
+}
+
+// Below should still lint
+
+pub fn g(x: Ordering) {
+    match x {
+        Ordering::Relaxed => println!("relaxed"),
+        Ordering::Release => println!("release"),
+        Ordering::Acquire => println!("acquire"),
+        Ordering::AcqRel | Ordering::SeqCst => panic!(),
+        _ => panic!(),
+    }
+}
+
+mod g {
+    use super::*;
+
+    pub fn g(x: Ordering) {
+        match x {
+            Ordering::Relaxed => println!("relaxed"),
+            Ordering::Release => println!("release"),
+            Ordering::Acquire => println!("acquire"),
+            Ordering::AcqRel | Ordering::SeqCst => panic!(),
+            _ => panic!(),
+        }
+    }
+}

--- a/tests/ui/match_same_arms_non_exhaustive.stderr
+++ b/tests/ui/match_same_arms_non_exhaustive.stderr
@@ -1,0 +1,29 @@
+error: this match arm has an identical body to the `_` wildcard arm
+  --> $DIR/match_same_arms_non_exhaustive.rs:41:9
+   |
+LL |         Ordering::AcqRel | Ordering::SeqCst => panic!(),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the arm
+   |
+   = help: or try changing either arm body
+note: `_` wildcard arm here
+  --> $DIR/match_same_arms_non_exhaustive.rs:42:9
+   |
+LL |         _ => panic!(),
+   |         ^^^^^^^^^^^^^
+   = note: `-D clippy::match-same-arms` implied by `-D warnings`
+
+error: this match arm has an identical body to the `_` wildcard arm
+  --> $DIR/match_same_arms_non_exhaustive.rs:54:13
+   |
+LL |             Ordering::AcqRel | Ordering::SeqCst => panic!(),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the arm
+   |
+   = help: or try changing either arm body
+note: `_` wildcard arm here
+  --> $DIR/match_same_arms_non_exhaustive.rs:55:13
+   |
+LL |             _ => panic!(),
+   |             ^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #10327

changelog: [`match_same_arms`]: Don't lint if `non_exhaustive_omitted_patterns` is `warn` or `deny`
