### PR TITLE
Remove `#![allow(unused)]` and `--crate-name` from `cargo dev new_lint` generated tests

### DIFF
--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -96,8 +96,7 @@ fn create_test(lint: &LintData<'_>) -> io::Result<()> {
 
         path.push("src");
         fs::create_dir(&path)?;
-        let header = format!("//@compile-flags: --crate-name={lint_name}");
-        write_file(path.join("main.rs"), get_test_file_contents(lint_name, Some(&header)))?;
+        write_file(path.join("main.rs"), get_test_file_contents(lint_name))?;
 
         Ok(())
     }
@@ -113,7 +112,7 @@ fn create_test(lint: &LintData<'_>) -> io::Result<()> {
         println!("Generated test directories: `{relative_test_dir}/pass`, `{relative_test_dir}/fail`");
     } else {
         let test_path = format!("tests/ui/{}.rs", lint.name);
-        let test_contents = get_test_file_contents(lint.name, None);
+        let test_contents = get_test_file_contents(lint.name);
         write_file(lint.project_root.join(&test_path), test_contents)?;
 
         println!("Generated test file: `{test_path}`");
@@ -195,23 +194,16 @@ pub(crate) fn get_stabilization_version() -> String {
     parse_manifest(&contents).expect("Unable to find package version in `Cargo.toml`")
 }
 
-fn get_test_file_contents(lint_name: &str, header_commands: Option<&str>) -> String {
-    let mut contents = formatdoc!(
+fn get_test_file_contents(lint_name: &str) -> String {
+    formatdoc!(
         r#"
-        #![allow(unused)]
         #![warn(clippy::{lint_name})]
 
         fn main() {{
             // test code goes here
         }}
     "#
-    );
-
-    if let Some(header) = header_commands {
-        contents = format!("{header}\n{contents}");
-    }
-
-    contents
+    )
 }
 
 fn get_manifest_contents(lint_name: &str, hint: &str) -> String {

--- a/tests/ui-cargo/cargo_common_metadata/fail/src/main.rs
+++ b/tests/ui-cargo/cargo_common_metadata/fail/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=cargo_common_metadata
 #![warn(clippy::cargo_common_metadata)]
 
 fn main() {}

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish/src/main.rs
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=cargo_common_metadata
 #![warn(clippy::cargo_common_metadata)]
 
 fn main() {}

--- a/tests/ui-cargo/cargo_common_metadata/fail_publish_true/src/main.rs
+++ b/tests/ui-cargo/cargo_common_metadata/fail_publish_true/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=cargo_common_metadata
 #![warn(clippy::cargo_common_metadata)]
 
 fn main() {}

--- a/tests/ui-cargo/cargo_common_metadata/pass/src/main.rs
+++ b/tests/ui-cargo/cargo_common_metadata/pass/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=cargo_common_metadata
 #![warn(clippy::cargo_common_metadata)]
 
 fn main() {}

--- a/tests/ui-cargo/cargo_common_metadata/pass_publish_empty/src/main.rs
+++ b/tests/ui-cargo/cargo_common_metadata/pass_publish_empty/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=cargo_common_metadata
 #![warn(clippy::cargo_common_metadata)]
 
 fn main() {}

--- a/tests/ui-cargo/cargo_common_metadata/pass_publish_false/src/main.rs
+++ b/tests/ui-cargo/cargo_common_metadata/pass_publish_false/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=cargo_common_metadata
 #![warn(clippy::cargo_common_metadata)]
 
 fn main() {}

--- a/tests/ui-cargo/feature_name/fail/src/main.rs
+++ b/tests/ui-cargo/feature_name/fail/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=feature_name
 #![warn(clippy::redundant_feature_names)]
 #![warn(clippy::negative_feature_names)]
 

--- a/tests/ui-cargo/feature_name/pass/src/main.rs
+++ b/tests/ui-cargo/feature_name/pass/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=feature_name
 #![warn(clippy::redundant_feature_names)]
 #![warn(clippy::negative_feature_names)]
 

--- a/tests/ui-cargo/module_style/fail_mod_remap/src/main.rs
+++ b/tests/ui-cargo/module_style/fail_mod_remap/src/main.rs
@@ -1,3 +1,4 @@
+// FIXME: find a way to add rustflags to ui-cargo tests
 //@compile-flags: --remap-path-prefix {{src-base}}=/remapped
 
 #![warn(clippy::self_named_module_files)]

--- a/tests/ui-cargo/multiple_crate_versions/5041_allow_dev_build/src/main.rs
+++ b/tests/ui-cargo/multiple_crate_versions/5041_allow_dev_build/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=multiple_crate_versions
 #![warn(clippy::multiple_crate_versions)]
 
 fn main() {}

--- a/tests/ui-cargo/multiple_crate_versions/fail/src/main.rs
+++ b/tests/ui-cargo/multiple_crate_versions/fail/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=multiple_crate_versions
 #![warn(clippy::multiple_crate_versions)]
 
 fn main() {}

--- a/tests/ui-cargo/multiple_crate_versions/pass/src/main.rs
+++ b/tests/ui-cargo/multiple_crate_versions/pass/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=multiple_crate_versions
 #![warn(clippy::multiple_crate_versions)]
 
 fn main() {}

--- a/tests/ui-cargo/wildcard_dependencies/fail/src/main.rs
+++ b/tests/ui-cargo/wildcard_dependencies/fail/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=wildcard_dependencies
 #![warn(clippy::wildcard_dependencies)]
 
 fn main() {}

--- a/tests/ui-cargo/wildcard_dependencies/pass/src/main.rs
+++ b/tests/ui-cargo/wildcard_dependencies/pass/src/main.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --crate-name=wildcard_dependencies
 #![warn(clippy::wildcard_dependencies)]
 
 fn main() {}


### PR DESCRIPTION
changelog: none

Also removes some unused flags from `ui-cargo` tests because the entrypoint is now the `Cargo.toml`, not the `.rs` files