### PR TITLE
Lint `flatten()` under `lines_filter_map_ok`

### DIFF
--- a/clippy_lints/src/lines_filter_map_ok.rs
+++ b/clippy_lints/src/lines_filter_map_ok.rs
@@ -71,8 +71,7 @@ impl LateLintPass<'_> for LinesFilterMapOk {
                 LINES_FILTER_MAP_OK,
                 fm_span,
                 &format!(
-                    "`{}()` will run forever if the iterator repeatedly produces an `Err`",
-                    fm_method.ident
+                    "`{fm_method_str}()` will run forever if the iterator repeatedly produces an `Err`",
                 ),
                 |diag| {
                     diag.span_note(

--- a/clippy_lints/src/lines_filter_map_ok.rs
+++ b/clippy_lints/src/lines_filter_map_ok.rs
@@ -59,59 +59,65 @@ declare_lint_pass!(LinesFilterMapOk => [LINES_FILTER_MAP_OK]);
 
 impl LateLintPass<'_> for LinesFilterMapOk {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
-        if let ExprKind::MethodCall(fm_method, fm_receiver, fm_args, fm_span) = expr.kind &&
-            is_trait_method(cx, expr, sym::Iterator) &&
-            let fm_method_str = fm_method.ident.as_str() &&
-            matches!(fm_method_str, "filter_map" | "flat_map" | "flatten") &&
-            is_type_diagnostic_item(cx, cx.typeck_results().expr_ty_adjusted(fm_receiver), sym::IoLines)
+        if let ExprKind::MethodCall(fm_method, fm_receiver, fm_args, fm_span) = expr.kind
+            && is_trait_method(cx, expr, sym::Iterator)
+            && let fm_method_str = fm_method.ident.as_str()
+            && matches!(fm_method_str, "filter_map" | "flat_map" | "flatten")
+            && is_type_diagnostic_item(cx, cx.typeck_results().expr_ty_adjusted(fm_receiver), sym::IoLines)
+            && should_lint(cx, fm_args, fm_method_str)
         {
-            let lint = match fm_args {
-                [] => fm_method_str == "flatten",
-                [fm_arg] => {
-                    match &fm_arg.kind {
-                        // Detect `Result::ok`
-                        ExprKind::Path(qpath) =>
-                            cx.qpath_res(qpath, fm_arg.hir_id).opt_def_id().map(|did|
-                                match_def_path(cx, did, &paths::CORE_RESULT_OK_METHOD)).unwrap_or_default(),
-                        // Detect `|x| x.ok()`
-                        ExprKind::Closure(Closure { body, .. }) =>
-                            if let Body { params: [param], value, .. } = cx.tcx.hir().body(*body) &&
-                                let ExprKind::MethodCall(method, receiver, [], _) = value.kind &&
-                                path_to_local_id(receiver, param.pat.hir_id) &&
-                                let Some(method_did) = cx.typeck_results().type_dependent_def_id(value.hir_id)
-                            {
-                                is_diag_item_method(cx, method_did, sym::Result) && method.ident.as_str() == "ok"
-                            } else {
-                                false
-                            },
-                        _ => false,
-                    }
-                }
-                _ => false,
-            };
-
-            if lint {
-                span_lint_and_then(
-                    cx,
-                    LINES_FILTER_MAP_OK,
-                    fm_span,
-                    &format!(
-                        "`{}()` will run forever if the iterator repeatedly produces an `Err`",
-                        fm_method.ident
-                    ),
-                    |diag| {
-                        diag.span_note(
-                            fm_receiver.span,
-                            "this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error");
-                        diag.span_suggestion(
-                            fm_span,
-                            "replace with",
-                            "map_while(Result::ok)",
-                            Applicability::MaybeIncorrect,
-                        );
-                    },
-                );
-            }
+            span_lint_and_then(
+                cx,
+                LINES_FILTER_MAP_OK,
+                fm_span,
+                &format!(
+                    "`{}()` will run forever if the iterator repeatedly produces an `Err`",
+                    fm_method.ident
+                ),
+                |diag| {
+                    diag.span_note(
+                        fm_receiver.span,
+                        "this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error");
+                    diag.span_suggestion(
+                        fm_span,
+                        "replace with",
+                        "map_while(Result::ok)",
+                        Applicability::MaybeIncorrect,
+                    );
+                },
+            );
         }
+    }
+}
+
+fn should_lint(cx: &LateContext<'_>, args: &[Expr<'_>], method_str: &str) -> bool {
+    match args {
+        [] => method_str == "flatten",
+        [fm_arg] => {
+            match &fm_arg.kind {
+                // Detect `Result::ok`
+                ExprKind::Path(qpath) => cx
+                    .qpath_res(qpath, fm_arg.hir_id)
+                    .opt_def_id()
+                    .map(|did| match_def_path(cx, did, &paths::CORE_RESULT_OK_METHOD))
+                    .unwrap_or_default(),
+                // Detect `|x| x.ok()`
+                ExprKind::Closure(Closure { body, .. }) => {
+                    if let Body {
+                        params: [param], value, ..
+                    } = cx.tcx.hir().body(*body)
+                        && let ExprKind::MethodCall(method, receiver, [], _) = value.kind
+                        && path_to_local_id(receiver, param.pat.hir_id)
+                        && let Some(method_did) = cx.typeck_results().type_dependent_def_id(value.hir_id)
+                    {
+                        is_diag_item_method(cx, method_did, sym::Result) && method.ident.as_str() == "ok"
+                    } else {
+                        false
+                    }
+                },
+                _ => false,
+            }
+        },
+        _ => false,
     }
 }

