### PR TITLE
docs(explicit_write): add missing backtick to complete code snippet

### DIFF
--- a/clippy_lints/src/explicit_write.rs
+++ b/clippy_lints/src/explicit_write.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     /// replaced with `(e)print!()` / `(e)println!()`
     ///
     /// ### Why is this bad?
-    /// Using `(e)println! is clearer and more concise
+    /// Using `(e)println!` is clearer and more concise
     ///
     /// ### Example
     /// ```rust


### PR DESCRIPTION
close #11918 

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`explicit_write`]: add missing backtick to document to complete code snippet
