### PR TITLE
Update rust-cache GHA in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,9 @@ jobs:
       run: cargo generate-lockfile
 
     - name: Cache
-      uses: Swatinem/rust-cache@v1.3.0
+      uses: Swatinem/rust-cache@v2.7.0
+      with:
+        save-if: ${{ github.ref == 'refs/heads/master' }}
 
     - name: cargo collect-metadata
       run: cargo collect-metadata


### PR DESCRIPTION
This action was way outdated, produced a lot of warnings and didn't seem to work anymore.

changelog: none
