### PR TITLE
Fix typo in section '6.10. Macro Expansions' of the Clippy Book

### DIFF
--- a/book/src/development/macro_expansions.md
+++ b/book/src/development/macro_expansions.md
@@ -52,7 +52,7 @@ if expr.span.from_expansion() {
 
 ### `Span.ctxt` method
 
-The `span`'s context, given by the method [`ctxt`] and returning [SpanContext],
+The `span`'s context, given by the method [`ctxt`] and returning [SyntaxContext],
 represents if the span is from a macro expansion and, if it is, which
 macro call expanded this span.
 
@@ -155,4 +155,4 @@ if in_external_macro(cx.sess(), foo_span) {
 [`from_expansion`]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_span/struct.Span.html#method.from_expansion
 [`in_external_macro`]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_middle/lint/fn.in_external_macro.html
 [Span]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_span/struct.Span.html
-[SpanContext]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_span/hygiene/struct.SyntaxContext.html
+[SyntaxContext]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_span/hygiene/struct.SyntaxContext.html


### PR DESCRIPTION
Under the "Span.ctxt method" heading in *Section 6.10. Macro Expansions* of the *Clippy Book*, the type returned by the 
`Span::ctxt` method is listed as `SpanContext`.  The correct type name should be `SyntaxContext`.

---

changelog: Fixed typo in "Section 6.10. Macro Expansions" of the Clippy Book. `SpanContext` changed to `SyntaxContext`.
