### PR TITLE
Move `uninhabited_references` to `nursery`

### DIFF
--- a/clippy_lints/src/uninhabited_references.rs
+++ b/clippy_lints/src/uninhabited_references.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.76.0"]
     pub UNINHABITED_REFERENCES,
-    suspicious,
+    nursery,
     "reference to uninhabited type"
 }
 


### PR DESCRIPTION
I think this lint has too many false positives and should be put in pedantic. See #11984 and #11985 for context.

The lint is already in beta and is causing trouble for us, so I would also like this PR to be backported to beta as well.

changelog: Moved [`uninhabited_references`] to `nursery` (Now allow-by-default)
[#11997](https://github.com/rust-lang/rust-clippy/pull/11997)
(Check if this has been backported)

Fixes #11984.