### PR TITLE
WIP New lint: borrowed_option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5981,6 +5981,7 @@ Released 2018-09-13
 [`borrow_deref_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
 [`borrow_interior_mutable_const`]: https://rust-lang.github.io/rust-clippy/master/index.html#borrow_interior_mutable_const
 [`borrowed_box`]: https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box
+[`borrowed_option`]: https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_option
 [`box_collection`]: https://rust-lang.github.io/rust-clippy/master/index.html#box_collection
 [`box_default`]: https://rust-lang.github.io/rust-clippy/master/index.html#box_default
 [`box_vec`]: https://rust-lang.github.io/rust-clippy/master/index.html#box_vec

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -726,6 +726,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::transmute::WRONG_TRANSMUTE_INFO,
     crate::tuple_array_conversions::TUPLE_ARRAY_CONVERSIONS_INFO,
     crate::types::BORROWED_BOX_INFO,
+    crate::types::BORROWED_OPTION_INFO,
     crate::types::BOX_COLLECTION_INFO,
     crate::types::LINKEDLIST_INFO,
     crate::types::OPTION_OPTION_INFO,

--- a/clippy_lints/src/types/borrowed_box.rs
+++ b/clippy_lints/src/types/borrowed_box.rs
@@ -7,7 +7,7 @@ use rustc_hir::{
 use rustc_lint::LateContext;
 use rustc_span::sym;
 
-use super::BORROWED_BOX;
+use super::{BORROWED_BOX, BORROWED_OPTION};
 
 pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, lt: &Lifetime, mut_ty: &MutTy<'_>) -> bool {
     match mut_ty.ty.kind {
@@ -15,7 +15,8 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, lt: &Lifetime, m
             let hir_id = mut_ty.ty.hir_id;
             let def = cx.qpath_res(qpath, hir_id);
             if let Some(def_id) = def.opt_def_id()
-                && Some(def_id) == cx.tcx.lang_items().owned_box()
+                && (Some(def_id) == cx.tcx.lang_items().owned_box()
+                    || Some(def_id) == cx.tcx.lang_items().option_type())
                 && let QPath::Resolved(None, path) = *qpath
                 && let [ref bx] = *path.segments
                 && let Some(params) = bx.args
@@ -25,7 +26,8 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, lt: &Lifetime, m
                     _ => None,
                 })
             {
-                if is_any_trait(cx, inner.as_unambig_ty()) {
+                let is_box = Some(def_id) == cx.tcx.lang_items().owned_box();
+                if is_box && is_any_trait(cx, inner.as_unambig_ty()) {
                     // Ignore `Box<Any>` types; see issue #1884 for details.
                     return false;
                 }
@@ -39,6 +41,7 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, lt: &Lifetime, m
                 if mut_ty.mutbl == Mutability::Mut {
                     // Ignore `&mut Box<T>` types; see issue #2907 for
                     // details.
+                    // Same reasoning applies for `&mut Option<T>` types.
                     return false;
                 }
 
@@ -59,11 +62,19 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, lt: &Lifetime, m
                 };
                 span_lint_and_sugg(
                     cx,
-                    BORROWED_BOX,
+                    if is_box { BORROWED_BOX } else { BORROWED_OPTION },
                     hir_ty.span,
-                    "you seem to be trying to use `&Box<T>`. Consider using just `&T`",
+                    if is_box {
+                        "you seem to be trying to use `&Box<T>`. Consider using just `&T`"
+                    } else {
+                        "you seem to be trying to use `&Option<T>`. Consider using `Option<&T>` instead"
+                    },
                     "try",
-                    suggestion,
+                    if is_box {
+                        suggestion
+                    } else {
+                        format!("Option<{suggestion}>")
+                    },
                     // To make this `MachineApplicable`, at least one needs to check if it isn't a trait item
                     // because the trait impls of it will break otherwise;
                     // and there may be other cases that result in invalid code.

--- a/clippy_lints/src/types/mod.rs
+++ b/clippy_lints/src/types/mod.rs
@@ -188,6 +188,38 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for usage of [`&Option<T>`](https://doc.rust-lang.org/std/option/index.html) anywhere in the code.
+    ///
+    /// ### Why is this bad?
+    /// An `&Option<T>` parameter prevents calling the function if the caller holds a different type, e.g. `Result<T, E>`.
+    /// Using `Option<&T>` generalizes the function, e.g. allowing to pass `res.ok().as_ref()`.
+    /// Returning `&Option<T>` needlessly exposes implementation details and has no advantage over `Option<&T>`.
+    /// `&Option<T>` requieres a dereferencing to determine the variant (`Some` or `None`), while `Option<&T>` does not.
+    ///
+    /// ### Example
+    /// ```rust,compile_fail
+    /// fn foo(bar: &Option<String>) -> &Option<String> { bar }
+    /// fn call_foo(bar: &Result<String, ()>) {
+    ///     foo(bar.ok()); // does not work
+    /// }
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust
+    /// fn foo(bar: Option<&String>) -> Option<&String> { bar }
+    /// fn call_foo(bar: &Result<String, ()>) {
+    ///     foo(bar.ok().as_ref()); // works!
+    /// }
+    /// ```
+    #[clippy::version = "1.74.0"]
+    pub BORROWED_OPTION,
+    complexity,
+    "`&Option<T>` instead of `Option<&T>`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
     /// Checks for usage of redundant allocations anywhere in the code.
     ///
     /// ### Why is this bad?
@@ -403,6 +435,7 @@ impl_lint_pass!(Types => [
     OPTION_OPTION,
     LINKEDLIST,
     BORROWED_BOX,
+    BORROWED_OPTION,
     REDUNDANT_ALLOCATION,
     RC_BUFFER,
     RC_MUTEX,

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -615,7 +615,7 @@ fn relocalize_format_args_indexes(
         // If there are format options, we need to handle them as well
         if *format_options != FormatOptions::default() {
             // lambda to process width and precision format counts and add them to the suggestion
-            let mut process_format_count = |count: &Option<FormatCount>, formatter: &dyn Fn(usize) -> String| {
+            let mut process_format_count = |count: Option<&FormatCount>, formatter: &dyn Fn(usize) -> String| {
                 if let Some(FormatCount::Argument(FormatArgPosition {
                     index: Ok(format_arg_index),
                     kind: FormatArgPositionKind::Number,
@@ -626,8 +626,8 @@ fn relocalize_format_args_indexes(
                 }
             };
 
-            process_format_count(&format_options.width, &|index: usize| format!("{index}$"));
-            process_format_count(&format_options.precision, &|index: usize| format!(".{index}$"));
+            process_format_count(format_options.width.as_ref(), &|index: usize| format!("{index}$"));
+            process_format_count(format_options.precision.as_ref(), &|index: usize| format!(".{index}$"));
         }
     }
 }

--- a/clippy_utils/src/ast_utils/mod.rs
+++ b/clippy_utils/src/ast_utils/mod.rs
@@ -400,7 +400,7 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 && eq_fn_sig(lf, rf)
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
-                && eq_opt_fn_contract(lc, rc)
+                && eq_opt_fn_contract(lc.as_deref(), rc.as_deref())
                 && both(lb.as_ref(), rb.as_ref(), |l, r| eq_block(l, r))
         },
         (Mod(ls, li, lmk), Mod(rs, ri, rmk)) => {
@@ -554,7 +554,7 @@ pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
                 && eq_fn_sig(lf, rf)
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
-                && eq_opt_fn_contract(lc, rc)
+                && eq_opt_fn_contract(lc.as_deref(), rc.as_deref())
                 && both(lb.as_ref(), rb.as_ref(), |l, r| eq_block(l, r))
         },
         (
@@ -637,7 +637,7 @@ pub fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
                 && eq_fn_sig(lf, rf)
                 && eq_id(*li, *ri)
                 && eq_generics(lg, rg)
-                && eq_opt_fn_contract(lc, rc)
+                && eq_opt_fn_contract(lc.as_deref(), rc.as_deref())
                 && both(lb.as_ref(), rb.as_ref(), |l, r| eq_block(l, r))
         },
         (
@@ -723,8 +723,7 @@ pub fn eq_fn_header(l: &FnHeader, r: &FnHeader) -> bool {
         && eq_ext(&l.ext, &r.ext)
 }
 
-#[expect(clippy::ref_option, reason = "This is the type how it is stored in the AST")]
-pub fn eq_opt_fn_contract(l: &Option<Box<FnContract>>, r: &Option<Box<FnContract>>) -> bool {
+pub fn eq_opt_fn_contract(l: Option<&FnContract>, r: Option<&FnContract>) -> bool {
     match (l, r) {
         (Some(l), Some(r)) => {
             eq_expr_opt(l.requires.as_deref(), r.requires.as_deref())

--- a/tests/ui-toml/ref_option/ref_option.all.fixed
+++ b/tests/ui-toml/ref_option/ref_option.all.fixed
@@ -3,7 +3,7 @@
 //@[private] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/ref_option/private
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/ref_option/all
 
-#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box)]
+#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box, clippy::borrowed_option)]
 #![warn(clippy::ref_option)]
 
 fn opt_u8(a: Option<&u8>) {}

--- a/tests/ui-toml/ref_option/ref_option.private.fixed
+++ b/tests/ui-toml/ref_option/ref_option.private.fixed
@@ -3,7 +3,7 @@
 //@[private] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/ref_option/private
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/ref_option/all
 
-#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box)]
+#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box, clippy::borrowed_option)]
 #![warn(clippy::ref_option)]
 
 fn opt_u8(a: Option<&u8>) {}

--- a/tests/ui-toml/ref_option/ref_option.rs
+++ b/tests/ui-toml/ref_option/ref_option.rs
@@ -3,7 +3,7 @@
 //@[private] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/ref_option/private
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/ref_option/all
 
-#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box)]
+#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box, clippy::borrowed_option)]
 #![warn(clippy::ref_option)]
 
 fn opt_u8(a: &Option<u8>) {}

--- a/tests/ui-toml/ref_option/ref_option_traits.all.stderr
+++ b/tests/ui-toml/ref_option/ref_option_traits.all.stderr
@@ -1,5 +1,5 @@
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui-toml/ref_option/ref_option_traits.rs:10:5
+  --> tests/ui-toml/ref_option/ref_option_traits.rs:11:5
    |
 LL |     fn pub_trait_opt(&self, a: &Option<Vec<u8>>);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^^
@@ -10,7 +10,7 @@ LL |     fn pub_trait_opt(&self, a: &Option<Vec<u8>>);
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui-toml/ref_option/ref_option_traits.rs:12:5
+  --> tests/ui-toml/ref_option/ref_option_traits.rs:13:5
    |
 LL |     fn pub_trait_ret(&self) -> &Option<Vec<u8>>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^
@@ -18,7 +18,7 @@ LL |     fn pub_trait_ret(&self) -> &Option<Vec<u8>>;
    |                                help: change this to: `Option<&Vec<u8>>`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui-toml/ref_option/ref_option_traits.rs:17:5
+  --> tests/ui-toml/ref_option/ref_option_traits.rs:18:5
    |
 LL |     fn trait_opt(&self, a: &Option<String>);
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^^
@@ -26,7 +26,7 @@ LL |     fn trait_opt(&self, a: &Option<String>);
    |                            help: change this to: `Option<&String>`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui-toml/ref_option/ref_option_traits.rs:19:5
+  --> tests/ui-toml/ref_option/ref_option_traits.rs:20:5
    |
 LL |     fn trait_ret(&self) -> &Option<String>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^

--- a/tests/ui-toml/ref_option/ref_option_traits.private.stderr
+++ b/tests/ui-toml/ref_option/ref_option_traits.private.stderr
@@ -1,5 +1,5 @@
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui-toml/ref_option/ref_option_traits.rs:17:5
+  --> tests/ui-toml/ref_option/ref_option_traits.rs:18:5
    |
 LL |     fn trait_opt(&self, a: &Option<String>);
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^^
@@ -10,7 +10,7 @@ LL |     fn trait_opt(&self, a: &Option<String>);
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui-toml/ref_option/ref_option_traits.rs:19:5
+  --> tests/ui-toml/ref_option/ref_option_traits.rs:20:5
    |
 LL |     fn trait_ret(&self) -> &Option<String>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^

--- a/tests/ui-toml/ref_option/ref_option_traits.rs
+++ b/tests/ui-toml/ref_option/ref_option_traits.rs
@@ -5,6 +5,7 @@
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui-toml/ref_option/all
 
 #![warn(clippy::ref_option)]
+#![allow(clippy::borrowed_option)]
 
 pub trait PubTrait {
     fn pub_trait_opt(&self, a: &Option<Vec<u8>>);

--- a/tests/ui/borrow_option.fixed
+++ b/tests/ui/borrow_option.fixed
@@ -1,0 +1,59 @@
+#![deny(clippy::borrowed_option)]
+#![allow(dead_code, unused_variables)]
+#![allow(
+    clippy::uninlined_format_args,
+    clippy::disallowed_names,
+    clippy::needless_pass_by_ref_mut,
+    clippy::needless_lifetimes
+)]
+
+use std::fmt::Display;
+
+pub fn test1(foo: &mut Option<bool>) {
+    // Although this function could be changed to "Option<&mut bool>",
+    // avoiding the borrowed option, mutable references to boxes are not
+    // flagged by this lint.
+    //
+    // This omission is intentional: By passing a "&mut Option<T>",
+    // the memory location of the pointed-to object could be
+    // modified. By passing a "Option<&mut T>", the contents
+    // could change, but not the location.
+    println!("{:?}", foo)
+}
+
+pub fn test2() {
+    let foo: Option<&bool>;
+    //~^ borrowed_option
+}
+
+struct Test3<'a> {
+    foo: Option<&'a bool>,
+    //~^ borrowed_option
+}
+
+trait Test4 {
+    fn test4(b: Option<&bool>);
+    //~^ borrowed_option
+}
+
+pub fn test5(_display: Option<&impl Display>) {}
+//~^ borrowed_option
+pub fn test6(_display: Option<&(impl Display + Send)>) {}
+//~^ borrowed_option
+pub fn test7<'a>(_display: Option<&'a (impl Display + 'a)>) {}
+//~^ borrowed_option
+
+#[allow(clippy::borrowed_box, clippy::borrowed_option)]
+trait Trait {
+    fn f(o: &Option<bool>);
+}
+
+// Trait impls are not linted
+impl Trait for () {
+    fn f(_: &Option<bool>) {}
+}
+
+fn main() {
+    test1(&mut Some(false));
+    test2();
+}

--- a/tests/ui/borrow_option.rs
+++ b/tests/ui/borrow_option.rs
@@ -1,0 +1,59 @@
+#![deny(clippy::borrowed_option)]
+#![allow(dead_code, unused_variables)]
+#![allow(
+    clippy::uninlined_format_args,
+    clippy::disallowed_names,
+    clippy::needless_pass_by_ref_mut,
+    clippy::needless_lifetimes
+)]
+
+use std::fmt::Display;
+
+pub fn test1(foo: &mut Option<bool>) {
+    // Although this function could be changed to "Option<&mut bool>",
+    // avoiding the borrowed option, mutable references to boxes are not
+    // flagged by this lint.
+    //
+    // This omission is intentional: By passing a "&mut Option<T>",
+    // the memory location of the pointed-to object could be
+    // modified. By passing a "Option<&mut T>", the contents
+    // could change, but not the location.
+    println!("{:?}", foo)
+}
+
+pub fn test2() {
+    let foo: &Option<bool>;
+    //~^ borrowed_option
+}
+
+struct Test3<'a> {
+    foo: &'a Option<bool>,
+    //~^ borrowed_option
+}
+
+trait Test4 {
+    fn test4(b: &Option<bool>);
+    //~^ borrowed_option
+}
+
+pub fn test5(_display: &Option<impl Display>) {}
+//~^ borrowed_option
+pub fn test6(_display: &Option<impl Display + Send>) {}
+//~^ borrowed_option
+pub fn test7<'a>(_display: &'a Option<impl Display + 'a>) {}
+//~^ borrowed_option
+
+#[allow(clippy::borrowed_box, clippy::borrowed_option)]
+trait Trait {
+    fn f(o: &Option<bool>);
+}
+
+// Trait impls are not linted
+impl Trait for () {
+    fn f(_: &Option<bool>) {}
+}
+
+fn main() {
+    test1(&mut Some(false));
+    test2();
+}

--- a/tests/ui/borrow_option.stderr
+++ b/tests/ui/borrow_option.stderr
@@ -1,0 +1,44 @@
+error: you seem to be trying to use `&Option<T>`. Consider using `Option<&T>` instead
+  --> tests/ui/borrow_option.rs:25:14
+   |
+LL |     let foo: &Option<bool>;
+   |              ^^^^^^^^^^^^^ help: try: `Option<&bool>`
+   |
+note: the lint level is defined here
+  --> tests/ui/borrow_option.rs:1:9
+   |
+LL | #![deny(clippy::borrowed_option)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: you seem to be trying to use `&Option<T>`. Consider using `Option<&T>` instead
+  --> tests/ui/borrow_option.rs:30:10
+   |
+LL |     foo: &'a Option<bool>,
+   |          ^^^^^^^^^^^^^^^^ help: try: `Option<&'a bool>`
+
+error: you seem to be trying to use `&Option<T>`. Consider using `Option<&T>` instead
+  --> tests/ui/borrow_option.rs:35:17
+   |
+LL |     fn test4(b: &Option<bool>);
+   |                 ^^^^^^^^^^^^^ help: try: `Option<&bool>`
+
+error: you seem to be trying to use `&Option<T>`. Consider using `Option<&T>` instead
+  --> tests/ui/borrow_option.rs:39:24
+   |
+LL | pub fn test5(_display: &Option<impl Display>) {}
+   |                        ^^^^^^^^^^^^^^^^^^^^^ help: try: `Option<&impl Display>`
+
+error: you seem to be trying to use `&Option<T>`. Consider using `Option<&T>` instead
+  --> tests/ui/borrow_option.rs:41:24
+   |
+LL | pub fn test6(_display: &Option<impl Display + Send>) {}
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Option<&(impl Display + Send)>`
+
+error: you seem to be trying to use `&Option<T>`. Consider using `Option<&T>` instead
+  --> tests/ui/borrow_option.rs:43:28
+   |
+LL | pub fn test7<'a>(_display: &'a Option<impl Display + 'a>) {}
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Option<&'a (impl Display + 'a)>`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/clone_on_copy.fixed
+++ b/tests/ui/clone_on_copy.fixed
@@ -6,7 +6,8 @@
     clippy::unnecessary_operation,
     clippy::vec_init_then_push,
     clippy::toplevel_ref_arg,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::borrowed_option
 )]
 
 use std::cell::RefCell;

--- a/tests/ui/clone_on_copy.rs
+++ b/tests/ui/clone_on_copy.rs
@@ -6,7 +6,8 @@
     clippy::unnecessary_operation,
     clippy::vec_init_then_push,
     clippy::toplevel_ref_arg,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::borrowed_option
 )]
 
 use std::cell::RefCell;

--- a/tests/ui/clone_on_copy.stderr
+++ b/tests/ui/clone_on_copy.stderr
@@ -1,5 +1,5 @@
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:23:5
+  --> tests/ui/clone_on_copy.rs:24:5
    |
 LL |     42.clone();
    |     ^^^^^^^^^^ help: try removing the `clone` call: `42`
@@ -8,49 +8,49 @@ LL |     42.clone();
    = help: to override `-D warnings` add `#[allow(clippy::clone_on_copy)]`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:28:5
+  --> tests/ui/clone_on_copy.rs:29:5
    |
 LL |     (&42).clone();
    |     ^^^^^^^^^^^^^ help: try dereferencing it: `*(&42)`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:32:5
+  --> tests/ui/clone_on_copy.rs:33:5
    |
 LL |     rc.borrow().clone();
    |     ^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*rc.borrow()`
 
 error: using `clone` on type `u32` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:36:5
+  --> tests/ui/clone_on_copy.rs:37:5
    |
 LL |     x.clone().rotate_left(1);
    |     ^^^^^^^^^ help: try removing the `clone` call: `x`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:51:5
+  --> tests/ui/clone_on_copy.rs:52:5
    |
 LL |     m!(42).clone();
    |     ^^^^^^^^^^^^^^ help: try removing the `clone` call: `m!(42)`
 
 error: using `clone` on type `[u32; 2]` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:62:5
+  --> tests/ui/clone_on_copy.rs:63:5
    |
 LL |     x.clone()[0];
    |     ^^^^^^^^^ help: try dereferencing it: `(*x)`
 
 error: using `clone` on type `char` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:73:14
+  --> tests/ui/clone_on_copy.rs:74:14
    |
 LL |     is_ascii('z'.clone());
    |              ^^^^^^^^^^^ help: try removing the `clone` call: `'z'`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:78:14
+  --> tests/ui/clone_on_copy.rs:79:14
    |
 LL |     vec.push(42.clone());
    |              ^^^^^^^^^^ help: try removing the `clone` call: `42`
 
 error: using `clone` on type `Option<i32>` which implements the `Copy` trait
-  --> tests/ui/clone_on_copy.rs:83:17
+  --> tests/ui/clone_on_copy.rs:84:17
    |
 LL |     let value = opt.clone()?; // operator precedence needed (*opt)?
    |                 ^^^^^^^^^^^ help: try dereferencing it: `(*opt)`

--- a/tests/ui/if_same_then_else2.rs
+++ b/tests/ui/if_same_then_else2.rs
@@ -7,6 +7,7 @@
     clippy::ifs_same_cond,
     clippy::needless_if,
     clippy::needless_return,
+    clippy::borrowed_option,
     clippy::single_element_loop,
     clippy::branches_sharing_code
 )]

--- a/tests/ui/if_same_then_else2.stderr
+++ b/tests/ui/if_same_then_else2.stderr
@@ -1,5 +1,5 @@
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else2.rs:15:13
+  --> tests/ui/if_same_then_else2.rs:16:13
    |
 LL |       if true {
    |  _____________^
@@ -11,7 +11,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> tests/ui/if_same_then_else2.rs:24:12
+  --> tests/ui/if_same_then_else2.rs:25:12
    |
 LL |       } else {
    |  ____________^
@@ -25,7 +25,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::if_same_then_else)]`
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else2.rs:36:13
+  --> tests/ui/if_same_then_else2.rs:37:13
    |
 LL |       if true {
    |  _____________^
@@ -34,7 +34,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> tests/ui/if_same_then_else2.rs:38:12
+  --> tests/ui/if_same_then_else2.rs:39:12
    |
 LL |       } else {
    |  ____________^
@@ -43,7 +43,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else2.rs:43:13
+  --> tests/ui/if_same_then_else2.rs:44:13
    |
 LL |       if true {
    |  _____________^
@@ -52,7 +52,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> tests/ui/if_same_then_else2.rs:45:12
+  --> tests/ui/if_same_then_else2.rs:46:12
    |
 LL |       } else {
    |  ____________^
@@ -61,19 +61,19 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else2.rs:93:21
+  --> tests/ui/if_same_then_else2.rs:94:21
    |
 LL |     let _ = if true { f32::NAN } else { f32::NAN };
    |                     ^^^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/if_same_then_else2.rs:93:39
+  --> tests/ui/if_same_then_else2.rs:94:39
    |
 LL |     let _ = if true { f32::NAN } else { f32::NAN };
    |                                       ^^^^^^^^^^^^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else2.rs:96:13
+  --> tests/ui/if_same_then_else2.rs:97:13
    |
 LL |       if true {
    |  _____________^
@@ -82,7 +82,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> tests/ui/if_same_then_else2.rs:98:12
+  --> tests/ui/if_same_then_else2.rs:99:12
    |
 LL |       } else {
    |  ____________^
@@ -91,7 +91,7 @@ LL | |     }
    | |_____^
 
 error: this `if` has identical blocks
-  --> tests/ui/if_same_then_else2.rs:120:20
+  --> tests/ui/if_same_then_else2.rs:121:20
    |
 LL |       } else if true {
    |  ____________________^
@@ -101,7 +101,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> tests/ui/if_same_then_else2.rs:123:12
+  --> tests/ui/if_same_then_else2.rs:124:12
    |
 LL |       } else {
    |  ____________^

--- a/tests/ui/iter_filter_is_some.fixed
+++ b/tests/ui/iter_filter_is_some.fixed
@@ -4,6 +4,7 @@
     clippy::result_filter_map,
     clippy::needless_borrow,
     clippy::option_filter_map,
+    clippy::borrowed_option,
     clippy::redundant_closure,
     clippy::unnecessary_get_then_check
 )]

--- a/tests/ui/iter_filter_is_some.rs
+++ b/tests/ui/iter_filter_is_some.rs
@@ -4,6 +4,7 @@
     clippy::result_filter_map,
     clippy::needless_borrow,
     clippy::option_filter_map,
+    clippy::borrowed_option,
     clippy::redundant_closure,
     clippy::unnecessary_get_then_check
 )]

