### PR TITLE
Add `BLESS` for compile-test and some cleanup

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -414,7 +414,7 @@ fn is_foo_fn(fn_kind: FnKind<'_>) -> bool {
 
 Now we should also run the full test suite with `cargo test`. At this point
 running `cargo test` should produce the expected output. Remember to run `cargo
-dev bless` to update the `.stderr` file.
+bless` to update the `.stderr` file.
 
 `cargo test` (as opposed to `cargo uitest`) will also ensure that our lint
 implementation is not violating any Clippy lints itself.

--- a/clippy_test_deps/Cargo.toml
+++ b/clippy_test_deps/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.1.4", features = ["derive"] }
 clippy_utils = { path = "../clippy_utils" }
 derive-new = "0.5"
 if_chain = "1.0"
@@ -17,7 +16,6 @@ syn = { version = "2.0", features = ["full"] }
 futures = "0.3"
 parking_lot = "0.12"
 tokio = { version = "1", features = ["io-util"] }
-rustc-semver = "1.1"
 regex = "1.5"
 clippy_lints = { path = "../clippy_lints" }
 

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -24,7 +24,7 @@ fn base_config(test_dir: &str) -> compiletest::Config {
         mode: TestMode::Yolo,
         stderr_filters: vec![],
         stdout_filters: vec![],
-        output_conflict_handling: if std::env::args().any(|arg| arg == "--bless") {
+        output_conflict_handling: if var_os("BLESS").is_some() || env::args().any(|arg| arg == "--bless") {
             compiletest::OutputConflictHandling::Bless
         } else {
             compiletest::OutputConflictHandling::Error("cargo test -- -- --bless".into())
@@ -295,7 +295,6 @@ fn rustfix_coverage_known_exceptions_accuracy() {
         let rs_path = Path::new("tests/ui").join(filename);
         assert!(rs_path.exists(), "`{}` does not exist", rs_path.display());
         let fixed_path = rs_path.with_extension("fixed");
-        println!("{}", fixed_path.display());
         assert!(!fixed_path.exists(), "`{}` exists", fixed_path.display());
     }
 }


### PR DESCRIPTION
changelog: none

Allows passing the environment variable `BLESS` to bless tests, which is useful when you want to bless internal tests - `BLESS= cargo uitest -Finternal`

Also updates a place in the docs referring to `cargo dev bless` and removes some unused test deps