### PR TITLE
fix filter_map_bool_then with a bool reference

### DIFF
--- a/tests/ui/filter_map_bool_then.fixed
+++ b/tests/ui/filter_map_bool_then.fixed
@@ -55,3 +55,8 @@ fn main() {
 fn issue11309<'a>(iter: impl Iterator<Item = (&'a str, &'a str)>) -> Vec<&'a str> {
     iter.filter_map(|(_, s): (&str, _)| Some(s)).collect()
 }
+
+fn issue11503() {
+    let bools: &[bool] = &[true, false, false, true];
+    let _: Vec<usize> = bools.iter().enumerate().filter(|&(i, b)| *b).map(|(i, b)| i).collect();
+}

--- a/tests/ui/filter_map_bool_then.rs
+++ b/tests/ui/filter_map_bool_then.rs
@@ -55,3 +55,8 @@ fn main() {
 fn issue11309<'a>(iter: impl Iterator<Item = (&'a str, &'a str)>) -> Vec<&'a str> {
     iter.filter_map(|(_, s): (&str, _)| Some(s)).collect()
 }
+
+fn issue11503() {
+    let bools: &[bool] = &[true, false, false, true];
+    let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
+}

--- a/tests/ui/filter_map_bool_then.stderr
+++ b/tests/ui/filter_map_bool_then.stderr
@@ -37,5 +37,11 @@ error: usage of `bool::then` in `filter_map`
 LL |     v.clone().iter().filter_map(|i| (i == &NonCopy).then(|| i));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i == &NonCopy)).map(|i| i)`
 
-error: aborting due to 6 previous errors
+error: usage of `bool::then` in `filter_map`
+  --> $DIR/filter_map_bool_then.rs:61:50
+   |
+LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| *b).map(|(i, b)| i)`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
changelog: [`filter_map_bool_then`]: Fix the incorrect autofix when the `bool` in question is a reference.

fix #11503 