### PR TITLE
don't hide lifetimes for `LateContext`

### DIFF
--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -358,6 +358,10 @@ fn create_lint_for_ty(lint: &LintData<'_>, enable_msrv: bool, ty: &str) -> io::R
 
     let mod_file_path = ty_dir.join("mod.rs");
     let context_import = setup_mod_file(&mod_file_path, lint)?;
+    let pass_lifetimes = match context_import {
+        "LateContext" => "<'_>",
+        _ => "",
+    };
 
     let name_upper = lint.name.to_uppercase();
     let mut lint_file_contents = String::new();
@@ -372,7 +376,7 @@ fn create_lint_for_ty(lint: &LintData<'_>, enable_msrv: bool, ty: &str) -> io::R
                 use super::{name_upper};
 
                 // TODO: Adjust the parameters as necessary
-                pub(super) fn check(cx: &{context_import}, msrv: &Msrv) {{
+                pub(super) fn check(cx: &{context_import}{pass_lifetimes}, msrv: &Msrv) {{
                     if !msrv.meets(todo!("Add a new entry in `clippy_utils/src/msrvs`")) {{
                         return;
                     }}
@@ -389,7 +393,7 @@ fn create_lint_for_ty(lint: &LintData<'_>, enable_msrv: bool, ty: &str) -> io::R
                 use super::{name_upper};
 
                 // TODO: Adjust the parameters as necessary
-                pub(super) fn check(cx: &{context_import}) {{
+                pub(super) fn check(cx: &{context_import}{pass_lifetimes}) {{
                     todo!();
                 }}
            "#


### PR DESCRIPTION
Running `cargo dev new_lint --type methods` creates the lint file with hidden lifetimes for the `LateContext` parameter (i.e. `&LateContext`, when it should be `&LateContext<'_>`). This is already warned on with `#![warn(rust_2018_idioms)]`, so clippy should not use hidden lifetimes

changelog: none