### PR TITLE
[`format_push_string`]: look through `match` and `if` expressions

### DIFF
--- a/tests/ui/format_push_string.rs
+++ b/tests/ui/format_push_string.rs
@@ -5,3 +5,32 @@ fn main() {
     string += &format!("{:?}", 1234);
     string.push_str(&format!("{:?}", 5678));
 }
+
+mod issue9493 {
+    pub fn u8vec_to_hex(vector: &Vec<u8>, upper: bool) -> String {
+        let mut hex = String::with_capacity(vector.len() * 2);
+        for byte in vector {
+            hex += &(if upper {
+                format!("{byte:02X}")
+            } else {
+                format!("{byte:02x}")
+            });
+        }
+        hex
+    }
+
+    pub fn other_cases() {
+        let mut s = String::new();
+        // if let
+        s += &(if let Some(_a) = Some(1234) {
+            format!("{}", 1234)
+        } else {
+            format!("{}", 1234)
+        });
+        // match
+        s += &(match Some(1234) {
+            Some(_) => format!("{}", 1234),
+            None => format!("{}", 1234),
+        });
+    }
+}

--- a/tests/ui/format_push_string.stderr
+++ b/tests/ui/format_push_string.stderr
@@ -15,5 +15,40 @@ LL |     string.push_str(&format!("{:?}", 5678));
    |
    = help: consider using `write!` to avoid the extra allocation
 
-error: aborting due to 2 previous errors
+error: `format!(..)` appended to existing `String`
+  --> $DIR/format_push_string.rs:13:13
+   |
+LL | /             hex += &(if upper {
+LL | |                 format!("{byte:02X}")
+LL | |             } else {
+LL | |                 format!("{byte:02x}")
+LL | |             });
+   | |______________^
+   |
+   = help: consider using `write!` to avoid the extra allocation
+
+error: `format!(..)` appended to existing `String`
+  --> $DIR/format_push_string.rs:25:9
+   |
+LL | /         s += &(if let Some(_a) = Some(1234) {
+LL | |             format!("{}", 1234)
+LL | |         } else {
+LL | |             format!("{}", 1234)
+LL | |         });
+   | |__________^
+   |
+   = help: consider using `write!` to avoid the extra allocation
+
+error: `format!(..)` appended to existing `String`
+  --> $DIR/format_push_string.rs:31:9
+   |
+LL | /         s += &(match Some(1234) {
+LL | |             Some(_) => format!("{}", 1234),
+LL | |             None => format!("{}", 1234),
+LL | |         });
+   | |__________^
+   |
+   = help: consider using `write!` to avoid the extra allocation
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Closes #9493.

changelog: [`format_push_string`]: look through `match` and `if` expressions
