### PR TITLE
new lint `iter_skip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4873,6 +4873,7 @@ Released 2018-09-13
 [`iter_on_empty_collections`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_on_empty_collections
 [`iter_on_single_items`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_on_single_items
 [`iter_overeager_cloned`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_overeager_cloned
+[`iter_skip`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip
 [`iter_skip_next`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip_next
 [`iter_with_drain`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_with_drain
 [`iterator_step_by_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#iterator_step_by_zero

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -353,6 +353,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::ITER_ON_EMPTY_COLLECTIONS_INFO,
     crate::methods::ITER_ON_SINGLE_ITEMS_INFO,
     crate::methods::ITER_OVEREAGER_CLONED_INFO,
+    crate::methods::ITER_SKIP_INFO,
     crate::methods::ITER_SKIP_NEXT_INFO,
     crate::methods::ITER_WITH_DRAIN_INFO,
     crate::methods::MANUAL_FILTER_MAP_INFO,

--- a/clippy_lints/src/loops/manual_memcpy.rs
+++ b/clippy_lints/src/loops/manual_memcpy.rs
@@ -407,10 +407,11 @@ fn get_assignments<'a, 'tcx>(
             if let ExprKind::AssignOp(_, place, _) = e.kind {
                 path_to_local(place).map_or(false, |id| {
                     !loop_counters
-                        .iter()
                         // skip the first item which should be `StartKind::Range`
                         // this makes it possible to use the slice with `StartKind::Range` in the same iterator loop.
-                        .skip(1)
+                        .get(1..)
+                        .unwrap_or(&[])
+                        .iter()
                         .any(|counter| counter.id == id)
                 })
             } else {

--- a/clippy_lints/src/methods/iter_skip.rs
+++ b/clippy_lints/src/methods/iter_skip.rs
@@ -1,0 +1,58 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::is_trait_method;
+use clippy_utils::source::snippet_with_applicability;
+use rustc_ast::Mutability;
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind, Node};
+use rustc_lint::LateContext;
+use rustc_span::sym;
+use rustc_span::Span;
+use std::borrow::Cow;
+
+use super::ITER_SKIP;
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, iter_method: &str, trim_span: Span) {
+    let mutability = match iter_method {
+        "iter" | "into_iter" => Mutability::Not,
+        "iter_mut" => Mutability::Mut,
+        _ => unreachable!("pattern in `mod.rs` only matches for these"),
+    };
+
+    if is_trait_method(cx, expr, sym::Iterator) {
+        let needs_iter = if let Node::Expr(next_call) = cx.tcx.hir().get_parent(expr.hir_id)
+            && let ExprKind::MethodCall(..) = next_call.kind
+        {
+            true
+        } else {
+            false
+        };
+
+        let mut app = Applicability::MachineApplicable;
+        span_lint_and_then(
+            cx,
+            ITER_SKIP,
+            expr.span.with_lo(trim_span.hi()),
+            &format!("called `{iter_method}()` followed by `skip(..)`"),
+            |diag| {
+                diag.span_suggestion(
+                    expr.span.with_lo(trim_span.hi()),
+                    "use `get` instead",
+                    format!(
+                        ".get{}({}..).unwrap_or(&{}[]){}",
+                        if mutability.is_mut() { "_mut" } else { "" },
+                        snippet_with_applicability(cx, arg.span, "<i>", &mut app),
+                        if mutability.is_mut() { "mut " } else { "" },
+                        // If there's another call after `skip`, we must convert it to an iterator
+                        if needs_iter {
+                            format!(".{iter_method}()").into()
+                        } else {
+                            Cow::Borrowed("")
+                        },
+                    ),
+                    app,
+                );
+                diag.note("you may need to call `copied`");
+            },
+        );
+    }
+}

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -172,7 +172,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                     !preds.is_empty() && {
                         let ty_empty_region = cx.tcx.mk_imm_ref(cx.tcx.lifetimes.re_erased, ty);
                         preds.iter().all(|t| {
-                            let ty_params = t.trait_ref.substs.iter().skip(1).collect::<Vec<_>>();
+                            let ty_params = t.trait_ref.substs.get(1..).unwrap_or(&[]).to_vec();
                             implements_trait(cx, ty_empty_region, t.def_id(), &ty_params)
                         })
                     },

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -199,7 +199,7 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                 if bounds.len() != unique_traits.len() {
                     let mut bounds_span = bounds[0].span;
 
-                    for bound in bounds.iter().skip(1) {
+                    for bound in bounds.get(1..).unwrap_or(&[]) {
                         bounds_span = bounds_span.to(bound.span);
                     }
 

--- a/tests/ui/iter_overeager_cloned.fixed
+++ b/tests/ui/iter_overeager_cloned.fixed
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::iter_overeager_cloned, clippy::redundant_clone, clippy::filter_next)]
-#![allow(dead_code, clippy::let_unit_value, clippy::useless_vec)]
+#![allow(dead_code, clippy::let_unit_value, clippy::useless_vec, clippy::iter_skip)]
 
 fn main() {
     let vec = vec!["1".to_string(), "2".to_string(), "3".to_string()];

--- a/tests/ui/iter_overeager_cloned.rs
+++ b/tests/ui/iter_overeager_cloned.rs
@@ -1,6 +1,6 @@
 //@run-rustfix
 #![warn(clippy::iter_overeager_cloned, clippy::redundant_clone, clippy::filter_next)]
-#![allow(dead_code, clippy::let_unit_value, clippy::useless_vec)]
+#![allow(dead_code, clippy::let_unit_value, clippy::useless_vec, clippy::iter_skip)]
 
 fn main() {
     let vec = vec!["1".to_string(), "2".to_string(), "3".to_string()];

--- a/tests/ui/iter_skip.fixed
+++ b/tests/ui/iter_skip.fixed
@@ -1,0 +1,44 @@
+//@run-rustfix
+#![warn(clippy::iter_skip)]
+#![allow(
+    clippy::iter_skip_next,
+    clippy::useless_vec,
+    clippy::into_iter_on_ref,
+    for_loops_over_fallibles,
+    clippy::iter_next_loop
+)]
+#![no_main]
+
+pub fn _1(list: &[u32]) {
+    for _ in list.get(5..).unwrap_or(&[]) {}
+}
+
+pub fn _2(list: &mut [u32]) {
+    for _ in list.get_mut(5..).unwrap_or(&mut []) {}
+}
+
+pub fn _3(list: Vec<u32>) {
+    for _ in list.get(5..).unwrap_or(&[]) {}
+}
+
+pub fn _4(mut list: Vec<u32>) {
+    for _ in list.get_mut(5..).unwrap_or(&mut []) {}
+}
+
+pub fn _5(list: &[u32]) {
+    for _ in list.get(5..).unwrap_or(&[]) {}
+}
+
+pub fn _6(list: &mut [u32]) {
+    for _ in list.get(5..).unwrap_or(&[]) {}
+}
+
+// Don't lint
+
+pub fn _7(list: &[u32]) {
+    for _ in list.get(5..).unwrap_or(&[]).iter().next() {}
+}
+
+pub fn _8(list: &[u32]) {
+    for _ in list.get(5..).unwrap_or(&[]).iter().next() {}
+}

