### PR TITLE
Use Span#from_expansion instead of in_external_macro

### DIFF
--- a/clippy_lints/src/implicit_hasher.rs
+++ b/clippy_lints/src/implicit_hasher.rs
@@ -6,9 +6,8 @@ use rustc_hir as hir;
 use rustc_hir::intravisit::{walk_body, walk_expr, walk_inf, walk_ty, Visitor};
 use rustc_hir::{Body, Expr, ExprKind, GenericArg, Item, ItemKind, QPath, TyKind};
 use rustc_hir_analysis::hir_ty_to_ty;
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::hir::nested_filter;
-use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::{Ty, TypeckResults};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Span;
@@ -162,7 +161,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitHasher {
                     vis.visit_ty(ty);
 
                     for target in &vis.found {
-                        if in_external_macro(cx.sess(), generics.span) {
+                        if generics.span.from_expansion() {
                             continue;
                         }
                         let generics_suggestion_span = generics.span.substitute_dummy({


### PR DESCRIPTION
- fixes #10511 

I checked [the reported repository](https://github.com/rust-lang/rust-clippy/issues/10511#issuecomment-1474271205) and found that clippy hangs at [py_sync.rs#L85](https://github.com/rigetti/qcs-sdk-rust/blob/842094068ed6174ba08b52a2fbae39dda77cbd00/crates/python/src/py_sync.rs#L85), where a macro(`py_function_sync_async`) defines type parameters. this macro is used in the same crate, so `in_external_macro` wouldn't catch them.

This PR fixes the problem by using `Span#from_expansion`.

---

changelog: ICE: [`implicit_hasher`]: No longer lints inside macros, which could cause ICEs
[#11593](https://github.com/rust-lang/rust-clippy/pull/11593)
