### PR TITLE
fix: match stmts conversion to expr and their interaction with return

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -417,12 +417,7 @@ fn check_final_expr<'tcx>(
                         arm.body,
                         semi_spans.clone(),
                         RetReplacement::Unit,
-                        // Here we pass this as arm could have
-                        // - match directly as expr: in this case our thing works
-                        // - block expr: in this case our thing gets overriden
-                        // by call to check_block_return
-                        // - anything else: doesn't matter
-                        Some(StmtKind::Expr(arm.body)),
+                        None,
                         parent_fn_return_type,
                     );
                 });

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -307,12 +307,29 @@ mod issue10049 {
     }
 }
 
-fn test_match_as_stmt() {
+fn issue10546() {
     let x = 9;
     match x {
         1 => 2,
         2 => return,
         _ => 0,
+    };
+}
+
+fn issue10390_same_arm_return_typs_diff_func_ret_typ(input: u8) {
+    match input {
+        3 => 4.1,
+        _ => 5.1,
+    };
+}
+
+fn issue10390_different_arm_return_types(input: u8) {
+    match input {
+        _ => {
+            // side effect ...
+            return;
+        },
+        3 => 4,
     };
 }
 

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -317,12 +317,29 @@ mod issue10049 {
     }
 }
 
-fn test_match_as_stmt() {
+fn issue10546() {
     let x = 9;
     match x {
         1 => 2,
         2 => return,
         _ => 0,
+    };
+}
+
+fn issue10390_same_arm_return_typs_diff_func_ret_typ(input: u8) {
+    match input {
+        3 => 4.1,
+        _ => 5.1,
+    };
+}
+
+fn issue10390_different_arm_return_types(input: u8) {
+    match input {
+        _ => {
+            // side effect ...
+            return;
+        },
+        3 => 4,
     };
 }
 


### PR DESCRIPTION
Should fix #10390 

Eariler I opened a PR to fix an issue in needless_return lint here: #10593. This fixed issue's mentioned particular scenario, but didn't fix other scenarios like #10390 . Thanks to @kadiwa4 's tag I noticed that particular issue, this time I _**tried**_ to go back to square one and think of different scenarios and made changes to hopefully cover all cases. So this PR may also cover other different issues which could have been lingering around to be found.

Explaining changes:

According to my understanding this lint's function is:
- Try to convert match stmt to match expr if it is last stmt of function/block, and then remove returns from it
- Try to remove returns in a match expr

- For cases of match expr, we don't want to change our current analysis
- For cases of match stmt, we need to check if match's return type is equal to function's return type and only do further analysis if they match exactly, for cases showed in code in above issue:

```rust
fn func(input: u8) {
    match input {
        3 => 4,
        _ => {
            // side effect ...
            return;
        },
    };
}
```

match expr return type is `u8` which is different from function's return type and hence we do not take any action :)

Do let me know if you still think there's some problem in some change 😅

---

changelog: [`needless_return`]: Fix various scenarios of match stmt/expr transformation and them apperaing with returns