### PR TITLE
Fix broken URL in `Lint Configuration`

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -278,7 +278,7 @@ The minimum number of struct fields for the lints about field names to trigger
 
 ---
 **Affected lints:**
-* [`struct_variant_names`](https://rust-lang.github.io/rust-clippy/master/index.html#struct_variant_names)
+* [`struct_field_names`](https://rust-lang.github.io/rust-clippy/master/index.html#struct_field_names)
 
 
 ## `enum-variant-size-threshold`

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -325,7 +325,7 @@ define_Conf! {
     ///
     /// The minimum number of enum variants for the lints about variant names to trigger
     (enum_variant_name_threshold: u64 = 3),
-    /// Lint: STRUCT_VARIANT_NAMES.
+    /// Lint: STRUCT_FIELD_NAMES.
     ///
     /// The minimum number of struct fields for the lints about field names to trigger
     (struct_field_name_threshold: u64 = 3),


### PR DESCRIPTION
Pretty sure it's meant to be `struct_field_names` and not `struct_variant_names`.

This change is gargantuan!!! review carefully

changelog: none
