### PR TITLE
[`identity_op`]: Fix duplicate diagnostics

### DIFF
--- a/tests/ui/identity_op.fixed
+++ b/tests/ui/identity_op.fixed
@@ -1,5 +1,3 @@
-//@compile-flags: -Zdeduplicate-diagnostics=yes
-
 #![warn(clippy::identity_op)]
 #![allow(unused)]
 #![allow(

--- a/tests/ui/identity_op.rs
+++ b/tests/ui/identity_op.rs
@@ -1,5 +1,3 @@
-//@compile-flags: -Zdeduplicate-diagnostics=yes
-
 #![warn(clippy::identity_op)]
 #![allow(unused)]
 #![allow(

--- a/tests/ui/identity_op.stderr
+++ b/tests/ui/identity_op.stderr
@@ -1,5 +1,5 @@
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:46:5
+  --> tests/ui/identity_op.rs:44:5
    |
 LL |     x + 0;
    |     ^^^^^ help: consider reducing it to: `x`
@@ -8,307 +8,307 @@ LL |     x + 0;
    = help: to override `-D warnings` add `#[allow(clippy::identity_op)]`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:48:5
+  --> tests/ui/identity_op.rs:46:5
    |
 LL |     x + (1 - 1);
    |     ^^^^^^^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:51:5
+  --> tests/ui/identity_op.rs:49:5
    |
 LL |     0 + x;
    |     ^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:55:5
+  --> tests/ui/identity_op.rs:53:5
    |
 LL |     x | (0);
    |     ^^^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:59:5
+  --> tests/ui/identity_op.rs:57:5
    |
 LL |     x * 1;
    |     ^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:61:5
+  --> tests/ui/identity_op.rs:59:5
    |
 LL |     1 * x;
    |     ^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:68:5
+  --> tests/ui/identity_op.rs:66:5
    |
 LL |     -1 & x;
    |     ^^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:72:5
+  --> tests/ui/identity_op.rs:70:5
    |
 LL |     u & 255;
    |     ^^^^^^^ help: consider reducing it to: `u`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:76:5
+  --> tests/ui/identity_op.rs:74:5
    |
 LL |     42 << 0;
    |     ^^^^^^^ help: consider reducing it to: `42`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:78:5
+  --> tests/ui/identity_op.rs:76:5
    |
 LL |     1 >> 0;
    |     ^^^^^^ help: consider reducing it to: `1`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:80:5
+  --> tests/ui/identity_op.rs:78:5
    |
 LL |     42 >> 0;
    |     ^^^^^^^ help: consider reducing it to: `42`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:82:5
+  --> tests/ui/identity_op.rs:80:5
    |
 LL |     &x >> 0;
    |     ^^^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:84:5
+  --> tests/ui/identity_op.rs:82:5
    |
 LL |     x >> &0;
    |     ^^^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:92:5
+  --> tests/ui/identity_op.rs:90:5
    |
 LL |     2 % 3;
    |     ^^^^^ help: consider reducing it to: `2`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:94:5
+  --> tests/ui/identity_op.rs:92:5
    |
 LL |     -2 % 3;
    |     ^^^^^^ help: consider reducing it to: `-2`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:96:5
+  --> tests/ui/identity_op.rs:94:5
    |
 LL |     2 % -3 + x;
    |     ^^^^^^ help: consider reducing it to: `2`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:98:5
+  --> tests/ui/identity_op.rs:96:5
    |
 LL |     -2 % -3 + x;
    |     ^^^^^^^ help: consider reducing it to: `-2`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:100:9
+  --> tests/ui/identity_op.rs:98:9
    |
 LL |     x + 1 % 3;
    |         ^^^^^ help: consider reducing it to: `1`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:109:5
