### PR TITLE
Remove mitigations for incorrect node args

### DIFF
--- a/clippy_lints/src/methods/unnecessary_to_owned.rs
+++ b/clippy_lints/src/methods/unnecessary_to_owned.rs
@@ -445,11 +445,12 @@ fn can_change_type<'a>(cx: &LateContext<'a>, mut expr: &'a Expr<'a>, mut ty: Ty<
                 {
                     let bound_fn_sig = cx.tcx.fn_sig(callee_def_id);
                     let fn_sig = bound_fn_sig.skip_binder();
-                    if let Some(arg_index) = recv.into_iter().chain(call_args).position(|arg| arg.hir_id == expr.hir_id)
+                    if let Some(arg_index) = recv
+                        .into_iter()
+                        .chain(call_args)
+                        .position(|arg| arg.hir_id == expr.hir_id)
                         && let param_ty = fn_sig.input(arg_index).skip_binder()
-                        && let ty::Param(ParamTy { index: param_index , ..}) = *param_ty.kind()
-                        // https://github.com/rust-lang/rust-clippy/issues/9504 and https://github.com/rust-lang/rust-clippy/issues/10021
-                        && (param_index as usize) < call_generic_args.len()
+                        && let ty::Param(ParamTy { index: param_index, .. }) = *param_ty.kind()
                     {
                         if fn_sig
                             .skip_binder()


### PR DESCRIPTION
This change https://github.com/rust-lang/rust/pull/118420/files#r1419874371 adds a missing `write_args` to properly record node args for lang-item calls.

Thus, in the `unnecessary_to_owned` lint, this ensures that the `call_generic_args` extracted by `get_callee_generic_args_and_args` are always correct, and we can remove the mitigation for #9504 and #10021 since the root cause has been fixed.

I'm not sure if there is other now-unnecessary code that can be removed, but this is the one I found when investigating https://github.com/rust-lang/rust-clippy/issues/11965#issuecomment-1871732518.

changelog: none
