### PR TITLE
[`mod_module_files`] Don't emit lint for mod.rs in tests

### DIFF
--- a/clippy_lints/src/module_style.rs
+++ b/clippy_lints/src/module_style.rs
@@ -153,8 +153,11 @@ fn process_paths_for_mod_files<'a>(
 }
 
 /// Checks every path for the presence of `mod.rs` files and emits the lint if found.
+/// We should not emit a lint for test modules in the presence of `mod.rs`.
+/// Using `mod.rs` in integration tests is a [common pattern](https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-test)
+/// for code-sharing between tests.
 fn check_self_named_mod_exists(cx: &EarlyContext<'_>, path: &Path, file: &SourceFile) {
-    if path.ends_with("mod.rs") {
+    if path.ends_with("mod.rs") && !path.starts_with("tests") {
         let mut mod_file = path.to_path_buf();
         mod_file.pop();
         mod_file.set_extension("rs");


### PR DESCRIPTION
fixes: #11775

current state: indiscriminately emits the lint for mod files in tests.

The following

```
tests/
  common/
    mod.rs
  test.rs
```

is a common pattern for code shared across the tests and is suggested in the rust book. The change adds an additional check to verify that the mod file is not in tests.

changelog: Fix [`mod_module_files`]: false positive for mod files in tests folder

