### PR TITLE
Improve `redundant_locals` help message

### DIFF
--- a/clippy_lints/src/redundant_locals.rs
+++ b/clippy_lints/src/redundant_locals.rs
@@ -74,10 +74,10 @@ impl<'tcx> LateLintPass<'tcx> for RedundantLocals {
                 span_lint_and_help(
                     cx,
                     REDUNDANT_LOCALS,
-                    vec![binding_pat.span, local.span],
-                    "redundant redefinition of a binding",
-                    None,
-                    &format!("remove the redefinition of `{ident}`"),
+                    local.span,
+                    &format!("redundant redefinition of a binding `{ident}`"),
+                    Some(binding_pat.span),
+                    &format!("`{ident}` is initially defined here"),
                 );
             }
         }

--- a/tests/ui/redundant_locals.stderr
+++ b/tests/ui/redundant_locals.stderr
@@ -1,148 +1,172 @@
-error: redundant redefinition of a binding
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:12:5
+   |
+LL |     let x = x;
+   |     ^^^^^^^^^^
+   |
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:11:9
    |
 LL |     let x = 1;
    |         ^
-LL |     let x = x;
-   |     ^^^^^^^^^^
-   |
-   = help: remove the redefinition of `x`
    = note: `-D clippy::redundant-locals` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::redundant_locals)]`
 
-error: redundant redefinition of a binding
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:17:5
+   |
+LL |     let mut x = x;
+   |     ^^^^^^^^^^^^^^
+   |
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:16:9
    |
 LL |     let mut x = 1;
    |         ^^^^^
-LL |     let mut x = x;
-   |     ^^^^^^^^^^^^^^
-   |
-   = help: remove the redefinition of `x`
 
-error: redundant redefinition of a binding
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:47:5
+   |
+LL |     let x = x;
+   |     ^^^^^^^^^^
+   |
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:46:14
    |
 LL | fn parameter(x: i32) {
    |              ^
+
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:52:5
+   |
 LL |     let x = x;
    |     ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:51:9
    |
 LL |     let x = 1;
    |         ^
+
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:53:5
+   |
 LL |     let x = x;
    |     ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:52:9
    |
 LL |     let x = x;
    |         ^
+
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:54:5
+   |
 LL |     let x = x;
    |     ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:53:9
    |
 LL |     let x = x;
    |         ^
+
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:55:5
+   |
 LL |     let x = x;
    |     ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:54:9
    |
 LL |     let x = x;
    |         ^
-LL |     let x = x;
+
+error: redundant redefinition of a binding `a`
+  --> $DIR/redundant_locals.rs:61:5
+   |
+LL |     let a = a;
    |     ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `a` is initially defined here
   --> $DIR/redundant_locals.rs:59:9
    |
 LL |     let a = 1;
    |         ^
-LL |     let b = 2;
-LL |     let a = a;
+
+error: redundant redefinition of a binding `b`
+  --> $DIR/redundant_locals.rs:62:5
+   |
+LL |     let b = b;
    |     ^^^^^^^^^^
    |
-   = help: remove the redefinition of `a`
-
-error: redundant redefinition of a binding
+help: `b` is initially defined here
   --> $DIR/redundant_locals.rs:60:9
    |
 LL |     let b = 2;
    |         ^
-LL |     let a = a;
-LL |     let b = b;
-   |     ^^^^^^^^^^
-   |
-   = help: remove the redefinition of `b`
 
-error: redundant redefinition of a binding
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:68:9
+   |
+LL |         let x = x;
+   |         ^^^^^^^^^^
+   |
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:67:13
    |
 LL |         let x = 1;
    |             ^
+
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:75:9
+   |
 LL |         let x = x;
    |         ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:74:13
    |
 LL |         let x = 1;
    |             ^
+
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:78:9
+   |
 LL |         let x = x;
    |         ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:77:6
    |
 LL |     |x: i32| {
    |      ^
+
+error: redundant redefinition of a binding `x`
+  --> $DIR/redundant_locals.rs:97:9
+   |
 LL |         let x = x;
    |         ^^^^^^^^^^
    |
-   = help: remove the redefinition of `x`
-
-error: redundant redefinition of a binding
+help: `x` is initially defined here
   --> $DIR/redundant_locals.rs:94:9
    |
 LL |     let x = 1;
    |         ^
-...
-LL |         let x = x;
-   |         ^^^^^^^^^^
-   |
-   = help: remove the redefinition of `x`
 
-error: redundant redefinition of a binding
+error: redundant redefinition of a binding `a`
+  --> $DIR/redundant_locals.rs:144:5
+   |
+LL |     let a = a;
+   |     ^^^^^^^^^^
+   |
+help: `a` is initially defined here
   --> $DIR/redundant_locals.rs:142:9
    |
 LL |     let a = WithoutDrop(1);
    |         ^
-LL |     let b = WithoutDrop(2);
-LL |     let a = a;
-   |     ^^^^^^^^^^
-   |
-   = help: remove the redefinition of `a`
 
 error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Fixes #11625

AFAIK, `span_lint_and_help` points the beginning of spans when we pass multiple spans to the second argument, so This PR I also modified its help span and its message.

lint result of the given example in the issue will be:

```console
error: redundant redefinition of a binding `apple`
 --> src/main.rs:5:5
  |
5 |     let apple = apple;
  |     ^^^^^^^^^^^^^^^^^^
  |
help: `apple` is initially defined here
 --> src/main.rs:4:9
  |
4 |     let apple = 42;
  |         ^^^^^
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_locals
```

I hope that this change might help reduce user confusion, but I'd appreciate alternative suggestions:)

changelog: [`redundant_locals`]: Now points at the rebinding of the variable