--- a/tests/ui/iter_skip.rs
+++ b/tests/ui/iter_skip.rs
@@ -1,0 +1,44 @@
+//@run-rustfix
+#![warn(clippy::iter_skip)]
+#![allow(
+    clippy::iter_skip_next,
+    clippy::useless_vec,
+    clippy::into_iter_on_ref,
+    for_loops_over_fallibles,
+    clippy::iter_next_loop
+)]
+#![no_main]
+
+pub fn _1(list: &[u32]) {
+    for _ in list.iter().skip(5) {}
+}
+
+pub fn _2(list: &mut [u32]) {
+    for _ in list.iter_mut().skip(5) {}
+}
+
+pub fn _3(list: Vec<u32>) {
+    for _ in list.iter().skip(5) {}
+}
+
+pub fn _4(mut list: Vec<u32>) {
+    for _ in list.iter_mut().skip(5) {}
+}
+
+pub fn _5(list: &[u32]) {
+    for _ in list.into_iter().skip(5) {}
+}
+
+pub fn _6(list: &mut [u32]) {
+    for _ in list.into_iter().skip(5) {}
+}
+
+// Don't lint
+
+pub fn _7(list: &[u32]) {
+    for _ in list.iter().skip(5).next() {}
+}
+
+pub fn _8(list: &[u32]) {
+    for _ in list.iter().skip(5).next() {}
+}

