### PR TITLE
Add new lint `might_panic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5279,6 +5279,7 @@ Released 2018-09-13
 [`mem_replace_option_with_none`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_option_with_none
 [`mem_replace_with_default`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default
 [`mem_replace_with_uninit`]: https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_uninit
+[`might_panic`]: https://rust-lang.github.io/rust-clippy/master/index.html#might_panic
 [`min_ident_chars`]: https://rust-lang.github.io/rust-clippy/master/index.html#min_ident_chars
 [`min_max`]: https://rust-lang.github.io/rust-clippy/master/index.html#min_max
 [`misaligned_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#misaligned_transmute

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -452,6 +452,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::WAKER_CLONE_WAKE_INFO,
     crate::methods::WRONG_SELF_CONVENTION_INFO,
     crate::methods::ZST_OFFSET_INFO,
+    crate::might_panic::MIGHT_PANIC_INFO,
     crate::min_ident_chars::MIN_IDENT_CHARS_INFO,
     crate::minmax::MIN_MAX_INFO,
     crate::misc::SHORT_CIRCUIT_STATEMENT_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -204,6 +204,7 @@ mod match_result_ok;
 mod matches;
 mod mem_replace;
 mod methods;
+mod might_panic;
 mod min_ident_chars;
 mod minmax;
 mod misc;
@@ -1070,6 +1071,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(|_| Box::new(iter_without_into_iter::IterWithoutIntoIter));
     store.register_late_pass(|_| Box::new(iter_over_hash_type::IterOverHashType));
     store.register_late_pass(|_| Box::new(impl_hash_with_borrow_str_and_bytes::ImplHashWithBorrowStrBytes));
+    store.register_late_pass(|_| Box::new(might_panic::MightPanic));
     store.register_late_pass(|_| Box::new(repeat_vec_with_capacity::RepeatVecWithCapacity));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/clippy_lints/src/might_panic.rs
+++ b/clippy_lints/src/might_panic.rs
@@ -1,0 +1,89 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::snippet_opt;
+use rustc_ast::ast::LitKind;
+use rustc_errors::Applicability;
+use rustc_hir as hir;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// replace accessing array with an `idx`` by a `get(idx)`.
+    ///
+    /// ### Why is this bad?
+    /// it's easier to locate error where you access array when
+    /// out of boundary; and you can write your error handle to
+    /// solve this problem.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let numbers = &[4, 7, 3];
+        /// let my_number = numbers[5];
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let numbers = &[4, 7, 3];
+    /// let Some(my_number) = numbers.get(5) else {
+    ///     panic!();
+    /// };
+    /// ```
+    #[clippy::version = "1.76.0"]
+    pub MIGHT_PANIC,
+    style,
+    "use `get()` function if you're not sure whether index is legal"
+}
+
+declare_lint_pass!(MightPanic => [MIGHT_PANIC]);
+
+impl LateLintPass<'_> for MightPanic {
+    fn check_stmt<'tcx>(&mut self, cx: &LateContext<'tcx>, stmt: &hir::Stmt<'tcx>) {
+        // pattern matching an `let` stmt satisfy form like `let x: ty = arr[idx];`
+        if let hir::StmtKind::Local(hir::Local {
+            pat,
+            ty,
+            init,
+            els: _,
+            hir_id: _,
+            span,
+            source: _,
+        }) = &stmt.kind
+            && let hir::PatKind::Binding(_, _, ident, _) = pat.kind
+            && let Some(expr) = init
+            && let hir::ExprKind::Index(arr, idx, _) = &expr.kind
+            && let hir::ExprKind::Path(_) = arr.kind
+            && let hir::ExprKind::Lit(spanned) = idx.kind
+            && let LitKind::Int(v, _) = spanned.node
+        {
+            // get type info string by stmt.local.ty.span
+            // may not have an explict type, it doesn't matter
+            let mut ty_str = String::new();
+            if let Some(hir::Ty {
+                hir_id: _,
+                kind: _,
+                span: ty_span,
+            }) = ty
+                && let Some(snip) = snippet_opt(cx, *ty_span)
+            {
+                ty_str = snip;
+            }
+            let span = *span;
+            span_lint_and_then(
+                cx,
+                MIGHT_PANIC,
+                span,
+                "use `get()` function if you're not sure whether index is legal",
+                |diag| {
+                    if let Some(snip) = snippet_opt(cx, arr.span) {
+                        // format sugg string
+                        let sugg = if ty_str.is_empty() {
+                            format!("let Some({ident}) = {snip}.get({v}) else {{ panic!() }};")
+                        } else {
+                            format!("let Some({ident}): Option<&{ty_str}> = {snip}.get({v}) else {{ panic!() }};")
+                        };
+                        diag.span_suggestion(span, "Try", sugg, Applicability::MachineApplicable);
+                    }
+                },
+            );
+        }
+    }
+}

