### PR TITLE
allow calling `to_owned` on borrowed value for [`implicit_clone`]

### DIFF
--- a/clippy_lints/src/methods/implicit_clone.rs
+++ b/clippy_lints/src/methods/implicit_clone.rs
@@ -17,6 +17,7 @@ pub fn check(cx: &LateContext<'_>, method_name: &str, expr: &hir::Expr<'_>, recv
         let return_type = cx.typeck_results().expr_ty(expr);
         let input_type = cx.typeck_results().expr_ty(recv);
         let (input_type, ref_count) = peel_mid_ty_refs(input_type);
+        if !(ref_count > 0 && is_diag_trait_item(cx, method_def_id, sym::ToOwned));
         if let Some(ty_name) = input_type.ty_adt_def().map(|adt_def| cx.tcx.item_name(adt_def.did()));
         if return_type == input_type;
         if let Some(clone_trait) = cx.tcx.lang_items().clone_trait();

--- a/tests/ui/implicit_clone.fixed
+++ b/tests/ui/implicit_clone.fixed
@@ -67,7 +67,7 @@ fn main() {
 
     let vec_ref = &vec;
     let _ = return_owned_from_slice(vec_ref);
-    let _ = vec_ref.clone();
+    let _ = vec_ref.to_owned();
     let _ = vec_ref.clone();
 
     // we expect no lint for this

--- a/tests/ui/implicit_clone.stderr
+++ b/tests/ui/implicit_clone.stderr
@@ -12,12 +12,6 @@ error: implicitly cloning a `Vec` by calling `to_vec` on its dereferenced type
 LL |     let _ = vec.to_vec();
    |             ^^^^^^^^^^^^ help: consider using: `vec.clone()`
 
-error: implicitly cloning a `Vec` by calling `to_owned` on its dereferenced type
-  --> $DIR/implicit_clone.rs:70:13
-   |
-LL |     let _ = vec_ref.to_owned();
-   |             ^^^^^^^^^^^^^^^^^^ help: consider using: `vec_ref.clone()`
-
 error: implicitly cloning a `Vec` by calling `to_vec` on its dereferenced type
   --> $DIR/implicit_clone.rs:71:13
    |
@@ -72,5 +66,5 @@ error: implicitly cloning a `PathBuf` by calling `to_path_buf` on its dereferenc
 LL |     let _ = pathbuf_ref.to_path_buf();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(**pathbuf_ref).clone()`
 
-error: aborting due to 12 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
fixes: #11281 

a small and simple fix that give up checking for `referenced_value.to_owned()` usage.

changelog: allow calling `to_owned` with borrowed value for [`implicit_clone`]
