### PR TITLE
Ignore closures for some type lints

### DIFF
--- a/tests/ui/redundant_allocation.rs
+++ b/tests/ui/redundant_allocation.rs
@@ -159,4 +159,9 @@ mod box_fat_ptr {
     //~| NOTE: `Box<Box<DynSized>>` is already on the heap, `Rc<Box<Box<DynSized>>>` makes
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/11417
+fn type_in_closure() {
+    let _ = |_: &mut Box<Box<dyn ToString>>| {};
+}
+
 fn main() {}

--- a/tests/ui/vec_box_sized.fixed
+++ b/tests/ui/vec_box_sized.fixed
@@ -49,4 +49,9 @@ mod inner_mod {
     }
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/11417
+fn in_closure() {
+    let _ = |_: Vec<Box<dyn ToString>>| {};
+}
+
 fn main() {}

--- a/tests/ui/vec_box_sized.rs
+++ b/tests/ui/vec_box_sized.rs
@@ -49,4 +49,9 @@ mod inner_mod {
     }
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/11417
+fn in_closure() {
+    let _ = |_: Vec<Box<dyn ToString>>| {};
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes #11417

`hir_ty_to_ty` is used in a couple of the `!is_local` lints, which doesn't play nicely inside bodies

changelog: none
