### PR TITLE
Fixing some other typos

### DIFF
--- a/clippy_lints/src/default_constructed_unit_structs.rs
+++ b/clippy_lints/src/default_constructed_unit_structs.rs
@@ -42,7 +42,7 @@ declare_clippy_lint! {
     #[clippy::version = "1.71.0"]
     pub DEFAULT_CONSTRUCTED_UNIT_STRUCTS,
     complexity,
-    "unit structs can be contructed without calling `default`"
+    "unit structs can be constructed without calling `default`"
 }
 declare_lint_pass!(DefaultConstructedUnitStructs => [DEFAULT_CONSTRUCTED_UNIT_STRUCTS]);
 

--- a/clippy_lints/src/implied_bounds_in_impls.rs
+++ b/clippy_lints/src/implied_bounds_in_impls.rs
@@ -158,7 +158,7 @@ fn try_resolve_type<'tcx>(
 
 /// This function tries to, for all generic type parameters in a supertrait predicate `trait ...<U>:
 /// GenericTrait<U>`, check if the substituted type in the implied-by bound matches with what's
-/// subtituted in the implied bound.
+/// substituted in the implied bound.
 ///
 /// Consider this example.
 /// ```rust,ignore

--- a/clippy_lints/src/ineffective_open_options.rs
+++ b/clippy_lints/src/ineffective_open_options.rs
@@ -16,7 +16,7 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     /// `.append(true)` already enables `write(true)`, making this one
-    /// superflous.
+    /// superfluous.
     ///
     /// ### Example
     /// ```no_run


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none