### PR TITLE
Temporary review vacation to focus on performance

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,6 +19,7 @@ new_pr = true
 
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
+users_on_vacation = ["blyxyas"]
 
 [assign.owners]
 "/.github" = ["@flip1995"]


### PR DESCRIPTION
We are at Feb. 9, I have done practically nothing in regards to performance and bors just keeps giving me reviews, so I'm going to set myself on vacation on this repo and reroll some PRs. Sadly I cannot postpone performance for reviews.

I'll revert this commit on 12-15 days. I'd love to the discussion in this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/review.20queue.20.26.20capacity) to make some progress so that I don't have to get into version control my busyness status.

changelog:none
r? ghost