### PR TITLE
Fix typo in `needless_pass_by_ref_mut` lint description

### DIFF
--- a/clippy_lints/src/needless_pass_by_ref_mut.rs
+++ b/clippy_lints/src/needless_pass_by_ref_mut.rs
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// ### What it does
     /// Check if a `&mut` function argument is actually used mutably.
     ///
-    /// Be careful if the function is publically reexported as it would break compatibility with
+    /// Be careful if the function is publicly reexported as it would break compatibility with
     /// users of this function.
     ///
     /// ### Why is this bad?


### PR DESCRIPTION
Someone nicely showed me that I made a small typo in https://github.com/rust-lang/rust-clippy/pull/10900.

changelog: none