### PR TITLE
CI: replace `cancel-outdated-builds` with `concurrency` group

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -26,6 +26,12 @@ env:
   NO_FMT_TEST: 1
   CARGO_INCREMENTAL: 0
 
+concurrency:
+  # For a given workflow, if we push to the same PR, cancel all previous builds on that PR.
+  # If the push is not attached to a PR, we will cancel all builds on the same branch.
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   base:
     # NOTE: If you modify this job, make sure you copy the changes to clippy_bors.yml
@@ -33,10 +39,6 @@ jobs:
 
     steps:
     # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
-
     - name: Checkout
       uses: actions/checkout@v4
 

--- a/.github/workflows/clippy_bors.yml
+++ b/.github/workflows/clippy_bors.yml
@@ -12,6 +12,11 @@ env:
   NO_FMT_TEST: 1
   CARGO_INCREMENTAL: 0
 
+concurrency:
+  # For a given workflow, if we push to the same branch, cancel all previous builds on that branch.
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -21,10 +26,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -67,10 +68,6 @@ jobs:
     # NOTE: If you modify this job, make sure you copy the changes to clippy.yml
     steps:
     # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
-
     - name: Checkout
       uses: actions/checkout@v4
 
@@ -131,10 +128,6 @@ jobs:
 
     steps:
      # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
-
     - name: Checkout
       uses: actions/checkout@v4
 
@@ -155,10 +148,6 @@ jobs:
 
     steps:
     # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
-
     - name: Checkout
       uses: actions/checkout@v4
 
@@ -211,10 +200,6 @@ jobs:
 
     steps:
     # Setup
-    - uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
-      with:
-        github_token: "${{ secrets.github_token }}"
-
     - name: Checkout
       uses: actions/checkout@v4
 


### PR DESCRIPTION
This is the last remaining [usage](https://github.com/search?q=org%3Arust-lang%20cancel-outdated-builds&type=code) of the [cancel-outdated-builds](https://github.com/rust-lang/simpleinfra/tree/master/github-actions/cancel-outdated-builds) CI action. Which means that if we remove its usage, we can remove the code of the action :)

This action was replaced in `rust-lang/rust` with the native Github Actions `concurrency` group [last year](https://github.com/rust-lang/rust/pull/112955).

Note that unlike `rust-lang/rust`, which explicitly allows parallel try builds, `clippy` did not allow them, as all steps of the `clippy_bors.yaml` workflow used the `cancel-outdated-builds` action, regardless of the branch. So the new `concurrency` group mirrors that, which makes it a bit simpler than on `rust-lang/rust`.

r? @Mark-Simulacrum