### PR TITLE
Make `assigning_clones` MSRV check more precise

### DIFF
--- a/tests/ui/assigning_clones.fixed
+++ b/tests/ui/assigning_clones.fixed
@@ -129,14 +129,16 @@ fn ignore_generic_clone<T: Clone>(a: &mut T, b: &T) {
 }
 
 #[clippy::msrv = "1.62"]
-fn msrv_1_62(mut a: String, b: &str) {
+fn msrv_1_62(mut a: String, b: String, c: &str) {
+    a.clone_from(&b);
     // Should not be linted, as clone_into wasn't stabilized until 1.63
-    a = b.to_owned();
+    a = c.to_owned();
 }
 
 #[clippy::msrv = "1.63"]
-fn msrv_1_63(mut a: String, b: &str) {
-    b.clone_into(&mut a);
+fn msrv_1_63(mut a: String, b: String, c: &str) {
+    a.clone_from(&b);
+    c.clone_into(&mut a);
 }
 
 macro_rules! clone_inside {

--- a/tests/ui/assigning_clones.rs
+++ b/tests/ui/assigning_clones.rs
@@ -129,14 +129,16 @@ fn ignore_generic_clone<T: Clone>(a: &mut T, b: &T) {
 }
 
 #[clippy::msrv = "1.62"]
-fn msrv_1_62(mut a: String, b: &str) {
+fn msrv_1_62(mut a: String, b: String, c: &str) {
+    a = b.clone();
     // Should not be linted, as clone_into wasn't stabilized until 1.63
-    a = b.to_owned();
+    a = c.to_owned();
 }
 
 #[clippy::msrv = "1.63"]
-fn msrv_1_63(mut a: String, b: &str) {
-    a = b.to_owned();
+fn msrv_1_63(mut a: String, b: String, c: &str) {
+    a = b.clone();
+    a = c.to_owned();
 }
 
 macro_rules! clone_inside {

--- a/tests/ui/assigning_clones.stderr
+++ b/tests/ui/assigning_clones.stderr
@@ -67,47 +67,59 @@ error: assigning the result of `Clone::clone()` may be inefficient
 LL |         a = b.clone();
    |         ^^^^^^^^^^^^^ help: use `clone_from()`: `a.clone_from(&b)`
 
-error: assigning the result of `ToOwned::to_owned()` may be inefficient
-  --> tests/ui/assigning_clones.rs:139:5
+error: assigning the result of `Clone::clone()` may be inefficient
+  --> tests/ui/assigning_clones.rs:133:5
    |
-LL |     a = b.to_owned();
-   |     ^^^^^^^^^^^^^^^^ help: use `clone_into()`: `b.clone_into(&mut a)`
+LL |     a = b.clone();
+   |     ^^^^^^^^^^^^^ help: use `clone_from()`: `a.clone_from(&b)`
+
+error: assigning the result of `Clone::clone()` may be inefficient
+  --> tests/ui/assigning_clones.rs:140:5
+   |
+LL |     a = b.clone();
+   |     ^^^^^^^^^^^^^ help: use `clone_from()`: `a.clone_from(&b)`
 
 error: assigning the result of `ToOwned::to_owned()` may be inefficient
-  --> tests/ui/assigning_clones.rs:156:5
+  --> tests/ui/assigning_clones.rs:141:5
+   |
+LL |     a = c.to_owned();
+   |     ^^^^^^^^^^^^^^^^ help: use `clone_into()`: `c.clone_into(&mut a)`
+
+error: assigning the result of `ToOwned::to_owned()` may be inefficient
+  --> tests/ui/assigning_clones.rs:158:5
    |
 LL |     *mut_string = ref_str.to_owned();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `ref_str.clone_into(mut_string)`
 
 error: assigning the result of `ToOwned::to_owned()` may be inefficient
-  --> tests/ui/assigning_clones.rs:160:5
+  --> tests/ui/assigning_clones.rs:162:5
    |
 LL |     mut_string = ref_str.to_owned();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `ref_str.clone_into(&mut mut_string)`
 
 error: assigning the result of `ToOwned::to_owned()` may be inefficient
-  --> tests/ui/assigning_clones.rs:181:5
+  --> tests/ui/assigning_clones.rs:183:5
    |
 LL |     **mut_box_string = ref_str.to_owned();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `ref_str.clone_into(&mut (*mut_box_string))`
 
 error: assigning the result of `ToOwned::to_owned()` may be inefficient
-  --> tests/ui/assigning_clones.rs:185:5
+  --> tests/ui/assigning_clones.rs:187:5
    |
 LL |     **mut_box_string = ref_str.to_owned();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `ref_str.clone_into(&mut (*mut_box_string))`
 
 error: assigning the result of `ToOwned::to_owned()` may be inefficient
-  --> tests/ui/assigning_clones.rs:189:5
+  --> tests/ui/assigning_clones.rs:191:5
    |
 LL |     *mut_thing = ToOwned::to_owned(ref_str);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `ToOwned::clone_into(ref_str, mut_thing)`
 
 error: assigning the result of `ToOwned::to_owned()` may be inefficient
-  --> tests/ui/assigning_clones.rs:193:5
+  --> tests/ui/assigning_clones.rs:195:5
    |
 LL |     mut_thing = ToOwned::to_owned(ref_str);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `ToOwned::clone_into(ref_str, &mut mut_thing)`
 
-error: aborting due to 18 previous errors
+error: aborting due to 20 previous errors
 


### PR DESCRIPTION
Continuation of #12511

`clone_into` is the only suggestion subject to the 1.63 MSRV requirement, and the lint should still emit other suggestions regardless of the MSRV.

changelog: [assigning_clones]: only apply MSRV check to `clone_into` suggestions.