### PR TITLE
fix FP with needless_raw_string_hashes

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -616,7 +616,7 @@ fn check_should_panic_reason(cx: &LateContext<'_>, attr: &Attribute) {
             attr.span,
             "#[should_panic] attribute without a reason",
             "consider specifying the expected panic",
-            r#"#[should_panic(expected = /* panic message */)]"#.into(),
+            "#[should_panic(expected = /* panic message */)]".into(),
             Applicability::HasPlaceholders,
         );
     }

--- a/clippy_lints/src/raw_strings.rs
+++ b/clippy_lints/src/raw_strings.rs
@@ -96,8 +96,9 @@ impl EarlyLintPass for RawStrings {
                         );
                     },
                 );
-
-                return;
+                if !matches!(cx.get_lint_level(NEEDLESS_RAW_STRINGS), rustc_lint::Allow) {
+                    return;
+                }
             }
 
             let req = {

--- a/tests/ui/needless_raw_string_hashes.fixed
+++ b/tests/ui/needless_raw_string_hashes.fixed
@@ -21,4 +21,7 @@ fn main() {
         multiline
         string
     ";
+
+    r"rust";
+    r"hello world";
 }

--- a/tests/ui/needless_raw_string_hashes.rs
+++ b/tests/ui/needless_raw_string_hashes.rs
@@ -21,4 +21,7 @@ fn main() {
         multiline
         string
     "#;
+
+    r###"rust"###;
+    r#"hello world"#;
 }

--- a/tests/ui/needless_raw_string_hashes.stderr
+++ b/tests/ui/needless_raw_string_hashes.stderr
@@ -163,5 +163,29 @@ LL |         string
 LL ~     ";
    |
 
-error: aborting due to 13 previous errors
+error: unnecessary hashes around raw string literal
+  --> $DIR/needless_raw_string_hashes.rs:25:5
+   |
+LL |     r###"rust"###;
+   |     ^^^^^^^^^^^^^
+   |
+help: remove all the hashes around the literal
+   |
+LL -     r###"rust"###;
+LL +     r"rust";
+   |
+
+error: unnecessary hashes around raw string literal
+  --> $DIR/needless_raw_string_hashes.rs:26:5
+   |
+LL |     r#"hello world"#;
+   |     ^^^^^^^^^^^^^^^^
+   |
+help: remove all the hashes around the literal
+   |
+LL -     r#"hello world"#;
+LL +     r"hello world";
+   |
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
changelog: Fix [`needless_raw_string_hashes`]: Continue the lint checking of raw string when `needless_raw_strings` is allowed.

fix #11420 