### PR TITLE
[`redundant_guards`]: don't lint on float literals

### DIFF
--- a/clippy_lints/src/matches/redundant_guards.rs
+++ b/clippy_lints/src/matches/redundant_guards.rs
@@ -2,6 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::path_to_local;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::visitors::{for_each_expr, is_local_used};
+use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Arm, BinOpKind, Expr, ExprKind, Guard, MatchSource, Node, Pat, PatKind};
@@ -177,8 +178,8 @@ fn expr_can_be_pat(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
             ExprKind::AddrOf(..)
             | ExprKind::Array(..)
             | ExprKind::Tup(..)
-            | ExprKind::Struct(..)
-            | ExprKind::Lit(..) => true,
+            | ExprKind::Struct(..) => true,
+            ExprKind::Lit(lit) if !matches!(lit.node, LitKind::Float(..)) => true,
             _ => false,
         } {
             return ControlFlow::Continue(());

--- a/clippy_lints/src/matches/redundant_guards.rs
+++ b/clippy_lints/src/matches/redundant_guards.rs
@@ -161,6 +161,11 @@ fn emit_redundant_guards<'tcx>(
 }
 
 /// Checks if the given `Expr` can also be represented as a `Pat`.
+///
+/// All literals generally also work as patterns, however float literals are special.
+/// They are currently (as of 2023/08/08) still allowed in patterns, but that will become
+/// an error in the future, and rustc already actively warns against this (see rust#41620),
+/// so we don't consider those as usable within patterns for linting purposes.
 fn expr_can_be_pat(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     for_each_expr(expr, |expr| {
         if match expr.kind {

--- a/tests/ui/redundant_guards.fixed
+++ b/tests/ui/redundant_guards.fixed
@@ -15,9 +15,15 @@ struct B {
 
 struct C(u32, u32);
 
+#[derive(PartialEq)]
+struct FloatWrapper(f32);
 fn issue11304() {
     match 0.1 {
         x if x == 0.0 => todo!(),
+        _ => todo!(),
+    }
+    match FloatWrapper(0.1) {
+        x if x == FloatWrapper(0.0) => todo!(),
         _ => todo!(),
     }
 }

--- a/tests/ui/redundant_guards.fixed
+++ b/tests/ui/redundant_guards.fixed
@@ -15,6 +15,13 @@ struct B {
 
 struct C(u32, u32);
 
+fn issue11304() {
+    match 0.1 {
+        x if x == 0.0 => todo!(),
+        _ => todo!(),
+    }
+}
+
 fn main() {
     let c = C(1, 2);
     match c {

--- a/tests/ui/redundant_guards.rs
+++ b/tests/ui/redundant_guards.rs
@@ -15,9 +15,15 @@ struct B {
 
 struct C(u32, u32);
 
+#[derive(PartialEq)]
+struct FloatWrapper(f32);
 fn issue11304() {
     match 0.1 {
         x if x == 0.0 => todo!(),
+        _ => todo!(),
+    }
+    match FloatWrapper(0.1) {
+        x if x == FloatWrapper(0.0) => todo!(),
         _ => todo!(),
     }
 }

--- a/tests/ui/redundant_guards.rs
+++ b/tests/ui/redundant_guards.rs
@@ -15,6 +15,13 @@ struct B {
 
 struct C(u32, u32);
 
+fn issue11304() {
+    match 0.1 {
+        x if x == 0.0 => todo!(),
+        _ => todo!(),
+    }
+}
+
 fn main() {
     let c = C(1, 2);
     match c {

--- a/tests/ui/redundant_guards.stderr
+++ b/tests/ui/redundant_guards.stderr
@@ -1,5 +1,5 @@
 error: redundant guard
-  --> $DIR/redundant_guards.rs:28:20
+  --> $DIR/redundant_guards.rs:34:20
    |
 LL |         C(x, y) if let 1 = y => ..,
    |                    ^^^^^^^^^
@@ -12,7 +12,7 @@ LL +         C(x, 1) => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:34:20
+  --> $DIR/redundant_guards.rs:40:20
    |
 LL |         Some(x) if matches!(x, Some(1) if true) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |         Some(Some(1)) if true => ..,
    |              ~~~~~~~  ~~~~~~~
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:35:20
+  --> $DIR/redundant_guards.rs:41:20
    |
 LL |         Some(x) if matches!(x, Some(1)) => {
    |                    ^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL +         Some(Some(1)) => {
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:39:20
+  --> $DIR/redundant_guards.rs:45:20
    |
 LL |         Some(x) if let Some(1) = x => ..,
    |                    ^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL +         Some(Some(1)) => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:40:20
+  --> $DIR/redundant_guards.rs:46:20
    |
 LL |         Some(x) if x == Some(2) => ..,
    |                    ^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL +         Some(Some(2)) => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:63:20
+  --> $DIR/redundant_guards.rs:69:20
    |
 LL |         B { e } if matches!(e, Some(A(2))) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL +         B { e: Some(A(2)) } => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:100:20
+  --> $DIR/redundant_guards.rs:106:20
    |
 LL |         E::A(y) if y == "not from an or pattern" => {},
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL +         E::A("not from an or pattern") => {},
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:107:14
+  --> $DIR/redundant_guards.rs:113:14
    |
 LL |         x if matches!(x, Some(0)) => ..,
    |              ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/redundant_guards.stderr
+++ b/tests/ui/redundant_guards.stderr
@@ -1,5 +1,5 @@
 error: redundant guard
-  --> $DIR/redundant_guards.rs:21:20
+  --> $DIR/redundant_guards.rs:28:20
    |
 LL |         C(x, y) if let 1 = y => ..,
    |                    ^^^^^^^^^
@@ -12,7 +12,7 @@ LL +         C(x, 1) => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:27:20
+  --> $DIR/redundant_guards.rs:34:20
    |
 LL |         Some(x) if matches!(x, Some(1) if true) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |         Some(Some(1)) if true => ..,
    |              ~~~~~~~  ~~~~~~~
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:28:20
+  --> $DIR/redundant_guards.rs:35:20
    |
 LL |         Some(x) if matches!(x, Some(1)) => {
    |                    ^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL +         Some(Some(1)) => {
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:32:20
+  --> $DIR/redundant_guards.rs:39:20
    |
 LL |         Some(x) if let Some(1) = x => ..,
    |                    ^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL +         Some(Some(1)) => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:33:20
+  --> $DIR/redundant_guards.rs:40:20
    |
 LL |         Some(x) if x == Some(2) => ..,
    |                    ^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL +         Some(Some(2)) => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:56:20
+  --> $DIR/redundant_guards.rs:63:20
    |
 LL |         B { e } if matches!(e, Some(A(2))) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL +         B { e: Some(A(2)) } => ..,
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:93:20
+  --> $DIR/redundant_guards.rs:100:20
    |
 LL |         E::A(y) if y == "not from an or pattern" => {},
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL +         E::A("not from an or pattern") => {},
    |
 
 error: redundant guard
-  --> $DIR/redundant_guards.rs:100:14
+  --> $DIR/redundant_guards.rs:107:14
    |
 LL |         x if matches!(x, Some(0)) => ..,
    |              ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #11304

changelog: [`redundant_guards`]: don't lint on float literals

r? @Centri3 i figured you are probably a good reviewer for this since you implemented the lint ^^