### PR TITLE
Tolerate hidden, binary files in tests/

### DIFF
--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -12,7 +12,12 @@ fn old_test_headers() {
 
     for entry in WalkDir::new("tests") {
         let entry = entry.unwrap();
-        if !entry.file_type().is_file() {
+        let is_hidden_file = entry
+            .file_name()
+            .to_str()
+            .expect("non-UTF-8 file name")
+            .starts_with('.');
+        if is_hidden_file || !entry.file_type().is_file() {
             continue;
         }
 


### PR DESCRIPTION
Avoid scanning temporary files created by editors like this one created by Vim:

---- old_test_headers stdout ----
thread 'old_test_headers' panicked at tests/headers.rs:19:74: tests/ui/.regex.rs.swp: stream did not contain valid UTF-8 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

changelog: none