### PR TITLE
Update `comparison_chain` lint solution to make it work with `no_std` as well

### DIFF
--- a/clippy_lints/src/comparison_chain.rs
+++ b/clippy_lints/src/comparison_chain.rs
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     ///
     /// Use instead:
     /// ```rust,ignore
-    /// use std::cmp::Ordering;
+    /// use core::cmp::Ordering;
     /// # fn a() {}
     /// # fn b() {}
     /// # fn c() {}


### PR DESCRIPTION
Fixes #11785.

Just a small sentence fix to also make it work in `no_std` crates.

r? @llogiq 

changelog: Update `comparison_chain` lint solution to make it work with `no_std` as well