### PR TITLE
Remove `derive_new` test dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ itertools = "0.10.1"
 
 # UI test dependencies
 clippy_utils = { path = "clippy_utils" }
-derive-new = "0.5"
 if_chain = "1.0"
 quote = "1.0"
 serde = { version = "1.0.125", features = ["derive"] }

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -18,7 +18,6 @@ use test_utils::IS_RUSTC_TEST_SUITE;
 // in the depinfo file (otherwise cargo thinks they are unused)
 extern crate clippy_lints;
 extern crate clippy_utils;
-extern crate derive_new;
 extern crate futures;
 extern crate if_chain;
 extern crate itertools;
@@ -33,7 +32,6 @@ mod test_utils;
 static TEST_DEPENDENCIES: &[&str] = &[
     "clippy_lints",
     "clippy_utils",
-    "derive_new",
     "futures",
     "if_chain",
     "itertools",

--- a/tests/ui/redundant_field_names.fixed
+++ b/tests/ui/redundant_field_names.fixed
@@ -1,8 +1,9 @@
+//@aux-build:proc_macros.rs
 #![warn(clippy::redundant_field_names)]
 #![allow(clippy::extra_unused_type_parameters, clippy::no_effect, dead_code, unused_variables)]
 
 #[macro_use]
-extern crate derive_new;
+extern crate proc_macros;
 
 use std::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 
@@ -18,7 +19,6 @@ struct Person {
     foo: u8,
 }
 
-#[derive(new)]
 pub struct S {
     v: String,
 }
@@ -57,6 +57,13 @@ fn main() {
     let _ = Range { start, end };
     let _ = RangeInclusive::new(start, end);
     let _ = RangeToInclusive { end };
+
+    external! {
+        let v = String::new();
+        let _ = S {
+            v: v
+        };
+    }
 }
 
 fn issue_3476() {

--- a/tests/ui/redundant_field_names.rs
+++ b/tests/ui/redundant_field_names.rs
@@ -1,8 +1,9 @@
+//@aux-build:proc_macros.rs
 #![warn(clippy::redundant_field_names)]
 #![allow(clippy::extra_unused_type_parameters, clippy::no_effect, dead_code, unused_variables)]
 
 #[macro_use]
-extern crate derive_new;
+extern crate proc_macros;
 
 use std::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 
@@ -18,7 +19,6 @@ struct Person {
     foo: u8,
 }
 
-#[derive(new)]
 pub struct S {
     v: String,
 }
@@ -57,6 +57,13 @@ fn main() {
     let _ = Range { start: start, end: end };
     let _ = RangeInclusive::new(start, end);
     let _ = RangeToInclusive { end: end };
+
+    external! {
+        let v = String::new();
+        let _ = S {
+            v: v
+        };
+    }
 }
 
 fn issue_3476() {

--- a/tests/ui/redundant_field_names.stderr
+++ b/tests/ui/redundant_field_names.stderr
@@ -44,7 +44,7 @@ LL |     let _ = RangeToInclusive { end: end };
    |                                ^^^^^^^^ help: replace it with: `end`
 
 error: redundant field names in struct initialization
-  --> $DIR/redundant_field_names.rs:81:25
+  --> $DIR/redundant_field_names.rs:88:25
    |
 LL |     let _ = RangeFrom { start: start };
    |                         ^^^^^^^^^^^^ help: replace it with: `start`


### PR DESCRIPTION
It is the last thing depending on syn 1.0 in clippy

changelog: none
