### PR TITLE
[`option_if_let_else`]: suggest `.as_ref()` if scrutinee is of type `&Option<_>`

### DIFF
--- a/clippy_lints/src/option_if_let_else.rs
+++ b/clippy_lints/src/option_if_let_else.rs
@@ -140,6 +140,9 @@ fn try_get_option_occurrence<'tcx>(
             let (as_ref, as_mut) = match &expr.kind {
                 ExprKind::AddrOf(_, Mutability::Not, _) => (true, false),
                 ExprKind::AddrOf(_, Mutability::Mut, _) => (false, true),
+                _ if let Some(mutb) = cx.typeck_results().expr_ty(expr).ref_mutability() => {
+                    (mutb == Mutability::Not, mutb == Mutability::Mut)
+                }
                 _ => (bind_annotation == BindingAnnotation::REF, bind_annotation == BindingAnnotation::REF_MUT),
             };
 

--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -198,8 +198,6 @@ fn main() {
     let _ = res.map_or(1, |a| a + 1);
     let _ = res.map_or(1, |a| a + 1);
     let _ = res.map_or(5, |a| a + 1);
-    issue10729::reproduce(&None);
-    issue10729::reproduce2(&mut None);
 }
 
 #[allow(dead_code)]
@@ -212,7 +210,7 @@ fn issue9742() -> Option<&'static str> {
 }
 
 mod issue10729 {
-    #![allow(clippy::unit_arg)]
+    #![allow(clippy::unit_arg, dead_code)]
 
     pub fn reproduce(initial: &Option<String>) {
         // 👇 needs `.as_ref()` because initial is an `&Option<_>`

--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -198,6 +198,8 @@ fn main() {
     let _ = res.map_or(1, |a| a + 1);
     let _ = res.map_or(1, |a| a + 1);
     let _ = res.map_or(5, |a| a + 1);
+    issue10729::reproduce(&None);
+    issue10729::reproduce2(&mut None);
 }
 
 #[allow(dead_code)]
@@ -207,4 +209,20 @@ fn issue9742() -> Option<&'static str> {
         Some(name) if name.starts_with("foo") => Some(name.trim()),
         _ => None,
     }
+}
+
+mod issue10729 {
+    #![allow(clippy::unit_arg)]
+
+    pub fn reproduce(initial: &Option<String>) {
+        // 👇 needs `.as_ref()` because initial is an `&Option<_>`
+        initial.as_ref().map_or({}, |value| do_something(value))
+    }
+
+    pub fn reproduce2(initial: &mut Option<String>) {
+        initial.as_mut().map_or({}, |value| do_something2(value))
+    }
+
+    fn do_something(_value: &str) {}
+    fn do_something2(_value: &mut str) {}
 }

--- a/tests/ui/option_if_let_else.rs
+++ b/tests/ui/option_if_let_else.rs
@@ -239,6 +239,8 @@ fn main() {
         Ok(a) => a + 1,
     };
     let _ = if let Ok(a) = res { a + 1 } else { 5 };
+    issue10729::reproduce(&None);
+    issue10729::reproduce2(&mut None);
 }
 
 #[allow(dead_code)]
@@ -248,4 +250,26 @@ fn issue9742() -> Option<&'static str> {
         Some(name) if name.starts_with("foo") => Some(name.trim()),
         _ => None,
     }
+}
+
+mod issue10729 {
+    #![allow(clippy::unit_arg)]
+
+    pub fn reproduce(initial: &Option<String>) {
+        // 👇 needs `.as_ref()` because initial is an `&Option<_>`
+        match initial {
+            Some(value) => do_something(value),
+            None => {},
+        }
+    }
+
+    pub fn reproduce2(initial: &mut Option<String>) {
+        match initial {
+            Some(value) => do_something2(value),
+            None => {},
+        }
+    }
+
+    fn do_something(_value: &str) {}
+    fn do_something2(_value: &mut str) {}
 }

--- a/tests/ui/option_if_let_else.rs
+++ b/tests/ui/option_if_let_else.rs
@@ -239,8 +239,6 @@ fn main() {
         Ok(a) => a + 1,
     };
     let _ = if let Ok(a) = res { a + 1 } else { 5 };
-    issue10729::reproduce(&None);
-    issue10729::reproduce2(&mut None);
 }
 
 #[allow(dead_code)]
@@ -253,7 +251,7 @@ fn issue9742() -> Option<&'static str> {
 }
 
 mod issue10729 {
-    #![allow(clippy::unit_arg)]
+    #![allow(clippy::unit_arg, dead_code)]
 
     pub fn reproduce(initial: &Option<String>) {
         // 👇 needs `.as_ref()` because initial is an `&Option<_>`

--- a/tests/ui/option_if_let_else.stderr
+++ b/tests/ui/option_if_let_else.stderr
@@ -271,5 +271,23 @@ error: use Option::map_or instead of an if let/else
 LL |     let _ = if let Ok(a) = res { a + 1 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or(5, |a| a + 1)`
 
-error: aborting due to 21 previous errors
+error: use Option::map_or instead of an if let/else
+  --> $DIR/option_if_let_else.rs:260:9
+   |
+LL | /         match initial {
+LL | |             Some(value) => do_something(value),
+LL | |             None => {},
+LL | |         }
+   | |_________^ help: try: `initial.as_ref().map_or({}, |value| do_something(value))`
+
+error: use Option::map_or instead of an if let/else
+  --> $DIR/option_if_let_else.rs:267:9
+   |
+LL | /         match initial {
+LL | |             Some(value) => do_something2(value),
+LL | |             None => {},
+LL | |         }
+   | |_________^ help: try: `initial.as_mut().map_or({}, |value| do_something2(value))`
+
+error: aborting due to 23 previous errors
 

--- a/tests/ui/option_if_let_else.stderr
+++ b/tests/ui/option_if_let_else.stderr
@@ -272,7 +272,7 @@ LL |     let _ = if let Ok(a) = res { a + 1 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:260:9
+  --> $DIR/option_if_let_else.rs:258:9
    |
 LL | /         match initial {
 LL | |             Some(value) => do_something(value),
@@ -281,7 +281,7 @@ LL | |         }
    | |_________^ help: try: `initial.as_ref().map_or({}, |value| do_something(value))`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:267:9
+  --> $DIR/option_if_let_else.rs:265:9
    |
 LL | /         match initial {
 LL | |             Some(value) => do_something2(value),


### PR DESCRIPTION
Fixes #10729

`Option::map_or` takes ownership, so if matching on an `&Option<_>`, we need to suggest `.as_ref()` before calling `map_or` to get the same effect and to not cause a borrowck error. 

changelog: [`option_if_let_else`]: suggest `.as_ref()`/`.as_mut()` if scrutinee is of type `&Option<_>`/`&mut Option<_>`
