### PR TITLE
Default test output conflict handling to error

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -5,7 +5,7 @@
 #![allow(unused_extern_crates)]
 
 use ui_test::spanned::Spanned;
-use ui_test::{status_emitter, Args, CommandBuilder, Config, Match, Mode};
+use ui_test::{status_emitter, Args, CommandBuilder, Config, Match, Mode, OutputConflictHandling};
 
 use std::collections::BTreeMap;
 use std::env::{self, set_var, var_os};
@@ -113,6 +113,7 @@ fn base_config(test_dir: &str) -> (Config, Args) {
 
     let target_dir = PathBuf::from(var_os("CARGO_TARGET_DIR").unwrap_or_else(|| "target".into()));
     let mut config = Config {
+        output_conflict_handling: OutputConflictHandling::Error,
         filter_files: env::var("TESTNAME")
             .map(|filters| filters.split(',').map(str::to_string).collect())
             .unwrap_or_default(),


### PR DESCRIPTION
https://github.com/oli-obk/ui_test/pull/175 got rid of the `bool` that controlled the default handling so we need to specify it ourselves

r? @flip1995

changelog: none
