### PR TITLE
[`unnecessary_literal_unwrap`]: Fix ICE on None.unwrap_or_default()

### DIFF
--- a/tests/ui/unnecessary_literal_unwrap.fixed
+++ b/tests/ui/unnecessary_literal_unwrap.fixed
@@ -19,9 +19,11 @@ fn unwrap_option_some() {
 fn unwrap_option_none() {
     let _val = panic!();
     let _val = panic!("this always happens");
+    let _val: String = String::default();
 
     panic!();
     panic!("this always happens");
+    String::default();
 }
 
 fn unwrap_result_ok() {

--- a/tests/ui/unnecessary_literal_unwrap.fixed
+++ b/tests/ui/unnecessary_literal_unwrap.fixed
@@ -16,14 +16,23 @@ fn unwrap_option_some() {
     1;
 }
 
+#[rustfmt::skip] // force rustfmt not to remove braces in `|| { 234 }`
 fn unwrap_option_none() {
     let _val = panic!();
     let _val = panic!("this always happens");
     let _val: String = String::default();
+    let _val: u16 = 234;
+    let _val: u16 = 234;
+    let _val: u16 = { 234 };
+    let _val: u16 =  { 234 };
 
     panic!();
     panic!("this always happens");
     String::default();
+    234;
+    234;
+    { 234 };
+     { 234 };
 }
 
 fn unwrap_result_ok() {

--- a/tests/ui/unnecessary_literal_unwrap.rs
+++ b/tests/ui/unnecessary_literal_unwrap.rs
@@ -19,9 +19,11 @@ fn unwrap_option_some() {
 fn unwrap_option_none() {
     let _val = None::<()>.unwrap();
     let _val = None::<()>.expect("this always happens");
+    let _val: String = None.unwrap_or_default();
 
     None::<()>.unwrap();
     None::<()>.expect("this always happens");
+    None::<String>.unwrap_or_default();
 }
 
 fn unwrap_result_ok() {

--- a/tests/ui/unnecessary_literal_unwrap.rs
+++ b/tests/ui/unnecessary_literal_unwrap.rs
@@ -16,14 +16,23 @@ fn unwrap_option_some() {
     Some(1).expect("this never happens");
 }
 
+#[rustfmt::skip] // force rustfmt not to remove braces in `|| { 234 }`
 fn unwrap_option_none() {
     let _val = None::<()>.unwrap();
     let _val = None::<()>.expect("this always happens");
     let _val: String = None.unwrap_or_default();
+    let _val: u16 = None.unwrap_or(234);
+    let _val: u16 = None.unwrap_or_else(|| 234);
+    let _val: u16 = None.unwrap_or_else(|| { 234 });
+    let _val: u16 = None.unwrap_or_else(|| -> u16 { 234 });
 
     None::<()>.unwrap();
     None::<()>.expect("this always happens");
     None::<String>.unwrap_or_default();
+    None::<u16>.unwrap_or(234);
+    None::<u16>.unwrap_or_else(|| 234);
+    None::<u16>.unwrap_or_else(|| { 234 });
+    None::<u16>.unwrap_or_else(|| -> u16 { 234 });
 }
 
 fn unwrap_result_ok() {

--- a/tests/ui/unnecessary_literal_unwrap.stderr
+++ b/tests/ui/unnecessary_literal_unwrap.stderr
@@ -48,13 +48,13 @@ LL +     1;
    |
 
 error: used `unwrap()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:20:16
+  --> $DIR/unnecessary_literal_unwrap.rs:21:16
    |
 LL |     let _val = None::<()>.unwrap();
    |                ^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap()`: `panic!()`
 
 error: used `expect()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:21:16
+  --> $DIR/unnecessary_literal_unwrap.rs:22:16
    |
 LL |     let _val = None::<()>.expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,19 +65,67 @@ LL |     let _val = panic!("this always happens");
    |                ~~~~~~~                     ~
 
 error: used `unwrap_or_default()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:22:24
+  --> $DIR/unnecessary_literal_unwrap.rs:23:24
    |
 LL |     let _val: String = None.unwrap_or_default();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
 
+error: used `unwrap_or()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:24:21
+   |
+LL |     let _val: u16 = None.unwrap_or(234);
+   |                     ^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or()`
+   |
+LL -     let _val: u16 = None.unwrap_or(234);
+LL +     let _val: u16 = 234;
+   |
+
+error: used `unwrap_or_else()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:25:21
+   |
+LL |     let _val: u16 = None.unwrap_or_else(|| 234);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_else()`
+   |
+LL -     let _val: u16 = None.unwrap_or_else(|| 234);
+LL +     let _val: u16 = 234;
+   |
+
+error: used `unwrap_or_else()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:26:21
+   |
+LL |     let _val: u16 = None.unwrap_or_else(|| { 234 });
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_else()`
+   |
+LL -     let _val: u16 = None.unwrap_or_else(|| { 234 });
+LL +     let _val: u16 = { 234 };
+   |
+
+error: used `unwrap_or_else()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:27:21
+   |
+LL |     let _val: u16 = None.unwrap_or_else(|| -> u16 { 234 });
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_else()`
+   |
+LL -     let _val: u16 = None.unwrap_or_else(|| -> u16 { 234 });
+LL +     let _val: u16 =  { 234 };
+   |
+
 error: used `unwrap()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:24:5
+  --> $DIR/unnecessary_literal_unwrap.rs:29:5
    |
 LL |     None::<()>.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap()`: `panic!()`
 
 error: used `expect()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:25:5
+  --> $DIR/unnecessary_literal_unwrap.rs:30:5
    |
 LL |     None::<()>.expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,13 +136,61 @@ LL |     panic!("this always happens");
    |     ~~~~~~~                     ~
 
 error: used `unwrap_or_default()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:26:5
+  --> $DIR/unnecessary_literal_unwrap.rs:31:5
    |
 LL |     None::<String>.unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
 
+error: used `unwrap_or()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:32:5
+   |
+LL |     None::<u16>.unwrap_or(234);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or()`
+   |
+LL -     None::<u16>.unwrap_or(234);
+LL +     234;
+   |
+
+error: used `unwrap_or_else()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:33:5
+   |
+LL |     None::<u16>.unwrap_or_else(|| 234);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_else()`
+   |
+LL -     None::<u16>.unwrap_or_else(|| 234);
+LL +     234;
+   |
+
+error: used `unwrap_or_else()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:34:5
+   |
+LL |     None::<u16>.unwrap_or_else(|| { 234 });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_else()`
+   |
+LL -     None::<u16>.unwrap_or_else(|| { 234 });
+LL +     { 234 };
+   |
+
+error: used `unwrap_or_else()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:35:5
+   |
+LL |     None::<u16>.unwrap_or_else(|| -> u16 { 234 });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the `None` and `unwrap_or_else()`
+   |
+LL -     None::<u16>.unwrap_or_else(|| -> u16 { 234 });
+LL +      { 234 };
+   |
+
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:30:16
+  --> $DIR/unnecessary_literal_unwrap.rs:39:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,7 +202,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:31:16
+  --> $DIR/unnecessary_literal_unwrap.rs:40:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +214,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:32:16
+  --> $DIR/unnecessary_literal_unwrap.rs:41:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +225,7 @@ LL |     let _val = panic!("{:?}", 1);
    |                ~~~~~~~~~~~~~~  ~
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:33:16
+  --> $DIR/unnecessary_literal_unwrap.rs:42:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +236,7 @@ LL |     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |                ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:35:5
+  --> $DIR/unnecessary_literal_unwrap.rs:44:5
    |
 LL |     Ok::<_, ()>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -152,7 +248,7 @@ LL +     1;
    |
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:36:5
+  --> $DIR/unnecessary_literal_unwrap.rs:45:5
    |
 LL |     Ok::<_, ()>(1).expect("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +260,7 @@ LL +     1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:37:5
+  --> $DIR/unnecessary_literal_unwrap.rs:46:5
    |
 LL |     Ok::<_, ()>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,7 +271,7 @@ LL |     panic!("{:?}", 1);
    |     ~~~~~~~~~~~~~~  ~
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:38:5
+  --> $DIR/unnecessary_literal_unwrap.rs:47:5
    |
 LL |     Ok::<_, ()>(1).expect_err("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -186,7 +282,7 @@ LL |     panic!("{1}: {:?}", 1, "this always happens");
    |     ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:42:16
+  --> $DIR/unnecessary_literal_unwrap.rs:51:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -198,7 +294,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:43:16
+  --> $DIR/unnecessary_literal_unwrap.rs:52:16
    |
 LL |     let _val = Err::<(), _>(1).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +306,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:44:16
+  --> $DIR/unnecessary_literal_unwrap.rs:53:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,7 +317,7 @@ LL |     let _val = panic!("{:?}", 1);
    |                ~~~~~~~~~~~~~~  ~
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:45:16
+  --> $DIR/unnecessary_literal_unwrap.rs:54:16
    |
 LL |     let _val = Err::<(), _>(1).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -232,7 +328,7 @@ LL |     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |                ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:47:5
+  --> $DIR/unnecessary_literal_unwrap.rs:56:5
    |
 LL |     Err::<(), _>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,7 +340,7 @@ LL +     1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:48:5
+  --> $DIR/unnecessary_literal_unwrap.rs:57:5
    |
 LL |     Err::<(), _>(1).expect_err("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -256,7 +352,7 @@ LL +     1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:49:5
+  --> $DIR/unnecessary_literal_unwrap.rs:58:5
    |
 LL |     Err::<(), _>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -267,7 +363,7 @@ LL |     panic!("{:?}", 1);
    |     ~~~~~~~~~~~~~~  ~
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:50:5
+  --> $DIR/unnecessary_literal_unwrap.rs:59:5
    |
 LL |     Err::<(), _>(1).expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -278,7 +374,7 @@ LL |     panic!("{1}: {:?}", 1, "this always happens");
    |     ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:54:16
+  --> $DIR/unnecessary_literal_unwrap.rs:63:16
    |
 LL |     let _val = Some(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -290,7 +386,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:55:16
+  --> $DIR/unnecessary_literal_unwrap.rs:64:16
    |
 LL |     let _val = Some(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +398,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:56:16
+  --> $DIR/unnecessary_literal_unwrap.rs:65:16
    |
 LL |     let _val = Some(1).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -314,7 +410,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:58:5
+  --> $DIR/unnecessary_literal_unwrap.rs:67:5
    |
 LL |     Some(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -326,7 +422,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:59:5
+  --> $DIR/unnecessary_literal_unwrap.rs:68:5
    |
 LL |     Some(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -338,7 +434,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:60:5
+  --> $DIR/unnecessary_literal_unwrap.rs:69:5
    |
 LL |     Some(1).unwrap_or_else(|| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,7 +446,7 @@ LL +     1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:64:16
+  --> $DIR/unnecessary_literal_unwrap.rs:73:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -362,7 +458,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:65:16
+  --> $DIR/unnecessary_literal_unwrap.rs:74:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -374,7 +470,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:66:16
+  --> $DIR/unnecessary_literal_unwrap.rs:75:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -386,7 +482,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:68:5
+  --> $DIR/unnecessary_literal_unwrap.rs:77:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -398,7 +494,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:69:5
+  --> $DIR/unnecessary_literal_unwrap.rs:78:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -410,7 +506,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:70:5
+  --> $DIR/unnecessary_literal_unwrap.rs:79:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +518,7 @@ LL +     1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:84:22
+  --> $DIR/unnecessary_literal_unwrap.rs:93:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -434,7 +530,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:85:22
+  --> $DIR/unnecessary_literal_unwrap.rs:94:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() + *(&1 as *const i32) }; // needs to keep the unsafe block
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -446,7 +542,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) }; // needs to keep the unsafe
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:86:22
+  --> $DIR/unnecessary_literal_unwrap.rs:95:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -458,7 +554,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:87:22
+  --> $DIR/unnecessary_literal_unwrap.rs:96:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -470,7 +566,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:88:22
+  --> $DIR/unnecessary_literal_unwrap.rs:97:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() + *(&1 as *const i32) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -482,7 +578,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) };
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:89:22
+  --> $DIR/unnecessary_literal_unwrap.rs:98:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -494,7 +590,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_err_unchecked()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:90:22
+  --> $DIR/unnecessary_literal_unwrap.rs:99:22
    |
 LL |     let _ = unsafe { Err::<(), i32>(123).unwrap_err_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -505,5 +601,5 @@ LL -     let _ = unsafe { Err::<(), i32>(123).unwrap_err_unchecked() };
 LL +     let _ = 123;
    |
 
-error: aborting due to 45 previous errors
+error: aborting due to 53 previous errors
 

--- a/tests/ui/unnecessary_literal_unwrap.stderr
+++ b/tests/ui/unnecessary_literal_unwrap.stderr
@@ -64,14 +64,20 @@ help: remove the `None` and `expect()`
 LL |     let _val = panic!("this always happens");
    |                ~~~~~~~                     ~
 
+error: used `unwrap_or_default()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:22:24
+   |
+LL |     let _val: String = None.unwrap_or_default();
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
+
 error: used `unwrap()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:23:5
+  --> $DIR/unnecessary_literal_unwrap.rs:24:5
    |
 LL |     None::<()>.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap()`: `panic!()`
 
 error: used `expect()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:24:5
+  --> $DIR/unnecessary_literal_unwrap.rs:25:5
    |
 LL |     None::<()>.expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,8 +87,14 @@ help: remove the `None` and `expect()`
 LL |     panic!("this always happens");
    |     ~~~~~~~                     ~
 
+error: used `unwrap_or_default()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap.rs:26:5
+   |
+LL |     None::<String>.unwrap_or_default();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
+
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:28:16
+  --> $DIR/unnecessary_literal_unwrap.rs:30:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +106,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:29:16
+  --> $DIR/unnecessary_literal_unwrap.rs:31:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,7 +118,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:30:16
+  --> $DIR/unnecessary_literal_unwrap.rs:32:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,7 +129,7 @@ LL |     let _val = panic!("{:?}", 1);
    |                ~~~~~~~~~~~~~~  ~
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:31:16
+  --> $DIR/unnecessary_literal_unwrap.rs:33:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -128,7 +140,7 @@ LL |     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |                ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:33:5
+  --> $DIR/unnecessary_literal_unwrap.rs:35:5
    |
 LL |     Ok::<_, ()>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +152,7 @@ LL +     1;
    |
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:34:5
+  --> $DIR/unnecessary_literal_unwrap.rs:36:5
    |
 LL |     Ok::<_, ()>(1).expect("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -152,7 +164,7 @@ LL +     1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:35:5
+  --> $DIR/unnecessary_literal_unwrap.rs:37:5
    |
 LL |     Ok::<_, ()>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +175,7 @@ LL |     panic!("{:?}", 1);
    |     ~~~~~~~~~~~~~~  ~
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:36:5
+  --> $DIR/unnecessary_literal_unwrap.rs:38:5
    |
 LL |     Ok::<_, ()>(1).expect_err("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -174,7 +186,7 @@ LL |     panic!("{1}: {:?}", 1, "this always happens");
    |     ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:40:16
+  --> $DIR/unnecessary_literal_unwrap.rs:42:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -186,7 +198,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:41:16
+  --> $DIR/unnecessary_literal_unwrap.rs:43:16
    |
 LL |     let _val = Err::<(), _>(1).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -198,7 +210,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:42:16
+  --> $DIR/unnecessary_literal_unwrap.rs:44:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -209,7 +221,7 @@ LL |     let _val = panic!("{:?}", 1);
    |                ~~~~~~~~~~~~~~  ~
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:43:16
+  --> $DIR/unnecessary_literal_unwrap.rs:45:16
    |
 LL |     let _val = Err::<(), _>(1).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +232,7 @@ LL |     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |                ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:45:5
+  --> $DIR/unnecessary_literal_unwrap.rs:47:5
    |
 LL |     Err::<(), _>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -232,7 +244,7 @@ LL +     1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:46:5
+  --> $DIR/unnecessary_literal_unwrap.rs:48:5
    |
 LL |     Err::<(), _>(1).expect_err("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,7 +256,7 @@ LL +     1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:47:5
+  --> $DIR/unnecessary_literal_unwrap.rs:49:5
    |
 LL |     Err::<(), _>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -255,7 +267,7 @@ LL |     panic!("{:?}", 1);
    |     ~~~~~~~~~~~~~~  ~
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:48:5
+  --> $DIR/unnecessary_literal_unwrap.rs:50:5
    |
 LL |     Err::<(), _>(1).expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -266,7 +278,7 @@ LL |     panic!("{1}: {:?}", 1, "this always happens");
    |     ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:52:16
+  --> $DIR/unnecessary_literal_unwrap.rs:54:16
    |
 LL |     let _val = Some(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -278,7 +290,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:53:16
+  --> $DIR/unnecessary_literal_unwrap.rs:55:16
    |
 LL |     let _val = Some(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -290,7 +302,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:54:16
+  --> $DIR/unnecessary_literal_unwrap.rs:56:16
    |
 LL |     let _val = Some(1).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +314,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:56:5
+  --> $DIR/unnecessary_literal_unwrap.rs:58:5
    |
 LL |     Some(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -314,7 +326,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:57:5
+  --> $DIR/unnecessary_literal_unwrap.rs:59:5
    |
 LL |     Some(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -326,7 +338,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:58:5
+  --> $DIR/unnecessary_literal_unwrap.rs:60:5
    |
 LL |     Some(1).unwrap_or_else(|| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -338,7 +350,7 @@ LL +     1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:62:16
+  --> $DIR/unnecessary_literal_unwrap.rs:64:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -350,7 +362,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:63:16
+  --> $DIR/unnecessary_literal_unwrap.rs:65:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -362,7 +374,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:64:16
+  --> $DIR/unnecessary_literal_unwrap.rs:66:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -374,7 +386,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:66:5
+  --> $DIR/unnecessary_literal_unwrap.rs:68:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -386,7 +398,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:67:5
+  --> $DIR/unnecessary_literal_unwrap.rs:69:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -398,7 +410,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:68:5
+  --> $DIR/unnecessary_literal_unwrap.rs:70:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -410,7 +422,7 @@ LL +     1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:82:22
+  --> $DIR/unnecessary_literal_unwrap.rs:84:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -422,7 +434,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:83:22
+  --> $DIR/unnecessary_literal_unwrap.rs:85:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() + *(&1 as *const i32) }; // needs to keep the unsafe block
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -434,7 +446,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) }; // needs to keep the unsafe
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:84:22
+  --> $DIR/unnecessary_literal_unwrap.rs:86:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -446,7 +458,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:85:22
+  --> $DIR/unnecessary_literal_unwrap.rs:87:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -458,7 +470,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:86:22
+  --> $DIR/unnecessary_literal_unwrap.rs:88:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() + *(&1 as *const i32) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -470,7 +482,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) };
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:87:22
+  --> $DIR/unnecessary_literal_unwrap.rs:89:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -482,7 +494,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_err_unchecked()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:88:22
+  --> $DIR/unnecessary_literal_unwrap.rs:90:22
    |
 LL |     let _ = unsafe { Err::<(), i32>(123).unwrap_err_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -493,5 +505,5 @@ LL -     let _ = unsafe { Err::<(), i32>(123).unwrap_err_unchecked() };
 LL +     let _ = 123;
    |
 
-error: aborting due to 43 previous errors
+error: aborting due to 45 previous errors
 

--- a/tests/ui/unnecessary_literal_unwrap_unfixable.rs
+++ b/tests/ui/unnecessary_literal_unwrap_unfixable.rs
@@ -21,6 +21,8 @@ fn unwrap_option_none() {
     let val = None::<()>;
     let _val2 = val.unwrap();
     let _val2 = val.expect("this always happens");
+    let _val3: u8 = None.unwrap_or_default();
+    None::<()>.unwrap_or_default();
 }
 
 fn unwrap_result_ok() {

--- a/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
+++ b/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
@@ -95,509 +95,521 @@ help: remove the `None` and `expect()`
 LL |     let val = None::<()>;
    |               ^^^^^^^^^^
 
+error: used `unwrap_or_default()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:24:21
+   |
+LL |     let _val3: u8 = None.unwrap_or_default();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `Default::default()`
+
+error: used `unwrap_or_default()` on `None` value
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:25:5
+   |
+LL |     None::<()>.unwrap_or_default();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `Default::default()`
+
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:28:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:30:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:27:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:29:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:29:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:31:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:27:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:29:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:30:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:32:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:27:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:29:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:31:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:33:17
    |
 LL |     let _val2 = val.expect_err("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:27:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:29:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:35:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:37:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:35:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:37:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:36:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:38:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:36:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:38:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:37:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:39:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:37:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:39:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:38:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:40:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:38:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:40:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:41:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:43:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:40:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:42:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:42:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:44:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:40:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:42:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:43:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:45:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:40:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:42:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:44:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:46:17
    |
 LL |     let _val2 = val.expect_err("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:40:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:42:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:49:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:51:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:48:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:50:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:50:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:52:17
    |
 LL |     let _val2 = val.expect_err("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:48:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:50:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:51:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:53:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:48:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:50:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:52:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:54:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:48:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:50:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:56:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:58:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:56:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:58:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:57:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:59:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:57:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:59:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:58:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:60:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:58:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:60:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:59:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:59:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:62:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:64:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:63:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:63:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:65:17
    |
 LL |     let _val2 = val.expect_err("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:63:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:64:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:66:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:63:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:65:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:67:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:63:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:70:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:72:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:69:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:71:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:71:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:73:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:69:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:71:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:72:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:74:17
    |
 LL |     let _val2 = val.unwrap_or_else(|| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:69:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:71:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:76:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:78:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:76:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:78:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:77:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:79:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:77:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:79:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:78:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:80:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:78:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:80:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:81:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:83:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:80:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:82:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:82:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:84:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:80:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:82:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:83:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:85:17
    |
 LL |     let _val2 = val.unwrap_or_else(|| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:80:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:82:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:88:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:90:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:87:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:89:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:89:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:91:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:87:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:89:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:90:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:92:17
    |
 LL |     let _val2 = val.unwrap_or_else(|_| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:87:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:89:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:94:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:96:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:94:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:96:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:95:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:97:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:95:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:97:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:96:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:98:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:96:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:98:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:99:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:101:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:98:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:100:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:100:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:102:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:98:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:100:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:101:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:103:17
    |
 LL |     let _val2 = val.unwrap_or_else(|_| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:98:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:100:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 50 previous errors
+error: aborting due to 52 previous errors
 


### PR DESCRIPTION
Fixes #11099 
Fixes #11064 

I'm running into #11099 (cc @y21) on my Rust codebase. Clippy ICEs on this code when evaluating the `unnecessary_literal_unwrap` lint:
```rust
fn main() {
    let val1: u8 = None.unwrap_or_default();
}
```

This fixes that ICE and adds an message specifically for that case:

```
error: used `unwrap_or_default()` on `None` value
  --> $DIR/unnecessary_literal_unwrap.rs:26:5
   |
LL |     None::<String>.unwrap_or_default();
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
```

This PR also fixes the same ICE with `None.unwrap_or_else` (by giving the generic error message for the lint in that case).

changelog: Fix ICE in `unnecessary_literal_unwrap` on `None.unwrap_or_default()`
