### PR TITLE
Add slice_as_bytes lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5205,6 +5205,7 @@ Released 2018-09-13
 [`size_of_in_element_count`]: https://rust-lang.github.io/rust-clippy/master/index.html#size_of_in_element_count
 [`size_of_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#size_of_ref
 [`skip_while_next`]: https://rust-lang.github.io/rust-clippy/master/index.html#skip_while_next
+[`slice_as_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#slice_as_bytes
 [`slow_vector_initialization`]: https://rust-lang.github.io/rust-clippy/master/index.html#slow_vector_initialization
 [`stable_sort_primitive`]: https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive
 [`std_instead_of_alloc`]: https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_alloc

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -398,6 +398,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::SINGLE_CHAR_ADD_STR_INFO,
     crate::methods::SINGLE_CHAR_PATTERN_INFO,
     crate::methods::SKIP_WHILE_NEXT_INFO,
+    crate::methods::SLICE_AS_BYTES_INFO,
     crate::methods::STABLE_SORT_PRIMITIVE_INFO,
     crate::methods::STRING_EXTEND_CHARS_INFO,
     crate::methods::SUSPICIOUS_COMMAND_ARG_SPACE_INFO,

--- a/clippy_lints/src/methods/slice_as_bytes.rs
+++ b/clippy_lints/src/methods/slice_as_bytes.rs
@@ -1,0 +1,39 @@
+use clippy_utils::{diagnostics::span_lint_and_sugg, source::snippet_with_applicability, ty::is_type_lang_item};
+use rustc_errors::Applicability;
+use rustc_hir::{
+    Expr, ExprKind,
+    LangItem::{self, Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive},
+    QPath,
+};
+use rustc_lint::LateContext;
+
+use super::SLICE_AS_BYTES;
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>) {
+    if let ExprKind::Index(indexed, index) = recv.kind {
+        if let ExprKind::Struct(QPath::LangItem(Range | RangeFrom | RangeTo | RangeToInclusive | RangeFull, ..), ..) =
+            index.kind
+        {
+            let ty = cx.typeck_results().expr_ty(indexed).peel_refs();
+            let is_str = ty.is_str();
+            let is_string = is_type_lang_item(cx, ty, LangItem::String);
+            if is_str || is_string {
+                let mut applicability = Applicability::MachineApplicable;
+                let stringish = snippet_with_applicability(cx, indexed.span, "..", &mut applicability);
+                let range = snippet_with_applicability(cx, index.span, "..", &mut applicability);
+                let type_name = if is_str { "str" } else { "String" };
+                span_lint_and_sugg(
+                    cx,
+                    SLICE_AS_BYTES,
+                    expr.span,
+                    &(format!(
+                        "slicing a {type_name} before calling `as_bytes` results in needless UTF-8 alignment checks, and has the possiblity of panicking"
+                    )),
+                    "try",
+                    format!("&{stringish}.as_bytes()[{range}]"),
+                    applicability,
+                );
+            }
+        }
+    }
+}

--- a/clippy_lints/src/methods/slice_as_bytes.rs
+++ b/clippy_lints/src/methods/slice_as_bytes.rs
@@ -1,19 +1,13 @@
 use clippy_utils::{diagnostics::span_lint_and_sugg, source::snippet_with_applicability, ty::is_type_lang_item};
 use rustc_errors::Applicability;
