### PR TITLE
Move `collection_is_never_read` from `nursery` to `suspicious`

### DIFF
--- a/clippy_lints/src/collection_is_never_read.rs
+++ b/clippy_lints/src/collection_is_never_read.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.70.0"]
     pub COLLECTION_IS_NEVER_READ,
-    nursery,
+    suspicious,
     "a collection is never queried"
 }
 declare_lint_pass!(CollectionIsNeverRead => [COLLECTION_IS_NEVER_READ]);

--- a/tests/ui-toml/too_large_for_stack/useless_vec.fixed
+++ b/tests/ui-toml/too_large_for_stack/useless_vec.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::useless_vec)]
+#![allow(clippy::collection_is_never_read)]
 
 fn main() {
     let x = [0u8; 500];

--- a/tests/ui-toml/too_large_for_stack/useless_vec.rs
+++ b/tests/ui-toml/too_large_for_stack/useless_vec.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::useless_vec)]
+#![allow(clippy::collection_is_never_read)]
 
 fn main() {
     let x = vec![0u8; 500];

--- a/tests/ui-toml/too_large_for_stack/useless_vec.stderr
+++ b/tests/ui-toml/too_large_for_stack/useless_vec.stderr
@@ -1,5 +1,5 @@
 error: useless use of `vec!`
-  --> $DIR/useless_vec.rs:4:13
+  --> $DIR/useless_vec.rs:5:13
    |
 LL |     let x = vec![0u8; 500];
    |             ^^^^^^^^^^^^^^ help: you can use an array directly: `[0u8; 500]`

--- a/tests/ui/boxed_local.rs
+++ b/tests/ui/boxed_local.rs
@@ -4,7 +4,8 @@
     clippy::needless_pass_by_value,
     clippy::unused_unit,
     clippy::redundant_clone,
-    clippy::match_single_binding
+    clippy::match_single_binding,
+    clippy::collection_is_never_read
 )]
 #![warn(clippy::boxed_local)]
 

--- a/tests/ui/boxed_local.stderr
+++ b/tests/ui/boxed_local.stderr
@@ -1,5 +1,5 @@
 error: local variable doesn't need to be boxed here
-  --> $DIR/boxed_local.rs:40:13
+  --> $DIR/boxed_local.rs:41:13
    |
 LL | fn warn_arg(x: Box<A>) {
    |             ^
@@ -8,19 +8,19 @@ LL | fn warn_arg(x: Box<A>) {
    = help: to override `-D warnings` add `#[allow(clippy::boxed_local)]`
 
 error: local variable doesn't need to be boxed here
-  --> $DIR/boxed_local.rs:123:12
+  --> $DIR/boxed_local.rs:124:12
    |
 LL | pub fn new(_needs_name: Box<PeekableSeekable<&()>>) -> () {}
    |            ^^^^^^^^^^^
 
 error: local variable doesn't need to be boxed here
-  --> $DIR/boxed_local.rs:188:44
+  --> $DIR/boxed_local.rs:189:44
    |
 LL |         fn default_impl_x(self: Box<Self>, x: Box<u32>) -> u32 {
    |                                            ^
 
 error: local variable doesn't need to be boxed here
-  --> $DIR/boxed_local.rs:196:16
+  --> $DIR/boxed_local.rs:197:16
    |
 LL |         fn foo(x: Box<u32>) {}
    |                ^

--- a/tests/ui/branches_sharing_code/shared_at_top.rs
+++ b/tests/ui/branches_sharing_code/shared_at_top.rs
@@ -1,6 +1,10 @@
 #![deny(clippy::branches_sharing_code, clippy::if_same_then_else)]
 #![allow(dead_code)]
-#![allow(clippy::mixed_read_write_in_expression, clippy::uninlined_format_args)]
+#![allow(
+    clippy::mixed_read_write_in_expression,
+    clippy::uninlined_format_args,
+    clippy::collection_is_never_read
+)]
 //@no-rustfix
 // This tests the branches_sharing_code lint at the start of blocks
 

--- a/tests/ui/branches_sharing_code/shared_at_top.stderr
+++ b/tests/ui/branches_sharing_code/shared_at_top.stderr
@@ -1,5 +1,5 @@
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:11:5
+  --> $DIR/shared_at_top.rs:15:5
    |
 LL | /     if true {
 LL | |
@@ -18,7 +18,7 @@ LL +     if true {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:21:5
+  --> $DIR/shared_at_top.rs:25:5
    |
 LL | /     if x == 0 {
 LL | |
@@ -37,7 +37,7 @@ LL +     if x == 0 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:43:5
+  --> $DIR/shared_at_top.rs:47:5
    |
 LL | /     let _ = if x == 7 {
 LL | |
@@ -51,7 +51,7 @@ LL +     let _ = if x == 7 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:62:5
+  --> $DIR/shared_at_top.rs:66:5
    |
 LL | /     if x == 10 {
 LL | |
@@ -68,7 +68,7 @@ LL +     if x == 10 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:77:5
+  --> $DIR/shared_at_top.rs:81:5
    |
 LL | /     if x == 11 {
 LL | |
@@ -85,7 +85,7 @@ LL +     if x == 11 {
    |
 
 error: all if blocks contain the same code at the start
-  --> $DIR/shared_at_top.rs:94:5
+  --> $DIR/shared_at_top.rs:98:5
    |
 LL | /     if x == 2020 {
 LL | |
@@ -101,7 +101,7 @@ LL +     if x == 2020 {
    |
 
 error: this `if` has identical blocks
-  --> $DIR/shared_at_top.rs:103:18
+  --> $DIR/shared_at_top.rs:107:18
    |
 LL |       if x == 2019 {
    |  __________________^
@@ -111,7 +111,7 @@ LL | |     } else {
    | |_____^
    |
 note: same as this
-  --> $DIR/shared_at_top.rs:106:12
+  --> $DIR/shared_at_top.rs:110:12
    |
 LL |       } else {
    |  ____________^

--- a/tests/ui/clear_with_drain.fixed
+++ b/tests/ui/clear_with_drain.fixed
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::collection_is_never_read)]
 #![warn(clippy::clear_with_drain)]
 
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};

--- a/tests/ui/clear_with_drain.rs
+++ b/tests/ui/clear_with_drain.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::collection_is_never_read)]
 #![warn(clippy::clear_with_drain)]
 
 use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};

--- a/tests/ui/clone_on_copy.fixed
+++ b/tests/ui/clone_on_copy.fixed
@@ -6,7 +6,8 @@
     clippy::unnecessary_operation,
     clippy::vec_init_then_push,
     clippy::toplevel_ref_arg,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::collection_is_never_read
 )]
 
 use std::cell::RefCell;

--- a/tests/ui/clone_on_copy.rs
+++ b/tests/ui/clone_on_copy.rs
@@ -6,7 +6,8 @@
     clippy::unnecessary_operation,
     clippy::vec_init_then_push,
     clippy::toplevel_ref_arg,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::collection_is_never_read
 )]
 
 use std::cell::RefCell;

--- a/tests/ui/clone_on_copy.stderr
+++ b/tests/ui/clone_on_copy.stderr
@@ -1,5 +1,5 @@
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:23:5
+  --> $DIR/clone_on_copy.rs:24:5
    |
 LL |     42.clone();
    |     ^^^^^^^^^^ help: try removing the `clone` call: `42`
@@ -8,49 +8,49 @@ LL |     42.clone();
    = help: to override `-D warnings` add `#[allow(clippy::clone_on_copy)]`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:27:5
+  --> $DIR/clone_on_copy.rs:28:5
    |
 LL |     (&42).clone();
    |     ^^^^^^^^^^^^^ help: try dereferencing it: `*(&42)`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:30:5
+  --> $DIR/clone_on_copy.rs:31:5
    |
 LL |     rc.borrow().clone();
    |     ^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*rc.borrow()`
 
 error: using `clone` on type `u32` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:33:5
+  --> $DIR/clone_on_copy.rs:34:5
    |
 LL |     x.clone().rotate_left(1);
    |     ^^^^^^^^^ help: try removing the `clone` call: `x`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:47:5
+  --> $DIR/clone_on_copy.rs:48:5
    |
 LL |     m!(42).clone();
    |     ^^^^^^^^^^^^^^ help: try removing the `clone` call: `m!(42)`
 
 error: using `clone` on type `[u32; 2]` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:57:5
+  --> $DIR/clone_on_copy.rs:58:5
    |
 LL |     x.clone()[0];
    |     ^^^^^^^^^ help: try dereferencing it: `(*x)`
 
 error: using `clone` on type `char` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:67:14
+  --> $DIR/clone_on_copy.rs:68:14
    |
 LL |     is_ascii('z'.clone());
    |              ^^^^^^^^^^^ help: try removing the `clone` call: `'z'`
 
 error: using `clone` on type `i32` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:71:14
+  --> $DIR/clone_on_copy.rs:72:14
    |
 LL |     vec.push(42.clone());
    |              ^^^^^^^^^^ help: try removing the `clone` call: `42`
 
 error: using `clone` on type `Option<i32>` which implements the `Copy` trait
-  --> $DIR/clone_on_copy.rs:75:17
+  --> $DIR/clone_on_copy.rs:76:17
    |
 LL |     let value = opt.clone()?; // operator precedence needed (*opt)?
    |                 ^^^^^^^^^^^ help: try dereferencing it: `(*opt)`

--- a/tests/ui/crashes/ice-2774.fixed
+++ b/tests/ui/crashes/ice-2774.fixed
@@ -10,7 +10,7 @@ pub struct Bar {
 #[derive(Eq, PartialEq, Debug, Hash)]
 pub struct Foo;
 
-#[allow(clippy::implicit_hasher)]
+#[allow(clippy::implicit_hasher, clippy::collection_is_never_read)]
 // This should not cause a "cannot relate bound region" ICE.
 pub fn add_barfoos_to_foos(bars: &HashSet<&Bar>) {
     //~^ ERROR: the following explicit lifetimes could be elided: 'a
@@ -19,7 +19,7 @@ pub fn add_barfoos_to_foos(bars: &HashSet<&Bar>) {
     foos.extend(bars.iter().map(|b| &b.foo));
 }
 
-#[allow(clippy::implicit_hasher)]
+#[allow(clippy::implicit_hasher, clippy::collection_is_never_read)]
 // Also, this should not cause a "cannot relate bound region" ICE.
 pub fn add_barfoos_to_foos2(bars: &HashSet<&Bar>) {
     let mut foos = HashSet::new();

--- a/tests/ui/crashes/ice-2774.rs
+++ b/tests/ui/crashes/ice-2774.rs
@@ -10,7 +10,7 @@ pub struct Bar {
 #[derive(Eq, PartialEq, Debug, Hash)]
 pub struct Foo;
 
-#[allow(clippy::implicit_hasher)]
+#[allow(clippy::implicit_hasher, clippy::collection_is_never_read)]
 // This should not cause a "cannot relate bound region" ICE.
 pub fn add_barfoos_to_foos<'a>(bars: &HashSet<&'a Bar>) {
     //~^ ERROR: the following explicit lifetimes could be elided: 'a
@@ -19,7 +19,7 @@ pub fn add_barfoos_to_foos<'a>(bars: &HashSet<&'a Bar>) {
     foos.extend(bars.iter().map(|b| &b.foo));
 }
 
-#[allow(clippy::implicit_hasher)]
+#[allow(clippy::implicit_hasher, clippy::collection_is_never_read)]
 // Also, this should not cause a "cannot relate bound region" ICE.
 pub fn add_barfoos_to_foos2(bars: &HashSet<&Bar>) {
     let mut foos = HashSet::new();

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -8,7 +8,8 @@
     clippy::redundant_closure_call,
     clippy::uninlined_format_args,
     clippy::useless_vec,
-    clippy::unnecessary_map_on_constructor
+    clippy::unnecessary_map_on_constructor,
+    clippy::collection_is_never_read
 )]
 
 use std::path::{Path, PathBuf};

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -8,7 +8,8 @@
     clippy::redundant_closure_call,
     clippy::uninlined_format_args,
     clippy::useless_vec,
-    clippy::unnecessary_map_on_constructor
+    clippy::unnecessary_map_on_constructor,
+    clippy::collection_is_never_read
 )]
 
 use std::path::{Path, PathBuf};

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -1,5 +1,5 @@
 error: redundant closure
-  --> $DIR/eta.rs:29:27
+  --> $DIR/eta.rs:30:27
    |
 LL |     let a = Some(1u8).map(|a| foo(a));
    |                           ^^^^^^^^^^ help: replace the closure with the function itself: `foo`
@@ -8,31 +8,31 @@ LL |     let a = Some(1u8).map(|a| foo(a));
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure)]`
 
 error: redundant closure
-  --> $DIR/eta.rs:33:40
+  --> $DIR/eta.rs:34:40
    |
 LL |     let _: Option<Vec<u8>> = true.then(|| vec![]); // special case vec!
    |                                        ^^^^^^^^^ help: replace the closure with `Vec::new`: `std::vec::Vec::new`
 
 error: redundant closure
-  --> $DIR/eta.rs:34:35
+  --> $DIR/eta.rs:35:35
    |
 LL |     let d = Some(1u8).map(|a| foo((|b| foo2(b))(a))); //is adjusted?
    |                                   ^^^^^^^^^^^^^ help: replace the closure with the function itself: `foo2`
 
 error: redundant closure
-  --> $DIR/eta.rs:35:26
+  --> $DIR/eta.rs:36:26
    |
 LL |     all(&[1, 2, 3], &&2, |x, y| below(x, y)); //is adjusted
    |                          ^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `below`
 
 error: redundant closure
-  --> $DIR/eta.rs:42:27
+  --> $DIR/eta.rs:43:27
    |
 LL |     let e = Some(1u8).map(|a| generic(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `generic`
 
 error: redundant closure
-  --> $DIR/eta.rs:94:51
+  --> $DIR/eta.rs:95:51
    |
 LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.foo());
    |                                                   ^^^^^^^^^^^ help: replace the closure with the method itself: `TestStruct::foo`
@@ -41,127 +41,127 @@ LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.foo());
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_for_method_calls)]`
 
 error: redundant closure
-  --> $DIR/eta.rs:95:51
+  --> $DIR/eta.rs:96:51
    |
 LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.trait_foo());
    |                                                   ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `TestTrait::trait_foo`
 
 error: redundant closure
-  --> $DIR/eta.rs:97:42
+  --> $DIR/eta.rs:98:42
    |
 LL |     let e = Some(&mut vec![1, 2, 3]).map(|v| v.clear());
    |                                          ^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::vec::Vec::clear`
 
 error: redundant closure
