### PR TITLE
Add `missing_transmute_annotations` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5426,6 +5426,7 @@ Released 2018-09-13
 [`missing_safety_doc`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_safety_doc
 [`missing_spin_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_spin_loop
 [`missing_trait_methods`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_trait_methods
+[`missing_transmute_annotations`]: https://rust-lang.github.io/rust-clippy/master/index.html#missing_transmute_annotations
 [`mistyped_literal_suffixes`]: https://rust-lang.github.io/rust-clippy/master/index.html#mistyped_literal_suffixes
 [`mixed_attributes_style`]: https://rust-lang.github.io/rust-clippy/master/index.html#mixed_attributes_style
 [`mixed_case_hex_literals`]: https://rust-lang.github.io/rust-clippy/master/index.html#mixed_case_hex_literals

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -677,6 +677,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::trait_bounds::TYPE_REPETITION_IN_BOUNDS_INFO,
     crate::transmute::CROSSPOINTER_TRANSMUTE_INFO,
     crate::transmute::EAGER_TRANSMUTE_INFO,
+    crate::transmute::MISSING_TRANSMUTE_ANNOTATIONS_INFO,
     crate::transmute::TRANSMUTES_EXPRESSIBLE_AS_PTR_CASTS_INFO,
     crate::transmute::TRANSMUTE_BYTES_TO_STR_INFO,
     crate::transmute::TRANSMUTE_FLOAT_TO_INT_INFO,

--- a/clippy_lints/src/transmute/missing_transmute_annotations.rs
+++ b/clippy_lints/src/transmute/missing_transmute_annotations.rs
@@ -1,0 +1,53 @@
+use rustc_errors::Applicability;
+use rustc_hir::{GenericArg, HirId, Node, Path, TyKind};
+use rustc_lint::LateContext;
+use rustc_middle::lint::in_external_macro;
+use rustc_middle::ty::Ty;
+
+use clippy_utils::diagnostics::span_lint_and_sugg;
+
+use crate::transmute::MISSING_TRANSMUTE_ANNOTATIONS;
+
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    path: &Path<'tcx>,
+    from_ty: Ty<'tcx>,
+    to_ty: Ty<'tcx>,
+    expr_hir_id: HirId,
+) -> bool {
+    let last = path.segments.last().unwrap();
+    if in_external_macro(cx.tcx.sess, last.ident.span) {
+        // If it comes from a non-local macro, we ignore it.
+        return false;
+    }
+    let args = last.args;
+    let missing_generic = match args {
+        Some(args) if !args.args.is_empty() => args.args.iter().any(|arg| match arg {
+            GenericArg::Infer(_) => true,
+            GenericArg::Type(ty) => matches!(ty.kind, TyKind::Infer),
+            _ => false,
+        }),
+        _ => true,
+    };
+    if !missing_generic {
+        return false;
+    }
+    // If it's being set as a local variable value...
+    if let Some((_, node)) = cx.tcx.hir().parent_iter(expr_hir_id).next()
+        && let Node::Local(local) = node
+        // ... which does have type annotations.
+        && local.ty.is_some()
+    {
+        return false;
+    }
+    span_lint_and_sugg(
+        cx,
+        MISSING_TRANSMUTE_ANNOTATIONS,
+        last.ident.span.with_hi(path.span.hi()),
+        "transmute used without annotations",
+        "consider adding missing annotations",
+        format!("{}::<{from_ty}, {to_ty}>", last.ident.as_str()),
+        Applicability::MaybeIncorrect,
+    );
+    true
+}

--- a/tests/ui/author/issue_3849.rs
+++ b/tests/ui/author/issue_3849.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![allow(clippy::zero_ptr)]
 #![allow(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::transmuting_null)]
+#![allow(clippy::transmuting_null, clippy::missing_transmute_annotations)]
 
 pub const ZPTR: *const usize = 0 as *const _;
 

--- a/tests/ui/auxiliary/macro_rules.rs
+++ b/tests/ui/auxiliary/macro_rules.rs
@@ -50,3 +50,10 @@ macro_rules! macro_with_panic {
         panic!()
     };
 }
+
+#[macro_export]
+macro_rules! bad_transmute {
+    ($e:expr) => {
+        std::mem::transmute($e)
+    };
+}

--- a/tests/ui/blocks_in_conditions.fixed
+++ b/tests/ui/blocks_in_conditions.fixed
@@ -1,7 +1,12 @@
 //@aux-build:proc_macro_attr.rs
 
 #![warn(clippy::blocks_in_conditions)]
-#![allow(unused, clippy::let_and_return, clippy::needless_if)]
+#![allow(
+    unused,
+    clippy::let_and_return,
+    clippy::needless_if,
+    clippy::missing_transmute_annotations
+)]
 #![warn(clippy::nonminimal_bool)]
 
 macro_rules! blocky {

--- a/tests/ui/blocks_in_conditions.rs
+++ b/tests/ui/blocks_in_conditions.rs
@@ -1,7 +1,12 @@
 //@aux-build:proc_macro_attr.rs
 
 #![warn(clippy::blocks_in_conditions)]
-#![allow(unused, clippy::let_and_return, clippy::needless_if)]
+#![allow(
+    unused,
+    clippy::let_and_return,
+    clippy::needless_if,
+    clippy::missing_transmute_annotations
+)]
 #![warn(clippy::nonminimal_bool)]
 
 macro_rules! blocky {

--- a/tests/ui/blocks_in_conditions.stderr
+++ b/tests/ui/blocks_in_conditions.stderr
@@ -1,5 +1,5 @@
 error: in an `if` condition, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-  --> tests/ui/blocks_in_conditions.rs:25:5
+  --> tests/ui/blocks_in_conditions.rs:30:5
    |
 LL | /     if {
 LL | |
@@ -20,13 +20,13 @@ LL ~     }; if res {
    |
 
 error: omit braces around single expression condition
-  --> tests/ui/blocks_in_conditions.rs:37:8
+  --> tests/ui/blocks_in_conditions.rs:42:8
    |
 LL |     if { true } { 6 } else { 10 }
    |        ^^^^^^^^ help: try: `true`
 
 error: this boolean expression can be simplified
-  --> tests/ui/blocks_in_conditions.rs:43:8
+  --> tests/ui/blocks_in_conditions.rs:48:8
    |
 LL |     if true && x == 3 { 6 } else { 10 }
    |        ^^^^^^^^^^^^^^ help: try: `x == 3`
@@ -35,7 +35,7 @@ LL |     if true && x == 3 { 6 } else { 10 }
    = help: to override `-D warnings` add `#[allow(clippy::nonminimal_bool)]`
 
 error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
-  --> tests/ui/blocks_in_conditions.rs:70:5
+  --> tests/ui/blocks_in_conditions.rs:75:5
    |
 LL | /     match {
 LL | |

--- a/tests/ui/crashes/ice-1782.rs
+++ b/tests/ui/crashes/ice-1782.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, unused_variables)]
-#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::unnecessary_cast, clippy::missing_transmute_annotations)]
 
 /// Should not trigger an ICE in `SpanlessEq` / `consts::constant`
 ///

--- a/tests/ui/eager_transmute.fixed
+++ b/tests/ui/eager_transmute.fixed
@@ -1,6 +1,6 @@
 #![feature(rustc_attrs)]
 #![warn(clippy::eager_transmute)]
-#![allow(clippy::transmute_int_to_non_zero)]
+#![allow(clippy::transmute_int_to_non_zero, clippy::missing_transmute_annotations)]
 
 use std::num::NonZeroU8;
 

--- a/tests/ui/eager_transmute.rs
+++ b/tests/ui/eager_transmute.rs
@@ -1,6 +1,6 @@
 #![feature(rustc_attrs)]
 #![warn(clippy::eager_transmute)]
-#![allow(clippy::transmute_int_to_non_zero)]
+#![allow(clippy::transmute_int_to_non_zero, clippy::missing_transmute_annotations)]
 
 use std::num::NonZeroU8;
 

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::missing_const_for_fn)]
-#![allow(incomplete_features, clippy::let_and_return)]
+#![allow(incomplete_features, clippy::let_and_return, clippy::missing_transmute_annotations)]
 #![feature(const_mut_refs)]
 #![feature(const_trait_impl)]
 

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -9,6 +9,7 @@ extern crate macro_rules;
 macro_rules! local_bad_transmute {
     ($e:expr) => {
         std::mem::transmute::<[u16; 2], i32>($e)
+        //~^ ERROR: transmute used without annotations
     };
 }
 
@@ -17,55 +18,46 @@ fn bar(x: i32) -> i32 {
 }
 
 unsafe fn foo1() -> i32 {
-    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
+    // Should not warn!
+    std::mem::transmute([1u16, 2u16])
 }
 
