### PR TITLE
Add "Known problems" section to `needless_borrow` documentation

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -77,6 +77,11 @@ declare_clippy_lint! {
     /// Suggests that the receiver of the expression borrows
     /// the expression.
     ///
+    /// ### Known problems
+    /// The lint cannot tell when the implementation of a trait
+    /// for `&T` and `T` do different things. Removing a borrow
+    /// in such a case can change the semantics of the code.
+    ///
     /// ### Example
     /// ```rust
     /// fn fun(_a: &i32) {}


### PR DESCRIPTION
While this PR doesn't fix the issue in #11142, it at least communicates that this is a known limitation.

r? @Jarcho

changelog: Add "Known problems" section to `needless_borrow` documentation