--- a/tests/ui/iter_filter_is_some.stderr
+++ b/tests/ui/iter_filter_is_some.stderr
@@ -1,5 +1,5 @@
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:15:58
+  --> tests/ui/iter_filter_is_some.rs:16:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(Option::is_some);
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
@@ -8,55 +8,55 @@ LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(Option::is_
    = help: to override `-D warnings` add `#[allow(clippy::iter_filter_is_some)]`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:18:58
+  --> tests/ui/iter_filter_is_some.rs:19:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|a| a.is_some());
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:22:58
+  --> tests/ui/iter_filter_is_some.rs:23:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|o| { o.is_some() });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:29:14
+  --> tests/ui/iter_filter_is_some.rs:30:14
    |
 LL |             .filter(std::option::Option::is_some);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:34:14
+  --> tests/ui/iter_filter_is_some.rs:35:14
    |
 LL |             .filter(|a| std::option::Option::is_some(a));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:38:58
+  --> tests/ui/iter_filter_is_some.rs:39:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|a| { std::option::Option::is_some(a) });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:43:58
+  --> tests/ui/iter_filter_is_some.rs:44:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|&a| a.is_some());
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:47:58
+  --> tests/ui/iter_filter_is_some.rs:48:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|&o| { o.is_some() });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:52:58
+  --> tests/ui/iter_filter_is_some.rs:53:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|ref a| a.is_some());
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:56:58
+  --> tests/ui/iter_filter_is_some.rs:57:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|ref o| { o.is_some() });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`

--- a/tests/ui/iter_overeager_cloned.fixed
+++ b/tests/ui/iter_overeager_cloned.fixed
@@ -3,6 +3,7 @@
     dead_code,
     clippy::let_unit_value,
     clippy::useless_vec,
+    clippy::borrowed_option,
     clippy::double_ended_iterator_last
 )]
 

--- a/tests/ui/iter_overeager_cloned.rs
+++ b/tests/ui/iter_overeager_cloned.rs
@@ -3,6 +3,7 @@
     dead_code,
     clippy::let_unit_value,
     clippy::useless_vec,
+    clippy::borrowed_option,
     clippy::double_ended_iterator_last
 )]
 

--- a/tests/ui/iter_overeager_cloned.stderr
+++ b/tests/ui/iter_overeager_cloned.stderr
@@ -1,5 +1,5 @@
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:12:29
+  --> tests/ui/iter_overeager_cloned.rs:13:29
    |
 LL |     let _: Option<String> = vec.iter().cloned().last();
    |                             ^^^^^^^^^^----------------
@@ -10,7 +10,7 @@ LL |     let _: Option<String> = vec.iter().cloned().last();
    = help: to override `-D warnings` add `#[allow(clippy::iter_overeager_cloned)]`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:15:29
