### PR TITLE
Update regex-syntax to support new word boundry assertions

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -16,7 +16,7 @@ clippy_utils = { path = "../clippy_utils" }
 declare_clippy_lint = { path = "../declare_clippy_lint" }
 itertools = "0.11"
 quine-mc_cluskey = "0.2"
-regex-syntax = "0.7"
+regex-syntax = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 tempfile = { version = "3.3.0", optional = true }

--- a/tests/ui/regex.rs
+++ b/tests/ui/regex.rs
@@ -112,6 +112,10 @@ fn trivial_regex() {
 
     // #6005: unicode classes in bytes::Regex
     let a_byte_of_unicode = BRegex::new(r"\p{C}");
+
+    // start and end word boundry, introduced in regex 0.10
+    let _ = BRegex::new(r"\<word\>");
+    let _ = BRegex::new(r"\b{start}word\b{end}");
 }
 
 fn main() {


### PR DESCRIPTION
From the regex v1.10.0 release notes [1]:

    This is a new minor release of regex that adds support for start
    and end word boundary assertions. [...]

    The new word boundary assertions are:

        • \< or \b{start}: a Unicode start-of-word boundary (\W|\A
          on the left, \w on the right).
        • \> or \b{end}: a Unicode end-of-word boundary (\w on the
          left, \W|\z on the right)).
        • \b{start-half}: half of a Unicode start-of-word boundary
          (\W|\A on the left).
        • \b{end-half}: half of a Unicode end-of-word boundary
          (\W|\z on the right).

[1]: https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#1100-2023-10-09

changelog: [`regex`]: add support for start and end word boundary assertions ("\<", "\b{start}", etc.) introduced in regex v0.10