### PR TITLE
Don't emit `struct_field_names` lint if all fields are booleans and don't start with the type's name

### DIFF
--- a/clippy_lints/src/item_name_repetitions.rs
+++ b/clippy_lints/src/item_name_repetitions.rs
@@ -1,6 +1,7 @@
 //! lint on enum variants that are prefixed or suffixed by the same characters
 
 use clippy_utils::diagnostics::{span_lint, span_lint_and_help, span_lint_hir};
+use clippy_utils::is_bool;
 use clippy_utils::macros::span_is_local;
 use clippy_utils::source::is_present_in_source;
 use clippy_utils::str_utils::{camel_case_split, count_match_end, count_match_start, to_camel_case, to_snake_case};
@@ -231,6 +232,10 @@ fn check_fields(cx: &LateContext<'_>, threshold: u64, item: &Item<'_>, fields: &
             (false, _) => ("pre", prefix),
             (true, false) => ("post", postfix),
         };
+        if fields.iter().all(|field| is_bool(field.ty)) {
+            // If all fields are booleans, we don't want to emit this lint.
+            return;
+        }
         span_lint_and_help(
             cx,
             STRUCT_FIELD_NAMES,

--- a/tests/ui/struct_fields.rs
+++ b/tests/ui/struct_fields.rs
@@ -39,14 +39,14 @@ struct DataStruct {
 struct DoublePrefix {
     //~^ ERROR: all fields have the same prefix: `some_data`
     some_data_a: bool,
-    some_data_b: bool,
+    some_data_b: i8,
     some_data_c: bool,
 }
 
 struct DoublePostfix {
     //~^ ERROR: all fields have the same postfix: `some_data`
     a_some_data: bool,
-    b_some_data: bool,
+    b_some_data: i8,
     c_some_data: bool,
 }
 
@@ -54,14 +54,14 @@ struct DoublePostfix {
 struct NotSnakeCase {
     //~^ ERROR: all fields have the same postfix: `someData`
     a_someData: bool,
-    b_someData: bool,
+    b_someData: i8,
     c_someData: bool,
 }
 #[allow(non_snake_case)]
 struct NotSnakeCase2 {
     //~^ ERROR: all fields have the same prefix: `someData`
     someData_c: bool,
-    someData_b: bool,
+    someData_b: i8,
     someData_a_b: bool,
 }
 
@@ -326,6 +326,20 @@ external! {
         invisible_data: u8,
     }
 
+}
+
+// Should not warn
+struct Config {
+    use_foo: bool,
+    use_bar: bool,
+    use_baz: bool,
+}
+
+struct Use {
+    use_foo: bool,
+    //~^ ERROR: field name starts with the struct's name
+    use_bar: bool,
+    use_baz: bool,
 }
 
 fn main() {}

--- a/tests/ui/struct_fields.stderr
+++ b/tests/ui/struct_fields.stderr
@@ -45,7 +45,7 @@ error: all fields have the same prefix: `some_data`
 LL | / struct DoublePrefix {
 LL | |
 LL | |     some_data_a: bool,
-LL | |     some_data_b: bool,
+LL | |     some_data_b: i8,
 LL | |     some_data_c: bool,
 LL | | }
    | |_^
@@ -58,7 +58,7 @@ error: all fields have the same postfix: `some_data`
 LL | / struct DoublePostfix {
 LL | |
 LL | |     a_some_data: bool,
-LL | |     b_some_data: bool,
+LL | |     b_some_data: i8,
 LL | |     c_some_data: bool,
 LL | | }
    | |_^
@@ -71,7 +71,7 @@ error: all fields have the same postfix: `someData`
 LL | / struct NotSnakeCase {
 LL | |
 LL | |     a_someData: bool,
-LL | |     b_someData: bool,
+LL | |     b_someData: i8,
 LL | |     c_someData: bool,
 LL | | }
    | |_^
@@ -84,7 +84,7 @@ error: all fields have the same prefix: `someData`
 LL | / struct NotSnakeCase2 {
 LL | |
 LL | |     someData_c: bool,
-LL | |     someData_b: bool,
+LL | |     someData_b: i8,
 LL | |     someData_a_b: bool,
 LL | | }
    | |_^
@@ -261,5 +261,23 @@ LL |       mk_struct_full_def!(PrefixData, some_data, some_meta, some_other);
    = help: remove the prefixes
    = note: this error originates in the macro `mk_struct_full_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 21 previous errors
+error: field name starts with the struct's name
+  --> $DIR/struct_fields.rs:339:5
+   |
+LL |     use_foo: bool,
+   |     ^^^^^^^^^^^^^
+
+error: field name starts with the struct's name
+  --> $DIR/struct_fields.rs:341:5
+   |
+LL |     use_bar: bool,
+   |     ^^^^^^^^^^^^^
+
+error: field name starts with the struct's name
+  --> $DIR/struct_fields.rs:342:5
+   |
+LL |     use_baz: bool,
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Fixes #11936.

I only checked that all fields are booleans and not the prefix (nor the suffix) because when I started to list accepted prefixes (like "is", "has", "should", "could", etc), the list was starting to get a bit too long and I thought it was not really worth for such a small change.

r? @llogiq 

changelog: Don't emit `struct_field_names` lint if all fields are booleans and don't start with the type's name