### PR TITLE
[`case_sensitive_file_extension_comparisons`]: Don't trigger on digits-only extensions

### DIFF
--- a/clippy_lints/src/methods/case_sensitive_file_extension_comparisons.rs
+++ b/clippy_lints/src/methods/case_sensitive_file_extension_comparisons.rs
@@ -38,6 +38,7 @@ pub(super) fn check<'tcx>(
         && ext_str.starts_with('.')
         && (ext_str.chars().skip(1).all(|c| c.is_uppercase() || c.is_ascii_digit())
             || ext_str.chars().skip(1).all(|c| c.is_lowercase() || c.is_ascii_digit()))
+        && !ext_str.chars().skip(1).all(|c| c.is_ascii_digit())
         && let recv_ty = cx.typeck_results().expr_ty(recv).peel_refs()
         && (recv_ty.is_str() || is_type_lang_item(cx, recv_ty, LangItem::String))
     {

--- a/tests/ui/case_sensitive_file_extension_comparisons.fixed
+++ b/tests/ui/case_sensitive_file_extension_comparisons.fixed
@@ -63,4 +63,9 @@ fn main() {
     let _ = String::new().ends_with("a.ext");
     let _ = "str".ends_with("a.extA");
     TestStruct {}.ends_with("a.ext");
+
+    // Shouldn't fail if the extension has no ascii letter
+    let _ = String::new().ends_with(".123");
+    let _ = "str".ends_with(".123");
+    TestStruct {}.ends_with(".123");
 }

--- a/tests/ui/case_sensitive_file_extension_comparisons.rs
+++ b/tests/ui/case_sensitive_file_extension_comparisons.rs
@@ -51,4 +51,9 @@ fn main() {
     let _ = String::new().ends_with("a.ext");
     let _ = "str".ends_with("a.extA");
     TestStruct {}.ends_with("a.ext");
+
+    // Shouldn't fail if the extension has no ascii letter
+    let _ = String::new().ends_with(".123");
+    let _ = "str".ends_with(".123");
+    TestStruct {}.ends_with(".123");
 }


### PR DESCRIPTION
If we find a file extension check with only digits (`.123`), do not trigger `case_sensitive_file_extension_comparisons`.

Fixes #12252 

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`case_sensitive_file_extension_comparisons`]: Don't trigger on digits-only extensions
