### PR TITLE
[`useless_vec`]: add more tests and don't lint inside of macros

### DIFF
--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -154,6 +154,10 @@ impl UselessVec {
         span: Span,
         suggest_slice: SuggestedType,
     ) {
+        if span.from_expansion() {
+            return;
+        }
+
         let mut applicability = Applicability::MachineApplicable;
 
         let snippet = match *vec_args {

--- a/tests/ui/vec.fixed
+++ b/tests/ui/vec.fixed
@@ -124,6 +124,35 @@ fn issue11075() {
     for _string in [repro!(true), repro!(null)] {
         unimplemented!();
     }
+
+    macro_rules! in_macro {
+        ($e:expr, $vec:expr, $vec2:expr) => {{
+            vec![1; 2].fill(3);
+            vec![1, 2].fill(3);
+            for _ in vec![1, 2] {}
+            for _ in vec![1; 2] {}
+            for _ in vec![$e, $e] {}
+            for _ in vec![$e; 2] {}
+            for _ in $vec {}
+            for _ in $vec2 {}
+        }};
+    }
+
+    in_macro!(1, [1, 2], [1; 2]);
+
+    macro_rules! from_macro {
+        () => {
+            vec![1, 2, 3]
+        };
+    }
+    macro_rules! from_macro_repeat {
+        () => {
+            vec![1; 3]
+        };
+    }
+
+    for _ in from_macro!() {}
+    for _ in from_macro_repeat!() {}
 }
 
 #[clippy::msrv = "1.53"]

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -124,6 +124,35 @@ fn issue11075() {
     for _string in vec![repro!(true), repro!(null)] {
         unimplemented!();
     }
+
+    macro_rules! in_macro {
+        ($e:expr, $vec:expr, $vec2:expr) => {{
+            vec![1; 2].fill(3);
+            vec![1, 2].fill(3);
+            for _ in vec![1, 2] {}
+            for _ in vec![1; 2] {}
+            for _ in vec![$e, $e] {}
+            for _ in vec![$e; 2] {}
+            for _ in $vec {}
+            for _ in $vec2 {}
+        }};
+    }
+
+    in_macro!(1, vec![1, 2], vec![1; 2]);
+
+    macro_rules! from_macro {
+        () => {
+            vec![1, 2, 3]
+        };
+    }
+    macro_rules! from_macro_repeat {
+        () => {
+            vec![1; 3]
+        };
+    }
+
+    for _ in from_macro!() {}
+    for _ in from_macro_repeat!() {}
 }
 
 #[clippy::msrv = "1.53"]

--- a/tests/ui/vec.stderr
+++ b/tests/ui/vec.stderr
@@ -91,16 +91,28 @@ LL |     for _string in vec![repro!(true), repro!(null)] {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly: `[repro!(true), repro!(null)]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:131:14
+  --> $DIR/vec.rs:141:18
+   |
+LL |     in_macro!(1, vec![1, 2], vec![1; 2]);
+   |                  ^^^^^^^^^^ help: you can use an array directly: `[1, 2]`
+
+error: useless use of `vec!`
+  --> $DIR/vec.rs:141:30
+   |
+LL |     in_macro!(1, vec![1, 2], vec![1; 2]);
+   |                              ^^^^^^^^^^ help: you can use an array directly: `[1; 2]`
+
+error: useless use of `vec!`
+  --> $DIR/vec.rs:160:14
    |
 LL |     for a in vec![1, 2, 3] {
    |              ^^^^^^^^^^^^^ help: you can use an array directly: `[1, 2, 3]`
 
 error: useless use of `vec!`
-  --> $DIR/vec.rs:135:14
+  --> $DIR/vec.rs:164:14
    |
 LL |     for a in vec![String::new(), String::new()] {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can use an array directly: `[String::new(), String::new()]`
 
-error: aborting due to 17 previous errors
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
Closes #11084.

I realized that the fix I added in #11081 itself also causes an error in a suggestion when inside of a macro. Example:
```rs
macro_rules! x {
  () => {
    for _ in vec![1, 2] {}
  }
}
x!();
```
Here it would suggest replacing `vec![1, 2]` with `[x!()]`, because that's what the source callsite is (reminder: it does this to get the correct span of `x!()` for code like `for _ in vec![x!()]`), but that's wrong when *inside* macros, so I decided to make it not lint if the whole loop construct is inside a macro to avoid this issue.

changelog: [`useless_vec`]: add more tests and don't lint inside of macros

r? @Alexendoo since these were your tests, I figured it makes most sense to assign you