### PR TITLE
Move `needless_raw_string_hashes` to `pedantic`

### DIFF
--- a/clippy_lints/src/raw_strings.rs
+++ b/clippy_lints/src/raw_strings.rs
@@ -49,7 +49,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.72.0"]
     pub NEEDLESS_RAW_STRING_HASHES,
-    style,
+    pedantic,
     "suggests reducing the number of hashes around a raw string literal"
 }
 impl_lint_pass!(RawStrings => [NEEDLESS_RAW_STRINGS, NEEDLESS_RAW_STRING_HASHES]);


### PR DESCRIPTION
IMO it doesn't improve code enough to be warn by default. [It seems to be unclear to some also](https://github.com/rust-lang/rust-clippy/issues/11402), but that can probably be remedied separately

changelog: Moved [`needless_raw_string_hashes`] to `pedantic` (Now allow-by-default)
[#11415](https://github.com/rust-lang/rust-clippy/pull/11415)

r? @flip1995