### PR TITLE
blocks_in_conditions: do not warn if condition comes from macro

### DIFF
--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -67,6 +67,11 @@ impl<'tcx> LateLintPass<'tcx> for BlocksInConditions {
         );
 
         if let ExprKind::Block(block, _) = &cond.kind {
+            if !block.span.eq_ctxt(expr.span) {
+                // If the block comes from a macro, or as an argument to a macro,
+                // do not lint.
+                return;
+            }
             if block.rules == BlockCheckMode::DefaultBlock {
                 if block.stmts.is_empty() {
                     if let Some(ex) = &block.expr {

--- a/tests/ui/blocks_in_conditions.fixed
+++ b/tests/ui/blocks_in_conditions.fixed
@@ -85,4 +85,18 @@ fn block_in_match_expr(num: i32) -> i32 {
     }
 }
 
+// issue #12162
+macro_rules! timed {
+    ($name:expr, $body:expr $(,)?) => {{
+        let __scope = ();
+        $body
+    }};
+}
+
+fn issue_12162() {
+    if timed!("check this!", false) {
+        println!();
+    }
+}
+
 fn main() {}

--- a/tests/ui/blocks_in_conditions.rs
+++ b/tests/ui/blocks_in_conditions.rs
@@ -85,4 +85,18 @@ fn block_in_match_expr(num: i32) -> i32 {
     }
 }
 
+// issue #12162
+macro_rules! timed {
+    ($name:expr, $body:expr $(,)?) => {{
+        let __scope = ();
+        $body
+    }};
+}
+
+fn issue_12162() {
+    if timed!("check this!", false) {
+        println!();
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
changelog: [`blocks_in_conditions`]: do not warn if condition comes from macro

Fix #12162
