### PR TITLE
New lint `needless_cow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5082,6 +5082,7 @@ Released 2018-09-13
 [`needless_borrowed_reference`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrowed_reference
 [`needless_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_collect
 [`needless_continue`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_continue
+[`needless_cow`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_cow
 [`needless_doctest_main`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main
 [`needless_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_else
 [`needless_for_each`]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_for_each

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -478,6 +478,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::needless_bool::NEEDLESS_BOOL_ASSIGN_INFO,
     crate::needless_borrowed_ref::NEEDLESS_BORROWED_REFERENCE_INFO,
     crate::needless_continue::NEEDLESS_CONTINUE_INFO,
+    crate::needless_cow::NEEDLESS_COW_INFO,
     crate::needless_else::NEEDLESS_ELSE_INFO,
     crate::needless_for_each::NEEDLESS_FOR_EACH_INFO,
     crate::needless_if::NEEDLESS_IF_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -24,6 +24,7 @@
 extern crate rustc_arena;
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
+extern crate rustc_const_eval;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;
@@ -36,6 +37,7 @@ extern crate rustc_infer;
 extern crate rustc_lexer;
 extern crate rustc_lint;
 extern crate rustc_middle;
+extern crate rustc_mir_dataflow;
 extern crate rustc_parse;
 extern crate rustc_session;
 extern crate rustc_span;
@@ -228,6 +230,7 @@ mod needless_arbitrary_self_type;
 mod needless_bool;
 mod needless_borrowed_ref;
 mod needless_continue;
+mod needless_cow;
 mod needless_else;
 mod needless_for_each;
 mod needless_if;
@@ -1095,6 +1098,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     });
     store.register_late_pass(|_| Box::new(redundant_locals::RedundantLocals));
     store.register_late_pass(|_| Box::new(ignored_unit_patterns::IgnoredUnitPatterns));
+    store.register_late_pass(move |_| Box::new(needless_cow::NeedlessCow));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/needless_cow.rs
+++ b/clippy_lints/src/needless_cow.rs
@@ -1,0 +1,306 @@
+use clippy_utils::diagnostics::span_lint_hir_and_then;
+use clippy_utils::fn_has_unsatisfiable_preds;
+use clippy_utils::ty::is_type_diagnostic_item;
+use itertools::Itertools;
+use rustc_const_eval::interpret::{AllocId, AllocRange, ConstValue, GlobalAlloc};
+use rustc_data_structures::fx::{FxIndexMap, IndexEntry};
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::FnKind;
+use rustc_hir::{Body, FnDecl};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::mir::{
+    self, AggregateKind, ConstantKind, Location, Operand, Place, Rvalue, SourceInfo, Statement, StatementKind,
+};
+use rustc_middle::ty::TyCtxt;
+use rustc_mir_dataflow::lattice::FlatSet;
+use rustc_mir_dataflow::value_analysis::{Map, State, ValueAnalysis, ValueAnalysisWrapper, ValueOrPlace};
+use rustc_mir_dataflow::{Analysis, Results, ResultsVisitor};
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::{sym, Span};
+use rustc_target::abi::{FieldIdx, Size};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for locals who are assigned a `Cow`, yet the `Borrowed` variant is only ever used for
+    /// empty string slices.
+    ///
+    /// ### Why is this bad?
+    /// An empty string does not allocate any memory. This can use `String` instead, with the
+    /// `Borrowed` invocations substituted for `String::new`.
+    ///
+    /// ### Example
+    /// ```rust
+    /// # let my_owned_string = String::new();
+    /// # let something = true;
+    /// # let other_thing = true;
+    /// let _ = if something {
+    ///     Cow::Owned(my_owned_string);
+    /// } else if other_thing {
+    ///     Cow::Owned(String::new());
+    /// } else {
+    ///     Cow::Borrowed("");
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// # let my_owned_string = String::new();
+    /// # let something = true;
+    /// # let other_thing = true;
+    /// let _ = if something {
+    ///     my_owned_string;
+    /// } else if other_thing {
+    ///     String::new();
+    /// } else {
+    ///     String::new();
+    /// }
+    /// ```
+    #[clippy::version = "1.73.0"]
+    pub NEEDLESS_COW,
+    nursery,
+    "usage of `Cow` with only empty strings in `Borrow` variant"
+}
+impl_lint_pass!(NeedlessCow => [NEEDLESS_COW]);
+
+pub struct NeedlessCow;
+
+impl<'tcx> LateLintPass<'tcx> for NeedlessCow {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        _: &'tcx FnDecl<'tcx>,
+        _: &'tcx Body<'tcx>,
+        _: Span,
+        def_id: LocalDefId,
+    ) {
+        // Probably unnecessary nowadays considering dummy MIR is created for these functions.
+        if fn_has_unsatisfiable_preds(cx, def_id.to_def_id()) {
+            return;
+        }
+
+        let mir = cx.tcx.optimized_mir(def_id);
+        let mut cow_locals_to_assignments = FxIndexMap::default();
+
+        for local in mir
+            .local_decls
+            .iter_enumerated()
+            .filter(|(_, decl)| is_type_diagnostic_item(cx, decl.ty, sym::Cow))
+            .map(|(i, _)| i)
+        {
+            cow_locals_to_assignments.insert(local, vec![]);
+        }
+
+        let mut results = NeedlessCowAnalysis {
+            map: Map::from_filter(cx.tcx, mir, |ty| ty.peel_refs().is_str(), None),
+        }
+        .wrap()
+        .into_engine(cx.tcx, mir)
+        .iterate_to_fixpoint();
+
+        results.visit_reachable_with(
+            mir,
+            &mut NeedlessCowVisitor {
+                cx,
+                cow_locals_to_assignments: &mut cow_locals_to_assignments,
+            },
+        );
+
+        for assignments in cow_locals_to_assignments.into_values() {
+            if assignments.len() == 1 {
+                continue;
+            }
+            let Some(first) = assignments.first() else {
+                continue;
+            };
+
+            span_lint_hir_and_then(
+                cx,
+                NEEDLESS_COW,
+                mir.source_scopes[first.scope]
+                    .local_data
+                    .as_ref()
+                    .assert_crate_local()
+                    .lint_root,
+                assignments.into_iter().map(|scope| scope.span).collect_vec(),
+                "usage of `Cow` where the `Borrowed` variant is only ever used for empty strings",
+                |diag| {
+                    diag.help("remove the `Cow` and use `String::new` instead, as it allocates no memory");
+                },
+            );
+        }
+    }
+}
+
+struct NeedlessCowAnalysis {
+    map: Map,
+}
+
+impl<'tcx> ValueAnalysis<'tcx> for NeedlessCowAnalysis {
+    type Value = FlatSet<ConstantKind<'tcx>>;
+
+    const NAME: &'static str = "NeedlessCowAnalysis";
+
+    fn map(&self) -> &Map {
+        &self.map
+    }
+
+    fn handle_assign(&self, target: Place<'tcx>, rvalue: &Rvalue<'tcx>, state: &mut State<Self::Value>) {
+        state.flood(target.as_ref(), &self.map);
+
+        let Some(target_idx) = self.map.find(target.as_ref()) else {
+            return;
+        };
+
+        let result = match rvalue {
+            Rvalue::Use(Operand::Constant(box constant)) => ValueOrPlace::Value(FlatSet::Elem(constant.literal)),
+            Rvalue::Use(Operand::Move(place) | Operand::Copy(place))
+            | Rvalue::Ref(_, _, place)
+            | Rvalue::CopyForDeref(place) => {
+                if (place.projection.is_empty() || place.is_indirect_first_projection() && place.projection.len() == 1)
+                    // Clear projections if this is either a deref or has no projections. Not sure
+                    // why this is needed, but otherwise this is always `Top`. It's probably because
+                    // an assignment to `_5` and an access to `*_5` are considered different. This
+                    // should be ok since dereferencing a `str` is not possible, and dereferencing a
+                    // `&str` has no side effects. (We're filtering by `str`)
+                    && let Some(place_idx) = self.map.find(Place::from(place.local).as_ref())
+                {
+                    ValueOrPlace::Place(place_idx)
+                } else {
+                    // Not sure why we can't use a guard here, but `place_idx` is apparently
+                    // uninitialized
+                    self.super_assign(target, rvalue, state);
+                    return;
+                }
+            },
+            _ => {
+                self.super_assign(target, rvalue, state);
+                return;
+            },
+        };
+
+        state.insert_idx(target_idx, result, &self.map);
+    }
+}
+
+struct NeedlessCowVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    cow_locals_to_assignments: &'a mut FxIndexMap<mir::Local, Vec<SourceInfo>>,
+}
+
+impl<'mir, 'tcx> ResultsVisitor<'mir, 'tcx, Results<'tcx, ValueAnalysisWrapper<NeedlessCowAnalysis>>>
+    for NeedlessCowVisitor<'_, 'tcx>
+{
+    type FlowState = State<FlatSet<ConstantKind<'tcx>>>;
+
+    fn visit_statement_before_primary_effect(
+        &mut self,
+        results: &Results<'tcx, ValueAnalysisWrapper<NeedlessCowAnalysis>>,
+        state: &Self::FlowState,
+        stmt: &'mir Statement<'tcx>,
+        _: Location,
+    ) {
+        let Self {
+            cx,
+            cow_locals_to_assignments,
+        } = self;
+
+        let StatementKind::Assign(box (target, rvalue)) = &stmt.kind else {
+            return;
+        };
+
+        match rvalue {
+            Rvalue::Aggregate(box AggregateKind::Adt(def_id, variant, args, _, None), init)
+                if let Some(arg_place) = init.get(FieldIdx::from(0u32)).and_then(Operand::place)
+                    && let ty = cx.tcx.type_of(def_id).instantiate(cx.tcx, args)
+                    && is_type_diagnostic_item(cx, ty, sym::Cow)
+                    && let Some(def) = ty.ty_adt_def()
+                    && let Some(assignments) = cow_locals_to_assignments.get_mut(&target.local) =>
+            {
+                // Only used for its span
+                if def.variant(*variant).name == sym!(Owned) {
+                    assignments.push(stmt.source_info);
+                    return;
+                }
+
+                if let FlatSet::Elem(value) = state.get(
+                        arg_place.as_ref(),
+                        &results.analysis.0.map,
+                    )
+                    && let value = value.eval(cx.tcx, cx.param_env)
+                    && is_empty_str(cx.tcx, value)
+                {
+                    assignments.push(stmt.source_info);
+                } else if let IndexEntry::Occupied(entry) = cow_locals_to_assignments.entry(target.local) {
+                    entry.remove_entry();
+                }
+            }
+            _ => {},
+        }
+    }
+}
+
+fn is_empty_str<'tcx>(tcx: TyCtxt<'tcx>, value: ConstantKind<'tcx>) -> bool {
+    let ConstantKind::Val(value, ty) = value else {
+        return false;
+    };
+    if !ty.peel_refs().is_str() {
+        return false;
+    }
+
+    // String slices are represented like this (if they aren't promoted). If either `start` or
+    // `end` aren't `0`, this isn't empty.
+    if let ConstValue::Slice { start, end, .. } = value {
+        return start == 0 && end == 0;
+    }
+
+    // A promoted string slice
+    if let ConstValue::Scalar(scalar) = value
+        && let Ok(p) = scalar.to_pointer(&tcx)
+        && let Some(alloc_id) = p.provenance
+    {
+        return is_alloc_empty_str(tcx, alloc_id);
+    }
+
+    false
+}
+
+/// This is pretty hacky, but for anything like `&*""` we don't have a simple `const ""`, instead,
+/// we have a promoted constant! So we must traverse the evaluated constant backwards until we find
+/// the final reference, then we can just check if its bytes are empty. Pretty hacky, but I (and
+/// maybe others) have written worse.
+fn is_alloc_empty_str(tcx: TyCtxt<'_>, alloc_id: AllocId) -> bool {
+    let Some(GlobalAlloc::Memory(alloc)) = tcx.try_get_global_alloc(alloc_id) else {
+        return false;
+    };
+
+    let alloc = alloc.inner();
+    let range = AllocRange {
+        start: Size::from_bytes(0),
+        size: alloc.size(),
+    };
+
+    if !alloc.provenance().range_empty(range, &tcx) {
+        let Ok(scalar) = alloc.read_scalar(
+            &tcx,
+            AllocRange {
+                size: tcx.data_layout.pointer_size,
+                ..range
+            },
+            true,
+        ) else {
+            return false;
+        };
+        let Ok(ptr) = scalar.to_pointer(&tcx) else {
+            return false;
+        };
+        let Some(alloc_id) = ptr.provenance else {
+            return false;
+        };
+
+        return is_alloc_empty_str(tcx, alloc_id);
+    }
+
+    alloc
+        .get_bytes_strip_provenance(&tcx, range)
+        .is_ok_and(<[u8]>::is_empty)
+}