--- a/tests/ui/might_panic.rs
+++ b/tests/ui/might_panic.rs
@@ -1,0 +1,18 @@
+#![allow(clippy::might_panic)]
+
+fn main() {
+    // declare 2 array to access
+    let arr1 = &[1, 2, 3];
+    let arr2 = &[[1], [2], [3]];
+
+    // trigger `might-panic` lint
+    // with and without explicit type declaration
+    let _num1 = arr1[1]; // warning
+    let _num2: i32 = arr1[5]; // warning
+
+    let _num3 = arr2[1]; // warning
+    let _num4: [i32; 1] = arr2[5]; // warning
+
+    // not trigger `might-panic` lint
+    let _num5 = arr2[0][0]; // no warning
+}

--- a/tests/ui/missing_asserts_for_indexing_unfixable.rs
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 #![warn(clippy::missing_asserts_for_indexing)]
+#![allow(clippy::might_panic)]
 
 fn sum(v: &[u8]) -> u8 {
     v[0] + v[1] + v[2] + v[3] + v[4]

--- a/tests/ui/missing_asserts_for_indexing_unfixable.stderr
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.stderr
@@ -1,32 +1,32 @@
 error: indexing into a slice multiple times without an `assert`
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:5:5
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:6:5
    |
 LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider asserting the length before indexing: `assert!(v.len() > 4);`
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:5:5
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:6:5
    |
 LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    |     ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:5:12
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:6:12
    |
 LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    |            ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:5:19
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:6:19
    |
 LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    |                   ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:5:26
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:6:26
    |
 LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    |                          ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:5:33
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:6:33
    |
 LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    |                                 ^^^^
@@ -35,7 +35,7 @@ LL |     v[0] + v[1] + v[2] + v[3] + v[4]
    = help: to override `-D warnings` add `#[allow(clippy::missing_asserts_for_indexing)]`
 
 error: indexing into a slice multiple times without an `assert`
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:10:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:11:13
    |
 LL |       let _ = v[0];
    |  _____________^
@@ -45,19 +45,19 @@ LL | |     let _ = v[1..4];
    |
    = help: consider asserting the length before indexing: `assert!(v.len() > 3);`
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:10:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:11:13
    |
 LL |     let _ = v[0];
    |             ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:12:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:13:13
    |
 LL |     let _ = v[1..4];
    |             ^^^^^^^
    = note: asserting the length before indexing will elide bounds checks
 
 error: indexing into a slice multiple times without an `assert`
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:16:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:17:13
    |
 LL |       let a = v[0];
    |  _____________^
@@ -68,112 +68,112 @@ LL | |     let c = v[2];
    |
    = help: consider asserting the length before indexing: `assert!(v.len() > 2);`
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:16:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:17:13
    |
 LL |     let a = v[0];
    |             ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:18:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:19:13
    |
 LL |     let b = v[1];
    |             ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:19:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:20:13
    |
 LL |     let c = v[2];
    |             ^^^^
    = note: asserting the length before indexing will elide bounds checks
 
 error: indexing into a slice multiple times without an `assert`
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:24:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:25:13
    |
 LL |     let _ = v1[0] + v1[12];
    |             ^^^^^^^^^^^^^^
    |
    = help: consider asserting the length before indexing: `assert!(v1.len() > 12);`
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:24:13
-   |
-LL |     let _ = v1[0] + v1[12];
-   |             ^^^^^
-note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:24:21
-   |
-LL |     let _ = v1[0] + v1[12];
-   |                     ^^^^^^
-   = note: asserting the length before indexing will elide bounds checks
-
-error: indexing into a slice multiple times without an `assert`
   --> $DIR/missing_asserts_for_indexing_unfixable.rs:25:13
    |
-LL |     let _ = v2[5] + v2[15];
-   |             ^^^^^^^^^^^^^^
-   |
-   = help: consider asserting the length before indexing: `assert!(v2.len() > 15);`
-note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:25:13
-   |
-LL |     let _ = v2[5] + v2[15];
+LL |     let _ = v1[0] + v1[12];
    |             ^^^^^
 note: slice indexed here
   --> $DIR/missing_asserts_for_indexing_unfixable.rs:25:21
    |
-LL |     let _ = v2[5] + v2[15];
+LL |     let _ = v1[0] + v1[12];
    |                     ^^^^^^
    = note: asserting the length before indexing will elide bounds checks
 
 error: indexing into a slice multiple times without an `assert`
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:31:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:26:13
    |
 LL |     let _ = v2[5] + v2[15];
    |             ^^^^^^^^^^^^^^
    |
    = help: consider asserting the length before indexing: `assert!(v2.len() > 15);`
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:31:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:26:13
    |
 LL |     let _ = v2[5] + v2[15];
    |             ^^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:31:21
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:26:21
    |
 LL |     let _ = v2[5] + v2[15];
    |                     ^^^^^^
    = note: asserting the length before indexing will elide bounds checks
 
 error: indexing into a slice multiple times without an `assert`
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:40:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:32:13
+   |
+LL |     let _ = v2[5] + v2[15];
+   |             ^^^^^^^^^^^^^^
+   |
+   = help: consider asserting the length before indexing: `assert!(v2.len() > 15);`
+note: slice indexed here
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:32:13
+   |
+LL |     let _ = v2[5] + v2[15];
+   |             ^^^^^
+note: slice indexed here
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:32:21
+   |
+LL |     let _ = v2[5] + v2[15];
+   |                     ^^^^^^
+   = note: asserting the length before indexing will elide bounds checks
+
+error: indexing into a slice multiple times without an `assert`
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:41:13
    |
 LL |     let _ = f.v[0] + f.v[1];
    |             ^^^^^^^^^^^^^^^
    |
    = help: consider asserting the length before indexing: `assert!(f.v.len() > 1);`
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:40:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:41:13
    |
 LL |     let _ = f.v[0] + f.v[1];
    |             ^^^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:40:22
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:41:22
    |
 LL |     let _ = f.v[0] + f.v[1];
    |                      ^^^^^^
    = note: asserting the length before indexing will elide bounds checks
 
 error: indexing into a slice multiple times without an `assert`
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:54:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:55:13
    |
 LL |     let _ = x[0] + x[1];
    |             ^^^^^^^^^^^
    |
    = help: consider asserting the length before indexing: `assert!(x.len() > 1);`
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:54:13
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:55:13
    |
 LL |     let _ = x[0] + x[1];
    |             ^^^^
 note: slice indexed here
-  --> $DIR/missing_asserts_for_indexing_unfixable.rs:54:20
+  --> $DIR/missing_asserts_for_indexing_unfixable.rs:55:20
    |
 LL |     let _ = x[0] + x[1];
    |                    ^^^^

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -5,7 +5,8 @@
     clippy::let_unit_value,
     clippy::needless_if,
     clippy::redundant_guards,
-    clippy::redundant_locals
+    clippy::redundant_locals,
+    clippy::might_panic
 )]
 
 extern crate proc_macro_derive;

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -1,11 +1,11 @@
 error: `x` is shadowed by itself in `x`
