### PR TITLE
[`unnecessary_mut_passed`]: don't lint in macro expansions

### DIFF
--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -37,6 +37,11 @@ declare_lint_pass!(UnnecessaryMutPassed => [UNNECESSARY_MUT_PASSED]);
 
 impl<'tcx> LateLintPass<'tcx> for UnnecessaryMutPassed {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
+        if e.span.from_expansion() {
+            // Issue #11268
+            return;
+        }
+
         match e.kind {
             ExprKind::Call(fn_expr, arguments) => {
                 if let ExprKind::Path(ref path) = fn_expr.kind {

--- a/tests/ui/mut_reference.rs
+++ b/tests/ui/mut_reference.rs
@@ -1,7 +1,20 @@
-#![allow(unused_variables)]
+#![allow(unused_variables, dead_code)]
 
 fn takes_an_immutable_reference(a: &i32) {}
 fn takes_a_mutable_reference(a: &mut i32) {}
+
+mod issue11268 {
+    macro_rules! x {
+        ($f:expr) => {
+            $f(&mut 1);
+        };
+    }
+
+    fn f() {
+        x!(super::takes_an_immutable_reference);
+        x!(super::takes_a_mutable_reference);
+    }
+}
 
 struct MyStruct;
 

--- a/tests/ui/mut_reference.stderr
+++ b/tests/ui/mut_reference.stderr
@@ -1,5 +1,5 @@
 error: the function `takes_an_immutable_reference` doesn't need a mutable reference
-  --> $DIR/mut_reference.rs:17:34
+  --> $DIR/mut_reference.rs:30:34
    |
 LL |     takes_an_immutable_reference(&mut 42);
    |                                  ^^^^^^^
@@ -7,19 +7,19 @@ LL |     takes_an_immutable_reference(&mut 42);
    = note: `-D clippy::unnecessary-mut-passed` implied by `-D warnings`
 
 error: the function `as_ptr` doesn't need a mutable reference
-  --> $DIR/mut_reference.rs:19:12
+  --> $DIR/mut_reference.rs:32:12
    |
 LL |     as_ptr(&mut 42);
    |            ^^^^^^^
 
 error: the method `takes_an_immutable_reference` doesn't need a mutable reference
-  --> $DIR/mut_reference.rs:23:44
+  --> $DIR/mut_reference.rs:36:44
    |
 LL |     my_struct.takes_an_immutable_reference(&mut 42);
    |                                            ^^^^^^^
 
 error: this argument is a mutable reference, but not used mutably
-  --> $DIR/mut_reference.rs:11:44
+  --> $DIR/mut_reference.rs:24:44
    |
 LL |     fn takes_a_mutable_reference(&self, a: &mut i32) {}
    |                                            ^^^^^^^^ help: consider changing to: `&i32`


### PR DESCRIPTION
Fixes #11268

changelog: [`unnecessary_mut_passed`]: don't lint in macro expansions