### PR TITLE
Change applicability of `assigning_clones` to `Unspecified`

### DIFF
--- a/clippy_lints/src/assigning_clones.rs
+++ b/clippy_lints/src/assigning_clones.rs
@@ -212,7 +212,7 @@ fn suggest<'tcx>(
     call: &CallCandidate<'tcx>,
 ) {
     span_lint_and_then(cx, ASSIGNING_CLONES, assign_expr.span, call.message(), |diag| {
-        let mut applicability = Applicability::MachineApplicable;
+        let mut applicability = Applicability::Unspecified;
 
         diag.span_suggestion(
             assign_expr.span,


### PR DESCRIPTION
Before we deal with https://github.com/rust-lang/rust-clippy/pull/12473 and the borrow checker errors, I think that it would be better to downgrade this lint, since it can break code.

changelog: Change the applicability of `assigning_clones` to `Unspecified`

r? @blyxyas