### PR TITLE
Allow unused_imports, and unused_import_braces on `use`

### DIFF
--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -564,6 +564,8 @@ impl<'tcx> LateLintPass<'tcx> for Attributes {
                                             || is_word(lint, sym::deprecated)
                                             || is_word(lint, sym!(unreachable_pub))
                                             || is_word(lint, sym!(unused))
+                                            || is_word(lint, sym!(unused_import_braces))
+                                            || is_word(lint, sym!(unused_imports))
                                             || extract_clippy_lint(lint).map_or(false, |s| {
                                                 matches!(
                                                     s.as_str(),

--- a/clippy_lints/src/attrs.rs
+++ b/clippy_lints/src/attrs.rs
@@ -565,7 +565,6 @@ impl<'tcx> LateLintPass<'tcx> for Attributes {
                                             || is_word(lint, sym!(unreachable_pub))
                                             || is_word(lint, sym!(unused))
                                             || is_word(lint, sym!(unused_import_braces))
-                                            || is_word(lint, sym!(unused_imports))
                                             || extract_clippy_lint(lint).map_or(false, |s| {
                                                 matches!(
                                                     s.as_str(),

--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -80,6 +80,14 @@ pub mod split {
 #[allow(clippy::single_component_path_imports)]
 use regex;
 
+mod module {
+    pub(crate) struct Struct;
+}
+
+#[rustfmt::skip]
+#[allow(unused_import_braces, unused_imports)]
+use module::{Struct};
+
 fn main() {
     test_indented_attr();
 }

--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -85,7 +85,7 @@ mod module {
 }
 
 #[rustfmt::skip]
-#[allow(unused_import_braces, unused_imports)]
+#[allow(unused_import_braces)]
 use module::{Struct};
 
 fn main() {

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -80,6 +80,14 @@ pub mod split {
 #[allow(clippy::single_component_path_imports)]
 use regex;
 
+mod module {
+    pub(crate) struct Struct;
+}
+
+#[rustfmt::skip]
+#[allow(unused_import_braces, unused_imports)]
+use module::{Struct};
+
 fn main() {
     test_indented_attr();
 }

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -85,7 +85,7 @@ mod module {
 }
 
 #[rustfmt::skip]
-#[allow(unused_import_braces, unused_imports)]
+#[allow(unused_import_braces)]
 use module::{Struct};
 
 fn main() {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/12223.

Both `unused_import_braces` and `unused_imports` are valid on `use`-items, additional to the two previously allowed. 

changelog: [`useless_attribute`]: Allow `rustc_lint` `unused_import_braces` and `unused_imports` on `use`-items