+  --> tests/ui/iter_overeager_cloned.rs:16:29
    |
 LL |     let _: Option<String> = vec.iter().chain(vec.iter()).cloned().next();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------
@@ -18,7 +18,7 @@ LL |     let _: Option<String> = vec.iter().chain(vec.iter()).cloned().next();
    |                                                         help: try: `.next().cloned()`
 
 error: unneeded cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:18:20
+  --> tests/ui/iter_overeager_cloned.rs:19:20
    |
 LL |     let _: usize = vec.iter().filter(|x| x == &"2").cloned().count();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------------
@@ -29,7 +29,7 @@ LL |     let _: usize = vec.iter().filter(|x| x == &"2").cloned().count();
    = help: to override `-D warnings` add `#[allow(clippy::redundant_clone)]`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:21:21
+  --> tests/ui/iter_overeager_cloned.rs:22:21
    |
 LL |     let _: Vec<_> = vec.iter().cloned().take(2).collect();
    |                     ^^^^^^^^^^-----------------
@@ -37,7 +37,7 @@ LL |     let _: Vec<_> = vec.iter().cloned().take(2).collect();
    |                               help: try: `.take(2).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:24:21
+  --> tests/ui/iter_overeager_cloned.rs:25:21
    |
 LL |     let _: Vec<_> = vec.iter().cloned().skip(2).collect();
    |                     ^^^^^^^^^^-----------------
@@ -45,7 +45,7 @@ LL |     let _: Vec<_> = vec.iter().cloned().skip(2).collect();
    |                               help: try: `.skip(2).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:27:13
