### PR TITLE
add help text where missing to lints

### DIFF
--- a/clippy_lints/src/casts/cast_possible_wrap.rs
+++ b/clippy_lints/src/casts/cast_possible_wrap.rs
@@ -1,5 +1,6 @@
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir::Expr;
-use rustc_lint::{LateContext, LintContext};
+use rustc_lint::LateContext;
 use rustc_middle::ty::Ty;
 
 use super::{utils, CAST_POSSIBLE_WRAP};
@@ -78,13 +79,11 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_from: Ty<'_>, ca
         ),
     };
 
-    cx.struct_span_lint(CAST_POSSIBLE_WRAP, expr.span, message, |diag| {
+    span_lint_and_then(cx, CAST_POSSIBLE_WRAP, expr.span, &message, |diag| {
         if let EmitState::LintOnPtrSize(16) = should_lint {
             diag
-            .note("`usize` and `isize` may be as small as 16 bits on some platforms")
-            .note("for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types")
-        } else {
-            diag
-        }
+                .note("`usize` and `isize` may be as small as 16 bits on some platforms")
+                .note("for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types");
+        };
     });
 }

--- a/clippy_lints/src/module_style.rs
+++ b/clippy_lints/src/module_style.rs
@@ -1,3 +1,4 @@
+use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_ast::ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_lint::{EarlyContext, EarlyLintPass, Level, LintContext};
@@ -124,11 +125,13 @@ impl EarlyLintPass for ModStyle {
                     correct.pop();
                     correct.push(folder);
                     correct.push("mod.rs");
-                    cx.struct_span_lint(
+                    span_lint_and_help(
+                        cx,
                         SELF_NAMED_MODULE_FILES,
                         Span::new(file.start_pos, file.start_pos, SyntaxContext::root(), None),
-                        format!("`mod.rs` files are required, found `{}`", path.display()),
-                        |lint| lint.help(format!("move `{}` to `{}`", path.display(), correct.display(),)),
+                        &format!("`mod.rs` files are required, found `{}`", path.display()),
+                        None,
+                        &format!("move `{}` to `{}`", path.display(), correct.display(),),
                     );
                 }
             }
@@ -162,11 +165,13 @@ fn check_self_named_mod_exists(cx: &EarlyContext<'_>, path: &Path, file: &Source
         mod_file.pop();
         mod_file.set_extension("rs");
 
-        cx.struct_span_lint(
+        span_lint_and_help(
+            cx,
             MOD_MODULE_FILES,
             Span::new(file.start_pos, file.start_pos, SyntaxContext::root(), None),
-            format!("`mod.rs` files are not allowed, found `{}`", path.display()),
-            |lint| lint.help(format!("move `{}` to `{}`", path.display(), mod_file.display())),
+            &format!("`mod.rs` files are not allowed, found `{}`", path.display()),
+            None,
+            &format!("move `{}` to `{}`", path.display(), mod_file.display()),
         );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/11805

Essentially just changes the section of code that applies the lint from using `cx.struct_span_lint` and instead opts for `span_lint_and_then`, which automatically appends the help text.

changelog: add missing help text for `cast_possible_wrap`, `mod_module_files`, and `self_named_module_files` lints