### PR TITLE
Fix version.py after deleting v* dirs

### DIFF
--- a/util/versions.py
+++ b/util/versions.py
@@ -1,24 +1,27 @@
 #!/usr/bin/env python
 
 import json
+import logging as log
 import os
 import sys
-import logging as log
-log.basicConfig(level=log.INFO, format='%(levelname)s: %(message)s')
+
+log.basicConfig(level=log.INFO, format="%(levelname)s: %(message)s")
 
 
 def key(v):
-    if v == 'master':
-        return float('inf')
-    if v == 'stable':
+    if v == "master":
+        return float("inf")
+    if v == "stable":
         return sys.maxsize
-    if v == 'beta':
+    if v == "beta":
         return sys.maxsize - 1
+    if v == "pre-1.29.0":
+        return -1
 
-    v = v.replace('v', '').replace('rust-', '')
+    v = v.replace("rust-", "")
 
     s = 0
-    for i, val in enumerate(v.split('.')[::-1]):
+    for i, val in enumerate(v.split(".")[::-1]):
         s += int(val) * 100**i
 
     return s
@@ -31,7 +34,11 @@ def main():
 
     outdir = sys.argv[1]
     versions = [
-        dir for dir in os.listdir(outdir) if not dir.startswith(".") and os.path.isdir(os.path.join(outdir, dir))
+        dir
+        for dir in os.listdir(outdir)
+        if not dir.startswith(".")
+        and not dir.startswith("v")
+        and os.path.isdir(os.path.join(outdir, dir))
     ]
     versions.sort(key=key)
 


### PR DESCRIPTION
I missed updating this file.

I also ran black and isort over it.

Fixes the [deployment failure](https://github.com/rust-lang/rust-clippy/actions/runs/5297071588/jobs/9588599397)

r? @ghost

changelog: none
