### PR TITLE
fix: [manual_memcpy] reduce indexing suggestions when array length is equal to loop range

### DIFF
--- a/tests/ui/manual_memcpy/without_loop_counters.rs
+++ b/tests/ui/manual_memcpy/without_loop_counters.rs
@@ -138,6 +138,26 @@ pub fn manual_copy(src: &[i32], dst: &mut [i32], dst2: &mut [i32]) {
     for i in 0..dst.len() {
         dst[i] = src[i];
     }
+
+    // Range is equal to array length
+    let src = [0, 1, 2, 3, 4];
+    let mut dst = [0; 4];
+    for i in 0..4 {
+        //~^ ERROR: it looks like you're manually copying between slices
+        dst[i] = src[i];
+    }
+
+    let mut dst = [0; 6];
+    for i in 0..5 {
+        //~^ ERROR: it looks like you're manually copying between slices
+        dst[i] = src[i];
+    }
+
+    let mut dst = [0; 5];
+    for i in 0..5 {
+        //~^ ERROR: it looks like you're manually copying between slices
+        dst[i] = src[i];
+    }
 }
 
 #[warn(clippy::needless_range_loop, clippy::manual_memcpy)]

--- a/tests/ui/manual_memcpy/without_loop_counters.stderr
+++ b/tests/ui/manual_memcpy/without_loop_counters.stderr
@@ -106,7 +106,7 @@ LL | /     for i in 0..5 {
 LL | |
 LL | |         dst[i - 0] = src[i];
 LL | |     }
-   | |_____^ help: try replacing the loop by: `dst[..5].copy_from_slice(&src[..5]);`
+   | |_____^ help: try replacing the loop by: `dst[..5].copy_from_slice(&src);`
 
 error: it looks like you're manually copying between slices
   --> $DIR/without_loop_counters.rs:121:5
@@ -120,11 +120,38 @@ LL | |     }
 error: it looks like you're manually copying between slices
   --> $DIR/without_loop_counters.rs:145:5
    |
+LL | /     for i in 0..4 {
+LL | |
+LL | |         dst[i] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst.copy_from_slice(&src[..4]);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/without_loop_counters.rs:151:5
+   |
+LL | /     for i in 0..5 {
+LL | |
+LL | |         dst[i] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst[..5].copy_from_slice(&src);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/without_loop_counters.rs:157:5
+   |
+LL | /     for i in 0..5 {
+LL | |
+LL | |         dst[i] = src[i];
+LL | |     }
+   | |_____^ help: try replacing the loop by: `dst.copy_from_slice(&src);`
+
+error: it looks like you're manually copying between slices
+  --> $DIR/without_loop_counters.rs:165:5
+   |
 LL | /     for i in 0..src.len() {
 LL | |
 LL | |         dst[i] = src[i].clone();
 LL | |     }
    | |_____^ help: try replacing the loop by: `dst[..src.len()].clone_from_slice(&src[..]);`
 
-error: aborting due to 13 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
fixes: #11689 

This PR improves `manual_memcpy` suggestions by reducing unnecessary indexing.

For example, 
```rust
let src = [0, 1, 2, 3, 4];
let mut dest = [0; 4];
for i in 0..4 {
    dest[i] = src[i];
{
```
Clippy suggests `dest[..4].copy_from_slice(&src[..4]);`.
I reduced this suggestion as `dest.copy_from_slice(&src[..4]);`. (Removed needless indexing.)

changelog: [`manual_memcpy`]: Reduce indexing suggestions when array length is equal to loop range