+  --> tests/ui/iter_overeager_cloned.rs:28:13
    |
 LL |     let _ = vec.iter().filter(|x| x == &"2").cloned().nth(2);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------
@@ -53,7 +53,7 @@ LL |     let _ = vec.iter().filter(|x| x == &"2").cloned().nth(2);
    |                                             help: try: `.nth(2).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:30:13
+  --> tests/ui/iter_overeager_cloned.rs:31:13
    |
 LL |       let _ = [Some(Some("str".to_string())), Some(Some("str".to_string()))]
    |  _____________^
@@ -70,7 +70,7 @@ LL ~         .flatten().cloned();
    |
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:36:13
+  --> tests/ui/iter_overeager_cloned.rs:37:13
    |
 LL |     let _ = vec.iter().cloned().filter(|x| x.starts_with('2'));
    |             ^^^^^^^^^^----------------------------------------
@@ -78,7 +78,7 @@ LL |     let _ = vec.iter().cloned().filter(|x| x.starts_with('2'));
    |                       help: try: `.filter(|&x| x.starts_with('2')).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:39:13
+  --> tests/ui/iter_overeager_cloned.rs:40:13
    |
 LL |     let _ = vec.iter().cloned().find(|x| x == "2");
    |             ^^^^^^^^^^----------------------------
