### PR TITLE
Add necessary parentheses to `manual_unwrap_or_default` lint output

### DIFF
--- a/clippy_lints/src/manual_unwrap_or_default.rs
+++ b/clippy_lints/src/manual_unwrap_or_default.rs
@@ -1,3 +1,4 @@
+use clippy_utils::sugg::Sugg;
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
 use rustc_hir::{Arm, Expr, ExprKind, HirId, LangItem, MatchSource, Pat, PatKind, QPath};
@@ -124,7 +125,7 @@ fn handle_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
         // We now check the `None` arm is calling a method equivalent to `Default::default`.
         && let body_none = body_none.peel_blocks()
         && is_default_equivalent(cx, body_none)
-        && let Some(match_expr_snippet) = snippet_opt(cx, match_expr.span)
+        && let Some(receiver) = Sugg::hir_opt(cx, match_expr).map(Sugg::maybe_par)
     {
         span_lint_and_sugg(
             cx,
@@ -132,7 +133,7 @@ fn handle_match<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> bool {
             expr.span,
             "match can be simplified with `.unwrap_or_default()`",
             "replace it with",
-            format!("{match_expr_snippet}.unwrap_or_default()"),
+            format!("{receiver}.unwrap_or_default()"),
             Applicability::MachineApplicable,
         );
     }

--- a/tests/ui/manual_unwrap_or_default.fixed
+++ b/tests/ui/manual_unwrap_or_default.fixed
@@ -17,3 +17,12 @@ fn main() {
     let x: Option<Vec<String>> = None;
     x.unwrap_or_default();
 }
+
+// Issue #12531
+unsafe fn no_deref_ptr(a: Option<i32>, b: *const Option<i32>) -> i32 {
+    match a {
+        // `*b` being correct depends on `a == Some(_)`
+        Some(_) => (*b).unwrap_or_default(),
+        _ => 0,
+    }
+}

--- a/tests/ui/manual_unwrap_or_default.rs
+++ b/tests/ui/manual_unwrap_or_default.rs
@@ -38,3 +38,15 @@ fn main() {
         Vec::default()
     };
 }
+
+// Issue #12531
+unsafe fn no_deref_ptr(a: Option<i32>, b: *const Option<i32>) -> i32 {
+    match a {
+        // `*b` being correct depends on `a == Some(_)`
+        Some(_) => match *b {
+            Some(v) => v,
+            _ => 0,
+        },
+        _ => 0,
+    }
+}

--- a/tests/ui/manual_unwrap_or_default.stderr
+++ b/tests/ui/manual_unwrap_or_default.stderr
@@ -52,5 +52,15 @@ LL | |         Vec::default()
 LL | |     };
    | |_____^ help: replace it with: `x.unwrap_or_default()`
 
-error: aborting due to 5 previous errors
+error: match can be simplified with `.unwrap_or_default()`
+  --> tests/ui/manual_unwrap_or_default.rs:46:20
+   |
+LL |           Some(_) => match *b {
+   |  ____________________^
+LL | |             Some(v) => v,
+LL | |             _ => 0,
+LL | |         },
+   | |_________^ help: replace it with: `(*b).unwrap_or_default()`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Fix #12531

----

changelog: [`manual_unwrap_or_default`]: add parentheses to suggestion when appropriate