### PR TITLE
Now `declare_interior_mutable_const` and `borrow_interior_mutable_const` respect the `ignore-interior-mutability` configuration entry

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -807,7 +807,8 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
             suppress_restriction_lint_in_const,
         ))
     });
-    store.register_late_pass(|_| Box::new(non_copy_const::NonCopyConst));
+    let ignore_interior_mutability = conf.ignore_interior_mutability.clone();
+    store.register_late_pass(move |_| Box::new(non_copy_const::NonCopyConst::new(ignore_interior_mutability.clone())));
     store.register_late_pass(|_| Box::new(ptr_offset_with_cast::PtrOffsetWithCast));
     store.register_late_pass(|_| Box::new(redundant_clone::RedundantClone));
     store.register_late_pass(|_| Box::new(slow_vector_initialization::SlowVectorInit));

--- a/tests/ui-toml/borrow_interior_mutable_const/clippy.toml
+++ b/tests/ui-toml/borrow_interior_mutable_const/clippy.toml
@@ -1,0 +1,1 @@
+ignore-interior-mutability = ["borrow_interior_mutable_const_ignore::Counted"]

--- a/tests/ui-toml/borrow_interior_mutable_const/ignore.rs
+++ b/tests/ui-toml/borrow_interior_mutable_const/ignore.rs
@@ -1,0 +1,37 @@
+//@compile-flags: --crate-name borrow_interior_mutable_const_ignore
+
+#![warn(clippy::borrow_interior_mutable_const)]
+#![allow(clippy::declare_interior_mutable_const)]
+
+use core::cell::Cell;
+use std::cmp::{Eq, PartialEq};
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct Counted<T> {
+    count: AtomicUsize,
+    val: T,
+}
+
+impl<T> Counted<T> {
+    const fn new(val: T) -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+            val,
+        }
+    }
+}
+
+enum OptionalCell {
+    Unfrozen(Counted<bool>),
+    Frozen,
+}
+
+const UNFROZEN_VARIANT: OptionalCell = OptionalCell::Unfrozen(Counted::new(true));
+const FROZEN_VARIANT: OptionalCell = OptionalCell::Frozen;
+
+fn main() {
+    let _ = &UNFROZEN_VARIANT;
+}

--- a/tests/ui-toml/declare_interior_mutable_const/clippy.toml
+++ b/tests/ui-toml/declare_interior_mutable_const/clippy.toml
@@ -1,0 +1,1 @@
+ignore-interior-mutability = ["declare_interior_mutable_const_ignore::Counted"]

--- a/tests/ui-toml/declare_interior_mutable_const/ignore.rs
+++ b/tests/ui-toml/declare_interior_mutable_const/ignore.rs
@@ -1,0 +1,46 @@
+//@compile-flags: --crate-name declare_interior_mutable_const_ignore
+
+#![warn(clippy::declare_interior_mutable_const)]
+#![allow(clippy::borrow_interior_mutable_const)]
+
+use core::cell::Cell;
+use std::cmp::{Eq, PartialEq};
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct Counted<T> {
+    count: AtomicUsize,
+    val: T,
+}
+
+impl<T> Counted<T> {
+    const fn new(val: T) -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+            val,
+        }
+    }
+}
+
+enum OptionalCell {
+    Unfrozen(Counted<bool>),
+    Frozen,
+}
+
+const UNFROZEN_VARIANT: OptionalCell = OptionalCell::Unfrozen(Counted::new(true));
+const FROZEN_VARIANT: OptionalCell = OptionalCell::Frozen;
+
+const fn unfrozen_variant() -> OptionalCell {
+    OptionalCell::Unfrozen(Counted::new(true))
+}
+
+const fn frozen_variant() -> OptionalCell {
+    OptionalCell::Frozen
+}
+
+const UNFROZEN_VARIANT_FROM_FN: OptionalCell = unfrozen_variant();
+const FROZEN_VARIANT_FROM_FN: OptionalCell = frozen_variant();
+
+fn main() {}


### PR DESCRIPTION
Fix #10537

changelog: Now `declare_interior_mutable_const` and `borrow_interior_mutable_const` respect the `ignore-interior-mutability` configuration entry
