### PR TITLE
make [`mutex_atomic`] more type aware

### DIFF
--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -6,7 +6,7 @@ use clippy_utils::diagnostics::span_lint;
 use clippy_utils::ty::is_type_diagnostic_item;
 use rustc_hir::Expr;
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::{self, IntTy, Ty, UintTy};
 use rustc_session::declare_lint_pass;
 use rustc_span::sym;
 
@@ -105,8 +105,28 @@ impl<'tcx> LateLintPass<'tcx> for Mutex {
 fn get_atomic_name(ty: Ty<'_>) -> Option<&'static str> {
     match ty.kind() {
         ty::Bool => Some("AtomicBool"),
-        ty::Uint(_) => Some("AtomicUsize"),
-        ty::Int(_) => Some("AtomicIsize"),
+        ty::Uint(uint_ty) => {
+            match uint_ty {
+                UintTy::U8 => Some("AtomicU8"),
+                UintTy::U16 => Some("AtomicU16"),
+                UintTy::U32 => Some("AtomicU32"),
+                UintTy::U64 => Some("AtomicU64"),
+                UintTy::Usize => Some("AtomicUsize"),
+                // There's no `AtomicU128`.
+                UintTy::U128 => None,
+            }
+        },
+        ty::Int(int_ty) => {
+            match int_ty {
+                IntTy::I8 => Some("AtomicI8"),
+                IntTy::I16 => Some("AtomicI16"),
+                IntTy::I32 => Some("AtomicI32"),
+                IntTy::I64 => Some("AtomicI64"),
+                IntTy::Isize => Some("AtomicIsize"),
+                // There's no `AtomicI128`.
+                IntTy::I128 => None,
+            }
+        },
         ty::RawPtr(_) => Some("AtomicPtr"),
         _ => None,
     }

--- a/tests/ui/mutex_atomic.rs
+++ b/tests/ui/mutex_atomic.rs
@@ -18,9 +18,24 @@ fn main() {
     Mutex::new(&mut x as *mut u32);
     //~^ ERROR: consider using an `AtomicPtr` instead of a `Mutex` here; if you just want
     Mutex::new(0u32);
-    //~^ ERROR: consider using an `AtomicUsize` instead of a `Mutex` here; if you just wan
+    //~^ ERROR: consider using an `AtomicU32` instead of a `Mutex` here; if you just wan
     //~| NOTE: `-D clippy::mutex-integer` implied by `-D warnings`
     Mutex::new(0i32);
-    //~^ ERROR: consider using an `AtomicIsize` instead of a `Mutex` here; if you just wan
+    //~^ ERROR: consider using an `AtomicI32` instead of a `Mutex` here; if you just wan
     Mutex::new(0f32); // there are no float atomics, so this should not lint
+    Mutex::new(0u8);
+    //~^ ERROR: consider using an `AtomicU8` instead of a `Mutex` here; if you just wan
+    Mutex::new(0i16);
+    //~^ ERROR: consider using an `AtomicI16` instead of a `Mutex` here; if you just wan
+    let _x: Mutex<i8> = Mutex::new(0);
+    //~^ ERROR: consider using an `AtomicI8` instead of a `Mutex` here; if you just wan
+    const X: i64 = 0;
+    Mutex::new(X);
+    //~^ ERROR: consider using an `AtomicI64` instead of a `Mutex` here; if you just wan
+
+    // there are no 128 atomics, so these two should not lint
+    {
+        Mutex::new(0u128);
+        let _x: Mutex<i128> = Mutex::new(0);
+    }
 }

--- a/tests/ui/mutex_atomic.stderr
+++ b/tests/ui/mutex_atomic.stderr
@@ -31,7 +31,7 @@ error: consider using an `AtomicPtr` instead of a `Mutex` here; if you just want
 LL |     Mutex::new(&mut x as *mut u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: consider using an `AtomicUsize` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+error: consider using an `AtomicU32` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
   --> $DIR/mutex_atomic.rs:20:5
    |
 LL |     Mutex::new(0u32);
@@ -40,11 +40,35 @@ LL |     Mutex::new(0u32);
    = note: `-D clippy::mutex-integer` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mutex_integer)]`
 
-error: consider using an `AtomicIsize` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+error: consider using an `AtomicI32` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
   --> $DIR/mutex_atomic.rs:23:5
    |
 LL |     Mutex::new(0i32);
    |     ^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: consider using an `AtomicU8` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+  --> $DIR/mutex_atomic.rs:26:5
+   |
+LL |     Mutex::new(0u8);
+   |     ^^^^^^^^^^^^^^^
+
+error: consider using an `AtomicI16` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+  --> $DIR/mutex_atomic.rs:28:5
+   |
+LL |     Mutex::new(0i16);
+   |     ^^^^^^^^^^^^^^^^
+
+error: consider using an `AtomicI8` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+  --> $DIR/mutex_atomic.rs:30:25
+   |
+LL |     let _x: Mutex<i8> = Mutex::new(0);
+   |                         ^^^^^^^^^^^^^
+
+error: consider using an `AtomicI64` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
+  --> $DIR/mutex_atomic.rs:33:5
+   |
+LL |     Mutex::new(X);
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
fixes: #9872 

---

changelog: [`mutex_atomic`] now suggests more specific atomic types and skips mutex i128 and u128
