### PR TITLE
Add missing lint description headers

### DIFF
--- a/clippy_lints/src/allow_attributes.rs
+++ b/clippy_lints/src/allow_attributes.rs
@@ -8,6 +8,7 @@ use rustc_middle::lint::in_external_macro;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
+    /// ### What it does
     /// Checks for usage of the `#[allow]` attribute and suggests replacing it with
     /// the `#[expect]` (See [RFC 2383](https://rust-lang.github.io/rfcs/2383-lint-reasons.html))
     ///
@@ -19,7 +20,6 @@ declare_clippy_lint! {
     /// (`#![allow]`) are usually used to enable or disable lints on a global scale.
     ///
     /// ### Why is this bad?
-    ///
     /// `#[expect]` attributes suppress the lint emission, but emit a warning, if
     /// the expectation is unfulfilled. This can be useful to be notified when the
     /// lint is no longer triggered.

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3368,6 +3368,7 @@ declare_clippy_lint! {
 }
 
 declare_clippy_lint! {
+    /// ### What it does
     /// Looks for calls to [`Stdin::read_line`] to read a line from the standard input
     /// into a string, then later attempting to parse this string into a type without first trimming it, which will
     /// always fail because the string has a trailing newline in it.


### PR DESCRIPTION
Discovered in https://github.com/rust-lang/rust-analyzer/pull/15680/files#diff-7cb229b5139c72b6c230e3c195be375724c92226421fd57d5cf08872503e8c27L214-R226

changelog: none