### PR TITLE
[`else_if_without_else`]: Fix duplicate diagnostics

### DIFF
--- a/clippy_lints/src/else_if_without_else.rs
+++ b/clippy_lints/src/else_if_without_else.rs
@@ -49,24 +49,22 @@ declare_clippy_lint! {
 declare_lint_pass!(ElseIfWithoutElse => [ELSE_IF_WITHOUT_ELSE]);
 
 impl EarlyLintPass for ElseIfWithoutElse {
-    fn check_expr(&mut self, cx: &EarlyContext<'_>, mut item: &Expr) {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, item: &Expr) {
         if in_external_macro(cx.sess(), item.span) {
             return;
         }
 
-        while let ExprKind::If(_, _, Some(ref els)) = item.kind {
-            if let ExprKind::If(_, _, None) = els.kind {
-                span_lint_and_help(
-                    cx,
-                    ELSE_IF_WITHOUT_ELSE,
-                    els.span,
-                    "`if` expression with an `else if`, but without a final `else`",
-                    None,
-                    "add an `else` block here",
-                );
-            }
-
-            item = els;
+        if let ExprKind::If(_, _, Some(ref els)) = item.kind
+            && let ExprKind::If(_, _, None) = els.kind
+        {
+            span_lint_and_help(
+                cx,
+                ELSE_IF_WITHOUT_ELSE,
+                els.span,
+                "`if` expression with an `else if`, but without a final `else`",
+                None,
+                "add an `else` block here",
+            );
         }
     }
 }

--- a/tests/ui/else_if_without_else.rs
+++ b/tests/ui/else_if_without_else.rs
@@ -1,7 +1,5 @@
-//@compile-flags: -Zdeduplicate-diagnostics=yes
-
-#![warn(clippy::all)]
 #![warn(clippy::else_if_without_else)]
+#![allow(clippy::collapsible_else_if)]
 
 fn bla1() -> bool {
     unimplemented!()
@@ -10,6 +8,12 @@ fn bla2() -> bool {
     unimplemented!()
 }
 fn bla3() -> bool {
+    unimplemented!()
+}
+fn bla4() -> bool {
+    unimplemented!()
+}
+fn bla5() -> bool {
     unimplemented!()
 }
 
@@ -56,5 +60,63 @@ fn main() {
     } else if bla3() {
         //~^ ERROR: `if` expression with an `else if`, but without a final `else`
         println!("else if 2");
+    }
+
+    if bla1() {
+        println!("if");
+    } else if bla2() {
+        println!("else if 1");
+    } else if bla3() {
+        println!("else if 2");
+    } else if bla4() {
+        println!("else if 3");
+    } else if bla5() {
+        println!("else if 4");
+    } else {
+        println!("else");
+    }
+
+    if bla1() {
+        println!("if");
+    } else if bla2() {
+        println!("else if 1");
+    } else if bla3() {
+        println!("else if 2");
+    } else if bla4() {
+        println!("else if 3");
+    } else if bla5() {
+        //~^ ERROR: `if` expression with an `else if`, but without a final `else`
+        println!("else if 4");
+    }
+
+    if bla1() {
+        println!("if");
+    } else if bla2() {
+        println!("else if 1");
+    } else {
+        if bla3() {
+            println!("else if 2");
+        } else if bla4() {
+            println!("else if 3");
+        } else if bla5() {
+            println!("else if 4");
+        } else {
+            println!("else");
+        }
+    }
+
+    if bla1() {
+        println!("if");
+    } else if bla2() {
+        println!("else if 1");
+    } else {
+        if bla3() {
+            println!("else if 2");
+        } else if bla4() {
+            println!("else if 3");
+        } else if bla5() {
+            //~^ ERROR: `if` expression with an `else if`, but without a final `else`
+            println!("else if 4");
+        }
     }
 }

--- a/tests/ui/else_if_without_else.stderr
+++ b/tests/ui/else_if_without_else.stderr
@@ -1,5 +1,5 @@
 error: `if` expression with an `else if`, but without a final `else`
-  --> tests/ui/else_if_without_else.rs:47:12
+  --> tests/ui/else_if_without_else.rs:51:12
    |
 LL |       } else if bla2() {
    |  ____________^
@@ -13,7 +13,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::else_if_without_else)]`
 
 error: `if` expression with an `else if`, but without a final `else`
-  --> tests/ui/else_if_without_else.rs:56:12
+  --> tests/ui/else_if_without_else.rs:60:12
    |
 LL |       } else if bla3() {
    |  ____________^
@@ -24,5 +24,29 @@ LL | |     }
    |
    = help: add an `else` block here
 
-error: aborting due to 2 previous errors
+error: `if` expression with an `else if`, but without a final `else`
+  --> tests/ui/else_if_without_else.rs:87:12
+   |
+LL |       } else if bla5() {
+   |  ____________^
+LL | |
+LL | |         println!("else if 4");
+LL | |     }
+   | |_____^
+   |
+   = help: add an `else` block here
+
+error: `if` expression with an `else if`, but without a final `else`
+  --> tests/ui/else_if_without_else.rs:117:16
+   |
+LL |           } else if bla5() {
+   |  ________________^
+LL | |
+LL | |             println!("else if 4");
+LL | |         }
+   | |_________^
+   |
+   = help: add an `else` block here
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Relates to: #12379 

changelog:  Fix duplicate lint diagnostic emission from [`else_if_without_else`]
