### PR TITLE
Fix `items_after_test_module` for non root modules, add applicable suggestion

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -80,7 +80,6 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 use if_chain::if_chain;
 use itertools::Itertools;
 use rustc_ast::ast::{self, LitKind, RangeLimits};
-use rustc_ast::Attribute;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::unhash::UnhashMap;
 use rustc_hir::def::{DefKind, Res};
@@ -2452,11 +2451,12 @@ pub fn is_in_test_function(tcx: TyCtxt<'_>, id: hir::HirId) -> bool {
     })
 }
 
-/// Checks if the item containing the given `HirId` has `#[cfg(test)]` attribute applied
+/// Checks if `id` has a `#[cfg(test)]` attribute applied
 ///
-/// Note: Add `//@compile-flags: --test` to UI tests with a `#[cfg(test)]` function
-pub fn is_in_cfg_test(tcx: TyCtxt<'_>, id: hir::HirId) -> bool {
-    fn is_cfg_test(attr: &Attribute) -> bool {
+/// This only checks directly applied attributes, to see if a node is inside a `#[cfg(test)]` parent
+/// use [`is_in_cfg_test`]
+pub fn is_cfg_test(tcx: TyCtxt<'_>, id: hir::HirId) -> bool {
+    tcx.hir().attrs(id).iter().any(|attr| {
         if attr.has_name(sym::cfg)
             && let Some(items) = attr.meta_item_list()
             && let [item] = &*items
@@ -2466,11 +2466,14 @@ pub fn is_in_cfg_test(tcx: TyCtxt<'_>, id: hir::HirId) -> bool {
         } else {
             false
         }
-    }
+    })
+}
+
+/// Checks if any parent node of `HirId` has `#[cfg(test)]` attribute applied
+pub fn is_in_cfg_test(tcx: TyCtxt<'_>, id: hir::HirId) -> bool {
     tcx.hir()
-        .parent_iter(id)
-        .flat_map(|(parent_id, _)| tcx.hir().attrs(parent_id))
-        .any(is_cfg_test)
+        .parent_id_iter(id)
+        .any(|parent_id| is_cfg_test(tcx, parent_id))
 }
 
 /// Checks if the item of any of its parents has `#[cfg(...)]` attribute applied.

--- a/tests/ui/items_after_test_module/after_proc_macros.rs
+++ b/tests/ui/items_after_test_module/after_proc_macros.rs
@@ -1,0 +1,11 @@
+//@aux-build:../auxiliary/proc_macros.rs
+extern crate proc_macros;
+
+proc_macros::with_span! {
+    span
+    #[cfg(test)]
+    mod tests {}
+}
+
+#[test]
+fn f() {}

--- a/tests/ui/items_after_test_module/auxiliary/submodule.rs
+++ b/tests/ui/items_after_test_module/auxiliary/submodule.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+mod tests {}
+
+fn in_submodule() {}

--- a/tests/ui/items_after_test_module/block_module.stderr
+++ b/tests/ui/items_after_test_module/block_module.stderr
@@ -1,2 +1,0 @@
-error: Option 'test' given more than once
-

--- a/tests/ui/items_after_test_module/in_submodule.rs
+++ b/tests/ui/items_after_test_module/in_submodule.rs
@@ -1,0 +1,8 @@
+#[path = "auxiliary/submodule.rs"]
+mod submodule;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn t() {}
+}

--- a/tests/ui/items_after_test_module/in_submodule.stderr
+++ b/tests/ui/items_after_test_module/in_submodule.stderr
@@ -1,0 +1,14 @@
+error: items after a test module
+  --> $DIR/auxiliary/submodule.rs:2:1
+   |
+LL | mod tests {}
+   | ^^^^^^^^^
+LL |
+LL | fn in_submodule() {}
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::items-after-test-module` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::items_after_test_module)]`
+
+error: aborting due to previous error
+

--- a/tests/ui/items_after_test_module/multiple_modules.rs
+++ b/tests/ui/items_after_test_module/multiple_modules.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn f() {}
+}
+
+#[cfg(test)]
+mod more_tests {
+    #[test]
+    fn g() {}
+}

--- a/tests/ui/items_after_test_module/root_module.fixed
+++ b/tests/ui/items_after_test_module/root_module.fixed
@@ -1,0 +1,22 @@
+#![allow(unused)]
+#![warn(clippy::items_after_test_module)]
+
+fn main() {}
+
+fn should_not_lint() {}
+
+fn should_lint() {}
+
+const SHOULD_ALSO_LINT: usize = 1;
+macro_rules! should_lint {
+    () => {};
+}
+
+#[allow(dead_code)]
+#[allow(unused)] // Some attributes to check that span replacement is good enough
+#[allow(clippy::allow_attributes)]
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn hi() {}
+}

--- a/tests/ui/items_after_test_module/root_module.rs
+++ b/tests/ui/items_after_test_module/root_module.rs
@@ -1,4 +1,3 @@
-//@compile-flags: --test
 #![allow(unused)]
 #![warn(clippy::items_after_test_module)]
 
@@ -18,6 +17,6 @@ mod tests {
 fn should_lint() {}
 
 const SHOULD_ALSO_LINT: usize = 1;
-macro_rules! should_not_lint {
+macro_rules! should_lint {
     () => {};
 }

--- a/tests/ui/items_after_test_module/root_module.stderr
+++ b/tests/ui/items_after_test_module/root_module.stderr
@@ -1,0 +1,20 @@
+error: items after a test module
+  --> $DIR/root_module.rs:12:1
+   |
+LL | mod tests {
+   | ^^^^^^^^^
+...
+LL | fn should_lint() {}
+   | ^^^^^^^^^^^^^^^^
+LL |
+LL | const SHOULD_ALSO_LINT: usize = 1;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | macro_rules! should_lint {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::items-after-test-module` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::items_after_test_module)]`
+   = help: move the items to before the test module was defined
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #11050
Fixes #11153

changelog: [`items_after_test_module`]: Now suggests a machine-applicable suggestion.
changelog: [`items:after_test_module`]: Also lints for non root modules
