### PR TITLE
fix/issue#11243: allow 3-digit-grouped binary in non_octal_unix_permissions

### DIFF
--- a/clippy_lints/src/non_octal_unix_permissions.rs
+++ b/clippy_lints/src/non_octal_unix_permissions.rs
@@ -50,10 +50,15 @@ fn check_binary_unix_permissions(lit_kind: &LitKind, snip: &str) -> bool {
 
         let group_sizes: Vec<usize> = num_lit.integer.split('_').map(str::len).collect();
         // check whether is binary format unix permissions
-        if group_sizes.len() != 3 && group_sizes.len() != 4 {
-            return false;
+        if group_sizes.len() == 1 && (num_lit.integer.len() == 9 || num_lit.integer.len() == 12) {
+            // 0bxxxxxxxxx or 0bxxxxxxxxxxxx
+            true
+        } else if group_sizes.len() == 3 || group_sizes.len() == 4 {
+            // 0bxxx_xxx_xxx or 0bxxx_xxx_xxx_xxx
+            group_sizes.iter().all(|len| *len == 3)
+        } else {
+            false
         }
-        group_sizes.iter().all(|len| *len == 3)
     } else {
         false
     }

--- a/clippy_lints/src/non_octal_unix_permissions.rs
+++ b/clippy_lints/src/non_octal_unix_permissions.rs
@@ -1,6 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::numeric_literal::{NumericLiteral, Radix};
 use clippy_utils::source::{snippet_opt, snippet_with_applicability};
 use clippy_utils::{match_def_path, paths};
+use rustc_ast::LitKind;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -39,6 +41,24 @@ declare_clippy_lint! {
 
 declare_lint_pass!(NonOctalUnixPermissions => [NON_OCTAL_UNIX_PERMISSIONS]);
 
+fn check_binary_unix_permissions(lit_kind: &LitKind, snip: &str) -> bool {
+    // support binary unix permissions
+    if let Some(num_lit) = NumericLiteral::from_lit_kind(snip, lit_kind) {
+        if num_lit.radix != Radix::Binary {
+            return false;
+        }
+
+        let group_sizes: Vec<usize> = num_lit.integer.split('_').map(str::len).collect();
+        // check whether is binary format unix permissions
+        if group_sizes.len() != 3 {
+            return false;
+        }
+        group_sizes.iter().all(|len| *len == 3)
+    } else {
+        false
+    }
+}
+
 impl<'tcx> LateLintPass<'tcx> for NonOctalUnixPermissions {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         match &expr.kind {
@@ -51,26 +71,22 @@ impl<'tcx> LateLintPass<'tcx> for NonOctalUnixPermissions {
                         ))
                         || (path.ident.name == sym!(set_mode)
                             && cx.tcx.is_diagnostic_item(sym::FsPermissions, adt.did())))
-                    && let ExprKind::Lit(_) = param.kind
+                    && let ExprKind::Lit(lit_kind) = param.kind
                     && param.span.eq_ctxt(expr.span)
+                    && let Some(snip) = snippet_opt(cx, param.span)
+                    && !(snip.starts_with("0o") || check_binary_unix_permissions(&lit_kind.node, &snip))
                 {
-                    let Some(snip) = snippet_opt(cx, param.span) else {
-                        return;
-                    };
-
-                    if !snip.starts_with("0o") {
-                        show_error(cx, param);
-                    }
+                    show_error(cx, param);
                 }
             },
             ExprKind::Call(func, [param]) => {
                 if let ExprKind::Path(ref path) = func.kind
                     && let Some(def_id) = cx.qpath_res(path, func.hir_id).opt_def_id()
                     && match_def_path(cx, def_id, &paths::PERMISSIONS_FROM_MODE)
-                    && let ExprKind::Lit(_) = param.kind
+                    && let ExprKind::Lit(lit_kind) = param.kind
                     && param.span.eq_ctxt(expr.span)
                     && let Some(snip) = snippet_opt(cx, param.span)
-                    && !snip.starts_with("0o")
+                    && !(snip.starts_with("0o") || check_binary_unix_permissions(&lit_kind.node, &snip))
                 {
                     show_error(cx, param);
                 }

--- a/clippy_lints/src/non_octal_unix_permissions.rs
+++ b/clippy_lints/src/non_octal_unix_permissions.rs
@@ -50,7 +50,7 @@ fn check_binary_unix_permissions(lit_kind: &LitKind, snip: &str) -> bool {
 
         let group_sizes: Vec<usize> = num_lit.integer.split('_').map(str::len).collect();
         // check whether is binary format unix permissions
-        if group_sizes.len() != 3 {
+        if group_sizes.len() != 3 && group_sizes.len() != 4 {
             return false;
         }
         group_sizes.iter().all(|len| *len == 3)

--- a/tests/ui/non_octal_unix_permissions.fixed
+++ b/tests/ui/non_octal_unix_permissions.fixed
@@ -25,9 +25,13 @@ fn main() {
 
     permissions.set_mode(0o644);
     permissions.set_mode(0o704);
+    // no error
+    permissions.set_mode(0b111_000_100);
 
     // DirBuilderExt::mode
     let mut builder = DirBuilder::new();
     builder.mode(0o755);
     builder.mode(0o406);
+    // no error
+    permissions.set_mode(0b111000100);
 }

--- a/tests/ui/non_octal_unix_permissions.rs
+++ b/tests/ui/non_octal_unix_permissions.rs
@@ -25,9 +25,13 @@ fn main() {
 
     permissions.set_mode(644);
     permissions.set_mode(0o704);
+    // no error
+    permissions.set_mode(0b111_000_100);
 
     // DirBuilderExt::mode
     let mut builder = DirBuilder::new();
     builder.mode(755);
     builder.mode(0o406);
+    // no error
+    permissions.set_mode(0b111000100);
 }

--- a/tests/ui/non_octal_unix_permissions.stderr
+++ b/tests/ui/non_octal_unix_permissions.stderr
@@ -20,7 +20,7 @@ LL |     permissions.set_mode(644);
    |                          ^^^ help: consider using an octal literal instead: `0o644`
 
 error: using a non-octal value to set unix file permissions
-  --> $DIR/non_octal_unix_permissions.rs:31:18
+  --> $DIR/non_octal_unix_permissions.rs:33:18
    |
 LL |     builder.mode(755);
    |                  ^^^ help: consider using an octal literal instead: `0o755`


### PR DESCRIPTION
fixes [Issue#11243](https://github.com/rust-lang/rust-clippy/issues/11243)

Issue#11243 suggest lint `non_octal_unix_permissions` should not report binary format literal unix permissions as an error, and we think binary format is a good way to understand these permissions.

To solve this problem, we need to add check for binary literal, which is written in function `check_binary_unix_permissions` , only `binary, 3 groups and each group length equals to 3` is a legal format.

changelog: [`non_octal_unix_permissions`]: Add check for binary format literal unix permissions like 0b111_111_111
