### PR TITLE
Handle `rustc_on_unimplemented` in duplicated_attributes

### DIFF
--- a/clippy_lints/src/attrs/duplicated_attributes.rs
+++ b/clippy_lints/src/attrs/duplicated_attributes.rs
@@ -36,9 +36,10 @@ fn check_duplicated_attr(
     }
     let Some(ident) = attr.ident() else { return };
     let name = ident.name;
-    if name == sym::doc || name == sym::cfg_attr {
+    if name == sym::doc || name == sym::cfg_attr || name == sym::rustc_on_unimplemented {
         // FIXME: Would be nice to handle `cfg_attr` as well. Only problem is to check that cfg
         // conditions are the same.
+        // `#[rustc_on_unimplemented]` contains duplicated subattributes, that's expected.
         return;
     }
     if let Some(direct_parent) = parent.last()

--- a/tests/ui/duplicated_attributes.rs
+++ b/tests/ui/duplicated_attributes.rs
@@ -1,5 +1,5 @@
 //@aux-build:proc_macro_attr.rs
-
+#![feature(rustc_attrs)]
 #![warn(clippy::duplicated_attributes)]
 #![cfg(any(unix, windows))]
 #![allow(dead_code)]
@@ -19,6 +19,10 @@ fn foo() {}
 #[cfg(windows)]
 #[cfg(unix)] // cfgs are not handled
 fn bar() {}
+
+// No warning:
+#[rustc_on_unimplemented(on(_Self = "&str", label = "`a"), on(_Self = "alloc::string::String", label = "a"))]
+trait Abc {}
 
 #[proc_macro_attr::duplicated_attr()] // Should not warn!
 fn babar() {}


### PR DESCRIPTION
```rust
#[rustc_on_unimplemented(
    on(
        _Self = "&str",
        label = "`a"
    ),
    on(
        _Self = "alloc::string::String",
        label = "a"
    ),
)]
```

The lint treats this as a repetition because `rustc_on_unimplemented::on::label` appears twice, but that's ok.

Fixes #12619

changelog: [`duplicated_attributes`]: fix handling of `rustc_on_unimplemented`
