### PR TITLE
disallow calls to `LintContext::struct_span_lint` and `TyCtxt::struct_span_lint_hir`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,7 @@
 avoid-breaking-exported-api = false
+
+# use the various `span_lint_*` methods instead, which also add a link to the docs
+disallowed-methods = [
+    "rustc_lint::context::LintContext::struct_span_lint",
+    "rustc_middle::ty::context::TyCtxt::struct_span_lint_hir"
+]

--- a/clippy_utils/src/diagnostics.rs
+++ b/clippy_utils/src/diagnostics.rs
@@ -46,6 +46,7 @@ fn docs_link(diag: &mut Diagnostic, lint: &'static Lint) {
 ///    |     ^^^^^^^^^^^^^^^^^^^^^^^
 /// ```
 pub fn span_lint<T: LintContext>(cx: &T, lint: &'static Lint, sp: impl Into<MultiSpan>, msg: &str) {
+    #[expect(clippy::disallowed_methods)]
     cx.struct_span_lint(lint, sp, msg.to_string(), |diag| {
         docs_link(diag, lint);
         diag
@@ -80,6 +81,7 @@ pub fn span_lint_and_help<T: LintContext>(
     help_span: Option<Span>,
     help: &str,
 ) {
+    #[expect(clippy::disallowed_methods)]
     cx.struct_span_lint(lint, span, msg.to_string(), |diag| {
         let help = help.to_string();
         if let Some(help_span) = help_span {
@@ -123,6 +125,7 @@ pub fn span_lint_and_note<T: LintContext>(
     note_span: Option<Span>,
     note: &str,
 ) {
+    #[expect(clippy::disallowed_methods)]
     cx.struct_span_lint(lint, span, msg.to_string(), |diag| {
         let note = note.to_string();
         if let Some(note_span) = note_span {
@@ -145,6 +148,7 @@ where
     S: Into<MultiSpan>,
     F: FnOnce(&mut Diagnostic),
 {
+    #[expect(clippy::disallowed_methods)]
     cx.struct_span_lint(lint, sp, msg.to_string(), |diag| {
         f(diag);
         docs_link(diag, lint);
@@ -153,6 +157,7 @@ where
 }
 
 pub fn span_lint_hir(cx: &LateContext<'_>, lint: &'static Lint, hir_id: HirId, sp: Span, msg: &str) {
+    #[expect(clippy::disallowed_methods)]
     cx.tcx.struct_span_lint_hir(lint, hir_id, sp, msg.to_string(), |diag| {
         docs_link(diag, lint);
         diag
@@ -167,6 +172,7 @@ pub fn span_lint_hir_and_then(
     msg: &str,
     f: impl FnOnce(&mut Diagnostic),
 ) {
+    #[expect(clippy::disallowed_methods)]
     cx.tcx.struct_span_lint_hir(lint, hir_id, sp, msg.to_string(), |diag| {
         f(diag);
         docs_link(diag, lint);

--- a/tests/ui-internal/disallow_struct_span_lint.rs
+++ b/tests/ui-internal/disallow_struct_span_lint.rs
@@ -1,0 +1,27 @@
+#![feature(rustc_private)]
+
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_lint;
+extern crate rustc_middle;
+
+use rustc_errors::{DiagnosticMessage, MultiSpan};
+use rustc_hir::hir_id::HirId;
+use rustc_lint::{Lint, LintContext};
+use rustc_middle::ty::TyCtxt;
+
+pub fn a(cx: impl LintContext, lint: &'static Lint, span: impl Into<MultiSpan>, msg: impl Into<DiagnosticMessage>) {
+    cx.struct_span_lint(lint, span, msg, |b| b);
+}
+
+pub fn b(
+    tcx: TyCtxt<'_>,
+    lint: &'static Lint,
+    hir_id: HirId,
+    span: impl Into<MultiSpan>,
+    msg: impl Into<DiagnosticMessage>,
+) {
+    tcx.struct_span_lint_hir(lint, hir_id, span, msg, |b| b);
+}
+
+fn main() {}

--- a/tests/ui-internal/disallow_struct_span_lint.stderr
+++ b/tests/ui-internal/disallow_struct_span_lint.stderr
@@ -1,0 +1,17 @@
+error: use of a disallowed method `rustc_lint::context::LintContext::struct_span_lint`
+  --> $DIR/disallow_struct_span_lint.rs:14:5
+   |
+LL |     cx.struct_span_lint(lint, span, msg, |b| b);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::disallowed-methods` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
+
+error: use of a disallowed method `rustc_middle::ty::context::TyCtxt::struct_span_lint_hir`
+  --> $DIR/disallow_struct_span_lint.rs:24:5
+   |
+LL |     tcx.struct_span_lint_hir(lint, hir_id, span, msg, |b| b);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
`LintContext::struct_span_lint` and `TyCtxt::struct_span_lint_hir` don't show the link to the clippy documentation, see: #11805

In #11810, the last few calls to those methods were replaced with `span_lint_*`. It seems like we should just disallow them altogether so that no new code tries to use them.

The existing `disallowed_methods` lint makes this easy.

changelog: none