### PR TITLE
[arithmetic_side_effects] Fix #11266

### DIFF
--- a/tests/ui/arithmetic_side_effects.rs
+++ b/tests/ui/arithmetic_side_effects.rs
@@ -521,6 +521,19 @@ pub fn issue_11393() {
     example_rem(x, maybe_zero);
 }
 
+pub fn issue_11266_literal<const N: usize>() {
+    let _ = N + 1;
+    let _ = 1 + N;
+    let _ = N + N;
+}
+
+pub fn issue_11266_runtime<const N: usize>() {
+    fn runtime_number() -> usize {
+        1
+    }
+    let _ = N + runtime_number();
+}
+
 pub fn issue_12318() {
     use core::ops::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
     let mut one: i32 = 1;

--- a/tests/ui/arithmetic_side_effects.stderr
+++ b/tests/ui/arithmetic_side_effects.stderr
@@ -716,16 +716,22 @@ LL |         x % maybe_zero
    |         ^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:527:5
+  --> tests/ui/arithmetic_side_effects.rs:534:13
+   |
+LL |     let _ = N + runtime_number();
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: arithmetic operation that can potentially result in unexpected side-effects
+  --> tests/ui/arithmetic_side_effects.rs:540:5
    |
 LL |     one.add_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: arithmetic operation that can potentially result in unexpected side-effects
-  --> tests/ui/arithmetic_side_effects.rs:531:5
+  --> tests/ui/arithmetic_side_effects.rs:544:5
    |
 LL |     one.sub_assign(1);
    |     ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 121 previous errors
+error: aborting due to 122 previous errors
 


### PR DESCRIPTION
Fix #11266

changelog: [`arithmetic_side_effects`]: Let rustc deal with possible overflows involving constant paramenters