### PR TITLE
fix: ICE when array index exceeds usize

### DIFF
--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -174,6 +174,7 @@ impl<'tcx> LateLintPass<'tcx> for IndexingSlicing {
                         // only `usize` index is legal in rust array index
                         // leave other type to rustc
                         if let Constant::Int(off) = constant
+                            && off <= usize::MAX as u128
                             && let ty::Uint(utype) = cx.typeck_results().expr_ty(index).kind()
                             && *utype == ty::UintTy::Usize
                             && let ty::Array(_, s) = ty.kind()

--- a/tests/ui/crashes/ice-12253.rs
+++ b/tests/ui/crashes/ice-12253.rs
@@ -1,0 +1,5 @@
+#[allow(overflowing_literals, unconditional_panic, clippy::no_effect)]
+fn main() {
+    let arr: [i32; 5] = [0; 5];
+    arr[0xfffffe7ffffffffffffffffffffffff];
+}


### PR DESCRIPTION
fixes #12253 

This PR fixes ICE in `indexing_slicing` as it panics when the index of the array exceeds `usize`.

changelog: none