### PR TITLE
11973: Don't escape `"` in `'"'`

### DIFF
--- a/clippy_lints/src/methods/utils.rs
+++ b/clippy_lints/src/methods/utils.rs
@@ -74,6 +74,7 @@ pub(super) fn get_hint_if_single_char_arg(
             match ch {
                 "'" => "\\'",
                 r"\" => "\\\\",
+                "\\\"" => "\"", // no need to escape `"` in `'"'`
                 _ => ch,
             }
         );

--- a/tests/ui/single_char_pattern.fixed
+++ b/tests/ui/single_char_pattern.fixed
@@ -42,6 +42,8 @@ fn main() {
     x.split('\n');
     x.split('\'');
     x.split('\'');
+    // Issue #11973: Don't escape `"` in `'"'`
+    x.split('"');
 
     let h = HashSet::<String>::new();
     h.contains("X"); // should not warn

--- a/tests/ui/single_char_pattern.rs
+++ b/tests/ui/single_char_pattern.rs
@@ -42,6 +42,8 @@ fn main() {
     x.split("\n");
     x.split("'");
     x.split("\'");
+    // Issue #11973: Don't escape `"` in `'"'`
+    x.split("\"");
 
     let h = HashSet::<String>::new();
     h.contains("X"); // should not warn

--- a/tests/ui/single_char_pattern.stderr
+++ b/tests/ui/single_char_pattern.stderr
@@ -182,58 +182,64 @@ LL |     x.split("\'");
    |             ^^^^ help: try using a `char` instead: `'\''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:49:31
+  --> $DIR/single_char_pattern.rs:46:13
+   |
+LL |     x.split("\"");
+   |             ^^^^ help: try using a `char` instead: `'"'`
+
+error: single-character string constant used as pattern
+  --> $DIR/single_char_pattern.rs:51:31
    |
 LL |     x.replace(';', ",").split(","); // issue #2978
    |                               ^^^ help: try using a `char` instead: `','`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:50:19
+  --> $DIR/single_char_pattern.rs:52:19
    |
 LL |     x.starts_with("\x03"); // issue #2996
    |                   ^^^^^^ help: try using a `char` instead: `'\x03'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:57:13
+  --> $DIR/single_char_pattern.rs:59:13
    |
 LL |     x.split(r"a");
    |             ^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:58:13
+  --> $DIR/single_char_pattern.rs:60:13
    |
 LL |     x.split(r#"a"#);
    |             ^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:59:13
+  --> $DIR/single_char_pattern.rs:61:13
    |
 LL |     x.split(r###"a"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'a'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:60:13
+  --> $DIR/single_char_pattern.rs:62:13
    |
 LL |     x.split(r###"'"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'\''`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:61:13
+  --> $DIR/single_char_pattern.rs:63:13
    |
 LL |     x.split(r###"#"###);
    |             ^^^^^^^^^^ help: try using a `char` instead: `'#'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:63:13
+  --> $DIR/single_char_pattern.rs:65:13
    |
 LL |     x.split(r#"\"#);
    |             ^^^^^^ help: try using a `char` instead: `'\\'`
 
 error: single-character string constant used as pattern
-  --> $DIR/single_char_pattern.rs:64:13
+  --> $DIR/single_char_pattern.rs:66:13
    |
 LL |     x.split(r"\");
    |             ^^^^ help: try using a `char` instead: `'\\'`
 
-error: aborting due to 39 previous errors
+error: aborting due to 40 previous errors
 


### PR DESCRIPTION
Fixes #11973.

```
changelog: [`single_char_pattern`]: don't escape `"` in `'"'`
```