-unsafe fn foo2() -> i32 {
-    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo3() -> i32 {
-    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo4() -> i32 {
-    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo5() -> i32 {
-    let x: i32 = bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
-    //~^ ERROR: transmute used without annotations
-    bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]))
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo6() -> i32 {
-    local_bad_transmute!([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo7() -> i32 {
-    // Should not warn.
-    bad_transmute!([1u16, 2u16])
-}
+// Should not warn!
+const _: i32 = unsafe { std::mem::transmute([1u16, 2u16]) };
 
 #[repr(i32)]
 enum Foo {
     A = 0,
 }
 
-unsafe fn foo8() -> Foo {
-    std::mem::transmute::<i32, Foo>(0i32)
+unsafe fn foo2() -> i32 {
+    let mut i: i32 = 0;
+    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
     //~^ ERROR: transmute used without annotations
-}
+    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+    //~^ ERROR: transmute used without annotations
+    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+    //~^ ERROR: transmute used without annotations
+    i = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+    //~^ ERROR: transmute used without annotations
 
-unsafe fn foo9() -> i32 {
-    std::mem::transmute::<Foo, i32>(Foo::A)
+    let x: i32 = bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
     //~^ ERROR: transmute used without annotations
+    bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
+    //~^ ERROR: transmute used without annotations
+
+    i = local_bad_transmute!([1u16, 2u16]);
+
+    // Should not warn.
+    i = bad_transmute!([1u16, 2u16]);
+
+    i = std::mem::transmute::<[i16; 2], i32>([0i16, 0i16]);
+    //~^ ERROR: transmute used without annotations
+
+    i = std::mem::transmute::<Foo, i32>(Foo::A);
+    //~^ ERROR: transmute used without annotations
+
+    i
 }
 
 fn main() {

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -1,6 +1,7 @@
 //@aux-build:macro_rules.rs
 
 #![warn(clippy::missing_transmute_annotations)]
+#![allow(clippy::let_with_type_underscore)]
 
 #[macro_use]
 extern crate macro_rules;
@@ -68,7 +69,12 @@ unsafe fn foo9() -> i32 {
 }
 
 fn main() {
+    let x: _ = unsafe { std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]) };
+    //~^ ERROR: transmute used without annotations
     unsafe {
+        let x: _ = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+
         // Should not warn.
         std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
         let x = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
@@ -76,4 +82,5 @@ fn main() {
         let x: i32 = std::mem::transmute::<_, i32>([1u16, 2u16]);
         let x: i32 = std::mem::transmute([1u16, 2u16]);
     }
+    let x: i32 = unsafe { std::mem::transmute([1u16, 2u16]) };
 }

--- a/tests/ui/missing_transmute_annotations.fixed
+++ b/tests/ui/missing_transmute_annotations.fixed
@@ -1,0 +1,79 @@
+//@aux-build:macro_rules.rs
+
+#![warn(clippy::missing_transmute_annotations)]
+
+#[macro_use]
+extern crate macro_rules;
+
+macro_rules! local_bad_transmute {
+    ($e:expr) => {
+        std::mem::transmute::<[u16; 2], i32>($e)
+    };
+}
+
+fn bar(x: i32) -> i32 {
+    x
+}
+
+unsafe fn foo1() -> i32 {
+    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo2() -> i32 {
+    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo3() -> i32 {
+    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo4() -> i32 {
+    std::mem::transmute::<[u16; 2], i32>([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo5() -> i32 {
+    let x: i32 = bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]));
+    //~^ ERROR: transmute used without annotations
+    bar(std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]))
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo6() -> i32 {
+    local_bad_transmute!([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo7() -> i32 {
+    // Should not warn.
+    bad_transmute!([1u16, 2u16])
+}
+
+#[repr(i32)]
+enum Foo {
+    A = 0,
+}
+
+unsafe fn foo8() -> Foo {
+    std::mem::transmute::<i32, Foo>(0i32)
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo9() -> i32 {
+    std::mem::transmute::<Foo, i32>(Foo::A)
+    //~^ ERROR: transmute used without annotations
+}
+
+fn main() {
+    unsafe {
+        // Should not warn.
+        std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        let x = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        let x: i32 = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
+        let x: i32 = std::mem::transmute::<_, i32>([1u16, 2u16]);
+        let x: i32 = std::mem::transmute([1u16, 2u16]);
+    }
+}

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -1,0 +1,79 @@
+//@aux-build:macro_rules.rs
+
+#![warn(clippy::missing_transmute_annotations)]
+
+#[macro_use]
+extern crate macro_rules;
+
+macro_rules! local_bad_transmute {
+    ($e:expr) => {
+        std::mem::transmute($e)
+    };
+}
+
+fn bar(x: i32) -> i32 {
+    x
+}
+
+unsafe fn foo1() -> i32 {
+    std::mem::transmute([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo2() -> i32 {
+    std::mem::transmute::<_, _>([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo3() -> i32 {
+    std::mem::transmute::<_, i32>([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo4() -> i32 {
+    std::mem::transmute::<[u16; 2], _>([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo5() -> i32 {
+    let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
+    //~^ ERROR: transmute used without annotations
+    bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]))
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo6() -> i32 {
+    local_bad_transmute!([1u16, 2u16])
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo7() -> i32 {
+    // Should not warn.
+    bad_transmute!([1u16, 2u16])
+}
+
+#[repr(i32)]
+enum Foo {
+    A = 0,
+}
+
+unsafe fn foo8() -> Foo {
+    std::mem::transmute(0i32)
+    //~^ ERROR: transmute used without annotations
+}
+
+unsafe fn foo9() -> i32 {
+    std::mem::transmute(Foo::A)
+    //~^ ERROR: transmute used without annotations
+}
+
+fn main() {
+    unsafe {
+        // Should not warn.
+        std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        let x = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
+        let x: i32 = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
+        let x: i32 = std::mem::transmute::<_, i32>([1u16, 2u16]);
+        let x: i32 = std::mem::transmute([1u16, 2u16]);
+    }
+}

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -1,6 +1,7 @@
 //@aux-build:macro_rules.rs
 
 #![warn(clippy::missing_transmute_annotations)]
+#![allow(clippy::let_with_type_underscore)]
 
 #[macro_use]
 extern crate macro_rules;
@@ -68,7 +69,12 @@ unsafe fn foo9() -> i32 {
 }
 
 fn main() {
+    let x: _ = unsafe { std::mem::transmute::<_, i32>([1u16, 2u16]) };
+    //~^ ERROR: transmute used without annotations
     unsafe {
+        let x: _ = std::mem::transmute::<_, i32>([1u16, 2u16]);
+        //~^ ERROR: transmute used without annotations
+
         // Should not warn.
         std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
         let x = std::mem::transmute::<[u16; 2], i32>([1u16, 2u16]);
@@ -76,4 +82,5 @@ fn main() {
         let x: i32 = std::mem::transmute::<_, i32>([1u16, 2u16]);
         let x: i32 = std::mem::transmute([1u16, 2u16]);
     }
+    let x: i32 = unsafe { std::mem::transmute([1u16, 2u16]) };
 }

--- a/tests/ui/missing_transmute_annotations.rs
+++ b/tests/ui/missing_transmute_annotations.rs
@@ -9,6 +9,7 @@ extern crate macro_rules;
 macro_rules! local_bad_transmute {
     ($e:expr) => {
         std::mem::transmute($e)
+        //~^ ERROR: transmute used without annotations
     };
 }
 
@@ -17,55 +18,46 @@ fn bar(x: i32) -> i32 {
 }
 
 unsafe fn foo1() -> i32 {
+    // Should not warn!
     std::mem::transmute([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
 }
 
-unsafe fn foo2() -> i32 {
-    std::mem::transmute::<_, _>([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo3() -> i32 {
-    std::mem::transmute::<_, i32>([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo4() -> i32 {
-    std::mem::transmute::<[u16; 2], _>([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo5() -> i32 {
-    let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
-    //~^ ERROR: transmute used without annotations
-    bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]))
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo6() -> i32 {
-    local_bad_transmute!([1u16, 2u16])
-    //~^ ERROR: transmute used without annotations
-}
-
-unsafe fn foo7() -> i32 {
-    // Should not warn.
-    bad_transmute!([1u16, 2u16])
-}
+// Should not warn!
+const _: i32 = unsafe { std::mem::transmute([1u16, 2u16]) };
 
 #[repr(i32)]
 enum Foo {
     A = 0,
 }
 
-unsafe fn foo8() -> Foo {
-    std::mem::transmute(0i32)
+unsafe fn foo2() -> i32 {
+    let mut i: i32 = 0;
+    i = std::mem::transmute([1u16, 2u16]);
     //~^ ERROR: transmute used without annotations
-}
+    i = std::mem::transmute::<_, _>([1u16, 2u16]);
+    //~^ ERROR: transmute used without annotations
+    i = std::mem::transmute::<_, i32>([1u16, 2u16]);
+    //~^ ERROR: transmute used without annotations
+    i = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
+    //~^ ERROR: transmute used without annotations
 
-unsafe fn foo9() -> i32 {
-    std::mem::transmute(Foo::A)
+    let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
     //~^ ERROR: transmute used without annotations
+    bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
+    //~^ ERROR: transmute used without annotations
+
+    i = local_bad_transmute!([1u16, 2u16]);
+
+    // Should not warn.
+    i = bad_transmute!([1u16, 2u16]);
+
+    i = std::mem::transmute([0i16, 0i16]);
+    //~^ ERROR: transmute used without annotations
+
+    i = std::mem::transmute(Foo::A);
+    //~^ ERROR: transmute used without annotations
+
+    i
 }
 
 fn main() {

--- a/tests/ui/missing_transmute_annotations.stderr
+++ b/tests/ui/missing_transmute_annotations.stderr
@@ -1,40 +1,40 @@
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:20:15
+  --> tests/ui/missing_transmute_annotations.rs:35:19
    |
-LL |     std::mem::transmute([1u16, 2u16])
-   |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |     i = std::mem::transmute([1u16, 2u16]);
+   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
    |
    = note: `-D clippy::missing-transmute-annotations` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:25:15
+  --> tests/ui/missing_transmute_annotations.rs:37:19
    |
-LL |     std::mem::transmute::<_, _>([1u16, 2u16])
-   |               ^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |     i = std::mem::transmute::<_, _>([1u16, 2u16]);
+   |                   ^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:30:15
+  --> tests/ui/missing_transmute_annotations.rs:39:19
    |
-LL |     std::mem::transmute::<_, i32>([1u16, 2u16])
-   |               ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |     i = std::mem::transmute::<_, i32>([1u16, 2u16]);
+   |                   ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:35:15
+  --> tests/ui/missing_transmute_annotations.rs:41:19
    |
-LL |     std::mem::transmute::<[u16; 2], _>([1u16, 2u16])
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+LL |     i = std::mem::transmute::<[u16; 2], _>([1u16, 2u16]);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:40:32
+  --> tests/ui/missing_transmute_annotations.rs:44:32
    |
 LL |     let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:42:19
+  --> tests/ui/missing_transmute_annotations.rs:46:19
    |
-LL |     bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]))
+LL |     bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
@@ -43,31 +43,31 @@ error: transmute used without annotations
 LL |         std::mem::transmute($e)
    |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 ...
-LL |     local_bad_transmute!([1u16, 2u16])
-   |     ---------------------------------- in this macro invocation
+LL |     i = local_bad_transmute!([1u16, 2u16]);
+   |         ---------------------------------- in this macro invocation
    |
    = note: this error originates in the macro `local_bad_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:62:15
+  --> tests/ui/missing_transmute_annotations.rs:54:19
    |
-LL |     std::mem::transmute(0i32)
-   |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<i32, Foo>`
+LL |     i = std::mem::transmute([0i16, 0i16]);
+   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[i16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:67:15
+  --> tests/ui/missing_transmute_annotations.rs:57:19
    |
-LL |     std::mem::transmute(Foo::A)
-   |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<Foo, i32>`
+LL |     i = std::mem::transmute(Foo::A);
+   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<Foo, i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:72:35
+  --> tests/ui/missing_transmute_annotations.rs:64:35
    |
 LL |     let x: _ = unsafe { std::mem::transmute::<_, i32>([1u16, 2u16]) };
    |                                   ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:75:30
+  --> tests/ui/missing_transmute_annotations.rs:67:30
    |
 LL |         let x: _ = std::mem::transmute::<_, i32>([1u16, 2u16]);
    |                              ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`

--- a/tests/ui/missing_transmute_annotations.stderr
+++ b/tests/ui/missing_transmute_annotations.stderr
@@ -1,0 +1,64 @@
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:19:15
+   |
+LL |     std::mem::transmute([1u16, 2u16])
+   |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+   |
+   = note: `-D clippy::missing-transmute-annotations` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:24:15
+   |
+LL |     std::mem::transmute::<_, _>([1u16, 2u16])
+   |               ^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:29:15
+   |
+LL |     std::mem::transmute::<_, i32>([1u16, 2u16])
+   |               ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:34:15
+   |
+LL |     std::mem::transmute::<[u16; 2], _>([1u16, 2u16])
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:39:32
+   |
+LL |     let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:41:19
+   |
+LL |     bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]))
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:10:19
+   |
+LL |         std::mem::transmute($e)
+   |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+...
+LL |     local_bad_transmute!([1u16, 2u16])
+   |     ---------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `local_bad_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:61:15
+   |
+LL |     std::mem::transmute(0i32)
+   |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<i32, Foo>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:66:15
+   |
+LL |     std::mem::transmute(Foo::A)
+   |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<Foo, i32>`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/missing_transmute_annotations.stderr
+++ b/tests/ui/missing_transmute_annotations.stderr
@@ -1,5 +1,5 @@
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:19:15
+  --> tests/ui/missing_transmute_annotations.rs:20:15
    |
 LL |     std::mem::transmute([1u16, 2u16])
    |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
@@ -8,37 +8,37 @@ LL |     std::mem::transmute([1u16, 2u16])
    = help: to override `-D warnings` add `#[allow(clippy::missing_transmute_annotations)]`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:24:15
+  --> tests/ui/missing_transmute_annotations.rs:25:15
    |
 LL |     std::mem::transmute::<_, _>([1u16, 2u16])
    |               ^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:29:15
+  --> tests/ui/missing_transmute_annotations.rs:30:15
    |
 LL |     std::mem::transmute::<_, i32>([1u16, 2u16])
    |               ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:34:15
+  --> tests/ui/missing_transmute_annotations.rs:35:15
    |
 LL |     std::mem::transmute::<[u16; 2], _>([1u16, 2u16])
    |               ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:39:32
+  --> tests/ui/missing_transmute_annotations.rs:40:32
    |
 LL |     let x: i32 = bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:41:19
+  --> tests/ui/missing_transmute_annotations.rs:42:19
    |
 LL |     bar(std::mem::transmute::<[u16; 2], _>([1u16, 2u16]))
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:10:19
+  --> tests/ui/missing_transmute_annotations.rs:11:19
    |
 LL |         std::mem::transmute($e)
    |                   ^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
@@ -49,16 +49,28 @@ LL |     local_bad_transmute!([1u16, 2u16])
    = note: this error originates in the macro `local_bad_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:61:15
+  --> tests/ui/missing_transmute_annotations.rs:62:15
    |
 LL |     std::mem::transmute(0i32)
    |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<i32, Foo>`
 
 error: transmute used without annotations
-  --> tests/ui/missing_transmute_annotations.rs:66:15
+  --> tests/ui/missing_transmute_annotations.rs:67:15
    |
 LL |     std::mem::transmute(Foo::A)
    |               ^^^^^^^^^ help: consider adding missing annotations: `transmute::<Foo, i32>`
 
-error: aborting due to 9 previous errors
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:72:35
+   |
+LL |     let x: _ = unsafe { std::mem::transmute::<_, i32>([1u16, 2u16]) };
+   |                                   ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+
+error: transmute used without annotations
+  --> tests/ui/missing_transmute_annotations.rs:75:30
+   |
+LL |         let x: _ = std::mem::transmute::<_, i32>([1u16, 2u16]);
+   |                              ^^^^^^^^^^^^^^^^^^^ help: consider adding missing annotations: `transmute::<[u16; 2], i32>`
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/ptr_cast_constness.fixed
+++ b/tests/ui/ptr_cast_constness.fixed
@@ -1,7 +1,12 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::ptr_cast_constness)]
-#![allow(clippy::transmute_ptr_to_ref, clippy::unnecessary_cast, unused)]
+#![allow(
+    clippy::transmute_ptr_to_ref,
+    clippy::unnecessary_cast,
+    unused,
+    clippy::missing_transmute_annotations
+)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/ptr_cast_constness.rs
+++ b/tests/ui/ptr_cast_constness.rs
@@ -1,7 +1,12 @@
 //@aux-build:proc_macros.rs
 
 #![warn(clippy::ptr_cast_constness)]
-#![allow(clippy::transmute_ptr_to_ref, clippy::unnecessary_cast, unused)]
+#![allow(
+    clippy::transmute_ptr_to_ref,
+    clippy::unnecessary_cast,
+    unused,
+    clippy::missing_transmute_annotations
+)]
 
 extern crate proc_macros;
 use proc_macros::{external, inline_macros};

--- a/tests/ui/ptr_cast_constness.stderr
+++ b/tests/ui/ptr_cast_constness.stderr
@@ -1,5 +1,5 @@
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:10:41
+  --> tests/ui/ptr_cast_constness.rs:15:41
    |
 LL |     let _: &mut T = std::mem::transmute(p as *mut T);
    |                                         ^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
@@ -8,37 +8,37 @@ LL |     let _: &mut T = std::mem::transmute(p as *mut T);
    = help: to override `-D warnings` add `#[allow(clippy::ptr_cast_constness)]`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:11:19
+  --> tests/ui/ptr_cast_constness.rs:16:19
    |
 LL |     let _ = &mut *(p as *mut T);
    |                   ^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `p.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:26:17
+  --> tests/ui/ptr_cast_constness.rs:31:17
    |
 LL |         let _ = *ptr_ptr as *mut u32;
    |                 ^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `(*ptr_ptr).cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:29:13
+  --> tests/ui/ptr_cast_constness.rs:34:13
    |
 LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:30:13
+  --> tests/ui/ptr_cast_constness.rs:35:13
    |
 LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:59:13
+  --> tests/ui/ptr_cast_constness.rs:64:13
    |
 LL |     let _ = ptr as *mut u32;
    |             ^^^^^^^^^^^^^^^ help: try `pointer::cast_mut`, a safer alternative: `ptr.cast_mut()`
 
 error: `as` casting between raw pointers while changing only its constness
-  --> tests/ui/ptr_cast_constness.rs:60:13
+  --> tests/ui/ptr_cast_constness.rs:65:13
    |
 LL |     let _ = mut_ptr as *const u32;
    |             ^^^^^^^^^^^^^^^^^^^^^ help: try `pointer::cast_const`, a safer alternative: `mut_ptr.cast_const()`

--- a/tests/ui/transmute.rs
+++ b/tests/ui/transmute.rs
@@ -1,4 +1,9 @@
-#![allow(dead_code, clippy::borrow_as_ptr, clippy::needless_lifetimes)]
+#![allow(
+    dead_code,
+    clippy::borrow_as_ptr,
+    clippy::needless_lifetimes,
+    clippy::missing_transmute_annotations
+)]
 //@no-rustfix
 extern crate core;
 

--- a/tests/ui/transmute.stderr
+++ b/tests/ui/transmute.stderr
@@ -1,5 +1,5 @@
 error: transmute from a reference to a pointer
-  --> tests/ui/transmute.rs:24:23
+  --> tests/ui/transmute.rs:29:23
    |
 LL |     let _: *const T = core::intrinsics::transmute(t);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T`
@@ -8,61 +8,61 @@ LL |     let _: *const T = core::intrinsics::transmute(t);
    = help: to override `-D warnings` add `#[allow(clippy::useless_transmute)]`
 
 error: transmute from a reference to a pointer
-  --> tests/ui/transmute.rs:28:21
+  --> tests/ui/transmute.rs:33:21
    |
 LL |     let _: *mut T = core::intrinsics::transmute(t);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T as *mut T`
 
 error: transmute from a reference to a pointer
-  --> tests/ui/transmute.rs:31:23
+  --> tests/ui/transmute.rs:36:23
    |
 LL |     let _: *const U = core::intrinsics::transmute(t);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `t as *const T as *const U`
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:38:27
+  --> tests/ui/transmute.rs:43:27
    |
 LL |         let _: Vec<i32> = core::intrinsics::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:41:27
+  --> tests/ui/transmute.rs:46:27
    |
 LL |         let _: Vec<i32> = core::mem::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:44:27
+  --> tests/ui/transmute.rs:49:27
    |
 LL |         let _: Vec<i32> = std::intrinsics::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:47:27
+  --> tests/ui/transmute.rs:52:27
    |
 LL |         let _: Vec<i32> = std::mem::transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`std::vec::Vec<i32>`) to itself
-  --> tests/ui/transmute.rs:50:27
+  --> tests/ui/transmute.rs:55:27
    |
 LL |         let _: Vec<i32> = my_transmute(my_vec());
    |                           ^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from an integer to a pointer
-  --> tests/ui/transmute.rs:53:31
+  --> tests/ui/transmute.rs:58:31
    |
 LL |         let _: *const usize = std::mem::transmute(5_isize);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `5_isize as *const usize`
 
 error: transmute from an integer to a pointer
-  --> tests/ui/transmute.rs:58:31
+  --> tests/ui/transmute.rs:63:31
    |
 LL |         let _: *const usize = std::mem::transmute(1 + 1usize);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(1 + 1usize) as *const usize`
 
 error: transmute from a type (`*const Usize`) to the type that it points to (`Usize`)
-  --> tests/ui/transmute.rs:90:24
+  --> tests/ui/transmute.rs:95:24
    |
 LL |         let _: Usize = core::intrinsics::transmute(int_const_ptr);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,25 +71,25 @@ LL |         let _: Usize = core::intrinsics::transmute(int_const_ptr);
    = help: to override `-D warnings` add `#[allow(clippy::crosspointer_transmute)]`
 
 error: transmute from a type (`*mut Usize`) to the type that it points to (`Usize`)
-  --> tests/ui/transmute.rs:94:24
+  --> tests/ui/transmute.rs:99:24
    |
 LL |         let _: Usize = core::intrinsics::transmute(int_mut_ptr);
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`Usize`) to a pointer to that type (`*const Usize`)
-  --> tests/ui/transmute.rs:97:31
+  --> tests/ui/transmute.rs:102:31
    |
 LL |         let _: *const Usize = core::intrinsics::transmute(my_int());
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a type (`Usize`) to a pointer to that type (`*mut Usize`)
-  --> tests/ui/transmute.rs:100:29
+  --> tests/ui/transmute.rs:105:29
    |
 LL |         let _: *mut Usize = core::intrinsics::transmute(my_int());
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from a `u8` to a `bool`
-  --> tests/ui/transmute.rs:107:28
+  --> tests/ui/transmute.rs:112:28
    |
 LL |     let _: bool = unsafe { std::mem::transmute(0_u8) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `0_u8 != 0`
@@ -98,7 +98,7 @@ LL |     let _: bool = unsafe { std::mem::transmute(0_u8) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_bool)]`
 
 error: transmute from a `u32` to a `f32`
-  --> tests/ui/transmute.rs:115:31
+  --> tests/ui/transmute.rs:120:31
    |
 LL |         let _: f32 = unsafe { std::mem::transmute(0_u32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(0_u32)`
@@ -107,25 +107,25 @@ LL |         let _: f32 = unsafe { std::mem::transmute(0_u32) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_float)]`
 
 error: transmute from a `i32` to a `f32`
-  --> tests/ui/transmute.rs:118:31
+  --> tests/ui/transmute.rs:123:31
    |
 LL |         let _: f32 = unsafe { std::mem::transmute(0_i32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f32::from_bits(0_i32 as u32)`
 
 error: transmute from a `u64` to a `f64`
-  --> tests/ui/transmute.rs:120:31
+  --> tests/ui/transmute.rs:125:31
    |
 LL |         let _: f64 = unsafe { std::mem::transmute(0_u64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(0_u64)`
 
 error: transmute from a `i64` to a `f64`
-  --> tests/ui/transmute.rs:122:31
+  --> tests/ui/transmute.rs:127:31
    |
 LL |         let _: f64 = unsafe { std::mem::transmute(0_i64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f64::from_bits(0_i64 as u64)`
 
 error: transmute from a `u8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:143:30
+  --> tests/ui/transmute.rs:148:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u8.to_ne_bytes()`
@@ -134,85 +134,85 @@ LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    = help: to override `-D warnings` add `#[allow(clippy::transmute_num_to_bytes)]`
 
 error: transmute from a `u32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:146:30
+  --> tests/ui/transmute.rs:151:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0u32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u32.to_ne_bytes()`
 
 error: transmute from a `u128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:148:31
+  --> tests/ui/transmute.rs:153:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0u128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u128.to_ne_bytes()`
 
 error: transmute from a `i8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:150:30
+  --> tests/ui/transmute.rs:155:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0i8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i8.to_ne_bytes()`
 
 error: transmute from a `i32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:152:30
+  --> tests/ui/transmute.rs:157:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0i32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i32.to_ne_bytes()`
 
 error: transmute from a `i128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:154:31
+  --> tests/ui/transmute.rs:159:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0i128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i128.to_ne_bytes()`
 
 error: transmute from a `f32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:156:30
+  --> tests/ui/transmute.rs:161:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0.0f32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f32.to_ne_bytes()`
 
 error: transmute from a `f64` to a `[u8; 8]`
-  --> tests/ui/transmute.rs:158:30
+  --> tests/ui/transmute.rs:163:30
    |
 LL |             let _: [u8; 8] = std::mem::transmute(0.0f64);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0.0f64.to_ne_bytes()`
 
 error: transmute from a `u8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:164:30
+  --> tests/ui/transmute.rs:169:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0u8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u8.to_ne_bytes()`
 
 error: transmute from a `u32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:166:30
+  --> tests/ui/transmute.rs:171:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0u32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u32.to_ne_bytes()`
 
 error: transmute from a `u128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:168:31
+  --> tests/ui/transmute.rs:173:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0u128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0u128.to_ne_bytes()`
 
 error: transmute from a `i8` to a `[u8; 1]`
-  --> tests/ui/transmute.rs:170:30
+  --> tests/ui/transmute.rs:175:30
    |
 LL |             let _: [u8; 1] = std::mem::transmute(0i8);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i8.to_ne_bytes()`
 
 error: transmute from a `i32` to a `[u8; 4]`
-  --> tests/ui/transmute.rs:172:30
+  --> tests/ui/transmute.rs:177:30
    |
 LL |             let _: [u8; 4] = std::mem::transmute(0i32);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i32.to_ne_bytes()`
 
 error: transmute from a `i128` to a `[u8; 16]`
-  --> tests/ui/transmute.rs:174:31
+  --> tests/ui/transmute.rs:179:31
    |
 LL |             let _: [u8; 16] = std::mem::transmute(0i128);
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `to_ne_bytes()`: `0i128.to_ne_bytes()`
 
 error: transmute from a `&[u8]` to a `&str`
-  --> tests/ui/transmute.rs:185:28
+  --> tests/ui/transmute.rs:190:28
    |
 LL |     let _: &str = unsafe { std::mem::transmute(B) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8(B).unwrap()`
@@ -221,13 +221,13 @@ LL |     let _: &str = unsafe { std::mem::transmute(B) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_bytes_to_str)]`
 
 error: transmute from a `&mut [u8]` to a `&mut str`
-  --> tests/ui/transmute.rs:188:32
+  --> tests/ui/transmute.rs:193:32
    |
 LL |     let _: &mut str = unsafe { std::mem::transmute(mb) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_mut(mb).unwrap()`
 
 error: transmute from a `&[u8]` to a `&str`
-  --> tests/ui/transmute.rs:190:30
+  --> tests/ui/transmute.rs:195:30
    |
 LL |     const _: &str = unsafe { std::mem::transmute(B) };
    |                              ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::str::from_utf8_unchecked(B)`

--- a/tests/ui/transmute_collection.rs
+++ b/tests/ui/transmute_collection.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::unsound_collection_transmute)]
+#![allow(clippy::missing_transmute_annotations)]
 
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, VecDeque};
 use std::mem::{transmute, MaybeUninit};

--- a/tests/ui/transmute_collection.stderr
+++ b/tests/ui/transmute_collection.stderr
@@ -1,5 +1,5 @@
 error: transmute from `std::vec::Vec<u8>` to `std::vec::Vec<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:9:17
+  --> tests/ui/transmute_collection.rs:10:17
    |
 LL |         let _ = transmute::<_, Vec<u32>>(vec![0u8]);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,103 +8,103 @@ LL |         let _ = transmute::<_, Vec<u32>>(vec![0u8]);
    = help: to override `-D warnings` add `#[allow(clippy::unsound_collection_transmute)]`
 
 error: transmute from `std::vec::Vec<u32>` to `std::vec::Vec<[u8; 4]>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:13:17
+  --> tests/ui/transmute_collection.rs:14:17
    |
 LL |         let _ = transmute::<_, Vec<[u8; 4]>>(vec![1234u32]);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::VecDeque<u8>` to `std::collections::VecDeque<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:17:17
+  --> tests/ui/transmute_collection.rs:18:17
    |
 LL |         let _ = transmute::<_, VecDeque<u32>>(VecDeque::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::VecDeque<[u8; 4]>` to `std::collections::VecDeque<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:20:17
+  --> tests/ui/transmute_collection.rs:21:17
    |
 LL |         let _ = transmute::<_, VecDeque<u32>>(VecDeque::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BinaryHeap<u8>` to `std::collections::BinaryHeap<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:24:17
+  --> tests/ui/transmute_collection.rs:25:17
    |
 LL |         let _ = transmute::<_, BinaryHeap<u32>>(BinaryHeap::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BinaryHeap<[u8; 4]>` to `std::collections::BinaryHeap<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:27:17
+  --> tests/ui/transmute_collection.rs:28:17
    |
 LL |         let _ = transmute::<_, BinaryHeap<u32>>(BinaryHeap::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BTreeSet<u8>` to `std::collections::BTreeSet<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:31:17
+  --> tests/ui/transmute_collection.rs:32:17
    |
 LL |         let _ = transmute::<_, BTreeSet<u32>>(BTreeSet::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BTreeSet<[u8; 4]>` to `std::collections::BTreeSet<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:34:17
+  --> tests/ui/transmute_collection.rs:35:17
    |
 LL |         let _ = transmute::<_, BTreeSet<u32>>(BTreeSet::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::HashSet<u8>` to `std::collections::HashSet<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:38:17
+  --> tests/ui/transmute_collection.rs:39:17
    |
 LL |         let _ = transmute::<_, HashSet<u32>>(HashSet::<u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::HashSet<[u8; 4]>` to `std::collections::HashSet<u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:41:17
+  --> tests/ui/transmute_collection.rs:42:17
    |
 LL |         let _ = transmute::<_, HashSet<u32>>(HashSet::<[u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BTreeMap<u8, u8>` to `std::collections::BTreeMap<u8, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:45:17
+  --> tests/ui/transmute_collection.rs:46:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u8, u32>>(BTreeMap::<u8, u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BTreeMap<u32, u32>` to `std::collections::BTreeMap<u8, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:47:17
+  --> tests/ui/transmute_collection.rs:48:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u8, u32>>(BTreeMap::<u32, u32>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BTreeMap<u8, [u8; 4]>` to `std::collections::BTreeMap<u8, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:50:17
+  --> tests/ui/transmute_collection.rs:51:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u8, u32>>(BTreeMap::<u8, [u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::BTreeMap<[u8; 4], u32>` to `std::collections::BTreeMap<u32, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:52:17
+  --> tests/ui/transmute_collection.rs:53:17
    |
 LL |         let _ = transmute::<_, BTreeMap<u32, u32>>(BTreeMap::<[u8; 4], u32>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::HashMap<u8, u8>` to `std::collections::HashMap<u8, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:56:17
+  --> tests/ui/transmute_collection.rs:57:17
    |
 LL |         let _ = transmute::<_, HashMap<u8, u32>>(HashMap::<u8, u8>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::HashMap<u32, u32>` to `std::collections::HashMap<u8, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:58:17
+  --> tests/ui/transmute_collection.rs:59:17
    |
 LL |         let _ = transmute::<_, HashMap<u8, u32>>(HashMap::<u32, u32>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::HashMap<u8, [u8; 4]>` to `std::collections::HashMap<u8, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:61:17
+  --> tests/ui/transmute_collection.rs:62:17
    |
 LL |         let _ = transmute::<_, HashMap<u8, u32>>(HashMap::<u8, [u8; 4]>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `std::collections::HashMap<[u8; 4], u32>` to `std::collections::HashMap<u32, u32>` with mismatched layout is unsound
-  --> tests/ui/transmute_collection.rs:63:17
+  --> tests/ui/transmute_collection.rs:64:17
    |
 LL |         let _ = transmute::<_, HashMap<u32, u32>>(HashMap::<[u8; 4], u32>::new());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/transmute_float_to_int.fixed
+++ b/tests/ui/transmute_float_to_int.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::transmute_float_to_int)]
+#![allow(clippy::missing_transmute_annotations)]
 
 fn float_to_int() {
     let _: u32 = unsafe { 1f32.to_bits() };

--- a/tests/ui/transmute_float_to_int.rs
+++ b/tests/ui/transmute_float_to_int.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::transmute_float_to_int)]
+#![allow(clippy::missing_transmute_annotations)]
 
 fn float_to_int() {
     let _: u32 = unsafe { std::mem::transmute(1f32) };

--- a/tests/ui/transmute_float_to_int.stderr
+++ b/tests/ui/transmute_float_to_int.stderr
@@ -1,5 +1,5 @@
 error: transmute from a `f32` to a `u32`
-  --> tests/ui/transmute_float_to_int.rs:4:27
+  --> tests/ui/transmute_float_to_int.rs:5:27
    |
 LL |     let _: u32 = unsafe { std::mem::transmute(1f32) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1f32.to_bits()`
@@ -8,31 +8,31 @@ LL |     let _: u32 = unsafe { std::mem::transmute(1f32) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_float_to_int)]`
 
 error: transmute from a `f32` to a `i32`
-  --> tests/ui/transmute_float_to_int.rs:7:27
+  --> tests/ui/transmute_float_to_int.rs:8:27
    |
 LL |     let _: i32 = unsafe { std::mem::transmute(1f32) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1f32.to_bits() as i32`
 
 error: transmute from a `f64` to a `u64`
-  --> tests/ui/transmute_float_to_int.rs:9:27
+  --> tests/ui/transmute_float_to_int.rs:10:27
    |
 LL |     let _: u64 = unsafe { std::mem::transmute(1f64) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1f64.to_bits()`
 
 error: transmute from a `f64` to a `i64`
-  --> tests/ui/transmute_float_to_int.rs:11:27
+  --> tests/ui/transmute_float_to_int.rs:12:27
    |
 LL |     let _: i64 = unsafe { std::mem::transmute(1f64) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1f64.to_bits() as i64`
 
 error: transmute from a `f64` to a `u64`
-  --> tests/ui/transmute_float_to_int.rs:13:27
+  --> tests/ui/transmute_float_to_int.rs:14:27
    |
 LL |     let _: u64 = unsafe { std::mem::transmute(1.0) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `1.0f64.to_bits()`
 
 error: transmute from a `f64` to a `u64`
-  --> tests/ui/transmute_float_to_int.rs:15:27
+  --> tests/ui/transmute_float_to_int.rs:16:27
    |
 LL |     let _: u64 = unsafe { std::mem::transmute(-1.0) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(-1.0f64).to_bits()`

--- a/tests/ui/transmute_int_to_char.fixed
+++ b/tests/ui/transmute_int_to_char.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::transmute_int_to_char)]
+#![allow(clippy::missing_transmute_annotations)]
 
 fn int_to_char() {
     let _: char = unsafe { std::char::from_u32(0_u32).unwrap() };

--- a/tests/ui/transmute_int_to_char.rs
+++ b/tests/ui/transmute_int_to_char.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::transmute_int_to_char)]
+#![allow(clippy::missing_transmute_annotations)]
 
 fn int_to_char() {
     let _: char = unsafe { std::mem::transmute(0_u32) };

--- a/tests/ui/transmute_int_to_char.stderr
+++ b/tests/ui/transmute_int_to_char.stderr
@@ -1,5 +1,5 @@
 error: transmute from a `u32` to a `char`
-  --> tests/ui/transmute_int_to_char.rs:4:28
+  --> tests/ui/transmute_int_to_char.rs:5:28
    |
 LL |     let _: char = unsafe { std::mem::transmute(0_u32) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::char::from_u32(0_u32).unwrap()`
@@ -8,7 +8,7 @@ LL |     let _: char = unsafe { std::mem::transmute(0_u32) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_char)]`
 
 error: transmute from a `i32` to a `char`
-  --> tests/ui/transmute_int_to_char.rs:7:28
+  --> tests/ui/transmute_int_to_char.rs:8:28
    |
 LL |     let _: char = unsafe { std::mem::transmute(0_i32) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::char::from_u32(0_i32 as u32).unwrap()`

--- a/tests/ui/transmute_int_to_char_no_std.fixed
+++ b/tests/ui/transmute_int_to_char_no_std.fixed
@@ -1,6 +1,7 @@
 #![no_std]
 #![feature(lang_items)]
 #![warn(clippy::transmute_int_to_char)]
+#![allow(clippy::missing_transmute_annotations)]
 
 use core::panic::PanicInfo;
 

--- a/tests/ui/transmute_int_to_char_no_std.rs
+++ b/tests/ui/transmute_int_to_char_no_std.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![feature(lang_items)]
 #![warn(clippy::transmute_int_to_char)]
+#![allow(clippy::missing_transmute_annotations)]
 
 use core::panic::PanicInfo;
 

--- a/tests/ui/transmute_int_to_char_no_std.stderr
+++ b/tests/ui/transmute_int_to_char_no_std.stderr
@@ -1,5 +1,5 @@
 error: transmute from a `u32` to a `char`
-  --> tests/ui/transmute_int_to_char_no_std.rs:16:28
+  --> tests/ui/transmute_int_to_char_no_std.rs:17:28
    |
 LL |     let _: char = unsafe { core::mem::transmute(0_u32) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `core::char::from_u32(0_u32).unwrap()`
@@ -8,7 +8,7 @@ LL |     let _: char = unsafe { core::mem::transmute(0_u32) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_char)]`
 
 error: transmute from a `i32` to a `char`
-  --> tests/ui/transmute_int_to_char_no_std.rs:19:28
+  --> tests/ui/transmute_int_to_char_no_std.rs:20:28
    |
 LL |     let _: char = unsafe { core::mem::transmute(0_i32) };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `core::char::from_u32(0_i32 as u32).unwrap()`

--- a/tests/ui/transmute_int_to_non_zero.fixed
+++ b/tests/ui/transmute_int_to_non_zero.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::transmute_int_to_non_zero)]
+#![allow(clippy::missing_transmute_annotations)]
 
 use core::num::*;
 

--- a/tests/ui/transmute_int_to_non_zero.rs
+++ b/tests/ui/transmute_int_to_non_zero.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::transmute_int_to_non_zero)]
+#![allow(clippy::missing_transmute_annotations)]
 
 use core::num::*;
 

--- a/tests/ui/transmute_int_to_non_zero.stderr
+++ b/tests/ui/transmute_int_to_non_zero.stderr
@@ -1,5 +1,5 @@
 error: transmute from a `u8` to a `NonZeroU8`
-  --> tests/ui/transmute_int_to_non_zero.rs:18:33
+  --> tests/ui/transmute_int_to_non_zero.rs:19:33
    |
 LL |     let _: NonZeroU8 = unsafe { std::mem::transmute(int_u8) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroU8::new_unchecked(int_u8)`
@@ -8,55 +8,55 @@ LL |     let _: NonZeroU8 = unsafe { std::mem::transmute(int_u8) };
    = help: to override `-D warnings` add `#[allow(clippy::transmute_int_to_non_zero)]`
 
 error: transmute from a `u16` to a `NonZeroU16`
-  --> tests/ui/transmute_int_to_non_zero.rs:21:34
+  --> tests/ui/transmute_int_to_non_zero.rs:22:34
    |
 LL |     let _: NonZeroU16 = unsafe { std::mem::transmute(int_u16) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroU16::new_unchecked(int_u16)`
 
 error: transmute from a `u32` to a `NonZeroU32`
-  --> tests/ui/transmute_int_to_non_zero.rs:23:34
+  --> tests/ui/transmute_int_to_non_zero.rs:24:34
    |
 LL |     let _: NonZeroU32 = unsafe { std::mem::transmute(int_u32) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroU32::new_unchecked(int_u32)`
 
 error: transmute from a `u64` to a `NonZeroU64`
-  --> tests/ui/transmute_int_to_non_zero.rs:25:34
+  --> tests/ui/transmute_int_to_non_zero.rs:26:34
    |
 LL |     let _: NonZeroU64 = unsafe { std::mem::transmute(int_u64) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroU64::new_unchecked(int_u64)`
 
 error: transmute from a `u128` to a `NonZeroU128`
-  --> tests/ui/transmute_int_to_non_zero.rs:27:35
+  --> tests/ui/transmute_int_to_non_zero.rs:28:35
    |
 LL |     let _: NonZeroU128 = unsafe { std::mem::transmute(int_u128) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroU128::new_unchecked(int_u128)`
 
 error: transmute from a `i8` to a `NonZeroI8`
-  --> tests/ui/transmute_int_to_non_zero.rs:30:33
+  --> tests/ui/transmute_int_to_non_zero.rs:31:33
    |
 LL |     let _: NonZeroI8 = unsafe { std::mem::transmute(int_i8) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroI8::new_unchecked(int_i8)`
 
 error: transmute from a `i16` to a `NonZeroI16`
-  --> tests/ui/transmute_int_to_non_zero.rs:32:34
+  --> tests/ui/transmute_int_to_non_zero.rs:33:34
    |
 LL |     let _: NonZeroI16 = unsafe { std::mem::transmute(int_i16) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroI16::new_unchecked(int_i16)`
 
 error: transmute from a `i32` to a `NonZeroI32`
-  --> tests/ui/transmute_int_to_non_zero.rs:34:34
+  --> tests/ui/transmute_int_to_non_zero.rs:35:34
    |
 LL |     let _: NonZeroI32 = unsafe { std::mem::transmute(int_i32) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroI32::new_unchecked(int_i32)`
 
 error: transmute from a `i64` to a `NonZeroI64`
-  --> tests/ui/transmute_int_to_non_zero.rs:36:34
+  --> tests/ui/transmute_int_to_non_zero.rs:37:34
    |
 LL |     let _: NonZeroI64 = unsafe { std::mem::transmute(int_i64) };
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroI64::new_unchecked(int_i64)`
 
 error: transmute from a `i128` to a `NonZeroI128`
-  --> tests/ui/transmute_int_to_non_zero.rs:38:35
+  --> tests/ui/transmute_int_to_non_zero.rs:39:35
    |
 LL |     let _: NonZeroI128 = unsafe { std::mem::transmute(int_i128) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `NonZeroI128::new_unchecked(int_i128)`

--- a/tests/ui/transmute_null_to_fn.rs
+++ b/tests/ui/transmute_null_to_fn.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 #![warn(clippy::transmute_null_to_fn)]
-#![allow(clippy::zero_ptr)]
+#![allow(clippy::zero_ptr, clippy::missing_transmute_annotations)]
 
 // Easy to lint because these only span one line.
 fn one_liners() {

--- a/tests/ui/transmute_ptr_to_ptr.fixed
+++ b/tests/ui/transmute_ptr_to_ptr.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::borrow_as_ptr, clippy::missing_transmute_annotations)]
 
 // Make sure we can modify lifetimes, which is one of the recommended uses
 // of transmute

--- a/tests/ui/transmute_ptr_to_ptr.rs
+++ b/tests/ui/transmute_ptr_to_ptr.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(clippy::borrow_as_ptr)]
+#![allow(clippy::borrow_as_ptr, clippy::missing_transmute_annotations)]
 
 // Make sure we can modify lifetimes, which is one of the recommended uses
 // of transmute

--- a/tests/ui/transmute_ptr_to_ref.fixed
+++ b/tests/ui/transmute_ptr_to_ref.fixed
@@ -1,5 +1,9 @@
 #![warn(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::match_single_binding, clippy::unnecessary_cast)]
+#![allow(
+    clippy::match_single_binding,
+    clippy::unnecessary_cast,
+    clippy::missing_transmute_annotations
+)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = &*p;

--- a/tests/ui/transmute_ptr_to_ref.rs
+++ b/tests/ui/transmute_ptr_to_ref.rs
@@ -1,5 +1,9 @@
 #![warn(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::match_single_binding, clippy::unnecessary_cast)]
+#![allow(
+    clippy::match_single_binding,
+    clippy::unnecessary_cast,
+    clippy::missing_transmute_annotations
+)]
 
 unsafe fn _ptr_to_ref<T, U>(p: *const T, m: *mut T, o: *const U, om: *mut U) {
     let _: &T = std::mem::transmute(p);

--- a/tests/ui/transmute_ptr_to_ref.stderr
+++ b/tests/ui/transmute_ptr_to_ref.stderr
@@ -1,5 +1,5 @@
 error: transmute from a pointer type (`*const T`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:5:17
+  --> tests/ui/transmute_ptr_to_ref.rs:9:17
    |
 LL |     let _: &T = std::mem::transmute(p);
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*p`
@@ -8,127 +8,127 @@ LL |     let _: &T = std::mem::transmute(p);
    = help: to override `-D warnings` add `#[allow(clippy::transmute_ptr_to_ref)]`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&mut T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:8:21
+  --> tests/ui/transmute_ptr_to_ref.rs:12:21
    |
 LL |     let _: &mut T = std::mem::transmute(m);
    |                     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *m`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:11:17
+  --> tests/ui/transmute_ptr_to_ref.rs:15:17
    |
 LL |     let _: &T = std::mem::transmute(m);
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*m`
 
 error: transmute from a pointer type (`*mut T`) to a reference type (`&mut T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:14:21
+  --> tests/ui/transmute_ptr_to_ref.rs:18:21
    |
 LL |     let _: &mut T = std::mem::transmute(p as *mut T);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(p as *mut T)`
 
 error: transmute from a pointer type (`*const U`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:17:17
+  --> tests/ui/transmute_ptr_to_ref.rs:21:17
    |
 LL |     let _: &T = std::mem::transmute(o);
    |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(o as *const T)`
 
 error: transmute from a pointer type (`*mut U`) to a reference type (`&mut T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:20:21
+  --> tests/ui/transmute_ptr_to_ref.rs:24:21
    |
 LL |     let _: &mut T = std::mem::transmute(om);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut *(om as *mut T)`
 
 error: transmute from a pointer type (`*mut U`) to a reference type (`&T`)
-  --> tests/ui/transmute_ptr_to_ref.rs:23:17
+  --> tests/ui/transmute_ptr_to_ref.rs:27:17
    |
 LL |     let _: &T = std::mem::transmute(om);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(om as *const T)`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, u8>`)
-  --> tests/ui/transmute_ptr_to_ref.rs:33:32
+  --> tests/ui/transmute_ptr_to_ref.rs:37:32
    |
 LL |     let _: &Foo<u8> = unsafe { std::mem::transmute::<_, &Foo<_>>(raw) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*raw.cast::<Foo<_>>()`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&_issue1231::Foo<'_, &u8>`)
-  --> tests/ui/transmute_ptr_to_ref.rs:35:33
+  --> tests/ui/transmute_ptr_to_ref.rs:39:33
    |
 LL |     let _: &Foo<&u8> = unsafe { std::mem::transmute::<_, &Foo<&_>>(raw) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*raw.cast::<Foo<&_>>()`
 
 error: transmute from a pointer type (`*const i32`) to a reference type (`&u8`)
-  --> tests/ui/transmute_ptr_to_ref.rs:39:14
+  --> tests/ui/transmute_ptr_to_ref.rs:43:14
    |
 LL |     unsafe { std::mem::transmute::<_, Bar>(raw) };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(raw as *const u8)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:44:14
+  --> tests/ui/transmute_ptr_to_ref.rs:48:14
    |
 LL |         0 => std::mem::transmute(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:45:14
+  --> tests/ui/transmute_ptr_to_ref.rs:49:14
    |
 LL |         1 => std::mem::transmute(y),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:46:14
+  --> tests/ui/transmute_ptr_to_ref.rs:50:14
    |
 LL |         2 => std::mem::transmute::<_, &&'b u32>(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:47:14
+  --> tests/ui/transmute_ptr_to_ref.rs:51:14
    |
 LL |         _ => std::mem::transmute::<_, &&'b u32>(y),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*y.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:55:19
+  --> tests/ui/transmute_ptr_to_ref.rs:59:19
    |
 LL |     let _: &u32 = std::mem::transmute(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:56:19
+  --> tests/ui/transmute_ptr_to_ref.rs:60:19
    |
 LL |     let _: &u32 = std::mem::transmute::<_, &u32>(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a.cast::<u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:58:14
+  --> tests/ui/transmute_ptr_to_ref.rs:62:14
    |
 LL |         0 => std::mem::transmute(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&u32>()`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:59:14
+  --> tests/ui/transmute_ptr_to_ref.rs:63:14
    |
 LL |         _ => std::mem::transmute::<_, &&'b u32>(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*x.cast::<&'b u32>()`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:67:19
+  --> tests/ui/transmute_ptr_to_ref.rs:71:19
    |
 LL |     let _: &u32 = std::mem::transmute(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*a`
 
 error: transmute from a pointer type (`*const u32`) to a reference type (`&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:68:19
+  --> tests/ui/transmute_ptr_to_ref.rs:72:19
    |
 LL |     let _: &u32 = std::mem::transmute::<_, &u32>(a);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(a as *const u32)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:70:14
+  --> tests/ui/transmute_ptr_to_ref.rs:74:14
    |
 LL |         0 => std::mem::transmute(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &u32)`
 
 error: transmute from a pointer type (`*const &u32`) to a reference type (`&&u32`)
-  --> tests/ui/transmute_ptr_to_ref.rs:71:14
+  --> tests/ui/transmute_ptr_to_ref.rs:75:14
    |
 LL |         _ => std::mem::transmute::<_, &&'b u32>(x),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&*(x as *const () as *const &'b u32)`

--- a/tests/ui/transmute_ref_to_ref.rs
+++ b/tests/ui/transmute_ref_to_ref.rs
@@ -1,7 +1,7 @@
 //@no-rustfix
 
 #![deny(clippy::transmute_ptr_to_ptr)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::missing_transmute_annotations)]
 
 fn main() {
     unsafe {

--- a/tests/ui/transmute_ref_to_ref_no_std.rs
+++ b/tests/ui/transmute_ref_to_ref_no_std.rs
@@ -1,7 +1,7 @@
 //@no-rustfix
 
 #![deny(clippy::transmute_ptr_to_ptr)]
-#![allow(dead_code)]
+#![allow(dead_code, clippy::missing_transmute_annotations)]
 #![feature(lang_items)]
 #![no_std]
 

--- a/tests/ui/transmute_undefined_repr.rs
+++ b/tests/ui/transmute_undefined_repr.rs
@@ -1,5 +1,10 @@
 #![warn(clippy::transmute_undefined_repr)]
-#![allow(clippy::unit_arg, clippy::transmute_ptr_to_ref, clippy::useless_transmute)]
+#![allow(
+    clippy::unit_arg,
+    clippy::transmute_ptr_to_ref,
+    clippy::useless_transmute,
+    clippy::missing_transmute_annotations
+)]
 
 use core::any::TypeId;
 use core::ffi::c_void;

--- a/tests/ui/transmute_undefined_repr.stderr
+++ b/tests/ui/transmute_undefined_repr.stderr
@@ -1,5 +1,5 @@
 error: transmute from `Ty2<u32, i32>` which has an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:29:33
+  --> tests/ui/transmute_undefined_repr.rs:34:33
    |
 LL |         let _: Ty2C<u32, i32> = transmute(value::<Ty2<u32, i32>>());
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,13 +8,13 @@ LL |         let _: Ty2C<u32, i32> = transmute(value::<Ty2<u32, i32>>());
    = help: to override `-D warnings` add `#[allow(clippy::transmute_undefined_repr)]`
 
 error: transmute into `Ty2<u32, i32>` which has an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:33:32
+  --> tests/ui/transmute_undefined_repr.rs:38:32
    |
 LL |         let _: Ty2<u32, i32> = transmute(value::<Ty2C<u32, i32>>());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: transmute from `Ty<Ty2<u32, i32>>` to `Ty2<u32, f32>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:42:32
+  --> tests/ui/transmute_undefined_repr.rs:47:32
    |
 LL |         let _: Ty2<u32, f32> = transmute(value::<Ty<Ty2<u32, i32>>>());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |         let _: Ty2<u32, f32> = transmute(value::<Ty<Ty2<u32, i32>>>());
    = note: two instances of the same generic type (`Ty2`) may have different layouts
 
 error: transmute from `Ty2<u32, f32>` to `Ty<Ty2<u32, i32>>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:46:36
+  --> tests/ui/transmute_undefined_repr.rs:51:36
    |
 LL |         let _: Ty<Ty2<u32, i32>> = transmute(value::<Ty2<u32, f32>>());
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL |         let _: Ty<Ty2<u32, i32>> = transmute(value::<Ty2<u32, f32>>());
    = note: two instances of the same generic type (`Ty2`) may have different layouts
 
 error: transmute from `Ty<&Ty2<u32, i32>>` to `&Ty2<u32, f32>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:54:33
+  --> tests/ui/transmute_undefined_repr.rs:59:33
    |
 LL |         let _: &Ty2<u32, f32> = transmute(value::<Ty<&Ty2<u32, i32>>>());
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |         let _: &Ty2<u32, f32> = transmute(value::<Ty<&Ty2<u32, i32>>>());
    = note: two instances of the same generic type (`Ty2`) may have different layouts
 
 error: transmute from `&Ty2<u32, f32>` to `Ty<&Ty2<u32, i32>>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:58:37
+  --> tests/ui/transmute_undefined_repr.rs:63:37
    |
 LL |         let _: Ty<&Ty2<u32, i32>> = transmute(value::<&Ty2<u32, f32>>());
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ LL |         let _: Ty<&Ty2<u32, i32>> = transmute(value::<&Ty2<u32, f32>>());
    = note: two instances of the same generic type (`Ty2`) may have different layouts
 
 error: transmute from `std::boxed::Box<Ty2<u32, u32>>` to `&mut Ty2<u32, f32>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:88:45
+  --> tests/ui/transmute_undefined_repr.rs:93:45
    |
 LL |         let _: &'static mut Ty2<u32, f32> = transmute(value::<Box<Ty2<u32, u32>>>());
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,7 +54,7 @@ LL |         let _: &'static mut Ty2<u32, f32> = transmute(value::<Box<Ty2<u32, 
    = note: two instances of the same generic type (`Ty2`) may have different layouts
 
 error: transmute from `&mut Ty2<u32, f32>` to `std::boxed::Box<Ty2<u32, u32>>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:92:37
+  --> tests/ui/transmute_undefined_repr.rs:97:37
    |
 LL |         let _: Box<Ty2<u32, u32>> = transmute(value::<&'static mut Ty2<u32, f32>>());
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,7 +62,7 @@ LL |         let _: Box<Ty2<u32, u32>> = transmute(value::<&'static mut Ty2<u32,
    = note: two instances of the same generic type (`Ty2`) may have different layouts
 
 error: transmute into `*const Ty2<u32, u32>` which has an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:189:39
+  --> tests/ui/transmute_undefined_repr.rs:194:39
    |
 LL |         let _: *const Ty2<u32, u32> = transmute(value::<*const Ty2C<u32, Ty2<u32, u32>>>());
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,7 +70,7 @@ LL |         let _: *const Ty2<u32, u32> = transmute(value::<*const Ty2C<u32, Ty
    = note: the contained type `Ty2<u32, u32>` has an undefined layout
 
 error: transmute from `*const Ty2<u32, u32>` which has an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:193:50
+  --> tests/ui/transmute_undefined_repr.rs:198:50
    |
 LL |         let _: *const Ty2C<u32, Ty2<u32, u32>> = transmute(value::<*const Ty2<u32, u32>>());
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,7 +78,7 @@ LL |         let _: *const Ty2C<u32, Ty2<u32, u32>> = transmute(value::<*const T
    = note: the contained type `Ty2<u32, u32>` has an undefined layout
 
 error: transmute from `std::vec::Vec<Ty2<U, i32>>` to `std::vec::Vec<Ty2<T, u32>>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:240:35
+  --> tests/ui/transmute_undefined_repr.rs:245:35
    |
 LL |         let _: Vec<Ty2<T, u32>> = transmute(value::<Vec<Ty2<U, i32>>>());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -86,7 +86,7 @@ LL |         let _: Vec<Ty2<T, u32>> = transmute(value::<Vec<Ty2<U, i32>>>());
    = note: two instances of the same generic type (`Vec`) may have different layouts
 
 error: transmute from `std::vec::Vec<Ty2<T, u32>>` to `std::vec::Vec<Ty2<U, i32>>`, both of which have an undefined layout
-  --> tests/ui/transmute_undefined_repr.rs:244:35
+  --> tests/ui/transmute_undefined_repr.rs:249:35
    |
 LL |         let _: Vec<Ty2<U, i32>> = transmute(value::<Vec<Ty2<T, u32>>>());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/transmutes_expressible_as_ptr_casts.fixed
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.fixed
@@ -3,7 +3,7 @@
 // would otherwise be responsible for
 #![warn(clippy::useless_transmute)]
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(unused, clippy::borrow_as_ptr)]
+#![allow(unused, clippy::borrow_as_ptr, clippy::missing_transmute_annotations)]
 
 use std::mem::{size_of, transmute};
 

--- a/tests/ui/transmutes_expressible_as_ptr_casts.rs
+++ b/tests/ui/transmutes_expressible_as_ptr_casts.rs
@@ -3,7 +3,7 @@
 // would otherwise be responsible for
 #![warn(clippy::useless_transmute)]
 #![warn(clippy::transmute_ptr_to_ptr)]
-#![allow(unused, clippy::borrow_as_ptr)]
+#![allow(unused, clippy::borrow_as_ptr, clippy::missing_transmute_annotations)]
 
 use std::mem::{size_of, transmute};
 

--- a/tests/ui/transmuting_null.rs
+++ b/tests/ui/transmuting_null.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::transmuting_null)]
 #![allow(clippy::zero_ptr)]
 #![allow(clippy::transmute_ptr_to_ref)]
-#![allow(clippy::eq_op)]
+#![allow(clippy::eq_op, clippy::missing_transmute_annotations)]
 
 // Easy to lint because these only span one line.
 fn one_liners() {

--- a/tests/ui/uninhabited_references.rs
+++ b/tests/ui/uninhabited_references.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::uninhabited_references)]
+#![allow(clippy::missing_transmute_annotations)]
 #![feature(never_type)]
 
 fn ret_uninh_ref() -> &'static std::convert::Infallible {

--- a/tests/ui/uninhabited_references.stderr
+++ b/tests/ui/uninhabited_references.stderr
@@ -1,5 +1,5 @@
 error: dereferencing a reference to an uninhabited type would be undefined behavior
-  --> tests/ui/uninhabited_references.rs:4:23
+  --> tests/ui/uninhabited_references.rs:5:23
    |
 LL | fn ret_uninh_ref() -> &'static std::convert::Infallible {
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | fn ret_uninh_ref() -> &'static std::convert::Infallible {
    = help: to override `-D warnings` add `#[allow(clippy::uninhabited_references)]`
 
 error: dereferencing a reference to an uninhabited type would be undefined behavior
-  --> tests/ui/uninhabited_references.rs:10:30
+  --> tests/ui/uninhabited_references.rs:11:30
    |
 LL |         fn $name(x: &$ty) -> &$ty {
    |                              ^^^^
@@ -19,7 +19,7 @@ LL | ret_something!(id_never, !);
    = note: this error originates in the macro `ret_something` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: dereferencing a reference to an uninhabited type is undefined behavior
-  --> tests/ui/uninhabited_references.rs:11:14
+  --> tests/ui/uninhabited_references.rs:12:14
    |
 LL |             &*x
    |              ^^
@@ -30,7 +30,7 @@ LL | ret_something!(id_never, !);
    = note: this error originates in the macro `ret_something` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: dereferencing a reference to an uninhabited type is undefined behavior
-  --> tests/ui/uninhabited_references.rs:21:13
+  --> tests/ui/uninhabited_references.rs:22:13
    |
 LL |     let _ = *x;
    |             ^^

--- a/tests/ui/use_self.fixed
+++ b/tests/ui/use_self.fixed
@@ -7,7 +7,9 @@
     clippy::upper_case_acronyms,
     clippy::from_over_into,
     clippy::self_named_constructors,
-    clippy::needless_lifetimes
+    clippy::needless_lifetimes,
+    clippy::missing_transmute_annotations,
+    clippy::missing_transmute_annotations
 )]
 
 #[macro_use]

--- a/tests/ui/use_self.rs
+++ b/tests/ui/use_self.rs
@@ -7,7 +7,9 @@
     clippy::upper_case_acronyms,
     clippy::from_over_into,
     clippy::self_named_constructors,
-    clippy::needless_lifetimes
+    clippy::needless_lifetimes,
+    clippy::missing_transmute_annotations,
+    clippy::missing_transmute_annotations
 )]
 
 #[macro_use]

--- a/tests/ui/use_self.stderr
+++ b/tests/ui/use_self.stderr
@@ -1,5 +1,5 @@
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:22:21
+  --> tests/ui/use_self.rs:24:21
    |
 LL |         fn new() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
@@ -8,253 +8,253 @@ LL |         fn new() -> Foo {
    = help: to override `-D warnings` add `#[allow(clippy::use_self)]`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:23:13
+  --> tests/ui/use_self.rs:25:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:25:22
+  --> tests/ui/use_self.rs:27:22
    |
 LL |         fn test() -> Foo {
    |                      ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:26:13
+  --> tests/ui/use_self.rs:28:13
    |
 LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:31:25
+  --> tests/ui/use_self.rs:33:25
    |
 LL |         fn default() -> Foo {
    |                         ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:32:13
+  --> tests/ui/use_self.rs:34:13
    |
 LL |             Foo::new()
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:73:28
+  --> tests/ui/use_self.rs:75:28
    |
 LL |         fn clone(&self) -> Foo<'a> {
    |                            ^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:106:24
+  --> tests/ui/use_self.rs:108:24
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                        ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:106:55
+  --> tests/ui/use_self.rs:108:55
    |
 LL |         fn bad(foos: &[Foo]) -> impl Iterator<Item = &Foo> {
    |                                                       ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:121:13
+  --> tests/ui/use_self.rs:123:13
    |
 LL |             TS(0)
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:156:29
+  --> tests/ui/use_self.rs:158:29
    |
 LL |                 fn bar() -> Bar {
    |                             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:157:21
+  --> tests/ui/use_self.rs:159:21
    |
 LL |                     Bar { foo: Foo {} }
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:168:21
+  --> tests/ui/use_self.rs:170:21
    |
 LL |         fn baz() -> Foo {
    |                     ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:169:13
+  --> tests/ui/use_self.rs:171:13
    |
 LL |             Foo {}
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:186:21
+  --> tests/ui/use_self.rs:188:21
    |
 LL |             let _ = Enum::B(42);
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:187:21
+  --> tests/ui/use_self.rs:189:21
    |
 LL |             let _ = Enum::C { field: true };
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:188:21
+  --> tests/ui/use_self.rs:190:21
    |
 LL |             let _ = Enum::A;
    |                     ^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:230:13
+  --> tests/ui/use_self.rs:232:13
    |
 LL |             nested::A::fun_1();
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:231:13
+  --> tests/ui/use_self.rs:233:13
    |
 LL |             nested::A::A;
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:233:13
+  --> tests/ui/use_self.rs:235:13
    |
 LL |             nested::A {};
    |             ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:252:13
+  --> tests/ui/use_self.rs:254:13
    |
 LL |             TestStruct::from_something()
    |             ^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:266:25
+  --> tests/ui/use_self.rs:268:25
    |
 LL |         async fn g() -> S {
    |                         ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:267:13
+  --> tests/ui/use_self.rs:269:13
    |
 LL |             S {}
    |             ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:271:16
+  --> tests/ui/use_self.rs:273:16
    |
 LL |             &p[S::A..S::B]
    |                ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:271:22
+  --> tests/ui/use_self.rs:273:22
    |
 LL |             &p[S::A..S::B]
    |                      ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:294:29
+  --> tests/ui/use_self.rs:296:29
    |
 LL |         fn foo(value: T) -> Foo<T> {
    |                             ^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:295:13
+  --> tests/ui/use_self.rs:297:13
    |
 LL |             Foo::<T> { value }
    |             ^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:467:13
+  --> tests/ui/use_self.rs:469:13
    |
 LL |             A::new::<submod::B>(submod::B {})
    |             ^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:504:13
+  --> tests/ui/use_self.rs:506:13
    |
 LL |             S2::new()
    |             ^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:541:17
+  --> tests/ui/use_self.rs:543:17
    |
 LL |                 Foo::Bar => unimplemented!(),
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:542:17
+  --> tests/ui/use_self.rs:544:17
    |
 LL |                 Foo::Baz => unimplemented!(),
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:548:20
+  --> tests/ui/use_self.rs:550:20
    |
 LL |             if let Foo::Bar = self {
    |                    ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:572:17
+  --> tests/ui/use_self.rs:574:17
    |
 LL |                 Something::Num(n) => *n,
    |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:573:17
+  --> tests/ui/use_self.rs:575:17
    |
 LL |                 Something::TupleNums(n, _m) => *n,
    |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:574:17
+  --> tests/ui/use_self.rs:576:17
    |
 LL |                 Something::StructNums { one, two: _ } => *one,
    |                 ^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:580:17
+  --> tests/ui/use_self.rs:582:17
    |
 LL |                 crate::issue8845::Something::Num(n) => *n,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:581:17
+  --> tests/ui/use_self.rs:583:17
    |
 LL |                 crate::issue8845::Something::TupleNums(n, _m) => *n,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:582:17
+  --> tests/ui/use_self.rs:584:17
    |
 LL |                 crate::issue8845::Something::StructNums { one, two: _ } => *one,
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:598:17
+  --> tests/ui/use_self.rs:600:17
    |
 LL |             let Foo(x) = self;
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:603:17
+  --> tests/ui/use_self.rs:605:17
    |
 LL |             let crate::issue8845::Foo(x) = self;
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:610:17
+  --> tests/ui/use_self.rs:612:17
    |
 LL |             let Bar { x, .. } = self;
    |                 ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:615:17
+  --> tests/ui/use_self.rs:617:17
    |
 LL |             let crate::issue8845::Bar { x, .. } = self;
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> tests/ui/use_self.rs:654:17
+  --> tests/ui/use_self.rs:656:17
    |
 LL |                 E::A => {},
    |                 ^ help: use the applicable keyword: `Self`


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/715.

r? @blyxyas 

changelog: Add `missing_transmute_annotations` lint