+  --> tests/ui/identity_op.rs:107:5
    |
 LL |     0 + if b { 1 } else { 2 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:111:5
+  --> tests/ui/identity_op.rs:109:5
    |
 LL |     0 + if b { 1 } else { 2 } + if b { 3 } else { 4 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:113:5
+  --> tests/ui/identity_op.rs:111:5
    |
 LL |     0 + match a { 0 => 10, _ => 20 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(match a { 0 => 10, _ => 20 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:115:5
+  --> tests/ui/identity_op.rs:113:5
    |
 LL |     0 + match a { 0 => 10, _ => 20 } + match a { 0 => 30, _ => 40 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(match a { 0 => 10, _ => 20 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:117:5
+  --> tests/ui/identity_op.rs:115:5
    |
 LL |     0 + if b { 1 } else { 2 } + match a { 0 => 30, _ => 40 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:119:5
+  --> tests/ui/identity_op.rs:117:5
    |
 LL |     0 + match a { 0 => 10, _ => 20 } + if b { 3 } else { 4 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(match a { 0 => 10, _ => 20 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:121:5
+  --> tests/ui/identity_op.rs:119:5
    |
 LL |     (if b { 1 } else { 2 }) + 0;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if b { 1 } else { 2 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:124:5
+  --> tests/ui/identity_op.rs:122:5
    |
 LL |     0 + { a } + 3;
    |     ^^^^^^^^^ help: consider reducing it to: `({ a })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:126:5
+  --> tests/ui/identity_op.rs:124:5
    |
 LL |     0 + { a } * 2;
    |     ^^^^^^^^^^^^^ help: consider reducing it to: `({ a } * 2)`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:128:5
+  --> tests/ui/identity_op.rs:126:5
    |
 LL |     0 + loop { let mut c = 0; if c == 10 { break c; } c += 1; } + { a * 2 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(loop { let mut c = 0; if c == 10 { break c; } c += 1; })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:135:7
+  --> tests/ui/identity_op.rs:133:7
    |
 LL |     f(1 * a + { 8 * 5 });
    |       ^^^^^ help: consider reducing it to: `a`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:137:7
+  --> tests/ui/identity_op.rs:135:7
    |
 LL |     f(0 + if b { 1 } else { 2 } + 3);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `if b { 1 } else { 2 }`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:140:20
+  --> tests/ui/identity_op.rs:138:20
    |
 LL |     const _: i32 = { 2 * 4 } + 0 + 3;
    |                    ^^^^^^^^^^^^^ help: consider reducing it to: `{ 2 * 4 }`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:142:20
+  --> tests/ui/identity_op.rs:140:20
    |
 LL |     const _: i32 = 0 + { 1 + 2 * 3 } + 3;
    |                    ^^^^^^^^^^^^^^^^^ help: consider reducing it to: `{ 1 + 2 * 3 }`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:145:5
+  --> tests/ui/identity_op.rs:143:5
    |
 LL |     0 + a as usize;
    |     ^^^^^^^^^^^^^^ help: consider reducing it to: `a as usize`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:147:13
+  --> tests/ui/identity_op.rs:145:13
    |
 LL |     let _ = 0 + a as usize;
    |             ^^^^^^^^^^^^^^ help: consider reducing it to: `a as usize`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:149:5
+  --> tests/ui/identity_op.rs:147:5
    |
 LL |     0 + { a } as usize;
    |     ^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `({ a } as usize)`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:152:9
+  --> tests/ui/identity_op.rs:150:9
    |
 LL |     2 * (0 + { a });
    |         ^^^^^^^^^^^ help: consider reducing it to: `{ a }`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:154:5
+  --> tests/ui/identity_op.rs:152:5
    |
 LL |     1 * ({ a } + 4);
    |     ^^^^^^^^^^^^^^^ help: consider reducing it to: `(({ a } + 4))`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:156:5
+  --> tests/ui/identity_op.rs:154:5
    |
 LL |     1 * 1;
    |     ^^^^^ help: consider reducing it to: `1`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:161:18
+  --> tests/ui/identity_op.rs:159:18
    |
 LL |     let _: i32 = &x + 0;
    |                  ^^^^^^ help: consider reducing it to: `x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:166:5
+  --> tests/ui/identity_op.rs:164:5
    |
 LL |     0 + if a { 1 } else { 2 } + if b { 3 } else { 5 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider reducing it to: `(if a { 1 } else { 2 })`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:177:22
+  --> tests/ui/identity_op.rs:175:22
    |
 LL |         let _: i32 = *x + 0;
    |                      ^^^^^^ help: consider reducing it to: `*x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:179:22
+  --> tests/ui/identity_op.rs:177:22
    |
 LL |         let _: i32 = x + 0;
    |                      ^^^^^ help: consider reducing it to: `*x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:184:22
+  --> tests/ui/identity_op.rs:182:22
    |
 LL |         let _: i32 = **x + 0;
    |                      ^^^^^^^ help: consider reducing it to: `**x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:187:22
+  --> tests/ui/identity_op.rs:185:22
    |
 LL |         let _: i32 = *x + 0;
    |                      ^^^^^^ help: consider reducing it to: `**x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:193:22
+  --> tests/ui/identity_op.rs:191:22
    |
 LL |         let _: i32 = ***x + 0;
    |                      ^^^^^^^^ help: consider reducing it to: `***x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:195:22
+  --> tests/ui/identity_op.rs:193:22
    |
 LL |         let _: i32 = **x + 0;
    |                      ^^^^^^^ help: consider reducing it to: `***x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:198:22
+  --> tests/ui/identity_op.rs:196:22
    |
 LL |         let _: i32 = *&x + 0;
    |                      ^^^^^^^ help: consider reducing it to: `*&x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:200:22
+  --> tests/ui/identity_op.rs:198:22
    |
 LL |         let _: i32 = **&&x + 0;
    |                      ^^^^^^^^^ help: consider reducing it to: `**&&x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:202:22
+  --> tests/ui/identity_op.rs:200:22
    |
 LL |         let _: i32 = *&*&x + 0;
    |                      ^^^^^^^^^ help: consider reducing it to: `*&*&x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:204:22
+  --> tests/ui/identity_op.rs:202:22
    |
 LL |         let _: i32 = **&&*&x + 0;
    |                      ^^^^^^^^^^^ help: consider reducing it to: `**&&*&x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:211:22
+  --> tests/ui/identity_op.rs:209:22
    |
 LL |         let _: i32 = **&&*&x + 0;
    |                      ^^^^^^^^^^^ help: consider reducing it to: `***&&*&x`
 
 error: this operation has no effect
-  --> tests/ui/identity_op.rs:213:22
+  --> tests/ui/identity_op.rs:211:22
    |
 LL |         let _: i32 = **&&*&x + 0;
    |                      ^^^^^^^^^^^ help: consider reducing it to: `***&&*&x`


### PR DESCRIPTION
Relates to #12379

In the `identity_op` lint, the following diagnostic was emitted two times
 
```
  --> tests/ui/identity_op.rs:156:5
   |
LL |     1 * 1;
   |     ^^^^^ help: consider reducing it to: `1`
   |
```

because both of the left operand and the right operand are the identity element of the multiplication.

This PR fixes the issue so that if a diagnostic is created for an operand, the check of the other operand will be skipped. It's fine because the result is always the same in the affected operators.

---

changelog: [`identity_op`]: Fix duplicate diagnostics