### PR TITLE
[new_without_default]: include `where` clause in suggestions, make applicable

### DIFF
--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -155,7 +155,7 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                                                 &generics_sugg,
                                                 &where_clause_sugg
                                             ),
-                                            Applicability::MaybeIncorrect,
+                                            Applicability::MachineApplicable,
                                         );
                                     },
                                 );

--- a/tests/ui/new_without_default.fixed
+++ b/tests/ui/new_without_default.fixed
@@ -102,7 +102,6 @@ impl<'c> LtKo<'c> {
     pub fn new() -> LtKo<'c> {
         unimplemented!()
     }
-    // FIXME: that suggestion is missing lifetimes
 }
 
 struct Private;
@@ -271,5 +270,32 @@ pub struct IgnoreLifetimeNew;
 impl IgnoreLifetimeNew {
     pub fn new<'a>() -> Self {
         Self
+    }
+}
+
+// From issue #11267
+
+pub struct MyStruct<K, V>
+where
+    K: std::hash::Hash + Eq + PartialEq,
+{
+    _kv: Option<(K, V)>,
+}
+
+impl<K, V> Default for MyStruct<K, V>
+where
+    K: std::hash::Hash + Eq + PartialEq,
+ {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> MyStruct<K, V>
+where
+    K: std::hash::Hash + Eq + PartialEq,
+{
+    pub fn new() -> Self {
+        Self { _kv: None }
     }
 }

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -230,3 +230,21 @@ impl IgnoreLifetimeNew {
         Self
     }
 }
+
+// From issue #11267
+
+pub struct MyStruct<K, V>
+where
+    K: std::hash::Hash + Eq + PartialEq,
+{
+    _kv: Option<(K, V)>,
+}
+
+impl<K, V> MyStruct<K, V>
+where
+    K: std::hash::Hash + Eq + PartialEq,
+{
+    pub fn new() -> Self {
+        Self { _kv: None }
+    }
+}

--- a/tests/ui/new_without_default.rs
+++ b/tests/ui/new_without_default.rs
@@ -84,7 +84,6 @@ impl<'c> LtKo<'c> {
     pub fn new() -> LtKo<'c> {
         unimplemented!()
     }
-    // FIXME: that suggestion is missing lifetimes
 }
 
 struct Private;

--- a/tests/ui/new_without_default.stderr
+++ b/tests/ui/new_without_default.stderr
@@ -51,7 +51,7 @@ LL + }
    |
 
 error: you should consider adding a `Default` implementation for `NewNotEqualToDerive`
-  --> $DIR/new_without_default.rs:177:5
+  --> $DIR/new_without_default.rs:176:5
    |
 LL | /     pub fn new() -> Self {
 LL | |         NewNotEqualToDerive { foo: 1 }
@@ -68,7 +68,7 @@ LL + }
    |
 
 error: you should consider adding a `Default` implementation for `FooGenerics<T>`
-  --> $DIR/new_without_default.rs:185:5
+  --> $DIR/new_without_default.rs:184:5
    |
 LL | /     pub fn new() -> Self {
 LL | |         Self(Default::default())
@@ -85,7 +85,7 @@ LL + }
    |
 
 error: you should consider adding a `Default` implementation for `BarGenerics<T>`
-  --> $DIR/new_without_default.rs:192:5
+  --> $DIR/new_without_default.rs:191:5
    |
 LL | /     pub fn new() -> Self {
 LL | |         Self(Default::default())
@@ -102,7 +102,7 @@ LL + }
    |
 
 error: you should consider adding a `Default` implementation for `Foo<T>`
-  --> $DIR/new_without_default.rs:203:9
+  --> $DIR/new_without_default.rs:202:9
    |
 LL | /         pub fn new() -> Self {
 LL | |             todo!()

--- a/tests/ui/new_without_default.stderr
+++ b/tests/ui/new_without_default.stderr
@@ -120,5 +120,25 @@ LL +
 LL ~     impl<T> Foo<T> {
    |
 
-error: aborting due to 7 previous errors
+error: you should consider adding a `Default` implementation for `MyStruct<K, V>`
+  --> $DIR/new_without_default.rs:247:5
+   |
+LL | /     pub fn new() -> Self {
+LL | |         Self { _kv: None }
+LL | |     }
+   | |_____^
+   |
+help: try adding this
+   |
+LL + impl<K, V> Default for MyStruct<K, V>
+LL + where
+LL +     K: std::hash::Hash + Eq + PartialEq,
+LL +  {
+LL +     fn default() -> Self {
+LL +         Self::new()
+LL +     }
+LL + }
+   |
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Fixes #11267

changelog: [`new_without_default`]: include `where` clause in suggestions
