### PR TITLE
[`incompatible_msrv`]: allow expressions that come from desugaring

### DIFF
--- a/clippy_lints/src/incompatible_msrv.rs
+++ b/clippy_lints/src/incompatible_msrv.rs
@@ -9,7 +9,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_semver::RustcVersion;
 use rustc_session::impl_lint_pass;
 use rustc_span::def_id::DefId;
-use rustc_span::Span;
+use rustc_span::{ExpnKind, Span};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -89,6 +89,11 @@ impl IncompatibleMsrv {
         }
         let version = self.get_def_id_version(cx.tcx, def_id);
         if self.msrv.meets(version) || is_in_test_function(cx.tcx, node) {
+            return;
+        }
+        if let ExpnKind::AstPass(_) | ExpnKind::Desugaring(_) = span.ctxt().outer_expn_data().kind {
+            // Desugared expressions get to cheat and stability is ignored.
+            // Intentionally not using `.from_expansion()`, since we do still care about macro expansions
             return;
         }
         self.emit_lint_for(cx, span, version);

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -4,6 +4,7 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::future::Future;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -23,6 +24,13 @@ fn foo() {
 #[test]
 fn test() {
     sleep(Duration::new(1, 0));
+}
+
+#[clippy::msrv = "1.63.0"]
+async fn issue12273(v: impl Future<Output = ()>) {
+    // `.await` desugaring has a call to `IntoFuture::into_future` marked #[stable(since = "1.64.0")],
+    // but its stability is ignored
+    v.await;
 }
 
 fn main() {}

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -1,5 +1,5 @@
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.10.0`
-  --> $DIR/incompatible_msrv.rs:12:39
+  --> $DIR/incompatible_msrv.rs:13:39
    |
 LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    |                                       ^^^^^
@@ -8,13 +8,13 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> $DIR/incompatible_msrv.rs:15:11
+  --> $DIR/incompatible_msrv.rs:16:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> $DIR/incompatible_msrv.rs:19:5
+  --> $DIR/incompatible_msrv.rs:20:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^


### PR DESCRIPTION
Fixes #12273

changelog: [`incompatible_msrv`]: don't lint on the `IntoFuture::into_future` call desugared by `.await`