### PR TITLE
Fix `box_default` behaviour with empty `vec![]` coming from macro arg

### DIFF
--- a/clippy_lints/src/box_default.rs
+++ b/clippy_lints/src/box_default.rs
@@ -45,7 +45,7 @@ impl LateLintPass<'_> for BoxDefault {
             && let ExprKind::Path(QPath::TypeRelative(ty, seg)) = box_new.kind
             && let ExprKind::Call(arg_path, ..) = arg.kind
             && !in_external_macro(cx.sess(), expr.span)
-            && (expr.span.eq_ctxt(arg.span) || is_vec_expn(cx, arg))
+            && (expr.span.eq_ctxt(arg.span) || is_local_vec_expn(cx, arg, expr))
             && seg.ident.name == sym::new
             && path_def_id(cx, ty).map_or(false, |id| Some(id) == cx.tcx.lang_items().owned_box())
             && is_default_equivalent(cx, arg)
@@ -81,10 +81,10 @@ fn is_plain_default(cx: &LateContext<'_>, arg_path: &Expr<'_>) -> bool {
     }
 }
 
-fn is_vec_expn(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    macro_backtrace(expr.span)
-        .next()
-        .map_or(false, |call| cx.tcx.is_diagnostic_item(sym::vec_macro, call.def_id))
+fn is_local_vec_expn(cx: &LateContext<'_>, expr: &Expr<'_>, ref_expr: &Expr<'_>) -> bool {
+    macro_backtrace(expr.span).next().map_or(false, |call| {
+        cx.tcx.is_diagnostic_item(sym::vec_macro, call.def_id) && call.span.eq_ctxt(ref_expr.span)
+    })
 }
 
 #[derive(Default)]

--- a/tests/ui/box_default.fixed
+++ b/tests/ui/box_default.fixed
@@ -90,3 +90,17 @@ fn issue_10381() {
 
     assert!(maybe_get_bar(2).is_some());
 }
+
+#[allow(unused)]
+fn issue_11868() {
+    fn foo(_: &mut Vec<usize>) {}
+
+    macro_rules! bar {
+        ($baz:expr) => {
+            Box::leak(Box::new($baz))
+        };
+    }
+
+    foo(bar!(vec![]));
+    foo(bar!(vec![1]));
+}

--- a/tests/ui/box_default.rs
+++ b/tests/ui/box_default.rs
@@ -90,3 +90,17 @@ fn issue_10381() {
 
     assert!(maybe_get_bar(2).is_some());
 }
+
+#[allow(unused)]
+fn issue_11868() {
+    fn foo(_: &mut Vec<usize>) {}
+
+    macro_rules! bar {
+        ($baz:expr) => {
+            Box::leak(Box::new($baz))
+        };
+    }
+
+    foo(bar!(vec![]));
+    foo(bar!(vec![1]));
+}


### PR DESCRIPTION
Fix #11868 

changelog: [`box_default`]: do not warn on `Box::new(vec![])` if the `vec![]` comes from a macro argument