### PR TITLE
[`incorrect_clone_impl_on_copy_type`]: Do not lint if only has `MaybeUninit` fields

### DIFF
--- a/clippy_lints/src/incorrect_impls.rs
+++ b/clippy_lints/src/incorrect_impls.rs
@@ -161,16 +161,19 @@ impl LateLintPass<'_> for IncorrectImpls {
                         // `MaybeUninit<T>`
                         ty::Adt(_, _) if is_type_lang_item(cx, ty, LangItem::MaybeUninit) => true,
                         // `[MaybeUninit<T>; N]`
-                        ty::Array(inner_ty, _) | ty::Slice(inner_ty)
-                            if is_type_lang_item(cx, *inner_ty, LangItem::MaybeUninit) =>
-                        {
-                            true
+                        ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
+                            is_type_lang_item(cx, *inner_ty, LangItem::MaybeUninit)
                         },
                         // Other cases are likely pretty rare.
                         _ => false,
                     }
                 })
             {
+                return;
+            }
+
+            // Skip `never`-like enums
+            if def.is_enum() && def.variants().is_empty() {
                 return;
             }
 

--- a/tests/ui/incorrect_clone_impl_on_copy_type.fixed
+++ b/tests/ui/incorrect_clone_impl_on_copy_type.fixed
@@ -95,3 +95,14 @@ impl<A: Copy> Clone for Uwu<A> {
 }
 
 impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
+
+// do not lint if type has only `MaybeUninit` fields
+struct G([std::mem::MaybeUninit<u32>; 100]);
+
+impl Clone for G {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+impl Copy for G {}

--- a/tests/ui/incorrect_clone_impl_on_copy_type.fixed
+++ b/tests/ui/incorrect_clone_impl_on_copy_type.fixed
@@ -96,7 +96,8 @@ impl<A: Copy> Clone for Uwu<A> {
 
 impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
 
-// do not lint if type has only `MaybeUninit` fields
+// do not lint if type has only `MaybeUninit` fields, #11072
+
 struct G([std::mem::MaybeUninit<u32>; 100]);
 
 impl Clone for G {
@@ -106,3 +107,15 @@ impl Clone for G {
 }
 
 impl Copy for G {}
+
+// do not lint `never`-like enums, #11071
+
+enum H {}
+
+impl Clone for H {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+impl Copy for H {}

--- a/tests/ui/incorrect_clone_impl_on_copy_type.rs
+++ b/tests/ui/incorrect_clone_impl_on_copy_type.rs
@@ -106,7 +106,8 @@ impl<A: Copy> Clone for Uwu<A> {
 
 impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
 
-// do not lint if type has only `MaybeUninit` fields
+// do not lint if type has only `MaybeUninit` fields, #11072
+
 struct G([std::mem::MaybeUninit<u32>; 100]);
 
 impl Clone for G {
@@ -116,3 +117,15 @@ impl Clone for G {
 }
 
 impl Copy for G {}
+
+// do not lint `never`-like enums, #11071
+
+enum H {}
+
+impl Clone for H {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+impl Copy for H {}

--- a/tests/ui/incorrect_clone_impl_on_copy_type.rs
+++ b/tests/ui/incorrect_clone_impl_on_copy_type.rs
@@ -105,3 +105,14 @@ impl<A: Copy> Clone for Uwu<A> {
 }
 
 impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
+
+// do not lint if type has only `MaybeUninit` fields
+struct G([std::mem::MaybeUninit<u32>; 100]);
+
+impl Clone for G {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+impl Copy for G {}

--- a/tests/ui/incorrect_clone_impl_on_copy_type.stderr
+++ b/tests/ui/incorrect_clone_impl_on_copy_type.stderr
@@ -7,7 +7,7 @@ LL | |         Self(self.0)
 LL | |     }
    | |_____^ help: change this to: `{ *self }`
    |
-   = note: `#[deny(clippy::incorrect_clone_impl_on_copy_type)]` on by default
+   = note: `-D clippy::incorrect-clone-impl-on-copy-type` implied by `-D warnings`
 
 error: incorrect implementation of `clone_from` on a `Copy` type
   --> $DIR/incorrect_clone_impl_on_copy_type.rs:14:5


### PR DESCRIPTION
Closes #11072
Closes #11071

changelog: Enhancement: [`incorrect_clone_impl_on_copy_type`]: Do not lint if only has `MaybeUninit` fields
changelog: Enhancement: [`incorrect_clone_impl_on_copy_type`]: Downgrade to `complexity`
changelog: Enhancement: [`incorrect_clone_impl_on_copy_type`]: Do not lint `never`-like enums