-  --> $DIR/eta.rs:101:29
+  --> $DIR/eta.rs:102:29
    |
 LL |     let e = Some("str").map(|s| s.to_string());
    |                             ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::string::ToString::to_string`
 
 error: redundant closure
-  --> $DIR/eta.rs:102:27
+  --> $DIR/eta.rs:103:27
    |
 LL |     let e = Some('a').map(|s| s.to_uppercase());
    |                           ^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `char::to_uppercase`
 
 error: redundant closure
-  --> $DIR/eta.rs:104:65
+  --> $DIR/eta.rs:105:65
    |
 LL |     let e: std::vec::Vec<char> = vec!['a', 'b', 'c'].iter().map(|c| c.to_ascii_uppercase()).collect();
    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `char::to_ascii_uppercase`
 
 error: redundant closure
-  --> $DIR/eta.rs:167:22
+  --> $DIR/eta.rs:168:22
    |
 LL |     requires_fn_once(|| x());
    |                      ^^^^^^ help: replace the closure with the function itself: `x`
 
 error: redundant closure
-  --> $DIR/eta.rs:174:27
+  --> $DIR/eta.rs:175:27
    |
 LL |     let a = Some(1u8).map(|a| foo_ptr(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `foo_ptr`
 
 error: redundant closure
-  --> $DIR/eta.rs:179:27
+  --> $DIR/eta.rs:180:27
    |
 LL |     let a = Some(1u8).map(|a| closure(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `closure`
 
 error: redundant closure
-  --> $DIR/eta.rs:211:28
+  --> $DIR/eta.rs:212:28
    |
 LL |     x.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut add_to_res`
 
 error: redundant closure
-  --> $DIR/eta.rs:212:28
+  --> $DIR/eta.rs:213:28
    |
 LL |     y.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut add_to_res`
 
 error: redundant closure
-  --> $DIR/eta.rs:213:28
+  --> $DIR/eta.rs:214:28
    |
 LL |     z.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `add_to_res`
 
 error: redundant closure
-  --> $DIR/eta.rs:220:21
+  --> $DIR/eta.rs:221:21
    |
 LL |         Some(1).map(|n| closure(n));
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut closure`
 
 error: redundant closure
-  --> $DIR/eta.rs:224:21
+  --> $DIR/eta.rs:225:21
    |
 LL |         Some(1).map(|n| in_loop(n));
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `in_loop`
 
 error: redundant closure
-  --> $DIR/eta.rs:317:18
+  --> $DIR/eta.rs:318:18
    |
 LL |     takes_fn_mut(|| f());
    |                  ^^^^^^ help: replace the closure with the function itself: `&mut f`
 
 error: redundant closure
-  --> $DIR/eta.rs:320:19
+  --> $DIR/eta.rs:321:19
    |
 LL |     takes_fn_once(|| f());
    |                   ^^^^^^ help: replace the closure with the function itself: `&mut f`
 
 error: redundant closure
-  --> $DIR/eta.rs:324:26
+  --> $DIR/eta.rs:325:26
    |
 LL |     move || takes_fn_mut(|| f_used_once())
    |                          ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut f_used_once`
 
 error: redundant closure
-  --> $DIR/eta.rs:336:19
+  --> $DIR/eta.rs:337:19
    |
 LL |     array_opt.map(|a| a.as_slice());
    |                   ^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<[u8; 3]>::as_slice`
 
 error: redundant closure
-  --> $DIR/eta.rs:339:19
+  --> $DIR/eta.rs:340:19
    |
 LL |     slice_opt.map(|s| s.len());
    |                   ^^^^^^^^^^^ help: replace the closure with the method itself: `<[u8]>::len`
 
 error: redundant closure
-  --> $DIR/eta.rs:342:17
+  --> $DIR/eta.rs:343:17
    |
 LL |     ptr_opt.map(|p| p.is_null());
    |                 ^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<*const usize>::is_null`
 
 error: redundant closure
-  --> $DIR/eta.rs:346:17
+  --> $DIR/eta.rs:347:17
    |
 LL |     dyn_opt.map(|d| d.method_on_dyn());
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<dyn TestTrait>::method_on_dyn`
 
 error: redundant closure
-  --> $DIR/eta.rs:389:19
+  --> $DIR/eta.rs:390:19
    |
 LL |     let _ = f(&0, |x, y| f2(x, y));
    |                   ^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `f2`

--- a/tests/ui/expect_fun_call.fixed
+++ b/tests/ui/expect_fun_call.fixed
@@ -2,7 +2,8 @@
 #![allow(
     clippy::to_string_in_format_args,
     clippy::uninlined_format_args,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::collection_is_never_read
 )]
 
 /// Checks implementation of the `EXPECT_FUN_CALL` lint

--- a/tests/ui/expect_fun_call.rs
+++ b/tests/ui/expect_fun_call.rs
@@ -2,7 +2,8 @@
 #![allow(
     clippy::to_string_in_format_args,
     clippy::uninlined_format_args,
-    clippy::unnecessary_literal_unwrap
+    clippy::unnecessary_literal_unwrap,
+    clippy::collection_is_never_read
 )]
 
 /// Checks implementation of the `EXPECT_FUN_CALL` lint

--- a/tests/ui/expect_fun_call.stderr
+++ b/tests/ui/expect_fun_call.stderr
@@ -1,5 +1,5 @@
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:37:26
+  --> $DIR/expect_fun_call.rs:38:26
    |
 LL |     with_none_and_format.expect(&format!("Error {}: fake error", error_code));
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
@@ -8,85 +8,85 @@ LL |     with_none_and_format.expect(&format!("Error {}: fake error", error_code
    = help: to override `-D warnings` add `#[allow(clippy::expect_fun_call)]`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:40:26
+  --> $DIR/expect_fun_call.rs:41:26
    |
 LL |     with_none_and_as_str.expect(format!("Error {}: fake error", error_code).as_str());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:43:37
+  --> $DIR/expect_fun_call.rs:44:37
    |
 LL |     with_none_and_format_with_macro.expect(format!("Error {}: fake error", one!()).as_str());
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("Error {}: fake error", one!()))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:53:25
+  --> $DIR/expect_fun_call.rs:54:25
    |
 LL |     with_err_and_format.expect(&format!("Error {}: fake error", error_code));
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:56:25
+  --> $DIR/expect_fun_call.rs:57:25
    |
 LL |     with_err_and_as_str.expect(format!("Error {}: fake error", error_code).as_str());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| panic!("Error {}: fake error", error_code))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:68:17
+  --> $DIR/expect_fun_call.rs:69:17
    |
 LL |     Some("foo").expect(format!("{} {}", 1, 2).as_ref());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{} {}", 1, 2))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:89:21
+  --> $DIR/expect_fun_call.rs:90:21
    |
 LL |         Some("foo").expect(&get_string());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:90:21
+  --> $DIR/expect_fun_call.rs:91:21
    |
 LL |         Some("foo").expect(get_string().as_ref());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:91:21
+  --> $DIR/expect_fun_call.rs:92:21
    |
 LL |         Some("foo").expect(get_string().as_str());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:93:21
+  --> $DIR/expect_fun_call.rs:94:21
    |
 LL |         Some("foo").expect(get_static_str());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_static_str()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:94:21
+  --> $DIR/expect_fun_call.rs:95:21
    |
 LL |         Some("foo").expect(get_non_static_str(&0));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| { panic!("{}", get_non_static_str(&0).to_string()) })`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:98:16
+  --> $DIR/expect_fun_call.rs:99:16
    |
 LL |     Some(true).expect(&format!("key {}, {}", 1, 2));
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("key {}, {}", 1, 2))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:104:17
+  --> $DIR/expect_fun_call.rs:105:17
    |
 LL |         opt_ref.expect(&format!("{:?}", opt_ref));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{:?}", opt_ref))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:108:20
+  --> $DIR/expect_fun_call.rs:109:20
    |
 LL |     format_capture.expect(&format!("{error_code}"));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{error_code}"))`
 
 error: use of `expect` followed by a function call
-  --> $DIR/expect_fun_call.rs:111:30
+  --> $DIR/expect_fun_call.rs:112:30
    |
 LL |     format_capture_and_value.expect(&format!("{error_code}, {}", 1));
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| panic!("{error_code}, {}", 1))`

--- a/tests/ui/extend_with_drain.fixed
+++ b/tests/ui/extend_with_drain.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::extend_with_drain)]
-#![allow(clippy::iter_with_drain)]
+#![allow(clippy::iter_with_drain, clippy::collection_is_never_read)]
 use std::collections::BinaryHeap;
 fn main() {
     //gets linted

--- a/tests/ui/extend_with_drain.rs
+++ b/tests/ui/extend_with_drain.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::extend_with_drain)]
-#![allow(clippy::iter_with_drain)]
+#![allow(clippy::iter_with_drain, clippy::collection_is_never_read)]
 use std::collections::BinaryHeap;
 fn main() {
     //gets linted

--- a/tests/ui/from_iter_instead_of_collect.fixed
+++ b/tests/ui/from_iter_instead_of_collect.fixed
@@ -1,6 +1,6 @@
 #![warn(clippy::from_iter_instead_of_collect)]
 #![allow(unused_imports, unused_tuple_struct_fields)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::collection_is_never_read)]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 

--- a/tests/ui/from_iter_instead_of_collect.rs
+++ b/tests/ui/from_iter_instead_of_collect.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::from_iter_instead_of_collect)]
 #![allow(unused_imports, unused_tuple_struct_fields)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::collection_is_never_read)]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 

--- a/tests/ui/iter_count.fixed
+++ b/tests/ui/iter_count.fixed
@@ -7,7 +7,8 @@
     unused_mut,
     clippy::into_iter_on_ref,
     clippy::unnecessary_operation,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::collection_is_never_read
 )]
 
 extern crate option_helpers;

--- a/tests/ui/iter_count.rs
+++ b/tests/ui/iter_count.rs
@@ -7,7 +7,8 @@
     unused_mut,
     clippy::into_iter_on_ref,
     clippy::unnecessary_operation,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::collection_is_never_read
 )]
 
 extern crate option_helpers;

--- a/tests/ui/iter_count.stderr
+++ b/tests/ui/iter_count.stderr
@@ -1,5 +1,5 @@
 error: called `.iter().count()` on a `slice`
-  --> $DIR/iter_count.rs:54:6
+  --> $DIR/iter_count.rs:55:6
    |
 LL |     &vec[..].iter().count();
    |      ^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec[..].len()`
@@ -8,145 +8,145 @@ LL |     &vec[..].iter().count();
    = help: to override `-D warnings` add `#[allow(clippy::iter_count)]`
 
 error: called `.iter().count()` on a `Vec`
-  --> $DIR/iter_count.rs:55:5
+  --> $DIR/iter_count.rs:56:5
    |
 LL |     vec.iter().count();
    |     ^^^^^^^^^^^^^^^^^^ help: try: `vec.len()`
 
 error: called `.iter().count()` on a `slice`
-  --> $DIR/iter_count.rs:56:5
+  --> $DIR/iter_count.rs:57:5
    |
 LL |     boxed_slice.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `boxed_slice.len()`
 
 error: called `.iter().count()` on a `VecDeque`
-  --> $DIR/iter_count.rs:57:5
+  --> $DIR/iter_count.rs:58:5
    |
 LL |     vec_deque.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec_deque.len()`
 
 error: called `.iter().count()` on a `HashSet`
-  --> $DIR/iter_count.rs:58:5
+  --> $DIR/iter_count.rs:59:5
    |
 LL |     hash_set.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_set.len()`
 
 error: called `.iter().count()` on a `HashMap`
-  --> $DIR/iter_count.rs:59:5
+  --> $DIR/iter_count.rs:60:5
    |
 LL |     hash_map.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_map.len()`
 
 error: called `.iter().count()` on a `BTreeMap`
-  --> $DIR/iter_count.rs:60:5
+  --> $DIR/iter_count.rs:61:5
    |
 LL |     b_tree_map.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_map.len()`
 
 error: called `.iter().count()` on a `BTreeSet`
-  --> $DIR/iter_count.rs:61:5
+  --> $DIR/iter_count.rs:62:5
    |
 LL |     b_tree_set.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_set.len()`
 
 error: called `.iter().count()` on a `LinkedList`
-  --> $DIR/iter_count.rs:62:5
+  --> $DIR/iter_count.rs:63:5
    |
 LL |     linked_list.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `linked_list.len()`
 
 error: called `.iter().count()` on a `BinaryHeap`
-  --> $DIR/iter_count.rs:63:5
+  --> $DIR/iter_count.rs:64:5
    |
 LL |     binary_heap.iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `binary_heap.len()`
 
 error: called `.iter_mut().count()` on a `Vec`
-  --> $DIR/iter_count.rs:65:5
+  --> $DIR/iter_count.rs:66:5
    |
 LL |     vec.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.len()`
 
 error: called `.iter_mut().count()` on a `slice`
