### PR TITLE
Add . to end of lint lists in configuration + Fix typo in pub_underscore_fields_behavior

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -769,6 +769,8 @@ Additional dotfiles (files or directories starting with a dot) to allow
 
 
 ## `enforce-iter-loop-reborrow`
+Whether to recommend using implicit into iter for reborrowed values.
+
 #### Example
 ```no_run
 let mut vec = vec![1, 2, 3];
@@ -793,7 +795,7 @@ for _ in &mut *rmvec {}
 
 
 ## `check-private-items`
-
+Whether to also run the listed lints on private items.
 
 **Default Value:** `false`
 
@@ -806,7 +808,8 @@ for _ in &mut *rmvec {}
 
 
 ## `pub-underscore-fields-behavior`
-
+Meow "public" fields in a struct that are prefixed with an underscore based on their
+exported visibility, or whether they are marked as "pub".
 
 **Default Value:** `"PublicallyExported"`
 

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -808,10 +808,10 @@ Whether to also run the listed lints on private items.
 
 
 ## `pub-underscore-fields-behavior`
-Meow "public" fields in a struct that are prefixed with an underscore based on their
+Lint "public" fields in a struct that are prefixed with an underscore based on their
 exported visibility, or whether they are marked as "pub".
 
-**Default Value:** `"PublicallyExported"`
+**Default Value:** `"PubliclyExported"`
 
 ---
 **Affected lints:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -551,7 +551,7 @@ define_Conf! {
     ///
     /// Lint "public" fields in a struct that are prefixed with an underscore based on their
     /// exported visibility, or whether they are marked as "pub".
-    (pub_underscore_fields_behavior: PubUnderscoreFieldsBehaviour = PubUnderscoreFieldsBehaviour::PublicallyExported),
+    (pub_underscore_fields_behavior: PubUnderscoreFieldsBehaviour = PubUnderscoreFieldsBehaviour::PubliclyExported),
 }
 
 /// Search for the configuration file.

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -523,7 +523,7 @@ define_Conf! {
     ///
     /// Additional dotfiles (files or directories starting with a dot) to allow
     (allowed_dotfiles: FxHashSet<String> = FxHashSet::default()),
-    /// Lint: EXPLICIT_ITER_LOOP
+    /// Lint: EXPLICIT_ITER_LOOP.
     ///
     /// Whether to recommend using implicit into iter for reborrowed values.
     ///
@@ -543,11 +543,11 @@ define_Conf! {
     /// for _ in &mut *rmvec {}
     /// ```
     (enforce_iter_loop_reborrow: bool = false),
-    /// Lint: MISSING_SAFETY_DOC, UNNECESSARY_SAFETY_DOC, MISSING_PANICS_DOC, MISSING_ERRORS_DOC
+    /// Lint: MISSING_SAFETY_DOC, UNNECESSARY_SAFETY_DOC, MISSING_PANICS_DOC, MISSING_ERRORS_DOC.
     ///
     /// Whether to also run the listed lints on private items.
     (check_private_items: bool = false),
-    /// Lint: PUB_UNDERSCORE_FIELDS
+    /// Lint: PUB_UNDERSCORE_FIELDS.
     ///
     /// Lint "public" fields in a struct that are prefixed with an underscore based on their
     /// exported visibility, or whether they are marked as "pub".

--- a/clippy_config/src/types.rs
+++ b/clippy_config/src/types.rs
@@ -129,6 +129,6 @@ unimplemented_serialize! {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum PubUnderscoreFieldsBehaviour {
-    PublicallyExported,
+    PubliclyExported,
     AllPubFields,
 }

--- a/clippy_lints/src/pub_underscore_fields.rs
+++ b/clippy_lints/src/pub_underscore_fields.rs
@@ -54,7 +54,7 @@ impl<'tcx> LateLintPass<'tcx> for PubUnderscoreFields {
         };
 
         let is_visible = |field: &FieldDef<'_>| match self.behavior {
-            PubUnderscoreFieldsBehaviour::PublicallyExported => cx.effective_visibilities.is_reachable(field.def_id),
+            PubUnderscoreFieldsBehaviour::PubliclyExported => cx.effective_visibilities.is_reachable(field.def_id),
             PubUnderscoreFieldsBehaviour::AllPubFields => {
                 // If there is a visibility span then the field is marked pub in some way.
                 !field.vis_span.is_empty()

--- a/tests/ui-toml/pub_underscore_fields/exported/clippy.toml
+++ b/tests/ui-toml/pub_underscore_fields/exported/clippy.toml
@@ -1,1 +1,1 @@
-pub-underscore-fields-behavior = "PublicallyExported"
+pub-underscore-fields-behavior = "PubliclyExported"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/pull/10283#issuecomment-1890600381

In the "/// Lint: " list on each configuration option, you have to end with a dot. If the lint list doesn't have a dot, the configuration won't have documentation.

This PR adds those missing dots in some of the configuration, thus also adding their documentation.

changelog: Fix bug where a lot of config documentation wasn't showing.
changelog: Fix typo in `pub_underscore_fields_behavior` (`PublicallyExported` -> `PubliclyExported`)
