### PR TITLE
faster dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,7 @@ rustc_private = true
 [[test]]
 name = "compile-test"
 harness = false
+
+[profile.dev]
+package.clippy_utils.codegen-units=1
+package.clippy_lints.codegen-units=1


### PR DESCRIPTION
Reduces build time (and size) for dev builds, tested on HDD:
clean build change: 6.5Gb 2min -> 1.2Gb 1min. Incremental faster too, but harder to measure,

Didn't tested on SSD, will it have the same effect here too?

changelog: none
