### PR TITLE
respect `#[allow]` attributes in `single_call_fn` lint

### DIFF
--- a/tests/ui/single_call_fn.rs
+++ b/tests/ui/single_call_fn.rs
@@ -69,6 +69,17 @@ fn e() {
 #[test]
 fn k() {}
 
+mod issue12182 {
+    #[allow(clippy::single_call_fn)]
+    fn print_foo(text: &str) {
+        println!("{text}");
+    }
+
+    fn use_print_foo() {
+        print_foo("foo");
+    }
+}
+
 #[test]
 fn l() {
     k();


### PR DESCRIPTION
Fixes #12182

If we delay linting to `check_crate_post`, we need to use `span_lint_hir_and_then`, since otherwise it would only respect those lint level attributes at the crate root.
<sub>... maybe we can have an internal lint for this somehow?</sub>

changelog: respect `#[allow]` attributes in `single_call_fn` lint