### PR TITLE
rename `DocMarkdown` pass to `Documentation`

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -305,15 +305,14 @@ declare_clippy_lint! {
     "suspicious usage of (outer) doc comments"
 }
 
-#[expect(clippy::module_name_repetitions)]
 #[derive(Clone)]
-pub struct DocMarkdown {
+pub struct Documentation {
     valid_idents: FxHashSet<String>,
     in_trait_impl: bool,
     check_private_items: bool,
 }
 
-impl DocMarkdown {
+impl Documentation {
     pub fn new(valid_idents: &[String], check_private_items: bool) -> Self {
         Self {
             valid_idents: valid_idents.iter().cloned().collect(),
@@ -323,7 +322,7 @@ impl DocMarkdown {
     }
 }
 
-impl_lint_pass!(DocMarkdown => [
+impl_lint_pass!(Documentation => [
     DOC_LINK_WITH_QUOTES,
     DOC_MARKDOWN,
     MISSING_SAFETY_DOC,
@@ -334,7 +333,7 @@ impl_lint_pass!(DocMarkdown => [
     SUSPICIOUS_DOC_COMMENTS
 ]);
 
-impl<'tcx> LateLintPass<'tcx> for DocMarkdown {
+impl<'tcx> LateLintPass<'tcx> for Documentation {
     fn check_crate(&mut self, cx: &LateContext<'tcx>) {
         let attrs = cx.tcx.hir().attrs(hir::CRATE_HIR_ID);
         check_attrs(cx, &self.valid_idents, attrs);

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -747,7 +747,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
             avoid_breaking_exported_api,
         ))
     });
-    store.register_late_pass(move |_| Box::new(doc::DocMarkdown::new(doc_valid_idents, check_private_items)));
+    store.register_late_pass(move |_| Box::new(doc::Documentation::new(doc_valid_idents, check_private_items)));
     store.register_late_pass(|_| Box::new(neg_multiply::NegMultiply));
     store.register_late_pass(|_| Box::new(let_if_seq::LetIfSeq));
     store.register_late_pass(|_| Box::new(mixed_read_write_in_expression::EvalOrderDependence));


### PR DESCRIPTION
Followup of #11801

This was discussed in todays meeting: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Meeting.202023-11-28/near/404667082

Decided to go with `Documentation`, because this would also make it consistent with how `Attributes` is named in `attrs.rs` (and it also sounds good).

changelog: none