### PR TITLE
fix: needless_range_loop's FP on the `Field` expr

### DIFF
--- a/clippy_lints/src/loops/needless_range_loop.rs
+++ b/clippy_lints/src/loops/needless_range_loop.rs
@@ -295,6 +295,11 @@ impl<'a, 'tcx> VarVisitor<'a, 'tcx> {
                 }
             }
         }
+
+        // check whether the struct/tuple is referenced by a name, when the seqexpr is a field expr.
+        if let ExprKind::Field(sq_expr, _) = seqexpr.kind {
+            return self.check(idx, sq_expr, expr);
+        }
         true
     }
 }

--- a/tests/ui/needless_range_loop2.rs
+++ b/tests/ui/needless_range_loop2.rs
@@ -117,3 +117,17 @@ mod issue2277 {
         }
     }
 }
+
+mod issue11399 {
+    pub struct Block {
+        data: [i32; 3],
+    }
+
+    pub fn example() {
+        let values: [i8; 3] = [1, 2, 3];
+        let mut block = Block { data: [0; 3] };
+        for i in 0..values.len() {
+            block.data[i] = values[i] as i32;
+        }
+    }
+}


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

fix #11399 

changelog: [`needless_range_loop`]: Fix the FP warning when the index-var is used in another "field" sequence.
