### PR TITLE
 [iter_overeager_cloned]: detect `.cloned().filter()` and `.cloned().find()`

### DIFF
--- a/tests/ui/iter_overeager_cloned.fixed
+++ b/tests/ui/iter_overeager_cloned.fixed
@@ -20,17 +20,47 @@ fn main() {
         .iter()
         .flatten().cloned();
 
-    // Not implemented yet
-    let _ = vec.iter().cloned().filter(|x| x.starts_with('2'));
+    let _ = vec.iter().filter(|&x| x.starts_with('2')).cloned();
+
+    let _ = vec.iter().find(|&x| x == "2").cloned();
+
+    {
+        let f = |x: &String| x.starts_with('2');
+        let _ = vec.iter().filter(|&x| f(x)).cloned();
+        let _ = vec.iter().find(|&x| f(x)).cloned();
+    }
+
+    {
+        let vec: Vec<(String, String)> = vec![];
+        let f = move |x: &(String, String)| x.0.starts_with('2');
+        let _ = vec.iter().filter(|&x| f(x)).cloned();
+        let _ = vec.iter().find(|&x| f(x)).cloned();
+    }
+
+    fn test_move<'a>(
+        iter: impl Iterator<Item = &'a (&'a u32, String)> + 'a,
+        target: String,
+    ) -> impl Iterator<Item = (&'a u32, String)> + 'a {
+        iter.filter(move |&(&a, b)| a == 1 && b == &target).cloned()
+    }
+
+    {
+        #[derive(Clone)]
+        struct S<'a> {
+            a: &'a u32,
+            b: String,
+        }
+
+        fn bar<'a>(iter: impl Iterator<Item = &'a S<'a>> + 'a, target: String) -> impl Iterator<Item = S<'a>> + 'a {
+            iter.filter(move |&S { a, b }| **a == 1 && b == &target).cloned()
+        }
+    }
 
     // Not implemented yet
     let _ = vec.iter().cloned().map(|x| x.len());
 
     // This would fail if changed.
     let _ = vec.iter().cloned().map(|x| x + "2");
-
-    // Not implemented yet
-    let _ = vec.iter().cloned().find(|x| x == "2");
 
     // Not implemented yet
     let _ = vec.iter().cloned().for_each(|x| assert!(!x.is_empty()));

--- a/tests/ui/iter_overeager_cloned.rs
+++ b/tests/ui/iter_overeager_cloned.rs
@@ -21,17 +21,47 @@ fn main() {
         .cloned()
         .flatten();
 
-    // Not implemented yet
     let _ = vec.iter().cloned().filter(|x| x.starts_with('2'));
+
+    let _ = vec.iter().cloned().find(|x| x == "2");
+
+    {
+        let f = |x: &String| x.starts_with('2');
+        let _ = vec.iter().cloned().filter(f);
+        let _ = vec.iter().cloned().find(f);
+    }
+
+    {
+        let vec: Vec<(String, String)> = vec![];
+        let f = move |x: &(String, String)| x.0.starts_with('2');
+        let _ = vec.iter().cloned().filter(f);
+        let _ = vec.iter().cloned().find(f);
+    }
+
+    fn test_move<'a>(
+        iter: impl Iterator<Item = &'a (&'a u32, String)> + 'a,
+        target: String,
+    ) -> impl Iterator<Item = (&'a u32, String)> + 'a {
+        iter.cloned().filter(move |(&a, b)| a == 1 && b == &target)
+    }
+
+    {
+        #[derive(Clone)]
+        struct S<'a> {
+            a: &'a u32,
+            b: String,
+        }
+
+        fn bar<'a>(iter: impl Iterator<Item = &'a S<'a>> + 'a, target: String) -> impl Iterator<Item = S<'a>> + 'a {
+            iter.cloned().filter(move |S { a, b }| **a == 1 && b == &target)
+        }
+    }
 
     // Not implemented yet
     let _ = vec.iter().cloned().map(|x| x.len());
 
     // This would fail if changed.
     let _ = vec.iter().cloned().map(|x| x + "2");
-
-    // Not implemented yet
-    let _ = vec.iter().cloned().find(|x| x == "2");
 
     // Not implemented yet
     let _ = vec.iter().cloned().for_each(|x| assert!(!x.is_empty()));

--- a/tests/ui/iter_overeager_cloned.stderr
+++ b/tests/ui/iter_overeager_cloned.stderr
@@ -66,5 +66,69 @@ LL ~         .iter()
 LL ~         .flatten().cloned();
    |
 
-error: aborting due to 7 previous errors
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:24:13
+   |
+LL |     let _ = vec.iter().cloned().filter(|x| x.starts_with('2'));
+   |             ^^^^^^^^^^----------------------------------------
+   |                       |
+   |                       help: try: `.filter(|&x| x.starts_with('2')).cloned()`
+
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:26:13
+   |
+LL |     let _ = vec.iter().cloned().find(|x| x == "2");
+   |             ^^^^^^^^^^----------------------------
+   |                       |
+   |                       help: try: `.find(|&x| x == "2").cloned()`
+
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:30:17
+   |
+LL |         let _ = vec.iter().cloned().filter(f);
+   |                 ^^^^^^^^^^-------------------
+   |                           |
+   |                           help: try: `.filter(|&x| f(x)).cloned()`
+
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:31:17
+   |
+LL |         let _ = vec.iter().cloned().find(f);
+   |                 ^^^^^^^^^^-----------------
+   |                           |
+   |                           help: try: `.find(|&x| f(x)).cloned()`
+
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:37:17
+   |
+LL |         let _ = vec.iter().cloned().filter(f);
+   |                 ^^^^^^^^^^-------------------
+   |                           |
+   |                           help: try: `.filter(|&x| f(x)).cloned()`
+
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:38:17
+   |
+LL |         let _ = vec.iter().cloned().find(f);
+   |                 ^^^^^^^^^^-----------------
+   |                           |
+   |                           help: try: `.find(|&x| f(x)).cloned()`
+
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:45:9
+   |
+LL |         iter.cloned().filter(move |(&a, b)| a == 1 && b == &target)
+   |         ^^^^-------------------------------------------------------
+   |             |
+   |             help: try: `.filter(move |&(&a, b)| a == 1 && b == &target).cloned()`
+
+error: unnecessarily eager cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:56:13
+   |
+LL |             iter.cloned().filter(move |S { a, b }| **a == 1 && b == &target)
+   |             ^^^^------------------------------------------------------------
+   |                 |
+   |                 help: try: `.filter(move |&S { a, b }| **a == 1 && b == &target).cloned()`
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
changelog: [`iter_overeager_cloned`]: detect `.cloned().filter()` and `.cloned().find()`

Key idea:
```
// before
iter.cloned().filter(|x| unimplemented!() )
// after
iter.filter(|&x| unimplemented!() ).cloned()

// before
iter.cloned().filter( foo )
// after
// notice `iter` must be `Iterator<Item= &T>` (callee of `cloned()`)
// so the parameter in the closure of `filter` must be `&&T`
// so the deref is safe
iter.filter(|&x| foo(x) ).cloned()
```