### PR TITLE
move `readonly_write_lock` to perf

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3590,7 +3590,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.73.0"]
     pub READONLY_WRITE_LOCK,
-    nursery,
+    perf,
     "acquiring a write lock when a read lock would work"
 }
 

--- a/tests/ui/await_holding_lock.rs
+++ b/tests/ui/await_holding_lock.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::await_holding_lock)]
+#![allow(clippy::readonly_write_lock)]
 
 // When adding or modifying a test, please do the same for parking_lot::Mutex.
 mod std_mutex {

--- a/tests/ui/await_holding_lock.stderr
+++ b/tests/ui/await_holding_lock.stderr
@@ -1,12 +1,12 @@
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:9:13
+  --> tests/ui/await_holding_lock.rs:10:13
    |
 LL |         let guard = x.lock().unwrap();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:11:15
+  --> tests/ui/await_holding_lock.rs:12:15
    |
 LL |         baz().await
    |               ^^^^^
@@ -14,40 +14,40 @@ LL |         baz().await
    = help: to override `-D warnings` add `#[allow(clippy::await_holding_lock)]`
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:25:13
+  --> tests/ui/await_holding_lock.rs:26:13
    |
 LL |         let guard = x.read().unwrap();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:27:15
+  --> tests/ui/await_holding_lock.rs:28:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:31:13
+  --> tests/ui/await_holding_lock.rs:32:13
    |
 LL |         let mut guard = x.write().unwrap();
    |             ^^^^^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:33:15
+  --> tests/ui/await_holding_lock.rs:34:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:53:13
+  --> tests/ui/await_holding_lock.rs:54:13
    |
 LL |         let guard = x.lock().unwrap();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:56:28
+  --> tests/ui/await_holding_lock.rs:57:28
    |
 LL |         let second = baz().await;
    |                            ^^^^^
@@ -56,79 +56,79 @@ LL |         let third = baz().await;
    |                           ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:67:17
+  --> tests/ui/await_holding_lock.rs:68:17
    |
 LL |             let guard = x.lock().unwrap();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:69:19
+  --> tests/ui/await_holding_lock.rs:70:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:80:17
+  --> tests/ui/await_holding_lock.rs:81:17
    |
 LL |             let guard = x.lock().unwrap();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:82:19
+  --> tests/ui/await_holding_lock.rs:83:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:93:13
+  --> tests/ui/await_holding_lock.rs:94:13
    |
 LL |         let guard = x.lock();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:95:15
+  --> tests/ui/await_holding_lock.rs:96:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:109:13
+  --> tests/ui/await_holding_lock.rs:110:13
    |
 LL |         let guard = x.read();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:111:15
+  --> tests/ui/await_holding_lock.rs:112:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:115:13
+  --> tests/ui/await_holding_lock.rs:116:13
    |
 LL |         let mut guard = x.write();
    |             ^^^^^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:117:15
+  --> tests/ui/await_holding_lock.rs:118:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:137:13
+  --> tests/ui/await_holding_lock.rs:138:13
    |
 LL |         let guard = x.lock();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:140:28
+  --> tests/ui/await_holding_lock.rs:141:28
    |
 LL |         let second = baz().await;
    |                            ^^^^^
@@ -137,40 +137,40 @@ LL |         let third = baz().await;
    |                           ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:151:17
+  --> tests/ui/await_holding_lock.rs:152:17
    |
 LL |             let guard = x.lock();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:153:19
+  --> tests/ui/await_holding_lock.rs:154:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:164:17
+  --> tests/ui/await_holding_lock.rs:165:17
    |
 LL |             let guard = x.lock();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:166:19
+  --> tests/ui/await_holding_lock.rs:167:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:185:9
+  --> tests/ui/await_holding_lock.rs:186:9
    |
 LL |     let mut guard = x.lock().unwrap();
    |         ^^^^^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:189:11
+  --> tests/ui/await_holding_lock.rs:190:11
    |
 LL |     baz().await;
    |           ^^^^^


### PR DESCRIPTION
[There haven't been any issues](https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+readonly_write_lock) since its creation and it's a pretty useful lint I think, so I'd say it's worth giving it a try?

Did a lintcheck run on 300 crates with no results, but I guess `RwLock` is usually not something that's used much in libraries.

changelog: move [`readonly_write_lock`] to perf (now warn-by-default)