### PR TITLE
Remove most usage of `hir_ty_to_ty`

### DIFF
--- a/clippy_lints/src/loops/utils.rs
+++ b/clippy_lints/src/loops/utils.rs
@@ -5,7 +5,6 @@ use rustc_ast::ast::{LitIntType, LitKind};
 use rustc_errors::Applicability;
 use rustc_hir::intravisit::{walk_expr, walk_local, walk_pat, walk_stmt, Visitor};
 use rustc_hir::{BinOpKind, BorrowKind, Expr, ExprKind, HirId, HirIdMap, Local, Mutability, Pat, PatKind, Stmt};
-use rustc_hir_analysis::hir_ty_to_ty;
 use rustc_lint::LateContext;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, Ty};
@@ -150,7 +149,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InitializeVisitor<'a, 'tcx> {
             if l.pat.hir_id == self.var_id;
             if let PatKind::Binding(.., ident, _) = l.pat.kind;
             then {
-                let ty = l.ty.map(|ty| hir_ty_to_ty(self.cx.tcx, ty));
+                let ty = l.ty.map(|_| self.cx.typeck_results().pat_ty(l.pat));
 
                 self.state = l.init.map_or(InitializeVisitorState::Declared(ident.name, ty), |init| {
                     InitializeVisitorState::Initialized {

--- a/clippy_lints/src/matches/needless_match.rs
+++ b/clippy_lints/src/matches/needless_match.rs
@@ -8,8 +8,7 @@ use clippy_utils::{
 };
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::OptionNone;
-use rustc_hir::{Arm, BindingAnnotation, ByRef, Expr, ExprKind, FnRetTy, Guard, Node, Pat, PatKind, Path, QPath};
-use rustc_hir_analysis::hir_ty_to_ty;
+use rustc_hir::{Arm, BindingAnnotation, ByRef, Expr, ExprKind, Guard, ItemKind, Node, Pat, PatKind, Path, QPath};
 use rustc_lint::LateContext;
 use rustc_span::sym;
 
@@ -141,11 +140,15 @@ fn expr_ty_matches_p_ty(cx: &LateContext<'_>, expr: &Expr<'_>, p_expr: &Expr<'_>
                 return same_type_and_consts(results.node_type(local.hir_id), results.expr_ty(expr));
             },
             // compare match_expr ty with RetTy in `fn foo() -> RetTy`
-            Node::Item(..) => {
-                if let Some(fn_decl) = p_node.fn_decl() {
-                    if let FnRetTy::Return(ret_ty) = fn_decl.output {
-                        return same_type_and_consts(hir_ty_to_ty(cx.tcx, ret_ty), cx.typeck_results().expr_ty(expr));
-                    }
+            Node::Item(item) => {
+                if let ItemKind::Fn(..) = item.kind {
+                    let output = cx
+                        .tcx
+                        .fn_sig(item.owner_id)
+                        .instantiate_identity()
+                        .output()
+                        .skip_binder();
+                    return same_type_and_consts(output, cx.typeck_results().expr_ty(expr));
                 }
             },
             // check the parent expr for this whole block `{ match match_expr {..} }`

--- a/tests/ui/no_effect_return.rs
+++ b/tests/ui/no_effect_return.rs
@@ -76,6 +76,7 @@ fn h() -> Vec<u16> {
 
 fn i() -> () {
     {
+        // does not suggest on function with explicit unit return type
         ();
         //~^ ERROR: statement with no effect
     }

--- a/tests/ui/no_effect_return.stderr
+++ b/tests/ui/no_effect_return.stderr
@@ -54,15 +54,13 @@ LL |         ControlFlow::Break::<()>(());
    |         help: did you mean to return it?: `return`
 
 error: statement with no effect
-  --> $DIR/no_effect_return.rs:79:9
+  --> $DIR/no_effect_return.rs:80:9
    |
 LL |         ();
-   |         -^^
-   |         |
-   |         help: did you mean to return it?: `return`
+   |         ^^^
 
 error: statement with no effect
-  --> $DIR/no_effect_return.rs:88:9
+  --> $DIR/no_effect_return.rs:89:9
    |
 LL |         ();
    |         ^^^


### PR DESCRIPTION
Removes the usages where there's a suitable query or the type was already available elsewhere. The remaining cases would all require more involved changes

changelog: none

r? @Jarcho
