### PR TITLE
Prevent PR assignments to `@matthiaskrgr`, `@giraffate`, and `@Centri3`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,7 +19,12 @@ new_pr = true
 
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
-users_on_vacation = ["y21"]
+users_on_vacation = [
+    "y21",
+    "matthiaskrgr",
+    "giraffate",
+    "Centri3",
+]
 
 [assign.owners]
 "/.github" = ["@flip1995"]


### PR DESCRIPTION
When commenting r? clippy, rustbot takes a random member from the team. I'm setting you kings and queen to be on vacation, so that rustbot doesn't target you.

---

changelog: none

cc: @matthiaskrgr @giraffate and @Centri3
