### PR TITLE
Add missing tests for configuration options

### DIFF
--- a/tests/ui-toml/decimal_literal_representation/clippy.toml
+++ b/tests/ui-toml/decimal_literal_representation/clippy.toml
@@ -1,0 +1,1 @@
+literal-representation-threshold = 0xFFFFFF

--- a/tests/ui-toml/decimal_literal_representation/decimal_literal_representation.fixed
+++ b/tests/ui-toml/decimal_literal_representation/decimal_literal_representation.fixed
@@ -1,0 +1,6 @@
+#![warn(clippy::decimal_literal_representation)]
+fn main() {
+    let _ = 8388608;
+    let _ = 0x00FF_FFFF;
+    //~^ ERROR: integer literal has a better hexadecimal representation
+}

--- a/tests/ui-toml/decimal_literal_representation/decimal_literal_representation.rs
+++ b/tests/ui-toml/decimal_literal_representation/decimal_literal_representation.rs
@@ -1,0 +1,6 @@
+#![warn(clippy::decimal_literal_representation)]
+fn main() {
+    let _ = 8388608;
+    let _ = 16777215;
+    //~^ ERROR: integer literal has a better hexadecimal representation
+}

--- a/tests/ui-toml/decimal_literal_representation/decimal_literal_representation.stderr
+++ b/tests/ui-toml/decimal_literal_representation/decimal_literal_representation.stderr
@@ -1,0 +1,11 @@
+error: integer literal has a better hexadecimal representation
+  --> $DIR/decimal_literal_representation.rs:4:13
+   |
+LL |     let _ = 16777215;
+   |             ^^^^^^^^ help: consider: `0x00FF_FFFF`
+   |
+   = note: `-D clippy::decimal-literal-representation` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::decimal_literal_representation)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/disallowed_script_idents/clippy.toml
+++ b/tests/ui-toml/disallowed_script_idents/clippy.toml
@@ -1,0 +1,1 @@
+allowed-scripts = ["Cyrillic"]

--- a/tests/ui-toml/disallowed_script_idents/disallowed_script_idents.rs
+++ b/tests/ui-toml/disallowed_script_idents/disallowed_script_idents.rs
@@ -1,0 +1,6 @@
+#![warn(clippy::disallowed_script_idents)]
+fn main() {
+    let счётчик = 10;
+    let カウンタ = 10;
+    //~^ ERROR: identifier `カウンタ` has a Unicode script that is not allowed by configuration
+}

