### PR TITLE
Add `unnecessary_clippy_cfg` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5726,6 +5726,7 @@ Released 2018-09-13
 [`unknown_clippy_lints`]: https://rust-lang.github.io/rust-clippy/master/index.html#unknown_clippy_lints
 [`unnecessary_box_returns`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_box_returns
 [`unnecessary_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
+[`unnecessary_clippy_cfg`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_clippy_cfg
 [`unnecessary_fallible_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fallible_conversions
 [`unnecessary_filter_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_filter_map
 [`unnecessary_find_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_find_map

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -60,6 +60,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::attrs::MISMATCHED_TARGET_OS_INFO,
     crate::attrs::NON_MINIMAL_CFG_INFO,
     crate::attrs::SHOULD_PANIC_WITHOUT_EXPECT_INFO,
+    crate::attrs::UNNECESSARY_CLIPPY_CFG_INFO,
     crate::attrs::USELESS_ATTRIBUTE_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_INVALID_TYPE_INFO,
     crate::await_holding_invalid::AWAIT_HOLDING_LOCK_INFO,

--- a/tests/ui/unnecessary_clippy_cfg.rs
+++ b/tests/ui/unnecessary_clippy_cfg.rs
@@ -1,0 +1,23 @@
+//@no-rustfix
+
+#![warn(clippy::unnecessary_clippy_cfg)]
+#![cfg_attr(clippy, deny(clippy::non_minimal_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+#![cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+#![cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+#![cfg_attr(clippy, deny(clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+
+#[cfg_attr(clippy, deny(clippy::non_minimal_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+#[cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+#[cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+#[cfg_attr(clippy, deny(clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+//~^ ERROR: no need to put clippy lints behind a `clippy` cfg
+pub struct Bar;
+
+fn main() {}

--- a/tests/ui/unnecessary_clippy_cfg.stderr
+++ b/tests/ui/unnecessary_clippy_cfg.stderr
@@ -1,0 +1,61 @@
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:13:1
+   |
+LL | #[cfg_attr(clippy, deny(clippy::non_minimal_cfg))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `#[deny(clippy::non_minimal_cfg)]`
+   |
+   = note: `-D clippy::unnecessary-clippy-cfg` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_clippy_cfg)]`
+
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:15:36
+   |
+LL | #[cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg))]
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: write instead: `#[deny(clippy::non_minimal_cfg)]`
+
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:17:36
+   |
+LL | #[cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: write instead: `#[deny(clippy::non_minimal_cfg,clippy::maybe_misused_cfg)]`
+
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:19:1
+   |
+LL | #[cfg_attr(clippy, deny(clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `#[deny(clippy::non_minimal_cfg, clippy::maybe_misused_cfg)]`
+
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:4:1
+   |
+LL | #![cfg_attr(clippy, deny(clippy::non_minimal_cfg))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `#![deny(clippy::non_minimal_cfg)]`
+
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:6:37
+   |
+LL | #![cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg))]
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: write instead: `#![deny(clippy::non_minimal_cfg)]`
+
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:8:37
+   |
+LL | #![cfg_attr(clippy, deny(dead_code, clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: write instead: `#![deny(clippy::non_minimal_cfg,clippy::maybe_misused_cfg)]`
+
+error: no need to put clippy lints behind a `clippy` cfg
+  --> tests/ui/unnecessary_clippy_cfg.rs:10:1
+   |
+LL | #![cfg_attr(clippy, deny(clippy::non_minimal_cfg, clippy::maybe_misused_cfg))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `#![deny(clippy::non_minimal_cfg, clippy::maybe_misused_cfg)]`
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust-clippy/pull/12292.

r? @flip1995 

changelog: Add `unnecessary_clippy_cfg` lint