### PR TITLE
[`arithmetic_side_effects`] Fix #11393

### DIFF
--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -98,16 +98,17 @@ impl ArithmeticSideEffects {
                 Some(sym::NonZeroU128 | sym::NonZeroU16 | sym::NonZeroU32 | sym::NonZeroU64 | sym::NonZeroU8)
             )
         };
+        let is_sat_or_wrap = |ty: Ty<'_>| match_type(cx, ty, SATURATING) || match_type(cx, ty, WRAPPING);
+
         // If the RHS is NonZeroU*, then division or module by zero will never occur
         if is_non_zero_u(type_diagnostic_name(cx, rhs_ty)) && is_div_or_rem {
             return true;
         }
         // `Saturation` and `Wrapping` can overflow if the RHS is zero in a division or module
-        let is_lhs_sat_or_wrap = match_type(cx, lhs_ty, SATURATING) || match_type(cx, lhs_ty, WRAPPING);
-        let is_rhs_sat_or_wrap = match_type(cx, rhs_ty, SATURATING) || match_type(cx, rhs_ty, WRAPPING);
-        if is_lhs_sat_or_wrap || is_rhs_sat_or_wrap {
+        if is_sat_or_wrap(lhs_ty) || is_sat_or_wrap(rhs_ty) {
             return !is_div_or_rem;
         }
+
         false
     }
 

--- a/clippy_lints/src/operators/arithmetic_side_effects.rs
+++ b/clippy_lints/src/operators/arithmetic_side_effects.rs
@@ -105,7 +105,7 @@ impl ArithmeticSideEffects {
             return true;
         }
         // `Saturation` and `Wrapping` can overflow if the RHS is zero in a division or module
-        if is_sat_or_wrap(lhs_ty) || is_sat_or_wrap(rhs_ty) {
+        if is_sat_or_wrap(lhs_ty) {
             return !is_div_or_rem;
         }
 

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -714,5 +714,17 @@ error: arithmetic operation that can potentially result in unexpected side-effec
 LL |         unsigned % nonzero_unsigned
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 119 previous errors
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:512:9
+   |
+LL |         x / maybe_zero
+   |         ^^^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> $DIR/arithmetic_side_effects.rs:516:9
+   |
+LL |         x % maybe_zero
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 121 previous errors
 


### PR DESCRIPTION
#11395 tried to fix #11393 but it actually didn't due to an oversight on my side. Now everything should be OK.

```
changelog: [`arithmetic_side_effects`]: Detect division by zero for `Wrapping` and `Saturating`
```