### PR TITLE
[`arc_with_non_send_sync`]: No longer lints macro-generated code

### DIFF
--- a/tests/ui/arc_with_non_send_sync.rs
+++ b/tests/ui/arc_with_non_send_sync.rs
@@ -1,6 +1,12 @@
+//@aux-build:proc_macros.rs:proc-macro
 #![warn(clippy::arc_with_non_send_sync)]
 #![allow(unused_variables)]
+
+#[macro_use]
+extern crate proc_macros;
+
 use std::cell::RefCell;
+use std::ptr::{null, null_mut};
 use std::sync::{Arc, Mutex};
 
 fn foo<T>(x: T) {
@@ -11,14 +17,32 @@ fn issue11076<T>() {
     let a: Arc<Vec<T>> = Arc::new(Vec::new());
 }
 
+fn issue11232() {
+    external! {
+        let a: Arc<*const u8> = Arc::new(null());
+        let a: Arc<*mut u8> = Arc::new(null_mut());
+    }
+    with_span! {
+        span
+        let a: Arc<*const u8> = Arc::new(null());
+        let a: Arc<*mut u8> = Arc::new(null_mut());
+    }
+}
+
 fn main() {
     let _ = Arc::new(42);
 
-    // !Sync
     let _ = Arc::new(RefCell::new(42));
+    //~^ ERROR: usage of an `Arc` that is not `Send` or `Sync`
+    //~| NOTE: the trait `Sync` is not implemented for `RefCell<i32>`
+
     let mutex = Mutex::new(1);
-    // !Send
     let _ = Arc::new(mutex.lock().unwrap());
-    // !Send + !Sync
+    //~^ ERROR: usage of an `Arc` that is not `Send` or `Sync`
+    //~| NOTE: the trait `Send` is not implemented for `MutexGuard<'_, i32>`
+
     let _ = Arc::new(&42 as *const i32);
+    //~^ ERROR: usage of an `Arc` that is not `Send` or `Sync`
+    //~| NOTE: the trait `Send` is not implemented for `*const i32`
+    //~| NOTE: the trait `Sync` is not implemented for `*const i32`
 }

--- a/tests/ui/arc_with_non_send_sync.stderr
+++ b/tests/ui/arc_with_non_send_sync.stderr
@@ -1,5 +1,5 @@
 error: usage of an `Arc` that is not `Send` or `Sync`
-  --> $DIR/arc_with_non_send_sync.rs:18:13
+  --> $DIR/arc_with_non_send_sync.rs:35:13
    |
 LL |     let _ = Arc::new(RefCell::new(42));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     let _ = Arc::new(RefCell::new(42));
    = note: `-D clippy::arc-with-non-send-sync` implied by `-D warnings`
 
 error: usage of an `Arc` that is not `Send` or `Sync`
-  --> $DIR/arc_with_non_send_sync.rs:21:13
+  --> $DIR/arc_with_non_send_sync.rs:40:13
    |
 LL |     let _ = Arc::new(mutex.lock().unwrap());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |     let _ = Arc::new(mutex.lock().unwrap());
    = help: consider using an `Rc` instead or wrapping the inner type with a `Mutex`
 
 error: usage of an `Arc` that is not `Send` or `Sync`
-  --> $DIR/arc_with_non_send_sync.rs:23:13
+  --> $DIR/arc_with_non_send_sync.rs:44:13
    |
 LL |     let _ = Arc::new(&42 as *const i32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #11232

changelog: [`arc_with_non_send_sync`]: No longer lints macro-generated code