@@ -86,7 +86,7 @@ LL |     let _ = vec.iter().cloned().find(|x| x == "2");
    |                       help: try: `.find(|&x| x == "2").cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:44:17
+  --> tests/ui/iter_overeager_cloned.rs:45:17
    |
 LL |         let _ = vec.iter().cloned().filter(f);
    |                 ^^^^^^^^^^-------------------
@@ -94,7 +94,7 @@ LL |         let _ = vec.iter().cloned().filter(f);
    |                           help: try: `.filter(|&x| f(x)).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:46:17
+  --> tests/ui/iter_overeager_cloned.rs:47:17
    |
 LL |         let _ = vec.iter().cloned().find(f);
    |                 ^^^^^^^^^^-----------------
@@ -102,7 +102,7 @@ LL |         let _ = vec.iter().cloned().find(f);
    |                           help: try: `.find(|&x| f(x)).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:53:17
+  --> tests/ui/iter_overeager_cloned.rs:54:17
    |
 LL |         let _ = vec.iter().cloned().filter(f);
    |                 ^^^^^^^^^^-------------------
@@ -110,7 +110,7 @@ LL |         let _ = vec.iter().cloned().filter(f);
    |                           help: try: `.filter(|&x| f(x)).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:55:17
+  --> tests/ui/iter_overeager_cloned.rs:56:17
    |
 LL |         let _ = vec.iter().cloned().find(f);
    |                 ^^^^^^^^^^-----------------
