### PR TITLE
Make `single_range_in_vec_init` ignore type annotations, fn arguments and `ExprField`s

### DIFF
--- a/tests/ui/single_range_in_vec_init.rs
+++ b/tests/ui/single_range_in_vec_init.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 //@no-rustfix: overlapping suggestions
-#![allow(clippy::no_effect, clippy::useless_vec, unused)]
+#![allow(clippy::temporary_assignment, clippy::no_effect, clippy::useless_vec, unused)]
 #![warn(clippy::single_range_in_vec_init)]
 #![feature(generic_arg_infer)]
 
@@ -48,6 +48,22 @@ fn main() {
     vec![0.0..200.0];
     // Issue #11086
     let do_not_lint_if_has_type_annotations: Vec<Range<_>> = vec![0..200];
+    // https://github.com/rust-lang/rust-clippy/issues/11086#issuecomment-1636996525
+    struct DoNotLintStructInitializersUnit(Vec<Range<usize>>);
+    struct DoNotLintStructInitializersNamed {
+        a: Vec<Range<usize>>,
+    };
+    enum DoNotLintEnums {
+        One(Vec<Range<usize>>),
+        Two(Vec<Range<usize>>),
+    }
+    DoNotLintStructInitializersUnit(vec![0..200]).0 = vec![0..200];
+    DoNotLintStructInitializersNamed { a: vec![0..200] }.a = vec![0..200];
+    let o = DoNotLintEnums::One(vec![0..200]);
+    match o {
+        DoNotLintEnums::One(mut e) => e = vec![0..200],
+        _ => todo!(),
+    }
     do_not_lint_as_argument(vec![0..200]);
     // `Copy` is not implemented for `Range`, so this doesn't matter
     // FIXME: [0..200; 2];

--- a/tests/ui/single_range_in_vec_init.rs
+++ b/tests/ui/single_range_in_vec_init.rs
@@ -7,6 +7,8 @@
 #[macro_use]
 extern crate proc_macros;
 
+use std::ops::Range;
+
 macro_rules! a {
     () => {
         vec![0..200];
@@ -21,6 +23,8 @@ fn awa_vec<T: PartialOrd>(start: T, end: T) {
     vec![start..end];
 }
 
+fn do_not_lint_as_argument(_: Vec<Range<usize>>) {}
+
 fn main() {
     // Lint
     [0..200];
@@ -34,11 +38,17 @@ fn main() {
     // Only suggest collect
     [0..200isize];
     vec![0..200isize];
+    // Lints, but suggests adding type annotations
+    let x = vec![0..200];
+    do_not_lint_as_argument(vec![0..200]);
     // Do not lint
     [0..200, 0..100];
     vec![0..200, 0..100];
     [0.0..200.0];
     vec![0.0..200.0];
+    // Issue #11086
+    let do_not_lint_if_has_type_annotations: Vec<Range<_>> = vec![0..200];
+    do_not_lint_as_argument(vec![0..200]);
     // `Copy` is not implemented for `Range`, so this doesn't matter
     // FIXME: [0..200; 2];
     // FIXME: [vec!0..200; 2];

--- a/tests/ui/single_range_in_vec_init.stderr
+++ b/tests/ui/single_range_in_vec_init.stderr
@@ -1,5 +1,5 @@
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:26:5
+  --> tests/ui/single_range_in_vec_init.rs:30:5
    |
 LL |     [0..200];
    |     ^^^^^^^^
@@ -16,7 +16,7 @@ LL |     [0; 200];
    |      ~~~~~~
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:27:5
+  --> tests/ui/single_range_in_vec_init.rs:31:5
    |
 LL |     vec![0..200];
    |     ^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     vec![0; 200];
    |          ~~~~~~
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:28:5
+  --> tests/ui/single_range_in_vec_init.rs:32:5
    |
 LL |     [0u8..200];
    |     ^^^^^^^^^^
@@ -46,7 +46,7 @@ LL |     [0u8; 200];
    |      ~~~~~~~~
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:29:5
+  --> tests/ui/single_range_in_vec_init.rs:33:5
    |
 LL |     [0usize..200];
    |     ^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     [0usize; 200];
    |      ~~~~~~~~~~~
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:30:5
+  --> tests/ui/single_range_in_vec_init.rs:34:5
    |
 LL |     [0..200usize];
    |     ^^^^^^^^^^^^^
@@ -76,7 +76,7 @@ LL |     [0; 200usize];
    |      ~~~~~~~~~~~
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:31:5
+  --> tests/ui/single_range_in_vec_init.rs:35:5
    |
 LL |     vec![0u8..200];
    |     ^^^^^^^^^^^^^^
@@ -91,7 +91,7 @@ LL |     vec![0u8; 200];
    |          ~~~~~~~~
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:32:5
+  --> tests/ui/single_range_in_vec_init.rs:36:5
    |
 LL |     vec![0usize..200];
    |     ^^^^^^^^^^^^^^^^^
@@ -106,7 +106,7 @@ LL |     vec![0usize; 200];
    |          ~~~~~~~~~~~
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:33:5
+  --> tests/ui/single_range_in_vec_init.rs:37:5
    |
 LL |     vec![0..200usize];
    |     ^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     vec![0; 200usize];
    |          ~~~~~~~~~~~
 
 error: an array of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:35:5
+  --> tests/ui/single_range_in_vec_init.rs:39:5
    |
 LL |     [0..200isize];
    |     ^^^^^^^^^^^^^
@@ -132,7 +132,7 @@ LL |     (0..200isize).collect::<std::vec::Vec<isize>>();
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: a `Vec` of `Range` that is only one element
-  --> tests/ui/single_range_in_vec_init.rs:36:5
+  --> tests/ui/single_range_in_vec_init.rs:40:5
    |
 LL |     vec![0..200isize];
    |     ^^^^^^^^^^^^^^^^^
@@ -142,5 +142,24 @@ help: if you wanted a `Vec` that contains the entire range, try
 LL |     (0..200isize).collect::<std::vec::Vec<isize>>();
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 10 previous errors
+error: a `Vec` of `Range` that is only one element
+  --> tests/ui/single_range_in_vec_init.rs:42:13
+   |
+LL |     let x = vec![0..200];
+   |             ^^^^^^^^^^^^
+   |
+help: if you wanted a `Vec` that contains the entire range, try
+   |
+LL |     let x = (0..200).collect::<std::vec::Vec<i32>>();
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+help: if you wanted a `Vec` of len 200, try
+   |
+LL |     let x = vec![0; 200];
+   |                  ~~~~~~
+help: if this is intended, give it type annotations
+   |
+LL |     let x: std::vec::Vec<std::ops::Range<i32>> = vec![0..200];
+   |          +++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
picking up on #11088.

I will still look at using #11166, as @Alexendoo suggested there.

changelog: FP [`single_range_in_vec_init`]: Ignores if it's a local that has type annotations, or is immediately passed to a function or struct initializer