### PR TITLE
Convert `redundant_clone` to an analysis pass

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(array_windows)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(box_patterns)]
+#![feature(hash_extract_if)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
@@ -36,6 +37,7 @@ extern crate rustc_infer;
 extern crate rustc_lexer;
 extern crate rustc_lint;
 extern crate rustc_middle;
+extern crate rustc_mir_dataflow;
 extern crate rustc_parse;
 extern crate rustc_session;
 extern crate rustc_span;

--- a/tests/ui/zz.rs
+++ b/tests/ui/zz.rs
@@ -1,0 +1,49 @@
+#![deny(clippy::redundant_clone)]
+
+use std::hint::black_box;
+
+fn main() {
+    {
+        let x = String::new();
+        let _ = x.clone();
+    }
+    {
+        let x = String::new();
+        let _x = x.clone();
+    }
+    {
+        let x = String::new();
+        let _ = black_box(x.clone());
+    }
+    {
+        let x = String::new();
+        let _ = black_box(&mut x.clone());
+    }
+    {
+        let x = String::new();
+        let mut y = x.clone();
+        y.push_str("xx");
+        println!("{y} {x}");
+    }
+    {
+        let x = String::new();
+        let _ = black_box(x.clone());
+        println!("{x}");
+    }
+    {
+        let x = String::new();
+        let _ = black_box(&mut x.clone());
+        println!("{x}");
+    }
+    {
+        let x = String::new();
+        let y = String::new();
+        let z = if black_box(true) { &x } else { &y };
+
+        black_box(x.clone());
+        black_box(y.clone());
+        black_box(z.clone());
+
+        println!("{z}");
+    }
+}

--- a/tests/ui/zz.stderr
+++ b/tests/ui/zz.stderr
@@ -1,0 +1,32 @@
+error: redundant clone
+  --> $DIR/zz.rs:8:17
+   |
+LL |         let _ = x.clone();
+   |                 ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/zz.rs:1:9
+   |
+LL | #![deny(clippy::redundant_clone)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: redundant clone
+  --> $DIR/zz.rs:12:18
+   |
+LL |         let _x = x.clone();
+   |                  ^^^^^^^^^
+
+error: redundant clone
+  --> $DIR/zz.rs:16:27
+   |
+LL |         let _ = black_box(x.clone());
+   |                           ^^^^^^^^^
+
+error: redundant clone
+  --> $DIR/zz.rs:20:32
+   |
+LL |         let _ = black_box(&mut x.clone());
+   |                                ^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
fixes #10940
fixes #10893
fixes #10870
fixes #10577
fixes #10545
fixes #10517

This is mostly finished, but blocked until rust-lang/rust#114900 is merged (or something similar). This isn't worth reviewing until then.

changelog:
