### PR TITLE
Fix `find_format_arg_expr` when incremental compilation is enabled

### DIFF
--- a/tests/ui/to_string_in_format_args_incremental.fixed
+++ b/tests/ui/to_string_in_format_args_incremental.fixed
@@ -1,0 +1,9 @@
+//@run-rustfix
+//@compile-flags: -C incremental=target/debug/test/incr
+
+// see https://github.com/rust-lang/rust-clippy/issues/10969
+
+fn main() {
+    let s = "Hello, world!";
+    println!("{}", s);
+}

--- a/tests/ui/to_string_in_format_args_incremental.rs
+++ b/tests/ui/to_string_in_format_args_incremental.rs
@@ -1,0 +1,9 @@
+//@run-rustfix
+//@compile-flags: -C incremental=target/debug/test/incr
+
+// see https://github.com/rust-lang/rust-clippy/issues/10969
+
+fn main() {
+    let s = "Hello, world!";
+    println!("{}", s.to_string());
+}

--- a/tests/ui/to_string_in_format_args_incremental.stderr
+++ b/tests/ui/to_string_in_format_args_incremental.stderr
@@ -1,0 +1,10 @@
+error: `to_string` applied to a type that implements `Display` in `println!` args
+  --> $DIR/to_string_in_format_args_incremental.rs:8:21
+   |
+LL |     println!("{}", s.to_string());
+   |                     ^^^^^^^^^^^^ help: remove this
+   |
+   = note: `-D clippy::to-string-in-format-args` implied by `-D warnings`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #10969

[`lower_span`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast_lowering/struct.LoweringContext.html#method.lower_span) gives AST spans a [parent](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_span/struct.SpanData.html#structfield.parent) when lowering to the HIR. That meant the `==` span comparison would return false even though the spans are pointing to the same thing. We now ignore the parent when comparing the spans

Debugging this was quite the puzzle, because the parent is not included in the debug output of `Span`s or `SpanData` 😬

changelog: none
