### PR TITLE
ignore lower-camel-case words in `doc_markdown`

### DIFF
--- a/clippy_lints/src/doc.rs
+++ b/clippy_lints/src/doc.rs
@@ -756,11 +756,12 @@ fn check_text(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, text: &str
 }
 
 fn check_word(cx: &LateContext<'_>, word: &str, span: Span) {
-    /// Checks if a string is camel-case, i.e., contains at least two uppercase
-    /// letters (`Clippy` is ok) and one lower-case letter (`NASA` is ok).
+    /// Checks if a string is upper-camel-case, i.e., starts with an uppercase and
+    /// contains at least two uppercase letters (`Clippy` is ok) and one lower-case
+    /// letter (`NASA` is ok).
     /// Plurals are also excluded (`IDs` is ok).
     fn is_camel_case(s: &str) -> bool {
-        if s.starts_with(|c: char| c.is_ascii_digit()) {
+        if s.starts_with(|c: char| c.is_ascii_digit() | c.is_ascii_lowercase()) {
             return false;
         }
 

--- a/tests/ui/doc/doc-fixable.fixed
+++ b/tests/ui/doc/doc-fixable.fixed
@@ -224,3 +224,6 @@ where [(); N.checked_next_power_of_two().unwrap()]: {
         }
     }
 }
+
+/// this checks if the lowerCamelCase issue is fixed
+fn issue_11568() {}

--- a/tests/ui/doc/doc-fixable.rs
+++ b/tests/ui/doc/doc-fixable.rs
@@ -224,3 +224,6 @@ where [(); N.checked_next_power_of_two().unwrap()]: {
         }
     }
 }
+
+/// this checks if the lowerCamelCase issue is fixed
+fn issue_11568() {}


### PR DESCRIPTION
This fixes #11568 by ignoring camelCase words starting with a lower case letter.

r? @blyxyas 

---

changelog: none
