### PR TITLE
`borrowed_box`: Ignore return types

### DIFF
--- a/tests/ui/borrow_box.rs
+++ b/tests/ui/borrow_box.rs
@@ -104,6 +104,16 @@ pub fn test19<'a>(_display: &'a Box<impl Display + 'a>) {}
 // it's fine that unnecessary parentheses appear in the future for some reason.
 pub fn test20(_display: &Box<(dyn Display + Send)>) {}
 
+// Don't lint
+pub fn test21<'a>() -> &'a Box<u32> {
+    unimplemented!();
+}
+
+// Don't lint (not a reference)
+pub fn test22() -> Box<u32> {
+    unimplemented!();
+}
+
 fn main() {
     test1(&mut Box::new(false));
     test2();


### PR DESCRIPTION
Now `borrowed_box` ignores a `&Box<T>` if its being used as a return type.
Fixes #10982 (new discussion just arised in #10982, please read that issue)

changelog:none
