### PR TITLE
WIP: Add a lint that detects non-portable usize literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5784,6 +5784,7 @@ Released 2018-09-13
 [`useless_let_if_seq`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_let_if_seq
 [`useless_transmute`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_transmute
 [`useless_vec`]: https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
+[`usize_unportable_32_bit_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#usize_unportable_32_bit_literal
 [`vec_box`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_box
 [`vec_init_then_push`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push
 [`vec_resize_to_zero`]: https://rust-lang.github.io/rust-clippy/master/index.html#vec_resize_to_zero

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -727,6 +727,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::upper_case_acronyms::UPPER_CASE_ACRONYMS_INFO,
     crate::use_self::USE_SELF_INFO,
     crate::useless_conversion::USELESS_CONVERSION_INFO,
+    crate::usize_unportable_32_bit_literal::USIZE_UNPORTABLE_32_BIT_LITERAL_INFO,
     crate::vec::USELESS_VEC_INFO,
     crate::vec_init_then_push::VEC_INIT_THEN_PUSH_INFO,
     crate::visibility::NEEDLESS_PUB_SELF_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -360,6 +360,7 @@ mod unwrap_in_result;
 mod upper_case_acronyms;
 mod use_self;
 mod useless_conversion;
+mod usize_unportable_32_bit_literal;
 mod vec;
 mod vec_init_then_push;
 mod visibility;
@@ -1111,6 +1112,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     });
     store.register_late_pass(move |_| Box::new(incompatible_msrv::IncompatibleMsrv::new(msrv())));
     store.register_late_pass(|_| Box::new(to_string_trait_impl::ToStringTraitImpl));
+    store.register_late_pass(|_| Box::new(usize_unportable_32_bit_literal::UsizeUnportable32BitLiteral));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/usize_unportable_32_bit_literal.rs
+++ b/clippy_lints/src/usize_unportable_32_bit_literal.rs
@@ -1,0 +1,136 @@
+use clippy_utils::diagnostics::span_lint_and_help;
+use rustc_ast::ast::AttrArgs;
+use rustc_ast::token::{Ident, TokenKind};
+use rustc_ast::tokenstream::TokenTree::Token;
+use rustc_ast::AttrKind::Normal;
+use rustc_ast::UintTy::Usize;
+use rustc_ast::{Attribute, LitKind};
+use rustc_hir::PrimTy::Uint;
+use rustc_hir::{ExprKind, HirId, QPath, Stmt, StmtKind, TyKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::TyCtxt;
+use rustc_session::declare_lint_pass;
+use rustc_span::symbol::sym::target_pointer_width;
+use rustc_span::symbol::Symbol;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Checks for assigning a value larges than u32::MAX to an usize variable.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// This makes the code non-portable to platforms that have 32-bit pointer width.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// let foo : usize = ;
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// let foo : u64 = 1<<32;
+    /// ```
+    #[clippy::version = "1.78.0"]
+    pub USIZE_UNPORTABLE_32_BIT_LITERAL,
+    correctness,
+    "assignment of a too large literal to an usize variable"
+}
+
+declare_lint_pass!(UsizeUnportable32BitLiteral => [USIZE_UNPORTABLE_32_BIT_LITERAL]);
+
+/// Checks if the type is usize
+fn is_usize<'tcx>(stmt: &'tcx Stmt<'tcx>) -> bool {
+    if let StmtKind::Local(l) = stmt.kind
+        && let Some(ty) = l.ty
+    {
+        match ty.kind {
+            TyKind::Path(QPath::Resolved(_, path)) => matches!(path.res, rustc_hir::def::Res::PrimTy(Uint(Usize))),
+            _ => false,
+        }
+    } else {
+        false
+    }
+}
+
+/// checks if the statement contains a literal that is larger than
+/// `u32::MAX`
+fn is_larger_than_32bit<'tcx>(stmt: &'tcx Stmt<'tcx>) -> bool {
+    if let StmtKind::Local(l) = stmt.kind
+        && let Some(init) = l.init
+    {
+        match init.kind {
+            ExprKind::Lit(lit) => match lit.node {
+                LitKind::Int(v, _) => v.0 > u32::MAX.into(),
+                _ => false,
+            },
+            _ => false,
+        }
+    } else {
+        false
+    }
+}
+
+/// Checks if the attribute contains `target_pointer_width` = "64"
+fn has_pointer_width_64_attr(attrs: &[Attribute]) -> bool {
+    let ident = Ident(target_pointer_width, false);
+    let str64 = TokenKind::Literal(rustc_ast::token::Lit {
+        kind: rustc_ast::token::LitKind::Str,
+        symbol: Symbol::intern("64"),
+        suffix: None,
+    });
+    let mut state = 0;
+    for attr in attrs {
+        if let Normal(normal_attr) = &attr.kind
+            && let AttrArgs::Delimited(args) = &normal_attr.item.args
+        {
+            for t in args.tokens.trees() {
+                if let Token(token, _) = t {
+                    if state == 0 && token.kind == ident {
+                        state = 1;
+                    } else if state == 1 && token.kind == TokenKind::Eq {
+                        state = 2;
+                    } else if state == 2 && token.kind == str64 {
+                        return true;
+                    } else {
+                        state = 0;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Checks if we are in the context of a `target_pointer_width` = "64" config
+fn any_parent_has_64_pointer_width(tcx: TyCtxt<'_>, node: HirId) -> bool {
+    let map = &tcx.hir();
+    let mut prev_enclosing_node = None;
+    let mut enclosing_node = node;
+    while Some(enclosing_node) != prev_enclosing_node {
+        if has_pointer_width_64_attr(map.attrs(enclosing_node)) {
+            return true;
+        }
+        prev_enclosing_node = Some(enclosing_node);
+        enclosing_node = map.get_parent_item(enclosing_node).into();
+    }
+
+    false
+}
+
+impl<'tcx> LateLintPass<'tcx> for UsizeUnportable32BitLiteral {
+    fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'tcx>) {
+        if any_parent_has_64_pointer_width(cx.tcx, stmt.hir_id) {
+            return;
+        }
+        if is_usize(stmt) && is_larger_than_32bit(stmt) {
+            span_lint_and_help(
+                cx,
+                USIZE_UNPORTABLE_32_BIT_LITERAL,
+                stmt.span,
+                "assignement to usize not portable to 32bit architectures",
+                None,
+                "use u64 as the data type if you need values larger than 32 bit",
+            );
+        }
+    }
+}

--- a/tests/ui/cast_size.64bit.stderr
+++ b/tests/ui/cast_size.64bit.stderr
@@ -168,5 +168,14 @@ error: casting `usize` to `f64` causes a loss of precision on targets with 64-bi
 LL |     9_999_999_999_999_999usize as f64;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 18 previous errors
+error: usize literals larger than u32::MAX is not portable to 32bit architectures
+  --> tests/ui/cast_size.rs:36:5
+   |
+LL |     9_999_999_999_999_999usize as f64;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use u64 as the data type if you need values larger than 32 bit
+   = note: `#[deny(clippy::usize_unportable_32_bit_literal)]` on by default
+
+error: aborting due to 19 previous errors
 

--- a/tests/ui/literals.stderr
+++ b/tests/ui/literals.stderr
@@ -168,5 +168,14 @@ help: if you mean to use a decimal constant, remove the `0` to avoid confusion
 LL |     let _ = 89;
    |             ~~
 
-error: aborting due to 20 previous errors
+error: usize literals larger than u32::MAX is not portable to 32bit architectures
+  --> tests/ui/literals.rs:48:16
+   |
+LL |     let ok17 = 0x123_4567_8901_usize;
+   |                ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use u64 as the data type if you need values larger than 32 bit
+   = note: `#[deny(clippy::usize_unportable_32_bit_literal)]` on by default
+
+error: aborting due to 21 previous errors
 

--- a/tests/ui/usize_unportable_32_bit_literal.rs
+++ b/tests/ui/usize_unportable_32_bit_literal.rs
@@ -1,8 +1,12 @@
 #![warn(clippy::usize_unportable_32_bit_literal)]
+#![allow(clippy::no_effect)]
 
 fn main() {
     // assignment of value larger than 32 bit can express
     let _: usize = 4294967296;
+
+    // single literals are also problematic
+    4294967297usize;
 
     // A counter example
     let _: usize = 1;
@@ -13,4 +17,8 @@ fn main() {
     // if the code only runs on 64 bit platforms it's not a problem
     #[cfg(target_pointer_width = "64")]
     let _: usize = 4294967296;
+
+    // single literals on 64bit platforms only is not a problem either
+    #[cfg(target_pointer_width = "64")]
+    4294967297usize;
 }

--- a/tests/ui/usize_unportable_32_bit_literal.rs
+++ b/tests/ui/usize_unportable_32_bit_literal.rs
@@ -1,0 +1,16 @@
+#![warn(clippy::usize_unportable_32_bit_literal)]
+
+fn main() {
+    // assignment of value larger than 32 bit can express
+    let _: usize = 4294967296;
+
+    // A counter example
+    let _: usize = 1;
+
+    // u32::MAX shouldn't be a problem
+    let _: usize = 4_294_967_295usize;
+
+    // if the code only runs on 64 bit platforms it's not a problem
+    #[cfg(target_pointer_width = "64")]
+    let _: usize = 4294967296;
+}

--- a/tests/ui/usize_unportable_32_bit_literal.stderr
+++ b/tests/ui/usize_unportable_32_bit_literal.stderr
@@ -1,5 +1,5 @@
 error: assignement to usize not portable to 32bit architectures
-  --> tests/ui/usize_unportable_32_bit_literal.rs:5:5
+  --> tests/ui/usize_unportable_32_bit_literal.rs:6:5
    |
 LL |     let _: usize = 4294967296;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,5 +8,13 @@ LL |     let _: usize = 4294967296;
    = note: `-D clippy::usize-unportable-32-bit-literal` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::usize_unportable_32_bit_literal)]`
 
-error: aborting due to 1 previous error
+error: usize literals larger than u32::MAX is not portable to 32bit architectures
+  --> tests/ui/usize_unportable_32_bit_literal.rs:9:5
+   |
+LL |     4294967297usize;
+   |     ^^^^^^^^^^^^^^^
+   |
+   = help: use u64 as the data type if you need values larger than 32 bit
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/usize_unportable_32_bit_literal.stderr
+++ b/tests/ui/usize_unportable_32_bit_literal.stderr
@@ -1,0 +1,12 @@
+error: assignement to usize not portable to 32bit architectures
+  --> tests/ui/usize_unportable_32_bit_literal.rs:5:5
+   |
+LL |     let _: usize = 4294967296;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use u64 as the data type if you need values larger than 32 bit
+   = note: `-D clippy::usize-unportable-32-bit-literal` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::usize_unportable_32_bit_literal)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
First lint I write, so I thought I should start with a minimal version and get feedback on it before spending the time fleshing it out.

I'm doing some packaging of rust crates for Debian in my spare time, and that results in running the builds and unit-tests for crates on more architectures than the author typically have access to, and there are a number of common mistakes that makes code nonportable.

Not thinking about `usize` and `isize` sizes are maybe the most common error.

One example of the issues that I would like to prevent is here: https://gitlab.com/sequoia-pgp/sequoia-chameleon-gnupg/-/issues/41

Since this codebase is very new to me, I would love feedback on everything.

I also realize that there are a large number of cases that isn't caught by this lint, but as mentioned before, I would rather get an early round of feedback.

---

changelog: [`usize_unportable_32_bit_literal`]: Add a lint that detects usize assignments that are not portable to 32bit architectures
