### PR TITLE
Look for `implied_bounds_in_impls` in more positions

### DIFF
--- a/tests/ui/implied_bounds_in_impls.fixed
+++ b/tests/ui/implied_bounds_in_impls.fixed
@@ -1,5 +1,6 @@
 #![warn(clippy::implied_bounds_in_impls)]
 #![allow(dead_code)]
+#![feature(impl_trait_in_assoc_type, type_alias_impl_trait)]
 
 use std::ops::{Deref, DerefMut};
 
@@ -148,6 +149,28 @@ fn issue11880() {
     fn f3() -> impl Y {}
     fn f4() -> impl Y<T = u32> {}
     fn f5() -> impl Y<T = u32, U = String> {}
+}
+
+fn apit(_: impl Deref + DerefMut) {}
+
+trait Rpitit {
+    fn f() -> impl DerefMut;
+}
+
+trait Atpit {
+    type Assoc;
+    fn define() -> Self::Assoc;
+}
+impl Atpit for () {
+    type Assoc = impl DerefMut;
+    fn define() -> Self::Assoc {
+        &mut [] as &mut [()]
+    }
+}
+
+type Tait = impl DerefMut;
+fn define() -> Tait {
+    &mut [] as &mut [()]
 }
 
 fn main() {}

--- a/tests/ui/implied_bounds_in_impls.fixed
+++ b/tests/ui/implied_bounds_in_impls.fixed
@@ -151,7 +151,7 @@ fn issue11880() {
     fn f5() -> impl Y<T = u32, U = String> {}
 }
 
-fn apit(_: impl Deref + DerefMut) {}
+fn apit(_: impl DerefMut) {}
 
 trait Rpitit {
     fn f() -> impl DerefMut;

--- a/tests/ui/implied_bounds_in_impls.rs
+++ b/tests/ui/implied_bounds_in_impls.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::implied_bounds_in_impls)]
 #![allow(dead_code)]
+#![feature(impl_trait_in_assoc_type, type_alias_impl_trait)]
 
 use std::ops::{Deref, DerefMut};
 
@@ -148,6 +149,28 @@ fn issue11880() {
     fn f3() -> impl X + Y {}
     fn f4() -> impl X + Y<T = u32> {}
     fn f5() -> impl X<U = String> + Y<T = u32> {}
+}
+
+fn apit(_: impl Deref + DerefMut) {}
+
+trait Rpitit {
+    fn f() -> impl Deref + DerefMut;
+}
+
+trait Atpit {
+    type Assoc;
+    fn define() -> Self::Assoc;
+}
+impl Atpit for () {
+    type Assoc = impl Deref + DerefMut;
+    fn define() -> Self::Assoc {
+        &mut [] as &mut [()]
+    }
+}
+
+type Tait = impl Deref + DerefMut;
+fn define() -> Tait {
+    &mut [] as &mut [()]
 }
 
 fn main() {}

--- a/tests/ui/implied_bounds_in_impls.stderr
+++ b/tests/ui/implied_bounds_in_impls.stderr
@@ -1,5 +1,5 @@
 error: this bound is already specified as the supertrait of `DerefMut<Target = T>`
