### PR TITLE
Fix SPEEDTEST instructions and output

### DIFF
--- a/book/src/development/speedtest.md
+++ b/book/src/development/speedtest.md
@@ -9,16 +9,12 @@ accessed by the `SPEEDTEST` (and `SPEEDTEST_*`) environment variables.
 To do a simple speed test of a lint (e.g. `allow_attributes`), use this command.
 
 ```sh
-$ SPEEDTEST=ui TESTNAME="allow_attributes" cargo uitest -- --nocapture
+$ SPEEDTEST=ui TESTNAME="allow_attributes" cargo uitest
 ```
 
 This will test all `ui` tests (`SPEEDTEST=ui`) whose names start with `allow_attributes`. By default, `SPEEDTEST` will
 iterate your test 1000 times. But you can change this with `SPEEDTEST_ITERATIONS`.
 
 ```sh
-$ SPEEDTEST=toml SPEEDTEST_ITERATIONS=100 TESTNAME="semicolon_block" cargo uitest -- --nocapture
+$ SPEEDTEST=toml SPEEDTEST_ITERATIONS=100 TESTNAME="semicolon_block" cargo uitest
 ```
-
-> **WARNING**: Be sure to use `-- --nocapture` at the end of the command to see the average test time. If you don't
-> use `-- --nocapture` (e.g. `SPEEDTEST=ui` `TESTNAME="let_underscore_untyped" cargo uitest -- --nocapture`), this
-> will not show up.

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -349,7 +349,11 @@ fn main() {
             f();
             sum += start.elapsed().as_millis();
         }
-        println!("average {} time: {} millis.", speedtest.to_uppercase(), sum / 1000);
+        println!(
+            "average {} time: {} millis.",
+            speedtest.to_uppercase(),
+            sum / u128::from(iterations)
+        );
     } else {
         run_ui();
         run_ui_toml();


### PR DESCRIPTION
* `--nocapture` hasn't been needed anymore since forever (even before `ui_test`)
* the result was dividing by 1000 instead of the number of test runs, giving bogus (but still useful for the purpose) timing results.

changelog: fix SPEEDTEST instructions and output