--- a/clippy_lints/src/lines_filter_map_ok.rs
+++ b/clippy_lints/src/lines_filter_map_ok.rs
@@ -65,27 +65,29 @@ impl LateLintPass<'_> for LinesFilterMapOk {
             matches!(fm_method_str, "filter_map" | "flat_map" | "flatten") &&
             is_type_diagnostic_item(cx, cx.typeck_results().expr_ty_adjusted(fm_receiver), sym::IoLines)
         {
-            let lint = if let [fm_arg] = fm_args {
-                match &fm_arg.kind {
-                    // Detect `Result::ok`
-                    ExprKind::Path(qpath) =>
-                        cx.qpath_res(qpath, fm_arg.hir_id).opt_def_id().map(|did|
-                            match_def_path(cx, did, &paths::CORE_RESULT_OK_METHOD)).unwrap_or_default(),
-                    // Detect `|x| x.ok()`
-                    ExprKind::Closure(Closure { body, .. }) =>
-                        if let Body { params: [param], value, .. } = cx.tcx.hir().body(*body) &&
-                            let ExprKind::MethodCall(method, receiver, [], _) = value.kind &&
-                            path_to_local_id(receiver, param.pat.hir_id) &&
-                            let Some(method_did) = cx.typeck_results().type_dependent_def_id(value.hir_id)
-                        {
-                            is_diag_item_method(cx, method_did, sym::Result) && method.ident.as_str() == "ok"
-                        } else {
-                            false
-                        },
-                    _ => false,
+            let lint = match fm_args {
+                [] => fm_method_str == "flatten",
+                [fm_arg] => {
+                    match &fm_arg.kind {
+                        // Detect `Result::ok`
+                        ExprKind::Path(qpath) =>
+                            cx.qpath_res(qpath, fm_arg.hir_id).opt_def_id().map(|did|
+                                match_def_path(cx, did, &paths::CORE_RESULT_OK_METHOD)).unwrap_or_default(),
+                        // Detect `|x| x.ok()`
+                        ExprKind::Closure(Closure { body, .. }) =>
+                            if let Body { params: [param], value, .. } = cx.tcx.hir().body(*body) &&
+                                let ExprKind::MethodCall(method, receiver, [], _) = value.kind &&
+                                path_to_local_id(receiver, param.pat.hir_id) &&
+                                let Some(method_did) = cx.typeck_results().type_dependent_def_id(value.hir_id)
+                            {
+                                is_diag_item_method(cx, method_did, sym::Result) && method.ident.as_str() == "ok"
+                            } else {
+                                false
+                            },
+                        _ => false,
+                    }
                 }
-            } else {
-                fm_method_str == "flatten"
+                _ => false,
             };
 
             if lint {

--- a/clippy_lints/src/lines_filter_map_ok.rs
+++ b/clippy_lints/src/lines_filter_map_ok.rs
@@ -70,9 +70,7 @@ impl LateLintPass<'_> for LinesFilterMapOk {
                 cx,
                 LINES_FILTER_MAP_OK,
                 fm_span,
-                &format!(
-                    "`{fm_method_str}()` will run forever if the iterator repeatedly produces an `Err`",
-                ),
+                &format!("`{fm_method_str}()` will run forever if the iterator repeatedly produces an `Err`",),
                 |diag| {
                     diag.span_note(
                         fm_receiver.span,

--- a/tests/ui/lines_filter_map_ok.fixed
+++ b/tests/ui/lines_filter_map_ok.fixed
@@ -10,7 +10,13 @@ fn main() -> io::Result<()> {
     // Lint
     let f = std::fs::File::open("/")?;
     BufReader::new(f).lines().map_while(Result::ok).for_each(|_| ());
+    // Lint
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).lines().map_while(Result::ok).for_each(|_| ());
+
     let s = "foo\nbar\nbaz\n";
+    // Lint
+    io::stdin().lines().map_while(Result::ok).for_each(|_| ());
     // Lint
     io::stdin().lines().map_while(Result::ok).for_each(|_| ());
     // Lint

--- a/tests/ui/lines_filter_map_ok.rs
+++ b/tests/ui/lines_filter_map_ok.rs
@@ -10,11 +10,17 @@ fn main() -> io::Result<()> {
     // Lint
     let f = std::fs::File::open("/")?;
     BufReader::new(f).lines().flat_map(Result::ok).for_each(|_| ());
+    // Lint
+    let f = std::fs::File::open("/")?;
+    BufReader::new(f).lines().flatten().for_each(|_| ());
+
     let s = "foo\nbar\nbaz\n";
     // Lint
     io::stdin().lines().filter_map(Result::ok).for_each(|_| ());
     // Lint
     io::stdin().lines().filter_map(|x| x.ok()).for_each(|_| ());
+    // Lint
+    io::stdin().lines().flatten().for_each(|_| ());
     // Do not lint (not a `Lines` iterator)
     io::stdin()
         .lines()

--- a/tests/ui/lines_filter_map_ok.stderr
+++ b/tests/ui/lines_filter_map_ok.stderr
@@ -24,29 +24,53 @@ note: this expression returning a `std::io::Lines` may produce an infinite numbe
 LL |     BufReader::new(f).lines().flat_map(Result::ok).for_each(|_| ());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
-  --> $DIR/lines_filter_map_ok.rs:15:25
+error: `flatten()` will run forever if the iterator repeatedly produces an `Err`
+  --> $DIR/lines_filter_map_ok.rs:15:31
    |
-LL |     io::stdin().lines().filter_map(Result::ok).for_each(|_| ());
-   |                         ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+LL |     BufReader::new(f).lines().flatten().for_each(|_| ());
+   |                               ^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> $DIR/lines_filter_map_ok.rs:15:5
    |
+LL |     BufReader::new(f).lines().flatten().for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
+  --> $DIR/lines_filter_map_ok.rs:19:25
+   |
+LL |     io::stdin().lines().filter_map(Result::ok).for_each(|_| ());
+   |                         ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
+  --> $DIR/lines_filter_map_ok.rs:19:5
+   |
 LL |     io::stdin().lines().filter_map(Result::ok).for_each(|_| ());
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
-  --> $DIR/lines_filter_map_ok.rs:17:25
+  --> $DIR/lines_filter_map_ok.rs:21:25
    |
 LL |     io::stdin().lines().filter_map(|x| x.ok()).for_each(|_| ());
    |                         ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
-  --> $DIR/lines_filter_map_ok.rs:17:5
+  --> $DIR/lines_filter_map_ok.rs:21:5
    |
 LL |     io::stdin().lines().filter_map(|x| x.ok()).for_each(|_| ());
    |     ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: `flatten()` will run forever if the iterator repeatedly produces an `Err`
+  --> $DIR/lines_filter_map_ok.rs:23:25
+   |
+LL |     io::stdin().lines().flatten().for_each(|_| ());
+   |                         ^^^^^^^^^ help: replace with: `map_while(Result::ok)`
+   |
+note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
+  --> $DIR/lines_filter_map_ok.rs:23:5
+   |
+LL |     io::stdin().lines().flatten().for_each(|_| ());
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Fixes #11686 

changelog: [`lines_filter_map_ok`]: Also lint calls to `flatten()`