-  --> $DIR/shadow.rs:24:9
+  --> $DIR/shadow.rs:25:9
    |
 LL |     let x = x;
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:23:9
+  --> $DIR/shadow.rs:24:9
    |
 LL |     let x = 1;
    |         ^
@@ -13,49 +13,49 @@ LL |     let x = 1;
    = help: to override `-D warnings` add `#[allow(clippy::shadow_same)]`
 
 error: `mut x` is shadowed by itself in `&x`
-  --> $DIR/shadow.rs:25:13
+  --> $DIR/shadow.rs:26:13
    |
 LL |     let mut x = &x;
    |             ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:24:9
+  --> $DIR/shadow.rs:25:9
    |
 LL |     let x = x;
    |         ^
 
 error: `x` is shadowed by itself in `&mut x`
-  --> $DIR/shadow.rs:26:9
+  --> $DIR/shadow.rs:27:9
    |
 LL |     let x = &mut x;
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:25:9
+  --> $DIR/shadow.rs:26:9
    |
 LL |     let mut x = &x;
    |         ^^^^^
 
 error: `x` is shadowed by itself in `*x`
-  --> $DIR/shadow.rs:27:9
+  --> $DIR/shadow.rs:28:9
    |
 LL |     let x = *x;
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:26:9
+  --> $DIR/shadow.rs:27:9
    |
 LL |     let x = &mut x;
    |         ^
 
 error: `x` is shadowed
