### PR TITLE
Fix #12438 std_instead_of_core regression

### DIFF
--- a/clippy_lints/src/std_instead_of_core.rs
+++ b/clippy_lints/src/std_instead_of_core.rs
@@ -109,6 +109,7 @@ impl<'tcx> LateLintPass<'tcx> for StdReexports {
                     sym::core => (STD_INSTEAD_OF_CORE, "std", "core"),
                     sym::alloc => (STD_INSTEAD_OF_ALLOC, "std", "alloc"),
                     _ => {
+                        self.prev_span = first_segment.ident.span;
                         return;
                     },
                 },
@@ -116,6 +117,7 @@ impl<'tcx> LateLintPass<'tcx> for StdReexports {
                     if cx.tcx.crate_name(def_id.krate) == sym::core {
                         (ALLOC_INSTEAD_OF_CORE, "alloc", "core")
                     } else {
+                        self.prev_span = first_segment.ident.span;
                         return;
                     }
                 },

--- a/tests/ui/std_instead_of_core.fixed
+++ b/tests/ui/std_instead_of_core.fixed
@@ -17,7 +17,7 @@ fn std_instead_of_core() {
     use ::core::hash::Hash;
     //~^ ERROR: used import from `std` instead of `core`
     // Don't lint on `env` macro
-    use core::env;
+    use std::env;
 
     // Multiple imports
     use core::fmt::{Debug, Result};

--- a/tests/ui/std_instead_of_core.stderr
+++ b/tests/ui/std_instead_of_core.stderr
@@ -14,12 +14,6 @@ LL |     use ::std::hash::Hash;
    |           ^^^ help: consider importing the item from `core`: `core`
 
 error: used import from `std` instead of `core`
-  --> tests/ui/std_instead_of_core.rs:20:9
-   |
-LL |     use std::env;
-   |         ^^^ help: consider importing the item from `core`: `core`
-
-error: used import from `std` instead of `core`
   --> tests/ui/std_instead_of_core.rs:23:9
    |
 LL |     use std::fmt::{Debug, Result};
@@ -85,5 +79,5 @@ LL |     use alloc::slice::from_ref;
    = note: `-D clippy::alloc-instead-of-core` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::alloc_instead_of_core)]`
 
-error: aborting due to 13 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Fixes #12438.

Boy-scouting removed two paths that checks for duplication since I thought they were unused. However, that's just because I didn't spot it in the diff.

I installed [difftastic](https://github.com/Wilfred/difftastic) and ran it on the old one:

![image](https://github.com/rust-lang/rust-clippy/assets/34198073/5c51276c-055a-49a3-9425-6f7da0590fb0)

And the new one (fixed):

![image](https://github.com/rust-lang/rust-clippy/assets/34198073/6e10f29c-6d6b-4f64-893f-de526424f1cd)

New one (stderr):
![image](https://github.com/rust-lang/rust-clippy/assets/34198073/c4c07776-ee0f-47ba-996f-6b632de47c81)

Good teachings for the future when inspecting diffs with a lot of line changes, should've thought of that before, sorry for the trouble!

changelog: [`std_instead_of_core`] Fix false positive for crates that are in `std` but not `core`
