### PR TITLE
[`inherent_to_string`]: Don't lint `unsafe` or `extern` fns

### DIFF
--- a/tests/ui/inherent_to_string.rs
+++ b/tests/ui/inherent_to_string.rs
@@ -1,5 +1,4 @@
-#![warn(clippy::inherent_to_string)]
-#![deny(clippy::inherent_to_string_shadow_display)]
+#![allow(improper_ctypes_definitions)]
 
 use std::fmt;
 
@@ -14,6 +13,9 @@ struct D;
 struct E;
 struct F;
 struct G;
+struct H;
+struct I;
+struct J;
 
 impl A {
     // Should be detected; emit warning
@@ -76,6 +78,26 @@ impl F {
 impl G {
     // Should not be detected, as it does not match the function signature
     fn to_string<const _N: usize>(&self) -> String {
+        "G.to_string()".to_string()
+    }
+}
+
+// Issue #11201
+
+impl H {
+    unsafe fn to_string(&self) -> String {
+        "G.to_string()".to_string()
+    }
+}
+
+impl I {
+    extern "C" fn to_string(&self) -> String {
+        "G.to_string()".to_string()
+    }
+}
+
+impl J {
+    unsafe extern "C" fn to_string(&self) -> String {
         "G.to_string()".to_string()
     }
 }

--- a/tests/ui/inherent_to_string.stderr
+++ b/tests/ui/inherent_to_string.stderr
@@ -1,5 +1,5 @@
 error: implementation of inherent method `to_string(&self) -> String` for type `A`
-  --> $DIR/inherent_to_string.rs:20:5
+  --> $DIR/inherent_to_string.rs:22:5
    |
 LL | /     fn to_string(&self) -> String {
 LL | |         "A.to_string()".to_string()
@@ -10,7 +10,7 @@ LL | |     }
    = note: `-D clippy::inherent-to-string` implied by `-D warnings`
 
 error: type `C` implements inherent method `to_string(&self) -> String` which shadows the implementation of `Display`
-  --> $DIR/inherent_to_string.rs:44:5
+  --> $DIR/inherent_to_string.rs:46:5
    |
 LL | /     fn to_string(&self) -> String {
 LL | |         "C.to_string()".to_string()
@@ -18,11 +18,7 @@ LL | |     }
    | |_____^
    |
    = help: remove the inherent method from type `C`
-note: the lint level is defined here
-  --> $DIR/inherent_to_string.rs:2:9
-   |
-LL | #![deny(clippy::inherent_to_string_shadow_display)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(clippy::inherent_to_string_shadow_display)]` on by default
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #11201

changelog: [`inherent_to_string`]: No longer lints `unsafe` or `extern` fns
