### PR TITLE
[`unnecessary_literal_unwrap`]: don't lint if binding initializer comes from expansion

### DIFF
--- a/clippy_lints/src/methods/unnecessary_literal_unwrap.rs
+++ b/clippy_lints/src/methods/unnecessary_literal_unwrap.rs
@@ -29,6 +29,11 @@ pub(super) fn check(
     args: &[hir::Expr<'_>],
 ) {
     let init = clippy_utils::expr_or_init(cx, recv);
+    if init.span.from_expansion() {
+        // don't lint if the receiver or binding initializer comes from a macro
+        // (e.g. `let x = option_env!(..); x.unwrap()`)
+        return;
+    }
 
     let (constructor, call_args, ty) = if let hir::ExprKind::Call(call, call_args) = init.kind {
         let Some(qpath) = call.qpath_opt() else { return };

--- a/tests/ui/unnecessary_literal_unwrap.fixed
+++ b/tests/ui/unnecessary_literal_unwrap.fixed
@@ -68,6 +68,16 @@ fn unwrap_methods_result() {
     1;
 }
 
+fn unwrap_from_binding() {
+    macro_rules! from_macro {
+        () => {
+            Some("")
+        };
+    }
+    let val = from_macro!();
+    let _ = val.unwrap_or("");
+}
+
 fn main() {
     unwrap_option_some();
     unwrap_option_none();

--- a/tests/ui/unnecessary_literal_unwrap.rs
+++ b/tests/ui/unnecessary_literal_unwrap.rs
@@ -68,6 +68,16 @@ fn unwrap_methods_result() {
     Ok::<_, ()>(1).unwrap_or_else(|_| 2);
 }
 
+fn unwrap_from_binding() {
+    macro_rules! from_macro {
+        () => {
+            Some("")
+        };
+    }
+    let val = from_macro!();
+    let _ = val.unwrap_or("");
+}
+
 fn main() {
     unwrap_option_some();
     unwrap_option_none();


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/discussions/11109

changelog: [`unnecessary_literal_unwrap`]: don't lint if binding initializer comes from expansion