### PR TITLE
Don't suggest `a.mul_add(b, c)` if parameters are not float

### DIFF
--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -496,9 +496,13 @@ fn check_mul_add(cx: &LateContext<'_>, expr: &Expr<'_>) {
             if let BinOpKind::Sub = op { -sugg } else { sugg }
         };
 
-        let (recv, arg1, arg2) = if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, lhs) {
+        let (recv, arg1, arg2) = if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, lhs)
+            && cx.typeck_results().expr_ty(rhs).is_floating_point()
+        {
             (inner_lhs, Sugg::hir(cx, inner_rhs, ".."), maybe_neg_sugg(rhs))
-        } else if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, rhs) {
+        } else if let Some((inner_lhs, inner_rhs)) = is_float_mul_expr(cx, rhs)
+            && cx.typeck_results().expr_ty(lhs).is_floating_point()
+        {
             (inner_lhs, maybe_neg_sugg(inner_rhs), Sugg::hir(cx, lhs, ".."))
         } else {
             return;

--- a/tests/ui/floating_point_mul_add.fixed
+++ b/tests/ui/floating_point_mul_add.fixed
@@ -39,3 +39,21 @@ fn main() {
     // Cases where the lint shouldn't be applied
     let _ = (a * a + b * b).sqrt();
 }
+
+fn _issue11831() {
+    struct NotAFloat;
+
+    impl std::ops::Add<f64> for NotAFloat {
+        type Output = Self;
+
+        fn add(self, _: f64) -> Self {
+            NotAFloat
+        }
+    }
+
+    let a = NotAFloat;
+    let b = 1.0_f64;
+    let c = 1.0;
+
+    let _ = a + b * c;
+}

--- a/tests/ui/floating_point_mul_add.rs
+++ b/tests/ui/floating_point_mul_add.rs
@@ -39,3 +39,21 @@ fn main() {
     // Cases where the lint shouldn't be applied
     let _ = (a * a + b * b).sqrt();
 }
+
+fn _issue11831() {
+    struct NotAFloat;
+
+    impl std::ops::Add<f64> for NotAFloat {
+        type Output = Self;
+
+        fn add(self, _: f64) -> Self {
+            NotAFloat
+        }
+    }
+
+    let a = NotAFloat;
+    let b = 1.0_f64;
+    let c = 1.0;
+
+    let _ = a + b * c;
+}


### PR DESCRIPTION
clippy::suboptimal_flops used to not check if the second parameter to f32/f64.mul_add() was float. Since the method is only defined to take `Self` as parameters, the suggestion was wrong.

Fixes #11831

changelog: [`suboptimal_float`]: Don't suggest `a.mul_add(b, c)` if parameters are not f32/f64
