### PR TITLE
Add markdown link to diagnostic

### DIFF
--- a/clippy_utils/src/diagnostics.rs
+++ b/clippy_utils/src/diagnostics.rs
@@ -18,7 +18,7 @@ fn docs_link(diag: &mut Diagnostic, lint: &'static Lint) {
     if env::var("CLIPPY_DISABLE_DOCS_LINKS").is_err() {
         if let Some(lint) = lint.name_lower().strip_prefix("clippy::") {
             diag.help(format!(
-                "for further information visit https://rust-lang.github.io/rust-clippy/{}/index.html#{lint}",
+                "for further information visit [rust-lang.github.io/rust-clippy/{}/index.html#{lint}](https://rust-lang.github.io/rust-clippy/{}/index.html#{lint})",
                 &option_env!("RUST_RELEASE_NUM").map_or("master".to_string(), |n| {
                     // extract just major + minor version and ignore patch versions
                     format!("rust-{}", n.rsplit_once('.').unwrap().1)


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: changes the link in diagnostics to a markdown link so editors like VSCode can create a clickable link