### PR TITLE
Correct version for incompatible_msrv

### DIFF
--- a/clippy_lints/src/incompatible_msrv.rs
+++ b/clippy_lints/src/incompatible_msrv.rs
@@ -33,7 +33,7 @@ declare_clippy_lint! {
     ///
     /// To fix this problem, either increase your MSRV or use another item
     /// available in your current MSRV.
-    #[clippy::version = "1.77.0"]
+    #[clippy::version = "1.78.0"]
     pub INCOMPATIBLE_MSRV,
     suspicious,
     "ensures that all items used in the crate are available for the current MSRV"


### PR DESCRIPTION
Unsure what happened here

Probably what caused https://github.com/rust-lang/blog.rust-lang.org/issues/1277

changelog: none