@@ -118,7 +118,7 @@ LL |         let _ = vec.iter().cloned().find(f);
    |                           help: try: `.find(|&x| f(x)).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:63:9
+  --> tests/ui/iter_overeager_cloned.rs:64:9
    |
 LL |         iter.cloned().filter(move |&(&a, ref b)| a == 1 && b == &target)
    |         ^^^^------------------------------------------------------------
@@ -126,7 +126,7 @@ LL |         iter.cloned().filter(move |&(&a, ref b)| a == 1 && b == &target)
    |             help: try: `.filter(move |&&(&a, ref b)| a == 1 && b == &target).cloned()`
 
 error: unnecessarily eager cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:75:13
+  --> tests/ui/iter_overeager_cloned.rs:76:13
    |
 LL |             iter.cloned().filter(move |S { a, b }| **a == 1 && b == &target)
    |             ^^^^------------------------------------------------------------
@@ -134,7 +134,7 @@ LL |             iter.cloned().filter(move |S { a, b }| **a == 1 && b == &target
    |                 help: try: `.filter(move |&S { a, b }| **a == 1 && b == &target).cloned()`
 
 error: unneeded cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:80:13
+  --> tests/ui/iter_overeager_cloned.rs:81:13
    |
 LL |     let _ = vec.iter().cloned().map(|x| x.len());
    |             ^^^^^^^^^^--------------------------
@@ -142,7 +142,7 @@ LL |     let _ = vec.iter().cloned().map(|x| x.len());
    |                       help: try: `.map(|x| x.len())`
 
 error: unneeded cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:86:13
+  --> tests/ui/iter_overeager_cloned.rs:87:13
    |
 LL |     let _ = vec.iter().cloned().for_each(|x| assert!(!x.is_empty()));
    |             ^^^^^^^^^^----------------------------------------------
@@ -150,7 +150,7 @@ LL |     let _ = vec.iter().cloned().for_each(|x| assert!(!x.is_empty()));
    |                       help: try: `.for_each(|x| assert!(!x.is_empty()))`
 
 error: unneeded cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:89:13
+  --> tests/ui/iter_overeager_cloned.rs:90:13
    |
 LL |     let _ = vec.iter().cloned().all(|x| x.len() == 1);
    |             ^^^^^^^^^^-------------------------------
@@ -158,7 +158,7 @@ LL |     let _ = vec.iter().cloned().all(|x| x.len() == 1);
    |                       help: try: `.all(|x| x.len() == 1)`
 
 error: unneeded cloning of iterator items
-  --> tests/ui/iter_overeager_cloned.rs:92:13
+  --> tests/ui/iter_overeager_cloned.rs:93:13
    |
 LL |     let _ = vec.iter().cloned().any(|x| x.len() == 1);
    |             ^^^^^^^^^^-------------------------------

--- a/tests/ui/manual_map_option.fixed
+++ b/tests/ui/manual_map_option.fixed
@@ -6,6 +6,7 @@
     clippy::match_ref_pats,
     clippy::redundant_pattern_matching,
     clippy::unnecessary_map_on_constructor,
+    clippy::borrowed_option,
     for_loops_over_fallibles,
     dead_code
 )]

--- a/tests/ui/manual_map_option.rs
+++ b/tests/ui/manual_map_option.rs
@@ -6,6 +6,7 @@
     clippy::match_ref_pats,
     clippy::redundant_pattern_matching,
     clippy::unnecessary_map_on_constructor,
+    clippy::borrowed_option,
     for_loops_over_fallibles,
     dead_code
 )]

--- a/tests/ui/manual_map_option.stderr
+++ b/tests/ui/manual_map_option.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:14:5
+  --> tests/ui/manual_map_option.rs:15:5
    |
 LL | /     match Some(0) {
 LL | |
@@ -12,7 +12,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::manual_map)]`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:20:5
+  --> tests/ui/manual_map_option.rs:21:5
    |
 LL | /     match Some(0) {
 LL | |
@@ -22,7 +22,7 @@ LL | |     };
    | |_____^ help: try: `Some(0).map(|x| x + 1)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:26:5
+  --> tests/ui/manual_map_option.rs:27:5
    |
 LL | /     match Some("") {
 LL | |
@@ -32,7 +32,7 @@ LL | |     };
    | |_____^ help: try: `Some("").map(|x| x.is_empty())`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:32:5
+  --> tests/ui/manual_map_option.rs:33:5
    |
 LL | /     if let Some(x) = Some(0) {
 LL | |
@@ -43,7 +43,7 @@ LL | |     };
    | |_____^ help: try: `Some(0).map(|x| !x)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:40:5
+  --> tests/ui/manual_map_option.rs:41:5
    |
 LL | /     match Some(0) {
 LL | |
@@ -53,7 +53,7 @@ LL | |     };
    | |_____^ help: try: `Some(0).map(std::convert::identity)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:46:5
+  --> tests/ui/manual_map_option.rs:47:5
    |
 LL | /     match Some(&String::new()) {
 LL | |
@@ -63,7 +63,7 @@ LL | |     };
    | |_____^ help: try: `Some(&String::new()).map(|x| str::len(x))`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:57:5
+  --> tests/ui/manual_map_option.rs:58:5
    |
 LL | /     match &Some([0, 1]) {
 LL | |
@@ -73,7 +73,7 @@ LL | |     };
    | |_____^ help: try: `Some([0, 1]).as_ref().map(|x| x[0])`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:63:5
+  --> tests/ui/manual_map_option.rs:64:5
    |
 LL | /     match &Some(0) {
 LL | |
@@ -83,7 +83,7 @@ LL | |     };
    | |_____^ help: try: `Some(0).map(|x| x * 2)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:69:5
+  --> tests/ui/manual_map_option.rs:70:5
    |
 LL | /     match Some(String::new()) {
 LL | |
@@ -93,7 +93,7 @@ LL | |     };
    | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.is_empty())`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:75:5
+  --> tests/ui/manual_map_option.rs:76:5
    |
 LL | /     match &&Some(String::new()) {
 LL | |
@@ -103,7 +103,7 @@ LL | |     };
    | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.len())`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:81:5
+  --> tests/ui/manual_map_option.rs:82:5
    |
 LL | /     match &&Some(0) {
 LL | |
@@ -113,7 +113,7 @@ LL | |     };
    | |_____^ help: try: `Some(0).map(|x| x + x)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:95:9
+  --> tests/ui/manual_map_option.rs:96:9
    |
 LL | /         match &mut Some(String::new()) {
 LL | |
@@ -123,7 +123,7 @@ LL | |         };
    | |_________^ help: try: `Some(String::new()).as_mut().map(|x| x.push_str(""))`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:102:5
+  --> tests/ui/manual_map_option.rs:103:5
    |
 LL | /     match &mut Some(String::new()) {
 LL | |
@@ -133,7 +133,7 @@ LL | |     };
    | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.len())`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:108:5
+  --> tests/ui/manual_map_option.rs:109:5
    |
 LL | /     match &mut &Some(String::new()) {
 LL | |
@@ -143,7 +143,7 @@ LL | |     };
    | |_____^ help: try: `Some(String::new()).as_ref().map(|x| x.is_empty())`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:114:5
+  --> tests/ui/manual_map_option.rs:115:5
    |
 LL | /     match Some((0, 1, 2)) {
 LL | |
@@ -153,7 +153,7 @@ LL | |     };
    | |_____^ help: try: `Some((0, 1, 2)).map(|(x, y, z)| x + y + z)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:120:5
+  --> tests/ui/manual_map_option.rs:121:5
    |
 LL | /     match Some([1, 2, 3]) {
 LL | |
@@ -163,7 +163,7 @@ LL | |     };
    | |_____^ help: try: `Some([1, 2, 3]).map(|[first, ..]| first)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:126:5
+  --> tests/ui/manual_map_option.rs:127:5
    |
 LL | /     match &Some((String::new(), "test")) {
 LL | |
@@ -173,7 +173,7 @@ LL | |     };
    | |_____^ help: try: `Some((String::new(), "test")).as_ref().map(|(x, y)| (y, x))`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:196:5
+  --> tests/ui/manual_map_option.rs:197:5
    |
 LL | /     match option_env!("") {
 LL | |
@@ -183,7 +183,7 @@ LL | |     };
    | |_____^ help: try: `option_env!("").map(String::from)`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:217:12
+  --> tests/ui/manual_map_option.rs:218:12
    |
 LL |       } else if let Some(x) = Some(0) {
    |  ____________^
@@ -195,7 +195,7 @@ LL | |     };
    | |_____^ help: try: `{ Some(0).map(|x| x + 1) }`
 
 error: manual implementation of `Option::map`