--- a/tests/ui-toml/disallowed_script_idents/disallowed_script_idents.stderr
+++ b/tests/ui-toml/disallowed_script_idents/disallowed_script_idents.stderr
@@ -1,0 +1,11 @@
+error: identifier `カウンタ` has a Unicode script that is not allowed by configuration: Katakana
+  --> $DIR/disallowed_script_idents.rs:4:9
+   |
+LL |     let カウンタ = 10;
+   |         ^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-script-idents` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_script_idents)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/enum_variant_names/clippy.toml
+++ b/tests/ui-toml/enum_variant_names/clippy.toml
@@ -1,0 +1,1 @@
+enum-variant-name-threshold = 5

--- a/tests/ui-toml/enum_variant_names/enum_variant_names.rs
+++ b/tests/ui-toml/enum_variant_names/enum_variant_names.rs
@@ -1,0 +1,16 @@
+enum Foo {
+    AFoo,
+    BFoo,
+    CFoo,
+    DFoo,
+}
+enum Foo2 {
+    //~^ ERROR: all variants have the same postfix
+    AFoo,
+    BFoo,
+    CFoo,
+    DFoo,
+    EFoo,
+}
+
+fn main() {}

--- a/tests/ui-toml/enum_variant_names/enum_variant_names.stderr
+++ b/tests/ui-toml/enum_variant_names/enum_variant_names.stderr
@@ -1,0 +1,18 @@
+error: all variants have the same postfix: `Foo`
+  --> $DIR/enum_variant_names.rs:7:1
+   |
+LL | / enum Foo2 {
+LL | |
+LL | |     AFoo,
+LL | |     BFoo,
+...  |
+LL | |     EFoo,
+LL | | }
+   | |_^
+   |
+   = help: remove the postfixes and use full paths to the variants instead of glob imports
+   = note: `-D clippy::enum-variant-names` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::enum_variant_names)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/enum_variant_size/clippy.toml
+++ b/tests/ui-toml/enum_variant_size/clippy.toml
@@ -1,0 +1,1 @@
+enum-variant-size-threshold = 500

--- a/tests/ui-toml/enum_variant_size/enum_variant_size.fixed
+++ b/tests/ui-toml/enum_variant_size/enum_variant_size.fixed
@@ -1,0 +1,11 @@
+enum Fine {
+    A(()),
+    B([u8; 500]),
+}
+enum Bad {
+    //~^ ERROR: large size difference between variants
+    A(()),
+    B(Box<[u8; 501]>),
+}
+
+fn main() {}

--- a/tests/ui-toml/enum_variant_size/enum_variant_size.rs
+++ b/tests/ui-toml/enum_variant_size/enum_variant_size.rs
@@ -1,0 +1,11 @@
+enum Fine {
+    A(()),
+    B([u8; 500]),
+}
+enum Bad {
+    //~^ ERROR: large size difference between variants
+    A(()),
+    B([u8; 501]),
+}
+
+fn main() {}

--- a/tests/ui-toml/enum_variant_size/enum_variant_size.stderr
+++ b/tests/ui-toml/enum_variant_size/enum_variant_size.stderr
@@ -1,0 +1,21 @@
+error: large size difference between variants
+  --> $DIR/enum_variant_size.rs:5:1
+   |
+LL | / enum Bad {
+LL | |
+LL | |     A(()),
+   | |     ----- the second-largest variant contains at least 0 bytes
+LL | |     B([u8; 501]),
+   | |     ------------ the largest variant contains at least 501 bytes
+LL | | }
+   | |_^ the entire enum is at least 502 bytes
+   |
+   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::large_enum_variant)]`
+help: consider boxing the large fields to reduce the total size of the enum
+   |
+LL |     B(Box<[u8; 501]>),
+   |       ~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/explicit_iter_loop/clippy.toml
+++ b/tests/ui-toml/explicit_iter_loop/clippy.toml
@@ -1,0 +1,1 @@
+enforce-iter-loop-reborrow = true

--- a/tests/ui-toml/explicit_iter_loop/explicit_iter_loop.fixed
+++ b/tests/ui-toml/explicit_iter_loop/explicit_iter_loop.fixed
@@ -1,0 +1,10 @@
+#![warn(clippy::explicit_iter_loop)]
+
+fn main() {
+    let mut vec = vec![1, 2, 3];
+    let rmvec = &mut vec;
+    for _ in &*rmvec {}
+    //~^ ERROR: it is more concise to loop over references to containers
+    for _ in &mut *rmvec {}
+    //~^ ERROR: it is more concise to loop over references to containers
+}

--- a/tests/ui-toml/explicit_iter_loop/explicit_iter_loop.rs
+++ b/tests/ui-toml/explicit_iter_loop/explicit_iter_loop.rs
@@ -1,0 +1,10 @@
+#![warn(clippy::explicit_iter_loop)]
+
+fn main() {
+    let mut vec = vec![1, 2, 3];
+    let rmvec = &mut vec;
+    for _ in rmvec.iter() {}
+    //~^ ERROR: it is more concise to loop over references to containers
+    for _ in rmvec.iter_mut() {}
+    //~^ ERROR: it is more concise to loop over references to containers
+}

