### PR TITLE
Fix sign-handling bugs and false negatives in `cast_sign_loss`

### DIFF
--- a/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/clippy_lints/src/casts/cast_sign_loss.rs
@@ -1,5 +1,8 @@
+use std::ops::ControlFlow;
+
 use clippy_utils::consts::{constant, Constant};
 use clippy_utils::diagnostics::span_lint;
+use clippy_utils::visitors::{for_each_expr, Descend};
 use clippy_utils::{method_chain_args, sext};
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::LateContext;
@@ -216,34 +219,37 @@ fn expr_muldiv_sign(cx: &LateContext<'_>, expr: &Expr<'_>) -> Sign {
 ///
 /// Expressions using other operators are preserved, so we can try to evaluate them later.
 fn exprs_with_muldiv_binop_peeled<'e>(expr: &'e Expr<'_>) -> Vec<&'e Expr<'e>> {
-    #[inline]
-    fn collect_operands<'e>(expr: &'e Expr<'e>, operands: &mut Vec<&'e Expr<'e>>) {
-        match expr.kind {
-            ExprKind::Binary(op, lhs, rhs) => {
+    let mut res = vec![];
+
+    for_each_expr(expr, |sub_expr| {
+        match sub_expr.kind {
+            ExprKind::Binary(op, lhs, _rhs) => {
                 if matches!(op.node, BinOpKind::Mul | BinOpKind::Div) {
                     // For binary operators which both contribute to the sign of the result,
                     // collect all their operands, recursively. This ignores overflow.
-                    collect_operands(lhs, operands);
-                    collect_operands(rhs, operands);
+                    ControlFlow::Continue(Descend::Yes)
                 } else if matches!(op.node, BinOpKind::Rem) {
                     // For binary operators where the left hand side determines the sign of the result,
                     // only collect that side, recursively. Overflow panics, so this always holds.
                     //
                     // > Given remainder = dividend % divisor, the remainder will have the same sign as the dividend
                     // https://doc.rust-lang.org/reference/expressions/operator-expr.html#arithmetic-and-logical-binary-operators
-                    collect_operands(lhs, operands);
+                    res.push(lhs);
+                    ControlFlow::Break(())
                 } else {
                     // The sign of the result of other binary operators depends on the values of the operands,
                     // so try to evaluate the expression.
-                    operands.push(expr);
+                    res.push(expr);
+                    ControlFlow::Continue(Descend::No)
                 }
             },
             // For other expressions, including unary operators and constants, try to evaluate the expression.
-            _ => operands.push(expr),
+            _ => {
+                res.push(expr);
+                ControlFlow::Continue(Descend::No)
+            },
         }
-    }
+    });
 
-    let mut res = vec![];
-    collect_operands(expr, &mut res);
     res
 }

--- a/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/clippy_lints/src/casts/cast_sign_loss.rs
@@ -7,7 +7,12 @@ use rustc_middle::ty::{self, Ty, UintTy};
 
 use super::CAST_SIGN_LOSS;
 
-const METHODS_RET_POSITIVE: &[&str] = &["abs", "checked_abs", "rem_euclid", "checked_rem_euclid"];
+/// A list of methods that can never return a negative value.
+/// Includes methods that panic rather than returning a negative value.
+///
+/// Methods that can overflow and return a negative value must not be included in this list,
+/// because checking for negative return values from those functions can be useful.
+const METHODS_RET_POSITIVE: &[&str] = &["checked_abs", "rem_euclid", "checked_rem_euclid"];
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_op: &Expr<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>) {
     if should_lint(cx, cast_op, cast_from, cast_to) {
@@ -27,13 +32,15 @@ fn should_lint(cx: &LateContext<'_>, cast_op: &Expr<'_>, cast_from: Ty<'_>, cast
                 return false;
             }
 
-            // Don't lint if `cast_op` is known to be positive.
+            // Don't lint if `cast_op` is known to be positive, ignoring overflow.
             if let Sign::ZeroOrPositive = expr_sign(cx, cast_op, cast_from) {
                 return false;
             }
 
             let (mut uncertain_count, mut negative_count) = (0, 0);
-            // Peel off possible binary expressions, e.g. x * x * y => [x, x, y]
+            // Peel off possible binary expressions, for example:
+            // x * x * y => [x, x, y]
+            // a % b => [a]
             let Some(exprs) = exprs_with_selected_binop_peeled(cast_op) else {
                 // Assume cast sign lose if we cannot determine the sign of `cast_op`
                 return true;
@@ -47,8 +54,9 @@ fn should_lint(cx: &LateContext<'_>, cast_op: &Expr<'_>, cast_from: Ty<'_>, cast
                 };
             }
 
-            // Lint if there are odd number of uncertain or negative results
-            uncertain_count % 2 == 1 || negative_count % 2 == 1
+            // Lint if there are any uncertain results (because they could be negative or positive),
+            // or an odd number of negative results.
+            uncertain_count > 0 || negative_count % 2 == 1
         },
 
         (false, true) => !cast_to.is_signed(),
@@ -87,6 +95,12 @@ fn expr_sign(cx: &LateContext<'_>, expr: &Expr<'_>, ty: Ty<'_>) -> Sign {
         {
             method_name = inner_path.ident.name.as_str();
         }
+        if method_name == "expect"
+            && let Some(arglist) = method_chain_args(expr, &["expect"])
+            && let ExprKind::MethodCall(inner_path, ..) = &arglist[0].0.kind
+        {
+            method_name = inner_path.ident.name.as_str();
+        }
 
         if method_name == "pow"
             && let [arg] = args
@@ -100,53 +114,69 @@ fn expr_sign(cx: &LateContext<'_>, expr: &Expr<'_>, ty: Ty<'_>) -> Sign {
     Sign::Uncertain
 }
 
-/// Return the sign of the `pow` call's result.
+/// Return the sign of the `pow` call's result, ignoring overflow.
 ///
-/// If the caller is a positive number, the result is always positive,
-/// If the `power_of` is a even number, the result is always positive as well,
-/// Otherwise a [`Sign::Uncertain`] will be returned.
+/// If the base is positive, the result is always positive.
+/// If the base is negative, and the exponent is a even number, the result is always positive,
+/// otherwise if the exponent is an odd number, the result is always negative.
+///
+/// If either value can't be evaluated, [`Sign::Uncertain`] will be returned.
 fn pow_call_result_sign(cx: &LateContext<'_>, caller: &Expr<'_>, power_of: &Expr<'_>) -> Sign {
     let caller_ty = cx.typeck_results().expr_ty(caller);
-    if let Some(caller_val) = get_const_int_eval(cx, caller, caller_ty)
-        && caller_val >= 0
-    {
+    let Some(caller_val) = get_const_int_eval(cx, caller, caller_ty) else {
+        return Sign::Uncertain;
+    }
+    // Non-negative values raised to non-negative exponents are always non-negative, ignoring overflow.
+    // (Rust's integer pow() function takes an unsigned exponent.)
+    if caller_val >= 0 {
         return Sign::ZeroOrPositive;
     }
 
-    if let Some(Constant::Int(n)) = constant(cx, cx.typeck_results(), power_of)
-        && clip(cx.tcx, n, UintTy::U32) % 2 == 0
-    {
-        return Sign::ZeroOrPositive;
+    let Some(Constant::Int(n)) = constant(cx, cx.typeck_results(), power_of) else {
+        return Sign::Uncertain;
     }
-
-    Sign::Uncertain
+    // A negative value raised to an even exponent is non-negative, and an odd exponent
+    // is negative, ignoring overflow.
+    if clip(cx.tcx, n, UintTy::U32) % 2 == 0 0 {
+        return Sign::ZeroOrPositive;
+    } else {
+        return Sign::Negative;
+    }
 }
 
 /// Peels binary operators such as [`BinOpKind::Mul`], [`BinOpKind::Div`] or [`BinOpKind::Rem`],
-/// which the result could always be positive under certain condition.
+/// which the result could always be positive under certain conditions, ignoring overflow.
 ///
-/// Other operators such as `+`/`-` causing the result's sign hard to determine, which we will
-/// return `None`
-fn exprs_with_selected_binop_peeled<'a>(expr: &'a Expr<'_>) -> Option<Vec<&'a Expr<'a>>> {
+/// Expressions using other operators are preserved, so we can try to evaluate them later.
+fn exprs_with_selected_binop_peeled<'a>(expr: &'a Expr<'_>) -> Vec<&'a Expr<'a>> {
     #[inline]
-    fn collect_operands<'a>(expr: &'a Expr<'a>, operands: &mut Vec<&'a Expr<'a>>) -> Option<()> {
+    fn collect_operands<'a>(expr: &'a Expr<'a>, operands: &mut Vec<&'a Expr<'a>>) {
         match expr.kind {
             ExprKind::Binary(op, lhs, rhs) => {
-                if matches!(op.node, BinOpKind::Mul | BinOpKind::Div | BinOpKind::Rem) {
+                if matches!(op.node, BinOpKind::Mul | BinOpKind::Div) {
+                    // For binary operators which both contribute to the sign of the result,
+                    // collect all their operands, recursively. This ignores overflow.
                     collect_operands(lhs, operands);
-                    operands.push(rhs);
+                    collect_operands(rhs, operands);
+                } else if matches!(op.node, BinOpKind::Rem) {
+                    // For binary operators where the left hand side determines the sign of the result,
+                    // only collect that side, recursively. Overflow panics, so this always holds.
+                    //
+                    // > Given remainder = dividend % divisor, the remainder will have the same sign as the dividend
+                    // https://doc.rust-lang.org/reference/expressions/operator-expr.html#arithmetic-and-logical-binary-operators
+                    collect_operands(lhs, operands);
                 } else {
-                    // Things are complicated when there are other binary ops exist,
-                    // abort checking by returning `None` for now.
-                    return None;
+                    // The sign of the result of other binary operators depends on the values of the operands,
+                    // so try to evaluate the expression.
+                    operands.push(expr);
                 }
             },
+            // For other expressions, including unary operators and constants, try to evaluate the expression.
             _ => operands.push(expr),
         }
-        Some(())
     }
 
     let mut res = vec![];
-    collect_operands(expr, &mut res)?;
-    Some(res)
+    collect_operands(expr, &mut res);
+    res
 }

--- a/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/clippy_lints/src/casts/cast_sign_loss.rs
@@ -11,8 +11,28 @@ use super::CAST_SIGN_LOSS;
 /// Includes methods that panic rather than returning a negative value.
 ///
 /// Methods that can overflow and return a negative value must not be included in this list,
-/// because checking for negative return values from those functions can be useful.
-const METHODS_RET_POSITIVE: &[&str] = &["checked_abs", "rem_euclid", "checked_rem_euclid"];
+/// because casting their return values can still result in sign loss.
+const METHODS_RET_POSITIVE: &[&str] = &[
+    "checked_abs",
+    "saturating_abs",
+    "isqrt",
+    "checked_isqrt",
+    "rem_euclid",
+    "checked_rem_euclid",
+    "wrapping_rem_euclid",
+];
+
+/// A list of methods that act like `pow()`, and can never return:
+/// - a negative value from a non-negative base
+/// - a negative value from a negative base and even exponent
+/// - a non-negative value from a negative base and odd exponent
+///
+/// Methods that can overflow and return a negative value must not be included in this list,
+/// because casting their return values can still result in sign loss.
+const METHODS_POW: &[&str] = &["pow", "saturating_pow", "checked_pow"];
+
+/// A list of methods that act like `unwrap()`, and don't change the sign of the inner value.
+const METHODS_UNWRAP: &[&str] = &["unwrap", "unwrap_unchecked", "expect", "into_ok"];
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_op: &Expr<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>) {
     if should_lint(cx, cast_op, cast_from, cast_to) {

--- a/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/clippy_lints/src/casts/cast_sign_loss.rs
@@ -173,17 +173,18 @@ fn pow_call_result_sign(cx: &LateContext<'_>, base: &Expr<'_>, exponent: &Expr<'
 
     match (base_sign, exponent_is_even) {
         // Non-negative bases always return non-negative results, ignoring overflow.
-        (Sign::ZeroOrPositive, _) => Sign::ZeroOrPositive,
-
+        (Sign::ZeroOrPositive, _) |
         // Any base raised to an even exponent is non-negative.
-        // This is true even if we don't know the value of the base.
-        (_, Some(true)) => Sign::ZeroOrPositive,
+        // These both hold even if we don't know the value of the base.
+        (_, Some(true))
+            => Sign::ZeroOrPositive,
 
         // A negative base raised to an odd exponent is non-negative.
         (Sign::Negative, Some(false)) => Sign::Negative,
 
-        // Negative or unknown base to an unknown exponent, or an unknown base to an odd exponent.
-        (Sign::Negative | Sign::Uncertain, None) => Sign::Uncertain,
+        // Negative/unknown base to an unknown exponent, or unknown base to an odd exponent.
+        // Could be negative or positive depending on the actual values.
+        (Sign::Negative | Sign::Uncertain, None) |
         (Sign::Uncertain, Some(false)) => Sign::Uncertain,
     }
 }

--- a/clippy_lints/src/casts/cast_sign_loss.rs
+++ b/clippy_lints/src/casts/cast_sign_loss.rs
@@ -63,6 +63,7 @@ fn should_lint<'cx>(cx: &LateContext<'cx>, cast_op: &Expr<'_>, cast_from: Ty<'cx
                 return false;
             }
 
+            // We don't check for sums of all-positive or all-negative values, but we could.
             if let Sign::ZeroOrPositive = expr_muldiv_sign(cx, cast_op) {
                 return false;
             }
@@ -222,6 +223,7 @@ fn exprs_with_muldiv_binop_peeled<'e>(expr: &'e Expr<'_>) -> Vec<&'e Expr<'e>> {
     let mut res = vec![];
 
     for_each_expr(expr, |sub_expr| {
+        // We don't check for mul/div/rem methods here, but we could.
         if let ExprKind::Binary(op, lhs, _rhs) = sub_expr.kind {
             if matches!(op.node, BinOpKind::Mul | BinOpKind::Div) {
                 // For binary operators which both contribute to the sign of the result,

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -1,6 +1,7 @@
 //@no-rustfix
 
 #![feature(repr128)]
+#![feature(isqrt)]
 #![allow(incomplete_features)]
 #![warn(
     clippy::cast_precision_loss,
@@ -149,8 +150,8 @@ fn main() {
     (-1isize).checked_isqrt().expect("-1 is a small number") as usize;
 
     (-1i8).rem_euclid(1i8) as u8;
-    (-1i8).wrapping_rem_euclid(1i8).unwrap() as u16;
-    (-1i16).rem_euclid(1i16).unwrap() as u16;
+    (-1i8).wrapping_rem_euclid(1i8) as u16;
+    (-1i16).rem_euclid(1i16) as u16;
     (-1i16).rem_euclid(1i16) as u32;
     (-1i32).rem_euclid(1i32) as u32;
     (-1i32).rem_euclid(1i32) as u64;
@@ -400,11 +401,11 @@ fn issue11642() {
     (-2_i32).pow(3) as u32;
     //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
 
-    (2_i32 % 1) as u32;
-    (2_i32 % -1) as u32;
-    (-2_i32 % 1) as u32;
+    (3_i32 % 2) as u32;
+    (3_i32 % -2) as u32;
+    (-5_i32 % 2) as u32;
     //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
-    (-2_i32 % -1) as u32;
+    (-5_i32 % -2) as u32;
     //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
     (2_i32 >> 1) as u32;
     (-2_i32 >> 1) as u32;

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -116,21 +116,41 @@ fn main() {
     i64::MAX as u64;
     i128::MAX as u128;
 
-    (-1i8).abs() as u8;
-    (-1i16).abs() as u16;
-    (-1i32).abs() as u32;
+    (-1i8).saturating_abs() as u8;
+    // abs() can return a negative value in release builds
+    (i8::MIN).abs() as u8;
+    //~^ ERROR: casting `i8` to `u8` may lose the sign of the value
+    (-1i16).saturating_abs() as u16;
+    (-1i32).saturating_abs() as u32;
     (-1i64).abs() as u64;
     (-1isize).abs() as usize;
 
     (-1i8).checked_abs().unwrap() as u8;
+    (i8::MIN).checked_abs().unwrap() as u8;
     (-1i16).checked_abs().unwrap() as u16;
     (-1i32).checked_abs().unwrap() as u32;
-    (-1i64).checked_abs().unwrap() as u64;
-    (-1isize).checked_abs().unwrap() as usize;
+    // SAFETY: -1 is a small number which will always return Some
+    (unsafe { (-1i64).checked_abs().unwrap_unchecked() }) as u64;
+    (-1isize).checked_abs().expect("-1 is a small number") as usize;
+
+    (-1i8).isqrt() as u8;
+    (i8::MIN).isqrt() as u8;
+    (-1i16).isqrt() as u16;
+    (-1i32).isqrt() as u32;
+    (-1i64).isqrt() as u64;
+    (-1isize).isqrt() as usize;
+
+    (-1i8).checked_isqrt().unwrap() as u8;
+    (i8::MIN).checked_isqrt().unwrap() as u8;
+    (-1i16).checked_isqrt().unwrap() as u16;
+    (-1i32).checked_isqrt().unwrap() as u32;
+    // SAFETY: -1 is a small number which will always return Some
+    (unsafe { (-1i64).checked_isqrt().unwrap_unchecked() }) as u64;
+    (-1isize).checked_isqrt().expect("-1 is a small number") as usize;
 
     (-1i8).rem_euclid(1i8) as u8;
-    (-1i8).rem_euclid(1i8) as u16;
-    (-1i16).rem_euclid(1i16) as u16;
+    (-1i8).wrapping_rem_euclid(1i8).unwrap() as u16;
+    (-1i16).rem_euclid(1i16).unwrap() as u16;
     (-1i16).rem_euclid(1i16) as u32;
     (-1i32).rem_euclid(1i32) as u32;
     (-1i32).rem_euclid(1i32) as u64;
@@ -138,7 +158,7 @@ fn main() {
     (-1i64).rem_euclid(1i64) as u128;
     (-1isize).rem_euclid(1isize) as usize;
     (1i8).rem_euclid(-1i8) as u8;
-    (1i8).rem_euclid(-1i8) as u16;
+    (1i8).wrapping_rem_euclid(-1i8) as u16;
     (1i16).rem_euclid(-1i16) as u16;
     (1i16).rem_euclid(-1i16) as u32;
     (1i32).rem_euclid(-1i32) as u32;
@@ -371,12 +391,23 @@ fn issue11642() {
         let x = x as i32;
         (x * x) as u32;
         x.pow(2) as u32;
-        (-2_i32).pow(2) as u32
+        (-2_i32).saturating_pow(2) as u32
     }
 
     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
 
+    (2_i32).checked_pow(3).unwrap() as u32;
     (-2_i32).pow(3) as u32;
+    //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
+
+    (2_i32 % 1) as u32;
+    (2_i32 % -1) as u32;
+    (-2_i32 % 1) as u32;
+    //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
+    (-2_i32 % -1) as u32;
+    //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
+    (2_i32 >> 1) as u32;
+    (-2_i32 >> 1) as u32;
     //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
 
     let x: i32 = 10;
@@ -387,11 +418,21 @@ fn issue11642() {
     let y: i16 = -2;
     (y * y * y * y * -2) as u16;
     //~^ ERROR: casting `i16` to `u16` may lose the sign of the value
-    (y * y * y * y * 2) as u16;
-    (y * y * y * 2) as u16;
+    (y * y * y / y * 2) as u16;
+    (y * y / y * 2) as u16;
     //~^ ERROR: casting `i16` to `u16` may lose the sign of the value
-    (y * y * y * -2) as u16;
+    (y / y * y * -2) as u16;
     //~^ ERROR: casting `i16` to `u16` may lose the sign of the value
+
+    (y + y + y + -2) as u16;
+    //~^ ERROR: casting `i16` to `u16` may lose the sign of the value
+    (y + y + y + 2) as u16;
+    //~^ ERROR: casting `i16` to `u16` may lose the sign of the value
+
+    let z: i16 = 2;
+    (z + -2) as u16;
+    //~^ ERROR: casting `i16` to `u16` may lose the sign of the value
+    (z + z + 2) as u16;
 
     fn foo(a: i32, b: i32, c: i32) -> u32 {
         (a * a * b * b * c * c) as u32;
@@ -409,8 +450,9 @@ fn issue11642() {
         //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
         (a / b + b * c) as u32;
         //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
-        a.pow(3) as u32;
+        a.saturating_pow(3) as u32;
         //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
         (a.abs() * b.pow(2) / c.abs()) as u32
+        //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
     }
 }

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -600,5 +600,5 @@ error: casting `i32` to `u32` may lose the sign of the value
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 77 previous errors
+error: aborting due to 76 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -1,5 +1,5 @@
 error: casting `i32` to `f32` causes a loss of precision (`i32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:16:5
+  --> tests/ui/cast.rs:17:5
    |
 LL |     x0 as f32;
    |     ^^^^^^^^^
@@ -8,37 +8,37 @@ LL |     x0 as f32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_precision_loss)]`
 
 error: casting `i64` to `f32` causes a loss of precision (`i64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:20:5
+  --> tests/ui/cast.rs:21:5
    |
 LL |     x1 as f32;
    |     ^^^^^^^^^
 
 error: casting `i64` to `f64` causes a loss of precision (`i64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:22:5
+  --> tests/ui/cast.rs:23:5
    |
 LL |     x1 as f64;
    |     ^^^^^^^^^
 
 error: casting `u32` to `f32` causes a loss of precision (`u32` is 32 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:25:5
+  --> tests/ui/cast.rs:26:5
    |
 LL |     x2 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f32` causes a loss of precision (`u64` is 64 bits wide, but `f32`'s mantissa is only 23 bits wide)
-  --> tests/ui/cast.rs:28:5
+  --> tests/ui/cast.rs:29:5
    |
 LL |     x3 as f32;
    |     ^^^^^^^^^
 
 error: casting `u64` to `f64` causes a loss of precision (`u64` is 64 bits wide, but `f64`'s mantissa is only 52 bits wide)
-  --> tests/ui/cast.rs:30:5
+  --> tests/ui/cast.rs:31:5
    |
 LL |     x3 as f64;
    |     ^^^^^^^^^
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:33:5
+  --> tests/ui/cast.rs:34:5
    |
 LL |     1f32 as i32;
    |     ^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     1f32 as i32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_truncation)]`
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:35:5
+  --> tests/ui/cast.rs:36:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     1f32 as u32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:35:5
+  --> tests/ui/cast.rs:36:5
    |
 LL |     1f32 as u32;
    |     ^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     1f32 as u32;
    = help: to override `-D warnings` add `#[allow(clippy::cast_sign_loss)]`
 
 error: casting `f64` to `f32` may truncate the value
-  --> tests/ui/cast.rs:39:5
+  --> tests/ui/cast.rs:40:5
    |
 LL |     1f64 as f32;
    |     ^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     1f64 as f32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:41:5
+  --> tests/ui/cast.rs:42:5
    |
 LL |     1i32 as i8;
    |     ^^^^^^^^^^
@@ -85,7 +85,7 @@ LL |     i8::try_from(1i32);
    |     ~~~~~~~~~~~~~~~~~~
 
 error: casting `i32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:43:5
+  --> tests/ui/cast.rs:44:5
    |
 LL |     1i32 as u8;
    |     ^^^^^^^^^^
@@ -97,7 +97,7 @@ LL |     u8::try_from(1i32);
    |     ~~~~~~~~~~~~~~~~~~
 
 error: casting `f64` to `isize` may truncate the value
-  --> tests/ui/cast.rs:45:5
+  --> tests/ui/cast.rs:46:5
    |
 LL |     1f64 as isize;
    |     ^^^^^^^^^^^^^
@@ -105,7 +105,7 @@ LL |     1f64 as isize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may truncate the value
-  --> tests/ui/cast.rs:47:5
+  --> tests/ui/cast.rs:48:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
@@ -113,13 +113,13 @@ LL |     1f64 as usize;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:47:5
+  --> tests/ui/cast.rs:48:5
    |
 LL |     1f64 as usize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u32` to `u16` may truncate the value
-  --> tests/ui/cast.rs:50:5
+  --> tests/ui/cast.rs:51:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     u16::try_from(1f32 as u32);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `f32` to `u32` may truncate the value
-  --> tests/ui/cast.rs:50:5
+  --> tests/ui/cast.rs:51:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
@@ -139,13 +139,13 @@ LL |     1f32 as u32 as u16;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:50:5
+  --> tests/ui/cast.rs:51:5
    |
 LL |     1f32 as u32 as u16;
    |     ^^^^^^^^^^^
 
 error: casting `i32` to `i8` may truncate the value
-  --> tests/ui/cast.rs:55:22
+  --> tests/ui/cast.rs:56:22
    |
 LL |         let _x: i8 = 1i32 as _;
    |                      ^^^^^^^^^
@@ -157,7 +157,7 @@ LL |         let _x: i8 = 1i32.try_into();
    |                      ~~~~~~~~~~~~~~~
 
 error: casting `f32` to `i32` may truncate the value
-  --> tests/ui/cast.rs:57:9
+  --> tests/ui/cast.rs:58:9
    |
 LL |         1f32 as i32;
    |         ^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL |         1f32 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f64` to `i32` may truncate the value
-  --> tests/ui/cast.rs:59:9
+  --> tests/ui/cast.rs:60:9
    |
 LL |         1f64 as i32;
    |         ^^^^^^^^^^^
@@ -173,7 +173,7 @@ LL |         1f64 as i32;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:61:9
+  --> tests/ui/cast.rs:62:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
@@ -181,13 +181,13 @@ LL |         1f32 as u8;
    = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
 
 error: casting `f32` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:61:9
+  --> tests/ui/cast.rs:62:9
    |
 LL |         1f32 as u8;
    |         ^^^^^^^^^^
 
 error: casting `u8` to `i8` may wrap around the value
-  --> tests/ui/cast.rs:66:5
+  --> tests/ui/cast.rs:67:5
    |
 LL |     1u8 as i8;
    |     ^^^^^^^^^
@@ -196,31 +196,31 @@ LL |     1u8 as i8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_possible_wrap)]`
 
 error: casting `u16` to `i16` may wrap around the value
-  --> tests/ui/cast.rs:69:5
+  --> tests/ui/cast.rs:70:5
    |
 LL |     1u16 as i16;
    |     ^^^^^^^^^^^
 
 error: casting `u32` to `i32` may wrap around the value
-  --> tests/ui/cast.rs:71:5
+  --> tests/ui/cast.rs:72:5
    |
 LL |     1u32 as i32;
    |     ^^^^^^^^^^^
 
 error: casting `u64` to `i64` may wrap around the value
-  --> tests/ui/cast.rs:73:5
+  --> tests/ui/cast.rs:74:5
    |
 LL |     1u64 as i64;
    |     ^^^^^^^^^^^
 
 error: casting `usize` to `isize` may wrap around the value
-  --> tests/ui/cast.rs:75:5
+  --> tests/ui/cast.rs:76:5
    |
 LL |     1usize as isize;
    |     ^^^^^^^^^^^^^^^
 
 error: casting `usize` to `i8` may truncate the value
-  --> tests/ui/cast.rs:78:5
+  --> tests/ui/cast.rs:79:5
    |
 LL |     1usize as i8;
    |     ^^^^^^^^^^^^
@@ -232,7 +232,7 @@ LL |     i8::try_from(1usize);
    |     ~~~~~~~~~~~~~~~~~~~~
 
 error: casting `usize` to `i16` may truncate the value
-  --> tests/ui/cast.rs:81:5
+  --> tests/ui/cast.rs:82:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -244,7 +244,7 @@ LL |     i16::try_from(1usize);
    |     ~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `usize` to `i16` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:81:5
+  --> tests/ui/cast.rs:82:5
    |
 LL |     1usize as i16;
    |     ^^^^^^^^^^^^^
@@ -253,7 +253,7 @@ LL |     1usize as i16;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `usize` to `i32` may truncate the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:86:5
+  --> tests/ui/cast.rs:87:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
@@ -265,19 +265,19 @@ LL |     i32::try_from(1usize);
    |     ~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `usize` to `i32` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:86:5
+  --> tests/ui/cast.rs:87:5
    |
 LL |     1usize as i32;
    |     ^^^^^^^^^^^^^
 
 error: casting `usize` to `i64` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:90:5
+  --> tests/ui/cast.rs:91:5
    |
 LL |     1usize as i64;
    |     ^^^^^^^^^^^^^
 
 error: casting `u16` to `isize` may wrap around the value on targets with 16-bit wide pointers
-  --> tests/ui/cast.rs:95:5
+  --> tests/ui/cast.rs:96:5
    |
 LL |     1u16 as isize;
    |     ^^^^^^^^^^^^^
@@ -286,13 +286,13 @@ LL |     1u16 as isize;
    = note: for more information see https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
 
 error: casting `u32` to `isize` may wrap around the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:99:5
+  --> tests/ui/cast.rs:100:5
    |
 LL |     1u32 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `u64` to `isize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:102:5
+  --> tests/ui/cast.rs:103:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
@@ -304,55 +304,55 @@ LL |     isize::try_from(1u64);
    |     ~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `u64` to `isize` may wrap around the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:102:5
+  --> tests/ui/cast.rs:103:5
    |
 LL |     1u64 as isize;
    |     ^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:107:5
+  --> tests/ui/cast.rs:108:5
    |
 LL |     -1i32 as u32;
    |     ^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:110:5
+  --> tests/ui/cast.rs:111:5
    |
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
 error: casting `i8` to `u8` may lose the sign of the value
-  --> tests/ui/cast.rs:119:5
+  --> tests/ui/cast.rs:122:5
    |
-LL |     (-1i8).abs() as u8;
-   |     ^^^^^^^^^^^^^^^^^^
-
-error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:120:5
-   |
-LL |     (-1i16).abs() as u16;
-   |     ^^^^^^^^^^^^^^^^^^^^
-
-error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:121:5
-   |
-LL |     (-1i32).abs() as u32;
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL |     (i8::MIN).abs() as u8;
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i64` to `u64` may lose the sign of the value
-  --> tests/ui/cast.rs:122:5
+  --> tests/ui/cast.rs:126:5
    |
 LL |     (-1i64).abs() as u64;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: casting `isize` to `usize` may lose the sign of the value
-  --> tests/ui/cast.rs:123:5
+  --> tests/ui/cast.rs:127:5
    |
 LL |     (-1isize).abs() as usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: casting `i64` to `u64` may lose the sign of the value
+  --> tests/ui/cast.rs:134:5
+   |
+LL |     (unsafe { (-1i64).checked_abs().unwrap_unchecked() }) as u64;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i64` to `u64` may lose the sign of the value
+  --> tests/ui/cast.rs:149:5
+   |
+LL |     (unsafe { (-1i64).checked_isqrt().unwrap_unchecked() }) as u64;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: casting `i64` to `i8` may truncate the value
-  --> tests/ui/cast.rs:179:5
+  --> tests/ui/cast.rs:200:5
    |
 LL |     (-99999999999i64).min(1) as i8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -364,7 +364,7 @@ LL |     i8::try_from((-99999999999i64).min(1));
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `u64` to `u8` may truncate the value
-  --> tests/ui/cast.rs:193:5
+  --> tests/ui/cast.rs:214:5
    |
 LL |     999999u64.clamp(0, 256) as u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -376,7 +376,7 @@ LL |     u8::try_from(999999u64.clamp(0, 256));
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `main::E2` to `u8` may truncate the value
-  --> tests/ui/cast.rs:216:21
+  --> tests/ui/cast.rs:237:21
    |
 LL |             let _ = self as u8;
    |                     ^^^^^^^^^^
@@ -388,7 +388,7 @@ LL |             let _ = u8::try_from(self);
    |                     ~~~~~~~~~~~~~~~~~~
 
 error: casting `main::E2::B` to `u8` will truncate the value
-  --> tests/ui/cast.rs:218:21
+  --> tests/ui/cast.rs:239:21
    |
 LL |             let _ = Self::B as u8;
    |                     ^^^^^^^^^^^^^
@@ -397,7 +397,7 @@ LL |             let _ = Self::B as u8;
    = help: to override `-D warnings` add `#[allow(clippy::cast_enum_truncation)]`
 
 error: casting `main::E5` to `i8` may truncate the value
-  --> tests/ui/cast.rs:260:21
+  --> tests/ui/cast.rs:281:21
    |
 LL |             let _ = self as i8;
    |                     ^^^^^^^^^^
@@ -409,13 +409,13 @@ LL |             let _ = i8::try_from(self);
    |                     ~~~~~~~~~~~~~~~~~~
 
 error: casting `main::E5::A` to `i8` will truncate the value
-  --> tests/ui/cast.rs:262:21
+  --> tests/ui/cast.rs:283:21
    |
 LL |             let _ = Self::A as i8;
    |                     ^^^^^^^^^^^^^
 
 error: casting `main::E6` to `i16` may truncate the value
-  --> tests/ui/cast.rs:279:21
+  --> tests/ui/cast.rs:300:21
    |
 LL |             let _ = self as i16;
    |                     ^^^^^^^^^^^
@@ -427,7 +427,7 @@ LL |             let _ = i16::try_from(self);
    |                     ~~~~~~~~~~~~~~~~~~~
 
 error: casting `main::E7` to `usize` may truncate the value on targets with 32-bit wide pointers
-  --> tests/ui/cast.rs:298:21
+  --> tests/ui/cast.rs:319:21
    |
 LL |             let _ = self as usize;
    |                     ^^^^^^^^^^^^^
@@ -439,7 +439,7 @@ LL |             let _ = usize::try_from(self);
    |                     ~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `main::E10` to `u16` may truncate the value
-  --> tests/ui/cast.rs:345:21
+  --> tests/ui/cast.rs:366:21
    |
 LL |             let _ = self as u16;
    |                     ^^^^^^^^^^^
@@ -451,7 +451,7 @@ LL |             let _ = u16::try_from(self);
    |                     ~~~~~~~~~~~~~~~~~~~
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:356:13
+  --> tests/ui/cast.rs:377:13
    |
 LL |     let c = (q >> 16) as u8;
    |             ^^^^^^^^^^^^^^^
@@ -463,7 +463,7 @@ LL |     let c = u8::try_from(q >> 16);
    |             ~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `u32` to `u8` may truncate the value
-  --> tests/ui/cast.rs:360:13
+  --> tests/ui/cast.rs:381:13
    |
 LL |     let c = (q / 1000) as u8;
    |             ^^^^^^^^^^^^^^^^
@@ -475,124 +475,180 @@ LL |     let c = u8::try_from(q / 1000);
    |             ~~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:372:9
+  --> tests/ui/cast.rs:393:9
    |
 LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:377:32
+  --> tests/ui/cast.rs:398:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
    |                                ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:379:5
+  --> tests/ui/cast.rs:400:5
+   |
+LL |     (2_i32).checked_pow(3).unwrap() as u32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:401:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:383:5
+  --> tests/ui/cast.rs:406:5
+   |
+LL |     (-5_i32 % 2) as u32;
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:408:5
+   |
+LL |     (-5_i32 % -2) as u32;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:411:5
+   |
+LL |     (-2_i32 >> 1) as u32;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:415:5
    |
 LL |     (x * x) as u32;
    |     ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:384:5
+  --> tests/ui/cast.rs:416:5
    |
 LL |     (x * x * x) as u32;
    |     ^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:388:5
+  --> tests/ui/cast.rs:420:5
    |
 LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:390:5
+  --> tests/ui/cast.rs:422:5
    |
-LL |     (y * y * y * y * 2) as u16;
+LL |     (y * y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:391:5
+  --> tests/ui/cast.rs:423:5
    |
-LL |     (y * y * y * 2) as u16;
+LL |     (y * y / y * 2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
-  --> tests/ui/cast.rs:393:5
+  --> tests/ui/cast.rs:425:5
    |
-LL |     (y * y * y * -2) as u16;
+LL |     (y / y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
+error: equal expressions as operands to `/`
+  --> tests/ui/cast.rs:425:6
+   |
+LL |     (y / y * y * -2) as u16;
+   |      ^^^^^
+   |
+   = note: `#[deny(clippy::eq_op)]` on by default
+
+error: casting `i16` to `u16` may lose the sign of the value
+  --> tests/ui/cast.rs:428:5
+   |
+LL |     (y + y + y + -2) as u16;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i16` to `u16` may lose the sign of the value
+  --> tests/ui/cast.rs:430:5
+   |
+LL |     (y + y + y + 2) as u16;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i16` to `u16` may lose the sign of the value
+  --> tests/ui/cast.rs:434:5
+   |
+LL |     (z + -2) as u16;
+   |     ^^^^^^^^^^^^^^^
+
+error: casting `i16` to `u16` may lose the sign of the value
+  --> tests/ui/cast.rs:436:5
+   |
+LL |     (z + z + 2) as u16;
+   |     ^^^^^^^^^^^^^^^^^^
+
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:397:9
+  --> tests/ui/cast.rs:439:9
    |
 LL |         (a * a * b * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:398:9
+  --> tests/ui/cast.rs:440:9
    |
 LL |         (a * b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:400:9
+  --> tests/ui/cast.rs:442:9
    |
 LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:402:9
+  --> tests/ui/cast.rs:444:9
    |
 LL |         (a * b * c * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:403:9
+  --> tests/ui/cast.rs:445:9
    |
 LL |         (a * -2) as u32;
    |         ^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:405:9
+  --> tests/ui/cast.rs:447:9
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:407:9
+  --> tests/ui/cast.rs:449:9
    |
 LL |         (a / b) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:408:9
+  --> tests/ui/cast.rs:450:9
    |
 LL |         (a / b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:410:9
+  --> tests/ui/cast.rs:452:9
    |
 LL |         (a / b + b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:412:9
+  --> tests/ui/cast.rs:454:9
    |
-LL |         a.pow(3) as u32;
-   |         ^^^^^^^^^^^^^^^
+LL |         a.saturating_pow(3) as u32;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:414:9
+  --> tests/ui/cast.rs:456:9
    |
 LL |         (a.abs() * b.pow(2) / c.abs()) as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 76 previous errors
+error: aborting due to 85 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -321,6 +321,36 @@ error: casting `isize` to `usize` may lose the sign of the value
 LL |     -1isize as usize;
    |     ^^^^^^^^^^^^^^^^
 
+error: casting `i8` to `u8` may lose the sign of the value
+  --> tests/ui/cast.rs:119:5
+   |
+LL |     (-1i8).abs() as u8;
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: casting `i16` to `u16` may lose the sign of the value
+  --> tests/ui/cast.rs:120:5
+   |
+LL |     (-1i16).abs() as u16;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:121:5
+   |
+LL |     (-1i32).abs() as u32;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i64` to `u64` may lose the sign of the value
+  --> tests/ui/cast.rs:122:5
+   |
+LL |     (-1i64).abs() as u64;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: casting `isize` to `usize` may lose the sign of the value
+  --> tests/ui/cast.rs:123:5
+   |
+LL |     (-1isize).abs() as usize;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: casting `i64` to `i8` may truncate the value
   --> tests/ui/cast.rs:179:5
    |
@@ -445,10 +475,34 @@ LL |     let c = u8::try_from(q / 1000);
    |             ~~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:372:9
+   |
+LL |         (x * x) as u32;
+   |         ^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:373:9
+   |
+LL |         x.pow(2) as u32;
+   |         ^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:377:32
+   |
+LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };
+   |                                ^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
   --> tests/ui/cast.rs:379:5
    |
 LL |     (-2_i32).pow(3) as u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:383:5
+   |
+LL |     (x * x) as u32;
+   |     ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
   --> tests/ui/cast.rs:384:5
@@ -463,6 +517,12 @@ LL |     (y * y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i16` to `u16` may lose the sign of the value
+  --> tests/ui/cast.rs:390:5
+   |
+LL |     (y * y * y * y * 2) as u16;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i16` to `u16` may lose the sign of the value
   --> tests/ui/cast.rs:391:5
    |
 LL |     (y * y * y * 2) as u16;
@@ -473,6 +533,12 @@ error: casting `i16` to `u16` may lose the sign of the value
    |
 LL |     (y * y * y * -2) as u16;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:397:9
+   |
+LL |         (a * a * b * b * c * c) as u32;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
   --> tests/ui/cast.rs:398:9
@@ -487,6 +553,12 @@ LL |         (a * -b * c) as u32;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:402:9
+   |
+LL |         (a * b * c * c) as u32;
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
   --> tests/ui/cast.rs:403:9
    |
 LL |         (a * -2) as u32;
@@ -497,6 +569,12 @@ error: casting `i32` to `u32` may lose the sign of the value
    |
 LL |         (a * b * c * -2) as u32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:407:9
+   |
+LL |         (a / b) as u32;
+   |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
   --> tests/ui/cast.rs:408:9
@@ -516,5 +594,11 @@ error: casting `i32` to `u32` may lose the sign of the value
 LL |         a.pow(3) as u32;
    |         ^^^^^^^^^^^^^^^
 
-error: aborting due to 63 previous errors
+error: casting `i32` to `u32` may lose the sign of the value
+  --> tests/ui/cast.rs:414:9
+   |
+LL |         (a.abs() * b.pow(2) / c.abs()) as u32
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 77 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -481,12 +481,6 @@ LL |         (x * x) as u32;
    |         ^^^^^^^^^^^^^^
 
 error: casting `i32` to `u32` may lose the sign of the value
-  --> tests/ui/cast.rs:373:9
-   |
-LL |         x.pow(2) as u32;
-   |         ^^^^^^^^^^^^^^^
-
-error: casting `i32` to `u32` may lose the sign of the value
   --> tests/ui/cast.rs:377:32
    |
 LL |     let _a = |x: i32| -> u32 { (x * x * x * x) as u32 };


### PR DESCRIPTION
**Note: anyone should feel free to move this PR forward, I might not see notifications from reviewers.**


changelog: [`cast_sign_loss`]: Fix sign-handling bugs and false negatives

This PR fixes some arithmetic bugs and false negatives in PR #11883 (and maybe earlier PRs).
Cc @J-ZhengLi

I haven't updated the tests yet. I was hoping for some initial feedback before adding tests to cover the cases listed below.

Here are the issues I've attempted to fix:

#### `abs()` can return a negative value in release builds

Example:
```rust
i32::MIN.abs()
```
https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=022d200f9ef6ee72f629c0c9c1af11b8

Docs: https://doc.rust-lang.org/std/primitive.i32.html#method.abs

Other overflows that produce negative values could cause false negatives (and underflows could produce false positives), but they're harder to detect.

#### Values with uncertain signs can be positive or negative

Any number of values with uncertain signs cause the whole expression to have an uncertain sign, because an uncertain sign can be positive or negative.

Example (from UI tests):
```rust
fn main() {
    foo(a: i32, b: i32, c: i32) -> u32 {
        (a * b * c * c) as u32
        //~^ ERROR: casting `i32` to `u32` may lose the sign of the value
    }
    
    println!("{}", foo(1, -1, 1));
}
```
https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=165d2e2676ee8343b1b9fe60db32aadd

#### Handle `expect()` the same way as `unwrap()`

Since we're ignoring `unwrap()` we might as well do the same with `expect()`.

This doesn't seem to have tests but I'm happy to add some like `Some(existing_test).unwrap() as u32`.

#### A negative base to an odd exponent is guaranteed to be negative

An integer `pow()`'s sign is only uncertain when its operants are uncertain. (Ignoring overflow.)

Example:
```rust
((-2_i32).pow(3) * -2) as u32
```

This offsets some of the false positives created by one or more uncertain signs producing an uncertain sign. (Rather than just an odd number of uncertain signs.)

#### Both sides of a multiply or divide should be peeled recursively

I'm not sure why the lhs was peeled recursively, and the rhs was left intact. But the sign of any sequence of multiplies and divides is determined by the signs of its operands. (Ignoring overflow.)

I'm not sure what to use as an example here, because most expressions I want to use are const-evaluable.

But if `p()` is [a non-const function that returns a positive value](https://doc.rust-lang.org/std/primitive.i32.html#method.isqrt), and if the lint handles unary negation, these should all lint:
```rust
fn peel_all(x: i32) {
    (-p(x) * -p(x) * -p(x)) as u32;
    ((-p(x) * -p(x)) * -p(x)) as u32;
    (-p(x) * (-p(x) * -p(x))) as u32;
}
```

#### The right hand side of a Rem doesn't change the sign

Unlike Mul and Div,
> Given remainder = dividend % divisor, the remainder will have the same sign as the dividend.
https://doc.rust-lang.org/reference/expressions/operator-expr.html#arithmetic-and-logical-binary-operators

I'm not sure what to use as an example here, because most expressions I want to use are const-evaluable.

But if `p()` is [a non-const function that returns a positive value](https://doc.rust-lang.org/std/primitive.i32.html#method.isqrt), and if the lint handles unary negation, only the first six expressions should lint.

The expressions that start with a constant should lint (or not lint) regardless of whether the lint supports `p()` or unary negation, because only the dividend's sign matters.

Example:
```rust
fn rem_lhs(x: i32) {
    (-p(x) % -1) as u32;
    (-p(x) % 1) as u32;
    (-1 % -p(x)) as u32;
    (-1 % p(x)) as u32;
    (-1 % -x) as u32;
    (-1 % x) as u32;
    // These shouldn't lint:
    (p(x) % -1) as u32;
    (p(x) % 1) as u32;
    (1 % -p(x)) as u32;
    (1 % p(x)) as u32;
    (1 % -x) as u32;
    (1 % x) as u32;
}
```

#### There's no need to bail on other expressions

When peeling, any other operators or expressions can be left intact and sent to the constant evaluator.

If these expressions can be evaluated, this offsets some of the false positives created by one or more uncertain signs producing an uncertain sign. If not, they end up marked as having uncertain sign.