### PR TITLE
Be careful with expressions with attributes

### DIFF
--- a/clippy_lints/src/unused_unit.rs
+++ b/clippy_lints/src/unused_unit.rs
@@ -58,6 +58,7 @@ impl EarlyLintPass for UnusedUnit {
             && let ctxt = block.span.ctxt()
             && stmt.span.ctxt() == ctxt
             && expr.span.ctxt() == ctxt
+            && expr.attrs.is_empty()
         {
             let sp = expr.span;
             span_lint_and_sugg(

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -94,3 +94,10 @@ mod issue9748 {
         let _ = for<'a> |_: &'a u32| -> () {};
     }
 }
+
+mod issue9949 {
+    fn main() {
+        #[doc = "documentation"]
+        ()
+    }
+}

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -94,3 +94,10 @@ mod issue9748 {
         let _ = for<'a> |_: &'a u32| -> () {};
     }
 }
+
+mod issue9949 {
+    fn main() {
+        #[doc = "documentation"]
+        ()
+    }
+}


### PR DESCRIPTION
Fix #9949.

changelog: [`unused_unit`]: skip expressions with attributes