### PR TITLE
Do not suggest `[T; n]` instead of `vec![T; n]` if `T` is not `Copy`

### DIFF
--- a/tests/ui/vec.fixed
+++ b/tests/ui/vec.fixed
@@ -210,3 +210,10 @@ fn issue11861() {
     // should not lint
     m!(vec![1]);
 }
+
+fn issue_11958() {
+    fn f(_s: &[String]) {}
+
+    // should not lint, `String` is not `Copy`
+    f(&vec!["test".to_owned(); 2]);
+}

--- a/tests/ui/vec.rs
+++ b/tests/ui/vec.rs
@@ -210,3 +210,10 @@ fn issue11861() {
     // should not lint
     m!(vec![1]);
 }
+
+fn issue_11958() {
+    fn f(_s: &[String]) {}
+
+    // should not lint, `String` is not `Copy`
+    f(&vec!["test".to_owned(); 2]);
+}


### PR DESCRIPTION
changelog: [`useless_vec`]: do not suggest replacing `&vec![T; N]` by `&[T; N]` if `T` is not `Copy`

Fix #11958