--- a/tests/ui-toml/explicit_iter_loop/explicit_iter_loop.stderr
+++ b/tests/ui-toml/explicit_iter_loop/explicit_iter_loop.stderr
@@ -1,0 +1,17 @@
+error: it is more concise to loop over references to containers instead of using explicit iteration methods
+  --> $DIR/explicit_iter_loop.rs:6:14
+   |
+LL |     for _ in rmvec.iter() {}
+   |              ^^^^^^^^^^^^ help: to write this more concisely, try: `&*rmvec`
+   |
+   = note: `-D clippy::explicit-iter-loop` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::explicit_iter_loop)]`
+
+error: it is more concise to loop over references to containers instead of using explicit iteration methods
+  --> $DIR/explicit_iter_loop.rs:8:14
+   |
+LL |     for _ in rmvec.iter_mut() {}
+   |              ^^^^^^^^^^^^^^^^ help: to write this more concisely, try: `&mut *rmvec`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui-toml/large_stack_frames/clippy.toml
+++ b/tests/ui-toml/large_stack_frames/clippy.toml
@@ -1,1 +1,1 @@
-stack-size-threshold = 4294967296
+stack-size-threshold = 1000

--- a/tests/ui-toml/large_stack_frames/clippy.toml
+++ b/tests/ui-toml/large_stack_frames/clippy.toml
@@ -1,0 +1,1 @@
+stack-size-threshold = 4294967296

--- a/tests/ui-toml/large_stack_frames/large_stack_frames.rs
+++ b/tests/ui-toml/large_stack_frames/large_stack_frames.rs
@@ -1,0 +1,17 @@
+#![warn(clippy::large_stack_frames)]
+
+// We use this helper function instead of writing [0; 4294967297] directly to represent a
+// case that large_stack_arrays can't catch
+fn create_array<const N: usize>() -> [u8; N] {
+    [0; N]
+}
+
+fn f() {
+    let _x = create_array::<4294967296>();
+}
+fn f2() {
+    //~^ ERROR: this function allocates a large amount of stack space
+    let _x = create_array::<4294967297>();
+}
+
+fn main() {}

--- a/tests/ui-toml/large_stack_frames/large_stack_frames.rs
+++ b/tests/ui-toml/large_stack_frames/large_stack_frames.rs
@@ -7,11 +7,11 @@ fn create_array<const N: usize>() -> [u8; N] {
 }
 
 fn f() {
-    let _x = create_array::<4294967296>();
+    let _x = create_array::<1000>();
 }
 fn f2() {
     //~^ ERROR: this function allocates a large amount of stack space
-    let _x = create_array::<4294967297>();
+    let _x = create_array::<1001>();
 }
 
 fn main() {}

--- a/tests/ui-toml/large_stack_frames/large_stack_frames.stderr
+++ b/tests/ui-toml/large_stack_frames/large_stack_frames.stderr
@@ -3,7 +3,7 @@ error: this function allocates a large amount of stack space
    |
 LL | / fn f2() {
 LL | |
-LL | |     let _x = create_array::<4294967297>();
+LL | |     let _x = create_array::<1001>();
 LL | | }
    | |_^
    |

--- a/tests/ui-toml/large_stack_frames/large_stack_frames.stderr
+++ b/tests/ui-toml/large_stack_frames/large_stack_frames.stderr
@@ -1,0 +1,15 @@
+error: this function allocates a large amount of stack space
+  --> $DIR/large_stack_frames.rs:12:1
+   |
+LL | / fn f2() {
+LL | |
+LL | |     let _x = create_array::<4294967297>();
+LL | | }
+   | |_^
+   |
+   = note: allocating large amounts of stack space can overflow the stack
+   = note: `-D clippy::large-stack-frames` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::large_stack_frames)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/large_types_passed_by_value/clippy.toml
+++ b/tests/ui-toml/large_types_passed_by_value/clippy.toml
@@ -1,0 +1,1 @@
+pass-by-value-size-limit = 512

--- a/tests/ui-toml/large_types_passed_by_value/large_types_passed_by_value.fixed
+++ b/tests/ui-toml/large_types_passed_by_value/large_types_passed_by_value.fixed
@@ -1,0 +1,7 @@
+#![warn(clippy::large_types_passed_by_value)]
+
+fn f(_v: [u8; 512]) {}
+fn f2(_v: &[u8; 513]) {}
+//~^ ERROR: this argument (513 byte) is passed by value
+
+fn main() {}

--- a/tests/ui-toml/large_types_passed_by_value/large_types_passed_by_value.rs
+++ b/tests/ui-toml/large_types_passed_by_value/large_types_passed_by_value.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::large_types_passed_by_value)]
+
+fn f(_v: [u8; 512]) {}
+fn f2(_v: [u8; 513]) {}
+//~^ ERROR: this argument (513 byte) is passed by value
+
+fn main() {}

--- a/tests/ui-toml/large_types_passed_by_value/large_types_passed_by_value.stderr
+++ b/tests/ui-toml/large_types_passed_by_value/large_types_passed_by_value.stderr
@@ -1,0 +1,11 @@
+error: this argument (513 byte) is passed by value, but might be more efficient if passed by reference (limit: 512 byte)
+  --> $DIR/large_types_passed_by_value.rs:4:11
+   |
+LL | fn f2(_v: [u8; 513]) {}
+   |           ^^^^^^^^^ help: consider passing by reference instead: `&[u8; 513]`
+   |
+   = note: `-D clippy::large-types-passed-by-value` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::large_types_passed_by_value)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/manual_let_else/clippy.toml
+++ b/tests/ui-toml/manual_let_else/clippy.toml
@@ -1,0 +1,1 @@
+matches-for-let-else = "AllTypes"

--- a/tests/ui-toml/manual_let_else/manual_let_else.fixed
+++ b/tests/ui-toml/manual_let_else/manual_let_else.fixed
@@ -1,0 +1,10 @@
+#![warn(clippy::manual_let_else)]
+
+enum Foo {
+    A(u8),
+    B,
+}
+
+fn main() {
+    let Foo::A(x) = Foo::A(1) else { return };
+}

--- a/tests/ui-toml/manual_let_else/manual_let_else.rs
+++ b/tests/ui-toml/manual_let_else/manual_let_else.rs
@@ -1,0 +1,14 @@
+#![warn(clippy::manual_let_else)]
+
+enum Foo {
+    A(u8),
+    B,
+}
+
+fn main() {
+    let x = match Foo::A(1) {
+        //~^ ERROR: this could be rewritten as `let...else`
+        Foo::A(x) => x,
+        Foo::B => return,
+    };
+}

--- a/tests/ui-toml/manual_let_else/manual_let_else.stderr
+++ b/tests/ui-toml/manual_let_else/manual_let_else.stderr
@@ -1,0 +1,15 @@
+error: this could be rewritten as `let...else`
+  --> $DIR/manual_let_else.rs:9:5
+   |
+LL | /     let x = match Foo::A(1) {
+LL | |
+LL | |         Foo::A(x) => x,
+LL | |         Foo::B => return,
+LL | |     };
+   | |______^ help: consider writing: `let Foo::A(x) = Foo::A(1) else { return };`
+   |
+   = note: `-D clippy::manual-let-else` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_let_else)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/path_ends_with_ext/clippy.toml
+++ b/tests/ui-toml/path_ends_with_ext/clippy.toml
@@ -1,0 +1,1 @@
+allowed-dotfiles = ["dot"]

--- a/tests/ui-toml/path_ends_with_ext/path_ends_with_ext.rs
+++ b/tests/ui-toml/path_ends_with_ext/path_ends_with_ext.rs
@@ -1,0 +1,9 @@
+#![warn(clippy::path_ends_with_ext)]
+
+use std::path::Path;
+
+fn f(p: &Path) {
+    p.ends_with(".dot");
+}
+
+fn main() {}

--- a/tests/ui-toml/result_large_err/clippy.toml
+++ b/tests/ui-toml/result_large_err/clippy.toml
@@ -1,0 +1,1 @@
+large-error-threshold = 512

--- a/tests/ui-toml/result_large_err/result_large_err.rs
+++ b/tests/ui-toml/result_large_err/result_large_err.rs
@@ -1,0 +1,10 @@
+#![warn(clippy::result_large_err)]
+
+fn f() -> Result<(), [u8; 511]> {
+    todo!()
+}
+fn f2() -> Result<(), [u8; 512]> {
+    //~^ ERROR: the `Err`-variant returned from this function is very large
+    todo!()
+}
+fn main() {}

--- a/tests/ui-toml/result_large_err/result_large_err.stderr
+++ b/tests/ui-toml/result_large_err/result_large_err.stderr
@@ -1,0 +1,12 @@
+error: the `Err`-variant returned from this function is very large
+  --> $DIR/result_large_err.rs:6:12
+   |
+LL | fn f2() -> Result<(), [u8; 512]> {
+   |            ^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 512 bytes
+   |
+   = help: try reducing the size of `[u8; 512]`, for example by boxing large elements or replacing it with `Box<[u8; 512]>`
+   = note: `-D clippy::result-large-err` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::result_large_err)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/too_large_for_stack/boxed_local.rs
+++ b/tests/ui-toml/too_large_for_stack/boxed_local.rs
@@ -1,0 +1,5 @@
+fn f(x: Box<[u8; 500]>) {}
+//~^ ERROR: local variable doesn't need to be boxed here
+fn f2(x: Box<[u8; 501]>) {}
+
+fn main() {}

--- a/tests/ui-toml/too_large_for_stack/boxed_local.stderr
+++ b/tests/ui-toml/too_large_for_stack/boxed_local.stderr
@@ -1,0 +1,11 @@
+error: local variable doesn't need to be boxed here
+  --> $DIR/boxed_local.rs:1:6
+   |
+LL | fn f(x: Box<[u8; 500]>) {}
+   |      ^
+   |
+   = note: `-D clippy::boxed-local` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::boxed_local)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/too_large_for_stack/clippy.toml
+++ b/tests/ui-toml/too_large_for_stack/clippy.toml
@@ -1,0 +1,1 @@
+too-large-for-stack = 500

--- a/tests/ui-toml/too_large_for_stack/useless_vec.fixed
+++ b/tests/ui-toml/too_large_for_stack/useless_vec.fixed
@@ -1,0 +1,9 @@
+#![warn(clippy::useless_vec)]
+
+fn main() {
+    let x = [0u8; 500];
+    //~^ ERROR: useless use of `vec!`
+    x.contains(&1);
+    let y = vec![0u8; 501];
+    y.contains(&1);
+}

--- a/tests/ui-toml/too_large_for_stack/useless_vec.rs
+++ b/tests/ui-toml/too_large_for_stack/useless_vec.rs
@@ -1,0 +1,9 @@
+#![warn(clippy::useless_vec)]
+
+fn main() {
+    let x = vec![0u8; 500];
+    //~^ ERROR: useless use of `vec!`
+    x.contains(&1);
+    let y = vec![0u8; 501];
+    y.contains(&1);
+}

--- a/tests/ui-toml/too_large_for_stack/useless_vec.stderr
+++ b/tests/ui-toml/too_large_for_stack/useless_vec.stderr
@@ -1,0 +1,11 @@
+error: useless use of `vec!`
+  --> $DIR/useless_vec.rs:4:13
+   |
+LL |     let x = vec![0u8; 500];
+   |             ^^^^^^^^^^^^^^ help: you can use an array directly: `[0u8; 500]`
+   |
+   = note: `-D clippy::useless-vec` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::useless_vec)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/too_many_arguments/clippy.toml
+++ b/tests/ui-toml/too_many_arguments/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 10

--- a/tests/ui-toml/too_many_arguments/too_many_arguments.rs
+++ b/tests/ui-toml/too_many_arguments/too_many_arguments.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::too_many_arguments)]
+
+fn not_too_many(p1: u8, p2: u8, p3: u8, p4: u8, p5: u8, p6: u8, p7: u8, p8: u8, p9: u8, p10: u8) {}
+fn too_many(p1: u8, p2: u8, p3: u8, p4: u8, p5: u8, p6: u8, p7: u8, p8: u8, p9: u8, p10: u8, p11: u8) {}
+//~^ ERROR: this function has too many arguments
+
+fn main() {}

--- a/tests/ui-toml/too_many_arguments/too_many_arguments.stderr
+++ b/tests/ui-toml/too_many_arguments/too_many_arguments.stderr
@@ -1,0 +1,11 @@
+error: this function has too many arguments (11/10)
+  --> $DIR/too_many_arguments.rs:4:1
+   |
+LL | fn too_many(p1: u8, p2: u8, p3: u8, p4: u8, p5: u8, p6: u8, p7: u8, p8: u8, p9: u8, p10: u8, p11: u8) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::too-many-arguments` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::too_many_arguments)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/type_complexity/clippy.toml
+++ b/tests/ui-toml/type_complexity/clippy.toml
@@ -1,0 +1,1 @@
+type-complexity-threshold = 500

