### PR TITLE
bug fix: lint numbered_fields message error

### DIFF
--- a/clippy_lints/src/init_numbered_fields.rs
+++ b/clippy_lints/src/init_numbered_fields.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::source::{snippet_with_applicability, snippet_with_context};
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Expr, ExprKind};
@@ -62,7 +62,7 @@ impl<'tcx> LateLintPass<'tcx> for NumberedFields {
                     snippet_with_applicability(cx, path.span(), "..", &mut appl),
                     expr_spans
                         .into_iter_sorted()
-                        .map(|(_, span)| snippet_with_applicability(cx, span, "..", &mut appl))
+                        .map(|(_, span)| snippet_with_context(cx, span, path.span().ctxt(), "..", &mut appl).0)
                         .intersperse(Cow::Borrowed(", "))
                         .collect::<String>()
                 );

--- a/tests/ui/numbered_fields.fixed
+++ b/tests/ui/numbered_fields.fixed
@@ -34,4 +34,9 @@ fn main() {
 
     // Aliases can't be tuple constructed #8638
     let _ = Alias { 0: 0, 1: 1, 2: 2 };
+
+    // Issue #12367
+    struct TupleStructVec(Vec<usize>);
+
+    let _ = TupleStructVec(vec![0, 1, 2, 3]);
 }

--- a/tests/ui/numbered_fields.rs
+++ b/tests/ui/numbered_fields.rs
@@ -42,4 +42,9 @@ fn main() {
 
     // Aliases can't be tuple constructed #8638
     let _ = Alias { 0: 0, 1: 1, 2: 2 };
+
+    // Issue #12367
+    struct TupleStructVec(Vec<usize>);
+
+    let _ = TupleStructVec { 0: vec![0, 1, 2, 3] };
 }

--- a/tests/ui/numbered_fields.stderr
+++ b/tests/ui/numbered_fields.stderr
@@ -23,5 +23,11 @@ LL | |         1: 3u32,
 LL | |     };
    | |_____^ help: try: `TupleStruct(1u32, 3u32, 2u8)`
 
-error: aborting due to 2 previous errors
+error: used a field initializer for a tuple struct
+  --> tests/ui/numbered_fields.rs:49:13
+   |
+LL |     let _ = TupleStructVec { 0: vec![0, 1, 2, 3] };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `TupleStructVec(vec![0, 1, 2, 3])`
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
fixes #12367

changelog: [`numbered_fields`]: fix macro expand message error.