### PR TITLE
Allow `allow`ing `upper_case_acronyms` on enum variants

### DIFF
--- a/clippy_lints/src/upper_case_acronyms.rs
+++ b/clippy_lints/src/upper_case_acronyms.rs
@@ -1,7 +1,7 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use itertools::Itertools;
 use rustc_errors::Applicability;
-use rustc_hir::{Item, ItemKind};
+use rustc_hir::{HirId, Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_session::impl_lint_pass;
@@ -77,7 +77,7 @@ fn correct_ident(ident: &str) -> String {
     ident
 }
 
-fn check_ident(cx: &LateContext<'_>, ident: &Ident, be_aggressive: bool) {
+fn check_ident(cx: &LateContext<'_>, ident: &Ident, hir_id: HirId, be_aggressive: bool) {
     let span = ident.span;
     let ident = ident.as_str();
     let corrected = correct_ident(ident);
@@ -89,14 +89,20 @@ fn check_ident(cx: &LateContext<'_>, ident: &Ident, be_aggressive: bool) {
     // upper-case-acronyms-aggressive config option enabled
     || (be_aggressive && ident != corrected)
     {
-        span_lint_and_sugg(
+        span_lint_hir_and_then(
             cx,
             UPPER_CASE_ACRONYMS,
+            hir_id,
             span,
             &format!("name `{ident}` contains a capitalized acronym"),
-            "consider making the acronym lowercase, except the initial letter",
-            corrected,
-            Applicability::MaybeIncorrect,
+            |diag| {
+                diag.span_suggestion(
+                    span,
+                    "consider making the acronym lowercase, except the initial letter",
+                    corrected,
+                    Applicability::MaybeIncorrect,
+                );
+            },
         );
     }
 }
@@ -111,16 +117,15 @@ impl LateLintPass<'_> for UpperCaseAcronyms {
         }
         match it.kind {
             ItemKind::TyAlias(..) | ItemKind::Struct(..) | ItemKind::Trait(..) => {
-                check_ident(cx, &it.ident, self.upper_case_acronyms_aggressive);
+                check_ident(cx, &it.ident, it.hir_id(), self.upper_case_acronyms_aggressive);
             },
             ItemKind::Enum(ref enumdef, _) => {
-                check_ident(cx, &it.ident, self.upper_case_acronyms_aggressive);
+                check_ident(cx, &it.ident, it.hir_id(), self.upper_case_acronyms_aggressive);
                 // check enum variants separately because again we only want to lint on private enums and
                 // the fn check_variant does not know about the vis of the enum of its variants
-                enumdef
-                    .variants
-                    .iter()
-                    .for_each(|variant| check_ident(cx, &variant.ident, self.upper_case_acronyms_aggressive));
+                enumdef.variants.iter().for_each(|variant| {
+                    check_ident(cx, &variant.ident, variant.hir_id, self.upper_case_acronyms_aggressive);
+                });
             },
             _ => {},
         }

--- a/tests/ui/upper_case_acronyms.fixed
+++ b/tests/ui/upper_case_acronyms.fixed
@@ -59,4 +59,12 @@ enum Yaml {
     Str(String),
 }
 
+// test for issue #7708
+enum AllowOnField {
+    Disallow,
+    //~^ ERROR: name `DISALLOW` contains a capitalized acronym
+    #[allow(clippy::upper_case_acronyms)]
+    ALLOW,
+}
+
 fn main() {}

--- a/tests/ui/upper_case_acronyms.rs
+++ b/tests/ui/upper_case_acronyms.rs
@@ -59,4 +59,12 @@ enum YAML {
     Str(String),
 }
 
+// test for issue #7708
+enum AllowOnField {
+    DISALLOW,
+    //~^ ERROR: name `DISALLOW` contains a capitalized acronym
+    #[allow(clippy::upper_case_acronyms)]
+    ALLOW,
+}
+
 fn main() {}

--- a/tests/ui/upper_case_acronyms.stderr
+++ b/tests/ui/upper_case_acronyms.stderr
@@ -67,5 +67,11 @@ error: name `YAML` contains a capitalized acronym
 LL | enum YAML {
    |      ^^^^ help: consider making the acronym lowercase, except the initial letter: `Yaml`
 
-error: aborting due to 11 previous errors
+error: name `DISALLOW` contains a capitalized acronym
+  --> $DIR/upper_case_acronyms.rs:64:5
+   |
+LL |     DISALLOW,
+   |     ^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `Disallow`
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Fixes #7708

changelog: [`upper_case_acronyms`]: allow `allow`ing on enum variants

