### PR TITLE
[`arc_with_non_send_sync`]: don't lint if type has nested type parameters

### DIFF
--- a/tests/ui/arc_with_non_send_sync.rs
+++ b/tests/ui/arc_with_non_send_sync.rs
@@ -7,6 +7,9 @@ fn foo<T>(x: T) {
     // Should not lint - purposefully ignoring generic args.
     let a = Arc::new(x);
 }
+fn issue11076<T>() {
+    let a: Arc<Vec<T>> = Arc::new(Vec::new());
+}
 
 fn main() {
     // This is safe, as `i32` implements `Send` and `Sync`.

--- a/tests/ui/arc_with_non_send_sync.stderr
+++ b/tests/ui/arc_with_non_send_sync.stderr
@@ -1,5 +1,5 @@
 error: usage of `Arc<T>` where `T` is not `Send` or `Sync`
-  --> $DIR/arc_with_non_send_sync.rs:16:13
+  --> $DIR/arc_with_non_send_sync.rs:19:13
    |
 LL |     let b = Arc::new(RefCell::new(42));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #11076

changelog: [`arc_with_non_send_sync`]: don't lint if type has nested type parameters

r? @Manishearth 
