### PR TITLE
New lint [`iter_skip_zero`]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4939,6 +4939,7 @@ Released 2018-09-13
 [`iter_on_single_items`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_on_single_items
 [`iter_overeager_cloned`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_overeager_cloned
 [`iter_skip_next`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip_next
+[`iter_skip_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_skip_zero
 [`iter_with_drain`]: https://rust-lang.github.io/rust-clippy/master/index.html#iter_with_drain
 [`iterator_step_by_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#iterator_step_by_zero
 [`just_underscores_and_digits`]: https://rust-lang.github.io/rust-clippy/master/index.html#just_underscores_and_digits

--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -257,7 +257,7 @@ fn is_cast_from_ty_alias<'tcx>(cx: &LateContext<'tcx>, expr: impl Visitable<'tcx
                 // Will this work for more complex types? Probably not!
                 if !snippet
                     .split("->")
-                    .skip(0)
+                    .skip(1)
                     .map(|s| {
                         s.trim() == cast_from.to_string()
                             || s.split("where").any(|ty| ty.trim() == cast_from.to_string())

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -360,6 +360,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::ITER_ON_SINGLE_ITEMS_INFO,
     crate::methods::ITER_OVEREAGER_CLONED_INFO,
     crate::methods::ITER_SKIP_NEXT_INFO,
+    crate::methods::ITER_SKIP_ZERO_INFO,
     crate::methods::ITER_WITH_DRAIN_INFO,
     crate::methods::MANUAL_FILTER_MAP_INFO,
     crate::methods::MANUAL_FIND_MAP_INFO,

--- a/clippy_lints/src/methods/iter_skip_zero.rs
+++ b/clippy_lints/src/methods/iter_skip_zero.rs
@@ -1,0 +1,34 @@
+use clippy_utils::consts::{constant, Constant};
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::{is_from_proc_macro, is_trait_method};
+use rustc_errors::Applicability;
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_span::sym;
+
+use super::ITER_SKIP_ZERO;
+
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg_expr: &Expr<'_>) {
+    if !expr.span.from_expansion()
+        && is_trait_method(cx, expr, sym::Iterator)
+        && let Some(arg) = constant(cx, cx.typeck_results(), arg_expr).and_then(|constant| {
+            if let Constant::Int(arg) = constant {
+                Some(arg)
+            } else {
+                None
+            }
+        })
+        && arg == 0
+        && !is_from_proc_macro(cx, expr)
+    {
+        span_lint_and_then(cx, ITER_SKIP_ZERO, arg_expr.span, "usage of `.skip(0)`", |diag| {
+            diag.span_suggestion(
+                arg_expr.span,
+                "if you meant to skip the first element, use",
+                "1",
+                Applicability::MaybeIncorrect,
+            )
+            .note("this call to `skip` does nothing and is useless; remove it");
+        });
+    }
+}

--- a/tests/ui/iter_skip_zero.fixed
+++ b/tests/ui/iter_skip_zero.fixed
@@ -1,0 +1,25 @@
+//@run-rustfix
+//@aux-build:proc_macros.rs:proc-macro
+#![allow(clippy::useless_vec, unused)]
+#![warn(clippy::iter_skip_zero)]
+
+#[macro_use]
+extern crate proc_macros;
+
+use std::iter::once;
+
+fn main() {
+    let _ = [1, 2, 3].iter().skip(1);
+    let _ = vec![1, 2, 3].iter().skip(1);
+    let _ = once([1, 2, 3]).skip(1);
+    let _ = vec![1, 2, 3].iter().chain([1, 2, 3].iter().skip(1)).skip(1);
+    // Don't lint
+    let _ = [1, 2, 3].iter().skip(1);
+    let _ = vec![1, 2, 3].iter().skip(1);
+    external! {
+        let _ = [1, 2, 3].iter().skip(0);
+    }
+    with_span! {
+        let _ = [1, 2, 3].iter().skip(0);
+    }
+}

--- a/tests/ui/iter_skip_zero.rs
+++ b/tests/ui/iter_skip_zero.rs
@@ -1,0 +1,25 @@
+//@run-rustfix
+//@aux-build:proc_macros.rs:proc-macro
+#![allow(clippy::useless_vec, unused)]
+#![warn(clippy::iter_skip_zero)]
+
+#[macro_use]
+extern crate proc_macros;
+
+use std::iter::once;
+
+fn main() {
+    let _ = [1, 2, 3].iter().skip(0);
+    let _ = vec![1, 2, 3].iter().skip(0);
+    let _ = once([1, 2, 3]).skip(0);
+    let _ = vec![1, 2, 3].iter().chain([1, 2, 3].iter().skip(0)).skip(0);
+    // Don't lint
+    let _ = [1, 2, 3].iter().skip(1);
+    let _ = vec![1, 2, 3].iter().skip(1);
+    external! {
+        let _ = [1, 2, 3].iter().skip(0);
+    }
+    with_span! {
+        let _ = [1, 2, 3].iter().skip(0);
+    }
+}

--- a/tests/ui/iter_skip_zero.stderr
+++ b/tests/ui/iter_skip_zero.stderr
@@ -1,0 +1,43 @@
+error: usage of `.skip(0)`
+  --> $DIR/iter_skip_zero.rs:12:35
+   |
+LL |     let _ = [1, 2, 3].iter().skip(0);
+   |                                   ^ help: if you meant to skip the first element, use: `1`
+   |
+   = note: this call to `skip` does nothing and is useless; remove it
+   = note: `-D clippy::iter-skip-zero` implied by `-D warnings`
+
+error: usage of `.skip(0)`
+  --> $DIR/iter_skip_zero.rs:13:39
+   |
+LL |     let _ = vec![1, 2, 3].iter().skip(0);
+   |                                       ^ help: if you meant to skip the first element, use: `1`
+   |
+   = note: this call to `skip` does nothing and is useless; remove it
+
+error: usage of `.skip(0)`
+  --> $DIR/iter_skip_zero.rs:14:34
+   |
+LL |     let _ = once([1, 2, 3]).skip(0);
+   |                                  ^ help: if you meant to skip the first element, use: `1`
+   |
+   = note: this call to `skip` does nothing and is useless; remove it
+
+error: usage of `.skip(0)`
+  --> $DIR/iter_skip_zero.rs:15:71
+   |
+LL |     let _ = vec![1, 2, 3].iter().chain([1, 2, 3].iter().skip(0)).skip(0);
+   |                                                                       ^ help: if you meant to skip the first element, use: `1`
+   |
+   = note: this call to `skip` does nothing and is useless; remove it
+
+error: usage of `.skip(0)`
+  --> $DIR/iter_skip_zero.rs:15:62
+   |
+LL |     let _ = vec![1, 2, 3].iter().chain([1, 2, 3].iter().skip(0)).skip(0);
+   |                                                              ^ help: if you meant to skip the first element, use: `1`
+   |
+   = note: this call to `skip` does nothing and is useless; remove it
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Idea came from my contribution to `unnecessary_cast` recently. Sorry about that :sweat_smile:

Could be an issue if somebody manually implements `skip`, but I don't think anybody will (and this would be an issue with other lints too, afaik)

changelog: New lint [`iter_skip_zero`]
