### PR TITLE
Don't lint `manual_non_exhaustive` when enum is `#[non_exhaustive]`

### DIFF
--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -200,16 +200,14 @@ impl<'tcx> LateLintPass<'tcx> for ManualNonExhaustiveEnum {
                 enum_span,
                 "this seems like a manual implementation of the non-exhaustive pattern",
                 |diag| {
-                    if !cx.tcx.adt_def(enum_id).is_variant_list_non_exhaustive()
-                        && let header_span = cx.sess().source_map().span_until_char(enum_span, '{')
-                        && let Some(snippet) = snippet_opt(cx, header_span)
-                    {
-                            diag.span_suggestion(
-                                header_span,
-                                "add the attribute",
-                                format!("#[non_exhaustive] {snippet}"),
-                                Applicability::Unspecified,
-                            );
+                    let header_span = cx.sess().source_map().span_until_char(enum_span, '{');
+                    if let Some(snippet) = snippet_opt(cx, header_span) {
+                        diag.span_suggestion(
+                            header_span,
+                            "add the attribute",
+                            format!("#[non_exhaustive] {snippet}"),
+                            Applicability::Unspecified,
+                        );
                     }
                     diag.span_help(variant_span, "remove this variant");
                 },

--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -3,6 +3,7 @@ use clippy_utils::is_doc_hidden;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::snippet_opt;
 use rustc_ast::ast::{self, VisibilityKind};
+use rustc_ast::attr;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
@@ -158,7 +159,8 @@ impl<'tcx> LateLintPass<'tcx> for ManualNonExhaustiveEnum {
             let mut iter = def.variants.iter().filter_map(|v| {
                 (matches!(v.data, hir::VariantData::Unit(_, _))
                     && v.ident.as_str().starts_with('_')
-                    && is_doc_hidden(cx.tcx.hir().attrs(v.hir_id)))
+                    && is_doc_hidden(cx.tcx.hir().attrs(v.hir_id))
+                    && !attr::contains_name(cx.tcx.hir().attrs(item.hir_id()), sym::non_exhaustive))
                 .then_some((v.def_id, v.span))
             });
             if let Some((id, span)) = iter.next()

--- a/tests/ui/manual_non_exhaustive_enum.rs
+++ b/tests/ui/manual_non_exhaustive_enum.rs
@@ -10,10 +10,9 @@ enum E {
     _C,
 }
 
-// user forgot to remove the marker
+// if the user explicitly marks as nonexhaustive we shouldn't warn them
 #[non_exhaustive]
 enum Ep {
-    //~^ ERROR: this seems like a manual implementation of the non-exhaustive pattern
     A,
     B,
     #[doc(hidden)]

--- a/tests/ui/manual_non_exhaustive_enum.stderr
+++ b/tests/ui/manual_non_exhaustive_enum.stderr
@@ -22,23 +22,5 @@ LL |     _C,
    = note: `-D clippy::manual-non-exhaustive` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_non_exhaustive)]`
 
-error: this seems like a manual implementation of the non-exhaustive pattern
-  --> $DIR/manual_non_exhaustive_enum.rs:15:1
-   |
-LL | / enum Ep {
-LL | |
-LL | |     A,
-LL | |     B,
-LL | |     #[doc(hidden)]
-LL | |     _C,
-LL | | }
-   | |_^
-   |
-help: remove this variant
-  --> $DIR/manual_non_exhaustive_enum.rs:20:5
-   |
-LL |     _C,
-   |     ^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #11583

changelog: Fix [`manual_non_exhaustive`] false positive for unit enum variants when enum is explicitly `non_exhaustive`.