### PR TITLE
Add type details to unnecessary_fallible_conversions note

### DIFF
--- a/tests/ui/unnecessary_fallible_conversions.stderr
+++ b/tests/ui/unnecessary_fallible_conversions.stderr
@@ -4,6 +4,7 @@ error: use of a fallible conversion when an infallible one could be used
 LL |     let _: i64 = 0i32.try_into().unwrap();
    |                       ^^^^^^^^^^^^^^^^^^^ help: use: `into()`
    |
+   = note: converting `i32` to `i64` cannot fail
    = note: `-D clippy::unnecessary-fallible-conversions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_fallible_conversions)]`
 
@@ -12,6 +13,8 @@ error: use of a fallible conversion when an infallible one could be used
    |
 LL |     let _: i64 = 0i32.try_into().expect("can't happen");
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `into()`
+   |
+   = note: converting `i32` to `i64` cannot fail
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unnecessary_fallible_conversions_unfixable.stderr
+++ b/tests/ui/unnecessary_fallible_conversions_unfixable.stderr
@@ -4,6 +4,7 @@ error: use of a fallible conversion when an infallible one could be used
 LL |     let _: Result<Foo, _> = 0i64.try_into();
    |                                  ^^^^^^^^ help: use: `into`
    |
+   = note: converting `i64` to `Foo` cannot fail
    = note: `-D clippy::unnecessary-fallible-conversions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_fallible_conversions)]`
 
@@ -12,30 +13,40 @@ error: use of a fallible conversion when an infallible one could be used
    |
 LL |     let _: Result<Foo, _> = i64::try_into(0i64);
    |                             ^^^^^^^^^^^^^ help: use: `Into::into`
+   |
+   = note: converting `i64` to `Foo` cannot fail
 
 error: use of a fallible conversion when an infallible one could be used
   --> $DIR/unnecessary_fallible_conversions_unfixable.rs:31:29
    |
 LL |     let _: Result<Foo, _> = Foo::try_from(0i64);
    |                             ^^^^^^^^^^^^^ help: use: `From::from`
+   |
+   = note: converting `i64` to `Foo` cannot fail
 
 error: use of a fallible conversion when an infallible one could be used
   --> $DIR/unnecessary_fallible_conversions_unfixable.rs:34:34
    |
 LL |     let _: Result<i64, _> = 0i32.try_into();
    |                                  ^^^^^^^^ help: use: `into`
+   |
+   = note: converting `i32` to `i64` cannot fail
 
 error: use of a fallible conversion when an infallible one could be used
   --> $DIR/unnecessary_fallible_conversions_unfixable.rs:36:29
    |
 LL |     let _: Result<i64, _> = i32::try_into(0i32);
    |                             ^^^^^^^^^^^^^ help: use: `Into::into`
+   |
+   = note: converting `i32` to `i64` cannot fail
 
 error: use of a fallible conversion when an infallible one could be used
   --> $DIR/unnecessary_fallible_conversions_unfixable.rs:38:29
    |
 LL |     let _: Result<i64, _> = <_>::try_from(0i32);
    |                             ^^^^^^^^^^^^^ help: use: `From::from`
+   |
+   = note: converting `i32` to `i64` cannot fail
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fixes: #11753 

changelog: [`unnecessary_fallible_conversions`]: add type details to lint note