### PR TITLE
Fix tuple_array_conversions lint on nightly

### DIFF
--- a/clippy_lints/src/tuple_array_conversions.rs
+++ b/clippy_lints/src/tuple_array_conversions.rs
@@ -189,8 +189,8 @@ fn all_bindings_are_for_conv<'tcx>(
                     tys.len() == elements.len() && tys.iter().chain(final_tys.iter().copied()).all_equal()
                 },
                 (ToType::Tuple, ty::Array(ty, len)) => {
-                    len.eval_target_usize(cx.tcx, cx.param_env) as usize == elements.len()
-                        && final_tys.iter().chain(once(ty)).all_equal()
+                    let Some(len) = len.try_eval_target_usize(cx.tcx, cx.param_env) else { return false };
+                    len as usize == elements.len() && final_tys.iter().chain(once(ty)).all_equal()
                 },
                 _ => false,
             }

--- a/tests/ui/tuple_array_conversions.rs
+++ b/tests/ui/tuple_array_conversions.rs
@@ -82,6 +82,11 @@ fn main() {
     [a, c];
     let [[a, b], [c, d]] = [[1, 2], [3, 4]];
     (a, c);
+    // Array length is not usize (#11144)
+    fn generic_array_length<const N: usize>() {
+        let src = [0; N];
+        let dest: (u8,) = (src[0],);
+    }
 }
 
 #[clippy::msrv = "1.70.0"]

--- a/tests/ui/tuple_array_conversions.stderr
+++ b/tests/ui/tuple_array_conversions.stderr
@@ -64,7 +64,7 @@ LL |     (src, dest);
    = help: use `.into()` instead, or `<(T0, T1, ..., Tn)>::from` if type annotations are needed
 
 error: it looks like you're trying to convert an array to a tuple
-  --> $DIR/tuple_array_conversions.rs:99:13
+  --> $DIR/tuple_array_conversions.rs:104:13
    |
 LL |     let x = (x[0], x[1]);
    |             ^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     let x = (x[0], x[1]);
    = help: use `.into()` instead, or `<(T0, T1, ..., Tn)>::from` if type annotations are needed
 
 error: it looks like you're trying to convert a tuple to an array
-  --> $DIR/tuple_array_conversions.rs:100:13
+  --> $DIR/tuple_array_conversions.rs:105:13
    |
 LL |     let x = [x.0, x.1];
    |             ^^^^^^^^^^


### PR DESCRIPTION
```
changelog: ICE: [`tuple_array_conversions`]: Don't expect array length to always be usize
```

tl;dr: changed [`Const::eval_target_usize`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_middle/src/ty/consts.rs#L359) to [`Consts::try_eval_target_usize`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_middle/src/ty/consts.rs#L327) to get rid of ICE.

I have encountered a problem with clippy: it caught ICE when working with a codebase that uses a lot of nightly features.
Here's a (stripped) ICE info:

```
error: internal compiler error: /rustc/5c6a7e71cd66705c31c9af94077901a220f0870c/compiler/rustc_middle/src/ty/consts.rs:361:32: expected usize, got Const { ty: usize, kind: N/#1 }

thread 'rustc' panicked at /rustc/5c6a7e71cd66705c31c9af94077901a220f0870c/compiler/rustc_errors/src/lib.rs:1635:9:
Box<dyn Any>
stack backtrace:
...
  16:        0x110b9c590 - rustc_middle[449edf845976488d]::util::bug::bug_fmt
  17:        0x102f76ae0 - clippy_lints[71754038dd04c2d2]::tuple_array_conversions::all_bindings_are_for_conv
...
```

I don't really know what's going on low-level-wise, but seems like this lin assumed that the length of the array can always be treated as `usize`, and *I assume* this doesn't play well with `feat(generic_const_exprs)`.

I wasn't able to build a minimal reproducible example, but locally this fix does resolve the issue.