### PR TITLE
Add documentation update hint using `cargo collect-metadata`

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -518,6 +518,8 @@ define_Conf! {
 
 [`clippy_config::msrvs`]: https://doc.rust-lang.org/nightly/nightly-rustc/clippy_config/msrvs/index.html
 
+Afterwards update the documentation for the book as described in [Adding configuration to a lint](#adding-configuration-to-a-lint).
+
 ## Author lint
 
 If you have trouble implementing your lint, there is also the internal `author`


### PR DESCRIPTION
This adds a little reminder to update the documentation in the book using `cargo collect-metadata` after changing the lint configuration since this can easily be missed (been there done that 🙈).

> Yeah a note would be good, would be good for us to see if we can make it automatic also

_Originally posted by @Alexendoo in https://github.com/rust-lang/rust-clippy/issues/11757#issuecomment-1823474156_

Regarding the automation Im not sure whats the best option here. I thought about a kind of a "semi-automated" way, e.g. a `cargo dev` command which runs the "is the documentation updated" check (and maybe other useful checks) locally and reminds the user of updating the documentation so this gets caught before pushing.  

changelog: none
