### PR TITLE
Don't emit `doc_markdown` lint for missing backticks if it's inside a quote

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -611,6 +611,10 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                     code_level += 1;
                 } else if tag.starts_with("</code") {
                     code_level -= 1;
+                } else if tag.starts_with("<blockquote") || tag.starts_with("<q") {
+                    blockquote_level += 1;
+                } else if tag.starts_with("</blockquote") || tag.starts_with("</q") {
+                    blockquote_level -= 1;
                 }
             },
             Start(BlockQuote) => blockquote_level += 1,

--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -7,7 +7,7 @@ use clippy_utils::{is_entrypoint_fn, method_chain_args};
 use pulldown_cmark::Event::{
     Code, End, FootnoteReference, HardBreak, Html, Rule, SoftBreak, Start, TaskListMarker, Text,
 };
-use pulldown_cmark::Tag::{CodeBlock, Heading, Item, Link, Paragraph};
+use pulldown_cmark::Tag::{BlockQuote, CodeBlock, Heading, Item, Link, Paragraph};
 use pulldown_cmark::{BrokenLink, CodeBlockKind, CowStr, Options};
 use rustc_ast::ast::Attribute;
 use rustc_data_structures::fx::FxHashSet;
@@ -602,6 +602,7 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
     let mut text_to_check: Vec<(CowStr<'_>, Range<usize>, isize)> = Vec::new();
     let mut paragraph_range = 0..0;
     let mut code_level = 0;
+    let mut blockquote_level = 0;
 
     for (event, range) in events {
         match event {
@@ -612,6 +613,8 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                     code_level -= 1;
                 }
             },
+            Start(BlockQuote) => blockquote_level += 1,
+            End(BlockQuote) => blockquote_level -= 1,
             Start(CodeBlock(ref kind)) => {
                 in_code = true;
                 if let CodeBlockKind::Fenced(lang) = kind {
@@ -663,7 +666,7 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                 } else {
                     for (text, range, assoc_code_level) in text_to_check {
                         if let Some(span) = fragments.span(cx, range) {
-                            markdown::check(cx, valid_idents, &text, span, assoc_code_level);
+                            markdown::check(cx, valid_idents, &text, span, assoc_code_level, blockquote_level);
                         }
                     }
                 }

--- a/tests/ui/doc/issue_10262.fixed
+++ b/tests/ui/doc/issue_10262.fixed
@@ -1,0 +1,8 @@
+#![warn(clippy::doc_markdown)]
+
+// Should only warn for the first line!
+/// `AviSynth` documentation:
+//~^ ERROR: item in documentation is missing backticks
+///
+/// > AvisynthPluginInit3 may be called more than once with different IScriptEnvironments.
+pub struct Foo;

--- a/tests/ui/doc/issue_10262.fixed
+++ b/tests/ui/doc/issue_10262.fixed
@@ -5,4 +5,8 @@
 //~^ ERROR: item in documentation is missing backticks
 ///
 /// > AvisynthPluginInit3 may be called more than once with different IScriptEnvironments.
+///
+/// <blockquote>bla AvisynthPluginInit3 bla</blockquote>
+///
+/// <q>bla AvisynthPluginInit3 bla</q>
 pub struct Foo;

--- a/tests/ui/doc/issue_10262.rs
+++ b/tests/ui/doc/issue_10262.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::doc_markdown)]
+
+// Should only warn for the first line!
+/// AviSynth documentation:
+//~^ ERROR: item in documentation is missing backticks
+///
+/// > AvisynthPluginInit3 may be called more than once with different IScriptEnvironments.
+pub struct Foo;

--- a/tests/ui/doc/issue_10262.rs
+++ b/tests/ui/doc/issue_10262.rs
@@ -5,4 +5,8 @@
 //~^ ERROR: item in documentation is missing backticks
 ///
 /// > AvisynthPluginInit3 may be called more than once with different IScriptEnvironments.
+///
+/// <blockquote>bla AvisynthPluginInit3 bla</blockquote>
+///
+/// <q>bla AvisynthPluginInit3 bla</q>
 pub struct Foo;

--- a/tests/ui/doc/issue_10262.stderr
+++ b/tests/ui/doc/issue_10262.stderr
@@ -1,0 +1,15 @@
+error: item in documentation is missing backticks
+  --> tests/ui/doc/issue_10262.rs:4:5
+   |
+LL | /// AviSynth documentation:
+   |     ^^^^^^^^
+   |
+   = note: `-D clippy::doc-markdown` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::doc_markdown)]`
+help: try
+   |
+LL | /// `AviSynth` documentation:
+   |     ~~~~~~~~~~
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #10262.

changelog: Don't emit `doc_markdown` lint for missing backticks if it's inside a quote