### PR TITLE
WIP: empty_doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4985,6 +4985,7 @@ Released 2018-09-13
 [`duplicate_underscore_argument`]: https://rust-lang.github.io/rust-clippy/master/index.html#duplicate_underscore_argument
 [`duration_subsec`]: https://rust-lang.github.io/rust-clippy/master/index.html#duration_subsec
 [`else_if_without_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#else_if_without_else
+[`empty_docs`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_docs
 [`empty_drop`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_drop
 [`empty_enum`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_enum
 [`empty_line_after_doc_comments`]: https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -146,6 +146,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::drop_forget_ref::MEM_FORGET_INFO,
     crate::duplicate_mod::DUPLICATE_MOD_INFO,
     crate::else_if_without_else::ELSE_IF_WITHOUT_ELSE_INFO,
+    crate::empty_docs::EMPTY_DOCS_INFO,
     crate::empty_drop::EMPTY_DROP_INFO,
     crate::empty_enum::EMPTY_ENUM_INFO,
     crate::empty_structs_with_brackets::EMPTY_STRUCTS_WITH_BRACKETS_INFO,

--- a/clippy_lints/src/empty_docs.rs
+++ b/clippy_lints/src/empty_docs.rs
@@ -41,20 +41,17 @@ fn trim_comment(comment: &str) -> String {
 
 impl EarlyLintPass for EmptyDocs {
     fn check_attribute(&mut self, cx: &EarlyContext<'_>, attribute: &Attribute) {
-        match attribute.kind {
-            AttrKind::DocComment(_line, comment) => {
-                if trim_comment(comment.as_str()).len() == 0 {
-                    span_lint_and_help(
-                        cx,
-                        EMPTY_DOCS,
-                        attribute.span,
-                        "empty doc comment",
-                        None,
-                        "consider removing or fill it",
-                    );
-                }
-            },
-            _ => {},
+        if let AttrKind::DocComment(_line, comment) = attribute.kind {
+            if trim_comment(comment.as_str()).len() == 0 {
+                span_lint_and_help(
+                    cx,
+                    EMPTY_DOCS,
+                    attribute.span,
+                    "empty doc comment",
+                    None,
+                    "consider removing or fill it",
+                );
+            }
         }
     }
 }

--- a/clippy_lints/src/empty_docs.rs
+++ b/clippy_lints/src/empty_docs.rs
@@ -1,0 +1,61 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_ast::ast::*;
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Detects documentation that is empty.
+
+    /// ### Why is this bad?
+    /// It is unlikely there is any reason to have empty documentation for an entity
+    ///
+    /// ### Example
+    /// ```rust
+    /// ///
+    /// fn returns_true() {
+    ///     true
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// fn returns_true() {
+    ///     true
+    /// }
+    /// ```
+    #[clippy::version = "1.74.0"]
+    pub EMPTY_DOCS,
+    suspicious,
+    "docstrings exist but documentation is empty"
+}
+
+declare_lint_pass!(EmptyDocs => [EMPTY_DOCS]);
+
+fn trim_comment(comment: &str) -> String {
+    comment
+        .trim()
+        .split("\n")
+        .map(|comment| comment.trim().trim_matches('*').trim_matches('!'))
+        .collect::<Vec<&str>>()
+        .join("")
+}
+
+impl EarlyLintPass for EmptyDocs {
+    fn check_attribute(&mut self, cx: &EarlyContext<'_>, attribute: &Attribute) {
+        match attribute.kind {
+            AttrKind::DocComment(_line, comment) => {
+                if trim_comment(comment.as_str()).len() == 0 {
+                    span_lint_and_help(
+                        cx,
+                        EMPTY_DOCS,
+                        attribute.span,
+                        "empty doc comment",
+                        None,
+                        "consider removing or fill it",
+                    );
+                }
+            },
+            _ => {},
+        }
+    }
+}

--- a/clippy_lints/src/empty_docs.rs
+++ b/clippy_lints/src/empty_docs.rs
@@ -6,7 +6,6 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 declare_clippy_lint! {
     /// ### What it does
     /// Detects documentation that is empty.
-
     /// ### Why is this bad?
     /// It is unlikely there is any reason to have empty documentation for an entity
     ///

--- a/clippy_lints/src/empty_docs.rs
+++ b/clippy_lints/src/empty_docs.rs
@@ -7,7 +7,7 @@ declare_clippy_lint! {
     /// ### What it does
     /// Detects documentation that is empty.
     /// ### Why is this bad?
-    /// It is unlikely there is any reason to have empty documentation for an entity
+    /// It is unlikely that there is any reason to have empty documentation for an item
     ///
     /// ### Example
     /// ```rust

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -115,6 +115,7 @@ mod double_parens;
 mod drop_forget_ref;
 mod duplicate_mod;
 mod else_if_without_else;
+mod empty_docs;
 mod empty_drop;
 mod empty_enum;
 mod empty_structs_with_brackets;
@@ -1123,6 +1124,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     });
     store.register_late_pass(move |_| Box::new(manual_hash_one::ManualHashOne::new(msrv())));
     store.register_late_pass(|_| Box::new(iter_without_into_iter::IterWithoutIntoIter));
