### PR TITLE
don't visit nested bodies in `is_const_evaluatable`

### DIFF
--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -316,10 +316,7 @@ pub fn is_const_evaluatable<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> 
         is_const: bool,
     }
     impl<'tcx> Visitor<'tcx> for V<'_, 'tcx> {
-        type NestedFilter = nested_filter::OnlyBodies;
-        fn nested_visit_map(&mut self) -> Self::Map {
-            self.cx.tcx.hir()
-        }
+        type NestedFilter = rustc_hir::intravisit::nested_filter::None;
 
         fn visit_expr(&mut self, e: &'tcx Expr<'_>) {
             if !self.is_const {

--- a/tests/ui/crashes/ice-11939.rs
+++ b/tests/ui/crashes/ice-11939.rs
@@ -1,0 +1,14 @@
+#![allow(clippy::unit_arg, clippy::no_effect)]
+
+const fn v(_: ()) {}
+
+fn main() {
+    if true {
+        v({
+            [0; 1 + 1];
+        });
+        Some(())
+    } else {
+        None
+    };
+}


### PR DESCRIPTION
Fixes #11939

This ICE happened in `if_let_some_else_none`, but the root problem is in one of the utils that it uses.
It is (was) possible for `is_const_evalutable` to visit nested bodies which would lead to it trying to get the type of one of the expressions with the wrong typeck table, which won't have the type stored.

Notably, for the expression `Bytes::from_static(&[0; 256 * 1024]);` in the linked issue, the array length is an anonymous const in which type checking happens on its own, so we can't use the typeck table of the enclosing function in there.

Visiting nested bodies is also not needed for checking whether an expression can be const, so I think it's safe to ignore just ignore them altogether.

changelog: Fix ICE when checking for constness in nested bodies