### PR TITLE
stop linting [`blocks_in_conditions`] on `match` with weird attr macro case

### DIFF
--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::{span_lint, span_lint_and_sugg};
 use clippy_utils::source::snippet_block_with_applicability;
 use clippy_utils::ty::implements_trait;
 use clippy_utils::visitors::{for_each_expr, Descend};
-use clippy_utils::{get_parent_expr, higher};
+use clippy_utils::{get_parent_expr, higher, is_from_proc_macro};
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
 use rustc_hir::{BlockCheckMode, Expr, ExprKind, MatchSource};
@@ -94,7 +94,7 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
                     }
                 } else {
                     let span = block.expr.as_ref().map_or_else(|| block.stmts[0].span, |e| e.span);
-                    if span.from_expansion() || expr.span.from_expansion() {
+                    if span.from_expansion() || expr.span.from_expansion() || is_from_proc_macro(cx, cond) {
                         return;
                     }
                     // move block higher

--- a/tests/ui/blocks_in_conditions.fixed
+++ b/tests/ui/blocks_in_conditions.fixed
@@ -104,7 +104,7 @@ fn issue_12162() {
 mod issue_12016 {
     #[proc_macro_attr::fake_desugar_await]
     pub async fn await_becomes_block() -> i32 {
-        let res = await; match res {
+        match Some(1).await {
             Some(1) => 2,
             Some(2) => 3,
             _ => 0,

--- a/tests/ui/blocks_in_conditions.fixed
+++ b/tests/ui/blocks_in_conditions.fixed
@@ -1,3 +1,5 @@
+//@aux-build:proc_macro_attr.rs
+
 #![warn(clippy::blocks_in_conditions)]
 #![allow(unused, clippy::let_and_return, clippy::needless_if)]
 #![warn(clippy::nonminimal_bool)]
@@ -96,6 +98,17 @@ macro_rules! timed {
 fn issue_12162() {
     if timed!("check this!", false) {
         println!();
+    }
+}
+
+mod issue_12016 {
+    #[proc_macro_attr::fake_desugar_await]
+    pub async fn await_becomes_block() -> i32 {
+        let res = await; match res {
+            Some(1) => 2,
+            Some(2) => 3,
+            _ => 0,
+        }
     }
 }
 

--- a/tests/ui/blocks_in_conditions.rs
+++ b/tests/ui/blocks_in_conditions.rs
@@ -1,3 +1,5 @@
+//@aux-build:proc_macro_attr.rs
+
 #![warn(clippy::blocks_in_conditions)]
 #![allow(unused, clippy::let_and_return, clippy::needless_if)]
 #![warn(clippy::nonminimal_bool)]
@@ -96,6 +98,17 @@ macro_rules! timed {
 fn issue_12162() {
     if timed!("check this!", false) {
         println!();
+    }
+}
+
+mod issue_12016 {
+    #[proc_macro_attr::fake_desugar_await]
+    pub async fn await_becomes_block() -> i32 {
+        match Some(1).await {
+            Some(1) => 2,
+            Some(2) => 3,
+            _ => 0,
+        }
     }
 }
 

--- a/tests/ui/blocks_in_conditions.stderr
+++ b/tests/ui/blocks_in_conditions.stderr
@@ -1,5 +1,5 @@
 error: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-  --> $DIR/blocks_in_conditions.rs:23:5
+  --> $DIR/blocks_in_conditions.rs:25:5
    |
 LL | /     if {
 LL | |
@@ -20,13 +20,13 @@ LL ~     }; if res {
    |
 
 error: omit braces around single expression condition
-  --> $DIR/blocks_in_conditions.rs:35:8
+  --> $DIR/blocks_in_conditions.rs:37:8
    |
 LL |     if { true } { 6 } else { 10 }
    |        ^^^^^^^^ help: try: `true`
 
 error: this boolean expression can be simplified
-  --> $DIR/blocks_in_conditions.rs:41:8
+  --> $DIR/blocks_in_conditions.rs:43:8
    |
 LL |     if true && x == 3 { 6 } else { 10 }
    |        ^^^^^^^^^^^^^^ help: try: `x == 3`
@@ -35,7 +35,7 @@ LL |     if true && x == 3 { 6 } else { 10 }
    = help: to override `-D warnings` add `#[allow(clippy::nonminimal_bool)]`
 
 error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-  --> $DIR/blocks_in_conditions.rs:68:5
+  --> $DIR/blocks_in_conditions.rs:70:5
    |
 LL | /     match {
 LL | |
@@ -53,5 +53,11 @@ LL +         opt
 LL ~     }; match res {
    |
 
-error: aborting due to 4 previous errors
+error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
+  --> $DIR/blocks_in_conditions.rs:107:9
+   |
+LL |         match Some(1).await {
+   |         ^^^^^^^^^^^^^^^^^^^ help: try: `let res = await; match res`
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/blocks_in_conditions.stderr
+++ b/tests/ui/blocks_in_conditions.stderr
@@ -53,11 +53,5 @@ LL +         opt
 LL ~     }; match res {
    |
 
-error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-  --> $DIR/blocks_in_conditions.rs:107:9
-   |
-LL |         match Some(1).await {
-   |         ^^^^^^^^^^^^^^^^^^^ help: try: `let res = await; match res`
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
should fixes: #12016 

---

changelog: [`blocks_in_conditions`] - fix FP on `match` with weird attr macro


This might not be the best solution, as the root cause (i think?) is the `span` of block was incorrectly given by the compiler?

I'm open to better solutions