### PR TITLE
[blocked] attempt to check rust-lang/rust with clippy in ci

### DIFF
--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -202,6 +202,7 @@ jobs:
       max-parallel: 6
       matrix:
         integration:
+        - 'rust-lang/rust'
         - 'rust-lang/cargo'
         - 'rust-lang/chalk'
         - 'rust-lang/rustfmt'

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -214,7 +214,8 @@ fn integration_test_rustc() {
         .output()
         .expect("rustc failed to print sysroot");
     let untrimmed = String::from_utf8_lossy(&sysroot_output.stdout).to_string();
-    let mut sysroot = dbg!(untrimmed.trim());
+    let sysroot2 = dbg!(untrimmed.trim());
+    let mut sysroot = sysroot2.to_string();
     sysroot.push('/');
     dbg!(&sysroot);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -246,7 +246,7 @@ fn integration_test_rustc() {
             let old_path = dbg!(file.clone());
             let new_base = dbg!(PathBuf::from(&bin_dir));
             let bin_file_name = dbg!(old_path.parent().unwrap());
-            let new_path = dbg!(new_base.join(&bin_file_name));
+            let new_path = dbg!(new_base.with_file_name(&bin_file_name));
 
             fs::copy(dbg!(old_path), dbg!(new_path)).expect("could not copy files"); //error
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -171,6 +171,11 @@ fn integration_test_rustc() {
     let st_git_cl = Command::new("git")
         .args([
             OsStr::new("clone"),
+            // we can't use depth=x because we don't know how far away the master branc tip is from our nightly commit
+            // that we need.
+            // however, we can still gain a lot by using --filter=tree:0 which is still ~10x faster than a full clone
+
+            // https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
             OsStr::new("--filter=tree:0"),
             OsStr::new(&repo_url),
             OsStr::new(&repo_dir),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -195,7 +195,8 @@ fn integration_test_rustc() {
 
     let path_env = target_dir.join(env!("PROFILE"));
 
-    let output = Command::new("./x.py")
+    let output = Command::new("python")
+        .arg("./x.py")
         .current_dir(&repo_dir)
         .env("RUST_BACKTRACE", "full")
         .env("PATH", path_env)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -175,9 +175,11 @@ fn integration_test_rustc() {
         .strip_prefix("commit-hash: ")
         .expect("failed parsing commit line");
 
+    dbg!(&commit);
     // check out the commit in the rustc repo to ensure clippy is compatible
 
     let st_git_checkout = Command::new("git")
+        .current_dir(&repo_dir)
         .arg("checkout")
         .arg(commit)
         .status()
@@ -186,15 +188,15 @@ fn integration_test_rustc() {
 
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let target_dir = std::path::Path::new(&root_dir).join("target");
-    let clippy_binary = target_dir.join(env!("PROFILE")).join(CARGO_CLIPPY);
+    // let clippy_binary = target_dir.join(env!("PROFILE")).join(CARGO_CLIPPY);
 
     // we need to make sure that `x.py clippy` picks up our self-built clippy
     // try to make the target dir discoverable as PATH
 
     let path_env = target_dir.join(env!("PROFILE"));
 
-    let output = Command::new("x.py")
-        .current_dir("rust")
+    let output = Command::new("./x.py")
+        .current_dir(&repo_dir)
         .env("RUST_BACKTRACE", "full")
         .env("PATH", path_env)
         .args(["clippy", "-Wclippy::pedantic", "-Wclippy::nursery"])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -216,7 +216,7 @@ fn integration_test_rustc() {
     let sysroot = dbg!(String::from_utf8_lossy(&sysroot_output.stdout).to_string());
 
     let mut sysroot_path = PathBuf::from(sysroot);
-    sysroot_path.push("/");
+    sysroot_path.join("/");
     assert!(
         sysroot_path.exists(),
         "{}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -237,7 +237,9 @@ fn integration_test_rustc() {
             let new_base = PathBuf::from(&bin_dir);
             let new_path = new_base.join(&file.file_name().expect("got directory instead of file"));
 
-            fs::copy(old_path, new_path).expect("could not copy files");
+            fs::copy(dbg!(old_path), dbg!(new_path)).expect("could not copy files"); //error
+
+            //   https://github.com/rust-lang/rust-clippy/actions/runs/5700035285/job/15449530554#step:8:132
         });
     let output = dbg!(
         Command::new("python")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -198,12 +198,20 @@ fn integration_test_rustc() {
 
     let path_env = target_dir.join(env!("PROFILE"));
 
+    dbg!(&repo_dir);
+    assert!(repo_dir.is_dir(), "repo_dir not a dir!");
+
+    let path_env = std::env::var_os("PATH").expect("PATH env var not set");
+    let mut paths = env::split_paths(&path_env).collect::<Vec<_>>();
+    paths.push(target_dir.join(env!("PROFILE")));
+    let new_path = env::join_paths(paths).expect("failed to join paths");
+
     let output = dbg!(
         Command::new("python")
             .arg("./x.py")
             .current_dir(&repo_dir)
             .env("RUST_BACKTRACE", "full")
-            .env("PATH", path_env)
+            .env("PATH", path_new)
             .args(["clippy", "-Wclippy::pedantic", "-Wclippy::nursery"])
     )
     .output()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -245,7 +245,8 @@ fn integration_test_rustc() {
         .for_each(|file| {
             let old_path = dbg!(file.clone());
             let new_base = dbg!(PathBuf::from(&bin_dir));
-            let new_path = dbg!(new_base.join(&file));
+            let bin_file_name = dbg!(old_path.parent().unwrap());
+            let new_path = dbg!(new_base.join(&bin_file_name));
 
             fs::copy(dbg!(old_path), dbg!(new_path)).expect("could not copy files"); //error
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -250,7 +250,7 @@ fn integration_test_rustc() {
         .arg("./x.py")
         .current_dir(&repo_dir)
         .env("RUST_BACKTRACE", "full")
-        .args(["clippy", "-Wclippy::pedantic",/* "-Wclippy::cargo" */])
+        .args(["clippy", "-Wclippy::pedantic" /* "-Wclippy::cargo" */])
         .output()
         .expect("unable to run x.py clippy");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -250,7 +250,7 @@ fn integration_test_rustc() {
         .arg("./x.py")
         .current_dir(&repo_dir)
         .env("RUST_BACKTRACE", "full")
-        .args(["clippy", "-Wclippy::pedantic", "-Wclippy::cargo"])
+        .args(["clippy", "-Wclippy::pedantic",/* "-Wclippy::cargo" */])
         .output()
         .expect("unable to run x.py clippy");
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -130,6 +130,7 @@ fn integration_test() {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 #[cfg_attr(feature = "integration", test)]
 fn integration_test_rustc() {
     let repo_name = env::var("INTEGRATION").expect("`INTEGRATION` var not set");
@@ -187,7 +188,7 @@ fn integration_test_rustc() {
     // check out the commit in the rustc repo to ensure clippy is compatible with std/core and the
     // compiler internals
 
-    println!("checking out commit '{}' in rustc repo", commit);
+    println!("checking out commit '{commit}' in rustc repo");
     let st_git_checkout = Command::new("git")
         .current_dir(&repo_dir)
         .arg("checkout")
@@ -229,16 +230,16 @@ fn integration_test_rustc() {
     eprintln!("clippy binaries will be put int {}", sysroot_bin_dir.display());
 
     // copy files from target dir into our $sysroot/bin
-    std::fs::read_dir(&clippy_exec_dir)
+    std::fs::read_dir(clippy_exec_dir)
         .expect("failed to read clippys target/ dir that we downloaded from previous ci step")
-        .map(|entry| entry.ok().expect("DirEntry not ok"))
+        .map(|entry| entry.expect("DirEntry not ok"))
         .map(|entry| entry.path())
         .filter(|path| path.is_file())
         .for_each(|clippy_binary| {
             let new_base: PathBuf = sysroot_bin_dir.join("willbeoverwritten"); // file_name() will overwrite this
             // set the path from /foo/dir/willbeoverwritten to /foo/dir/cargo-clippy
             let bin_file_name: &std::ffi::OsStr = clippy_binary.file_name().unwrap();
-            let new_path: PathBuf = new_base.with_file_name(&bin_file_name);
+            let new_path: PathBuf = new_base.with_file_name(bin_file_name);
 
             fs::copy(dbg!(clippy_binary), dbg!(new_path))
                 .expect("could not copy file from '{clippy_binary}' to '{new_path}'");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -133,7 +133,8 @@ fn integration_test() {
 fn integration_test_rustc() {
     let repo_name = env::var("INTEGRATION").expect("`INTEGRATION` var not set");
 
-    if repo_name != "rust-lang/rust" {
+    // try to avoid running this test locally
+    if repo_name != "rust-lang/rust" || env::var("GITHUB_ACTIONS").is_none() {
         return;
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -243,10 +243,10 @@ fn integration_test_rustc() {
         .map(|entry| entry.path())
         .filter(|path| path.is_file())
         .for_each(|file| {
-            let old_path = dbg!(file.clone());
-            let new_base = dbg!(PathBuf::from(&bin_dir));
-            let bin_file_name = dbg!(old_path.parent().unwrap());
-            let new_path = dbg!(new_base.with_file_name(&bin_file_name));
+            let old_path: PathBuf = dbg!(file.clone());
+            let new_base: &PathBuf = dbg!(&bin_dir);
+            let bin_file_name: &std::ffi::OsStr = dbg!(old_path.file_name().unwrap());
+            let new_path: PathBuf = dbg!(new_base.with_file_name(&bin_file_name));
 
             fs::copy(dbg!(old_path), dbg!(new_path)).expect("could not copy files"); //error
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -213,10 +213,11 @@ fn integration_test_rustc() {
         .arg("sysroot")
         .output()
         .expect("rustc failed to print sysroot");
-    let sysroot = String::from_utf8_lossy(&sysroot_output.stdout).to_string();
+    let sysroot = dbg!(String::from_utf8_lossy(&sysroot_output.stdout).to_string());
+
     let sysroot_path = PathBuf::from(sysroot);
     assert!(
-        sysroot_path.is_dir(),
+        sysroot_path.exists(),
         "{}",
         format!("sysroot path '{}' not found!", sysroot_path.display())
     );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -215,7 +215,8 @@ fn integration_test_rustc() {
         .expect("rustc failed to print sysroot");
     let sysroot = dbg!(String::from_utf8_lossy(&sysroot_output.stdout).to_string());
 
-    let sysroot_path = PathBuf::from(sysroot);
+    let mut sysroot_path = PathBuf::from(sysroot);
+    sysroot_path.push("/");
     assert!(
         sysroot_path.exists(),
         "{}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -152,7 +152,7 @@ fn integration_test_rustc() {
     let st_git_cl = Command::new("git")
         .args([
             OsStr::new("clone"),
-            OsStr::new("--depth=5000"),
+            OsStr::new("--filter=tree:0"),
             OsStr::new(&repo_url),
             OsStr::new(&repo_dir),
         ])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -214,10 +214,12 @@ fn integration_test_rustc() {
         .output()
         .expect("rustc failed to print sysroot");
     let untrimmed = String::from_utf8_lossy(&sysroot_output.stdout).to_string();
-    let sysroot = dbg!(untrimmed.trim());
+    let mut sysroot = dbg!(untrimmed.trim());
+    sysroot.push('/');
+    dbg!(&sysroot);
 
     let sysroot_path = dbg!(PathBuf::from(sysroot));
-    let sysroot_path = sysroot_path.join("/");
+    //let sysroot_path = sysroot_path.join("/");
 
     dbg!(&sysroot_path);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -223,6 +223,8 @@ fn integration_test_rustc() {
         format!("sysroot path '{}' not found!", sysroot_path.display())
     );
 
+    dbg!(&sysroot_path);
+
     let bin_dir = sysroot_path.join("bin");
     dbg!(&bin_dir);
     //  ^ this is the dir we want to copy our clippy binary into now

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -213,7 +213,7 @@ fn integration_test_rustc() {
         .arg("sysroot")
         .output()
         .expect("rustc failed to print sysroot");
-    let sysroot = dbg!(String::from_utf8_lossy(&sysroot_output.stdout).to_string());
+    let sysroot = dbg!(String::from_utf8_lossy(&sysroot_output.stdout).to_string().trim());
 
     let mut sysroot_path = dbg!(PathBuf::from(sysroot));
     sysroot_path.join("/");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -133,8 +133,8 @@ fn integration_test() {
 fn integration_test_rustc() {
     let repo_name = env::var("INTEGRATION").expect("`INTEGRATION` var not set");
 
-    // try to avoid running this test locally
-    if repo_name != "rust-lang/rust" || env::var("GITHUB_ACTIONS").is_ok() {
+    // try to avoid running this test locall
+    if repo_name != "rust-lang/rust" || env::var("GITHUB_ACTIONS") == Ok(String::from("true")) {
         return;
     }
 
@@ -192,19 +192,17 @@ fn integration_test_rustc() {
 
     let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let target_dir = std::path::Path::new(&root_dir).join("target");
-    // let clippy_binary = target_dir.join(env!("PROFILE")).join(CARGO_CLIPPY);
+    let clippy_exec_dir = target_dir.join(env!("PROFILE"));
 
     // we need to make sure that `x.py clippy` picks up our self-built clippy
     // try to make the target dir discoverable as PATH
-
-    let path_env = target_dir.join(env!("PROFILE"));
 
     dbg!(&repo_dir);
     assert!(repo_dir.is_dir(), "repo_dir not a dir!");
 
     let path_env = std::env::var_os("PATH").expect("PATH env var not set");
     let mut paths = env::split_paths(&path_env).collect::<Vec<_>>();
-    paths.push(path_env.into());
+    paths.push(clippy_exec_dir);
     let new_path = env::join_paths(paths).expect("failed to join paths");
     dbg!(&new_path);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -133,8 +133,8 @@ fn integration_test() {
 fn integration_test_rustc() {
     let repo_name = env::var("INTEGRATION").expect("`INTEGRATION` var not set");
 
-    // try to avoid running this test locall
-    if repo_name != "rust-lang/rust" || env::var("GITHUB_ACTIONS") == Ok(String::from("true")) {
+    // try to avoid running this test locally
+    if !(repo_name == "rust-lang/rust" && env::var("GITHUB_ACTIONS") == Ok(String::from("true"))) {
         return;
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -134,7 +134,7 @@ fn integration_test_rustc() {
     let repo_name = env::var("INTEGRATION").expect("`INTEGRATION` var not set");
 
     // try to avoid running this test locally
-    if repo_name != "rust-lang/rust" || env::var("GITHUB_ACTIONS").is_none() {
+    if repo_name != "rust-lang/rust" || env::var("GITHUB_ACTIONS").is_ok() {
         return;
     }
 
@@ -204,8 +204,9 @@ fn integration_test_rustc() {
 
     let path_env = std::env::var_os("PATH").expect("PATH env var not set");
     let mut paths = env::split_paths(&path_env).collect::<Vec<_>>();
-    paths.push(target_dir.join(env!("PROFILE")));
+    paths.push(path_env.into());
     let new_path = env::join_paths(paths).expect("failed to join paths");
+    dbg!(&new_path);
 
     let output = dbg!(
         Command::new("python")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -23,6 +23,11 @@ const CARGO_CLIPPY: &str = "cargo-clippy.exe";
 #[cfg_attr(feature = "integration", test)]
 fn integration_test() {
     let repo_name = env::var("INTEGRATION").expect("`INTEGRATION` var not set");
+
+    if repo_name == "rust-lang/rust" {
+        return;
+    }
+
     let repo_url = format!("https://github.com/{repo_name}");
     let crate_name = repo_name
         .split('/')
@@ -63,6 +68,138 @@ fn integration_test() {
         ])
         .output()
         .expect("unable to run clippy");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // debug:
+    eprintln!("{stderr}");
+
+    // this is an internal test to make sure we would correctly panic on a delay_span_bug
+    if repo_name == "matthiaskrgr/clippy_ci_panic_test" {
+        // we need to kind of switch around our logic here:
+        // if we find a panic, everything is fine, if we don't panic, SOMETHING is broken about our testing
+
+        // the repo basically just contains a delay_span_bug that forces rustc/clippy to panic:
+        /*
+           #![feature(rustc_attrs)]
+           #[rustc_error(delay_span_bug_from_inside_query)]
+           fn main() {}
+        */
+
+        if stderr.find("error: internal compiler error").is_some() {
+            eprintln!("we saw that we intentionally panicked, yay");
+            return;
+        }
+
+        panic!("panic caused by delay_span_bug was NOT detected! Something is broken!");
+    }
+
+    if let Some(backtrace_start) = stderr.find("error: internal compiler error") {
+        static BACKTRACE_END_MSG: &str = "end of query stack";
+        let backtrace_end = stderr[backtrace_start..]
+            .find(BACKTRACE_END_MSG)
+            .expect("end of backtrace not found");
+
+        panic!(
+            "internal compiler error\nBacktrace:\n\n{}",
+            &stderr[backtrace_start..backtrace_start + backtrace_end + BACKTRACE_END_MSG.len()]
+        );
+    } else if stderr.contains("query stack during panic") {
+        panic!("query stack during panic in the output");
+    } else if stderr.contains("E0463") {
+        // Encountering E0463 (can't find crate for `x`) did _not_ cause the build to fail in the
+        // past. Even though it should have. That's why we explicitly panic here.
+        // See PR #3552 and issue #3523 for more background.
+        panic!("error: E0463");
+    } else if stderr.contains("E0514") {
+        panic!("incompatible crate versions");
+    } else if stderr.contains("failed to run `rustc` to learn about target-specific information") {
+        panic!("couldn't find librustc_driver, consider setting `LD_LIBRARY_PATH`");
+    } else {
+        assert!(
+            !stderr.contains("toolchain") || !stderr.contains("is not installed"),
+            "missing required toolchain"
+        );
+    }
+
+    match output.status.code() {
+        Some(0) => println!("Compilation successful"),
+        Some(code) => eprintln!("Compilation failed. Exit code: {code}"),
+        None => panic!("Process terminated by signal"),
+    }
+}
+
+#[cfg_attr(feature = "integration", test)]
+fn integration_test_rustc() {
+    let repo_name = env::var("INTEGRATION").expect("`INTEGRATION` var not set");
+
+    if repo_name != "rust-lang/rust" {
+        return;
+    }
+
+    let repo_url = format!("https://github.com/{repo_name}");
+    let crate_name = repo_name
+        .split('/')
+        .nth(1)
+        .expect("repo name should have format `<org>/<name>`");
+
+    let mut repo_dir = tempfile::tempdir().expect("couldn't create temp dir").into_path();
+    repo_dir.push(crate_name);
+
+    let st_git_cl = Command::new("git")
+        .args([
+            OsStr::new("clone"),
+            OsStr::new("--depth=5000"),
+            OsStr::new(&repo_url),
+            OsStr::new(&repo_dir),
+        ])
+        .status()
+        .expect("unable to run git");
+    assert!(st_git_cl.success());
+
+    // clippy is pinned to a specific nightly version
+    // check out the commit of that nightly to ensure compatibility
+    let rustc_output = Command::new("rustc")
+        .arg("--version")
+        .arg("--verbose")
+        .output()
+        .expect("failed to run rustc --version");
+
+    let commit_line = String::from_utf8_lossy(&rustc_output.stdout);
+    let commit_line_ = commit_line
+        .lines()
+        .find(|line| line.starts_with("commit-hash: "))
+        .expect("did not find 'commit-hash:' in --version output");
+
+    let commit = commit_line_
+        .strip_prefix("commit-hash: ")
+        .expect("failed parsing commit line");
+
+    // check out the commit in the rustc repo to ensure clippy is compatible
+
+    let st_git_checkout = Command::new("git")
+        .arg("checkout")
+        .arg(commit)
+        .status()
+        .expect("git failed to check out commit");
+    assert!(st_git_checkout.success());
+
+    let root_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target_dir = std::path::Path::new(&root_dir).join("target");
+    let clippy_binary = target_dir.join(env!("PROFILE")).join(CARGO_CLIPPY);
+
+    // we need to make sure that `x.py clippy` picks up our self-built clippy
+    // try to make the target dir discoverable as PATH
+
+    let path_env = target_dir.join(env!("PROFILE"));
+
+    let output = Command::new("x.py")
+        .current_dir("rust")
+        .env("RUST_BACKTRACE", "full")
+        .env("PATH", path_env)
+        .args(["clippy", "-Wclippy::pedantic", "-Wclippy::nursery"])
+        .output()
+        .expect("unable to run x.py  clippy");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -213,10 +213,11 @@ fn integration_test_rustc() {
         .arg("sysroot")
         .output()
         .expect("rustc failed to print sysroot");
-    let sysroot = dbg!(String::from_utf8_lossy(&sysroot_output.stdout).to_string().trim());
+    let untrimmed = String::from_utf8_lossy(&sysroot_output.stdout).to_string();
+    let sysroot = dbg!(untrimmed.trim());
 
-    let mut sysroot_path = dbg!(PathBuf::from(sysroot));
-    sysroot_path.join("/");
+    let sysroot_path = dbg!(PathBuf::from(sysroot));
+    let sysroot_path = sysroot_path.join("/");
 
     dbg!(&sysroot_path);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -211,7 +211,7 @@ fn integration_test_rustc() {
             .arg("./x.py")
             .current_dir(&repo_dir)
             .env("RUST_BACKTRACE", "full")
-            .env("PATH", path_new)
+            .env("PATH", new_path)
             .args(["clippy", "-Wclippy::pedantic", "-Wclippy::nursery"])
     )
     .output()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -224,6 +224,7 @@ fn integration_test_rustc() {
     );
 
     let bin_dir = sysroot_path.join("bin");
+    dbg!(&bin_dir);
     //  ^ this is the dir we want to copy our clippy binary into now
 
     // there should not be
@@ -233,9 +234,9 @@ fn integration_test_rustc() {
         .map(|entry| entry.path())
         .filter(|path| path.is_file())
         .for_each(|file| {
-            let old_path = file.clone();
-            let new_base = PathBuf::from(&bin_dir);
-            let new_path = new_base.join(&file.file_name().expect("got directory instead of file"));
+            let old_path = dbg!(file.clone());
+            let new_base = dbg!(PathBuf::from(&bin_dir));
+            let new_path = dbg!(new_base.join(&file));
 
             fs::copy(dbg!(old_path), dbg!(new_path)).expect("could not copy files"); //error
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -146,6 +146,7 @@ fn integration_test_rustc() {
     let mut repo_dir = tempfile::tempdir().expect("couldn't create temp dir").into_path();
     repo_dir.push(crate_name);
 
+    dbg!("cloning git repo");
     let st_git_cl = Command::new("git")
         .args([
             OsStr::new("clone"),
@@ -157,6 +158,7 @@ fn integration_test_rustc() {
         .expect("unable to run git");
     assert!(st_git_cl.success());
 
+    dbg!("getting rustc version");
     // clippy is pinned to a specific nightly version
     // check out the commit of that nightly to ensure compatibility
     let rustc_output = Command::new("rustc")
@@ -178,6 +180,7 @@ fn integration_test_rustc() {
     dbg!(&commit);
     // check out the commit in the rustc repo to ensure clippy is compatible
 
+    dbg!("checking out commit in rustc repo");
     let st_git_checkout = Command::new("git")
         .current_dir(&repo_dir)
         .arg("checkout")
@@ -195,14 +198,16 @@ fn integration_test_rustc() {
 
     let path_env = target_dir.join(env!("PROFILE"));
 
-    let output = Command::new("python")
-        .arg("./x.py")
-        .current_dir(&repo_dir)
-        .env("RUST_BACKTRACE", "full")
-        .env("PATH", path_env)
-        .args(["clippy", "-Wclippy::pedantic", "-Wclippy::nursery"])
-        .output()
-        .expect("unable to run x.py  clippy");
+    let output = dbg!(
+        Command::new("python")
+            .arg("./x.py")
+            .current_dir(&repo_dir)
+            .env("RUST_BACKTRACE", "full")
+            .env("PATH", path_env)
+            .args(["clippy", "-Wclippy::pedantic", "-Wclippy::nursery"])
+    )
+    .output()
+    .expect("unable to run x.py  clippy");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -244,7 +244,7 @@ fn integration_test_rustc() {
         .filter(|path| path.is_file())
         .for_each(|file| {
             let old_path: PathBuf = dbg!(file.clone());
-            let new_base: &PathBuf = dbg!(&bin_dir);
+            let new_base: PathBuf = dbg!(&bin_dir).join("willbeoverwritten");
             let bin_file_name: &std::ffi::OsStr = dbg!(old_path.file_name().unwrap());
             let new_path: PathBuf = dbg!(new_base.with_file_name(&bin_file_name));
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -215,8 +215,11 @@ fn integration_test_rustc() {
         .expect("rustc failed to print sysroot");
     let sysroot = dbg!(String::from_utf8_lossy(&sysroot_output.stdout).to_string());
 
-    let mut sysroot_path = PathBuf::from(sysroot);
+    let mut sysroot_path = dbg!(PathBuf::from(sysroot));
     sysroot_path.join("/");
+
+    dbg!(&sysroot_path);
+
     assert!(
         sysroot_path.exists(),
         "{}",


### PR DESCRIPTION
r? @ghost


changelog: run clippy on rust-lang/rust as integration test 

This might be blocked on at least 
https://github.com/rust-lang/rust-clippy/issues/11230
https://github.com/rust-lang/rust-clippy/issues/11176
https://github.com/rust-lang/rust-clippy/issues/11256
