### PR TITLE
Fix false positive for `unusual_byte_groupings`

### DIFF
--- a/tests/ui/large_digit_groups.fixed
+++ b/tests/ui/large_digit_groups.fixed
@@ -16,14 +16,22 @@ fn main() {
         1_234.12_f32,
         1_234.123_f32,
         1.123_4_f32,
+        0b000_00_11_0,
+        0b0_00_00_110,
     );
     let _bad = (
-        0b1_10110_i64,
+        0b11_0110_i64,
+        //~^ ERROR: digit groups should be smaller
         0xdead_beef_usize,
+        //~^ ERROR: digits of hex, binary or octal literal not in groups of equal size
         123_456_f32,
+        //~^ ERROR: digit groups should be smaller
         123_456.12_f32,
+        //~^ ERROR: digit groups should be smaller
         123_456.123_45_f64,
+        //~^ ERROR: digit groups should be smaller
         123_456.123_456_f64,
+        //~^ ERROR: digit groups should be smaller
     );
     // Ignore literals in macros
     let _ = mac!();

--- a/tests/ui/large_digit_groups.rs
+++ b/tests/ui/large_digit_groups.rs
@@ -16,14 +16,22 @@ fn main() {
         1_234.12_f32,
         1_234.123_f32,
         1.123_4_f32,
+        0b000_00_11_0,
+        0b0_00_00_110,
     );
     let _bad = (
         0b1_10110_i64,
+        //~^ ERROR: digit groups should be smaller
         0xd_e_adbee_f_usize,
+        //~^ ERROR: digits of hex, binary or octal literal not in groups of equal size
         1_23456_f32,
+        //~^ ERROR: digit groups should be smaller
         1_23456.12_f32,
+        //~^ ERROR: digit groups should be smaller
         1_23456.12345_f64,
+        //~^ ERROR: digit groups should be smaller
         1_23456.12345_6_f64,
+        //~^ ERROR: digit groups should be smaller
     );
     // Ignore literals in macros
     let _ = mac!();

--- a/tests/ui/large_digit_groups.stderr
+++ b/tests/ui/large_digit_groups.stderr
@@ -1,5 +1,14 @@
+error: digit groups should be smaller
+  --> $DIR/large_digit_groups.rs:23:9
+   |
+LL |         0b1_10110_i64,
+   |         ^^^^^^^^^^^^^ help: consider: `0b11_0110_i64`
+   |
+   = note: `-D clippy::large-digit-groups` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::large_digit_groups)]`
+
 error: digits of hex, binary or octal literal not in groups of equal size
-  --> $DIR/large_digit_groups.rs:22:9
+  --> $DIR/large_digit_groups.rs:25:9
    |
 LL |         0xd_e_adbee_f_usize,
    |         ^^^^^^^^^^^^^^^^^^^ help: consider: `0xdead_beef_usize`
@@ -8,31 +17,28 @@ LL |         0xd_e_adbee_f_usize,
    = help: to override `-D warnings` add `#[allow(clippy::unusual_byte_groupings)]`
 
 error: digit groups should be smaller
-  --> $DIR/large_digit_groups.rs:23:9
+  --> $DIR/large_digit_groups.rs:27:9
    |
 LL |         1_23456_f32,
    |         ^^^^^^^^^^^ help: consider: `123_456_f32`
-   |
-   = note: `-D clippy::large-digit-groups` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::large_digit_groups)]`
 
 error: digit groups should be smaller
-  --> $DIR/large_digit_groups.rs:24:9
+  --> $DIR/large_digit_groups.rs:29:9
    |
 LL |         1_23456.12_f32,
    |         ^^^^^^^^^^^^^^ help: consider: `123_456.12_f32`
 
 error: digit groups should be smaller
-  --> $DIR/large_digit_groups.rs:25:9
+  --> $DIR/large_digit_groups.rs:31:9
    |
 LL |         1_23456.12345_f64,
    |         ^^^^^^^^^^^^^^^^^ help: consider: `123_456.123_45_f64`
 
 error: digit groups should be smaller
-  --> $DIR/large_digit_groups.rs:26:9
+  --> $DIR/large_digit_groups.rs:33:9
    |
 LL |         1_23456.12345_6_f64,
    |         ^^^^^^^^^^^^^^^^^^^ help: consider: `123_456.123_456_f64`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/11749.

r? @blyxyas 

changelog: [`unusual_byte_groupings`]: Fix false positive