### PR TITLE
Do not warn on .map(_::clone) for Arc, Rc, and their weak variants

### DIFF
--- a/clippy_lints/src/methods/map_clone.rs
+++ b/clippy_lints/src/methods/map_clone.rs
@@ -124,6 +124,11 @@ fn handle_path(
             && let ty::Ref(_, ty, Mutability::Not) = ty.kind()
             && let ty::FnDef(_, lst) = cx.typeck_results().expr_ty(arg).kind()
             && lst.iter().all(|l| l.as_type() == Some(*ty))
+            && !matches!(
+                ty.ty_adt_def()
+                    .and_then(|adt_def| cx.tcx.get_diagnostic_name(adt_def.did())),
+                Some(sym::Arc | sym::ArcWeak | sym::Rc | sym::RcWeak)
+            )
         {
             lint_path(cx, e.span, recv.span, is_copy(cx, ty.peel_refs()));
         }

--- a/tests/ui/map_clone.fixed
+++ b/tests/ui/map_clone.fixed
@@ -131,4 +131,28 @@ fn main() {
         let x: Vec<&u8> = vec![];
         let y = x.into_iter().map(|x| u8::clone(loop {}));
     }
+
+    // Issue #12528
+    {
+        // Don't lint these
+        use std::rc::{Rc, Weak as RcWeak};
+        use std::sync::{Arc, Weak as ArcWeak};
+        struct Foo;
+
+        let x = Arc::new(Foo);
+        let y = Some(&x);
+        let _z = y.map(Arc::clone);
+
+        let x = Rc::new(Foo);
+        let y = Some(&x);
+        let _z = y.map(Rc::clone);
+
+        let x = Arc::downgrade(&Arc::new(Foo));
+        let y = Some(&x);
+        let _z = y.map(ArcWeak::clone);
+
+        let x = Rc::downgrade(&Rc::new(Foo));
+        let y = Some(&x);
+        let _z = y.map(RcWeak::clone);
+    }
 }

--- a/tests/ui/map_clone.rs
+++ b/tests/ui/map_clone.rs
@@ -131,4 +131,28 @@ fn main() {
         let x: Vec<&u8> = vec![];
         let y = x.into_iter().map(|x| u8::clone(loop {}));
     }
+
+    // Issue #12528
+    {
+        // Don't lint these
+        use std::rc::{Rc, Weak as RcWeak};
+        use std::sync::{Arc, Weak as ArcWeak};
+        struct Foo;
+
+        let x = Arc::new(Foo);
+        let y = Some(&x);
+        let _z = y.map(Arc::clone);
+
+        let x = Rc::new(Foo);
+        let y = Some(&x);
+        let _z = y.map(Rc::clone);
+
+        let x = Arc::downgrade(&Arc::new(Foo));
+        let y = Some(&x);
+        let _z = y.map(ArcWeak::clone);
+
+        let x = Rc::downgrade(&Rc::new(Foo));
+        let y = Some(&x);
+        let _z = y.map(RcWeak::clone);
+    }
 }


### PR DESCRIPTION
Those constructions are idiomatic, and using `Arc::clone(x)` and `Rc::clone(x)` is often the recommended way of cloning a `Arc` or a `Rc`.

Fix #12528

changelog: [`map_clone`]: do not warn on `.map(_::clone)` for `Arc`, `Rc`, and their `Weak` variants