### PR TITLE
Fix missing parenthesis in suboptimal floating point help

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -323,9 +323,9 @@ fn check_powi(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, args: 
                     let maybe_neg_sugg = |expr, hir_id| {
                         let sugg = Sugg::hir(cx, expr, "..");
                         if matches!(op, BinOpKind::Sub) && hir_id == rhs.hir_id {
-                            format!("-{}", sugg.maybe_par())
+                            -sugg
                         } else {
-                            sugg.to_string()
+                            sugg
                         }
                     };
 
@@ -470,25 +470,13 @@ fn check_mul_add(cx: &LateContext<'_>, expr: &Expr<'_>) {
 
         let maybe_neg_sugg = |expr| {
             let sugg = Sugg::hir(cx, expr, "..");
-            if let BinOpKind::Sub = op {
-                format!("-{sugg}")
-            } else {
-                sugg.to_string()
-            }
+            if let BinOpKind::Sub = op { -sugg } else { sugg }
         };
 
         let (recv, arg1, arg2) = if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, lhs) {
-            (
-                inner_lhs,
-                Sugg::hir(cx, inner_rhs, "..").to_string(),
-                maybe_neg_sugg(rhs),
-            )
+            (inner_lhs, Sugg::hir(cx, inner_rhs, ".."), maybe_neg_sugg(rhs))
         } else if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, rhs) {
-            (
-                inner_lhs,
-                maybe_neg_sugg(inner_rhs),
-                Sugg::hir(cx, lhs, "..").to_string(),
-            )
+            (inner_lhs, maybe_neg_sugg(inner_rhs), Sugg::hir(cx, lhs, ".."))
         } else {
             return;
         };

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -465,7 +465,10 @@ forward_binop_impls_to_ref!(impl Sub, sub for Sugg<'_>, type Output = Sugg<'stat
 impl Neg for Sugg<'_> {
     type Output = Sugg<'static>;
     fn neg(self) -> Sugg<'static> {
-        make_unop("-", self)
+        match &self {
+            Self::BinOp(AssocOp::As, ..) => Sugg::MaybeParen(format!("-({self})").into()),
+            _ => make_unop("-", self),
+        }
     }
 }
 

--- a/tests/ui/floating_point_mul_add.fixed
+++ b/tests/ui/floating_point_mul_add.fixed
@@ -33,6 +33,9 @@ fn main() {
 
     let _ = a.mul_add(a, b).sqrt();
 
+    let u = 1usize;
+    let _ = b.mul_add(-(u as f64), a);
+
     // Cases where the lint shouldn't be applied
     let _ = (a * a + b * b).sqrt();
 }

--- a/tests/ui/floating_point_mul_add.rs
+++ b/tests/ui/floating_point_mul_add.rs
@@ -33,6 +33,9 @@ fn main() {
 
     let _ = (a * a + b).sqrt();
 
+    let u = 1usize;
+    let _ = a - (b * u as f64);
+
     // Cases where the lint shouldn't be applied
     let _ = (a * a + b * b).sqrt();
 }

--- a/tests/ui/floating_point_mul_add.stderr
+++ b/tests/ui/floating_point_mul_add.stderr
@@ -73,5 +73,11 @@ error: multiply and add expressions can be calculated more efficiently and accur
 LL |     let _ = (a * a + b).sqrt();
    |             ^^^^^^^^^^^ help: consider using: `a.mul_add(a, b)`
 
-error: aborting due to 12 previous errors
+error: multiply and add expressions can be calculated more efficiently and accurately
+  --> $DIR/floating_point_mul_add.rs:37:13
+   |
+LL |     let _ = a - (b * u as f64);
+   |             ^^^^^^^^^^^^^^^^^^ help: consider using: `b.mul_add(-(u as f64), a)`
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
This fixes #11559 by adding a branch in the `Neg` implementation for `Sugg` that adds parentheses to keep precedence in order, then using that in the suggestion. I also removed some needless `.to_string()`s while I was at it.

---

changelog: none
