### PR TITLE
Coming back to reviewer rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,7 +19,6 @@ new_pr = true
 
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
-users_on_vacation = ["blyxyas"]
 
 [assign.owners]
 "/.github" = ["@flip1995"]


### PR DESCRIPTION
After this current CPP period, in which I set myself as on-vacation to focus on performance, I'm now available again. I'd love if my vacation status wasn't present in version control

changelog:none
r? ghost