### PR TITLE
Set doc-tests to `no_run`

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -774,7 +774,7 @@ Additional dotfiles (files or directories starting with a dot) to allow
 
 ## `enforce-iter-loop-reborrow`
 #### Example
-```
+```no_run
 let mut vec = vec![1, 2, 3];
 let rmvec = &mut vec;
 for _ in rmvec.iter() {}
@@ -782,7 +782,7 @@ for _ in rmvec.iter_mut() {}
 ```
 
 Use instead:
-```
+```no_run
 let mut vec = vec![1, 2, 3];
 let rmvec = &mut vec;
 for _ in &*rmvec {}

--- a/clippy_dev/src/new_lint.rs
+++ b/clippy_dev/src/new_lint.rs
@@ -346,11 +346,11 @@ fn get_lint_declaration(name_upper: &str, category: &str) -> String {
                 /// ### Why is this bad?
                 ///
                 /// ### Example
-                /// ```rust
+                /// ```no_run
                 /// // example code where clippy issues a warning
                 /// ```
                 /// Use instead:
-                /// ```rust
+                /// ```no_run
                 /// // example code which does not raise clippy warning
                 /// ```
                 #[clippy::version = "{}"]

--- a/clippy_lints/src/absolute_paths.rs
+++ b/clippy_lints/src/absolute_paths.rs
@@ -24,11 +24,11 @@ declare_clippy_lint! {
     /// using absolute paths is the proper way of referencing items in one.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = std::f64::consts::PI;
     /// ```
     /// Use any of the below instead, or anything else:
-    /// ```rust
+    /// ```no_run
     /// use std::f64;
     /// use std::f64::consts;
     /// use std::f64::consts::PI;

--- a/clippy_lints/src/almost_complete_range.rs
+++ b/clippy_lints/src/almost_complete_range.rs
@@ -17,11 +17,11 @@ declare_clippy_lint! {
     /// This (`'a'..'z'`) is almost certainly a typo meant to include all letters.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = 'a'..'z';
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let _ = 'a'..='z';
     /// ```
     #[clippy::version = "1.68.0"]

--- a/clippy_lints/src/approx_const.rs
+++ b/clippy_lints/src/approx_const.rs
@@ -24,12 +24,12 @@ declare_clippy_lint! {
     /// issue](https://github.com/rust-lang/rust/issues).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 3.14;
     /// let y = 1_f64 / x;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = std::f32::consts::PI;
     /// let y = std::f64::consts::FRAC_1_PI;
     /// ```

--- a/clippy_lints/src/arc_with_non_send_sync.rs
+++ b/clippy_lints/src/arc_with_non_send_sync.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// either `T` should be made `Send + Sync` or an `Rc` should be used instead of an `Arc`
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::cell::RefCell;
     /// # use std::sync::Arc;
     ///

--- a/clippy_lints/src/async_yields_async.rs
+++ b/clippy_lints/src/async_yields_async.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// An await is likely missing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// async fn foo() {}
     ///
     /// fn bar() {
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// async fn foo() {}
     ///
     /// fn bar() {

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -129,7 +129,7 @@ declare_clippy_lint! {
     /// a valid semver. Failing that, the contained information is useless.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[deprecated(since = "forever")]
     /// fn something_else() { /* ... */ }
     /// ```
@@ -156,14 +156,14 @@ declare_clippy_lint! {
     /// currently works for basic cases but is not perfect.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[allow(dead_code)]
     ///
     /// fn not_quite_good_code() { }
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // Good (as inner attribute)
     /// #![allow(dead_code)]
     ///
@@ -198,25 +198,25 @@ declare_clippy_lint! {
     /// Does not detect empty lines after doc attributes (e.g. `#[doc = ""]`).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// /// Some doc comment with a blank line after it.
     ///
     /// fn not_quite_good_code() { }
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// /// Good (no blank line)
     /// fn this_is_fine() { }
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// // Good (convert to a regular comment)
     ///
     /// fn this_is_fine_too() { }
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// //! Good (convert to a comment on an inner attribute)
     ///
     /// fn this_is_fine_as_well() { }
@@ -236,12 +236,12 @@ declare_clippy_lint! {
     /// These lints should only be enabled on a lint-by-lint basis and with careful consideration.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #![deny(clippy::restriction)]
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #![deny(clippy::as_conversions)]
     /// ```
     #[clippy::version = "1.47.0"]
@@ -265,13 +265,13 @@ declare_clippy_lint! {
     /// [#3123](https://github.com/rust-lang/rust-clippy/pull/3123#issuecomment-422321765)
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[cfg_attr(rustfmt, rustfmt_skip)]
     /// fn main() { }
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[rustfmt::skip]
     /// fn main() { }
     /// ```
@@ -290,13 +290,13 @@ declare_clippy_lint! {
     /// by the conditional compilation engine.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[cfg(linux)]
     /// fn conditional() { }
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # mod hidden {
     /// #[cfg(target_os = "linux")]
     /// fn conditional() { }
@@ -325,14 +325,14 @@ declare_clippy_lint! {
     /// ensure that others understand the reasoning
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #![feature(lint_reasons)]
     ///
     /// #![allow(clippy::some_lint)]
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #![feature(lint_reasons)]
     ///
     /// #![allow(clippy::some_lint, reason = "False positive rust-lang/rust-clippy#1002020")]
@@ -352,7 +352,7 @@ declare_clippy_lint! {
     /// panicking with the expected message, and not another unrelated panic.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn random() -> i32 { 0 }
     ///
     /// #[should_panic]
@@ -363,7 +363,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn random() -> i32 { 0 }
     ///
     /// #[should_panic = "attempt to divide by zero"]
@@ -386,13 +386,13 @@ declare_clippy_lint! {
     /// If there is only one condition, no need to wrap it into `any` or `all` combinators.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[cfg(any(unix))]
     /// pub struct Bar;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[cfg(unix)]
     /// pub struct Bar;
     /// ```
@@ -412,13 +412,13 @@ declare_clippy_lint! {
     /// may cause conditional compilation not work quitely.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[cfg(features = "some-feature")]
     /// fn conditional() { }
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[cfg(feature = "some-feature")]
     /// fn conditional() { }
     /// ```

--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// to wrap the `.lock()` call in a block instead of explicitly dropping the guard.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::sync::Mutex;
     /// # async fn baz() {}
     /// async fn foo(x: &Mutex<u32>) {
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::sync::Mutex;
     /// # async fn baz() {}
     /// async fn foo(x: &Mutex<u32>) {
@@ -87,7 +87,7 @@ declare_clippy_lint! {
     /// to wrap the `.borrow[_mut]()` call in a block instead of explicitly dropping the ref.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::cell::RefCell;
     /// # async fn baz() {}
     /// async fn foo(x: &RefCell<u32>) {
@@ -105,7 +105,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::cell::RefCell;
     /// # async fn baz() {}
     /// async fn foo(x: &RefCell<u32>) {
@@ -151,7 +151,7 @@ declare_clippy_lint! {
     /// ]
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// # async fn baz() {}
     /// struct CustomLockType;
     /// struct OtherCustomLockType;

--- a/clippy_lints/src/blocks_in_if_conditions.rs
+++ b/clippy_lints/src/blocks_in_if_conditions.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// Style, using blocks in the condition makes it hard to read.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// # fn somefunc() -> bool { true };
     /// if { true } { /* ... */ }
     ///
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn somefunc() -> bool { true };
     /// if true { /* ... */ }
     ///

--- a/clippy_lints/src/bool_assert_comparison.rs
+++ b/clippy_lints/src/bool_assert_comparison.rs
@@ -18,13 +18,13 @@ declare_clippy_lint! {
     /// It is shorter to use the equivalent.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// assert_eq!("a".is_empty(), false);
     /// assert_ne!("a".is_empty(), true);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// assert!(!"a".is_empty());
     /// ```
     #[clippy::version = "1.53.0"]

--- a/clippy_lints/src/bool_to_int_with_if.rs
+++ b/clippy_lints/src/bool_to_int_with_if.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// See https://doc.rust-lang.org/std/primitive.bool.html#impl-From%3Cbool%3E
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let condition = false;
     /// if condition {
     ///     1_i64
@@ -30,12 +30,12 @@ declare_clippy_lint! {
     /// };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let condition = false;
     /// i64::from(condition);
     /// ```
     /// or
-    /// ```rust
+    /// ```no_run
     /// # let condition = false;
     /// condition as i64;
     /// ```

--- a/clippy_lints/src/borrow_deref_ref.rs
+++ b/clippy_lints/src/borrow_deref_ref.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     ///
     /// ### Known problems
     /// False negative on such code:
-    /// ```
+    /// ```no_run
     /// let x = &12;
     /// let addr_x = &x as *const _ as usize;
     /// let addr_y = &&*x as *const _ as usize; // assert ok now, and lint triggered.
@@ -28,14 +28,14 @@ declare_clippy_lint! {
     /// ```
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let s = &String::new();
     ///
     /// let a: &String = &* s;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let s = &String::new();
     /// let a: &String = s;
     /// ```

--- a/clippy_lints/src/box_default.rs
+++ b/clippy_lints/src/box_default.rs
@@ -24,11 +24,11 @@ declare_clippy_lint! {
     /// [in certain cases](https://nnethercote.github.io/perf-book/standard-library-types.html#box).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: Box<String> = Box::new(Default::default());
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x: Box<String> = Box::default();
     /// ```
     #[clippy::version = "1.66.0"]

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -45,7 +45,7 @@ declare_clippy_lint! {
     /// those places in the code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = u64::MAX;
     /// x as f64;
     /// ```
@@ -67,7 +67,7 @@ declare_clippy_lint! {
     /// as a one-time check to see where numerical wrapping can arise.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let y: i8 = -1;
     /// y as u128; // will return 18446744073709551615
     /// ```
@@ -90,13 +90,13 @@ declare_clippy_lint! {
     /// checks could be beneficial.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn as_u8(x: u64) -> u8 {
     ///     x as u8
     /// }
     /// ```
     /// Use instead:
-    /// ```
+    /// ```no_run
     /// fn as_u8(x: u64) -> u8 {
     ///     if let Ok(x) = u8::try_from(x) {
     ///         x
@@ -132,7 +132,7 @@ declare_clippy_lint! {
     /// example below.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// u32::MAX as i32; // will yield a value of `-1`
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -155,7 +155,7 @@ declare_clippy_lint! {
     /// people reading the code to know that the conversion is lossless.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn as_u64(x: u8) -> u64 {
     ///     x as u64
     /// }
@@ -163,7 +163,7 @@ declare_clippy_lint! {
     ///
     /// Using `::from` would look like this:
     ///
-    /// ```rust
+    /// ```no_run
     /// fn as_u64(x: u8) -> u64 {
     ///     u64::from(x)
     /// }
@@ -191,14 +191,14 @@ declare_clippy_lint! {
     /// intermediate references, raw pointers and trait objects may or may not work.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = 2i32 as i32;
     /// let _ = 0.5 as f32;
     /// ```
     ///
     /// Better:
     ///
-    /// ```rust
+    /// ```no_run
     /// let _ = 2_i32;
     /// let _ = 0.5_f32;
     /// ```
@@ -223,7 +223,7 @@ declare_clippy_lint! {
     /// u64-> u8 -> u16 can be fine. Miri is able to do a more in-depth analysis.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = (&1u8 as *const u8) as *const u16;
     /// let _ = (&mut 1u8 as *mut u8) as *mut u16;
     ///
@@ -249,13 +249,13 @@ declare_clippy_lint! {
     /// Casting to isize also doesn't make sense since there are no signed addresses.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn fun() -> i32 { 1 }
     /// let _ = fun as i64;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn fun() -> i32 { 1 }
     /// let _ = fun as usize;
     /// ```
@@ -276,7 +276,7 @@ declare_clippy_lint! {
     /// a comment) to perform the truncation.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn fn1() -> i16 {
     ///     1
     /// };
@@ -284,7 +284,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // Cast to usize first, then comment with the reason for the truncation
     /// fn fn1() -> i16 {
     ///     1
@@ -310,7 +310,7 @@ declare_clippy_lint! {
     /// pointer casts in your code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // fn1 is cast as `usize`
     /// fn fn1() -> u16 {
     ///     1
@@ -319,7 +319,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // maybe you intended to call the function?
     /// fn fn2() -> u16 {
     ///     1
@@ -378,14 +378,14 @@ declare_clippy_lint! {
     /// it cannot accidentally change the pointer's mutability nor cast the pointer to other types like `usize`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let ptr: *const u32 = &42_u32;
     /// let mut_ptr: *mut u32 = &mut 42_u32;
     /// let _ = ptr as *const i32;
     /// let _ = mut_ptr as *mut i32;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let ptr: *const u32 = &42_u32;
     /// let mut_ptr: *mut u32 = &mut 42_u32;
     /// let _ = ptr.cast::<i32>();
@@ -408,13 +408,13 @@ declare_clippy_lint! {
     /// type.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let ptr: *const u32 = &42_u32;
     /// let mut_ptr = ptr as *mut u32;
     /// let ptr = mut_ptr as *const u32;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let ptr: *const u32 = &42_u32;
     /// let mut_ptr = ptr.cast_mut();
     /// let ptr = mut_ptr.cast_const();
@@ -434,7 +434,7 @@ declare_clippy_lint! {
     /// The resulting integral value will not match the value of the variant it came from.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum E { X = 256 };
     /// let _ = E::X as u8;
     /// ```
@@ -457,7 +457,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// // Missing data
-    /// ```rust
+    /// ```no_run
     /// let a = [1_i32, 2, 3, 4];
     /// let p = &a as *const [i32] as *const [u8];
     /// unsafe {
@@ -465,7 +465,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// // Undefined Behavior (note: also potential alignment issues)
-    /// ```rust
+    /// ```no_run
     /// let a = [1_u8, 2, 3, 4];
     /// let p = &a as *const [u8] as *const [u32];
     /// unsafe {
@@ -473,7 +473,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Instead use `ptr::slice_from_raw_parts` to construct a slice from a data pointer and the correct length
-    /// ```rust
+    /// ```no_run
     /// let a = [1_i32, 2, 3, 4];
     /// let old_ptr = &a as *const [i32];
     /// // The data pointer is cast to a pointer to the target `u8` not `[u8]`
@@ -497,7 +497,7 @@ declare_clippy_lint! {
     /// The cast is easily confused with casting a c-like enum value to an integer.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum E { X(i32) };
     /// let _ = E::X as usize;
     /// ```
@@ -515,12 +515,12 @@ declare_clippy_lint! {
     /// The `unsigned_abs()` method avoids panic when called on the MIN value.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: i32 = -42;
     /// let y: u32 = x.abs() as u32;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x: i32 = -42;
     /// let y: u32 = x.unsigned_abs();
     /// ```
@@ -541,13 +541,13 @@ declare_clippy_lint! {
     /// The lint is allowed by default as using `_` is less wordy than always specifying the type.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(n: usize) {}
     /// let n: u16 = 256;
     /// foo(n as _);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo(n: usize) {}
     /// let n: u16 = 256;
     /// foo(n as usize);
@@ -570,7 +570,7 @@ declare_clippy_lint! {
     /// Read the `ptr::addr_of` docs for more information.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let val = 1;
     /// let p = &val as *const i32;
     ///
@@ -578,7 +578,7 @@ declare_clippy_lint! {
     /// let p_mut = &mut val_mut as *mut i32;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let val = 1;
     /// let p = std::ptr::addr_of!(val);
     ///
@@ -627,13 +627,13 @@ declare_clippy_lint! {
     /// mutability is used, making it unlikely that having it as a mutable pointer is correct.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut vec = Vec::<u8>::with_capacity(1);
     /// let ptr = vec.as_ptr() as *mut u8;
     /// unsafe { ptr.write(4) }; // UNDEFINED BEHAVIOUR
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut vec = Vec::<u8>::with_capacity(1);
     /// let ptr = vec.as_mut_ptr();
     /// unsafe { ptr.write(4) };
@@ -675,12 +675,12 @@ declare_clippy_lint! {
     /// {`std`, `core`}`::ptr::`{`null`, `null_mut`}.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = 0 as *const u32;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = std::ptr::null::<u32>();
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -19,13 +19,13 @@ declare_clippy_lint! {
     /// Reduces the readability of statements & is error prone.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let foo: u32 = 5;
     /// foo <= i32::MAX as u32;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let foo = 1;
     /// # #[allow(unused)]
     /// i32::try_from(foo).is_ok();

--- a/clippy_lints/src/collapsible_if.rs
+++ b/clippy_lints/src/collapsible_if.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// makes code look more complex than it really is.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let (x, y) = (true, true);
     /// if x {
     ///     if y {
@@ -42,7 +42,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let (x, y) = (true, true);
     /// if x && y {
     ///     // …

--- a/clippy_lints/src/collection_is_never_read.rs
+++ b/clippy_lints/src/collection_is_never_read.rs
@@ -20,7 +20,7 @@ declare_clippy_lint! {
     /// instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let samples = vec![3, 1, 2];
     /// let mut sorted_samples = samples.clone();
     /// sorted_samples.sort();
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let samples = vec![3, 1, 2];
     /// let mut sorted_samples = samples.clone();
     /// sorted_samples.sort();

--- a/clippy_lints/src/crate_in_macro_def.rs
+++ b/clippy_lints/src/crate_in_macro_def.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// https://doc.rust-lang.org/reference/macros-by-example.html#hygiene
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[macro_export]
     /// macro_rules! print_message {
     ///     () => {
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     /// pub const MESSAGE: &str = "Hello!";
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[macro_export]
     /// macro_rules! print_message {
     ///     () => {

--- a/clippy_lints/src/default.rs
+++ b/clippy_lints/src/default.rs
@@ -23,12 +23,12 @@ declare_clippy_lint! {
     /// generic `Default`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let s: String = Default::default();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let s = String::default();
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -49,7 +49,7 @@ declare_clippy_lint! {
     /// Assignments to patterns that are of tuple type are not linted.
     ///
     /// ### Example
-    /// ```
+    /// ```no_run
     /// # #[derive(Default)]
     /// # struct A { i: i32 }
     /// let mut a: A = Default::default();
@@ -57,7 +57,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```
+    /// ```no_run
     /// # #[derive(Default)]
     /// # struct A { i: i32 }
     /// let a = A {

--- a/clippy_lints/src/default_constructed_unit_structs.rs
+++ b/clippy_lints/src/default_constructed_unit_structs.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// This adds code complexity and an unnecessary function call.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::marker::PhantomData;
     /// #[derive(Default)]
     /// struct S<T> {
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::marker::PhantomData;
     /// struct S<T> {
     ///     _marker: PhantomData<T>

--- a/clippy_lints/src/default_instead_of_iter_empty.rs
+++ b/clippy_lints/src/default_instead_of_iter_empty.rs
@@ -14,12 +14,12 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// `std::iter::empty()` is the more idiomatic way.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = std::iter::Empty::<usize>::default();
     /// let iter: std::iter::Empty<usize> = std::iter::Empty::default();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let _ = std::iter::empty::<usize>();
     /// let iter: std::iter::Empty<usize> = std::iter::empty();
     /// ```

--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -31,13 +31,13 @@ declare_clippy_lint! {
     /// This lint can only be allowed at the function level or above.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let i = 10;
     /// let f = 1.23;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let i = 10i32;
     /// let f = 1.23f64;
     /// ```

--- a/clippy_lints/src/default_union_representation.rs
+++ b/clippy_lints/src/default_union_representation.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// specified layout. These cases may lead to undefined behavior in unsafe blocks.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// union Foo {
     ///     a: i32,
     ///     b: u32,
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[repr(C)]
     /// union Foo {
     ///     a: i32,

--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -29,14 +29,14 @@ declare_clippy_lint! {
     /// when not part of a method chain.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::ops::Deref;
     /// let a: &mut String = &mut String::from("foo");
     /// let b: &str = a.deref();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a: &mut String = &mut String::from("foo");
     /// let b = &*a;
     /// ```
@@ -68,7 +68,7 @@ declare_clippy_lint! {
     /// in such a case can change the semantics of the code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn fun(_a: &i32) {}
     ///
     /// let x: &i32 = &&&&&&5;
@@ -76,7 +76,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn fun(_a: &i32) {}
     /// let x: &i32 = &5;
     /// fun(x);
@@ -95,7 +95,7 @@ declare_clippy_lint! {
     /// The address-of operator at the use site is clearer about the need for a reference.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = Some("");
     /// if let Some(ref x) = x {
     ///     // use `x` here
@@ -103,7 +103,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = Some("");
     /// if let Some(x) = x {
     ///     // use `&x` here
@@ -123,12 +123,12 @@ declare_clippy_lint! {
     /// This unnecessarily complicates the code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = String::new();
     /// let y: &str = &*x;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = String::new();
     /// let y: &str = &x;
     /// ```

--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// It is less concise.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo {
     ///     bar: bool
     /// }
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[derive(Default)]
     /// struct Foo {
     ///     bar: bool

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -173,7 +173,7 @@ declare_clippy_lint! {
     /// `Eq` themselves.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[derive(PartialEq)]
     /// struct Foo {
     ///     i_am_eq: i32,
@@ -181,7 +181,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[derive(PartialEq, Eq)]
     /// struct Foo {
     ///     i_am_eq: i32,

--- a/clippy_lints/src/disallowed_macros.rs
+++ b/clippy_lints/src/disallowed_macros.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     ///     { path = "serde::Serialize", reason = "no serializing" },
     /// ]
     /// ```
-    /// ```
+    /// ```no_run
     /// use serde::Serialize;
     ///
     /// // Example code where clippy issues a warning

--- a/clippy_lints/src/disallowed_names.rs
+++ b/clippy_lints/src/disallowed_names.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// avoided.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let foo = 3.14;
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/disallowed_script_idents.rs
+++ b/clippy_lints/src/disallowed_script_idents.rs
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     /// [`non_ascii_idents`]: https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#non-ascii-idents
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // Assuming that `clippy.toml` contains the following line:
     /// // allowed-scripts = ["Latin", "Cyrillic"]
     /// let counter = 10; // OK, latin is allowed.

--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -58,14 +58,14 @@ declare_clippy_lint! {
     /// would fail.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// /// Do something with the foo_bar parameter. See also
     /// /// that::other::module::foo.
     /// // ^ `foo_bar` and `that::other::module::foo` should be ticked.
     /// fn doit(foo_bar: usize) {}
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// // Link text with `[]` brackets should be written as following:
     /// /// Consume the array and return the inner
     /// /// [`SmallVec<[T; INLINE_CAPACITY]>`][SmallVec].
@@ -88,7 +88,7 @@ declare_clippy_lint! {
     /// preconditions, so that users can be sure they are using them safely.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     ///# type Universe = ();
     /// /// This function should really be documented
     /// pub unsafe fn start_apocalypse(u: &mut Universe) {
@@ -98,7 +98,7 @@ declare_clippy_lint! {
     ///
     /// At least write a line about safety:
     ///
-    /// ```rust
+    /// ```no_run
     ///# type Universe = ();
     /// /// # Safety
     /// ///
@@ -126,7 +126,7 @@ declare_clippy_lint! {
     /// Since the following function returns a `Result` it has an `# Errors` section in
     /// its doc comment:
     ///
-    /// ```rust
+    /// ```no_run
     ///# use std::io;
     /// /// # Errors
     /// ///
@@ -155,7 +155,7 @@ declare_clippy_lint! {
     /// Since the following function may panic it has a `# Panics` section in
     /// its doc comment:
     ///
-    /// ```rust
+    /// ```no_run
     /// /// # Panics
     /// ///
     /// /// Will panic if y is 0
@@ -182,7 +182,7 @@ declare_clippy_lint! {
     /// if the `fn main()` is left implicit.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// /// An example of a doctest with a `main()` function
     /// ///
     /// /// # Examples
@@ -210,12 +210,12 @@ declare_clippy_lint! {
     /// It is likely a typo when defining an intra-doc link
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// /// See also: ['foo']
     /// fn bar() {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// /// See also: [`foo`]
     /// fn bar() {}
     /// ```
@@ -235,7 +235,7 @@ declare_clippy_lint! {
     /// need to describe safety preconditions that users are required to uphold.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     ///# type Universe = ();
     /// /// # Safety
     /// ///
@@ -248,7 +248,7 @@ declare_clippy_lint! {
     /// The function is safe, so there shouldn't be any preconditions
     /// that have to be explained for safety reasons.
     ///
-    /// ```rust
+    /// ```no_run
     ///# type Universe = ();
     /// /// This function should really be documented
     /// pub fn start_apocalypse(u: &mut Universe) {

--- a/clippy_lints/src/double_parens.rs
+++ b/clippy_lints/src/double_parens.rs
@@ -12,7 +12,7 @@ declare_clippy_lint! {
     /// mistake.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn simple_double_parens() -> i32 {
     ///     ((0))
     /// }
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn simple_no_parens() -> i32 {
     ///     0
     /// }

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// have been intended.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo;
     /// let x = Foo;
     /// std::mem::drop(x);
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// have been intended.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo;
     /// let x = Foo;
     /// std::mem::forget(x);
@@ -57,7 +57,7 @@ declare_clippy_lint! {
     /// destructor, possibly causing leaks.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::mem;
     /// # use std::rc::Rc;
     /// mem::forget(Rc::new(55))

--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// Some coding guidelines require this (e.g., MISRA-C:2004 Rule 14.10).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn a() {}
     /// # fn b() {}
     /// # let x: i32 = 1;
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     ///
     /// Use instead:
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn a() {}
     /// # fn b() {}
     /// # let x: i32 = 1;

--- a/clippy_lints/src/empty_drop.rs
+++ b/clippy_lints/src/empty_drop.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// destructured, which might be the intention behind adding the implementation as a marker.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct S;
     ///
     /// impl Drop for S {
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct S;
     /// ```
     #[clippy::version = "1.62.0"]

--- a/clippy_lints/src/empty_enum.rs
+++ b/clippy_lints/src/empty_enum.rs
@@ -23,12 +23,12 @@ declare_clippy_lint! {
     ///
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum Test {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #![feature(never_type)]
     ///
     /// struct Test(!);

--- a/clippy_lints/src/empty_structs_with_brackets.rs
+++ b/clippy_lints/src/empty_structs_with_brackets.rs
@@ -15,11 +15,11 @@ declare_clippy_lint! {
     /// Empty brackets after a struct declaration can be omitted.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Cookie {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct Cookie;
     /// ```
     #[clippy::version = "1.62.0"]

--- a/clippy_lints/src/entry.rs
+++ b/clippy_lints/src/entry.rs
@@ -23,7 +23,7 @@ declare_clippy_lint! {
     ///
     /// ### Known problems
     /// The suggestion may have type inference errors in some cases. e.g.
-    /// ```rust
+    /// ```no_run
     /// let mut map = std::collections::HashMap::new();
     /// let _ = if !map.contains_key(&0) {
     ///     map.insert(0, 0)
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashMap;
     /// # let mut map = HashMap::new();
     /// # let k = 1;
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashMap;
     /// # let mut map = HashMap::new();
     /// # let k = 1;

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// architectures, but works fine on 64 bit.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # #[cfg(target_pointer_width = "64")]
     /// #[repr(usize)]
     /// enum NonPortable {

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -28,12 +28,12 @@ declare_clippy_lint! {
     /// into something.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(x: Box<u32>) {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo(x: u32) {}
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/excessive_bools.rs
+++ b/clippy_lints/src/excessive_bools.rs
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// readability and API.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct S {
     ///     is_pending: bool,
     ///     is_processing: bool,
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// enum S {
     ///     Pending,
     ///     Processing,

--- a/clippy_lints/src/exhaustive_items.rs
+++ b/clippy_lints/src/exhaustive_items.rs
@@ -17,14 +17,14 @@ declare_clippy_lint! {
     /// disable them by default.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum Foo {
     ///     Bar,
     ///     Baz
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[non_exhaustive]
     /// enum Foo {
     ///     Bar,
@@ -47,14 +47,14 @@ declare_clippy_lint! {
     /// disable them by default.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo {
     ///     bar: u8,
     ///     baz: String,
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[non_exhaustive]
     /// struct Foo {
     ///     bar: u8,

--- a/clippy_lints/src/exit.rs
+++ b/clippy_lints/src/exit.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// the main function.
     ///
     /// ### Example
-    /// ```
+    /// ```no_run
     /// std::process::exit(0)
     /// ```
     ///

--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// Using `(e)println! is clearer and more concise
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::io::Write;
     /// # let bar = "furchtbar";
     /// writeln!(&mut std::io::stderr(), "foo: {:?}", bar).unwrap();
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::io::Write;
     /// # let bar = "furchtbar";
     /// eprintln!("foo: {:?}", bar);

--- a/clippy_lints/src/extra_unused_type_parameters.rs
+++ b/clippy_lints/src/extra_unused_type_parameters.rs
@@ -23,13 +23,13 @@ declare_clippy_lint! {
     /// requires using a turbofish, which serves no purpose but to satisfy the compiler.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn unused_ty<T>(x: u8) {
     ///     // ..
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn no_unused_ty(x: u8) {
     ///     // ..
     /// }

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// `TryFrom` should be used if there's a possibility of failure.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo(i32);
     ///
     /// impl From<String> for Foo {
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct Foo(i32);
     ///
     /// impl TryFrom<String> for Foo {

--- a/clippy_lints/src/float_literal.rs
+++ b/clippy_lints/src/float_literal.rs
@@ -18,13 +18,13 @@ declare_clippy_lint! {
     /// Rust will truncate the literal silently.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let v: f32 = 0.123_456_789_9;
     /// println!("{}", v); //  0.123_456_789
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let v: f64 = 0.123_456_789_9;
     /// println!("{}", v); //  0.123_456_789_9
     /// ```
@@ -44,12 +44,12 @@ declare_clippy_lint! {
     /// conversion to a float.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _: f32 = 16_777_217.0; // 16_777_216.0
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let _: f32 = 16_777_216.0;
     /// let _: f64 = 16_777_217.0;
     /// ```

--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// Negatively impacts accuracy.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = 3f32;
     /// let _ = a.powf(1.0 / 3.0);
     /// let _ = (1.0 + a).ln();
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = 3f32;
     /// let _ = a.cbrt();
     /// let _ = a.ln_1p();
@@ -57,7 +57,7 @@ declare_clippy_lint! {
     /// Negatively impacts accuracy and performance.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::f32::consts::E;
     ///
     /// let a = 3f32;
@@ -83,7 +83,7 @@ declare_clippy_lint! {
     ///
     /// is better expressed as
     ///
-    /// ```rust
+    /// ```no_run
     /// use std::f32::consts::E;
     ///
     /// let a = 3f32;

--- a/clippy_lints/src/format.rs
+++ b/clippy_lints/src/format.rs
@@ -23,13 +23,13 @@ declare_clippy_lint! {
     /// if `foo: &str`.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// let foo = "foo";
     /// format!("{}", foo);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let foo = "foo";
     /// foo.to_owned();
     /// ```

--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -35,12 +35,12 @@ declare_clippy_lint! {
     /// The recommended code is both shorter and avoids a temporary allocation.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::panic::Location;
     /// println!("error: {}", format!("something failed at {}", Location::caller()));
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::panic::Location;
     /// println!("error: something failed at {}", Location::caller());
     /// ```
@@ -61,12 +61,12 @@ declare_clippy_lint! {
     /// unnecessary.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::panic::Location;
     /// println!("error: something failed at {}", Location::caller().to_string());
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::panic::Location;
     /// println!("error: something failed at {}", Location::caller());
     /// ```
@@ -87,7 +87,7 @@ declare_clippy_lint! {
     /// The inlined syntax, where allowed, is simpler.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let var = 42;
     /// # let width = 1;
     /// # let prec = 2;
@@ -98,7 +98,7 @@ declare_clippy_lint! {
     /// format!("{:.*}", prec, var);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let var = 42;
     /// # let width = 1;
     /// # let prec = 2;
@@ -111,12 +111,12 @@ declare_clippy_lint! {
     ///
     /// If allow-mixed-uninlined-format-args is set to false in clippy.toml,
     /// the following code will also trigger the lint:
-    /// ```rust
+    /// ```no_run
     /// # let var = 42;
     /// format!("{} {}", var, 1+2);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let var = 42;
     /// format!("{var} {}", 1+2);
     /// ```
@@ -141,13 +141,13 @@ declare_clippy_lint! {
     /// an expected formatting operation such as adding padding isn't happening.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// println!("{:.}", 1.0);
     ///
     /// println!("not padded: {:5}", format_args!("..."));
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// println!("{}", 1.0);
     ///
     /// println!("not padded: {}", format_args!("..."));

--- a/clippy_lints/src/format_impl.rs
+++ b/clippy_lints/src/format_impl.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     ///
     /// struct Structure(i32);
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     ///
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     ///
     /// struct Structure(i32);
@@ -59,7 +59,7 @@ declare_clippy_lint! {
     /// should write to the `Formatter`, not stdout/stderr.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::fmt::{Display, Error, Formatter};
     ///
     /// struct S;
@@ -72,7 +72,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt::{Display, Error, Formatter};
     ///
     /// struct S;

--- a/clippy_lints/src/format_push_string.rs
+++ b/clippy_lints/src/format_push_string.rs
@@ -21,13 +21,13 @@ declare_clippy_lint! {
     /// While using `write!` in the suggested way should never fail, this isn't necessarily clear to the programmer.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut s = String::new();
     /// s += &format!("0x{:X}", 1024);
     /// s.push_str(&format!("0x{:X}", 1024));
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt::Write as _; // import without risk of name clashing
     ///
     /// let mut s = String::new();

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     /// This is either a typo in the binary operator or confusing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let foo = true;
     /// # let bar = false;
     /// // &&! looks like a different operator
@@ -45,7 +45,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let foo = true;
     /// # let bar = false;
     /// if foo && !bar {}

--- a/clippy_lints/src/four_forward_slashes.rs
+++ b/clippy_lints/src/four_forward_slashes.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     /// comment.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// //// My amazing data structure
     /// pub struct Foo {
     ///     // ...
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// /// My amazing data structure
     /// pub struct Foo {
     ///     // ...

--- a/clippy_lints/src/from_over_into.rs
+++ b/clippy_lints/src/from_over_into.rs
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// According the std docs implementing `From<..>` is preferred since it gives you `Into<..>` for free where the reverse isn't true.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct StringWrapper(String);
     ///
     /// impl Into<StringWrapper> for String {
@@ -34,7 +34,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct StringWrapper(String);
     ///
     /// impl From<String> for StringWrapper {

--- a/clippy_lints/src/from_raw_with_void_ptr.rs
+++ b/clippy_lints/src/from_raw_with_void_ptr.rs
@@ -18,13 +18,13 @@ declare_clippy_lint! {
     /// For this to be safe, `c_void` would need to have the same memory layout as the original type, which is often not the case.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::ffi::c_void;
     /// let ptr = Box::into_raw(Box::new(42usize)) as *mut c_void;
     /// let _ = unsafe { Box::from_raw(ptr) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::ffi::c_void;
     /// # let ptr = Box::into_raw(Box::new(42usize)) as *mut c_void;
     /// let _ = unsafe { Box::from_raw(ptr as *mut usize) };

--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -23,7 +23,7 @@ declare_clippy_lint! {
     /// grouping some parameters into a new type.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct Color;
     /// fn foo(x: u32, y: u32, name: &str, c: Color, w: f32, h: f32, a: f32, b: f32) {
     ///     // ..
@@ -46,7 +46,7 @@ declare_clippy_lint! {
     /// multiple functions.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn im_too_long() {
     ///     println!("");
     ///     // ... 100 more LoC
@@ -129,7 +129,7 @@ declare_clippy_lint! {
     /// a remnant of a refactoring that removed the return type.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// #[must_use]
     /// fn useless() { }
     /// ```
@@ -151,7 +151,7 @@ declare_clippy_lint! {
     /// attribute to improve the lint message.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// #[must_use]
     /// fn double_must_use() -> Result<(), ()> {
     ///     unimplemented!();
@@ -183,7 +183,7 @@ declare_clippy_lint! {
     /// `#[must_use]`.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// // this could be annotated with `#[must_use]`.
     /// pub fn id<T>(t: T) -> T { t }
     /// ```
@@ -211,7 +211,7 @@ declare_clippy_lint! {
     /// instead.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// pub fn read_u8() -> Result<u8, ()> { Err(()) }
     /// ```
     /// should become
@@ -262,7 +262,7 @@ declare_clippy_lint! {
     /// The size determined by Clippy is platform-dependent.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// pub enum ParseError {
     ///     UnparsedBytes([u8; 512]),
     ///     UnexpectedEof,
@@ -274,7 +274,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// should be
-    /// ```
+    /// ```no_run
     /// pub enum ParseError {
     ///     UnparsedBytes(Box<[u8; 512]>),
     ///     UnexpectedEof,
@@ -301,7 +301,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
 
-    /// ```rust
+    /// ```no_run
     /// struct A {
     ///     a: String,
     ///     b: String,
@@ -315,7 +315,7 @@ declare_clippy_lint! {
 
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct A {
     ///     a: String,
     ///     b: String,
@@ -340,14 +340,14 @@ declare_clippy_lint! {
     /// Turbofish syntax (`::<>`) cannot be used when `impl Trait` is being used, making `impl Trait` less powerful. Readability may also be a factor.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// trait MyTrait {}
     /// fn foo(a: impl MyTrait) {
     /// 	// [...]
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// trait MyTrait {}
     /// fn foo<T: MyTrait>(a: T) {
     /// 	// [...]

--- a/clippy_lints/src/future_not_send.rs
+++ b/clippy_lints/src/future_not_send.rs
@@ -34,11 +34,11 @@ declare_clippy_lint! {
     /// produced.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// async fn not_send(bytes: std::rc::Rc<[u8]>) {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// async fn is_send(bytes: std::sync::Arc<[u8]>) {}
     /// ```
     #[clippy::version = "1.44.0"]

--- a/clippy_lints/src/if_not_else.rs
+++ b/clippy_lints/src/if_not_else.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// Negations reduce the readability of statements.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let v: Vec<usize> = vec![];
     /// # fn a() {}
     /// # fn b() {}
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     ///
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// # let v: Vec<usize> = vec![];
     /// # fn a() {}
     /// # fn b() {}

--- a/clippy_lints/src/if_then_some_else_none.rs
+++ b/clippy_lints/src/if_then_some_else_none.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// in comparison to `bool::then`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let v = vec![0];
     /// let a = if v.is_empty() {
     ///     println!("true!");
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     ///
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// # let v = vec![0];
     /// let a = v.is_empty().then(|| {
     ///     println!("true!");

--- a/clippy_lints/src/ignored_unit_patterns.rs
+++ b/clippy_lints/src/ignored_unit_patterns.rs
@@ -15,14 +15,14 @@ declare_clippy_lint! {
     /// would detect a type change that `_` would ignore.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// match std::fs::create_dir("tmp-work-dir") {
     ///    Ok(_) => println!("Working directory created"),
     ///    Err(s) => eprintln!("Could not create directory: {s}"),
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// match std::fs::create_dir("tmp-work-dir") {
     ///    Ok(()) => println!("Working directory created"),
     ///    Err(s) => eprintln!("Could not create directory: {s}"),

--- a/clippy_lints/src/implicit_hasher.rs
+++ b/clippy_lints/src/implicit_hasher.rs
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// pieces of code, possibly including external crates.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashMap;
     /// # use std::hash::{Hash, BuildHasher};
     /// # trait Serialize {};
@@ -44,7 +44,7 @@ declare_clippy_lint! {
     /// pub fn foo(map: &mut HashMap<i32, i32>) { }
     /// ```
     /// could be rewritten as
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashMap;
     /// # use std::hash::{Hash, BuildHasher};
     /// # trait Serialize {};

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -24,13 +24,13 @@ declare_clippy_lint! {
     /// corresponding statements.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(x: usize) -> usize {
     ///     x
     /// }
     /// ```
     /// add return
-    /// ```rust
+    /// ```no_run
     /// fn foo(x: usize) -> usize {
     ///     return x;
     /// }

--- a/clippy_lints/src/implicit_saturating_add.rs
+++ b/clippy_lints/src/implicit_saturating_add.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// The built-in function is more readable and may be faster.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     ///let mut u:u32 = 7000;
     ///
     /// if u != u32::MAX {
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     ///let mut u:u32 = 7000;
     ///
     /// u = u.saturating_add(1);

--- a/clippy_lints/src/implicit_saturating_sub.rs
+++ b/clippy_lints/src/implicit_saturating_sub.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// Simplicity and readability. Instead we can easily use an builtin function.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let end: u32 = 10;
     /// # let start: u32 = 5;
     /// let mut i: u32 = end - start;
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let end: u32 = 10;
     /// # let start: u32 = 5;
     /// let mut i: u32 = end - start;

--- a/clippy_lints/src/implied_bounds_in_impls.rs
+++ b/clippy_lints/src/implied_bounds_in_impls.rs
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// (e.g. `trait A {} trait B: A {} trait C: B {}`, then having an `fn() -> impl A + C`)
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::ops::{Deref,DerefMut};
     /// fn f() -> impl Deref<Target = i32> + DerefMut<Target = i32> {
     /// //             ^^^^^^^^^^^^^^^^^^^ unnecessary bound, already implied by the `DerefMut` trait bound
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::ops::{Deref,DerefMut};
     /// fn f() -> impl DerefMut<Target = i32> {
     ///     Box::new(123)

--- a/clippy_lints/src/inconsistent_struct_constructor.rs
+++ b/clippy_lints/src/inconsistent_struct_constructor.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// Since the order of fields in a constructor doesn't affect the
     /// resulted instance as the below example indicates,
     ///
-    /// ```rust
+    /// ```no_run
     /// #[derive(Debug, PartialEq, Eq)]
     /// struct Foo {
     ///     x: i32,
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// inconsistent order can be confusing and decreases readability and consistency.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo {
     ///     x: i32,
     ///     y: i32,
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # struct Foo {
     /// #     x: i32,
     /// #     y: i32,

--- a/clippy_lints/src/index_refutable_slice.rs
+++ b/clippy_lints/src/index_refutable_slice.rs
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// patterns.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let slice: Option<&[u32]> = Some(&[1, 2, 3]);
     ///
     /// if let Some(slice) = slice {
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let slice: Option<&[u32]> = Some(&[1, 2, 3]);
     ///
     /// if let Some(&[first, ..]) = slice {

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = [1, 2, 3, 4];
     /// // Index within bounds
     ///
@@ -65,7 +65,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # #![allow(unused)]
     ///
     /// # let x = vec![0; 5];

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// this lint is not clever enough to analyze it.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let infinite_iter = 0..;
     /// # #[allow(unused)]
     /// [0..].iter().zip(infinite_iter.take_while(|x| *x > 5));

--- a/clippy_lints/src/inherent_impl.rs
+++ b/clippy_lints/src/inherent_impl.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// Splitting the implementation of a type makes the code harder to navigate.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct X;
     /// impl X {
     ///     fn one() {}
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     ///
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// struct X;
     /// impl X {
     ///     fn one() {}

--- a/clippy_lints/src/inherent_to_string.rs
+++ b/clippy_lints/src/inherent_to_string.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// This method is also implicitly defined if a type implements the `Display` trait. As the functionality of `Display` is much more versatile, it should be preferred.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub struct A;
     ///
     /// impl A {
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     ///
     /// pub struct A;
@@ -51,7 +51,7 @@ declare_clippy_lint! {
     /// This method is also implicitly defined if a type implements the `Display` trait. The less versatile inherent method will then shadow the implementation introduced by `Display`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     ///
     /// pub struct A;
@@ -70,7 +70,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     ///
     /// pub struct A;

--- a/clippy_lints/src/init_numbered_fields.rs
+++ b/clippy_lints/src/init_numbered_fields.rs
@@ -20,7 +20,7 @@ declare_clippy_lint! {
     /// benefit as opposed to tuple initializers
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct TupleStruct(u8, u16);
     ///
     /// let _ = TupleStruct {

--- a/clippy_lints/src/inline_fn_without_body.rs
+++ b/clippy_lints/src/inline_fn_without_body.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// The inline attribute is ignored for trait methods without bodies.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// trait Animal {
     ///     #[inline]
     ///     fn name(&self) -> &'static str;

--- a/clippy_lints/src/instant_subtraction.rs
+++ b/clippy_lints/src/instant_subtraction.rs
@@ -21,13 +21,13 @@ declare_clippy_lint! {
     /// `prev_instant.elapsed()` also more clearly signals intention.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::time::Instant;
     /// let prev_instant = Instant::now();
     /// let duration = Instant::now() - prev_instant;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::time::Instant;
     /// let prev_instant = Instant::now();
     /// let duration = prev_instant.elapsed();
@@ -47,13 +47,13 @@ declare_clippy_lint! {
     /// unintentional panics.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::time::{Instant, Duration};
     /// let time_passed = Instant::now() - Duration::from_secs(5);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::time::{Instant, Duration};
     /// let time_passed = Instant::now().checked_sub(Duration::from_secs(5));
     /// ```

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -16,14 +16,14 @@ declare_clippy_lint! {
     /// Readability -- better to use `> y` instead of `>= y + 1`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// # let y = 1;
     /// if x >= y + 1 {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// # let y = 1;
     /// if x > y {}

--- a/clippy_lints/src/invalid_upcast_comparisons.rs
+++ b/clippy_lints/src/invalid_upcast_comparisons.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// https://github.com/rust-lang/rust-clippy/issues/886
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: u8 = 1;
     /// (x as u32) > 300;
     /// ```

--- a/clippy_lints/src/item_name_repetitions.rs
+++ b/clippy_lints/src/item_name_repetitions.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// (the prefixes are `Foo1` and `Foo2` respectively), as also `Bar螃`, `Bar蟹`
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum Cake {
     ///     BlackForestCake,
     ///     HummingbirdCake,
@@ -34,7 +34,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// enum Cake {
     ///     BlackForest,
     ///     Hummingbird,
@@ -56,14 +56,14 @@ declare_clippy_lint! {
     /// It requires the user to type the module name twice.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// mod cake {
     ///     struct BlackForestCake;
     /// }
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// mod cake {
     ///     struct BlackForest;
     /// }
@@ -119,7 +119,7 @@ declare_clippy_lint! {
     /// (the prefixes are `foo1` and `foo2` respectively), as also `bar螃`, `bar蟹`
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Cake {
     ///     cake_sugar: u8,
     ///     cake_flour: u8,
@@ -127,7 +127,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct Cake {
     ///     sugar: u8,
     ///     flour: u8,

--- a/clippy_lints/src/items_after_statements.rs
+++ b/clippy_lints/src/items_after_statements.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// it's hard to figure out which item is meant in a statement.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo() {
     ///     println!("cake");
     /// }
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo() {
     ///     println!("cake");
     /// }

--- a/clippy_lints/src/items_after_test_module.rs
+++ b/clippy_lints/src/items_after_test_module.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// Having items declared after the testing module is confusing and may lead to bad test coverage.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[cfg(test)]
     /// mod tests {
     ///     // [...]
@@ -25,7 +25,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn my_function() {
     ///     // [...]
     /// }

--- a/clippy_lints/src/iter_not_returning_iterator.rs
+++ b/clippy_lints/src/iter_not_returning_iterator.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// Methods named `iter` or `iter_mut` conventionally return an `Iterator`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // `String` does not implement `Iterator`
     /// struct Data {}
     /// impl Data {
@@ -25,7 +25,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::str::Chars;
     /// struct Data {}
     /// impl Data {

--- a/clippy_lints/src/iter_without_into_iter.rs
+++ b/clippy_lints/src/iter_without_into_iter.rs
@@ -20,7 +20,7 @@ declare_clippy_lint! {
     /// (`for val in &iter {}`), without having to first call `iter()` or `iter_mut()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct MySlice<'a>(&'a [u8]);
     /// impl<'a> MySlice<'a> {
     ///     pub fn iter(&self) -> std::slice::Iter<'a, u8> {
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct MySlice<'a>(&'a [u8]);
     /// impl<'a> MySlice<'a> {
     ///     pub fn iter(&self) -> std::slice::Iter<'a, u8> {
@@ -62,7 +62,7 @@ declare_clippy_lint! {
     /// in case of ambiguity with another `IntoIterator` impl.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct MySlice<'a>(&'a [u8]);
     /// impl<'a> IntoIterator for &MySlice<'a> {
     ///     type Item = &'a u8;
@@ -73,7 +73,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct MySlice<'a>(&'a [u8]);
     /// impl<'a> MySlice<'a> {
     ///     pub fn iter(&self) -> std::slice::Iter<'a, u8> {

--- a/clippy_lints/src/large_enum_variant.rs
+++ b/clippy_lints/src/large_enum_variant.rs
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     /// this may lead to a false positive.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum Test {
     ///     A(i32),
     ///     B([i32; 8000]),
@@ -46,7 +46,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // Possibly better
     /// enum Test2 {
     ///     A(i32),

--- a/clippy_lints/src/large_futures.rs
+++ b/clippy_lints/src/large_futures.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// large size of a `Future` may cause stack overflows.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// async fn large_future(_x: [u8; 16 * 1024]) {}
     ///
     /// pub async fn trigger() {
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     ///
     /// `Box::pin` the big future instead.
     ///
-    /// ```rust
+    /// ```no_run
     /// async fn large_future(_x: [u8; 16 * 1024]) {}
     ///
     /// pub async fn trigger() {

--- a/clippy_lints/src/large_stack_frames.rs
+++ b/clippy_lints/src/large_stack_frames.rs
@@ -49,7 +49,7 @@ declare_clippy_lint! {
     /// ### Example
     /// This function creates four 500 KB arrays on the stack. Quite big but just small enough to not trigger `large_stack_arrays`.
     /// However, looking at the function as a whole, it's clear that this uses a lot of stack space.
-    /// ```rust
+    /// ```no_run
     /// struct QuiteLargeType([u8; 500_000]);
     /// fn foo() {
     ///     // ... some function that uses a lot of stack space ...
@@ -62,7 +62,7 @@ declare_clippy_lint! {
     ///
     /// Instead of doing this, allocate the arrays on the heap.
     /// This currently requires going through a `Vec` first and then converting it to a `Box`:
-    /// ```rust
+    /// ```no_run
     /// struct NotSoLargeType(Box<[u8]>);
     ///
     /// fn foo() {

--- a/clippy_lints/src/let_underscore.rs
+++ b/clippy_lints/src/let_underscore.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// expr
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn f() -> Result<u32, u32> {
     ///     Ok(0)
     /// }
@@ -69,7 +69,7 @@ declare_clippy_lint! {
     /// and ignore the resulting value.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// async fn foo() -> Result<(), ()> {
     ///     Ok(())
     /// }
@@ -77,7 +77,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # async fn context() {
     /// async fn foo() -> Result<(), ()> {
     ///     Ok(())
@@ -107,14 +107,14 @@ declare_clippy_lint! {
     /// lints.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo() -> Result<u32, ()> {
     ///     Ok(123)
     /// }
     /// let _ = foo();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo() -> Result<u32, ()> {
     ///     Ok(123)
     /// }

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     /// are mentioned due to potential false positives.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // Unnecessary lifetime annotations
     /// fn in_and_out<'a>(x: &'a u8, y: u8) -> &'a u8 {
     ///     x
@@ -46,7 +46,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn elided(x: &u8, y: u8) -> &u8 {
     ///     x
     /// }
@@ -69,7 +69,7 @@ declare_clippy_lint! {
     /// them leads to more readable code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // unnecessary lifetimes
     /// fn unused_lifetime<'a>(x: u8) {
     ///     // ..
@@ -77,7 +77,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn no_lifetime(x: u8) {
     ///     // ...
     /// }

--- a/clippy_lints/src/lines_filter_map_ok.rs
+++ b/clippy_lints/src/lines_filter_map_ok.rs
@@ -34,7 +34,7 @@ declare_clippy_lint! {
     ///   successful results, using `map_while()` would stop at the first error.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::{fs::File, io::{self, BufRead, BufReader}};
     /// # let _ = || -> io::Result<()> {
     /// let mut lines = BufReader::new(File::open("some-path")?).lines().filter_map(Result::ok);
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// # Ok(()) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::{fs::File, io::{self, BufRead, BufReader}};
     /// # let _ = || -> io::Result<()> {
     /// let mut lines = BufReader::new(File::open("some-path")?).lines().map_while(Result::ok);

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -23,14 +23,14 @@ declare_clippy_lint! {
     /// Reading long numbers is difficult without separators.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let _: u64 =
     /// 61864918973511
     /// # ;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let _: u64 =
     /// 61_864_918_973_511
     /// # ;
@@ -73,14 +73,14 @@ declare_clippy_lint! {
     /// grouped digits.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let _: u64 =
     /// 618_64_9189_73_511
     /// # ;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let _: u64 =
     /// 61_864_918_973_511
     /// # ;
@@ -100,7 +100,7 @@ declare_clippy_lint! {
     /// Negatively impacts readability.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: u32 = 0xFFF_FFF;
     /// let y: u8 = 0b01_011_101;
     /// ```
@@ -120,7 +120,7 @@ declare_clippy_lint! {
     /// Negatively impacts readability.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: u64 = 6186491_8973511;
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// It is not as fast as a memcpy.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let src = vec![1];
     /// # let mut dst = vec![0; 65];
     /// for i in 0..src.len() {
@@ -45,7 +45,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let src = vec![1];
     /// # let mut dst = vec![0; 65];
     /// dst[64..(src.len() + 64)].clone_from_slice(&src[..]);
@@ -67,7 +67,7 @@ declare_clippy_lint! {
     /// the bounds check that is done when indexing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let vec = vec!['a', 'b', 'c'];
     /// for i in 0..vec.len() {
     ///     println!("{}", vec[i]);
@@ -75,7 +75,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let vec = vec!['a', 'b', 'c'];
     /// for i in vec {
     ///     println!("{}", i);
@@ -100,7 +100,7 @@ declare_clippy_lint! {
     /// types.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // with `y` a `Vec` or slice:
     /// # let y = vec![1];
     /// for x in y.iter() {
@@ -109,7 +109,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let y = vec![1];
     /// for x in &y {
     ///     // ..
@@ -130,7 +130,7 @@ declare_clippy_lint! {
     /// Readability.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let y = vec![1];
     /// // with `y` a `Vec` or slice:
     /// for x in y.into_iter() {
@@ -138,7 +138,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// can be rewritten to
-    /// ```rust
+    /// ```no_run
     /// # let y = vec![1];
     /// for x in y {
     ///     // ..
@@ -217,7 +217,7 @@ declare_clippy_lint! {
     /// declutters the code and may be faster in some instances.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let v = vec![1];
     /// # fn bar(bar: usize, baz: usize) {}
     /// let mut i = 0;
@@ -228,7 +228,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let v = vec![1];
     /// # fn bar(bar: usize, baz: usize) {}
     /// for (i, item) in v.iter().enumerate() { bar(i, *item); }
@@ -339,7 +339,7 @@ declare_clippy_lint! {
     /// code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// loop {
     ///     ..;
     ///     break;
@@ -362,7 +362,7 @@ declare_clippy_lint! {
     /// False positive when mutation is followed by a `break`, but the `break` is not immediately
     /// after the mutation:
     ///
-    /// ```rust
+    /// ```no_run
     /// let mut x = 5;
     /// for _ in 0..x {
     ///     x += 1; // x is a range bound that is mutated
@@ -374,7 +374,7 @@ declare_clippy_lint! {
     /// False positive on nested loops ([#6072](https://github.com/rust-lang/rust-clippy/issues/6072))
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut foo = 42;
     /// for i in 0..foo {
     ///     foo -= 1;
@@ -402,7 +402,7 @@ declare_clippy_lint! {
     /// in the condition and only `Upvar` `b` gets mutated in the body, the lint will not trigger.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let i = 0;
     /// while i > 10 {
     ///     println!("let me loop forever!");
@@ -425,7 +425,7 @@ declare_clippy_lint! {
     /// have better performance.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let item1 = 2;
     /// let item2 = 3;
     /// let mut vec: Vec<u8> = Vec::new();
@@ -438,7 +438,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let item1 = 2;
     /// let item2 = 3;
     /// let mut vec: Vec<u8> = vec![item1; 20];
@@ -459,7 +459,7 @@ declare_clippy_lint! {
     /// single element.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let item1 = 2;
     /// for item in &[item1] {
     ///     println!("{}", item);
@@ -467,7 +467,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let item1 = 2;
     /// let item = &item1;
     /// println!("{}", item);
@@ -489,7 +489,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// let x = vec![Some(1), Some(2), Some(3)];
     /// for n in x {
     ///     if let Some(n) = n {
@@ -498,7 +498,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = vec![Some(1), Some(2), Some(3)];
     /// for n in x.into_iter().flatten() {
     ///     println!("{}", n);
@@ -555,7 +555,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// fn example(arr: Vec<i32>) -> Option<i32> {
     ///     for el in arr {
     ///         if el == 1 {
@@ -566,7 +566,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn example(arr: Vec<i32>) -> Option<i32> {
     ///     arr.into_iter().find(|&el| el == 1)
     /// }
@@ -587,7 +587,7 @@ declare_clippy_lint! {
     /// pattern matching on the return value of `Vec::pop()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut numbers = vec![1, 2, 3, 4, 5];
     /// while !numbers.is_empty() {
     ///     let number = numbers.pop().unwrap();
@@ -595,7 +595,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut numbers = vec![1, 2, 3, 4, 5];
     /// while let Some(number) = numbers.pop() {
     ///     // use `number`

--- a/clippy_lints/src/manual_assert.rs
+++ b/clippy_lints/src/manual_assert.rs
@@ -16,14 +16,14 @@ declare_clippy_lint! {
     /// `assert!` is simpler than `if`-then-`panic!`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let sad_people: Vec<&str> = vec![];
     /// if !sad_people.is_empty() {
     ///     panic!("there are sad people: {:?}", sad_people);
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let sad_people: Vec<&str> = vec![];
     /// assert!(sad_people.is_empty(), "there are sad people: {:?}", sad_people);
     /// ```

--- a/clippy_lints/src/manual_async_fn.rs
+++ b/clippy_lints/src/manual_async_fn.rs
@@ -20,13 +20,13 @@ declare_clippy_lint! {
     /// It's more idiomatic to use the dedicated syntax.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::future::Future;
     ///
     /// fn foo() -> impl Future<Output = i32> { async { 42 } }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// async fn foo() -> i32 { 42 }
     /// ```
     #[clippy::version = "1.45.0"]

--- a/clippy_lints/src/manual_bits.rs
+++ b/clippy_lints/src/manual_bits.rs
@@ -20,11 +20,11 @@ declare_clippy_lint! {
     /// Can be written as the shorter `T::BITS`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// std::mem::size_of::<usize>() * 8;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// usize::BITS as usize;
     /// ```
     #[clippy::version = "1.60.0"]

--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     /// PR](https://github.com/rust-lang/rust-clippy/pull/9484#issuecomment-1278922613).
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// # let (input, min, max) = (0, -2, 1);
     /// if input > max {
     ///     max
@@ -50,13 +50,13 @@ declare_clippy_lint! {
     /// # ;
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// # let (input, min, max) = (0, -2, 1);
     /// input.max(min).min(max)
     /// # ;
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// # let (input, min, max) = (0, -2, 1);
     /// match input {
     ///     x if x > max => max,
@@ -66,14 +66,14 @@ declare_clippy_lint! {
     /// # ;
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// # let (input, min, max) = (0, -2, 1);
     /// let mut x = input;
     /// if x < min { x = min; }
     /// if x > max { x = max; }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let (input, min, max) = (0, -2, 1);
     /// input.clamp(min, max)
     /// # ;
@@ -207,7 +207,7 @@ impl TypeClampability {
 
 /// Targets patterns like
 ///
-/// ```
+/// ```no_run
 /// # let (input, min, max) = (0, -3, 12);
 ///
 /// if input < min {
@@ -256,7 +256,7 @@ fn is_if_elseif_else_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx
 
 /// Targets patterns like
 ///
-/// ```
+/// ```no_run
 /// # let (input, min_value, max_value) = (0, -3, 12);
 ///
 /// input.max(min_value).min(max_value)
@@ -287,7 +287,7 @@ fn is_max_min_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> O
 
 /// Targets patterns like
 ///
-/// ```
+/// ```no_run
 /// # let (input, min_value, max_value) = (0, -3, 12);
 /// # use std::cmp::{max, min};
 /// min(max(input, min_value), max_value)
@@ -369,7 +369,7 @@ fn is_call_max_min_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>)
 
 /// Targets patterns like
 ///
-/// ```
+/// ```no_run
 /// # let (input, min, max) = (0, -3, 12);
 ///
 /// match input {
@@ -428,7 +428,7 @@ fn is_match_pattern<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Opt
 
 /// Targets patterns like
 ///
-/// ```
+/// ```no_run
 /// # let (input, min, max) = (0, -3, 12);
 ///
 /// let mut x = input;
@@ -485,7 +485,7 @@ fn is_two_if_pattern<'tcx>(cx: &LateContext<'tcx>, block: &'tcx Block<'tcx>) -> 
 
 /// Targets patterns like
 ///
-/// ```
+/// ```no_run
 /// # let (mut input, min, max) = (0, -3, 12);
 ///
 /// if input < min {

--- a/clippy_lints/src/manual_float_methods.rs
+++ b/clippy_lints/src/manual_float_methods.rs
@@ -17,12 +17,12 @@ declare_clippy_lint! {
     /// The method `is_infinite` is shorter and more readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1.0f32;
     /// if x == f32::INFINITY || x == f32::NEG_INFINITY {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = 1.0f32;
     /// if x.is_infinite() {}
     /// ```
@@ -40,13 +40,13 @@ declare_clippy_lint! {
     /// The method `is_finite` is shorter and more readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1.0f32;
     /// if x != f32::INFINITY && x != f32::NEG_INFINITY {}
     /// if x.abs() < f32::INFINITY {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = 1.0f32;
     /// if x.is_finite() {}
     /// if x.is_finite() {}

--- a/clippy_lints/src/manual_hash_one.rs
+++ b/clippy_lints/src/manual_hash_one.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// It is more concise to use the `hash_one` method.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::hash::{BuildHasher, Hash, Hasher};
     /// use std::collections::hash_map::RandomState;
     ///
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// let hash = hasher.finish();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::hash::BuildHasher;
     /// use std::collections::hash_map::RandomState;
     ///

--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -23,7 +23,7 @@ declare_clippy_lint! {
     /// clear that it's not a specific subset of characters, but all
     /// ASCII (lowercase|uppercase|digit|hexdigit) characters.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     assert!(matches!('x', 'a'..='z'));
     ///     assert!(matches!(b'X', b'A'..=b'Z'));
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     assert!('x'.is_ascii_lowercase());
     ///     assert!(b'X'.is_ascii_uppercase());

--- a/clippy_lints/src/manual_let_else.rs
+++ b/clippy_lints/src/manual_let_else.rs
@@ -30,14 +30,14 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # let w = Some(0);
     /// let v = if let Some(v) = w { v } else { return };
     /// ```
     ///
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn main () {
     /// # let w = Some(0);
     /// let Some(v) = w else { return };

--- a/clippy_lints/src/manual_main_separator_str.rs
+++ b/clippy_lints/src/manual_main_separator_str.rs
@@ -19,11 +19,11 @@ declare_clippy_lint! {
     /// an extra memory allocation.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let s: &str = &std::path::MAIN_SEPARATOR.to_string();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let s: &str = std::path::MAIN_SEPARATOR_STR;
     /// ```
     #[clippy::version = "1.70.0"]

--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// and allows possible optimizations when applied to enums.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct S {
     ///     pub a: i32,
     ///     pub b: i32,
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// struct T(pub i32, pub i32, ());
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[non_exhaustive]
     /// struct S {
     ///     pub a: i32,

--- a/clippy_lints/src/manual_range_patterns.rs
+++ b/clippy_lints/src/manual_range_patterns.rs
@@ -22,12 +22,12 @@ declare_clippy_lint! {
     /// in order to support negative numbers.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 6;
     /// let foo = matches!(x, 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = 6;
     /// let foo = matches!(x, 1..=10);
     /// ```

--- a/clippy_lints/src/manual_rem_euclid.rs
+++ b/clippy_lints/src/manual_rem_euclid.rs
@@ -18,12 +18,12 @@ declare_clippy_lint! {
     /// It's simpler and more readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: i32 = 24;
     /// let rem = ((x % 4) + 4) % 4;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x: i32 = 24;
     /// let rem = x.rem_euclid(4);
     /// ```

--- a/clippy_lints/src/manual_retain.rs
+++ b/clippy_lints/src/manual_retain.rs
@@ -35,13 +35,13 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// `.retain()` is simpler and avoids needless allocation.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut vec = vec![0, 1, 2];
     /// vec = vec.iter().filter(|&x| x % 2 == 0).copied().collect();
     /// vec = vec.into_iter().filter(|x| x % 2 == 0).collect();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut vec = vec![0, 1, 2];
     /// vec.retain(|x| x % 2 == 0);
     /// ```

--- a/clippy_lints/src/manual_slice_size_calculation.rs
+++ b/clippy_lints/src/manual_slice_size_calculation.rs
@@ -22,12 +22,12 @@ declare_clippy_lint! {
     /// * Less turbofishing
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let data : &[i32] = &[1, 2, 3];
     /// let newlen = data.len() * std::mem::size_of::<i32>();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let data : &[i32] = &[1, 2, 3];
     /// let newlen = std::mem::size_of_val(data);
     /// ```

--- a/clippy_lints/src/manual_string_new.rs
+++ b/clippy_lints/src/manual_string_new.rs
@@ -19,12 +19,12 @@ declare_clippy_lint! {
     /// be confusing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = "".to_string();
     /// let b: String = "".into();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = String::new();
     /// let b = String::new();
     /// ```

--- a/clippy_lints/src/manual_strip.rs
+++ b/clippy_lints/src/manual_strip.rs
@@ -27,14 +27,14 @@ declare_clippy_lint! {
     /// used by `str::{starts,ends}_with` and in the slicing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let s = "hello, world!";
     /// if s.starts_with("hello, ") {
     ///     assert_eq!(s["hello, ".len()..].to_uppercase(), "WORLD!");
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let s = "hello, world!";
     /// if let Some(end) = s.strip_prefix("hello, ") {
     ///     assert_eq!(end.to_uppercase(), "WORLD!");

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// an if let statement
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn do_stuff() -> Option<String> { Some(String::new()) }
     /// # fn log_err_msg(foo: String) -> Option<String> { Some(foo) }
     /// # fn format_msg(foo: String) -> String { String::new() }
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     ///
     /// The correct use would be:
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn do_stuff() -> Option<String> { Some(String::new()) }
     /// # fn log_err_msg(foo: String) -> Option<String> { Some(foo) }
     /// # fn format_msg(foo: String) -> String { String::new() }
@@ -63,7 +63,7 @@ declare_clippy_lint! {
     /// an if let statement
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn do_stuff() -> Result<String, String> { Ok(String::new()) }
     /// # fn log_err_msg(foo: String) -> Result<String, String> { Ok(foo) }
     /// # fn format_msg(foo: String) -> String { String::new() }
@@ -75,7 +75,7 @@ declare_clippy_lint! {
     ///
     /// The correct use would be:
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn do_stuff() -> Result<String, String> { Ok(String::new()) }
     /// # fn log_err_msg(foo: String) -> Result<String, String> { Ok(foo) }
     /// # fn format_msg(foo: String) -> String { String::new() }

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -48,7 +48,7 @@ declare_clippy_lint! {
     /// Just readability – `if let` nests less than a `match`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn bar(stool: &str) {}
     /// # let x = Some("abc");
     /// match x {
@@ -58,7 +58,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn bar(stool: &str) {}
     /// # let x = Some("abc");
     /// if let Some(ref foo) = x {
@@ -85,7 +85,7 @@ declare_clippy_lint! {
     /// ### Example
     /// Using `match`:
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn bar(foo: &usize) {}
     /// # let other_ref: usize = 1;
     /// # let x: Option<&usize> = Some(&1);
@@ -97,7 +97,7 @@ declare_clippy_lint! {
     ///
     /// Using `if let` with `else`:
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn bar(foo: &usize) {}
     /// # let other_ref: usize = 1;
     /// # let x: Option<&usize> = Some(&1);
@@ -155,7 +155,7 @@ declare_clippy_lint! {
     /// It makes the code less readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn foo() {}
     /// # fn bar() {}
     /// let condition: bool = true;
@@ -165,7 +165,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use if/else instead:
-    /// ```rust
+    /// ```no_run
     /// # fn foo() {}
     /// # fn bar() {}
     /// let condition: bool = true;
@@ -190,7 +190,7 @@ declare_clippy_lint! {
     /// less obvious.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 5;
     /// match x {
     ///     1..=10 => println!("1 ... 10"),
@@ -214,7 +214,7 @@ declare_clippy_lint! {
     /// catching all exceptions in java with `catch(Exception)`
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: Result<i32, &str> = Ok(3);
     /// match x {
     ///     Ok(_) => println!("ok"),
@@ -236,7 +236,7 @@ declare_clippy_lint! {
     /// Using `as_ref()` or `as_mut()` instead is shorter.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: Option<()> = None;
     ///
     /// let r: Option<&()> = match x {
@@ -246,7 +246,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x: Option<()> = None;
     ///
     /// let r: Option<&()> = x.as_ref();
@@ -269,7 +269,7 @@ declare_clippy_lint! {
     /// variants, and also may not use correct path to enum if it's not present in the current scope.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # enum Foo { A(usize), B(usize) }
     /// # let x = Foo::B(1);
     /// match x {
@@ -279,7 +279,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # enum Foo { A(usize), B(usize) }
     /// # let x = Foo::B(1);
     /// match x {
@@ -305,7 +305,7 @@ declare_clippy_lint! {
     /// if it's not present in the current scope.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # enum Foo { A, B, C }
     /// # let x = Foo::B;
     /// match x {
@@ -316,7 +316,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # enum Foo { A, B, C }
     /// # let x = Foo::B;
     /// match x {
@@ -340,7 +340,7 @@ declare_clippy_lint! {
     /// It makes the code less readable, especially to spot wildcard pattern use in match arm.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let s = "foo";
     /// match s {
     ///     "a" => {},
@@ -349,7 +349,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let s = "foo";
     /// match s {
     ///     "a" => {},
@@ -371,7 +371,7 @@ declare_clippy_lint! {
     /// Just readability – `let` doesn't nest, whereas a `match` does.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum Wrapper {
     ///     Data(i32),
     /// }
@@ -384,7 +384,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// The correct use would be:
-    /// ```rust
+    /// ```no_run
     /// enum Wrapper {
     ///     Data(i32),
     /// }
@@ -410,7 +410,7 @@ declare_clippy_lint! {
     /// is actually binding temporary value, bringing a 'dropped while borrowed' error.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let a = 1;
     /// # let b = 2;
     /// match (a, b) {
@@ -421,7 +421,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let a = 1;
     /// # let b = 2;
     /// let (c, d) = (a, b);
@@ -441,7 +441,7 @@ declare_clippy_lint! {
     /// matching all enum variants explicitly.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct A { a: i32 }
     /// let a = A { a: 5 };
     ///
@@ -452,7 +452,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # struct A { a: i32 }
     /// # let a = A { a: 5 };
     /// match a {
@@ -484,7 +484,7 @@ declare_clippy_lint! {
     /// drop order.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::task::Poll;
     /// # use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     /// if let Ok(_) = Ok::<i32, i32>(42) {}
@@ -503,7 +503,7 @@ declare_clippy_lint! {
     ///
     /// The more idiomatic use would be:
     ///
-    /// ```rust
+    /// ```no_run
     /// # use std::task::Poll;
     /// # use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     /// if Ok::<i32, i32>(42).is_ok() {}
@@ -535,7 +535,7 @@ declare_clippy_lint! {
     /// `cfg` attributes that remove an arm evaluating to `false`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = Some(5);
     ///
     /// let a = match x {
@@ -551,7 +551,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = Some(5);
     /// let a = matches!(x, Some(0));
     /// ```
@@ -664,7 +664,7 @@ declare_clippy_lint! {
     /// It is unnecessarily verbose and complex.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn func(opt: Option<Result<u64, String>>) {
     ///     let n = match opt {
     ///         Some(n) => match n {
@@ -676,7 +676,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn func(opt: Option<Result<u64, String>>) {
     ///     let n = match opt {
     ///         Some(Ok(n)) => n,
@@ -698,7 +698,7 @@ declare_clippy_lint! {
     /// Concise code helps focusing on behavior instead of boilerplate.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let foo: Option<i32> = None;
     /// match foo {
     ///     Some(v) => v,
@@ -707,7 +707,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let foo: Option<i32> = None;
     /// foo.unwrap_or(1);
     /// ```
@@ -761,7 +761,7 @@ declare_clippy_lint! {
     /// The arm is unreachable, which is likely a mistake
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let text = "Foo";
     /// match &*text.to_ascii_lowercase() {
     ///     "foo" => {},
@@ -770,7 +770,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let text = "Foo";
     /// match &*text.to_ascii_lowercase() {
     ///     "foo" => {},
@@ -823,7 +823,7 @@ declare_clippy_lint! {
     /// println!("All done!");
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::sync::Mutex;
     /// # struct State {}
     /// # impl State {
@@ -861,7 +861,7 @@ declare_clippy_lint! {
     /// always return), it is more clear to write `return Err(x)`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(fail: bool) -> Result<i32, String> {
     ///     if fail {
     ///       Err("failed")?;
@@ -871,7 +871,7 @@ declare_clippy_lint! {
     /// ```
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// fn foo(fail: bool) -> Result<i32, String> {
     ///     if fail {
     ///       return Err("failed".into());
@@ -893,14 +893,14 @@ declare_clippy_lint! {
     /// Using the `map` method is clearer and more concise.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// match Some(0) {
     ///     Some(x) => Some(x + 1),
     ///     None => None,
     /// };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// Some(0).map(|x| x + 1);
     /// ```
     #[clippy::version = "1.52.0"]
@@ -917,7 +917,7 @@ declare_clippy_lint! {
     /// Using the `filter` method is clearer and more concise.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// match Some(0) {
     ///     Some(x) => if x % 2 == 0 {
     ///                     Some(x)
@@ -928,7 +928,7 @@ declare_clippy_lint! {
     /// };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// Some(0).filter(|&x| x % 2 == 0);
     /// ```
     #[clippy::version = "1.66.0"]

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -25,14 +25,14 @@ declare_clippy_lint! {
     /// `None`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::mem;
     ///
     /// let mut an_option = Some(0);
     /// let replaced = mem::replace(&mut an_option, None);
     /// ```
     /// Is better expressed with:
-    /// ```rust
+    /// ```no_run
     /// let mut an_option = Some(0);
     /// let taken = an_option.take();
     /// ```
@@ -53,7 +53,7 @@ declare_clippy_lint! {
     /// observed in the case of a panic.
     ///
     /// ### Example
-    /// ```
+    /// ```no_run
     /// use std::mem;
     ///# fn may_panic(v: Vec<i32>) -> Vec<i32> { v }
     ///
@@ -84,12 +84,12 @@ declare_clippy_lint! {
     /// take the current value and replace it with the default value of that type.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut text = String::from("foo");
     /// let replaced = std::mem::replace(&mut text, String::default());
     /// ```
     /// Is better expressed with:
-    /// ```rust
+    /// ```no_run
     /// let mut text = String::from("foo");
     /// let taken = std::mem::take(&mut text);
     /// ```

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -142,11 +142,11 @@ declare_clippy_lint! {
     /// implements `Copy`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// [1, 2, 3].iter().cloned();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// [1, 2, 3].iter().copied();
     /// ```
     #[clippy::version = "1.53.0"]
@@ -165,14 +165,14 @@ declare_clippy_lint! {
     /// with repetitive code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let hello = "hesuo worpd"
     ///     .replace('s', "l")
     ///     .replace("u", "l")
     ///     .replace('p', "l");
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let hello = "hesuo worpd".replace(['s', 'u', 'p'], "l");
     /// ```
     #[clippy::version = "1.65.0"]
@@ -194,14 +194,14 @@ declare_clippy_lint! {
     /// A code that relies on that side-effect could fail.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec!["string".to_string()];
     /// vec.iter().cloned().take(10);
     /// vec.iter().cloned().last();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec!["string".to_string()];
     /// vec.iter().take(10).cloned();
     /// vec.iter().last().cloned();
@@ -222,11 +222,11 @@ declare_clippy_lint! {
     /// `Option` is used to produce 0 or 1 items.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let nums: Vec<i32> = ["1", "2", "whee!"].iter().flat_map(|x| x.parse().ok()).collect();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let nums: Vec<i32> = ["1", "2", "whee!"].iter().filter_map(|x| x.parse().ok()).collect();
     /// ```
     #[clippy::version = "1.53.0"]
@@ -254,7 +254,7 @@ declare_clippy_lint! {
     /// where they may get displayed. Activate this lint to do just that.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// # let option = Some(1);
     /// # let result: Result<usize, ()> = Ok(1);
     /// option.unwrap();
@@ -262,7 +262,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let option = Some(1);
     /// # let result: Result<usize, ()> = Ok(1);
     /// option.expect("more helpful message");
@@ -293,14 +293,14 @@ declare_clippy_lint! {
     /// It is better to write the value directly without the indirection.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// let val1 = Some(1).unwrap();
     /// let val2 = Ok::<_, ()>(1).unwrap();
     /// let val3 = Err::<(), _>(1).unwrap_err();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let val1 = 1;
     /// let val2 = 1;
     /// let val3 = 1;
@@ -363,7 +363,7 @@ declare_clippy_lint! {
     /// them.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct X;
     /// impl X {
     ///     fn add(&self, other: &X) -> X {
@@ -412,7 +412,7 @@ declare_clippy_lint! {
     /// mutable reference to a `as_..` function.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct X;
     /// impl X {
     ///     fn as_str(self) -> &'static str {
@@ -439,13 +439,13 @@ declare_clippy_lint! {
     /// The error type needs to implement `Debug`
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = Ok::<_, ()>(());
     /// x.ok().expect("why did I do this again?");
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = Ok::<_, ()>(());
     /// x.expect("why did I do this again?");
     /// ```
@@ -496,7 +496,7 @@ declare_clippy_lint! {
     /// heuristic to try to identify such cases. However, the heuristic can produce false negatives.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// # let x = Some(1);
     /// # let mut map = std::collections::HashMap::<u64, String>::new();
     /// x.unwrap_or(Default::default());
@@ -504,7 +504,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = Some(1);
     /// # let mut map = std::collections::HashMap::<u64, String>::new();
     /// x.unwrap_or_default();
@@ -529,7 +529,7 @@ declare_clippy_lint! {
     /// The order of the arguments is not in execution order
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// # let option = Some(1);
     /// # let result: Result<usize, ()> = Ok(1);
     /// # fn some_function(foo: ()) -> usize { 1 }
@@ -539,7 +539,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let option = Some(1);
     /// # let result: Result<usize, ()> = Ok(1);
     /// # fn some_function(foo: ()) -> usize { 1 }
@@ -565,13 +565,13 @@ declare_clippy_lint! {
     /// The order of the arguments is not in execution order.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let opt = Some(1);
     /// opt.map_or(None, |a| Some(a + 1));
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let opt = Some(1);
     /// opt.and_then(|a| Some(a + 1));
     /// ```
@@ -590,13 +590,13 @@ declare_clippy_lint! {
     /// `_.ok()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let r: Result<u32, &str> = Ok(1);
     /// assert_eq!(Some(1), r.map_or(None, Some));
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let r: Result<u32, &str> = Ok(1);
     /// assert_eq!(Some(1), r.ok());
     /// ```
@@ -616,7 +616,7 @@ declare_clippy_lint! {
     /// `_.map(|x| y)` or `_.map_err(|x| y)`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn opt() -> Option<&'static str> { Some("42") }
     /// # fn res() -> Result<&'static str, &'static str> { Ok("42") }
     /// let _ = opt().and_then(|s| Some(s.len()));
@@ -626,7 +626,7 @@ declare_clippy_lint! {
     ///
     /// The correct use would be:
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn opt() -> Option<&'static str> { Some("42") }
     /// # fn res() -> Result<&'static str, &'static str> { Ok("42") }
     /// let _ = opt().map(|s| s.len());
@@ -648,13 +648,13 @@ declare_clippy_lint! {
     /// `_.find(_)`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![1];
     /// vec.iter().filter(|x| **x == 0).next();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![1];
     /// vec.iter().find(|x| **x == 0);
     /// ```
@@ -673,13 +673,13 @@ declare_clippy_lint! {
     /// `_.find(!condition)`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![1];
     /// vec.iter().skip_while(|x| **x == 0).next();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![1];
     /// vec.iter().find(|x| **x != 0);
     /// ```
@@ -698,7 +698,7 @@ declare_clippy_lint! {
     /// `_.flat_map(_)` for `Iterator` or `_.and_then(_)` for `Option`
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let vec = vec![vec![1]];
     /// let opt = Some(5);
     ///
@@ -707,7 +707,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![vec![1]];
     /// # let opt = Some(5);
     /// vec.iter().flat_map(|x| x.iter());
@@ -729,7 +729,7 @@ declare_clippy_lint! {
     /// less performant.
     ///
      /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # #![allow(unused)]
     /// (0_i32..10)
     ///     .filter(|n| n.checked_add(1).is_some())
@@ -737,7 +737,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # #[allow(unused)]
     /// (0_i32..10).filter_map(|n| n.checked_add(1));
     /// ```
@@ -757,14 +757,14 @@ declare_clippy_lint! {
     /// less performant.
     ///
      /// ### Example
-    /// ```rust
+    /// ```no_run
     /// (0_i32..10)
     ///     .find(|n| n.checked_add(1).is_some())
     ///     .map(|n| n.checked_add(1).unwrap());
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// (0_i32..10).find_map(|n| n.checked_add(1));
     /// ```
     #[clippy::version = "1.51.0"]
@@ -782,12 +782,12 @@ declare_clippy_lint! {
     /// `_.find_map(_)`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     ///  (0..3).filter_map(|x| if x == 2 { Some(x) } else { None }).next();
     /// ```
     /// Can be written as
     ///
-    /// ```rust
+    /// ```no_run
     ///  (0..3).find_map(|x| if x == 2 { Some(x) } else { None });
     /// ```
     #[clippy::version = "1.36.0"]
@@ -804,12 +804,12 @@ declare_clippy_lint! {
     /// Readability, this can be written more concisely by using `flatten`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let iter = vec![vec![0]].into_iter();
     /// iter.flat_map(|x| x);
     /// ```
     /// Can be written as
-    /// ```rust
+    /// ```no_run
     /// # let iter = vec![vec![0]].into_iter();
     /// iter.flatten();
     /// ```
@@ -830,7 +830,7 @@ declare_clippy_lint! {
     /// * `!_.any(_)`, or `!_.contains(_)` for `is_none()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # #![allow(unused)]
     /// let vec = vec![1];
     /// vec.iter().find(|x| **x == 0).is_some();
@@ -839,7 +839,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let vec = vec![1];
     /// vec.iter().any(|x| *x == 0);
     ///
@@ -862,13 +862,13 @@ declare_clippy_lint! {
     /// `_.starts_with(_)`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let name = "foo";
     /// if name.chars().next() == Some('_') {};
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let name = "foo";
     /// if name.starts_with('_') {};
     /// ```
@@ -897,13 +897,13 @@ declare_clippy_lint! {
     /// actually expensive to call or not.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let foo = Some(String::new());
     /// foo.unwrap_or(String::from("empty"));
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let foo = Some(String::new());
     /// foo.unwrap_or_else(|| String::from("empty"));
     /// ```
@@ -921,7 +921,7 @@ declare_clippy_lint! {
     /// You should use `.unwrap_or(…)` instead for clarity.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let fallback = "fallback";
     /// // Result
     /// # type Error = &'static str;
@@ -933,7 +933,7 @@ declare_clippy_lint! {
     /// let value = option.or(Some(fallback)).unwrap();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let fallback = "fallback";
     /// // Result
     /// # let result: Result<&str, &str> = Err("error");
@@ -962,7 +962,7 @@ declare_clippy_lint! {
     /// change the semantics of the program, but you shouldn't rely on that anyway.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let foo = Some(String::new());
     /// # let err_code = "418";
     /// # let err_msg = "I'm a teapot";
@@ -975,7 +975,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let foo = Some(String::new());
     /// # let err_code = "418";
     /// # let err_msg = "I'm a teapot";
@@ -996,7 +996,7 @@ declare_clippy_lint! {
     /// generics, not for using the `clone` method on a concrete type.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// 42u64.clone();
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -1017,7 +1017,7 @@ declare_clippy_lint! {
     /// data.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::rc::Rc;
     /// let x = Rc::new(1);
     ///
@@ -1025,7 +1025,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::rc::Rc;
     /// # let x = Rc::new(1);
     /// Rc::clone(&x);
@@ -1047,7 +1047,7 @@ declare_clippy_lint! {
     /// facilities.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // Generic implementation for `T: Display` is used (slow)
     /// ["foo", "bar"].iter().map(|s| s.to_string());
     ///
@@ -1070,7 +1070,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// In an impl block:
-    /// ```rust
+    /// ```no_run
     /// # struct Foo;
     /// # struct NotAFoo;
     /// impl Foo {
@@ -1080,7 +1080,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// # struct Foo;
     /// struct Bar(Foo);
     /// impl Foo {
@@ -1091,7 +1091,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// # struct Foo;
     /// # struct FooError;
     /// impl Foo {
@@ -1103,14 +1103,14 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Or in a trait definition:
-    /// ```rust
+    /// ```no_run
     /// pub trait Trait {
     ///     // Bad. The type name must contain `Self`
     ///     fn new();
     /// }
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// pub trait Trait {
     ///     // Good. Return type contains `Self`
     ///     fn new() -> Self;
@@ -1178,11 +1178,11 @@ declare_clippy_lint! {
     /// automatically does this without suspicious-looking `unwrap` calls.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = std::iter::empty::<Option<i32>>().filter(Option::is_some).map(Option::unwrap);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let _ = std::iter::empty::<Option<i32>>().flatten();
     /// ```
     #[clippy::version = "1.53.0"]
@@ -1201,7 +1201,7 @@ declare_clippy_lint! {
     ///  but is more readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashSet;
     /// # let mut s = HashSet::new();
     /// # s.insert(1);
@@ -1209,7 +1209,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashSet;
     /// # let mut s = HashSet::new();
     /// # s.insert(1);
@@ -1231,13 +1231,13 @@ declare_clippy_lint! {
     /// readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let some_vec = vec![0, 1, 2, 3];
     /// let bad_vec = some_vec.iter().nth(3);
     /// let bad_slice = &some_vec[..].iter().nth(3);
     /// ```
     /// The correct use would be:
-    /// ```rust
+    /// ```no_run
     /// let some_vec = vec![0, 1, 2, 3];
     /// let bad_vec = some_vec.get(3);
     /// let bad_slice = &some_vec[..].get(3);
@@ -1256,13 +1256,13 @@ declare_clippy_lint! {
     /// `.nth(x)` is cleaner
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let some_vec = vec![0, 1, 2, 3];
     /// let bad_vec = some_vec.iter().skip(3).next();
     /// let bad_slice = &some_vec[..].iter().skip(3).next();
     /// ```
     /// The correct use would be:
-    /// ```rust
+    /// ```no_run
     /// let some_vec = vec![0, 1, 2, 3];
     /// let bad_vec = some_vec.iter().nth(3);
     /// let bad_slice = &some_vec[..].iter().nth(3);
@@ -1281,13 +1281,13 @@ declare_clippy_lint! {
     /// `.into_iter()` is simpler with better performance.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashSet;
     /// let mut foo = vec![0, 1, 2, 3];
     /// let bar: HashSet<usize> = foo.drain(..).collect();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashSet;
     /// let foo = vec![0, 1, 2, 3];
     /// let bar: HashSet<usize> = foo.into_iter().collect();
@@ -1315,13 +1315,13 @@ declare_clippy_lint! {
     /// `x.get(index).unwrap()` instead of `x[index]`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = vec![2, 3, 5];
     /// let last_element = x.get(x.len() - 1);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = vec![2, 3, 5];
     /// let last_element = x.last();
     /// ```
@@ -1351,13 +1351,13 @@ declare_clippy_lint! {
     /// trait.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut some_vec = vec![0, 1, 2, 3];
     /// let last = some_vec.get(3).unwrap();
     /// *some_vec.get_mut(0).unwrap() = 1;
     /// ```
     /// The correct use would be:
-    /// ```rust
+    /// ```no_run
     /// let mut some_vec = vec![0, 1, 2, 3];
     /// let last = some_vec[3];
     /// some_vec[0] = 1;
@@ -1376,7 +1376,7 @@ declare_clippy_lint! {
     /// Using `append` instead of `extend` is more concise and faster
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut a = vec![1, 2, 3];
     /// let mut b = vec![4, 5, 6];
     ///
@@ -1384,7 +1384,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut a = vec![1, 2, 3];
     /// let mut b = vec![4, 5, 6];
     ///
@@ -1405,7 +1405,7 @@ declare_clippy_lint! {
     /// `.push_str(s)` is clearer
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let abc = "abc";
     /// let def = String::from("def");
     /// let mut s = String::new();
@@ -1413,7 +1413,7 @@ declare_clippy_lint! {
     /// s.extend(def.chars());
     /// ```
     /// The correct use would be:
-    /// ```rust
+    /// ```no_run
     /// let abc = "abc";
     /// let def = String::from("def");
     /// let mut s = String::new();
@@ -1435,12 +1435,12 @@ declare_clippy_lint! {
     /// `.to_vec()` is clearer
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let s = [1, 2, 3, 4, 5];
     /// let s2: Vec<isize> = s[..].iter().cloned().collect();
     /// ```
     /// The better use would be:
-    /// ```rust
+    /// ```no_run
     /// let s = [1, 2, 3, 4, 5];
     /// let s2: Vec<isize> = s.to_vec();
     /// ```
@@ -1460,13 +1460,13 @@ declare_clippy_lint! {
     /// `_.ends_with(_)`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let name = "_";
     /// name.chars().last() == Some('_') || name.chars().next_back() == Some('-');
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let name = "_";
     /// name.ends_with('_') || name.ends_with('-');
     /// ```
@@ -1485,13 +1485,13 @@ declare_clippy_lint! {
     /// The call is unnecessary.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn do_stuff(x: &[i32]) {}
     /// let x: &[i32] = &[1, 2, 3, 4, 5];
     /// do_stuff(x.as_ref());
     /// ```
     /// The correct use would be:
-    /// ```rust
+    /// ```no_run
     /// # fn do_stuff(x: &[i32]) {}
     /// let x: &[i32] = &[1, 2, 3, 4, 5];
     /// do_stuff(x);
@@ -1512,13 +1512,13 @@ declare_clippy_lint! {
     /// Readability.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # #[allow(unused)]
     /// (0..3).fold(false, |acc, x| acc || x > 2);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// (0..3).any(|x| x > 2);
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -1538,14 +1538,14 @@ declare_clippy_lint! {
     /// operation is being performed.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = (0..3).filter_map(|x| if x > 2 { Some(x) } else { None });
     ///
     /// // As there is no transformation of the argument this could be written as:
     /// let _ = (0..3).filter(|&x| x > 2);
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// let _ = (0..4).filter_map(|x| Some(x + 1));
     ///
     /// // As there is no conditional check on the argument this could be written as:
@@ -1568,14 +1568,14 @@ declare_clippy_lint! {
     /// operation is being performed.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = (0..3).find_map(|x| if x > 2 { Some(x) } else { None });
     ///
     /// // As there is no transformation of the argument this could be written as:
     /// let _ = (0..3).find(|&x| x > 2);
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// let _ = (0..4).find_map(|x| Some(x + 1));
     ///
     /// // As there is no conditional check on the argument this could be written as:
@@ -1598,13 +1598,13 @@ declare_clippy_lint! {
     /// `iter_mut` directly.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![3, 4, 5];
     /// (&vec).into_iter();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![3, 4, 5];
     /// (&vec).iter();
     /// ```
@@ -1625,7 +1625,7 @@ declare_clippy_lint! {
     /// completion, you can just use `for_each` instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _ = (0..3).map(|x| x + 2).count();
     /// ```
     #[clippy::version = "1.39.0"]
@@ -1647,7 +1647,7 @@ declare_clippy_lint! {
     /// data, but those are not yet rigorously defined.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // Beware the UB
     /// use std::mem::MaybeUninit;
     ///
@@ -1656,7 +1656,7 @@ declare_clippy_lint! {
     ///
     /// Note that the following is OK:
     ///
-    /// ```rust
+    /// ```no_run
     /// use std::mem::MaybeUninit;
     ///
     /// let _: [MaybeUninit<bool>; 5] = unsafe {
@@ -1677,7 +1677,7 @@ declare_clippy_lint! {
     /// These can be written simply with `saturating_add/sub` methods.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let y: u32 = 0;
     /// # let x: u32 = 100;
     /// let add = x.checked_add(y).unwrap_or(u32::MAX);
@@ -1686,7 +1686,7 @@ declare_clippy_lint! {
     ///
     /// can be written using dedicated methods for saturating addition/subtraction as:
     ///
-    /// ```rust
+    /// ```no_run
     /// # let y: u32 = 0;
     /// # let x: u32 = 100;
     /// let add = x.saturating_add(y);
@@ -1707,7 +1707,7 @@ declare_clippy_lint! {
     /// This is a no-op, and likely unintended
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// unsafe { (&() as *const ()).offset(1) };
     /// ```
     #[clippy::version = "1.41.0"]
@@ -1727,7 +1727,7 @@ declare_clippy_lint! {
     /// symlink in windows. Using `!FileType::is_dir()` is a better way to that intention.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # || {
     /// let metadata = std::fs::metadata("foo.txt")?;
     /// let filetype = metadata.file_type();
@@ -1741,7 +1741,7 @@ declare_clippy_lint! {
     ///
     /// should be written as:
     ///
-    /// ```rust
+    /// ```no_run
     /// # || {
     /// let metadata = std::fs::metadata("foo.txt")?;
     /// let filetype = metadata.file_type();
@@ -1767,13 +1767,13 @@ declare_clippy_lint! {
     /// `_.as_deref()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let opt = Some("".to_string());
     /// opt.as_ref().map(String::as_str)
     /// # ;
     /// ```
     /// Can be written as
-    /// ```rust
+    /// ```no_run
     /// # let opt = Some("".to_string());
     /// opt.as_deref()
     /// # ;
@@ -1792,14 +1792,14 @@ declare_clippy_lint! {
     /// These can be shortened into `.get()`
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let a = [1, 2, 3];
     /// # let b = vec![1, 2, 3];
     /// a[2..].iter().next();
     /// b.iter().next();
     /// ```
     /// should be written as:
-    /// ```rust
+    /// ```no_run
     /// # let a = [1, 2, 3];
     /// # let b = vec![1, 2, 3];
     /// a.get(2);
@@ -1820,14 +1820,14 @@ declare_clippy_lint! {
     /// It's less clear that we are pushing a single character.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let mut string = String::new();
     /// string.insert_str(0, "R");
     /// string.push_str("R");
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let mut string = String::new();
     /// string.insert(0, 'R');
     /// string.push('R');
@@ -1860,14 +1860,14 @@ declare_clippy_lint! {
     /// side effects. Eagerly evaluating them can change the semantics of the program.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // example code where clippy issues a warning
     /// let opt: Option<u32> = None;
     ///
     /// opt.unwrap_or_else(|| 42);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let opt: Option<u32> = None;
     ///
     /// opt.unwrap_or(42);
@@ -1886,11 +1886,11 @@ declare_clippy_lint! {
     /// Using `try_for_each` instead is more readable and idiomatic.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// (0..3).map(|t| Err(t)).collect::<Result<(), _>>();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// (0..3).try_for_each(|t| Err(t));
     /// ```
     #[clippy::version = "1.49.0"]
@@ -1909,7 +1909,7 @@ declare_clippy_lint! {
     /// [FromIterator documentation](https://doc.rust-lang.org/std/iter/trait.FromIterator.html)
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let five_fives = std::iter::repeat(5).take(5);
     ///
     /// let v = Vec::from_iter(five_fives);
@@ -1917,7 +1917,7 @@ declare_clippy_lint! {
     /// assert_eq!(v, vec![5, 5, 5, 5, 5]);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let five_fives = std::iter::repeat(5).take(5);
     ///
     /// let v: Vec<i32> = five_fives.collect();
@@ -1939,7 +1939,7 @@ declare_clippy_lint! {
     /// inside `inspect` at the beginning of the closure in `for_each`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// [1,2,3,4,5].iter()
     /// .inspect(|&x| println!("inspect the number: {}", x))
     /// .for_each(|&x| {
@@ -1947,7 +1947,7 @@ declare_clippy_lint! {
     /// });
     /// ```
     /// Can be written as
-    /// ```rust
+    /// ```no_run
     /// [1,2,3,4,5].iter()
     /// .for_each(|&x| {
     ///     println!("inspect the number: {}", x);
@@ -1968,12 +1968,12 @@ declare_clippy_lint! {
     /// Readability, this can be written more concisely by using `flatten`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let iter = vec![Some(1)].into_iter();
     /// iter.filter_map(|x| x);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let iter = vec![Some(1)].into_iter();
     /// iter.flatten();
     /// ```
@@ -1991,12 +1991,12 @@ declare_clippy_lint! {
     /// It can be written more concisely without the call to `map`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = [1, 2, 3];
     /// let y: Vec<_> = x.iter().map(|x| x).map(|x| 2*x).collect();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = [1, 2, 3];
     /// let y: Vec<_> = x.iter().map(|x| 2*x).collect();
     /// ```
@@ -2015,13 +2015,13 @@ declare_clippy_lint! {
     /// readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # #[allow(unused)]
     /// "Hello".bytes().nth(3);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # #[allow(unused)]
     /// "Hello".as_bytes().get(3);
     /// ```
@@ -2040,13 +2040,13 @@ declare_clippy_lint! {
     /// to why we are calling `to_vec` on something that is already a `Vec` or calling `to_owned` on something that is already owned.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = vec![1, 2, 3];
     /// let b = a.to_vec();
     /// let c = a.to_owned();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = vec![1, 2, 3];
     /// let b = a.clone();
     /// let c = a.clone();
@@ -2066,7 +2066,7 @@ declare_clippy_lint! {
     /// readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # #![allow(unused)]
     /// let some_vec = vec![0, 1, 2, 3];
     ///
@@ -2075,7 +2075,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let some_vec = vec![0, 1, 2, 3];
     ///
     /// some_vec.len();
@@ -2104,7 +2104,7 @@ declare_clippy_lint! {
     /// was the original intent, using `into_owned` instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::borrow::Cow;
     /// let s = "Hello world!";
     /// let cow = Cow::Borrowed(s);
@@ -2113,7 +2113,7 @@ declare_clippy_lint! {
     /// assert!(matches!(data, Cow::Borrowed(_)))
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::borrow::Cow;
     /// let s = "Hello world!";
     /// let cow = Cow::Borrowed(s);
@@ -2122,7 +2122,7 @@ declare_clippy_lint! {
     /// assert!(matches!(data, Cow::Borrowed(_)))
     /// ```
     /// or
-    /// ```rust
+    /// ```no_run
     /// # use std::borrow::Cow;
     /// let s = "Hello world!";
     /// let cow = Cow::Borrowed(s);
@@ -2146,7 +2146,7 @@ declare_clippy_lint! {
     /// likely to be intended as a different number.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let s = "";
     /// for x in s.splitn(1, ":") {
     ///     // ..
@@ -2154,7 +2154,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let s = "";
     /// for x in s.splitn(2, ":") {
     ///     // ..
@@ -2174,12 +2174,12 @@ declare_clippy_lint! {
     /// These are both harder to read, as well as less performant.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: String = std::iter::repeat('x').take(10).collect();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x: String = "x".repeat(10);
     /// ```
     #[clippy::version = "1.54.0"]
@@ -2231,13 +2231,13 @@ declare_clippy_lint! {
     /// The function `split` is simpler and there is no performance difference in these cases, considering
     /// that both functions return a lazy iterator.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let str = "key=value=add";
     /// let _ = str.splitn(3, '=').next().unwrap();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let str = "key=value=add";
     /// let _ = str.split('=').next().unwrap();
     /// ```
@@ -2261,13 +2261,13 @@ declare_clippy_lint! {
     /// [#8148](https://github.com/rust-lang/rust-clippy/issues/8148).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let path = std::path::Path::new("x");
     /// foo(&path.to_string_lossy().to_string());
     /// fn foo(s: &str) {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let path = std::path::Path::new("x");
     /// foo(&path.to_string_lossy());
     /// fn foo(s: &str) {}
@@ -2286,13 +2286,13 @@ declare_clippy_lint! {
     /// `.collect::<String>()` is more concise and might be more performant
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let vector = vec!["hello",  "world"];
     /// let output = vector.iter().map(|item| item.to_uppercase()).collect::<Vec<String>>().join("");
     /// println!("{}", output);
     /// ```
     /// The correct use would be:
-    /// ```rust
+    /// ```no_run
     /// let vector = vec!["hello",  "world"];
     /// let output = vector.iter().map(|item| item.to_uppercase()).collect::<String>();
     /// println!("{}", output);
@@ -2319,13 +2319,13 @@ declare_clippy_lint! {
     /// Redundant code and improving readability.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = Some(&1);
     /// let b = a.as_deref(); // goes from Option<&i32> to Option<&i32>
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = Some(&1);
     /// let b = a;
     /// ```
@@ -2345,13 +2345,13 @@ declare_clippy_lint! {
     /// `is_digit(..)` is slower and requires specifying the radix.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let c: char = '6';
     /// c.is_digit(10);
     /// c.is_digit(16);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let c: char = '6';
     /// c.is_ascii_digit();
     /// c.is_ascii_hexdigit();
@@ -2371,12 +2371,12 @@ declare_clippy_lint! {
     /// In this case the modification is useless as it's a temporary that cannot be read from afterwards.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = Some(3);
     /// x.as_ref().take();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = Some(3);
     /// x.as_ref();
     /// ```
@@ -2394,7 +2394,7 @@ declare_clippy_lint! {
     /// It's either a mistake or confusing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// "1234".replace("12", "12");
     /// "1234".replacen("12", "12", 1);
     /// ```
@@ -2417,12 +2417,12 @@ declare_clippy_lint! {
     /// to account for similar patterns.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = true;
     /// x.then_some("a").unwrap_or("b");
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = true;
     /// if x { "a" } else { "b" };
     /// ```
@@ -2444,12 +2444,12 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// let a = [123].iter();
     /// let b = Some(123).into_iter();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::iter;
     /// let a = iter::once(&123);
     /// let b = iter::once(123);
@@ -2475,13 +2475,13 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// use std::{slice, option};
     /// let a: slice::Iter<i32> = [].iter();
     /// let f: option::IntoIter<i32> = None.into_iter();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::iter;
     /// let a: iter::Empty<i32> = iter::empty();
     /// let b: iter::Empty<i32> = iter::empty();
@@ -2511,7 +2511,7 @@ declare_clippy_lint! {
     /// faster in those cases.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let vec = vec![1_u8];
     /// let count = vec.iter().filter(|x| **x == 0u8).count();
     /// ```
@@ -2537,12 +2537,12 @@ declare_clippy_lint! {
     /// `str::len()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// "hello".bytes().count();
     /// String::from("hello").bytes().count();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// "hello".len();
     /// String::from("hello").len();
     /// ```
@@ -2561,13 +2561,13 @@ declare_clippy_lint! {
     /// `ends_with` is case-sensitive and may not detect files with a valid extension.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn is_rust_file(filename: &str) -> bool {
     ///     filename.ends_with(".rs")
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn is_rust_file(filename: &str) -> bool {
     ///     let filename = std::path::Path::new(filename);
     ///     filename.extension()
@@ -2590,13 +2590,13 @@ declare_clippy_lint! {
     /// result.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = vec![2, 3, 5];
     /// let first_element = x.get(0);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = vec![2, 3, 5];
     /// let first_element = x.first();
     /// ```
@@ -2616,13 +2616,13 @@ declare_clippy_lint! {
     /// Concise code helps focusing on behavior instead of boilerplate.
     ///
     /// ### Examples
-    /// ```rust
+    /// ```no_run
     /// let foo: Option<i32> = None;
     /// foo.map_or(Err("error"), |v| Ok(v));
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let foo: Option<i32> = None;
     /// foo.ok_or("error");
     /// ```
@@ -2642,7 +2642,7 @@ declare_clippy_lint! {
     /// Readability, this can be written more concisely
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = vec![42, 43];
     /// let y = x.iter();
     /// let z = y.map(|i| *i);
@@ -2650,7 +2650,7 @@ declare_clippy_lint! {
     ///
     /// The correct use would be:
     ///
-    /// ```rust
+    /// ```no_run
     /// let x = vec![42, 43];
     /// let y = x.iter();
     /// let z = y.cloned();
@@ -2670,7 +2670,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// Before:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     ///
     /// #[derive(Debug)]
@@ -2772,7 +2772,7 @@ declare_clippy_lint! {
     /// guarantee.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::sync::{Arc, Mutex};
     ///
     /// let mut value_rc = Arc::new(Mutex::new(42_u8));
@@ -2782,7 +2782,7 @@ declare_clippy_lint! {
     /// *value += 1;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::sync::{Arc, Mutex};
     ///
     /// let mut value_rc = Arc::new(Mutex::new(42_u8));
@@ -2807,7 +2807,7 @@ declare_clippy_lint! {
     /// necessary. I don't know the worst case.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::fs::OpenOptions;
     ///
     /// OpenOptions::new().read(true).truncate(true);
@@ -2828,7 +2828,7 @@ declare_clippy_lint! {
     /// previous defined path.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::path::PathBuf;
     ///
     /// let mut x = PathBuf::from("/foo");
@@ -2837,7 +2837,7 @@ declare_clippy_lint! {
     /// ```
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// use std::path::PathBuf;
     ///
     /// let mut x = PathBuf::from("/foo");
@@ -2859,13 +2859,13 @@ declare_clippy_lint! {
     /// The code is better expressed with `.enumerate()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = vec![1];
     /// let _ = x.iter().zip(0..x.len());
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = vec![1];
     /// let _ = x.iter().enumerate();
     /// ```
@@ -2890,13 +2890,13 @@ declare_clippy_lint! {
     /// the string is the intention behind this, `clone()` should be used.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     let x = String::from("hello world").repeat(1);
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     let x = String::from("hello world").clone();
     /// }
@@ -2930,12 +2930,12 @@ declare_clippy_lint! {
     /// issue linked above.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut vec = vec![2, 1, 3];
     /// vec.sort();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut vec = vec![2, 1, 3];
     /// vec.sort_unstable();
     /// ```
@@ -2963,7 +2963,7 @@ declare_clippy_lint! {
     /// assert_eq!(any_box.type_id(), TypeId::of::<i32>()); // ⚠️ this fails!
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::any::{Any, TypeId};
     ///
     /// let any_box: Box<dyn Any> = Box::new(42_i32);
@@ -2984,7 +2984,7 @@ declare_clippy_lint! {
     /// Hashing a unit value doesn't do anything as the implementation of `Hash` for `()` is a no-op.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::hash::Hash;
     /// # use std::collections::hash_map::DefaultHasher;
     /// # enum Foo { Empty, WithValue(u8) }
@@ -2997,7 +2997,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::hash::Hash;
     /// # use std::collections::hash_map::DefaultHasher;
     /// # enum Foo { Empty, WithValue(u8) }
@@ -3030,14 +3030,14 @@ declare_clippy_lint! {
     /// imported by a use statement, then it will need to be added manually.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct A;
     /// # impl A { fn foo(&self) {} }
     /// # let mut vec: Vec<A> = Vec::new();
     /// vec.sort_by(|a, b| a.foo().cmp(&b.foo()));
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # struct A;
     /// # impl A { fn foo(&self) {} }
     /// # let mut vec: Vec<A> = Vec::new();
@@ -3057,12 +3057,12 @@ declare_clippy_lint! {
     /// This is probably an argument inversion mistake.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// vec![1, 2, 3, 4, 5].resize(0, 5)
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// vec![1, 2, 3, 4, 5].clear()
     /// ```
     #[clippy::version = "1.46.0"]
@@ -3111,14 +3111,14 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```
+    /// ```no_run
     /// # use std::collections::HashMap;
     /// let map: HashMap<u32, u32> = HashMap::new();
     /// let values = map.iter().map(|(_, value)| value).collect::<Vec<_>>();
     /// ```
     ///
     /// Use instead:
-    /// ```
+    /// ```no_run
     /// # use std::collections::HashMap;
     /// let map: HashMap<u32, u32> = HashMap::new();
     /// let values = map.values().collect::<Vec<_>>();
@@ -3184,14 +3184,14 @@ declare_clippy_lint! {
     /// this exact scenario.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::io;
     /// fn foo<T: io::Seek>(t: &mut T) {
     ///     t.seek(io::SeekFrom::Start(0));
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::io;
     /// fn foo<T: io::Seek>(t: &mut T) {
     ///     t.rewind();
@@ -3213,12 +3213,12 @@ declare_clippy_lint! {
     /// when this allocation may not be needed.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let iterator = vec![1].into_iter();
     /// let len = iterator.collect::<Vec<_>>().len();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let iterator = vec![1].into_iter();
     /// let len = iterator.count();
     /// ```
@@ -3241,11 +3241,11 @@ declare_clippy_lint! {
     /// which is likely not what was intended.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// std::process::Command::new("echo").arg("-n hello").spawn().unwrap();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// std::process::Command::new("echo").args(["-n", "hello"]).spawn().unwrap();
     /// ```
     #[clippy::version = "1.69.0"]
@@ -3264,12 +3264,12 @@ declare_clippy_lint! {
     /// Calling `.clear()` also makes the intent clearer.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut v = vec![1, 2, 3];
     /// v.drain(..);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut v = vec![1, 2, 3];
     /// v.clear();
     /// ```
@@ -3287,12 +3287,12 @@ declare_clippy_lint! {
     /// `.next_back()` is cleaner.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let foo = [0; 10];
     /// foo.iter().rev().next();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let foo = [0; 10];
     /// foo.iter().next_back();
     /// ```
@@ -3320,13 +3320,13 @@ declare_clippy_lint! {
     /// to keep the capacity on the original `Vec`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn remove_all(v: &mut Vec<i32>) -> Vec<i32> {
     ///     v.drain(..).collect()
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::mem;
     /// fn remove_all(v: &mut Vec<i32>) -> Vec<i32> {
     ///     mem::take(v)
@@ -3354,11 +3354,11 @@ declare_clippy_lint! {
     /// desirable in those cases.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// vec![1, 2, 3].iter().fold(Some(0i32), |sum, i| sum?.checked_add(*i));
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// vec![1, 2, 3].iter().try_fold(0i32, |sum, i| sum.checked_add(*i));
     /// ```
     #[clippy::version = "1.72.0"]
@@ -3410,12 +3410,12 @@ declare_clippy_lint! {
     /// for situations where that additional performance is absolutely necessary.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let c = 'c';
     /// "\\.+*?()|[]{}^$#&-~".chars().any(|x| x == c);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let c = 'c';
     /// matches!(c, '\\' | '.' | '+' | '*' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '#' | '&' | '-' | '~');
     /// ```
@@ -3439,13 +3439,13 @@ declare_clippy_lint! {
     /// so it can be safely ignored or unwrapped.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn hex_encode(bytes: &[u8]) -> String {
     ///     bytes.iter().map(|b| format!("{b:02X}")).collect()
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt::Write;
     /// fn hex_encode(bytes: &[u8]) -> String {
     ///     bytes.iter().fold(String::new(), |mut output, b| {
@@ -3469,7 +3469,7 @@ declare_clippy_lint! {
     /// nothing. If not, the call should be removed.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let v = vec![1, 2, 3];
     /// let x = v.iter().skip(0).collect::<Vec<_>>();
     /// let y = v.iter().collect::<Vec<_>>();
@@ -3495,13 +3495,13 @@ declare_clippy_lint! {
     /// This can create differing behavior, so better safe than sorry.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn really_expensive_fn(i: i32) -> i32 { i }
     /// # let v = vec![];
     /// _ = v.into_iter().filter_map(|i| (i % 2 == 0).then(|| really_expensive_fn(i)));
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn really_expensive_fn(i: i32) -> i32 { i }
     /// # let v = vec![];
     /// _ = v.into_iter().filter(|i| i % 2 == 0).map(|i| really_expensive_fn(i));
@@ -3521,7 +3521,7 @@ declare_clippy_lint! {
     /// can access the lock while this writer is active.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::sync::RwLock;
     /// fn assert_is_zero(lock: &RwLock<i32>) {
     ///     let num = lock.write().unwrap();
@@ -3530,7 +3530,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::sync::RwLock;
     /// fn assert_is_zero(lock: &RwLock<i32>) {
     ///     let num = lock.read().unwrap();
@@ -3554,11 +3554,11 @@ declare_clippy_lint! {
     /// This is most likely not what the user intended to do.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// for _ in [1, 2, 3].iter().take(4) {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// for _ in [1, 2, 3].iter() {}
     /// ```
     #[clippy::version = "1.74.0"]
@@ -3587,14 +3587,14 @@ declare_clippy_lint! {
     /// therefore ignored.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::path::Path;
     /// fn is_markdown(path: &Path) -> bool {
     ///     path.ends_with(".md")
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::path::Path;
     /// fn is_markdown(path: &Path) -> bool {
     ///     path.extension().is_some_and(|ext| ext == "md")
@@ -3614,14 +3614,14 @@ declare_clippy_lint! {
     /// The `as_str()` conversion is pointless and can be removed for simplicity and cleanliness.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # #![allow(unused)]
     /// let owned_string = "This is a string".to_owned();
     /// owned_string.as_str().as_bytes();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # #![allow(unused)]
     /// let owned_string = "This is a string".to_owned();
     /// owned_string.as_bytes();

--- a/clippy_lints/src/methods/str_splitn.rs
+++ b/clippy_lints/src/methods/str_splitn.rs
@@ -115,7 +115,7 @@ fn check_manual_split_once(
 
 /// checks for
 ///
-/// ```
+/// ```no_run
 /// let mut iter = "a.b.c".splitn(2, '.');
 /// let a = iter.next();
 /// let b = iter.next();

--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -41,12 +41,12 @@ declare_clippy_lint! {
     /// dereferences, e.g., changing `*x` to `x` within the function.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(ref _x: u8) {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo(_x: &u8) {}
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -70,7 +70,7 @@ declare_clippy_lint! {
     /// macro, it has been allowed in the mean time.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _x = 0;
     /// let y = _x + 1; // Here we are using `_x`, even though it has a leading
     ///                 // underscore. We should rename `_x` to `x`

--- a/clippy_lints/src/misc_early/mod.rs
+++ b/clippy_lints/src/misc_early/mod.rs
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     /// the fields that are actually bound.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct Foo {
     /// #     a: i32,
     /// #     b: i32,
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # struct Foo {
     /// #     a: i32,
     /// #     b: i32,
@@ -71,12 +71,12 @@ declare_clippy_lint! {
     /// It affects code readability.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(a: i32, _a: i32) {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn bar(a: i32, _b: i32) {}
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -94,7 +94,7 @@ declare_clippy_lint! {
     /// decremented.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut x = 3;
     /// --x;
     /// ```
@@ -113,14 +113,14 @@ declare_clippy_lint! {
     /// It looks confusing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let _ =
     /// 0x1a9BAcD
     /// # ;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let _ =
     /// 0x1A9BACD
     /// # ;
@@ -142,14 +142,14 @@ declare_clippy_lint! {
     /// Suffix style should be consistent.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let _ =
     /// 123832i32
     /// # ;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let _ =
     /// 123832_i32
     /// # ;
@@ -170,14 +170,14 @@ declare_clippy_lint! {
     /// Suffix style should be consistent.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let _ =
     /// 123832_i32
     /// # ;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let _ =
     /// 123832i32
     /// # ;
@@ -202,7 +202,7 @@ declare_clippy_lint! {
     /// ### Example
     ///
     /// In Rust:
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     let a = 0123;
     ///     println!("{}", a);
@@ -258,7 +258,7 @@ declare_clippy_lint! {
     /// bindings.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let v = Some("abc");
     /// match v {
     ///     Some(x) => (),
@@ -267,7 +267,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let v = Some("abc");
     /// match v {
     ///     Some(x) => (),
@@ -295,7 +295,7 @@ declare_clippy_lint! {
     /// can match that element as well.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct TupleStruct(u32, u32, u32);
     /// # let t = TupleStruct(1, 2, 3);
     /// match t {
@@ -305,7 +305,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # struct TupleStruct(u32, u32, u32);
     /// # let t = TupleStruct(1, 2, 3);
     /// match t {

--- a/clippy_lints/src/mismatching_type_param_order.rs
+++ b/clippy_lints/src/mismatching_type_param_order.rs
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// ignored.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo<A, B> {
     ///     x: A,
     ///     y: B,
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     /// impl<B, A> Foo<B, A> {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct Foo<A, B> {
     ///     x: A,
     ///     y: B,

--- a/clippy_lints/src/missing_assert_message.rs
+++ b/clippy_lints/src/missing_assert_message.rs
@@ -27,14 +27,14 @@ declare_clippy_lint! {
     /// don't provide any extra information.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct Service { ready: bool }
     /// fn call(service: Service) {
     ///     assert!(service.ready);
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # struct Service { ready: bool }
     /// fn call(service: Service) {
     ///     assert!(service.ready, "`service.poll_ready()` must be called first to ensure that service is ready to receive requests");

--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -43,14 +43,14 @@ declare_clippy_lint! {
     /// about the length of a slice, but this lint will not detect that.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn sum(v: &[u8]) -> u8 {
     ///     // 4 bounds checks
     ///     v[0] + v[1] + v[2] + v[3]
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn sum(v: &[u8]) -> u8 {
     ///     assert!(v.len() > 4);
     ///     // no bounds checks

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     ///
     /// Also, the lint only runs one pass over the code. Consider these two non-const functions:
     ///
-    /// ```rust
+    /// ```no_run
     /// fn a() -> i32 {
     ///     0
     /// }
@@ -42,7 +42,7 @@ declare_clippy_lint! {
     ///
     /// If you are marking a public function with `const`, removing it again will break API compatibility.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct Foo {
     /// #     random_number: usize,
     /// # }
@@ -55,7 +55,7 @@ declare_clippy_lint! {
     ///
     /// Could be a const fn:
     ///
-    /// ```rust
+    /// ```no_run
     /// # struct Foo {
     /// #     random_number: usize,
     /// # }

--- a/clippy_lints/src/missing_fields_in_debug.rs
+++ b/clippy_lints/src/missing_fields_in_debug.rs
@@ -40,7 +40,7 @@ declare_clippy_lint! {
     /// making it much less likely to accidentally forget to update the `Debug` impl when adding a new variant.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     /// struct Foo {
     ///     data: String,
@@ -57,7 +57,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::fmt;
     /// struct Foo {
     ///     data: String,

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// then opt out for specific methods where this might not make sense.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub fn foo() {} // missing #[inline]
     /// fn ok() {} // ok
     /// #[inline] pub fn bar() {} // ok

--- a/clippy_lints/src/missing_trait_methods.rs
+++ b/clippy_lints/src/missing_trait_methods.rs
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// Indicates that a method is missing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// trait Trait {
     ///     fn required();
     ///
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// trait Trait {
     ///     fn required();
     ///

--- a/clippy_lints/src/mixed_read_write_in_expression.rs
+++ b/clippy_lints/src/mixed_read_write_in_expression.rs
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// order, or which is correct for any evaluation order.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut x = 0;
     ///
     /// let a = {
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let mut x = 0;
     /// let tmp = {
     ///     x = 1;

--- a/clippy_lints/src/multi_assignments.rs
+++ b/clippy_lints/src/multi_assignments.rs
@@ -13,12 +13,12 @@ declare_clippy_lint! {
     /// where such assignments return a copy of the assigned value.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     ///# let (a, b);
     /// a = b = 42;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     ///# let (a, b);
     /// b = 42;
     /// a = b;

--- a/clippy_lints/src/multiple_unsafe_ops_per_block.rs
+++ b/clippy_lints/src/multiple_unsafe_ops_per_block.rs
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// elimination of unnecessary unsafe blocks through refactoring.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// /// Reads a `char` from the given pointer.
     /// ///
     /// /// # Safety
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// /// Reads a `char` from the given pointer.
     /// ///
     /// /// # Safety

--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -47,7 +47,7 @@ declare_clippy_lint! {
     /// [#6745](https://github.com/rust-lang/rust-clippy/issues/6745).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::cmp::{PartialEq, Eq};
     /// use std::collections::HashSet;
     /// use std::hash::{Hash, Hasher};

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// misunderstanding of references.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let mut y = 1;
     /// let x = &mut &mut y;
     /// ```

--- a/clippy_lints/src/mut_reference.rs
+++ b/clippy_lints/src/mut_reference.rs
@@ -15,14 +15,14 @@ declare_clippy_lint! {
     /// the value. Also the code misleads about the intent of the call site.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let mut vec = Vec::new();
     /// # let mut value = 5;
     /// vec.push(&mut value);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let mut vec = Vec::new();
     /// # let value = 5;
     /// vec.push(&value);

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -29,14 +29,14 @@ declare_clippy_lint! {
     /// for waiting before a critical section.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let y = true;
     /// # use std::sync::Mutex;
     /// let x = Mutex::new(&y);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let y = true;
     /// # use std::sync::atomic::AtomicBool;
     /// let x = AtomicBool::new(y);
@@ -62,13 +62,13 @@ declare_clippy_lint! {
     /// for waiting before a critical section.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::sync::Mutex;
     /// let x = Mutex::new(0usize);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::sync::atomic::AtomicUsize;
     /// let x = AtomicUsize::new(0usize);
     /// ```

--- a/clippy_lints/src/needless_arbitrary_self_type.rs
+++ b/clippy_lints/src/needless_arbitrary_self_type.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// Increases the amount and decreases the readability of code
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// enum ValType {
     ///     I32,
     ///     I64,
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     ///
     /// Could be rewritten as
     ///
-    /// ```rust
+    /// ```no_run
     /// enum ValType {
     ///     I32,
     ///     I64,

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// shorter code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = true;
     /// if x {
     ///     false
@@ -43,7 +43,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = true;
     /// !x
     /// # ;

--- a/clippy_lints/src/needless_borrowed_ref.rs
+++ b/clippy_lints/src/needless_borrowed_ref.rs
@@ -13,7 +13,7 @@ declare_clippy_lint! {
     /// This pattern has no effect in almost all cases.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut v = Vec::<String>::new();
     /// v.iter_mut().filter(|&ref a| a.is_empty());
     ///
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut v = Vec::<String>::new();
     /// v.iter_mut().filter(|a| a.is_empty());
     ///

--- a/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     /// in such a case can change the semantics of the code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn f(_: impl AsRef<str>) {}
     ///
     /// let x = "foo";
@@ -44,7 +44,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn f(_: impl AsRef<str>) {}
     ///
     /// let x = "foo";

--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -55,7 +55,7 @@ declare_clippy_lint! {
     /// statement within the THEN block and omitting the else block completely.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn condition() -> bool { false }
     /// # fn update_condition() {}
     /// # let x = false;
@@ -72,7 +72,7 @@ declare_clippy_lint! {
     ///
     /// Could be rewritten as
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn condition() -> bool { false }
     /// # fn update_condition() {}
     /// # let x = false;
@@ -87,7 +87,7 @@ declare_clippy_lint! {
     ///
     /// As another example, the following code
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn waiting() -> bool { false }
     /// loop {
     ///     if waiting() {
@@ -100,7 +100,7 @@ declare_clippy_lint! {
     /// ```
     /// Could be rewritten as
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn waiting() -> bool { false }
     /// loop {
     ///     if waiting() {
@@ -408,7 +408,7 @@ fn check_and_warn(cx: &EarlyContext<'_>, expr: &ast::Expr) {
 /// till a non-whitespace character is found.  e.g., the string. If no closing `}` is present, the
 /// string will be preserved.
 ///
-/// ```rust
+/// ```no_run
 /// {
 ///     let x = 5;
 /// }

--- a/clippy_lints/src/needless_else.rs
+++ b/clippy_lints/src/needless_else.rs
@@ -13,7 +13,7 @@ declare_clippy_lint! {
     /// An empty else branch does nothing and can be removed.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     ///# fn check() -> bool { true }
     /// if check() {
     ///     println!("Check successful!");
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     ///# fn check() -> bool { true }
     /// if check() {
     ///     println!("Check successful!");

--- a/clippy_lints/src/needless_for_each.rs
+++ b/clippy_lints/src/needless_for_each.rs
@@ -25,14 +25,14 @@ declare_clippy_lint! {
     /// But when none of these apply, a simple `for` loop is more idiomatic.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let v = vec![0, 1, 2];
     /// v.iter().for_each(|elem| {
     ///     println!("{}", elem);
     /// })
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let v = vec![0, 1, 2];
     /// for elem in v.iter() {
     ///     println!("{}", elem);

--- a/clippy_lints/src/needless_late_init.rs
+++ b/clippy_lints/src/needless_late_init.rs
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     /// Assigning in the `let` statement is less repetitive.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a;
     /// a = 1;
     ///
@@ -41,7 +41,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = 1;
     ///
     /// let b = match 3 {

--- a/clippy_lints/src/needless_parens_on_range_literals.rs
+++ b/clippy_lints/src/needless_parens_on_range_literals.rs
@@ -20,7 +20,7 @@ declare_clippy_lint! {
   ///
   /// ### Example
   ///
-  /// ```rust
+  /// ```no_run
   /// for i in (0)..10 {
   ///   println!("{i}");
   /// }
@@ -28,7 +28,7 @@ declare_clippy_lint! {
   ///
   /// Use instead:
   ///
-  /// ```rust
+  /// ```no_run
   /// for i in 0..10 {
   ///   println!("{i}");
   /// }

--- a/clippy_lints/src/needless_pass_by_ref_mut.rs
+++ b/clippy_lints/src/needless_pass_by_ref_mut.rs
@@ -37,13 +37,13 @@ declare_clippy_lint! {
     /// opportunities for parallelization.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(y: &mut i32) -> i32 {
     ///     12 + *y
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo(y: &i32) -> i32 {
     ///     12 + *y
     /// }

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -43,13 +43,13 @@ declare_clippy_lint! {
     /// (by using `Borrow` trait, for example), depending on how the function is used.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(v: Vec<i32>) {
     ///     assert_eq!(v.len(), 42);
     /// }
     /// ```
     /// should be
-    /// ```rust
+    /// ```no_run
     /// fn foo(v: &[i32]) {
     ///     assert_eq!(v.len(), 42);
     /// }

--- a/clippy_lints/src/needless_question_mark.rs
+++ b/clippy_lints/src/needless_question_mark.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// There's no reason to use `?` to short-circuit when execution of the body will end there anyway.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct TO {
     ///     magic: Option<usize>,
     /// }
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     ///
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct TO {
     ///     magic: Option<usize>,
     /// }

--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// somewhere), and make the code less readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # struct Point {
     /// #     x: i32,
     /// #     y: i32,

--- a/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
+++ b/clippy_lints/src/neg_cmp_op_on_partial_ord.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// especially easy to miss if the operator based comparison result is negated.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = 1.0;
     /// let b = f64::NAN;
     ///
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::cmp::Ordering;
     /// # let a = 1.0;
     /// # let b = f64::NAN;

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -23,7 +23,7 @@ declare_clippy_lint! {
     /// readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// 0;
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/no_mangle_with_rust_abi.rs
+++ b/clippy_lints/src/no_mangle_with_rust_abi.rs
@@ -18,13 +18,13 @@ declare_clippy_lint! {
     /// Rust ABI can break this at any point.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     ///  #[no_mangle]
     ///  fn example(arg_one: u32, arg_two: usize) {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     ///  #[no_mangle]
     ///  extern "C" fn example(arg_one: u32, arg_two: usize) {}
     /// ```

--- a/clippy_lints/src/non_canonical_impls.rs
+++ b/clippy_lints/src/non_canonical_impls.rs
@@ -64,7 +64,7 @@ declare_clippy_lint! {
     /// in `Some`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::cmp::Ordering;
     /// #[derive(Eq, PartialEq)]
     /// struct A(u32);
@@ -84,7 +84,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::cmp::Ordering;
     /// #[derive(Eq, PartialEq)]
     /// struct A(u32);

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -58,7 +58,7 @@ declare_clippy_lint! {
     /// [#5812](https://github.com/rust-lang/rust-clippy/issues/5812) and
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
     ///
     /// const CONST_ATOM: AtomicUsize = AtomicUsize::new(12);
@@ -67,7 +67,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
     /// static STATIC_ATOM: AtomicUsize = AtomicUsize::new(15);
     /// STATIC_ATOM.store(9, SeqCst);
@@ -105,7 +105,7 @@ declare_clippy_lint! {
     /// [#3825](https://github.com/rust-lang/rust-clippy/issues/3825)
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
     /// const CONST_ATOM: AtomicUsize = AtomicUsize::new(12);
     ///
@@ -114,7 +114,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
     /// const CONST_ATOM: AtomicUsize = AtomicUsize::new(12);
     ///

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -63,7 +63,7 @@ declare_clippy_lint! {
     /// descriptive name.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let _1 = 1;
     /// let ___1 = 1;
     /// let __1___2 = 11;

--- a/clippy_lints/src/nonstandard_macro_braces.rs
+++ b/clippy_lints/src/nonstandard_macro_braces.rs
@@ -23,11 +23,11 @@ declare_clippy_lint! {
     /// doesn't give you a semicolon in item position, which can be unexpected.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// vec!{1, 2, 3};
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// vec![1, 2, 3];
     /// ```
     #[clippy::version = "1.55.0"]

--- a/clippy_lints/src/octal_escapes.rs
+++ b/clippy_lints/src/octal_escapes.rs
@@ -32,13 +32,13 @@ declare_clippy_lint! {
     /// can see it.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let one = "\033[1m Bold? \033[0m";  // \033 intended as escape
     /// let two = "\033\0";                 // \033 intended as null-3-3
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let one = "\x1b[1mWill this be bold?\x1b[0m";
     /// let two = "\x0033\x00";
     /// ```

--- a/clippy_lints/src/only_used_in_recursion.rs
+++ b/clippy_lints/src/only_used_in_recursion.rs
@@ -30,7 +30,7 @@ declare_clippy_lint! {
     ///
     /// In some cases, this would not catch all useless arguments.
     ///
-    /// ```rust
+    /// ```no_run
     /// fn foo(a: usize, b: usize) -> usize {
     ///     let f = |x| x + 1;
     ///
@@ -53,7 +53,7 @@ declare_clippy_lint! {
     /// Also, when you recurse the function name with path segments, it is not possible to detect.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn f(a: usize, b: usize) -> usize {
     ///     if a == 0 {
     ///         1
@@ -66,7 +66,7 @@ declare_clippy_lint! {
     /// # }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn f(a: usize) -> usize {
     ///     if a == 0 {
     ///         1

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -48,7 +48,7 @@ declare_clippy_lint! {
     /// like `#[cfg(target_pointer_width = "64")] ..` instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let vec: Vec<isize> = Vec::new();
     /// if vec.len() <= 0 {}
     /// if 100 > i32::MAX {}
@@ -76,7 +76,7 @@ declare_clippy_lint! {
     /// desirable to explicitly call checked, wrapping or saturating arithmetic methods.
     ///
     /// #### Example
-    /// ```rust
+    /// ```no_run
     /// // `n` can be any number, including `i32::MAX`.
     /// fn foo(n: i32) -> i32 {
     ///   n + 1
@@ -105,7 +105,7 @@ declare_clippy_lint! {
     /// can be useful to rule out floating-point numbers.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let a = 0.0;
     /// a + 1.0;
     /// ```
@@ -128,7 +128,7 @@ declare_clippy_lint! {
     /// implementations that differ from the regular `Op` impl.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut a = 5;
     /// let b = 0;
     /// // ...
@@ -137,7 +137,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut a = 5;
     /// let b = 0;
     /// // ...
@@ -165,7 +165,7 @@ declare_clippy_lint! {
     /// written as `a = a op a op b` as it's less confusing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut a = 5;
     /// let b = 2;
     /// // ...
@@ -205,7 +205,7 @@ declare_clippy_lint! {
     /// test-case for this lint.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// if (x & 1 == 2) { }
     /// ```
@@ -238,7 +238,7 @@ declare_clippy_lint! {
     /// uncommon).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// if (x | 1 > 3) {  }
     /// ```
@@ -261,7 +261,7 @@ declare_clippy_lint! {
     /// llvm generates better code for `x & 15 == 0` on x86
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// if x & 0b1111 == 0 { }
     /// ```
@@ -280,7 +280,7 @@ declare_clippy_lint! {
     /// Readability.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// # let y = 2;
     /// if x == y || x < y {}
@@ -288,7 +288,7 @@ declare_clippy_lint! {
     ///
     /// Use instead:
     ///
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// # let y = 2;
     /// if x <= y {}
@@ -308,7 +308,7 @@ declare_clippy_lint! {
     /// which is probably not the programmer's intention
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let status_code = 200;
     /// if status_code <= 400 && status_code > 500 {}
     /// ```
@@ -328,7 +328,7 @@ declare_clippy_lint! {
     /// different value entirely.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let status_code = 200;
     /// if status_code <= 400 && status_code < 500 {}
     /// ```
@@ -348,7 +348,7 @@ declare_clippy_lint! {
     /// `Duration::subsec_millis()` than to calculate them.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::time::Duration;
     /// # let duration = Duration::new(5, 0);
     /// let micros = duration.subsec_nanos() / 1_000;
@@ -356,7 +356,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::time::Duration;
     /// # let duration = Duration::new(5, 0);
     /// let micros = duration.subsec_micros();
@@ -384,7 +384,7 @@ declare_clippy_lint! {
     /// calls. We may introduce a list of known pure functions in the future.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// if x + 1 == x + 1 {}
     ///
@@ -434,7 +434,7 @@ declare_clippy_lint! {
     /// corrected
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 1;
     /// 0 / x;
     /// 0 * x;
@@ -462,13 +462,13 @@ declare_clippy_lint! {
     /// with an allow.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub fn is_roughly_equal(a: f32, b: f32) -> bool {
     ///     (a - b) < f32::EPSILON
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// pub fn is_roughly_equal(a: f32, b: f32) -> bool {
     ///     (a - b).abs() < f32::EPSILON
     /// }
@@ -488,7 +488,7 @@ declare_clippy_lint! {
     /// meaning. So it just obscures what's going on. Delete it mercilessly.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// x / 1 + 0 * 1 - 0 | 0;
     /// ```
@@ -508,13 +508,13 @@ declare_clippy_lint! {
     /// remainder.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 3 / 2;
     /// println!("{}", x);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = 3f32 / 2f32;
     /// println!("{}", x);
     /// ```
@@ -535,14 +535,14 @@ declare_clippy_lint! {
     /// needlessly consuming code and heap space.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = "foo";
     /// # let y = String::from("foo");
     /// if x.to_owned() == y {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = "foo";
     /// # let y = String::from("foo");
     /// if x == y {}
@@ -566,7 +566,7 @@ declare_clippy_lint! {
     /// guide](http://www.floating-point-gui.de/errors/comparison).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 1.2331f64;
     /// let y = 1.2332f64;
     ///
@@ -575,7 +575,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = 1.2331f64;
     /// # let y = 1.2332f64;
     /// let error_margin = f64::EPSILON; // Use an epsilon for comparison
@@ -603,7 +603,7 @@ declare_clippy_lint! {
     /// guide](http://www.floating-point-gui.de/errors/comparison).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x: f64 = 1.0;
     /// const ONE: f64 = 1.00;
     ///
@@ -611,7 +611,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x: f64 = 1.0;
     /// # const ONE: f64 = 1.00;
     /// let error_margin = f64::EPSILON; // Use an epsilon for comparison
@@ -638,7 +638,7 @@ declare_clippy_lint! {
     /// contest, it's probably a bad idea. Use something more underhanded.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// let a = x % 1;
     /// let a = x % -1;
@@ -662,7 +662,7 @@ declare_clippy_lint! {
     /// For example, in Rust `17 % -3 = 2`, but in Python `17 % -3 = -1`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = -17 % 3;
     /// ```
     #[clippy::version = "1.42.0"]
@@ -685,12 +685,12 @@ declare_clippy_lint! {
     /// determination is quite conservative.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let (x,y) = (true, false);
     /// if x & !y {} // where both x and y are booleans
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let (x,y) = (true, false);
     /// if x && !y {}
     /// ```
@@ -710,14 +710,14 @@ declare_clippy_lint! {
     /// comparing the values they point to.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = &[1, 2, 3];
     /// let b = &[1, 2, 3];
     ///
     /// assert!(a as *const _ as usize == b as *const _ as usize);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = &[1, 2, 3];
     /// let b = &[1, 2, 3];
     ///
@@ -742,7 +742,7 @@ declare_clippy_lint! {
     /// indexing operations they are assumed not to have any side effects.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Event {
     ///     x: i32,
     /// }
@@ -753,7 +753,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Should be:
-    /// ```rust
+    /// ```no_run
     /// struct Event {
     ///     x: i32,
     /// }

--- a/clippy_lints/src/option_if_let_else.rs
+++ b/clippy_lints/src/option_if_let_else.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// this lint will not be raised.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let optional: Option<u32> = Some(0);
     /// # fn do_complicated_function() -> u32 { 5 };
     /// let _ = if let Some(foo) = optional {
@@ -54,7 +54,7 @@ declare_clippy_lint! {
     ///
     /// should be
     ///
-    /// ```rust
+    /// ```no_run
     /// # let optional: Option<u32> = Some(0);
     /// # fn do_complicated_function() -> u32 { 5 };
     /// let _ = optional.map_or(5, |foo| foo);

--- a/clippy_lints/src/overflow_check_conditional.rs
+++ b/clippy_lints/src/overflow_check_conditional.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     /// Rust. Users can use functions like `overflowing_*` and `wrapping_*` instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let a = 1;
     /// # let b = 2;
     /// a + b < a;

--- a/clippy_lints/src/panic_in_result_fn.rs
+++ b/clippy_lints/src/panic_in_result_fn.rs
@@ -22,14 +22,14 @@ declare_clippy_lint! {
     /// Functions called from a function returning a `Result` may invoke a panicking macro. This is not checked.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn result_with_panic() -> Result<bool, String>
     /// {
     ///     panic!("error");
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn result_without_panic() -> Result<bool, String> {
     ///     Err(String::from("error"))
     /// }

--- a/clippy_lints/src/partial_pub_fields.rs
+++ b/clippy_lints/src/partial_pub_fields.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// * Data: relatively simple objects which group a bunch of related attributes together.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub struct Color {
     ///     pub r: u8,
     ///     pub g: u8,
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// pub struct Color {
     ///     pub r: u8,
     ///     pub g: u8,

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// re-implement it.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo;
     ///
     /// impl PartialEq for Foo {

--- a/clippy_lints/src/partialeq_to_none.rs
+++ b/clippy_lints/src/partialeq_to_none.rs
@@ -21,13 +21,13 @@ declare_clippy_lint! {
     /// way relies on `T: PartialEq` to do the comparison, which is unneeded.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(f: Option<u32>) -> &'static str {
     ///     if f != None { "yay" } else { "nay" }
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo(f: Option<u32>) -> &'static str {
     ///     if f.is_some() { "yay" } else { "nay" }
     /// }

--- a/clippy_lints/src/pass_by_ref_or_value.rs
+++ b/clippy_lints/src/pass_by_ref_or_value.rs
@@ -58,12 +58,12 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// fn foo(v: &u32) {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo(v: u32) {}
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -86,7 +86,7 @@ declare_clippy_lint! {
     /// `memcpy`, which can be expensive.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[derive(Clone, Copy)]
     /// struct TooLarge([u8; 2048]);
     ///
@@ -94,7 +94,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # #[derive(Clone, Copy)]
     /// # struct TooLarge([u8; 2048]);
     /// fn foo(v: &TooLarge) {}

--- a/clippy_lints/src/permissions_set_readonly_false.rs
+++ b/clippy_lints/src/permissions_set_readonly_false.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     /// On Unix platforms this results in the file being world writable,
     /// equivalent to `chmod a+w <file>`.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::fs::File;
     /// let f = File::create("foo.txt").unwrap();
     /// let metadata = f.metadata().unwrap();

--- a/clippy_lints/src/ptr_offset_with_cast.rs
+++ b/clippy_lints/src/ptr_offset_with_cast.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     /// cast by using the `add` method instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let vec = vec![b'a', b'b', b'c'];
     /// let ptr = vec.as_ptr();
     /// let offset = 1_usize;
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     ///
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// let vec = vec![b'a', b'b', b'c'];
     /// let ptr = vec.as_ptr();
     /// let offset = 1_usize;

--- a/clippy_lints/src/pub_use.rs
+++ b/clippy_lints/src/pub_use.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     /// unintentional exports or to encourage placing exported items directly in public modules
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub mod outer {
     ///     mod inner {
     ///         pub struct Test {}
@@ -25,7 +25,7 @@ declare_clippy_lint! {
     /// use outer::Test;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// pub mod outer {
     ///     pub struct Test {}
     /// }

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// ([#3307](https://github.com/rust-lang/rust-clippy/issues/3307)).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 0;
     /// # let y = 1;
     /// for i in x..(y+1) {
@@ -48,7 +48,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = 0;
     /// # let y = 1;
     /// for i in x..=y {
@@ -77,7 +77,7 @@ declare_clippy_lint! {
     /// ([#3307](https://github.com/rust-lang/rust-clippy/issues/3307)).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 0;
     /// # let y = 1;
     /// for i in x..=(y-1) {
@@ -86,7 +86,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = 0;
     /// # let y = 1;
     /// for i in x..y {
@@ -118,7 +118,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     (0..=10).rev().for_each(|x| println!("{}", x));
     ///
@@ -142,14 +142,14 @@ declare_clippy_lint! {
     /// failure modes (such as fencepost errors or using `||` instead of `&&`).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // given
     /// let x = 6;
     ///
     /// assert!(x >= 3 && x < 8);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     ///# let x = 6;
     /// assert!((3..8).contains(&x));
     /// ```

--- a/clippy_lints/src/raw_strings.rs
+++ b/clippy_lints/src/raw_strings.rs
@@ -20,11 +20,11 @@ declare_clippy_lint! {
     /// idiomatic than a string literal, so it's opt-in.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let r = r"Hello, world!";
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let r = "Hello, world!";
     /// ```
     #[clippy::version = "1.72.0"]
@@ -41,11 +41,11 @@ declare_clippy_lint! {
     /// necessary.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let r = r###"Hello, "world"!"###;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let r = r#"Hello, "world"!"#;
     /// ```
     #[clippy::version = "1.72.0"]

--- a/clippy_lints/src/rc_clone_in_vec_init.rs
+++ b/clippy_lints/src/rc_clone_in_vec_init.rs
@@ -21,13 +21,13 @@ declare_clippy_lint! {
     /// than different instances.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let v = vec![std::sync::Arc::new("some data".to_string()); 100];
     /// // or
     /// let v = vec![std::rc::Rc::new("some data".to_string()); 100];
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // Initialize each value separately:
     /// let mut data = Vec::with_capacity(100);
     /// for _ in 0..100 {

--- a/clippy_lints/src/read_zero_byte_vec.rs
+++ b/clippy_lints/src/read_zero_byte_vec.rs
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// a zero-byte read would allocate a `Vec` for it.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::io;
     /// fn foo<F: io::Read>(mut f: F) {
     ///     let mut data = Vec::with_capacity(100);
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::io;
     /// fn foo<F: io::Read>(mut f: F) {
     ///     let mut data = Vec::with_capacity(100);

--- a/clippy_lints/src/redundant_async_block.rs
+++ b/clippy_lints/src/redundant_async_block.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// It is simpler and more efficient to use the future directly.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let f = async {
     ///    1 + 2
     /// };
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     /// };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let f = async {
     ///    1 + 2
     /// };

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     /// False-negatives: analysis performed by this lint is conservative and limited.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::path::Path;
     /// # #[derive(Clone)]
     /// # struct Foo;

--- a/clippy_lints/src/redundant_closure_call.rs
+++ b/clippy_lints/src/redundant_closure_call.rs
@@ -23,12 +23,12 @@ declare_clippy_lint! {
     /// complexity.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = (|| 42)();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = 42;
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/redundant_else.rs
+++ b/clippy_lints/src/redundant_else.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// Some may prefer to keep the `else` block for clarity.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn my_func(count: u32) {
     ///     if count == 0 {
     ///         print!("Nothing to do");
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn my_func(count: u32) {
     ///     if count == 0 {
     ///         print!("Nothing to do");

--- a/clippy_lints/src/redundant_field_names.rs
+++ b/clippy_lints/src/redundant_field_names.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// the field name is redundant.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let bar: u8 = 123;
     ///
     /// struct Foo {

--- a/clippy_lints/src/redundant_locals.rs
+++ b/clippy_lints/src/redundant_locals.rs
@@ -20,7 +20,7 @@ declare_clippy_lint! {
     /// Note that although these bindings do not affect your code's meaning, they _may_ affect `rustc`'s stack allocation.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let a = 0;
     /// let a = a;
     ///
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let a = 0;
     /// // no redefinition with the same name
     ///

--- a/clippy_lints/src/redundant_pub_crate.rs
+++ b/clippy_lints/src/redundant_pub_crate.rs
@@ -18,14 +18,14 @@ declare_clippy_lint! {
     /// module's visibility.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// mod internal {
     ///     pub(crate) fn internal_fn() { }
     /// }
     /// ```
     /// This function is not visible outside the module and it can be declared with `pub` or
     /// private visibility
-    /// ```rust
+    /// ```no_run
     /// mod internal {
     ///     pub fn internal_fn() { }
     /// }

--- a/clippy_lints/src/redundant_slicing.rs
+++ b/clippy_lints/src/redundant_slicing.rs
@@ -51,12 +51,12 @@ declare_clippy_lint! {
     /// Some people may prefer to dereference rather than slice.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let vec = vec![1, 2, 3];
     /// let slice = &vec[..];
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let vec = vec![1, 2, 3];
     /// let slice = &*vec;
     /// ```

--- a/clippy_lints/src/redundant_type_annotations.rs
+++ b/clippy_lints/src/redundant_type_annotations.rs
@@ -24,11 +24,11 @@ declare_clippy_lint! {
     /// - `Path` to anything else than a primitive type.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let foo: String = String::new();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let foo = String::new();
     /// ```
     #[clippy::version = "1.72.0"]

--- a/clippy_lints/src/ref_patterns.rs
+++ b/clippy_lints/src/ref_patterns.rs
@@ -10,12 +10,12 @@ declare_clippy_lint! {
     /// The `ref` keyword can be confusing for people unfamiliar with it, and often
     /// it is more concise to use `&` instead.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let opt = Some(5);
     /// if let Some(ref foo) = opt {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let opt = Some(5);
     /// if let Some(foo) = &opt {}
     /// ```

--- a/clippy_lints/src/reserve_after_initialization.rs
+++ b/clippy_lints/src/reserve_after_initialization.rs
@@ -18,12 +18,12 @@ declare_clippy_lint! {
     /// The `Vec::with_capacity` constructor is less complex.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut v: Vec<usize> = vec![];
     /// v.reserve(10);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut v: Vec<usize> = Vec::with_capacity(10);
     /// ```
     #[clippy::version = "1.73.0"]

--- a/clippy_lints/src/return_self_not_must_use.rs
+++ b/clippy_lints/src/return_self_not_must_use.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// if it was added on constructors for example.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub struct Bar;
     /// impl Bar {
     ///     // Missing attribute
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # {
     /// // It's better to have the `#[must_use]` attribute on the method like this:
     /// pub struct Bar;

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -34,14 +34,14 @@ declare_clippy_lint! {
     /// bound without first assigning it to a let-binding.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo() -> String {
     ///     let x = String::new();
     ///     x
     /// }
     /// ```
     /// instead, use
-    /// ```
+    /// ```no_run
     /// fn foo() -> String {
     ///     String::new()
     /// }
@@ -61,13 +61,13 @@ declare_clippy_lint! {
     /// more rusty.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(x: usize) -> usize {
     ///     return x;
     /// }
     /// ```
     /// simplify to
-    /// ```rust
+    /// ```no_run
     /// fn foo(x: usize) -> usize {
     ///     x
     /// }

--- a/clippy_lints/src/same_name_method.rs
+++ b/clippy_lints/src/same_name_method.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// Confusing.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// trait T {
     ///     fn foo(&self) {}
     /// }

--- a/clippy_lints/src/semicolon_block.rs
+++ b/clippy_lints/src/semicolon_block.rs
@@ -19,13 +19,13 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn f(_: u32) {}
     /// # let x = 0;
     /// unsafe { f(x) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn f(_: u32) {}
     /// # let x = 0;
     /// unsafe { f(x); }
@@ -48,13 +48,13 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # fn f(_: u32) {}
     /// # let x = 0;
     /// unsafe { f(x); }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn f(_: u32) {}
     /// # let x = 0;
     /// unsafe { f(x) };

--- a/clippy_lints/src/semicolon_if_nothing_returned.rs
+++ b/clippy_lints/src/semicolon_if_nothing_returned.rs
@@ -17,13 +17,13 @@ declare_clippy_lint! {
     /// code, it doesn't require a change in previous last line.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     println!("Hello world")
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     println!("Hello world");
     /// }

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -21,13 +21,13 @@ declare_clippy_lint! {
     /// lint to `Warn`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// let x = &x;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let x = 1;
     /// let y = &x; // use different variable name
     /// ```
@@ -49,12 +49,12 @@ declare_clippy_lint! {
     /// the code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 2;
     /// let x = x + 1;
     /// ```
     /// use different variable name:
-    /// ```rust
+    /// ```no_run
     /// let x = 2;
     /// let y = x + 1;
     /// ```
@@ -77,7 +77,7 @@ declare_clippy_lint! {
     /// names to bindings or introducing more scopes to contain the bindings.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let y = 1;
     /// # let z = 2;
     /// let x = y;
@@ -85,7 +85,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let y = 1;
     /// # let z = 2;
     /// let x = y;

--- a/clippy_lints/src/single_call_fn.rs
+++ b/clippy_lints/src/single_call_fn.rs
@@ -23,7 +23,7 @@ declare_clippy_lint! {
     /// Note: If this lint is used, prepare to allow this a lot.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub fn a<T>(t: &T)
     /// where
     ///     T: AsRef<str>,
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     ///
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// pub fn a<T>(t: &T)
     /// where
     ///     T: AsRef<str>,

--- a/clippy_lints/src/single_char_lifetime_names.rs
+++ b/clippy_lints/src/single_char_lifetime_names.rs
@@ -22,13 +22,13 @@ declare_clippy_lint! {
     /// be obvious or, rarely, expressible in one character.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct DiagnosticCtx<'a> {
     ///     source: &'a str,
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct DiagnosticCtx<'src> {
     ///     source: &'src str,
     /// }

--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -21,11 +21,11 @@ declare_clippy_lint! {
     /// the end of the range to be the length instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = [0..200];
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // If it was intended to include every element in the range...
     /// let x = (0..200).collect::<Vec<i32>>();
     /// // ...Or if 200 was meant to be the len

--- a/clippy_lints/src/size_of_ref.rs
+++ b/clippy_lints/src/size_of_ref.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// the reference.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo {
     ///     buffer: [u8],
     /// }
@@ -35,7 +35,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct Foo {
     ///     buffer: [u8],
     /// }

--- a/clippy_lints/src/slow_vector_initialization.rs
+++ b/clippy_lints/src/slow_vector_initialization.rs
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// The `resize` call first allocates memory (since `Vec::new()` did not), and only *then* zero-initializes it.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use core::iter::repeat;
     /// # let len = 4;
     /// let mut vec1 = Vec::new();
@@ -45,7 +45,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let len = 4;
     /// let mut vec1 = vec![0; len];
     /// let mut vec2 = vec![0; len];

--- a/clippy_lints/src/std_instead_of_core.rs
+++ b/clippy_lints/src/std_instead_of_core.rs
@@ -22,11 +22,11 @@ declare_clippy_lint! {
     /// migrating to become `no_std` compatible.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::hash::Hasher;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use core::hash::Hasher;
     /// ```
     #[clippy::version = "1.64.0"]
@@ -47,11 +47,11 @@ declare_clippy_lint! {
     /// for crates migrating to become `no_std` compatible.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::vec::Vec;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # extern crate alloc;
     /// use alloc::vec::Vec;
     /// ```
@@ -73,12 +73,12 @@ declare_clippy_lint! {
     /// is also useful for crates migrating to become `no_std` compatible.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # extern crate alloc;
     /// use alloc::slice::from_ref;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use core::slice::from_ref;
     /// ```
     #[clippy::version = "1.64.0"]

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// `.push_str(_)` method is more readable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut x = "Hello".to_owned();
     /// x = x + ", World";
     ///
@@ -58,13 +58,13 @@ declare_clippy_lint! {
     /// particular lint `allow` by default.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = "Hello".to_owned();
     /// x + ", World";
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let mut x = "Hello".to_owned();
     /// x.push_str(", World");
     /// ```
@@ -106,12 +106,12 @@ declare_clippy_lint! {
     /// more readable than a function call.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let bstr = "a byte string".as_bytes();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let bstr = b"a byte string";
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -231,12 +231,12 @@ declare_clippy_lint! {
     /// It's unnecessary, the string can be used directly.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// std::str::from_utf8(&"Hello World!".as_bytes()[6..11]).unwrap();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// &"Hello World!"[6..11];
     /// ```
     #[clippy::version = "1.50.0"]
@@ -387,12 +387,12 @@ declare_clippy_lint! {
     /// expressed with `.to_owned()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // example code where clippy issues a warning
     /// let _ = "str".to_string();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // example code which does not raise clippy warning
     /// let _ = "str".to_owned();
     /// ```
@@ -435,13 +435,13 @@ declare_clippy_lint! {
     /// When called on a `String` it only clones the `String`, which can be better expressed with `.clone()`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // example code where clippy issues a warning
     /// let msg = String::from("Hello World");
     /// let _ = msg.to_string();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// // example code which does not raise clippy warning
     /// let msg = String::from("Hello World");
     /// let _ = msg.clone();
@@ -483,11 +483,11 @@ declare_clippy_lint! {
     /// `split_whitespace` already ignores leading and trailing whitespace.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// " A B C ".trim().split_whitespace();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// " A B C ".split_whitespace();
     /// ```
     #[clippy::version = "1.62.0"]

--- a/clippy_lints/src/suspicious_doc_comments.rs
+++ b/clippy_lints/src/suspicious_doc_comments.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// In this example, the doc comment is attached to the *function*, rather than the *module*.
-    /// ```rust
+    /// ```no_run
     /// pub mod util {
     ///     ///! This module contains utility functions.
     ///
@@ -41,7 +41,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// pub mod util {
     ///     //! This module contains utility functions.
     ///

--- a/clippy_lints/src/suspicious_operation_groupings.rs
+++ b/clippy_lints/src/suspicious_operation_groupings.rs
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     /// unusual that happens to look like a typo.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Vec3 {
     ///     x: f64,
     ///     y: f64,
@@ -45,7 +45,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # struct Vec3 {
     /// #     x: f64,
     /// #     y: f64,

--- a/clippy_lints/src/suspicious_xor_used_as_pow.rs
+++ b/clippy_lints/src/suspicious_xor_used_as_pow.rs
@@ -14,11 +14,11 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// It's most probably a typo and may lead to unexpected behaviours.
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 3_i32 ^ 4_i32;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = 3_i32.pow(4);
     /// ```
     #[clippy::version = "1.67.0"]

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -25,7 +25,7 @@ declare_clippy_lint! {
     /// without deinitializing or copying either variable.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut a = 42;
     /// let mut b = 1337;
     ///
@@ -34,7 +34,7 @@ declare_clippy_lint! {
     /// a = t;
     /// ```
     /// Use std::mem::swap():
-    /// ```rust
+    /// ```no_run
     /// let mut a = 1;
     /// let mut b = 2;
     /// std::mem::swap(&mut a, &mut b);
@@ -53,14 +53,14 @@ declare_clippy_lint! {
     /// This looks like a failed attempt to swap.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let mut a = 1;
     /// # let mut b = 2;
     /// a = b;
     /// b = a;
     /// ```
     /// If swapping is intended, use `swap()` instead:
-    /// ```rust
+    /// ```no_run
     /// # let mut a = 1;
     /// # let mut b = 2;
     /// std::mem::swap(&mut a, &mut b);

--- a/clippy_lints/src/swap_ptr_to_ref.rs
+++ b/clippy_lints/src/swap_ptr_to_ref.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// other. This would then lead to undefined behavior.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// unsafe fn swap(x: &[*mut u32], y: &[*mut u32]) {
     ///     for (&x, &y) in x.iter().zip(y) {
     ///         core::mem::swap(&mut *x, &mut *y);
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// unsafe fn swap(x: &[*mut u32], y: &[*mut u32]) {
     ///     for (&x, &y) in x.iter().zip(y) {
     ///         core::ptr::swap(x, y);

--- a/clippy_lints/src/tabs_in_doc_comments.rs
+++ b/clippy_lints/src/tabs_in_doc_comments.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// display settings of the author and reader differ.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// ///
     /// /// Struct to hold two strings:
     /// /// 	- first		one
@@ -34,7 +34,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Will be converted to:
-    /// ```rust
+    /// ```no_run
     /// ///
     /// /// Struct to hold two strings:
     /// ///     - first        one

--- a/clippy_lints/src/temporary_assignment.rs
+++ b/clippy_lints/src/temporary_assignment.rs
@@ -14,7 +14,7 @@ declare_clippy_lint! {
     /// updated, why not write the structure you want in the first place?
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// (0, 0).0 = 1
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/tests_outside_test_module.rs
+++ b/clippy_lints/src/tests_outside_test_module.rs
@@ -15,7 +15,7 @@ declare_clippy_lint! {
     /// The idiomatic (and more performant) way of writing tests is inside a testing module (flagged with `#[cfg(test)]`),
     /// having test functions outside of this module is confusing and may lead to them being "hidden".
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// #[test]
     /// fn my_cool_test() {
     ///     // [...]
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     ///
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[cfg(test)]
     /// mod tests {
     ///     #[test]

--- a/clippy_lints/src/to_digit_is_some.rs
+++ b/clippy_lints/src/to_digit_is_some.rs
@@ -17,13 +17,13 @@ declare_clippy_lint! {
     /// more straight forward to use the dedicated `is_digit` method.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let c = 'c';
     /// # let radix = 10;
     /// let is_digit = c.to_digit(radix).is_some();
     /// ```
     /// can be written as:
-    /// ```
+    /// ```no_run
     /// # let c = 'c';
     /// # let radix = 10;
     /// let is_digit = c.is_digit(radix);

--- a/clippy_lints/src/trailing_empty_array.rs
+++ b/clippy_lints/src/trailing_empty_array.rs
@@ -13,7 +13,7 @@ declare_clippy_lint! {
     /// Zero-sized arrays aren't very useful in Rust itself, so such a struct is likely being created to pass to C code or in some other situation where control over memory layout matters (for example, in conjunction with manual allocation to make it easy to compute the offset of the array). Either way, `#[repr(C)]` (or another `repr` attribute) is needed.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct RarelyUseful {
     ///     some_field: u32,
     ///     last: [u32; 0],
@@ -21,7 +21,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[repr(C)]
     /// struct MoreOftenUseful {
     ///     some_field: usize,

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -27,12 +27,12 @@ declare_clippy_lint! {
     /// less readable than combining the bounds
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// pub fn foo<T>(t: T) where T: Copy, T: Clone {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// pub fn foo<T>(t: T) where T: Copy + Clone {}
     /// ```
     #[clippy::version = "1.38.0"]
@@ -51,12 +51,12 @@ declare_clippy_lint! {
     /// less readable than specifying them only once.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn func<T: Clone + Default>(arg: T) where T: Clone + Default {}
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # mod hidden {
     /// fn func<T: Clone + Default>(arg: T) {}
     /// # }
@@ -66,19 +66,19 @@ declare_clippy_lint! {
     /// fn func<T>(arg: T) where T: Clone + Default {}
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// fn foo<T: Default + Default>(bar: T) {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo<T: Default>(bar: T) {}
     /// ```
     ///
-    /// ```rust
+    /// ```no_run
     /// fn foo<T>(bar: T) where T: Default + Default {}
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo<T>(bar: T) where T: Default {}
     /// ```
     #[clippy::version = "1.47.0"]

--- a/clippy_lints/src/transmute/mod.rs
+++ b/clippy_lints/src/transmute/mod.rs
@@ -78,12 +78,12 @@ declare_clippy_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```no_run
     /// # let p: *const [i32] = &[];
     /// unsafe { std::mem::transmute::<*const [i32], *const [u16]>(p) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # let p: *const [i32] = &[];
     /// p as *const [u16];
     /// ```
@@ -159,7 +159,7 @@ declare_clippy_lint! {
     /// [`from_u32_unchecked`]: https://doc.rust-lang.org/std/char/fn.from_u32_unchecked.html
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 1_u32;
     /// unsafe {
     ///     let _: char = std::mem::transmute(x); // where x: u32
@@ -193,7 +193,7 @@ declare_clippy_lint! {
     /// [`from_utf8_unchecked`]: https://doc.rust-lang.org/std/str/fn.from_utf8_unchecked.html
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let b: &[u8] = &[1_u8, 2_u8];
     /// unsafe {
     ///     let _: &str = std::mem::transmute(b); // where b: &[u8]
@@ -216,7 +216,7 @@ declare_clippy_lint! {
     /// This might result in an invalid in-memory representation of a `bool`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 1_u8;
     /// unsafe {
     ///     let _: bool = std::mem::transmute(x); // where x: u8
@@ -240,7 +240,7 @@ declare_clippy_lint! {
     /// and safe.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// unsafe {
     ///     let _: f32 = std::mem::transmute(1_u32); // where x: u32
     /// }
@@ -264,12 +264,12 @@ declare_clippy_lint! {
     /// elsewhere. `new_unchecked` only works for the appropriate types instead.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use core::num::NonZeroU32;
     /// let _non_zero: NonZeroU32 = unsafe { std::mem::transmute(123) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use core::num::NonZeroU32;
     /// let _non_zero = unsafe { NonZeroU32::new_unchecked(123) };
     /// ```
@@ -288,7 +288,7 @@ declare_clippy_lint! {
     /// and safe.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// unsafe {
     ///     let _: u32 = std::mem::transmute(1f32);
     /// }
@@ -311,7 +311,7 @@ declare_clippy_lint! {
     /// is intuitive and safe.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// unsafe {
     ///     let x: [u8; 8] = std::mem::transmute(1i64);
     /// }
@@ -335,7 +335,7 @@ declare_clippy_lint! {
     /// written as casts.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let ptr = &1u32 as *const u32;
     /// unsafe {
     ///     // pointer-to-pointer transmute
@@ -366,7 +366,7 @@ declare_clippy_lint! {
     /// collection, so we just lint the ones that come with `std`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // different size, therefore likely out-of-bounds memory access
     /// // You absolutely do not want this in your code!
     /// unsafe {
@@ -376,7 +376,7 @@ declare_clippy_lint! {
     ///
     /// You must always iterate, map and collect the values:
     ///
-    /// ```rust
+    /// ```no_run
     /// vec![2_u16].into_iter().map(u32::from).collect::<Vec<_>>();
     /// ```
     #[clippy::version = "1.40.0"]
@@ -398,12 +398,12 @@ declare_clippy_lint! {
     /// [#8496](https://github.com/rust-lang/rust-clippy/issues/8496) for more details.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo<T>(u32, T);
     /// let _ = unsafe { core::mem::transmute::<Foo<u32>, Foo<i32>>(Foo(0u32, 0u32)) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// #[repr(C)]
     /// struct Foo<T>(u32, T);
     /// let _ = unsafe { core::mem::transmute::<Foo<u32>, Foo<i32>>(Foo(0u32, 0u32)) };
@@ -427,7 +427,7 @@ declare_clippy_lint! {
     /// call, aren't detectable yet.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let null_ref: &u64 = unsafe { std::mem::transmute(0 as *const u64) };
     /// ```
     #[clippy::version = "1.35.0"]
@@ -451,11 +451,11 @@ declare_clippy_lint! {
     /// call, aren't detectable yet.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let null_fn: fn() = unsafe { std::mem::transmute( std::ptr::null::<()>() ) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let null_fn: Option<fn()> = None;
     /// ```
     #[clippy::version = "1.68.0"]

--- a/clippy_lints/src/types/mod.rs
+++ b/clippy_lints/src/types/mod.rs
@@ -64,7 +64,7 @@ declare_clippy_lint! {
     /// 1st comment).
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct X {
     ///     values: Vec<Box<i32>>,
     /// }
@@ -72,7 +72,7 @@ declare_clippy_lint! {
     ///
     /// Better:
     ///
-    /// ```rust
+    /// ```no_run
     /// struct X {
     ///     values: Vec<i32>,
     /// }
@@ -97,7 +97,7 @@ declare_clippy_lint! {
     /// consider a custom `enum` instead, with clear names for each case.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn get_data() -> Option<Option<u32>> {
     ///     None
     /// }
@@ -105,7 +105,7 @@ declare_clippy_lint! {
     ///
     /// Better:
     ///
-    /// ```rust
+    /// ```no_run
     /// pub enum Contents {
     ///     Data(Vec<u8>), // Was Some(Some(Vec<u8>))
     ///     NotYetFetched, // Was Some(None)
@@ -152,7 +152,7 @@ declare_clippy_lint! {
     /// `LinkedList` makes sense are few and far between, but they can still happen.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::LinkedList;
     /// let x: LinkedList<usize> = LinkedList::new();
     /// ```
@@ -197,14 +197,14 @@ declare_clippy_lint! {
     /// `Arc<Arc<T>>`, `Arc<Box<T>>`, `Box<&T>`, `Box<Rc<T>>`, `Box<Arc<T>>`, `Box<Box<T>>`, add an unnecessary level of indirection.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::rc::Rc;
     /// fn foo(bar: Rc<&usize>) {}
     /// ```
     ///
     /// Better:
     ///
-    /// ```rust
+    /// ```no_run
     /// fn foo(bar: &usize) {}
     /// ```
     #[clippy::version = "1.44.0"]
@@ -258,7 +258,7 @@ declare_clippy_lint! {
     /// using a `type` definition to simplify them.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::rc::Rc;
     /// struct Foo {
     ///     inner: Rc<Vec<Vec<Box<(u32, u32, u32, u32)>>>>,

--- a/clippy_lints/src/undocumented_unsafe_blocks.rs
+++ b/clippy_lints/src/undocumented_unsafe_blocks.rs
@@ -44,14 +44,14 @@ declare_clippy_lint! {
     /// and bugs.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::ptr::NonNull;
     /// let a = &mut 42;
     ///
     /// let ptr = unsafe { NonNull::new_unchecked(a) };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::ptr::NonNull;
     /// let a = &mut 42;
     ///
@@ -72,7 +72,7 @@ declare_clippy_lint! {
     /// describe safety invariants.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::ptr::NonNull;
     /// let a = &mut 42;
     ///
@@ -80,7 +80,7 @@ declare_clippy_lint! {
     /// let ptr = NonNull::new(a).unwrap();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::ptr::NonNull;
     /// let a = &mut 42;
     ///

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -39,12 +39,12 @@ declare_clippy_lint! {
     /// requirements, activating this lint could be useful.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = String::from("€");
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = String::from("\u{20ac}");
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/unit_return_expecting_ord.rs
+++ b/clippy_lints/src/unit_return_expecting_ord.rs
@@ -25,7 +25,7 @@ declare_clippy_lint! {
     /// way of specifying this without triggering needless_return lint
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut twins = vec![(1, 1), (2, 2)];
     /// twins.sort_by_key(|x| { x.1; });
     /// ```

--- a/clippy_lints/src/unit_types/mod.rs
+++ b/clippy_lints/src/unit_types/mod.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// binding one is kind of pointless.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = {
     ///     1;
     /// };
@@ -38,7 +38,7 @@ declare_clippy_lint! {
     /// adds semicolons at the end of the operands.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # fn foo() {};
     /// # fn bar() {};
     /// # fn baz() {};
@@ -51,7 +51,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// is equal to
-    /// ```rust
+    /// ```no_run
     /// # fn foo() {};
     /// # fn bar() {};
     /// # fn baz() {};
@@ -63,7 +63,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// For asserts:
-    /// ```rust
+    /// ```no_run
     /// # fn foo() {};
     /// # fn bar() {};
     /// assert_eq!({ foo(); }, { bar(); });

--- a/clippy_lints/src/unnamed_address.rs
+++ b/clippy_lints/src/unnamed_address.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// the same address after being merged together.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// type F = fn();
     /// fn a() {}
     /// let f: F = a;

--- a/clippy_lints/src/unnecessary_box_returns.rs
+++ b/clippy_lints/src/unnecessary_box_returns.rs
@@ -22,13 +22,13 @@ declare_clippy_lint! {
     /// `Box<T>` been dropped.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo() -> Box<String> {
     ///     Box::new(String::from("Hello, world!"))
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn foo() -> String {
     ///     String::from("Hello, world!")
     /// }

--- a/clippy_lints/src/unnecessary_map_on_constructor.rs
+++ b/clippy_lints/src/unnecessary_map_on_constructor.rs
@@ -16,11 +16,11 @@ declare_clippy_lint! {
     /// construct the Option or Result from the output.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// Some(4).map(i32::swap_bytes);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// Some(i32::swap_bytes(4));
     /// ```
     #[clippy::version = "1.73.0"]

--- a/clippy_lints/src/unnecessary_owned_empty_strings.rs
+++ b/clippy_lints/src/unnecessary_owned_empty_strings.rs
@@ -20,11 +20,11 @@ declare_clippy_lint! {
     /// This results in longer and less readable code
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// vec!["1", "2", "3"].join(&String::new());
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// vec!["1", "2", "3"].join("");
     /// ```
     #[clippy::version = "1.62.0"]

--- a/clippy_lints/src/unnecessary_self_imports.rs
+++ b/clippy_lints/src/unnecessary_self_imports.rs
@@ -19,11 +19,11 @@ declare_clippy_lint! {
     /// to detect this scenario and that is why it is a restriction lint.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::io::{self};
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::io;
     /// ```
     #[clippy::version = "1.53.0"]

--- a/clippy_lints/src/unnecessary_struct_initialization.rs
+++ b/clippy_lints/src/unnecessary_struct_initialization.rs
@@ -15,14 +15,14 @@ declare_clippy_lint! {
     /// Readability suffers from unnecessary struct building.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct S { s: String }
     ///
     /// let a = S { s: String::from("Hello, world!") };
     /// let b = S { ..a };
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct S { s: String }
     ///
     /// let a = S { s: String::from("Hello, world!") };

--- a/clippy_lints/src/unnecessary_wraps.rs
+++ b/clippy_lints/src/unnecessary_wraps.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// fit some external requirement.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn get_cool_number(a: bool, b: bool) -> Option<i32> {
     ///     if a && b {
     ///         return Some(50);
@@ -39,7 +39,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn get_cool_number(a: bool, b: bool) -> i32 {
     ///     if a && b {
     ///         return 50;

--- a/clippy_lints/src/unnested_or_patterns.rs
+++ b/clippy_lints/src/unnested_or_patterns.rs
@@ -29,13 +29,13 @@ declare_clippy_lint! {
     /// In the example above, `Some` is repeated, which unnecessarily complicates the pattern.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     if let Some(0) | Some(2) = Some(0) {}
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn main() {
     ///     if let Some(0 | 2) = Some(0) {}
     /// }

--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -19,7 +19,7 @@ declare_clippy_lint! {
     /// causes runtime overhead and hassle for the caller.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// async fn get_random_number() -> i64 {
     ///     4 // Chosen by fair dice roll. Guaranteed to be random.
     /// }
@@ -27,7 +27,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// fn get_random_number_improved() -> i64 {
     ///     4 // Chosen by fair dice roll. Guaranteed to be random.
     /// }

--- a/clippy_lints/src/unused_peekable.rs
+++ b/clippy_lints/src/unused_peekable.rs
@@ -18,7 +18,7 @@ declare_clippy_lint! {
     /// or just a leftover after a refactor.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let collection = vec![1, 2, 3];
     /// let iter = collection.iter().peekable();
     ///
@@ -28,7 +28,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let collection = vec![1, 2, 3];
     /// let iter = collection.iter();
     ///

--- a/clippy_lints/src/unused_rounding.rs
+++ b/clippy_lints/src/unused_rounding.rs
@@ -16,11 +16,11 @@ declare_clippy_lint! {
     /// This is unnecessary and confusing to the reader. Doing this is probably a mistake.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let x = 1f32.ceil();
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let x = 1f32;
     /// ```
     #[clippy::version = "1.63.0"]

--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -19,13 +19,13 @@ declare_clippy_lint! {
     /// statement look like a function call.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn return_unit() -> () {
     ///     ()
     /// }
     /// ```
     /// is equivalent to
-    /// ```rust
+    /// ```no_run
     /// fn return_unit() {}
     /// ```
     #[clippy::version = "1.31.0"]

--- a/clippy_lints/src/unwrap.rs
+++ b/clippy_lints/src/unwrap.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// Using `if let` or `match` is more idiomatic.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let option = Some(0);
     /// # fn do_something_with(_x: usize) {}
     /// if option.is_some() {
@@ -36,7 +36,7 @@ declare_clippy_lint! {
     ///
     /// Could be written:
     ///
-    /// ```rust
+    /// ```no_run
     /// # let option = Some(0);
     /// # fn do_something_with(_x: usize) {}
     /// if let Some(value) = option {
@@ -61,7 +61,7 @@ declare_clippy_lint! {
     /// So something like `let x: Option<()> = None; x.unwrap();` will not be recognized.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let option = Some(0);
     /// # fn do_something_with(_x: usize) {}
     /// if option.is_none() {

--- a/clippy_lints/src/unwrap_in_result.rs
+++ b/clippy_lints/src/unwrap_in_result.rs
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// Before:
-    /// ```rust
+    /// ```no_run
     /// fn divisible_by_3(i_str: String) -> Result<(), String> {
     ///     let i = i_str
     ///         .parse::<i32>()
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// After:
-    /// ```rust
+    /// ```no_run
     /// fn divisible_by_3(i_str: String) -> Result<(), String> {
     ///     let i = i_str
     ///         .parse::<i32>()

--- a/clippy_lints/src/upper_case_acronyms.rs
+++ b/clippy_lints/src/upper_case_acronyms.rs
@@ -26,11 +26,11 @@ declare_clippy_lint! {
     /// the letters in the second acronym.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct HTTPResponse;
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// struct HttpResponse;
     /// ```
     #[clippy::version = "1.51.0"]

--- a/clippy_lints/src/use_self.rs
+++ b/clippy_lints/src/use_self.rs
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// - Unaddressed false negative in fn bodies of trait implementations
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// struct Foo;
     /// impl Foo {
     ///     fn new() -> Foo {
@@ -40,7 +40,7 @@ declare_clippy_lint! {
     /// }
     /// ```
     /// could be
-    /// ```rust
+    /// ```no_run
     /// struct Foo;
     /// impl Foo {
     ///     fn new() -> Self {

--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -26,13 +26,13 @@ declare_clippy_lint! {
     /// Redundant code.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// // format!() returns a `String`
     /// let s: String = format!("hello").into();
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let s: String = format!("hello");
     /// ```
     #[clippy::version = "1.45.0"]

--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -549,7 +549,7 @@ define_Conf! {
     /// Whether to recommend using implicit into iter for reborrowed values.
     ///
     /// #### Example
-    /// ```
+    /// ```no_run
     /// let mut vec = vec![1, 2, 3];
     /// let rmvec = &mut vec;
     /// for _ in rmvec.iter() {}
@@ -557,7 +557,7 @@ define_Conf! {
     /// ```
     ///
     /// Use instead:
-    /// ```
+    /// ```no_run
     /// let mut vec = vec![1, 2, 3];
     /// let rmvec = &mut vec;
     /// for _ in &*rmvec {}

--- a/clippy_lints/src/vec.rs
+++ b/clippy_lints/src/vec.rs
@@ -33,14 +33,14 @@ declare_clippy_lint! {
     /// This is less efficient.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// fn foo(_x: &[u8]) {}
     ///
     /// foo(&vec![1, 2]);
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # fn foo(_x: &[u8]) {}
     /// foo(&[1, 2]);
     /// ```

--- a/clippy_lints/src/vec_init_then_push.rs
+++ b/clippy_lints/src/vec_init_then_push.rs
@@ -30,12 +30,12 @@ declare_clippy_lint! {
     /// multiple `push` calls.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let mut v = Vec::new();
     /// v.push(0);
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let v = vec![0];
     /// ```
     #[clippy::version = "1.51.0"]

--- a/clippy_lints/src/wildcard_imports.rs
+++ b/clippy_lints/src/wildcard_imports.rs
@@ -24,7 +24,7 @@ declare_clippy_lint! {
     /// still around.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// use std::cmp::Ordering::*;
     ///
     /// # fn foo(_: std::cmp::Ordering) {}
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// use std::cmp::Ordering;
     ///
     /// # fn foo(_: Ordering) {}

--- a/clippy_lints/src/write.rs
+++ b/clippy_lints/src/write.rs
@@ -22,12 +22,12 @@ declare_clippy_lint! {
     /// You should use `println!()`, which is simpler.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// println!("");
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// println!();
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -46,12 +46,12 @@ declare_clippy_lint! {
     /// newline.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let name = "World";
     /// print!("Hello {}!\n", name);
     /// ```
     /// use println!() instead
-    /// ```rust
+    /// ```no_run
     /// # let name = "World";
     /// println!("Hello {}!", name);
     /// ```
@@ -74,7 +74,7 @@ declare_clippy_lint! {
     /// Only catches `print!` and `println!` calls.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// println!("Hello world!");
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -96,7 +96,7 @@ declare_clippy_lint! {
     /// Only catches `eprint!` and `eprintln!` calls.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// eprintln!("Hello world!");
     /// ```
     #[clippy::version = "1.50.0"]
@@ -115,7 +115,7 @@ declare_clippy_lint! {
     /// debugging Rust code. It should not be used in user-facing output.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # let foo = "bar";
     /// println!("{:?}", foo);
     /// ```
@@ -135,11 +135,11 @@ declare_clippy_lint! {
     /// (i.e., just put the literal in the format string)
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// println!("{}", "foo");
     /// ```
     /// use the literal without formatting:
-    /// ```rust
+    /// ```no_run
     /// println!("foo");
     /// ```
     #[clippy::version = "pre 1.29.0"]
@@ -157,14 +157,14 @@ declare_clippy_lint! {
     /// You should use `writeln!(buf)`, which is simpler.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
     /// writeln!(buf, "");
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
     /// writeln!(buf);
@@ -186,7 +186,7 @@ declare_clippy_lint! {
     /// newline.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
     /// # let name = "World";
@@ -194,7 +194,7 @@ declare_clippy_lint! {
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
     /// # let name = "World";
@@ -216,14 +216,14 @@ declare_clippy_lint! {
     /// (i.e., just put the literal in the format string)
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
     /// writeln!(buf, "{}", "foo");
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::fmt::Write;
     /// # let mut buf = String::new();
     /// writeln!(buf, "foo");

--- a/clippy_lints/src/zero_div_zero.rs
+++ b/clippy_lints/src/zero_div_zero.rs
@@ -13,12 +13,12 @@ declare_clippy_lint! {
     /// It's less readable than `f32::NAN` or `f64::NAN`.
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// let nan = 0.0f32 / 0.0;
     /// ```
     ///
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// let nan = f32::NAN;
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/zero_sized_map_values.rs
+++ b/clippy_lints/src/zero_sized_map_values.rs
@@ -23,14 +23,14 @@ declare_clippy_lint! {
     /// * This lints the signature of public items
     ///
     /// ### Example
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashMap;
     /// fn unique_words(text: &str) -> HashMap<&str, ()> {
     ///     todo!();
     /// }
     /// ```
     /// Use instead:
-    /// ```rust
+    /// ```no_run
     /// # use std::collections::HashSet;
     /// fn unique_words(text: &str) -> HashSet<&str> {
     ///     todo!();

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -144,7 +144,7 @@ macro_rules! extract_msrv_attr {
 /// instead.
 ///
 /// Examples:
-/// ```
+/// ```no_run
 /// let abc = 1;
 /// //        ^ output
 /// let def = abc;
@@ -699,7 +699,7 @@ pub fn get_trait_def_id(cx: &LateContext<'_>, path: &[&str]) -> Option<DefId> {
 ///
 /// Use this if you want to find the `TraitRef` of the `Add` trait in this example:
 ///
-/// ```rust
+/// ```no_run
 /// struct Point(isize, isize);
 ///
 /// impl std::ops::Add for Point {
@@ -895,7 +895,7 @@ fn is_default_equivalent_from(cx: &LateContext<'_>, from_func: &Expr<'_>, arg: &
 ///
 /// For example, given the following function:
 ///
-/// ```
+/// ```no_run
 /// fn f<'a>(iter: &mut impl Iterator<Item = (usize, &'a mut String)>) {
 ///     for item in iter {
 ///         let s = item.1;
@@ -1609,7 +1609,7 @@ pub fn is_expn_of(mut span: Span, name: &str) -> Option<Span> {
 /// Returns the pre-expansion span if the span directly comes from an expansion
 /// of the macro `name`.
 /// The difference with [`is_expn_of`] is that in
-/// ```rust
+/// ```no_run
 /// # macro_rules! foo { ($name:tt!$args:tt) => { $name!$args } }
 /// # macro_rules! bar { ($e:expr) => { $e } }
 /// foo!(bar!(42));
@@ -2204,7 +2204,7 @@ pub fn is_no_core_crate(cx: &LateContext<'_>) -> bool {
 
 /// Check if parent of a hir node is a trait implementation block.
 /// For example, `f` in
-/// ```rust
+/// ```no_run
 /// # struct S;
 /// # trait Trait { fn f(); }
 /// impl Trait for S {

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -108,7 +108,7 @@ fn first_char_in_first_line<T: LintContext>(cx: &T, span: Span) -> Option<BytePo
 
 /// Extends the span to the beginning of the spans line, incl. whitespaces.
 ///
-/// ```rust
+/// ```no_run
 ///        let x = ();
 /// //             ^^
 /// // will be converted to

--- a/clippy_utils/src/str_utils.rs
+++ b/clippy_utils/src/str_utils.rs
@@ -14,7 +14,7 @@ impl StrIndex {
 
 /// Returns the index of the character after the first camel-case component of `s`.
 ///
-/// ```
+/// ```no_run
 /// # use clippy_utils::str_utils::{camel_case_until, StrIndex};
 /// assert_eq!(camel_case_until("AbcDef"), StrIndex::new(6, 6));
 /// assert_eq!(camel_case_until("ABCD"), StrIndex::new(0, 0));
@@ -58,7 +58,7 @@ pub fn camel_case_until(s: &str) -> StrIndex {
 
 /// Returns index of the first camel-case component of `s`.
 ///
-/// ```
+/// ```no_run
 /// # use clippy_utils::str_utils::{camel_case_start, StrIndex};
 /// assert_eq!(camel_case_start("AbcDef"), StrIndex::new(0, 0));
 /// assert_eq!(camel_case_start("abcDef"), StrIndex::new(3, 3));
@@ -73,7 +73,7 @@ pub fn camel_case_start(s: &str) -> StrIndex {
 
 /// Returns `StrIndex` of the last camel-case component of `s[idx..]`.
 ///
-/// ```
+/// ```no_run
 /// # use clippy_utils::str_utils::{camel_case_start_from_idx, StrIndex};
 /// assert_eq!(camel_case_start_from_idx("AbcDef", 0), StrIndex::new(0, 0));
 /// assert_eq!(camel_case_start_from_idx("AbcDef", 1), StrIndex::new(3, 3));
@@ -122,7 +122,7 @@ pub fn camel_case_start_from_idx(s: &str, start_idx: usize) -> StrIndex {
 
 /// Get the indexes of camel case components of a string `s`
 ///
-/// ```
+/// ```no_run
 /// # use clippy_utils::str_utils::{camel_case_indices, StrIndex};
 /// assert_eq!(
 ///     camel_case_indices("AbcDef"),
@@ -149,7 +149,7 @@ pub fn camel_case_indices(s: &str) -> Vec<StrIndex> {
 
 /// Split camel case string into a vector of its components
 ///
-/// ```
+/// ```no_run
 /// # use clippy_utils::str_utils::{camel_case_split, StrIndex};
 /// assert_eq!(camel_case_split("AbcDef"), vec!["Abc", "Def"]);
 /// ```
@@ -181,7 +181,7 @@ impl StrCount {
 
 /// Returns the number of chars that match from the start
 ///
-/// ```
+/// ```no_run
 /// # use clippy_utils::str_utils::{count_match_start, StrCount};
 /// assert_eq!(count_match_start("hello_mouse", "hello_penguin"), StrCount::new(6, 6));
 /// assert_eq!(count_match_start("hello_clippy", "bye_bugs"), StrCount::new(0, 0));
@@ -207,7 +207,7 @@ pub fn count_match_start(str1: &str, str2: &str) -> StrCount {
 
 /// Returns the number of chars and bytes that match from the end
 ///
-/// ```
+/// ```no_run
 /// # use clippy_utils::str_utils::{count_match_end, StrCount};
 /// assert_eq!(count_match_end("hello_cat", "bye_cat"), StrCount::new(4, 4));
 /// assert_eq!(count_match_end("if_item_thing", "enum_value"), StrCount::new(0, 0));
@@ -237,7 +237,7 @@ pub fn count_match_end(str1: &str, str2: &str) -> StrCount {
 }
 
 /// Returns a `snake_case` version of the input
-/// ```
+/// ```no_run
 /// use clippy_utils::str_utils::to_snake_case;
 /// assert_eq!(to_snake_case("AbcDef"), "abc_def");
 /// assert_eq!(to_snake_case("ABCD"), "a_b_c_d");
@@ -260,7 +260,7 @@ pub fn to_snake_case(name: &str) -> String {
     s
 }
 /// Returns a `CamelCase` version of the input
-/// ```
+/// ```no_run
 /// use clippy_utils::str_utils::to_camel_case;
 /// assert_eq!(to_camel_case("abc_def"), "AbcDef");
 /// assert_eq!(to_camel_case("a_b_c_d"), "ABCD");

--- a/declare_clippy_lint/src/lib.rs
+++ b/declare_clippy_lint/src/lib.rs
@@ -94,7 +94,7 @@ impl Parse for ClippyLint {
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// use rustc_session::declare_tool_lint;
 ///
 /// declare_clippy_lint! {


### PR DESCRIPTION
This excludes `should_panic` tests, those are still run to ensure they panic. Most of our other doc snippets don't gain much from being run though so this frees up a nice bit of CI time

It also fixes the occasional issue such as `foo.txt`s being created https://github.com/rust-lang/rust-clippy/blob/f942470ca774b9648bac042f5d4c4ec74b81b61a/clippy_lints/src/permissions_set_readonly_false.rs#L19

changelog: none
