### PR TITLE
Include GitLab in the CI section of the clippy doc book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Clippy's Lints](lints.md)
 - [Continuous Integration](continuous_integration/README.md)
     - [GitHub Actions](continuous_integration/github_actions.md)
+    - [GitLab CI](continuous_integration/gitlab.md)
     - [Travis CI](continuous_integration/travis.md)
 - [Development](development/README.md)
     - [Basics](development/basics.md)

--- a/book/src/continuous_integration/gitlab.md
+++ b/book/src/continuous_integration/gitlab.md
@@ -1,0 +1,16 @@
+# GitLab CI
+
+You can add Clippy to GitLab CI by using the latest stable [rust docker image](https://hub.docker.com/_/rust),
+as it is shown in the `.gitlab-ci.yml` CI configuration file below,
+
+```yml
+# Make sure CI fails on all warnings, including Clippy lints
+variables:
+  RUSTFLAGS: "-Dwarnings"
+
+clippy_check:
+  image: rust:latest
+  script:
+    - rustup component add clippy
+    - cargo clippy --all-targets --all-features
+```


### PR DESCRIPTION
Fixes #12012
changelog: Docs: [`Continuous Integration`] now includes how to use clippy in GitLab CI.