### PR TITLE
[`misrefactored_assign_op`]: Fix duplicate diagnostics

### DIFF
--- a/clippy_lints/src/operators/misrefactored_assign_op.rs
+++ b/clippy_lints/src/operators/misrefactored_assign_op.rs
@@ -21,9 +21,8 @@ pub(super) fn check<'tcx>(
         // lhs op= l op r
         if eq_expr_value(cx, lhs, l) {
             lint_misrefactored_assign_op(cx, expr, op, rhs, lhs, r);
-        }
-        // lhs op= l commutative_op r
-        if is_commutative(op) && eq_expr_value(cx, lhs, r) {
+        } else if is_commutative(op) && eq_expr_value(cx, lhs, r) {
+            // lhs op= l commutative_op r
             lint_misrefactored_assign_op(cx, expr, op, rhs, lhs, l);
         }
     }

--- a/tests/ui/assign_ops2.rs
+++ b/tests/ui/assign_ops2.rs
@@ -1,6 +1,4 @@
 //@no-rustfix: overlapping suggestions
-//@compile-flags: -Zdeduplicate-diagnostics=yes
-
 #![allow(clippy::uninlined_format_args)]
 
 #[allow(unused_assignments)]

--- a/tests/ui/assign_ops2.stderr
+++ b/tests/ui/assign_ops2.stderr
@@ -1,5 +1,5 @@
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:10:5
+  --> tests/ui/assign_ops2.rs:8:5
    |
 LL |     a += a + 1;
    |     ^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     a = a + a + 1;
    |     ~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:13:5
+  --> tests/ui/assign_ops2.rs:11:5
    |
 LL |     a += 1 + a;
    |     ^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     a = a + 1 + a;
    |     ~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:15:5
+  --> tests/ui/assign_ops2.rs:13:5
    |
 LL |     a -= a - 1;
    |     ^^^^^^^^^^
@@ -46,7 +46,7 @@ LL |     a = a - (a - 1);
    |     ~~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:17:5
+  --> tests/ui/assign_ops2.rs:15:5
    |
 LL |     a *= a * 99;
    |     ^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     a = a * a * 99;
    |     ~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:19:5
+  --> tests/ui/assign_ops2.rs:17:5
    |
 LL |     a *= 42 * a;
    |     ^^^^^^^^^^^
@@ -76,7 +76,7 @@ LL |     a = a * 42 * a;
    |     ~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:21:5
+  --> tests/ui/assign_ops2.rs:19:5
    |
 LL |     a /= a / 2;
    |     ^^^^^^^^^^
@@ -91,7 +91,7 @@ LL |     a = a / (a / 2);
    |     ~~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:23:5
+  --> tests/ui/assign_ops2.rs:21:5
    |
 LL |     a %= a % 5;
    |     ^^^^^^^^^^
@@ -106,7 +106,7 @@ LL |     a = a % (a % 5);
    |     ~~~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:25:5
+  --> tests/ui/assign_ops2.rs:23:5
    |
 LL |     a &= a & 1;
    |     ^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     a = a & a & 1;
    |     ~~~~~~~~~~~~~
 
 error: variable appears on both sides of an assignment operation
-  --> tests/ui/assign_ops2.rs:27:5
+  --> tests/ui/assign_ops2.rs:25:5
    |
 LL |     a *= a * a;
    |     ^^^^^^^^^^
@@ -136,7 +136,7 @@ LL |     a = a * a * a;
    |     ~~~~~~~~~~~~~
 
 error: manual implementation of an assign operation
-  --> tests/ui/assign_ops2.rs:65:5
+  --> tests/ui/assign_ops2.rs:63:5
    |
 LL |     buf = buf + cows.clone();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `buf += cows.clone()`


### PR DESCRIPTION
Relate to #12379

The following diagnostics appear twice
```
  --> tests/ui/assign_ops2.rs:26:5
   |
LL |     a *= a * a;
   |     ^^^^^^^^^^
   |
help: did you mean `a = a * a` or `a = a * a * a`? Consider replacing it with
```

because `a` (lhs) appears in both left operand and right operand in the right hand side.
This PR fixes the issue so that if a diagnostic is created for an operand, the check of the other operand will be skipped. It's fine because the result is always the same in the affected operators.

changelog: [`misrefactored_assign_op`]: Fix duplicate diagnostics