### PR TITLE
changelog: [`min_ident_chars`]: don't lint const generics

### DIFF
--- a/clippy_lints/src/min_ident_chars.rs
+++ b/clippy_lints/src/min_ident_chars.rs
@@ -129,6 +129,14 @@ impl Visitor<'_> for IdentVisitor<'_, '_> {
                 return;
             }
 
+            // `struct Array<T, const N: usize>([T; N])`
+            //                        ^
+            if let Node::GenericParam(generic_param) = node
+                && let GenericParamKind::Const { .. } = generic_param.kind
+            {
+                return;
+            }
+
             if is_from_proc_macro(cx, &ident) {
                 return;
             }

--- a/tests/ui/min_ident_chars.rs
+++ b/tests/ui/min_ident_chars.rs
@@ -81,3 +81,7 @@ fn b() {}
 fn wrong_pythagoras(a: f32, b: f32) -> f32 {
     a * a + a * b
 }
+
+mod issue_11163 {
+    struct Array<T, const N: usize>([T; N]);
+}


### PR DESCRIPTION
Fixes: #11163 

changelog: [`min_ident_chars`]: don't lint const generics