### PR TITLE
Make `eq_op` suggest `.is_nan()`

### DIFF
--- a/tests/ui/eq_op.rs
+++ b/tests/ui/eq_op.rs
@@ -10,6 +10,8 @@ fn main() {
     let _ = false != false;
     let _ = 1.5 < 1.5;
     let _ = 1u64 >= 1u64;
+    let x = f32::NAN;
+    let _ = x != x;
 
     // casts, methods, parentheses
     let _ = (1u32 as u64) & (1u32 as u64);

--- a/tests/ui/eq_op.stderr
+++ b/tests/ui/eq_op.stderr
@@ -30,143 +30,151 @@ error: equal expressions as operands to `>=`
 LL |     let _ = 1u64 >= 1u64;
    |             ^^^^^^^^^^^^
 
+error: equal expressions as operands to `!=`
+  --> $DIR/eq_op.rs:14:13
+   |
+LL |     let _ = x != x;
+   |             ^^^^^^
+   |
+   = note: if you intended to check if the operand is NaN, use `.is_nan()` instead
+
 error: equal expressions as operands to `&`
-  --> $DIR/eq_op.rs:15:13
+  --> $DIR/eq_op.rs:17:13
    |
 LL |     let _ = (1u32 as u64) & (1u32 as u64);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `^`
-  --> $DIR/eq_op.rs:18:17
+  --> $DIR/eq_op.rs:20:17
    |
 LL |         let _ = 1 ^ ((((((1))))));
    |                 ^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `<`
-  --> $DIR/eq_op.rs:22:13
+  --> $DIR/eq_op.rs:24:13
    |
 LL |     let _ = (-(2) < -(2));
    |             ^^^^^^^^^^^^^
 
 error: equal expressions as operands to `==`
-  --> $DIR/eq_op.rs:23:13
+  --> $DIR/eq_op.rs:25:13
    |
 LL |     let _ = ((1 + 1) & (1 + 1) == (1 + 1) & (1 + 1));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `&`
-  --> $DIR/eq_op.rs:23:14
+  --> $DIR/eq_op.rs:25:14
    |
 LL |     let _ = ((1 + 1) & (1 + 1) == (1 + 1) & (1 + 1));
    |              ^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `&`
-  --> $DIR/eq_op.rs:23:35
+  --> $DIR/eq_op.rs:25:35
    |
 LL |     let _ = ((1 + 1) & (1 + 1) == (1 + 1) & (1 + 1));
    |                                   ^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `==`
-  --> $DIR/eq_op.rs:24:13
+  --> $DIR/eq_op.rs:26:13
    |
 LL |     let _ = (1 * 2) + (3 * 4) == 1 * 2 + 3 * 4;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `!=`
-  --> $DIR/eq_op.rs:27:13
+  --> $DIR/eq_op.rs:29:13
    |
 LL |     let _ = ([1] != [1]);
    |             ^^^^^^^^^^^^
 
 error: equal expressions as operands to `!=`
-  --> $DIR/eq_op.rs:28:13
+  --> $DIR/eq_op.rs:30:13
    |
 LL |     let _ = ((1, 2) != (1, 2));
    |             ^^^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `==`
-  --> $DIR/eq_op.rs:32:13
+  --> $DIR/eq_op.rs:34:13
    |
 LL |     let _ = 1 + 1 == 2;
    |             ^^^^^^^^^^
 
 error: equal expressions as operands to `==`
-  --> $DIR/eq_op.rs:33:13
+  --> $DIR/eq_op.rs:35:13
    |
 LL |     let _ = 1 - 1 == 0;
    |             ^^^^^^^^^^
 
 error: equal expressions as operands to `-`
-  --> $DIR/eq_op.rs:33:13
+  --> $DIR/eq_op.rs:35:13
    |
 LL |     let _ = 1 - 1 == 0;
    |             ^^^^^
 
 error: equal expressions as operands to `-`
-  --> $DIR/eq_op.rs:35:13
+  --> $DIR/eq_op.rs:37:13
    |
 LL |     let _ = 1 - 1;
    |             ^^^^^
 
 error: equal expressions as operands to `/`
-  --> $DIR/eq_op.rs:36:13
+  --> $DIR/eq_op.rs:38:13
    |
 LL |     let _ = 1 / 1;
    |             ^^^^^
 
 error: equal expressions as operands to `&&`
-  --> $DIR/eq_op.rs:37:13
+  --> $DIR/eq_op.rs:39:13
    |
 LL |     let _ = true && true;
    |             ^^^^^^^^^^^^
 
 error: equal expressions as operands to `||`
-  --> $DIR/eq_op.rs:39:13
+  --> $DIR/eq_op.rs:41:13
    |
 LL |     let _ = true || true;
    |             ^^^^^^^^^^^^
 
 error: equal expressions as operands to `&&`
-  --> $DIR/eq_op.rs:44:13
+  --> $DIR/eq_op.rs:46:13
    |
 LL |     let _ = a == b && b == a;
    |             ^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `&&`
-  --> $DIR/eq_op.rs:45:13
+  --> $DIR/eq_op.rs:47:13
    |
 LL |     let _ = a != b && b != a;
    |             ^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `&&`
-  --> $DIR/eq_op.rs:46:13
+  --> $DIR/eq_op.rs:48:13
    |
 LL |     let _ = a < b && b > a;
    |             ^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `&&`
-  --> $DIR/eq_op.rs:47:13
+  --> $DIR/eq_op.rs:49:13
    |
 LL |     let _ = a <= b && b >= a;
    |             ^^^^^^^^^^^^^^^^
 
 error: equal expressions as operands to `==`
-  --> $DIR/eq_op.rs:50:13
+  --> $DIR/eq_op.rs:52:13
    |
 LL |     let _ = a == a;
    |             ^^^^^^
 
 error: equal expressions as operands to `/`
-  --> $DIR/eq_op.rs:60:20
+  --> $DIR/eq_op.rs:62:20
    |
 LL |     const D: u32 = A / A;
    |                    ^^^^^
 
 error: equal expressions as operands to `==`
-  --> $DIR/eq_op.rs:91:5
+  --> $DIR/eq_op.rs:93:5
    |
 LL |     (n1.inner.0).0 == (n1.inner.0).0 && (n1.inner.1).0 == (n2.inner.1).0 && (n1.inner.2).0 == (n2.inner.2).0
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 28 previous errors
+error: aborting due to 29 previous errors
 


### PR DESCRIPTION
changelog: Enhancement: [`eq_op`]: Suggests `is_nan()` for `x != x` where `x` is a float
