### PR TITLE
Removing @Centri3 from reviewer rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -33,5 +33,4 @@ contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIB
     "@dswij",
     "@Jarcho",
     "@blyxyas",
-    "@Centri3",
 ]


### PR DESCRIPTION
Catherine decided that the best course of action would be to (maybe temporarily) remove her from the reviewer's rotation (but not unassign her from her current reviews). This PR does that. She'll always be welcomed back if she wants to review some more :heart:

> Alejandra González: [youremyfrennow.mp4](https://rust-lang.zulipchat.com/user_uploads/4715/7nE2W6cb8Q02gcK-vubvmsPM/youremyfrennow.mp4)
>
>Catherine, Fred (@xFrednet ) noticed that you aren't as active as in the summer, and proposed that maybe you preferred to be removed from the reviewer rotation. Don't worry, you aren't being taken out of the team, just wanted to know if you maybe preferred to not have those reviews pilling up (they can be pretty stressful to see).
>
>If you decide to step out of the reviewers rotation, you wouldn't be removed from the team, you just wouldn't have that responsability. Everyone takes break and that's fine, so yeah, if you want to not have to review PRs, let me know!
>
>So yeah, from weird teenager transfem to (probably weird) teenager transfem, the choice is in your hand.
>
>Alejandra González: meow meow ^•ﻌ•^
>
>Catherine (Centri3): Yeah that's probably best now, I'll still try with any I'm currently assigned to but I would prefer not to get anymore until then
>Catherine (Centri3): meow meow :3

changelog:none

r? @Centri3