-  --> tests/ui/manual_map_option.rs:226:12
+  --> tests/ui/manual_map_option.rs:227:12
    |
 LL |       } else if let Some(x) = Some(0) {
    |  ____________^

--- a/tests/ui/manual_map_option_2.fixed
+++ b/tests/ui/manual_map_option_2.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_map)]
-#![allow(clippy::toplevel_ref_arg)]
+#![allow(clippy::toplevel_ref_arg, clippy::borrowed_option)]
 
 fn main() {
     // Lint. `y` is declared within the arm, so it isn't captured by the map closure

--- a/tests/ui/manual_map_option_2.rs
+++ b/tests/ui/manual_map_option_2.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_map)]
-#![allow(clippy::toplevel_ref_arg)]
+#![allow(clippy::toplevel_ref_arg, clippy::borrowed_option)]
 
 fn main() {
     // Lint. `y` is declared within the arm, so it isn't captured by the map closure

--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -1,6 +1,7 @@
 #![warn(clippy::option_if_let_else)]
 #![allow(
     clippy::ref_option_ref,
+    clippy::borrowed_option,
     clippy::equatable_if_let,
     clippy::let_unit_value,
     clippy::redundant_locals,

--- a/tests/ui/option_if_let_else.rs
+++ b/tests/ui/option_if_let_else.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::option_if_let_else)]
 #![allow(
     clippy::ref_option_ref,
+    clippy::borrowed_option,
     clippy::equatable_if_let,
     clippy::let_unit_value,
     clippy::redundant_locals,

--- a/tests/ui/option_if_let_else.stderr
+++ b/tests/ui/option_if_let_else.stderr
@@ -1,5 +1,5 @@
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:13:5
+  --> tests/ui/option_if_let_else.rs:14:5
    |
 LL | /     if let Some(x) = string {
 LL | |
@@ -13,19 +13,19 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::option_if_let_else)]`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:32:13
+  --> tests/ui/option_if_let_else.rs:33:13
    |
 LL |     let _ = if let Some(s) = *string { s.len() } else { 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.map_or(0, |s| s.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:34:13
+  --> tests/ui/option_if_let_else.rs:35:13
    |
 LL |     let _ = if let Some(s) = &num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:36:13
+  --> tests/ui/option_if_let_else.rs:37:13
    |
 LL |       let _ = if let Some(s) = &mut num {
    |  _____________^
@@ -47,13 +47,13 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:43:13
+  --> tests/ui/option_if_let_else.rs:44:13
    |
 LL |     let _ = if let Some(ref s) = num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:45:13
+  --> tests/ui/option_if_let_else.rs:46:13
    |
 LL |       let _ = if let Some(mut s) = num {
    |  _____________^
@@ -75,7 +75,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:52:13
+  --> tests/ui/option_if_let_else.rs:53:13
    |
 LL |       let _ = if let Some(ref mut s) = num {
    |  _____________^
@@ -97,7 +97,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:62:5
+  --> tests/ui/option_if_let_else.rs:63:5
    |
 LL | /     if let Some(x) = arg {
 LL | |
@@ -118,7 +118,7 @@ LL +     })
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:76:13
+  --> tests/ui/option_if_let_else.rs:77:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -131,7 +131,7 @@ LL | |     };
    | |_____^ help: try: `arg.map_or_else(side_effect, |x| x)`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:86:13
+  --> tests/ui/option_if_let_else.rs:87:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -154,7 +154,7 @@ LL ~     }, |x| x * x * x * x);
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:120:13
+  --> tests/ui/option_if_let_else.rs:121:13
    |
 LL | /             if let Some(idx) = s.find('.') {
 LL | |
@@ -165,7 +165,7 @@ LL | |             }
    | |_____________^ help: try: `s.find('.').map_or_else(|| vec![s.to_string()], |idx| vec![s[..idx].to_string(), s[idx..].to_string()])`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:132:5
+  --> tests/ui/option_if_let_else.rs:133:5
    |
 LL | /     if let Ok(binding) = variable {
 LL | |
@@ -189,7 +189,7 @@ LL +     })
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:157:5
+  --> tests/ui/option_if_let_else.rs:158:5
    |
 LL | /     match r {
 LL | |
@@ -199,7 +199,7 @@ LL | |     }
    | |_____^ help: try: `r.map_or_else(|_| Vec::new(), |s| s.to_owned())`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:166:5
+  --> tests/ui/option_if_let_else.rs:167:5
    |
 LL | /     if let Ok(s) = r { s.to_owned() }
 LL | |
@@ -207,13 +207,13 @@ LL | |     else { Vec::new() }
    | |_______________________^ help: try: `r.map_or_else(|_| Vec::new(), |s| s.to_owned())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:173:13
+  --> tests/ui/option_if_let_else.rs:174:13
    |
 LL |     let _ = if let Some(x) = optional { x + 2 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `optional.map_or(5, |x| x + 2)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:184:13
+  --> tests/ui/option_if_let_else.rs:185:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -235,13 +235,13 @@ LL ~         });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:213:13
+  --> tests/ui/option_if_let_else.rs:214:13
    |
 LL |     let _ = if let Some(x) = Some(0) { s.len() + x } else { s.len() };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(0).map_or(s.len(), |x| s.len() + x)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:218:13
+  --> tests/ui/option_if_let_else.rs:219:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -263,7 +263,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:258:13
+  --> tests/ui/option_if_let_else.rs:259:13
    |
 LL |       let _ = match s {
    |  _____________^
@@ -274,7 +274,7 @@ LL | |     };
    | |_____^ help: try: `s.map_or(1, |string| string.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:263:13
+  --> tests/ui/option_if_let_else.rs:264:13
    |
 LL |       let _ = match Some(10) {
    |  _____________^
@@ -285,7 +285,7 @@ LL | |     };
    | |_____^ help: try: `Some(10).map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:270:13
+  --> tests/ui/option_if_let_else.rs:271:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -296,7 +296,7 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:275:13
+  --> tests/ui/option_if_let_else.rs:276:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -307,13 +307,13 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:280:13
+  --> tests/ui/option_if_let_else.rs:281:13
    |
 LL |     let _ = if let Ok(a) = res { a + 1 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:298:17
+  --> tests/ui/option_if_let_else.rs:299:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -324,7 +324,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_ref().map_or(42, |value| do_something(value))`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:306:17
+  --> tests/ui/option_if_let_else.rs:307:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -335,7 +335,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_mut().map_or(42, |value| do_something2(value))`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:330:24
+  --> tests/ui/option_if_let_else.rs:331:24
    |
 LL |       let mut _hashmap = if let Some(hm) = &opt {
    |  ________________________^
@@ -347,19 +347,19 @@ LL | |     };
    | |_____^ help: try: `opt.as_ref().map_or_else(HashMap::new, |hm| hm.clone())`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:337:19
+  --> tests/ui/option_if_let_else.rs:338:19
    |
 LL |     let mut _hm = if let Some(hm) = &opt { hm.clone() } else { new_map!() };
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.as_ref().map_or_else(|| new_map!(), |hm| hm.clone())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:388:22
+  --> tests/ui/option_if_let_else.rs:389:22
    |
 LL |     let _ = unsafe { if let Some(o) = *opt_raw_ptr { o } else { 1 } };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(*opt_raw_ptr).map_or(1, |o| o)`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:394:13
+  --> tests/ui/option_if_let_else.rs:395:13
    |
 LL |       let _ = match res {
    |  _____________^

--- a/tests/ui/partialeq_to_none.fixed
+++ b/tests/ui/partialeq_to_none.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::eq_op, clippy::borrowed_option, clippy::needless_if)]
 
 struct Foobar;
 

--- a/tests/ui/partialeq_to_none.rs
+++ b/tests/ui/partialeq_to_none.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::partialeq_to_none)]
-#![allow(clippy::eq_op, clippy::needless_if)]
+#![allow(clippy::eq_op, clippy::borrowed_option, clippy::needless_if)]
 
 struct Foobar;
 

