### PR TITLE
Update bug URL to use the ice template

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -192,7 +192,7 @@ You can use tool lints to allow or deny lints from your code, eg.:
     );
 }
 
-const BUG_REPORT_URL: &str = "https://github.com/rust-lang/rust-clippy/issues/new";
+const BUG_REPORT_URL: &str = "https://github.com/rust-lang/rust-clippy/issues/new?template=ice.yml";
 
 #[allow(clippy::too_many_lines)]
 pub fn main() {

--- a/tests/ui-internal/custom_ice_message.stderr
+++ b/tests/ui-internal/custom_ice_message.stderr
@@ -3,7 +3,7 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 error: the compiler unexpectedly panicked. this is a bug.
 
-note: we would appreciate a bug report: https://github.com/rust-lang/rust-clippy/issues/new
+note: we would appreciate a bug report: https://github.com/rust-lang/rust-clippy/issues/new?template=ice.yml
 
 note: rustc <version> running on <target>
 


### PR DESCRIPTION
The previous URL linked to the blank new issue from without any template. This will now link to the ICE template :)

* Before: https://github.com/rust-lang/rust-clippy/issues/new
* After: https://github.com/rust-lang/rust-clippy/issues/new?template=ice.yml

That's it, nothing too interesting besides that. For everyone reading this: here, have some free cream :ice_cream: :icecream: and have a beautiful day. :upside_down_face: 

changelog: none