### PR TITLE
Remove giraffate from the reviewer rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -28,7 +28,6 @@ users_on_vacation = ["blyxyas"]
 "*" = [
     "@Manishearth",
     "@llogiq",
-    "@giraffate",
     "@xFrednet",
     "@Alexendoo",
     "@dswij",


### PR DESCRIPTION
I've been less active in Clippy recently because I'm so busy that I don't have time for maintaining Clippy in my spare time. So, I remove myself from the reviewer rotation once. I hope to come back again.

I'll reassign the PRs later.

changelog: none