--- a/tests/ui/needless_cow.rs
+++ b/tests/ui/needless_cow.rs
@@ -54,6 +54,18 @@ fn main() {
         _ => return,
     };
 
+    if true {
+        "".into()
+    } else {
+        Cow::Owned(String::new())
+    };
+
+    if true {
+        Cow::from("")
+    } else {
+        Cow::Owned(String::new())
+    };
+
     // Probably a bit too pedantic to lint this.
     _ = Cow::Borrowed("");
 }

--- a/tests/ui/needless_cow.rs
+++ b/tests/ui/needless_cow.rs
@@ -1,0 +1,59 @@
+#![allow(
+    clippy::borrow_deref_ref,
+    clippy::collapsible_else_if,
+    clippy::deref_addrof,
+    clippy::if_same_then_else
+)]
+#![warn(clippy::needless_cow)]
+
+use std::borrow::Cow;
+
+// FIXME: Should not lint.
+fn passed_to_fn() {
+    fn helper(_: Cow<'static, str>) {}
+
+    let x = if true { Cow::Borrowed("") } else { Cow::Borrowed("") };
+    let y = x;
+
+    helper(y);
+}
+
+// FIXME: Should not lint.
+fn passed_to_fn_mut_ref() {
+    fn helper(_: &mut Cow<'static, str>) {}
+
+    let x = if true { Cow::Borrowed("") } else { Cow::Borrowed("") };
+    let mut y = x;
+
+    helper(&mut y);
+}
+
+// FIXME: Should not lint.
+fn returning() -> Cow<'static, str> {
+    if true { Cow::Borrowed("") } else { Cow::Borrowed("") }
+}
+
+fn main() {
+    if true {
+        Cow::Owned(String::new())
+    } else {
+        if true { Cow::Borrowed("") } else { Cow::Borrowed(&*"") }
+    };
+
+    if true {
+        Cow::Borrowed(" ")
+    } else {
+        Cow::Borrowed("")
+    };
+
+    match 1 {
+        1 => Cow::Owned(String::new()),
+        2 => Cow::Borrowed(""),
+        3 => Cow::Borrowed(""),
+        4 => Cow::Owned("aa".to_string()),
+        _ => return,
+    };
+
+    // Probably a bit too pedantic to lint this.
+    _ = Cow::Borrowed("");
+}

--- a/tests/ui/needless_cow.stderr
+++ b/tests/ui/needless_cow.stderr
@@ -1,0 +1,52 @@
+error: usage of `Cow` where the `Borrowed` variant is only ever used for empty strings
+  --> $DIR/needless_cow.rs:15:23
+   |
+LL |     let x = if true { Cow::Borrowed("") } else { Cow::Borrowed("") };
+   |                       ^^^^^^^^^^^^^^^^^          ^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
+   = note: `-D clippy::needless-cow` implied by `-D warnings`
+
+error: usage of `Cow` where the `Borrowed` variant is only ever used for empty strings
+  --> $DIR/needless_cow.rs:25:23
+   |
+LL |     let x = if true { Cow::Borrowed("") } else { Cow::Borrowed("") };
+   |                       ^^^^^^^^^^^^^^^^^          ^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
+
+error: usage of `Cow` where the `Borrowed` variant is only ever used for empty strings
+  --> $DIR/needless_cow.rs:33:15
+   |
+LL |     if true { Cow::Borrowed("") } else { Cow::Borrowed("") }
+   |               ^^^^^^^^^^^^^^^^^          ^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
+
+error: usage of `Cow` where the `Borrowed` variant is only ever used for empty strings
+  --> $DIR/needless_cow.rs:38:9
+   |
+LL |         Cow::Owned(String::new())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     } else {
+LL |         if true { Cow::Borrowed("") } else { Cow::Borrowed(&*"") }
+   |                   ^^^^^^^^^^^^^^^^^          ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
+
+error: usage of `Cow` where the `Borrowed` variant is only ever used for empty strings
+  --> $DIR/needless_cow.rs:50:14
+   |
+LL |         1 => Cow::Owned(String::new()),
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         2 => Cow::Borrowed(""),
+   |              ^^^^^^^^^^^^^^^^^
+LL |         3 => Cow::Borrowed(""),
+   |              ^^^^^^^^^^^^^^^^^
+LL |         4 => Cow::Owned("aa".to_string()),
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/needless_cow.stderr
+++ b/tests/ui/needless_cow.stderr
@@ -48,5 +48,37 @@ LL |         4 => Cow::Owned("aa".to_string()),
    |
    = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
 
-error: aborting due to 5 previous errors
+error: usage of `Cow` where the `Borrowed` variant is only ever used for empty strings
+  --> $DIR/needless_cow.rs:58:9
+   |
+LL |         "".into()
+   |         ^^^^^^^^^
+LL |     } else {
+LL |         Cow::Owned(String::new())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
+note: this implicitly constructs `Borrowed`
+  --> $DIR/needless_cow.rs:58:9
+   |
+LL |         "".into()
+   |         ^^^^^^^^^
+
+error: usage of `Cow` where the `Borrowed` variant is only ever used for empty strings
+  --> $DIR/needless_cow.rs:64:9
+   |
+LL |         Cow::from("")
+   |         ^^^^^^^^^^^^^
+LL |     } else {
+LL |         Cow::Owned(String::new())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove the `Cow` and use `String::new` instead, as it allocates no memory
+note: this implicitly constructs `Borrowed`
+  --> $DIR/needless_cow.rs:64:9
+   |
+LL |         Cow::from("")
+   |         ^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Closes #11328 

This is actually probably easiest as a MIR lint. Most of the problems with it currently would persist if it operated on the HIR anyway.
r? @Jarcho

Currently in `nursery` since there's quite a few issues.

changelog: New lint [`needless_cow`]
