### PR TITLE
New lint `require_workspace_dependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5300,6 +5300,7 @@ Released 2018-09-13
 [`regex_macro`]: https://rust-lang.github.io/rust-clippy/master/index.html#regex_macro
 [`repeat_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#repeat_once
 [`replace_consts`]: https://rust-lang.github.io/rust-clippy/master/index.html#replace_consts
+[`require_workspace_dependencies`]: https://rust-lang.github.io/rust-clippy/master/index.html#require_workspace_dependencies
 [`reserve_after_initialization`]: https://rust-lang.github.io/rust-clippy/master/index.html#reserve_after_initialization
 [`rest_pat_in_fully_bound_structs`]: https://rust-lang.github.io/rust-clippy/master/index.html#rest_pat_in_fully_bound_structs
 [`result_expect_used`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_expect_used

--- a/clippy_lints/src/cargo/require_workspace_dependencies.rs
+++ b/clippy_lints/src/cargo/require_workspace_dependencies.rs
@@ -14,7 +14,7 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
             cx,
             REQUIRE_WORKSPACE_DEPENDENCIES,
             DUMMY_SP,
-            &format!("unable to read the crate manifest `{}`", manifest_path),
+            &format!("unable to read the crate manifest `{manifest_path}`"),
         );
         return;
     };
@@ -23,7 +23,7 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
             cx,
             REQUIRE_WORKSPACE_DEPENDENCIES,
             DUMMY_SP,
-            &format!("unable to parse the crate manifest `{}`", manifest_path),
+            &format!("unable to parse the crate manifest `{manifest_path}`"),
         );
         return;
     };
@@ -34,8 +34,8 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
         manifest.build_dependencies,
     ]
     .into_iter()
-    .flat_map(|maybe_table| maybe_table.into_iter())
-    .flat_map(|table| table.into_iter());
+    .flat_map(std::iter::IntoIterator::into_iter)
+    .flat_map(std::iter::IntoIterator::into_iter);
 
     for (name, dep) in all_deps {
         if_chain! {
@@ -51,7 +51,7 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
             cx,
             REQUIRE_WORKSPACE_DEPENDENCIES,
             DUMMY_SP,
-            &format!("non-workspace dependency `{}`", name),
+            &format!("non-workspace dependency `{name}`"),
         );
     }
 }

