### PR TITLE
Remove underscore check for `manual_non_exhaustive` lint

### DIFF
--- a/clippy_lints/src/manual_non_exhaustive.rs
+++ b/clippy_lints/src/manual_non_exhaustive.rs
@@ -118,7 +118,6 @@ impl EarlyLintPass for ManualNonExhaustiveStruct {
             if let Some(Ok(field)) = iter.next()
                 && iter.next().is_none()
                 && field.ty.kind.is_unit()
-                && field.ident.map_or(true, |name| name.as_str().starts_with('_'))
             {
                 span_lint_and_then(
                     cx,
@@ -158,7 +157,6 @@ impl<'tcx> LateLintPass<'tcx> for ManualNonExhaustiveEnum {
         {
             let mut iter = def.variants.iter().filter_map(|v| {
                 (matches!(v.data, hir::VariantData::Unit(_, _))
-                    && v.ident.as_str().starts_with('_')
                     && is_doc_hidden(cx.tcx.hir().attrs(v.hir_id))
                     && !attr::contains_name(cx.tcx.hir().attrs(item.hir_id()), sym::non_exhaustive))
                 .then_some((v.def_id, v.span))
@@ -173,9 +171,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualNonExhaustiveEnum {
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
         if let ExprKind::Path(QPath::Resolved(None, p)) = &e.kind
-            && let [.., name] = p.segments
             && let Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Const), id) = p.res
-            && name.ident.as_str().starts_with('_')
         {
             let variant_id = cx.tcx.parent(id);
             let enum_id = cx.tcx.parent(variant_id);

--- a/tests/ui/manual_non_exhaustive_enum.rs
+++ b/tests/ui/manual_non_exhaustive_enum.rs
@@ -26,7 +26,7 @@ enum NoDocHidden {
     _C,
 }
 
-// name of variant with doc hidden does not start with underscore, should be ignored
+// name of variant with doc hidden does not start with underscore
 enum NoUnderscore {
     A,
     B,

--- a/tests/ui/manual_non_exhaustive_enum.stderr
+++ b/tests/ui/manual_non_exhaustive_enum.stderr
@@ -22,5 +22,26 @@ LL |     _C,
    = note: `-D clippy::manual-non-exhaustive` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_non_exhaustive)]`
 
-error: aborting due to previous error
+error: this seems like a manual implementation of the non-exhaustive pattern
+  --> $DIR/manual_non_exhaustive_enum.rs:30:1
+   |
+LL |   enum NoUnderscore {
+   |   ^----------------
+   |   |
+   |  _help: add the attribute: `#[non_exhaustive] enum NoUnderscore`
+   | |
+LL | |     A,
+LL | |     B,
+LL | |     #[doc(hidden)]
+LL | |     C,
+LL | | }
+   | |_^
+   |
+help: remove this variant
+  --> $DIR/manual_non_exhaustive_enum.rs:34:5
+   |
+LL |     C,
+   |     ^
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/manual_non_exhaustive_struct.stderr
+++ b/tests/ui/manual_non_exhaustive_struct.stderr
@@ -39,6 +39,26 @@ LL |         _c: (),
    |         ^^^^^^
 
 error: this seems like a manual implementation of the non-exhaustive pattern
+  --> $DIR/manual_non_exhaustive_struct.rs:29:5
+   |
+LL |       struct NoUnderscore {
+   |       ^------------------
+   |       |
+   |  _____help: add the attribute: `#[non_exhaustive] struct NoUnderscore`
+   | |
+LL | |         pub a: i32,
+LL | |         pub b: i32,
+LL | |         c: (),
+LL | |     }
+   | |_____^
+   |
+help: remove this field
+  --> $DIR/manual_non_exhaustive_struct.rs:32:9
+   |
+LL |         c: (),
+   |         ^^^^^
+
+error: this seems like a manual implementation of the non-exhaustive pattern
   --> $DIR/manual_non_exhaustive_struct.rs:56:5
    |
 LL |     struct T(pub i32, pub i32, ());
@@ -64,5 +84,5 @@ help: remove this field
 LL |     struct Tp(pub i32, pub i32, ());
    |                                 ^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/10550.

As indicated in https://github.com/rust-lang/rust-clippy/pull/10559, the underscore check should be removed.

changelog: remove underscore check for `manual_non_exhaustive` lint

r? @blyxyas 