### PR TITLE
Add regression test for #11610 about mutable usage of argument in async function for the `needless_pass_by_ref_mut` lint

### DIFF
--- a/tests/ui/needless_pass_by_ref_mut.rs
+++ b/tests/ui/needless_pass_by_ref_mut.rs
@@ -270,6 +270,12 @@ pub async fn closure4(n: &mut usize) {
     })();
 }
 
+// Should not warn.
+async fn _f(v: &mut Vec<()>) {
+    let x = || v.pop();
+    _ = || || x;
+}
+
 fn main() {
     let mut u = 0;
     let mut v = vec![0];


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/11610.

This was already fixed. I simply added a regression test.

changelog: Add regression test for #11610 about mutable usage of argument in async function for the `needless_pass_by_ref_mut` lint