### PR TITLE
restrict manual_clamp to const case, bring it out of nursery

### DIFF
--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -116,8 +116,9 @@ impl<'tcx> ClampSuggestion<'tcx> {
         }
         if let Some(max) = constant(cx, cx.typeck_results(), self.params.max)
             && let Some(min) = constant(cx, cx.typeck_results(), self.params.min)
+            && let Some(ord) = Constant::partial_cmp(cx.tcx, max_type, &min, &max)
         {
-            Constant::partial_cmp(cx.tcx, max_type, &min, &max).is_some_and(|o| o != Ordering::Greater)
+            ord != Ordering::Greater
         } else {
             false
         }

--- a/clippy_lints/src/manual_clamp.rs
+++ b/clippy_lints/src/manual_clamp.rs
@@ -114,12 +114,13 @@ impl<'tcx> ClampSuggestion<'tcx> {
         if max_type != min_type {
             return false;
         }
-        let max = constant(cx, cx.typeck_results(), self.params.max);
-        let min = constant(cx, cx.typeck_results(), self.params.min);
-        let cmp = max
-            .zip(min)
-            .and_then(|(max, min)| Constant::partial_cmp(cx.tcx, max_type, &min, &max));
-        cmp.is_some_and(|cmp| cmp != Ordering::Greater)
+        if let Some(max) = constant(cx, cx.typeck_results(), self.params.max)
+            && let Some(min) = constant(cx, cx.typeck_results(), self.params.min)
+        {
+            Constant::partial_cmp(cx.tcx, max_type, &min, &max).is_some_and(|o| o != Ordering::Greater)
+        } else {
+            false
+        }
     }
 }
 

