### PR TITLE
I'm not on vacation (again)

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,7 +19,6 @@ new_pr = true
 
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
-users_on_vacation = ["blyxyas"]
 
 [assign.owners]
 "/.github" = ["@flip1995"]


### PR DESCRIPTION
A few weeks ago I opened #12011 removing me from `users_on_vacation`, it got merged. The subtree sync reverted this change (weirdly)

changelog: none

r? @xFrednet