### PR TITLE
unsafe_derive_deserialize: `Why is this bad?` explanation typo

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -132,7 +132,7 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     /// Deriving `serde::Deserialize` will create a constructor
-    /// that may violate invariants hold by another constructor.
+    /// that may violate invariants held by another constructor.
     ///
     /// ### Example
     /// ```rust,ignore


### PR DESCRIPTION
changelog: [`unsafe_derive_deserialize`]: Correct `Why is this bad?` explanation typo
