### PR TITLE
Extend `maybe_misused_cfg` lint over `cfg(test)`

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -407,20 +407,26 @@ declare_clippy_lint! {
     /// Checks for `#[cfg(features = "...")]` and suggests to replace it with
     /// `#[cfg(feature = "...")]`.
     ///
+    /// It also checks if `cfg(test)` was misspelled.
+    ///
     /// ### Why is this bad?
-    /// Misspelling `feature` as `features` can be sometimes hard to spot. It
+    /// Misspelling `feature` as `features` or `test` as `tests` can be sometimes hard to spot. It
     /// may cause conditional compilation not work quietly.
     ///
     /// ### Example
     /// ```no_run
     /// #[cfg(features = "some-feature")]
     /// fn conditional() { }
+    /// #[cfg(tests)]
+    /// mod tests { }
     /// ```
     ///
     /// Use instead:
     /// ```no_run
     /// #[cfg(feature = "some-feature")]
     /// fn conditional() { }
+    /// #[cfg(test)]
+    /// mod tests { }
     /// ```
     #[clippy::version = "1.69.0"]
     pub MAYBE_MISUSED_CFG,

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -946,6 +946,19 @@ fn check_nested_misused_cfg(cx: &EarlyContext<'_>, items: &[NestedMetaItem]) {
             }
             if let MetaItemKind::List(list) = &meta.kind {
                 check_nested_misused_cfg(cx, list);
+            // If this is not a list, then we check for `cfg(test)`.
+            } else if let Some(ident) = meta.ident()
+                && matches!(ident.name.as_str(), "tests" | "Test")
+            {
+                span_lint_and_sugg(
+                    cx,
+                    MAYBE_MISUSED_CFG,
+                    meta.span,
+                    &format!("'test' may be misspelled as '{}'", ident.name.as_str()),
+                    "do you mean",
+                    "test".to_string(),
+                    Applicability::MaybeIncorrect,
+                );
             }
         }
     }

--- a/tests/ui/cfg_features.fixed
+++ b/tests/ui/cfg_features.fixed
@@ -14,4 +14,16 @@ fn main() {
     //~^ ERROR: feature may misspelled as features
     //~| ERROR: feature may misspelled as features
     let _ = 1 + 2;
+
+    #[cfg(test)]
+    //~^ ERROR: 'test' may be misspelled as 'tests'
+    let _ = 2;
+    #[cfg(test)]
+    //~^ ERROR: 'test' may be misspelled as 'Test'
+    let _ = 2;
+
+    #[cfg(all(test, test))]
+    //~^ ERROR: 'test' may be misspelled as 'tests'
+    //~| ERROR: 'test' may be misspelled as 'Test'
+    let _ = 2;
 }

--- a/tests/ui/cfg_features.rs
+++ b/tests/ui/cfg_features.rs
@@ -14,4 +14,16 @@ fn main() {
     //~^ ERROR: feature may misspelled as features
     //~| ERROR: feature may misspelled as features
     let _ = 1 + 2;
+
+    #[cfg(tests)]
+    //~^ ERROR: 'test' may be misspelled as 'tests'
+    let _ = 2;
+    #[cfg(Test)]
+    //~^ ERROR: 'test' may be misspelled as 'Test'
+    let _ = 2;
+
+    #[cfg(all(tests, Test))]
+    //~^ ERROR: 'test' may be misspelled as 'tests'
+    //~| ERROR: 'test' may be misspelled as 'Test'
+    let _ = 2;
 }

--- a/tests/ui/cfg_features.stderr
+++ b/tests/ui/cfg_features.stderr
@@ -25,5 +25,29 @@ error: feature may misspelled as features
 LL |     #[cfg(all(features = "wrong1", any(feature = "right", features = "wrong2", feature, features)))]
    |                                                           ^^^^^^^^^^^^^^^^^^^ help: use: `feature = "wrong2"`
 
-error: aborting due to 4 previous errors
+error: 'test' may be misspelled as 'tests'
+  --> $DIR/cfg_features.rs:18:11
+   |
+LL |     #[cfg(tests)]
+   |           ^^^^^ help: do you mean: `test`
+
+error: 'test' may be misspelled as 'Test'
+  --> $DIR/cfg_features.rs:21:11
+   |
+LL |     #[cfg(Test)]
+   |           ^^^^ help: do you mean: `test`
+
+error: 'test' may be misspelled as 'tests'
+  --> $DIR/cfg_features.rs:25:15
+   |
+LL |     #[cfg(all(tests, Test))]
+   |               ^^^^^ help: do you mean: `test`
+
+error: 'test' may be misspelled as 'Test'
+  --> $DIR/cfg_features.rs:25:22
+   |
+LL |     #[cfg(all(tests, Test))]
+   |                      ^^^^ help: do you mean: `test`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Fixes #11240.

One thought I had is that we could use the levenshtein distance (of 1) to ensure this is indeed `test` that was targeted. But maybe it's overkill, not sure.

changelog: [`maybe_misused_cfg`]: Extend lint over `cfg(test)`

r? @blyxyas