### PR TITLE
fix: metadata-collector lists wrong affected lints

### DIFF
--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -550,7 +550,7 @@ define_Conf! {
     /// Lint: PUB_UNDERSCORE_FIELDS
     ///
     /// Lint "public" fields in a struct that are prefixed with an underscore based on their
-    /// exported visibility; or whether they are marked as "pub".
+    /// exported visibility, or whether they are marked as "pub".
     (pub_underscore_fields_behavior: PubUnderscoreFieldsBehaviour = PubUnderscoreFieldsBehaviour::PublicallyExported),
 }
 

--- a/clippy_config/src/metadata.rs
+++ b/clippy_config/src/metadata.rs
@@ -96,6 +96,9 @@ fn parse_config_field_doc(doc_comment: &str) -> Option<(Vec<String>, String)> {
         doc_comment.make_ascii_lowercase();
         let lints: Vec<String> = doc_comment
             .split_off(DOC_START.len())
+            .lines()
+            .next()
+            .unwrap()
             .split(", ")
             .map(str::to_string)
             .collect();


### PR DESCRIPTION
fixes #12042 

This PR addresses the issue where the `metadata collector` incorrectly generates the `Affected Lints` section when a comma is included in the configuration documentation.

I made adjustments; however, if the `/// Lint: SOMETHING` section ends with `.` it always produces the correct output.
For example, 
```rust
/// Lint: PUB_UNDERSCORE_FIELDS
```
should be
```rust
/// Lint: PUB_UNDERSCORE_FIELDS.
```

changelog: none
