### PR TITLE
Fix `match_same_arms` false positive for arms with different comments

### DIFF
--- a/clippy_lints/src/matches/match_same_arms.rs
+++ b/clippy_lints/src/matches/match_same_arms.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::snippet;
-use clippy_utils::{is_lint_allowed, path_to_local, search_same, SpanlessEq, SpanlessHash};
+use clippy_utils::{is_lint_allowed, path_to_local, search_same, span_extract_comment, SpanlessEq, SpanlessHash};
 use core::cmp::Ordering;
 use core::{iter, slice};
 use rustc_arena::DroplessArena;
@@ -9,7 +9,7 @@ use rustc_errors::Applicability;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{Arm, Expr, ExprKind, HirId, HirIdMap, HirIdMapEntry, HirIdSet, Pat, PatKind, RangeEnd};
 use rustc_lint::builtin::NON_EXHAUSTIVE_OMITTED_PATTERNS;
-use rustc_lint::LateContext;
+use rustc_lint::{LateContext, LintContext};
 use rustc_middle::ty;
 use rustc_span::Symbol;
 
@@ -100,6 +100,10 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, arms: &'tcx [Arm<'_>]) {
 
     let indexed_arms: Vec<(usize, &Arm<'_>)> = arms.iter().enumerate().collect();
     for (&(i, arm1), &(j, arm2)) in search_same(&indexed_arms, hash, eq) {
+        let arm1_comment = span_extract_comment(cx.sess().source_map(), arm1.span);
+        if !arm1_comment.is_empty() && arm1_comment != span_extract_comment(cx.sess().source_map(), arm2.span) {
+            continue;
+        }
         if matches!(arm2.pat.kind, PatKind::Wild) {
             if !cx.tcx.features().non_exhaustive_omitted_patterns_lint
                 || is_lint_allowed(cx, NON_EXHAUSTIVE_OMITTED_PATTERNS, arm2.hir_id)

--- a/tests/ui/match_same_arms.rs
+++ b/tests/ui/match_same_arms.rs
@@ -56,6 +56,37 @@ mod issue4244 {
     }
 }
 
+mod issue12044 {
+    enum Sky {
+        Clear,
+        Cloudy,
+    }
+
+    impl Sky {
+        fn text(&self) -> String {
+            // Should not trigger the lint as the comments are different.
+            match self {
+                Sky::Clear => {
+                    // The sky is clear.
+                    "Fine weather".to_string()
+                },
+                Sky::Cloudy => {
+                    // The sky is cloudy.
+                    "Fine weather".to_string()
+                },
+            }
+        }
+
+        fn text_without_comments(&self) -> String {
+            match self {
+                Sky::Clear => "Fine weather".to_string(),
+                Sky::Cloudy => "Fine weather".to_string(),
+            }
+            //~^^ ERROR: this match arm has an identical body to another arm
+        }
+    }
+}
+
 macro_rules! m {
     (foo) => {};
     (bar) => {};

--- a/tests/ui/match_same_arms.stderr
+++ b/tests/ui/match_same_arms.stderr
@@ -118,5 +118,20 @@ note: other arm here
 LL |                 CommandInfo::BuiltIn { name, .. } => name.to_string(),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: this match arm has an identical body to another arm
+  --> $DIR/match_same_arms.rs:83:17
+   |
+LL |                 Sky::Cloudy => "Fine weather".to_string(),
+   |                 -----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 help: try merging the arm patterns: `Sky::Cloudy | Sky::Clear`
+   |
+   = help: or try changing either arm body
+note: other arm here
+  --> $DIR/match_same_arms.rs:82:17
+   |
+LL |                 Sky::Clear => "Fine weather".to_string(),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/match_same_arms2.rs
+++ b/tests/ui/match_same_arms2.rs
@@ -13,7 +13,6 @@ fn foo() -> bool {
 fn match_same_arms() {
     let _ = match 42 {
         42 => {
-            //~^ ERROR: this match arm has an identical body to the `_` wildcard arm
             foo();
             let mut a = 42 + [23].len() as i32;
             if true {
@@ -32,6 +31,7 @@ fn match_same_arms() {
             a
         },
     };
+    //~^^^^^^^^^^^^^^^^^^^ ERROR: this match arm has an identical body to the `_` wildcard arm
 
     let _ = match 42 {
         42 => foo(),

--- a/tests/ui/match_same_arms2.stderr
+++ b/tests/ui/match_same_arms2.stderr
@@ -2,9 +2,9 @@ error: this match arm has an identical body to the `_` wildcard arm
   --> $DIR/match_same_arms2.rs:15:9
    |
 LL | /         42 => {
-LL | |
 LL | |             foo();
 LL | |             let mut a = 42 + [23].len() as i32;
+LL | |             if true {
 ...  |
 LL | |             a
 LL | |         },
@@ -12,7 +12,7 @@ LL | |         },
    |
    = help: or try changing either arm body
 note: `_` wildcard arm here
-  --> $DIR/match_same_arms2.rs:25:9
+  --> $DIR/match_same_arms2.rs:24:9
    |
 LL | /         _ => {
 LL | |             foo();


### PR DESCRIPTION
This PR:
- fixes FPs for match arms with different comments.
- adds relevant UI tests.

Closes #12044 

```
changelog: [`match_same_arms`]: The lint is no longer emitted for match arms with different comments.
```