### PR TITLE
Pin `remark-lint-maximum-line-length` version

### DIFF
--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: '18.x'
 
     - name: Install remark
-      run: npm install remark-cli remark-lint remark-lint-maximum-line-length remark-preset-lint-recommended remark-gfm
+      run: npm install remark-cli remark-lint remark-lint-maximum-line-length@^3.1.3 remark-preset-lint-recommended remark-gfm
 
     - name: Install mdbook
       run: |


### PR DESCRIPTION
Pins the remark versions to the ones from before the most recent set of updates which errors on [some line lengths](https://github.com/remarkjs/remark-lint/issues/318) that aren't clear how to resolve

Currently blocking CI

changelog:  none
