### PR TITLE
[`useless_vec`]: use the source span for initializer

### DIFF
--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -181,7 +181,7 @@ impl UselessVec {
                     if args.len() as u64 * size_of(cx, last) > self.too_large_for_stack {
                         return;
                     }
-                    let span = args[0].span.to(last.span);
+                    let span = args[0].span.source_callsite().to(last.span.source_callsite());
                     let args = snippet_with_applicability(cx, span, "..", &mut applicability);
 
                     match suggest_slice {

--- a/tests/ui/vec.fixed
+++ b/tests/ui/vec.fixed
@@ -115,6 +115,17 @@ fn main() {
     let _x = vec![1; 201];
 }
 
+fn issue11075() {
+    macro_rules! repro {
+        ($e:expr) => {
+            stringify!($e)
+        };
+    }
+    for _string in [repro!(true), repro!(null)] {
+        unimplemented!();
+    }
+}
+
 #[clippy::msrv = "1.53"]
 fn above() {
     for a in [1, 2, 3] {

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -115,6 +115,17 @@ fn main() {
     let _x = vec![1; 201];
 }
 
+fn issue11075() {
+    macro_rules! repro {
+        ($e:expr) => {
+            stringify!($e)
+        };
+    }
+    for _string in vec![repro!(true), repro!(null)] {
+        unimplemented!();
+    }
+}
+
 #[clippy::msrv = "1.53"]
 fn above() {
     for a in vec![1, 2, 3] {

--- a/tests/ui/vec.stderr
+++ b/tests/ui/vec.stderr
@@ -85,16 +85,22 @@ LL |     for _ in vec![1, 2, 3] {}
    |              ^^^^^^^^^^^^^ help: you can use an array directly: `[1, 2, 3]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:120:14
+  --> $DIR/vec.rs:124:20
+   |
+LL |     for _string in vec![repro!(true), repro!(null)] {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly: `[repro!(true), repro!(null)]`
+
+error: useless use of `vec!`
+  --> $DIR/vec.rs:131:14
    |
 LL |     for a in vec![1, 2, 3] {
    |              ^^^^^^^^^^^^^ help: you can use an array directly: `[1, 2, 3]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:124:14
+  --> $DIR/vec.rs:135:14
    |
 LL |     for a in vec![String::new(), String::new()] {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly: `[String::new(), String::new()]`
 
-error: aborting due to 16 previous errors
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
Fixes #11075.

changelog: [`useless_vec`]: use the source span for the initializer expression when inside of a macro