### PR TITLE
Forbid lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5275,6 +5275,7 @@ Released 2018-09-13
 [`for_loop_over_option`]: https://rust-lang.github.io/rust-clippy/master/index.html#for_loop_over_option
 [`for_loop_over_result`]: https://rust-lang.github.io/rust-clippy/master/index.html#for_loop_over_result
 [`for_loops_over_fallibles`]: https://rust-lang.github.io/rust-clippy/master/index.html#for_loops_over_fallibles
+[`forbid`]: https://rust-lang.github.io/rust-clippy/master/index.html#forbid
 [`forget_copy`]: https://rust-lang.github.io/rust-clippy/master/index.html#forget_copy
 [`forget_non_drop`]: https://rust-lang.github.io/rust-clippy/master/index.html#forget_non_drop
 [`forget_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#forget_ref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5292,6 +5292,7 @@ Released 2018-09-13
 [`get_last_with_len`]: https://rust-lang.github.io/rust-clippy/master/index.html#get_last_with_len
 [`get_unwrap`]: https://rust-lang.github.io/rust-clippy/master/index.html#get_unwrap
 [`host_endian_bytes`]: https://rust-lang.github.io/rust-clippy/master/index.html#host_endian_bytes
+[`hypocrisy`]: https://rust-lang.github.io/rust-clippy/master/index.html#hypocrisy
 [`identity_conversion`]: https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
 [`identity_op`]: https://rust-lang.github.io/rust-clippy/master/index.html#identity_op
 [`if_let_mutex`]: https://rust-lang.github.io/rust-clippy/master/index.html#if_let_mutex

--- a/clippy_lints/src/attrs/forbid.rs
+++ b/clippy_lints/src/attrs/forbid.rs
@@ -1,0 +1,35 @@
+use super::utils::extract_clippy_lint;
+use super::{FORBID, HYPOCRISY};
+use clippy_utils::diagnostics::span_lint;
+use rustc_ast::Attribute;
+use rustc_lint::EarlyContext;
+use rustc_span::sym;
+
+pub(super) fn check(cx: &EarlyContext<'_>, attr: &Attribute) {
+    if !attr.has_name(sym::forbid) {
+        return;
+    }
+
+    let Some(lints) = attr.meta_item_list() else {
+        return;
+    };
+
+    if lints.is_empty() {
+        return;
+    }
+
+    let is_hypocritical = lints
+        .iter()
+        .any(|lint| extract_clippy_lint(lint).is_some_and(|l| l == sym::forbid));
+
+    if is_hypocritical {
+        span_lint(
+            cx,
+            HYPOCRISY,
+            attr.span,
+            "you have declared `#[forbid(clippy::forbid)]`, which is hypocritical",
+        );
+    } else {
+        span_lint(cx, FORBID, attr.span, "you have used the `forbid` attribute");
+    }
+}

--- a/clippy_lints/src/attrs/forbid.rs
+++ b/clippy_lints/src/attrs/forbid.rs
@@ -1,6 +1,6 @@
 use super::utils::extract_clippy_lint;
 use super::{FORBID, HYPOCRISY};
-use clippy_utils::diagnostics::span_lint;
+use clippy_utils::diagnostics::{span_lint, span_lint_and_help};
 use rustc_ast::Attribute;
 use rustc_lint::EarlyContext;
 use rustc_span::sym;
@@ -30,6 +30,13 @@ pub(super) fn check(cx: &EarlyContext<'_>, attr: &Attribute) {
             "you have declared `#[forbid(clippy::forbid)]`, which is hypocritical",
         );
     } else {
-        span_lint(cx, FORBID, attr.span, "you have used the `forbid` attribute");
+        span_lint_and_help(
+            cx,
+            FORBID,
+            attr.span,
+            "you have used the `forbid` attribute",
+            None,
+            "consider using `deny` instead",
+        );
     }
 }

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -6,6 +6,7 @@ mod deprecated_cfg_attr;
 mod deprecated_semver;
 mod duplicated_attributes;
 mod empty_line_after;
+mod forbid;
 mod inline_always;
 mod maybe_misused_cfg;
 mod mismatched_target_os;