-  --> $DIR/iter_count.rs:66:6
+  --> $DIR/iter_count.rs:67:6
    |
 LL |     &vec[..].iter_mut().count();
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec[..].len()`
 
 error: called `.iter_mut().count()` on a `VecDeque`
-  --> $DIR/iter_count.rs:67:5
+  --> $DIR/iter_count.rs:68:5
    |
 LL |     vec_deque.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec_deque.len()`
 
 error: called `.iter_mut().count()` on a `HashMap`
-  --> $DIR/iter_count.rs:68:5
+  --> $DIR/iter_count.rs:69:5
    |
 LL |     hash_map.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_map.len()`
 
 error: called `.iter_mut().count()` on a `BTreeMap`
-  --> $DIR/iter_count.rs:69:5
+  --> $DIR/iter_count.rs:70:5
    |
 LL |     b_tree_map.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_map.len()`
 
 error: called `.iter_mut().count()` on a `LinkedList`
-  --> $DIR/iter_count.rs:70:5
+  --> $DIR/iter_count.rs:71:5
    |
 LL |     linked_list.iter_mut().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `linked_list.len()`
 
 error: called `.into_iter().count()` on a `slice`
-  --> $DIR/iter_count.rs:72:6
+  --> $DIR/iter_count.rs:73:6
    |
 LL |     &vec[..].into_iter().count();
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec[..].len()`
 
 error: called `.into_iter().count()` on a `Vec`
-  --> $DIR/iter_count.rs:73:5
+  --> $DIR/iter_count.rs:74:5
    |
 LL |     vec.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.len()`
 
 error: called `.into_iter().count()` on a `VecDeque`
-  --> $DIR/iter_count.rs:74:5
+  --> $DIR/iter_count.rs:75:5
    |
 LL |     vec_deque.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec_deque.len()`
 
 error: called `.into_iter().count()` on a `HashSet`
-  --> $DIR/iter_count.rs:75:5
+  --> $DIR/iter_count.rs:76:5
    |
 LL |     hash_set.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_set.len()`
 
 error: called `.into_iter().count()` on a `HashMap`
-  --> $DIR/iter_count.rs:76:5
+  --> $DIR/iter_count.rs:77:5
    |
 LL |     hash_map.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `hash_map.len()`
 
 error: called `.into_iter().count()` on a `BTreeMap`
-  --> $DIR/iter_count.rs:77:5
+  --> $DIR/iter_count.rs:78:5
    |
 LL |     b_tree_map.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_map.len()`
 
 error: called `.into_iter().count()` on a `BTreeSet`
-  --> $DIR/iter_count.rs:78:5
+  --> $DIR/iter_count.rs:79:5
    |
 LL |     b_tree_set.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `b_tree_set.len()`
 
 error: called `.into_iter().count()` on a `LinkedList`
-  --> $DIR/iter_count.rs:79:5
+  --> $DIR/iter_count.rs:80:5
    |
 LL |     linked_list.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `linked_list.len()`
 
 error: called `.into_iter().count()` on a `BinaryHeap`
-  --> $DIR/iter_count.rs:80:5
+  --> $DIR/iter_count.rs:81:5
    |
 LL |     binary_heap.into_iter().count();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `binary_heap.len()`

--- a/tests/ui/manual_filter.fixed
+++ b/tests/ui/manual_filter.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_filter)]
-#![allow(unused_variables, dead_code, clippy::useless_vec)]
+#![allow(unused_variables, dead_code, clippy::useless_vec, clippy::collection_is_never_read)]
 
 fn main() {
     Some(0).filter(|&x| x <= 0);

--- a/tests/ui/manual_filter.rs
+++ b/tests/ui/manual_filter.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_filter)]
-#![allow(unused_variables, dead_code, clippy::useless_vec)]
+#![allow(unused_variables, dead_code, clippy::useless_vec, clippy::collection_is_never_read)]
 
 fn main() {
     match Some(0) {

--- a/tests/ui/manual_retain.fixed
+++ b/tests/ui/manual_retain.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_retain)]
-#![allow(unused, clippy::redundant_clone)]
+#![allow(unused, clippy::redundant_clone, clippy::collection_is_never_read)]
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 
 fn main() {

--- a/tests/ui/manual_retain.rs
+++ b/tests/ui/manual_retain.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_retain)]
-#![allow(unused, clippy::redundant_clone)]
+#![allow(unused, clippy::redundant_clone, clippy::collection_is_never_read)]
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 
 fn main() {

--- a/tests/ui/needless_collect.fixed
+++ b/tests/ui/needless_collect.fixed
@@ -1,4 +1,10 @@
-#![allow(unused, clippy::needless_if, clippy::suspicious_map, clippy::iter_count)]
+#![allow(
+    unused,
+    clippy::needless_if,
+    clippy::suspicious_map,
+    clippy::iter_count,
+    clippy::collection_is_never_read
+)]
 
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList};
 

--- a/tests/ui/needless_collect.rs
+++ b/tests/ui/needless_collect.rs
@@ -1,4 +1,10 @@
-#![allow(unused, clippy::needless_if, clippy::suspicious_map, clippy::iter_count)]
+#![allow(
+    unused,
+    clippy::needless_if,
+    clippy::suspicious_map,
+    clippy::iter_count,
+    clippy::collection_is_never_read
+)]
 
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList};
 

--- a/tests/ui/needless_collect.stderr
+++ b/tests/ui/needless_collect.stderr
@@ -1,5 +1,5 @@
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:9:29
+  --> $DIR/needless_collect.rs:15:29
    |
 LL |     let len = sample.iter().collect::<Vec<_>>().len();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `count()`
@@ -8,109 +8,109 @@ LL |     let len = sample.iter().collect::<Vec<_>>().len();
    = help: to override `-D warnings` add `#[allow(clippy::needless_collect)]`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:10:22
+  --> $DIR/needless_collect.rs:16:22
    |
 LL |     if sample.iter().collect::<Vec<_>>().is_empty() {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:13:28
+  --> $DIR/needless_collect.rs:19:28
    |
 LL |     sample.iter().cloned().collect::<Vec<_>>().contains(&1);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == 1)`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:18:35
+  --> $DIR/needless_collect.rs:24:35
    |
 LL |     sample.iter().map(|x| (x, x)).collect::<HashMap<_, _>>().is_empty();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:19:35
+  --> $DIR/needless_collect.rs:25:35
    |
 LL |     sample.iter().map(|x| (x, x)).collect::<BTreeMap<_, _>>().is_empty();
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:26:19
+  --> $DIR/needless_collect.rs:32:19
    |
 LL |     sample.iter().collect::<LinkedList<_>>().len();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `count()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:27:19
+  --> $DIR/needless_collect.rs:33:19
    |
 LL |     sample.iter().collect::<LinkedList<_>>().is_empty();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:28:28
+  --> $DIR/needless_collect.rs:34:28
    |
 LL |     sample.iter().cloned().collect::<LinkedList<_>>().contains(&1);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == 1)`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:29:19
+  --> $DIR/needless_collect.rs:35:19
    |
 LL |     sample.iter().collect::<LinkedList<_>>().contains(&&1);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == &1)`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:32:19
+  --> $DIR/needless_collect.rs:38:19
    |
 LL |     sample.iter().collect::<BinaryHeap<_>>().len();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `count()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:33:19
+  --> $DIR/needless_collect.rs:39:19
    |
 LL |     sample.iter().collect::<BinaryHeap<_>>().is_empty();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:38:27
+  --> $DIR/needless_collect.rs:44:27
    |
 LL |     let _ = sample.iter().collect::<HashSet<_>>().is_empty();
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:39:27
+  --> $DIR/needless_collect.rs:45:27
    |
 LL |     let _ = sample.iter().collect::<HashSet<_>>().contains(&&0);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == &0)`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:61:27
+  --> $DIR/needless_collect.rs:67:27
    |
 LL |     let _ = sample.iter().collect::<VecWrapper<_>>().is_empty();
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `next().is_none()`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:62:27
+  --> $DIR/needless_collect.rs:68:27
    |
 LL |     let _ = sample.iter().collect::<VecWrapper<_>>().contains(&&0);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `any(|x| x == &0)`
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:66:40
+  --> $DIR/needless_collect.rs:72:40
    |
 LL |         Vec::<u8>::new().extend((0..10).collect::<Vec<_>>());
    |                                        ^^^^^^^^^^^^^^^^^^^^ help: remove this call
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:67:20
+  --> $DIR/needless_collect.rs:73:20
    |
 LL |         foo((0..10).collect::<Vec<_>>());
    |                    ^^^^^^^^^^^^^^^^^^^^ help: remove this call
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:68:49
+  --> $DIR/needless_collect.rs:74:49
    |
 LL |         bar((0..10).collect::<Vec<_>>(), (0..10).collect::<Vec<_>>());
    |                                                 ^^^^^^^^^^^^^^^^^^^^ help: remove this call
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect.rs:69:37
+  --> $DIR/needless_collect.rs:75:37
    |
 LL |         baz((0..10), (), ('a'..='z').collect::<Vec<_>>())
    |                                     ^^^^^^^^^^^^^^^^^^^^ help: remove this call

--- a/tests/ui/needless_collect_indirect.rs
+++ b/tests/ui/needless_collect_indirect.rs
@@ -1,5 +1,10 @@
-#![allow(clippy::uninlined_format_args, clippy::useless_vec)]
-#![allow(clippy::needless_if, clippy::uninlined_format_args)]
+#![allow(
+    clippy::uninlined_format_args,
+    clippy::useless_vec,
+    clippy::needless_if,
+    clippy::uninlined_format_args,
+    clippy::collection_is_never_read
+)]
 #![warn(clippy::needless_collect)]
 //@no-rustfix
 use std::collections::{BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};

--- a/tests/ui/needless_collect_indirect.stderr
+++ b/tests/ui/needless_collect_indirect.stderr
@@ -1,5 +1,5 @@
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:9:39
+  --> $DIR/needless_collect_indirect.rs:14:39
    |
 LL |     let indirect_iter = sample.iter().collect::<Vec<_>>();
    |                                       ^^^^^^^
@@ -18,7 +18,7 @@ LL ~     sample.iter().map(|x| (x, x + 1)).collect::<HashMap<_, _>>();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:13:38
+  --> $DIR/needless_collect_indirect.rs:18:38
    |
 LL |     let indirect_len = sample.iter().collect::<VecDeque<_>>();
    |                                      ^^^^^^^
@@ -34,7 +34,7 @@ LL ~     sample.iter().count();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:16:40
+  --> $DIR/needless_collect_indirect.rs:21:40
    |
 LL |     let indirect_empty = sample.iter().collect::<VecDeque<_>>();
    |                                        ^^^^^^^
@@ -50,7 +50,7 @@ LL ~     sample.iter().next().is_none();
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:19:43
+  --> $DIR/needless_collect_indirect.rs:24:43
    |
 LL |     let indirect_contains = sample.iter().collect::<VecDeque<_>>();
    |                                           ^^^^^^^
@@ -66,7 +66,7 @@ LL ~     sample.iter().any(|x| x == &5);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:32:48
+  --> $DIR/needless_collect_indirect.rs:37:48
    |
 LL |     let non_copy_contains = sample.into_iter().collect::<Vec<_>>();
    |                                                ^^^^^^^
@@ -82,7 +82,7 @@ LL ~     sample.into_iter().any(|x| x == a);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:62:51
+  --> $DIR/needless_collect_indirect.rs:67:51
    |
 LL |         let buffer: Vec<&str> = string.split('/').collect();
    |                                                   ^^^^^^^
@@ -98,7 +98,7 @@ LL ~         string.split('/').count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:68:55
+  --> $DIR/needless_collect_indirect.rs:73:55
    |
 LL |         let indirect_len: VecDeque<_> = sample.iter().collect();
    |                                                       ^^^^^^^
@@ -114,7 +114,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:74:57
+  --> $DIR/needless_collect_indirect.rs:79:57
    |
 LL |         let indirect_len: LinkedList<_> = sample.iter().collect();
    |                                                         ^^^^^^^
@@ -130,7 +130,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:80:57
+  --> $DIR/needless_collect_indirect.rs:85:57
    |
 LL |         let indirect_len: BinaryHeap<_> = sample.iter().collect();
    |                                                         ^^^^^^^
@@ -146,7 +146,7 @@ LL ~         sample.iter().count()
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:141:59
+  --> $DIR/needless_collect_indirect.rs:146:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -164,7 +164,7 @@ LL ~             vec.iter().map(|k| k * k).any(|x| x == i);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:167:59
+  --> $DIR/needless_collect_indirect.rs:172:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -182,7 +182,7 @@ LL ~             vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:197:63
+  --> $DIR/needless_collect_indirect.rs:202:63
    |
 LL |                 let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                               ^^^^^^^
@@ -200,7 +200,7 @@ LL ~                 vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:234:59
+  --> $DIR/needless_collect_indirect.rs:239:59
    |
 LL |             let y: Vec<usize> = vec.iter().map(|k| k * k).collect();
    |                                                           ^^^^^^^
@@ -218,7 +218,7 @@ LL ~                 vec.iter().map(|k| k * k).any(|x| x == n);
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:260:26
+  --> $DIR/needless_collect_indirect.rs:265:26
    |
 LL |         let w = v.iter().collect::<Vec<_>>();
    |                          ^^^^^^^