--- a/tests/ui/iter_skip.stderr
+++ b/tests/ui/iter_skip.stderr
@@ -1,0 +1,67 @@
+error: called `iter()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:13:18
+   |
+LL |     for _ in list.iter().skip(5) {}
+   |                  ^^^^^^^^^^^^^^^ help: use `get` instead: `.get(5..).unwrap_or(&[])`
+   |
+   = note: you may need to call `copied`
+   = note: `-D clippy::iter-skip` implied by `-D warnings`
+
+error: called `iter_mut()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:17:18
+   |
+LL |     for _ in list.iter_mut().skip(5) {}
+   |                  ^^^^^^^^^^^^^^^^^^^ help: use `get` instead: `.get_mut(5..).unwrap_or(&mut [])`
+   |
+   = note: you may need to call `copied`
+
+error: called `iter()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:21:18
+   |
+LL |     for _ in list.iter().skip(5) {}
+   |                  ^^^^^^^^^^^^^^^ help: use `get` instead: `.get(5..).unwrap_or(&[])`
+   |
+   = note: you may need to call `copied`
+
+error: called `iter_mut()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:25:18
+   |
+LL |     for _ in list.iter_mut().skip(5) {}
+   |                  ^^^^^^^^^^^^^^^^^^^ help: use `get` instead: `.get_mut(5..).unwrap_or(&mut [])`
+   |
+   = note: you may need to call `copied`
+
+error: called `into_iter()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:29:18
+   |
+LL |     for _ in list.into_iter().skip(5) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^ help: use `get` instead: `.get(5..).unwrap_or(&[])`
+   |
+   = note: you may need to call `copied`
+
+error: called `into_iter()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:33:18
+   |
+LL |     for _ in list.into_iter().skip(5) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^ help: use `get` instead: `.get(5..).unwrap_or(&[])`
+   |
+   = note: you may need to call `copied`
+
+error: called `iter()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:39:18
+   |
+LL |     for _ in list.iter().skip(5).next() {}
+   |                  ^^^^^^^^^^^^^^^ help: use `get` instead: `.get(5..).unwrap_or(&[]).iter()`
+   |
+   = note: you may need to call `copied`
+
+error: called `iter()` followed by `skip(..)`
+  --> $DIR/iter_skip.rs:43:18
+   |
+LL |     for _ in list.iter().skip(5).next() {}
+   |                  ^^^^^^^^^^^^^^^ help: use `get` instead: `.get(5..).unwrap_or(&[]).iter()`
+   |
+   = note: you may need to call `copied`
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/iter_skip_next.fixed
+++ b/tests/ui/iter_skip_next.fixed
@@ -4,6 +4,7 @@
 #![warn(clippy::iter_skip_next)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::iter_nth)]
+#![allow(clippy::iter_skip)]
 #![allow(clippy::useless_vec)]
 #![allow(unused_mut, dead_code)]
 

--- a/tests/ui/iter_skip_next.rs
+++ b/tests/ui/iter_skip_next.rs
@@ -4,6 +4,7 @@
 #![warn(clippy::iter_skip_next)]
 #![allow(clippy::disallowed_names)]
 #![allow(clippy::iter_nth)]
+#![allow(clippy::iter_skip)]
 #![allow(clippy::useless_vec)]
 #![allow(unused_mut, dead_code)]
 

--- a/tests/ui/iter_skip_next.stderr
+++ b/tests/ui/iter_skip_next.stderr
@@ -1,5 +1,5 @@
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:17:28
+  --> $DIR/iter_skip_next.rs:18:28
    |
 LL |     let _ = some_vec.iter().skip(42).next();
    |                            ^^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(42)`
