### PR TITLE
Fix issue #12034: add autofixes for unnecessary_fallible_conversions

### DIFF
--- a/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
+++ b/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
@@ -63,6 +63,7 @@ fn check<'tcx>(
             }
         });
 
+        // If there is an unwrap/expect call, extend the span to include the call
         let span = if let Some(unwrap_call) = parent_unwrap_call {
             primary_span.with_hi(unwrap_call.hi())
         } else {

--- a/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
+++ b/clippy_lints/src/methods/unnecessary_fallible_conversions.rs
@@ -52,23 +52,18 @@ impl FunctionKind {
     }
 
     fn machine_applicable_sugg(&self, primary_span: Span, unwrap_span: Span) -> Vec<(Span, String)> {
-        use FunctionKind::*;
-        use SpansKind::*;
-
-        let (trait_name, fn_name) = {
-            let (a, b) = match self {
-                TryFromFunction(_) => ("From", "from"),
-                TryIntoFunction(_) | TryIntoMethod => ("Into", "into"),
-            };
-            (a.to_string(), b.to_string())
+        let (trait_name, fn_name) = match self {
+            FunctionKind::TryFromFunction(_) => ("From".to_owned(), "from".to_owned()),
+            FunctionKind::TryIntoFunction(_) | FunctionKind::TryIntoMethod => ("Into".to_owned(), "into".to_owned()),
         };
 
         let mut sugg = match *self {
-            TryFromFunction(Some(spans)) | TryIntoFunction(Some(spans)) => match spans {
-                TraitFn { trait_span, fn_span } => vec![(trait_span, trait_name), (fn_span, fn_name)],
-                Fn { fn_span } => vec![(fn_span, fn_name)],
+            FunctionKind::TryFromFunction(Some(spans)) | FunctionKind::TryIntoFunction(Some(spans)) => match spans {
+                SpansKind::TraitFn { trait_span, fn_span } => vec![(trait_span, trait_name), (fn_span, fn_name)],
+                SpansKind::Fn { fn_span } => vec![(fn_span, fn_name)],
             },
-            TryIntoMethod => vec![(primary_span, fn_name)],
+            FunctionKind::TryIntoMethod => vec![(primary_span, fn_name)],
+            // Or the suggestion is not machine-applicable
             _ => unreachable!(),
         };
 

--- a/tests/ui/unnecessary_fallible_conversions.fixed
+++ b/tests/ui/unnecessary_fallible_conversions.fixed
@@ -1,18 +1,43 @@
 #![warn(clippy::unnecessary_fallible_conversions)]
 
 fn main() {
+    // --- TryFromMethod `T::try_from(u)` ---
+
     let _: i64 = 0i32.into();
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _: i64 = 0i32.into();
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryFromFunction `T::try_from(U)` ---
 
     let _ = i64::from(0i32);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _ = i64::from(0i32);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryIntoFunction `U::try_into(t)` ---
 
     let _: i64 = i32::into(0);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _: i64 = i32::into(0i32);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryFromFunction `<T as TryFrom<U>>::try_from(U)` ---
 
     let _ = <i64 as From<i32>>::from(0);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _ = <i64 as From<i32>>::from(0);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryIntoFunction `<U as TryInto<_>>::try_into(U)` ---
 
     let _: i64 = <i32 as Into<_>>::into(0);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _: i64 = <i32 as Into<_>>::into(0);
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
 }

--- a/tests/ui/unnecessary_fallible_conversions.fixed
+++ b/tests/ui/unnecessary_fallible_conversions.fixed
@@ -3,4 +3,16 @@
 fn main() {
     let _: i64 = 0i32.into();
     let _: i64 = 0i32.into();
+
+    let _ = i64::from(0i32);
+    let _ = i64::from(0i32);
+
+    let _: i64 = i32::into(0);
+    let _: i64 = i32::into(0i32);
+
+    let _ = <i64 as From<i32>>::from(0);
+    let _ = <i64 as From<i32>>::from(0);
+
+    let _: i64 = <i32 as Into<_>>::into(0);
+    let _: i64 = <i32 as Into<_>>::into(0);
 }

--- a/tests/ui/unnecessary_fallible_conversions.rs
+++ b/tests/ui/unnecessary_fallible_conversions.rs
@@ -10,10 +10,8 @@ fn main() {
     let _: i64 = i32::try_into(0).unwrap();
     let _: i64 = i32::try_into(0i32).expect("can't happen");
 
-    let _ = <i64 as TryFrom<i32>>::try_from(0)
-        .unwrap();
-    let _ = <i64 as TryFrom<i32>>::try_from(0).
-        expect("can't happen");
+    let _ = <i64 as TryFrom<i32>>::try_from(0).unwrap();
+    let _ = <i64 as TryFrom<i32>>::try_from(0).expect("can't happen");
 
     let _: i64 = <i32 as TryInto<_>>::try_into(0).unwrap();
     let _: i64 = <i32 as TryInto<_>>::try_into(0).expect("can't happen");

--- a/tests/ui/unnecessary_fallible_conversions.rs
+++ b/tests/ui/unnecessary_fallible_conversions.rs
@@ -3,4 +3,18 @@
 fn main() {
     let _: i64 = 0i32.try_into().unwrap();
     let _: i64 = 0i32.try_into().expect("can't happen");
+
+    let _ = i64::try_from(0i32).unwrap();
+    let _ = i64::try_from(0i32).expect("can't happen");
+
+    let _: i64 = i32::try_into(0).unwrap();
+    let _: i64 = i32::try_into(0i32).expect("can't happen");
+
+    let _ = <i64 as TryFrom<i32>>::try_from(0)
+        .unwrap();
+    let _ = <i64 as TryFrom<i32>>::try_from(0).
+        expect("can't happen");
+
+    let _: i64 = <i32 as TryInto<_>>::try_into(0).unwrap();
+    let _: i64 = <i32 as TryInto<_>>::try_into(0).expect("can't happen");
 }

--- a/tests/ui/unnecessary_fallible_conversions.rs
+++ b/tests/ui/unnecessary_fallible_conversions.rs
@@ -1,18 +1,43 @@
 #![warn(clippy::unnecessary_fallible_conversions)]
 
 fn main() {
+    // --- TryFromMethod `T::try_from(u)` ---
+
     let _: i64 = 0i32.try_into().unwrap();
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _: i64 = 0i32.try_into().expect("can't happen");
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryFromFunction `T::try_from(U)` ---
 
     let _ = i64::try_from(0i32).unwrap();
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _ = i64::try_from(0i32).expect("can't happen");
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryIntoFunction `U::try_into(t)` ---
 
     let _: i64 = i32::try_into(0).unwrap();
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _: i64 = i32::try_into(0i32).expect("can't happen");
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryFromFunction `<T as TryFrom<U>>::try_from(U)` ---
 
     let _ = <i64 as TryFrom<i32>>::try_from(0).unwrap();
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _ = <i64 as TryFrom<i32>>::try_from(0).expect("can't happen");
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
+    // --- TryIntoFunction `<U as TryInto<_>>::try_into(U)` ---
 
     let _: i64 = <i32 as TryInto<_>>::try_into(0).unwrap();
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
+
     let _: i64 = <i32 as TryInto<_>>::try_into(0).expect("can't happen");
+    //~^ ERROR: use of a fallible conversion when an infallible one could be used
 }

--- a/tests/ui/unnecessary_fallible_conversions.stderr
+++ b/tests/ui/unnecessary_fallible_conversions.stderr
@@ -2,19 +2,137 @@ error: use of a fallible conversion when an infallible one could be used
   --> $DIR/unnecessary_fallible_conversions.rs:4:23
    |
 LL |     let _: i64 = 0i32.try_into().unwrap();
-   |                       ^^^^^^^^^^^^^^^^^^^ help: use: `into()`
+   |                       ^^^^^^^^^^^^^^^^^^^
    |
    = note: converting `i32` to `i64` cannot fail
    = note: `-D clippy::unnecessary-fallible-conversions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_fallible_conversions)]`
+help: use
+   |
+LL -     let _: i64 = 0i32.try_into().unwrap();
+LL +     let _: i64 = 0i32.into();
+   |
 
 error: use of a fallible conversion when an infallible one could be used
   --> $DIR/unnecessary_fallible_conversions.rs:5:23
    |
 LL |     let _: i64 = 0i32.try_into().expect("can't happen");
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `into()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: i64 = 0i32.try_into().expect("can't happen");
+LL +     let _: i64 = 0i32.into();
+   |
 
-error: aborting due to 2 previous errors
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:7:13
+   |
+LL |     let _ = i64::try_from(0i32).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _ = i64::try_from(0i32).unwrap();
+LL +     let _ = i64::from(0i32);
+   |
+
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:8:13
+   |
+LL |     let _ = i64::try_from(0i32).expect("can't happen");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _ = i64::try_from(0i32).expect("can't happen");
+LL +     let _ = i64::from(0i32);
+   |
+
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:10:18
+   |
+LL |     let _: i64 = i32::try_into(0).unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: i64 = i32::try_into(0).unwrap();
+LL +     let _: i64 = i32::into(0);
+   |
+
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:11:18
+   |
+LL |     let _: i64 = i32::try_into(0i32).expect("can't happen");
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: i64 = i32::try_into(0i32).expect("can't happen");
+LL +     let _: i64 = i32::into(0i32);
+   |
+
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:13:13
+   |
+LL |       let _ = <i64 as TryFrom<i32>>::try_from(0)
+   |  _____________^
+LL | |         .unwrap();
+   | |_________________^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _ = <i64 as TryFrom<i32>>::try_from(0)
+LL +     let _ = <i64 as From<i32>>::from(0);
+   |
+
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:15:13
+   |
+LL |       let _ = <i64 as TryFrom<i32>>::try_from(0).
+   |  _____________^
+LL | |         expect("can't happen");
+   | |______________________________^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _ = <i64 as TryFrom<i32>>::try_from(0).
+LL +     let _ = <i64 as From<i32>>::from(0);
+   |
+
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:18:18
+   |
+LL |     let _: i64 = <i32 as TryInto<_>>::try_into(0).unwrap();
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: i64 = <i32 as TryInto<_>>::try_into(0).unwrap();
+LL +     let _: i64 = <i32 as Into<_>>::into(0);
+   |
+
+error: use of a fallible conversion when an infallible one could be used
+  --> $DIR/unnecessary_fallible_conversions.rs:19:18
+   |
+LL |     let _: i64 = <i32 as TryInto<_>>::try_into(0).expect("can't happen");
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: converting `i32` to `i64` cannot fail
+help: use
+   |
+LL -     let _: i64 = <i32 as TryInto<_>>::try_into(0).expect("can't happen");
+LL +     let _: i64 = <i32 as Into<_>>::into(0);
+   |
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/unnecessary_fallible_conversions.stderr
+++ b/tests/ui/unnecessary_fallible_conversions.stderr
@@ -81,35 +81,31 @@ LL +     let _: i64 = i32::into(0i32);
 error: use of a fallible conversion when an infallible one could be used
   --> $DIR/unnecessary_fallible_conversions.rs:13:13
    |
-LL |       let _ = <i64 as TryFrom<i32>>::try_from(0)
-   |  _____________^
-LL | |         .unwrap();
-   | |_________________^
+LL |     let _ = <i64 as TryFrom<i32>>::try_from(0).unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: converting `i32` to `i64` cannot fail
 help: use
    |
-LL -     let _ = <i64 as TryFrom<i32>>::try_from(0)
+LL -     let _ = <i64 as TryFrom<i32>>::try_from(0).unwrap();
 LL +     let _ = <i64 as From<i32>>::from(0);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:15:13
+  --> $DIR/unnecessary_fallible_conversions.rs:14:13
    |
-LL |       let _ = <i64 as TryFrom<i32>>::try_from(0).
-   |  _____________^
-LL | |         expect("can't happen");
-   | |______________________________^
+LL |     let _ = <i64 as TryFrom<i32>>::try_from(0).expect("can't happen");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: converting `i32` to `i64` cannot fail
 help: use
    |
-LL -     let _ = <i64 as TryFrom<i32>>::try_from(0).
+LL -     let _ = <i64 as TryFrom<i32>>::try_from(0).expect("can't happen");
 LL +     let _ = <i64 as From<i32>>::from(0);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:18:18
+  --> $DIR/unnecessary_fallible_conversions.rs:16:18
    |
 LL |     let _: i64 = <i32 as TryInto<_>>::try_into(0).unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +118,7 @@ LL +     let _: i64 = <i32 as Into<_>>::into(0);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:19:18
+  --> $DIR/unnecessary_fallible_conversions.rs:17:18
    |
 LL |     let _: i64 = <i32 as TryInto<_>>::try_into(0).expect("can't happen");
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unnecessary_fallible_conversions.stderr
+++ b/tests/ui/unnecessary_fallible_conversions.stderr
@@ -1,5 +1,5 @@
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:4:23
+  --> $DIR/unnecessary_fallible_conversions.rs:6:23
    |
 LL |     let _: i64 = 0i32.try_into().unwrap();
    |                       ^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL +     let _: i64 = 0i32.into();
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:5:23
+  --> $DIR/unnecessary_fallible_conversions.rs:9:23
    |
 LL |     let _: i64 = 0i32.try_into().expect("can't happen");
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL +     let _: i64 = 0i32.into();
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:7:13
+  --> $DIR/unnecessary_fallible_conversions.rs:14:13
    |
 LL |     let _ = i64::try_from(0i32).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +40,7 @@ LL +     let _ = i64::from(0i32);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:8:13
+  --> $DIR/unnecessary_fallible_conversions.rs:17:13
    |
 LL |     let _ = i64::try_from(0i32).expect("can't happen");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL +     let _ = i64::from(0i32);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:10:18
+  --> $DIR/unnecessary_fallible_conversions.rs:22:18
    |
 LL |     let _: i64 = i32::try_into(0).unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL +     let _: i64 = i32::into(0);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:11:18
+  --> $DIR/unnecessary_fallible_conversions.rs:25:18
    |
 LL |     let _: i64 = i32::try_into(0i32).expect("can't happen");
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL +     let _: i64 = i32::into(0i32);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:13:13
+  --> $DIR/unnecessary_fallible_conversions.rs:30:13
    |
 LL |     let _ = <i64 as TryFrom<i32>>::try_from(0).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL +     let _ = <i64 as From<i32>>::from(0);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:14:13
+  --> $DIR/unnecessary_fallible_conversions.rs:33:13
    |
 LL |     let _ = <i64 as TryFrom<i32>>::try_from(0).expect("can't happen");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL +     let _ = <i64 as From<i32>>::from(0);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:16:18
+  --> $DIR/unnecessary_fallible_conversions.rs:38:18
    |
 LL |     let _: i64 = <i32 as TryInto<_>>::try_into(0).unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL +     let _: i64 = <i32 as Into<_>>::into(0);
    |
 
 error: use of a fallible conversion when an infallible one could be used
-  --> $DIR/unnecessary_fallible_conversions.rs:17:18
+  --> $DIR/unnecessary_fallible_conversions.rs:41:18
    |
 LL |     let _: i64 = <i32 as TryInto<_>>::try_into(0).expect("can't happen");
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
fixes #12034

Currently, the `unnecessary_fallible_conversions` lint was capable of autofixing expressions like `0i32.try_into().unwrap()`. However, it couldn't autofix expressions in the form of `i64::try_from(0i32).unwrap()` or `<i64 as TryFrom<i32>>::try_from(0).unwrap()`.

This pull request extends the functionality to correctly autofix these latter forms as well.

changelog: [`unnecessary_fallible_conversions`]: Add autofixes for more forms