### PR TITLE
Correct parentheses for [`needless_borrow`] suggestion

### DIFF
--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -1014,9 +1014,15 @@ fn report<'tcx>(
                         },
                         _ => (0, false),
                     };
+                    let is_in_tuple = match cx.tcx.parent_hir_node(data.first_expr.hir_id) {
+                        Node::Expr(e) => matches!(e.kind, ExprKind::Tup(_)),
+                        _ => false,
+                    };
+
                     let sugg = if !snip_is_macro
                         && (calls_field || expr.precedence().order() < precedence)
                         && !has_enclosing_paren(&snip)
+                        && !is_in_tuple
                     {
                         format!("({snip})")
                     } else {

--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -1014,10 +1014,13 @@ fn report<'tcx>(
                         },
                         _ => (0, false),
                     };
-                    let is_in_tuple = match cx.tcx.parent_hir_node(data.first_expr.hir_id) {
-                        Node::Expr(e) => matches!(e.kind, ExprKind::Tup(_)),
-                        _ => false,
-                    };
+                    let is_in_tuple = matches!(
+                        get_parent_expr(cx, data.first_expr),
+                        Some(Expr {
+                            kind: ExprKind::Tup(..),
+                            ..
+                        })
+                    );
 
                     let sugg = if !snip_is_macro
                         && (calls_field || expr.precedence().order() < precedence)

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -251,3 +251,10 @@ mod issue_10253 {
         (&S).f::<()>();
     }
 }
+
+fn issue_12268() {
+    let option = Some((&1,));
+    let x = (&1,);
+    // Lint here.
+    option.unwrap_or((x.0,));
+}

--- a/tests/ui/needless_borrow.fixed
+++ b/tests/ui/needless_borrow.fixed
@@ -255,6 +255,7 @@ mod issue_10253 {
 fn issue_12268() {
     let option = Some((&1,));
     let x = (&1,);
-    // Lint here.
     option.unwrap_or((x.0,));
+    //~^ ERROR: this expression creates a reference which is immediately dereferenced by the
+    // compiler
 }

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -251,3 +251,10 @@ mod issue_10253 {
         (&S).f::<()>();
     }
 }
+
+fn issue_12268() {
+    let option = Some((&1,));
+    let x = (&1,);
+    // Lint here.
+    option.unwrap_or((&x.0,));
+}

--- a/tests/ui/needless_borrow.rs
+++ b/tests/ui/needless_borrow.rs
@@ -255,6 +255,7 @@ mod issue_10253 {
 fn issue_12268() {
     let option = Some((&1,));
     let x = (&1,);
-    // Lint here.
     option.unwrap_or((&x.0,));
+    //~^ ERROR: this expression creates a reference which is immediately dereferenced by the
+    // compiler
 }

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -163,5 +163,11 @@ error: this expression borrows a value the compiler would automatically borrow
 LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
-error: aborting due to 27 previous errors
+error: this expression creates a reference which is immediately dereferenced by the compiler
+  --> tests/ui/needless_borrow.rs:259:23
+   |
+LL |     option.unwrap_or((&x.0,));
+   |                       ^^^^ help: change this to: `x.0`
+
+error: aborting due to 28 previous errors
 

--- a/tests/ui/needless_borrow.stderr
+++ b/tests/ui/needless_borrow.stderr
@@ -164,7 +164,7 @@ LL |         let _ = &mut (&mut { x.u }).x;
    |                      ^^^^^^^^^^^^^^ help: change this to: `{ x.u }`
 
 error: this expression creates a reference which is immediately dereferenced by the compiler
-  --> tests/ui/needless_borrow.rs:259:23
+  --> tests/ui/needless_borrow.rs:258:23
    |
 LL |     option.unwrap_or((&x.0,));
    |                       ^^^^ help: change this to: `x.0`


### PR DESCRIPTION
This fixes #12268 

Clippy no longer adds unnecessary parentheses in suggestions when the expression is part of a tuple.

---

changelog: Fix [`needless_borrow`] unnecessary parentheses in suggestion.