### PR TITLE
[`overly_complex_bool_expr`]: Fix trigger wrongly on never type

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -232,6 +232,11 @@ impl<'a, 'tcx, 'v> Hir2Qmm<'a, 'tcx, 'v> {
                 _ => (),
             }
         }
+
+        if self.cx.typeck_results().expr_ty(e).is_never() {
+            return Err("contains never type".to_owned());
+        }
+
         for (n, expr) in self.terminals.iter().enumerate() {
             if eq_expr_value(self.cx, e, expr) {
                 #[expect(clippy::cast_possible_truncation)]

--- a/tests/ui/overly_complex_bool_expr.fixed
+++ b/tests/ui/overly_complex_bool_expr.fixed
@@ -37,3 +37,13 @@ fn check_expect() {
     #[expect(clippy::overly_complex_bool_expr)]
     let _ = a < b && a >= b;
 }
+
+#[allow(clippy::never_loop)]
+fn check_never_type() {
+    loop {
+        _ = (break) || true;
+    }
+    loop {
+        _ = (return) || true;
+    }
+}

--- a/tests/ui/overly_complex_bool_expr.rs
+++ b/tests/ui/overly_complex_bool_expr.rs
@@ -37,3 +37,13 @@ fn check_expect() {
     #[expect(clippy::overly_complex_bool_expr)]
     let _ = a < b && a >= b;
 }
+
+#[allow(clippy::never_loop)]
+fn check_never_type() {
+    loop {
+        _ = (break) || true;
+    }
+    loop {
+        _ = (return) || true;
+    }
+}


### PR DESCRIPTION
fixes #12689 

---

changelog: fix [`overly_complex_bool_expr`] triggers wrongly on never type
