### PR TITLE
Resolve type aliases in `type_certainty`

### DIFF
--- a/tests/ui/unwrap_or_else_default.fixed
+++ b/tests/ui/unwrap_or_else_default.fixed
@@ -109,6 +109,10 @@ fn type_certainty(option: Option<Vec<u64>>) {
     // should not be changed: no type annotation, unconcretized initializer
     let option = None;
     option.unwrap_or_else(Vec::new).push(1);
+
+    type Alias = Option<Vec<u32>>;
+    let option: Alias = Option::<Vec<u32>>::Some(Vec::new());
+    option.unwrap_or_default().push(1);
 }
 
 fn method_call_with_deref() {

--- a/tests/ui/unwrap_or_else_default.rs
+++ b/tests/ui/unwrap_or_else_default.rs
@@ -109,6 +109,10 @@ fn type_certainty(option: Option<Vec<u64>>) {
     // should not be changed: no type annotation, unconcretized initializer
     let option = None;
     option.unwrap_or_else(Vec::new).push(1);
+
+    type Alias = Option<Vec<u32>>;
+    let option: Alias = Option::<Vec<u32>>::Some(Vec::new());
+    option.unwrap_or_else(Vec::new).push(1);
 }
 
 fn method_call_with_deref() {

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -84,11 +84,17 @@ error: use of `unwrap_or_else` to construct default value
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
+error: use of `unwrap_or_else` to construct default value
+  --> $DIR/unwrap_or_else_default.rs:115:12
+   |
+LL |     option.unwrap_or_else(Vec::new).push(1);
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
+
 error: use of `or_insert_with` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:128:32
+  --> $DIR/unwrap_or_else_default.rs:132:32
    |
 LL |     let _ = inner_map.entry(0).or_insert_with(Default::default);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
-error: aborting due to 15 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Fixes #11256

changelog: `unwrap_or_default`: Fix ICE when local types are declared using alias types