-  --> $DIR/shadow.rs:32:9
+  --> $DIR/shadow.rs:33:9
    |
 LL |     let x = x.0;
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:31:9
+  --> $DIR/shadow.rs:32:9
    |
 LL |     let x = ([[0]], ());
    |         ^
@@ -63,97 +63,97 @@ LL |     let x = ([[0]], ());
    = help: to override `-D warnings` add `#[allow(clippy::shadow_reuse)]`
 
 error: `x` is shadowed
-  --> $DIR/shadow.rs:33:9
+  --> $DIR/shadow.rs:34:9
    |
 LL |     let x = x[0];
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:32:9
+  --> $DIR/shadow.rs:33:9
    |
 LL |     let x = x.0;
    |         ^
 
 error: `x` is shadowed
-  --> $DIR/shadow.rs:34:10
+  --> $DIR/shadow.rs:35:10
    |
 LL |     let [x] = x;
    |          ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:33:9
+  --> $DIR/shadow.rs:34:9
    |
 LL |     let x = x[0];
    |         ^
 
 error: `x` is shadowed
-  --> $DIR/shadow.rs:35:9
+  --> $DIR/shadow.rs:36:9
    |
 LL |     let x = Some(x);
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:34:10
+  --> $DIR/shadow.rs:35:10
    |
 LL |     let [x] = x;
    |          ^
 
 error: `x` is shadowed
-  --> $DIR/shadow.rs:36:9
+  --> $DIR/shadow.rs:37:9
    |
 LL |     let x = foo(x);
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:35:9
+  --> $DIR/shadow.rs:36:9
    |
 LL |     let x = Some(x);
    |         ^
 
 error: `x` is shadowed
-  --> $DIR/shadow.rs:37:9
+  --> $DIR/shadow.rs:38:9
    |
 LL |     let x = || x;
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:36:9
+  --> $DIR/shadow.rs:37:9
    |
 LL |     let x = foo(x);
    |         ^
 
 error: `x` is shadowed
-  --> $DIR/shadow.rs:38:9
+  --> $DIR/shadow.rs:39:9
    |
 LL |     let x = Some(1).map(|_| x)?;
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:37:9
+  --> $DIR/shadow.rs:38:9
    |
 LL |     let x = || x;
    |         ^
 
 error: `y` is shadowed
