### PR TITLE
std_instead_of_core: avoid lint inside of proc-macro

### DIFF
--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -21,6 +21,18 @@ pub fn derive(_: TokenStream) -> TokenStream {
     output
 }
 
+#[proc_macro_derive(ImplStructWithStdDisplay)]
+pub fn derive_std(_: TokenStream) -> TokenStream {
+    quote! {
+        struct A {}
+        impl ::std::fmt::Display for A {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, "A")
+            }
+        }
+    }
+}
+
 #[proc_macro_derive(FieldReassignWithDefault)]
 pub fn derive_foo(_input: TokenStream) -> TokenStream {
     quote! {

--- a/tests/ui/std_instead_of_core.fixed
+++ b/tests/ui/std_instead_of_core.fixed
@@ -1,7 +1,11 @@
+//@aux-build:proc_macro_derive.rs
 #![warn(clippy::std_instead_of_core)]
 #![allow(unused_imports)]
 
 extern crate alloc;
+
+#[macro_use]
+extern crate proc_macro_derive;
 
 #[warn(clippy::std_instead_of_core)]
 fn std_instead_of_core() {
@@ -53,6 +57,13 @@ fn std_instead_of_alloc() {
 fn alloc_instead_of_core() {
     use core::slice::from_ref;
     //~^ ERROR: used import from `alloc` instead of `core`
+}
+
+mod std_in_proc_macro_derive {
+    #[warn(clippy::alloc_instead_of_core)]
+    #[allow(unused)]
+    #[derive(ImplStructWithStdDisplay)]
+    struct B {}
 }
 
 fn main() {

--- a/tests/ui/std_instead_of_core.rs
+++ b/tests/ui/std_instead_of_core.rs
@@ -1,7 +1,11 @@
+//@aux-build:proc_macro_derive.rs
 #![warn(clippy::std_instead_of_core)]
 #![allow(unused_imports)]
 
 extern crate alloc;
+
+#[macro_use]
+extern crate proc_macro_derive;
 
 #[warn(clippy::std_instead_of_core)]
 fn std_instead_of_core() {
@@ -53,6 +57,13 @@ fn std_instead_of_alloc() {
 fn alloc_instead_of_core() {
     use alloc::slice::from_ref;
     //~^ ERROR: used import from `alloc` instead of `core`
+}
+
+mod std_in_proc_macro_derive {
+    #[warn(clippy::alloc_instead_of_core)]
+    #[allow(unused)]
+    #[derive(ImplStructWithStdDisplay)]
+    struct B {}
 }
 
 fn main() {

--- a/tests/ui/std_instead_of_core.stderr
+++ b/tests/ui/std_instead_of_core.stderr
@@ -1,5 +1,5 @@
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:9:9
+  --> $DIR/std_instead_of_core.rs:13:9
    |
 LL |     use std::hash::Hasher;
    |         ^^^ help: consider importing the item from `core`: `core`
@@ -8,49 +8,49 @@ LL |     use std::hash::Hasher;
    = help: to override `-D warnings` add `#[allow(clippy::std_instead_of_core)]`
 
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:12:11
+  --> $DIR/std_instead_of_core.rs:16:11
    |
 LL |     use ::std::hash::Hash;
    |           ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:18:9
+  --> $DIR/std_instead_of_core.rs:22:9
    |
 LL |     use std::fmt::{Debug, Result};
    |         ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:22:15
+  --> $DIR/std_instead_of_core.rs:26:15
    |
 LL |     let ptr = std::ptr::null::<u32>();
    |               ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:24:21
+  --> $DIR/std_instead_of_core.rs:28:21
    |
 LL |     let ptr_mut = ::std::ptr::null_mut::<usize>();
    |                     ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:28:16
+  --> $DIR/std_instead_of_core.rs:32:16
    |
 LL |     let cell = std::cell::Cell::new(8u32);
    |                ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:30:27
+  --> $DIR/std_instead_of_core.rs:34:27
    |
 LL |     let cell_absolute = ::std::cell::Cell::new(8u32);
    |                           ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `core`
-  --> $DIR/std_instead_of_core.rs:39:9
+  --> $DIR/std_instead_of_core.rs:43:9
    |
 LL |     use std::iter::Iterator;
    |         ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `alloc`
-  --> $DIR/std_instead_of_core.rs:46:9
+  --> $DIR/std_instead_of_core.rs:50:9
    |
 LL |     use std::vec;
    |         ^^^ help: consider importing the item from `alloc`: `alloc`
@@ -59,13 +59,13 @@ LL |     use std::vec;
    = help: to override `-D warnings` add `#[allow(clippy::std_instead_of_alloc)]`
 
 error: used import from `std` instead of `alloc`
-  --> $DIR/std_instead_of_core.rs:48:9
+  --> $DIR/std_instead_of_core.rs:52:9
    |
 LL |     use std::vec::Vec;
    |         ^^^ help: consider importing the item from `alloc`: `alloc`
 
 error: used import from `alloc` instead of `core`
-  --> $DIR/std_instead_of_core.rs:54:9
+  --> $DIR/std_instead_of_core.rs:58:9
    |
 LL |     use alloc::slice::from_ref;
    |         ^^^^^ help: consider importing the item from `core`: `core`


### PR DESCRIPTION
- fixes https://github.com/rust-lang/rust-clippy/issues/10198

note: The lint for the reported `thiserror::Error` has been suppressed by [Don't lint unstable moves in std_instead_of_core](https://github.com/rust-lang/rust-clippy/pull/9545/files#diff-2cb8a24429cf9d9898de901450d640115503a10454d692dddc6a073a299fbb7eR29) because `thiserror::Error`  internally implements `std::error::Error for (derived struct)`.

changelog: [`std_intead_of_core`]: avoid linting inside proc-macro

I confirmed this change fixes the problem:
<details>
<summary>test result without the change</summary>

```console
error: used import from `std` instead of `core`
  --> tests/ui/std_instead_of_core.rs:65:14
   |
LL |     #[derive(ImplStructWithStdDisplay)]
   |              ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the derive macro `ImplStructWithStdDisplay` (in Nightly builds, run with -Z macro-backtrace for more info)
```
</details>