### PR TITLE
Fix `is_test_module_or_function`

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2505,8 +2505,9 @@ fn with_test_item_names(tcx: TyCtxt<'_>, module: LocalModDefId, f: impl Fn(&[Sym
 /// Note: Add `//@compile-flags: --test` to UI tests with a `#[test]` function
 pub fn is_in_test_function(tcx: TyCtxt<'_>, id: HirId) -> bool {
     with_test_item_names(tcx, tcx.parent_module(id), |names| {
-        tcx.hir()
-            .parent_iter(id)
+        let node = tcx.hir_node(id);
+        once((id, node))
+            .chain(tcx.hir().parent_iter(id))
             // Since you can nest functions we need to collect all until we leave
             // function scope
             .any(|(_id, node)| {

--- a/tests/ui/disallowed_names.rs
+++ b/tests/ui/disallowed_names.rs
@@ -71,3 +71,8 @@ mod tests {
         }
     }
 }
+
+#[test]
+fn test_with_disallowed_name() {
+    let foo = 0;
+}


### PR DESCRIPTION
The rustdoc comment for `is_test_module_or_function` states: https://github.com/rust-lang/rust-clippy/blob/2795a6018944a5918b7d276267165484f5d62d6a/clippy_utils/src/lib.rs#L2561-L2566

Given `item`, the function calls `is_in_test_function` with `item.hir_id()`. However, `is_in_test_function` considers only `item`'s parents, not `item` itself. This PR fixes the problem.

The `test_with_disallowed_name` test fails without the fix, but passes once applied.

changelog: none
