### PR TITLE
Fix/12035 silence struct field names

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1846,6 +1846,14 @@ pub fn is_lint_allowed(cx: &LateContext<'_>, lint: &'static Lint, id: HirId) -> 
     cx.tcx.lint_level_at_node(lint, id).0 == Level::Allow
 }
 
+/// Returns `true` if any of the `impl`s for the given `item` has the lint allowed
+pub fn any_impl_has_lint_allowed(cx: &LateContext<'_>, lint: &'static Lint, id: DefId) -> bool {
+    cx.tcx
+        .inherent_impls(id)
+        .iter()
+        .any(|imp| is_lint_allowed(cx, lint, cx.tcx.hir().expect_item(imp.expect_local()).hir_id()))
+}
+
 pub fn strip_pat_refs<'hir>(mut pat: &'hir Pat<'hir>) -> &'hir Pat<'hir> {
     while let PatKind::Ref(subpat, _) = pat.kind {
         pat = subpat;

--- a/tests/ui-toml/item_name_repetitions/threshold5/item_name_repetitions.rs
+++ b/tests/ui-toml/item_name_repetitions/threshold5/item_name_repetitions.rs
@@ -29,4 +29,28 @@ enum Foo2 {
     EFoo,
 }
 
+// This should not trigger the lint as one of it's impl has allow attribute
+struct Data3 {
+    a_data: u8,
+    b_data: u8,
+    c_data: u8,
+    d_data: u8,
+    e_data: u8,
+}
+
+#[allow(clippy::struct_field_names)]
+impl Data3 {}
+
+// This should not trigger the lint as one of it's impl has allow attribute
+enum Foo3 {
+    AFoo,
+    BFoo,
+    CFoo,
+    DFoo,
+    EFoo,
+}
+
+#[allow(clippy::enum_variant_names)]
+impl Foo3 {}
+
 fn main() {}


### PR DESCRIPTION
fixes #12035 

Allows to silence lints `struct_field_names` and `enum_variant_names` through their impls. 
This is done in order for some crates such as `serde` to  silence those lints

changelog: [`struct_field_names`]: allow to silence lint through struct's impl
changelog: [`enum_variant_names`]: allow to silence lint through enum's impl