### PR TITLE
Fix dependency specifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/driver.rs"
 clippy_config = { path = "clippy_config" }
 clippy_lints = { path = "clippy_lints" }
 rustc_tools_util = "0.3.0"
-tempfile = { version = "3.2", optional = true }
+tempfile = { version = "3.3", optional = true }
 termize = "0.1"
 color-print = "0.3.4"
 anstream = "0.6.0"
@@ -32,7 +32,7 @@ anstream = "0.6.0"
 [dev-dependencies]
 ui_test = "0.22.2"
 tester = "0.9"
-regex = "1.5"
+regex = "1.5.5"
 toml = "0.7.3"
 walkdir = "2.3"
 # This is used by the `collect-metadata` alias.
@@ -42,8 +42,8 @@ itertools = "0.12"
 # UI test dependencies
 clippy_utils = { path = "clippy_utils" }
 if_chain = "1.0"
-quote = "1.0"
-serde = { version = "1.0.125", features = ["derive"] }
+quote = "1.0.25"
+serde = { version = "1.0.145", features = ["derive"] }
 syn = { version = "2.0", features = ["full"] }
 futures = "0.3"
 parking_lot = "0.12"


### PR DESCRIPTION
As Clippy lacks `Cargo.lock`, it makes sense to test its dependency specifications with [direct-minimal-versions](https://doc.rust-lang.org/cargo/reference/unstable.html#direct-minimal-versions). This can be done with the following addition to `.cargo/config.toml`.

```toml
[unstable]
direct-minimal-versions = true
```

* `tempfile` 3.3 is required by `clippy_lints`.
* `regex` 1.5.5 is required by `ui_test` 0.22.2.
* `quote` 1.0.25 is required by `syn` 2.0.0.
* `serde` 1.0.145 is required by `toml` 0.7.3.

changelog: none