### PR TITLE
Auto deref does not apply on union field

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -1399,6 +1399,13 @@ fn report<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, state: State, data
                 return;
             }
 
+            if let ExprKind::Field(parent_expr, _) = expr.kind
+                && let ty::Adt(adt, _) = cx.typeck_results().expr_ty(parent_expr).kind()
+                && adt.is_union()
+            {
+                // Auto deref does not apply on union field
+                return;
+            }
             span_lint_hir_and_then(
                 cx,
                 EXPLICIT_AUTO_DEREF,

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -299,4 +299,26 @@ fn main() {
         Some(x) => x,
         None => panic!(),
     };
+
+    // Issue #11474
+    pub struct Variant {
+        pub anonymous: Variant0,
+    }
+
+    pub union Variant0 {
+        pub anonymous: std::mem::ManuallyDrop<Variant00>,
+    }
+
+    pub struct Variant00 {
+        pub anonymous: Variant000,
+    }
+
+    pub union Variant000 {
+        pub val: i32,
+    }
+
+    unsafe {
+        let mut p = core::mem::zeroed::<Variant>();
+        (*p.anonymous.anonymous).anonymous.val = 1;
+    }
 }

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -299,4 +299,26 @@ fn main() {
         Some(x) => &mut *x,
         None => panic!(),
     };
+
+    // Issue #11474
+    pub struct Variant {
+        pub anonymous: Variant0,
+    }
+
+    pub union Variant0 {
+        pub anonymous: std::mem::ManuallyDrop<Variant00>,
+    }
+
+    pub struct Variant00 {
+        pub anonymous: Variant000,
+    }
+
+    pub union Variant000 {
+        pub val: i32,
+    }
+
+    unsafe {
+        let mut p = core::mem::zeroed::<Variant>();
+        (*p.anonymous.anonymous).anonymous.val = 1;
+    }
 }


### PR DESCRIPTION
changelog: [`explicit_auto_deref`]: do not suggest propose to auto-dereference an union field

Fix #11474 