### PR TITLE
allow [`manual_unwrap_or_default`] in const function

### DIFF
--- a/clippy_lints/src/manual_unwrap_or_default.rs
+++ b/clippy_lints/src/manual_unwrap_or_default.rs
@@ -7,9 +7,9 @@ use rustc_session::declare_lint_pass;
 use rustc_span::sym;
 
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::is_default_equivalent;
 use clippy_utils::source::snippet_opt;
 use clippy_utils::ty::implements_trait;
+use clippy_utils::{in_constant, is_default_equivalent};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -172,7 +172,7 @@ fn handle_if_let<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
 
 impl<'tcx> LateLintPass<'tcx> for ManualUnwrapOrDefault {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        if expr.span.from_expansion() {
+        if expr.span.from_expansion() || in_constant(cx, expr.hir_id) {
             return;
         }
         if !handle_match(cx, expr) {

--- a/tests/ui/manual_unwrap_or_default.fixed
+++ b/tests/ui/manual_unwrap_or_default.fixed
@@ -26,3 +26,10 @@ unsafe fn no_deref_ptr(a: Option<i32>, b: *const Option<i32>) -> i32 {
         _ => 0,
     }
 }
+
+const fn issue_12568(opt: Option<bool>) -> bool {
+    match opt {
+        Some(s) => s,
+        None => false,
+    }
+}

--- a/tests/ui/manual_unwrap_or_default.rs
+++ b/tests/ui/manual_unwrap_or_default.rs
@@ -50,3 +50,10 @@ unsafe fn no_deref_ptr(a: Option<i32>, b: *const Option<i32>) -> i32 {
         _ => 0,
     }
 }
+
+const fn issue_12568(opt: Option<bool>) -> bool {
+    match opt {
+        Some(s) => s,
+        None => false,
+    }
+}


### PR DESCRIPTION
closes: #12568 

---

changelog: allow [`manual_unwrap_or_default`] in const function


This is a small fix, I was originally decided to fix it along with `#12568` but there are some problems needs to be addressed (which is why my branch is called `issue12569` 😆 ), so I decide to open a separated PR to fix them one at a time.