-  --> tests/ui/implied_bounds_in_impls.rs:12:36
+  --> tests/ui/implied_bounds_in_impls.rs:13:36
    |
 LL | fn deref_derefmut<T>(x: T) -> impl Deref<Target = T> + DerefMut<Target = T> {
    |                                    ^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL + fn deref_derefmut<T>(x: T) -> impl DerefMut<Target = T> {
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<U, W, U>`
-  --> tests/ui/implied_bounds_in_impls.rs:29:37
+  --> tests/ui/implied_bounds_in_impls.rs:30:37
    |
 LL | fn generics_implied<U, W>() -> impl GenericTrait<W> + GenericSubtrait<U, W, U>
    |                                     ^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL + fn generics_implied<U, W>() -> impl GenericSubtrait<U, W, U>
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), i32, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:35:40
+  --> tests/ui/implied_bounds_in_impls.rs:36:40
    |
 LL | fn generics_implied_multi<V>() -> impl GenericTrait<i32> + GenericTrait2<V> + GenericSubtrait<(), i32, V> {}
    |                                        ^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL + fn generics_implied_multi<V>() -> impl GenericTrait2<V> + GenericSubtrait<(
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), i32, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:35:60
+  --> tests/ui/implied_bounds_in_impls.rs:36:60
    |
 LL | fn generics_implied_multi<V>() -> impl GenericTrait<i32> + GenericTrait2<V> + GenericSubtrait<(), i32, V> {}
    |                                                            ^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL + fn generics_implied_multi<V>() -> impl GenericTrait<i32> + GenericSubtrait<
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), T, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:37:44
+  --> tests/ui/implied_bounds_in_impls.rs:38:44
    |
 LL | fn generics_implied_multi2<T, V>() -> impl GenericTrait<T> + GenericTrait2<V> + GenericSubtrait<(), T, V>
    |                                            ^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL + fn generics_implied_multi2<T, V>() -> impl GenericTrait2<V> + GenericSubtra
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), T, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:37:62
+  --> tests/ui/implied_bounds_in_impls.rs:38:62
    |
 LL | fn generics_implied_multi2<T, V>() -> impl GenericTrait<T> + GenericTrait2<V> + GenericSubtrait<(), T, V>
    |                                                              ^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL + fn generics_implied_multi2<T, V>() -> impl GenericTrait<T> + GenericSubtrai
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), i32, ()>`
-  --> tests/ui/implied_bounds_in_impls.rs:47:28
+  --> tests/ui/implied_bounds_in_impls.rs:48:28
    |
 LL | fn generics_same() -> impl GenericTrait<i32> + GenericSubtrait<(), i32, ()> {}
    |                            ^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL + fn generics_same() -> impl GenericSubtrait<(), i32, ()> {}
    |
 
 error: this bound is already specified as the supertrait of `DerefMut<Target = u8>`
-  --> tests/ui/implied_bounds_in_impls.rs:51:20
+  --> tests/ui/implied_bounds_in_impls.rs:52:20
    |
 LL |     fn f() -> impl Deref + DerefMut<Target = u8>;
    |                    ^^^^^
@@ -97,7 +97,7 @@ LL +     fn f() -> impl DerefMut<Target = u8>;
    |
 
 error: this bound is already specified as the supertrait of `DerefMut<Target = u8>`
-  --> tests/ui/implied_bounds_in_impls.rs:56:20
+  --> tests/ui/implied_bounds_in_impls.rs:57:20
    |
 LL |     fn f() -> impl Deref + DerefMut<Target = u8> {
    |                    ^^^^^
@@ -109,7 +109,7 @@ LL +     fn f() -> impl DerefMut<Target = u8> {
    |
 
 error: this bound is already specified as the supertrait of `DerefMut<Target = u8>`
-  --> tests/ui/implied_bounds_in_impls.rs:62:20
+  --> tests/ui/implied_bounds_in_impls.rs:63:20
    |
 LL |     fn f() -> impl Deref + DerefMut<Target = u8> {
    |                    ^^^^^
@@ -121,7 +121,7 @@ LL +     fn f() -> impl DerefMut<Target = u8> {
    |
 
 error: this bound is already specified as the supertrait of `PartialOrd`
-  --> tests/ui/implied_bounds_in_impls.rs:73:41
+  --> tests/ui/implied_bounds_in_impls.rs:74:41
    |
 LL |     fn default_generic_param1() -> impl PartialEq + PartialOrd + Debug {}
    |                                         ^^^^^^^^^
@@ -133,7 +133,7 @@ LL +     fn default_generic_param1() -> impl PartialOrd + Debug {}
    |
 
 error: this bound is already specified as the supertrait of `PartialOrd`
-  --> tests/ui/implied_bounds_in_impls.rs:74:54
+  --> tests/ui/implied_bounds_in_impls.rs:75:54
    |
 LL |     fn default_generic_param2() -> impl PartialOrd + PartialEq + Debug {}
    |                                                      ^^^^^^^^^
@@ -145,7 +145,7 @@ LL +     fn default_generic_param2() -> impl PartialOrd + Debug {}
    |
 
 error: this bound is already specified as the supertrait of `DoubleEndedIterator`
-  --> tests/ui/implied_bounds_in_impls.rs:87:26
+  --> tests/ui/implied_bounds_in_impls.rs:88:26
    |
 LL |     fn my_iter() -> impl Iterator<Item = u32> + DoubleEndedIterator {
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     fn my_iter() -> impl DoubleEndedIterator<Item = u32> {
    |
 
 error: this bound is already specified as the supertrait of `Copy`
-  --> tests/ui/implied_bounds_in_impls.rs:92:27
+  --> tests/ui/implied_bounds_in_impls.rs:93:27
    |
 LL |     fn f() -> impl Copy + Clone {
    |                           ^^^^^
@@ -169,7 +169,7 @@ LL +     fn f() -> impl Copy {
    |
 
 error: this bound is already specified as the supertrait of `Trait2<i32>`
-  --> tests/ui/implied_bounds_in_impls.rs:106:21
+  --> tests/ui/implied_bounds_in_impls.rs:107:21
    |
 LL |     fn f2() -> impl Trait1<i32, U = i64> + Trait2<i32> {}
    |                     ^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     fn f2() -> impl Trait2<i32, U = i64> {}
    |
 
 error: this bound is already specified as the supertrait of `Trait4<i8, X = i32>`
-  --> tests/ui/implied_bounds_in_impls.rs:121:21
+  --> tests/ui/implied_bounds_in_impls.rs:122:21
    |
 LL |     fn f3() -> impl Trait3<i8, i16, i64, X = i32, Y = i128> + Trait4<i8, X = i32> {}
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL +     fn f3() -> impl Trait4<i8, X = i32, Y = i128> {}
    |
 
 error: this bound is already specified as the supertrait of `Y`
-  --> tests/ui/implied_bounds_in_impls.rs:148:21
+  --> tests/ui/implied_bounds_in_impls.rs:149:21
    |
 LL |     fn f3() -> impl X + Y {}
    |                     ^
@@ -205,7 +205,7 @@ LL +     fn f3() -> impl Y {}
    |
 
 error: this bound is already specified as the supertrait of `Y<T = u32>`
-  --> tests/ui/implied_bounds_in_impls.rs:149:21
+  --> tests/ui/implied_bounds_in_impls.rs:150:21
    |
 LL |     fn f4() -> impl X + Y<T = u32> {}
    |                     ^
@@ -217,7 +217,7 @@ LL +     fn f4() -> impl Y<T = u32> {}
    |
 
 error: this bound is already specified as the supertrait of `Y<T = u32>`
-  --> tests/ui/implied_bounds_in_impls.rs:150:21
+  --> tests/ui/implied_bounds_in_impls.rs:151:21
    |
 LL |     fn f5() -> impl X<U = String> + Y<T = u32> {}
    |                     ^^^^^^^^^^^^^
@@ -228,5 +228,41 @@ LL -     fn f5() -> impl X<U = String> + Y<T = u32> {}
 LL +     fn f5() -> impl Y<T = u32, U = String> {}
    |
 
-error: aborting due to 19 previous errors
+error: this bound is already specified as the supertrait of `DerefMut`
+  --> tests/ui/implied_bounds_in_impls.rs:157:20
+   |
+LL |     fn f() -> impl Deref + DerefMut;
+   |                    ^^^^^
+   |
+help: try removing this bound
+   |
+LL -     fn f() -> impl Deref + DerefMut;
+LL +     fn f() -> impl DerefMut;
+   |
+
+error: this bound is already specified as the supertrait of `DerefMut`
+  --> tests/ui/implied_bounds_in_impls.rs:165:23
+   |
+LL |     type Assoc = impl Deref + DerefMut;
+   |                       ^^^^^
+   |
+help: try removing this bound
+   |
+LL -     type Assoc = impl Deref + DerefMut;
+LL +     type Assoc = impl DerefMut;
+   |
+
+error: this bound is already specified as the supertrait of `DerefMut`
+  --> tests/ui/implied_bounds_in_impls.rs:171:18
+   |
+LL | type Tait = impl Deref + DerefMut;
+   |                  ^^^^^
+   |
+help: try removing this bound
+   |
+LL - type Tait = impl Deref + DerefMut;
+LL + type Tait = impl DerefMut;
+   |
+
+error: aborting due to 22 previous errors
 

--- a/tests/ui/implied_bounds_in_impls.stderr
+++ b/tests/ui/implied_bounds_in_impls.stderr
@@ -229,6 +229,18 @@ LL +     fn f5() -> impl Y<T = u32, U = String> {}
    |
 
 error: this bound is already specified as the supertrait of `DerefMut`
+  --> tests/ui/implied_bounds_in_impls.rs:154:17
+   |
+LL | fn apit(_: impl Deref + DerefMut) {}
+   |                 ^^^^^
+   |
+help: try removing this bound
+   |
+LL - fn apit(_: impl Deref + DerefMut) {}
+LL + fn apit(_: impl DerefMut) {}
+   |
+
+error: this bound is already specified as the supertrait of `DerefMut`
   --> tests/ui/implied_bounds_in_impls.rs:157:20
    |
 LL |     fn f() -> impl Deref + DerefMut;
@@ -264,5 +276,5 @@ LL - type Tait = impl Deref + DerefMut;
 LL + type Tait = impl DerefMut;
    |
 
-error: aborting due to 22 previous errors
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
With this, we lint `impl Trait` implied bounds in more positions:
- Type alias impl trait
- Associated type position impl trait
- Argument position impl trait
  - these are not opaque types, but instead are desugared to `where` clauses, so we need extra logic for finding them (`check_generics`), however the rest of the logic is the same


Before this, we'd only lint RPIT `impl Trait`s.
"Hide whitespaces" and reviewing commits individually might make this easier

changelog: [`implied_bounds_in_impls`]: start linting implied bounds in APIT, ATPIT, TAIT