--- a/tests/ui/pattern_type_mismatch/pattern_alternatives.rs
+++ b/tests/ui/pattern_type_mismatch/pattern_alternatives.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::pattern_type_mismatch)]
+#![allow(clippy::borrowed_option)]
 
 fn main() {}
 

--- a/tests/ui/pattern_type_mismatch/pattern_alternatives.stderr
+++ b/tests/ui/pattern_type_mismatch/pattern_alternatives.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:14:12
+  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:15:12
    |
 LL |     if let Value::B | Value::A(_) = ref_value {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     if let Value::B | Value::A(_) = ref_value {}
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:17:34
+  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:18:34
    |
 LL |     if let &Value::B | &Value::A(Some(_)) = ref_value {}
    |                                  ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let &Value::B | &Value::A(Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:20:32
+  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:21:32
    |
 LL |     if let Value::B | Value::A(Some(_)) = *ref_value {}
    |                                ^^^^^^^

--- a/tests/ui/pattern_type_mismatch/pattern_structs.rs
+++ b/tests/ui/pattern_type_mismatch/pattern_structs.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::pattern_type_mismatch)]
+#![allow(clippy::borrowed_option)]
 
 fn main() {}
 

--- a/tests/ui/pattern_type_mismatch/pattern_structs.stderr
+++ b/tests/ui/pattern_type_mismatch/pattern_structs.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:12:9
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:13:9
    |
 LL |     let Struct { .. } = ref_value;
    |         ^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let Struct { .. } = ref_value;
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:15:33
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:16:33
    |
 LL |     if let &Struct { ref_inner: Some(_) } = ref_value {}
    |                                 ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let &Struct { ref_inner: Some(_) } = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:18:32
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:19:32
    |
 LL |     if let Struct { ref_inner: Some(_) } = *ref_value {}
    |                                ^^^^^^^
@@ -25,7 +25,7 @@ LL |     if let Struct { ref_inner: Some(_) } = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:36:12
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:37:12
    |
 LL |     if let StructEnum::Var { .. } = ref_value {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     if let StructEnum::Var { .. } = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:39:12
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:40:12
    |
 LL |     if let StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     if let StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:42:42
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:43:42
    |
 LL |     if let &StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    |                                          ^^^^^^^
@@ -49,7 +49,7 @@ LL |     if let &StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:45:41
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:46:41
    |
 LL |     if let StructEnum::Var { inner_ref: Some(_) } = *ref_value {}
    |                                         ^^^^^^^
@@ -57,7 +57,7 @@ LL |     if let StructEnum::Var { inner_ref: Some(_) } = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:48:12
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:49:12
    |
 LL |     if let StructEnum::Empty = ref_value {}
    |            ^^^^^^^^^^^^^^^^^

--- a/tests/ui/pattern_type_mismatch/pattern_tuples.rs
+++ b/tests/ui/pattern_type_mismatch/pattern_tuples.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::pattern_type_mismatch)]
+#![allow(clippy::borrowed_option)]
 
 fn main() {}
 

--- a/tests/ui/pattern_type_mismatch/pattern_tuples.stderr
+++ b/tests/ui/pattern_type_mismatch/pattern_tuples.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:10:9
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:11:9
    |
 LL |     let TupleStruct(_) = ref_value;
    |         ^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let TupleStruct(_) = ref_value;
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:13:25
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:14:25
    |
 LL |     if let &TupleStruct(Some(_)) = ref_value {}
    |                         ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let &TupleStruct(Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:16:24
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:17:24
    |
 LL |     if let TupleStruct(Some(_)) = *ref_value {}
    |                        ^^^^^^^
@@ -25,7 +25,7 @@ LL |     if let TupleStruct(Some(_)) = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:34:12
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:35:12
    |
 LL |     if let TupleEnum::Var(_) = ref_value {}
    |            ^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     if let TupleEnum::Var(_) = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:37:28
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:38:28
    |
 LL |     if let &TupleEnum::Var(Some(_)) = ref_value {}
    |                            ^^^^^^^
@@ -41,7 +41,7 @@ LL |     if let &TupleEnum::Var(Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:40:27
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:41:27
    |
 LL |     if let TupleEnum::Var(Some(_)) = *ref_value {}
    |                           ^^^^^^^
@@ -49,7 +49,7 @@ LL |     if let TupleEnum::Var(Some(_)) = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:43:12
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:44:12
    |
 LL |     if let TupleEnum::Empty = ref_value {}
    |            ^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     if let TupleEnum::Empty = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:59:9
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:60:9
    |
 LL |     let (_a, _b) = ref_value;
    |         ^^^^^^^^
@@ -65,7 +65,7 @@ LL |     let (_a, _b) = ref_value;
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:62:18
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:63:18
    |
 LL |     if let &(_a, Some(_)) = ref_value {}
    |                  ^^^^^^^
@@ -73,7 +73,7 @@ LL |     if let &(_a, Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:65:17
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:66:17
    |
 LL |     if let (_a, Some(_)) = *ref_value {}
    |                 ^^^^^^^

--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -1,5 +1,5 @@
 #![feature(try_blocks)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::unnecessary_wraps, clippy::borrowed_option)]
 
 use std::sync::MutexGuard;
 

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -1,5 +1,5 @@
 #![feature(try_blocks)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::unnecessary_wraps, clippy::borrowed_option)]
 
 use std::sync::MutexGuard;
 

--- a/tests/ui/ref_option_ref.rs
+++ b/tests/ui/ref_option_ref.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::borrowed_option)]
 #![warn(clippy::ref_option_ref)]
 //@no-rustfix
 // This lint is not tagged as run-rustfix because automatically


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/11463)*

This is inspired by this excellent video: https://www.youtube.com/watch?v=6c7pZYP_iIE

Some things I'd appreciate feedback on:

- [x] I've added this to the `borrowed_box.rs` check, since these two lints would share a lot of common code. We should probably rename that file, but to what? `borrowed_box_or_option.rs`? (same goes for the tests) (Edit: looks like the corresponding issue has been closed for now, so let's keep it like it is for now?
- [x] There's a special case for ignoring `&Box<Any>` (see rust-lang/rust-clippy#1884), I'm not sure if this is needed for `&Option<Any>` as well.
- [x] The wording of `What it does` and `Why is this bad` could probably use some improvements, suggestions are welcome!

---

changelog: new lint: [`borrowed_option`]