### PR TITLE
Don't suggest `Box::default()` in functions with differing generics

### DIFF
--- a/clippy_lints/src/box_default.rs
+++ b/clippy_lints/src/box_default.rs
@@ -121,9 +121,9 @@ fn given_type(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
             if let Some(index) = args.iter().position(|arg| arg.hir_id == expr.hir_id)
                 && let Some(sig) = expr_sig(cx, path)
                 && let Some(input) = sig.input(index)
-                && !cx.typeck_results().expr_ty_adjusted(expr).boxed_ty().is_trait()
+                && let Some(input_ty) = input.no_bound_vars()
             {
-                input.no_bound_vars().is_some()
+                input_ty == cx.typeck_results().expr_ty_adjusted(expr)
             } else {
                 false
             }

--- a/tests/ui/box_default.fixed
+++ b/tests/ui/box_default.fixed
@@ -65,6 +65,8 @@ fn main() {
     // Would have a suggestion after https://github.com/rust-lang/rust/blob/fdd030127cc68afec44a8d3f6341525dd34e50ae/compiler/rustc_middle/src/ty/diagnostics.rs#L554-L563
     let mut unnameable = Box::new(Option::default());
     let _ = unnameable.insert(|| {});
+
+    let _ = Box::into_raw(Box::new(String::default()));
 }
 
 fn ret_ty_fn() -> Box<bool> {
@@ -73,6 +75,16 @@ fn ret_ty_fn() -> Box<bool> {
 
 fn call_ty_fn(_b: Box<u8>) {
     issue_9621_dyn_trait();
+}
+
+struct X<T>(T);
+
+impl<T: Default> X<T> {
+    fn x(_: Box<T>) {}
+
+    fn same_generic_param() {
+        Self::x(Box::default());
+    }
 }
 
 use std::io::{Read, Result};

--- a/tests/ui/box_default.rs
+++ b/tests/ui/box_default.rs
@@ -65,6 +65,8 @@ fn main() {
     // Would have a suggestion after https://github.com/rust-lang/rust/blob/fdd030127cc68afec44a8d3f6341525dd34e50ae/compiler/rustc_middle/src/ty/diagnostics.rs#L554-L563
     let mut unnameable = Box::new(Option::default());
     let _ = unnameable.insert(|| {});
+
+    let _ = Box::into_raw(Box::new(String::default()));
 }
 
 fn ret_ty_fn() -> Box<bool> {
@@ -73,6 +75,16 @@ fn ret_ty_fn() -> Box<bool> {
 
 fn call_ty_fn(_b: Box<u8>) {
     issue_9621_dyn_trait();
+}
+
+struct X<T>(T);
+
+impl<T: Default> X<T> {
+    fn x(_: Box<T>) {}
+
+    fn same_generic_param() {
+        Self::x(Box::new(T::default()));
+    }
 }
 
 use std::io::{Read, Result};

--- a/tests/ui/box_default.stderr
+++ b/tests/ui/box_default.stderr
@@ -55,5 +55,11 @@ error: `Box::new(_)` of default value
 LL |     call_ty_fn(Box::new(u8::default()));
    |                ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
 
-error: aborting due to 9 previous errors
+error: `Box::new(_)` of default value
+  --> tests/ui/box_default.rs:86:17
+   |
+LL |         Self::x(Box::new(T::default()));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::default()`
+
+error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Fixes #12684

changelog: none
