### PR TITLE
fix: documentation of `blocks_in_conditions` lint

### DIFF
--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -13,7 +13,7 @@ use rustc_span::sym;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for `if` conditions that use blocks containing an
+    /// Checks for `if` and `match` conditions that use blocks containing an
     /// expression, statements or conditions that use closures with blocks.
     ///
     /// ### Why is this bad?
@@ -25,6 +25,8 @@ declare_clippy_lint! {
     /// if { true } { /* ... */ }
     ///
     /// if { let x = somefunc(); x } { /* ... */ }
+    ///
+    /// match { let e = somefunc(); e } { /* ... */ }
     /// ```
     ///
     /// Use instead:
@@ -34,6 +36,9 @@ declare_clippy_lint! {
     ///
     /// let res = { let x = somefunc(); x };
     /// if res { /* ... */ }
+    ///
+    /// let res = { let e = somefunc(); e };
+    /// match res { /* ... */ }
     /// ```
     #[clippy::version = "1.45.0"]
     pub BLOCKS_IN_CONDITIONS,

--- a/clippy_lints/src/blocks_in_conditions.rs
+++ b/clippy_lints/src/blocks_in_conditions.rs
@@ -26,7 +26,10 @@ declare_clippy_lint! {
     ///
     /// if { let x = somefunc(); x } { /* ... */ }
     ///
-    /// match { let e = somefunc(); e } { /* ... */ }
+    /// match { let e = somefunc(); e } {
+    ///     // ...
+    /// #   _ => {}
+    /// }
     /// ```
     ///
     /// Use instead:
@@ -38,7 +41,10 @@ declare_clippy_lint! {
     /// if res { /* ... */ }
     ///
     /// let res = { let e = somefunc(); e };
-    /// match res { /* ... */ }
+    /// match res {
+    ///     // ...
+    /// #   _ => {}
+    /// }
     /// ```
     #[clippy::version = "1.45.0"]
     pub BLOCKS_IN_CONDITIONS,


### PR DESCRIPTION
Updated documentation + example of `blocks_in_conditions` lint, which has been updated recently to include `match` statements as well.

changelog: none
