### PR TITLE
fix typo in infinite loop lint

### DIFF
--- a/clippy_lints/src/loops/infinite_loop.rs
+++ b/clippy_lints/src/loops/infinite_loop.rs
@@ -49,7 +49,7 @@ pub(super) fn check<'tcx>(
             if let FnRetTy::DefaultReturn(ret_span) = parent_fn_ret {
                 diag.span_suggestion(
                     ret_span,
-                    "if this is intentional, consider specifing `!` as function return",
+                    "if this is intentional, consider specifying `!` as function return",
                     " -> !",
                     Applicability::MaybeIncorrect,
                 );

--- a/tests/ui/infinite_loops.stderr
+++ b/tests/ui/infinite_loops.stderr
@@ -256,3 +256,4 @@ LL | |     })
    = help: if this is not intended, try adding a `break` or `return` condition in the loop
 
 error: aborting due to 17 previous errors
+

--- a/tests/ui/infinite_loops.stderr
+++ b/tests/ui/infinite_loops.stderr
@@ -9,7 +9,7 @@ LL | |     }
    |
    = note: `-D clippy::infinite-loop` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::infinite_loop)]`
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn no_break() -> ! {
    |               ++++
@@ -26,7 +26,7 @@ LL | |         do_something();
 LL | |     }
    | |_____^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn all_inf() -> ! {
    |              ++++
@@ -43,7 +43,7 @@ LL | |             }
 LL | |         }
    | |_________^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn all_inf() -> ! {
    |              ++++
@@ -57,7 +57,7 @@ LL | |                 do_something();
 LL | |             }
    | |_____________^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn all_inf() -> ! {
    |              ++++
@@ -84,7 +84,7 @@ LL | |         do_something();
 LL | |     }
    | |_____^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn no_break_never_ret_noise() -> ! {
    |                               ++++
@@ -101,7 +101,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn break_inner_but_not_outer_1(cond: bool) -> ! {
    |                                            ++++
@@ -118,7 +118,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn break_inner_but_not_outer_2(cond: bool) -> ! {
    |                                            ++++
@@ -132,7 +132,7 @@ LL | |             do_something();
 LL | |         }
    | |_________^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn break_outer_but_not_inner() -> ! {
    |                                ++++
@@ -149,7 +149,7 @@ LL | |             }
 LL | |         }
    | |_________^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn break_wrong_loop(cond: bool) -> ! {
    |                                 ++++
@@ -166,7 +166,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn match_like() -> ! {
    |                 ++++
@@ -180,7 +180,7 @@ LL | |         let _x = matches!(result, Ok(v) if v != 0).then_some(0);
 LL | |     }
    | |_____^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn match_like() -> ! {
    |                 ++++
@@ -197,7 +197,7 @@ LL | |         });
 LL | |     }
    | |_____^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL | fn match_like() -> ! {
    |                 ++++
@@ -211,7 +211,7 @@ LL | |             do_something();
 LL | |         }
    | |_________^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL |     fn problematic_trait_method() -> ! {
    |                                   ++++
@@ -225,7 +225,7 @@ LL | |             do_something();
 LL | |         }
    | |_________^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL |     fn could_be_problematic() -> ! {
    |                               ++++
@@ -239,7 +239,7 @@ LL | |             do_something();
 LL | |         }
    | |_________^
    |
-help: if this is intentional, consider specifing `!` as function return
+help: if this is intentional, consider specifying `!` as function return
    |
 LL |     let _loop_forever = || -> ! {
    |                            ++++
@@ -256,4 +256,3 @@ LL | |     })
    = help: if this is not intended, try adding a `break` or `return` condition in the loop
 
 error: aborting due to 17 previous errors
-


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: This fixes a small typo introduced in https://github.com/rust-lang/rust-clippy/pull/11829
