### PR TITLE
"try this" -> "try"

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -589,7 +589,7 @@ impl<'tcx> LateLintPass<'tcx> for Dereferencing<'tcx> {
                     pat.spans,
                     "this pattern creates a reference to a reference",
                     |diag| {
-                        diag.multipart_suggestion("try this", replacements, app);
+                        diag.multipart_suggestion("try", replacements, app);
                     },
                 );
             }
@@ -1531,7 +1531,7 @@ fn report<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, state: State, data
                     Mutability::Not => "explicit `deref` method call",
                     Mutability::Mut => "explicit `deref_mut` method call",
                 },
-                "try this",
+                "try",
                 format!("{addr_of_str}{deref_str}{expr_str}"),
                 app,
             );
@@ -1593,7 +1593,7 @@ fn report<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, state: State, data
                         } else {
                             format!("{prefix}{snip}")
                         };
-                    diag.span_suggestion(data.span, "try this", sugg, app);
+                    diag.span_suggestion(data.span, "try", sugg, app);
                 },
             );
         },
@@ -1620,7 +1620,7 @@ fn report<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, state: State, data
                 |diag| {
                     let mut app = Applicability::MachineApplicable;
                     let snip = snippet_with_context(cx, expr.span, data.span.ctxt(), "..", &mut app).0;
-                    diag.span_suggestion(data.span, "try this", snip.into_owned(), app);
+                    diag.span_suggestion(data.span, "try", snip.into_owned(), app);
                 },
             );
         },

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -186,7 +186,7 @@ impl<'tcx> LateLintPass<'tcx> for HashMapPass {
             MAP_ENTRY,
             expr.span,
             &format!("usage of `contains_key` followed by `insert` on a `{}`", map_ty.name()),
-            "try this",
+            "try",
             sugg,
             app,
         );

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -100,7 +100,7 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitWrite {
                     EXPLICIT_WRITE,
                     expr.span,
                     &format!("use of `{used}.unwrap()`"),
-                    "try this",
+                    "try",
                     format!("{prefix}{sugg_mac}!({inputs_snippet})"),
                     applicability,
                 );

--- a/clippy_lints/src/init_numbered_fields.rs
+++ b/clippy_lints/src/init_numbered_fields.rs
@@ -71,7 +71,7 @@ impl<'tcx> LateLintPass<'tcx> for NumberedFields {
                     INIT_NUMBERED_FIELDS,
                     e.span,
                     "used a field initializer for a tuple struct",
-                    "try this instead",
+                    "try",
                     snippet,
                     appl,
                 );

--- a/clippy_lints/src/loops/missing_spin_loop.rs
+++ b/clippy_lints/src/loops/missing_spin_loop.rs
@@ -43,7 +43,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, cond: &'tcx Expr<'_>, body: &'
                 MISSING_SPIN_LOOP,
                 body.span,
                 "busy-waiting loop should at least have a spin loop hint",
-                "try this",
+                "try",
                 (if is_no_std_crate(cx) {
                     "{ core::hint::spin_loop() }"
                 } else {

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -226,7 +226,7 @@ fn lint_map_unit_fn(
         );
 
         span_lint_and_then(cx, lint, expr.span, &msg, |diag| {
-            diag.span_suggestion(stmt.span, "try this", suggestion, applicability);
+            diag.span_suggestion(stmt.span, "try", suggestion, applicability);
         });
     } else if let Some((binding, closure_expr)) = unit_closure(cx, fn_arg) {
         let msg = suggestion_msg("closure", map_type);
@@ -241,7 +241,7 @@ fn lint_map_unit_fn(
                     snippet_with_applicability(cx, var_arg.span, "_", &mut applicability),
                     snippet_with_context(cx, reduced_expr_span, var_arg.span.ctxt(), "_", &mut applicability).0,
                 );
-                diag.span_suggestion(stmt.span, "try this", suggestion, applicability);
+                diag.span_suggestion(stmt.span, "try", suggestion, applicability);
             } else {
                 let suggestion = format!(
                     "if let {0}({1}) = {2} {{ ... }}",
@@ -249,7 +249,7 @@ fn lint_map_unit_fn(
                     snippet(cx, binding.pat.span, "_"),
                     snippet(cx, var_arg.span, "_"),
                 );
-                diag.span_suggestion(stmt.span, "try this", suggestion, Applicability::HasPlaceholders);
+                diag.span_suggestion(stmt.span, "try", suggestion, Applicability::HasPlaceholders);
             }
         });
     }

--- a/clippy_lints/src/matches/infallible_destructuring_match.rs
+++ b/clippy_lints/src/matches/infallible_destructuring_match.rs
@@ -28,7 +28,7 @@ pub(crate) fn check(cx: &LateContext<'_>, local: &Local<'_>) -> bool {
                 local.span,
                 "you seem to be trying to use `match` to destructure a single infallible pattern. \
                 Consider using `let`",
-                "try this",
+                "try",
                 format!(
                     "let {}({}{}) = {};",
                     snippet_with_applicability(cx, variant_name.span, "..", &mut applicability),

--- a/clippy_lints/src/matches/manual_filter.rs
+++ b/clippy_lints/src/matches/manual_filter.rs
@@ -143,7 +143,7 @@ fn check<'tcx>(
             MANUAL_FILTER,
             expr.span,
             "manual implementation of `Option::filter`",
-            "try this",
+            "try",
             if sugg_info.needs_brackets {
                 format!(
                     "{{ {}{}.filter({body_str}) }}",

--- a/clippy_lints/src/matches/manual_map.rs
+++ b/clippy_lints/src/matches/manual_map.rs
@@ -58,7 +58,7 @@ fn check<'tcx>(
             MANUAL_MAP,
             expr.span,
             "manual implementation of `Option::map`",
-            "try this",
+            "try",
             if sugg_info.needs_brackets {
                 format!(
                     "{{ {}{}.map({}) }}",

--- a/clippy_lints/src/matches/match_as_ref.rs
+++ b/clippy_lints/src/matches/match_as_ref.rs
@@ -46,7 +46,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>], expr:
                 MATCH_AS_REF,
                 expr.span,
                 &format!("use `{suggestion}()` instead"),
-                "try this",
+                "try",
                 format!(
                     "{}.{suggestion}(){cast}",
                     snippet_with_applicability(cx, ex.span, "_", &mut applicability),

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -139,7 +139,7 @@ where
                 MATCH_LIKE_MATCHES_MACRO,
                 expr.span,
                 &format!("{} expression looks like `matches!` macro", if is_if_let { "if let .. else" } else { "match" }),
-                "try this",
+                "try",
                 format!(
                     "{}matches!({}, {pat_and_guard})",
                     if b0 { "" } else { "!" },

--- a/clippy_lints/src/matches/match_on_vec_items.rs
+++ b/clippy_lints/src/matches/match_on_vec_items.rs
@@ -22,7 +22,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, scrutinee: &'tcx Expr<'_>) {
                 MATCH_ON_VEC_ITEMS,
                 scrutinee.span,
                 "indexing into a vector may panic",
-                "try this",
+                "try",
                 format!(
                     "{}.get({})",
                     snippet(cx, vec.span, ".."),

--- a/clippy_lints/src/matches/match_wild_enum.rs
+++ b/clippy_lints/src/matches/match_wild_enum.rs
@@ -143,7 +143,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>]) {
             MATCH_WILDCARD_FOR_SINGLE_VARIANTS,
             wildcard_span,
             "wildcard matches only a single variant and will also match any future added variants",
-            "try this",
+            "try",
             format_suggestion(x),
             Applicability::MaybeIncorrect,
         ),
@@ -161,7 +161,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>]) {
                 WILDCARD_ENUM_MATCH_ARM,
                 wildcard_span,
                 message,
-                "try this",
+                "try",
                 suggestions.join(" | "),
                 Applicability::MaybeIncorrect,
             );

--- a/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -175,7 +175,7 @@ fn find_sugg_for_if_let<'tcx>(
                 .maybe_par()
                 .to_string();
 
-            diag.span_suggestion(span, "try this", format!("{keyword} {sugg}.{good_method}"), app);
+            diag.span_suggestion(span, "try", format!("{keyword} {sugg}.{good_method}"), app);
 
             if needs_drop {
                 diag.note("this will change drop order of the result, as well as all temporaries");
@@ -200,7 +200,7 @@ pub(super) fn check_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, op
                 REDUNDANT_PATTERN_MATCHING,
                 span,
                 &format!("redundant pattern matching, consider using `{good_method}`"),
-                "try this",
+                "try",
                 format!("{}.{good_method}", snippet(cx, result_expr.span, "_")),
                 Applicability::MachineApplicable,
             );

--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -136,7 +136,7 @@ fn report_single_pattern(
         }
     };
 
-    span_lint_and_sugg(cx, lint, expr.span, msg, "try this", sugg, app);
+    span_lint_and_sugg(cx, lint, expr.span, msg, "try", sugg, app);
 }
 
 fn check_opt_like<'a>(

--- a/clippy_lints/src/matches/try_err.rs
+++ b/clippy_lints/src/matches/try_err.rs
@@ -70,7 +70,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, scrutine
                 TRY_ERR,
                 expr.span,
                 "returning an `Err(_)` with the `?` operator",
-                "try this",
+                "try",
                 suggestion,
                 applicability,
             );

--- a/clippy_lints/src/methods/bind_instead_of_map.rs
+++ b/clippy_lints/src/methods/bind_instead_of_map.rs
@@ -87,7 +87,7 @@ pub(crate) trait BindInsteadOfMap {
                     BIND_INSTEAD_OF_MAP,
                     expr.span,
                     &msg,
-                    "try this",
+                    "try",
                     note,
                     app,
                 );
@@ -124,7 +124,7 @@ pub(crate) trait BindInsteadOfMap {
         span_lint_and_then(cx, BIND_INSTEAD_OF_MAP, expr.span, &msg, |diag| {
             multispan_sugg_with_applicability(
                 diag,
-                "try this",
+                "try",
                 Applicability::MachineApplicable,
                 std::iter::once((span, Self::GOOD_METHOD_NAME.into())).chain(
                     suggs

--- a/clippy_lints/src/methods/clone_on_ref_ptr.rs
+++ b/clippy_lints/src/methods/clone_on_ref_ptr.rs
@@ -42,7 +42,7 @@ pub(super) fn check(
             CLONE_ON_REF_PTR,
             expr.span,
             "using `.clone()` on a ref-counted pointer",
-            "try this",
+            "try",
             format!("{caller_type}::<{}>::clone(&{snippet})", subst.type_at(0)),
             app,
         );

--- a/clippy_lints/src/methods/expect_fun_call.rs
+++ b/clippy_lints/src/methods/expect_fun_call.rs
@@ -144,7 +144,7 @@ pub(super) fn check<'tcx>(
                 EXPECT_FUN_CALL,
                 span_replace_word,
                 &format!("use of `{name}` followed by a function call"),
-                "try this",
+                "try",
                 format!("unwrap_or_else({closure_args} panic!({sugg}))"),
                 applicability,
             );
@@ -162,7 +162,7 @@ pub(super) fn check<'tcx>(
         EXPECT_FUN_CALL,
         span_replace_word,
         &format!("use of `{name}` followed by a function call"),
-        "try this",
+        "try",
         format!("unwrap_or_else({closure_args} {{ panic!(\"{{}}\", {arg_root_snippet}) }})"),
         applicability,
     );

--- a/clippy_lints/src/methods/extend_with_drain.rs
+++ b/clippy_lints/src/methods/extend_with_drain.rs
@@ -31,7 +31,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, arg:
                 EXTEND_WITH_DRAIN,
                 expr.span,
                 "use of `extend` instead of `append` for adding the full range of a second vector",
-                "try this",
+                "try",
                 format!(
                     "{}.append({}{})",
                     snippet_with_applicability(cx, recv.span, "..", &mut applicability),

--- a/clippy_lints/src/methods/filter_map_next.rs
+++ b/clippy_lints/src/methods/filter_map_next.rs
@@ -31,7 +31,7 @@ pub(super) fn check<'tcx>(
                 FILTER_MAP_NEXT,
                 expr.span,
                 msg,
-                "try this",
+                "try",
                 format!("{iter_snippet}.find_map({filter_snippet})"),
                 Applicability::MachineApplicable,
             );

--- a/clippy_lints/src/methods/filter_next.rs
+++ b/clippy_lints/src/methods/filter_next.rs
@@ -31,7 +31,7 @@ pub(super) fn check<'tcx>(
                 FILTER_NEXT,
                 expr.span,
                 msg,
-                "try this",
+                "try",
                 format!("{iter_snippet}.find({filter_snippet})"),
                 Applicability::MachineApplicable,
             );

--- a/clippy_lints/src/methods/get_unwrap.rs
+++ b/clippy_lints/src/methods/get_unwrap.rs
@@ -71,7 +71,7 @@ pub(super) fn check<'tcx>(
         GET_UNWRAP,
         span,
         &format!("called `.get{mut_str}().unwrap()` on a {caller_type}. Using `[]` is more clear and more concise"),
-        "try this",
+        "try",
         format!(
             "{borrow_str}{}[{get_args_str}]",
             snippet_with_applicability(cx, recv.span, "..", &mut applicability)

--- a/clippy_lints/src/methods/iter_overeager_cloned.rs
+++ b/clippy_lints/src/methods/iter_overeager_cloned.rs
@@ -51,7 +51,7 @@ pub(super) fn check<'tcx>(
                 if let Some(mut snip) = snippet_opt(cx, method_span) {
                     snip.push_str(trailing_clone);
                     let replace_span = expr.span.with_lo(cloned_recv.span.hi());
-                    diag.span_suggestion(replace_span, "try this", snip, Applicability::MachineApplicable);
+                    diag.span_suggestion(replace_span, "try", snip, Applicability::MachineApplicable);
                 }
             }
         );

--- a/clippy_lints/src/methods/iter_with_drain.rs
+++ b/clippy_lints/src/methods/iter_with_drain.rs
@@ -21,7 +21,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, span
             ITER_WITH_DRAIN,
             span.with_hi(expr.span.hi()),
             &format!("`drain(..)` used on a `{ty_name}`"),
-            "try this",
+            "try",
             "into_iter()".to_string(),
             Applicability::MaybeIncorrect,
         );

--- a/clippy_lints/src/methods/manual_str_repeat.rs
+++ b/clippy_lints/src/methods/manual_str_repeat.rs
@@ -88,7 +88,7 @@ pub(super) fn check(
                 MANUAL_STR_REPEAT,
                 collect_expr.span,
                 "manual implementation of `str::repeat` using iterators",
-                "try this",
+                "try",
                 format!("{val_str}.repeat({count_snip})"),
                 app
             )

--- a/clippy_lints/src/methods/map_collect_result_unit.rs
+++ b/clippy_lints/src/methods/map_collect_result_unit.rs
@@ -25,7 +25,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, iter: &hir::Expr
                 MAP_COLLECT_RESULT_UNIT,
                 expr.span,
                 "`.map().collect()` can be replaced with `.try_for_each()`",
-                "try this",
+                "try",
                 format!(
                     "{}.try_for_each({})",
                     snippet(cx, iter.span, ".."),

--- a/clippy_lints/src/methods/map_unwrap_or.rs
+++ b/clippy_lints/src/methods/map_unwrap_or.rs
@@ -63,7 +63,7 @@ pub(super) fn check<'tcx>(
                 MAP_UNWRAP_OR,
                 expr.span,
                 msg,
-                "try this",
+                "try",
                 format!("{var_snippet}.map_or_else({unwrap_snippet}, {map_snippet})"),
                 Applicability::MachineApplicable,
             );

--- a/clippy_lints/src/methods/needless_option_as_deref.rs
+++ b/clippy_lints/src/methods/needless_option_as_deref.rs
@@ -29,7 +29,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>, name
             NEEDLESS_OPTION_AS_DEREF,
             expr.span,
             "derefed type is same as origin",
-            "try this",
+            "try",
             snippet_opt(cx, recv.span).unwrap(),
             Applicability::MachineApplicable,
         );

--- a/clippy_lints/src/methods/or_fun_call.rs
+++ b/clippy_lints/src/methods/or_fun_call.rs
@@ -62,7 +62,7 @@ pub(super) fn check<'tcx>(
                     OR_FUN_CALL,
                     method_span.with_hi(span.hi()),
                     &format!("use of `{name}` followed by a call to `{path}`"),
-                    "try this",
+                    "try",
                     format!("{sugg}()"),
                     Applicability::MachineApplicable,
                 );
@@ -139,7 +139,7 @@ pub(super) fn check<'tcx>(
                     OR_FUN_CALL,
                     span_replace_word,
                     &format!("use of `{name}` followed by a function call"),
-                    "try this",
+                    "try",
                     format!("{name}_{suffix}({sugg})"),
                     app,
                 );

--- a/clippy_lints/src/methods/or_then_unwrap.rs
+++ b/clippy_lints/src/methods/or_then_unwrap.rs
@@ -50,7 +50,7 @@ pub(super) fn check<'tcx>(
         OR_THEN_UNWRAP,
         unwrap_expr.span.with_lo(or_span.lo()),
         title,
-        "try this",
+        "try",
         suggestion,
         applicability,
     );

