### PR TITLE
fix: make `#[allow]` work on field for `pub_underscore_fields`

### DIFF
--- a/clippy_lints/src/pub_underscore_fields.rs
+++ b/clippy_lints/src/pub_underscore_fields.rs
@@ -1,6 +1,6 @@
 use clippy_config::types::PubUnderscoreFieldsBehaviour;
 use clippy_utils::attrs::is_doc_hidden;
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::is_path_lang_item;
 use rustc_hir::{FieldDef, Item, ItemKind, LangItem};
 use rustc_lint::{LateContext, LateLintPass};
@@ -69,13 +69,15 @@ impl<'tcx> LateLintPass<'tcx> for PubUnderscoreFields {
                 // We ignore fields that are `PhantomData`.
                 && !is_path_lang_item(cx, field.ty, LangItem::PhantomData)
             {
-                span_lint_and_help(
+                span_lint_hir_and_then(
                     cx,
                     PUB_UNDERSCORE_FIELDS,
+                    field.hir_id,
                     field.vis_span.to(field.ident.span),
                     "field marked as public but also inferred as unused because it's prefixed with `_`",
-                    None,
-                    "consider removing the underscore, or making the field private",
+                    |diag| {
+                        diag.help("consider removing the underscore, or making the field private");
+                    },
                 );
             }
         }

--- a/tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs
+++ b/tests/ui-toml/pub_underscore_fields/pub_underscore_fields.rs
@@ -63,4 +63,10 @@ fn main() {
         _pub: String,
         pub(crate) _mark: PhantomData<u8>,
     }
+
+    // shouldn't warn when `#[allow]` is used on field level
+    pub struct AllowedViolations {
+        #[allow(clippy::pub_underscore_fields)]
+        pub _first: u32,
+    }
 }


### PR DESCRIPTION
Closes #12286 

changelog: `#[allow(clippy::pub_underscore_fields)]` now works on linted field