-  --> $DIR/shadow.rs:40:9
+  --> $DIR/shadow.rs:41:9
    |
 LL |     let y = match y {
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:39:9
+  --> $DIR/shadow.rs:40:9
    |
 LL |     let y = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:55:9
+  --> $DIR/shadow.rs:56:9
    |
 LL |     let x = 2;
    |         ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:54:9
+  --> $DIR/shadow.rs:55:9
    |
 LL |     let x = 1;
    |         ^
@@ -161,121 +161,121 @@ LL |     let x = 1;
    = help: to override `-D warnings` add `#[allow(clippy::shadow_unrelated)]`
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:60:13
+  --> $DIR/shadow.rs:61:13
    |
 LL |         let x = 1;
    |             ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:59:10
+  --> $DIR/shadow.rs:60:10
    |
 LL |     fn f(x: u32) {
    |          ^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:65:14
+  --> $DIR/shadow.rs:66:14
    |
 LL |         Some(x) => {
    |              ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:62:9
+  --> $DIR/shadow.rs:63:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:66:17
+  --> $DIR/shadow.rs:67:17
    |
 LL |             let x = 1;
    |                 ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:65:14
+  --> $DIR/shadow.rs:66:14
    |
 LL |         Some(x) => {
    |              ^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:70:17
+  --> $DIR/shadow.rs:71:17
    |
 LL |     if let Some(x) = Some(1) {}
    |                 ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:62:9
+  --> $DIR/shadow.rs:63:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:71:20
+  --> $DIR/shadow.rs:72:20
    |
 LL |     while let Some(x) = Some(1) {}
    |                    ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:62:9
+  --> $DIR/shadow.rs:63:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:72:15
+  --> $DIR/shadow.rs:73:15
    |
 LL |     let _ = |[x]: [u32; 1]| {
    |               ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:62:9
+  --> $DIR/shadow.rs:63:9
    |
 LL |     let x = 1;
    |         ^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:73:13
+  --> $DIR/shadow.rs:74:13
    |
 LL |         let x = 1;
    |             ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:72:15
+  --> $DIR/shadow.rs:73:15
    |
 LL |     let _ = |[x]: [u32; 1]| {
    |               ^
 
 error: `y` is shadowed
-  --> $DIR/shadow.rs:76:17
+  --> $DIR/shadow.rs:77:17
    |
 LL |     if let Some(y) = y {}
    |                 ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:75:9
+  --> $DIR/shadow.rs:76:9
    |
 LL |     let y = Some(1);
    |         ^
 
 error: `_b` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:112:9
+  --> $DIR/shadow.rs:113:9
    |
 LL |     let _b = _a;
    |         ^^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:111:28
+  --> $DIR/shadow.rs:112:28
    |
 LL | pub async fn foo2(_a: i32, _b: i64) {
    |                            ^^
 
 error: `x` shadows a previous, unrelated binding
-  --> $DIR/shadow.rs:118:21
+  --> $DIR/shadow.rs:119:21
    |
 LL |         if let Some(x) = Some(1) { x } else { 1 }
    |                     ^
    |
 note: previous binding is here
-  --> $DIR/shadow.rs:117:13
+  --> $DIR/shadow.rs:118:13
    |
 LL |         let x = 1;
    |             ^

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -11,7 +11,8 @@
     unused_variables,
     clippy::let_and_return,
     clippy::useless_vec,
-    clippy::redundant_locals
+    clippy::redundant_locals,
+    clippy::might_panic
 )]
 
 struct Foo(u32);

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -11,7 +11,8 @@
     unused_variables,
     clippy::let_and_return,
     clippy::useless_vec,
-    clippy::redundant_locals
+    clippy::redundant_locals,
+    clippy::might_panic
 )]
 
 struct Foo(u32);

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:28:5
+  --> $DIR/swap.rs:29:5
    |
 LL | /     let temp = bar.a;
 LL | |     bar.a = bar.b;
@@ -11,7 +11,7 @@ LL | |     bar.b = temp;
    = help: to override `-D warnings` add `#[allow(clippy::manual_swap)]`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:40:5
+  --> $DIR/swap.rs:41:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -19,7 +19,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:49:5
+  --> $DIR/swap.rs:50:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -27,7 +27,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:68:5
+  --> $DIR/swap.rs:69:5
    |
 LL | /     let temp = foo[0];
 LL | |     foo[0] = foo[1];
@@ -35,7 +35,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:79:5
+  --> $DIR/swap.rs:80:5
    |
 LL | /     a ^= b;
 LL | |     b ^= a;
@@ -43,7 +43,7 @@ LL | |     a ^= b;
    | |___________^ help: try: `std::mem::swap(&mut a, &mut b);`
 
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> $DIR/swap.rs:87:5
+  --> $DIR/swap.rs:88:5
    |
 LL | /     bar.a ^= bar.b;
 LL | |     bar.b ^= bar.a;
@@ -51,7 +51,7 @@ LL | |     bar.a ^= bar.b;
    | |___________________^ help: try: `std::mem::swap(&mut bar.a, &mut bar.b);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> $DIR/swap.rs:95:5
+  --> $DIR/swap.rs:96:5
    |
 LL | /     foo[0] ^= foo[1];
 LL | |     foo[1] ^= foo[0];
@@ -59,7 +59,7 @@ LL | |     foo[0] ^= foo[1];
    | |_____________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `foo[0][1]` and `bar[1][0]` manually
-  --> $DIR/swap.rs:124:5
+  --> $DIR/swap.rs:125:5
    |
 LL | /     let temp = foo[0][1];
 LL | |     foo[0][1] = bar[1][0];
@@ -69,7 +69,7 @@ LL | |     bar[1][0] = temp;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `a` and `b` manually
-  --> $DIR/swap.rs:138:7
+  --> $DIR/swap.rs:139:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -80,7 +80,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> $DIR/swap.rs:147:7
+  --> $DIR/swap.rs:148:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -91,7 +91,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `b` and `a` manually
-  --> $DIR/swap.rs:173:5
+  --> $DIR/swap.rs:174:5
    |
 LL | /     let t = b;
 LL | |     b = a;
@@ -101,7 +101,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:135:5
+  --> $DIR/swap.rs:136:5
    |
 LL | /     a = b;
 LL | |     b = a;
@@ -112,7 +112,7 @@ LL | |     b = a;
    = help: to override `-D warnings` add `#[allow(clippy::almost_swapped)]`
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> $DIR/swap.rs:144:5
+  --> $DIR/swap.rs:145:5
    |
 LL | /     c.0 = a;
 LL | |     a = c.0;
@@ -121,7 +121,7 @@ LL | |     a = c.0;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:151:5
+  --> $DIR/swap.rs:152:5
    |
 LL | /     let a = b;
 LL | |     let b = a;
@@ -130,7 +130,7 @@ LL | |     let b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `d` and `c`
-  --> $DIR/swap.rs:156:5
+  --> $DIR/swap.rs:157:5
    |
 LL | /     d = c;
 LL | |     c = d;
@@ -139,7 +139,7 @@ LL | |     c = d;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> $DIR/swap.rs:160:5
+  --> $DIR/swap.rs:161:5
    |
 LL | /     let a = b;
 LL | |     b = a;
@@ -148,7 +148,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `s.0.x` and `s.0.y` manually
-  --> $DIR/swap.rs:208:5
+  --> $DIR/swap.rs:209:5
    |
 LL | /     let t = s.0.x;
 LL | |     s.0.x = s.0.y;


### PR DESCRIPTION
fixes [#issue11808](https://github.com/rust-lang/rust-clippy/issues/11808)

This lint check accessing array or slice with index but don't know whether this index is legal.

For example, the code
```
let numbers = &[4, 7, 3];
let _my_number = numbers[5];
```

can be written as
```
let numbers = &[4, 7, 3];
let Some(_my_number) = numbers.get(5) else { panic!(); }
```

Besides, if you declare `my_number` with its type `i32`,
```
let numbers = &[4, 7, 3];
let _my_number : i32 = numbers[5];
```

it can be written as
```
let numbers = &[4, 7, 3];
let Some(_my_number): Option<&i32> = numbers.get(5) else { panic!() };
```

This lint can help programmer to locate where you access array out of boundary easilier, and can write their handler.

changelog: add new lint `might_panic`
