### PR TITLE
Fix ice in `redundant_locals`

### DIFF
--- a/clippy_lints/src/redundant_locals.rs
+++ b/clippy_lints/src/redundant_locals.rs
@@ -62,7 +62,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantLocals {
             if let Res::Local(binding_id) = cx.qpath_res(&qpath, expr.hir_id);
             if let Node::Pat(binding_pat) = cx.tcx.hir().get(binding_id);
             // the previous binding has the same mutability
-            if find_binding(binding_pat, ident).unwrap().1 == mutability;
+            if find_binding(binding_pat, ident).is_some_and(|bind| bind.1 == mutability);
             // the local does not change the effect of assignments to the binding. see #11290
             if !affects_assignments(cx, mutability, binding_id, local.hir_id);
             // the local does not affect the code's drop behavior

--- a/tests/ui/redundant_locals.rs
+++ b/tests/ui/redundant_locals.rs
@@ -117,6 +117,14 @@ fn macros() {
         let x = 1;
         let x = x;
     }
+
+    let x = 10;
+    macro_rules! rebind_outer_macro {
+        ($x:ident) => {
+            let x = x;
+        };
+    }
+    rebind_outer_macro!(y);
 }
 
 struct WithDrop(usize);

--- a/tests/ui/redundant_locals.stderr
+++ b/tests/ui/redundant_locals.stderr
@@ -157,13 +157,13 @@ LL |     let x = 1;
    |         ^
 
 error: redundant redefinition of a binding `a`
-  --> $DIR/redundant_locals.rs:144:5
+  --> $DIR/redundant_locals.rs:152:5
    |
 LL |     let a = a;
    |     ^^^^^^^^^^
    |
 help: `a` is initially defined here
-  --> $DIR/redundant_locals.rs:142:9
+  --> $DIR/redundant_locals.rs:150:9
    |
 LL |     let a = WithoutDrop(1);
    |         ^


### PR DESCRIPTION
Fixes #11619 

Rebinding over macro like the code below, idents will be different (`x#4` and `x#0` in that case).

```rust
fn reassign_in_macro() {
  let x = 10;
  macro_rules! mac {
    ($i:ident) => {
      let mut x = x;
    }
  }
  mac!(y);
}
```

It causes unwrapping `None`. 

https://github.com/rust-lang/rust-clippy/blob/9554e477c29e6ddca9e5cdce71524341ef9d48e8/clippy_lints/src/redundant_locals.rs#L88-L98

changelog: ICE: [`redundant_locals`]: No longer lints rebinding over macro
