### PR TITLE
Test that each config value exists in a test clippy.toml

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -28,6 +28,9 @@ semver = "1.0"
 rustc-semver = "1.1"
 url = "2.2"
 
+[dev-dependencies]
+walkdir = "2.3"
+
 [features]
 deny-warnings = ["clippy_utils/deny-warnings"]
 # build clippy with internal lints enabled, off by default


### PR DESCRIPTION
Inspired by #11560, adds a test that each config option exists in some form in a `clippy.toml` in `tests/` (currently some are in `ui-toml`, some in `ui-cargo`)

changelog: none
