### PR TITLE
fix ICE by `u64::try_from(<u128>)`

### DIFF
--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -44,7 +44,7 @@ fn apply_reductions(cx: &LateContext<'_>, nbits: u64, expr: &Expr<'_>, signed: b
                 .unwrap_or(u64::max_value())
                 .min(apply_reductions(cx, nbits, left, signed)),
             BinOpKind::Shr => apply_reductions(cx, nbits, left, signed)
-                .saturating_sub(constant_int(cx, right).map_or(0, |s| u64::try_from(s).expect("shift too high"))),
+                .saturating_sub(constant_int(cx, right).map_or(0, |s| u64::try_from(s).unwrap_or_default())),
             _ => nbits,
         },
         ExprKind::MethodCall(method, left, [right], _) => {

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -361,3 +361,7 @@ fn avoid_subtract_overflow(q: u32) {
     //~^ ERROR: casting `u32` to `u8` may truncate the value
     c as usize;
 }
+
+fn issue11426() {
+    (&42u8 >> 0xa9008fb6c9d81e42_0e25730562a601c8_u128) as usize;
+}


### PR DESCRIPTION
changelog: Fix the ICE in [`cast_possible_truncation`], when the `Shr` bits is larger than `u64::MAX`

fix #11426 