### PR TITLE
Improve maybe misused cfg

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -929,15 +929,16 @@ fn check_nested_cfg(cx: &EarlyContext<'_>, items: &[NestedMetaItem]) {
 fn check_nested_misused_cfg(cx: &EarlyContext<'_>, items: &[NestedMetaItem]) {
     for item in items {
         if let NestedMetaItem::MetaItem(meta) = item {
-            if meta.has_name(sym!(features))
+            if let Some(ident) = meta.ident()
+                && ident.name.as_str() == "features"
                 && let Some(val) = meta.value_str()
             {
                 span_lint_and_sugg(
                     cx,
                     MAYBE_MISUSED_CFG,
                     meta.span,
-                    "feature may misspelled as features",
-                    "use",
+                    "'feature' may be misspelled as 'features'",
+                    "did you mean",
                     format!("feature = \"{val}\""),
                     Applicability::MaybeIncorrect,
                 );
@@ -953,7 +954,7 @@ fn check_nested_misused_cfg(cx: &EarlyContext<'_>, items: &[NestedMetaItem]) {
                     MAYBE_MISUSED_CFG,
                     meta.span,
                     &format!("'test' may be misspelled as '{}'", ident.name.as_str()),
-                    "do you mean",
+                    "did you mean",
                     "test".to_string(),
                     Applicability::MaybeIncorrect,
                 );

--- a/tests/ui/cfg_features.fixed
+++ b/tests/ui/cfg_features.fixed
@@ -2,17 +2,17 @@
 
 fn main() {
     #[cfg(feature = "not-really-a-feature")]
-    //~^ ERROR: feature may misspelled as features
+    //~^ ERROR: 'feature' may be misspelled as 'features'
     //~| NOTE: `-D clippy::maybe-misused-cfg` implied by `-D warnings`
     let _ = 1 + 2;
 
     #[cfg(all(feature = "right", feature = "wrong"))]
-    //~^ ERROR: feature may misspelled as features
+    //~^ ERROR: 'feature' may be misspelled as 'features'
     let _ = 1 + 2;
 
     #[cfg(all(feature = "wrong1", any(feature = "right", feature = "wrong2", feature, features)))]
-    //~^ ERROR: feature may misspelled as features
-    //~| ERROR: feature may misspelled as features
+    //~^ ERROR: 'feature' may be misspelled as 'features'
+    //~| ERROR: 'feature' may be misspelled as 'features'
     let _ = 1 + 2;
 
     #[cfg(test)]

--- a/tests/ui/cfg_features.rs
+++ b/tests/ui/cfg_features.rs
@@ -2,17 +2,17 @@
 
 fn main() {
     #[cfg(features = "not-really-a-feature")]
-    //~^ ERROR: feature may misspelled as features
+    //~^ ERROR: 'feature' may be misspelled as 'features'
     //~| NOTE: `-D clippy::maybe-misused-cfg` implied by `-D warnings`
     let _ = 1 + 2;
 
     #[cfg(all(feature = "right", features = "wrong"))]
-    //~^ ERROR: feature may misspelled as features
+    //~^ ERROR: 'feature' may be misspelled as 'features'
     let _ = 1 + 2;
 
     #[cfg(all(features = "wrong1", any(feature = "right", features = "wrong2", feature, features)))]
-    //~^ ERROR: feature may misspelled as features
-    //~| ERROR: feature may misspelled as features
+    //~^ ERROR: 'feature' may be misspelled as 'features'
+    //~| ERROR: 'feature' may be misspelled as 'features'
     let _ = 1 + 2;
 
     #[cfg(tests)]

--- a/tests/ui/cfg_features.stderr
+++ b/tests/ui/cfg_features.stderr
@@ -1,53 +1,53 @@
-error: feature may misspelled as features
+error: 'feature' may be misspelled as 'features'
   --> $DIR/cfg_features.rs:4:11
    |
 LL |     #[cfg(features = "not-really-a-feature")]
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `feature = "not-really-a-feature"`
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `feature = "not-really-a-feature"`
    |
    = note: `-D clippy::maybe-misused-cfg` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::maybe_misused_cfg)]`
 
-error: feature may misspelled as features
+error: 'feature' may be misspelled as 'features'
   --> $DIR/cfg_features.rs:9:34
    |
 LL |     #[cfg(all(feature = "right", features = "wrong"))]
-   |                                  ^^^^^^^^^^^^^^^^^^ help: use: `feature = "wrong"`
+   |                                  ^^^^^^^^^^^^^^^^^^ help: did you mean: `feature = "wrong"`
 
-error: feature may misspelled as features
+error: 'feature' may be misspelled as 'features'
   --> $DIR/cfg_features.rs:13:15
    |
 LL |     #[cfg(all(features = "wrong1", any(feature = "right", features = "wrong2", feature, features)))]
-   |               ^^^^^^^^^^^^^^^^^^^ help: use: `feature = "wrong1"`
+   |               ^^^^^^^^^^^^^^^^^^^ help: did you mean: `feature = "wrong1"`
 
-error: feature may misspelled as features
+error: 'feature' may be misspelled as 'features'
   --> $DIR/cfg_features.rs:13:59
    |
 LL |     #[cfg(all(features = "wrong1", any(feature = "right", features = "wrong2", feature, features)))]
-   |                                                           ^^^^^^^^^^^^^^^^^^^ help: use: `feature = "wrong2"`
+   |                                                           ^^^^^^^^^^^^^^^^^^^ help: did you mean: `feature = "wrong2"`
 
 error: 'test' may be misspelled as 'tests'
   --> $DIR/cfg_features.rs:18:11
    |
 LL |     #[cfg(tests)]
-   |           ^^^^^ help: do you mean: `test`
+   |           ^^^^^ help: did you mean: `test`
 
 error: 'test' may be misspelled as 'Test'
   --> $DIR/cfg_features.rs:21:11
    |
 LL |     #[cfg(Test)]
-   |           ^^^^ help: do you mean: `test`
+   |           ^^^^ help: did you mean: `test`
 
 error: 'test' may be misspelled as 'tests'
   --> $DIR/cfg_features.rs:25:15
    |
 LL |     #[cfg(all(tests, Test))]
-   |               ^^^^^ help: do you mean: `test`
+   |               ^^^^^ help: did you mean: `test`
 
 error: 'test' may be misspelled as 'Test'
   --> $DIR/cfg_features.rs:25:22
    |
 LL |     #[cfg(all(tests, Test))]
-   |                      ^^^^ help: do you mean: `test`
+   |                      ^^^^ help: did you mean: `test`
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Follow-up of the improvements that were suggested to me in https://github.com/rust-lang/rust-clippy/pull/11821:

 * I unified the output to use the same terms.
 * I updated the code to prevent creating a new symbol.

r? @blyxyas

changelog: [`maybe_misued_cfg`]: Output and code improvements