@@ -7,37 +7,37 @@ LL |     let _ = some_vec.iter().skip(42).next();
    = note: `-D clippy::iter-skip-next` implied by `-D warnings`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:18:36
+  --> $DIR/iter_skip_next.rs:19:36
    |
 LL |     let _ = some_vec.iter().cycle().skip(42).next();
    |                                    ^^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(42)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:19:20
+  --> $DIR/iter_skip_next.rs:20:20
    |
 LL |     let _ = (1..10).skip(10).next();
    |                    ^^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(10)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:20:33
+  --> $DIR/iter_skip_next.rs:21:33
    |
 LL |     let _ = &some_vec[..].iter().skip(3).next();
    |                                 ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(3)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:28:26
+  --> $DIR/iter_skip_next.rs:29:26
    |
 LL |     let _: Vec<&str> = sp.skip(1).next().unwrap().split(' ').collect();
    |                          ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(1)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:30:29
+  --> $DIR/iter_skip_next.rs:31:29
    |
 LL |         let _: Vec<&str> = s.skip(1).next().unwrap().split(' ').collect();
    |                             ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(1)`
 
 error: called `skip(..).next()` on an iterator
-  --> $DIR/iter_skip_next.rs:36:29
+  --> $DIR/iter_skip_next.rs:37:29
    |
 LL |         let _: Vec<&str> = s.skip(1).next().unwrap().split(' ').collect();
    |                             ^^^^^^^^^^^^^^^ help: use `nth` instead: `.nth(1)`

--- a/tests/ui/mut_mut.rs
+++ b/tests/ui/mut_mut.rs
@@ -1,7 +1,12 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::mut_mut)]
 #![allow(unused)]
-#![allow(clippy::no_effect, clippy::uninlined_format_args, clippy::unnecessary_operation)]
+#![allow(
+    clippy::no_effect,
+    clippy::iter_skip,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_operation
+)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/mut_mut.stderr
+++ b/tests/ui/mut_mut.stderr
@@ -1,5 +1,5 @@
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:9:11
+  --> $DIR/mut_mut.rs:14:11
    |
 LL | fn fun(x: &mut &mut u32) -> bool {
    |           ^^^^^^^^^^^^^
@@ -7,13 +7,13 @@ LL | fn fun(x: &mut &mut u32) -> bool {
    = note: `-D clippy::mut-mut` implied by `-D warnings`
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:26:17
+  --> $DIR/mut_mut.rs:31:17
    |
 LL |     let mut x = &mut &mut 1u32;
    |                 ^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:41:25
+  --> $DIR/mut_mut.rs:46:25
    |
 LL |     let mut z = inline!(&mut $(&mut 3u32));
    |                         ^
@@ -21,37 +21,37 @@ LL |     let mut z = inline!(&mut $(&mut 3u32));
    = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this expression mutably borrows a mutable reference. Consider reborrowing
-  --> $DIR/mut_mut.rs:28:21
+  --> $DIR/mut_mut.rs:33:21
    |
 LL |         let mut y = &mut x;
    |                     ^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:32:32
+  --> $DIR/mut_mut.rs:37:32
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                                ^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:32:16
+  --> $DIR/mut_mut.rs:37:16
    |
 LL |         let y: &mut &mut u32 = &mut &mut 2;
    |                ^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:37:37
+  --> $DIR/mut_mut.rs:42:37
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                                     ^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:37:16
+  --> $DIR/mut_mut.rs:42:16
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                ^^^^^^^^^^^^^^^^^^
 
 error: generally you want to avoid `&mut &mut _` if possible
-  --> $DIR/mut_mut.rs:37:21
+  --> $DIR/mut_mut.rs:42:21
    |
 LL |         let y: &mut &mut &mut u32 = &mut &mut &mut 2;
    |                     ^^^^^^^^^^^^^


### PR DESCRIPTION
Closes #10196, while this is `perf` I believe that this is ever-so-slightly easier to understand as well.

changelog: New lint [`iter_skip`]
