### PR TITLE
[`borrow_as_ptr`]: Ignore temporaries

### DIFF
--- a/tests/ui/borrow_as_ptr.fixed
+++ b/tests/ui/borrow_as_ptr.fixed
@@ -1,9 +1,18 @@
 //@run-rustfix
 #![warn(clippy::borrow_as_ptr)]
+#![allow(clippy::useless_vec)]
+
+fn a() -> i32 {
+    0
+}
 
 fn main() {
     let val = 1;
     let _p = std::ptr::addr_of!(val);
+    let _p = &0 as *const i32;
+    let _p = &a() as *const i32;
+    let vec = vec![1];
+    let _p = &vec.len() as *const usize;
 
     let mut val_mut = 1;
     let _p_mut = std::ptr::addr_of_mut!(val_mut);

--- a/tests/ui/borrow_as_ptr.rs
+++ b/tests/ui/borrow_as_ptr.rs
@@ -1,9 +1,18 @@
 //@run-rustfix
 #![warn(clippy::borrow_as_ptr)]
+#![allow(clippy::useless_vec)]
+
+fn a() -> i32 {
+    0
+}
 
 fn main() {
     let val = 1;
     let _p = &val as *const i32;
+    let _p = &0 as *const i32;
+    let _p = &a() as *const i32;
+    let vec = vec![1];
+    let _p = &vec.len() as *const usize;
 
     let mut val_mut = 1;
     let _p_mut = &mut val_mut as *mut i32;

--- a/tests/ui/borrow_as_ptr.stderr
+++ b/tests/ui/borrow_as_ptr.stderr
@@ -1,5 +1,5 @@
 error: borrow as raw pointer
-  --> $DIR/borrow_as_ptr.rs:6:14
+  --> $DIR/borrow_as_ptr.rs:11:14
    |
 LL |     let _p = &val as *const i32;
    |              ^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of!(val)`
@@ -7,7 +7,7 @@ LL |     let _p = &val as *const i32;
    = note: `-D clippy::borrow-as-ptr` implied by `-D warnings`
 
 error: borrow as raw pointer
-  --> $DIR/borrow_as_ptr.rs:9:18
+  --> $DIR/borrow_as_ptr.rs:18:18
    |
 LL |     let _p_mut = &mut val_mut as *mut i32;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `std::ptr::addr_of_mut!(val_mut)`


### PR DESCRIPTION
Fixes #9884

changelog: [`borrow_as_ptr`]: Ignore temporaries
