### PR TITLE
prevent ice when threshold is 0 and enum has no variants

### DIFF
--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -167,7 +167,10 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
         return;
     }
 
-    let first = &def.variants[0].ident.name.as_str();
+    let first = match &def.variants.get(0) {
+        Some(variant) => variant.ident.name.as_str(),
+        None => return,
+    };
     let mut pre = camel_case_split(first);
     let mut post = pre.clone();
     post.reverse();

--- a/clippy_lints/src/enum_variants.rs
+++ b/clippy_lints/src/enum_variants.rs
@@ -167,7 +167,7 @@ fn check_variant(cx: &LateContext<'_>, threshold: u64, def: &EnumDef<'_>, item_n
         return;
     }
 
-    let first = match &def.variants.get(0) {
+    let first = match def.variants.first() {
         Some(variant) => variant.ident.name.as_str(),
         None => return,
     };

--- a/tests/ui-toml/enum_variants_threshold0/clippy.toml
+++ b/tests/ui-toml/enum_variants_threshold0/clippy.toml
@@ -1,0 +1,1 @@
+enum-variant-name-threshold = 0

--- a/tests/ui-toml/enum_variants_threshold0/enum_variants_name_threshold.rs
+++ b/tests/ui-toml/enum_variants_threshold0/enum_variants_name_threshold.rs
@@ -1,0 +1,3 @@
+enum Actions {}
+
+fn main() {}


### PR DESCRIPTION
changelog: [`enum_variant_names`]: prevent ice when threshold is 0 and enum has no variants

r? @y21 

Fixes the same ice issue raised during review of https://github.com/rust-lang/rust-clippy/pull/11496