### PR TITLE
Add `waker_clone_and_wake` lint to check needless `Waker` clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5589,6 +5589,7 @@ Released 2018-09-13
 [`verbose_bit_mask`]: https://rust-lang.github.io/rust-clippy/master/index.html#verbose_bit_mask
 [`verbose_file_reads`]: https://rust-lang.github.io/rust-clippy/master/index.html#verbose_file_reads
 [`vtable_address_comparisons`]: https://rust-lang.github.io/rust-clippy/master/index.html#vtable_address_comparisons
+[`waker_clone_wake`]: https://rust-lang.github.io/rust-clippy/master/index.html#waker_clone_wake
 [`while_immutable_condition`]: https://rust-lang.github.io/rust-clippy/master/index.html#while_immutable_condition
 [`while_let_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#while_let_loop
 [`while_let_on_iterator`]: https://rust-lang.github.io/rust-clippy/master/index.html#while_let_on_iterator

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -441,6 +441,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::USELESS_ASREF_INFO,
     crate::methods::VEC_RESIZE_TO_ZERO_INFO,
     crate::methods::VERBOSE_FILE_READS_INFO,
+    crate::methods::WAKER_CLONE_WAKE_INFO,
     crate::methods::WRONG_SELF_CONVENTION_INFO,
     crate::methods::ZST_OFFSET_INFO,
     crate::min_ident_chars::MIN_IDENT_CHARS_INFO,

--- a/clippy_lints/src/methods/waker_clone_wake.rs
+++ b/clippy_lints/src/methods/waker_clone_wake.rs
@@ -1,0 +1,34 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::{match_def_path, paths};
+use rustc_errors::Applicability;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::LateContext;
+use rustc_span::sym;
+
+use super::WAKER_CLONE_WAKE;
+
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'tcx Expr<'_>) {
+    let ty = cx.typeck_results().expr_ty(recv);
+
+    if let Some(did) = ty.ty_adt_def()
+        && match_def_path(cx, did.did(), &paths::WAKER)
+        && let ExprKind::MethodCall(func, waker_ref, &[], _) = recv.kind
+        && func.ident.name == sym::clone
+    {
+        let mut applicability = Applicability::MachineApplicable;
+
+        span_lint_and_sugg(
+            cx,
+            WAKER_CLONE_WAKE,
+            expr.span,
+            "cloning a `Waker` only to wake it",
+            "replace with",
+            format!(
+                "{}.wake_by_ref()",
+                snippet_with_applicability(cx, waker_ref.span, "..", &mut applicability)
+            ),
+            applicability,
+        );
+    }
+}

--- a/clippy_utils/src/paths.rs
+++ b/clippy_utils/src/paths.rs
@@ -112,6 +112,7 @@ pub const VEC_RESIZE: [&str; 4] = ["alloc", "vec", "Vec", "resize"];
 pub const INSTANT_NOW: [&str; 4] = ["std", "time", "Instant", "now"];
 pub const VEC_IS_EMPTY: [&str; 4] = ["alloc", "vec", "Vec", "is_empty"];
 pub const VEC_POP: [&str; 4] = ["alloc", "vec", "Vec", "pop"];
+pub const WAKER: [&str; 4] = ["core", "task", "wake", "Waker"];
 pub const OPTION_UNWRAP: [&str; 4] = ["core", "option", "Option", "unwrap"];
 pub const OPTION_EXPECT: [&str; 4] = ["core", "option", "Option", "expect"];
 #[expect(clippy::invalid_paths)] // not sure why it thinks this, it works so

--- a/tests/ui/waker_clone_wake.fixed
+++ b/tests/ui/waker_clone_wake.fixed
@@ -1,0 +1,22 @@
+#[derive(Clone)]
+pub struct Custom;
+
+impl Custom {
+    pub fn wake(self) {}
+}
+
+pub fn wake(cx: &mut std::task::Context) {
+    cx.waker().wake_by_ref();
+
+    // We don't do that for now
+    let w = cx.waker().clone();
+    w.wake();
+
+    cx.waker().clone().wake_by_ref();
+}
+
+pub fn no_lint(c: &Custom) {
+    c.clone().wake()
+}
+
+fn main() {}

--- a/tests/ui/waker_clone_wake.fixed
+++ b/tests/ui/waker_clone_wake.fixed
@@ -5,18 +5,25 @@ impl Custom {
     pub fn wake(self) {}
 }
 
+macro_rules! mac {
+    ($cx:ident) => {
+        $cx.waker()
+    };
+}
+
 pub fn wake(cx: &mut std::task::Context) {
     cx.waker().wake_by_ref();
 
-    // We don't do that for now
+    mac!(cx).wake_by_ref();
+}
+
+pub fn no_lint(cx: &mut std::task::Context, c: &Custom) {
+    c.clone().wake();
+
     let w = cx.waker().clone();
     w.wake();
 
     cx.waker().clone().wake_by_ref();
-}
-
-pub fn no_lint(c: &Custom) {
-    c.clone().wake()
 }
 
 fn main() {}

--- a/tests/ui/waker_clone_wake.rs
+++ b/tests/ui/waker_clone_wake.rs
@@ -1,0 +1,22 @@
+#[derive(Clone)]
+pub struct Custom;
+
+impl Custom {
+    pub fn wake(self) {}
+}
+
+pub fn wake(cx: &mut std::task::Context) {
+    cx.waker().clone().wake();
+
+    // We don't do that for now
+    let w = cx.waker().clone();
+    w.wake();
+
+    cx.waker().clone().wake_by_ref();
+}
+
+pub fn no_lint(c: &Custom) {
+    c.clone().wake()
+}
+
+fn main() {}

--- a/tests/ui/waker_clone_wake.rs
+++ b/tests/ui/waker_clone_wake.rs
@@ -5,18 +5,25 @@ impl Custom {
     pub fn wake(self) {}
 }
 
+macro_rules! mac {
+    ($cx:ident) => {
+        $cx.waker()
+    };
+}
+
 pub fn wake(cx: &mut std::task::Context) {
     cx.waker().clone().wake();
 
-    // We don't do that for now
+    mac!(cx).clone().wake();
+}
+
+pub fn no_lint(cx: &mut std::task::Context, c: &Custom) {
+    c.clone().wake();
+
     let w = cx.waker().clone();
     w.wake();
 
     cx.waker().clone().wake_by_ref();
-}
-
-pub fn no_lint(c: &Custom) {
-    c.clone().wake()
 }
 
 fn main() {}

--- a/tests/ui/waker_clone_wake.stderr
+++ b/tests/ui/waker_clone_wake.stderr
@@ -1,0 +1,11 @@
+error: cloning a `Waker` only to wake it
+  --> $DIR/waker_clone_wake.rs:9:5
+   |
+LL |     cx.waker().clone().wake();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `cx.waker().wake_by_ref()`
+   |
+   = note: `-D clippy::waker-clone-wake` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::waker_clone_wake)]`
+
+error: aborting due to previous error
+

--- a/tests/ui/waker_clone_wake.stderr
+++ b/tests/ui/waker_clone_wake.stderr
@@ -1,5 +1,5 @@
 error: cloning a `Waker` only to wake it
-  --> $DIR/waker_clone_wake.rs:9:5
+  --> $DIR/waker_clone_wake.rs:15:5
    |
 LL |     cx.waker().clone().wake();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `cx.waker().wake_by_ref()`
@@ -7,5 +7,11 @@ LL |     cx.waker().clone().wake();
    = note: `-D clippy::waker-clone-wake` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::waker_clone_wake)]`
 
-error: aborting due to previous error
+error: cloning a `Waker` only to wake it
+  --> $DIR/waker_clone_wake.rs:17:5
+   |
+LL |     mac!(cx).clone().wake();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `mac!(cx).wake_by_ref()`
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Check for patterns of `waker.clone().wake()` and replace them with `waker.wake_by_ref()`.

An alternative name could be `waker_clone_then_wake`

changelog: [ `waker_clone_wake`]: new lint