### PR TITLE
Add *no merge policy* note via rustbot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -9,6 +9,9 @@ allow-unauthenticated = [
 # See https://github.com/rust-lang/triagebot/wiki/Shortcuts
 [shortcut]
 
+# Have rustbot inform users about the *No Merge Policy*
+[no-merges]
+
 [autolabel."S-waiting-on-review"]
 new_pr = true
 


### PR DESCRIPTION
I just found out that `@rustbot` can automatically add a note about our *no-merge commits* policy, if it detects a merge commit: https://forge.rust-lang.org/triagebot/no-merge.html

Funnly enough, I found this while writing documentation for Marker. `@rustbot` is a cool tool :+1: 

---

r? @flip1995 since you'll probably be the person that will see this message the most ^^

changelog: none