### PR TITLE
Add `blyxyas` to `users_on_vacation`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,6 +19,7 @@ new_pr = true
 
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
+users_on_vacation = ["blyxyas"]
 
 [assign.owners]
 "/.github" = ["@flip1995"]


### PR DESCRIPTION
I have a surgery this Wednesday, so I won't be able to review anything from that day up to (at least) Dec. 22, I'll open another PR by then.

I'm not sure if `users_on_vacation` will work here, if it doesn't work, I'll just remove myself from the reviewer rotation

changelog:none