### PR TITLE
Remove unnecessary dot in the 'unconditional recursion' lint description

### DIFF
--- a/clippy_lints/src/unconditional_recursion.rs
+++ b/clippy_lints/src/unconditional_recursion.rs
@@ -23,7 +23,7 @@ declare_clippy_lint! {
     /// implementations.
     ///
     /// ### Why is this bad?
-    /// This is a hard to find infinite recursion that will crash any code.
+    /// This is a hard to find infinite recursion that will crash any code
     /// using it.
     ///
     /// ### Example


### PR DESCRIPTION
I don't think such changes should be reflected in the changelog.

changelog: none
