### PR TITLE
Ignore span's parents in `collect_ast_format_args`/`find_format_args`

### DIFF
--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -389,7 +389,9 @@ thread_local! {
 /// `FormatArgsCollector`
 pub fn collect_ast_format_args(span: Span, format_args: &FormatArgs) {
     AST_FORMAT_ARGS.with(|ast_format_args| {
-        ast_format_args.borrow_mut().insert(span, format_args.clone());
+        ast_format_args
+            .borrow_mut()
+            .insert(span.with_parent(None), format_args.clone());
     });
 }
 
@@ -414,7 +416,7 @@ pub fn find_format_args(cx: &LateContext<'_>, start: &Expr<'_>, expn_id: ExpnId,
 
     if let Some(expr) = format_args_expr {
         AST_FORMAT_ARGS.with(|ast_format_args| {
-            ast_format_args.borrow().get(&expr.span).map(callback);
+            ast_format_args.borrow().get(&expr.span.with_parent(None)).map(callback);
         });
     }
 }


### PR DESCRIPTION
Fixes #11470, covers some cases missed by #10980

Can't have a test yet because of #11126 but it works locally

changelog: none

r? @dswij