### PR TITLE
fix enum_variant_names depending lint depending on order

### DIFF
--- a/clippy_lints/src/item_name_repetitions.rs
+++ b/clippy_lints/src/item_name_repetitions.rs
@@ -320,6 +320,11 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
         return;
     }
 
+    for var in def.variants {
+        check_enum_start(cx, item_name, var);
+        check_enum_end(cx, item_name, var);
+    }
+
     let first = match def.variants.first() {
         Some(variant) => variant.ident.name.as_str(),
         None => return,
@@ -328,8 +333,6 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
     let mut post = pre.clone();
     post.reverse();
     for var in def.variants {
-        check_enum_start(cx, item_name, var);
-        check_enum_end(cx, item_name, var);
         let name = var.ident.name.as_str();
 
         let variant_split = camel_case_split(name);

--- a/tests/ui/enum_variants.rs
+++ b/tests/ui/enum_variants.rs
@@ -204,4 +204,21 @@ mod allow_attributes_on_variants {
     }
 }
 
+mod issue11494 {
+    // variant order should not affect lint
+    enum Data {
+        Valid,
+        Invalid,
+        DataDependent,
+        //~^ ERROR: variant name starts with the enum's name
+    }
+
+    enum Datas {
+        DatasDependent,
+        //~^ ERROR: variant name starts with the enum's name
+        Valid,
+        Invalid,
+    }
+}
+
 fn main() {}

--- a/tests/ui/enum_variants.stderr
+++ b/tests/ui/enum_variants.stderr
@@ -158,5 +158,17 @@ LL | |     }
    |
    = help: remove the postfixes and use full paths to the variants instead of glob imports
 
-error: aborting due to 14 previous errors
+error: variant name starts with the enum's name
+  --> $DIR/enum_variants.rs:212:9
+   |
+LL |         DataDependent,
+   |         ^^^^^^^^^^^^^
+
+error: variant name starts with the enum's name
+  --> $DIR/enum_variants.rs:217:9
+   |
+LL |         DatasDependent,
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
changelog: [`enum_variant_names`]: fix single word variants preventing lint of later variant pre/postfixed with the enum name 

fixes #11494 

Single word variants prevented checking the `check_enum_start` and `check_enum_end` for being run on later variants