### PR TITLE
Fix website dash replacement

### DIFF
--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -406,7 +406,7 @@
                 }
 
                 // Search by id
-                if (lint.id.indexOf(searchStr.replace("-", "_")) !== -1) {
+                if (lint.id.indexOf(searchStr.replaceAll("-", "_")) !== -1) {
                     return true;
                 }
 


### PR DESCRIPTION
Fixes: #12718
changelog: Made clippy lints website search replace all occurrences of dashes with underscores instead of only the first one. This is in order to allow the user to search for lints with more than two words using dahses.