### PR TITLE
Don't emit "missing backticks" lint if the element is wrapped in `<code>` HTML tags

### DIFF
--- a/clippy_lints/src/doc/markdown.rs
+++ b/clippy_lints/src/doc/markdown.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use crate::doc::DOC_MARKDOWN;
 
-pub fn check(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, text: &str, span: Span) {
+pub fn check(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, text: &str, span: Span, code_level: isize) {
     for orig_word in text.split(|c: char| c.is_whitespace() || c == '\'') {
         // Trim punctuation as in `some comment (see foo::bar).`
         //                                                   ^^
@@ -46,11 +46,11 @@ pub fn check(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, text: &str,
             span.parent(),
         );
 
-        check_word(cx, word, span);
+        check_word(cx, word, span, code_level);
     }
 }
 
-fn check_word(cx: &LateContext<'_>, word: &str, span: Span) {
+fn check_word(cx: &LateContext<'_>, word: &str, span: Span, code_level: isize) {
     /// Checks if a string is upper-camel-case, i.e., starts with an uppercase and
     /// contains at least two uppercase letters (`Clippy` is ok) and one lower-case
     /// letter (`NASA` is ok).
@@ -90,7 +90,7 @@ fn check_word(cx: &LateContext<'_>, word: &str, span: Span) {
     }
 
     // We assume that mixed-case words are not meant to be put inside backticks. (Issue #2343)
-    if has_underscore(word) && has_hyphen(word) {
+    if code_level > 0 || (has_underscore(word) && has_hyphen(word)) {
         return;
     }
 

--- a/tests/ui/doc/issue_9473.fixed
+++ b/tests/ui/doc/issue_9473.fixed
@@ -1,0 +1,9 @@
+#![warn(clippy::doc_markdown)]
+
+// Should not warn!
+/// Blah blah blah <code>[FooBar]&lt;[FooBar]&gt;</code>.
+pub struct Foo(u32);
+
+// Should warn.
+/// Blah blah blah <code>[FooBar]&lt;[FooBar]&gt;</code>[`FooBar`].
+pub struct FooBar(u32);

--- a/tests/ui/doc/issue_9473.rs
+++ b/tests/ui/doc/issue_9473.rs
@@ -1,0 +1,9 @@
+#![warn(clippy::doc_markdown)]
+
+// Should not warn!
+/// Blah blah blah <code>[FooBar]&lt;[FooBar]&gt;</code>.
+pub struct Foo(u32);
+
+// Should warn.
+/// Blah blah blah <code>[FooBar]&lt;[FooBar]&gt;</code>[FooBar].
+pub struct FooBar(u32);

--- a/tests/ui/doc/issue_9473.stderr
+++ b/tests/ui/doc/issue_9473.stderr
@@ -1,0 +1,15 @@
+error: item in documentation is missing backticks
+  --> tests/ui/doc/issue_9473.rs:8:58
+   |
+LL | /// Blah blah blah <code>[FooBar]&lt;[FooBar]&gt;</code>[FooBar].
+   |                                                          ^^^^^^
+   |
+   = note: `-D clippy::doc-markdown` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::doc_markdown)]`
+help: try
+   |
+LL | /// Blah blah blah <code>[FooBar]&lt;[FooBar]&gt;</code>[`FooBar`].
+   |                                                          ~~~~~~~~
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #9473.

changelog: Don't emit "missing backticks" lint if the element is wrapped in `<code>` HTML tags