### PR TITLE
Correctly suggest std or core path depending if this is a `no_std` crate

### DIFF
--- a/clippy_lints/src/default_instead_of_iter_empty.rs
+++ b/clippy_lints/src/default_instead_of_iter_empty.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::last_path_segment;
 use clippy_utils::source::snippet_with_context;
+use clippy_utils::{is_no_std_crate, last_path_segment};
 use rustc_errors::Applicability;
 use rustc_hir::{def, Expr, ExprKind, GenericArg, QPath, TyKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -42,12 +42,17 @@ impl<'tcx> LateLintPass<'tcx> for DefaultIterEmpty {
             && ty.span.ctxt() == ctxt
         {
             let mut applicability = Applicability::MachineApplicable;
-            let sugg = make_sugg(cx, ty_path, ctxt, &mut applicability);
+            let path = if is_no_std_crate(cx) {
+                "core::iter::empty"
+            } else {
+                "std::iter::empty"
+            };
+            let sugg = make_sugg(cx, ty_path, ctxt, &mut applicability, path);
             span_lint_and_sugg(
                 cx,
                 DEFAULT_INSTEAD_OF_ITER_EMPTY,
                 expr.span,
-                "`std::iter::empty()` is the more idiomatic way",
+                &format!("`{path}()` is the more idiomatic way"),
                 "try",
                 sugg,
                 applicability,
@@ -61,6 +66,7 @@ fn make_sugg(
     ty_path: &rustc_hir::QPath<'_>,
     ctxt: SyntaxContext,
     applicability: &mut Applicability,
+    path: &str,
 ) -> String {
     if let Some(last) = last_path_segment(ty_path).args
         && let Some(iter_ty) = last.args.iter().find_map(|arg| match arg {
@@ -69,10 +75,10 @@ fn make_sugg(
         })
     {
         format!(
-            "std::iter::empty::<{}>()",
+            "{path}::<{}>()",
             snippet_with_context(cx, iter_ty.span, ctxt, "..", applicability).0
         )
     } else {
-        "std::iter::empty()".to_owned()
+        format!("{path}()")
     }
 }

--- a/clippy_lints/src/default_instead_of_iter_empty.rs
+++ b/clippy_lints/src/default_instead_of_iter_empty.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_context;
-use clippy_utils::{is_no_std_crate, last_path_segment};
+use clippy_utils::{last_path_segment, std_or_core};
 use rustc_errors::Applicability;
 use rustc_hir::{def, Expr, ExprKind, GenericArg, QPath, TyKind};
 use rustc_lint::{LateContext, LateLintPass};
@@ -42,12 +42,9 @@ impl<'tcx> LateLintPass<'tcx> for DefaultIterEmpty {
             && ty.span.ctxt() == ctxt
         {
             let mut applicability = Applicability::MachineApplicable;
-            let path = if is_no_std_crate(cx) {
-                "core::iter::empty"
-            } else {
-                "std::iter::empty"
-            };
-            let sugg = make_sugg(cx, ty_path, ctxt, &mut applicability, path);
+            let Some(path) = std_or_core(cx) else { return };
+            let path = format!("{path}::iter::empty");
+            let sugg = make_sugg(cx, ty_path, ctxt, &mut applicability, &path);
             span_lint_and_sugg(
                 cx,
                 DEFAULT_INSTEAD_OF_ITER_EMPTY,

--- a/clippy_lints/src/methods/iter_on_single_or_empty_collections.rs
+++ b/clippy_lints/src/methods/iter_on_single_or_empty_collections.rs
@@ -58,10 +58,10 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, method_name: &str, re
         return;
     }
 
+    let top_crate = if is_no_std_crate(cx) { "core" } else { "std" };
     if let Some(i) = item {
         let sugg = format!(
-            "{}::iter::once({}{})",
-            if is_no_std_crate(cx) { "core" } else { "std" },
+            "{top_crate}::iter::once({}{})",
             iter_type.ref_prefix(),
             snippet(cx, i.span, "...")
         );
@@ -81,11 +81,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, method_name: &str, re
             expr.span,
             &format!("`{method_name}` call on an empty collection"),
             "try",
-            if is_no_std_crate(cx) {
-                "core::iter::empty()".to_string()
-            } else {
-                "std::iter::empty()".to_string()
-            },
+            format!("{top_crate}::iter::empty()"),
             Applicability::MaybeIncorrect,
         );
     }

--- a/clippy_lints/src/methods/iter_on_single_or_empty_collections.rs
+++ b/clippy_lints/src/methods/iter_on_single_or_empty_collections.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet;
-use clippy_utils::{get_expr_use_or_unification_node, is_no_std_crate, is_res_lang_ctor, path_res};
+use clippy_utils::{get_expr_use_or_unification_node, is_res_lang_ctor, path_res, std_or_core};
 
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::{OptionNone, OptionSome};
@@ -58,7 +58,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, method_name: &str, re
         return;
     }
 
-    let top_crate = if is_no_std_crate(cx) { "core" } else { "std" };
+    let Some(top_crate) = std_or_core(cx) else { return };
     if let Some(i) = item {
         let sugg = format!(
             "{top_crate}::iter::once({}{})",

--- a/clippy_lints/src/methods/unnecessary_sort_by.rs
+++ b/clippy_lints/src/methods/unnecessary_sort_by.rs
@@ -204,7 +204,7 @@ pub(super) fn check<'tcx>(
             cx,
             UNNECESSARY_SORT_BY,
             expr.span,
-            "use Vec::sort_by_key here instead",
+            "consider using `sort_by_key`",
             "try",
             format!(
                 "{}.sort{}_by_key(|{}| {})",
@@ -227,7 +227,7 @@ pub(super) fn check<'tcx>(
             cx,
             UNNECESSARY_SORT_BY,
             expr.span,
-            "use Vec::sort here instead",
+            "consider using `sort`",
             "try",
             format!(
                 "{}.sort{}()",

--- a/clippy_lints/src/operators/ptr_eq.rs
+++ b/clippy_lints/src/operators/ptr_eq.rs
@@ -1,12 +1,11 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_no_std_crate;
 use clippy_utils::source::snippet_opt;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::LateContext;
 
 use super::PTR_EQ;
-
-static LINT_MSG: &str = "use `std::ptr::eq` when comparing raw pointers";
 
 pub(super) fn check<'tcx>(
     cx: &LateContext<'tcx>,
@@ -26,13 +25,14 @@ pub(super) fn check<'tcx>(
             && let Some(left_snip) = snippet_opt(cx, left_var.span)
             && let Some(right_snip) = snippet_opt(cx, right_var.span)
         {
+            let top_crate = if is_no_std_crate(cx) { "core" } else { "std" };
             span_lint_and_sugg(
                 cx,
                 PTR_EQ,
                 expr.span,
-                LINT_MSG,
+                &format!("use `{top_crate}::ptr::eq` when comparing raw pointers"),
                 "try",
-                format!("std::ptr::eq({left_snip}, {right_snip})"),
+                format!("{top_crate}::ptr::eq({left_snip}, {right_snip})"),
                 Applicability::MachineApplicable,
             );
         }

--- a/clippy_lints/src/operators/ptr_eq.rs
+++ b/clippy_lints/src/operators/ptr_eq.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::is_no_std_crate;
 use clippy_utils::source::snippet_opt;
+use clippy_utils::std_or_core;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::LateContext;
@@ -25,7 +25,7 @@ pub(super) fn check<'tcx>(
             && let Some(left_snip) = snippet_opt(cx, left_var.span)
             && let Some(right_snip) = snippet_opt(cx, right_var.span)
         {
-            let top_crate = if is_no_std_crate(cx) { "core" } else { "std" };
+            let Some(top_crate) = std_or_core(cx) else { return };
             span_lint_and_sugg(
                 cx,
                 PTR_EQ,

--- a/clippy_lints/src/transmute/transmute_int_to_char.rs
+++ b/clippy_lints/src/transmute/transmute_int_to_char.rs
@@ -1,6 +1,6 @@
 use super::TRANSMUTE_INT_TO_CHAR;
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::{is_no_std_crate, sugg};
+use clippy_utils::{std_or_core, sugg};
 use rustc_ast as ast;
 use rustc_errors::Applicability;
 use rustc_hir::Expr;
@@ -25,6 +25,7 @@ pub(super) fn check<'tcx>(
                 e.span,
                 &format!("transmute from a `{from_ty}` to a `char`"),
                 |diag| {
+                    let Some(top_crate) = std_or_core(cx) else { return };
                     let arg = sugg::Sugg::hir(cx, arg, "..");
                     let arg = if let ty::Int(_) = from_ty.kind() {
                         arg.as_ty(ast::UintTy::U32.name_str())
@@ -34,10 +35,7 @@ pub(super) fn check<'tcx>(
                     diag.span_suggestion(
                         e.span,
                         "consider using",
-                        format!(
-                            "{}::char::from_u32({arg}).unwrap()",
-                            if is_no_std_crate(cx) { "core" } else { "std" }
-                        ),
+                        format!("{top_crate}::char::from_u32({arg}).unwrap()"),
                         Applicability::Unspecified,
                     );
                 },

--- a/clippy_lints/src/transmute/transmute_int_to_char.rs
+++ b/clippy_lints/src/transmute/transmute_int_to_char.rs
@@ -1,6 +1,6 @@
 use super::TRANSMUTE_INT_TO_CHAR;
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::sugg;
+use clippy_utils::{is_no_std_crate, sugg};
 use rustc_ast as ast;
 use rustc_errors::Applicability;
 use rustc_hir::Expr;
@@ -34,7 +34,10 @@ pub(super) fn check<'tcx>(
                     diag.span_suggestion(
                         e.span,
                         "consider using",
-                        format!("std::char::from_u32({arg}).unwrap()"),
+                        format!(
+                            "{}::char::from_u32({arg}).unwrap()",
+                            if is_no_std_crate(cx) { "core" } else { "std" }
+                        ),
                         Applicability::Unspecified,
                     );
                 },

--- a/clippy_lints/src/transmute/transmute_ref_to_ref.rs
+++ b/clippy_lints/src/transmute/transmute_ref_to_ref.rs
@@ -1,7 +1,7 @@
 use super::{TRANSMUTE_BYTES_TO_STR, TRANSMUTE_PTR_TO_PTR};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet;
-use clippy_utils::{is_no_std_crate, sugg};
+use clippy_utils::{std_or_core, sugg};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, Mutability};
 use rustc_lint::LateContext;
@@ -25,11 +25,11 @@ pub(super) fn check<'tcx>(
             && let ty::Uint(ty::UintTy::U8) = slice_ty.kind()
             && from_mutbl == to_mutbl
         {
+            let Some(top_crate) = std_or_core(cx) else { return true };
+
             let postfix = if *from_mutbl == Mutability::Mut { "_mut" } else { "" };
 
             let snippet = snippet(cx, arg.span, "..");
-
-            let top_crate = if is_no_std_crate(cx) { "core" } else { "std" };
 
             span_lint_and_sugg(
                 cx,

--- a/clippy_lints/src/transmute/transmute_ref_to_ref.rs
+++ b/clippy_lints/src/transmute/transmute_ref_to_ref.rs
@@ -1,7 +1,7 @@
 use super::{TRANSMUTE_BYTES_TO_STR, TRANSMUTE_PTR_TO_PTR};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet;
-use clippy_utils::sugg;
+use clippy_utils::{is_no_std_crate, sugg};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, Mutability};
 use rustc_lint::LateContext;
@@ -29,6 +29,8 @@ pub(super) fn check<'tcx>(
 
             let snippet = snippet(cx, arg.span, "..");
 
+            let top_crate = if is_no_std_crate(cx) { "core" } else { "std" };
+
             span_lint_and_sugg(
                 cx,
                 TRANSMUTE_BYTES_TO_STR,
@@ -36,9 +38,9 @@ pub(super) fn check<'tcx>(
                 &format!("transmute from a `{from_ty}` to a `{to_ty}`"),
                 "consider using",
                 if const_context {
-                    format!("std::str::from_utf8_unchecked{postfix}({snippet})")
+                    format!("{top_crate}::str::from_utf8_unchecked{postfix}({snippet})")
                 } else {
-                    format!("std::str::from_utf8{postfix}({snippet}).unwrap()")
+                    format!("{top_crate}::str::from_utf8{postfix}({snippet}).unwrap()")
                 },
                 Applicability::MaybeIncorrect,
             );

--- a/tests/ui/default_instead_of_iter_empty_no_std.fixed
+++ b/tests/ui/default_instead_of_iter_empty_no_std.fixed
@@ -1,0 +1,28 @@
+#![warn(clippy::default_instead_of_iter_empty)]
+#![allow(dead_code)]
+#![feature(lang_items)]
+#![no_std]
+
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[derive(Default)]
+struct Iter {
+    iter: core::iter::Empty<usize>,
+}
+
+fn main() {
+    // Do lint.
+    let _ = core::iter::empty::<usize>();
+    let _foo: core::iter::Empty<usize> = core::iter::empty();
+
+    // Do not lint.
+    let _ = Iter::default();
+}

--- a/tests/ui/default_instead_of_iter_empty_no_std.rs
+++ b/tests/ui/default_instead_of_iter_empty_no_std.rs
@@ -1,0 +1,28 @@
+#![warn(clippy::default_instead_of_iter_empty)]
+#![allow(dead_code)]
+#![feature(lang_items)]
+#![no_std]
+
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[derive(Default)]
+struct Iter {
+    iter: core::iter::Empty<usize>,
+}
+
+fn main() {
+    // Do lint.
+    let _ = core::iter::Empty::<usize>::default();
+    let _foo: core::iter::Empty<usize> = core::iter::Empty::default();
+
+    // Do not lint.
+    let _ = Iter::default();
+}

--- a/tests/ui/default_instead_of_iter_empty_no_std.stderr
+++ b/tests/ui/default_instead_of_iter_empty_no_std.stderr
@@ -1,0 +1,17 @@
+error: `core::iter::empty()` is the more idiomatic way
+  --> $DIR/default_instead_of_iter_empty_no_std.rs:23:13
+   |
+LL |     let _ = core::iter::Empty::<usize>::default();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `core::iter::empty::<usize>()`
+   |
+   = note: `-D clippy::default-instead-of-iter-empty` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::default_instead_of_iter_empty)]`
+
+error: `core::iter::empty()` is the more idiomatic way
+  --> $DIR/default_instead_of_iter_empty_no_std.rs:24:42
+   |
+LL |     let _foo: core::iter::Empty<usize> = core::iter::Empty::default();
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `core::iter::empty()`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/mem_replace_no_std.fixed
+++ b/tests/ui/mem_replace_no_std.fixed
@@ -1,0 +1,82 @@
+#![allow(unused)]
+#![warn(
+    clippy::all,
+    clippy::style,
+    clippy::mem_replace_option_with_none,
+    clippy::mem_replace_with_default
+)]
+#![feature(lang_items)]
+#![no_std]
+
+use core::mem;
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+fn replace_option_with_none() {
+    let mut an_option = Some(1);
+    let _ = an_option.take();
+    let an_option = &mut Some(1);
+    let _ = an_option.take();
+}
+
+fn replace_with_default() {
+    let mut refstr = "hello";
+    let _ = core::mem::take(&mut refstr);
+
+    let mut slice: &[i32] = &[1, 2, 3];
+    let _ = core::mem::take(&mut slice);
+}
+
+// lint is disabled for primitives because in this case `take`
+// has no clear benefit over `replace` and sometimes is harder to read
+fn dont_lint_primitive() {
+    let mut pbool = true;
+    let _ = mem::replace(&mut pbool, false);
+
+    let mut pint = 5;
+    let _ = mem::replace(&mut pint, 0);
+}
+
+fn main() {
+    replace_option_with_none();
+    replace_with_default();
+    dont_lint_primitive();
+}
+
+fn issue9824() {
+    struct Foo<'a>(Option<&'a str>);
+    impl<'a> core::ops::Deref for Foo<'a> {
+        type Target = Option<&'a str>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<'a> core::ops::DerefMut for Foo<'a> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    struct Bar {
+        opt: Option<u8>,
+        val: u8,
+    }
+
+    let mut f = Foo(Some("foo"));
+    let mut b = Bar { opt: Some(1), val: 12 };
+
+    // replace option with none
+    let _ = f.0.take();
+    let _ = (*f).take();
+    let _ = b.opt.take();
+    // replace with default
+    let _ = mem::replace(&mut b.val, u8::default());
+}

--- a/tests/ui/mem_replace_no_std.rs
+++ b/tests/ui/mem_replace_no_std.rs
@@ -1,0 +1,82 @@
+#![allow(unused)]
+#![warn(
+    clippy::all,
+    clippy::style,
+    clippy::mem_replace_option_with_none,
+    clippy::mem_replace_with_default
+)]
+#![feature(lang_items)]
+#![no_std]
+
+use core::mem;
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+fn replace_option_with_none() {
+    let mut an_option = Some(1);
+    let _ = mem::replace(&mut an_option, None);
+    let an_option = &mut Some(1);
+    let _ = mem::replace(an_option, None);
+}
+
+fn replace_with_default() {
+    let mut refstr = "hello";
+    let _ = mem::replace(&mut refstr, "");
+
+    let mut slice: &[i32] = &[1, 2, 3];
+    let _ = mem::replace(&mut slice, &[]);
+}
+
+// lint is disabled for primitives because in this case `take`
+// has no clear benefit over `replace` and sometimes is harder to read
+fn dont_lint_primitive() {
+    let mut pbool = true;
+    let _ = mem::replace(&mut pbool, false);
+
+    let mut pint = 5;
+    let _ = mem::replace(&mut pint, 0);
+}
+
+fn main() {
+    replace_option_with_none();
+    replace_with_default();
+    dont_lint_primitive();
+}
+
+fn issue9824() {
+    struct Foo<'a>(Option<&'a str>);
+    impl<'a> core::ops::Deref for Foo<'a> {
+        type Target = Option<&'a str>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<'a> core::ops::DerefMut for Foo<'a> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    struct Bar {
+        opt: Option<u8>,
+        val: u8,
+    }
+
+    let mut f = Foo(Some("foo"));
+    let mut b = Bar { opt: Some(1), val: 12 };
+
+    // replace option with none
+    let _ = mem::replace(&mut f.0, None);
+    let _ = mem::replace(&mut *f, None);
+    let _ = mem::replace(&mut b.opt, None);
+    // replace with default
+    let _ = mem::replace(&mut b.val, u8::default());
+}

--- a/tests/ui/mem_replace_no_std.stderr
+++ b/tests/ui/mem_replace_no_std.stderr
@@ -1,0 +1,50 @@
+error: replacing an `Option` with `None`
+  --> $DIR/mem_replace_no_std.rs:24:13
+   |
+LL |     let _ = mem::replace(&mut an_option, None);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `an_option.take()`
+   |
+   = note: `-D clippy::mem-replace-option-with-none` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::mem_replace_option_with_none)]`
+
+error: replacing an `Option` with `None`
+  --> $DIR/mem_replace_no_std.rs:26:13
+   |
+LL |     let _ = mem::replace(an_option, None);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `an_option.take()`
+
+error: replacing a value of type `T` with `T::default()` is better expressed using `core::mem::take`
+  --> $DIR/mem_replace_no_std.rs:31:13
+   |
+LL |     let _ = mem::replace(&mut refstr, "");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `core::mem::take(&mut refstr)`
+   |
+   = note: `-D clippy::mem-replace-with-default` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::mem_replace_with_default)]`
+
+error: replacing a value of type `T` with `T::default()` is better expressed using `core::mem::take`
+  --> $DIR/mem_replace_no_std.rs:34:13
+   |
+LL |     let _ = mem::replace(&mut slice, &[]);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `core::mem::take(&mut slice)`
+
+error: replacing an `Option` with `None`
+  --> $DIR/mem_replace_no_std.rs:77:13
+   |
+LL |     let _ = mem::replace(&mut f.0, None);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `f.0.take()`
+
+error: replacing an `Option` with `None`
+  --> $DIR/mem_replace_no_std.rs:78:13
+   |
+LL |     let _ = mem::replace(&mut *f, None);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `(*f).take()`
+
+error: replacing an `Option` with `None`
+  --> $DIR/mem_replace_no_std.rs:79:13
+   |
+LL |     let _ = mem::replace(&mut b.opt, None);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::take()` instead: `b.opt.take()`
+
+error: aborting due to 7 previous errors
+

--- a/tests/ui/ptr_eq_no_std.fixed
+++ b/tests/ui/ptr_eq_no_std.fixed
@@ -1,0 +1,49 @@
+#![warn(clippy::ptr_eq)]
+#![no_std]
+#![feature(lang_items)]
+
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+macro_rules! mac {
+    ($a:expr, $b:expr) => {
+        $a as *const _ as usize == $b as *const _ as usize
+    };
+}
+
+macro_rules! another_mac {
+    ($a:expr, $b:expr) => {
+        $a as *const _ == $b as *const _
+    };
+}
+
+fn main() {
+    let a = &[1, 2, 3];
+    let b = &[1, 2, 3];
+
+    let _ = core::ptr::eq(a, b);
+    let _ = core::ptr::eq(a, b);
+    let _ = a.as_ptr() == b as *const _;
+    let _ = a.as_ptr() == b.as_ptr();
+
+    // Do not lint
+
+    let _ = mac!(a, b);
+    let _ = another_mac!(a, b);
+
+    let a = &mut [1, 2, 3];
+    let b = &mut [1, 2, 3];
+
+    let _ = a.as_mut_ptr() == b as *mut [i32] as *mut _;
+    let _ = a.as_mut_ptr() == b.as_mut_ptr();
+
+    let _ = a == b;
+    let _ = core::ptr::eq(a, b);
+}

--- a/tests/ui/ptr_eq_no_std.rs
+++ b/tests/ui/ptr_eq_no_std.rs
@@ -1,0 +1,49 @@
+#![warn(clippy::ptr_eq)]
+#![no_std]
+#![feature(lang_items)]
+
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+macro_rules! mac {
+    ($a:expr, $b:expr) => {
+        $a as *const _ as usize == $b as *const _ as usize
+    };
+}
+
+macro_rules! another_mac {
+    ($a:expr, $b:expr) => {
+        $a as *const _ == $b as *const _
+    };
+}
+
+fn main() {
+    let a = &[1, 2, 3];
+    let b = &[1, 2, 3];
+
+    let _ = a as *const _ as usize == b as *const _ as usize;
+    let _ = a as *const _ == b as *const _;
+    let _ = a.as_ptr() == b as *const _;
+    let _ = a.as_ptr() == b.as_ptr();
+
+    // Do not lint
+
+    let _ = mac!(a, b);
+    let _ = another_mac!(a, b);
+
+    let a = &mut [1, 2, 3];
+    let b = &mut [1, 2, 3];
+
+    let _ = a.as_mut_ptr() == b as *mut [i32] as *mut _;
+    let _ = a.as_mut_ptr() == b.as_mut_ptr();
+
+    let _ = a == b;
+    let _ = core::ptr::eq(a, b);
+}

--- a/tests/ui/ptr_eq_no_std.stderr
+++ b/tests/ui/ptr_eq_no_std.stderr
@@ -1,0 +1,17 @@
+error: use `core::ptr::eq` when comparing raw pointers
+  --> $DIR/ptr_eq_no_std.rs:31:13
+   |
+LL |     let _ = a as *const _ as usize == b as *const _ as usize;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `core::ptr::eq(a, b)`
+   |
+   = note: `-D clippy::ptr-eq` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::ptr_eq)]`
+
+error: use `core::ptr::eq` when comparing raw pointers
+  --> $DIR/ptr_eq_no_std.rs:32:13
+   |
+LL |     let _ = a as *const _ == b as *const _;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `core::ptr::eq(a, b)`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/transmute.rs
+++ b/tests/ui/transmute.rs
@@ -102,19 +102,6 @@ fn crosspointer() {
     }
 }
 
-#[warn(clippy::transmute_int_to_char)]
-fn int_to_char() {
-    let _: char = unsafe { std::mem::transmute(0_u32) };
-    //~^ ERROR: transmute from a `u32` to a `char`
-    //~| NOTE: `-D clippy::transmute-int-to-char` implied by `-D warnings`
-    let _: char = unsafe { std::mem::transmute(0_i32) };
-    //~^ ERROR: transmute from a `i32` to a `char`
-
-    // These shouldn't warn
-    const _: char = unsafe { std::mem::transmute(0_u32) };
-    const _: char = unsafe { std::mem::transmute(0_i32) };
-}
-
 #[warn(clippy::transmute_int_to_bool)]
 fn int_to_bool() {
     let _: bool = unsafe { std::mem::transmute(0_u8) };

--- a/tests/ui/transmute.stderr
+++ b/tests/ui/transmute.stderr
@@ -88,23 +88,8 @@ error: transmute from a type (`Usize`) to a pointer to that type (`*mut Usize`)
 LL |         let _: *mut Usize = core::intrinsics::transmute(my_int());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: transmute from a `u32` to a `char`
-  --> $DIR/transmute.rs:107:28
-   |
-LL |     let _: char = unsafe { std::mem::transmute(0_u32) };
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::char::from_u32(0_u32).unwrap()`
-   |
-   = note: `-D clippy::transmute-int-to-char` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_char)]`
-
-error: transmute from a `i32` to a `char`
-  --> $DIR/transmute.rs:110:28
-   |
-LL |     let _: char = unsafe { std::mem::transmute(0_i32) };
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::char::from_u32(0_i32 as u32).unwrap()`
-
 error: transmute from a `u8` to a `bool`
-  --> $DIR/transmute.rs:120:28
+  --> $DIR/transmute.rs:107:28
    |
 LL |     let _: bool = unsafe { std::mem::transmute(0_u8) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `0_u8 != 0`
@@ -113,7 +98,7 @@ LL |     let _: bool = unsafe { std::mem::transmute(0_u8) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_bool)]`
 
 error: transmute from a `u32` to a `f32`
-  --> $DIR/transmute.rs:128:31
+  --> $DIR/transmute.rs:115:31
    |
 LL |         let _: f32 = unsafe { std::mem::transmute(0_u32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(0_u32)`
@@ -122,25 +107,25 @@ LL |         let _: f32 = unsafe { std::mem::transmute(0_u32) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_float)]`
 
 error: transmute from a `i32` to a `f32`
-  --> $DIR/transmute.rs:131:31
+  --> $DIR/transmute.rs:118:31
    |
 LL |         let _: f32 = unsafe { std::mem::transmute(0_i32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(0_i32 as u32)`
 
 error: transmute from a `u64` to a `f64`
-  --> $DIR/transmute.rs:133:31
+  --> $DIR/transmute.rs:120:31
    |
 LL |         let _: f64 = unsafe { std::mem::transmute(0_u64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(0_u64)`
 
 error: transmute from a `i64` to a `f64`
-  --> $DIR/transmute.rs:135:31
+  --> $DIR/transmute.rs:122:31
    |
 LL |         let _: f64 = unsafe { std::mem::transmute(0_i64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(0_i64 as u64)`
 
 error: transmute from a `u8` to a `[u8; 1]`
-  --> $DIR/transmute.rs:156:30
+  --> $DIR/transmute.rs:143:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u8.to_ne_bytes()`
@@ -149,85 +134,85 @@ LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    = help: to override `-D warnings` add `#[allow(clippy::transmute_num_to_bytes)]`
 
 error: transmute from a `u32` to a `[u8; 4]`
-  --> $DIR/transmute.rs:159:30
+  --> $DIR/transmute.rs:146:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0u32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u32.to_ne_bytes()`
 
 error: transmute from a `u128` to a `[u8; 16]`
-  --> $DIR/transmute.rs:161:31
+  --> $DIR/transmute.rs:148:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0u128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u128.to_ne_bytes()`
 
 error: transmute from a `i8` to a `[u8; 1]`
-  --> $DIR/transmute.rs:163:30
+  --> $DIR/transmute.rs:150:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0i8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i8.to_ne_bytes()`
 
 error: transmute from a `i32` to a `[u8; 4]`
-  --> $DIR/transmute.rs:165:30
+  --> $DIR/transmute.rs:152:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0i32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i32.to_ne_bytes()`
 
 error: transmute from a `i128` to a `[u8; 16]`
-  --> $DIR/transmute.rs:167:31
+  --> $DIR/transmute.rs:154:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0i128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i128.to_ne_bytes()`
 
 error: transmute from a `f32` to a `[u8; 4]`
-  --> $DIR/transmute.rs:169:30
+  --> $DIR/transmute.rs:156:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0.0f32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f32.to_ne_bytes()`
 
 error: transmute from a `f64` to a `[u8; 8]`
-  --> $DIR/transmute.rs:171:30
+  --> $DIR/transmute.rs:158:30
    |
 LL |             let _: [u8; 8] = std::mem::transmute(0.0f64);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f64.to_ne_bytes()`
 
 error: transmute from a `u8` to a `[u8; 1]`
-  --> $DIR/transmute.rs:177:30
+  --> $DIR/transmute.rs:164:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u8.to_ne_bytes()`
 
 error: transmute from a `u32` to a `[u8; 4]`
-  --> $DIR/transmute.rs:179:30
+  --> $DIR/transmute.rs:166:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0u32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u32.to_ne_bytes()`
 
 error: transmute from a `u128` to a `[u8; 16]`
-  --> $DIR/transmute.rs:181:31
+  --> $DIR/transmute.rs:168:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0u128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u128.to_ne_bytes()`
 
 error: transmute from a `i8` to a `[u8; 1]`
-  --> $DIR/transmute.rs:183:30
+  --> $DIR/transmute.rs:170:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0i8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i8.to_ne_bytes()`
 
 error: transmute from a `i32` to a `[u8; 4]`
-  --> $DIR/transmute.rs:185:30
+  --> $DIR/transmute.rs:172:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0i32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i32.to_ne_bytes()`
 
 error: transmute from a `i128` to a `[u8; 16]`
-  --> $DIR/transmute.rs:187:31
+  --> $DIR/transmute.rs:174:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0i128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i128.to_ne_bytes()`
 
 error: transmute from a `&[u8]` to a `&str`
-  --> $DIR/transmute.rs:198:28
+  --> $DIR/transmute.rs:185:28
    |
 LL |     let _: &str = unsafe { std::mem::transmute(B) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8(B).unwrap()`
@@ -236,16 +221,16 @@ LL |     let _: &str = unsafe { std::mem::transmute(B) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_bytes_to_str)]`
 
 error: transmute from a `&mut [u8]` to a `&mut str`
-  --> $DIR/transmute.rs:201:32
+  --> $DIR/transmute.rs:188:32
    |
 LL |     let _: &mut str = unsafe { std::mem::transmute(mb) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_mut(mb).unwrap()`
 
 error: transmute from a `&[u8]` to a `&str`
-  --> $DIR/transmute.rs:203:30
+  --> $DIR/transmute.rs:190:30
    |
 LL |     const _: &str = unsafe { std::mem::transmute(B) };
    |                              ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_unchecked(B)`
 
-error: aborting due to 38 previous errors
+error: aborting due to 36 previous errors
 

--- a/tests/ui/transmute_int_to_char.fixed
+++ b/tests/ui/transmute_int_to_char.fixed
@@ -1,0 +1,15 @@
+#![warn(clippy::transmute_int_to_char)]
+
+fn int_to_char() {
+    let _: char = unsafe { std::char::from_u32(0_u32).unwrap() };
+    //~^ ERROR: transmute from a `u32` to a `char`
+    //~| NOTE: `-D clippy::transmute-int-to-char` implied by `-D warnings`
+    let _: char = unsafe { std::char::from_u32(0_i32 as u32).unwrap() };
+    //~^ ERROR: transmute from a `i32` to a `char`
+
+    // These shouldn't warn
+    const _: char = unsafe { std::mem::transmute(0_u32) };
+    const _: char = unsafe { std::mem::transmute(0_i32) };
+}
+
+fn main() {}

--- a/tests/ui/transmute_int_to_char.rs
+++ b/tests/ui/transmute_int_to_char.rs
@@ -1,0 +1,15 @@
+#![warn(clippy::transmute_int_to_char)]
+
+fn int_to_char() {
+    let _: char = unsafe { std::mem::transmute(0_u32) };
+    //~^ ERROR: transmute from a `u32` to a `char`
+    //~| NOTE: `-D clippy::transmute-int-to-char` implied by `-D warnings`
+    let _: char = unsafe { std::mem::transmute(0_i32) };
+    //~^ ERROR: transmute from a `i32` to a `char`
+
+    // These shouldn't warn
+    const _: char = unsafe { std::mem::transmute(0_u32) };
+    const _: char = unsafe { std::mem::transmute(0_i32) };
+}
+
+fn main() {}

--- a/tests/ui/transmute_int_to_char.stderr
+++ b/tests/ui/transmute_int_to_char.stderr
@@ -1,0 +1,17 @@
+error: transmute from a `u32` to a `char`
+  --> $DIR/transmute_int_to_char.rs:4:28
+   |
+LL |     let _: char = unsafe { std::mem::transmute(0_u32) };
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::char::from_u32(0_u32).unwrap()`
+   |
+   = note: `-D clippy::transmute-int-to-char` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_char)]`
+
+error: transmute from a `i32` to a `char`
+  --> $DIR/transmute_int_to_char.rs:7:28
+   |
+LL |     let _: char = unsafe { std::mem::transmute(0_i32) };
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::char::from_u32(0_i32 as u32).unwrap()`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/transmute_int_to_char_no_std.fixed
+++ b/tests/ui/transmute_int_to_char_no_std.fixed
@@ -1,0 +1,27 @@
+#![no_std]
+#![feature(lang_items)]
+#![warn(clippy::transmute_int_to_char)]
+
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+fn int_to_char() {
+    let _: char = unsafe { core::char::from_u32(0_u32).unwrap() };
+    //~^ ERROR: transmute from a `u32` to a `char`
+    //~| NOTE: `-D clippy::transmute-int-to-char` implied by `-D warnings`
+    let _: char = unsafe { core::char::from_u32(0_i32 as u32).unwrap() };
+    //~^ ERROR: transmute from a `i32` to a `char`
+
+    // These shouldn't warn
+    const _: char = unsafe { core::mem::transmute(0_u32) };
+    const _: char = unsafe { core::mem::transmute(0_i32) };
+}
+
+fn main() {}

--- a/tests/ui/transmute_int_to_char_no_std.rs
+++ b/tests/ui/transmute_int_to_char_no_std.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![feature(lang_items)]
+#![warn(clippy::transmute_int_to_char)]
+
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
+
+fn int_to_char() {
+    let _: char = unsafe { core::mem::transmute(0_u32) };
+    //~^ ERROR: transmute from a `u32` to a `char`
+    //~| NOTE: `-D clippy::transmute-int-to-char` implied by `-D warnings`
+    let _: char = unsafe { core::mem::transmute(0_i32) };
+    //~^ ERROR: transmute from a `i32` to a `char`
+
+    // These shouldn't warn
+    const _: char = unsafe { core::mem::transmute(0_u32) };
+    const _: char = unsafe { core::mem::transmute(0_i32) };
+}
+
+fn main() {}

--- a/tests/ui/transmute_int_to_char_no_std.stderr
+++ b/tests/ui/transmute_int_to_char_no_std.stderr
@@ -1,0 +1,17 @@
+error: transmute from a `u32` to a `char`
+  --> $DIR/transmute_int_to_char_no_std.rs:16:28
+   |
+LL |     let _: char = unsafe { core::mem::transmute(0_u32) };
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `core::char::from_u32(0_u32).unwrap()`
+   |
+   = note: `-D clippy::transmute-int-to-char` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_char)]`
+
+error: transmute from a `i32` to a `char`
+  --> $DIR/transmute_int_to_char_no_std.rs:19:28
+   |
+LL |     let _: char = unsafe { core::mem::transmute(0_i32) };
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `core::char::from_u32(0_i32 as u32).unwrap()`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/transmute_ref_to_ref.stderr
+++ b/tests/ui/transmute_ref_to_ref.stderr
@@ -19,8 +19,8 @@ LL |         let b: &[u8] = unsafe { std::mem::transmute(a) };
 error: transmute from a reference to a reference
   --> $DIR/transmute_ref_to_ref.rs:15:42
    |
-LL |         let alt_slice: &[u32] = unsafe { core::mem::transmute(bytes) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(bytes as *const [u8] as *const [u32])`
+LL |         let alt_slice: &[u32] = unsafe { std::mem::transmute(bytes) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(bytes as *const [u8] as *const [u32])`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/transmute_ref_to_ref_no_std.rs
+++ b/tests/ui/transmute_ref_to_ref_no_std.rs
@@ -2,17 +2,29 @@
 
 #![deny(clippy::transmute_ptr_to_ptr)]
 #![allow(dead_code)]
+#![feature(lang_items)]
+#![no_std]
+
+use core::panic::PanicInfo;
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}
 
 fn main() {
     unsafe {
         let single_u64: &[u64] = &[0xDEAD_BEEF_DEAD_BEEF];
-        let bools: &[bool] = unsafe { std::mem::transmute(single_u64) };
+        let bools: &[bool] = unsafe { core::mem::transmute(single_u64) };
         //~^ ERROR: transmute from a reference to a reference
         let a: &[u32] = &[0x12345678, 0x90ABCDEF, 0xFEDCBA09, 0x87654321];
-        let b: &[u8] = unsafe { std::mem::transmute(a) };
+        let b: &[u8] = unsafe { core::mem::transmute(a) };
         //~^ ERROR: transmute from a reference to a reference
         let bytes = &[1u8, 2u8, 3u8, 4u8] as &[u8];
-        let alt_slice: &[u32] = unsafe { std::mem::transmute(bytes) };
+        let alt_slice: &[u32] = unsafe { core::mem::transmute(bytes) };
         //~^ ERROR: transmute from a reference to a reference
     }
 }

--- a/tests/ui/transmute_ref_to_ref_no_std.stderr
+++ b/tests/ui/transmute_ref_to_ref_no_std.stderr
@@ -1,0 +1,26 @@
+error: transmute from a reference to a reference
+  --> $DIR/transmute_ref_to_ref_no_std.rs:21:39
+   |
+LL |         let bools: &[bool] = unsafe { core::mem::transmute(single_u64) };
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(single_u64 as *const [u64] as *const [bool])`
+   |
+note: the lint level is defined here
+  --> $DIR/transmute_ref_to_ref_no_std.rs:3:9
+   |
+LL | #![deny(clippy::transmute_ptr_to_ptr)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: transmute from a reference to a reference
+  --> $DIR/transmute_ref_to_ref_no_std.rs:24:33
+   |
+LL |         let b: &[u8] = unsafe { core::mem::transmute(a) };
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(a as *const [u32] as *const [u8])`
+
+error: transmute from a reference to a reference
+  --> $DIR/transmute_ref_to_ref_no_std.rs:27:42
+   |
+LL |         let alt_slice: &[u32] = unsafe { core::mem::transmute(bytes) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(bytes as *const [u8] as *const [u32])`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/unnecessary_sort_by.stderr
+++ b/tests/ui/unnecessary_sort_by.stderr
@@ -1,4 +1,4 @@
-error: use Vec::sort here instead
+error: consider using `sort`
   --> $DIR/unnecessary_sort_by.rs:12:5
    |
 LL |     vec.sort_by(|a, b| a.cmp(b));
@@ -7,67 +7,67 @@ LL |     vec.sort_by(|a, b| a.cmp(b));
    = note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_sort_by)]`
 
-error: use Vec::sort here instead
+error: consider using `sort`
   --> $DIR/unnecessary_sort_by.rs:13:5
    |
 LL |     vec.sort_unstable_by(|a, b| a.cmp(b));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_unstable()`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:14:5
    |
 LL |     vec.sort_by(|a, b| (a + 5).abs().cmp(&(b + 5).abs()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_by_key(|a| (a + 5).abs())`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:15:5
    |
 LL |     vec.sort_unstable_by(|a, b| id(-a).cmp(&id(-b)));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_unstable_by_key(|a| id(-a))`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:18:5
    |
 LL |     vec.sort_by(|a, b| (b + 5).abs().cmp(&(a + 5).abs()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_by_key(|b| std::cmp::Reverse((b + 5).abs()))`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:19:5
    |
 LL |     vec.sort_unstable_by(|a, b| id(-b).cmp(&id(-a)));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_unstable_by_key(|b| std::cmp::Reverse(id(-b)))`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:29:5
    |
 LL |     vec.sort_by(|a, b| (***a).abs().cmp(&(***b).abs()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_by_key(|a| (***a).abs())`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:30:5
    |
 LL |     vec.sort_unstable_by(|a, b| (***a).abs().cmp(&(***b).abs()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_unstable_by_key(|a| (***a).abs())`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:89:9
    |
 LL |         args.sort_by(|a, b| a.name().cmp(&b.name()));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `args.sort_by_key(|a| a.name())`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:90:9
    |
 LL |         args.sort_unstable_by(|a, b| a.name().cmp(&b.name()));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `args.sort_unstable_by_key(|a| a.name())`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:92:9
    |
 LL |         args.sort_by(|a, b| b.name().cmp(&a.name()));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `args.sort_by_key(|b| std::cmp::Reverse(b.name()))`
 
-error: use Vec::sort_by_key here instead
+error: consider using `sort_by_key`
   --> $DIR/unnecessary_sort_by.rs:93:9
    |
 LL |         args.sort_unstable_by(|a, b| b.name().cmp(&a.name()));


### PR DESCRIPTION
A few lints emit suggestions using `std` paths whether or not this is a `no_std` crate, which is an issue when running `rustfix` afterwards. So in case this is an item that is defined in both `std` and `core`, we need to check if the crate is `no_std` to emit the right path.

r? @llogiq 

changelog: Correctly suggest std or core path depending if this is a `no_std` crate