### PR TITLE
move `read_zero_byte_vec` to nursery

### DIFF
--- a/clippy_lints/src/read_zero_byte_vec.rs
+++ b/clippy_lints/src/read_zero_byte_vec.rs
@@ -42,7 +42,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.63.0"]
     pub READ_ZERO_BYTE_VEC,
-    correctness,
+    nursery,
     "checks for reads into a zero-length `Vec`"
 }
 declare_lint_pass!(ReadZeroByteVec => [READ_ZERO_BYTE_VEC]);


### PR DESCRIPTION
I think the concerns in #9274 are valid, and we should move this to nursery while we're reworking this.

changelog: [`read_zero_byte_vec`] moved to nursery
