### PR TITLE
WIP: New lint [`manual_position`]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5361,6 +5361,7 @@ Released 2018-09-13
 [`manual_next_back`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_next_back
 [`manual_non_exhaustive`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_non_exhaustive
 [`manual_ok_or`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_or
+[`manual_position`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_position
 [`manual_range_contains`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
 [`manual_range_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_patterns
 [`manual_rem_euclid`]: https://rust-lang.github.io/rust-clippy/master/index.html#manual_rem_euclid

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -394,6 +394,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::methods::MANUAL_IS_VARIANT_AND_INFO,
     crate::methods::MANUAL_NEXT_BACK_INFO,
     crate::methods::MANUAL_OK_OR_INFO,
+    crate::methods::MANUAL_POSITION_INFO,
     crate::methods::MANUAL_SATURATING_ARITHMETIC_INFO,
     crate::methods::MANUAL_SPLIT_ONCE_INFO,
     crate::methods::MANUAL_STR_REPEAT_INFO,

--- a/clippy_lints/src/methods/manual_position.rs
+++ b/clippy_lints/src/methods/manual_position.rs
@@ -1,0 +1,180 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet_opt;
+use clippy_utils::{is_diag_item_method, is_diag_trait_item, path_to_local_id, peel_blocks_with_stmt};
+use rustc_errors::Applicability;
+use rustc_hir::{Body, ClosureKind, Expr, ExprKind, HirId, LangItem, Node, Pat, PatKind, QPath};
+use rustc_lint::LateContext;
+use rustc_span::{sym, Span};
+
+use super::MANUAL_POSITION;
+
+#[derive(Debug, PartialEq, Eq)]
+enum UsageKind {
+    Expect(Span),
+    Unwrap,
+    QuestionMark,
+    Map,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Usage {
+    kind: UsageKind,
+    end_span: Span,
+}
+
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, start_span: Span, rev: bool) {
+    if let ExprKind::Closure(c) = arg.kind
+        && matches!(c.kind, ClosureKind::Closure)
+        && let typeck = cx.typeck_results()
+        && let Some(fn_id) = typeck.type_dependent_def_id(expr.hir_id)
+        && (is_diag_trait_item(cx, fn_id, sym::Iterator))
+        && let body = cx.tcx.hir().body(c.body)
+        && let [param] = body.params
+        && let parent = cx.tcx.hir().parent_iter(expr.hir_id)
+        && let Some(usage) = parse_usage(cx, parent)
+        && let pat = match param.pat.kind {
+            PatKind::Ref(pat, _) => pat,
+            _ => param.pat,
+        }
+        && let PatKind::Tuple([position_arg, item_arg], _) = pat.kind
+        && matches!(position_arg.kind, PatKind::Wild)
+        && let Some(param_snippet) = snippet_opt(cx, item_arg.span)
+        && let Some(predicate_body) = snippet_opt(cx, body.value.span)
+        && let Some(usage_sugg) = usage.kind.to_sugg(cx)
+    {
+        let applicability = Applicability::MaybeIncorrect;
+        let rev = if rev { "r" } else { "" };
+        let msg = format!("manual implementation of {rev}position");
+        span_lint_and_sugg(
+            cx,
+            MANUAL_POSITION,
+            start_span.to(usage.end_span),
+            &msg,
+            "replace with",
+            format!("{rev}position(|{param_snippet}|{predicate_body}){usage_sugg}"),
+            applicability,
+        );
+    }
+}
+
+fn parse_usage<'tcx>(cx: &LateContext<'tcx>, mut iter: impl Iterator<Item = (HirId, Node<'tcx>)>) -> Option<Usage> {
+    let (kind, end_span) = if let Some((_, Node::Expr(e))) = iter.next() {
+        match e.kind {
+            ExprKind::Call(
+                Expr {
+                    kind: ExprKind::Path(QPath::LangItem(LangItem::TryTraitBranch, ..)),
+                    ..
+                },
+                _,
+            ) => {
+                if let Some((_, Node::Expr(e))) = iter.nth(1)
+                    && let Some(span) = is_using_position(e)
+                {
+                    (UsageKind::QuestionMark, span)
+                } else {
+                    return None;
+                }
+            },
+            ExprKind::MethodCall(name, _, args, span) if name.ident.name == sym::map => {
+                if let Some(map_arg) = args.first()
+                    && let ExprKind::Closure(c) = map_arg.kind
+                    && matches!(c.kind, ClosureKind::Closure)
+                    && let body = cx.tcx.hir().body(c.body)
+                    && is_expr_returning_first_field(body)
+                {
+                    (UsageKind::Map, span)
+                } else {
+                    return None;
+                }
+            },
+            ExprKind::MethodCall(name, _, [], _)
+                if name.ident.name == sym::unwrap
+                    && cx
+                        .typeck_results()
+                        .type_dependent_def_id(e.hir_id)
+                        .map_or(false, |id| is_diag_item_method(cx, id, sym::Option)) =>
+            {
+                if let Some((_, Node::Expr(e))) = iter.next()
+                    && let Some(span) = is_using_position(e)
+                {
+                    (UsageKind::Unwrap, span)
+                } else {
+                    return None;
+                }
+            },
+            ExprKind::MethodCall(name, _, [param], _)
+                if name.ident.name == sym::expect
+                    && cx
+                        .typeck_results()
+                        .type_dependent_def_id(e.hir_id)
+                        .map_or(false, |id| is_diag_item_method(cx, id, sym::Option)) =>
+            {
+                if let Some((_, Node::Expr(e))) = iter.next()
+                    && let Some(span) = is_using_position(e)
+                {
+                    (UsageKind::Expect(param.span), span)
+                } else {
+                    return None;
+                }
+            },
+            _ => return None,
+        }
+    } else {
+        return None;
+    };
+    Some(Usage { kind, end_span })
+}
+
+impl UsageKind {
+    fn to_sugg(&self, cx: &LateContext<'_>) -> Option<String> {
+        match self {
+            UsageKind::Expect(span) => snippet_opt(cx, *span).map(|span| format!(".expect({span})")),
+            UsageKind::Unwrap => Some(".unwrap()".into()),
+            UsageKind::QuestionMark => Some("?".into()),
+            UsageKind::Map => Some(String::default()),
+        }
+    }
+}
+
+fn is_using_position(expr: &Expr<'_>) -> Option<Span> {
+    match expr.kind {
+        ExprKind::Field(_, id) if id.name == sym!(0) => Some(expr.span.shrink_to_hi()),
+        _ => None,
+    }
+}
+
+fn is_expr_returning_first_field(func: &Body<'_>) -> bool {
+    fn check_pat(pat: &Pat<'_>, expr: &Expr<'_>) -> bool {
+        match (&pat.kind, expr.kind) {
+            (&PatKind::Binding(_, id, _, _), ExprKind::Field(expr, field)) if field.name == sym!(0) => {
+                path_to_local_id(expr, id)
+            },
+            (PatKind::Tuple([a, _], etc), _) if etc.as_opt_usize().is_none() => {
+                if let PatKind::Binding(_, id, _, _) = a.kind {
+                    path_to_local_id(expr, id)
+                } else {
+                    false
+                }
+            },
+            (PatKind::Tuple([a], etc), _) if etc.as_opt_usize().is_some_and(|dot_dot_pos| dot_dot_pos == 1) => {
+                if let PatKind::Binding(_, id, _, _) = a.kind {
+                    path_to_local_id(expr, id)
+                } else {
+                    false
+                }
+            },
+            _ => false,
+        }
+    }
+    let [param] = func.params else {
+        return false;
+    };
+    let mut expr = func.value;
+    loop {
+        expr = peel_blocks_with_stmt(expr);
+        match expr.kind {
+            ExprKind::Ret(Some(e)) => expr = e,
+            _ => return check_pat(param.pat, expr),
+        }
+    }
+}

--- a/tests/ui/manual_position.fixed
+++ b/tests/ui/manual_position.fixed
@@ -1,0 +1,71 @@
+#![warn(clippy::manual_position)]
+#![allow(clippy::needless_return)]
+
+fn main() {
+    unwrap_test();
+    expect_test();
+    try_test();
+    map_test();
+    find_test();
+    deref_test();
+    rposition_test();
+}
+
+fn expect_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().position(|&ch|ch == 3).expect("");
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).expect("").1;
+}
+
+fn unwrap_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().position(|&ch|ch == 3).unwrap();
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().1;
+}
+
+fn try_test() -> Option<()> {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().position(|&ch|ch == 3)?;
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3)?.1;
+    Some(())
+}
+
+fn map_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().position(|&ch|ch == 3);
+    #[rustfmt::skip]
+    let _ = v.iter().position(|&ch|ch == 3);
+    let _ = v.iter().position(|&ch|ch == 3);
+    let _ = v.iter().position(|&ch|ch == 3);
+
+    // Only trigger when returning the first field of the result
+    let x = (1, 2);
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|_| x.0);
+}
+
+fn find_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().position(|&ch|ch == 3).unwrap();
+    // Doesn't trigger when the predicate use the index
+    let _ = v.iter().enumerate().find(|&(i, _)| i >= 1).unwrap().0;
+    let _ = v.iter().enumerate().find(|&(i, &ch)| ch == 3 && i >= 1).unwrap().0;
+}
+
+fn deref_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().position(|&ch|ch == 3).unwrap();
+    let _ = v.iter().position(|&ch|ch == 3).unwrap();
+    let _ = v.iter().position(|ch|*ch == 3).unwrap();
+    // let _ = v.iter().enumerate().find(|(_, ch)| **ch == 3).unwrap().0;
+    // Sugestion make:
+    // let _ = v.iter().position(|ch|**ch == 3).unwrap();
+    // but need to be:
+    // let _ = v.iter().position(|ch|*ch == 3).unwrap();
+    // or
+    // let _ = v.iter().position(|&ch|ch == 3).unwrap();
+}
+
+fn rposition_test() {
+    let v = [1, 2, 3, 5, 3, 6];
+    let _ = v.iter().rposition(|&ch|ch == 3).unwrap();
+}

--- a/tests/ui/manual_position.rs
+++ b/tests/ui/manual_position.rs
@@ -1,0 +1,73 @@
+#![warn(clippy::manual_position)]
+#![allow(clippy::needless_return)]
+
+fn main() {
+    unwrap_test();
+    expect_test();
+    try_test();
+    map_test();
+    find_test();
+    deref_test();
+    rposition_test();
+}
+
+fn expect_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).expect("").0;
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).expect("").1;
+}
+
+fn unwrap_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().0;
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().1;
+}
+
+fn try_test() -> Option<()> {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3)?.0;
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3)?.1;
+    Some(())
+}
+
+fn map_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().enumerate().find(|&(_, &ch)| ch == 3).map(|c| c.0);
+    #[rustfmt::skip]
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|c| { return c.0  });
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|(p, _)| p);
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|(p, ..)| {
+        return p;
+    });
+
+    // Only trigger when returning the first field of the result
+    let x = (1, 2);
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|_| x.0);
+}
+
+fn find_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().0;
+    // Doesn't trigger when the predicate use the index
+    let _ = v.iter().enumerate().find(|&(i, _)| i >= 1).unwrap().0;
+    let _ = v.iter().enumerate().find(|&(i, &ch)| ch == 3 && i >= 1).unwrap().0;
+}
+
+fn deref_test() {
+    let v = [1, 2, 3, 5, 6];
+    let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().0;
+    let _ = v.iter().enumerate().find(|&(_, &ch)| ch == 3).unwrap().0;
+    let _ = v.iter().enumerate().find(|&(_, ch)| *ch == 3).unwrap().0;
+    // let _ = v.iter().enumerate().find(|(_, ch)| **ch == 3).unwrap().0;
+    // Sugestion make:
+    // let _ = v.iter().position(|ch|**ch == 3).unwrap();
+    // but need to be:
+    // let _ = v.iter().position(|ch|*ch == 3).unwrap();
+    // or
+    // let _ = v.iter().position(|&ch|ch == 3).unwrap();
+}
+
+fn rposition_test() {
+    let v = [1, 2, 3, 5, 3, 6];
+    let _ = v.iter().enumerate().rev().find(|(_, &ch)| ch == 3).unwrap().0;
+}

--- a/tests/ui/manual_position.stderr
+++ b/tests/ui/manual_position.stderr
@@ -1,0 +1,80 @@
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:16:22
+   |
+LL |     let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).expect("").0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3).expect("")`
+   |
+   = note: `-D clippy::manual-position` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_position)]`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:22:22
+   |
+LL |     let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3).unwrap()`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:28:22
+   |
+LL |     let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3)?.0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3)?`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:35:22
+   |
+LL |     let _ = v.iter().enumerate().find(|&(_, &ch)| ch == 3).map(|c| c.0);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3)`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:37:22
+   |
+LL |     let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|c| { return c.0  });
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3)`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:38:22
+   |
+LL |     let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|(p, _)| p);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3)`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:39:22
+   |
+LL |       let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).map(|(p, ..)| {
+   |  ______________________^
+LL | |         return p;
+LL | |     });
+   | |______^ help: replace with: `position(|&ch|ch == 3)`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:50:22
+   |
+LL |     let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3).unwrap()`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:58:22
+   |
+LL |     let _ = v.iter().enumerate().find(|(_, &ch)| ch == 3).unwrap().0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3).unwrap()`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:59:22
+   |
+LL |     let _ = v.iter().enumerate().find(|&(_, &ch)| ch == 3).unwrap().0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|&ch|ch == 3).unwrap()`
+
+error: manual implementation of position
+  --> tests/ui/manual_position.rs:60:22
+   |
+LL |     let _ = v.iter().enumerate().find(|&(_, ch)| *ch == 3).unwrap().0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `position(|ch|*ch == 3).unwrap()`
+
+error: manual implementation of rposition
+  --> tests/ui/manual_position.rs:72:22
+   |
+LL |     let _ = v.iter().enumerate().rev().find(|(_, &ch)| ch == 3).unwrap().0;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `rposition(|&ch|ch == 3).unwrap()`
+
+error: aborting due to 12 previous errors
+


### PR DESCRIPTION
Add a new lint to detect manual implementation of position(_) using enumerate(_).find(_)

changelog: Add new [`manual_position`] lint

fixes #2282

I need help handling this case when I need to change the deref on the body of the closure.
```rust
    let v = [1, 2, 3, 5, 6];
    let _ = v.iter().enumerate().find(|(_, ch)|**ch == 3).unwrap().0;
    // Right now, the lint is suggesting this (which does not compile):
    let _ = v.iter().position(|ch|**ch == 3).unwrap();
    // but i think i need to make like this:
    let _ = v.iter().position(|ch|*ch == 3).unwrap();
    // or this:
    let _ = v.iter().position(|&ch|ch == 3).unwrap();
```
