### PR TITLE
Remove Gha status emitter in compile-test

### DIFF
--- a/clippy_lints/src/utils/mod.rs
+++ b/clippy_lints/src/utils/mod.rs
@@ -18,7 +18,7 @@ const BOOK_CONFIGS_PATH: &str = "https://doc.rust-lang.org/clippy/lint_configura
 // ==================================================================
 // Configuration
 // ==================================================================
-#[derive(Debug, Clone, Default)] //~ ERROR no such field
+#[derive(Debug, Clone, Default)]
 pub struct ClippyConfiguration {
     pub name: String,
     #[allow(dead_code)]

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -5,7 +5,7 @@
 #![warn(rust_2018_idioms, unused_lifetimes)]
 #![allow(unused_extern_crates)]
 
-use compiletest::{status_emitter, CommandBuilder};
+use compiletest::{status_emitter, CommandBuilder, OutputConflictHandling};
 use ui_test as compiletest;
 use ui_test::Mode as TestMode;
 
@@ -116,9 +116,9 @@ fn base_config(test_dir: &str) -> compiletest::Config {
         stderr_filters: vec![],
         stdout_filters: vec![],
         output_conflict_handling: if var_os("BLESS").is_some() || env::args().any(|arg| arg == "--bless") {
-            compiletest::OutputConflictHandling::Bless
+            OutputConflictHandling::Bless
         } else {
-            compiletest::OutputConflictHandling::Error("cargo test -- -- --bless".into())
+            OutputConflictHandling::Error("cargo uibless".into())
         },
         target: None,
         out_dir: PathBuf::from(std::env::var_os("CARGO_TARGET_DIR").unwrap_or("target".into())).join("ui_test"),
@@ -187,9 +187,6 @@ fn run_ui() {
                 .to_string()
         }),
     );
-    eprintln!("   Compiler: {}", config.program.display());
-
-    let name = config.root_dir.display().to_string();
 
     let test_filter = test_filter();
 
@@ -197,7 +194,7 @@ fn run_ui() {
         config,
         move |path| compiletest::default_file_filter(path) && test_filter(path),
         compiletest::default_per_file_config,
-        (status_emitter::Text, status_emitter::Gha::<true> { name }),
+        status_emitter::Text,
     )
     .unwrap();
     check_rustfix_coverage();
@@ -208,8 +205,19 @@ fn run_internal_tests() {
     if !RUN_INTERNAL_TESTS {
         return;
     }
-    let config = base_config("ui-internal");
-    compiletest::run_tests(config).unwrap();
+    let mut config = base_config("ui-internal");
+    if let OutputConflictHandling::Error(err) = &mut config.output_conflict_handling {
+        *err = "cargo uitest --features internal -- -- --bless".into();
+    }
+    let test_filter = test_filter();
+
+    compiletest::run_tests_generic(
+        config,
+        move |path| compiletest::default_file_filter(path) && test_filter(path),
+        compiletest::default_per_file_config,
+        status_emitter::Text,
+    )
+    .unwrap();
 }
 
 fn run_ui_toml() {
@@ -228,13 +236,11 @@ fn run_ui_toml() {
         "$$DIR",
     );
 
-    let name = config.root_dir.display().to_string();
-
     let test_filter = test_filter();
 
     ui_test::run_tests_generic(
         config,
-        |path| test_filter(path) && path.extension() == Some("rs".as_ref()),
+        |path| compiletest::default_file_filter(path) && test_filter(path),
         |config, path| {
             let mut config = config.clone();
             config
@@ -243,7 +249,7 @@ fn run_ui_toml() {
                 .push(("CLIPPY_CONF_DIR".into(), Some(path.parent().unwrap().into())));
             Some(config)
         },
-        (status_emitter::Text, status_emitter::Gha::<true> { name }),
+        status_emitter::Text,
     )
     .unwrap();
 }
@@ -284,8 +290,6 @@ fn run_ui_cargo() {
         "$$DIR",
     );
 
-    let name = config.root_dir.display().to_string();
-
     let test_filter = test_filter();
 
     ui_test::run_tests_generic(
@@ -296,7 +300,7 @@ fn run_ui_cargo() {
             config.out_dir = PathBuf::from("target/ui_test_cargo/").join(path.parent().unwrap());
             Some(config)
         },
-        (status_emitter::Text, status_emitter::Gha::<true> { name }),
+        status_emitter::Text,
     )
     .unwrap();
 }


### PR DESCRIPTION
Disables the github specific output for now since it can be a bit confusing - https://github.com/oli-obk/ui_test/issues/109, in particular the truncation/repetition

r? @flip1995

changelog: none