--- a/tests/ui-toml/type_complexity/type_complexity.rs
+++ b/tests/ui-toml/type_complexity/type_complexity.rs
@@ -1,0 +1,7 @@
+// 480
+fn f(_: (u8, (u8, (u8, (u8, (u8, (u8,))))))) {}
+// 550
+fn f2(_: (u8, (u8, (u8, (u8, (u8, (u8, u8))))))) {}
+//~^ ERROR: very complex type used
+
+fn main() {}

--- a/tests/ui-toml/type_complexity/type_complexity.stderr
+++ b/tests/ui-toml/type_complexity/type_complexity.stderr
@@ -1,0 +1,11 @@
+error: very complex type used. Consider factoring parts into `type` definitions
+  --> $DIR/type_complexity.rs:4:10
+   |
+LL | fn f2(_: (u8, (u8, (u8, (u8, (u8, (u8, u8))))))) {}
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::type-complexity` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::type_complexity)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/type_repetition_in_bounds/clippy.toml
+++ b/tests/ui-toml/type_repetition_in_bounds/clippy.toml
@@ -1,0 +1,1 @@
+max-trait-bounds = 5

--- a/tests/ui-toml/type_repetition_in_bounds/main.rs
+++ b/tests/ui-toml/type_repetition_in_bounds/main.rs
@@ -1,0 +1,18 @@
+#![warn(clippy::type_repetition_in_bounds)]
+
+fn f<T>()
+where
+    T: Copy + Clone + Sync + Send + ?Sized + Unpin,
+    T: PartialEq,
+{
+}
+
+fn f2<T>()
+where
+    T: Copy + Clone + Sync + Send + ?Sized,
+    T: Unpin + PartialEq,
+    //~^ ERROR: this type has already been used as a bound predicate
+{
+}
+
+fn main() {}

--- a/tests/ui-toml/type_repetition_in_bounds/main.stderr
+++ b/tests/ui-toml/type_repetition_in_bounds/main.stderr
@@ -1,0 +1,12 @@
+error: this type has already been used as a bound predicate
+  --> $DIR/main.rs:13:5
+   |
+LL |     T: Unpin + PartialEq,
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider combining the bounds: `T: Copy + Clone + Sync + Send + ?Sized + Unpin + PartialEq`
+   = note: `-D clippy::type-repetition-in-bounds` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::type_repetition_in_bounds)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/unnecessary_box_returns/clippy.toml
+++ b/tests/ui-toml/unnecessary_box_returns/clippy.toml
@@ -1,0 +1,1 @@
+unnecessary-box-size = 64

--- a/tests/ui-toml/unnecessary_box_returns/unnecessary_box_returns.fixed
+++ b/tests/ui-toml/unnecessary_box_returns/unnecessary_box_returns.fixed
@@ -1,0 +1,11 @@
+#![warn(clippy::unnecessary_box_returns)]
+
+fn f() -> [u8; 64] {
+    //~^ ERROR: boxed return of the sized type `[u8; 64]`
+    todo!()
+}
+fn f2() -> Box<[u8; 65]> {
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui-toml/unnecessary_box_returns/unnecessary_box_returns.rs
+++ b/tests/ui-toml/unnecessary_box_returns/unnecessary_box_returns.rs
@@ -1,0 +1,11 @@
+#![warn(clippy::unnecessary_box_returns)]
+
+fn f() -> Box<[u8; 64]> {
+    //~^ ERROR: boxed return of the sized type `[u8; 64]`
+    todo!()
+}
+fn f2() -> Box<[u8; 65]> {
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui-toml/unnecessary_box_returns/unnecessary_box_returns.stderr
+++ b/tests/ui-toml/unnecessary_box_returns/unnecessary_box_returns.stderr
@@ -1,0 +1,12 @@
+error: boxed return of the sized type `[u8; 64]`
+  --> $DIR/unnecessary_box_returns.rs:3:11
+   |
+LL | fn f() -> Box<[u8; 64]> {
+   |           ^^^^^^^^^^^^^ help: try: `[u8; 64]`
+   |
+   = help: changing this also requires a change to the return expressions in this function
+   = note: `-D clippy::unnecessary-box-returns` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_box_returns)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/verbose_bit_mask/clippy.toml
+++ b/tests/ui-toml/verbose_bit_mask/clippy.toml
@@ -1,0 +1,1 @@
+verbose-bit-mask-threshold = 31

--- a/tests/ui-toml/verbose_bit_mask/verbose_bit_mask.fixed
+++ b/tests/ui-toml/verbose_bit_mask/verbose_bit_mask.fixed
@@ -1,0 +1,7 @@
+#![warn(clippy::verbose_bit_mask)]
+fn main() {
+    let v: i32 = 0;
+    let _ = v & 0b11111 == 0;
+    let _ = v.trailing_zeros() >= 6;
+    //~^ ERROR: bit mask could be simplified
+}

--- a/tests/ui-toml/verbose_bit_mask/verbose_bit_mask.rs
+++ b/tests/ui-toml/verbose_bit_mask/verbose_bit_mask.rs
@@ -1,0 +1,7 @@
+#![warn(clippy::verbose_bit_mask)]
+fn main() {
+    let v: i32 = 0;
+    let _ = v & 0b11111 == 0;
+    let _ = v & 0b111111 == 0;
+    //~^ ERROR: bit mask could be simplified
+}

--- a/tests/ui-toml/verbose_bit_mask/verbose_bit_mask.stderr
+++ b/tests/ui-toml/verbose_bit_mask/verbose_bit_mask.stderr
@@ -1,0 +1,11 @@
+error: bit mask could be simplified with a call to `trailing_zeros`
+  --> $DIR/verbose_bit_mask.rs:5:13
+   |
+LL |     let _ = v & 0b111111 == 0;
+   |             ^^^^^^^^^^^^^^^^^ help: try: `v.trailing_zeros() >= 6`
+   |
+   = note: `-D clippy::verbose-bit-mask` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::verbose_bit_mask)]`
+
+error: aborting due to previous error
+