--- a/clippy_lints/src/cargo/require_workspace_dependencies.rs
+++ b/clippy_lints/src/cargo/require_workspace_dependencies.rs
@@ -1,0 +1,66 @@
+use cargo_metadata::Metadata;
+use clippy_utils::diagnostics::span_lint;
+use if_chain::if_chain;
+use rustc_lint::LateContext;
+use rustc_span::source_map::DUMMY_SP;
+
+use super::REQUIRE_WORKSPACE_DEPENDENCIES;
+
+pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
+    let manifest_path = &metadata.packages[0].manifest_path;
+
+    let Ok(manifest) = std::fs::read_to_string(manifest_path) else {
+        span_lint(
+            cx,
+            REQUIRE_WORKSPACE_DEPENDENCIES,
+            DUMMY_SP,
+            &format!("unable to read the crate manifest `{}`", manifest_path),
+        );
+        return;
+    };
+    let Ok(manifest) = toml::from_str::<Manifest>(&manifest) else {
+        span_lint(
+            cx,
+            REQUIRE_WORKSPACE_DEPENDENCIES,
+            DUMMY_SP,
+            &format!("unable to parse the crate manifest `{}`", manifest_path),
+        );
+        return;
+    };
+
+    let all_deps = [
+        manifest.dependencies,
+        manifest.dev_dependencies,
+        manifest.build_dependencies,
+    ]
+    .into_iter()
+    .flat_map(|maybe_table| maybe_table.into_iter())
+    .flat_map(|table| table.into_iter());
+
+    for (name, dep) in all_deps {
+        if_chain! {
+            if let Some(workspace) = dep.get("workspace");
+            if let Some(is_workspace_dep) = workspace.as_bool();
+            if is_workspace_dep;
+            then {
+                continue;
+            }
+        }
+
+        span_lint(
+            cx,
+            REQUIRE_WORKSPACE_DEPENDENCIES,
+            DUMMY_SP,
+            &format!("non-workspace dependency `{}`", name),
+        );
+    }
+}
+
+/// The bare-bones [`Cargo.toml`] manifest to parse out the dependencies.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename = "param-case")]
+pub struct Manifest {
+    pub dependencies: Option<toml::Table>,
+    pub dev_dependencies: Option<toml::Table>,
+    pub build_dependencies: Option<toml::Table>,
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -74,6 +74,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::cargo::MULTIPLE_CRATE_VERSIONS_INFO,
     crate::cargo::NEGATIVE_FEATURE_NAMES_INFO,
     crate::cargo::REDUNDANT_FEATURE_NAMES_INFO,
+    crate::cargo::REQUIRE_WORKSPACE_DEPENDENCIES_INFO,
     crate::cargo::WILDCARD_DEPENDENCIES_INFO,
     crate::casts::AS_PTR_CAST_MUT_INFO,
     crate::casts::AS_UNDERSCORE_INFO,

--- a/tests/ui-cargo/require_workspace_dependencies/fail/Cargo.stderr
+++ b/tests/ui-cargo/require_workspace_dependencies/fail/Cargo.stderr
@@ -1,0 +1,5 @@
+error: non-workspace dependency `regex`
+  |
+  = note: `-D clippy::require-workspace-dependencies` implied by `-D warnings`
+
+error: could not compile `require_workspace_dependencies` (bin "require_workspace_dependencies") due to previous error

--- a/tests/ui-cargo/require_workspace_dependencies/fail/Cargo.toml
+++ b/tests/ui-cargo/require_workspace_dependencies/fail/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "require_workspace_dependencies"
+version = "0.1.0"
+publish = false
+
+[workspace]
+
+[workspace.dependencies]
+regex = "1"
+
+[dependencies]
+regex = "1"

--- a/tests/ui-cargo/require_workspace_dependencies/fail/src/main.rs
+++ b/tests/ui-cargo/require_workspace_dependencies/fail/src/main.rs
@@ -1,0 +1,3 @@
+#![warn(clippy::require_workspace_dependencies)]
+
+fn main() {}

--- a/tests/ui-cargo/require_workspace_dependencies/pass/Cargo.toml
+++ b/tests/ui-cargo/require_workspace_dependencies/pass/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "require_workspace_dependencies"
+version = "0.1.0"
+publish = false
+
+[workspace]
+
+[workspace.dependencies]
+regex = "1"
+
+[dependencies]
+regex = { workspace = true }

--- a/tests/ui-cargo/require_workspace_dependencies/pass/src/main.rs
+++ b/tests/ui-cargo/require_workspace_dependencies/pass/src/main.rs
@@ -1,0 +1,3 @@
+#![warn(clippy::require_workspace_dependencies)]
+
+fn main() {}

--- a/tests/ui/blanket_clippy_restriction_lints.stderr
+++ b/tests/ui/blanket_clippy_restriction_lints.stderr
@@ -4,6 +4,21 @@ error: `clippy::restriction` is not meant to be enabled as a group
    = help: enable the restriction lints you need individually
    = note: `-D clippy::blanket-clippy-restriction-lints` implied by `-D warnings`
 
+error: non-workspace dependency `clippy_lints`
+   |
+note: the lint level is defined here
+  --> $DIR/blanket_clippy_restriction_lints.rs:10:11
+   |
+LL | #![forbid(clippy::restriction)]
+   |           ^^^^^^^^^^^^^^^^^^^
+   = note: `#[forbid(clippy::require_workspace_dependencies)]` implied by `#[forbid(clippy::restriction)]`
+
+error: non-workspace dependency `rustc_tools_util`
+
+error: non-workspace dependency `tempfile`
+
+error: non-workspace dependency `termize`
+
 error: `clippy::restriction` is not meant to be enabled as a group
   --> $DIR/blanket_clippy_restriction_lints.rs:6:9
    |
@@ -28,5 +43,5 @@ LL | #![forbid(clippy::restriction)]
    |
    = help: enable the restriction lints you need individually
 
-error: aborting due to 4 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/enum_clike_unportable_variant.stderr
+++ b/tests/ui/enum_clike_unportable_variant.stderr
@@ -7,49 +7,49 @@ LL |     X = 0x1_0000_0000,
    = note: `-D clippy::enum-clike-unportable-variant` implied by `-D warnings`
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:15:5
+  --> $DIR/enum_clike_unportable_variant.rs:17:5
    |
 LL |     X = 0x1_0000_0000,
    |     ^^^^^^^^^^^^^^^^^
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:18:5
+  --> $DIR/enum_clike_unportable_variant.rs:21:5
    |
 LL |     A = 0xFFFF_FFFF,
    |     ^^^^^^^^^^^^^^^
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:25:5
+  --> $DIR/enum_clike_unportable_variant.rs:29:5
    |
 LL |     Z = 0xFFFF_FFFF,
    |     ^^^^^^^^^^^^^^^
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:26:5
+  --> $DIR/enum_clike_unportable_variant.rs:31:5
    |
 LL |     A = 0x1_0000_0000,
    |     ^^^^^^^^^^^^^^^^^
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:28:5
+  --> $DIR/enum_clike_unportable_variant.rs:34:5
    |
 LL |     C = (i32::MIN as isize) - 1,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:34:5
+  --> $DIR/enum_clike_unportable_variant.rs:41:5
    |
 LL |     Z = 0xFFFF_FFFF,
    |     ^^^^^^^^^^^^^^^
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:35:5
+  --> $DIR/enum_clike_unportable_variant.rs:43:5
    |
 LL |     A = 0x1_0000_0000,
    |     ^^^^^^^^^^^^^^^^^
 
 error: C-like enum variant discriminant is not portable to 32-bit targets
-  --> $DIR/enum_clike_unportable_variant.rs:40:5
+  --> $DIR/enum_clike_unportable_variant.rs:49:5
    |
 LL |     X = <usize as Trait>::Number,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
changelog: [`require_workspace_dependencies`]: new lint, opt-in to require all the dependencies to be `workspace = true`

---

To do:

- [x] settle on a name (is the current one good enough?); upd: no feedback, so I guess good enough it is!
- [ ] sort out the manual parsing of the manifest (might be ok but... idk) - this seems like a blocker
- [x] resolve breakage of existing tests
-  ~document the lint in the book (do I need to do it manually?)~