### PR TITLE
[`tuple_array_conversions`]: move from `complexity` to `nursery`

### DIFF
--- a/clippy_lints/src/tuple_array_conversions.rs
+++ b/clippy_lints/src/tuple_array_conversions.rs
@@ -16,8 +16,8 @@ declare_clippy_lint! {
     /// Checks for tuple<=>array conversions that are not done with `.into()`.
     ///
     /// ### Why is this bad?
-    /// It's unnecessary complexity. `.into()` works for tuples<=>arrays at or below 12 elements and
-    /// conveys the intent a lot better, while also leaving less room for hard to spot bugs!
+    /// It may be unnecessary complexity. `.into()` works for converting tuples
+    /// <=> arrays of up to 12 elements and may convey intent more clearly.
     ///
     /// ### Example
     /// ```rust,ignore
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.72.0"]
     pub TUPLE_ARRAY_CONVERSIONS,
-    complexity,
+    pedantic,
     "checks for tuple<=>array conversions that are not done with `.into()`"
 }
 impl_lint_pass!(TupleArrayConversions => [TUPLE_ARRAY_CONVERSIONS]);


### PR DESCRIPTION
The lint suggestion is arguably often less readable and more complex than the original code.

For example, which of the following is the most readable:
```rust
let _vertices = edges.flat_map(|(src, dst)| [src, dst]);
let _vertices = edges.flat_map(<_ as Into<[i32; 2]>>::into);
let _vertices = edges.flat_map(<[i32; 2]>::from);
```

The lint can be useful, but really only applies if the tuple is either long enough that naming the fields is silly (maybe at least 4 entries long), or if the author intends the fields to be homogenous, which is author intent and can't be determined by the lint. Therefore I think the lint should be marked as pedantic.

Currently, there are also a lot of false positives with the lint:
* https://github.com/rust-lang/rust-clippy/issues/11082
* https://github.com/rust-lang/rust-clippy/issues/11085
* https://github.com/rust-lang/rust-clippy/issues/11100 (https://github.com/rust-lang/rust-clippy/pull/11105)
* https://github.com/rust-lang/rust-clippy/issues/11124
* https://github.com/rust-lang/rust-clippy/issues/11144

Should fix those issues before enabling it for everyone.

---

changelog: Move [`tuple_array_conversions`] to `nursery` (Now allow-by-default)
<!-- FIY: Ignore this change, if the commit gets backported -->
[#11146](https://github.com/rust-lang/rust-clippy/pull/11146)

