### PR TITLE
Don't lint `incompatible_msrv` in test code

### DIFF
--- a/clippy_lints/src/incompatible_msrv.rs
+++ b/clippy_lints/src/incompatible_msrv.rs
@@ -1,8 +1,9 @@
 use clippy_config::msrvs::Msrv;
 use clippy_utils::diagnostics::span_lint;
+use clippy_utils::is_in_test_function;
 use rustc_attr::{StabilityLevel, StableSince};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, HirId};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::TyCtxt;
 use rustc_semver::RustcVersion;
@@ -81,13 +82,13 @@ impl IncompatibleMsrv {
         version
     }
 
-    fn emit_lint_if_under_msrv(&mut self, cx: &LateContext<'_>, def_id: DefId, span: Span) {
+    fn emit_lint_if_under_msrv(&mut self, cx: &LateContext<'_>, def_id: DefId, node: HirId, span: Span) {
         if def_id.is_local() {
             // We don't check local items since their MSRV is supposed to always be valid.
             return;
         }
         let version = self.get_def_id_version(cx.tcx, def_id);
-        if self.msrv.meets(version) {
+        if self.msrv.meets(version) || is_in_test_function(cx.tcx, node) {
             return;
         }
         self.emit_lint_for(cx, span, version);
@@ -117,14 +118,14 @@ impl<'tcx> LateLintPass<'tcx> for IncompatibleMsrv {
         match expr.kind {
             ExprKind::MethodCall(_, _, _, span) => {
                 if let Some(method_did) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {
-                    self.emit_lint_if_under_msrv(cx, method_did, span);
+                    self.emit_lint_if_under_msrv(cx, method_did, expr.hir_id, span);
                 }
             },
             ExprKind::Call(call, [_]) => {
                 if let ExprKind::Path(qpath) = call.kind
                     && let Some(path_def_id) = cx.qpath_res(&qpath, call.hir_id).opt_def_id()
                 {
-                    self.emit_lint_if_under_msrv(cx, path_def_id, call.span);
+                    self.emit_lint_if_under_msrv(cx, path_def_id, expr.hir_id, call.span);
                 }
             },
             _ => {},

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -20,4 +20,9 @@ fn foo() {
     //~^ ERROR: is `1.3.0` but this item is stable since `1.4.0`
 }
 
+#[test]
+fn test() {
+    sleep(Duration::new(1, 0));
+}
+
 fn main() {}


### PR DESCRIPTION
fixes #12257

changelog: `incompatible_msrv`: Don't lint in test code
