### PR TITLE
Fix failure of new internal lint `rustc::span_use_eq_ctxt`

### DIFF
--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -245,7 +245,7 @@ impl<'a> PanicExpn<'a> {
             return None;
         };
         let result = match name {
-            "panic" if arg.span.ctxt() == expr.span.ctxt() => Self::Empty,
+            "panic" if arg.span.eq_ctxt(expr.span) => Self::Empty,
             "panic" | "panic_str" => Self::Str(arg),
             "panic_display" | "panic_cold_display" => {
                 let ExprKind::AddrOf(_, _, e) = &arg.kind else {


### PR DESCRIPTION
I've implemented a new Rustc internal lint that forbids usage of `.ctxt() == .ctxt()` for spans, and suggests using `Span::eq_ctxt` directly instead (see https://github.com/rust-lang/rust/issues/49509 and https://github.com/rust-lang/rust/pull/116787).

Unfortunately the PR can't land yet because there's a violation of the lint in the Clippy codebase which (as it should) is causing CI failures, so this PR fixes that lint preemptively to unblock it from landing.

changelog: none
