### PR TITLE
Do not check twice whether `qpath` is a `QPath::TypeRelative` variant

### DIFF
--- a/clippy_lints/src/manual_string_new.rs
+++ b/clippy_lints/src/manual_string_new.rs
@@ -108,18 +108,16 @@ fn parse_call(cx: &LateContext<'_>, span: Span, func: &Expr<'_>, args: &[Expr<'_
 
     let arg_kind = &args[0].kind;
     if let ExprKind::Path(qpath) = &func.kind {
-        if let QPath::TypeRelative(_, _) = qpath {
-            // String::from(...) or String::try_from(...)
-            if let QPath::TypeRelative(ty, path_seg) = qpath
-                && [sym::from, sym::try_from].contains(&path_seg.ident.name)
-                && let TyKind::Path(qpath) = &ty.kind
-                && let QPath::Resolved(_, path) = qpath
-                && let [path_seg] = path.segments
-                && path_seg.ident.name == sym::String
-                && is_expr_kind_empty_str(arg_kind)
-            {
-                warn_then_suggest(cx, span);
-            }
+        // String::from(...) or String::try_from(...)
+        if let QPath::TypeRelative(ty, path_seg) = qpath
+            && [sym::from, sym::try_from].contains(&path_seg.ident.name)
+            && let TyKind::Path(qpath) = &ty.kind
+            && let QPath::Resolved(_, path) = qpath
+            && let [path_seg] = path.segments
+            && path_seg.ident.name == sym::String
+            && is_expr_kind_empty_str(arg_kind)
+        {
+            warn_then_suggest(cx, span);
         } else if let QPath::Resolved(_, path) = qpath {
             // From::from(...) or TryFrom::try_from(...)
             if let [path_seg1, path_seg2] = path.segments


### PR DESCRIPTION
This is a style fix: the outer `if` check was useless.

changelog: none