### PR TITLE
Fix: avoid changing drop order

### DIFF
--- a/tests/ui/redundant_locals.rs
+++ b/tests/ui/redundant_locals.rs
@@ -124,14 +124,34 @@ impl Drop for WithDrop {
     fn drop(&mut self) {}
 }
 
+struct InnerDrop(WithDrop);
+
+struct ComposeDrop {
+    d: WithDrop,
+}
+
 struct WithoutDrop(usize);
 
 fn drop_trait() {
     let a = WithDrop(1);
     let b = WithDrop(2);
     let a = a;
+}
 
-    let c = WithoutDrop(1);
-    let d = WithoutDrop(2);
-    let c = c;
+fn without_drop() {
+    let a = WithoutDrop(1);
+    let b = WithoutDrop(2);
+    let a = a;
+}
+
+fn drop_inner() {
+    let a = InnerDrop(WithDrop(1));
+    let b = InnerDrop(WithDrop(2));
+    let a = a;
+}
+
+fn drop_compose() {
+    let a = ComposeDrop { d: WithDrop(1) };
+    let b = ComposeDrop { d: WithDrop(1) };
+    let a = a;
 }

--- a/tests/ui/redundant_locals.rs
+++ b/tests/ui/redundant_locals.rs
@@ -118,3 +118,20 @@ fn macros() {
         let x = x;
     }
 }
+
+struct WithDrop(usize);
+impl Drop for WithDrop {
+    fn drop(&mut self) {}
+}
+
+struct WithoutDrop(usize);
+
+fn drop_trait() {
+    let a = WithDrop(1);
+    let b = WithDrop(2);
+    let a = a;
+
+    let c = WithoutDrop(1);
+    let d = WithoutDrop(2);
+    let c = c;
+}

--- a/tests/ui/redundant_locals.stderr
+++ b/tests/ui/redundant_locals.stderr
@@ -133,5 +133,16 @@ LL |         let x = x;
    |
    = help: remove the redefinition of `x`
 
-error: aborting due to 13 previous errors
+error: redundant redefinition of a binding
+  --> $DIR/redundant_locals.rs:134:9
+   |
+LL |     let c = WithoutDrop(1);
+   |         ^
+LL |     let d = WithoutDrop(2);
+LL |     let c = c;
+   |     ^^^^^^^^^^
+   |
+   = help: remove the redefinition of `c`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/redundant_locals.stderr
+++ b/tests/ui/redundant_locals.stderr
@@ -134,15 +134,15 @@ LL |         let x = x;
    = help: remove the redefinition of `x`
 
 error: redundant redefinition of a binding
-  --> $DIR/redundant_locals.rs:134:9
+  --> $DIR/redundant_locals.rs:142:9
    |
-LL |     let c = WithoutDrop(1);
+LL |     let a = WithoutDrop(1);
    |         ^
-LL |     let d = WithoutDrop(2);
-LL |     let c = c;
+LL |     let b = WithoutDrop(2);
+LL |     let a = a;
    |     ^^^^^^^^^^
    |
-   = help: remove the redefinition of `c`
+   = help: remove the redefinition of `a`
 
 error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/11599

changelog: [`redundant_locals`] No longer lints which implements Drop trait to avoid reordering