+    store.register_early_pass(|| Box::new(empty_docs::EmptyDocs));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/tests/ui/empty_docs.rs
+++ b/tests/ui/empty_docs.rs
@@ -1,0 +1,27 @@
+#![allow(unused)]
+#![warn(clippy::empty_docs)]
+
+pub mod outer_module {
+
+    //!
+
+    //! valid doc comment
+
+    //!!
+
+    //!! valid doc comment
+
+    ///
+
+    /// valid doc comment
+
+    /**
+     *
+     */
+
+    /**
+     * valid block doc comment
+     */
+
+    pub mod inner_module {}
+}

--- a/tests/ui/empty_docs.rs
+++ b/tests/ui/empty_docs.rs
@@ -4,16 +4,14 @@
 pub mod outer_module {
 
     //!
-
     //! valid doc comment
-
     //!!
-
     //!! valid doc comment
 
     ///
-
     /// valid doc comment
+    ///
+    /// valid block doc comment
 
     /**
      *
@@ -21,6 +19,7 @@ pub mod outer_module {
 
     /**
      * valid block doc comment
+     *
      */
 
     pub mod inner_module {}

--- a/tests/ui/empty_docs.stderr
+++ b/tests/ui/empty_docs.stderr
@@ -1,0 +1,38 @@
+error: empty doc comment
+  --> $DIR/empty_docs.rs:14:5
+   |
+LL |     ///
+   |     ^^^
+   |
+   = help: consider removing it or fill it in
+   = note: `-D clippy::empty-docs` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::empty_docs)]`
+
+error: empty doc comment
+  --> $DIR/empty_docs.rs:18:5
+   |
+LL | /     /**
+LL | |      *
+LL | |      */
+   | |_______^
+   |
+   = help: consider removing it or fill it in
+
+error: empty doc comment
+  --> $DIR/empty_docs.rs:6:5
+   |
+LL |     //!
+   |     ^^^
+   |
+   = help: consider removing it or fill it in
+
+error: empty doc comment
+  --> $DIR/empty_docs.rs:10:5
+   |
+LL |     //!!
+   |     ^^^^
+   |
+   = help: consider removing it or fill it in
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/empty_docs.stderr
+++ b/tests/ui/empty_docs.stderr
@@ -4,7 +4,7 @@ error: empty doc comment
 LL |     ///
    |     ^^^
    |
-   = help: consider removing it or fill it in
+   = help: consider removing or fill it
    = note: `-D clippy::empty-docs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::empty_docs)]`
 
@@ -16,7 +16,7 @@ LL | |      *
 LL | |      */
    | |_______^
    |
-   = help: consider removing it or fill it in
+   = help: consider removing or fill it
 
 error: empty doc comment
   --> $DIR/empty_docs.rs:6:5
@@ -24,7 +24,7 @@ error: empty doc comment
 LL |     //!
    |     ^^^
    |
-   = help: consider removing it or fill it in
+   = help: consider removing or fill it
 
 error: empty doc comment
   --> $DIR/empty_docs.rs:10:5
@@ -32,7 +32,7 @@ error: empty doc comment
 LL |     //!!
    |     ^^^^
    |
-   = help: consider removing it or fill it in
+   = help: consider removing or fill it
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/empty_docs.stderr
+++ b/tests/ui/empty_docs.stderr
@@ -1,5 +1,5 @@
 error: empty doc comment
-  --> $DIR/empty_docs.rs:14:5
+  --> $DIR/empty_docs.rs:11:5
    |
 LL |     ///
    |     ^^^
@@ -9,7 +9,15 @@ LL |     ///
    = help: to override `-D warnings` add `#[allow(clippy::empty_docs)]`
 
 error: empty doc comment
-  --> $DIR/empty_docs.rs:18:5
+  --> $DIR/empty_docs.rs:13:5
+   |
+LL |     ///
+   |     ^^^
+   |
+   = help: consider removing or fill it
+
+error: empty doc comment
+  --> $DIR/empty_docs.rs:16:5
    |
 LL | /     /**
 LL | |      *
@@ -27,12 +35,12 @@ LL |     //!
    = help: consider removing or fill it
 
 error: empty doc comment
-  --> $DIR/empty_docs.rs:10:5
+  --> $DIR/empty_docs.rs:8:5
    |
 LL |     //!!
    |     ^^^^
    |
    = help: consider removing or fill it
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes #9931 
```
changelog: [`empty_doc`]: Detects documentation that is empty.
```