--- a/tests/ui/manual_clamp.fixed
+++ b/tests/ui/manual_clamp.fixed
@@ -17,48 +17,171 @@ const CONST_F64_MIN: f64 = 4.0;
 
 fn main() {
     let (input, min, max) = (0, -2, 3);
-    // Lint
-    let x0 = input.clamp(min, max);
+    // Min and max are not const, so this shouldn't trigger the lint.
+    let x0 = if max < input {
+        max
+    } else if min > input {
+        min
+    } else {
+        input
+    };
 
-    let x1 = input.clamp(min, max);
+    let x1 = if input > max {
+        max
+    } else if input < min {
+        min
+    } else {
+        input
+    };
 
-    let x2 = input.clamp(min, max);
+    let x2 = if input < min {
+        min
+    } else if input > max {
+        max
+    } else {
+        input
+    };
 
-    let x3 = input.clamp(min, max);
+    let x3 = if min > input {
+        min
+    } else if max < input {
+        max
+    } else {
+        input
+    };
 
-    let x4 = input.clamp(min, max);
-    //~^ ERROR: clamp-like pattern without using clamp function
-    //~| NOTE: clamp will panic if max < min
+    let x4 = input.max(min).min(max);
 
-    let x5 = input.clamp(min, max);
-    //~^ ERROR: clamp-like pattern without using clamp function
-    //~| NOTE: clamp will panic if max < min
+    let x5 = input.min(max).max(min);
 
-    let x6 = input.clamp(min, max);
+    let x6 = match input {
+        x if x > max => max,
+        x if x < min => min,
+        x => x,
+    };
 
-    let x7 = input.clamp(min, max);
+    let x7 = match input {
+        x if x < min => min,
+        x if x > max => max,
+        x => x,
+    };
 
-    let x8 = input.clamp(min, max);
+    let x8 = match input {
+        x if max < x => max,
+        x if min > x => min,
+        x => x,
+    };
 
     let mut x9 = input;
-    x9 = x9.clamp(min, max);
+    if x9 < min {
+        x9 = min;
+    }
+    if x9 > max {
+        x9 = max;
+    }
 
-    let x10 = input.clamp(min, max);
+    let x10 = match input {
+        x if min > x => min,
+        x if max < x => max,
+        x => x,
+    };
 
     let mut x11 = input;
     let _ = 1;
-    x11 = x11.clamp(min, max);
+    if x11 > max {
+        x11 = max;
+    }
+    if x11 < min {
+        x11 = min;
+    }
 
     let mut x12 = input;
-    x12 = x12.clamp(min, max);
+    if min > x12 {
+        x12 = min;
+    }
+    if max < x12 {
+        x12 = max;
+    }
 
     let mut x13 = input;
-    x13 = x13.clamp(min, max);
+    if max < x13 {
+        x13 = max;
+    }
+    if min > x13 {
+        x13 = min;
+    }
+
+    {
+        let (input, min, max) = (0.0f64, -2.0, 3.0);
+        let x14 = if input > max {
+            max
+        } else if input < min {
+            min
+        } else {
+            input
+        };
+    }
+    let mut x15 = input;
+    if x15 < min {
+        x15 = min;
+    } else if x15 > max {
+        x15 = max;
+    }
+
+    // It's important this be the last set of statements
+    let mut x16 = input;
+    if max < x16 {
+        x16 = max;
+    }
+    if min > x16 {
+        x16 = min;
+    }
+}
+
+fn const_main() {
+    let input = 0;
+    // Min and max are const, so this should trigger the lint.
+    let x0 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let x1 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let x2 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let x3 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let x4 = input.clamp(CONST_MIN, CONST_MAX);
+    //~^ ERROR: clamp-like pattern without using clamp function
+    //~| NOTE: clamp will panic if max < min
+
+    let x5 = input.clamp(CONST_MIN, CONST_MAX);
+    //~^ ERROR: clamp-like pattern without using clamp function
+    //~| NOTE: clamp will panic if max < min
+
+    let x6 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let x7 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let x8 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let mut x9 = input;
+    x9 = x9.clamp(CONST_MIN, CONST_MAX);
+
+    let x10 = input.clamp(CONST_MIN, CONST_MAX);
+
+    let mut x11 = input;
+    let _ = 1;
+    x11 = x11.clamp(CONST_MIN, CONST_MAX);
+
+    let mut x12 = input;
+    x12 = x12.clamp(CONST_MIN, CONST_MAX);
+
+    let mut x13 = input;
+    x13 = x13.clamp(CONST_MIN, CONST_MAX);
 
     let x14 = input.clamp(CONST_MIN, CONST_MAX);
     {
-        let (input, min, max) = (0.0f64, -2.0, 3.0);
-        let x15 = input.clamp(min, max);
+        let input = 0.0f64;
+        let x15 = input.clamp(CONST_F64_MIN, CONST_F64_MAX);
     }
     {
         let input: i32 = cmp_min_max(1);
@@ -114,108 +237,128 @@ fn main() {
         //~| NOTE: clamp will panic if max < min, min.is_nan(), or max.is_nan()
     }
     let mut x32 = input;
-    x32 = x32.clamp(min, max);
+    x32 = x32.clamp(CONST_MIN, CONST_MAX);
+
+    // Flip the script, swap the places of min and max. Make sure this doesn't
+    // trigger when clamp would be guaranteed to panic.
+    let mut x33 = input;
+    if x33 < CONST_MAX {
+        x33 = CONST_MAX;
+    } else if x33 > CONST_MIN {
+        x33 = CONST_MIN;
+    }
+
+    // Do it again for NaN
+    #[allow(invalid_nan_comparisons)]
+    {
+        let mut x34 = input as f64;
+        if x34 < f64::NAN {
+            x34 = f64::NAN;
+        } else if x34 > CONST_F64_MAX {
+            x34 = CONST_F64_MAX;
+        }
+    }
 
     // It's important this be the last set of statements
-    let mut x33 = input;
-    x33 = x33.clamp(min, max);
+    let mut x35 = input;
+    x35 = x35.clamp(CONST_MIN, CONST_MAX);
 }
 
 // This code intentionally nonsense.
 fn no_lint() {
-    let (input, min, max) = (0, -2, 3);
-    let x0 = if max < input {
-        max
-    } else if min > input {
-        max
+    let input = 0;
+    let x0 = if CONST_MAX < input {
+        CONST_MAX
+    } else if CONST_MIN > input {
+        CONST_MAX
     } else {
-        min
+        CONST_MIN
     };
 
-    let x1 = if input > max {
-        max
-    } else if input > min {
-        min
+    let x1 = if input > CONST_MAX {
+        CONST_MAX
+    } else if input > CONST_MIN {
+        CONST_MIN
     } else {
-        max
+        CONST_MAX
     };
 
-    let x2 = if max < min {
-        min
-    } else if input > max {
+    let x2 = if CONST_MAX < CONST_MIN {
+        CONST_MIN
+    } else if input > CONST_MAX {
         input
     } else {
         input
     };
 
-    let x3 = if min > input {
+    let x3 = if CONST_MIN > input {
         input
-    } else if max < input {
-        max
+    } else if CONST_MAX < input {
+        CONST_MAX
     } else {
-        max
+        CONST_MAX
     };
 
     let x6 = match input {
-        x if x < max => x,
-        x if x < min => x,
+        x if x < CONST_MAX => x,
+        x if x < CONST_MIN => x,
         x => x,
     };
 
     let x7 = match input {
-        x if x < min => max,
-        x if x > max => min,
+        x if x < CONST_MIN => CONST_MAX,
+        x if x > CONST_MAX => CONST_MIN,
         x => x,
     };
 
     let x8 = match input {
-        x if max > x => max,
-        x if min > x => min,
+        x if CONST_MAX > x => CONST_MAX,
+        x if CONST_MIN > x => CONST_MIN,
         x => x,
     };
 
     let mut x9 = input;
-    if x9 > min {
-        x9 = min;
+    if x9 > CONST_MIN {
+        x9 = CONST_MIN;
     }
-    if x9 > max {
-        x9 = max;
+    if x9 > CONST_MAX {
+        x9 = CONST_MAX;
     }
 
     let x10 = match input {
-        x if min > x => min,
-        x if max < x => max,
-        x => min,
+        x if CONST_MIN > x => CONST_MIN,
+        x if CONST_MAX < x => CONST_MAX,
+        x => CONST_MIN,
     };
 
     let mut x11 = input;
-    if x11 > max {
-        x11 = min;
+    if x11 > CONST_MAX {
+        x11 = CONST_MIN;
     }
-    if x11 < min {
-        x11 = max;
+    if x11 < CONST_MIN {
+        x11 = CONST_MAX;
     }
 
     let mut x12 = input;
-    if min > x12 {
-        x12 = max * 3;
+    if CONST_MIN > x12 {
+        x12 = CONST_MAX * 3;
     }
-    if max < x12 {
-        x12 = min;
+    if CONST_MAX < x12 {
+        x12 = CONST_MIN;
     }
 
     let mut x13 = input;
-    if max < x13 {
-        let x13 = max;
+    if CONST_MAX < x13 {
+        let x13 = CONST_MAX;
     }
-    if min > x13 {
-        x13 = min;
+    if CONST_MIN > x13 {
+        x13 = CONST_MIN;
     }
     let mut x14 = input;
-    if x14 < min {
+    if x14 < CONST_MIN {
         x14 = 3;
-    } else if x14 > max {
-        x14 = max;
+    } else if x14 > CONST_MAX {
+        x14 = CONST_MAX;
     }
     {
         let input: i32 = cmp_min_max(1);
@@ -272,8 +415,8 @@ fn msrv_1_49() {
 
 #[clippy::msrv = "1.50"]
 fn msrv_1_50() {
-    let (input, min, max) = (0, -1, 2);
-    let _ = input.clamp(min, max);
+    let input = 0;
+    let _ = input.clamp(CONST_MIN, CONST_MAX);
 }
 
 const fn _const() {

--- a/tests/ui/manual_clamp.rs
+++ b/tests/ui/manual_clamp.rs
@@ -17,10 +17,8 @@ const CONST_F64_MIN: f64 = 4.0;
 
 fn main() {
     let (input, min, max) = (0, -2, 3);
-    // Lint
+    // Min and max are not const, so this shouldn't trigger the lint.
     let x0 = if max < input {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         max
     } else if min > input {
         min
@@ -29,8 +27,6 @@ fn main() {
     };
 
     let x1 = if input > max {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         max
     } else if input < min {
         min
@@ -39,8 +35,6 @@ fn main() {
     };
 
     let x2 = if input < min {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         min
     } else if input > max {
         max
@@ -49,8 +43,6 @@ fn main() {
     };
 
     let x3 = if min > input {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         min
     } else if max < input {
         max
@@ -59,32 +51,22 @@ fn main() {
     };
 
     let x4 = input.max(min).min(max);
-    //~^ ERROR: clamp-like pattern without using clamp function
-    //~| NOTE: clamp will panic if max < min
 
     let x5 = input.min(max).max(min);
-    //~^ ERROR: clamp-like pattern without using clamp function
-    //~| NOTE: clamp will panic if max < min
 
     let x6 = match input {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x if x > max => max,
         x if x < min => min,
         x => x,
     };
 
     let x7 = match input {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x if x < min => min,
         x if x > max => max,
         x => x,
     };
 
     let x8 = match input {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x if max < x => max,
         x if min > x => min,
         x => x,
@@ -92,8 +74,6 @@ fn main() {
 
     let mut x9 = input;
     if x9 < min {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x9 = min;
     }
     if x9 > max {
@@ -101,8 +81,6 @@ fn main() {
     }
 
     let x10 = match input {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x if min > x => min,
         x if max < x => max,
         x => x,
@@ -111,8 +89,6 @@ fn main() {
     let mut x11 = input;
     let _ = 1;
     if x11 > max {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x11 = max;
     }
     if x11 < min {
@@ -121,8 +97,6 @@ fn main() {
 
     let mut x12 = input;
     if min > x12 {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x12 = min;
     }
     if max < x12 {
@@ -131,12 +105,161 @@ fn main() {
 
     let mut x13 = input;
     if max < x13 {
-        //~^ ERROR: clamp-like pattern without using clamp function
-        //~| NOTE: clamp will panic if max < min
         x13 = max;
     }
     if min > x13 {
         x13 = min;
+    }
+
+    {
+        let (input, min, max) = (0.0f64, -2.0, 3.0);
+        let x14 = if input > max {
+            max
+        } else if input < min {
+            min
+        } else {
+            input
+        };
+    }
+    let mut x15 = input;
+    if x15 < min {
+        x15 = min;
+    } else if x15 > max {
+        x15 = max;
+    }
+
+    // It's important this be the last set of statements
+    let mut x16 = input;
+    if max < x16 {
+        x16 = max;
+    }
+    if min > x16 {
+        x16 = min;
+    }
+}
+
+fn const_main() {
+    let input = 0;
+    // Min and max are const, so this should trigger the lint.
+    let x0 = if CONST_MAX < input {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        CONST_MAX
+    } else if CONST_MIN > input {
+        CONST_MIN
+    } else {
+        input
+    };
+
+    let x1 = if input > CONST_MAX {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        CONST_MAX
+    } else if input < CONST_MIN {
+        CONST_MIN
+    } else {
+        input
+    };
+
+    let x2 = if input < CONST_MIN {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        CONST_MIN
+    } else if input > CONST_MAX {
+        CONST_MAX
+    } else {
+        input
+    };
+
+    let x3 = if CONST_MIN > input {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        CONST_MIN
+    } else if CONST_MAX < input {
+        CONST_MAX
+    } else {
+        input
+    };
+
+    let x4 = input.max(CONST_MIN).min(CONST_MAX);
+    //~^ ERROR: clamp-like pattern without using clamp function
+    //~| NOTE: clamp will panic if max < min
+
+    let x5 = input.min(CONST_MAX).max(CONST_MIN);
+    //~^ ERROR: clamp-like pattern without using clamp function
+    //~| NOTE: clamp will panic if max < min
+
+    let x6 = match input {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x if x > CONST_MAX => CONST_MAX,
+        x if x < CONST_MIN => CONST_MIN,
+        x => x,
+    };
+
+    let x7 = match input {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x if x < CONST_MIN => CONST_MIN,
+        x if x > CONST_MAX => CONST_MAX,
+        x => x,
+    };
+
+    let x8 = match input {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x if CONST_MAX < x => CONST_MAX,
+        x if CONST_MIN > x => CONST_MIN,
+        x => x,
+    };
+
+    let mut x9 = input;
+    if x9 < CONST_MIN {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x9 = CONST_MIN;
+    }
+    if x9 > CONST_MAX {
+        x9 = CONST_MAX;
+    }
+
+    let x10 = match input {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x if CONST_MIN > x => CONST_MIN,
+        x if CONST_MAX < x => CONST_MAX,
+        x => x,
+    };
+
+    let mut x11 = input;
+    let _ = 1;
+    if x11 > CONST_MAX {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x11 = CONST_MAX;
+    }
+    if x11 < CONST_MIN {
+        x11 = CONST_MIN;
+    }
+
+    let mut x12 = input;
+    if CONST_MIN > x12 {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x12 = CONST_MIN;
+    }
+    if CONST_MAX < x12 {
+        x12 = CONST_MAX;
+    }
+
+    let mut x13 = input;
+    if CONST_MAX < x13 {
+        //~^ ERROR: clamp-like pattern without using clamp function
+        //~| NOTE: clamp will panic if max < min
+        x13 = CONST_MAX;
+    }
+    if CONST_MIN > x13 {
+        x13 = CONST_MIN;
     }
 
     let x14 = if input > CONST_MAX {
@@ -149,13 +272,13 @@ fn main() {
         input
     };
     {
-        let (input, min, max) = (0.0f64, -2.0, 3.0);
-        let x15 = if input > max {
+        let input = 0.0f64;
+        let x15 = if input > CONST_F64_MAX {
             //~^ ERROR: clamp-like pattern without using clamp function
-            //~| NOTE: clamp will panic if max < min, min.is_nan(), or max.is_nan()
-            max
-        } else if input < min {
-            min
+            //~| NOTE: clamp will panic if max < min
+            CONST_F64_MAX
+        } else if input < CONST_F64_MIN {
+            CONST_F64_MIN
         } else {
             input
         };
@@ -214,121 +337,141 @@ fn main() {
         //~| NOTE: clamp will panic if max < min, min.is_nan(), or max.is_nan()
     }
     let mut x32 = input;
-    if x32 < min {
+    if x32 < CONST_MIN {
         //~^ ERROR: clamp-like pattern without using clamp function
         //~| NOTE: clamp will panic if max < min
-        x32 = min;
-    } else if x32 > max {
-        x32 = max;
+        x32 = CONST_MIN;
+    } else if x32 > CONST_MAX {
+        x32 = CONST_MAX;
+    }
+
+    // Flip the script, swap the places of min and max. Make sure this doesn't
+    // trigger when clamp would be guaranteed to panic.
+    let mut x33 = input;
+    if x33 < CONST_MAX {
+        x33 = CONST_MAX;
+    } else if x33 > CONST_MIN {
+        x33 = CONST_MIN;
+    }
+
+    // Do it again for NaN
+    #[allow(invalid_nan_comparisons)]
+    {
+        let mut x34 = input as f64;
+        if x34 < f64::NAN {
+            x34 = f64::NAN;
+        } else if x34 > CONST_F64_MAX {
+            x34 = CONST_F64_MAX;
+        }
     }
 
     // It's important this be the last set of statements
-    let mut x33 = input;
-    if max < x33 {
+    let mut x35 = input;
+    if CONST_MAX < x35 {
         //~^ ERROR: clamp-like pattern without using clamp function
         //~| NOTE: clamp will panic if max < min
-        x33 = max;
+        x35 = CONST_MAX;
     }
-    if min > x33 {
-        x33 = min;
+    if CONST_MIN > x35 {
+        x35 = CONST_MIN;
     }
 }
 
 // This code intentionally nonsense.
 fn no_lint() {
-    let (input, min, max) = (0, -2, 3);
-    let x0 = if max < input {
-        max
-    } else if min > input {
-        max
+    let input = 0;
+    let x0 = if CONST_MAX < input {
+        CONST_MAX
+    } else if CONST_MIN > input {
+        CONST_MAX
     } else {
-        min
+        CONST_MIN
     };
 
-    let x1 = if input > max {
-        max
-    } else if input > min {
-        min
+    let x1 = if input > CONST_MAX {
+        CONST_MAX
+    } else if input > CONST_MIN {
+        CONST_MIN
     } else {
-        max
+        CONST_MAX
     };
 
-    let x2 = if max < min {
-        min
-    } else if input > max {
+    let x2 = if CONST_MAX < CONST_MIN {
+        CONST_MIN
+    } else if input > CONST_MAX {
         input
     } else {
         input
     };
 
-    let x3 = if min > input {
+    let x3 = if CONST_MIN > input {
         input
-    } else if max < input {
-        max
+    } else if CONST_MAX < input {
+        CONST_MAX
     } else {
-        max
+        CONST_MAX
     };
 
     let x6 = match input {
-        x if x < max => x,
-        x if x < min => x,
+        x if x < CONST_MAX => x,
+        x if x < CONST_MIN => x,
         x => x,
     };
 
     let x7 = match input {
-        x if x < min => max,
-        x if x > max => min,
+        x if x < CONST_MIN => CONST_MAX,
+        x if x > CONST_MAX => CONST_MIN,
         x => x,
     };
 
     let x8 = match input {
-        x if max > x => max,
-        x if min > x => min,
+        x if CONST_MAX > x => CONST_MAX,
+        x if CONST_MIN > x => CONST_MIN,
         x => x,
     };
 
     let mut x9 = input;
-    if x9 > min {
-        x9 = min;
+    if x9 > CONST_MIN {
+        x9 = CONST_MIN;
     }
-    if x9 > max {
-        x9 = max;
+    if x9 > CONST_MAX {
+        x9 = CONST_MAX;
     }
 
     let x10 = match input {
-        x if min > x => min,
-        x if max < x => max,
-        x => min,
+        x if CONST_MIN > x => CONST_MIN,
+        x if CONST_MAX < x => CONST_MAX,
+        x => CONST_MIN,
     };
 
     let mut x11 = input;
-    if x11 > max {
-        x11 = min;
+    if x11 > CONST_MAX {
+        x11 = CONST_MIN;
     }
-    if x11 < min {
-        x11 = max;
+    if x11 < CONST_MIN {
+        x11 = CONST_MAX;
     }
 
     let mut x12 = input;
-    if min > x12 {
-        x12 = max * 3;
+    if CONST_MIN > x12 {
+        x12 = CONST_MAX * 3;
     }
-    if max < x12 {
-        x12 = min;
+    if CONST_MAX < x12 {
+        x12 = CONST_MIN;
     }
 
     let mut x13 = input;
-    if max < x13 {
-        let x13 = max;
+    if CONST_MAX < x13 {
+        let x13 = CONST_MAX;
     }
-    if min > x13 {
-        x13 = min;
+    if CONST_MIN > x13 {
+        x13 = CONST_MIN;
     }
     let mut x14 = input;
-    if x14 < min {
+    if x14 < CONST_MIN {
         x14 = 3;
-    } else if x14 > max {
-        x14 = max;
+    } else if x14 > CONST_MAX {
+        x14 = CONST_MAX;
     }
     {
         let input: i32 = cmp_min_max(1);
@@ -385,13 +528,13 @@ fn msrv_1_49() {
 
 #[clippy::msrv = "1.50"]
 fn msrv_1_50() {
-    let (input, min, max) = (0, -1, 2);
-    let _ = if input < min {
+    let input = 0;
+    let _ = if input > CONST_MAX {
         //~^ ERROR: clamp-like pattern without using clamp function
         //~| NOTE: clamp will panic if max < min
-        min
-    } else if input > max {
-        max
+        CONST_MAX
+    } else if input < CONST_MIN {
+        CONST_MIN
     } else {
         input
     };

--- a/tests/ui/manual_clamp.stderr
+++ b/tests/ui/manual_clamp.stderr
@@ -1,213 +1,213 @@
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:94:5
+  --> tests/ui/manual_clamp.rs:217:5
    |
-LL | /     if x9 < min {
+LL | /     if x9 < CONST_MIN {
 LL | |
 LL | |
-LL | |         x9 = min;
+LL | |         x9 = CONST_MIN;
 ...  |
-LL | |         x9 = max;
+LL | |         x9 = CONST_MAX;
 LL | |     }
-   | |_____^ help: replace with clamp: `x9 = x9.clamp(min, max);`
+   | |_____^ help: replace with clamp: `x9 = x9.clamp(CONST_MIN, CONST_MAX);`
    |
    = note: clamp will panic if max < min
    = note: `-D clippy::manual-clamp` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_clamp)]`
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:113:5
+  --> tests/ui/manual_clamp.rs:236:5
    |
-LL | /     if x11 > max {
+LL | /     if x11 > CONST_MAX {
 LL | |
 LL | |
-LL | |         x11 = max;
+LL | |         x11 = CONST_MAX;
 ...  |
-LL | |         x11 = min;
+LL | |         x11 = CONST_MIN;
 LL | |     }
-   | |_____^ help: replace with clamp: `x11 = x11.clamp(min, max);`
+   | |_____^ help: replace with clamp: `x11 = x11.clamp(CONST_MIN, CONST_MAX);`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:123:5
+  --> tests/ui/manual_clamp.rs:246:5
    |
-LL | /     if min > x12 {
+LL | /     if CONST_MIN > x12 {
 LL | |
 LL | |
-LL | |         x12 = min;
+LL | |         x12 = CONST_MIN;
 ...  |
-LL | |         x12 = max;
+LL | |         x12 = CONST_MAX;
 LL | |     }
-   | |_____^ help: replace with clamp: `x12 = x12.clamp(min, max);`
+   | |_____^ help: replace with clamp: `x12 = x12.clamp(CONST_MIN, CONST_MAX);`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:133:5
+  --> tests/ui/manual_clamp.rs:256:5
    |
-LL | /     if max < x13 {
+LL | /     if CONST_MAX < x13 {
 LL | |
 LL | |
-LL | |         x13 = max;
+LL | |         x13 = CONST_MAX;
 ...  |
-LL | |         x13 = min;
+LL | |         x13 = CONST_MIN;
 LL | |     }
-   | |_____^ help: replace with clamp: `x13 = x13.clamp(min, max);`
+   | |_____^ help: replace with clamp: `x13 = x13.clamp(CONST_MIN, CONST_MAX);`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:227:5
+  --> tests/ui/manual_clamp.rs:370:5
    |
-LL | /     if max < x33 {
+LL | /     if CONST_MAX < x35 {
 LL | |
 LL | |
-LL | |         x33 = max;
+LL | |         x35 = CONST_MAX;
 ...  |
-LL | |         x33 = min;
+LL | |         x35 = CONST_MIN;
 LL | |     }
-   | |_____^ help: replace with clamp: `x33 = x33.clamp(min, max);`
+   | |_____^ help: replace with clamp: `x35 = x35.clamp(CONST_MIN, CONST_MAX);`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:21:14
+  --> tests/ui/manual_clamp.rs:144:14
    |
-LL |       let x0 = if max < input {
+LL |       let x0 = if CONST_MAX < input {
    |  ______________^
 LL | |
 LL | |
-LL | |         max
+LL | |         CONST_MAX
 ...  |
 LL | |         input
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:31:14
+  --> tests/ui/manual_clamp.rs:154:14
    |
-LL |       let x1 = if input > max {
+LL |       let x1 = if input > CONST_MAX {
    |  ______________^
 LL | |
 LL | |
-LL | |         max
+LL | |         CONST_MAX
 ...  |
 LL | |         input
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:41:14
+  --> tests/ui/manual_clamp.rs:164:14
    |
-LL |       let x2 = if input < min {
+LL |       let x2 = if input < CONST_MIN {
    |  ______________^
 LL | |
 LL | |
-LL | |         min
+LL | |         CONST_MIN
 ...  |
 LL | |         input
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:51:14
+  --> tests/ui/manual_clamp.rs:174:14
    |
-LL |       let x3 = if min > input {
+LL |       let x3 = if CONST_MIN > input {
    |  ______________^
 LL | |
 LL | |
-LL | |         min
+LL | |         CONST_MIN
 ...  |
 LL | |         input
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:61:14
+  --> tests/ui/manual_clamp.rs:184:14
    |
-LL |     let x4 = input.max(min).min(max);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(min, max)`
-   |
-   = note: clamp will panic if max < min
-
-error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:65:14
-   |
-LL |     let x5 = input.min(max).max(min);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(min, max)`
+LL |     let x4 = input.max(CONST_MIN).min(CONST_MAX);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:69:14
+  --> tests/ui/manual_clamp.rs:188:14
+   |
+LL |     let x5 = input.min(CONST_MAX).max(CONST_MIN);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
+   |
+   = note: clamp will panic if max < min
+
+error: clamp-like pattern without using clamp function
+  --> tests/ui/manual_clamp.rs:192:14
    |
 LL |       let x6 = match input {
    |  ______________^
 LL | |
 LL | |
-LL | |         x if x > max => max,
-LL | |         x if x < min => min,
+LL | |         x if x > CONST_MAX => CONST_MAX,
+LL | |         x if x < CONST_MIN => CONST_MIN,
 LL | |         x => x,
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:77:14
+  --> tests/ui/manual_clamp.rs:200:14
    |
 LL |       let x7 = match input {
    |  ______________^
 LL | |
 LL | |
-LL | |         x if x < min => min,
-LL | |         x if x > max => max,
+LL | |         x if x < CONST_MIN => CONST_MIN,
+LL | |         x if x > CONST_MAX => CONST_MAX,
 LL | |         x => x,
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:85:14
+  --> tests/ui/manual_clamp.rs:208:14
    |
 LL |       let x8 = match input {
    |  ______________^
 LL | |
 LL | |
-LL | |         x if max < x => max,
-LL | |         x if min > x => min,
+LL | |         x if CONST_MAX < x => CONST_MAX,
+LL | |         x if CONST_MIN > x => CONST_MIN,
 LL | |         x => x,
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:103:15
+  --> tests/ui/manual_clamp.rs:226:15
    |
 LL |       let x10 = match input {
    |  _______________^
 LL | |
 LL | |
-LL | |         x if min > x => min,
-LL | |         x if max < x => max,
+LL | |         x if CONST_MIN > x => CONST_MIN,
+LL | |         x if CONST_MAX < x => CONST_MAX,
 LL | |         x => x,
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:142:15
+  --> tests/ui/manual_clamp.rs:265:15
    |
 LL |       let x14 = if input > CONST_MAX {
    |  _______________^
@@ -222,23 +222,23 @@ LL | |     };
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:153:19
+  --> tests/ui/manual_clamp.rs:276:19
    |
-LL |           let x15 = if input > max {
+LL |           let x15 = if input > CONST_F64_MAX {
    |  ___________________^
 LL | |
 LL | |
-LL | |             max
+LL | |             CONST_F64_MAX
 ...  |
 LL | |             input
 LL | |         };
-   | |_________^ help: replace with clamp: `input.clamp(min, max)`
+   | |_________^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
    |
    = note: clamp will panic if max < min, min.is_nan(), or max.is_nan()
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:166:19
+  --> tests/ui/manual_clamp.rs:289:19
    |
 LL |         let x16 = cmp_max(cmp_min(input, CONST_MAX), CONST_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -246,7 +246,7 @@ LL |         let x16 = cmp_max(cmp_min(input, CONST_MAX), CONST_MIN);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:169:19
+  --> tests/ui/manual_clamp.rs:292:19
    |
 LL |         let x17 = cmp_min(cmp_max(input, CONST_MIN), CONST_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -254,7 +254,7 @@ LL |         let x17 = cmp_min(cmp_max(input, CONST_MIN), CONST_MAX);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:172:19
+  --> tests/ui/manual_clamp.rs:295:19
    |
 LL |         let x18 = cmp_max(CONST_MIN, cmp_min(input, CONST_MAX));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -262,7 +262,7 @@ LL |         let x18 = cmp_max(CONST_MIN, cmp_min(input, CONST_MAX));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:175:19
+  --> tests/ui/manual_clamp.rs:298:19
    |
 LL |         let x19 = cmp_min(CONST_MAX, cmp_max(input, CONST_MIN));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -270,7 +270,7 @@ LL |         let x19 = cmp_min(CONST_MAX, cmp_max(input, CONST_MIN));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:178:19
+  --> tests/ui/manual_clamp.rs:301:19
    |
 LL |         let x20 = cmp_max(cmp_min(CONST_MAX, input), CONST_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -278,7 +278,7 @@ LL |         let x20 = cmp_max(cmp_min(CONST_MAX, input), CONST_MIN);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:181:19
+  --> tests/ui/manual_clamp.rs:304:19
    |
 LL |         let x21 = cmp_min(cmp_max(CONST_MIN, input), CONST_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -286,7 +286,7 @@ LL |         let x21 = cmp_min(cmp_max(CONST_MIN, input), CONST_MAX);
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:184:19
+  --> tests/ui/manual_clamp.rs:307:19
    |
 LL |         let x22 = cmp_max(CONST_MIN, cmp_min(CONST_MAX, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -294,7 +294,7 @@ LL |         let x22 = cmp_max(CONST_MIN, cmp_min(CONST_MAX, input));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:187:19
+  --> tests/ui/manual_clamp.rs:310:19
    |
 LL |         let x23 = cmp_min(CONST_MAX, cmp_max(CONST_MIN, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
@@ -302,7 +302,7 @@ LL |         let x23 = cmp_min(CONST_MAX, cmp_max(CONST_MIN, input));
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:191:19
+  --> tests/ui/manual_clamp.rs:314:19
    |
 LL |         let x24 = f64::max(f64::min(input, CONST_F64_MAX), CONST_F64_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -311,7 +311,7 @@ LL |         let x24 = f64::max(f64::min(input, CONST_F64_MAX), CONST_F64_MIN);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:194:19
+  --> tests/ui/manual_clamp.rs:317:19
    |
 LL |         let x25 = f64::min(f64::max(input, CONST_F64_MIN), CONST_F64_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -320,7 +320,7 @@ LL |         let x25 = f64::min(f64::max(input, CONST_F64_MIN), CONST_F64_MAX);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:197:19
+  --> tests/ui/manual_clamp.rs:320:19
    |
 LL |         let x26 = f64::max(CONST_F64_MIN, f64::min(input, CONST_F64_MAX));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -329,7 +329,7 @@ LL |         let x26 = f64::max(CONST_F64_MIN, f64::min(input, CONST_F64_MAX));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:200:19
+  --> tests/ui/manual_clamp.rs:323:19
    |
 LL |         let x27 = f64::min(CONST_F64_MAX, f64::max(input, CONST_F64_MIN));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -338,7 +338,7 @@ LL |         let x27 = f64::min(CONST_F64_MAX, f64::max(input, CONST_F64_MIN));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:203:19
+  --> tests/ui/manual_clamp.rs:326:19
    |
 LL |         let x28 = f64::max(f64::min(CONST_F64_MAX, input), CONST_F64_MIN);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -347,7 +347,7 @@ LL |         let x28 = f64::max(f64::min(CONST_F64_MAX, input), CONST_F64_MIN);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:206:19
+  --> tests/ui/manual_clamp.rs:329:19
    |
 LL |         let x29 = f64::min(f64::max(CONST_F64_MIN, input), CONST_F64_MAX);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -356,7 +356,7 @@ LL |         let x29 = f64::min(f64::max(CONST_F64_MIN, input), CONST_F64_MAX);
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:209:19
+  --> tests/ui/manual_clamp.rs:332:19
    |
 LL |         let x30 = f64::max(CONST_F64_MIN, f64::min(CONST_F64_MAX, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -365,7 +365,7 @@ LL |         let x30 = f64::max(CONST_F64_MIN, f64::min(CONST_F64_MAX, input));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:212:19
+  --> tests/ui/manual_clamp.rs:335:19
    |
 LL |         let x31 = f64::min(CONST_F64_MAX, f64::max(CONST_F64_MIN, input));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `input.clamp(CONST_F64_MIN, CONST_F64_MAX)`
@@ -374,31 +374,31 @@ LL |         let x31 = f64::min(CONST_F64_MAX, f64::max(CONST_F64_MIN, input));
    = note: clamp returns NaN if the input is NaN
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:217:5
+  --> tests/ui/manual_clamp.rs:340:5
    |
-LL | /     if x32 < min {
+LL | /     if x32 < CONST_MIN {
 LL | |
 LL | |
-LL | |         x32 = min;
-LL | |     } else if x32 > max {
-LL | |         x32 = max;
+LL | |         x32 = CONST_MIN;
+LL | |     } else if x32 > CONST_MAX {
+LL | |         x32 = CONST_MAX;
 LL | |     }
-   | |_____^ help: replace with clamp: `x32 = x32.clamp(min, max);`
+   | |_____^ help: replace with clamp: `x32 = x32.clamp(CONST_MIN, CONST_MAX);`
    |
    = note: clamp will panic if max < min
 
 error: clamp-like pattern without using clamp function
-  --> tests/ui/manual_clamp.rs:389:13
+  --> tests/ui/manual_clamp.rs:532:13
    |
-LL |       let _ = if input < min {
+LL |       let _ = if input > CONST_MAX {
    |  _____________^
 LL | |
 LL | |
-LL | |         min
+LL | |         CONST_MAX
 ...  |
 LL | |         input
 LL | |     };
-   | |_____^ help: replace with clamp: `input.clamp(min, max)`
+   | |_____^ help: replace with clamp: `input.clamp(CONST_MIN, CONST_MAX)`
    |
    = note: clamp will panic if max < min
 


### PR DESCRIPTION
Implements the plan that I described in https://github.com/rust-lang/rust-clippy/pull/9484#issuecomment-1374522054

This does two things primarily

1. Restrict `manual_clamp` such that it will only trigger if we are able to guarantee that `clamp` won't panic at runtime.
2. Bring `manual_clamp` out of nursery status and move it into the complexity group.

changelog: [`manual_clamp`]: Restrict this lint such that it only triggers if max and min are const, and max is greater than or equal to min. Then bring it out of the nursery group.
