### PR TITLE
Fix typo in suggestion in `iter_without_into_iter.rs`

### DIFF
--- a/clippy_lints/src/iter_without_into_iter.rs
+++ b/clippy_lints/src/iter_without_into_iter.rs
@@ -247,8 +247,8 @@ impl {self_ty_without_ref} {{
 "
 impl IntoIterator for {self_ty_snippet} {{
     type IntoIter = {ret_ty};
-    type Iter = {iter_ty};
-    fn into_iter() -> Self::IntoIter {{
+    type Item = {iter_ty};
+    fn into_iter(self) -> Self::IntoIter {{
         self.iter()
     }}
 }}


### PR DESCRIPTION
A small edit to fix a couple typos in the suggestion in `iter_without_into_iter`. 

Fixes #11692.