### PR TITLE
Add `check_self_items` setting for `needless_pass_by_ref_mut` lint

### DIFF
--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -589,6 +589,10 @@ define_Conf! {
     /// 2. Paths with any segment that containing the word 'prelude'
     /// are already allowed by default.
     (allowed_wildcard_imports: FxHashSet<String> = FxHashSet::default()),
+    /// Lint: NEEDLESS_PASS_BY_REF_MUT.
+    ///
+    /// Lint on `self`.
+    (check_self_items: bool = false),
 }
 
 /// Search for the configuration file.

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -597,6 +597,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
 
         blacklisted_names: _,
         cyclomatic_complexity_threshold: _,
+        check_self_items,
     } = *conf;
     let msrv = || msrv.clone();
 
@@ -1070,6 +1071,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(move |_| {
         Box::new(needless_pass_by_ref_mut::NeedlessPassByRefMut::new(
             avoid_breaking_exported_api,
+            check_self_items,
         ))
     });
     store.register_late_pass(|_| Box::new(non_canonical_impls::NonCanonicalImpls));

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -25,6 +25,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            blacklisted-names
            cargo-ignore-publish
            check-private-items
+           check-self-items
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold
            disallowed-macros
@@ -104,6 +105,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            blacklisted-names
            cargo-ignore-publish
            check-private-items
+           check-self-items
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold
            disallowed-macros
@@ -183,6 +185,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            blacklisted-names
            cargo-ignore-publish
            check-private-items
+           check-self-items
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold
            disallowed-macros


### PR DESCRIPTION
Fixes #12589.
Fixes #9591.

This adds a `check_self_items` setting to allow the `needless_pass_by_ref_mut` lint to check for `&mut self` items.

changelog: Add `check_self_items` setting for `needless_pass_by_ref_mut` lint