### PR TITLE
Use `cargo build --tests` in CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -50,7 +50,7 @@ jobs:
         echo "LD_LIBRARY_PATH=${SYSROOT}/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
 
     - name: Build
-      run: cargo build --features deny-warnings,internal
+      run: cargo build --tests --features deny-warnings,internal
 
     - name: Test
       run: cargo test --features deny-warnings,internal

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -106,7 +106,7 @@ jobs:
         echo "$SYSROOT/bin" >> $GITHUB_PATH
 
     - name: Build
-      run: cargo build --features deny-warnings,internal
+      run: cargo build --tests --features deny-warnings,internal
 
     - name: Test
       if: runner.os == 'Linux'


### PR DESCRIPTION
I noticed that we run a `cargo build` but end up downloading/building a bunch of deps after that for tests in CI

https://github.com/rust-lang/rust-clippy/actions/runs/5426673277/jobs/9869019973#step:6:12
https://github.com/rust-lang/rust-clippy/actions/runs/5426673277/jobs/9869019973#step:7:11

This builds the tests in the build step too, it may speed up runs by downloading/building more in parallel

changelog: none
