### PR TITLE
Don't lint `needless_return` in fns across a macro boundary

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -174,6 +174,10 @@ impl<'tcx> LateLintPass<'tcx> for Return {
         sp: Span,
         _: LocalDefId,
     ) {
+        if sp.from_expansion() {
+            return;
+        }
+
         match kind {
             FnKind::Closure => {
                 // when returning without value in closure, replace this `return`

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -169,4 +169,14 @@ mod issue_5729 {
     }
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/11167
+macro_rules! fn_in_macro {
+    ($b:block) => {
+        fn f() -> usize $b
+    }
+}
+fn_in_macro!({
+    return 1;
+});
+
 fn main() {}


### PR DESCRIPTION
Fixes #11167

changelog: none
