### PR TITLE
Try to improve wording and fix dead link in description of arc_with_non_send_sync lint.

### DIFF
--- a/clippy_lints/src/arc_with_non_send_sync.rs
+++ b/clippy_lints/src/arc_with_non_send_sync.rs
@@ -14,10 +14,10 @@ declare_clippy_lint! {
     /// This lint warns when you use `Arc` with a type that does not implement `Send` or `Sync`.
     ///
     /// ### Why is this bad?
-    /// `Arc<T>` is an Atomic `Rc<T>` and guarantees that updates to the reference counter are
-    /// Atomic. This is useful in multithreading scenarios. To send an `Arc<T>` across threads
-    /// and make use of the atomic ref counter, `T` must be [both `Send` and `Sync`](https://doc.rust-lang.org/std/sync/struct.Arc.html#impl-Send-for-Arc%3CT%3E),
-    /// either `T` should be made `Send + Sync` or an `Rc` should be used instead of an `Arc`
+    /// `Arc<T>` is a thread-safe `Rc<T>` and guarantees that updates to the reference counter
+    /// use atomic operations. To send an `Arc<T>` across thread boundaries and
+    /// share ownership between multiple threads, `T` must be [both `Send` and `Sync`](https://doc.rust-lang.org/std/sync/struct.Arc.html#thread-safety),
+    /// so either `T` should be made `Send + Sync` or an `Rc` should be used instead of an `Arc`
     ///
     /// ### Example
     /// ```no_run


### PR DESCRIPTION
changelog: [`arc_with_non_send_sync`]: Improve wording and fix dead link.
