### PR TITLE
Avoid linting `extra_unused_type_parameters` on procedural macros

### DIFF
--- a/clippy_lints/src/extra_unused_type_parameters.rs
+++ b/clippy_lints/src/extra_unused_type_parameters.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
+use clippy_utils::is_from_proc_macro;
 use clippy_utils::trait_ref_of_method;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::Applicability;
@@ -265,6 +266,7 @@ impl<'tcx> LateLintPass<'tcx> for ExtraUnusedTypeParameters {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
         if let ItemKind::Fn(_, generics, body_id) = item.kind
             && !self.is_empty_exported_or_macro(cx, item.span, item.owner_id.def_id, body_id)
+            && !is_from_proc_macro(cx, item)
         {
             let mut walker = TypeWalker::new(cx, generics);
             walk_item(&mut walker, item);

--- a/tests/ui/extra_unused_type_parameters.fixed
+++ b/tests/ui/extra_unused_type_parameters.fixed
@@ -1,7 +1,11 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs
 
 #![allow(unused, clippy::needless_lifetimes)]
 #![warn(clippy::extra_unused_type_parameters)]
+
+extern crate proc_macros;
+use proc_macros::with_span;
 
 fn unused_ty(x: u8) {
     unimplemented!()
@@ -101,5 +105,13 @@ mod issue10319 {
     {
     }
 }
+
+with_span!(
+    span
+
+    fn should_not_lint<T>(x: u8) {
+        unimplemented!()
+    }
+);
 
 fn main() {}

--- a/tests/ui/extra_unused_type_parameters.rs
+++ b/tests/ui/extra_unused_type_parameters.rs
@@ -1,7 +1,11 @@
 //@run-rustfix
+//@aux-build:proc_macros.rs
 
 #![allow(unused, clippy::needless_lifetimes)]
 #![warn(clippy::extra_unused_type_parameters)]
+
+extern crate proc_macros;
+use proc_macros::with_span;
 
 fn unused_ty<T>(x: u8) {
     unimplemented!()
@@ -101,5 +105,13 @@ mod issue10319 {
     {
     }
 }
+
+with_span!(
+    span
+
+    fn should_not_lint<T>(x: u8) {
+        unimplemented!()
+    }
+);
 
 fn main() {}

--- a/tests/ui/extra_unused_type_parameters.stderr
+++ b/tests/ui/extra_unused_type_parameters.stderr
@@ -1,5 +1,5 @@
 error: type parameter `T` goes unused in function definition
-  --> $DIR/extra_unused_type_parameters.rs:6:13
+  --> $DIR/extra_unused_type_parameters.rs:10:13
    |
 LL | fn unused_ty<T>(x: u8) {
    |             ^^^ help: consider removing the parameter
@@ -7,19 +7,19 @@ LL | fn unused_ty<T>(x: u8) {
    = note: `-D clippy::extra-unused-type-parameters` implied by `-D warnings`
 
 error: type parameters go unused in function definition: T, U
-  --> $DIR/extra_unused_type_parameters.rs:10:16
+  --> $DIR/extra_unused_type_parameters.rs:14:16
    |
 LL | fn unused_multi<T, U>(x: u8) {
    |                ^^^^^^ help: consider removing the parameters
 
 error: type parameter `T` goes unused in function definition
-  --> $DIR/extra_unused_type_parameters.rs:14:21
+  --> $DIR/extra_unused_type_parameters.rs:18:21
    |
 LL | fn unused_with_lt<'a, T>(x: &'a u8) {
    |                     ^^^ help: consider removing the parameter
 
 error: type parameters go unused in function definition: T, V
-  --> $DIR/extra_unused_type_parameters.rs:26:19
+  --> $DIR/extra_unused_type_parameters.rs:30:19
    |
 LL | fn unused_bounded<T: Default, U, V: Default>(x: U) {
    |                   ^^^^^^^^^^^^ ^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL + fn unused_bounded<U>(x: U) {
    |
 
 error: type parameters go unused in function definition: A, D, E
-  --> $DIR/extra_unused_type_parameters.rs:30:16
+  --> $DIR/extra_unused_type_parameters.rs:34:16
    |
 LL | fn some_unused<A, B, C, D: Iterator<Item = (B, C)>, E>(b: B, c: C) {
    |                ^^^    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,19 +43,19 @@ LL + fn some_unused<B, C>(b: B, c: C) {
    |
 
 error: type parameter `T` goes unused in function definition
-  --> $DIR/extra_unused_type_parameters.rs:55:22
+  --> $DIR/extra_unused_type_parameters.rs:59:22
    |
 LL |     fn unused_ty_impl<T>(&self) {
    |                      ^^^ help: consider removing the parameter
 
 error: type parameters go unused in function definition: A, B
-  --> $DIR/extra_unused_type_parameters.rs:77:17
+  --> $DIR/extra_unused_type_parameters.rs:81:17
    |
 LL | fn unused_opaque<A, B>(dummy: impl Default) {
    |                 ^^^^^^ help: consider removing the parameters
 
 error: type parameter `U` goes unused in function definition
-  --> $DIR/extra_unused_type_parameters.rs:90:56
+  --> $DIR/extra_unused_type_parameters.rs:94:56
    |
 LL |     fn unused_with_priv_trait_bound<T: private::Private, U>() {
    |                                                        ^^^ help: consider removing the parameter


### PR DESCRIPTION
Don't lint `extra_unused_type_parameters` if code was generated by procedural macro.

This PR fixes https://github.com/rust-lang/rust-clippy/issues/11014

changelog: [`extra_unused_type_parameters`] avoid linting macro-generated code