### PR TITLE
[WIP] unnecessary_cast: append suffix on `(literal as ty).method(args)`

### DIFF
--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -188,23 +188,10 @@ fn lint_unnecessary_cast(
     // (-1).foo() instead of -1.foo())
     let sugg = if let Some(parent_expr) = get_parent_expr(cx, cast_expr)
         && let ExprKind::MethodCall(..) = parent_expr.kind
-        && literal_str.starts_with('-')
+        // TODO: this should be handled by typed ExprKind
+        && literal_str.starts_with(&['-', '!'])
     {
-        format!("({literal_str}_{cast_to})")
-    } else if let ExprKind::Cast(inner, _) = cast_expr.kind
-        && let ExprKind::Unary(..) = inner.kind
-    {
-        // (unary(_) as cast_to).foo(...)
-        //  ^~~~~~~~ inner    ^
-        //  ^~~~~~~~~~~~~~~~~~/ cast_source
-
-        // target is `(unary(src) as _cast_to).foo(...)`, so the receiver still needs to
-        // be parenthesised
-
-        // TODO: somehow this yields None, unable to determine
-        //       whether parent is a method call.
-        let _cast_source_parent = get_parent_expr(cx, cast_expr);
-
+        // TODO: issue 11882 should reach this path
         format!("({literal_str}_{cast_to})")
     } else {
         format!("{literal_str}_{cast_to}")

--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -9,7 +9,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Expr, ExprKind, Lit, Node, Path, QPath, TyKind, UnOp};
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::lint::in_external_macro;
-use rustc_middle::ty::{self, FloatTy, InferTy, Ty};
+use rustc_middle::ty::{self, FloatTy, InferTy, Ty, TyKind as MidTyKind};
 use std::ops::ControlFlow;
 
 use super::UNNECESSARY_CAST;
@@ -120,12 +120,6 @@ pub(super) fn check<'tcx>(
 
         match lit.node {
             LitKind::Int(val, LitIntType::Unsuffixed) if cast_to.is_integral() => {
-                // append literal suffix
-                let mut literal_str = val.to_string();
-                literal_str.push('_');
-                let suffix: &str = todo!("plaese fill this hole");
-                literal_str.push_str(suffix);
-
                 lint_unnecessary_cast(cx, expr, literal_str, cast_from, cast_to);
                 return false;
             },
@@ -197,12 +191,20 @@ fn lint_unnecessary_cast(
         && literal_str.starts_with('-')
     {
         format!("({literal_str}_{cast_to})")
-    } else if let Some(parent_expr) = get_parent_expr(cx, expr)
-        && let ExprKind::MethodCall(..) = parent_expr
-        && let ExprKind::Cast(src, _cast_to) = expr
-        && let ExprKind::Unary(..) = src.kind {
-        // parent_expr is `(unary(src) as _cast_to).foo(...)`, so the receiver still needs to
+    } else if let ExprKind::Cast(inner, _) = expr.kind
+        && let ExprKind::Unary(..) = inner.kind
+    {
+        // (unary(_) as cast_to).foo(...)
+        //  ^~~~~~~~ inner    ^
+        //  ^~~~~~~~~~~~~~~~~~/ cast_source
+
+        // target is `(unary(src) as _cast_to).foo(...)`, so the receiver still needs to
         // be parenthesised
+
+        // TODO: somehow this yields None, unable to determine
+        //       whether parent is a method call.
+        let _cast_source_parent = get_parent_expr(cx, expr);
+
         format!("({literal_str}_{cast_to})")
     } else {
         format!("{literal_str}_{cast_to}")

--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -119,7 +119,13 @@ pub(super) fn check<'tcx>(
         }
 
         match lit.node {
-            LitKind::Int(_, LitIntType::Unsuffixed) if cast_to.is_integral() => {
+            LitKind::Int(val, LitIntType::Unsuffixed) if cast_to.is_integral() => {
+                // append literal suffix
+                let mut literal_str = val.to_string();
+                literal_str.push('_');
+                let suffix: &str = todo!("plaese fill this hole");
+                literal_str.push_str(suffix);
+
                 lint_unnecessary_cast(cx, expr, literal_str, cast_from, cast_to);
                 return false;
             },
@@ -190,6 +196,13 @@ fn lint_unnecessary_cast(
         && let ExprKind::MethodCall(..) = parent_expr.kind
         && literal_str.starts_with('-')
     {
+        format!("({literal_str}_{cast_to})")
+    } else if let Some(parent_expr) = get_parent_expr(cx, expr)
+        && let ExprKind::MethodCall(..) = parent_expr
+        && let ExprKind::Cast(src, _cast_to) = expr
+        && let ExprKind::Unary(..) = src.kind {
+        // parent_expr is `(unary(src) as _cast_to).foo(...)`, so the receiver still needs to
+        // be parenthesised
         format!("({literal_str}_{cast_to})")
     } else {
         format!("{literal_str}_{cast_to}")

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -220,4 +220,8 @@ mod fixable {
     fn issue_9603() {
         let _: f32 = -0x400 as f32;
     }
+
+    fn issue_11882() -> u64 {
+        !0.overflowing_shr(1_u32).0
+    }
 }

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -220,4 +220,8 @@ mod fixable {
     fn issue_9603() {
         let _: f32 = -0x400 as f32;
     }
+
+    fn issue_11882() -> u64 {
+        (!0 as u64).overflowing_shr(1_u32).0
+    }
 }

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -241,5 +241,11 @@ error: casting to the same type is unnecessary (`f32` -> `f32`)
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`
 
-error: aborting due to 40 previous errors
+error: casting to the same type is unnecessary (`u64` -> `u64`)
+  --> $DIR/unnecessary_cast.rs:225:9
+   |
+LL |         (!0 as u64).overflowing_shr(1_u32).0
+   |         ^^^^^^^^^^^ help: try: `!0`
+
+error: aborting due to 41 previous errors
 


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`unnecessary_cast`]: fix handling if it is in method receiver

fix #11882, but it needs help about adding suffix to integral literal. Currently UI tests are not changed, I'll commit it before it become actually reviewable
