### PR TITLE
fix [`empty_docs`] trigger in proc-macro

### DIFF
--- a/tests/ui/auxiliary/proc_macro_attr.rs
+++ b/tests/ui/auxiliary/proc_macro_attr.rs
@@ -163,3 +163,16 @@ pub fn rewrite_struct(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     quote!(#item_struct).into()
 }
+
+#[proc_macro_attribute]
+pub fn with_empty_docs(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as syn::Item);
+    let attrs: Vec<syn::Attribute> = vec![];
+    let doc_comment = "";
+    quote! {
+        #(#attrs)*
+        #[doc = #doc_comment]
+        #item
+    }
+    .into()
+}

--- a/tests/ui/empty_docs.rs
+++ b/tests/ui/empty_docs.rs
@@ -1,6 +1,9 @@
+//@aux-build:proc_macro_attr.rs
+
 #![allow(unused)]
 #![warn(clippy::empty_docs)]
 #![allow(clippy::mixed_attributes_style)]
+#![feature(extern_types)]
 
 mod outer {
     //!
@@ -65,5 +68,19 @@ mod outer {
         x: i32,
         ///
         y: i32,
+    }
+}
+
+mod issue_12377 {
+    use proc_macro_attr::with_empty_docs;
+
+    #[with_empty_docs]
+    extern "C" {
+        type Test;
+    }
+
+    #[with_empty_docs]
+    struct Foo {
+        a: u8,
     }
 }

--- a/tests/ui/empty_docs.stderr
+++ b/tests/ui/empty_docs.stderr
@@ -1,5 +1,5 @@
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:6:5
+  --> tests/ui/empty_docs.rs:9:5
    |
 LL |     //!
    |     ^^^
@@ -9,7 +9,7 @@ LL |     //!
    = help: to override `-D warnings` add `#[allow(clippy::empty_docs)]`
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:14:5
+  --> tests/ui/empty_docs.rs:17:5
    |
 LL |     ///
    |     ^^^
@@ -17,7 +17,7 @@ LL |     ///
    = help: consider removing or filling it
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:16:9
+  --> tests/ui/empty_docs.rs:19:9
    |
 LL |         ///
    |         ^^^
@@ -25,7 +25,7 @@ LL |         ///
    = help: consider removing or filling it
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:27:5
+  --> tests/ui/empty_docs.rs:30:5
    |
 LL |     #[doc = ""]
    |     ^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     #[doc = ""]
    = help: consider removing or filling it
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:30:5
+  --> tests/ui/empty_docs.rs:33:5
    |
 LL | /     #[doc = ""]
 LL | |     #[doc = ""]
@@ -42,7 +42,7 @@ LL | |     #[doc = ""]
    = help: consider removing or filling it
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:37:5
+  --> tests/ui/empty_docs.rs:40:5
    |
 LL |     ///
    |     ^^^
@@ -50,7 +50,7 @@ LL |     ///
    = help: consider removing or filling it
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:50:13
+  --> tests/ui/empty_docs.rs:53:13
    |
 LL |             /*! */
    |             ^^^^^^
@@ -58,7 +58,7 @@ LL |             /*! */
    = help: consider removing or filling it
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:58:13
+  --> tests/ui/empty_docs.rs:61:13
    |
 LL |             ///
    |             ^^^
@@ -66,12 +66,30 @@ LL |             ///
    = help: consider removing or filling it
 
 error: empty doc comment
-  --> tests/ui/empty_docs.rs:66:9
+  --> tests/ui/empty_docs.rs:69:9
    |
 LL |         ///
    |         ^^^
    |
    = help: consider removing or filling it
 
-error: aborting due to 9 previous errors
+error: empty doc comment
+  --> tests/ui/empty_docs.rs:77:5
+   |
+LL |     #[with_empty_docs]
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing or filling it
+   = note: this error originates in the attribute macro `with_empty_docs` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: empty doc comment
+  --> tests/ui/empty_docs.rs:82:5
+   |
+LL |     #[with_empty_docs]
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider removing or filling it
+   = note: this error originates in the attribute macro `with_empty_docs` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/empty_docs.stderr
+++ b/tests/ui/empty_docs.stderr
@@ -73,23 +73,5 @@ LL |         ///
    |
    = help: consider removing or filling it
 
-error: empty doc comment
-  --> tests/ui/empty_docs.rs:77:5
-   |
-LL |     #[with_empty_docs]
-   |     ^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider removing or filling it
-   = note: this error originates in the attribute macro `with_empty_docs` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: empty doc comment
-  --> tests/ui/empty_docs.rs:82:5
-   |
-LL |     #[with_empty_docs]
-   |     ^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider removing or filling it
-   = note: this error originates in the attribute macro `with_empty_docs` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 11 previous errors
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
fixes: #12377 

---

changelog: fix [`empty_docs`] trigger in proc-macros
