### PR TITLE
Make [`missing_panics_doc`]  not lint for `todo!()`

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -909,7 +909,7 @@ impl<'a, 'tcx> Visitor<'tcx> for FindPanicUnwrap<'a, 'tcx> {
             if is_panic(self.cx, macro_call.def_id)
                 || matches!(
                     self.cx.tcx.item_name(macro_call.def_id).as_str(),
-                    "assert" | "assert_eq" | "assert_ne" | "todo"
+                    "assert" | "assert_eq" | "assert_ne"
                 )
             {
                 self.panic_span = Some(macro_call.span);

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -43,3 +43,10 @@ macro_rules! issue_10421 {
         b = a;
     };
 }
+
+#[macro_export]
+macro_rules! macro_with_panic {
+    () => {
+        panic!()
+    };
+}

--- a/tests/ui/missing_panics_doc.rs
+++ b/tests/ui/missing_panics_doc.rs
@@ -1,5 +1,12 @@
+//@aux-build:macro_rules.rs
 #![warn(clippy::missing_panics_doc)]
 #![allow(clippy::option_map_unit_fn, clippy::unnecessary_literal_unwrap)]
+
+#[macro_use]
+extern crate macro_rules;
+
+use macro_rules::macro_with_panic;
+
 fn main() {}
 
 /// This needs to be documented
@@ -11,11 +18,6 @@ pub fn unwrap() {
 /// This needs to be documented
 pub fn panic() {
     panic!("This function panics")
-}
-
-/// This needs to be documented
-pub fn todo() {
-    todo!()
 }
 
 /// This needs to be documented
@@ -81,15 +83,6 @@ pub fn inner_body_documented(opt: Option<u32>) {
 /// # Panics
 ///
 /// We still need to do this part
-pub fn todo_documented() {
-    todo!()
-}
-
-/// This is documented
-///
-/// # Panics
-///
-/// We still need to do this part
 pub fn unreachable_amd_panic_documented() {
     if true { unreachable!() } else { panic!() }
 }
@@ -114,6 +107,11 @@ pub fn assert_ne_documented() {
     assert_ne!(x, 0);
 }
 
+/// `todo!()` is fine
+pub fn todo() {
+    todo!()
+}
+
 /// This is okay because it is private
 fn unwrap_private() {
     let result = Err("Hi");
@@ -123,11 +121,6 @@ fn unwrap_private() {
 /// This is okay because it is private
 fn panic_private() {
     panic!("This function panics")
-}
-
-/// This is okay because it is private
-fn todo_private() {
-    todo!()
 }
 
 /// This is okay because it is private
@@ -182,4 +175,19 @@ pub mod issue10240 {
     pub fn last_expect(v: &[u32]) -> u32 {
         *v.last().expect("passed an empty thing")
     }
+}
+
+fn from_external_macro_should_not_lint() {
+    macro_with_panic!()
+}
+
+macro_rules! some_macro_that_panics {
+    () => {
+        panic!()
+    };
+}
+
+fn from_declared_macro_should_lint_at_macrosite() {
+    // Not here.
+    some_macro_that_panics!()
 }

--- a/tests/ui/missing_panics_doc.stderr
+++ b/tests/ui/missing_panics_doc.stderr
@@ -1,159 +1,147 @@
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:6:1
+  --> $DIR/missing_panics_doc.rs:13:1
    |
 LL | pub fn unwrap() {
    | ^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:8:5
+  --> $DIR/missing_panics_doc.rs:15:5
    |
 LL |     result.unwrap()
    |     ^^^^^^^^^^^^^^^
    = note: `-D clippy::missing-panics-doc` implied by `-D warnings`
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:12:1
+  --> $DIR/missing_panics_doc.rs:19:1
    |
 LL | pub fn panic() {
    | ^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:13:5
+  --> $DIR/missing_panics_doc.rs:20:5
    |
 LL |     panic!("This function panics")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:17:1
-   |
-LL | pub fn todo() {
-   | ^^^^^^^^^^^^^
-   |
-note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:18:5
-   |
-LL |     todo!()
-   |     ^^^^^^^
-
-error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:22:1
+  --> $DIR/missing_panics_doc.rs:24:1
    |
 LL | pub fn inner_body(opt: Option<u32>) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:25:13
+  --> $DIR/missing_panics_doc.rs:27:13
    |
 LL |             panic!()
    |             ^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:31:1
+  --> $DIR/missing_panics_doc.rs:33:1
    |
 LL | pub fn unreachable_and_panic() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:32:39
+  --> $DIR/missing_panics_doc.rs:34:39
    |
 LL |     if true { unreachable!() } else { panic!() }
    |                                       ^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:36:1
+  --> $DIR/missing_panics_doc.rs:38:1
    |
 LL | pub fn assert_eq() {
    | ^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:38:5
+  --> $DIR/missing_panics_doc.rs:40:5
    |
 LL |     assert_eq!(x, 0);
    |     ^^^^^^^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:42:1
+  --> $DIR/missing_panics_doc.rs:44:1
    |
 LL | pub fn assert_ne() {
    | ^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:44:5
+  --> $DIR/missing_panics_doc.rs:46:5
    |
 LL |     assert_ne!(x, 0);
    |     ^^^^^^^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:158:5
+  --> $DIR/missing_panics_doc.rs:151:5
    |
 LL |     pub fn option_unwrap<T>(v: &[T]) -> &T {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:160:9
+  --> $DIR/missing_panics_doc.rs:153:9
    |
 LL |         o.unwrap()
    |         ^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:163:5
+  --> $DIR/missing_panics_doc.rs:156:5
    |
 LL |     pub fn option_expect<T>(v: &[T]) -> &T {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:165:9
+  --> $DIR/missing_panics_doc.rs:158:9
    |
 LL |         o.expect("passed an empty thing")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:168:5
+  --> $DIR/missing_panics_doc.rs:161:5
    |
 LL |     pub fn result_unwrap<T>(v: &[T]) -> &T {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:170:9
+  --> $DIR/missing_panics_doc.rs:163:9
    |
 LL |         res.unwrap()
    |         ^^^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:173:5
+  --> $DIR/missing_panics_doc.rs:166:5
    |
 LL |     pub fn result_expect<T>(v: &[T]) -> &T {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:175:9
+  --> $DIR/missing_panics_doc.rs:168:9
    |
 LL |         res.expect("passed an empty thing")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:178:5
+  --> $DIR/missing_panics_doc.rs:171:5
    |
 LL |     pub fn last_unwrap(v: &[u32]) -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:179:10
+  --> $DIR/missing_panics_doc.rs:172:10
    |
 LL |         *v.last().unwrap()
    |          ^^^^^^^^^^^^^^^^^
 
 error: docs for function which may panic missing `# Panics` section
-  --> $DIR/missing_panics_doc.rs:182:5
+  --> $DIR/missing_panics_doc.rs:175:5
    |
 LL |     pub fn last_expect(v: &[u32]) -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first possible panic found here
-  --> $DIR/missing_panics_doc.rs:183:10
+  --> $DIR/missing_panics_doc.rs:176:10
    |
 LL |         *v.last().expect("passed an empty thing")
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
closes #10966

changelog: [`missing_panics_doc`] now does not lint for `todo!()`