### PR TITLE
Pause review rotation for y21

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -19,7 +19,7 @@ new_pr = true
 
 [assign]
 contributing_url = "https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md"
-users_on_vacation = []
+users_on_vacation = ["y21"]
 
 [assign.owners]
 "/.github" = ["@flip1995"]


### PR DESCRIPTION
Exams are coming up for me and I want to focus on that, so I'd like to pause PR assignments to me for a bit until that's over (will still continue to look at PRs that are assigned to me and might steal some PRs to review if I find the time). :)

--------------

changelog: none