### PR TITLE
[iter_overeager_cloned]: detect .cloned().map() and .cloned().for_each()

### DIFF
--- a/tests/ui/iter_overeager_cloned.fixed
+++ b/tests/ui/iter_overeager_cloned.fixed
@@ -56,14 +56,12 @@ fn main() {
         }
     }
 
-    // Not implemented yet
-    let _ = vec.iter().cloned().map(|x| x.len());
+    let _ = vec.iter().map(|x| x.len());
 
     // This would fail if changed.
     let _ = vec.iter().cloned().map(|x| x + "2");
 
-    // Not implemented yet
-    let _ = vec.iter().cloned().for_each(|x| assert!(!x.is_empty()));
+    let _ = vec.iter().for_each(|x| assert!(!x.is_empty()));
 
     // Not implemented yet
     let _ = vec.iter().cloned().all(|x| x.len() == 1);

--- a/tests/ui/iter_overeager_cloned.rs
+++ b/tests/ui/iter_overeager_cloned.rs
@@ -57,13 +57,11 @@ fn main() {
         }
     }
 
-    // Not implemented yet
     let _ = vec.iter().cloned().map(|x| x.len());
 
     // This would fail if changed.
     let _ = vec.iter().cloned().map(|x| x + "2");
 
-    // Not implemented yet
     let _ = vec.iter().cloned().for_each(|x| assert!(!x.is_empty()));
 
     // Not implemented yet

--- a/tests/ui/iter_overeager_cloned.stderr
+++ b/tests/ui/iter_overeager_cloned.stderr
@@ -130,5 +130,21 @@ LL |             iter.cloned().filter(move |S { a, b }| **a == 1 && b == &target
    |                 |
    |                 help: try: `.filter(move |&S { a, b }| **a == 1 && b == &target).cloned()`
 
-error: aborting due to 15 previous errors
+error: unneeded cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:60:13
+   |
+LL |     let _ = vec.iter().cloned().map(|x| x.len());
+   |             ^^^^^^^^^^--------------------------
+   |                       |
+   |                       help: try: `.map(|x| x.len())`
+
+error: unneeded cloning of iterator items
+  --> $DIR/iter_overeager_cloned.rs:65:13
+   |
+LL |     let _ = vec.iter().cloned().for_each(|x| assert!(!x.is_empty()));
+   |             ^^^^^^^^^^----------------------------------------------
+   |                       |
+   |                       help: try: `.for_each(|x| assert!(!x.is_empty()))`
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
changelog: [`iter_overeager_cloned`]

key idea:
for `f` in `.map(f)` and `.for_each(f)`:
1. `f` must be closure
2. don't lint if mutable paramter in clsure `f`: `|mut x| ...`
3. don't lint if parameter is moved
4. maybe incorrect