### PR TITLE
Add y21 to the review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -32,4 +32,5 @@ contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIB
     "@dswij",
     "@Jarcho",
     "@blyxyas",
+    "@y21",
 ]


### PR DESCRIPTION
https://github.com/rust-lang/team/pull/1342

r? @ghost, when you're ready to be added to the rotation `@bors r+` this @y21

changelog: none
