### PR TITLE
Fix error warning span for issue12045

### DIFF
--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::{span_lint_hir, span_lint_hir_and_then};
 use clippy_utils::source::snippet_opt;
 use clippy_utils::ty::has_drop;
-use clippy_utils::{get_parent_node, is_lint_allowed, peel_blocks};
+use clippy_utils::{any_parent_is_automatically_derived, get_parent_node, is_lint_allowed, peel_blocks};
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{
@@ -144,6 +144,7 @@ fn check_no_effect(cx: &LateContext<'_>, stmt: &Stmt<'_>) -> bool {
         }
     } else if let StmtKind::Local(local) = stmt.kind {
         if !is_lint_allowed(cx, NO_EFFECT_UNDERSCORE_BINDING, local.hir_id)
+            && !any_parent_is_automatically_derived(cx.tcx, local.hir_id)
             && let Some(init) = local.init
             && local.els.is_none()
             && !local.pat.span.from_expansion()

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -155,7 +155,7 @@ fn check_no_effect(cx: &LateContext<'_>, stmt: &Stmt<'_>) -> bool {
                 cx,
                 NO_EFFECT_UNDERSCORE_BINDING,
                 init.hir_id,
-                stmt.span,
+                ident.span,
                 "binding to `_` prefixed variable with no side-effect",
             );
             return true;

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -144,13 +144,13 @@ fn check_no_effect(cx: &LateContext<'_>, stmt: &Stmt<'_>) -> bool {
         }
     } else if let StmtKind::Local(local) = stmt.kind {
         if !is_lint_allowed(cx, NO_EFFECT_UNDERSCORE_BINDING, local.hir_id)
-            && !any_parent_is_automatically_derived(cx.tcx, local.hir_id)
             && let Some(init) = local.init
             && local.els.is_none()
             && !local.pat.span.from_expansion()
             && has_no_effect(cx, init)
             && let PatKind::Binding(_, _, ident, _) = local.pat.kind
             && ident.name.to_ident_string().starts_with('_')
+            && !any_parent_is_automatically_derived(cx.tcx, local.hir_id)
         {
             span_lint_hir(
                 cx,

--- a/tests/ui/no_effect.stderr
+++ b/tests/ui/no_effect.stderr
@@ -152,31 +152,31 @@ LL |     FooString { s: s };
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:175:5
+  --> $DIR/no_effect.rs:175:9
    |
 LL |     let _unused = 1;
-   |     ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^
    |
    = note: `-D clippy::no-effect-underscore-binding` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::no_effect_underscore_binding)]`
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:178:5
+  --> $DIR/no_effect.rs:178:9
    |
 LL |     let _penguin = || println!("Some helpful closure");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:180:5
+  --> $DIR/no_effect.rs:180:9
    |
 LL |     let _duck = Struct { field: 0 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^
 
 error: binding to `_` prefixed variable with no side-effect
-  --> $DIR/no_effect.rs:182:5
+  --> $DIR/no_effect.rs:182:9
    |
 LL |     let _cat = [2, 4, 6, 8][2];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^
 
 error: aborting due to 29 previous errors
 


### PR DESCRIPTION
fixes [Issue#12045](https://github.com/rust-lang/rust-clippy/issues/12045)

In issue#12045, unexpected warning span occurs on attribute `#[derive(typed_builder::TypedBuilder)]`, actually the warning should underline `_lifetime`.

In the source code we can find that the original intend is to warning on `ident.span`, but in this case, `stmt.span` is unequal with `ident.span`. So, fix the nit here is fine.

Besides, `ident.span` have an accurate range than `stmt.span`.

changelog: [`no_effect_underscore_binding`]: correct warning span
