### PR TITLE
fix cast_lossless with macro call

### DIFF
--- a/clippy_lints/src/casts/cast_lossless.rs
+++ b/clippy_lints/src/casts/cast_lossless.rs
@@ -25,14 +25,7 @@ pub(super) fn check(
     // The suggestion is to use a function call, so if the original expression
     // has parens on the outside, they are no longer needed.
     let mut applicability = Applicability::MachineApplicable;
-    let opt = snippet_opt(
-        cx,
-        if cast_op.span.from_expansion() {
-            cast_op.span.source_callsite()
-        } else {
-            cast_op.span
-        },
-    );
+    let opt = snippet_opt(cx, cast_op.span.source_callsite());
     let sugg = opt.as_ref().map_or_else(
         || {
             applicability = Applicability::HasPlaceholders;

--- a/clippy_lints/src/casts/cast_lossless.rs
+++ b/clippy_lints/src/casts/cast_lossless.rs
@@ -25,7 +25,14 @@ pub(super) fn check(
     // The suggestion is to use a function call, so if the original expression
     // has parens on the outside, they are no longer needed.
     let mut applicability = Applicability::MachineApplicable;
-    let opt = snippet_opt(cx, cast_op.span);
+    let opt = snippet_opt(
+        cx,
+        if cast_op.span.from_expansion() {
+            cast_op.span.source_callsite()
+        } else {
+            cast_op.span
+        },
+    );
     let sugg = opt.as_ref().map_or_else(
         || {
             applicability = Applicability::HasPlaceholders;

--- a/tests/ui/cast_lossless_integer.fixed
+++ b/tests/ui/cast_lossless_integer.fixed
@@ -49,3 +49,14 @@ mod cast_lossless_in_impl {
 enum Test {
     A = u32::MAX as i64 + 1,
 }
+
+fn issue11458() {
+    macro_rules! sign_cast {
+        ($var: ident, $src: ty, $dest: ty) => {
+            <$dest>::from_ne_bytes(($var as $src).to_ne_bytes())
+        };
+    }
+    let x = 10_u128;
+    let _ = i32::from(sign_cast!(x, u8, i8));
+    let _ = i32::from(sign_cast!(x, u8, i8) + 1);
+}

--- a/tests/ui/cast_lossless_integer.rs
+++ b/tests/ui/cast_lossless_integer.rs
@@ -49,3 +49,14 @@ mod cast_lossless_in_impl {
 enum Test {
     A = u32::MAX as i64 + 1,
 }
+
+fn issue11458() {
+    macro_rules! sign_cast {
+        ($var: ident, $src: ty, $dest: ty) => {
+            <$dest>::from_ne_bytes(($var as $src).to_ne_bytes())
+        };
+    }
+    let x = 10_u128;
+    let _ = sign_cast!(x, u8, i8) as i32;
+    let _ = (sign_cast!(x, u8, i8) + 1) as i32;
+}

--- a/tests/ui/cast_lossless_integer.stderr
+++ b/tests/ui/cast_lossless_integer.stderr
@@ -115,5 +115,17 @@ error: casting `u8` to `u16` may become silently lossy if you later change the t
 LL |     let _ = (1u8 + 1u8) as u16;
    |             ^^^^^^^^^^^^^^^^^^ help: try: `u16::from(1u8 + 1u8)`
 
-error: aborting due to 19 previous errors
+error: casting `i8` to `i32` may become silently lossy if you later change the type
+  --> $DIR/cast_lossless_integer.rs:60:13
+   |
+LL |     let _ = sign_cast!(x, u8, i8) as i32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i32::from(sign_cast!(x, u8, i8))`
+
+error: casting `i8` to `i32` may become silently lossy if you later change the type
+  --> $DIR/cast_lossless_integer.rs:61:13
+   |
+LL |     let _ = (sign_cast!(x, u8, i8) + 1) as i32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `i32::from(sign_cast!(x, u8, i8) + 1)`
+
+error: aborting due to 21 previous errors
 


### PR DESCRIPTION
changelog: fix [`cast_lossless`] in the case when the cast operand is a macro call

fix #11458 
