### PR TITLE
Remove use of `box_syntax` in `CONTRIBUTING.md` example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ pub mod else_if_without_else;
 
 pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf: &Conf) {
     // ...
-    store.register_early_pass(|| box else_if_without_else::ElseIfWithoutElse);
+    store.register_early_pass(|| Box::new(else_if_without_else::ElseIfWithoutElse));
     // ...
 
     store.register_group(true, "clippy::restriction", Some("clippy_restriction"), vec![


### PR DESCRIPTION
`box_syntax` no longer exists.
[`clippy_lints/src/lib.rs` now uses `Box::new`](https://github.com/rust-lang/rust-clipp/blob/d5298bea7fd0ce133506d156795e3dc7c68efc20/clippy_lints/src/lib.rs#L809C70-L809C70)

changelog: none