### PR TITLE
Do not bless by default in ui tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [alias]
-uitest = "test --test compile-test -- --check"
-uibless = "test --test compile-test"
-bless = "test"
+uitest = "test --test compile-test"
+uibless = "test --test compile-test -- -- --bless"
+bless = "test -- -- --bless"
 dev = "run --package clippy_dev --bin clippy_dev --manifest-path clippy_dev/Cargo.toml --"
 lintcheck = "run --package lintcheck --bin lintcheck --manifest-path lintcheck/Cargo.toml  -- "
 collect-metadata = "test --test dogfood --features internal -- run_metadata_collection_lint --ignored"


### PR DESCRIPTION
This restores the default behaviour to check the `.stderr`, it was changed in #11239 to bless by default in `cargo test` (unless in github actions), but check by default in `cargo uitest` which is fairly confusing

It also meant `cargo uitest -F internal` no longer worked

`--bless` prevents the use of `Args::test` but we can look at reintegrating with that after @oli-obk's vacation

r? @flip1995

changelog: none