-use rustc_hir::{
-    Expr, ExprKind,
-    LangItem::{self, Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive},
-    QPath,
-};
+use rustc_hir::{is_range_literal, Expr, ExprKind, LangItem};
 use rustc_lint::LateContext;
 
 use super::SLICE_AS_BYTES;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>) {
     if let ExprKind::Index(indexed, index) = recv.kind {
-        if let ExprKind::Struct(QPath::LangItem(Range | RangeFrom | RangeTo | RangeToInclusive | RangeFull, ..), ..) =
-            index.kind
-        {
+        if is_range_literal(index) {
             let ty = cx.typeck_results().expr_ty(indexed).peel_refs();
             let is_str = ty.is_str();
             let is_string = is_type_lang_item(cx, ty, LangItem::String);

--- a/tests/ui/bytes_nth.fixed
+++ b/tests/ui/bytes_nth.fixed
@@ -1,6 +1,7 @@
 //@run-rustfix
 
 #![allow(clippy::unnecessary_operation)]
+#![allow(clippy::slice_as_bytes)]
 #![warn(clippy::bytes_nth)]
 
 fn main() {

--- a/tests/ui/bytes_nth.rs
+++ b/tests/ui/bytes_nth.rs
@@ -1,6 +1,7 @@
 //@run-rustfix
 
 #![allow(clippy::unnecessary_operation)]
+#![allow(clippy::slice_as_bytes)]
 #![warn(clippy::bytes_nth)]
 
 fn main() {

--- a/tests/ui/bytes_nth.stderr
+++ b/tests/ui/bytes_nth.stderr
@@ -1,5 +1,5 @@
 error: called `.bytes().nth()` on a `String`
-  --> $DIR/bytes_nth.rs:8:13
+  --> $DIR/bytes_nth.rs:9:13
    |
 LL |     let _ = s.bytes().nth(3);
    |             ^^^^^^^^^^^^^^^^ help: try: `s.as_bytes().get(3).copied()`
@@ -7,13 +7,13 @@ LL |     let _ = s.bytes().nth(3);
    = note: `-D clippy::bytes-nth` implied by `-D warnings`
 
 error: called `.bytes().nth().unwrap()` on a `String`
-  --> $DIR/bytes_nth.rs:9:14
+  --> $DIR/bytes_nth.rs:10:14
    |
 LL |     let _ = &s.bytes().nth(3).unwrap();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.as_bytes()[3]`
 
 error: called `.bytes().nth()` on a `str`
-  --> $DIR/bytes_nth.rs:10:13
+  --> $DIR/bytes_nth.rs:11:13
    |
 LL |     let _ = s[..].bytes().nth(3);
    |             ^^^^^^^^^^^^^^^^^^^^ help: try: `s[..].as_bytes().get(3).copied()`

--- a/tests/ui/slice_as_bytes.fixed
+++ b/tests/ui/slice_as_bytes.fixed
@@ -1,0 +1,35 @@
+//@run-rustfix
+#![allow(unused)]
+#![warn(clippy::slice_as_bytes)]
+
+use std::ops::{Index, Range};
+
+struct Foo;
+
+struct Bar;
+
+impl Bar {
+    fn as_bytes(&self) -> &[u8] {
+        &[0, 1, 2, 3]
+    }
+}
+
+impl Index<Range<usize>> for Foo {
+    type Output = Bar;
+
+    fn index(&self, _: Range<usize>) -> &Self::Output {
+        &Bar
+    }
+}
+
+fn main() {
+    let s = "Lorem ipsum";
+    let string: String = "dolor sit amet".to_owned();
+
+    let bytes = &s.as_bytes()[1..5];
+    let bytes = &string.as_bytes()[1..];
+    let bytes = &"consectetur adipiscing".as_bytes()[..=5];
+
+    let f = Foo;
+    let bytes = f[0..4].as_bytes();
+}

--- a/tests/ui/slice_as_bytes.rs
+++ b/tests/ui/slice_as_bytes.rs
@@ -1,0 +1,35 @@
+//@run-rustfix
+#![allow(unused)]
+#![warn(clippy::slice_as_bytes)]
+
+use std::ops::{Index, Range};
+
+struct Foo;
+
+struct Bar;
+
+impl Bar {
+    fn as_bytes(&self) -> &[u8] {
+        &[0, 1, 2, 3]
+    }
+}
+
+impl Index<Range<usize>> for Foo {
+    type Output = Bar;
+
+    fn index(&self, _: Range<usize>) -> &Self::Output {
+        &Bar
+    }
+}
+
+fn main() {
+    let s = "Lorem ipsum";
+    let string: String = "dolor sit amet".to_owned();
+
+    let bytes = s[1..5].as_bytes();
+    let bytes = string[1..].as_bytes();
+    let bytes = "consectetur adipiscing"[..=5].as_bytes();
+
+    let f = Foo;
+    let bytes = f[0..4].as_bytes();
+}

--- a/tests/ui/slice_as_bytes.stderr
+++ b/tests/ui/slice_as_bytes.stderr
@@ -1,0 +1,22 @@
+error: slicing a str before calling `as_bytes` results in needless UTF-8 alignment checks, and has the possiblity of panicking
+  --> $DIR/slice_as_bytes.rs:29:17
+   |
+LL |     let bytes = s[1..5].as_bytes();
+   |                 ^^^^^^^^^^^^^^^^^^ help: try: `&s.as_bytes()[1..5]`
+   |
+   = note: `-D clippy::slice-as-bytes` implied by `-D warnings`
+
+error: slicing a String before calling `as_bytes` results in needless UTF-8 alignment checks, and has the possiblity of panicking
+  --> $DIR/slice_as_bytes.rs:30:17
+   |
+LL |     let bytes = string[1..].as_bytes();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&string.as_bytes()[1..]`
+
+error: slicing a str before calling `as_bytes` results in needless UTF-8 alignment checks, and has the possiblity of panicking
+  --> $DIR/slice_as_bytes.rs:31:17
+   |
+LL |     let bytes = "consectetur adipiscing"[..=5].as_bytes();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&"consectetur adipiscing".as_bytes()[..=5]`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Detects patterns like
```rust
s[1..5].as_bytes();
```
and suggest replacing with
```rust
&s.as_bytes()[1..5];
```

fixes: #10981 
```
changelog: [`slice_as_bytes`]: add new lilnt
```