### PR TITLE
Avoid invoking `ignored_unit_patterns` in macro definition

### DIFF
--- a/clippy_lints/src/ignored_unit_patterns.rs
+++ b/clippy_lints/src/ignored_unit_patterns.rs
@@ -37,6 +37,10 @@ declare_lint_pass!(IgnoredUnitPatterns => [IGNORED_UNIT_PATTERNS]);
 
 impl<'tcx> LateLintPass<'tcx> for IgnoredUnitPatterns {
     fn check_pat(&mut self, cx: &LateContext<'tcx>, pat: &'tcx hir::Pat<'tcx>) {
+        if pat.span.from_expansion() {
+            return;
+        }
+
         match cx.tcx.hir().get_parent(pat.hir_id) {
             Node::Param(param) if matches!(cx.tcx.hir().get_parent(param.hir_id), Node::Item(_)) => {
                 // Ignore function parameters

--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -153,3 +153,19 @@ pub fn shadow_derive(_: TokenStream) -> TokenStream {
         .into(),
     ])
 }
+
+#[proc_macro_derive(StructIgnoredUnitPattern)]
+pub fn derive_ignored_unit_pattern(_: TokenStream) -> TokenStream {
+    quote! {
+        struct A;
+        impl A {
+            fn a(&self) -> Result<(), ()> {
+                unimplemented!()
+            }
+
+            pub fn b(&self) {
+                let _ = self.a().unwrap();
+            }
+        }
+    }
+}

--- a/tests/ui/ignored_unit_patterns.fixed
+++ b/tests/ui/ignored_unit_patterns.fixed
@@ -1,3 +1,4 @@
+//@aux-build:proc_macro_derive.rs
 #![warn(clippy::ignored_unit_patterns)]
 #![allow(clippy::let_unit_value, clippy::redundant_pattern_matching, clippy::single_match)]
 
@@ -14,7 +15,21 @@ fn main() {
     //~^ ERROR: matching over `()` is more explicit
     let _ = foo().map_err(|()| todo!());
     //~^ ERROR: matching over `()` is more explicit
+
+    println!(
+        "{:?}",
+        match foo() {
+            Ok(()) => {},
+            //~^ ERROR: matching over `()` is more explicit
+            Err(()) => {},
+            //~^ ERROR: matching over `()` is more explicit
+        }
+    );
 }
+
+// ignored_unit_patterns in derive macro should be ok
+#[derive(proc_macro_derive::StructIgnoredUnitPattern)]
+pub struct B;
 
 #[allow(unused)]
 pub fn moo(_: ()) {

--- a/tests/ui/ignored_unit_patterns.rs
+++ b/tests/ui/ignored_unit_patterns.rs
@@ -1,3 +1,4 @@
+//@aux-build:proc_macro_derive.rs
 #![warn(clippy::ignored_unit_patterns)]
 #![allow(clippy::let_unit_value, clippy::redundant_pattern_matching, clippy::single_match)]
 
@@ -14,7 +15,21 @@ fn main() {
     //~^ ERROR: matching over `()` is more explicit
     let _ = foo().map_err(|_| todo!());
     //~^ ERROR: matching over `()` is more explicit
+
+    println!(
+        "{:?}",
+        match foo() {
+            Ok(_) => {},
+            //~^ ERROR: matching over `()` is more explicit
+            Err(_) => {},
+            //~^ ERROR: matching over `()` is more explicit
+        }
+    );
 }
+
+// ignored_unit_patterns in derive macro should be ok
+#[derive(proc_macro_derive::StructIgnoredUnitPattern)]
+pub struct B;
 
 #[allow(unused)]
 pub fn moo(_: ()) {

--- a/tests/ui/ignored_unit_patterns.stderr
+++ b/tests/ui/ignored_unit_patterns.stderr
@@ -1,5 +1,5 @@
 error: matching over `()` is more explicit
-  --> $DIR/ignored_unit_patterns.rs:10:12
+  --> $DIR/ignored_unit_patterns.rs:11:12
    |
 LL |         Ok(_) => {},
    |            ^ help: use `()` instead of `_`: `()`
@@ -8,28 +8,40 @@ LL |         Ok(_) => {},
    = help: to override `-D warnings` add `#[allow(clippy::ignored_unit_patterns)]`
 
 error: matching over `()` is more explicit
-  --> $DIR/ignored_unit_patterns.rs:11:13
+  --> $DIR/ignored_unit_patterns.rs:12:13
    |
 LL |         Err(_) => {},
    |             ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> $DIR/ignored_unit_patterns.rs:13:15
+  --> $DIR/ignored_unit_patterns.rs:14:15
    |
 LL |     if let Ok(_) = foo() {}
    |               ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> $DIR/ignored_unit_patterns.rs:15:28
+  --> $DIR/ignored_unit_patterns.rs:16:28
    |
 LL |     let _ = foo().map_err(|_| todo!());
    |                            ^ help: use `()` instead of `_`: `()`
 
 error: matching over `()` is more explicit
-  --> $DIR/ignored_unit_patterns.rs:21:9
+  --> $DIR/ignored_unit_patterns.rs:22:16
+   |
+LL |             Ok(_) => {},
+   |                ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> $DIR/ignored_unit_patterns.rs:24:17
+   |
+LL |             Err(_) => {},
+   |                 ^ help: use `()` instead of `_`: `()`
+
+error: matching over `()` is more explicit
+  --> $DIR/ignored_unit_patterns.rs:36:9
    |
 LL |     let _ = foo().unwrap();
    |         ^ help: use `()` instead of `_`: `()`
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/11601

The reported problem occured in [a derive macro](https://github.com/mpalmer/ct-structs/actions/runs/6386980382/job/17334587328#step:6:239). This PR avoid linting in macros.

changelog: [`ignored_unit_patterns`] No longer lints inside macro definitions