@@ -235,7 +235,7 @@ LL ~         for _ in 0..v.iter().count() {
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:283:30
+  --> $DIR/needless_collect_indirect.rs:288:30
    |
 LL |         let mut w = v.iter().collect::<Vec<_>>();
    |                              ^^^^^^^
@@ -252,7 +252,7 @@ LL ~         while 1 == v.iter().count() {
    |
 
 error: avoid using `collect()` when not needed
-  --> $DIR/needless_collect_indirect.rs:306:30
+  --> $DIR/needless_collect_indirect.rs:311:30
    |
 LL |         let mut w = v.iter().collect::<Vec<_>>();
    |                              ^^^^^^^

--- a/tests/ui/needless_late_init.fixed
+++ b/tests/ui/needless_late_init.fixed
@@ -8,7 +8,8 @@
     clippy::let_unit_value,
     clippy::nonminimal_bool,
     clippy::uninlined_format_args,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::collection_is_never_read
 )]
 
 extern crate proc_macros;

--- a/tests/ui/needless_late_init.rs
+++ b/tests/ui/needless_late_init.rs
@@ -8,7 +8,8 @@
     clippy::let_unit_value,
     clippy::nonminimal_bool,
     clippy::uninlined_format_args,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::collection_is_never_read
 )]
 
 extern crate proc_macros;

--- a/tests/ui/needless_late_init.stderr
+++ b/tests/ui/needless_late_init.stderr
@@ -1,5 +1,5 @@
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:27:5
+  --> $DIR/needless_late_init.rs:28:5
    |
 LL |     let a;
    |     ^^^^^^ created here
@@ -14,7 +14,7 @@ LL |     let a = "zero";
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:30:5
+  --> $DIR/needless_late_init.rs:31:5
    |
 LL |     let b;
    |     ^^^^^^ created here
@@ -28,7 +28,7 @@ LL |     let b = 1;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:31:5
+  --> $DIR/needless_late_init.rs:32:5
    |
 LL |     let c;
    |     ^^^^^^ created here
@@ -42,7 +42,7 @@ LL |     let c = 2;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:35:5
+  --> $DIR/needless_late_init.rs:36:5
    |
 LL |     let d: usize;
    |     ^^^^^^^^^^^^^ created here
@@ -55,7 +55,7 @@ LL |     let d: usize = 1;
    |     ~~~~~~~~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:38:5
+  --> $DIR/needless_late_init.rs:39:5
    |
 LL |     let e;
    |     ^^^^^^ created here
@@ -68,7 +68,7 @@ LL |     let e = format!("{}", d);
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:43:5
+  --> $DIR/needless_late_init.rs:44:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -89,7 +89,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:52:5
+  --> $DIR/needless_late_init.rs:53:5
    |
 LL |     let b;
    |     ^^^^^^
@@ -110,7 +110,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:59:5
+  --> $DIR/needless_late_init.rs:60:5
    |
 LL |     let d;
    |     ^^^^^^
@@ -131,7 +131,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:67:5
+  --> $DIR/needless_late_init.rs:68:5
    |
 LL |     let e;
    |     ^^^^^^
@@ -152,7 +152,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:74:5
+  --> $DIR/needless_late_init.rs:75:5
    |
 LL |     let f;
    |     ^^^^^^
@@ -168,7 +168,7 @@ LL +         1 => "three",
    |
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:80:5
+  --> $DIR/needless_late_init.rs:81:5
    |
 LL |     let g: usize;
    |     ^^^^^^^^^^^^^
@@ -188,7 +188,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:88:5
+  --> $DIR/needless_late_init.rs:89:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -202,7 +202,7 @@ LL |     let x = 1;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:92:5
+  --> $DIR/needless_late_init.rs:93:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -216,7 +216,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:96:5
+  --> $DIR/needless_late_init.rs:97:5
    |
 LL |     let x;
    |     ^^^^^^ created here
@@ -230,7 +230,7 @@ LL |     let x = SignificantDrop;
    |     ~~~~~
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:115:5
+  --> $DIR/needless_late_init.rs:116:5
    |
 LL |     let a;
    |     ^^^^^^
@@ -251,7 +251,7 @@ LL |     };
    |      +
 
 error: unneeded late initialization
-  --> $DIR/needless_late_init.rs:132:5
+  --> $DIR/needless_late_init.rs:133:5
    |
 LL |     let a;
    |     ^^^^^^

--- a/tests/ui/needless_option_take.fixed
+++ b/tests/ui/needless_option_take.fixed
@@ -1,3 +1,5 @@
+#![allow(clippy::collection_is_never_read)]
+
 fn main() {
     println!("Testing non erroneous option_take_on_temporary");
     let mut option = Some(1);

--- a/tests/ui/needless_option_take.rs
+++ b/tests/ui/needless_option_take.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::collection_is_never_read)]
+
 fn main() {
     println!("Testing non erroneous option_take_on_temporary");
     let mut option = Some(1);

--- a/tests/ui/needless_option_take.stderr
+++ b/tests/ui/needless_option_take.stderr
@@ -1,5 +1,5 @@
 error: called `Option::take()` on a temporary value
-  --> $DIR/needless_option_take.rs:12:5
+  --> $DIR/needless_option_take.rs:14:5
    |
 LL |     x.as_ref().take();
    |     ^^^^^^^^^^^^^^^^^ help: try: `x.as_ref()`

--- a/tests/ui/or_fun_call.fixed
+++ b/tests/ui/or_fun_call.fixed
@@ -5,7 +5,8 @@
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps,
     clippy::unnecessary_literal_unwrap,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::collection_is_never_read
 )]
 
 use std::collections::{BTreeMap, HashMap};

--- a/tests/ui/or_fun_call.rs
+++ b/tests/ui/or_fun_call.rs
@@ -5,7 +5,8 @@
     clippy::uninlined_format_args,
     clippy::unnecessary_wraps,
     clippy::unnecessary_literal_unwrap,
-    clippy::useless_vec
+    clippy::useless_vec,
+    clippy::collection_is_never_read
 )]
 
 use std::collections::{BTreeMap, HashMap};

--- a/tests/ui/or_fun_call.stderr
+++ b/tests/ui/or_fun_call.stderr
@@ -1,5 +1,5 @@
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:52:22
+  --> $DIR/or_fun_call.rs:53:22
    |
 LL |     with_constructor.unwrap_or(make());
    |                      ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(make)`
@@ -8,7 +8,7 @@ LL |     with_constructor.unwrap_or(make());
    = help: to override `-D warnings` add `#[allow(clippy::or_fun_call)]`
 
 error: use of `unwrap_or` to construct default value
-  --> $DIR/or_fun_call.rs:55:14
+  --> $DIR/or_fun_call.rs:56:14
    |
 LL |     with_new.unwrap_or(Vec::new());
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
@@ -17,175 +17,175 @@ LL |     with_new.unwrap_or(Vec::new());
    = help: to override `-D warnings` add `#[allow(clippy::unwrap_or_default)]`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:58:21
+  --> $DIR/or_fun_call.rs:59:21
    |
 LL |     with_const_args.unwrap_or(Vec::with_capacity(12));
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:61:14
+  --> $DIR/or_fun_call.rs:62:14
    |
 LL |     with_err.unwrap_or(make());
    |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| make())`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:64:19
+  --> $DIR/or_fun_call.rs:65:19
    |
 LL |     with_err_args.unwrap_or(Vec::with_capacity(12));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|_| Vec::with_capacity(12))`
 
 error: use of `unwrap_or` to construct default value
-  --> $DIR/or_fun_call.rs:67:24
+  --> $DIR/or_fun_call.rs:68:24
    |
 LL |     with_default_trait.unwrap_or(Default::default());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> $DIR/or_fun_call.rs:70:23
+  --> $DIR/or_fun_call.rs:71:23
    |
 LL |     with_default_type.unwrap_or(u64::default());
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:73:18
+  --> $DIR/or_fun_call.rs:74:18
    |
 LL |     self_default.unwrap_or(<FakeDefault>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(<FakeDefault>::default)`
 
 error: use of `unwrap_or` to construct default value
-  --> $DIR/or_fun_call.rs:76:18
+  --> $DIR/or_fun_call.rs:77:18
    |
 LL |     real_default.unwrap_or(<FakeDefault as Default>::default());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> $DIR/or_fun_call.rs:79:14
+  --> $DIR/or_fun_call.rs:80:14
    |
 LL |     with_vec.unwrap_or(vec![]);
    |              ^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:82:21
+  --> $DIR/or_fun_call.rs:83:21
    |
 LL |     without_default.unwrap_or(Foo::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(Foo::new)`
 
 error: use of `or_insert` to construct default value
-  --> $DIR/or_fun_call.rs:85:19
+  --> $DIR/or_fun_call.rs:86:19
    |
 LL |     map.entry(42).or_insert(String::new());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> $DIR/or_fun_call.rs:88:23
+  --> $DIR/or_fun_call.rs:89:23
    |
 LL |     map_vec.entry(42).or_insert(vec![]);
    |                       ^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> $DIR/or_fun_call.rs:91:21
+  --> $DIR/or_fun_call.rs:92:21
    |
 LL |     btree.entry(42).or_insert(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert` to construct default value
-  --> $DIR/or_fun_call.rs:94:25
+  --> $DIR/or_fun_call.rs:95:25
    |
 LL |     btree_vec.entry(42).or_insert(vec![]);
    |                         ^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or` to construct default value
-  --> $DIR/or_fun_call.rs:97:21
+  --> $DIR/or_fun_call.rs:98:21
    |
 LL |     let _ = stringy.unwrap_or(String::new());
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:105:21
+  --> $DIR/or_fun_call.rs:106:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:107:21
+  --> $DIR/or_fun_call.rs:108:21
    |
 LL |     let _ = Some(1).unwrap_or(map[&1]);
    |                     ^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| map[&1])`
 
 error: use of `or` followed by a function call
-  --> $DIR/or_fun_call.rs:131:35
+  --> $DIR/or_fun_call.rs:132:35
    |
 LL |     let _ = Some("a".to_string()).or(Some("b".to_string()));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_else(|| Some("b".to_string()))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:170:14
+  --> $DIR/or_fun_call.rs:171:14
    |
 LL |         None.unwrap_or(ptr_to_ref(s));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| ptr_to_ref(s))`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:176:14
+  --> $DIR/or_fun_call.rs:177:14
    |
 LL |         None.unwrap_or(unsafe { ptr_to_ref(s) });
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `unwrap_or` followed by a function call
-  --> $DIR/or_fun_call.rs:178:14
+  --> $DIR/or_fun_call.rs:179:14
    |
 LL |         None.unwrap_or( unsafe { ptr_to_ref(s) }    );
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| unsafe { ptr_to_ref(s) })`
 
 error: use of `map_or` followed by a function call
-  --> $DIR/or_fun_call.rs:253:25
+  --> $DIR/or_fun_call.rs:254:25
    |
 LL |         let _ = Some(4).map_or(g(), |v| v);
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `map_or_else(g, |v| v)`
 
 error: use of `map_or` followed by a function call
-  --> $DIR/or_fun_call.rs:254:25
+  --> $DIR/or_fun_call.rs:255:25
    |
 LL |         let _ = Some(4).map_or(g(), f);
    |                         ^^^^^^^^^^^^^^ help: try: `map_or_else(g, f)`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/or_fun_call.rs:285:18
+  --> $DIR/or_fun_call.rs:286:18
    |
 LL |         with_new.unwrap_or_else(Vec::new);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/or_fun_call.rs:288:28
+  --> $DIR/or_fun_call.rs:289:28
    |
 LL |         with_default_trait.unwrap_or_else(Default::default);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/or_fun_call.rs:291:27
+  --> $DIR/or_fun_call.rs:292:27
    |
 LL |         with_default_type.unwrap_or_else(u64::default);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/or_fun_call.rs:294:22
+  --> $DIR/or_fun_call.rs:295:22
    |
 LL |         real_default.unwrap_or_else(<FakeDefault as Default>::default);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> $DIR/or_fun_call.rs:297:23
+  --> $DIR/or_fun_call.rs:298:23
    |
 LL |         map.entry(42).or_insert_with(String::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> $DIR/or_fun_call.rs:300:25
+  --> $DIR/or_fun_call.rs:301:25
    |
 LL |         btree.entry(42).or_insert_with(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/or_fun_call.rs:303:25
+  --> $DIR/or_fun_call.rs:304:25
    |
 LL |         let _ = stringy.unwrap_or_else(String::new);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`

--- a/tests/ui/range_plus_minus_one.fixed
+++ b/tests/ui/range_plus_minus_one.fixed
@@ -1,5 +1,5 @@
 #![allow(unused_parens)]
-#![allow(clippy::iter_with_drain)]
+#![allow(clippy::iter_with_drain, clippy::collection_is_never_read)]
 fn f() -> usize {
     42
 }

--- a/tests/ui/range_plus_minus_one.rs
+++ b/tests/ui/range_plus_minus_one.rs
@@ -1,5 +1,5 @@
 #![allow(unused_parens)]
-#![allow(clippy::iter_with_drain)]
+#![allow(clippy::iter_with_drain, clippy::collection_is_never_read)]
 fn f() -> usize {
     42
 }

--- a/tests/ui/reserve_after_initialization.fixed
+++ b/tests/ui/reserve_after_initialization.fixed
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::reserve_after_initialization)]
+#![allow(clippy::collection_is_never_read)]
 #![no_main]
 
 extern crate proc_macros;

--- a/tests/ui/reserve_after_initialization.rs
+++ b/tests/ui/reserve_after_initialization.rs
@@ -1,5 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::reserve_after_initialization)]
+#![allow(clippy::collection_is_never_read)]
 #![no_main]
 
 extern crate proc_macros;

--- a/tests/ui/reserve_after_initialization.stderr
+++ b/tests/ui/reserve_after_initialization.stderr
@@ -1,5 +1,5 @@
 error: call to `reserve` immediately after creation
