### PR TITLE
Move `mixed_attributes_style` to style

### DIFF
--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -496,7 +496,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.78.0"]
     pub MIXED_ATTRIBUTES_STYLE,
-    suspicious,
+    style,
     "item has both inner and outer attributes"
 }
 


### PR DESCRIPTION
> It currently is in suspicious. I wouldn't say that the linted code is "most likely wrong or useless"
[...]
> :sweat_smile: I would still argue that this doesn't belong in the suspicious group, but rather in the style group. 



These are some good points made [on zulip](https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/mixed_attributes_style.20on.20outlined.20modules/near/429823328).

----

changelog: Move [`mixed_attributes_style`] to the `style` category