### PR TITLE
Ignore wildcards in function arguments and local bindings

### DIFF
--- a/clippy_lints/src/ignored_unit_patterns.rs
+++ b/clippy_lints/src/ignored_unit_patterns.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use hir::PatKind;
+use hir::{Node, PatKind};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
@@ -37,6 +37,17 @@ declare_lint_pass!(IgnoredUnitPatterns => [IGNORED_UNIT_PATTERNS]);
 
 impl<'tcx> LateLintPass<'tcx> for IgnoredUnitPatterns {
     fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx hir::Pat<'tcx>) {
+        match cx.tcx.hir().get_parent(pat.hir_id) {
+            Node::Param(param) if matches!(cx.tcx.hir().get_parent(param.hir_id), Node::Item(_)) => {
+                // Ignore function parameters
+                return;
+            },
+            Node::Local(local) if local.ty.is_some() => {
+                // Ignore let bindings with explicit type
+                return;
+            },
+            _ => {},
+        }
         if matches!(pat.kind, PatKind::Wild) && cx.typeck_results().pat_ty(pat).is_unit() {
             span_lint_and_sugg(
                 cx,

--- a/tests/ui/ignored_unit_patterns.fixed
+++ b/tests/ui/ignored_unit_patterns.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::ignored_unit_patterns)]
-#![allow(clippy::redundant_pattern_matching, clippy::single_match)]
+#![allow(clippy::let_unit_value, clippy::redundant_pattern_matching, clippy::single_match)]
 
 fn foo() -> Result<(), ()> {
     unimplemented!()
@@ -14,4 +14,12 @@ fn main() {
     //~^ ERROR: matching over `()` is more explicit
     let _ = foo().map_err(|()| todo!());
     //~^ ERROR: matching over `()` is more explicit
+}
+
+#[allow(unused)]
+pub fn moo(_: ()) {
+    let () = foo().unwrap();
+    //~^ ERROR: matching over `()` is more explicit
+    let _: () = foo().unwrap();
+    let _: () = ();
 }

--- a/tests/ui/ignored_unit_patterns.fixed
+++ b/tests/ui/ignored_unit_patterns.fixed
@@ -7,9 +7,11 @@ fn foo() -> Result<(), ()> {
 
 fn main() {
     match foo() {
-        Ok(()) => {},
-        Err(()) => {},
+        Ok(()) => {},  //~ ERROR: matching over `()` is more explicit
+        Err(()) => {}, //~ ERROR: matching over `()` is more explicit
     }
     if let Ok(()) = foo() {}
+    //~^ ERROR: matching over `()` is more explicit
     let _ = foo().map_err(|()| todo!());
+    //~^ ERROR: matching over `()` is more explicit
 }

--- a/tests/ui/ignored_unit_patterns.rs
+++ b/tests/ui/ignored_unit_patterns.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::ignored_unit_patterns)]
-#![allow(clippy::redundant_pattern_matching, clippy::single_match)]
+#![allow(clippy::let_unit_value, clippy::redundant_pattern_matching, clippy::single_match)]
 
 fn foo() -> Result<(), ()> {
     unimplemented!()
@@ -14,4 +14,12 @@ fn main() {
     //~^ ERROR: matching over `()` is more explicit
     let _ = foo().map_err(|_| todo!());
     //~^ ERROR: matching over `()` is more explicit
+}
+
+#[allow(unused)]
+pub fn moo(_: ()) {
+    let _ = foo().unwrap();
+    //~^ ERROR: matching over `()` is more explicit
+    let _: () = foo().unwrap();
+    let _: () = ();
 }

--- a/tests/ui/ignored_unit_patterns.rs
+++ b/tests/ui/ignored_unit_patterns.rs
@@ -7,9 +7,11 @@ fn foo() -> Result<(), ()> {
 
 fn main() {
     match foo() {
-        Ok(_) => {},
-        Err(_) => {},
+        Ok(_) => {},  //~ ERROR: matching over `()` is more explicit
+        Err(_) => {}, //~ ERROR: matching over `()` is more explicit
     }
     if let Ok(_) = foo() {}
+    //~^ ERROR: matching over `()` is more explicit
     let _ = foo().map_err(|_| todo!());
+    //~^ ERROR: matching over `()` is more explicit
 }

--- a/tests/ui/ignored_unit_patterns.stderr
+++ b/tests/ui/ignored_unit_patterns.stderr
@@ -24,5 +24,11 @@ error: matching over `()` is more explicit
 LL |     let _ = foo().map_err(|_| todo!());
    |                            ^ help: use `()` instead of `_`: `()`
 
-error: aborting due to 4 previous errors
+error: matching over `()` is more explicit
+  --> $DIR/ignored_unit_patterns.rs:21:9
+   |
+LL |     let _ = foo().unwrap();
+   |         ^ help: use `()` instead of `_`: `()`
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/ignored_unit_patterns.stderr
+++ b/tests/ui/ignored_unit_patterns.stderr
@@ -19,7 +19,7 @@ LL |     if let Ok(_) = foo() {}
    |               ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> $DIR/ignored_unit_patterns.rs:14:28
+  --> $DIR/ignored_unit_patterns.rs:15:28
    |
 LL |     let _ = foo().map_err(|_| todo!());
    |                            ^ help: use `()` instead of `_`: `()`


### PR DESCRIPTION
Fix #11403

changelog: none