### PR TITLE
fix: `suspicious_else_formatting` false positive when else is included …

### DIFF
--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -214,7 +214,8 @@ fn check_else(cx: &EarlyContext<'_>, expr: &Expr) {
         // the snippet should look like " else \n    " with maybe comments anywhere
         // it’s bad when there is a ‘\n’ after the “else”
         && let Some(else_snippet) = snippet_opt(cx, else_span)
-        && let Some((pre_else, post_else)) = split_once_with_else(&else_snippet)
+        && let Some((pre_else, post_else)) = else_snippet.split_once("else")
+        && !else_snippet.contains('/')
         && let Some((_, post_else_post_eol)) = post_else.split_once('\n')
     {
         // Allow allman style braces `} \n else \n {`
@@ -322,45 +323,4 @@ fn is_block(expr: &Expr) -> bool {
 /// Check if the expression is an `if` or `if let`
 fn is_if(expr: &Expr) -> bool {
     matches!(expr.kind, ExprKind::If(..))
-}
-
-fn split_once_with_else(base: &str) -> Option<(&str, &str)> {
-    let else_str = "else";
-
-    let indices: Vec<_> = base.match_indices(else_str).map(|(i, _)| i).collect();
-
-    match indices.len() {
-        0 => return None,
-        1 => return base.split_once(else_str),
-        _ => {},
-    }
-
-    let mut i = 0;
-    let mut is_in_comment = false;
-
-    for line in base.lines() {
-        if let Some(else_pos) = line.find(else_str) {
-            if let Some(pos) = line.find("//") {
-                if pos > else_pos {
-                    return Some(base.split_at(indices[i]));
-                }
-            } else if let Some(pos) = line.find("/*") {
-                if pos > else_pos {
-                    return Some(base.split_at(indices[i]));
-                }
-                is_in_comment = true;
-            } else if let Some(pos) = line.find("*/") {
-                if pos < else_pos {
-                    return Some(base.split_at(indices[i]));
-                }
-                is_in_comment = false;
-            } else if !is_in_comment {
-                return Some(base.split_at(indices[i]));
-            }
-
-            i += 1;
-        }
-    }
-
-    None
 }

--- a/tests/ui/suspicious_else_formatting.rs
+++ b/tests/ui/suspicious_else_formatting.rs
@@ -120,6 +120,34 @@ fn main() {
     /* whelp */
     {
     }
+
+    // #12497 Don't trigger lint as rustfmt wants it
+    if true {
+        println!("true");
+    }
+    /*else if false {
+}*/
+    else {
+        println!("false");
+    }
+
+    if true {
+        println!("true");
+    } // else if false {}
+    else {
+        println!("false");
+    }
+
+    if true {
+        println!("true");
+    } /* if true {
+        println!("true");
+}
+    */
+    else {
+        println!("false");
+    }
+
 }
 
 // #7650 - Don't lint. Proc-macro using bad spans for `if` expressions.


### PR DESCRIPTION
This PR addresses an issue where invalid suggestions are generated for `if-else` formatting if comments contain the keyword `else`.

The root of the problem is identified [here](https://github.com/rust-lang/rust-clippy/blob/95c62ffae9bbce793f68a6f1473e3fc24af19bdd/clippy_lints/src/formatting.rs#L217). Specifically, when a comment contains the word `else`, the lint mistakenly interprets it as part of an `if-else` clause. This misinterpretation leads to an incorrect splitting of the snippet, resulting in erroneous suggestions.


fixes: #12497 

changelog: [`suspicious_else_formatting`]: Fixes invalid suggestions when comments include word else
