### PR TITLE
fix [`undocumented_unsafe_block`] and [`unnecessary_safety_comment`]  not detecting associated constants

### DIFF
--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.default.stderr
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.default.stderr
@@ -312,5 +312,73 @@ LL |             let bar = unsafe {};
    |
    = help: consider adding a safety comment on the preceding line
 
-error: aborting due to 35 previous errors
+error: associated constant has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:590:9
+   |
+LL |         const SAFE_CONST_IN_TRAIT: u8 = 1;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:589:9
+   |
+LL |         // SAFETY: unnecessary, lint
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:592:37
+   |
+LL |         const MAYBE_NO_SAFETY: u8 = unsafe { 0 };
+   |                                     ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:596:41
+   |
+LL |         const NO_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
+   |                                         ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: associated constant has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:604:9
+   |
+LL |         const SAFE_CONST: u8 = 0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:603:9
+   |
+LL |         // SAFETY: unnecessary, lint
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:608:42
+   |
+LL |         const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 3 };
+   |                                          ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:615:31
+   |
+LL |         const NO_SAFETY: u8 = unsafe { 5 };
+   |                               ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: associated constant has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:618:9
+   |
+LL |         const SAFE: u8 = 1;
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:617:9
+   |
+LL |         // SAFETY: unnecessary, lint
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 42 previous errors
 

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.disabled.stderr
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.disabled.stderr
@@ -392,5 +392,73 @@ LL |     unsafe {}
    |
    = help: consider adding a safety comment on the preceding line
 
-error: aborting due to 45 previous errors
+error: associated constant has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:590:9
+   |
+LL |         const SAFE_CONST_IN_TRAIT: u8 = 1;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:589:9
+   |
+LL |         // SAFETY: unnecessary, lint
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:592:37
+   |
+LL |         const MAYBE_NO_SAFETY: u8 = unsafe { 0 };
+   |                                     ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:596:41
+   |
+LL |         const NO_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
+   |                                         ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: associated constant has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:604:9
+   |
+LL |         const SAFE_CONST: u8 = 0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:603:9
+   |
+LL |         // SAFETY: unnecessary, lint
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:608:42
+   |
+LL |         const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 3 };
+   |                                          ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: unsafe block missing a safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:615:31
+   |
+LL |         const NO_SAFETY: u8 = unsafe { 5 };
+   |                               ^^^^^^^^^^^^
+   |
+   = help: consider adding a safety comment on the preceding line
+
+error: associated constant has unnecessary safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:618:9
+   |
+LL |         const SAFE: u8 = 1;
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing the safety comment
+  --> $DIR/undocumented_unsafe_blocks.rs:617:9
+   |
+LL |         // SAFETY: unnecessary, lint
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 52 previous errors
 

--- a/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
+++ b/tests/ui-toml/undocumented_unsafe_blocks/undocumented_unsafe_blocks.rs
@@ -582,4 +582,42 @@ mod issue_11246 {
 // Safety: Another safety comment
 const FOO: () = unsafe {};
 
+// trait items and impl items
+mod issue_11709 {
+    trait MyTrait {
+        const SAFE_CONST: u8 = 0;
+        // SAFETY: unnecessary, lint
+        const SAFE_CONST_IN_TRAIT: u8 = 1;
+        //~^ ERROR: associated constant has unnecessary safety comment
+        const MAYBE_NO_SAFETY: u8 = unsafe { 0 };
+        //~^ ERROR: unsafe block missing a safety comment
+        // SAFETY: safe, trust me
+        const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
+        const NO_SAFETY_IN_TRAIT: i32 = unsafe { 1 };
+        //~^ ERROR: unsafe block missing a safety comment
+    }
+
+    struct UnsafeStruct;
+
+    impl MyTrait for UnsafeStruct {
+        // SAFETY: unnecessary, lint
+        const SAFE_CONST: u8 = 0;
+        //~^ ERROR: associated constant has unnecessary safety comment
+        // SAFETY: safe in this impl
+        const MAYBE_NO_SAFETY: u8 = unsafe { 2 };
+        const HAS_SAFETY_IN_TRAIT: i32 = unsafe { 3 };
+        //~^ ERROR: unsafe block missing a safety comment
+    }
+
+    impl UnsafeStruct {
+        // SAFETY: safe
+        const HAS_SAFETY: u8 = unsafe { 4 };
+        const NO_SAFETY: u8 = unsafe { 5 };
+        //~^ ERROR: unsafe block missing a safety comment
+        // SAFETY: unnecessary, lint
+        const SAFE: u8 = 1;
+        //~^ ERROR: associated constant has unnecessary safety comment
+    }
+}
+
 fn main() {}

--- a/tests/ui/doc_unsafe.rs
+++ b/tests/ui/doc_unsafe.rs
@@ -7,6 +7,7 @@ use proc_macros::external;
 
 /// This is not sufficiently documented
 pub unsafe fn destroy_the_planet() {
+    //~^ ERROR: unsafe function's docs miss `# Safety` section
     unimplemented!();
 }
 
@@ -30,6 +31,7 @@ mod private_mod {
     }
 
     pub unsafe fn republished() {
+        //~^ ERROR: unsafe function's docs miss `# Safety` section
         unimplemented!();
     }
 }
@@ -38,12 +40,14 @@ pub use private_mod::republished;
 
 pub trait SafeTraitUnsafeMethods {
     unsafe fn woefully_underdocumented(self);
+    //~^ ERROR: unsafe function's docs miss `# Safety` section
 
     /// # Safety
     unsafe fn at_least_somewhat_documented(self);
 }
 
 pub unsafe trait UnsafeTrait {
+    //~^ ERROR: docs for unsafe trait missing `# Safety` section
     fn method();
 }
 
@@ -74,6 +78,7 @@ unsafe impl DocumentedUnsafeTrait for Struct {
 
 impl Struct {
     pub unsafe fn more_undocumented_unsafe() -> Self {
+        //~^ ERROR: unsafe function's docs miss `# Safety` section
         unimplemented!();
     }
 
@@ -103,6 +108,7 @@ macro_rules! very_unsafe {
 }
 
 very_unsafe!();
+//~^ ERROR: unsafe function's docs miss `# Safety` section
 
 // we don't lint code from external macros
 external! {

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -8,31 +8,31 @@ LL | pub unsafe fn destroy_the_planet() {
    = help: to override `-D warnings` add `#[allow(clippy::missing_safety_doc)]`
 
 error: unsafe function's docs miss `# Safety` section
-  --> $DIR/doc_unsafe.rs:32:5
+  --> $DIR/doc_unsafe.rs:33:5
    |
 LL |     pub unsafe fn republished() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs miss `# Safety` section
-  --> $DIR/doc_unsafe.rs:40:5
+  --> $DIR/doc_unsafe.rs:42:5
    |
 LL |     unsafe fn woefully_underdocumented(self);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: docs for unsafe trait missing `# Safety` section
-  --> $DIR/doc_unsafe.rs:46:1
+  --> $DIR/doc_unsafe.rs:49:1
    |
 LL | pub unsafe trait UnsafeTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs miss `# Safety` section
-  --> $DIR/doc_unsafe.rs:76:5
+  --> $DIR/doc_unsafe.rs:80:5
    |
 LL |     pub unsafe fn more_undocumented_unsafe() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unsafe function's docs miss `# Safety` section
-  --> $DIR/doc_unsafe.rs:92:9
+  --> $DIR/doc_unsafe.rs:97:9
    |
 LL |         pub unsafe fn whee() {
    |         ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
fixes: #11709 

changelog: fix FP on [`undocumented_unsafe_block`] and [`unnecessary_safety_comment`]
