### PR TITLE
Move tuple_array_conversions to nursery

### DIFF
--- a/clippy_lints/src/tuple_array_conversions.rs
+++ b/clippy_lints/src/tuple_array_conversions.rs
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.72.0"]
     pub TUPLE_ARRAY_CONVERSIONS,
-    pedantic,
+    nursery,
     "checks for tuple<=>array conversions that are not done with `.into()`"
 }
 impl_lint_pass!(TupleArrayConversions => [TUPLE_ARRAY_CONVERSIONS]);


### PR DESCRIPTION
changelog: Move [`tuple_array_conversions`] to `nursery` (Now allow-by-default)
<!-- FIY: Ignore this change, if the commit gets backported and also https://github.com/rust-lang/rust-clippy/pull/11146 -->
[#11172](https://github.com/rust-lang/rust-clippy/pull/11172)

The nursery change got lost in #11146 and it ended up in pedantic, this puts it in nursery and gives something to backport

r? @xFrednet