### PR TITLE
ptr_arg should ignore extern functions

### DIFF
--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -163,12 +163,13 @@ impl<'tcx> LateLintPass<'tcx> for Ptr {
                 return;
             }
 
+            check_mut_from_ref(cx, sig, None);
+
             if !matches!(sig.header.abi, Abi::Rust) {
                 // Ignore `extern` functions with non-Rust calling conventions
                 return;
             }
 
-            check_mut_from_ref(cx, sig, None);
             for arg in check_fn_args(
                 cx,
                 cx.tcx.fn_sig(item.owner_id).subst_identity().skip_binder().inputs(),
@@ -223,12 +224,13 @@ impl<'tcx> LateLintPass<'tcx> for Ptr {
             _ => return,
         };
 
+        check_mut_from_ref(cx, sig, Some(body));
+
         if !matches!(sig.header.abi, Abi::Rust) {
             // Ignore `extern` functions with non-Rust calling conventions
             return;
         }
 
-        check_mut_from_ref(cx, sig, Some(body));
         let decl = sig.decl;
         let sig = cx.tcx.fn_sig(item_id).subst_identity().skip_binder();
         let lint_args: Vec<_> = check_fn_args(cx, sig.inputs(), decl.inputs, &decl.output, body.params)

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -26,6 +26,7 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Span;
 use rustc_span::sym;
 use rustc_span::symbol::Symbol;
+use rustc_target::spec::abi::Abi;
 use rustc_trait_selection::infer::InferCtxtExt as _;
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
 use std::{fmt, iter};
@@ -162,6 +163,11 @@ impl<'tcx> LateLintPass<'tcx> for Ptr {
                 return;
             }
 
+            if !matches!(sig.header.abi, Abi::Rust) {
+                // Ignore `extern` functions with non-Rust calling conventions
+                return;
+            }
+
             check_mut_from_ref(cx, sig, None);
             for arg in check_fn_args(
                 cx,
@@ -216,6 +222,11 @@ impl<'tcx> LateLintPass<'tcx> for Ptr {
             },
             _ => return,
         };
+
+        if !matches!(sig.header.abi, Abi::Rust) {
+            // Ignore `extern` functions with non-Rust calling conventions
+            return;
+        }
 
         check_mut_from_ref(cx, sig, Some(body));
         let decl = sig.decl;

--- a/tests/ui/ptr_arg.rs
+++ b/tests/ui/ptr_arg.rs
@@ -267,3 +267,16 @@ mod issue_9218 {
         todo!()
     }
 }
+
+mod issue_11181 {
+    extern "C" fn allowed(_v: &Vec<u32>) {}
+
+    struct S;
+    impl S {
+        extern "C" fn allowed(_v: &Vec<u32>) {}
+    }
+
+    trait T {
+        extern "C" fn allowed(_v: &Vec<u32>) {}
+    }
+}


### PR DESCRIPTION
Fixes: #11181

changelog: [`ptr_arg`]: ignore extern functions that are not  

I am not sure whether we should ignore other Rust calling conventions like `rust-intrinsic`, `rust-call` or `rust-cold`.