### PR TITLE
Update remark CI deps

### DIFF
--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '14.x'
+        node-version: '18.x'
 
     - name: Install remark
       run: npm install remark-cli remark-lint remark-lint-maximum-line-length remark-preset-lint-recommended remark-gfm
@@ -29,19 +29,19 @@ jobs:
     - name: Install mdbook
       run: |
         mkdir mdbook
-        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+        curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.34/mdbook-v0.4.34-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
 
     # Run
     - name: Check *.md files
-      run: git ls-files -z '*.md' | xargs -0 -n 1 -I {} ./node_modules/.bin/remark {} -u lint -f > /dev/null
+      run: ./node_modules/.bin/remark -u lint -f .
 
     - name: Linkcheck book
       run: |
         rustup toolchain install nightly --component rust-docs
         curl https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh -o linkcheck.sh
         sh linkcheck.sh clippy --path ./book
-        
+
     - name: Build mdbook
       run: mdbook build book
 


### PR DESCRIPTION
[Remark v15](https://github.com/remarkjs/remark/releases/tag/15.0.0) was just released that needs a newer node version, this updates us to 18 (the current LTS)

Also updates mdbook while we're at it

changelog: none