@@ -526,6 +527,47 @@ declare_clippy_lint! {
     "duplicated attribute"
 }
 
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for items annotated with `#[forbid(...)]`.
+    ///
+    /// ### Why is this bad?
+    /// Banning certain coding practices outright might be harmful,
+    /// since there might very well be reasonable exceptions.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #![forbid(panic)]
+    /// ```
+    ///
+    /// Use instead:
+    /// ```no_run
+    /// #![deny(panic)]
+    /// ```
+    #[clippy::version = "1.79.0"]
+    pub FORBID,
+    restriction,
+    "usage of `forbid(...)`"
+}
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for items annotated with `#[forbid(clippy::forbid)]`.
+    ///
+    /// ### Why is this bad?
+    /// Prohibiting others from banning anything is hypocritical.
+    /// Additionally, there might be valid reasons to ban certain coding practices in certain projects.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #![forbid(clippy::forbid)]
+    /// ```
+    #[clippy::version = "1.79.0"]
+    pub HYPOCRISY,
+    suspicious,
+    "usage of `forbid(clippy::forbid)`"
+}
+
 declare_lint_pass!(Attributes => [
     ALLOW_ATTRIBUTES_WITHOUT_REASON,
     INLINE_ALWAYS,
@@ -607,6 +649,8 @@ impl_lint_pass!(EarlyAttributes => [
     DEPRECATED_CLIPPY_CFG_ATTR,
     UNNECESSARY_CLIPPY_CFG,
     DUPLICATED_ATTRIBUTES,
+    FORBID,
+    HYPOCRISY,
 ]);
 
 impl EarlyLintPass for EarlyAttributes {
@@ -625,6 +669,7 @@ impl EarlyLintPass for EarlyAttributes {
         mismatched_target_os::check(cx, attr);
         non_minimal_cfg::check(cx, attr);
         maybe_misused_cfg::check(cx, attr);
+        forbid::check(cx, attr);
     }
 
     extract_msrv_attr!(EarlyContext);

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -57,6 +57,8 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::attrs::DUPLICATED_ATTRIBUTES_INFO,
     crate::attrs::EMPTY_LINE_AFTER_DOC_COMMENTS_INFO,
     crate::attrs::EMPTY_LINE_AFTER_OUTER_ATTR_INFO,
+    crate::attrs::FORBID_INFO,
+    crate::attrs::HYPOCRISY_INFO,
     crate::attrs::INLINE_ALWAYS_INFO,
     crate::attrs::MAYBE_MISUSED_CFG_INFO,
     crate::attrs::MISMATCHED_TARGET_OS_INFO,

--- a/tests/ui/blanket_clippy_restriction_lints.stderr
+++ b/tests/ui/blanket_clippy_restriction_lints.stderr
@@ -4,6 +4,7 @@ error: you have used the `forbid` attribute
 LL | #![forbid(clippy::restriction)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = help: consider using `deny` instead
 note: the lint level is defined here
   --> tests/ui/blanket_clippy_restriction_lints.rs:10:11
    |

--- a/tests/ui/blanket_clippy_restriction_lints.stderr
+++ b/tests/ui/blanket_clippy_restriction_lints.stderr
@@ -1,3 +1,16 @@
+error: you have used the `forbid` attribute
+  --> tests/ui/blanket_clippy_restriction_lints.rs:10:1
+   |
+LL | #![forbid(clippy::restriction)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> tests/ui/blanket_clippy_restriction_lints.rs:10:11
+   |
+LL | #![forbid(clippy::restriction)]
+   |           ^^^^^^^^^^^^^^^^^^^
+   = note: `#[forbid(clippy::forbid)]` implied by `#[forbid(clippy::restriction)]`
+
 error: `clippy::restriction` is not meant to be enabled as a group
   --> tests/ui/blanket_clippy_restriction_lints.rs:6:9
    |
@@ -29,5 +42,5 @@ error: `clippy::restriction` is not meant to be enabled as a group
    = note: because of the command line `--warn clippy::restriction`
    = help: enable the restriction lints you need individually
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Rust and Clippy support the `#[forbid(...)]` attribute, allowing crate authors to outright ban the use of certain coding practices in their codebase. However, `forbid`ing lints indiscriminately can be dangerous: Common wisdom states that there is an exception to every rule, and this applies to linting as well. What's usually considered bad style might greatly improve readability in specific cases. Additionally, many lints may have false positives.

This PR adds a new `restriction` lint called `clippy::forbid`, which triggers on any uses of `#[forbid(...)]`. This allows maintainers to issue a warning whenever anyone tries to ban something without second thought:

```rs
#![warn(clippy::forbid)]
#![forbid(clippy::panic)]

fn main() {}
```

```
warning: you have used the `forbid` attribute
 --> src/main.rs:2:1
  |
2 | #![forbid(clippy::panic)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: consider using `deny` instead
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#forbid
```

You can even use `#![forbid(clippy::forbid)]` to ban uses of `forbid` outright, but in that case you will need to add `#![allow(clippy::hypocrisy)]` as well.

**TODO**: Consider adding lints for other lint levels as well.

changelog: new lint: [`forbid`]
