### PR TITLE
Add .as_ref() to suggestion to remove .to_string()

### DIFF
--- a/tests/ui/unnecessary_to_owned_on_split.fixed
+++ b/tests/ui/unnecessary_to_owned_on_split.fixed
@@ -1,4 +1,18 @@
-#[allow(clippy::single_char_pattern)]
+#![allow(clippy::single_char_pattern)]
+
+struct Issue12068;
+
+impl AsRef<str> for Issue12068 {
+    fn as_ref(&self) -> &str {
+        ""
+    }
+}
+
+impl ToString for Issue12068 {
+    fn to_string(&self) -> String {
+        String::new()
+    }
+}
 
 fn main() {
     let _ = "a".split('a').next().unwrap();
@@ -9,6 +23,8 @@ fn main() {
     //~^ ERROR: unnecessary use of `to_owned`
     let _ = "a".split("a").next().unwrap();
     //~^ ERROR: unnecessary use of `to_owned`
+    let _ = Issue12068.as_ref().split('a').next().unwrap();
+    //~^ ERROR: unnecessary use of `to_string`
 
     let _ = [1].split(|x| *x == 2).next().unwrap();
     //~^ ERROR: unnecessary use of `to_vec`

--- a/tests/ui/unnecessary_to_owned_on_split.rs
+++ b/tests/ui/unnecessary_to_owned_on_split.rs
@@ -1,4 +1,18 @@
-#[allow(clippy::single_char_pattern)]
+#![allow(clippy::single_char_pattern)]
+
+struct Issue12068;
+
+impl AsRef<str> for Issue12068 {
+    fn as_ref(&self) -> &str {
+        ""
+    }
+}
+
+impl ToString for Issue12068 {
+    fn to_string(&self) -> String {
+        String::new()
+    }
+}
 
 fn main() {
     let _ = "a".to_string().split('a').next().unwrap();
@@ -9,6 +23,8 @@ fn main() {
     //~^ ERROR: unnecessary use of `to_owned`
     let _ = "a".to_owned().split("a").next().unwrap();
     //~^ ERROR: unnecessary use of `to_owned`
+    let _ = Issue12068.to_string().split('a').next().unwrap();
+    //~^ ERROR: unnecessary use of `to_string`
 
     let _ = [1].to_vec().split(|x| *x == 2).next().unwrap();
     //~^ ERROR: unnecessary use of `to_vec`

--- a/tests/ui/unnecessary_to_owned_on_split.stderr
+++ b/tests/ui/unnecessary_to_owned_on_split.stderr
@@ -1,5 +1,5 @@
 error: unnecessary use of `to_string`
-  --> $DIR/unnecessary_to_owned_on_split.rs:4:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:18:13
    |
 LL |     let _ = "a".to_string().split('a').next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `"a".split('a')`
@@ -8,46 +8,52 @@ LL |     let _ = "a".to_string().split('a').next().unwrap();
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_to_owned)]`
 
 error: unnecessary use of `to_string`
-  --> $DIR/unnecessary_to_owned_on_split.rs:6:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:20:13
    |
 LL |     let _ = "a".to_string().split("a").next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `"a".split("a")`
 
 error: unnecessary use of `to_owned`
-  --> $DIR/unnecessary_to_owned_on_split.rs:8:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:22:13
    |
 LL |     let _ = "a".to_owned().split('a').next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `"a".split('a')`
 
 error: unnecessary use of `to_owned`
-  --> $DIR/unnecessary_to_owned_on_split.rs:10:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:24:13
    |
 LL |     let _ = "a".to_owned().split("a").next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `"a".split("a")`
 
+error: unnecessary use of `to_string`
+  --> $DIR/unnecessary_to_owned_on_split.rs:26:13
+   |
+LL |     let _ = Issue12068.to_string().split('a').next().unwrap();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `Issue12068.as_ref().split('a')`
+
 error: unnecessary use of `to_vec`
-  --> $DIR/unnecessary_to_owned_on_split.rs:13:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:29:13
    |
 LL |     let _ = [1].to_vec().split(|x| *x == 2).next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `[1].split(|x| *x == 2)`
 
 error: unnecessary use of `to_vec`
-  --> $DIR/unnecessary_to_owned_on_split.rs:15:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:31:13
    |
 LL |     let _ = [1].to_vec().split(|x| *x == 2).next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `[1].split(|x| *x == 2)`
 
 error: unnecessary use of `to_owned`
-  --> $DIR/unnecessary_to_owned_on_split.rs:17:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:33:13
    |
 LL |     let _ = [1].to_owned().split(|x| *x == 2).next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `[1].split(|x| *x == 2)`
 
 error: unnecessary use of `to_owned`
-  --> $DIR/unnecessary_to_owned_on_split.rs:19:13
+  --> $DIR/unnecessary_to_owned_on_split.rs:35:13
    |
 LL |     let _ = [1].to_owned().split(|x| *x == 2).next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `[1].split(|x| *x == 2)`
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
The case of `.to_owned().split(…)` is treated specially in the `unnecessary_to_owned` lint. Test cases check that it works both for slices and for strings, but they missed a corner case: `x.to_string().split(…)` when `x` implements `AsRef<str>` but not `Deref<Target = str>`. In this case, it is wrong to suggest to remove `.to_string()` without adding `.as_ref()` instead.

Fix #12068

changelog: [`unnecessary_to_owned`]: suggest replacing `.to_string()` by `.as_ref()`
