### PR TITLE
Do not suggest `bool::then()` and `bool::then_some` in `const` contexts

### DIFF
--- a/clippy_lints/src/if_then_some_else_none.rs
+++ b/clippy_lints/src/if_then_some_else_none.rs
@@ -3,7 +3,7 @@ use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::eager_or_lazy::switch_to_eager_eval;
 use clippy_utils::source::snippet_with_context;
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{contains_return, higher, is_else_clause, is_res_lang_ctor, path_res, peel_blocks};
+use clippy_utils::{contains_return, higher, in_constant, is_else_clause, is_res_lang_ctor, path_res, peel_blocks};
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::{OptionNone, OptionSome};
 use rustc_hir::{Expr, ExprKind};
@@ -71,6 +71,11 @@ impl<'tcx> LateLintPass<'tcx> for IfThenSomeElseNone {
 
         // We only care about the top-most `if` in the chain
         if is_else_clause(cx.tcx, expr) {
+            return;
+        }
+
+        // `bool::then()` and `bool::then_some()` are not const
+        if in_constant(cx, expr.hir_id) {
             return;
         }
 

--- a/tests/ui/if_then_some_else_none.rs
+++ b/tests/ui/if_then_some_else_none.rs
@@ -130,3 +130,8 @@ fn issue11394(b: bool, v: Result<(), ()>) -> Result<(), ()> {
 
     Ok(())
 }
+
+const fn issue12103(x: u32) -> Option<u32> {
+    // Should not issue an error in `const` context
+    if x > 42 { Some(150) } else { None }
+}


### PR DESCRIPTION
Fix #12103

changelog: [`if_then_some_else_none`]: Do not trigger in `const` contexts
