### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -193,7 +193,7 @@ jobs:
     - name: Upload Binaries
       uses: actions/upload-artifact@v3
       with:
-        name: target/debug
+        name: binaries
         path: target/debug
 
   integration:
@@ -236,7 +236,7 @@ jobs:
     - name: Download target dir
       uses: actions/download-artifact@v3
       with:
-        name: target/debug
+        name: binaries
         path: target/debug
 
     - name: Make Binaries Executable

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -193,8 +193,8 @@ jobs:
     - name: Upload Binaries
       uses: actions/upload-artifact@v3
       with:
-        name: $CARGO_TARGET_DIR/debug
-        path: $CARGO_TARGET_DIR/debug
+        name: target/debug
+        path: target/debug
 
   integration:
     needs: integration_build
@@ -236,8 +236,8 @@ jobs:
     - name: Download target dir
       uses: actions/download-artifact@v3
       with:
-        name: $CARGO_TARGET_DIR/debug
-        path: $CARGO_TARGET_DIR/debug
+        name: target/debug
+        path: target/debug
 
     - name: Make Binaries Executable
       run: chmod +x $CARGO_TARGET_DIR/debug/*

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -188,15 +188,15 @@ jobs:
       run: |
         DIR=$CARGO_TARGET_DIR/debug
         rm $DIR/deps/integration-*.d
+        rm $DIR/deps/integration-*.dwo
         mv $DIR/deps/integration-* $DIR/integration
         find $DIR ! -executable -o -type d ! -path $DIR | xargs rm -rf
-        rm -rf $CARGO_TARGET_DIR/release
 
     - name: Upload Binaries
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
-        name: target
-        path: target
+        name: $CARGO_TARGET_DIR/debug
+        path: $CARGO_TARGET_DIR/debug
 
   integration:
     needs: integration_build
@@ -206,16 +206,13 @@ jobs:
       matrix:
         integration:
         - 'rust-lang/cargo'
-        # FIXME: re-enable once fmt_macros is renamed in RLS
-        # - 'rust-lang/rls'
         - 'rust-lang/chalk'
         - 'rust-lang/rustfmt'
         - 'Marwes/combine'
         - 'Geal/nom'
         - 'rust-lang/stdarch'
         - 'serde-rs/serde'
-        # FIXME: chrono currently cannot be compiled with `--all-targets`
-        # - 'chronotope/chrono'
+        - 'chronotope/chrono'
         - 'hyperium/hyper'
         - 'rust-random/rand'
         - 'rust-lang/futures-rs'
@@ -239,10 +236,10 @@ jobs:
 
     # Download
     - name: Download target dir
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
-        name: target
-        path: target
+        name: $CARGO_TARGET_DIR/debug
+        path: $CARGO_TARGET_DIR/debug
 
     - name: Make Binaries Executable
       run: chmod +x $CARGO_TARGET_DIR/debug/*

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -187,9 +187,7 @@ jobs:
     - name: Extract Binaries
       run: |
         DIR=$CARGO_TARGET_DIR/debug
-        rm $DIR/deps/integration-*.d
-        rm $DIR/deps/integration-*.dwo
-        mv $DIR/deps/integration-* $DIR/integration
+        find $DIR/deps/integration-* -executable ! -type d | xargs -I {} mv {} $DIR/integration
         find $DIR ! -executable -o -type d ! -path $DIR | xargs rm -rf
 
     - name: Upload Binaries


### PR DESCRIPTION
It sees like the `integration` test binary was no longer uploaded. I wonder how it was the successfully "run". First attempt to fix this.

Also updates the artifacts actions to v3.

r? @xFrednet 

changelog: none
