### PR TITLE
fix FP on [`semicolon_if_nothing_returned`]

### DIFF
--- a/tests/ui/semicolon_if_nothing_returned.fixed
+++ b/tests/ui/semicolon_if_nothing_returned.fixed
@@ -1,5 +1,10 @@
+//@aux-build:proc_macro_attr.rs
+
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![allow(clippy::redundant_closure, clippy::uninlined_format_args, clippy::needless_late_init)]
+
+#[macro_use]
+extern crate proc_macro_attr;
 
 fn get_unit() {}
 
@@ -119,4 +124,26 @@ fn let_else_stmts() {
     let Some(x) = function_returning_option() else {
         return;
     };
+}
+
+mod issue12123 {
+    #[rustfmt::skip]
+    mod this_triggers {
+        #[fake_main];
+        async fn main() {
+            
+        }
+    }
+
+    mod and_this {
+        #[fake_main];
+        async fn main() {
+            println!("hello");
+        }
+    }
+
+    mod but_this_does_not {
+        #[fake_main]
+        async fn main() {}
+    }
 }

--- a/tests/ui/semicolon_if_nothing_returned.fixed
+++ b/tests/ui/semicolon_if_nothing_returned.fixed
@@ -129,16 +129,23 @@ fn let_else_stmts() {
 mod issue12123 {
     #[rustfmt::skip]
     mod this_triggers {
-        #[fake_main];
+        #[fake_main]
         async fn main() {
-            
+
         }
     }
 
     mod and_this {
-        #[fake_main];
+        #[fake_main]
         async fn main() {
             println!("hello");
+        }
+    }
+
+    #[rustfmt::skip]
+    mod maybe_this {
+        /** */ #[fake_main]
+        async fn main() {
         }
     }
 

--- a/tests/ui/semicolon_if_nothing_returned.rs
+++ b/tests/ui/semicolon_if_nothing_returned.rs
@@ -1,5 +1,10 @@
+//@aux-build:proc_macro_attr.rs
+
 #![warn(clippy::semicolon_if_nothing_returned)]
 #![allow(clippy::redundant_closure, clippy::uninlined_format_args, clippy::needless_late_init)]
+
+#[macro_use]
+extern crate proc_macro_attr;
 
 fn get_unit() {}
 
@@ -119,4 +124,26 @@ fn let_else_stmts() {
     let Some(x) = function_returning_option() else {
         return;
     };
+}
+
+mod issue12123 {
+    #[rustfmt::skip]
+    mod this_triggers {
+        #[fake_main]
+        async fn main() {
+            
+        }
+    }
+
+    mod and_this {
+        #[fake_main]
+        async fn main() {
+            println!("hello");
+        }
+    }
+
+    mod but_this_does_not {
+        #[fake_main]
+        async fn main() {}
+    }
 }

--- a/tests/ui/semicolon_if_nothing_returned.rs
+++ b/tests/ui/semicolon_if_nothing_returned.rs
@@ -131,7 +131,7 @@ mod issue12123 {
     mod this_triggers {
         #[fake_main]
         async fn main() {
-            
+
         }
     }
 
@@ -139,6 +139,13 @@ mod issue12123 {
         #[fake_main]
         async fn main() {
             println!("hello");
+        }
+    }
+
+    #[rustfmt::skip]
+    mod maybe_this {
+        /** */ #[fake_main]
+        async fn main() {
         }
     }
 

--- a/tests/ui/semicolon_if_nothing_returned.stderr
+++ b/tests/ui/semicolon_if_nothing_returned.stderr
@@ -31,17 +31,5 @@ error: consider adding a `;` to the last statement for consistent formatting
 LL |         ptr::drop_in_place(s.as_mut_ptr())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add a `;` here: `ptr::drop_in_place(s.as_mut_ptr());`
 
-error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:132:9
-   |
-LL |         #[fake_main]
-   |         ^^^^^^^^^^^^ help: add a `;` here: `#[fake_main];`
-
-error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:139:9
-   |
-LL |         #[fake_main]
-   |         ^^^^^^^^^^^^ help: add a `;` here: `#[fake_main];`
-
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/semicolon_if_nothing_returned.stderr
+++ b/tests/ui/semicolon_if_nothing_returned.stderr
@@ -1,5 +1,5 @@
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:8:5
+  --> $DIR/semicolon_if_nothing_returned.rs:13:5
    |
 LL |     println!("Hello")
    |     ^^^^^^^^^^^^^^^^^ help: add a `;` here: `println!("Hello");`
@@ -8,28 +8,40 @@ LL |     println!("Hello")
    = help: to override `-D warnings` add `#[allow(clippy::semicolon_if_nothing_returned)]`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:12:5
+  --> $DIR/semicolon_if_nothing_returned.rs:17:5
    |
 LL |     get_unit()
    |     ^^^^^^^^^^ help: add a `;` here: `get_unit();`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:17:5
+  --> $DIR/semicolon_if_nothing_returned.rs:22:5
    |
 LL |     y = x + 1
    |     ^^^^^^^^^ help: add a `;` here: `y = x + 1;`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:23:9
+  --> $DIR/semicolon_if_nothing_returned.rs:28:9
    |
 LL |         hello()
    |         ^^^^^^^ help: add a `;` here: `hello();`
 
 error: consider adding a `;` to the last statement for consistent formatting
-  --> $DIR/semicolon_if_nothing_returned.rs:34:9
+  --> $DIR/semicolon_if_nothing_returned.rs:39:9
    |
 LL |         ptr::drop_in_place(s.as_mut_ptr())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add a `;` here: `ptr::drop_in_place(s.as_mut_ptr());`
 
-error: aborting due to 5 previous errors
+error: consider adding a `;` to the last statement for consistent formatting
+  --> $DIR/semicolon_if_nothing_returned.rs:132:9
+   |
+LL |         #[fake_main]
+   |         ^^^^^^^^^^^^ help: add a `;` here: `#[fake_main];`
+
+error: consider adding a `;` to the last statement for consistent formatting
+  --> $DIR/semicolon_if_nothing_returned.rs:139:9
+   |
+LL |         #[fake_main]
+   |         ^^^^^^^^^^^^ help: add a `;` here: `#[fake_main];`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
fixes: #12123 

---

changelog: fix FP on [`semicolon_if_nothing_returned`] which suggesting adding semicolon after attr macro
