### PR TITLE
Remove the `internal_warn` lint category

### DIFF
--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -199,7 +199,6 @@ fn get_clap_config() -> ArgMatches {
                             "cargo",
                             "nursery",
                             "internal",
-                            "internal_warn",
                         ]),
                     Arg::new("type").long("type").help("What directory the lint belongs in"),
                     Arg::new("msrv")

--- a/clippy_dev/src/update_lints.rs
+++ b/clippy_dev/src/update_lints.rs
@@ -588,7 +588,7 @@ impl Lint {
             .collect()
     }
 
-    /// Returns all internal lints (not `internal_warn` lints)
+    /// Returns all internal lints
     #[must_use]
     fn internal_lints(lints: &[Self]) -> Vec<Self> {
         lints.iter().filter(|l| l.group == "internal").cloned().collect()

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -6,8 +6,6 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     #[cfg(feature = "internal")]
     crate::utils::internal_lints::almost_standard_lint_formulation::ALMOST_STANDARD_LINT_FORMULATION_INFO,
     #[cfg(feature = "internal")]
-    crate::utils::internal_lints::clippy_lints_internal::CLIPPY_LINTS_INTERNAL_INFO,
-    #[cfg(feature = "internal")]
     crate::utils::internal_lints::collapsible_calls::COLLAPSIBLE_SPAN_LINT_CALLS_INFO,
     #[cfg(feature = "internal")]
     crate::utils::internal_lints::compiler_lint_functions::COMPILER_LINT_FUNCTIONS_INFO,
@@ -30,6 +28,8 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     #[cfg(feature = "internal")]
     crate::utils::internal_lints::lint_without_lint_pass::MISSING_CLIPPY_VERSION_ATTRIBUTE_INFO,
     #[cfg(feature = "internal")]
+    crate::utils::internal_lints::metadata_collector::METADATA_COLLECTOR_INFO,
+    #[cfg(feature = "internal")]
     crate::utils::internal_lints::msrv_attr_impl::MISSING_MSRV_ATTR_IMPL_INFO,
     #[cfg(feature = "internal")]
     crate::utils::internal_lints::outer_expn_data_pass::OUTER_EXPN_EXPN_DATA_INFO,
@@ -37,6 +37,8 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::utils::internal_lints::produce_ice::PRODUCE_ICE_INFO,
     #[cfg(feature = "internal")]
     crate::utils::internal_lints::unnecessary_def_path::UNNECESSARY_DEF_PATH_INFO,
+    #[cfg(feature = "internal")]
+    crate::utils::internal_lints::unsorted_clippy_utils_paths::UNSORTED_CLIPPY_UTILS_PATHS_INFO,
     crate::absolute_paths::ABSOLUTE_PATHS_INFO,
     crate::allow_attributes::ALLOW_ATTRIBUTES_INFO,
     crate::almost_complete_range::ALMOST_COMPLETE_RANGE_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -513,7 +513,9 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     // all the internal lints
     #[cfg(feature = "internal")]
     {
-        store.register_early_pass(|| Box::new(utils::internal_lints::clippy_lints_internal::ClippyLintsInternal));
+        store.register_early_pass(|| {
+            Box::new(utils::internal_lints::unsorted_clippy_utils_paths::UnsortedClippyUtilsPaths)
+        });
         store.register_early_pass(|| Box::new(utils::internal_lints::produce_ice::ProduceIce));
         store.register_late_pass(|_| Box::new(utils::internal_lints::collapsible_calls::CollapsibleCalls));
         store.register_late_pass(|_| {

--- a/clippy_lints/src/utils/author.rs
+++ b/clippy_lints/src/utils/author.rs
@@ -10,12 +10,12 @@ use rustc_hir::{
     ArrayLen, BindingAnnotation, Closure, ExprKind, FnRetTy, HirId, Lit, PatKind, QPath, StmtKind, TyKind,
 };
 use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_session::declare_lint_pass;
 use rustc_span::symbol::{Ident, Symbol};
 use std::cell::Cell;
 use std::fmt::{Display, Formatter, Write as _};
 
-declare_clippy_lint! {
+declare_lint_pass!(
     /// ### What it does
     /// Generates clippy code that detects the offending pattern
     ///
@@ -47,12 +47,8 @@ declare_clippy_lint! {
     ///     // report your lint here
     /// }
     /// ```
-    pub LINT_AUTHOR,
-    internal_warn,
-    "helper for writing lints"
-}
-
-declare_lint_pass!(Author => [LINT_AUTHOR]);
+    Author => []
+);
 
 /// Writes a line of output with indentation added
 macro_rules! out {

--- a/clippy_lints/src/utils/dump_hir.rs
+++ b/clippy_lints/src/utils/dump_hir.rs
@@ -2,9 +2,9 @@ use clippy_utils::get_attr;
 use hir::TraitItem;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_session::{declare_lint_pass, declare_tool_lint};
+use rustc_session::declare_lint_pass;
 
-declare_clippy_lint! {
+declare_lint_pass!(
     /// ### What it does
     /// It formats the attached node with `{:#?}` and writes the result to the
     /// standard output. This is intended for debugging.
@@ -19,12 +19,8 @@ declare_clippy_lint! {
     ///     input as u64
     /// }
     /// ```
-    pub DUMP_HIR,
-    internal_warn,
-    "helper to dump info about code"
-}
-
-declare_lint_pass!(DumpHir => [DUMP_HIR]);
+    DumpHir => []
+);
 
 impl<'tcx> LateLintPass<'tcx> for DumpHir {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'_>) {

--- a/clippy_lints/src/utils/internal_lints.rs
+++ b/clippy_lints/src/utils/internal_lints.rs
@@ -1,5 +1,4 @@
 pub mod almost_standard_lint_formulation;
-pub mod clippy_lints_internal;
 pub mod collapsible_calls;
 pub mod compiler_lint_functions;
 pub mod if_chain_style;
@@ -11,3 +10,4 @@ pub mod msrv_attr_impl;
 pub mod outer_expn_data_pass;
 pub mod produce_ice;
 pub mod unnecessary_def_path;
+pub mod unsorted_clippy_utils_paths;

--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -40,8 +40,6 @@ use std::process::Command;
 const JSON_OUTPUT_FILE: &str = "../util/gh-pages/lints.json";
 /// This is the markdown output file of the lint collector.
 const MARKDOWN_OUTPUT_FILE: &str = "../book/src/lint_configuration.md";
-/// These lints are excluded from the export.
-const BLACK_LISTED_LINTS: &[&str] = &["lint_author", "dump_hir", "internal_metadata_collector"];
 /// These groups will be ignored by the lint group matcher. This is useful for collections like
 /// `clippy::all`
 const IGNORED_LINT_GROUPS: [&str; 1] = ["clippy::all"];
@@ -121,7 +119,7 @@ declare_clippy_lint! {
     /// ### Example output
     /// ```json,ignore
     /// {
-    ///     "id": "internal_metadata_collector",
+    ///     "id": "metadata_collector",
     ///     "id_span": {
     ///         "path": "clippy_lints/src/utils/internal_lints/metadata_collector.rs",
     ///         "line": 1
@@ -131,12 +129,12 @@ declare_clippy_lint! {
     /// }
     /// ```
     #[clippy::version = "1.56.0"]
-    pub INTERNAL_METADATA_COLLECTOR,
-    internal_warn,
+    pub METADATA_COLLECTOR,
+    internal,
     "A busy bee collection metadata about lints"
 }
 
-impl_lint_pass!(MetadataCollector => [INTERNAL_METADATA_COLLECTOR]);
+impl_lint_pass!(MetadataCollector => [METADATA_COLLECTOR]);
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
@@ -550,7 +548,6 @@ impl<'hir> LateLintPass<'hir> for MetadataCollector {
                 if is_lint_ref_type(cx, ty);
                 // disallow check
                 let lint_name = sym_to_string(item.ident.name).to_ascii_lowercase();
-                if !BLACK_LISTED_LINTS.contains(&lint_name.as_str());
                 // metadata extraction
                 if let Some((group, level)) = get_lint_group_and_level_or_lint(cx, &lint_name, item);
                 if let Some(mut raw_docs) = extract_attr_docs_or_lint(cx, item);
@@ -575,7 +572,6 @@ impl<'hir> LateLintPass<'hir> for MetadataCollector {
                 if is_deprecated_lint(cx, ty);
                 // disallow check
                 let lint_name = sym_to_string(item.ident.name).to_ascii_lowercase();
-                if !BLACK_LISTED_LINTS.contains(&lint_name.as_str());
                 // Metadata the little we can get from a deprecated lint
                 if let Some(raw_docs) = extract_attr_docs_or_lint(cx, item);
                 then {
@@ -831,7 +827,7 @@ fn collect_renames(lints: &mut Vec<LintMetadata>) {
 fn lint_collection_error_item(cx: &LateContext<'_>, item: &Item<'_>, message: &str) {
     span_lint(
         cx,
-        INTERNAL_METADATA_COLLECTOR,
+        METADATA_COLLECTOR,
         item.ident.span,
         &format!("metadata collection error for `{}`: {message}", item.ident.name),
     );

--- a/clippy_lints/src/utils/internal_lints/unsorted_clippy_utils_paths.rs
+++ b/clippy_lints/src/utils/internal_lints/unsorted_clippy_utils_paths.rs
@@ -5,21 +5,21 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for various things we like to keep tidy in clippy.
+    /// Checks that [`clippy_utils::paths`] is sorted lexically
     ///
     /// ### Why is this bad?
     /// We like to pretend we're an example of tidy code.
     ///
     /// ### Example
     /// Wrong ordering of the util::paths constants.
-    pub CLIPPY_LINTS_INTERNAL,
+    pub UNSORTED_CLIPPY_UTILS_PATHS,
     internal,
     "various things that will negatively affect your clippy experience"
 }
 
-declare_lint_pass!(ClippyLintsInternal => [CLIPPY_LINTS_INTERNAL]);
+declare_lint_pass!(UnsortedClippyUtilsPaths => [UNSORTED_CLIPPY_UTILS_PATHS]);
 
-impl EarlyLintPass for ClippyLintsInternal {
+impl EarlyLintPass for UnsortedClippyUtilsPaths {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &Crate) {
         if let Some(utils) = krate.items.iter().find(|item| item.ident.name.as_str() == "utils") {
             if let ItemKind::Mod(_, ModKind::Loaded(ref items, ..)) = utils.kind {
@@ -32,7 +32,7 @@ impl EarlyLintPass for ClippyLintsInternal {
                                 if *last_name > *name {
                                     span_lint(
                                         cx,
-                                        CLIPPY_LINTS_INTERNAL,
+                                        UNSORTED_CLIPPY_UTILS_PATHS,
                                         item.span,
                                         "this constant should be before the previous constant due to lexical \
                                          ordering",

--- a/declare_clippy_lint/src/lib.rs
+++ b/declare_clippy_lint/src/lib.rs
@@ -136,28 +136,16 @@ pub fn declare_clippy_lint(input: TokenStream) -> TokenStream {
         "{}",
         match category.as_str() {
             "correctness" => "Deny",
-            "style" | "suspicious" | "complexity" | "perf" | "internal_warn" => "Warn",
+            "style" | "suspicious" | "complexity" | "perf" => "Warn",
             "pedantic" | "restriction" | "cargo" | "nursery" | "internal" => "Allow",
             _ => panic!("unknown category {category}"),
         },
     );
 
-    let info = if category == "internal_warn" {
-        None
-    } else {
-        let info_name = format_ident!("{name}_INFO");
+    let info_name = format_ident!("{name}_INFO");
 
-        (&mut category[0..1]).make_ascii_uppercase();
-        let category_variant = format_ident!("{category}");
-
-        Some(quote! {
-            pub(crate) static #info_name: &'static crate::LintInfo = &crate::LintInfo {
-                lint: &#name,
-                category: crate::LintCategory::#category_variant,
-                explanation: #explanation,
-            };
-        })
-    };
+    (&mut category[0..1]).make_ascii_uppercase();
+    let category_variant = format_ident!("{category}");
 
     let output = quote! {
         declare_tool_lint! {
@@ -168,7 +156,11 @@ pub fn declare_clippy_lint(input: TokenStream) -> TokenStream {
             report_in_external_macro: true
         }
 
-        #info
+        pub(crate) static #info_name: &'static crate::LintInfo = &crate::LintInfo {
+            lint: &#name,
+            category: crate::LintCategory::#category_variant,
+            explanation: #explanation,
+        };
     };
 
     TokenStream::from(output)


### PR DESCRIPTION
`LINT_AUTHOR` and `DUMP_HIR` can be removed since their corresponding lint passes are only used for side effects

The metadata collector lint can be made an `internal` lint since `clippy::internal` is set to deny when running the collector

Also renames some internal lints/passes

changelog: none