-  --> $DIR/reserve_after_initialization.rs:10:5
+  --> $DIR/reserve_after_initialization.rs:11:5
    |
 LL | /     let mut v1: Vec<usize> = vec![];
 LL | |     v1.reserve(10);
@@ -9,14 +9,14 @@ LL | |     v1.reserve(10);
    = help: to override `-D warnings` add `#[allow(clippy::reserve_after_initialization)]`
 
 error: call to `reserve` immediately after creation
-  --> $DIR/reserve_after_initialization.rs:17:5
+  --> $DIR/reserve_after_initialization.rs:18:5
    |
 LL | /     let mut v2: Vec<usize> = vec![];
 LL | |     v2.reserve(capacity);
    | |_________________________^ help: consider using `Vec::with_capacity(/* Space hint */)`: `let mut v2: Vec<usize> = Vec::with_capacity(capacity);`
 
 error: call to `reserve` immediately after creation
-  --> $DIR/reserve_after_initialization.rs:35:5
+  --> $DIR/reserve_after_initialization.rs:36:5
    |
 LL | /     v5 = Vec::new();
 LL | |     v5.reserve(10);

--- a/tests/ui/same_item_push.rs
+++ b/tests/ui/same_item_push.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::same_item_push)]
+#![allow(clippy::collection_is_never_read)]
 
 const VALUE: u8 = 7;
 

--- a/tests/ui/same_item_push.stderr
+++ b/tests/ui/same_item_push.stderr
@@ -1,5 +1,5 @@
 error: it looks like the same item is being pushed into this Vec
-  --> $DIR/same_item_push.rs:23:9
+  --> $DIR/same_item_push.rs:24:9
    |
 LL |         vec.push(item);
    |         ^^^
@@ -9,7 +9,7 @@ LL |         vec.push(item);
    = help: to override `-D warnings` add `#[allow(clippy::same_item_push)]`
 
 error: it looks like the same item is being pushed into this Vec
-  --> $DIR/same_item_push.rs:30:9
+  --> $DIR/same_item_push.rs:31:9
    |
 LL |         vec.push(item);
    |         ^^^
@@ -17,7 +17,7 @@ LL |         vec.push(item);
    = help: try using vec![item;SIZE] or vec.resize(NEW_SIZE, item)
 
 error: it looks like the same item is being pushed into this Vec
-  --> $DIR/same_item_push.rs:36:9
+  --> $DIR/same_item_push.rs:37:9
    |
 LL |         vec.push(13);
    |         ^^^
@@ -25,7 +25,7 @@ LL |         vec.push(13);
    = help: try using vec![13;SIZE] or vec.resize(NEW_SIZE, 13)
 
 error: it looks like the same item is being pushed into this Vec
-  --> $DIR/same_item_push.rs:42:9
+  --> $DIR/same_item_push.rs:43:9
    |
 LL |         vec.push(VALUE);
    |         ^^^
@@ -33,7 +33,7 @@ LL |         vec.push(VALUE);
    = help: try using vec![VALUE;SIZE] or vec.resize(NEW_SIZE, VALUE)
 
 error: it looks like the same item is being pushed into this Vec
-  --> $DIR/same_item_push.rs:49:9
+  --> $DIR/same_item_push.rs:50:9
    |
 LL |         vec.push(item);
    |         ^^^

