### PR TITLE
Bump nightly version -> 2024-04-05

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-04-04"
+channel = "nightly-2024-04-05"
 components = ["cargo", "llvm-tools", "rust-src", "rust-std", "rustc", "rustc-dev", "rustfmt"]


### PR DESCRIPTION
r? @ghost

changelog: none

This should unblock CI without doing a full sync. Proper sync on Thursday.
