### PR TITLE
FP: `needless_return_with_question_mark` with implicit Error Conversion

### DIFF
--- a/tests/ui/needless_return_with_question_mark.fixed
+++ b/tests/ui/needless_return_with_question_mark.fixed
@@ -77,3 +77,30 @@ fn issue11616() -> Result<(), ()> {
     };
     Ok(())
 }
+
+/// This is a false positive that occurs because of the way `?` is handled.
+/// The `?` operator is also doing a conversion from `Result<T, E>` to `Result<T, E'>`.
+/// In this case the conversion is needed, and thus the `?` operator is also needed.
+fn issue11982() {
+    mod bar {
+        pub struct Error;
+        pub fn foo(_: bool) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    pub struct Error;
+
+    impl From<bar::Error> for Error {
+        fn from(_: bar::Error) -> Self {
+            Error
+        }
+    }
+
+    fn foo(ok: bool) -> Result<(), Error> {
+        if !ok {
+            return bar::foo(ok).map(|_| Ok::<(), Error>(()))?;
+        };
+        Ok(())
+    }
+}

--- a/tests/ui/needless_return_with_question_mark.fixed
+++ b/tests/ui/needless_return_with_question_mark.fixed
@@ -104,3 +104,21 @@ fn issue11982() {
         Ok(())
     }
 }
+
+fn issue11982_no_conversion() {
+    mod bar {
+        pub struct Error;
+        pub fn foo(_: bool) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    fn foo(ok: bool) -> Result<(), bar::Error> {
+        if !ok {
+            bar::foo(ok).map(|_| Ok::<(), bar::Error>(()))?;
+            //~^ ERROR: unneeded `return` statement with `?` operator
+        };
+        Ok(())
+    }
+
+}

--- a/tests/ui/needless_return_with_question_mark.fixed
+++ b/tests/ui/needless_return_with_question_mark.fixed
@@ -78,9 +78,6 @@ fn issue11616() -> Result<(), ()> {
     Ok(())
 }
 
-/// This is a false positive that occurs because of the way `?` is handled.
-/// The `?` operator is also doing a conversion from `Result<T, E>` to `Result<T, E'>`.
-/// In this case the conversion is needed, and thus the `?` operator is also needed.
 fn issue11982() {
     mod bar {
         pub struct Error;
@@ -115,10 +112,18 @@ fn issue11982_no_conversion() {
 
     fn foo(ok: bool) -> Result<(), bar::Error> {
         if !ok {
-            bar::foo(ok).map(|_| Ok::<(), bar::Error>(()))?;
-            //~^ ERROR: unneeded `return` statement with `?` operator
+            return bar::foo(ok).map(|_| Ok::<(), bar::Error>(()))?;
         };
         Ok(())
     }
+}
 
+fn general_return() {
+    fn foo(ok: bool) -> Result<(), ()> {
+        let bar = Result::Ok(Result::<(), ()>::Ok(()));
+        if !ok {
+            return bar?;
+        };
+        Ok(())
+    }
 }

--- a/tests/ui/needless_return_with_question_mark.rs
+++ b/tests/ui/needless_return_with_question_mark.rs
@@ -77,3 +77,30 @@ fn issue11616() -> Result<(), ()> {
     };
     Ok(())
 }
+
+/// This is a false positive that occurs because of the way `?` is handled.
+/// The `?` operator is also doing a conversion from `Result<T, E>` to `Result<T, E'>`.
+/// In this case the conversion is needed, and thus the `?` operator is also needed.
+fn issue11982() {
+    mod bar {
+        pub struct Error;
+        pub fn foo(_: bool) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    pub struct Error;
+
+    impl From<bar::Error> for Error {
+        fn from(_: bar::Error) -> Self {
+            Error
+        }
+    }
+
+    fn foo(ok: bool) -> Result<(), Error> {
+        if !ok {
+            return bar::foo(ok).map(|_| Ok::<(), Error>(()))?;
+        };
+        Ok(())
+    }
+}

--- a/tests/ui/needless_return_with_question_mark.rs
+++ b/tests/ui/needless_return_with_question_mark.rs
@@ -104,3 +104,20 @@ fn issue11982() {
         Ok(())
     }
 }
+
+fn issue11982_no_conversion() {
+    mod bar {
+        pub struct Error;
+        pub fn foo(_: bool) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    fn foo(ok: bool) -> Result<(), bar::Error> {
+        if !ok {
+            return bar::foo(ok).map(|_| Ok::<(), bar::Error>(()))?;
+            //~^ ERROR: unneeded `return` statement with `?` operator
+        };
+        Ok(())
+    }
+}

--- a/tests/ui/needless_return_with_question_mark.rs
+++ b/tests/ui/needless_return_with_question_mark.rs
@@ -78,9 +78,6 @@ fn issue11616() -> Result<(), ()> {
     Ok(())
 }
 
-/// This is a false positive that occurs because of the way `?` is handled.
-/// The `?` operator is also doing a conversion from `Result<T, E>` to `Result<T, E'>`.
-/// In this case the conversion is needed, and thus the `?` operator is also needed.
 fn issue11982() {
     mod bar {
         pub struct Error;
@@ -116,7 +113,16 @@ fn issue11982_no_conversion() {
     fn foo(ok: bool) -> Result<(), bar::Error> {
         if !ok {
             return bar::foo(ok).map(|_| Ok::<(), bar::Error>(()))?;
-            //~^ ERROR: unneeded `return` statement with `?` operator
+        };
+        Ok(())
+    }
+}
+
+fn general_return() {
+    fn foo(ok: bool) -> Result<(), ()> {
+        let bar = Result::Ok(Result::<(), ()>::Ok(()));
+        if !ok {
+            return bar?;
         };
         Ok(())
     }

--- a/tests/ui/needless_return_with_question_mark.stderr
+++ b/tests/ui/needless_return_with_question_mark.stderr
@@ -13,5 +13,11 @@ error: unneeded `return` statement with `?` operator
 LL |         return Err(())?;
    |         ^^^^^^^ help: remove it
 
-error: aborting due to 2 previous errors
+error: unneeded `return` statement with `?` operator
+  --> $DIR/needless_return_with_question_mark.rs:118:13
+   |
+LL |             return bar::foo(ok).map(|_| Ok::<(), bar::Error>(()))?;
+   |             ^^^^^^^ help: remove it
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/needless_return_with_question_mark.stderr
+++ b/tests/ui/needless_return_with_question_mark.stderr
@@ -13,11 +13,5 @@ error: unneeded `return` statement with `?` operator
 LL |         return Err(())?;
    |         ^^^^^^^ help: remove it
 
-error: unneeded `return` statement with `?` operator
-  --> $DIR/needless_return_with_question_mark.rs:118:13
-   |
-LL |             return bar::foo(ok).map(|_| Ok::<(), bar::Error>(()))?;
-   |             ^^^^^^^ help: remove it
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Return with a question mark was triggered in situations where the `?` desuraging was performing error conversion via `Into`/`From`.

The desugared `?` produces a match over an expression with type `std::ops::ControlFlow<B,C>` with `B:Result<Infallible, E:Error>` and `C:Result<_, E':Error>`, and the arms perform the conversion. The patch adds another check in the lint that checks that `E == E'`. If `E == E'`, then the `?` is indeed unnecessary.

changelog: False Positive: [`needless_return_with_question_mark`] when implicit Error Conversion occurs.

fixes: #11982 