--- a/tests/ui/single_char_add_str.fixed
+++ b/tests/ui/single_char_add_str.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::single_char_add_str)]
-#![allow(clippy::needless_raw_strings, clippy::needless_raw_string_hashes)]
+#![allow(
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    clippy::collection_is_never_read
+)]
 
 macro_rules! get_string {
     () => {

--- a/tests/ui/single_char_add_str.rs
+++ b/tests/ui/single_char_add_str.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::single_char_add_str)]
-#![allow(clippy::needless_raw_strings, clippy::needless_raw_string_hashes)]
+#![allow(
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    clippy::collection_is_never_read
+)]
 
 macro_rules! get_string {
     () => {

--- a/tests/ui/single_char_add_str.stderr
+++ b/tests/ui/single_char_add_str.stderr
@@ -1,5 +1,5 @@
 error: calling `push_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:14:5
+  --> $DIR/single_char_add_str.rs:18:5
    |
 LL |     string.push_str("R");
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('R')`
@@ -8,85 +8,85 @@ LL |     string.push_str("R");
    = help: to override `-D warnings` add `#[allow(clippy::single_char_add_str)]`
 
 error: calling `push_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:15:5
+  --> $DIR/single_char_add_str.rs:19:5
    |
 LL |     string.push_str("'");
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('\'')`
 
 error: calling `push_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:20:5
+  --> $DIR/single_char_add_str.rs:24:5
    |
 LL |     string.push_str("\x52");
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('\x52')`
 
 error: calling `push_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:21:5
+  --> $DIR/single_char_add_str.rs:25:5
    |
 LL |     string.push_str("\u{0052}");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('\u{0052}')`
 
 error: calling `push_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:22:5
+  --> $DIR/single_char_add_str.rs:26:5
    |
 LL |     string.push_str(r##"a"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `string.push('a')`
 
 error: calling `push_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:24:5
+  --> $DIR/single_char_add_str.rs:28:5
    |
 LL |     get_string!().push_str("ö");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `get_string!().push('ö')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:29:5
+  --> $DIR/single_char_add_str.rs:33:5
    |
 LL |     string.insert_str(0, "R");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(0, 'R')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:30:5
+  --> $DIR/single_char_add_str.rs:34:5
    |
 LL |     string.insert_str(1, "'");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(1, '\'')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:35:5
+  --> $DIR/single_char_add_str.rs:39:5
    |
 LL |     string.insert_str(0, "\x52");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(0, '\x52')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:36:5
+  --> $DIR/single_char_add_str.rs:40:5
    |
 LL |     string.insert_str(0, "\u{0052}");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(0, '\u{0052}')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:38:5
+  --> $DIR/single_char_add_str.rs:42:5
    |
 LL |     string.insert_str(x, r##"a"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(x, 'a')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:40:5
+  --> $DIR/single_char_add_str.rs:44:5
    |
 LL |     string.insert_str(Y, r##"a"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(Y, 'a')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:41:5
+  --> $DIR/single_char_add_str.rs:45:5
    |
 LL |     string.insert_str(Y, r##"""##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(Y, '"')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:42:5
+  --> $DIR/single_char_add_str.rs:46:5
    |
 LL |     string.insert_str(Y, r##"'"##);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `string.insert(Y, '\'')`
 
 error: calling `insert_str()` using a single-character string literal
-  --> $DIR/single_char_add_str.rs:44:5
+  --> $DIR/single_char_add_str.rs:48:5
    |
 LL |     get_string!().insert_str(1, "?");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `insert` with a character literal: `get_string!().insert(1, '?')`

--- a/tests/ui/single_char_pattern.fixed
+++ b/tests/ui/single_char_pattern.fixed
@@ -1,4 +1,9 @@
-#![allow(clippy::needless_raw_strings, clippy::needless_raw_string_hashes, unused_must_use)]
+#![allow(
+    unused_must_use,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    clippy::collection_is_never_read
+)]
 
 use std::collections::HashSet;
 

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::needless_raw_strings, clippy::needless_raw_string_hashes, unused_must_use)]
+#![allow(
+    unused_must_use,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    clippy::collection_is_never_read
+)]
 
 use std::collections::HashSet;
 

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -1,5 +1,5 @@
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:7:13
+  --> $DIR/single_char_pattern.rs:12:13
    |
 LL |     x.split("x");
    |             ^^^ help: try using a `char` instead: `'x'`
@@ -8,229 +8,229 @@ LL |     x.split("x");
    = help: to override `-D warnings` add `#[allow(clippy::single_char_pattern)]`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:13:13
+  --> $DIR/single_char_pattern.rs:18:13
    |
 LL |     x.split("ß");
    |             ^^^ help: try using a `char` instead: `'ß'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:14:13
+  --> $DIR/single_char_pattern.rs:19:13
    |
 LL |     x.split("ℝ");
    |             ^^^ help: try using a `char` instead: `'ℝ'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:15:13
+  --> $DIR/single_char_pattern.rs:20:13
    |
 LL |     x.split("💣");
    |             ^^^^ help: try using a `char` instead: `'💣'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:18:23
+  --> $DIR/single_char_pattern.rs:23:23
    |
 LL |     x.split_inclusive("x");
    |                       ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:19:16
+  --> $DIR/single_char_pattern.rs:24:16
    |
 LL |     x.contains("x");
    |                ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:20:19
+  --> $DIR/single_char_pattern.rs:25:19
    |
 LL |     x.starts_with("x");
    |                   ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:21:17
+  --> $DIR/single_char_pattern.rs:26:17
    |
 LL |     x.ends_with("x");
    |                 ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:22:12
+  --> $DIR/single_char_pattern.rs:27:12
    |
 LL |     x.find("x");
    |            ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:23:13
+  --> $DIR/single_char_pattern.rs:28:13
    |
 LL |     x.rfind("x");
    |             ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:24:14
+  --> $DIR/single_char_pattern.rs:29:14
    |
 LL |     x.rsplit("x");
    |              ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:25:24
+  --> $DIR/single_char_pattern.rs:30:24
    |
 LL |     x.split_terminator("x");
    |                        ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:26:25
+  --> $DIR/single_char_pattern.rs:31:25
    |
 LL |     x.rsplit_terminator("x");
    |                         ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:27:17
+  --> $DIR/single_char_pattern.rs:32:17
    |
 LL |     x.splitn(2, "x");
    |                 ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:28:18
+  --> $DIR/single_char_pattern.rs:33:18
    |
 LL |     x.rsplitn(2, "x");
    |                  ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:29:18
+  --> $DIR/single_char_pattern.rs:34:18
    |
 LL |     x.split_once("x");
    |                  ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:30:19
+  --> $DIR/single_char_pattern.rs:35:19
    |
 LL |     x.rsplit_once("x");
    |                   ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:31:15
+  --> $DIR/single_char_pattern.rs:36:15
    |
 LL |     x.matches("x");
    |               ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:32:16
+  --> $DIR/single_char_pattern.rs:37:16
    |
 LL |     x.rmatches("x");
    |                ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:33:21
+  --> $DIR/single_char_pattern.rs:38:21
    |
 LL |     x.match_indices("x");
    |                     ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:34:22
+  --> $DIR/single_char_pattern.rs:39:22
    |
 LL |     x.rmatch_indices("x");
    |                      ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:35:26
+  --> $DIR/single_char_pattern.rs:40:26
    |
 LL |     x.trim_start_matches("x");
    |                          ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:36:24
+  --> $DIR/single_char_pattern.rs:41:24
    |
 LL |     x.trim_end_matches("x");
    |                        ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:37:20
+  --> $DIR/single_char_pattern.rs:42:20
    |
 LL |     x.strip_prefix("x");
    |                    ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:38:20
+  --> $DIR/single_char_pattern.rs:43:20
    |
 LL |     x.strip_suffix("x");
    |                    ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:39:15
+  --> $DIR/single_char_pattern.rs:44:15
    |
 LL |     x.replace("x", "y");
    |               ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:40:16
+  --> $DIR/single_char_pattern.rs:45:16
    |
 LL |     x.replacen("x", "y", 3);
    |                ^^^ help: try using a `char` instead: `'x'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:42:13
+  --> $DIR/single_char_pattern.rs:47:13
    |
 LL |     x.split("\n");
    |             ^^^^ help: try using a `char` instead: `'\n'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:43:13
+  --> $DIR/single_char_pattern.rs:48:13
    |
 LL |     x.split("'");
    |             ^^^ help: try using a `char` instead: `'\''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:44:13
+  --> $DIR/single_char_pattern.rs:49:13
    |
 LL |     x.split("\'");
    |             ^^^^ help: try using a `char` instead: `'\''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:49:31
+  --> $DIR/single_char_pattern.rs:54:31
    |
 LL |     x.replace(';', ",").split(","); // issue #2978
    |                               ^^^ help: try using a `char` instead: `','`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:50:19
+  --> $DIR/single_char_pattern.rs:55:19
    |
 LL |     x.starts_with("\x03"); // issue #2996
    |                   ^^^^^^ help: try using a `char` instead: `'\x03'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:57:13
+  --> $DIR/single_char_pattern.rs:62:13
    |
 LL |     x.split(r"a");
    |             ^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:58:13
+  --> $DIR/single_char_pattern.rs:63:13
    |
 LL |     x.split(r#"a"#);
    |             ^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:59:13
+  --> $DIR/single_char_pattern.rs:64:13
    |
 LL |     x.split(r###"a"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:60:13
+  --> $DIR/single_char_pattern.rs:65:13
    |
 LL |     x.split(r###"'"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'\''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:61:13
+  --> $DIR/single_char_pattern.rs:66:13
    |
 LL |     x.split(r###"#"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'#'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:63:13
+  --> $DIR/single_char_pattern.rs:68:13
    |
 LL |     x.split(r#"\"#);
    |             ^^^^^^ help: try using a `char` instead: `'\\'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:64:13
+  --> $DIR/single_char_pattern.rs:69:13
    |
 LL |     x.split(r"\");
    |             ^^^^ help: try using a `char` instead: `'\\'`

--- a/tests/ui/slow_vector_initialization.rs
+++ b/tests/ui/slow_vector_initialization.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::collection_is_never_read)]
+
 //@no-rustfix
 use std::iter::repeat;
 fn main() {

--- a/tests/ui/slow_vector_initialization.stderr
+++ b/tests/ui/slow_vector_initialization.stderr
@@ -1,5 +1,5 @@
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:14:5
+  --> $DIR/slow_vector_initialization.rs:16:5
    |
 LL |     let mut vec1 = Vec::with_capacity(len);
    |                    ----------------------- help: consider replacing this with: `vec![0; len]`
@@ -10,7 +10,7 @@ LL |     vec1.extend(repeat(0).take(len));
    = help: to override `-D warnings` add `#[allow(clippy::slow_vector_initialization)]`
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:20:5
+  --> $DIR/slow_vector_initialization.rs:22:5
    |
 LL |     let mut vec2 = Vec::with_capacity(len - 10);
    |                    ---------------------------- help: consider replacing this with: `vec![0; len - 10]`
@@ -18,7 +18,7 @@ LL |     vec2.extend(repeat(0).take(len - 10));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:28:5
+  --> $DIR/slow_vector_initialization.rs:30:5
    |
 LL |     let mut vec4 = Vec::with_capacity(len);
    |                    ----------------------- help: consider replacing this with: `vec![0; len]`
@@ -26,7 +26,7 @@ LL |     vec4.extend(repeat(0).take(vec4.capacity()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:39:5
+  --> $DIR/slow_vector_initialization.rs:41:5
    |
 LL |     let mut resized_vec = Vec::with_capacity(30);
    |                           ---------------------- help: consider replacing this with: `vec![0; 30]`
@@ -34,7 +34,7 @@ LL |     resized_vec.resize(30, 0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:43:5
+  --> $DIR/slow_vector_initialization.rs:45:5
    |
 LL |     let mut extend_vec = Vec::with_capacity(30);
    |                          ---------------------- help: consider replacing this with: `vec![0; 30]`
@@ -42,7 +42,7 @@ LL |     extend_vec.extend(repeat(0).take(30));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:51:5
+  --> $DIR/slow_vector_initialization.rs:53:5
    |
 LL |     let mut vec1 = Vec::with_capacity(len);
    |                    ----------------------- help: consider replacing this with: `vec![0; len]`
@@ -50,7 +50,7 @@ LL |     vec1.resize(len, 0);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:60:5
+  --> $DIR/slow_vector_initialization.rs:62:5
    |
 LL |     let mut vec3 = Vec::with_capacity(len - 10);
    |                    ---------------------------- help: consider replacing this with: `vec![0; len - 10]`
@@ -58,7 +58,7 @@ LL |     vec3.resize(len - 10, 0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:64:5
+  --> $DIR/slow_vector_initialization.rs:66:5
    |
 LL |     let mut vec4 = Vec::with_capacity(len);
    |                    ----------------------- help: consider replacing this with: `vec![0; len]`
@@ -66,7 +66,7 @@ LL |     vec4.resize(vec4.capacity(), 0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:69:5
+  --> $DIR/slow_vector_initialization.rs:71:5
    |
 LL |     vec1 = Vec::with_capacity(10);
    |            ---------------------- help: consider replacing this with: `vec![0; 10]`
@@ -74,7 +74,7 @@ LL |     vec1.resize(10, 0);
    |     ^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:77:5
+  --> $DIR/slow_vector_initialization.rs:79:5
    |
 LL |     let mut vec1 = Vec::new();
    |                    ---------- help: consider replacing this with: `vec![0; len]`
@@ -82,7 +82,7 @@ LL |     vec1.resize(len, 0);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:82:5
+  --> $DIR/slow_vector_initialization.rs:84:5
    |
 LL |     let mut vec3 = Vec::new();
    |                    ---------- help: consider replacing this with: `vec![0; len - 10]`
@@ -90,7 +90,7 @@ LL |     vec3.resize(len - 10, 0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:87:5
+  --> $DIR/slow_vector_initialization.rs:89:5
    |
 LL |     vec1 = Vec::new();
    |            ---------- help: consider replacing this with: `vec![0; 10]`
@@ -98,7 +98,7 @@ LL |     vec1.resize(10, 0);
    |     ^^^^^^^^^^^^^^^^^^
 
 error: slow zero-filling initialization
-  --> $DIR/slow_vector_initialization.rs:91:5
+  --> $DIR/slow_vector_initialization.rs:93:5
    |
 LL |     vec1 = vec![];
    |            ------ help: consider replacing this with: `vec![0; 10]`

--- a/tests/ui/stable_sort_primitive.fixed
+++ b/tests/ui/stable_sort_primitive.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::stable_sort_primitive)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::collection_is_never_read)]
 
 fn main() {
     // positive examples

--- a/tests/ui/stable_sort_primitive.rs
+++ b/tests/ui/stable_sort_primitive.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::stable_sort_primitive)]
-#![allow(clippy::useless_vec)]
+#![allow(clippy::useless_vec, clippy::collection_is_never_read)]
 
 fn main() {
     // positive examples

--- a/tests/ui/string_extend.fixed
+++ b/tests/ui/string_extend.fixed
@@ -1,3 +1,5 @@
+#![allow(clippy::collection_is_never_read)]
+
 #[derive(Copy, Clone)]
 struct HasChars;
 

--- a/tests/ui/string_extend.rs
+++ b/tests/ui/string_extend.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::collection_is_never_read)]
+
 #[derive(Copy, Clone)]
 struct HasChars;
 

--- a/tests/ui/string_extend.stderr
+++ b/tests/ui/string_extend.stderr
@@ -1,5 +1,5 @@
 error: calling `.extend(_.chars())`
-  --> $DIR/string_extend.rs:16:5
+  --> $DIR/string_extend.rs:18:5
    |
 LL |     s.extend(abc.chars());
    |     ^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str(abc)`
@@ -8,19 +8,19 @@ LL |     s.extend(abc.chars());
    = help: to override `-D warnings` add `#[allow(clippy::string_extend_chars)]`
 
 error: calling `.extend(_.chars())`
-  --> $DIR/string_extend.rs:19:5
+  --> $DIR/string_extend.rs:21:5
    |
 LL |     s.extend("abc".chars());
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str("abc")`
 
 error: calling `.extend(_.chars())`
-  --> $DIR/string_extend.rs:22:5
+  --> $DIR/string_extend.rs:24:5
    |
 LL |     s.extend(def.chars());
    |     ^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str(&def)`
 
 error: calling `.extend(_.chars())`
-  --> $DIR/string_extend.rs:32:5
+  --> $DIR/string_extend.rs:34:5
    |
 LL |     s.extend(abc[0..2].chars());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.push_str(&abc[0..2])`

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -11,7 +11,8 @@
     unused_variables,
     clippy::let_and_return,
     clippy::useless_vec,
-    clippy::redundant_locals
+    clippy::redundant_locals,
+    clippy::collection_is_never_read
 )]
 
 struct Foo(u32);

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -11,7 +11,8 @@
     unused_variables,
     clippy::let_and_return,
     clippy::useless_vec,
-    clippy::redundant_locals
+    clippy::redundant_locals,
+    clippy::collection_is_never_read
 )]
 
 struct Foo(u32);

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:28:5
+  --> $DIR/swap.rs:29:5
    |
 LL | /     let temp = bar.a;
 LL | |     bar.a = bar.b;
@@ -11,7 +11,7 @@ LL | |     bar.b = temp;
    = help: to override `-D warnings` add `#[allow(clippy::manual_swap)]`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:40:5
+  --> $DIR/swap.rs:41:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -19,7 +19,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:49:5
+  --> $DIR/swap.rs:50:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -27,7 +27,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:68:5
+  --> $DIR/swap.rs:69:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -35,7 +35,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:79:5
+  --> $DIR/swap.rs:80:5
    |
 LL | /     a ^= b;
 LL | |     b ^= a;
@@ -43,7 +43,7 @@ LL | |     a ^= b;
    | |___________^ help: try: `std::mem::swap(&mut a, &mut b);`
 
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:87:5
+  --> $DIR/swap.rs:88:5
    |
 LL | /     bar.a ^= bar.b;
 LL | |     bar.b ^= bar.a;
@@ -51,7 +51,7 @@ LL | |     bar.a ^= bar.b;
    | |___________________^ help: try: `std::mem::swap(&mut bar.a, &mut bar.b);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:95:5
+  --> $DIR/swap.rs:96:5
    |
 LL | /     foo[0] ^= foo[1];
 LL | |     foo[1] ^= foo[0];
@@ -59,7 +59,7 @@ LL | |     foo[0] ^= foo[1];
    | |_____________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `foo[0][1]` and `bar[1][0]` manually
-  --> $DIR/swap.rs:124:5
+  --> $DIR/swap.rs:125:5
    |
 LL | /     let temp = foo[0][1];
 LL | |     foo[0][1] = bar[1][0];
@@ -69,7 +69,7 @@ LL | |     bar[1][0] = temp;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:138:7
+  --> $DIR/swap.rs:139:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -80,7 +80,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:147:7
+  --> $DIR/swap.rs:148:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -91,7 +91,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `b` and `a` manually
-  --> $DIR/swap.rs:173:5
+  --> $DIR/swap.rs:174:5
    |
 LL | /     let t = b;
 LL | |     b = a;
@@ -101,7 +101,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:135:5
+  --> $DIR/swap.rs:136:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -112,7 +112,7 @@ LL | |     b = a;
    = help: to override `-D warnings` add `#[allow(clippy::almost_swapped)]`
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:144:5
+  --> $DIR/swap.rs:145:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;
@@ -121,7 +121,7 @@ LL | |     a = c.0;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:151:5
+  --> $DIR/swap.rs:152:5
    |
 LL | /     let a = b;
 LL | |     let b = a;
@@ -130,7 +130,7 @@ LL | |     let b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `d` and `c`
-  --> $DIR/swap.rs:156:5
+  --> $DIR/swap.rs:157:5
    |
 LL | /     d = c;
 LL | |     c = d;
@@ -139,7 +139,7 @@ LL | |     c = d;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:160:5
+  --> $DIR/swap.rs:161:5
    |
 LL | /     let a = b;
 LL | |     b = a;
@@ -148,7 +148,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `s.0.x` and `s.0.y` manually
-  --> $DIR/swap.rs:208:5
+  --> $DIR/swap.rs:209:5
    |
 LL | /     let t = s.0.x;
 LL | |     s.0.x = s.0.y;

--- a/tests/ui/uninit_vec.rs
+++ b/tests/ui/uninit_vec.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::uninit_vec)]
+#![allow(clippy::collection_is_never_read)]
 
 use std::mem::MaybeUninit;
 

--- a/tests/ui/uninit_vec.stderr
+++ b/tests/ui/uninit_vec.stderr
@@ -1,5 +1,5 @@
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:17:5
+  --> $DIR/uninit_vec.rs:18:5
    |
 LL |     let mut vec: Vec<u8> = Vec::with_capacity(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL |         vec.set_len(200);
    = help: to override `-D warnings` add `#[allow(clippy::uninit_vec)]`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:24:5
+  --> $DIR/uninit_vec.rs:25:5
    |
 LL |     vec.reserve(1000);
    |     ^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` on empty `Vec` creates out-of-bound values
-  --> $DIR/uninit_vec.rs:31:5
+  --> $DIR/uninit_vec.rs:32:5
    |
 LL |     let mut vec: Vec<u8> = Vec::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         vec.set_len(200);
    |         ^^^^^^^^^^^^^^^^
 
 error: calling `set_len()` on empty `Vec` creates out-of-bound values
-  --> $DIR/uninit_vec.rs:38:5
+  --> $DIR/uninit_vec.rs:39:5
    |
 LL |     let mut vec: Vec<u8> = Default::default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |         vec.set_len(200);
    |         ^^^^^^^^^^^^^^^^
 
 error: calling `set_len()` on empty `Vec` creates out-of-bound values
-  --> $DIR/uninit_vec.rs:44:5
+  --> $DIR/uninit_vec.rs:45:5
    |
 LL |     let mut vec: Vec<u8> = Vec::default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL |         vec.set_len(200);
    |         ^^^^^^^^^^^^^^^^
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:61:5
+  --> $DIR/uninit_vec.rs:62:5
    |
 LL |     let mut vec: Vec<u8> = Vec::with_capacity(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:71:5
+  --> $DIR/uninit_vec.rs:72:5
    |
 LL |     my_vec.vec.reserve(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |         my_vec.vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:77:5
+  --> $DIR/uninit_vec.rs:78:5
    |
 LL |     my_vec.vec = Vec::with_capacity(1000);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL |         my_vec.vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:52:9
+  --> $DIR/uninit_vec.rs:53:9
    |
 LL |         let mut vec: Vec<u8> = Vec::with_capacity(1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +94,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:56:9
+  --> $DIR/uninit_vec.rs:57:9
    |
 LL |         vec.reserve(1000);
    |         ^^^^^^^^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL |         vec.set_len(200);
    = help: initialize the buffer or wrap the content in `MaybeUninit`
 
 error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
-  --> $DIR/uninit_vec.rs:132:9
+  --> $DIR/uninit_vec.rs:133:9
    |
 LL |         let mut vec: Vec<T> = Vec::with_capacity(1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unit_return_expecting_ord.rs
+++ b/tests/ui/unit_return_expecting_ord.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::needless_return)]
 #![allow(clippy::unused_unit)]
 #![allow(clippy::useless_vec)]
+#![allow(clippy::collection_is_never_read)]
 #![feature(is_sorted)]
 
 struct Struct {

--- a/tests/ui/unit_return_expecting_ord.stderr
+++ b/tests/ui/unit_return_expecting_ord.stderr
@@ -1,11 +1,11 @@
 error: this closure returns the unit type which also implements Ord
-  --> $DIR/unit_return_expecting_ord.rs:19:25
+  --> $DIR/unit_return_expecting_ord.rs:20:25
    |
 LL |     structs.sort_by_key(|s| {
    |                         ^^^
    |
 help: probably caused by this trailing semicolon
-  --> $DIR/unit_return_expecting_ord.rs:21:24
+  --> $DIR/unit_return_expecting_ord.rs:22:24
    |
 LL |         double(s.field);
    |                        ^
@@ -13,25 +13,25 @@ LL |         double(s.field);
    = help: to override `-D warnings` add `#[allow(clippy::unit_return_expecting_ord)]`
 
 error: this closure returns the unit type which also implements PartialOrd
-  --> $DIR/unit_return_expecting_ord.rs:24:30
+  --> $DIR/unit_return_expecting_ord.rs:25:30
    |
 LL |     structs.is_sorted_by_key(|s| {
    |                              ^^^
    |
 help: probably caused by this trailing semicolon
-  --> $DIR/unit_return_expecting_ord.rs:26:24
+  --> $DIR/unit_return_expecting_ord.rs:27:24
    |
 LL |         double(s.field);
    |                        ^
 
 error: this closure returns the unit type which also implements PartialOrd
-  --> $DIR/unit_return_expecting_ord.rs:28:30
+  --> $DIR/unit_return_expecting_ord.rs:29:30
    |
 LL |     structs.is_sorted_by_key(|s| {
    |                              ^^^
 
 error: this closure returns the unit type which also implements Ord
-  --> $DIR/unit_return_expecting_ord.rs:39:25
+  --> $DIR/unit_return_expecting_ord.rs:40:25
    |
 LL |     structs.sort_by_key(|s| unit(s.field));
    |                         ^^^

--- a/tests/ui/unnecessary_literal_unwrap.fixed
+++ b/tests/ui/unnecessary_literal_unwrap.fixed
@@ -4,7 +4,8 @@
     clippy::unnecessary_lazy_evaluations,
     clippy::diverging_sub_expression,
     clippy::let_unit_value,
-    clippy::no_effect
+    clippy::no_effect,
+    clippy::collection_is_never_read
 )]
 
 fn unwrap_option_some() {

--- a/tests/ui/unnecessary_literal_unwrap.rs
+++ b/tests/ui/unnecessary_literal_unwrap.rs
@@ -4,7 +4,8 @@
     clippy::unnecessary_lazy_evaluations,
     clippy::diverging_sub_expression,
     clippy::let_unit_value,
-    clippy::no_effect
+    clippy::no_effect,
+    clippy::collection_is_never_read
 )]
 
 fn unwrap_option_some() {

--- a/tests/ui/unnecessary_literal_unwrap.stderr
+++ b/tests/ui/unnecessary_literal_unwrap.stderr
@@ -1,5 +1,5 @@
 error: used `unwrap()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:11:16
+  --> $DIR/unnecessary_literal_unwrap.rs:12:16
    |
 LL |     let _val = Some(1).unwrap();
    |                ^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:12:16
+  --> $DIR/unnecessary_literal_unwrap.rs:13:16
    |
 LL |     let _val = Some(1).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:14:5
+  --> $DIR/unnecessary_literal_unwrap.rs:15:5
    |
 LL |     Some(1).unwrap();
    |     ^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL +     1;
    |
 
 error: used `expect()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:15:5
+  --> $DIR/unnecessary_literal_unwrap.rs:16:5
    |
 LL |     Some(1).expect("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,13 +49,13 @@ LL +     1;
    |
 
 error: used `unwrap()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:20:16
+  --> $DIR/unnecessary_literal_unwrap.rs:21:16
    |
 LL |     let _val = None::<()>.unwrap();
    |                ^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap()`: `panic!()`
 
 error: used `expect()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:21:16
+  --> $DIR/unnecessary_literal_unwrap.rs:22:16
    |
 LL |     let _val = None::<()>.expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,13 +66,13 @@ LL |     let _val = panic!("this always happens");
    |                ~~~~~~~                     ~
 
 error: used `unwrap_or_default()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:22:24
+  --> $DIR/unnecessary_literal_unwrap.rs:23:24
    |
 LL |     let _val: String = None.unwrap_or_default();
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
 
 error: used `unwrap_or()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:23:21
+  --> $DIR/unnecessary_literal_unwrap.rs:24:21
    |
 LL |     let _val: u16 = None.unwrap_or(234);
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL +     let _val: u16 = 234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:24:21
+  --> $DIR/unnecessary_literal_unwrap.rs:25:21
    |
 LL |     let _val: u16 = None.unwrap_or_else(|| 234);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL +     let _val: u16 = 234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:25:21
+  --> $DIR/unnecessary_literal_unwrap.rs:26:21
    |
 LL |     let _val: u16 = None.unwrap_or_else(|| { 234 });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL +     let _val: u16 = { 234 };
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:26:21
+  --> $DIR/unnecessary_literal_unwrap.rs:27:21
    |
 LL |     let _val: u16 = None.unwrap_or_else(|| -> u16 { 234 });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,13 +120,13 @@ LL +     let _val: u16 =  { 234 };
    |
 
 error: used `unwrap()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:28:5
+  --> $DIR/unnecessary_literal_unwrap.rs:29:5
    |
 LL |     None::<()>.unwrap();
    |     ^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap()`: `panic!()`
 
 error: used `expect()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:29:5
+  --> $DIR/unnecessary_literal_unwrap.rs:30:5
    |
 LL |     None::<()>.expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,13 +137,13 @@ LL |     panic!("this always happens");
    |     ~~~~~~~                     ~
 
 error: used `unwrap_or_default()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:30:5
+  --> $DIR/unnecessary_literal_unwrap.rs:31:5
    |
 LL |     None::<String>.unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `String::default()`
 
 error: used `unwrap_or()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:31:5
+  --> $DIR/unnecessary_literal_unwrap.rs:32:5
    |
 LL |     None::<u16>.unwrap_or(234);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL +     234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:32:5
+  --> $DIR/unnecessary_literal_unwrap.rs:33:5
    |
 LL |     None::<u16>.unwrap_or_else(|| 234);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL +     234;
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:33:5
+  --> $DIR/unnecessary_literal_unwrap.rs:34:5
    |
 LL |     None::<u16>.unwrap_or_else(|| { 234 });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -179,7 +179,7 @@ LL +     { 234 };
    |
 
 error: used `unwrap_or_else()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap.rs:34:5
+  --> $DIR/unnecessary_literal_unwrap.rs:35:5
    |
 LL |     None::<u16>.unwrap_or_else(|| -> u16 { 234 });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -191,7 +191,7 @@ LL +      { 234 };
    |
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:38:16
+  --> $DIR/unnecessary_literal_unwrap.rs:39:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,7 +203,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:39:16
+  --> $DIR/unnecessary_literal_unwrap.rs:40:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,7 +215,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:40:16
+  --> $DIR/unnecessary_literal_unwrap.rs:41:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -226,7 +226,7 @@ LL |     let _val = panic!("{:?}", 1);
    |                ~~~~~~~~~~~~~~  ~
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:41:16
+  --> $DIR/unnecessary_literal_unwrap.rs:42:16
    |
 LL |     let _val = Ok::<_, ()>(1).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -237,7 +237,7 @@ LL |     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |                ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:43:5
+  --> $DIR/unnecessary_literal_unwrap.rs:44:5
    |
 LL |     Ok::<_, ()>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -249,7 +249,7 @@ LL +     1;
    |
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:44:5
+  --> $DIR/unnecessary_literal_unwrap.rs:45:5
    |
 LL |     Ok::<_, ()>(1).expect("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -261,7 +261,7 @@ LL +     1;
    |
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:45:5
+  --> $DIR/unnecessary_literal_unwrap.rs:46:5
    |
 LL |     Ok::<_, ()>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -272,7 +272,7 @@ LL |     panic!("{:?}", 1);
    |     ~~~~~~~~~~~~~~  ~
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:46:5
+  --> $DIR/unnecessary_literal_unwrap.rs:47:5
    |
 LL |     Ok::<_, ()>(1).expect_err("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -283,7 +283,7 @@ LL |     panic!("{1}: {:?}", 1, "this always happens");
    |     ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:50:16
+  --> $DIR/unnecessary_literal_unwrap.rs:51:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -295,7 +295,7 @@ LL +     let _val = 1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:51:16
+  --> $DIR/unnecessary_literal_unwrap.rs:52:16
    |
 LL |     let _val = Err::<(), _>(1).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -307,7 +307,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:52:16
+  --> $DIR/unnecessary_literal_unwrap.rs:53:16
    |
 LL |     let _val = Err::<(), _>(1).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -318,7 +318,7 @@ LL |     let _val = panic!("{:?}", 1);
    |                ~~~~~~~~~~~~~~  ~
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:53:16
+  --> $DIR/unnecessary_literal_unwrap.rs:54:16
    |
 LL |     let _val = Err::<(), _>(1).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -329,7 +329,7 @@ LL |     let _val = panic!("{1}: {:?}", 1, "this always happens");
    |                ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:55:5
+  --> $DIR/unnecessary_literal_unwrap.rs:56:5
    |
 LL |     Err::<(), _>(1).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -341,7 +341,7 @@ LL +     1;
    |
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:56:5
+  --> $DIR/unnecessary_literal_unwrap.rs:57:5
    |
 LL |     Err::<(), _>(1).expect_err("this never happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -353,7 +353,7 @@ LL +     1;
    |
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:57:5
+  --> $DIR/unnecessary_literal_unwrap.rs:58:5
    |
 LL |     Err::<(), _>(1).unwrap();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -364,7 +364,7 @@ LL |     panic!("{:?}", 1);
    |     ~~~~~~~~~~~~~~  ~
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:58:5
+  --> $DIR/unnecessary_literal_unwrap.rs:59:5
    |
 LL |     Err::<(), _>(1).expect("this always happens");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -375,7 +375,7 @@ LL |     panic!("{1}: {:?}", 1, "this always happens");
    |     ~~~~~~~~~~~~~~~~~~~  ~
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:62:16
+  --> $DIR/unnecessary_literal_unwrap.rs:63:16
    |
 LL |     let _val = Some(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -387,7 +387,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:63:16
+  --> $DIR/unnecessary_literal_unwrap.rs:64:16
    |
 LL |     let _val = Some(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -399,7 +399,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:64:16
+  --> $DIR/unnecessary_literal_unwrap.rs:65:16
    |
 LL |     let _val = Some(1).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -411,7 +411,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:66:5
+  --> $DIR/unnecessary_literal_unwrap.rs:67:5
    |
 LL |     Some(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -423,7 +423,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:67:5
+  --> $DIR/unnecessary_literal_unwrap.rs:68:5
    |
 LL |     Some(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -435,7 +435,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:68:5
+  --> $DIR/unnecessary_literal_unwrap.rs:69:5
    |
 LL |     Some(1).unwrap_or_else(|| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -447,7 +447,7 @@ LL +     1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:72:16
+  --> $DIR/unnecessary_literal_unwrap.rs:73:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -459,7 +459,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:73:16
+  --> $DIR/unnecessary_literal_unwrap.rs:74:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -471,7 +471,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:74:16
+  --> $DIR/unnecessary_literal_unwrap.rs:75:16
    |
 LL |     let _val = Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -483,7 +483,7 @@ LL +     let _val = 1;
    |
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:76:5
+  --> $DIR/unnecessary_literal_unwrap.rs:77:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or(2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -495,7 +495,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:77:5
+  --> $DIR/unnecessary_literal_unwrap.rs:78:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -507,7 +507,7 @@ LL +     1;
    |
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:78:5
+  --> $DIR/unnecessary_literal_unwrap.rs:79:5
    |
 LL |     Ok::<_, ()>(1).unwrap_or_else(|_| 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -519,7 +519,7 @@ LL +     1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:92:22
+  --> $DIR/unnecessary_literal_unwrap.rs:93:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -531,7 +531,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:93:22
+  --> $DIR/unnecessary_literal_unwrap.rs:94:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() + *(&1 as *const i32) }; // needs to keep the unsafe block
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -543,7 +543,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) }; // needs to keep the unsafe
    |
 
 error: used `unwrap_unchecked()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap.rs:94:22
+  --> $DIR/unnecessary_literal_unwrap.rs:95:22
    |
 LL |     let _ = unsafe { Some(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -555,7 +555,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:95:22
+  --> $DIR/unnecessary_literal_unwrap.rs:96:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -567,7 +567,7 @@ LL +     let _ = 1;
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:96:22
+  --> $DIR/unnecessary_literal_unwrap.rs:97:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() + *(&1 as *const i32) };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -579,7 +579,7 @@ LL +     let _ = unsafe { 1 + *(&1 as *const i32) };
    |
 
 error: used `unwrap_unchecked()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap.rs:97:22
+  --> $DIR/unnecessary_literal_unwrap.rs:98:22
    |
 LL |     let _ = unsafe { Ok::<_, ()>(1).unwrap_unchecked() } + 1;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -591,7 +591,7 @@ LL +     let _ = 1 + 1;
    |
 
 error: used `unwrap_err_unchecked()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap.rs:98:22
+  --> $DIR/unnecessary_literal_unwrap.rs:99:22
    |
 LL |     let _ = unsafe { Err::<(), i32>(123).unwrap_err_unchecked() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unnecessary_literal_unwrap_unfixable.rs
+++ b/tests/ui/unnecessary_literal_unwrap_unfixable.rs
@@ -1,6 +1,10 @@
 #![warn(clippy::unnecessary_literal_unwrap)]
 #![allow(unreachable_code)]
-#![allow(clippy::unnecessary_lazy_evaluations, clippy::let_unit_value)]
+#![allow(
+    clippy::unnecessary_lazy_evaluations,
+    clippy::let_unit_value,
+    clippy::collection_is_never_read
+)]
 //@no-rustfix
 fn unwrap_option_some() {
     let val = Some(1);

--- a/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
+++ b/tests/ui/unnecessary_literal_unwrap_unfixable.stderr
@@ -1,11 +1,11 @@
 error: used `unwrap()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:7:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:11:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:6:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:10:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
@@ -13,601 +13,601 @@ LL |     let val = Some(1);
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_literal_unwrap)]`
 
 error: used `expect()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:9:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:13:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:6:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:10:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:14:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:18:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:14:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:18:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:16:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:20:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:16:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:20:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:20:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:24:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:19:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:23:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:22:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:26:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:19:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:23:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:28:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:32:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `None` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:27:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:31:15
    |
 LL |     let val = None::<()>;
    |               ^^^^^^^^^^
 
 error: used `expect()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:30:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:34:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `None` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:27:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:31:15
    |
 LL |     let val = None::<()>;
    |               ^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:32:21
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:36:21
    |
 LL |     let _val3: u8 = None.unwrap_or_default();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `Default::default()`
 
 error: used `unwrap_or_default()` on `None` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:34:5
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:38:5
    |
 LL |     None::<()>.unwrap_or_default();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the `None` and `unwrap_or_default()`: `Default::default()`
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:40:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:44:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:39:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:43:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:42:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:46:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:39:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:43:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:44:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:48:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:39:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:43:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:46:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:50:17
    |
 LL |     let _val2 = val.expect_err("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:39:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:43:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:51:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:55:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:51:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:55:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:53:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:57:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:53:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:57:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:55:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:59:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:55:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:59:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:57:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:57:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).expect_err("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:61:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:65:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:60:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:64:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:63:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:67:17
    |
 LL |     let _val2 = val.expect("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:60:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:64:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:65:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:69:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:60:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:64:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:67:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:71:17
    |
 LL |     let _val2 = val.expect_err("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:60:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:64:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:73:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:77:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:75:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:79:17
    |
 LL |     let _val2 = val.expect_err("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:77:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:81:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:79:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:83:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:72:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:76:15
    |
 LL |     let val = Err::<(), _>(1);
    |               ^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:84:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:88:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:84:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:88:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap_err();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:86:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:90:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:86:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:90:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect_err("this never happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:88:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:92:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:88:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:92:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).unwrap();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:90:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:94:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:90:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:94:16
    |
 LL |     let _val = Err::<(), usize>([1, 2, 3].iter().sum()).expect("this always happens");
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:94:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:98:17
    |
 LL |     let _val2 = val.unwrap_err();
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:93:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:97:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect_err()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:96:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:100:17
    |
 LL |     let _val2 = val.expect_err("this never happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect_err()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:93:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:97:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:98:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:102:17
    |
 LL |     let _val2 = val.unwrap();
    |                 ^^^^^^^^^^^^
    |
 help: remove the `Err` and `unwrap()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:93:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:97:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `expect()` on `Err` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:100:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:104:17
    |
 LL |     let _val2 = val.expect("this always happens");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Err` and `expect()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:93:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:97:15
    |
 LL |     let val = Err::<(), usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:106:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:110:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:105:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:109:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:108:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:112:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:105:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:109:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:110:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:114:17
    |
 LL |     let _val2 = val.unwrap_or_else(|| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:105:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:109:15
    |
 LL |     let val = Some(1);
    |               ^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:115:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:119:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:115:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:119:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:117:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:121:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:117:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:121:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:119:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:123:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:119:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:123:16
    |
 LL |     let _val = Some::<usize>([1, 2, 3].iter().sum()).unwrap_or_else(|| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:123:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:127:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:122:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:126:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:125:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:129:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:122:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:126:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Some` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:127:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:131:17
    |
 LL |     let _val2 = val.unwrap_or_else(|| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Some` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:122:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:126:15
    |
 LL |     let val = Some::<usize>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:133:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:137:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:132:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:136:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:135:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:139:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:132:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:136:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:137:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:141:17
    |
 LL |     let _val2 = val.unwrap_or_else(|_| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:132:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:136:15
    |
 LL |     let val = Ok::<_, ()>(1);
    |               ^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:142:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:146:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:142:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:146:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or(2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:144:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:148:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:144:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:148:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_default();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:146:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:150:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:146:16
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:150:16
    |
 LL |     let _val = Ok::<usize, ()>([1, 2, 3].iter().sum()).unwrap_or_else(|_| 2);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:150:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:154:17
    |
 LL |     let _val2 = val.unwrap_or(2);
    |                 ^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:149:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:153:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_default()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:152:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:156:17
    |
 LL |     let _val2 = val.unwrap_or_default();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_default()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:149:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:153:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: used `unwrap_or_else()` on `Ok` value
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:154:17
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:158:17
    |
 LL |     let _val2 = val.unwrap_or_else(|_| 2);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: remove the `Ok` and `unwrap_or_else()`
-  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:149:15
+  --> $DIR/unnecessary_literal_unwrap_unfixable.rs:153:15
    |
 LL |     let val = Ok::<usize, ()>([1, 2, 3].iter().sum());
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unnecessary_map_on_constructor.fixed
+++ b/tests/ui/unnecessary_map_on_constructor.fixed
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::collection_is_never_read)]
 #![warn(clippy::unnecessary_map_on_constructor)]
 
 use std::ffi::OsStr;

--- a/tests/ui/unnecessary_map_on_constructor.rs
+++ b/tests/ui/unnecessary_map_on_constructor.rs
@@ -1,4 +1,4 @@
-#![allow(unused)]
+#![allow(unused, clippy::collection_is_never_read)]
 #![warn(clippy::unnecessary_map_on_constructor)]
 
 use std::ffi::OsStr;

--- a/tests/ui/unnecessary_sort_by.fixed
+++ b/tests/ui/unnecessary_sort_by.fixed
@@ -1,4 +1,4 @@
-#![allow(clippy::stable_sort_primitive, clippy::useless_vec)]
+#![allow(clippy::stable_sort_primitive, clippy::useless_vec, clippy::collection_is_never_read)]
 
 use std::cell::Ref;
 

--- a/tests/ui/unnecessary_sort_by.rs
+++ b/tests/ui/unnecessary_sort_by.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::stable_sort_primitive, clippy::useless_vec)]
+#![allow(clippy::stable_sort_primitive, clippy::useless_vec, clippy::collection_is_never_read)]
 
 use std::cell::Ref;
 

--- a/tests/ui/unwrap_or_else_default.fixed
+++ b/tests/ui/unwrap_or_else_default.fixed
@@ -1,6 +1,10 @@
 #![warn(clippy::unwrap_or_default)]
 #![allow(dead_code)]
-#![allow(clippy::unnecessary_wraps, clippy::unnecessary_literal_unwrap)]
+#![allow(
+    clippy::unnecessary_wraps,
+    clippy::unnecessary_literal_unwrap,
+    clippy::collection_is_never_read
+)]
 
 /// Checks implementation of the `UNWRAP_OR_DEFAULT` lint.
 fn unwrap_or_else_default() {

--- a/tests/ui/unwrap_or_else_default.rs
+++ b/tests/ui/unwrap_or_else_default.rs
@@ -1,6 +1,10 @@
 #![warn(clippy::unwrap_or_default)]
 #![allow(dead_code)]
-#![allow(clippy::unnecessary_wraps, clippy::unnecessary_literal_unwrap)]
+#![allow(
+    clippy::unnecessary_wraps,
+    clippy::unnecessary_literal_unwrap,
+    clippy::collection_is_never_read
+)]
 
 /// Checks implementation of the `UNWRAP_OR_DEFAULT` lint.
 fn unwrap_or_else_default() {

--- a/tests/ui/unwrap_or_else_default.stderr
+++ b/tests/ui/unwrap_or_else_default.stderr
@@ -1,5 +1,5 @@
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:46:14
+  --> $DIR/unwrap_or_else_default.rs:50:14
    |
 LL |     with_new.unwrap_or_else(Vec::new);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
@@ -8,91 +8,91 @@ LL |     with_new.unwrap_or_else(Vec::new);
    = help: to override `-D warnings` add `#[allow(clippy::unwrap_or_default)]`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:60:23
+  --> $DIR/unwrap_or_else_default.rs:64:23
    |
 LL |     with_real_default.unwrap_or_else(<HasDefaultAndDuplicate as Default>::default);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:63:24
+  --> $DIR/unwrap_or_else_default.rs:67:24
    |
 LL |     with_default_trait.unwrap_or_else(Default::default);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:66:23
+  --> $DIR/unwrap_or_else_default.rs:70:23
    |
 LL |     with_default_type.unwrap_or_else(u64::default);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:69:23
+  --> $DIR/unwrap_or_else_default.rs:73:23
    |
 LL |     with_default_type.unwrap_or_else(Vec::new);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:72:18
+  --> $DIR/unwrap_or_else_default.rs:76:18
    |
 LL |     empty_string.unwrap_or_else(|| "".to_string());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:76:12
+  --> $DIR/unwrap_or_else_default.rs:80:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:79:12
+  --> $DIR/unwrap_or_else_default.rs:83:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:82:12
+  --> $DIR/unwrap_or_else_default.rs:86:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:85:12
+  --> $DIR/unwrap_or_else_default.rs:89:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:88:12
+  --> $DIR/unwrap_or_else_default.rs:92:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:91:12
+  --> $DIR/unwrap_or_else_default.rs:95:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:94:12
+  --> $DIR/unwrap_or_else_default.rs:98:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:97:12
+  --> $DIR/unwrap_or_else_default.rs:101:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `unwrap_or_else` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:113:12
+  --> $DIR/unwrap_or_else_default.rs:117:12
    |
 LL |     option.unwrap_or_else(Vec::new).push(1);
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_default()`
 
 error: use of `or_insert_with` to construct default value
-  --> $DIR/unwrap_or_else_default.rs:130:32
+  --> $DIR/unwrap_or_else_default.rs:134:32
    |
 LL |     let _ = inner_map.entry(0).or_insert_with(Default::default);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`

--- a/tests/ui/vec_init_then_push.rs
+++ b/tests/ui/vec_init_then_push.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![allow(unused_variables, clippy::collection_is_never_read)]
 #![warn(clippy::vec_init_then_push)]
 //@no-rustfix
 fn main() {

--- a/tests/ui/vec_resize_to_zero.fixed
+++ b/tests/ui/vec_resize_to_zero.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::vec_resize_to_zero)]
+#![allow(clippy::collection_is_never_read)]
 
 fn main() {
     let mut v = vec![1, 2, 3, 4, 5];

--- a/tests/ui/vec_resize_to_zero.rs
+++ b/tests/ui/vec_resize_to_zero.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::vec_resize_to_zero)]
+#![allow(clippy::collection_is_never_read)]
 
 fn main() {
     let mut v = vec![1, 2, 3, 4, 5];

--- a/tests/ui/vec_resize_to_zero.stderr
+++ b/tests/ui/vec_resize_to_zero.stderr
@@ -1,5 +1,5 @@
 error: emptying a vector with `resize`
-  --> $DIR/vec_resize_to_zero.rs:7:5
+  --> $DIR/vec_resize_to_zero.rs:8:5
    |
 LL |     v.resize(0, 5);
    |     ^^------------

--- a/tests/ui/write_literal.fixed
+++ b/tests/ui/write_literal.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::write_literal)]
-#![allow(clippy::uninlined_format_args, unused_must_use)]
+#![allow(clippy::uninlined_format_args, unused_must_use, clippy::collection_is_never_read)]
 
 use std::io::Write;
 

--- a/tests/ui/write_literal.rs
+++ b/tests/ui/write_literal.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::write_literal)]
-#![allow(clippy::uninlined_format_args, unused_must_use)]
+#![allow(clippy::uninlined_format_args, unused_must_use, clippy::collection_is_never_read)]
 
 use std::io::Write;
 

--- a/tests/ui/write_literal_2.rs
+++ b/tests/ui/write_literal_2.rs
@@ -1,5 +1,5 @@
 //@no-rustfix: overlapping suggestions
-#![allow(unused_must_use)]
+#![allow(unused_must_use, clippy::collection_is_never_read)]
 #![warn(clippy::write_literal)]
 
 use std::io::Write;

--- a/tests/ui/write_with_newline.fixed
+++ b/tests/ui/write_with_newline.fixed
@@ -1,6 +1,6 @@
 // FIXME: Ideally these suggestions would be fixed via rustfix. Blocked by rust-lang/rust#53934
 
-#![allow(clippy::write_literal)]
+#![allow(clippy::write_literal, clippy::collection_is_never_read)]
 #![warn(clippy::write_with_newline)]
 
 use std::io::Write;

--- a/tests/ui/write_with_newline.rs
+++ b/tests/ui/write_with_newline.rs
@@ -1,6 +1,6 @@
 // FIXME: Ideally these suggestions would be fixed via rustfix. Blocked by rust-lang/rust#53934
 
-#![allow(clippy::write_literal)]
+#![allow(clippy::write_literal, clippy::collection_is_never_read)]
 #![warn(clippy::write_with_newline)]
 
 use std::io::Write;

--- a/tests/ui/writeln_empty_string.fixed
+++ b/tests/ui/writeln_empty_string.fixed
@@ -1,4 +1,4 @@
-#![allow(unused_must_use)]
+#![allow(unused_must_use, clippy::collection_is_never_read)]
 #![warn(clippy::writeln_empty_string)]
 use std::io::Write;
 

--- a/tests/ui/writeln_empty_string.rs
+++ b/tests/ui/writeln_empty_string.rs
@@ -1,4 +1,4 @@
-#![allow(unused_must_use)]
+#![allow(unused_must_use, clippy::collection_is_never_read)]
 #![warn(clippy::writeln_empty_string)]
 use std::io::Write;
 


### PR DESCRIPTION
This seems like a useful lint. I have not heard about any false positives. Let's make it more widely available.

changelog: Moved [`collection_is_never_read`] to `suspicious`
