### PR TITLE
Fix large_futures example

### DIFF
--- a/clippy_lints/src/large_futures.rs
+++ b/clippy_lints/src/large_futures.rs
@@ -17,26 +17,20 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```rust
-    /// async fn wait(f: impl std::future::Future<Output = ()>) {}
+    /// async fn large_future(_x: [u8; 16 * 1024]) {}
     ///
-    /// async fn big_fut(arg: [u8; 1024]) {}
-    ///
-    /// pub async fn test() {
-    ///     let fut = big_fut([0u8; 1024]);
-    ///     wait(fut).await;
+    /// pub async fn trigger() {
+    ///     large_future([0u8; 16 * 1024]).await;
     /// }
     /// ```
     ///
     /// `Box::pin` the big future instead.
     ///
     /// ```rust
-    /// async fn wait(f: impl std::future::Future<Output = ()>) {}
+    /// async fn large_future(_x: [u8; 16 * 1024]) {}
     ///
-    /// async fn big_fut(arg: [u8; 1024]) {}
-    ///
-    /// pub async fn test() {
-    ///     let fut = Box::pin(big_fut([0u8; 1024]));
-    ///     wait(fut).await;
+    /// pub async fn trigger() {
+    ///     Box::pin(large_future([0u8; 16 * 1024])).await;
     /// }
     /// ```
     #[clippy::version = "1.70.0"]


### PR DESCRIPTION
The value used in the large_futures example was not large enough to trigger the lint given the default threshold. The example also contained more code than necessary. This PR changes the value size from 1kB to 16kB and reduces the example in size.

changelog: [`large_futures`]: Fix and simplify example
