### PR TITLE
Bump ui_test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tempfile = { version = "3.2", optional = true }
 termize = "0.1"
 
 [dev-dependencies]
-ui_test = "0.17.0"
+ui_test = "0.18.1"
 tester = "0.9"
 regex = "1.5"
 toml = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tempfile = { version = "3.2", optional = true }
 termize = "0.1"
 
 [dev-dependencies]
-ui_test = "0.18.1"
+ui_test = "0.20"
 tester = "0.9"
 regex = "1.5"
 toml = "0.7.3"

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -130,7 +130,9 @@ fn base_config(test_dir: &str) -> (Config, Args) {
     };
 
     let mut config = Config {
-        mode: Mode::Yolo { rustfix: true },
+        mode: Mode::Yolo {
+            rustfix: ui_test::RustfixMode::Everything,
+        },
         stderr_filters: vec![(Match::PathBackslash, b"/")],
         stdout_filters: vec![],
         output_conflict_handling: if bless {


### PR DESCRIPTION
This makes `ui_test` parse `--bless` and allows a follow up change to use `Mode::Error` (instead of `Mode::Yolo`) with `RustfixMode::Everything`

changelog: none
