### PR TITLE
let_and_return: Wrap with parenthesis if necessary

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -1,5 +1,6 @@
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::source::{snippet_opt, snippet_with_context};
+use clippy_utils::sugg::has_enclosing_paren;
 use clippy_utils::visitors::{for_each_expr_with_closures, Descend};
 use clippy_utils::{fn_def_id, is_from_proc_macro, path_to_local_id, span_find_starting_semi};
 use core::ops::ControlFlow;
@@ -213,6 +214,9 @@ impl<'tcx> LateLintPass<'tcx> for Return {
 
                         if let Some(mut snippet) = snippet_opt(cx, initexpr.span) {
                             if !cx.typeck_results().expr_adjustments(retexpr).is_empty() {
+                                if !has_enclosing_paren(&snippet) {
+                                    snippet = format!("({snippet})");
+                                }
                                 snippet.push_str(" as _");
                             }
                             err.multipart_suggestion(

--- a/tests/ui/let_and_return.fixed
+++ b/tests/ui/let_and_return.fixed
@@ -168,7 +168,26 @@ mod issue_5729 {
     impl<T: Foo + 'static> FooStorage for FooStorageImpl<T> {
         fn foo_cloned(&self) -> Arc<dyn Foo> {
             
-            Arc::clone(&self.foo) as _
+            (Arc::clone(&self.foo)) as _
+            //~^ ERROR: returning the result of a `let` binding from a block
+        }
+    }
+}
+
+mod issue_11335 {
+    pub enum E<T> {
+        A(T),
+        B(T),
+    }
+
+    impl<T> E<T> {
+        pub fn inner(&self) -> &T {
+            
+
+            (match self {
+                E::A(x) => x,
+                E::B(x) => x,
+            }) as _
             //~^ ERROR: returning the result of a `let` binding from a block
         }
     }

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -174,6 +174,25 @@ mod issue_5729 {
     }
 }
 
+mod issue_11335 {
+    pub enum E<T> {
+        A(T),
+        B(T),
+    }
+
+    impl<T> E<T> {
+        pub fn inner(&self) -> &T {
+            let result = match self {
+                E::A(x) => x,
+                E::B(x) => x,
+            };
+
+            result
+            //~^ ERROR: returning the result of a `let` binding from a block
+        }
+    }
+}
+
 // https://github.com/rust-lang/rust-clippy/issues/11167
 macro_rules! fn_in_macro {
     ($b:block) => {

--- a/tests/ui/let_and_return.stderr
+++ b/tests/ui/let_and_return.stderr
@@ -53,8 +53,30 @@ LL |             clone
 help: return the expression directly
    |
 LL ~             
-LL ~             Arc::clone(&self.foo) as _
+LL ~             (Arc::clone(&self.foo)) as _
    |
 
-error: aborting due to 4 previous errors
+error: returning the result of a `let` binding from a block
+  --> $DIR/let_and_return.rs:190:13
+   |
+LL | /             let result = match self {
+LL | |                 E::A(x) => x,
+LL | |                 E::B(x) => x,
+LL | |             };
+   | |______________- unnecessary `let` binding
+LL |
+LL |               result
+   |               ^^^^^^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL | 
+LL ~             (match self {
+LL +                 E::A(x) => x,
+LL +                 E::B(x) => x,
+LL +             }) as _
+   |
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
- fixes https://github.com/rust-lang/rust-clippy/issues/11335

changelog: [`let_and_return`]: Wrap suggestion with parenthesis if necessary


r? @Centri3 