### PR TITLE
[`arithmetic_side_effect`]: allow different types on the right hand side for `Wrapping<T>`

### DIFF
--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -19,8 +19,8 @@ use rustc_span::{
 const HARD_CODED_ALLOWED_BINARY: &[[&str; 2]] = &[
     ["f32", "f32"],
     ["f64", "f64"],
-    ["std::num::Saturating", "std::num::Saturating"],
-    ["std::num::Wrapping", "std::num::Wrapping"],
+    ["std::num::Saturating", "*"],
+    ["std::num::Wrapping", "*"],
     ["std::string::String", "str"],
 ];
 const HARD_CODED_ALLOWED_UNARY: &[&str] = &["f32", "f64", "std::num::Saturating", "std::num::Wrapping"];

--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -481,4 +481,9 @@ pub fn issue_10792() {
     let _ = 10 / TWO.c;
 }
 
+pub fn issue_11145() {
+    let mut x: Wrapping<u32> = Wrapping(0_u32);
+    x += 1;
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes #11145

This lint has a list of allowed types, one of which is `Wrapping<T>`, but it was only actually allowed if the type on the right hand side was also `Wrapping<T>`, which meant that, for example, `Wrapping<u32> += u32` would still lint. It now allows binary ops involving `Wrapping<T>` regardless of the type on the rhs.
These impls have only existed since Rust 1.60.0, so that is probably why the lint was previously not handling this correctly

changelog: [`arithmetic_side_effect`]: allow different types on the right hand side for `Wrapping<T>` (e.g. `Wrapping<T> += T`)