--- a/tests/ui-toml/wildcard_imports/clippy.toml
+++ b/tests/ui-toml/wildcard_imports/clippy.toml
@@ -1,0 +1,1 @@
+warn-on-all-wildcard-imports = true

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.fixed
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.fixed
@@ -1,0 +1,11 @@
+#![warn(clippy::wildcard_imports)]
+
+mod prelude {
+    pub const FOO: u8 = 1;
+}
+use prelude::FOO;
+//~^ ERROR: usage of wildcard import
+
+fn main() {
+    let _ = FOO;
+}

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.rs
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.rs
@@ -1,0 +1,11 @@
+#![warn(clippy::wildcard_imports)]
+
+mod prelude {
+    pub const FOO: u8 = 1;
+}
+use prelude::*;
+//~^ ERROR: usage of wildcard import
+
+fn main() {
+    let _ = FOO;
+}

--- a/tests/ui-toml/wildcard_imports/wildcard_imports.stderr
+++ b/tests/ui-toml/wildcard_imports/wildcard_imports.stderr
@@ -1,0 +1,11 @@
+error: usage of wildcard import
+  --> $DIR/wildcard_imports.rs:6:5
+   |
+LL | use prelude::*;
+   |     ^^^^^^^^^^ help: try: `prelude::FOO`
+   |
+   = note: `-D clippy::wildcard-imports` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::wildcard_imports)]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
I noticed that a lot of lints didn't have test(s) for their configuration. This leads to issues like #11481 where the lint just does nothing with it.

This PR adds tests for *almost*[^1] all of the lints with a configuration that didn't have a test in ui-toml.
The tests that I wrote here are usually two cases: one for where it's right above or under the limit set by the config where it shouldn't lint and another one for right above where it should.

changelog: none

[^1]: allow-one-hash-in-raw-strings is ignored by needless_raw_string_hashes