### PR TITLE
lower `bstr` version requirement to `1.6.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ color-print = "0.3.4"
 anstream = "0.6.0"
 
 [dev-dependencies]
-ui_test = "0.22.1"
+ui_test = "0.22.2"
 tester = "0.9"
 regex = "1.5"
 toml = "0.7.3"

--- a/tests/ui/crashes/ice-6255.rs
+++ b/tests/ui/crashes/ice-6255.rs
@@ -4,6 +4,7 @@
 macro_rules! define_other_core {
     ( ) => {
         extern crate std as core;
+        //~^ ERROR: macro-expanded `extern crate` items cannot shadow names passed with `--extern`
     };
 }
 
@@ -12,4 +13,3 @@ fn main() {
 }
 
 define_other_core!();
-//~^ ERROR: macro-expanded `extern crate` items cannot shadow names passed with `--extern`

--- a/tests/ui/declare_interior_mutable_const/others.rs
+++ b/tests/ui/declare_interior_mutable_const/others.rs
@@ -14,9 +14,10 @@ const ATOMIC_TUPLE: ([AtomicUsize; 1], Vec<AtomicUsize>, u8) = ([ATOMIC], Vec::n
 macro_rules! declare_const {
     ($name:ident: $ty:ty = $e:expr) => {
         const $name: $ty = $e;
+        //~^ ERROR: interior mutable
     };
 }
-declare_const!(_ONCE: Once = Once::new()); //~ ERROR: interior mutable
+declare_const!(_ONCE: Once = Once::new());
 
 // const ATOMIC_REF: &AtomicUsize = &AtomicUsize::new(7); // This will simply trigger E0492.
 
@@ -49,7 +50,7 @@ mod issue_8493 {
         };
     }
 
-    issue_8493!(); //~ ERROR: interior mutable
+    issue_8493!();
 }
 
 fn main() {}

--- a/tests/ui/declare_interior_mutable_const/others.stderr
+++ b/tests/ui/declare_interior_mutable_const/others.stderr
@@ -37,7 +37,7 @@ LL | declare_const!(_ONCE: Once = Once::new());
    = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/others.rs:43:13
+  --> tests/ui/declare_interior_mutable_const/others.rs:44:13
    |
 LL |             const _BAZ: Cell<usize> = Cell::new(0);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/declare_interior_mutable_const/traits.rs
+++ b/tests/ui/declare_interior_mutable_const/traits.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicUsize;
 macro_rules! declare_const {
     ($name:ident: $ty:ty = $e:expr) => {
         const $name: $ty = $e;
+        //~^ ERROR: interior mutable
     };
 }
 
@@ -15,7 +16,7 @@ trait ConcreteTypes {
     const ATOMIC: AtomicUsize; //~ ERROR: interior mutable
     const INTEGER: u64;
     const STRING: String;
-    declare_const!(ANOTHER_ATOMIC: AtomicUsize = Self::ATOMIC); //~ ERROR: interior mutable
+    declare_const!(ANOTHER_ATOMIC: AtomicUsize = Self::ATOMIC);
 }
 
 impl ConcreteTypes for u64 {

--- a/tests/ui/declare_interior_mutable_const/traits.stderr
+++ b/tests/ui/declare_interior_mutable_const/traits.stderr
@@ -1,5 +1,5 @@
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:15:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:16:5
    |
 LL |     const ATOMIC: AtomicUsize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,55 +19,55 @@ LL |     declare_const!(ANOTHER_ATOMIC: AtomicUsize = Self::ATOMIC);
    = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:43:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:44:5
    |
 LL |     const TO_BE_CONCRETE: AtomicUsize = AtomicUsize::new(11);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:68:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:69:5
    |
 LL |     const TO_BE_UNFROZEN: Self::ToBeUnfrozen = AtomicUsize::new(13);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:69:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:70:5
    |
 LL |     const WRAPPED_TO_BE_UNFROZEN: Wrapper<Self::ToBeUnfrozen> = Wrapper(AtomicUsize::new(14));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:88:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:89:5
    |
 LL |     const BOUNDED: T::ToBeBounded;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:116:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:117:5
    |
 LL |     const SELF: Self = AtomicUsize::new(17);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:117:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:118:5
    |
 LL |     const WRAPPED_SELF: Option<Self> = Some(AtomicUsize::new(21));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:125:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:126:5
    |
 LL |     const INDIRECT: Cell<*const T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:141:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:142:5
    |
 LL |     const ATOMIC: AtomicUsize = AtomicUsize::new(18);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: a `const` item should never be interior mutable
-  --> tests/ui/declare_interior_mutable_const/traits.rs:147:5
+  --> tests/ui/declare_interior_mutable_const/traits.rs:148:5
    |
 LL |     const BOUNDED_ASSOC_TYPE: T::ToBeBounded = AtomicUsize::new(19);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/struct_fields.rs
+++ b/tests/ui/struct_fields.rs
@@ -224,6 +224,7 @@ mod macro_tests {
     macro_rules! mk_struct {
         () => {
             struct MacroStruct {
+                //~^ ERROR: all fields have the same prefix: `some`
                 some_a: i32,
                 some_b: i32,
                 some_c: i32,
@@ -231,24 +232,24 @@ mod macro_tests {
         };
     }
     mk_struct!();
-    //~^ ERROR: all fields have the same prefix: `some`
 
     macro_rules! mk_struct2 {
         () => {
             struct Macrobaz {
                 macrobaz_a: i32,
+                //~^ ERROR: field name starts with the struct's name
                 some_b: i32,
                 some_c: i32,
             }
         };
     }
     mk_struct2!();
-    //~^ ERROR: field name starts with the struct's name
 
     macro_rules! mk_struct_with_names {
         ($struct_name:ident, $field:ident) => {
             struct $struct_name {
                 $field: i32,
+                //~^ ERROR: field name starts with the struct's name
                 other_something: i32,
                 other_field: i32,
             }
@@ -256,7 +257,6 @@ mod macro_tests {
     }
     // expands to `struct Foo { foo: i32, ... }`
     mk_struct_with_names!(Foo, foo);
-    //~^ ERROR: field name starts with the struct's name
 
     // expands to a struct with all fields starting with `other` but should not
     // be linted because some fields come from the macro definition and the other from the input
@@ -289,6 +289,7 @@ mod macro_tests {
     macro_rules! mk_struct_full_def {
         ($struct_name:ident, $field1:ident, $field2:ident, $field3:ident) => {
             struct $struct_name {
+                //~^ ERROR: all fields have the same prefix: `some`
                 $field1: i32,
                 $field2: i32,
                 $field3: i32,
@@ -296,7 +297,6 @@ mod macro_tests {
         };
     }
     mk_struct_full_def!(PrefixData, some_data, some_meta, some_other);
-    //~^ ERROR: all fields have the same prefix: `some`
 }
 
 // should not lint on external code

--- a/tests/ui/struct_fields.stderr
+++ b/tests/ui/struct_fields.stderr
@@ -211,6 +211,7 @@ error: all fields have the same prefix: `some`
   --> tests/ui/struct_fields.rs:226:13
    |
 LL | /             struct MacroStruct {
+LL | |
 LL | |                 some_a: i32,
 LL | |                 some_b: i32,
 LL | |                 some_c: i32,
@@ -249,6 +250,7 @@ error: all fields have the same prefix: `some`
   --> tests/ui/struct_fields.rs:291:13
    |
 LL | /             struct $struct_name {
+LL | |
 LL | |                 $field1: i32,
 LL | |                 $field2: i32,
 LL | |                 $field3: i32,

--- a/tests/ui/unconditional_recursion.rs
+++ b/tests/ui/unconditional_recursion.rs
@@ -147,6 +147,7 @@ macro_rules! impl_partial_eq {
     ($ty:ident) => {
         impl PartialEq for $ty {
             fn eq(&self, other: &Self) -> bool {
+                //~^ ERROR: function cannot return without recursing
                 self == other
             }
         }
@@ -156,7 +157,6 @@ macro_rules! impl_partial_eq {
 struct S5;
 
 impl_partial_eq!(S5);
-//~^ ERROR: function cannot return without recursing
 
 struct S6 {
     field: String,

--- a/tests/ui/unconditional_recursion.stderr
+++ b/tests/ui/unconditional_recursion.stderr
@@ -291,6 +291,7 @@ error: function cannot return without recursing
   --> tests/ui/unconditional_recursion.rs:149:13
    |
 LL | /             fn eq(&self, other: &Self) -> bool {
+LL | |
 LL | |                 self == other
 LL | |             }
    | |_____________^
@@ -299,7 +300,7 @@ LL |   impl_partial_eq!(S5);
    |   -------------------- in this macro invocation
    |
 note: recursive call site
-  --> tests/ui/unconditional_recursion.rs:150:17
+  --> tests/ui/unconditional_recursion.rs:151:17
    |
 LL |                 self == other
    |                 ^^^^^^^^^^^^^


### PR DESCRIPTION
test changes are due to https://github.com/oli-obk/ui_test/pull/201 (cc @Jarcho)

changelog: none