### PR TITLE
implement disallowed trait methods

### DIFF
--- a/tests/ui-toml/toml_disallowed_methods/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_methods/clippy.toml
@@ -14,4 +14,5 @@ disallowed-methods = [
     "conf_disallowed_methods::Struct::method",
     "conf_disallowed_methods::Trait::provided_method",
     "conf_disallowed_methods::Trait::implemented_method",
+    "<conf_disallowed_methods::StructBad as conf_disallowed_methods::Trait>::provided_bad_method",
 ]

--- a/tests/ui-toml/toml_disallowed_methods/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_methods/clippy.toml
@@ -14,5 +14,6 @@ disallowed-methods = [
     "conf_disallowed_methods::Struct::method",
     "conf_disallowed_methods::Trait::provided_method",
     "conf_disallowed_methods::Trait::implemented_method",
+    "<std::string::String as std::default::Default>::default",
     "<conf_disallowed_methods::StructBad as conf_disallowed_methods::Trait>::provided_method",
 ]

--- a/tests/ui-toml/toml_disallowed_methods/clippy.toml
+++ b/tests/ui-toml/toml_disallowed_methods/clippy.toml
@@ -14,5 +14,5 @@ disallowed-methods = [
     "conf_disallowed_methods::Struct::method",
     "conf_disallowed_methods::Trait::provided_method",
     "conf_disallowed_methods::Trait::implemented_method",
-    "<conf_disallowed_methods::StructBad as conf_disallowed_methods::Trait>::provided_bad_method",
+    "<conf_disallowed_methods::StructBad as conf_disallowed_methods::Trait>::provided_method",
 ]

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -64,6 +64,7 @@ fn main() {
     s.provided_method();
     s.implemented_method();
 
+    _ = String::default();
     let s_bad = StructBad;
     s_bad.provided_method();
 }

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -22,7 +22,6 @@ impl Struct {
 trait Trait {
     fn provided_method(&self) {}
     fn implemented_method(&self);
-    fn provided_bad_method(&self) {}
 }
 
 impl Trait for Struct {
@@ -64,8 +63,7 @@ fn main() {
     s.method();
     s.provided_method();
     s.implemented_method();
-    _ = String::default();
-    s.provided_bad_method();
+
     let s_bad = StructBad;
-    s_bad.provided_bad_method();
+    s_bad.provided_method();
 }

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs
@@ -13,6 +13,7 @@ use regex::Regex;
 fn local_fn() {}
 
 struct Struct;
+struct StructBad;
 
 impl Struct {
     fn method(&self) {}
@@ -21,9 +22,14 @@ impl Struct {
 trait Trait {
     fn provided_method(&self) {}
     fn implemented_method(&self);
+    fn provided_bad_method(&self) {}
 }
 
 impl Trait for Struct {
+    fn implemented_method(&self) {}
+}
+
+impl Trait for StructBad {
     fn implemented_method(&self) {}
 }
 
@@ -58,4 +64,8 @@ fn main() {
     s.method();
     s.provided_method();
     s.implemented_method();
+    _ = String::default();
+    s.provided_bad_method();
+    let s_bad = StructBad;
+    s_bad.provided_bad_method();
 }

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -87,11 +87,17 @@ error: use of a disallowed method `conf_disallowed_methods::Trait::implemented_m
 LL |     s.implemented_method();
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
+error: use of a disallowed method `<std::string::String as std::default::Default>::default`
+  --> $DIR/conf_disallowed_methods.rs:67:9
+   |
+LL |     _ = String::default();
+   |         ^^^^^^^^^^^^^^^^^
+
 error: use of a disallowed method `conf_disallowed_methods::Trait::provided_method`
-  --> $DIR/conf_disallowed_methods.rs:68:5
+  --> $DIR/conf_disallowed_methods.rs:69:5
    |
 LL |     s_bad.provided_method();
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 15 previous errors
+error: aborting due to 16 previous errors
 

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -1,5 +1,5 @@
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:41:14
+  --> $DIR/conf_disallowed_methods.rs:40:14
    |
 LL |     let re = Regex::new(r"ab.*c").unwrap();
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let re = Regex::new(r"ab.*c").unwrap();
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
 
 error: use of a disallowed method `regex::Regex::is_match`
-  --> $DIR/conf_disallowed_methods.rs:42:5
+  --> $DIR/conf_disallowed_methods.rs:41:5
    |
 LL |     re.is_match("abc");
    |     ^^^^^^^^^^^^^^^^^^
@@ -16,82 +16,82 @@ LL |     re.is_match("abc");
    = note: no matching allowed (from clippy.toml)
 
 error: use of a disallowed method `std::iter::Iterator::sum`
-  --> $DIR/conf_disallowed_methods.rs:45:5
+  --> $DIR/conf_disallowed_methods.rs:44:5
    |
 LL |     a.iter().sum::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `slice::sort_unstable`
-  --> $DIR/conf_disallowed_methods.rs:47:5
+  --> $DIR/conf_disallowed_methods.rs:46:5
    |
 LL |     a.sort_unstable();
    |     ^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:49:13
+  --> $DIR/conf_disallowed_methods.rs:48:13
    |
 LL |     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:52:61
+  --> $DIR/conf_disallowed_methods.rs:51:61
    |
 LL |     let indirect: fn(&str) -> Result<Regex, regex::Error> = Regex::new;
    |                                                             ^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:55:28
+  --> $DIR/conf_disallowed_methods.rs:54:28
    |
 LL |     let in_call = Box::new(f32::clamp);
    |                            ^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:56:53
+  --> $DIR/conf_disallowed_methods.rs:55:53
    |
 LL |     let in_method_call = ["^", "$"].into_iter().map(Regex::new);
    |                                                     ^^^^^^^^^^
 
 error: use of a disallowed method `futures::stream::select_all`
-  --> $DIR/conf_disallowed_methods.rs:59:31
+  --> $DIR/conf_disallowed_methods.rs:58:31
    |
 LL |     let same_name_as_module = select_all(vec![empty::<()>()]);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_fn`
-  --> $DIR/conf_disallowed_methods.rs:61:5
+  --> $DIR/conf_disallowed_methods.rs:60:5
    |
 LL |     local_fn();
    |     ^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_mod::f`
-  --> $DIR/conf_disallowed_methods.rs:62:5
+  --> $DIR/conf_disallowed_methods.rs:61:5
    |
 LL |     local_mod::f();
    |     ^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Struct::method`
-  --> $DIR/conf_disallowed_methods.rs:64:5
+  --> $DIR/conf_disallowed_methods.rs:63:5
    |
 LL |     s.method();
    |     ^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::provided_method`
-  --> $DIR/conf_disallowed_methods.rs:65:5
+  --> $DIR/conf_disallowed_methods.rs:64:5
    |
 LL |     s.provided_method();
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::implemented_method`
-  --> $DIR/conf_disallowed_methods.rs:66:5
+  --> $DIR/conf_disallowed_methods.rs:65:5
    |
 LL |     s.implemented_method();
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: use of a disallowed method `<conf_disallowed_methods::StructBad as conf_disallowed_methods::Trait>::provided_bad_method`
-  --> $DIR/conf_disallowed_methods.rs:70:5
+error: use of a disallowed method `conf_disallowed_methods::Trait::provided_method`
+  --> $DIR/conf_disallowed_methods.rs:68:5
    |
-LL |     s_bad.provided_bad_method();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     s_bad.provided_method();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -1,5 +1,5 @@
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:35:14
+  --> $DIR/conf_disallowed_methods.rs:41:14
    |
 LL |     let re = Regex::new(r"ab.*c").unwrap();
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let re = Regex::new(r"ab.*c").unwrap();
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
 
 error: use of a disallowed method `regex::Regex::is_match`
-  --> $DIR/conf_disallowed_methods.rs:36:5
+  --> $DIR/conf_disallowed_methods.rs:42:5
    |
 LL |     re.is_match("abc");
    |     ^^^^^^^^^^^^^^^^^^
@@ -16,76 +16,82 @@ LL |     re.is_match("abc");
    = note: no matching allowed (from clippy.toml)
 
 error: use of a disallowed method `std::iter::Iterator::sum`
-  --> $DIR/conf_disallowed_methods.rs:39:5
+  --> $DIR/conf_disallowed_methods.rs:45:5
    |
 LL |     a.iter().sum::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `slice::sort_unstable`
-  --> $DIR/conf_disallowed_methods.rs:41:5
+  --> $DIR/conf_disallowed_methods.rs:47:5
    |
 LL |     a.sort_unstable();
    |     ^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:43:13
+  --> $DIR/conf_disallowed_methods.rs:49:13
    |
 LL |     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:46:61
+  --> $DIR/conf_disallowed_methods.rs:52:61
    |
 LL |     let indirect: fn(&str) -> Result<Regex, regex::Error> = Regex::new;
    |                                                             ^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> $DIR/conf_disallowed_methods.rs:49:28
+  --> $DIR/conf_disallowed_methods.rs:55:28
    |
 LL |     let in_call = Box::new(f32::clamp);
    |                            ^^^^^^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
-  --> $DIR/conf_disallowed_methods.rs:50:53
+  --> $DIR/conf_disallowed_methods.rs:56:53
    |
 LL |     let in_method_call = ["^", "$"].into_iter().map(Regex::new);
    |                                                     ^^^^^^^^^^
 
 error: use of a disallowed method `futures::stream::select_all`
-  --> $DIR/conf_disallowed_methods.rs:53:31
+  --> $DIR/conf_disallowed_methods.rs:59:31
    |
 LL |     let same_name_as_module = select_all(vec![empty::<()>()]);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_fn`
-  --> $DIR/conf_disallowed_methods.rs:55:5
+  --> $DIR/conf_disallowed_methods.rs:61:5
    |
 LL |     local_fn();
    |     ^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_mod::f`
-  --> $DIR/conf_disallowed_methods.rs:56:5
+  --> $DIR/conf_disallowed_methods.rs:62:5
    |
 LL |     local_mod::f();
    |     ^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Struct::method`
-  --> $DIR/conf_disallowed_methods.rs:58:5
+  --> $DIR/conf_disallowed_methods.rs:64:5
    |
 LL |     s.method();
    |     ^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::provided_method`
-  --> $DIR/conf_disallowed_methods.rs:59:5
+  --> $DIR/conf_disallowed_methods.rs:65:5
    |
 LL |     s.provided_method();
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::implemented_method`
-  --> $DIR/conf_disallowed_methods.rs:60:5
+  --> $DIR/conf_disallowed_methods.rs:66:5
    |
 LL |     s.implemented_method();
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: use of a disallowed method `<conf_disallowed_methods::StructBad as conf_disallowed_methods::Trait>::provided_bad_method`
+  --> $DIR/conf_disallowed_methods.rs:70:5
+   |
+LL |     s_bad.provided_bad_method();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
resolves #8581


changelog: [`disallowed_methods`]: Allow specific trait impls via qualified call syntax to be linted.