### PR TITLE
FIX(12243): redundant_guards

### DIFF
--- a/clippy_lints/src/matches/redundant_guards.rs
+++ b/clippy_lints/src/matches/redundant_guards.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::path_to_local;
 use clippy_utils::source::snippet;
 use clippy_utils::visitors::{for_each_expr, is_local_used};
+use clippy_utils::{in_constant, path_to_local};
 use rustc_ast::{BorrowKind, LitKind};
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
@@ -123,7 +123,7 @@ fn check_method_calls<'tcx>(
         // `s if s.is_empty()` becomes ""
         // `arr if arr.is_empty()` becomes []
 
-        if ty.is_str() {
+        if ty.is_str() && !in_constant(cx, if_expr.hir_id) {
             r#""""#.into()
         } else if slice_like {
             "[]".into()

--- a/tests/ui/redundant_guards.fixed
+++ b/tests/ui/redundant_guards.fixed
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![feature(if_let_guard)]
-#![allow(clippy::no_effect, unused)]
+#![allow(clippy::no_effect, unused, clippy::single_match)]
 #![warn(clippy::redundant_guards)]
 
 #[macro_use]
@@ -16,6 +16,7 @@ struct C(u32, u32);
 
 #[derive(PartialEq)]
 struct FloatWrapper(f32);
+
 fn issue11304() {
     match 0.1 {
         x if x == 0.0 => todo!(),
@@ -257,4 +258,50 @@ fn issue11807() {
         Some(Some(x)) if x.starts_with(&[1, 2]) => {},
         _ => {},
     }
+}
+
+mod issue12243 {
+    pub const fn const_fn(x: &str) {
+        match x {
+            // Shouldn't lint.
+            y if y.is_empty() => {},
+            _ => {},
+        }
+    }
+
+    pub fn non_const_fn(x: &str) {
+        match x {
+            "" => {},
+            //~^ ERROR: redundant guard
+            _ => {},
+        }
+    }
+
+    struct Bar;
+
+    impl Bar {
+        pub const fn const_bar(x: &str) {
+            match x {
+                // Shouldn't lint.
+                y if y.is_empty() => {},
+                _ => {},
+            }
+        }
+
+        pub fn non_const_bar(x: &str) {
+            match x {
+                "" => {},
+                //~^ ERROR: redundant guard
+                _ => {},
+            }
+        }
+    }
+
+    static FOO: () = {
+        match "" {
+            // Shouldn't lint.
+            x if x.is_empty() => {},
+            _ => {},
+        }
+    };
 }

--- a/tests/ui/redundant_guards.rs
+++ b/tests/ui/redundant_guards.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![feature(if_let_guard)]
-#![allow(clippy::no_effect, unused)]
+#![allow(clippy::no_effect, unused, clippy::single_match)]
 #![warn(clippy::redundant_guards)]
 
 #[macro_use]
@@ -16,6 +16,7 @@ struct C(u32, u32);
 
 #[derive(PartialEq)]
 struct FloatWrapper(f32);
+
 fn issue11304() {
     match 0.1 {
         x if x == 0.0 => todo!(),
@@ -257,4 +258,50 @@ fn issue11807() {
         Some(Some(x)) if x.starts_with(&[1, 2]) => {},
         _ => {},
     }
+}
+
+mod issue12243 {
+    pub const fn const_fn(x: &str) {
+        match x {
+            // Shouldn't lint.
+            y if y.is_empty() => {},
+            _ => {},
+        }
+    }
+
+    pub fn non_const_fn(x: &str) {
+        match x {
+            y if y.is_empty() => {},
+            //~^ ERROR: redundant guard
+            _ => {},
+        }
+    }
+
+    struct Bar;
+
+    impl Bar {
+        pub const fn const_bar(x: &str) {
+            match x {
+                // Shouldn't lint.
+                y if y.is_empty() => {},
+                _ => {},
+            }
+        }
+
+        pub fn non_const_bar(x: &str) {
+            match x {
+                y if y.is_empty() => {},
+                //~^ ERROR: redundant guard
+                _ => {},
+            }
+        }
+    }
+
+    static FOO: () = {
+        match "" {
+            // Shouldn't lint.
+            x if x.is_empty() => {},
+            _ => {},
+        }
+    };
 }

--- a/tests/ui/redundant_guards.stderr
+++ b/tests/ui/redundant_guards.stderr
@@ -1,5 +1,5 @@
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:33:20
+  --> tests/ui/redundant_guards.rs:34:20
    |
 LL |         C(x, y) if let 1 = y => ..,
    |                    ^^^^^^^^^
@@ -13,7 +13,7 @@ LL +         C(x, 1) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:39:20
+  --> tests/ui/redundant_guards.rs:40:20
    |
 LL |         Some(x) if matches!(x, Some(1) if true) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |         Some(Some(1)) if true => ..,
    |              ~~~~~~~  ~~~~~~~
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:40:20
+  --> tests/ui/redundant_guards.rs:41:20
    |
 LL |         Some(x) if matches!(x, Some(1)) => {
    |                    ^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL +         Some(Some(1)) => {
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:44:20
+  --> tests/ui/redundant_guards.rs:45:20
    |
 LL |         Some(x) if let Some(1) = x => ..,
    |                    ^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL +         Some(Some(1)) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:45:20
+  --> tests/ui/redundant_guards.rs:46:20
    |
 LL |         Some(x) if x == Some(2) => ..,
    |                    ^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL +         Some(Some(2)) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:46:20
+  --> tests/ui/redundant_guards.rs:47:20
    |
 LL |         Some(x) if Some(2) == x => ..,
    |                    ^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL +         Some(Some(2)) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:71:20
+  --> tests/ui/redundant_guards.rs:72:20
    |
 LL |         B { e } if matches!(e, Some(A(2))) => ..,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL +         B { e: Some(A(2)) } => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:108:20
+  --> tests/ui/redundant_guards.rs:109:20
    |
 LL |         E::A(y) if y == "not from an or pattern" => {},
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL +         E::A("not from an or pattern") => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:115:14
+  --> tests/ui/redundant_guards.rs:116:14
    |
 LL |         x if matches!(x, Some(0)) => ..,
    |              ^^^^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL +         Some(0) => ..,
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:122:14
+  --> tests/ui/redundant_guards.rs:123:14
    |
 LL |         i if i == -1 => {},
    |              ^^^^^^^
@@ -120,7 +120,7 @@ LL +         -1 => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:123:14
+  --> tests/ui/redundant_guards.rs:124:14
    |
 LL |         i if i == 1 => {},
    |              ^^^^^^
@@ -132,7 +132,7 @@ LL +         1 => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:173:28
+  --> tests/ui/redundant_guards.rs:174:28
    |
 LL |             Some(ref x) if x == &1 => {},
    |                            ^^^^^^^
@@ -144,7 +144,7 @@ LL +             Some(1) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:174:28
+  --> tests/ui/redundant_guards.rs:175:28
    |
 LL |             Some(ref x) if &1 == x => {},
    |                            ^^^^^^^
@@ -156,7 +156,7 @@ LL +             Some(1) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:175:28
+  --> tests/ui/redundant_guards.rs:176:28
    |
 LL |             Some(ref x) if let &2 = x => {},
    |                            ^^^^^^^^^^
@@ -168,7 +168,7 @@ LL +             Some(2) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:176:28
+  --> tests/ui/redundant_guards.rs:177:28
    |
 LL |             Some(ref x) if matches!(x, &3) => {},
    |                            ^^^^^^^^^^^^^^^
@@ -180,7 +180,7 @@ LL +             Some(3) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:196:32
+  --> tests/ui/redundant_guards.rs:197:32
    |
 LL |             B { ref c, .. } if c == &1 => {},
    |                                ^^^^^^^
@@ -192,7 +192,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:197:32
+  --> tests/ui/redundant_guards.rs:198:32
    |
 LL |             B { ref c, .. } if &1 == c => {},
    |                                ^^^^^^^
@@ -204,7 +204,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:198:32
+  --> tests/ui/redundant_guards.rs:199:32
    |
 LL |             B { ref c, .. } if let &1 = c => {},
    |                                ^^^^^^^^^^
@@ -216,7 +216,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:199:32
+  --> tests/ui/redundant_guards.rs:200:32
    |
 LL |             B { ref c, .. } if matches!(c, &1) => {},
    |                                ^^^^^^^^^^^^^^^
@@ -228,7 +228,7 @@ LL +             B { c: 1, .. } => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:209:26
+  --> tests/ui/redundant_guards.rs:210:26
    |
 LL |         Some(Some(x)) if x.is_empty() => {},
    |                          ^^^^^^^^^^^^
@@ -240,7 +240,7 @@ LL +         Some(Some("")) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:220:26
+  --> tests/ui/redundant_guards.rs:221:26
    |
 LL |         Some(Some(x)) if x.is_empty() => {},
    |                          ^^^^^^^^^^^^
@@ -252,7 +252,7 @@ LL +         Some(Some([])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:225:26
+  --> tests/ui/redundant_guards.rs:226:26
    |
 LL |         Some(Some(x)) if x.is_empty() => {},
    |                          ^^^^^^^^^^^^
@@ -264,7 +264,7 @@ LL +         Some(Some([])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:236:26
+  --> tests/ui/redundant_guards.rs:237:26
    |
 LL |         Some(Some(x)) if x.starts_with(&[]) => {},
    |                          ^^^^^^^^^^^^^^^^^^
@@ -276,7 +276,7 @@ LL +         Some(Some([..])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:241:26
+  --> tests/ui/redundant_guards.rs:242:26
    |
 LL |         Some(Some(x)) if x.starts_with(&[1]) => {},
    |                          ^^^^^^^^^^^^^^^^^^^
@@ -288,7 +288,7 @@ LL +         Some(Some([1, ..])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:246:26
+  --> tests/ui/redundant_guards.rs:247:26
    |
 LL |         Some(Some(x)) if x.starts_with(&[1, 2]) => {},
    |                          ^^^^^^^^^^^^^^^^^^^^^^
@@ -300,7 +300,7 @@ LL +         Some(Some([1, 2, ..])) => {},
    |
 
 error: redundant guard
-  --> tests/ui/redundant_guards.rs:251:26
+  --> tests/ui/redundant_guards.rs:252:26
    |
 LL |         Some(Some(x)) if x.ends_with(&[1, 2]) => {},
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -311,5 +311,29 @@ LL -         Some(Some(x)) if x.ends_with(&[1, 2]) => {},
 LL +         Some(Some([.., 1, 2])) => {},
    |
 
-error: aborting due to 26 previous errors
+error: redundant guard
+  --> tests/ui/redundant_guards.rs:274:18
+   |
+LL |             y if y.is_empty() => {},
+   |                  ^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -             y if y.is_empty() => {},
+LL +             "" => {},
+   |
+
+error: redundant guard
+  --> tests/ui/redundant_guards.rs:293:22
+   |
+LL |                 y if y.is_empty() => {},
+   |                      ^^^^^^^^^^^^
+   |
+help: try
+   |
+LL -                 y if y.is_empty() => {},
+LL +                 "" => {},
+   |
+
+error: aborting due to 28 previous errors
 


### PR DESCRIPTION
Fixed #12243 

changelog: Fix[`redundant_guards`]

I have made a correction so that no warning does  appear when y.is_empty() is used within a constant function as follows.

```rust
pub const fn const_fn(x: &str) {
    match x {
        // Shouldn't lint.
        y if y.is_empty() => {},
        _ => {},
    }
}
```