### PR TITLE
initial impl of manual_rfold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5243,6 +5243,7 @@ Released 2018-09-13
 [`manual_range_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_patterns
 [`manual_rem_euclid`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_rem_euclid
 [`manual_retain`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_retain
+[`manual_rfold`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_rfold
 [`manual_saturating_arithmetic`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_saturating_arithmetic
 [`manual_slice_size_calculation`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_slice_size_calculation
 [`manual_split_once`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_split_once

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -383,6 +383,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::MANUAL_FIND_MAP_INFO,
     crate::methods::MANUAL_NEXT_BACK_INFO,
     crate::methods::MANUAL_OK_OR_INFO,
+    crate::methods::MANUAL_RFOLD_INFO,
     crate::methods::MANUAL_SATURATING_ARITHMETIC_INFO,
     crate::methods::MANUAL_SPLIT_ONCE_INFO,
     crate::methods::MANUAL_STR_REPEAT_INFO,

--- a/clippy_lints/src/methods/manual_rfold.rs
+++ b/clippy_lints/src/methods/manual_rfold.rs
@@ -1,0 +1,39 @@
+
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_trait_method;
+use clippy_utils::ty::implements_trait;
+use rustc_errors::Applicability;
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_span::symbol::sym;
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    rev_call: &'tcx Expr<'_>,
+    rev_recv: &'tcx Expr<'_>,
+) {
+    let rev_recv_ty = cx.typeck_results().expr_ty(rev_recv);
+
+    // check that the receiver of `rev` implements `DoubleEndedIterator` and
+    // that `rev` and `fold` come from `Iterator`
+    if cx
+        .tcx
+        .get_diagnostic_item(sym::DoubleEndedIterator)
+        .map_or(false, |double_ended_iterator| {
+            implements_trait(cx, rev_recv_ty, double_ended_iterator, &[])
+        })
+        && is_trait_method(cx, rev_call, sym::Iterator)
+        && is_trait_method(cx, expr, sym::Iterator)
+    {
+        span_lint_and_sugg(
+            cx,
+            super::MANUAL_RFOLD,
+            expr.span.with_lo(rev_recv.span.hi()),
+            "manual backwards folding",
+            "use",
+            String::from(".rfold"),
+            Applicability::MachineApplicable,
+        );
+    }
+}

--- a/tests/ui/manual_rfold.fixed
+++ b/tests/ui/manual_rfold.fixed
@@ -1,0 +1,33 @@
+#![warn(clippy::manual_rfold)]
+
+struct FakeIter(std::ops::Range<i32>);
+
+impl FakeIter {
+    fn rev(self) -> Self {
+        self
+    }
+
+    fn next(&self) {}
+}
+
+impl DoubleEndedIterator for FakeIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+}
+
+impl Iterator for FakeIter {
+    type Item = i32;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+fn main() {
+    // should not lint
+    // FakeIter(0..10).rev().next();
+
+    // should lint
+    let _ = (1..10).rfold;
+    let _ = "something".bytes().rfold;
+}

--- a/tests/ui/manual_rfold.rs
+++ b/tests/ui/manual_rfold.rs
@@ -1,0 +1,33 @@
+#![warn(clippy::manual_rfold)]
+
+struct FakeIter(std::ops::Range<i32>);
+
+impl FakeIter {
+    fn rev(self) -> Self {
+        self
+    }
+
+    fn next(&self) {}
+}
+
+impl DoubleEndedIterator for FakeIter {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+}
+
+impl Iterator for FakeIter {
+    type Item = i32;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+fn main() {
+    // should not lint
+    // FakeIter(0..10).rev().next();
+
+    // should lint
+    let _ = (1..10).rev().fold(50, |acc, x| acc / x);
+    let _ = "something".bytes().rev().fold(50, |acc, x| acc / x);
+}

--- a/tests/ui/manual_rfold.stderr
+++ b/tests/ui/manual_rfold.stderr
@@ -1,0 +1,17 @@
+error: manual backwards folding
+  --> $DIR/manual_rfold.rs:31:20
+   |
+LL |     let _ = (1..10).rev().fold(50, |acc, x| acc / x);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `.rfold`
+   |
+   = note: `-D clippy::manual-rfold` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_rfold)]`
+
+error: manual backwards folding
+  --> $DIR/manual_rfold.rs:32:32
+   |
+LL |     let _ = "something".bytes().rev().fold(50, |acc, x| acc / x);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `.rfold`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION

Hello,

In an attempt to try and understand how all of this works I tried implementing a basis for a `manual_rfold` lint. I took the logic basically as-is from `manual_next_back`, changing what I could identify. I hope y'all would guide me to a better understanding of what's going on here.

changelog: [`manual_rfold`]: first implementation.
