### PR TITLE
Don't lint code from external macros for 8 lints

### DIFF
--- a/clippy_lints/src/misc_early/mod.rs
+++ b/clippy_lints/src/misc_early/mod.rs
@@ -339,6 +339,10 @@ impl EarlyLintPass for MiscEarlyLints {
     }
 
     fn check_pat(&mut self, cx: &EarlyContext<'_>, pat: &Pat) {
+        if in_external_macro(cx.sess(), pat.span) {
+            return;
+        }
+
         unneeded_field_pattern::check(cx, pat);
         redundant_pattern::check(cx, pat);
         unneeded_wildcard_pattern::check(cx, pat);

--- a/tests/ui/patterns.fixed
+++ b/tests/ui/patterns.fixed
@@ -1,7 +1,11 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs:proc-macro
 #![warn(clippy::all)]
 #![allow(unused)]
 #![allow(clippy::uninlined_format_args)]
+
+#[macro_use]
+extern crate proc_macros;
 
 fn main() {
     let v = Some(true);
@@ -33,5 +37,12 @@ fn main() {
     match mutv {
         ref x => println!("vec: {:?}", x),
         ref y if y == &vec![0] => (),
+    }
+    external! {
+        let v = Some(true);
+        match v {
+            Some(x) => (),
+            y @ _ => (),
+        }
     }
 }

--- a/tests/ui/patterns.rs
+++ b/tests/ui/patterns.rs
@@ -1,7 +1,11 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs:proc-macro
 #![warn(clippy::all)]
 #![allow(unused)]
 #![allow(clippy::uninlined_format_args)]
+
+#[macro_use]
+extern crate proc_macros;
 
 fn main() {
     let v = Some(true);
@@ -33,5 +37,12 @@ fn main() {
     match mutv {
         ref x @ _ => println!("vec: {:?}", x),
         ref y if y == &vec![0] => (),
+    }
+    external! {
+        let v = Some(true);
+        match v {
+            Some(x) => (),
+            y @ _ => (),
+        }
     }
 }

--- a/tests/ui/patterns.stderr
+++ b/tests/ui/patterns.stderr
@@ -1,5 +1,5 @@
 error: the `y @ _` pattern can be written as just `y`
-  --> $DIR/patterns.rs:11:9
+  --> $DIR/patterns.rs:15:9
    |
 LL |         y @ _ => (),
    |         ^^^^^ help: try: `y`
@@ -7,13 +7,13 @@ LL |         y @ _ => (),
    = note: `-D clippy::redundant-pattern` implied by `-D warnings`
 
 error: the `x @ _` pattern can be written as just `x`
-  --> $DIR/patterns.rs:26:9
+  --> $DIR/patterns.rs:30:9
    |
 LL |         ref mut x @ _ => {
    |         ^^^^^^^^^^^^^ help: try: `ref mut x`
 
 error: the `x @ _` pattern can be written as just `x`
-  --> $DIR/patterns.rs:34:9
+  --> $DIR/patterns.rs:38:9
    |
 LL |         ref x @ _ => println!("vec: {:?}", x),
    |         ^^^^^^^^^ help: try: `ref x`

--- a/tests/ui/unneeded_field_pattern.rs
+++ b/tests/ui/unneeded_field_pattern.rs
@@ -1,5 +1,9 @@
+//@aux-build:proc_macros.rs:proc-macro
 #![warn(clippy::unneeded_field_pattern)]
-#[allow(dead_code, unused)]
+#![allow(dead_code, unused)]
+
+#[macro_use]
+extern crate proc_macros;
 
 struct Foo {
     a: i32,
@@ -18,5 +22,13 @@ fn main() {
     match f {
         Foo { b: 0, .. } => {}, // should be OK
         Foo { .. } => {},       // and the Force might be with this one
+    }
+    external! {
+        let f = Foo { a: 0, b: 0, c: 0 };
+        match f {
+            Foo { a: _, b: 0, .. } => {},
+
+            Foo { a: _, b: _, c: _ } => {},
+        }
     }
 }

--- a/tests/ui/unneeded_field_pattern.stderr
+++ b/tests/ui/unneeded_field_pattern.stderr
@@ -1,5 +1,5 @@
 error: you matched a field with a wildcard pattern, consider using `..` instead
-  --> $DIR/unneeded_field_pattern.rs:14:15
+  --> $DIR/unneeded_field_pattern.rs:18:15
    |
 LL |         Foo { a: _, b: 0, .. } => {},
    |               ^^^^
@@ -8,7 +8,7 @@ LL |         Foo { a: _, b: 0, .. } => {},
    = note: `-D clippy::unneeded-field-pattern` implied by `-D warnings`
 
 error: all the struct fields are matched to a wildcard pattern, consider using `..`
-  --> $DIR/unneeded_field_pattern.rs:16:9
+  --> $DIR/unneeded_field_pattern.rs:20:9
    |
 LL |         Foo { a: _, b: _, c: _ } => {},
    |         ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unneeded_wildcard_pattern.fixed
+++ b/tests/ui/unneeded_wildcard_pattern.fixed
@@ -1,7 +1,11 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs:proc-macro
 #![feature(stmt_expr_attributes)]
 #![deny(clippy::unneeded_wildcard_pattern)]
 #![allow(clippy::needless_if)]
+
+#[macro_use]
+extern crate proc_macros;
 
 fn main() {
     let t = (0, 1, 2, 3);
@@ -42,5 +46,9 @@ fn main() {
     #[rustfmt::skip]
     {
         if let S(0, ..,) = s {};
+    }
+    external! {
+        let t = (0, 1, 2, 3);
+        if let (0, _, ..) = t {};
     }
 }

--- a/tests/ui/unneeded_wildcard_pattern.rs
+++ b/tests/ui/unneeded_wildcard_pattern.rs
@@ -1,7 +1,11 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs:proc-macro
 #![feature(stmt_expr_attributes)]
 #![deny(clippy::unneeded_wildcard_pattern)]
 #![allow(clippy::needless_if)]
+
+#[macro_use]
+extern crate proc_macros;
 
 fn main() {
     let t = (0, 1, 2, 3);
@@ -42,5 +46,9 @@ fn main() {
     #[rustfmt::skip]
     {
         if let S(0, .., _, _,) = s {};
+    }
+    external! {
+        let t = (0, 1, 2, 3);
+        if let (0, _, ..) = t {};
     }
 }

--- a/tests/ui/unneeded_wildcard_pattern.stderr
+++ b/tests/ui/unneeded_wildcard_pattern.stderr
@@ -1,89 +1,89 @@
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:9:18
+  --> $DIR/unneeded_wildcard_pattern.rs:13:18
    |
 LL |     if let (0, .., _) = t {};
    |                  ^^^ help: remove it
    |
 note: the lint level is defined here
-  --> $DIR/unneeded_wildcard_pattern.rs:3:9
+  --> $DIR/unneeded_wildcard_pattern.rs:4:9
    |
 LL | #![deny(clippy::unneeded_wildcard_pattern)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:10:16
+  --> $DIR/unneeded_wildcard_pattern.rs:14:16
    |
 LL |     if let (0, _, ..) = t {};
    |                ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:11:13
+  --> $DIR/unneeded_wildcard_pattern.rs:15:13
    |
 LL |     if let (_, .., 0) = t {};
    |             ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:12:15
+  --> $DIR/unneeded_wildcard_pattern.rs:16:15
    |
 LL |     if let (.., _, 0) = t {};
    |               ^^^ help: remove it
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:13:16
+  --> $DIR/unneeded_wildcard_pattern.rs:17:16
    |
 LL |     if let (0, _, _, ..) = t {};
    |                ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:14:18
+  --> $DIR/unneeded_wildcard_pattern.rs:18:18
    |
 LL |     if let (0, .., _, _) = t {};
    |                  ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:23:22
+  --> $DIR/unneeded_wildcard_pattern.rs:27:22
    |
 LL |         if let (0, .., _, _,) = t {};
    |                      ^^^^^^ help: remove them
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:30:19
+  --> $DIR/unneeded_wildcard_pattern.rs:34:19
    |
 LL |     if let S(0, .., _) = s {};
    |                   ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:31:17
+  --> $DIR/unneeded_wildcard_pattern.rs:35:17
    |
 LL |     if let S(0, _, ..) = s {};
    |                 ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:32:14
+  --> $DIR/unneeded_wildcard_pattern.rs:36:14
    |
 LL |     if let S(_, .., 0) = s {};
    |              ^^^ help: remove it
 
 error: this pattern is unneeded as the `..` pattern can match that element
-  --> $DIR/unneeded_wildcard_pattern.rs:33:16
+  --> $DIR/unneeded_wildcard_pattern.rs:37:16
    |
 LL |     if let S(.., _, 0) = s {};
    |                ^^^ help: remove it
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:34:17
+  --> $DIR/unneeded_wildcard_pattern.rs:38:17
    |
 LL |     if let S(0, _, _, ..) = s {};
    |                 ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:35:19
+  --> $DIR/unneeded_wildcard_pattern.rs:39:19
    |
 LL |     if let S(0, .., _, _) = s {};
    |                   ^^^^^^ help: remove them
 
 error: these patterns are unneeded as the `..` pattern can match those elements
-  --> $DIR/unneeded_wildcard_pattern.rs:44:23
+  --> $DIR/unneeded_wildcard_pattern.rs:48:23
    |
 LL |         if let S(0, .., _, _,) = s {};
    |                       ^^^^^^ help: remove them


### PR DESCRIPTION
Fixes #11008

changelog: [`unneeded_field_pattern`], [`redundant_pattern`], [`uneeded_wildcard_pattern`], [`double_neg`], [`separated_literal_suffix`], [`unseparated_literal_suffix`], [`mixed_case_hex_literals`], [`zero_prefixed_literal`]: Don't lint code from external macros

(wow, that's one hell of a changelog for such a small change...)
