### PR TITLE
[`filter_map_bool_then`]: peel as many refs as needed

### DIFF
--- a/clippy_lints/src/methods/filter_map_bool_then.rs
+++ b/clippy_lints/src/methods/filter_map_bool_then.rs
@@ -2,13 +2,13 @@ use super::FILTER_MAP_BOOL_THEN;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::paths::BOOL_THEN;
 use clippy_utils::source::snippet_opt;
-use clippy_utils::ty::is_copy;
+use clippy_utils::ty::{is_copy, peel_mid_ty_refs_is_mutable};
 use clippy_utils::{is_from_proc_macro, is_trait_method, match_def_path, peel_blocks};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::lint::in_external_macro;
-use rustc_middle::ty::{self, Binder};
+use rustc_middle::ty::Binder;
 use rustc_span::{sym, Span};
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &Expr<'_>, call_span: Span) {
@@ -36,7 +36,11 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &
         && let Some(def_id) = cx.typeck_results().type_dependent_def_id(value.hir_id)
         && match_def_path(cx, def_id, &BOOL_THEN)
         && !is_from_proc_macro(cx, expr)
-        && let ref_bool = matches!(cx.typeck_results().expr_ty(recv).kind(), ty::Ref(..))
+        // Peel all refs (e.g. `&&&&mut &&&bool` -> `bool`) and get its count so we can suggest the exact
+        // amount of derefs to get to the bool in the filter.
+        // `peel_mid_ty_refs` alone doesn't handle mutable reference, so we use `_is_mutable`
+        // instead which counts them too and just ignore the resulting mutability
+        && let (_, needed_derefs, _) = peel_mid_ty_refs_is_mutable(cx.typeck_results().expr_ty(recv))
         && let Some(param_snippet) = snippet_opt(cx, param.span)
         && let Some(filter) = snippet_opt(cx, recv.span)
         && let Some(map) = snippet_opt(cx, then_body.span)
@@ -47,7 +51,10 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>, arg: &
             call_span,
             "usage of `bool::then` in `filter_map`",
             "use `filter` then `map` instead",
-            format!("filter(|&{param_snippet}| {}{filter}).map(|{param_snippet}| {map})", if ref_bool { "*" } else { "" }),
+            format!(
+                "filter(|&{param_snippet}| {derefs}{filter}).map(|{param_snippet}| {map})",
+                derefs="*".repeat(needed_derefs)
+            ),
             Applicability::MachineApplicable,
         );
     }

--- a/tests/ui/filter_map_bool_then.fixed
+++ b/tests/ui/filter_map_bool_then.fixed
@@ -59,4 +59,12 @@ fn issue11309<'a>(iter: impl Iterator<Item = (&'a str, &'a str)>) -> Vec<&'a str
 fn issue11503() {
     let bools: &[bool] = &[true, false, false, true];
     let _: Vec<usize> = bools.iter().enumerate().filter(|&(i, b)| *b).map(|(i, b)| i).collect();
+
+    // Need to insert multiple derefs if there is more than one layer of references
+    let bools: &[&&bool] = &[&&true, &&false, &&false, &&true];
+    let _: Vec<usize> = bools.iter().enumerate().filter(|&(i, b)| ***b).map(|(i, b)| i).collect();
+
+    // Should also suggest derefs when going through a mutable reference
+    let bools: &[&mut bool] = &[&mut true];
+    let _: Vec<usize> = bools.iter().enumerate().filter(|&(i, b)| **b).map(|(i, b)| i).collect();
 }

--- a/tests/ui/filter_map_bool_then.rs
+++ b/tests/ui/filter_map_bool_then.rs
@@ -59,4 +59,12 @@ fn issue11309<'a>(iter: impl Iterator<Item = (&'a str, &'a str)>) -> Vec<&'a str
 fn issue11503() {
     let bools: &[bool] = &[true, false, false, true];
     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
+
+    // Need to insert multiple derefs if there is more than one layer of references
+    let bools: &[&&bool] = &[&&true, &&false, &&false, &&true];
+    let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
+
+    // Should also suggest derefs when going through a mutable reference
+    let bools: &[&mut bool] = &[&mut true];
+    let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
 }

--- a/tests/ui/filter_map_bool_then.stderr
+++ b/tests/ui/filter_map_bool_then.stderr
@@ -43,5 +43,17 @@ error: usage of `bool::then` in `filter_map`
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| *b).map(|(i, b)| i)`
 
-error: aborting due to 7 previous errors
+error: usage of `bool::then` in `filter_map`
+  --> $DIR/filter_map_bool_then.rs:65:50
+   |
+LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| ***b).map(|(i, b)| i)`
+
+error: usage of `bool::then` in `filter_map`
+  --> $DIR/filter_map_bool_then.rs:69:50
+   |
+LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| **b).map(|(i, b)| i)`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
In #11506 this lint was improved to suggest one deref if the bool is behind references (fixed the FP #11503), however it might need multiple dereferences if the bool is behind multiple layers of references. E.g. `&&&bool` needs `***b`.

changelog: [`filter_map_bool_then`]: peel as many references as needed and suggest multiple dereferences