--- a/clippy_lints/src/methods/str_splitn.rs
+++ b/clippy_lints/src/methods/str_splitn.rs
@@ -55,7 +55,7 @@ fn lint_needless(cx: &LateContext<'_>, method_name: &str, expr: &Expr<'_>, self_
         NEEDLESS_SPLITN,
         expr.span,
         &format!("unnecessary use of `{r}splitn`"),
-        "try this",
+        "try",
         format!(
             "{}.{r}split({})",
             snippet_with_context(cx, self_arg.span, expr.span.ctxt(), "..", &mut app).0,
@@ -110,7 +110,7 @@ fn check_manual_split_once(
         IterUsageKind::Nth(_) => return,
     };
 
-    span_lint_and_sugg(cx, MANUAL_SPLIT_ONCE, usage.span, msg, "try this", sugg, app);
+    span_lint_and_sugg(cx, MANUAL_SPLIT_ONCE, usage.span, msg, "try", sugg, app);
 }
 
 /// checks for

--- a/clippy_lints/src/methods/string_extend_chars.rs
+++ b/clippy_lints/src/methods/string_extend_chars.rs
@@ -34,7 +34,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr
             STRING_EXTEND_CHARS,
             expr.span,
             "calling `.extend(_.chars())`",
-            "try this",
+            "try",
             format!(
                 "{}.push_str({ref_str}{})",
                 snippet_with_applicability(cx, recv.span, "..", &mut applicability),

--- a/clippy_lints/src/methods/useless_asref.rs
+++ b/clippy_lints/src/methods/useless_asref.rs
@@ -37,7 +37,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, call_name: &str,
                 USELESS_ASREF,
                 expr.span,
                 &format!("this call to `{call_name}` does nothing"),
-                "try this",
+                "try",
                 snippet_with_applicability(cx, recvr.span, "..", &mut applicability).to_string(),
                 applicability,
             );

--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -94,7 +94,7 @@ impl EarlyLintPass for DerefAddrOf {
                         DEREF_ADDROF,
                         e.span,
                         "immediately dereferencing a reference",
-                        "try this",
+                        "try",
                         sugg.to_string(),
                         applicability,
                     );

--- a/clippy_lints/src/strlen_on_c_strings.rs
+++ b/clippy_lints/src/strlen_on_c_strings.rs
@@ -78,7 +78,7 @@ impl<'tcx> LateLintPass<'tcx> for StrlenOnCStrings {
                     STRLEN_ON_C_STRINGS,
                     span,
                     "using `libc::strlen` on a `CString` or `CStr` value",
-                    "try this",
+                    "try",
                     format!("{val_name}.{method_name}().len()"),
                     app,
                 );

--- a/clippy_lints/src/to_digit_is_some.rs
+++ b/clippy_lints/src/to_digit_is_some.rs
@@ -82,7 +82,7 @@ impl<'tcx> LateLintPass<'tcx> for ToDigitIsSome {
                         TO_DIGIT_IS_SOME,
                         expr.span,
                         "use of `.to_digit(..).is_some()`",
-                        "try this",
+                        "try",
                         if is_method_call {
                             format!("{char_arg_snip}.is_digit({radix_snip})")
                         } else {

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -522,7 +522,7 @@ fn check_literal(cx: &LateContext<'_>, format_args: &FormatArgs, name: &str) {
                     {
                         let replacement = replacement.replace('{', "{{").replace('}', "}}");
                         diag.multipart_suggestion(
-                            "try this",
+                            "try",
                             vec![(*placeholder_span, replacement), (removal_span, String::new())],
                             Applicability::MachineApplicable,
                         );

--- a/tests/lint_message_convention.rs
+++ b/tests/lint_message_convention.rs
@@ -18,18 +18,20 @@ impl Message {
     fn new(path: PathBuf) -> Self {
         // we don't want the first letter after "error: ", "help: " ... to be capitalized
         // also no punctuation (except for "?" ?) at the end of a line
+        // Prefer "try" over "try this".
         static REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
             RegexSet::new([
                 "error: [A-Z]",
                 "help: [A-Z]",
                 "warning: [A-Z]",
                 "note: [A-Z]",
-                "try this: [A-Z]",
+                "try: [A-Z]",
                 "error: .*[.!]$",
                 "help: .*[.!]$",
                 "warning: .*[.!]$",
                 "note: .*[.!]$",
-                "try this: .*[.!]$",
+                "try: .*[.!]$",
+                "try this",
             ])
             .unwrap()
         });

--- a/tests/ui-toml/allow_mixed_uninlined_format_args/uninlined_format_args.stderr
+++ b/tests/ui-toml/allow_mixed_uninlined_format_args/uninlined_format_args.stderr
@@ -30,7 +30,7 @@ LL |     println!("Hello {} is {:.*}", "x", local_i32, local_f64);
    |                                   ^^^
    |
    = note: `-D clippy::print-literal` implied by `-D warnings`
-help: try this
+help: try
    |
 LL -     println!("Hello {} is {:.*}", "x", local_i32, local_f64);
 LL +     println!("Hello x is {:.*}", local_i32, local_f64);

--- a/tests/ui-toml/unwrap_used/unwrap_used.stderr
+++ b/tests/ui-toml/unwrap_used/unwrap_used.stderr
@@ -2,7 +2,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/unwrap_used.rs:40:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&boxed_slice[1]`
    |
    = note: `-D clippy::get-unwrap` implied by `-D warnings`
 
@@ -19,7 +19,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/unwrap_used.rs:41:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:41:17
@@ -33,7 +33,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
   --> $DIR/unwrap_used.rs:42:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:42:17
@@ -47,7 +47,7 @@ error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more
   --> $DIR/unwrap_used.rs:43:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:43:17
@@ -61,7 +61,7 @@ error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more 
   --> $DIR/unwrap_used.rs:44:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_hashmap[&1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:44:17
@@ -75,7 +75,7 @@ error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more
   --> $DIR/unwrap_used.rs:45:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_btreemap[&1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:45:17
@@ -89,7 +89,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/unwrap_used.rs:49:21
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `boxed_slice[1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:49:22
@@ -103,7 +103,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
   --> $DIR/unwrap_used.rs:54:9
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `boxed_slice[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:54:10
@@ -117,7 +117,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
   --> $DIR/unwrap_used.rs:55:9
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:55:10
@@ -131,7 +131,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
   --> $DIR/unwrap_used.rs:56:9
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:56:10
@@ -145,7 +145,7 @@ error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and 
   --> $DIR/unwrap_used.rs:57:9
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:57:10
@@ -159,7 +159,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
   --> $DIR/unwrap_used.rs:69:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:69:17
@@ -173,7 +173,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
   --> $DIR/unwrap_used.rs:70:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/unwrap_used.rs:70:17
@@ -187,13 +187,13 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/unwrap_used.rs:77:13
    |
 LL |     let _ = boxed_slice.get(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&boxed_slice[1]`
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/unwrap_used.rs:95:17
    |
 LL |         let _ = Box::new([0]).get(1).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&Box::new([0])[1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&Box::new([0])[1]`
 
 error: aborting due to 28 previous errors
 

--- a/tests/ui/bind_instead_of_map.stderr
+++ b/tests/ui/bind_instead_of_map.stderr
@@ -14,7 +14,7 @@ error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed 
   --> $DIR/bind_instead_of_map.rs:10:13
    |
 LL |     let _ = x.and_then(|o| Some(o + 1));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `x.map(|o| o + 1)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.map(|o| o + 1)`
 
 error: using `Result.and_then(Ok)`, which is a no-op
   --> $DIR/bind_instead_of_map.rs:16:13

--- a/tests/ui/bind_instead_of_map_multipart.stderr
+++ b/tests/ui/bind_instead_of_map_multipart.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(clippy::bind_instead_of_map)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: try this
+help: try
    |
 LL |     let _ = Some("42").map(|s| if s.len() < 42 { 0 } else { s.len() });
    |                        ~~~                       ~          ~~~~~~~
@@ -20,7 +20,7 @@ error: using `Result.and_then(|x| Ok(y))`, which is more succinctly expressed as
 LL |     let _ = Ok::<_, ()>("42").and_then(|s| if s.len() < 42 { Ok(0) } else { Ok(s.len()) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try this
+help: try
    |
 LL |     let _ = Ok::<_, ()>("42").map(|s| if s.len() < 42 { 0 } else { s.len() });
    |                               ~~~                       ~          ~~~~~~~
@@ -31,7 +31,7 @@ error: using `Result.or_else(|x| Err(y))`, which is more succinctly expressed as
 LL |     let _ = Err::<(), _>("42").or_else(|s| if s.len() < 42 { Err(s.len() + 20) } else { Err(s.len()) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try this
+help: try
    |
 LL |     let _ = Err::<(), _>("42").map_err(|s| if s.len() < 42 { s.len() + 20 } else { s.len() });
    |                                ~~~~~~~                       ~~~~~~~~~~~~          ~~~~~~~
@@ -48,7 +48,7 @@ LL | |         }
 LL | |     });
    | |______^
    |
-help: try this
+help: try
    |
 LL ~     Some("42").map(|s| {
 LL |         if {
@@ -82,7 +82,7 @@ error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed 
 LL |     let _ = Some("").and_then(|s| if s.len() == 20 { Some(m!()) } else { Some(Some(20)) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: try this
+help: try
    |
 LL |     let _ = Some("").map(|s| if s.len() == 20 { m!() } else { Some(20) });
    |                      ~~~                        ~~~~          ~~~~~~~~

--- a/tests/ui/crashes/ice-7169.stderr
+++ b/tests/ui/crashes/ice-7169.stderr
@@ -2,7 +2,7 @@ error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/ice-7169.rs:10:12
    |
 LL |     if let Ok(_) = Ok::<_, ()>(A::<String>::default()) {}
-   |     -------^^^^^-------------------------------------- help: try this: `if Ok::<_, ()>(A::<String>::default()).is_ok()`
+   |     -------^^^^^-------------------------------------- help: try: `if Ok::<_, ()>(A::<String>::default()).is_ok()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 

--- a/tests/ui/crashes/ice-8250.stderr
+++ b/tests/ui/crashes/ice-8250.stderr
@@ -2,7 +2,7 @@ error: unnecessary use of `splitn`
   --> $DIR/ice-8250.rs:2:13
    |
 LL |     let _ = s[1..].splitn(2, '.').next()?;
-   |             ^^^^^^^^^^^^^^^^^^^^^ help: try this: `s[1..].split('.')`
+   |             ^^^^^^^^^^^^^^^^^^^^^ help: try: `s[1..].split('.')`
    |
    = note: `-D clippy::needless-splitn` implied by `-D warnings`
 

--- a/tests/ui/deref_addrof.stderr
+++ b/tests/ui/deref_addrof.stderr
@@ -2,7 +2,7 @@ error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:24:13
    |
 LL |     let b = *&a;
-   |             ^^^ help: try this: `a`
+   |             ^^^ help: try: `a`
    |
    = note: `-D clippy::deref-addrof` implied by `-D warnings`
 
@@ -10,49 +10,49 @@ error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:26:13
    |
 LL |     let b = *&get_number();
-   |             ^^^^^^^^^^^^^^ help: try this: `get_number()`
+   |             ^^^^^^^^^^^^^^ help: try: `get_number()`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:31:13
    |
 LL |     let b = *&bytes[1..2][0];
-   |             ^^^^^^^^^^^^^^^^ help: try this: `bytes[1..2][0]`
+   |             ^^^^^^^^^^^^^^^^ help: try: `bytes[1..2][0]`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:35:13
    |
 LL |     let b = *&(a);
-   |             ^^^^^ help: try this: `(a)`
+   |             ^^^^^ help: try: `(a)`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:37:13
    |
 LL |     let b = *(&a);
-   |             ^^^^^ help: try this: `a`
+   |             ^^^^^ help: try: `a`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:40:13
    |
 LL |     let b = *((&a));
-   |             ^^^^^^^ help: try this: `a`
+   |             ^^^^^^^ help: try: `a`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:42:13
    |
 LL |     let b = *&&a;
-   |             ^^^^ help: try this: `&a`
+   |             ^^^^ help: try: `&a`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:44:14
    |
 LL |     let b = **&aref;
-   |              ^^^^^^ help: try this: `aref`
+   |              ^^^^^^ help: try: `aref`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:54:17
    |
 LL |         inline!(*& $(@expr self))
-   |                 ^^^^^^^^^^^^^^^^ help: try this: `$(@expr self)`
+   |                 ^^^^^^^^^^^^^^^^ help: try: `$(@expr self)`
    |
    = note: this error originates in the macro `__inline_mac_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -60,7 +60,7 @@ error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:58:17
    |
 LL |         inline!(*&mut $(@expr self))
-   |                 ^^^^^^^^^^^^^^^^^^^ help: try this: `$(@expr self)`
+   |                 ^^^^^^^^^^^^^^^^^^^ help: try: `$(@expr self)`
    |
    = note: this error originates in the macro `__inline_mac_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/deref_addrof_double_trigger.stderr
+++ b/tests/ui/deref_addrof_double_trigger.stderr
@@ -2,7 +2,7 @@ error: immediately dereferencing a reference
   --> $DIR/deref_addrof_double_trigger.rs:10:14
    |
 LL |     let b = **&&a;
-   |              ^^^^ help: try this: `&a`
+   |              ^^^^ help: try: `&a`
    |
    = note: `-D clippy::deref-addrof` implied by `-D warnings`
 
@@ -10,13 +10,13 @@ error: immediately dereferencing a reference
   --> $DIR/deref_addrof_double_trigger.rs:14:17
    |
 LL |         let y = *&mut x;
-   |                 ^^^^^^^ help: try this: `x`
+   |                 ^^^^^^^ help: try: `x`
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof_double_trigger.rs:21:18
    |
 LL |         let y = **&mut &mut x;
-   |                  ^^^^^^^^^^^^ help: try this: `&mut x`
+   |                  ^^^^^^^^^^^^ help: try: `&mut x`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/entry.stderr
+++ b/tests/ui/entry.stderr
@@ -4,7 +4,7 @@ error: usage of `contains_key` followed by `insert` on a `HashMap`
 LL | /     if !m.contains_key(&k) {
 LL | |         m.insert(k, v);
 LL | |     }
-   | |_____^ help: try this: `m.entry(k).or_insert(v);`
+   | |_____^ help: try: `m.entry(k).or_insert(v);`
    |
    = note: `-D clippy::map-entry` implied by `-D warnings`
 
@@ -20,7 +20,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     m.entry(k).or_insert_with(|| {
 LL +         if true {
@@ -43,7 +43,7 @@ LL | |         };
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     m.entry(k).or_insert_with(|| {
 LL +         if true {
@@ -66,7 +66,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
 LL +         if true {
@@ -87,7 +87,7 @@ LL | |         m.insert(k, v);
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     m.entry(k).or_insert_with(|| {
 LL +         foo();
@@ -107,7 +107,7 @@ LL | |         };
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     m.entry(k).or_insert_with(|| {
 LL +         match 0 {
@@ -133,7 +133,7 @@ LL | |         };
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
 LL +         match 0 {
@@ -157,7 +157,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     m.entry(k).or_insert_with(|| {
 LL +         foo();
@@ -192,7 +192,7 @@ error: usage of `contains_key` followed by `insert` on a `HashMap`
 LL | /     if !m.contains_key(&m!(k)) {
 LL | |         m.insert(m!(k), m!(v));
 LL | |     }
-   | |_____^ help: try this: `m.entry(m!(k)).or_insert_with(|| m!(v));`
+   | |_____^ help: try: `m.entry(m!(k)).or_insert_with(|| m!(v));`
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:152:5
@@ -204,7 +204,7 @@ LL | |         m.insert(k, v);
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     m.entry(k).or_insert_with(|| {
 LL +         let x = (String::new(), String::new());

--- a/tests/ui/entry_btree.stderr
+++ b/tests/ui/entry_btree.stderr
@@ -8,7 +8,7 @@ LL | |     }
    | |_____^
    |
    = note: `-D clippy::map-entry` implied by `-D warnings`
-help: try this
+help: try
    |
 LL ~     if let std::collections::btree_map::Entry::Vacant(e) = m.entry(k) {
 LL +         e.insert(v);

--- a/tests/ui/entry_with_else.stderr
+++ b/tests/ui/entry_with_else.stderr
@@ -9,7 +9,7 @@ LL | |     }
    | |_____^
    |
    = note: `-D clippy::map-entry` implied by `-D warnings`
-help: try this
+help: try
    |
 LL ~     match m.entry(k) {
 LL +         std::collections::hash_map::Entry::Vacant(e) => {
@@ -31,7 +31,7 @@ LL | |         m.insert(k, v2);
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     match m.entry(k) {
 LL +         std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -53,7 +53,7 @@ LL | |         foo();
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let std::collections::hash_map::Entry::Vacant(e) = m.entry(k) {
 LL +         e.insert(v);
@@ -72,7 +72,7 @@ LL | |         m.insert(k, v);
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let std::collections::hash_map::Entry::Occupied(mut e) = m.entry(k) {
 LL +         e.insert(v);
@@ -91,7 +91,7 @@ LL | |         m.insert(k, v2);
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     match m.entry(k) {
 LL +         std::collections::hash_map::Entry::Vacant(e) => {
@@ -113,7 +113,7 @@ LL | |         m.insert(k, v)
 LL | |     };
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     match m.entry(k) {
 LL +         std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -137,7 +137,7 @@ LL | |         None
 LL | |     };
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let std::collections::hash_map::Entry::Occupied(mut e) = m.entry(k) {
 LL +         foo();

--- a/tests/ui/expect_fun_call.stderr
+++ b/tests/ui/expect_fun_call.stderr
@@ -2,7 +2,7 @@ error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:38:26
    |
 LL |     with_none_and_format.expect(&format!("Error {}: fake error", error_code));
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
    |
    = note: `-D clippy::expect-fun-call` implied by `-D warnings`
 
@@ -10,85 +10,85 @@ error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:41:26
    |
 LL |     with_none_and_as_str.expect(format!("Error {}: fake error", error_code).as_str());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:44:37
    |
 LL |     with_none_and_format_with_macro.expect(format!("Error {}: fake error", one!()).as_str());
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("Error {}: fake error", one!()))`
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("Error {}: fake error", one!()))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:54:25
    |
 LL |     with_err_and_format.expect(&format!("Error {}: fake error", error_code));
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:57:25
    |
 LL |     with_err_and_as_str.expect(format!("Error {}: fake error", error_code).as_str());
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:69:17
    |
 LL |     Some("foo").expect(format!("{} {}", 1, 2).as_ref());
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("{} {}", 1, 2))`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{} {}", 1, 2))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:90:21
    |
 LL |         Some("foo").expect(&get_string());
-   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_string()) })`
+   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:91:21
    |
 LL |         Some("foo").expect(get_string().as_ref());
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_string()) })`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:92:21
    |
 LL |         Some("foo").expect(get_string().as_str());
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_string()) })`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:94:21
    |
 LL |         Some("foo").expect(get_static_str());
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_static_str()) })`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_static_str()) })`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:95:21
    |
 LL |         Some("foo").expect(get_non_static_str(&0));
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| { panic!("{}", get_non_static_str(&0).to_string()) })`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_non_static_str(&0).to_string()) })`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:99:16
    |
 LL |     Some(true).expect(&format!("key {}, {}", 1, 2));
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("key {}, {}", 1, 2))`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("key {}, {}", 1, 2))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:105:17
    |
 LL |         opt_ref.expect(&format!("{:?}", opt_ref));
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("{:?}", opt_ref))`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{:?}", opt_ref))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:109:20
    |
 LL |     format_capture.expect(&format!("{error_code}"));
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("{error_code}"))`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{error_code}"))`
 
 error: use of `expect` followed by a function call
   --> $DIR/expect_fun_call.rs:112:30
    |
 LL |     format_capture_and_value.expect(&format!("{error_code}, {}", 1));
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| panic!("{error_code}, {}", 1))`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{error_code}, {}", 1))`
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -2,7 +2,7 @@ error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:70:19
    |
 LL |     let _: &str = &*s;
-   |                   ^^^ help: try this: `&s`
+   |                   ^^^ help: try: `&s`
    |
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
 
@@ -10,229 +10,229 @@ error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:71:19
    |
 LL |     let _: &str = &*{ String::new() };
-   |                   ^^^^^^^^^^^^^^^^^^^ help: try this: `&{ String::new() }`
+   |                   ^^^^^^^^^^^^^^^^^^^ help: try: `&{ String::new() }`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:72:19
    |
 LL |     let _: &str = &mut *{ String::new() };
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut { String::new() }`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut { String::new() }`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:76:11
    |
 LL |     f_str(&*s);
-   |           ^^^ help: try this: `&s`
+   |           ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:80:13
    |
 LL |     f_str_t(&*s, &*s); // Don't lint second param.
-   |             ^^^ help: try this: `&s`
+   |             ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:83:24
    |
 LL |     let _: &Box<i32> = &**b;
-   |                        ^^^^ help: try this: `&b`
+   |                        ^^^^ help: try: `&b`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:89:7
    |
 LL |     c(&*s);
-   |       ^^^ help: try this: `&s`
+   |       ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:95:9
    |
 LL |         &**x
-   |         ^^^^ help: try this: `x`
+   |         ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:99:11
    |
 LL |         { &**x }
-   |           ^^^^ help: try this: `x`
+   |           ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:103:9
    |
 LL |         &**{ x }
-   |         ^^^^^^^^ help: try this: `{ x }`
+   |         ^^^^^^^^ help: try: `{ x }`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:107:9
    |
 LL |         &***x
-   |         ^^^^^ help: try this: `x`
+   |         ^^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:124:12
    |
 LL |         f1(&*x);
-   |            ^^^ help: try this: `&x`
+   |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:125:12
    |
 LL |         f2(&*x);
-   |            ^^^ help: try this: `&x`
+   |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:126:12
    |
 LL |         f3(&*x);
-   |            ^^^ help: try this: `&x`
+   |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:127:27
    |
 LL |         f4.callable_str()(&*x);
-   |                           ^^^ help: try this: `&x`
+   |                           ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:128:12
    |
 LL |         f5(&*x);
-   |            ^^^ help: try this: `&x`
+   |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:129:12
    |
 LL |         f6(&*x);
-   |            ^^^ help: try this: `&x`
+   |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:130:27
    |
 LL |         f7.callable_str()(&*x);
-   |                           ^^^ help: try this: `&x`
+   |                           ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:131:25
    |
 LL |         f8.callable_t()(&*x);
-   |                         ^^^ help: try this: `&x`
+   |                         ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:132:12
    |
 LL |         f9(&*x);
-   |            ^^^ help: try this: `&x`
+   |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:133:13
    |
 LL |         f10(&*x);
-   |             ^^^ help: try this: `&x`
+   |             ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:134:26
    |
 LL |         f11.callable_t()(&*x);
-   |                          ^^^ help: try this: `&x`
+   |                          ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:138:16
    |
 LL |     let _ = S1(&*s);
-   |                ^^^ help: try this: `&s`
+   |                ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:143:21
    |
 LL |     let _ = S2 { s: &*s };
-   |                     ^^^ help: try this: `&s`
+   |                     ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:159:30
    |
 LL |             let _ = Self::S1(&**s);
-   |                              ^^^^ help: try this: `s`
+   |                              ^^^^ help: try: `s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:160:35
    |
 LL |             let _ = Self::S2 { s: &**s };
-   |                                   ^^^^ help: try this: `s`
+   |                                   ^^^^ help: try: `s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:163:20
    |
 LL |     let _ = E1::S1(&*s);
-   |                    ^^^ help: try this: `&s`
+   |                    ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:164:25
    |
 LL |     let _ = E1::S2 { s: &*s };
-   |                         ^^^ help: try this: `&s`
+   |                         ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:182:13
    |
 LL |     let _ = (*b).foo;
-   |             ^^^^ help: try this: `b`
+   |             ^^^^ help: try: `b`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:183:13
    |
 LL |     let _ = (**b).foo;
-   |             ^^^^^ help: try this: `b`
+   |             ^^^^^ help: try: `b`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:198:19
    |
 LL |     let _ = f_str(*ref_str);
-   |                   ^^^^^^^^ help: try this: `ref_str`
+   |                   ^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:200:19
    |
 LL |     let _ = f_str(**ref_ref_str);
-   |                   ^^^^^^^^^^^^^ help: try this: `ref_ref_str`
+   |                   ^^^^^^^^^^^^^ help: try: `ref_ref_str`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:210:13
    |
 LL |     f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
-   |             ^^^^^^^^ help: try this: `ref_str`
+   |             ^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:211:12
    |
 LL |     f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
-   |            ^^^^^^^^^^ help: try this: `ref_str`
+   |            ^^^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:220:41
    |
 LL |     let _ = || -> &'static str { return *s };
-   |                                         ^^ help: try this: `s`
+   |                                         ^^ help: try: `s`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:239:9
    |
 LL |         &**x
-   |         ^^^^ help: try this: `x`
+   |         ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:262:8
    |
 LL |     c1(*x);
-   |        ^^ help: try this: `x`
+   |        ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:265:20
    |
 LL |             return *x;
-   |                    ^^ help: try this: `x`
+   |                    ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
   --> $DIR/explicit_auto_deref.rs:267:9
    |
 LL |         *x
-   |         ^^ help: try this: `x`
+   |         ^^ help: try: `x`
 
 error: aborting due to 39 previous errors
 

--- a/tests/ui/explicit_deref_methods.stderr
+++ b/tests/ui/explicit_deref_methods.stderr
@@ -2,7 +2,7 @@ error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:54:19
    |
 LL |     let b: &str = a.deref();
-   |                   ^^^^^^^^^ help: try this: `&*a`
+   |                   ^^^^^^^^^ help: try: `&*a`
    |
    = note: `-D clippy::explicit-deref-methods` implied by `-D warnings`
 
@@ -10,67 +10,67 @@ error: explicit `deref_mut` method call
   --> $DIR/explicit_deref_methods.rs:56:23
    |
 LL |     let b: &mut str = a.deref_mut();
-   |                       ^^^^^^^^^^^^^ help: try this: `&mut **a`
+   |                       ^^^^^^^^^^^^^ help: try: `&mut **a`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:59:39
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
-   |                                       ^^^^^^^^^ help: try this: `&*a`
+   |                                       ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:59:50
    |
 LL |     let b: String = format!("{}, {}", a.deref(), a.deref());
-   |                                                  ^^^^^^^^^ help: try this: `&*a`
+   |                                                  ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:61:20
    |
 LL |     println!("{}", a.deref());
-   |                    ^^^^^^^^^ help: try this: `&*a`
+   |                    ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:64:11
    |
 LL |     match a.deref() {
-   |           ^^^^^^^^^ help: try this: `&*a`
+   |           ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:68:28
    |
 LL |     let b: String = concat(a.deref());
-   |                            ^^^^^^^^^ help: try this: `&*a`
+   |                            ^^^^^^^^^ help: try: `&*a`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:70:13
    |
 LL |     let b = just_return(a).deref();
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `just_return(a)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `just_return(a)`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:72:28
    |
 LL |     let b: String = concat(just_return(a).deref());
-   |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `just_return(a)`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^ help: try: `just_return(a)`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:74:19
    |
 LL |     let b: &str = a.deref().deref();
-   |                   ^^^^^^^^^^^^^^^^^ help: try this: `&**a`
+   |                   ^^^^^^^^^^^^^^^^^ help: try: `&**a`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:77:13
    |
 LL |     let b = opt_a.unwrap().deref();
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&*opt_a.unwrap()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*opt_a.unwrap()`
 
 error: explicit `deref` method call
   --> $DIR/explicit_deref_methods.rs:114:31
    |
 LL |     let b: &str = expr_deref!(a.deref());
-   |                               ^^^^^^^^^ help: try this: `&*a`
+   |                               ^^^^^^^^^ help: try: `&*a`
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/explicit_write.stderr
+++ b/tests/ui/explicit_write.stderr
@@ -2,7 +2,7 @@ error: use of `write!(stdout(), ...).unwrap()`
   --> $DIR/explicit_write.rs:24:9
    |
 LL |         write!(std::io::stdout(), "test").unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `print!("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `print!("test")`
    |
    = note: `-D clippy::explicit-write` implied by `-D warnings`
 
@@ -10,73 +10,73 @@ error: use of `write!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:25:9
    |
 LL |         write!(std::io::stderr(), "test").unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprint!("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprint!("test")`
 
 error: use of `writeln!(stdout(), ...).unwrap()`
   --> $DIR/explicit_write.rs:26:9
    |
 LL |         writeln!(std::io::stdout(), "test").unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `println!("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `println!("test")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:27:9
    |
 LL |         writeln!(std::io::stderr(), "test").unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("test")`
 
 error: use of `stdout().write_fmt(...).unwrap()`
   --> $DIR/explicit_write.rs:28:9
    |
 LL |         std::io::stdout().write_fmt(format_args!("test")).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `print!("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `print!("test")`
 
 error: use of `stderr().write_fmt(...).unwrap()`
   --> $DIR/explicit_write.rs:29:9
    |
 LL |         std::io::stderr().write_fmt(format_args!("test")).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprint!("test")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprint!("test")`
 
 error: use of `writeln!(stdout(), ...).unwrap()`
   --> $DIR/explicit_write.rs:32:9
    |
 LL |         writeln!(std::io::stdout(), "test/ntest").unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `println!("test/ntest")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `println!("test/ntest")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:33:9
    |
 LL |         writeln!(std::io::stderr(), "test/ntest").unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("test/ntest")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("test/ntest")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:36:9
    |
 LL |         writeln!(std::io::stderr(), "with {}", value).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("with {}", value)`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {}", value)`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:37:9
    |
 LL |         writeln!(std::io::stderr(), "with {} {}", 2, value).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("with {} {}", 2, value)`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {} {}", 2, value)`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:38:9
    |
 LL |         writeln!(std::io::stderr(), "with {value}").unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("with {value}")`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("with {value}")`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:39:9
    |
 LL |         writeln!(std::io::stderr(), "macro arg {}", one!()).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("macro arg {}", one!())`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("macro arg {}", one!())`
 
 error: use of `writeln!(stderr(), ...).unwrap()`
   --> $DIR/explicit_write.rs:41:9
    |
 LL |         writeln!(std::io::stderr(), "{:w$}", value, w = width).unwrap();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `eprintln!("{:w$}", value, w = width)`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `eprintln!("{:w$}", value, w = width)`
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/extend_with_drain.stderr
+++ b/tests/ui/extend_with_drain.stderr
@@ -2,7 +2,7 @@ error: use of `extend` instead of `append` for adding the full range of a second
   --> $DIR/extend_with_drain.rs:9:5
    |
 LL |     vec2.extend(vec1.drain(..));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `vec2.append(&mut vec1)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec2.append(&mut vec1)`
    |
    = note: `-D clippy::extend-with-drain` implied by `-D warnings`
 
@@ -10,19 +10,19 @@ error: use of `extend` instead of `append` for adding the full range of a second
   --> $DIR/extend_with_drain.rs:14:5
    |
 LL |     vec4.extend(vec3.drain(..));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `vec4.append(&mut vec3)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec4.append(&mut vec3)`
 
 error: use of `extend` instead of `append` for adding the full range of a second vector
   --> $DIR/extend_with_drain.rs:18:5
    |
 LL |     vec11.extend(return_vector().drain(..));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `vec11.append(&mut return_vector())`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec11.append(&mut return_vector())`
 
 error: use of `extend` instead of `append` for adding the full range of a second vector
   --> $DIR/extend_with_drain.rs:49:5
    |
 LL |     y.extend(ref_x.drain(..));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `y.append(ref_x)`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `y.append(ref_x)`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/filter_map_next_fixable.stderr
+++ b/tests/ui/filter_map_next_fixable.stderr
@@ -2,7 +2,7 @@ error: called `filter_map(..).next()` on an `Iterator`. This is more succinctly 
   --> $DIR/filter_map_next_fixable.rs:9:32
    |
 LL |     let element: Option<i32> = a.iter().filter_map(|s| s.parse().ok()).next();
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `a.iter().find_map(|s| s.parse().ok())`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.iter().find_map(|s| s.parse().ok())`
    |
    = note: `-D clippy::filter-map-next` implied by `-D warnings`
 
@@ -10,7 +10,7 @@ error: called `filter_map(..).next()` on an `Iterator`. This is more succinctly 
   --> $DIR/filter_map_next_fixable.rs:22:26
    |
 LL |     let _: Option<i32> = a.iter().filter_map(|s| s.parse().ok()).next();
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `a.iter().find_map(|s| s.parse().ok())`
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.iter().find_map(|s| s.parse().ok())`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/get_unwrap.stderr
+++ b/tests/ui/get_unwrap.stderr
@@ -2,7 +2,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/get_unwrap.rs:40:17
    |
 LL |         let _ = boxed_slice.get(1).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&boxed_slice[1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&boxed_slice[1]`
    |
 note: the lint level is defined here
   --> $DIR/get_unwrap.rs:10:9
@@ -23,7 +23,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/get_unwrap.rs:41:17
    |
 LL |         let _ = some_slice.get(0).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_slice[0]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:41:17
@@ -37,7 +37,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
   --> $DIR/get_unwrap.rs:42:17
    |
 LL |         let _ = some_vec.get(0).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vec[0]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:42:17
@@ -51,7 +51,7 @@ error: called `.get().unwrap()` on a VecDeque. Using `[]` is more clear and more
   --> $DIR/get_unwrap.rs:43:17
    |
 LL |         let _ = some_vecdeque.get(0).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_vecdeque[0]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:43:17
@@ -65,7 +65,7 @@ error: called `.get().unwrap()` on a HashMap. Using `[]` is more clear and more 
   --> $DIR/get_unwrap.rs:44:17
    |
 LL |         let _ = some_hashmap.get(&1).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_hashmap[&1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_hashmap[&1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:44:17
@@ -79,7 +79,7 @@ error: called `.get().unwrap()` on a BTreeMap. Using `[]` is more clear and more
   --> $DIR/get_unwrap.rs:45:17
    |
 LL |         let _ = some_btreemap.get(&1).unwrap();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&some_btreemap[&1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&some_btreemap[&1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:45:17
@@ -93,7 +93,7 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/get_unwrap.rs:49:21
    |
 LL |         let _: u8 = *boxed_slice.get(1).unwrap();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[1]`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `boxed_slice[1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:49:22
@@ -107,7 +107,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
   --> $DIR/get_unwrap.rs:54:9
    |
 LL |         *boxed_slice.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `boxed_slice[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `boxed_slice[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:54:10
@@ -121,7 +121,7 @@ error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and mor
   --> $DIR/get_unwrap.rs:55:9
    |
 LL |         *some_slice.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_slice[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_slice[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:55:10
@@ -135,7 +135,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
   --> $DIR/get_unwrap.rs:56:9
    |
 LL |         *some_vec.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vec[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:56:10
@@ -149,7 +149,7 @@ error: called `.get_mut().unwrap()` on a VecDeque. Using `[]` is more clear and 
   --> $DIR/get_unwrap.rs:57:9
    |
 LL |         *some_vecdeque.get_mut(0).unwrap() = 1;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vecdeque[0]`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vecdeque[0]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:57:10
@@ -163,7 +163,7 @@ error: called `.get().unwrap()` on a Vec. Using `[]` is more clear and more conc
   --> $DIR/get_unwrap.rs:69:17
    |
 LL |         let _ = some_vec.get(0..1).unwrap().to_vec();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:69:17
@@ -177,7 +177,7 @@ error: called `.get_mut().unwrap()` on a Vec. Using `[]` is more clear and more 
   --> $DIR/get_unwrap.rs:70:17
    |
 LL |         let _ = some_vec.get_mut(0..1).unwrap().to_vec();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `some_vec[0..1]`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `some_vec[0..1]`
 
 error: used `unwrap()` on an `Option` value
   --> $DIR/get_unwrap.rs:70:17
@@ -191,25 +191,25 @@ error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more co
   --> $DIR/get_unwrap.rs:80:24
    |
 LL |         let _x: &i32 = f.get(1 + 2).unwrap();
-   |                        ^^^^^^^^^^^^^^^^^^^^^ help: try this: `&f[1 + 2]`
+   |                        ^^^^^^^^^^^^^^^^^^^^^ help: try: `&f[1 + 2]`
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:83:18
    |
 LL |         let _x = f.get(1 + 2).unwrap().to_string();
-   |                  ^^^^^^^^^^^^^^^^^^^^^ help: try this: `f[1 + 2]`
+   |                  ^^^^^^^^^^^^^^^^^^^^^ help: try: `f[1 + 2]`
 
 error: called `.get().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:86:18
    |
 LL |         let _x = f.get(1 + 2).unwrap().abs();
-   |                  ^^^^^^^^^^^^^^^^^^^^^ help: try this: `f[1 + 2]`
+   |                  ^^^^^^^^^^^^^^^^^^^^^ help: try: `f[1 + 2]`
 
 error: called `.get_mut().unwrap()` on a slice. Using `[]` is more clear and more concise
   --> $DIR/get_unwrap.rs:103:33
    |
 LL |                         let b = rest.get_mut(linidx(j, k) - linidx(i, k) - 1).unwrap();
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `&mut rest[linidx(j, k) - linidx(i, k) - 1]`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut rest[linidx(j, k) - linidx(i, k) - 1]`
 
 error: aborting due to 30 previous errors
 

--- a/tests/ui/infallible_destructuring_match.stderr
+++ b/tests/ui/infallible_destructuring_match.stderr
@@ -4,7 +4,7 @@ error: you seem to be trying to use `match` to destructure a single infallible p
 LL | /     let data = match wrapper {
 LL | |         SingleVariantEnum::Variant(i) => i,
 LL | |     };
-   | |______^ help: try this: `let SingleVariantEnum::Variant(data) = wrapper;`
+   | |______^ help: try: `let SingleVariantEnum::Variant(data) = wrapper;`
    |
    = note: `-D clippy::infallible-destructuring-match` implied by `-D warnings`
 
@@ -14,7 +14,7 @@ error: you seem to be trying to use `match` to destructure a single infallible p
 LL | /     let data = match wrapper {
 LL | |         TupleStruct(i) => i,
 LL | |     };
-   | |______^ help: try this: `let TupleStruct(data) = wrapper;`
+   | |______^ help: try: `let TupleStruct(data) = wrapper;`
 
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
   --> $DIR/infallible_destructuring_match.rs:85:5
@@ -22,7 +22,7 @@ error: you seem to be trying to use `match` to destructure a single infallible p
 LL | /     let data = match wrapper {
 LL | |         TupleStructWithNonCopy(ref n) => n,
 LL | |     };
-   | |______^ help: try this: `let TupleStructWithNonCopy(ref data) = wrapper;`
+   | |______^ help: try: `let TupleStructWithNonCopy(ref data) = wrapper;`
 
 error: you seem to be trying to use `match` to destructure a single infallible pattern. Consider using `let`
   --> $DIR/infallible_destructuring_match.rs:104:5
@@ -30,7 +30,7 @@ error: you seem to be trying to use `match` to destructure a single infallible p
 LL | /     let data = match wrapper {
 LL | |         Ok(i) => i,
 LL | |     };
-   | |______^ help: try this: `let Ok(data) = wrapper;`
+   | |______^ help: try: `let Ok(data) = wrapper;`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/iter_overeager_cloned.stderr
+++ b/tests/ui/iter_overeager_cloned.stderr
@@ -4,7 +4,7 @@ error: unnecessarily eager cloning of iterator items
 LL |     let _: Option<String> = vec.iter().cloned().last();
    |                             ^^^^^^^^^^----------------
    |                                       |
-   |                                       help: try this: `.last().cloned()`
+   |                                       help: try: `.last().cloned()`
    |
    = note: `-D clippy::iter-overeager-cloned` implied by `-D warnings`
 
@@ -14,7 +14,7 @@ error: unnecessarily eager cloning of iterator items
 LL |     let _: Option<String> = vec.iter().chain(vec.iter()).cloned().next();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------
    |                                                         |
-   |                                                         help: try this: `.next().cloned()`
+   |                                                         help: try: `.next().cloned()`
 
 error: unneeded cloning of iterator items
   --> $DIR/iter_overeager_cloned.rs:12:20
@@ -22,7 +22,7 @@ error: unneeded cloning of iterator items
 LL |     let _: usize = vec.iter().filter(|x| x == &"2").cloned().count();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------
    |                                                    |
-   |                                                    help: try this: `.count()`
+   |                                                    help: try: `.count()`
    |
    = note: `-D clippy::redundant-clone` implied by `-D warnings`
 
@@ -32,7 +32,7 @@ error: unnecessarily eager cloning of iterator items
 LL |     let _: Vec<_> = vec.iter().cloned().take(2).collect();
    |                     ^^^^^^^^^^-----------------
    |                               |
-   |                               help: try this: `.take(2).cloned()`
+   |                               help: try: `.take(2).cloned()`
 
 error: unnecessarily eager cloning of iterator items
   --> $DIR/iter_overeager_cloned.rs:16:21
@@ -40,7 +40,7 @@ error: unnecessarily eager cloning of iterator items
 LL |     let _: Vec<_> = vec.iter().cloned().skip(2).collect();
    |                     ^^^^^^^^^^-----------------
    |                               |
-   |                               help: try this: `.skip(2).cloned()`
+   |                               help: try: `.skip(2).cloned()`
 
 error: unnecessarily eager cloning of iterator items
   --> $DIR/iter_overeager_cloned.rs:18:13
@@ -48,7 +48,7 @@ error: unnecessarily eager cloning of iterator items
 LL |     let _ = vec.iter().filter(|x| x == &"2").cloned().nth(2);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------
    |                                             |
-   |                                             help: try this: `.nth(2).cloned()`
+   |                                             help: try: `.nth(2).cloned()`
 
 error: unnecessarily eager cloning of iterator items
   --> $DIR/iter_overeager_cloned.rs:20:13
@@ -60,7 +60,7 @@ LL | |         .cloned()
 LL | |         .flatten();
    | |__________________^
    |
-help: try this
+help: try
    |
 LL ~         .iter()
 LL ~         .flatten().cloned();

--- a/tests/ui/iter_with_drain.stderr
+++ b/tests/ui/iter_with_drain.stderr
@@ -2,7 +2,7 @@ error: `drain(..)` used on a `Vec`
   --> $DIR/iter_with_drain.rs:11:34
    |
 LL |     let mut a: BinaryHeap<_> = a.drain(..).collect();
-   |                                  ^^^^^^^^^ help: try this: `into_iter()`
+   |                                  ^^^^^^^^^ help: try: `into_iter()`
    |
    = note: `-D clippy::iter-with-drain` implied by `-D warnings`
 
@@ -10,31 +10,31 @@ error: `drain(..)` used on a `VecDeque`
   --> $DIR/iter_with_drain.rs:14:27
    |
 LL |     let mut a: Vec<_> = a.drain(..).collect();
-   |                           ^^^^^^^^^ help: try this: `into_iter()`
+   |                           ^^^^^^^^^ help: try: `into_iter()`
 
 error: `drain(..)` used on a `Vec`
   --> $DIR/iter_with_drain.rs:15:34
    |
 LL |     let mut a: HashMap<_, _> = a.drain(..).map(|x| (x.clone(), x)).collect();
-   |                                  ^^^^^^^^^ help: try this: `into_iter()`
+   |                                  ^^^^^^^^^ help: try: `into_iter()`
 
 error: `drain(..)` used on a `Vec`
   --> $DIR/iter_with_drain.rs:21:34
    |
 LL |     let mut a: BinaryHeap<_> = a.drain(0..).collect();
-   |                                  ^^^^^^^^^^ help: try this: `into_iter()`
+   |                                  ^^^^^^^^^^ help: try: `into_iter()`
 
 error: `drain(..)` used on a `VecDeque`
   --> $DIR/iter_with_drain.rs:24:27
    |
 LL |     let mut a: Vec<_> = a.drain(..a.len()).collect();
-   |                           ^^^^^^^^^^^^^^^^ help: try this: `into_iter()`
+   |                           ^^^^^^^^^^^^^^^^ help: try: `into_iter()`
 
 error: `drain(..)` used on a `Vec`
   --> $DIR/iter_with_drain.rs:25:34
    |
 LL |     let mut a: HashMap<_, _> = a.drain(0..a.len()).map(|x| (x.clone(), x)).collect();
-   |                                  ^^^^^^^^^^^^^^^^^ help: try this: `into_iter()`
+   |                                  ^^^^^^^^^^^^^^^^^ help: try: `into_iter()`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/manual_filter.stderr
+++ b/tests/ui/manual_filter.stderr
@@ -8,7 +8,7 @@ LL | |             if x > 0 {
 ...  |
 LL | |         },
 LL | |     };
-   | |_____^ help: try this: `Some(0).filter(|&x| x <= 0)`
+   | |_____^ help: try: `Some(0).filter(|&x| x <= 0)`
    |
    = note: `-D clippy::manual-filter` implied by `-D warnings`
 
@@ -22,7 +22,7 @@ LL | |                 None
 ...  |
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(1).filter(|&x| x <= 0)`
+   | |_____^ help: try: `Some(1).filter(|&x| x <= 0)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:29:5
@@ -34,7 +34,7 @@ LL | |                 None
 ...  |
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(2).filter(|&x| x <= 0)`
+   | |_____^ help: try: `Some(2).filter(|&x| x <= 0)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:40:5
@@ -46,7 +46,7 @@ LL | |                 Some(x)
 ...  |
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(3).filter(|&x| x > 0)`
+   | |_____^ help: try: `Some(3).filter(|&x| x > 0)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:52:5
@@ -58,7 +58,7 @@ LL | |         Some(x) => {
 ...  |
 LL | |         },
 LL | |     };
-   | |_____^ help: try this: `y.filter(|&x| x <= 0)`
+   | |_____^ help: try: `y.filter(|&x| x <= 0)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:64:5
@@ -70,7 +70,7 @@ LL | |                 Some(x)
 ...  |
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(5).filter(|&x| x > 0)`
+   | |_____^ help: try: `Some(5).filter(|&x| x > 0)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:75:5
@@ -82,7 +82,7 @@ LL | |                 Some(x)
 ...  |
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(6).as_ref().filter(|&x| x > &0)`
+   | |_____^ help: try: `Some(6).as_ref().filter(|&x| x > &0)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:87:5
@@ -94,7 +94,7 @@ LL | |                 Some(x)
 ...  |
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(String::new()).filter(|x| external_cond)`
+   | |_____^ help: try: `Some(String::new()).filter(|x| external_cond)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:98:5
@@ -104,7 +104,7 @@ LL | |         if external_cond { Some(x) } else { None }
 LL | |     } else {
 LL | |         None
 LL | |     };
-   | |_____^ help: try this: `Some(7).filter(|&x| external_cond)`
+   | |_____^ help: try: `Some(7).filter(|&x| external_cond)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:104:5
@@ -116,7 +116,7 @@ LL | |                 Some(x)
 ...  |
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(8).filter(|&x| x != 0)`
+   | |_____^ help: try: `Some(8).filter(|&x| x != 0)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:115:5
@@ -128,7 +128,7 @@ LL | |                 Some(x)
 ...  |
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(9).filter(|&x| x > 10 && x < 100)`
+   | |_____^ help: try: `Some(9).filter(|&x| x > 10 && x < 100)`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:141:5
@@ -142,7 +142,7 @@ LL | |         None => None,
 LL | |     };
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     Some(11).filter(|&x| {
 LL +                 println!("foo");
@@ -161,7 +161,7 @@ LL | |                 Some(x)
 ...  |
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(14).filter(|&x| unsafe { f(x) })`
+   | |_____^ help: try: `Some(14).filter(|&x| unsafe { f(x) })`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:195:13
@@ -173,7 +173,7 @@ LL | |             if f(x) { Some(x) } else { None }
 LL | |         },
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(15).filter(|&x| unsafe { f(x) })`
+   | |_____^ help: try: `Some(15).filter(|&x| unsafe { f(x) })`
 
 error: manual implementation of `Option::filter`
   --> $DIR/manual_filter.rs:205:12
@@ -185,7 +185,7 @@ LL | |         if x % 2 == 0 { Some(x) } else { None }
 LL | |     } else {
 LL | |         None
 LL | |     };
-   | |_____^ help: try this: `{ Some(16).filter(|&x| x % 2 == 0) }`
+   | |_____^ help: try: `{ Some(16).filter(|&x| x % 2 == 0) }`
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/manual_map_option.stderr
+++ b/tests/ui/manual_map_option.stderr
@@ -5,7 +5,7 @@ LL | /     match Some(0) {
 LL | |         Some(_) => Some(2),
 LL | |         None::<u32> => None,
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|_| 2)`
+   | |_____^ help: try: `Some(0).map(|_| 2)`
    |
    = note: `-D clippy::manual-map` implied by `-D warnings`
 
@@ -16,7 +16,7 @@ LL | /     match Some(0) {
 LL | |         Some(x) => Some(x + 1),
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|x| x + 1)`
+   | |_____^ help: try: `Some(0).map(|x| x + 1)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:25:5
@@ -25,7 +25,7 @@ LL | /     match Some("") {
 LL | |         Some(x) => Some(x.is_empty()),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some("").map(|x| x.is_empty())`
+   | |_____^ help: try: `Some("").map(|x| x.is_empty())`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:30:5
@@ -35,7 +35,7 @@ LL | |         Some(!x)
 LL | |     } else {
 LL | |         None
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|x| !x)`
+   | |_____^ help: try: `Some(0).map(|x| !x)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:37:5
@@ -44,7 +44,7 @@ LL | /     match Some(0) {
 LL | |         Some(x) => { Some(std::convert::identity(x)) }
 LL | |         None => { None }
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(std::convert::identity)`
+   | |_____^ help: try: `Some(0).map(std::convert::identity)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:42:5
@@ -53,7 +53,7 @@ LL | /     match Some(&String::new()) {
 LL | |         Some(x) => Some(str::len(x)),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(&String::new()).map(|x| str::len(x))`
+   | |_____^ help: try: `Some(&String::new()).map(|x| str::len(x))`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:52:5
@@ -62,7 +62,7 @@ LL | /     match &Some([0, 1]) {
 LL | |         Some(x) => Some(x[0]),
 LL | |         &None => None,
 LL | |     };
-   | |_____^ help: try this: `Some([0, 1]).as_ref().map(|x| x[0])`
+   | |_____^ help: try: `Some([0, 1]).as_ref().map(|x| x[0])`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:57:5
@@ -71,7 +71,7 @@ LL | /     match &Some(0) {
 LL | |         &Some(x) => Some(x * 2),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|x| x * 2)`
+   | |_____^ help: try: `Some(0).map(|x| x * 2)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:62:5
@@ -80,7 +80,7 @@ LL | /     match Some(String::new()) {
 LL | |         Some(ref x) => Some(x.is_empty()),
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(String::new()).as_ref().map(|x| x.is_empty())`
+   | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.is_empty())`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:67:5
@@ -89,7 +89,7 @@ LL | /     match &&Some(String::new()) {
 LL | |         Some(x) => Some(x.len()),
 LL | |         _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(String::new()).as_ref().map(|x| x.len())`
+   | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.len())`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:72:5
@@ -98,7 +98,7 @@ LL | /     match &&Some(0) {
 LL | |         &&Some(x) => Some(x + x),
 LL | |         &&_ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|x| x + x)`
+   | |_____^ help: try: `Some(0).map(|x| x + x)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:85:9
@@ -107,7 +107,7 @@ LL | /         match &mut Some(String::new()) {
 LL | |             Some(x) => Some(x.push_str("")),
 LL | |             None => None,
 LL | |         };
-   | |_________^ help: try this: `Some(String::new()).as_mut().map(|x| x.push_str(""))`
+   | |_________^ help: try: `Some(String::new()).as_mut().map(|x| x.push_str(""))`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:91:5
@@ -116,7 +116,7 @@ LL | /     match &mut Some(String::new()) {
 LL | |         Some(ref x) => Some(x.len()),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(String::new()).as_ref().map(|x| x.len())`
+   | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.len())`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:96:5
@@ -125,7 +125,7 @@ LL | /     match &mut &Some(String::new()) {
 LL | |         Some(x) => Some(x.is_empty()),
 LL | |         &mut _ => None,
 LL | |     };
-   | |_____^ help: try this: `Some(String::new()).as_ref().map(|x| x.is_empty())`
+   | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.is_empty())`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:101:5
@@ -134,7 +134,7 @@ LL | /     match Some((0, 1, 2)) {
 LL | |         Some((x, y, z)) => Some(x + y + z),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some((0, 1, 2)).map(|(x, y, z)| x + y + z)`
+   | |_____^ help: try: `Some((0, 1, 2)).map(|(x, y, z)| x + y + z)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:106:5
@@ -143,7 +143,7 @@ LL | /     match Some([1, 2, 3]) {
 LL | |         Some([first, ..]) => Some(first),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some([1, 2, 3]).map(|[first, ..]| first)`
+   | |_____^ help: try: `Some([1, 2, 3]).map(|[first, ..]| first)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:111:5
@@ -152,7 +152,7 @@ LL | /     match &Some((String::new(), "test")) {
 LL | |         Some((x, y)) => Some((y, x)),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some((String::new(), "test")).as_ref().map(|(x, y)| (y, x))`
+   | |_____^ help: try: `Some((String::new(), "test")).as_ref().map(|(x, y)| (y, x))`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:169:5
@@ -161,7 +161,7 @@ LL | /     match Some(0) {
 LL | |         Some(x) => Some(vec![x]),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|x| vec![x])`
+   | |_____^ help: try: `Some(0).map(|x| vec![x])`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:174:5
@@ -170,7 +170,7 @@ LL | /     match option_env!("") {
 LL | |         Some(x) => Some(String::from(x)),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `option_env!("").map(String::from)`
+   | |_____^ help: try: `option_env!("").map(String::from)`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:194:12
@@ -181,7 +181,7 @@ LL | |         Some(x + 1)
 LL | |     } else {
 LL | |         None
 LL | |     };
-   | |_____^ help: try this: `{ Some(0).map(|x| x + 1) }`
+   | |_____^ help: try: `{ Some(0).map(|x| x + 1) }`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option.rs:202:12
@@ -192,7 +192,7 @@ LL | |         Some(x + 1)
 LL | |     } else {
 LL | |         None
 LL | |     };
-   | |_____^ help: try this: `{ Some(0).map(|x| x + 1) }`
+   | |_____^ help: try: `{ Some(0).map(|x| x + 1) }`
 
 error: aborting due to 21 previous errors
 

--- a/tests/ui/manual_map_option_2.stderr
+++ b/tests/ui/manual_map_option_2.stderr
@@ -12,7 +12,7 @@ LL | |     };
    | |_____^
    |
    = note: `-D clippy::manual-map` implied by `-D warnings`
-help: try this
+help: try
    |
 LL ~     let _ = Some(0).map(|x| {
 LL +             let y = (String::new(), String::new());
@@ -32,7 +32,7 @@ LL | |         None => None,
 LL | |     };
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     let _ = s.as_ref().map(|x| {
 LL +             if let Some(ref s) = s { (x.clone(), s) } else { panic!() }
@@ -47,7 +47,7 @@ LL |           let _ = match Some(0) {
 LL | |             Some(x) => Some(f(x)),
 LL | |             None => None,
 LL | |         };
-   | |_________^ help: try this: `Some(0).map(|x| f(x))`
+   | |_________^ help: try: `Some(0).map(|x| f(x))`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option_2.rs:67:13
@@ -57,7 +57,7 @@ LL |       let _ = match Some(0) {
 LL | |         Some(x) => unsafe { Some(f(x)) },
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|x| unsafe { f(x) })`
+   | |_____^ help: try: `Some(0).map(|x| unsafe { f(x) })`
 
 error: manual implementation of `Option::map`
   --> $DIR/manual_map_option_2.rs:71:13
@@ -67,7 +67,7 @@ LL |       let _ = match Some(0) {
 LL | |         Some(x) => Some(unsafe { f(x) }),
 LL | |         None => None,
 LL | |     };
-   | |_____^ help: try this: `Some(0).map(|x| unsafe { f(x) })`
+   | |_____^ help: try: `Some(0).map(|x| unsafe { f(x) })`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/manual_split_once.stderr
+++ b/tests/ui/manual_split_once.stderr
@@ -2,7 +2,7 @@ error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:13:13
    |
 LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=').unwrap().1`
    |
    = note: `-D clippy::manual-split-once` implied by `-D warnings`
 
@@ -10,73 +10,73 @@ error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:14:13
    |
 LL |     let _ = "key=value".splitn(2, '=').skip(1).next().unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:15:18
    |
 LL |     let (_, _) = "key=value".splitn(2, '=').next_tuple().unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=')`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=')`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:18:13
    |
 LL |     let _ = s.splitn(2, '=').nth(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').unwrap().1`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:21:13
    |
 LL |     let _ = s.splitn(2, '=').nth(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').unwrap().1`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:24:13
    |
 LL |     let _ = s.splitn(2, '=').skip(1).next().unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=').unwrap().1`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:27:17
    |
 LL |         let _ = s.splitn(2, '=').nth(1)?;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=')?.1`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=')?.1`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:28:17
    |
 LL |         let _ = s.splitn(2, '=').skip(1).next()?;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.split_once('=')?.1`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=')?.1`
 
 error: manual implementation of `rsplit_once`
   --> $DIR/manual_split_once.rs:29:17
    |
 LL |         let _ = s.rsplitn(2, '=').nth(1)?;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit_once('=')?.0`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.rsplit_once('=')?.0`
 
 error: manual implementation of `rsplit_once`
   --> $DIR/manual_split_once.rs:30:17
    |
 LL |         let _ = s.rsplitn(2, '=').skip(1).next()?;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit_once('=')?.0`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.rsplit_once('=')?.0`
 
 error: manual implementation of `rsplit_once`
   --> $DIR/manual_split_once.rs:38:13
    |
 LL |     let _ = "key=value".rsplitn(2, '=').nth(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".rsplit_once('=').unwrap().0`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".rsplit_once('=').unwrap().0`
 
 error: manual implementation of `rsplit_once`
   --> $DIR/manual_split_once.rs:39:18
    |
 LL |     let (_, _) = "key=value".rsplitn(2, '=').next_tuple().unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".rsplit_once('=').map(|(x, y)| (y, x))`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".rsplit_once('=').map(|(x, y)| (y, x))`
 
 error: manual implementation of `rsplit_once`
   --> $DIR/manual_split_once.rs:40:13
    |
 LL |     let _ = s.rsplitn(2, '=').nth(1);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit_once('=').map(|x| x.0)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.rsplit_once('=').map(|x| x.0)`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:44:5
@@ -182,7 +182,7 @@ error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:141:13
    |
 LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split_once('=').unwrap().1`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:143:5

--- a/tests/ui/manual_str_repeat.stderr
+++ b/tests/ui/manual_str_repeat.stderr
@@ -2,7 +2,7 @@ error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:9:21
    |
 LL |     let _: String = std::iter::repeat("test").take(10).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"test".repeat(10)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"test".repeat(10)`
    |
    = note: `-D clippy::manual-str-repeat` implied by `-D warnings`
 
@@ -10,55 +10,55 @@ error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:10:21
    |
 LL |     let _: String = std::iter::repeat('x').take(10).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"x".repeat(10)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"x".repeat(10)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:11:21
    |
 LL |     let _: String = std::iter::repeat('/'').take(10).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"'".repeat(10)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"'".repeat(10)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:12:21
    |
 LL |     let _: String = std::iter::repeat('"').take(10).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"/"".repeat(10)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"/"".repeat(10)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:16:13
    |
 LL |     let _ = repeat(x).take(count + 2).collect::<String>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `x.repeat(count + 2)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.repeat(count + 2)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:25:21
    |
 LL |     let _: String = repeat(*x).take(count).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(*x).repeat(count)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(*x).repeat(count)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:34:21
    |
 LL |     let _: String = repeat(x).take(count).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `x.repeat(count)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.repeat(count)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:46:21
    |
 LL |     let _: String = repeat(Cow::Borrowed("test")).take(count).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `Cow::Borrowed("test").repeat(count)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Cow::Borrowed("test").repeat(count)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:49:21
    |
 LL |     let _: String = repeat(x).take(count).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `x.repeat(count)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `x.repeat(count)`
 
 error: manual implementation of `str::repeat` using iterators
   --> $DIR/manual_str_repeat.rs:64:21
    |
 LL |     let _: String = std::iter::repeat("test").take(10).collect();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"test".repeat(10)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"test".repeat(10)`
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/map_collect_result_unit.stderr
+++ b/tests/ui/map_collect_result_unit.stderr
@@ -2,7 +2,7 @@ error: `.map().collect()` can be replaced with `.try_for_each()`
   --> $DIR/map_collect_result_unit.rs:6:17
    |
 LL |         let _ = (0..3).map(|t| Err(t + 1)).collect::<Result<(), _>>();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(0..3).try_for_each(|t| Err(t + 1))`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(0..3).try_for_each(|t| Err(t + 1))`
    |
    = note: `-D clippy::map-collect-result-unit` implied by `-D warnings`
 
@@ -10,7 +10,7 @@ error: `.map().collect()` can be replaced with `.try_for_each()`
   --> $DIR/map_collect_result_unit.rs:7:32
    |
 LL |         let _: Result<(), _> = (0..3).map(|t| Err(t + 1)).collect();
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(0..3).try_for_each(|t| Err(t + 1))`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(0..3).try_for_each(|t| Err(t + 1))`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/map_unwrap_or.stderr
+++ b/tests/ui/map_unwrap_or.stderr
@@ -162,7 +162,7 @@ error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value. This can be do
   --> $DIR/map_unwrap_or.rs:99:13
    |
 LL |     let _ = res.map(|x| x + 1).unwrap_or_else(|_e| 0);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `res.map_or_else(|_e| 0, |x| x + 1)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or_else(|_e| 0, |x| x + 1)`
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value. This can be done more directly by calling `map_or(<a>, <f>)` instead
   --> $DIR/map_unwrap_or.rs:106:13

--- a/tests/ui/map_unwrap_or_fixable.stderr
+++ b/tests/ui/map_unwrap_or_fixable.stderr
@@ -5,7 +5,7 @@ LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
 LL | |         // Should lint even though this call is on a separate line.
 LL | |         .unwrap_or_else(|| 0);
-   | |_____________________________^ help: try this: `opt.map_or_else(|| 0, |x| x + 1)`
+   | |_____________________________^ help: try: `opt.map_or_else(|| 0, |x| x + 1)`
    |
    = note: `-D clippy::map-unwrap-or` implied by `-D warnings`
 
@@ -16,7 +16,7 @@ LL |       let _ = res.map(|x| x + 1)
    |  _____________^
 LL | |         // should lint even though this call is on a separate line
 LL | |         .unwrap_or_else(|_e| 0);
-   | |_______________________________^ help: try this: `res.map_or_else(|_e| 0, |x| x + 1)`
+   | |_______________________________^ help: try: `res.map_or_else(|_e| 0, |x| x + 1)`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/match_as_ref.stderr
+++ b/tests/ui/match_as_ref.stderr
@@ -6,7 +6,7 @@ LL |       let borrowed: Option<&()> = match owned {
 LL | |         None => None,
 LL | |         Some(ref v) => Some(v),
 LL | |     };
-   | |_____^ help: try this: `owned.as_ref()`
+   | |_____^ help: try: `owned.as_ref()`
    |
    = note: `-D clippy::match-as-ref` implied by `-D warnings`
 
@@ -18,7 +18,7 @@ LL |       let borrow_mut: Option<&mut ()> = match mut_owned {
 LL | |         None => None,
 LL | |         Some(ref mut v) => Some(v),
 LL | |     };
-   | |_____^ help: try this: `mut_owned.as_mut()`
+   | |_____^ help: try: `mut_owned.as_mut()`
 
 error: use `as_ref()` instead
   --> $DIR/match_as_ref.rs:30:13
@@ -27,7 +27,7 @@ LL | /             match self.source {
 LL | |                 Some(ref s) => Some(s),
 LL | |                 None => None,
 LL | |             }
-   | |_____________^ help: try this: `self.source.as_ref().map(|x| x as _)`
+   | |_____________^ help: try: `self.source.as_ref().map(|x| x as _)`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/match_expr_like_matches_macro.stderr
+++ b/tests/ui/match_expr_like_matches_macro.stderr
@@ -6,7 +6,7 @@ LL |       let _y = match x {
 LL | |         Some(0) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `matches!(x, Some(0))`
+   | |_____^ help: try: `matches!(x, Some(0))`
    |
    = note: `-D clippy::match-like-matches-macro` implied by `-D warnings`
 
@@ -18,7 +18,7 @@ LL |       let _w = match x {
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `x.is_some()`
+   | |_____^ help: try: `x.is_some()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
@@ -30,7 +30,7 @@ LL |       let _z = match x {
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try this: `x.is_none()`
+   | |_____^ help: try: `x.is_none()`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:33:15
@@ -40,13 +40,13 @@ LL |       let _zz = match x {
 LL | |         Some(r) if r == 0 => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `!matches!(x, Some(r) if r == 0)`
+   | |_____^ help: try: `!matches!(x, Some(r) if r == 0)`
 
 error: if let .. else expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:39:16
    |
 LL |     let _zzz = if let Some(5) = x { true } else { false };
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `matches!(x, Some(5))`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches!(x, Some(5))`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:63:20
@@ -57,7 +57,7 @@ LL | |             E::A(_) => true,
 LL | |             E::B(_) => true,
 LL | |             _ => false,
 LL | |         };
-   | |_________^ help: try this: `matches!(x, E::A(_) | E::B(_))`
+   | |_________^ help: try: `matches!(x, E::A(_) | E::B(_))`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:73:20
@@ -70,7 +70,7 @@ LL | |             }
 LL | |             E::B(_) => true,
 LL | |             _ => false,
 LL | |         };
-   | |_________^ help: try this: `matches!(x, E::A(_) | E::B(_))`
+   | |_________^ help: try: `matches!(x, E::A(_) | E::B(_))`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:83:20
@@ -81,7 +81,7 @@ LL | |             E::B(_) => false,
 LL | |             E::C => false,
 LL | |             _ => true,
 LL | |         };
-   | |_________^ help: try this: `!matches!(x, E::B(_) | E::C)`
+   | |_________^ help: try: `!matches!(x, E::B(_) | E::C)`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:143:18
@@ -91,7 +91,7 @@ LL |           let _z = match &z {
 LL | |             Some(3) => true,
 LL | |             _ => false,
 LL | |         };
-   | |_________^ help: try this: `matches!(z, Some(3))`
+   | |_________^ help: try: `matches!(z, Some(3))`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:152:18
@@ -101,7 +101,7 @@ LL |           let _z = match &z {
 LL | |             Some(3) => true,
 LL | |             _ => false,
 LL | |         };
-   | |_________^ help: try this: `matches!(&z, Some(3))`
+   | |_________^ help: try: `matches!(&z, Some(3))`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:169:21
@@ -111,7 +111,7 @@ LL |               let _ = match &z {
 LL | |                 AnEnum::X => true,
 LL | |                 _ => false,
 LL | |             };
-   | |_____________^ help: try this: `matches!(&z, AnEnum::X)`
+   | |_____________^ help: try: `matches!(&z, AnEnum::X)`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:183:20
@@ -121,7 +121,7 @@ LL |           let _res = match &val {
 LL | |             &Some(ref _a) => true,
 LL | |             _ => false,
 LL | |         };
-   | |_________^ help: try this: `matches!(&val, &Some(ref _a))`
+   | |_________^ help: try: `matches!(&val, &Some(ref _a))`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:195:20
@@ -131,7 +131,7 @@ LL |           let _res = match &val {
 LL | |             &Some(ref _a) => true,
 LL | |             _ => false,
 LL | |         };
-   | |_________^ help: try this: `matches!(&val, &Some(ref _a))`
+   | |_________^ help: try: `matches!(&val, &Some(ref _a))`
 
 error: match expression looks like `matches!` macro
   --> $DIR/match_expr_like_matches_macro.rs:253:14
@@ -141,7 +141,7 @@ LL |       let _y = match Some(5) {
 LL | |         Some(0) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `matches!(Some(5), Some(0))`
+   | |_____^ help: try: `matches!(Some(5), Some(0))`
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/match_on_vec_items.stderr
+++ b/tests/ui/match_on_vec_items.stderr
@@ -2,7 +2,7 @@ error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:10:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try this: `arr.get(idx)`
+   |           ^^^^^^^^ help: try: `arr.get(idx)`
    |
    = note: `-D clippy::match-on-vec-items` implied by `-D warnings`
 
@@ -10,43 +10,43 @@ error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:17:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try this: `arr.get(range)`
+   |           ^^^^^^^^^^ help: try: `arr.get(range)`
 
 error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:30:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try this: `arr.get(idx)`
+   |           ^^^^^^^^ help: try: `arr.get(idx)`
 
 error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:37:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try this: `arr.get(range)`
+   |           ^^^^^^^^^^ help: try: `arr.get(range)`
 
 error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:50:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try this: `arr.get(idx)`
+   |           ^^^^^^^^ help: try: `arr.get(idx)`
 
 error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:57:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try this: `arr.get(range)`
+   |           ^^^^^^^^^^ help: try: `arr.get(range)`
 
 error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:70:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try this: `arr.get(idx)`
+   |           ^^^^^^^^ help: try: `arr.get(idx)`
 
 error: indexing into a vector may panic
   --> $DIR/match_on_vec_items.rs:77:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try this: `arr.get(range)`
+   |           ^^^^^^^^^^ help: try: `arr.get(range)`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/match_ref_pats.stderr
+++ b/tests/ui/match_ref_pats.stderr
@@ -35,7 +35,7 @@ error: redundant pattern matching, consider using `is_none()`
   --> $DIR/match_ref_pats.rs:38:12
    |
 LL |     if let &None = a {
-   |     -------^^^^^---- help: try this: `if a.is_none()`
+   |     -------^^^^^---- help: try: `if a.is_none()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
@@ -43,7 +43,7 @@ error: redundant pattern matching, consider using `is_none()`
   --> $DIR/match_ref_pats.rs:43:12
    |
 LL |     if let &None = &b {
-   |     -------^^^^^----- help: try this: `if b.is_none()`
+   |     -------^^^^^----- help: try: `if b.is_none()`
 
 error: you don't need to add `&` to all patterns
   --> $DIR/match_ref_pats.rs:103:9

--- a/tests/ui/match_same_arms2.stderr
+++ b/tests/ui/match_same_arms2.stderr
@@ -144,7 +144,7 @@ LL | |         E::A => false,
 LL | |         E::B => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `!matches!(x, E::A | E::B)`
+   | |_____^ help: try: `!matches!(x, E::A | E::B)`
    |
    = note: `-D clippy::match-like-matches-macro` implied by `-D warnings`
 

--- a/tests/ui/match_wildcard_for_single_variants.stderr
+++ b/tests/ui/match_wildcard_for_single_variants.stderr
@@ -2,7 +2,7 @@ error: wildcard matches only a single variant and will also match any future add
   --> $DIR/match_wildcard_for_single_variants.rs:24:13
    |
 LL |             _ => (),
-   |             ^ help: try this: `Self::Rgb(..)`
+   |             ^ help: try: `Self::Rgb(..)`
    |
    = note: `-D clippy::match-wildcard-for-single-variants` implied by `-D warnings`
 
@@ -10,55 +10,55 @@ error: wildcard matches only a single variant and will also match any future add
   --> $DIR/match_wildcard_for_single_variants.rs:34:9
    |
 LL |         _ => {},
-   |         ^ help: try this: `Foo::C`
+   |         ^ help: try: `Foo::C`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:44:9
    |
 LL |         _ => {},
-   |         ^ help: try this: `Color::Blue`
+   |         ^ help: try: `Color::Blue`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:52:9
    |
 LL |         _ => {},
-   |         ^ help: try this: `Color::Blue`
+   |         ^ help: try: `Color::Blue`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:58:9
    |
 LL |         _ => {},
-   |         ^ help: try this: `Color::Blue`
+   |         ^ help: try: `Color::Blue`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:75:9
    |
 LL |         &_ => (),
-   |         ^^ help: try this: `Color::Blue`
+   |         ^^ help: try: `Color::Blue`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:84:9
    |
 LL |         _ => (),
-   |         ^ help: try this: `C::Blue`
+   |         ^ help: try: `C::Blue`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:91:9
    |
 LL |         _ => (),
-   |         ^ help: try this: `Color::Blue`
+   |         ^ help: try: `Color::Blue`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:126:13
    |
 LL |             _ => (),
-   |             ^ help: try this: `Enum::__Private`
+   |             ^ help: try: `Enum::__Private`
 
 error: wildcard matches only a single variant and will also match any future added variants
   --> $DIR/match_wildcard_for_single_variants.rs:153:13
    |
 LL |             _ => 2,
-   |             ^ help: try this: `Foo::B`
+   |             ^ help: try: `Foo::B`
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/methods_fixable.stderr
+++ b/tests/ui/methods_fixable.stderr
@@ -2,7 +2,7 @@ error: called `filter(..).next()` on an `Iterator`. This is more succinctly expr
   --> $DIR/methods_fixable.rs:11:13
    |
 LL |     let _ = v.iter().filter(|&x| *x < 0).next();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `v.iter().find(|&x| *x < 0)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `v.iter().find(|&x| *x < 0)`
    |
    = note: `-D clippy::filter-next` implied by `-D warnings`
 

--- a/tests/ui/missing_spin_loop.stderr
+++ b/tests/ui/missing_spin_loop.stderr
@@ -2,7 +2,7 @@ error: busy-waiting loop should at least have a spin loop hint
   --> $DIR/missing_spin_loop.rs:11:37
    |
 LL |     while b.load(Ordering::Acquire) {}
-   |                                     ^^ help: try this: `{ std::hint::spin_loop() }`
+   |                                     ^^ help: try: `{ std::hint::spin_loop() }`
    |
    = note: `-D clippy::missing-spin-loop` implied by `-D warnings`
 
@@ -10,31 +10,31 @@ error: busy-waiting loop should at least have a spin loop hint
   --> $DIR/missing_spin_loop.rs:13:37
    |
 LL |     while !b.load(Ordering::SeqCst) {}
-   |                                     ^^ help: try this: `{ std::hint::spin_loop() }`
+   |                                     ^^ help: try: `{ std::hint::spin_loop() }`
 
 error: busy-waiting loop should at least have a spin loop hint
   --> $DIR/missing_spin_loop.rs:15:46
    |
 LL |     while b.load(Ordering::Acquire) == false {}
-   |                                              ^^ help: try this: `{ std::hint::spin_loop() }`
+   |                                              ^^ help: try: `{ std::hint::spin_loop() }`
 
 error: busy-waiting loop should at least have a spin loop hint
   --> $DIR/missing_spin_loop.rs:17:49
    |
 LL |     while { true == b.load(Ordering::Acquire) } {}
-   |                                                 ^^ help: try this: `{ std::hint::spin_loop() }`
+   |                                                 ^^ help: try: `{ std::hint::spin_loop() }`
 
 error: busy-waiting loop should at least have a spin loop hint
   --> $DIR/missing_spin_loop.rs:19:93
    |
 LL |     while b.compare_exchange(true, false, Ordering::Acquire, Ordering::Relaxed) != Ok(true) {}
-   |                                                                                             ^^ help: try this: `{ std::hint::spin_loop() }`
+   |                                                                                             ^^ help: try: `{ std::hint::spin_loop() }`
 
 error: busy-waiting loop should at least have a spin loop hint
   --> $DIR/missing_spin_loop.rs:21:94
    |
 LL |     while Ok(false) != b.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed) {}
-   |                                                                                              ^^ help: try this: `{ std::hint::spin_loop() }`
+   |                                                                                              ^^ help: try: `{ std::hint::spin_loop() }`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/missing_spin_loop_no_std.stderr
+++ b/tests/ui/missing_spin_loop_no_std.stderr
@@ -2,7 +2,7 @@ error: busy-waiting loop should at least have a spin loop hint
   --> $DIR/missing_spin_loop_no_std.rs:13:37
    |
 LL |     while b.load(Ordering::Acquire) {}
-   |                                     ^^ help: try this: `{ core::hint::spin_loop() }`
+   |                                     ^^ help: try: `{ core::hint::spin_loop() }`
    |
    = note: `-D clippy::missing-spin-loop` implied by `-D warnings`
 

--- a/tests/ui/needless_borrow_pat.stderr
+++ b/tests/ui/needless_borrow_pat.stderr
@@ -2,7 +2,7 @@ error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:59:14
    |
 LL |         Some(ref x) => x,
-   |              ^^^^^ help: try this: `x`
+   |              ^^^^^ help: try: `x`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
 
@@ -12,7 +12,7 @@ error: this pattern creates a reference to a reference
 LL |         Some(ref x) => *x,
    |              ^^^^^
    |
-help: try this
+help: try
    |
 LL |         Some(x) => x,
    |              ~     ~
@@ -23,7 +23,7 @@ error: this pattern creates a reference to a reference
 LL |         Some(ref x) => {
    |              ^^^^^
    |
-help: try this
+help: try
    |
 LL ~         Some(x) => {
 LL |             f1(x);
@@ -34,13 +34,13 @@ error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:81:14
    |
 LL |         Some(ref x) => m1!(x),
-   |              ^^^^^ help: try this: `x`
+   |              ^^^^^ help: try: `x`
 
 error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:86:15
    |
 LL |     let _ = |&ref x: &&String| {
-   |               ^^^^^ help: try this: `x`
+   |               ^^^^^ help: try: `x`
 
 error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:91:10
@@ -48,7 +48,7 @@ error: this pattern creates a reference to a reference
 LL |     let (ref y,) = (&x,);
    |          ^^^^^
    |
-help: try this
+help: try
    |
 LL ~     let (y,) = (&x,);
 LL ~     let _: &String = y;
@@ -58,7 +58,7 @@ error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:101:14
    |
 LL |         Some(ref x) => x.0,
-   |              ^^^^^ help: try this: `x`
+   |              ^^^^^ help: try: `x`
 
 error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:111:14
@@ -66,7 +66,7 @@ error: this pattern creates a reference to a reference
 LL |         E::A(ref x) | E::B(ref x) => *x,
    |              ^^^^^         ^^^^^
    |
-help: try this
+help: try
    |
 LL |         E::A(x) | E::B(x) => x,
    |              ~         ~     ~
@@ -75,7 +75,7 @@ error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:117:21
    |
 LL |         if let Some(ref x) = Some(&String::new());
-   |                     ^^^^^ help: try this: `x`
+   |                     ^^^^^ help: try: `x`
 
 error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:125:12
@@ -83,7 +83,7 @@ error: this pattern creates a reference to a reference
 LL | fn f2<'a>(&ref x: &&'a String) -> &'a String {
    |            ^^^^^
    |
-help: try this
+help: try
    |
 LL ~ fn f2<'a>(&x: &&'a String) -> &'a String {
 LL |     let _: &String = x;
@@ -94,7 +94,7 @@ error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:132:11
    |
 LL |     fn f(&ref x: &&String) {
-   |           ^^^^^ help: try this: `x`
+   |           ^^^^^ help: try: `x`
 
 error: this pattern creates a reference to a reference
   --> $DIR/needless_borrow_pat.rs:140:11
@@ -102,7 +102,7 @@ error: this pattern creates a reference to a reference
 LL |     fn f(&ref x: &&String) {
    |           ^^^^^
    |
-help: try this
+help: try
    |
 LL ~     fn f(&x: &&String) {
 LL ~         let _: &String = x;

--- a/tests/ui/needless_option_as_deref.stderr
+++ b/tests/ui/needless_option_as_deref.stderr
@@ -2,7 +2,7 @@ error: derefed type is same as origin
   --> $DIR/needless_option_as_deref.rs:9:29
    |
 LL |     let _: Option<&usize> = Some(&1).as_deref();
-   |                             ^^^^^^^^^^^^^^^^^^^ help: try this: `Some(&1)`
+   |                             ^^^^^^^^^^^^^^^^^^^ help: try: `Some(&1)`
    |
    = note: `-D clippy::needless-option-as-deref` implied by `-D warnings`
 
@@ -10,13 +10,13 @@ error: derefed type is same as origin
   --> $DIR/needless_option_as_deref.rs:10:33
    |
 LL |     let _: Option<&mut usize> = Some(&mut 1).as_deref_mut();
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `Some(&mut 1)`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(&mut 1)`
 
 error: derefed type is same as origin
   --> $DIR/needless_option_as_deref.rs:14:13
    |
 LL |     let _ = x.as_deref_mut();
-   |             ^^^^^^^^^^^^^^^^ help: try this: `x`
+   |             ^^^^^^^^^^^^^^^^ help: try: `x`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/needless_splitn.stderr
+++ b/tests/ui/needless_splitn.stderr
@@ -2,7 +2,7 @@ error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:14:13
    |
 LL |     let _ = str.splitn(2, '=').next();
-   |             ^^^^^^^^^^^^^^^^^^ help: try this: `str.split('=')`
+   |             ^^^^^^^^^^^^^^^^^^ help: try: `str.split('=')`
    |
    = note: `-D clippy::needless-splitn` implied by `-D warnings`
 
@@ -10,73 +10,73 @@ error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:15:13
    |
 LL |     let _ = str.splitn(2, '=').nth(0);
-   |             ^^^^^^^^^^^^^^^^^^ help: try this: `str.split('=')`
+   |             ^^^^^^^^^^^^^^^^^^ help: try: `str.split('=')`
 
 error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:18:18
    |
 LL |     let (_, _) = str.splitn(3, '=').next_tuple().unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^ help: try this: `str.split('=')`
+   |                  ^^^^^^^^^^^^^^^^^^ help: try: `str.split('=')`
 
 error: unnecessary use of `rsplitn`
   --> $DIR/needless_splitn.rs:21:13
    |
 LL |     let _ = str.rsplitn(2, '=').next();
-   |             ^^^^^^^^^^^^^^^^^^^ help: try this: `str.rsplit('=')`
+   |             ^^^^^^^^^^^^^^^^^^^ help: try: `str.rsplit('=')`
 
 error: unnecessary use of `rsplitn`
   --> $DIR/needless_splitn.rs:22:13
    |
 LL |     let _ = str.rsplitn(2, '=').nth(0);
-   |             ^^^^^^^^^^^^^^^^^^^ help: try this: `str.rsplit('=')`
+   |             ^^^^^^^^^^^^^^^^^^^ help: try: `str.rsplit('=')`
 
 error: unnecessary use of `rsplitn`
   --> $DIR/needless_splitn.rs:25:18
    |
 LL |     let (_, _) = str.rsplitn(3, '=').next_tuple().unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^ help: try this: `str.rsplit('=')`
+   |                  ^^^^^^^^^^^^^^^^^^^ help: try: `str.rsplit('=')`
 
 error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:27:13
    |
 LL |     let _ = str.splitn(5, '=').next();
-   |             ^^^^^^^^^^^^^^^^^^ help: try this: `str.split('=')`
+   |             ^^^^^^^^^^^^^^^^^^ help: try: `str.split('=')`
 
 error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:28:13
    |
 LL |     let _ = str.splitn(5, '=').nth(3);
-   |             ^^^^^^^^^^^^^^^^^^ help: try this: `str.split('=')`
+   |             ^^^^^^^^^^^^^^^^^^ help: try: `str.split('=')`
 
 error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:34:13
    |
 LL |     let _ = s.splitn(2, '=').next()?;
-   |             ^^^^^^^^^^^^^^^^ help: try this: `s.split('=')`
+   |             ^^^^^^^^^^^^^^^^ help: try: `s.split('=')`
 
 error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:35:13
    |
 LL |     let _ = s.splitn(2, '=').nth(0)?;
-   |             ^^^^^^^^^^^^^^^^ help: try this: `s.split('=')`
+   |             ^^^^^^^^^^^^^^^^ help: try: `s.split('=')`
 
 error: unnecessary use of `rsplitn`
   --> $DIR/needless_splitn.rs:36:13
    |
 LL |     let _ = s.rsplitn(2, '=').next()?;
-   |             ^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit('=')`
+   |             ^^^^^^^^^^^^^^^^^ help: try: `s.rsplit('=')`
 
 error: unnecessary use of `rsplitn`
   --> $DIR/needless_splitn.rs:37:13
    |
 LL |     let _ = s.rsplitn(2, '=').nth(0)?;
-   |             ^^^^^^^^^^^^^^^^^ help: try this: `s.rsplit('=')`
+   |             ^^^^^^^^^^^^^^^^^ help: try: `s.rsplit('=')`
 
 error: unnecessary use of `splitn`
   --> $DIR/needless_splitn.rs:45:13
    |
 LL |     let _ = "key=value".splitn(2, '=').nth(0).unwrap();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `"key=value".split('=')`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split('=')`
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/numbered_fields.stderr
+++ b/tests/ui/numbered_fields.stderr
@@ -7,7 +7,7 @@ LL | |         0: 1u32,
 LL | |         1: 42,
 LL | |         2: 23u8,
 LL | |     };
-   | |_____^ help: try this instead: `TupleStruct(1u32, 42, 23u8)`
+   | |_____^ help: try: `TupleStruct(1u32, 42, 23u8)`
    |
    = note: `-D clippy::init-numbered-fields` implied by `-D warnings`
 
@@ -20,7 +20,7 @@ LL | |         0: 1u32,
 LL | |         2: 2u8,
 LL | |         1: 3u32,
 LL | |     };
-   | |_____^ help: try this instead: `TupleStruct(1u32, 3u32, 2u8)`
+   | |_____^ help: try: `TupleStruct(1u32, 3u32, 2u8)`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/option_map_unit_fn_fixable.stderr
+++ b/tests/ui/option_map_unit_fn_fixable.stderr
@@ -4,7 +4,7 @@ error: called `map(f)` on an `Option` value where `f` is a function that returns
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(x_field) = x.field { do_nothing(x_field) }`
+   |     help: try: `if let Some(x_field) = x.field { do_nothing(x_field) }`
    |
    = note: `-D clippy::option-map-unit-fn` implied by `-D warnings`
 
@@ -14,7 +14,7 @@ error: called `map(f)` on an `Option` value where `f` is a function that returns
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(x_field) = x.field { do_nothing(x_field) }`
+   |     help: try: `if let Some(x_field) = x.field { do_nothing(x_field) }`
 
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:42:5
@@ -22,7 +22,7 @@ error: called `map(f)` on an `Option` value where `f` is a function that returns
 LL |     x.field.map(diverge);
    |     ^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(x_field) = x.field { diverge(x_field) }`
+   |     help: try: `if let Some(x_field) = x.field { diverge(x_field) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:48:5
@@ -30,7 +30,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| x.do_option_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { x.do_option_nothing(value + captured) }`
+   |     help: try: `if let Some(value) = x.field { x.do_option_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:50:5
@@ -38,7 +38,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { x.do_option_plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { x.do_option_plus_one(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { x.do_option_plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:53:5
@@ -46,7 +46,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| do_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
+   |     help: try: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:55:5
@@ -54,7 +54,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured) }`
+   |     help: try: `if let Some(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:57:5
@@ -62,7 +62,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:59:5
@@ -70,7 +70,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { do_nothing(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:62:5
@@ -78,7 +78,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| diverge(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
+   |     help: try: `if let Some(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:64:5
@@ -86,7 +86,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { diverge(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { diverge(value + captured) }`
+   |     help: try: `if let Some(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:66:5
@@ -94,7 +94,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { diverge(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:68:5
@@ -102,7 +102,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { diverge(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:73:5
@@ -110,7 +110,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { let y = plus_one(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { let y = plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:75:5
@@ -118,7 +118,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:77:5
@@ -126,7 +126,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = x.field { plus_one(value + captured); }`
+   |     help: try: `if let Some(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:80:5
@@ -134,7 +134,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(ref value) = x.field { do_nothing(value + captured) }`
+   |     help: try: `if let Some(ref value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Option` value where `f` is a function that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:82:5
@@ -142,7 +142,7 @@ error: called `map(f)` on an `Option` value where `f` is a function that returns
 LL |     option().map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(a) = option() { do_nothing(a) }`
+   |     help: try: `if let Some(a) = option() { do_nothing(a) }`
 
 error: called `map(f)` on an `Option` value where `f` is a closure that returns the unit type `()`
   --> $DIR/option_map_unit_fn_fixable.rs:84:5
@@ -150,7 +150,7 @@ error: called `map(f)` on an `Option` value where `f` is a closure that returns 
 LL |     option().map(|value| println!("{:?}", value));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Some(value) = option() { println!("{:?}", value) }`
+   |     help: try: `if let Some(value) = option() { println!("{:?}", value) }`
 
 error: aborting due to 19 previous errors
 

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -2,7 +2,7 @@ error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:54:22
    |
 LL |     with_constructor.unwrap_or(make());
-   |                      ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(make)`
+   |                      ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(make)`
    |
    = note: `-D clippy::or-fun-call` implied by `-D warnings`
 
@@ -10,163 +10,163 @@ error: use of `unwrap_or` followed by a call to `new`
   --> $DIR/or_fun_call.rs:57:14
    |
 LL |     with_new.unwrap_or(Vec::new());
-   |              ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:60:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| Vec::with_capacity(12))`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:63:14
    |
 LL |     with_err.unwrap_or(make());
-   |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| make())`
+   |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| make())`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:66:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|_| Vec::with_capacity(12))`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a call to `default`
   --> $DIR/or_fun_call.rs:69:24
    |
 LL |     with_default_trait.unwrap_or(Default::default());
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `default`
   --> $DIR/or_fun_call.rs:72:23
    |
 LL |     with_default_type.unwrap_or(u64::default());
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:75:18
    |
 LL |     self_default.unwrap_or(<FakeDefault>::default());
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(<FakeDefault>::default)`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(<FakeDefault>::default)`
 
 error: use of `unwrap_or` followed by a call to `default`
   --> $DIR/or_fun_call.rs:78:18
    |
 LL |     real_default.unwrap_or(<FakeDefault as Default>::default());
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
   --> $DIR/or_fun_call.rs:81:14
    |
 LL |     with_vec.unwrap_or(vec![]);
-   |              ^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:84:21
    |
 LL |     without_default.unwrap_or(Foo::new());
-   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(Foo::new)`
+   |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` followed by a call to `new`
   --> $DIR/or_fun_call.rs:87:19
    |
 LL |     map.entry(42).or_insert(String::new());
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
   --> $DIR/or_fun_call.rs:90:23
    |
 LL |     map_vec.entry(42).or_insert(vec![]);
-   |                       ^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
+   |                       ^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
   --> $DIR/or_fun_call.rs:93:21
    |
 LL |     btree.entry(42).or_insert(String::new());
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` followed by a call to `new`
   --> $DIR/or_fun_call.rs:96:25
    |
 LL |     btree_vec.entry(42).or_insert(vec![]);
-   |                         ^^^^^^^^^^^^^^^^^ help: try this: `or_default()`
+   |                         ^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
   --> $DIR/or_fun_call.rs:99:21
    |
 LL |     let _ = stringy.unwrap_or(String::new());
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:107:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
-   |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
+   |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:109:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
-   |                     ^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| map[&1])`
+   |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: use of `or` followed by a function call
   --> $DIR/or_fun_call.rs:133:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `or_else(|| Some("b".to_string()))`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_else(|| Some("b".to_string()))`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:172:14
    |
 LL |         None.unwrap_or(ptr_to_ref(s));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| ptr_to_ref(s))`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:178:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a function call
   --> $DIR/or_fun_call.rs:180:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a call to `new`
   --> $DIR/or_fun_call.rs:194:14
    |
 LL |             .unwrap_or(String::new());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
   --> $DIR/or_fun_call.rs:207:14
    |
 LL |             .unwrap_or(String::new());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
   --> $DIR/or_fun_call.rs:219:14
    |
 LL |             .unwrap_or(String::new());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a call to `new`
   --> $DIR/or_fun_call.rs:230:10
    |
 LL |         .unwrap_or(String::new());
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_default()`
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `map_or` followed by a function call
   --> $DIR/or_fun_call.rs:255:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
-   |                         ^^^^^^^^^^^^^^^^^^ help: try this: `map_or_else(g, |v| v)`
+   |                         ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(g, |v| v)`
 
 error: use of `map_or` followed by a function call
   --> $DIR/or_fun_call.rs:256:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
-   |                         ^^^^^^^^^^^^^^ help: try this: `map_or_else(g, f)`
+   |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: aborting due to 28 previous errors
 

--- a/tests/ui/or_then_unwrap.stderr
+++ b/tests/ui/or_then_unwrap.stderr
@@ -2,7 +2,7 @@ error: found `.or(Some(…)).unwrap()`
   --> $DIR/or_then_unwrap.rs:24:20
    |
 LL |     let _ = option.or(Some("fallback")).unwrap(); // should trigger lint
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or("fallback")`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or("fallback")`
    |
    = note: `-D clippy::or-then-unwrap` implied by `-D warnings`
 
@@ -10,13 +10,13 @@ error: found `.or(Ok(…)).unwrap()`
   --> $DIR/or_then_unwrap.rs:27:20
    |
 LL |     let _ = result.or::<&str>(Ok("fallback")).unwrap(); // should trigger lint
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or("fallback")`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or("fallback")`
 
 error: found `.or(Some(…)).unwrap()`
   --> $DIR/or_then_unwrap.rs:31:31
    |
 LL |     let _ = option.map(|v| v).or(Some("fallback")).unwrap().to_string().chars(); // should trigger lint
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or("fallback")`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or("fallback")`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/print_literal.stderr
+++ b/tests/ui/print_literal.stderr
@@ -5,7 +5,7 @@ LL |     print!("Hello {}", "world");
    |                        ^^^^^^^
    |
    = note: `-D clippy::print-literal` implied by `-D warnings`
-help: try this
+help: try
    |
 LL -     print!("Hello {}", "world");
 LL +     print!("Hello world");
@@ -17,7 +17,7 @@ error: literal with an empty format string
 LL |     println!("Hello {} {}", world, "world");
    |                                    ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("Hello {} {}", world, "world");
 LL +     println!("Hello {} world", world);
@@ -29,7 +29,7 @@ error: literal with an empty format string
 LL |     println!("Hello {}", "world");
    |                          ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("Hello {}", "world");
 LL +     println!("Hello world");
@@ -41,7 +41,7 @@ error: literal with an empty format string
 LL |     println!("{} {:.4}", "a literal", 5);
    |                          ^^^^^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{} {:.4}", "a literal", 5);
 LL +     println!("a literal {:.4}", 5);
@@ -53,7 +53,7 @@ error: literal with an empty format string
 LL |     println!("{0} {1}", "hello", "world");
    |                         ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{0} {1}", "hello", "world");
 LL +     println!("hello {1}", "world");
@@ -65,7 +65,7 @@ error: literal with an empty format string
 LL |     println!("{0} {1}", "hello", "world");
    |                                  ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{0} {1}", "hello", "world");
 LL +     println!("{0} world", "hello");
@@ -77,7 +77,7 @@ error: literal with an empty format string
 LL |     println!("{1} {0}", "hello", "world");
    |                                  ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{1} {0}", "hello", "world");
 LL +     println!("world {0}", "hello");
@@ -89,7 +89,7 @@ error: literal with an empty format string
 LL |     println!("{1} {0}", "hello", "world");
    |                         ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{1} {0}", "hello", "world");
 LL +     println!("{1} hello", "world");
@@ -101,7 +101,7 @@ error: literal with an empty format string
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                   ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{foo} {bar}", foo = "hello", bar = "world");
 LL +     println!("hello {bar}", bar = "world");
@@ -113,7 +113,7 @@ error: literal with an empty format string
 LL |     println!("{foo} {bar}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{foo} {bar}", foo = "hello", bar = "world");
 LL +     println!("{foo} world", foo = "hello");
@@ -125,7 +125,7 @@ error: literal with an empty format string
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                                  ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{bar} {foo}", foo = "hello", bar = "world");
 LL +     println!("world {foo}", foo = "hello");
@@ -137,7 +137,7 @@ error: literal with an empty format string
 LL |     println!("{bar} {foo}", foo = "hello", bar = "world");
    |                                   ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     println!("{bar} {foo}", foo = "hello", bar = "world");
 LL +     println!("{bar} hello", bar = "world");

--- a/tests/ui/redundant_pattern_matching_drop_order.stderr
+++ b/tests/ui/redundant_pattern_matching_drop_order.stderr
@@ -2,7 +2,7 @@ error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:17:12
    |
 LL |     if let Ok(_) = m.lock() {}
-   |     -------^^^^^----------- help: try this: `if m.lock().is_ok()`
+   |     -------^^^^^----------- help: try: `if m.lock().is_ok()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -12,7 +12,7 @@ error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:18:12
    |
 LL |     if let Err(_) = Err::<(), _>(m.lock().unwrap().0) {}
-   |     -------^^^^^^------------------------------------ help: try this: `if Err::<(), _>(m.lock().unwrap().0).is_err()`
+   |     -------^^^^^^------------------------------------ help: try: `if Err::<(), _>(m.lock().unwrap().0).is_err()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -21,7 +21,7 @@ error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:21:16
    |
 LL |         if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
-   |         -------^^^^^----------------------------------------- help: try this: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
+   |         -------^^^^^----------------------------------------- help: try: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -30,7 +30,7 @@ error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:23:12
    |
 LL |     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {
-   |     -------^^^^^----------------------------------------- help: try this: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
+   |     -------^^^^^----------------------------------------- help: try: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -39,31 +39,31 @@ error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:26:12
    |
 LL |     if let Ok(_) = Ok::<_, std::sync::MutexGuard<()>>(()) {}
-   |     -------^^^^^----------------------------------------- help: try this: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
+   |     -------^^^^^----------------------------------------- help: try: `if Ok::<_, std::sync::MutexGuard<()>>(()).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:27:12
    |
 LL |     if let Err(_) = Err::<std::sync::MutexGuard<()>, _>(()) {}
-   |     -------^^^^^^------------------------------------------ help: try this: `if Err::<std::sync::MutexGuard<()>, _>(()).is_err()`
+   |     -------^^^^^^------------------------------------------ help: try: `if Err::<std::sync::MutexGuard<()>, _>(()).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:29:12
    |
 LL |     if let Ok(_) = Ok::<_, ()>(String::new()) {}
-   |     -------^^^^^----------------------------- help: try this: `if Ok::<_, ()>(String::new()).is_ok()`
+   |     -------^^^^^----------------------------- help: try: `if Ok::<_, ()>(String::new()).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:30:12
    |
 LL |     if let Err(_) = Err::<(), _>((String::new(), ())) {}
-   |     -------^^^^^^------------------------------------ help: try this: `if Err::<(), _>((String::new(), ())).is_err()`
+   |     -------^^^^^^------------------------------------ help: try: `if Err::<(), _>((String::new(), ())).is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:33:12
    |
 LL |     if let Some(_) = Some(m.lock()) {}
-   |     -------^^^^^^^----------------- help: try this: `if Some(m.lock()).is_some()`
+   |     -------^^^^^^^----------------- help: try: `if Some(m.lock()).is_some()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -72,7 +72,7 @@ error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:34:12
    |
 LL |     if let Some(_) = Some(m.lock().unwrap().0) {}
-   |     -------^^^^^^^---------------------------- help: try this: `if Some(m.lock().unwrap().0).is_some()`
+   |     -------^^^^^^^---------------------------- help: try: `if Some(m.lock().unwrap().0).is_some()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -81,7 +81,7 @@ error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:37:16
    |
 LL |         if let None = None::<std::sync::MutexGuard<()>> {}
-   |         -------^^^^------------------------------------ help: try this: `if None::<std::sync::MutexGuard<()>>.is_none()`
+   |         -------^^^^------------------------------------ help: try: `if None::<std::sync::MutexGuard<()>>.is_none()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -90,7 +90,7 @@ error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:39:12
    |
 LL |     if let None = None::<std::sync::MutexGuard<()>> {
-   |     -------^^^^------------------------------------ help: try this: `if None::<std::sync::MutexGuard<()>>.is_none()`
+   |     -------^^^^------------------------------------ help: try: `if None::<std::sync::MutexGuard<()>>.is_none()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -99,25 +99,25 @@ error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:43:12
    |
 LL |     if let None = None::<std::sync::MutexGuard<()>> {}
-   |     -------^^^^------------------------------------ help: try this: `if None::<std::sync::MutexGuard<()>>.is_none()`
+   |     -------^^^^------------------------------------ help: try: `if None::<std::sync::MutexGuard<()>>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:45:12
    |
 LL |     if let Some(_) = Some(String::new()) {}
-   |     -------^^^^^^^---------------------- help: try this: `if Some(String::new()).is_some()`
+   |     -------^^^^^^^---------------------- help: try: `if Some(String::new()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:46:12
    |
 LL |     if let Some(_) = Some((String::new(), ())) {}
-   |     -------^^^^^^^---------------------------- help: try this: `if Some((String::new(), ())).is_some()`
+   |     -------^^^^^^^---------------------------- help: try: `if Some((String::new(), ())).is_some()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:49:12
    |
 LL |     if let Ready(_) = Ready(m.lock()) {}
-   |     -------^^^^^^^^------------------ help: try this: `if Ready(m.lock()).is_ready()`
+   |     -------^^^^^^^^------------------ help: try: `if Ready(m.lock()).is_ready()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -126,7 +126,7 @@ error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:50:12
    |
 LL |     if let Ready(_) = Ready(m.lock().unwrap().0) {}
-   |     -------^^^^^^^^----------------------------- help: try this: `if Ready(m.lock().unwrap().0).is_ready()`
+   |     -------^^^^^^^^----------------------------- help: try: `if Ready(m.lock().unwrap().0).is_ready()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -135,7 +135,7 @@ error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:53:16
    |
 LL |         if let Pending = Pending::<std::sync::MutexGuard<()>> {}
-   |         -------^^^^^^^--------------------------------------- help: try this: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
+   |         -------^^^^^^^--------------------------------------- help: try: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -144,7 +144,7 @@ error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:55:12
    |
 LL |     if let Pending = Pending::<std::sync::MutexGuard<()>> {
-   |     -------^^^^^^^--------------------------------------- help: try this: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
+   |     -------^^^^^^^--------------------------------------- help: try: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
@@ -153,19 +153,19 @@ error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:59:12
    |
 LL |     if let Pending = Pending::<std::sync::MutexGuard<()>> {}
-   |     -------^^^^^^^--------------------------------------- help: try this: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
+   |     -------^^^^^^^--------------------------------------- help: try: `if Pending::<std::sync::MutexGuard<()>>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:61:12
    |
 LL |     if let Ready(_) = Ready(String::new()) {}
-   |     -------^^^^^^^^----------------------- help: try this: `if Ready(String::new()).is_ready()`
+   |     -------^^^^^^^^----------------------- help: try: `if Ready(String::new()).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_drop_order.rs:62:12
    |
 LL |     if let Ready(_) = Ready((String::new(), ())) {}
-   |     -------^^^^^^^^----------------------------- help: try this: `if Ready((String::new(), ())).is_ready()`
+   |     -------^^^^^^^^----------------------------- help: try: `if Ready((String::new(), ())).is_ready()`
 
 error: aborting due to 22 previous errors
 

--- a/tests/ui/redundant_pattern_matching_ipaddr.stderr
+++ b/tests/ui/redundant_pattern_matching_ipaddr.stderr
@@ -2,7 +2,7 @@ error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:18:12
    |
 LL |     if let V4(_) = &ipaddr {}
-   |     -------^^^^^---------- help: try this: `if ipaddr.is_ipv4()`
+   |     -------^^^^^---------- help: try: `if ipaddr.is_ipv4()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
@@ -10,25 +10,25 @@ error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:20:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |     -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:22:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try this: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |     -------^^^^^-------------------------- help: try: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:24:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try this: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |     ----------^^^^^-------------------------- help: try: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:26:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try this: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |     ----------^^^^^-------------------------- help: try: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:36:5
@@ -37,7 +37,7 @@ LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => true,
 LL | |         V6(_) => false,
 LL | |     };
-   | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:41:5
@@ -46,7 +46,7 @@ LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => false,
 LL | |         V6(_) => true,
 LL | |     };
-   | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv6()`
+   | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:46:5
@@ -55,7 +55,7 @@ LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => false,
 LL | |         V6(_) => true,
 LL | |     };
-   | |_____^ help: try this: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:51:5
@@ -64,49 +64,49 @@ LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => true,
 LL | |         V6(_) => false,
 LL | |     };
-   | |_____^ help: try this: `V6(Ipv6Addr::LOCALHOST).is_ipv4()`
+   | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:56:20
    |
 LL |     let _ = if let V4(_) = V4(Ipv4Addr::LOCALHOST) {
-   |             -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |             -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:64:20
    |
 LL |     let _ = if let V4(_) = gen_ipaddr() {
-   |             -------^^^^^--------------- help: try this: `if gen_ipaddr().is_ipv4()`
+   |             -------^^^^^--------------- help: try: `if gen_ipaddr().is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:66:19
    |
 LL |     } else if let V6(_) = gen_ipaddr() {
-   |            -------^^^^^--------------- help: try this: `if gen_ipaddr().is_ipv6()`
+   |            -------^^^^^--------------- help: try: `if gen_ipaddr().is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:78:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try this: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |     -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:80:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     -------^^^^^-------------------------- help: try this: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |     -------^^^^^-------------------------- help: try: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:82:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try this: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   |     ----------^^^^^-------------------------- help: try: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:84:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
-   |     ----------^^^^^-------------------------- help: try this: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   |     ----------^^^^^-------------------------- help: try: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:86:5
@@ -115,7 +115,7 @@ LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |         V4(_) => true,
 LL | |         V6(_) => false,
 LL | |     };
-   | |_____^ help: try this: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
+   | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
   --> $DIR/redundant_pattern_matching_ipaddr.rs:91:5
@@ -124,7 +124,7 @@ LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |         V4(_) => false,
 LL | |         V6(_) => true,
 LL | |     };
-   | |_____^ help: try this: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
+   | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -2,7 +2,7 @@ error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:15:12
    |
 LL |     if let None = None::<()> {}
-   |     -------^^^^------------- help: try this: `if None::<()>.is_none()`
+   |     -------^^^^------------- help: try: `if None::<()>.is_none()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
@@ -10,37 +10,37 @@ error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:17:12
    |
 LL |     if let Some(_) = Some(42) {}
-   |     -------^^^^^^^----------- help: try this: `if Some(42).is_some()`
+   |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:19:12
    |
 LL |     if let Some(_) = Some(42) {
-   |     -------^^^^^^^----------- help: try this: `if Some(42).is_some()`
+   |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:25:15
    |
 LL |     while let Some(_) = Some(42) {}
-   |     ----------^^^^^^^----------- help: try this: `while Some(42).is_some()`
+   |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:27:15
    |
 LL |     while let None = Some(42) {}
-   |     ----------^^^^----------- help: try this: `while Some(42).is_none()`
+   |     ----------^^^^----------- help: try: `while Some(42).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:29:15
    |
 LL |     while let None = None::<()> {}
-   |     ----------^^^^------------- help: try this: `while None::<()>.is_none()`
+   |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:32:15
    |
 LL |     while let Some(_) = v.pop() {
-   |     ----------^^^^^^^---------- help: try this: `while v.pop().is_some()`
+   |     ----------^^^^^^^---------- help: try: `while v.pop().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:40:5
@@ -49,7 +49,7 @@ LL | /     match Some(42) {
 LL | |         Some(_) => true,
 LL | |         None => false,
 LL | |     };
-   | |_____^ help: try this: `Some(42).is_some()`
+   | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:45:5
@@ -58,7 +58,7 @@ LL | /     match None::<()> {
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try this: `None::<()>.is_none()`
+   | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:50:13
@@ -68,55 +68,55 @@ LL |       let _ = match None::<()> {
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try this: `None::<()>.is_none()`
+   | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:56:20
    |
 LL |     let _ = if let Some(_) = opt { true } else { false };
-   |             -------^^^^^^^------ help: try this: `if opt.is_some()`
+   |             -------^^^^^^^------ help: try: `if opt.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:62:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
-   |             -------^^^^^^^------------ help: try this: `if gen_opt().is_some()`
+   |             -------^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:64:19
    |
 LL |     } else if let None = gen_opt() {
-   |            -------^^^^------------ help: try this: `if gen_opt().is_none()`
+   |            -------^^^^------------ help: try: `if gen_opt().is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:70:12
    |
 LL |     if let Some(..) = gen_opt() {}
-   |     -------^^^^^^^^------------ help: try this: `if gen_opt().is_some()`
+   |     -------^^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:85:12
    |
 LL |     if let Some(_) = Some(42) {}
-   |     -------^^^^^^^----------- help: try this: `if Some(42).is_some()`
+   |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:87:12
    |
 LL |     if let None = None::<()> {}
-   |     -------^^^^------------- help: try this: `if None::<()>.is_none()`
+   |     -------^^^^------------- help: try: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:89:15
    |
 LL |     while let Some(_) = Some(42) {}
-   |     ----------^^^^^^^----------- help: try this: `while Some(42).is_some()`
+   |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:91:15
    |
 LL |     while let None = None::<()> {}
-   |     ----------^^^^------------- help: try this: `while None::<()>.is_none()`
+   |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:93:5
@@ -125,7 +125,7 @@ LL | /     match Some(42) {
 LL | |         Some(_) => true,
 LL | |         None => false,
 LL | |     };
-   | |_____^ help: try this: `Some(42).is_some()`
+   | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:98:5
@@ -134,19 +134,19 @@ LL | /     match None::<()> {
 LL | |         Some(_) => false,
 LL | |         None => true,
 LL | |     };
-   | |_____^ help: try this: `None::<()>.is_none()`
+   | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:106:12
    |
 LL |     if let None = *(&None::<()>) {}
-   |     -------^^^^----------------- help: try this: `if (&None::<()>).is_none()`
+   |     -------^^^^----------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:107:12
    |
 LL |     if let None = *&None::<()> {}
-   |     -------^^^^--------------- help: try this: `if (&None::<()>).is_none()`
+   |     -------^^^^--------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:113:5
@@ -155,7 +155,7 @@ LL | /     match x {
 LL | |         Some(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `x.is_some()`
+   | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:118:5
@@ -164,7 +164,7 @@ LL | /     match x {
 LL | |         None => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `x.is_none()`
+   | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:123:5
@@ -173,7 +173,7 @@ LL | /     match x {
 LL | |         Some(_) => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `x.is_none()`
+   | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:128:5
@@ -182,19 +182,19 @@ LL | /     match x {
 LL | |         None => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `x.is_some()`
+   | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_option.rs:143:13
    |
 LL |     let _ = matches!(x, Some(_));
-   |             ^^^^^^^^^^^^^^^^^^^^ help: try this: `x.is_some()`
+   |             ^^^^^^^^^^^^^^^^^^^^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
   --> $DIR/redundant_pattern_matching_option.rs:145:13
    |
 LL |     let _ = matches!(x, None);
-   |             ^^^^^^^^^^^^^^^^^ help: try this: `x.is_none()`
+   |             ^^^^^^^^^^^^^^^^^ help: try: `x.is_none()`
 
 error: aborting due to 28 previous errors
 

--- a/tests/ui/redundant_pattern_matching_poll.stderr
+++ b/tests/ui/redundant_pattern_matching_poll.stderr
@@ -2,7 +2,7 @@ error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:17:12
    |
 LL |     if let Pending = Pending::<()> {}
-   |     -------^^^^^^^---------------- help: try this: `if Pending::<()>.is_pending()`
+   |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
@@ -10,31 +10,31 @@ error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:19:12
    |
 LL |     if let Ready(_) = Ready(42) {}
-   |     -------^^^^^^^^------------ help: try this: `if Ready(42).is_ready()`
+   |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:21:12
    |
 LL |     if let Ready(_) = Ready(42) {
-   |     -------^^^^^^^^------------ help: try this: `if Ready(42).is_ready()`
+   |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:27:15
    |
 LL |     while let Ready(_) = Ready(42) {}
-   |     ----------^^^^^^^^------------ help: try this: `while Ready(42).is_ready()`
+   |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:29:15
    |
 LL |     while let Pending = Ready(42) {}
-   |     ----------^^^^^^^------------ help: try this: `while Ready(42).is_pending()`
+   |     ----------^^^^^^^------------ help: try: `while Ready(42).is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:31:15
    |
 LL |     while let Pending = Pending::<()> {}
-   |     ----------^^^^^^^---------------- help: try this: `while Pending::<()>.is_pending()`
+   |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:37:5
@@ -43,7 +43,7 @@ LL | /     match Ready(42) {
 LL | |         Ready(_) => true,
 LL | |         Pending => false,
 LL | |     };
-   | |_____^ help: try this: `Ready(42).is_ready()`
+   | |_____^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:42:5
@@ -52,7 +52,7 @@ LL | /     match Pending::<()> {
 LL | |         Ready(_) => false,
 LL | |         Pending => true,
 LL | |     };
-   | |_____^ help: try this: `Pending::<()>.is_pending()`
+   | |_____^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:47:13
@@ -62,49 +62,49 @@ LL |       let _ = match Pending::<()> {
 LL | |         Ready(_) => false,
 LL | |         Pending => true,
 LL | |     };
-   | |_____^ help: try this: `Pending::<()>.is_pending()`
+   | |_____^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:53:20
    |
 LL |     let _ = if let Ready(_) = poll { true } else { false };
-   |             -------^^^^^^^^------- help: try this: `if poll.is_ready()`
+   |             -------^^^^^^^^------- help: try: `if poll.is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:57:20
    |
 LL |     let _ = if let Ready(_) = gen_poll() {
-   |             -------^^^^^^^^------------- help: try this: `if gen_poll().is_ready()`
+   |             -------^^^^^^^^------------- help: try: `if gen_poll().is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:59:19
    |
 LL |     } else if let Pending = gen_poll() {
-   |            -------^^^^^^^------------- help: try this: `if gen_poll().is_pending()`
+   |            -------^^^^^^^------------- help: try: `if gen_poll().is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:75:12
    |
 LL |     if let Ready(_) = Ready(42) {}
-   |     -------^^^^^^^^------------ help: try this: `if Ready(42).is_ready()`
+   |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:77:12
    |
 LL |     if let Pending = Pending::<()> {}
-   |     -------^^^^^^^---------------- help: try this: `if Pending::<()>.is_pending()`
+   |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:79:15
    |
 LL |     while let Ready(_) = Ready(42) {}
-   |     ----------^^^^^^^^------------ help: try this: `while Ready(42).is_ready()`
+   |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:81:15
    |
 LL |     while let Pending = Pending::<()> {}
-   |     ----------^^^^^^^---------------- help: try this: `while Pending::<()>.is_pending()`
+   |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
   --> $DIR/redundant_pattern_matching_poll.rs:83:5
@@ -113,7 +113,7 @@ LL | /     match Ready(42) {
 LL | |         Ready(_) => true,
 LL | |         Pending => false,
 LL | |     };
-   | |_____^ help: try this: `Ready(42).is_ready()`
+   | |_____^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
   --> $DIR/redundant_pattern_matching_poll.rs:88:5
@@ -122,7 +122,7 @@ LL | /     match Pending::<()> {
 LL | |         Ready(_) => false,
 LL | |         Pending => true,
 LL | |     };
-   | |_____^ help: try this: `Pending::<()>.is_pending()`
+   | |_____^ help: try: `Pending::<()>.is_pending()`
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -2,7 +2,7 @@ error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:16:12
    |
 LL |     if let Ok(_) = &result {}
-   |     -------^^^^^---------- help: try this: `if result.is_ok()`
+   |     -------^^^^^---------- help: try: `if result.is_ok()`
    |
    = note: `-D clippy::redundant-pattern-matching` implied by `-D warnings`
 
@@ -10,25 +10,25 @@ error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:18:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
-   |     -------^^^^^--------------------- help: try this: `if Ok::<i32, i32>(42).is_ok()`
+   |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:20:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
-   |     -------^^^^^^---------------------- help: try this: `if Err::<i32, i32>(42).is_err()`
+   |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:22:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_ok()`
+   |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:24:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_err()`
+   |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:34:5
@@ -37,7 +37,7 @@ LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => true,
 LL | |         Err(_) => false,
 LL | |     };
-   | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
+   | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:39:5
@@ -46,7 +46,7 @@ LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => false,
 LL | |         Err(_) => true,
 LL | |     };
-   | |_____^ help: try this: `Ok::<i32, i32>(42).is_err()`
+   | |_____^ help: try: `Ok::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:44:5
@@ -55,7 +55,7 @@ LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => false,
 LL | |         Err(_) => true,
 LL | |     };
-   | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
+   | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:49:5
@@ -64,73 +64,73 @@ LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => true,
 LL | |         Err(_) => false,
 LL | |     };
-   | |_____^ help: try this: `Err::<i32, i32>(42).is_ok()`
+   | |_____^ help: try: `Err::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:54:20
    |
 LL |     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
-   |             -------^^^^^--------------------- help: try this: `if Ok::<usize, ()>(4).is_ok()`
+   |             -------^^^^^--------------------- help: try: `if Ok::<usize, ()>(4).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:62:20
    |
 LL |     let _ = if let Ok(_) = gen_res() {
-   |             -------^^^^^------------ help: try this: `if gen_res().is_ok()`
+   |             -------^^^^^------------ help: try: `if gen_res().is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:64:19
    |
 LL |     } else if let Err(_) = gen_res() {
-   |            -------^^^^^^------------ help: try this: `if gen_res().is_err()`
+   |            -------^^^^^^------------ help: try: `if gen_res().is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:87:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
-   |         ----------^^^^^^^----------------------- help: try this: `while r#try!(result_opt()).is_some()`
+   |         ----------^^^^^^^----------------------- help: try: `while r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:88:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
-   |         -------^^^^^^^----------------------- help: try this: `if r#try!(result_opt()).is_some()`
+   |         -------^^^^^^^----------------------- help: try: `if r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:94:12
    |
 LL |     if let Some(_) = m!() {}
-   |     -------^^^^^^^------- help: try this: `if m!().is_some()`
+   |     -------^^^^^^^------- help: try: `if m!().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
   --> $DIR/redundant_pattern_matching_result.rs:95:15
    |
 LL |     while let Some(_) = m!() {}
-   |     ----------^^^^^^^------- help: try this: `while m!().is_some()`
+   |     ----------^^^^^^^------- help: try: `while m!().is_some()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:113:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
-   |     -------^^^^^--------------------- help: try this: `if Ok::<i32, i32>(42).is_ok()`
+   |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:115:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
-   |     -------^^^^^^---------------------- help: try this: `if Err::<i32, i32>(42).is_err()`
+   |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:117:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_ok()`
+   |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:119:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
-   |     ----------^^^^^^--------------------- help: try this: `while Ok::<i32, i32>(10).is_err()`
+   |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:121:5
@@ -139,7 +139,7 @@ LL | /     match Ok::<i32, i32>(42) {
 LL | |         Ok(_) => true,
 LL | |         Err(_) => false,
 LL | |     };
-   | |_____^ help: try this: `Ok::<i32, i32>(42).is_ok()`
+   | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:126:5
@@ -148,7 +148,7 @@ LL | /     match Err::<i32, i32>(42) {
 LL | |         Ok(_) => false,
 LL | |         Err(_) => true,
 LL | |     };
-   | |_____^ help: try this: `Err::<i32, i32>(42).is_err()`
+   | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:136:5
@@ -157,7 +157,7 @@ LL | /     match x {
 LL | |         Ok(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `x.is_ok()`
+   | |_____^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:141:5
@@ -166,7 +166,7 @@ LL | /     match x {
 LL | |         Ok(_) => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `x.is_err()`
+   | |_____^ help: try: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:146:5
@@ -175,7 +175,7 @@ LL | /     match x {
 LL | |         Err(_) => true,
 LL | |         _ => false,
 LL | |     };
-   | |_____^ help: try this: `x.is_err()`
+   | |_____^ help: try: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:151:5
@@ -184,19 +184,19 @@ LL | /     match x {
 LL | |         Err(_) => false,
 LL | |         _ => true,
 LL | |     };
-   | |_____^ help: try this: `x.is_ok()`
+   | |_____^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
   --> $DIR/redundant_pattern_matching_result.rs:172:13
    |
 LL |     let _ = matches!(x, Ok(_));
-   |             ^^^^^^^^^^^^^^^^^^ help: try this: `x.is_ok()`
+   |             ^^^^^^^^^^^^^^^^^^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
   --> $DIR/redundant_pattern_matching_result.rs:174:13
    |
 LL |     let _ = matches!(x, Err(_));
-   |             ^^^^^^^^^^^^^^^^^^^ help: try this: `x.is_err()`
+   |             ^^^^^^^^^^^^^^^^^^^ help: try: `x.is_err()`
 
 error: aborting due to 28 previous errors
 

--- a/tests/ui/ref_binding_to_reference.stderr
+++ b/tests/ui/ref_binding_to_reference.stderr
@@ -5,7 +5,7 @@ LL |         Some(ref x) => x,
    |              ^^^^^
    |
    = note: `-D clippy::ref-binding-to-reference` implied by `-D warnings`
-help: try this
+help: try
    |
 LL |         Some(x) => &x,
    |              ~     ~~
@@ -16,7 +16,7 @@ error: this pattern creates a reference to a reference
 LL |         Some(ref x) => {
    |              ^^^^^
    |
-help: try this
+help: try
    |
 LL ~         Some(x) => {
 LL |             f1(x);
@@ -30,7 +30,7 @@ error: this pattern creates a reference to a reference
 LL |         Some(ref x) => m2!(x),
    |              ^^^^^
    |
-help: try this
+help: try
    |
 LL |         Some(x) => m2!(&x),
    |              ~         ~~
@@ -41,7 +41,7 @@ error: this pattern creates a reference to a reference
 LL |     let _ = |&ref x: &&String| {
    |               ^^^^^
    |
-help: try this
+help: try
    |
 LL ~     let _ = |&x: &&String| {
 LL ~         let _: &&String = &x;
@@ -53,7 +53,7 @@ error: this pattern creates a reference to a reference
 LL | fn f2<'a>(&ref x: &&'a String) -> &'a String {
    |            ^^^^^
    |
-help: try this
+help: try
    |
 LL ~ fn f2<'a>(&x: &&'a String) -> &'a String {
 LL ~     let _: &&String = &x;
@@ -66,7 +66,7 @@ error: this pattern creates a reference to a reference
 LL |     fn f(&ref x: &&String) {
    |           ^^^^^
    |
-help: try this
+help: try
    |
 LL ~     fn f(&x: &&String) {
 LL ~         let _: &&String = &x;
@@ -78,7 +78,7 @@ error: this pattern creates a reference to a reference
 LL |     fn f(&ref x: &&String) {
    |           ^^^^^
    |
-help: try this
+help: try
    |
 LL ~     fn f(&x: &&String) {
 LL ~         let _: &&String = &x;

--- a/tests/ui/result_map_unit_fn_fixable.stderr
+++ b/tests/ui/result_map_unit_fn_fixable.stderr
@@ -4,7 +4,7 @@ error: called `map(f)` on an `Result` value where `f` is a function that returns
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(x_field) = x.field { do_nothing(x_field) }`
+   |     help: try: `if let Ok(x_field) = x.field { do_nothing(x_field) }`
    |
    = note: `-D clippy::result-map-unit-fn` implied by `-D warnings`
 
@@ -14,7 +14,7 @@ error: called `map(f)` on an `Result` value where `f` is a function that returns
 LL |     x.field.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(x_field) = x.field { do_nothing(x_field) }`
+   |     help: try: `if let Ok(x_field) = x.field { do_nothing(x_field) }`
 
 error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:39:5
@@ -22,7 +22,7 @@ error: called `map(f)` on an `Result` value where `f` is a function that returns
 LL |     x.field.map(diverge);
    |     ^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(x_field) = x.field { diverge(x_field) }`
+   |     help: try: `if let Ok(x_field) = x.field { diverge(x_field) }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:45:5
@@ -30,7 +30,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| x.do_result_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { x.do_result_nothing(value + captured) }`
+   |     help: try: `if let Ok(value) = x.field { x.do_result_nothing(value + captured) }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:47:5
@@ -38,7 +38,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { x.do_result_plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { x.do_result_plus_one(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { x.do_result_plus_one(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:50:5
@@ -46,7 +46,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| do_nothing(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
+   |     help: try: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:52:5
@@ -54,7 +54,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured) }`
+   |     help: try: `if let Ok(value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:54:5
@@ -62,7 +62,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { do_nothing(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:56:5
@@ -70,7 +70,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { { do_nothing(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { do_nothing(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { do_nothing(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:59:5
@@ -78,7 +78,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| diverge(value + captured));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
+   |     help: try: `if let Ok(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:61:5
@@ -86,7 +86,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { diverge(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { diverge(value + captured) }`
+   |     help: try: `if let Ok(value) = x.field { diverge(value + captured) }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:63:5
@@ -94,7 +94,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { diverge(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:65:5
@@ -102,7 +102,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { { diverge(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { diverge(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { diverge(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:70:5
@@ -110,7 +110,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { let y = plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { let y = plus_one(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { let y = plus_one(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:72:5
@@ -118,7 +118,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { plus_one(value + captured); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:74:5
@@ -126,7 +126,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { { plus_one(value + captured); } });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { plus_one(value + captured); }`
+   |     help: try: `if let Ok(value) = x.field { plus_one(value + captured); }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:77:5
@@ -134,7 +134,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|ref value| { do_nothing(value + captured) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(ref value) = x.field { do_nothing(value + captured) }`
+   |     help: try: `if let Ok(ref value) = x.field { do_nothing(value + captured) }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_fixable.rs:79:5
@@ -142,7 +142,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| println!("{:?}", value));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { println!("{:?}", value) }`
+   |     help: try: `if let Ok(value) = x.field { println!("{:?}", value) }`
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/result_map_unit_fn_unfixable.stderr
+++ b/tests/ui/result_map_unit_fn_unfixable.stderr
@@ -4,7 +4,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { ... }`
+   |     help: try: `if let Ok(value) = x.field { ... }`
    |
    = note: `-D clippy::result-map-unit-fn` implied by `-D warnings`
 
@@ -14,7 +14,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| if value > 0 { do_nothing(value); do_nothing(value) });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { ... }`
+   |     help: try: `if let Ok(value) = x.field { ... }`
 
 error: called `map(f)` on an `Result` value where `f` is a closure that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:29:5
@@ -23,7 +23,7 @@ LL | //     x.field.map(|value| {
 LL | ||         do_nothing(value);
 LL | ||         do_nothing(value)
 LL | ||     });
-   | ||______^- help: try this: `if let Ok(value) = x.field { ... }`
+   | ||______^- help: try: `if let Ok(value) = x.field { ... }`
    |  |______|
    | 
 
@@ -33,7 +33,7 @@ error: called `map(f)` on an `Result` value where `f` is a closure that returns 
 LL |     x.field.map(|value| { do_nothing(value); do_nothing(value); });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(value) = x.field { ... }`
+   |     help: try: `if let Ok(value) = x.field { ... }`
 
 error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:37:5
@@ -41,7 +41,7 @@ error: called `map(f)` on an `Result` value where `f` is a function that returns
 LL |     "12".parse::<i32>().map(diverge);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(a) = "12".parse::<i32>() { diverge(a) }`
+   |     help: try: `if let Ok(a) = "12".parse::<i32>() { diverge(a) }`
 
 error: called `map(f)` on an `Result` value where `f` is a function that returns the unit type `()`
   --> $DIR/result_map_unit_fn_unfixable.rs:43:5
@@ -49,7 +49,7 @@ error: called `map(f)` on an `Result` value where `f` is a function that returns
 LL |     y.map(do_nothing);
    |     ^^^^^^^^^^^^^^^^^-
    |     |
-   |     help: try this: `if let Ok(_y) = y { do_nothing(_y) }`
+   |     help: try: `if let Ok(_y) = y { do_nothing(_y) }`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -10,7 +10,7 @@ LL | |     };
    | |_____^
    |
    = note: `-D clippy::single-match` implied by `-D warnings`
-help: try this
+help: try
    |
 LL ~     if let Some(y) = x {
 LL +         println!("{:?}", y);
@@ -27,7 +27,7 @@ LL | |         // is expanded before we can do anything.
 LL | |         Some(y) => println!("{:?}", y),
 LL | |         _ => (),
 LL | |     }
-   | |_____^ help: try this: `if let Some(y) = x { println!("{:?}", y) }`
+   | |_____^ help: try: `if let Some(y) = x { println!("{:?}", y) }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:31:5
@@ -36,7 +36,7 @@ LL | /     match z {
 LL | |         (2..=3, 7..=9) => dummy(),
 LL | |         _ => {},
 LL | |     };
-   | |_____^ help: try this: `if let (2..=3, 7..=9) = z { dummy() }`
+   | |_____^ help: try: `if let (2..=3, 7..=9) = z { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:60:5
@@ -45,7 +45,7 @@ LL | /     match x {
 LL | |         Some(y) => dummy(),
 LL | |         None => (),
 LL | |     };
-   | |_____^ help: try this: `if let Some(y) = x { dummy() }`
+   | |_____^ help: try: `if let Some(y) = x { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:65:5
@@ -54,7 +54,7 @@ LL | /     match y {
 LL | |         Ok(y) => dummy(),
 LL | |         Err(..) => (),
 LL | |     };
-   | |_____^ help: try this: `if let Ok(y) = y { dummy() }`
+   | |_____^ help: try: `if let Ok(y) = y { dummy() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:72:5
@@ -63,7 +63,7 @@ LL | /     match c {
 LL | |         Cow::Borrowed(..) => dummy(),
 LL | |         Cow::Owned(..) => (),
 LL | |     };
-   | |_____^ help: try this: `if let Cow::Borrowed(..) = c { dummy() }`
+   | |_____^ help: try: `if let Cow::Borrowed(..) = c { dummy() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
   --> $DIR/single_match.rs:93:5
@@ -72,7 +72,7 @@ LL | /     match x {
 LL | |         "test" => println!(),
 LL | |         _ => (),
 LL | |     }
-   | |_____^ help: try this: `if x == "test" { println!() }`
+   | |_____^ help: try: `if x == "test" { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
   --> $DIR/single_match.rs:106:5
@@ -81,7 +81,7 @@ LL | /     match x {
 LL | |         Foo::A => println!(),
 LL | |         _ => (),
 LL | |     }
-   | |_____^ help: try this: `if x == Foo::A { println!() }`
+   | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
   --> $DIR/single_match.rs:112:5
@@ -90,7 +90,7 @@ LL | /     match x {
 LL | |         FOO_C => println!(),
 LL | |         _ => (),
 LL | |     }
-   | |_____^ help: try this: `if x == FOO_C { println!() }`
+   | |_____^ help: try: `if x == FOO_C { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
   --> $DIR/single_match.rs:117:5
@@ -99,7 +99,7 @@ LL | /     match &&x {
 LL | |         Foo::A => println!(),
 LL | |         _ => (),
 LL | |     }
-   | |_____^ help: try this: `if x == Foo::A { println!() }`
+   | |_____^ help: try: `if x == Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for an equality check. Consider using `if`
   --> $DIR/single_match.rs:123:5
@@ -108,7 +108,7 @@ LL | /     match &x {
 LL | |         Foo::A => println!(),
 LL | |         _ => (),
 LL | |     }
-   | |_____^ help: try this: `if x == &Foo::A { println!() }`
+   | |_____^ help: try: `if x == &Foo::A { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:140:5
@@ -117,7 +117,7 @@ LL | /     match x {
 LL | |         Bar::A => println!(),
 LL | |         _ => (),
 LL | |     }
-   | |_____^ help: try this: `if let Bar::A = x { println!() }`
+   | |_____^ help: try: `if let Bar::A = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:148:5
@@ -126,7 +126,7 @@ LL | /     match x {
 LL | |         None => println!(),
 LL | |         _ => (),
 LL | |     };
-   | |_____^ help: try this: `if let None = x { println!() }`
+   | |_____^ help: try: `if let None = x { println!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:170:5
@@ -135,7 +135,7 @@ LL | /     match x {
 LL | |         (Some(_), _) => {},
 LL | |         (None, _) => {},
 LL | |     }
-   | |_____^ help: try this: `if let (Some(_), _) = x {}`
+   | |_____^ help: try: `if let (Some(_), _) = x {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:176:5
@@ -144,7 +144,7 @@ LL | /     match x {
 LL | |         (Some(E::V), _) => todo!(),
 LL | |         (_, _) => {},
 LL | |     }
-   | |_____^ help: try this: `if let (Some(E::V), _) = x { todo!() }`
+   | |_____^ help: try: `if let (Some(E::V), _) = x { todo!() }`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:182:5
@@ -153,7 +153,7 @@ LL | /     match (Some(42), Some(E::V), Some(42)) {
 LL | |         (.., Some(E::V), _) => {},
 LL | |         (..) => {},
 LL | |     }
-   | |_____^ help: try this: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
+   | |_____^ help: try: `if let (.., Some(E::V), _) = (Some(42), Some(E::V), Some(42)) {}`
 
 error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> $DIR/single_match.rs:254:5
@@ -167,7 +167,7 @@ LL | |         _ => {},
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(v) = bar { unsafe {
 LL +         let r = &v as *const i32;
@@ -187,7 +187,7 @@ LL | |         _ => {},
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(v) = bar {
 LL +         unsafe {

--- a/tests/ui/single_match_else.stderr
+++ b/tests/ui/single_match_else.stderr
@@ -12,7 +12,7 @@ LL | |     };
    | |_____^
    |
    = note: `-D clippy::single-match-else` implied by `-D warnings`
-help: try this
+help: try
    |
 LL ~     let _ = if let ExprNode::ExprAddrOf = ExprNode::Butterflies { Some(&NODE) } else {
 LL +         let x = 5;
@@ -32,7 +32,7 @@ LL | |         },
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(a) = Some(1) { println!("${:?}", a) } else {
 LL +         println!("else block");
@@ -52,7 +52,7 @@ LL | |         },
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(a) = Some(1) { println!("${:?}", a) } else {
 LL +         println!("else block");
@@ -72,7 +72,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Ok(a) = Result::<i32, Infallible>::Ok(1) { println!("${:?}", a) } else {
 LL +         println!("else block");
@@ -92,7 +92,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Cow::Owned(a) = Cow::from("moo") { println!("${:?}", a) } else {
 LL +         println!("else block");
@@ -112,7 +112,7 @@ LL | |         },
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(v) = bar { unsafe {
 LL +         let r = &v as *const i32;
@@ -135,7 +135,7 @@ LL | |         },
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(v) = bar {
 LL +         println!("Some");
@@ -159,7 +159,7 @@ LL | |         },
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(v) = bar { unsafe {
 LL +         let r = &v as *const i32;
@@ -183,7 +183,7 @@ LL | |         },
 LL | |     }
    | |_____^
    |
-help: try this
+help: try
    |
 LL ~     if let Some(v) = bar {
 LL +         unsafe {

--- a/tests/ui/string_extend.stderr
+++ b/tests/ui/string_extend.stderr
@@ -2,7 +2,7 @@ error: calling `.extend(_.chars())`
   --> $DIR/string_extend.rs:18:5
    |
 LL |     s.extend(abc.chars());
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.push_str(abc)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str(abc)`
    |
    = note: `-D clippy::string-extend-chars` implied by `-D warnings`
 
@@ -10,19 +10,19 @@ error: calling `.extend(_.chars())`
   --> $DIR/string_extend.rs:21:5
    |
 LL |     s.extend("abc".chars());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.push_str("abc")`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str("abc")`
 
 error: calling `.extend(_.chars())`
   --> $DIR/string_extend.rs:24:5
    |
 LL |     s.extend(def.chars());
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.push_str(&def)`
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str(&def)`
 
 error: calling `.extend(_.chars())`
   --> $DIR/string_extend.rs:34:5
    |
 LL |     s.extend(abc[0..2].chars());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `s.push_str(&abc[0..2])`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str(&abc[0..2])`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/strlen_on_c_strings.stderr
+++ b/tests/ui/strlen_on_c_strings.stderr
@@ -2,7 +2,7 @@ error: using `libc::strlen` on a `CString` or `CStr` value
   --> $DIR/strlen_on_c_strings.rs:15:13
    |
 LL |     let _ = unsafe { libc::strlen(cstring.as_ptr()) };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstring.as_bytes().len()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cstring.as_bytes().len()`
    |
    = note: `-D clippy::strlen-on-c-strings` implied by `-D warnings`
 
@@ -10,37 +10,37 @@ error: using `libc::strlen` on a `CString` or `CStr` value
   --> $DIR/strlen_on_c_strings.rs:19:13
    |
 LL |     let _ = unsafe { libc::strlen(cstr.as_ptr()) };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cstr.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
   --> $DIR/strlen_on_c_strings.rs:21:13
    |
 LL |     let _ = unsafe { strlen(cstr.as_ptr()) };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `cstr.to_bytes().len()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cstr.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
   --> $DIR/strlen_on_c_strings.rs:24:22
    |
 LL |     let _ = unsafe { strlen((*pcstr).as_ptr()) };
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(*pcstr).to_bytes().len()`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(*pcstr).to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
   --> $DIR/strlen_on_c_strings.rs:29:22
    |
 LL |     let _ = unsafe { strlen(unsafe_identity(cstr).as_ptr()) };
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe_identity(cstr).to_bytes().len()`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unsafe_identity(cstr).to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
   --> $DIR/strlen_on_c_strings.rs:30:13
    |
 LL |     let _ = unsafe { strlen(unsafe { unsafe_identity(cstr) }.as_ptr()) };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unsafe { unsafe_identity(cstr) }.to_bytes().len()`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unsafe { unsafe_identity(cstr) }.to_bytes().len()`
 
 error: using `libc::strlen` on a `CString` or `CStr` value
   --> $DIR/strlen_on_c_strings.rs:33:22
    |
 LL |     let _ = unsafe { strlen(f(cstr).as_ptr()) };
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `f(cstr).to_bytes().len()`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `f(cstr).to_bytes().len()`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/to_digit_is_some.stderr
+++ b/tests/ui/to_digit_is_some.stderr
@@ -2,7 +2,7 @@ error: use of `.to_digit(..).is_some()`
   --> $DIR/to_digit_is_some.rs:9:13
    |
 LL |     let _ = d.to_digit(8).is_some();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `d.is_digit(8)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `d.is_digit(8)`
    |
    = note: `-D clippy::to-digit-is-some` implied by `-D warnings`
 
@@ -10,7 +10,7 @@ error: use of `.to_digit(..).is_some()`
   --> $DIR/to_digit_is_some.rs:10:13
    |
 LL |     let _ = char::to_digit(c, 8).is_some();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `char::is_digit(c, 8)`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `char::is_digit(c, 8)`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/try_err.stderr
+++ b/tests/ui/try_err.stderr
@@ -2,7 +2,7 @@ error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:19:9
    |
 LL |         Err(err)?;
-   |         ^^^^^^^^^ help: try this: `return Err(err)`
+   |         ^^^^^^^^^ help: try: `return Err(err)`
    |
 note: the lint level is defined here
   --> $DIR/try_err.rs:4:9
@@ -14,25 +14,25 @@ error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:29:9
    |
 LL |         Err(err)?;
-   |         ^^^^^^^^^ help: try this: `return Err(err.into())`
+   |         ^^^^^^^^^ help: try: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:49:17
    |
 LL |                 Err(err)?;
-   |                 ^^^^^^^^^ help: try this: `return Err(err)`
+   |                 ^^^^^^^^^ help: try: `return Err(err)`
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:68:17
    |
 LL |                 Err(err)?;
-   |                 ^^^^^^^^^ help: try this: `return Err(err.into())`
+   |                 ^^^^^^^^^ help: try: `return Err(err.into())`
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:88:23
    |
 LL |             Err(_) => Err(1)?,
-   |                       ^^^^^^^ help: try this: `return Err(1)`
+   |                       ^^^^^^^ help: try: `return Err(1)`
    |
    = note: this error originates in the macro `__inline_mac_fn_calling_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -40,7 +40,7 @@ error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:95:23
    |
 LL |             Err(_) => Err(inline!(1))?,
-   |                       ^^^^^^^^^^^^^^^^ help: try this: `return Err(inline!(1))`
+   |                       ^^^^^^^^^^^^^^^^ help: try: `return Err(inline!(1))`
    |
    = note: this error originates in the macro `__inline_mac_fn_calling_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -48,31 +48,31 @@ error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:122:9
    |
 LL |         Err(inline!(inline!(String::from("aasdfasdfasdfa"))))?;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `return Err(inline!(inline!(String::from("aasdfasdfasdfa"))))`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Err(inline!(inline!(String::from("aasdfasdfasdfa"))))`
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:129:9
    |
 LL |         Err(io::ErrorKind::WriteZero)?
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))`
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:131:9
    |
 LL |         Err(io::Error::new(io::ErrorKind::InvalidInput, "error"))?
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidInput, "error")))`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidInput, "error")))`
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:139:9
    |
 LL |         Err(io::ErrorKind::NotFound)?
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `return Poll::Ready(Some(Err(io::ErrorKind::NotFound.into())))`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `return Poll::Ready(Some(Err(io::ErrorKind::NotFound.into())))`
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:148:16
    |
 LL |         return Err(42)?;
-   |                ^^^^^^^^ help: try this: `Err(42)`
+   |                ^^^^^^^^ help: try: `Err(42)`
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/unnecessary_clone.stderr
+++ b/tests/ui/unnecessary_clone.stderr
@@ -2,7 +2,7 @@ error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:23:5
    |
 LL |     rc.clone();
-   |     ^^^^^^^^^^ help: try this: `Rc::<bool>::clone(&rc)`
+   |     ^^^^^^^^^^ help: try: `Rc::<bool>::clone(&rc)`
    |
    = note: `-D clippy::clone-on-ref-ptr` implied by `-D warnings`
 
@@ -10,25 +10,25 @@ error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:26:5
    |
 LL |     arc.clone();
-   |     ^^^^^^^^^^^ help: try this: `Arc::<bool>::clone(&arc)`
+   |     ^^^^^^^^^^^ help: try: `Arc::<bool>::clone(&arc)`
 
 error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:29:5
    |
 LL |     rcweak.clone();
-   |     ^^^^^^^^^^^^^^ help: try this: `Weak::<bool>::clone(&rcweak)`
+   |     ^^^^^^^^^^^^^^ help: try: `Weak::<bool>::clone(&rcweak)`
 
 error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:32:5
    |
 LL |     arc_weak.clone();
-   |     ^^^^^^^^^^^^^^^^ help: try this: `Weak::<bool>::clone(&arc_weak)`
+   |     ^^^^^^^^^^^^^^^^ help: try: `Weak::<bool>::clone(&arc_weak)`
 
 error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:36:33
    |
 LL |     let _: Arc<dyn SomeTrait> = x.clone();
-   |                                 ^^^^^^^^^ help: try this: `Arc::<SomeImpl>::clone(&x)`
+   |                                 ^^^^^^^^^ help: try: `Arc::<SomeImpl>::clone(&x)`
 
 error: using `clone` on type `T` which implements the `Copy` trait
   --> $DIR/unnecessary_clone.rs:40:5
@@ -54,7 +54,7 @@ error: using `.clone()` on a ref-counted pointer
   --> $DIR/unnecessary_clone.rs:95:14
    |
 LL |         Some(try_opt!(Some(rc)).clone())
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `Rc::<u8>::clone(&try_opt!(Some(rc)))`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Rc::<u8>::clone(&try_opt!(Some(rc)))`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/unwrap_or.stderr
+++ b/tests/ui/unwrap_or.stderr
@@ -2,7 +2,7 @@ error: use of `unwrap_or` followed by a function call
   --> $DIR/unwrap_or.rs:5:47
    |
 LL |     let s = Some(String::from("test string")).unwrap_or("Fail".to_string()).len();
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| "Fail".to_string())`
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| "Fail".to_string())`
    |
    = note: `-D clippy::or-fun-call` implied by `-D warnings`
 
@@ -10,7 +10,7 @@ error: use of `unwrap_or` followed by a function call
   --> $DIR/unwrap_or.rs:9:47
    |
 LL |     let s = Some(String::from("test string")).unwrap_or("Fail".to_string()).len();
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| "Fail".to_string())`
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| "Fail".to_string())`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/useless_asref.stderr
+++ b/tests/ui/useless_asref.stderr
@@ -2,7 +2,7 @@ error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:43:18
    |
 LL |         foo_rstr(rstr.as_ref());
-   |                  ^^^^^^^^^^^^^ help: try this: `rstr`
+   |                  ^^^^^^^^^^^^^ help: try: `rstr`
    |
 note: the lint level is defined here
   --> $DIR/useless_asref.rs:2:9
@@ -14,61 +14,61 @@ error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:45:20
    |
 LL |         foo_rslice(rslice.as_ref());
-   |                    ^^^^^^^^^^^^^^^ help: try this: `rslice`
+   |                    ^^^^^^^^^^^^^^^ help: try: `rslice`
 
 error: this call to `as_mut` does nothing
   --> $DIR/useless_asref.rs:49:21
    |
 LL |         foo_mrslice(mrslice.as_mut());
-   |                     ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
+   |                     ^^^^^^^^^^^^^^^^ help: try: `mrslice`
 
 error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:51:20
    |
 LL |         foo_rslice(mrslice.as_ref());
-   |                    ^^^^^^^^^^^^^^^^ help: try this: `mrslice`
+   |                    ^^^^^^^^^^^^^^^^ help: try: `mrslice`
 
 error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:58:20
    |
 LL |         foo_rslice(rrrrrslice.as_ref());
-   |                    ^^^^^^^^^^^^^^^^^^^ help: try this: `rrrrrslice`
+   |                    ^^^^^^^^^^^^^^^^^^^ help: try: `rrrrrslice`
 
 error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:60:18
    |
 LL |         foo_rstr(rrrrrstr.as_ref());
-   |                  ^^^^^^^^^^^^^^^^^ help: try this: `rrrrrstr`
+   |                  ^^^^^^^^^^^^^^^^^ help: try: `rrrrrstr`
 
 error: this call to `as_mut` does nothing
   --> $DIR/useless_asref.rs:65:21
    |
 LL |         foo_mrslice(mrrrrrslice.as_mut());
-   |                     ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
+   |                     ^^^^^^^^^^^^^^^^^^^^ help: try: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:67:20
    |
 LL |         foo_rslice(mrrrrrslice.as_ref());
-   |                    ^^^^^^^^^^^^^^^^^^^^ help: try this: `mrrrrrslice`
+   |                    ^^^^^^^^^^^^^^^^^^^^ help: try: `mrrrrrslice`
 
 error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:71:16
    |
 LL |     foo_rrrrmr((&&&&MoreRef).as_ref());
-   |                ^^^^^^^^^^^^^^^^^^^^^^ help: try this: `(&&&&MoreRef)`
+   |                ^^^^^^^^^^^^^^^^^^^^^^ help: try: `(&&&&MoreRef)`
 
 error: this call to `as_mut` does nothing
   --> $DIR/useless_asref.rs:121:13
    |
 LL |     foo_mrt(mrt.as_mut());
-   |             ^^^^^^^^^^^^ help: try this: `mrt`
+   |             ^^^^^^^^^^^^ help: try: `mrt`
 
 error: this call to `as_ref` does nothing
   --> $DIR/useless_asref.rs:123:12
    |
 LL |     foo_rt(mrt.as_ref());
-   |            ^^^^^^^^^^^^ help: try this: `mrt`
+   |            ^^^^^^^^^^^^ help: try: `mrt`
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/wildcard_enum_match_arm.stderr
+++ b/tests/ui/wildcard_enum_match_arm.stderr
@@ -2,7 +2,7 @@ error: wildcard match will also match any future added variants
   --> $DIR/wildcard_enum_match_arm.rs:40:9
    |
 LL |         _ => eprintln!("Not red"),
-   |         ^ help: try this: `Color::Green | Color::Blue | Color::Rgb(..) | Color::Cyan`
+   |         ^ help: try: `Color::Green | Color::Blue | Color::Rgb(..) | Color::Cyan`
    |
 note: the lint level is defined here
   --> $DIR/wildcard_enum_match_arm.rs:3:9
@@ -14,31 +14,31 @@ error: wildcard match will also match any future added variants
   --> $DIR/wildcard_enum_match_arm.rs:44:9
    |
 LL |         _not_red => eprintln!("Not red"),
-   |         ^^^^^^^^ help: try this: `_not_red @ Color::Green | _not_red @ Color::Blue | _not_red @ Color::Rgb(..) | _not_red @ Color::Cyan`
+   |         ^^^^^^^^ help: try: `_not_red @ Color::Green | _not_red @ Color::Blue | _not_red @ Color::Rgb(..) | _not_red @ Color::Cyan`
 
 error: wildcard match will also match any future added variants
   --> $DIR/wildcard_enum_match_arm.rs:48:9
    |
 LL |         not_red => format!("{:?}", not_red),
-   |         ^^^^^^^ help: try this: `not_red @ Color::Green | not_red @ Color::Blue | not_red @ Color::Rgb(..) | not_red @ Color::Cyan`
+   |         ^^^^^^^ help: try: `not_red @ Color::Green | not_red @ Color::Blue | not_red @ Color::Rgb(..) | not_red @ Color::Cyan`
 
 error: wildcard match will also match any future added variants
   --> $DIR/wildcard_enum_match_arm.rs:64:9
    |
 LL |         _ => "No red",
-   |         ^ help: try this: `Color::Red | Color::Green | Color::Blue | Color::Rgb(..) | Color::Cyan`
+   |         ^ help: try: `Color::Red | Color::Green | Color::Blue | Color::Rgb(..) | Color::Cyan`
 
 error: wildcard matches known variants and will also match future added variants
   --> $DIR/wildcard_enum_match_arm.rs:81:9
    |
 LL |         _ => {},
-   |         ^ help: try this: `ErrorKind::PermissionDenied | _`
+   |         ^ help: try: `ErrorKind::PermissionDenied | _`
 
 error: wildcard match will also match any future added variants
   --> $DIR/wildcard_enum_match_arm.rs:99:13
    |
 LL |             _ => (),
-   |             ^ help: try this: `Enum::B | Enum::__Private`
+   |             ^ help: try: `Enum::B | Enum::__Private`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/write_literal.stderr
+++ b/tests/ui/write_literal.stderr
@@ -5,7 +5,7 @@ LL |     write!(v, "Hello {}", "world");
    |                           ^^^^^^^
    |
    = note: `-D clippy::write-literal` implied by `-D warnings`
-help: try this
+help: try
    |
 LL -     write!(v, "Hello {}", "world");
 LL +     write!(v, "Hello world");
@@ -17,7 +17,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "Hello {} {}", world, "world");
    |                                       ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "Hello {} {}", world, "world");
 LL +     writeln!(v, "Hello {} world", world);
@@ -29,7 +29,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "Hello {}", "world");
    |                             ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "Hello {}", "world");
 LL +     writeln!(v, "Hello world");
@@ -41,7 +41,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{} {:.4}", "a literal", 5);
    |                             ^^^^^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{} {:.4}", "a literal", 5);
 LL +     writeln!(v, "a literal {:.4}", 5);
@@ -53,7 +53,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{0} {1}", "hello", "world");
    |                            ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{0} {1}", "hello", "world");
 LL +     writeln!(v, "hello {1}", "world");
@@ -65,7 +65,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{0} {1}", "hello", "world");
    |                                     ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{0} {1}", "hello", "world");
 LL +     writeln!(v, "{0} world", "hello");
@@ -77,7 +77,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{1} {0}", "hello", "world");
    |                                     ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{1} {0}", "hello", "world");
 LL +     writeln!(v, "world {0}", "hello");
@@ -89,7 +89,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{1} {0}", "hello", "world");
    |                            ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{1} {0}", "hello", "world");
 LL +     writeln!(v, "{1} hello", "world");
@@ -101,7 +101,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{foo} {bar}", foo = "hello", bar = "world");
    |                                      ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{foo} {bar}", foo = "hello", bar = "world");
 LL +     writeln!(v, "hello {bar}", bar = "world");
@@ -113,7 +113,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{foo} {bar}", foo = "hello", bar = "world");
    |                                                     ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{foo} {bar}", foo = "hello", bar = "world");
 LL +     writeln!(v, "{foo} world", foo = "hello");
@@ -125,7 +125,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{bar} {foo}", foo = "hello", bar = "world");
    |                                                     ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{bar} {foo}", foo = "hello", bar = "world");
 LL +     writeln!(v, "world {foo}", foo = "hello");
@@ -137,7 +137,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{bar} {foo}", foo = "hello", bar = "world");
    |                                      ^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{bar} {foo}", foo = "hello", bar = "world");
 LL +     writeln!(v, "{bar} hello", bar = "world");

--- a/tests/ui/write_literal_2.stderr
+++ b/tests/ui/write_literal_2.stderr
@@ -13,7 +13,7 @@ LL |     writeln!(v, "{}", "{hello}");
    |                       ^^^^^^^^^
    |
    = note: `-D clippy::write-literal` implied by `-D warnings`
-help: try this
+help: try
    |
 LL -     writeln!(v, "{}", "{hello}");
 LL +     writeln!(v, "{{hello}}");
@@ -25,7 +25,7 @@ error: literal with an empty format string
 LL |     writeln!(v, r"{}", r"{hello}");
    |                        ^^^^^^^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, r"{}", r"{hello}");
 LL +     writeln!(v, r"{{hello}}");
@@ -37,7 +37,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{}", '/'');
    |                       ^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{}", '/'');
 LL +     writeln!(v, "'");
@@ -49,7 +49,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{}", '"');
    |                       ^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{}", '"');
 LL +     writeln!(v, "/"");
@@ -67,7 +67,7 @@ error: literal with an empty format string
 LL |     writeln!(v, r"{}", '/'');
    |                        ^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, r"{}", '/'');
 LL +     writeln!(v, r"'");
@@ -80,7 +80,7 @@ LL | /         "hello /
 LL | |         world!"
    | |_______________^
    |
-help: try this
+help: try
    |
 LL ~         "some hello /
 LL ~         world!"
@@ -92,7 +92,7 @@ error: literal with an empty format string
 LL |         "1", "2", "3",
    |         ^^^
    |
-help: try this
+help: try
    |
 LL ~         "some 1/
 LL ~         {} // {}", "2", "3",
@@ -104,7 +104,7 @@ error: literal with an empty format string
 LL |         "1", "2", "3",
    |              ^^^
    |
-help: try this
+help: try
    |
 LL ~         2 // {}",
 LL ~         "1", "3",
@@ -116,7 +116,7 @@ error: literal with an empty format string
 LL |         "1", "2", "3",
    |                   ^^^
    |
-help: try this
+help: try
    |
 LL ~         {} // 3",
 LL ~         "1", "2",
@@ -128,7 +128,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{}", "//");
    |                       ^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{}", "//");
 LL +     writeln!(v, "//");
@@ -140,7 +140,7 @@ error: literal with an empty format string
 LL |     writeln!(v, r"{}", "//");
    |                        ^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, r"{}", "//");
 LL +     writeln!(v, r"/");
@@ -152,7 +152,7 @@ error: literal with an empty format string
 LL |     writeln!(v, r#"{}"#, "//");
    |                          ^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, r#"{}"#, "//");
 LL +     writeln!(v, r#"/"#);
@@ -164,7 +164,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{}", r"/");
    |                       ^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{}", r"/");
 LL +     writeln!(v, "//");
@@ -176,7 +176,7 @@ error: literal with an empty format string
 LL |     writeln!(v, "{}", "/r");
    |                       ^^^^
    |
-help: try this
+help: try
    |
 LL -     writeln!(v, "{}", "/r");
 LL +     writeln!(v, "/r");


### PR DESCRIPTION
Current help messages contain a mix of "try", "try this", and one "try this instead". In the spirit of #10631, this PR adopts the first, as it is the most concise.

It also updates the `lint_message_conventions` test to catch cases of "try this".

(Aside: #10120 unfairly contained multiple changes in one PR. I am trying to break that PR up into smaller pieces.)

changelog: Make help messages more concise ("try this" -> "try").
