### PR TITLE
Fix [`multiple_crate_versions`] to correctly normalize package names to avoid missing the local one

### DIFF
--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -21,7 +21,6 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
             // the code below temporarily rectifies this discrepancy
             if p.name
                 .chars()
-                .into_iter()
                 .map(|c| if c == '-' { '_' } else { c })
                 .eq(local_name.as_str().chars())
             {

--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -16,7 +16,7 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
 
     if let Some(resolve) = &metadata.resolve
         && let Some(local_id) = packages.iter().find_map(|p| {
-            if p.name == local_name.as_str() {
+            if p.name.replace('-', "_") == local_name.as_str() {
                 Some(&p.id)
             } else {
                 None

--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -20,9 +20,10 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
             // local_name contains the crate name as a namespace, with the dashes converted to underscores
             // the code below temporarily rectifies this discrepancy
             if p.name
-                .chars()
-                .map(|c| if c == '-' { '_' } else { c })
-                .eq(local_name.as_str().chars())
+                .as_bytes()
+                .iter()
+                .map(|b| if b == &b'-' { &b'_' } else { b })
+                .eq(local_name.as_str().as_bytes())
             {
                 Some(&p.id)
             } else {

--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -16,7 +16,12 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
 
     if let Some(resolve) = &metadata.resolve
         && let Some(local_id) = packages.iter().find_map(|p| {
-            if p.name.replace('-', "_") == local_name.as_str() {
+            if p.name
+                .chars()
+                .into_iter()
+                .map(|c| if c == '-' { '_' } else { c })
+                .eq(local_name.as_str().chars())
+            {
                 Some(&p.id)
             } else {
                 None

--- a/clippy_lints/src/cargo/multiple_crate_versions.rs
+++ b/clippy_lints/src/cargo/multiple_crate_versions.rs
@@ -16,6 +16,9 @@ pub(super) fn check(cx: &LateContext<'_>, metadata: &Metadata) {
 
     if let Some(resolve) = &metadata.resolve
         && let Some(local_id) = packages.iter().find_map(|p| {
+            // p.name contains the original crate names with dashes intact
+            // local_name contains the crate name as a namespace, with the dashes converted to underscores
+            // the code below temporarily rectifies this discrepancy
             if p.name
                 .chars()
                 .into_iter()

--- a/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.stderr
+++ b/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.stderr
@@ -3,4 +3,4 @@ error: multiple versions for dependency `winapi`: 0.2.8, 0.3.9
   = note: `-D clippy::multiple-crate-versions` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::multiple_crate_versions)]`
 
-error: could not compile `multiple-crate-versions-with-dashes` (bin "multiple-crate-versions-with-dashes") due to 1 previous error
+error: could not compile `multiple-crate-versions` (bin "multiple-crate-versions") due to 1 previous error

--- a/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.stderr
+++ b/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.stderr
@@ -1,0 +1,6 @@
+error: multiple versions for dependency `winapi`: 0.2.8, 0.3.9
+  |
+  = note: `-D clippy::multiple-crate-versions` implied by `-D warnings`
+  = help: to override `-D warnings` add `#[allow(clippy::multiple_crate_versions)]`
+
+error: could not compile `multiple-crate-versions-with-dashes` (bin "multiple-crate-versions-with-dashes") due to 1 previous error

--- a/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.toml
+++ b/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.toml
@@ -1,0 +1,13 @@
+# Should not lint for dev or build dependencies. See issue 5041.
+
+[package]
+name = "multiple-crate-versions-with-dashes"
+version = "0.1.0"
+publish = false
+
+[workspace]
+
+# One of the versions of winapi is only a dev dependency: allowed
+[dependencies]
+winapi = "0.2"
+ansi_term = "=0.11.0"

--- a/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.toml
+++ b/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/Cargo.toml
@@ -1,7 +1,8 @@
 # Should not lint for dev or build dependencies. See issue 5041.
 
 [package]
-name = "multiple-crate-versions-with-dashes"
+# purposefully separated by - instead of _
+name = "multiple-crate-versions"
 version = "0.1.0"
 publish = false
 

--- a/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/src/main.rs
+++ b/tests/ui-cargo/multiple_crate_versions/12145_with_dashes/src/main.rs
@@ -1,0 +1,3 @@
+#![warn(clippy::multiple_crate_versions)]
+
+fn main() {}


### PR DESCRIPTION
Fixes #12145 

changelog: [`multiple_crate_versions`]: correctly normalize package name
