### PR TITLE
add documentation to the `span_lint_hir` functions

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,10 @@
 avoid-breaking-exported-api = false
 
-# use the various `clippy_utils::diagnostics::span_lint_*` functions instead, which also add a link to the docs
-disallowed-methods = [
-    "rustc_lint::context::LintContext::span_lint",
-    "rustc_middle::ty::context::TyCtxt::node_span_lint",
-]
+[[disallowed-methods]]
+path = "rustc_lint::context::LintContext::span_lint"
+reason = "this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint*` functions instead"
+
+
+[[disallowed-methods]]
+path = "rustc_middle::ty::context::TyCtxt::node_span_lint"
+reason = "this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint_hir*` functions instead"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 avoid-breaking-exported-api = false
 
-# use the various `span_lint_*` methods instead, which also add a link to the docs
+# use the various `clippy_utils::diagnostics::span_lint_*` functions instead, which also add a link to the docs
 disallowed-methods = [
     "rustc_lint::context::LintContext::span_lint",
-    "rustc_middle::ty::context::TyCtxt::node_span_lint"
+    "rustc_middle::ty::context::TyCtxt::node_span_lint",
 ]

--- a/clippy_utils/src/diagnostics.rs
+++ b/clippy_utils/src/diagnostics.rs
@@ -152,6 +152,25 @@ where
     });
 }
 
+/// Like [`span_lint`], but allows providing the `HirId` of the node that caused us to emit this
+/// lint.
+///
+/// The `HirId` is used for checking lint level attributes.
+///
+/// For example:
+/// ```ignore
+/// fn f() { /* '1 */
+///
+///     #[allow(clippy::some_lint)]
+///     let _x = /* '2 */;
+/// }
+/// ```
+/// If `some_lint` does its analysis in `LintPass::check_fn` (at `'1`) and emits a lint at `'2`
+/// using [`span_lint`], then allowing the lint at `'2` as attempted in the snippet will not work!
+/// Even though that is where the warning points at, which would be confusing to users.
+///
+/// Instead, use this function and also pass the `HirId` of the node at `'2`, which will let the
+/// compiler check lint level attributes at `'2` as one would expect, and the `#[allow]` will work.
 pub fn span_lint_hir(cx: &LateContext<'_>, lint: &'static Lint, hir_id: HirId, sp: Span, msg: &str) {
     #[expect(clippy::disallowed_methods)]
     cx.tcx.node_span_lint(lint, hir_id, sp, msg.to_string(), |diag| {
@@ -159,6 +178,25 @@ pub fn span_lint_hir(cx: &LateContext<'_>, lint: &'static Lint, hir_id: HirId, s
     });
 }
 
+/// Like [`span_lint_and_then`], but allows providing the `HirId` of the node that caused us to emit
+/// this lint.
+///
+/// The `HirId` is used for checking lint level attributes.
+///
+/// For example:
+/// ```ignore
+/// fn f() { /* '1 */
+///
+///     #[allow(clippy::some_lint)]
+///     let _x = /* '2 */;
+/// }
+/// ```
+/// If `some_lint` does its analysis in `LintPass::check_fn` (at `'1`) and emits a lint at `'2`
+/// using [`span_lint_and_then`], then allowing the lint at `'2` as attempted in the snippet will
+/// not work! Even though that is where the warning points at, which would be confusing to users.
+///
+/// Instead, use this function and also pass the `HirId` of the node at `'2`, which will let the
+/// compiler check lint level attributes at `'2` as one would expect, and the `#[allow]` will work.
 pub fn span_lint_hir_and_then(
     cx: &LateContext<'_>,
     lint: &'static Lint,

--- a/tests/ui-internal/disallow_span_lint.stderr
+++ b/tests/ui-internal/disallow_span_lint.stderr
@@ -4,6 +4,7 @@ error: use of a disallowed method `rustc_lint::context::LintContext::span_lint`
 LL |     cx.span_lint(lint, span, msg, |_| {});
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint*` functions instead (from clippy.toml)
    = note: `-D clippy::disallowed-methods` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
 
@@ -12,6 +13,8 @@ error: use of a disallowed method `rustc_middle::ty::context::TyCtxt::node_span_
    |
 LL |     tcx.node_span_lint(lint, hir_id, span, msg, |_| {});
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint_hir*` functions instead (from clippy.toml)
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
As far as I could tell, these weren't documented anywhere, and since this is sometimes needed over `span_lint` for `#[allow]` attrs to work, I thought I would add a little bit of documentation.
When I started with clippy development, I also had no idea what these functions were for.

changelog: none