### PR TITLE
fix incorrect suggestion for `!(a as type >= b)`

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -346,11 +346,18 @@ fn simplify_not(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<String> {
                 _ => None,
             }
             .and_then(|op| {
-                Some(format!(
-                    "{}{op}{}",
-                    snippet_opt(cx, lhs.span)?,
-                    snippet_opt(cx, rhs.span)?
-                ))
+                let lhs_snippet = snippet_opt(cx, lhs.span)?;
+                let rhs_snippet = snippet_opt(cx, rhs.span)?;
+
+                if !(lhs_snippet.starts_with('(') && lhs_snippet.ends_with(')')) {
+                    if let (ExprKind::Cast(..), BinOpKind::Ge) = (&lhs.kind, binop.node) {
+                        // e.g. `(a as u64) < b`. Without the parens the `<` is
+                        // interpreted as a start of generic arguments for `u64`
+                        return Some(format!("({lhs_snippet}){op}{rhs_snippet}"));
+                    }
+                }
+
+                Some(format!("{lhs_snippet}{op}{rhs_snippet}"))
             })
         },
         ExprKind::MethodCall(path, receiver, [], _) => {

--- a/tests/ui/nonminimal_bool_methods.fixed
+++ b/tests/ui/nonminimal_bool_methods.fixed
@@ -109,4 +109,12 @@ fn dont_warn_for_negated_partial_ord_comparison() {
     let _ = !(a >= b);
 }
 
+fn issue_12625() {
+    let a = 0;
+    let b = 0;
+    if (a as u64) < b {} //~ ERROR: this boolean expression can be simplified
+    if (a as u64) < b {} //~ ERROR: this boolean expression can be simplified
+    if a as u64 > b {} //~ ERROR: this boolean expression can be simplified
+}
+
 fn main() {}

--- a/tests/ui/nonminimal_bool_methods.rs
+++ b/tests/ui/nonminimal_bool_methods.rs
@@ -109,4 +109,12 @@ fn dont_warn_for_negated_partial_ord_comparison() {
     let _ = !(a >= b);
 }
 
+fn issue_12625() {
+    let a = 0;
+    let b = 0;
+    if !(a as u64 >= b) {} //~ ERROR: this boolean expression can be simplified
+    if !((a as u64) >= b) {} //~ ERROR: this boolean expression can be simplified
+    if !(a as u64 <= b) {} //~ ERROR: this boolean expression can be simplified
+}
+
 fn main() {}

--- a/tests/ui/nonminimal_bool_methods.stderr
+++ b/tests/ui/nonminimal_bool_methods.stderr
@@ -79,5 +79,23 @@ error: this boolean expression can be simplified
 LL |     if !res.is_none() {}
    |        ^^^^^^^^^^^^^^ help: try: `res.is_some()`
 
-error: aborting due to 13 previous errors
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:115:8
+   |
+LL |     if !(a as u64 >= b) {}
+   |        ^^^^^^^^^^^^^^^^ help: try: `(a as u64) < b`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:116:8
+   |
+LL |     if !((a as u64) >= b) {}
+   |        ^^^^^^^^^^^^^^^^^^ help: try: `(a as u64) < b`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:117:8
+   |
+LL |     if !(a as u64 <= b) {}
+   |        ^^^^^^^^^^^^^^^^ help: try: `a as u64 > b`
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
fixes #12625

The expression  `!(a as type >= b)` got simplified to `a as type < b`, but because of rust's parsing rules that `<` is interpreted as a start of generic arguments for `type`.  This is fixed by recognizing this case and adding extra parens around the left-hand side of the comparison.

changelog: [`nonminimal_bool`]: fix incorrect suggestion for  `!(a as type >= b)`
