### PR TITLE
`unusable_matches_binding` lint implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5558,6 +5558,7 @@ Released 2018-09-13
 [`unsound_collection_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#unsound_collection_transmute
 [`unstable_as_mut_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#unstable_as_mut_slice
 [`unstable_as_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#unstable_as_slice
+[`unusable_matches_binding`]: https://rust-lang.github.io/rust-clippy/master/index.html#unusable_matches_binding
 [`unused_async`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_async
 [`unused_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_collect
 [`unused_format_specs`]: https://rust-lang.github.io/rust-clippy/master/index.html#unused_format_specs

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -321,6 +321,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::matches::SINGLE_MATCH_INFO,
     crate::matches::SINGLE_MATCH_ELSE_INFO,
     crate::matches::TRY_ERR_INFO,
+    crate::matches::UNUSABLE_MATCHES_BINDING_INFO,
     crate::matches::WILDCARD_ENUM_MATCH_ARM_INFO,
     crate::matches::WILDCARD_IN_OR_PATTERNS_INFO,
     crate::mem_replace::MEM_REPLACE_OPTION_WITH_NONE_INFO,

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -974,7 +974,8 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     /// It could be hard to determine why the compiler complains about an unused variable,
-    /// also it could introduce behavior that was not intened by the programmer.
+    /// which was introduced by the `matches!` macro expansion, also, it could introduce
+    /// behavior that was not intended by the programmer.
     ///
     /// ### Example
     /// ```rust
@@ -1055,7 +1056,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
         if let ExprKind::Match(ex, arms, source) = expr.kind {
             if is_direct_expn_of(expr.span, "matches").is_some() {
                 redundant_pattern_match::check_match(cx, expr, ex, arms);
-                unusable_matches_binding::check_matches(cx, ex, arms, expr);
+                unusable_matches_binding::check_matches(cx, arms);
             }
 
             if source == MatchSource::Normal && !is_span_match(cx, expr.span) {

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -997,7 +997,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.75.0"]
     pub UNUSABLE_MATCHES_BINDING,
     correctness,
-    "default lint description"
+    "checks for unused bindings in `matches!` macro"
 }
 
 pub struct Matches {

--- a/clippy_lints/src/matches/unusable_matches_binding.rs
+++ b/clippy_lints/src/matches/unusable_matches_binding.rs
@@ -1,0 +1,61 @@
+use clippy_utils::diagnostics::span_lint_and_note;
+use clippy_utils::source::snippet_block;
+use clippy_utils::visitors::is_local_used;
+use rustc_hir::{Arm, Expr, PatKind};
+use rustc_lint::LateContext;
+
+use super::UNUSABLE_MATCHES_BINDING;
+
+pub(crate) fn check_matches<'tcx>(cx: &LateContext<'tcx>, ex: &Expr<'tcx>, arms: &'tcx [Arm<'tcx>], expr: &Expr<'tcx>) {
+    for arm in arms {
+        if let PatKind::Binding(_, id, ident, None) = arm.pat.kind {
+            let is_used_in_guard = arm.guard.is_some_and(|guard| is_local_used(cx, guard.body(), id));
+
+            if !is_local_used(cx, arm.body, id) {
+                if let Some(guard) = arm.guard {
+                    if is_used_in_guard {
+                        let first_matches_argument = snippet_block(cx, ex.span, "..", None);
+                        span_lint_and_note(
+                            cx,
+                            UNUSABLE_MATCHES_BINDING,
+                            arm.pat.span,
+                            &format!(
+                                "using identificator (`{}`) as matches! pattern argument matches all cases",
+                                ident.name
+                            ),
+                            Some(expr.span),
+                            &format!(
+                                "matches! invocation always evaluates to guard where `{}` was replaced by `{}`",
+                                ident.name, first_matches_argument
+                            ),
+                        );
+                    } else {
+                        span_lint_and_note(
+                            cx,
+                            UNUSABLE_MATCHES_BINDING,
+                            arm.pat.span,
+                            &format!(
+                                "using identificator (`{}`) as matches! pattern argument without usage in guard has the same effect as evaluating guard",
+                                ident.name
+                            ),
+                            Some(guard.body().span),
+                            "try replacing matches! expression with the content of the guard's body",
+                        );
+                    }
+                } else {
+                    span_lint_and_note(
+                        cx,
+                        UNUSABLE_MATCHES_BINDING,
+                        arm.pat.span,
+                        &format!(
+                            "using identificator (`{}`) as matches! pattern argument without guard matches all cases",
+                            ident.name
+                        ),
+                        Some(expr.span),
+                        "matches! invocation always evaluates to `true`",
+                    );
+                }
+            }
+        }
+    }
+}

--- a/tests/ui/unusable_matches_binding.rs
+++ b/tests/ui/unusable_matches_binding.rs
@@ -1,0 +1,22 @@
+#![warn(clippy::unusable_matches_binding)]
+
+#[derive(Clone, Copy)]
+struct TestingStructure(i32);
+
+impl TestingStructure {
+    fn is_valid(&self) -> bool {
+        self.0 > 5
+    }
+}
+
+fn main() {
+    let matching_data_source = TestingStructure(5);
+    let unrelated_data = 5;
+
+    let _ = matches!(matching_data_source, TestingStructure(4));
+
+    let _ = matches!(matching_data_source, unusable_binding);
+    let _ = matches!(matching_data_source, used_binding if used_binding.is_valid());
+
+    let _ = matches!(matching_data_source, unusable_binding if unrelated_data < 4);
+}

--- a/tests/ui/unusable_matches_binding.stderr
+++ b/tests/ui/unusable_matches_binding.stderr
@@ -1,42 +1,29 @@
-error: using identificator (`unusable_binding`) as matches! pattern argument without guard matches all cases
+error: identifier pattern in `matches!` macro always evaluates to true
   --> $DIR/unusable_matches_binding.rs:18:44
    |
 LL |     let _ = matches!(matching_data_source, unusable_binding);
    |                                            ^^^^^^^^^^^^^^^^
    |
-note: matches! invocation always evaluates to `true`
-  --> $DIR/unusable_matches_binding.rs:18:13
-   |
-LL |     let _ = matches!(matching_data_source, unusable_binding);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: the identifier pattern matches any value and creates an unusable binding in the process
+   = help: if you meant to compare two values, use `x == y` or `discriminant(x) == discriminant(y)`
    = note: `-D clippy::unusable-matches-binding` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unusable_matches_binding)]`
-   = note: this error originates in the macro `matches` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: using identificator (`used_binding`) as matches! pattern argument matches all cases
-  --> $DIR/unusable_matches_binding.rs:19:44
+error: identifier pattern in `matches!` macro always evaluates to the value of the guard
+  --> $DIR/unusable_matches_binding.rs:19:60
    |
 LL |     let _ = matches!(matching_data_source, used_binding if used_binding.is_valid());
-   |                                            ^^^^^^^^^^^^
+   |                                                            ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: matches! invocation always evaluates to guard where `used_binding` was replaced by `matching_data_source`
-  --> $DIR/unusable_matches_binding.rs:19:13
-   |
-LL |     let _ = matches!(matching_data_source, used_binding if used_binding.is_valid());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `matches` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: if you meant to check predicate, then try changing `matches!` macro into predicate the guard's checking
 
-error: using identificator (`unusable_binding`) as matches! pattern argument without usage in guard has the same effect as evaluating guard
-  --> $DIR/unusable_matches_binding.rs:21:44
-   |
-LL |     let _ = matches!(matching_data_source, unusable_binding if unrelated_data < 4);
-   |                                            ^^^^^^^^^^^^^^^^
-   |
-note: try replacing matches! expression with the content of the guard's body
+error: identifier pattern in `matches!` macro always evaluates to the value of the guard
   --> $DIR/unusable_matches_binding.rs:21:64
    |
 LL |     let _ = matches!(matching_data_source, unusable_binding if unrelated_data < 4);
    |                                                                ^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you meant to check predicate, then try changing `matches!` macro into predicate the guard's checking
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/unusable_matches_binding.stderr
+++ b/tests/ui/unusable_matches_binding.stderr
@@ -1,0 +1,42 @@
+error: using identificator (`unusable_binding`) as matches! pattern argument without guard matches all cases
+  --> $DIR/unusable_matches_binding.rs:18:44
+   |
+LL |     let _ = matches!(matching_data_source, unusable_binding);
+   |                                            ^^^^^^^^^^^^^^^^
+   |
+note: matches! invocation always evaluates to `true`
+  --> $DIR/unusable_matches_binding.rs:18:13
+   |
+LL |     let _ = matches!(matching_data_source, unusable_binding);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `-D clippy::unusable-matches-binding` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unusable_matches_binding)]`
+   = note: this error originates in the macro `matches` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: using identificator (`used_binding`) as matches! pattern argument matches all cases
+  --> $DIR/unusable_matches_binding.rs:19:44
+   |
+LL |     let _ = matches!(matching_data_source, used_binding if used_binding.is_valid());
+   |                                            ^^^^^^^^^^^^
+   |
+note: matches! invocation always evaluates to guard where `used_binding` was replaced by `matching_data_source`
+  --> $DIR/unusable_matches_binding.rs:19:13
+   |
+LL |     let _ = matches!(matching_data_source, used_binding if used_binding.is_valid());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `matches` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: using identificator (`unusable_binding`) as matches! pattern argument without usage in guard has the same effect as evaluating guard
+  --> $DIR/unusable_matches_binding.rs:21:44
+   |
+LL |     let _ = matches!(matching_data_source, unusable_binding if unrelated_data < 4);
+   |                                            ^^^^^^^^^^^^^^^^
+   |
+note: try replacing matches! expression with the content of the guard's body
+  --> $DIR/unusable_matches_binding.rs:21:64
+   |
+LL |     let _ = matches!(matching_data_source, unusable_binding if unrelated_data < 4);
+   |                                                                ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Hey,
This PR contains new lint implementation along with UI tests.
Fixes #7351.

changelog: [`unusable_matches_binding`]: Lint implementation and UI test
