### PR TITLE
[`derivable_impls`]: don't lint if `default()` call expr unsize-coerces to trait object

### DIFF
--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -78,12 +78,10 @@ fn is_path_self(e: &Expr<'_>) -> bool {
 
 fn contains_trait_object(cx: &LateContext<'_>, ty: ty::Ty<'_>) -> bool {
     match ty.kind() {
-        ty::TyKind::Ref(_, ty, _) => {
-            contains_trait_object(cx, *ty)
-        },
+        ty::TyKind::Ref(_, ty, _) => contains_trait_object(cx, *ty),
         ty::TyKind::Adt(def, substs) => {
             def.is_box() && substs[0].as_type().map_or(false, |ty| contains_trait_object(cx, ty))
-        }
+        },
         ty::TyKind::Dynamic(..) => true,
         _ => false,
     }
@@ -119,7 +117,7 @@ fn check_struct<'tcx>(
     let is_default_without_adjusts = |expr| {
         is_default_equivalent(cx, expr)
             && typeck_results.expr_adjustments(expr).iter().all(|adj| {
-                !matches!(adj.kind, Adjust::Pointer(PointerCast::Unsize) 
+                !matches!(adj.kind, Adjust::Pointer(PointerCast::Unsize)
                     if contains_trait_object(cx, adj.target))
             })
     };

--- a/tests/ui/derivable_impls.fixed
+++ b/tests/ui/derivable_impls.fixed
@@ -268,4 +268,25 @@ impl Default for OtherGenericType {
     }
 }
 
+mod issue10158 {
+    pub trait T {}
+
+    #[derive(Default)]
+    pub struct S {}
+    impl T for S {}
+
+    pub struct Outer {
+        pub inner: Box<dyn T>,
+    }
+
+    impl Default for Outer {
+        fn default() -> Self {
+            Outer {
+                // Box::<S>::default() adjusts to Box<dyn T>
+                inner: Box::<S>::default(),
+            }
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/derivable_impls.rs
+++ b/tests/ui/derivable_impls.rs
@@ -304,4 +304,25 @@ impl Default for OtherGenericType {
     }
 }
 
+mod issue10158 {
+    pub trait T {}
+
+    #[derive(Default)]
+    pub struct S {}
+    impl T for S {}
+
+    pub struct Outer {
+        pub inner: Box<dyn T>,
+    }
+
+    impl Default for Outer {
+        fn default() -> Self {
+            Outer {
+                // Box::<S>::default() adjusts to Box<dyn T>
+                inner: Box::<S>::default(),
+            }
+        }
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes #10158.

This fixes a FP where the derive-generated Default impl would have different behavior because of unsize coercion from `Box<T>` to `Box<dyn Trait>`:
```rs
struct S {
  x: Box<dyn std::fmt::Debug>
}
impl Default for S {
  fn default() -> Self {
    Self {
      x: Box::<()>::default()
     // ^~ Box<()> coerces to Box<dyn Debug>
     // #[derive(Default)] would call Box::<dyn Debug>::default()
    }
  }
}
```
(this intentionally only looks for trait objects `dyn` specifically, and not any unsize coercion, e.g. `&[i32; 5]` to `&[i32]`, because that breaks existing tests and isn't actually problematic, as far as I can tell)

changelog: [`derivable_impls`]: don't lint if `default()` call expression unsize-coerces to trait object
