### PR TITLE
Fix: no_effect_underscore_binding fires on ignored parameters of async fns

### DIFF
--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -43,10 +43,6 @@ declare_clippy_lint! {
     /// executed. However, as they have no effect and shouldn't be used further on, all they
     /// do is make the code less readable.
     ///
-    /// ### Known problems
-    /// Further usage of this variable is not checked, which can lead to false positives if it is
-    /// used later in the code.
-    ///
     /// ### Example
     /// ```rust,ignore
     /// let _i_serve_no_purpose = 1;

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -5,8 +5,8 @@ use clippy_utils::{any_parent_is_automatically_derived, get_parent_node, is_lint
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{
-    is_range_literal, BinOpKind, BlockCheckMode, Expr, ExprKind, HirId, HirIdMap, ItemKind, Node, PatKind, Stmt,
-    StmtKind, UnsafeSource,
+    is_range_literal, BinOpKind, BlockCheckMode, Expr, ExprKind, HirId, HirIdMap, ItemKind, LocalSource, Node, PatKind,
+    Stmt, StmtKind, UnsafeSource,
 };
 use rustc_infer::infer::TyCtxtInferExt as _;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
@@ -178,6 +178,7 @@ impl NoEffect {
             }
         } else if let StmtKind::Local(local) = stmt.kind {
             if !is_lint_allowed(cx, NO_EFFECT_UNDERSCORE_BINDING, local.hir_id)
+                && !matches!(local.source, LocalSource::AsyncFn)
                 && let Some(init) = local.init
                 && local.els.is_none()
                 && !local.pat.span.from_expansion()

--- a/tests/ui/no_effect_async_fn.rs
+++ b/tests/ui/no_effect_async_fn.rs
@@ -1,0 +1,50 @@
+#![warn(clippy::no_effect_underscore_binding)]
+#![no_main]
+
+trait AsyncTrait {
+    async fn bar(i: u64);
+}
+
+struct Bar;
+
+impl AsyncTrait for Bar {
+    // Shouldn't lint `binding to `_` prefixed variable with no side-effect`
+    async fn bar(_i: u64) {
+        let _a = 0;
+        //~^ ERROR: binding to `_` prefixed variable with no side-effect
+
+        // Shouldn't lint `binding to `_` prefixed variable with no side-effect`
+        let _b = num();
+
+        let _ = async {
+            let _c = 0;
+            //~^ ERROR: binding to `_` prefixed variable with no side-effect
+
+            // Shouldn't lint `binding to `_` prefixed variable with no side-effect`
+            let _d = num();
+        }
+        .await;
+    }
+}
+
+// Shouldn't lint `binding to `_` prefixed variable with no side-effect`
+async fn foo(_i: u64) {
+    let _a = 0;
+    //~^ ERROR: binding to `_` prefixed variable with no side-effect
+
+    // Shouldn't lint `binding to `_` prefixed variable with no side-effect`
+    let _b = num();
+
+    let _ = async {
+        let _c = 0;
+        //~^ ERROR: binding to `_` prefixed variable with no side-effect
+
+        // Shouldn't lint `binding to `_` prefixed variable with no side-effect`
+        let _d = num();
+    }
+    .await;
+}
+
+fn num() -> usize {
+    0
+}

--- a/tests/ui/no_effect_async_fn.stderr
+++ b/tests/ui/no_effect_async_fn.stderr
@@ -1,0 +1,29 @@
+error: binding to `_` prefixed variable with no side-effect
+  --> tests/ui/no_effect_async_fn.rs:20:17
+   |
+LL |             let _c = 0;
+   |                 ^^
+   |
+   = note: `-D clippy::no-effect-underscore-binding` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::no_effect_underscore_binding)]`
+
+error: binding to `_` prefixed variable with no side-effect
+  --> tests/ui/no_effect_async_fn.rs:13:13
+   |
+LL |         let _a = 0;
+   |             ^^
+
+error: binding to `_` prefixed variable with no side-effect
+  --> tests/ui/no_effect_async_fn.rs:39:13
+   |
+LL |         let _c = 0;
+   |             ^^
+
+error: binding to `_` prefixed variable with no side-effect
+  --> tests/ui/no_effect_async_fn.rs:32:9
+   |
+LL |     let _a = 0;
+   |         ^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #12279 
changelog: Fix [`no_effect_underscore_binding`])

The warning is no longer displayed when an underscore is given in the parameter name of an asynchronous function.