### PR TITLE
configurably allow `useless_vec` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5891,6 +5891,7 @@ Released 2018-09-13
 [`allow-print-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-print-in-tests
 [`allow-private-module-inception`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-private-module-inception
 [`allow-unwrap-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-unwrap-in-tests
+[`allow-useless-vec-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-useless-vec-in-tests
 [`allowed-dotfiles`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allowed-dotfiles
 [`allowed-duplicate-crates`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allowed-duplicate-crates
 [`allowed-idents-below-min-chars`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allowed-idents-below-min-chars

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -132,6 +132,16 @@ Whether `unwrap` should be allowed in test functions or `#[cfg(test)]`
 * [`unwrap_used`](https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_used)
 
 
+## `allow-useless-vec-in-tests`
+Whether `useless_vec` should ignore test functions or `#[cfg(test)]`
+
+**Default Value:** `false`
+
+---
+**Affected lints:**
+* [`useless_vec`](https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec)
+
+
 ## `allowed-dotfiles`
 Additional dotfiles (files or directories starting with a dot) to allow
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -463,6 +463,10 @@ define_Conf! {
     ///
     /// Whether print macros (ex. `println!`) should be allowed in test functions or `#[cfg(test)]`
     (allow_print_in_tests: bool = false),
+    /// Lint: USELESS_VEC.
+    ///
+    /// Whether `useless_vec` should ignore test functions or `#[cfg(test)]`
+    (allow_useless_vec_in_tests: bool = false),
     /// Lint: RESULT_LARGE_ERR.
     ///
     /// The maximum size of the `Err`-variant in a `Result` returned from a function

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -535,6 +535,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
         allow_print_in_tests,
         allow_private_module_inception,
         allow_unwrap_in_tests,
+        allow_useless_vec_in_tests,
         ref allowed_dotfiles,
         ref allowed_idents_below_min_chars,
         ref allowed_scripts,
@@ -754,6 +755,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
             too_large_for_stack,
             msrv: msrv(),
             span_to_lint_map: BTreeMap::new(),
+            allow_in_test: allow_useless_vec_in_tests,
         })
     });
     store.register_late_pass(|_| Box::new(panic_unimplemented::PanicUnimplemented));

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -2548,6 +2548,11 @@ pub fn is_in_cfg_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
         .any(|parent_id| is_cfg_test(tcx, parent_id))
 }
 
+/// Checks if the node is in a `#[test]` function or has any parent node marked `#[cfg(test)]`
+pub fn is_in_test(tcx: TyCtxt<'_>, hir_id: HirId) -> bool {
+    is_in_test_function(tcx, hir_id) || is_in_cfg_test(tcx, hir_id)
+}
+
 /// Checks if the item of any of its parents has `#[cfg(...)]` attribute applied.
 pub fn inherits_cfg(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     let hir = tcx.hir();

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -11,6 +11,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            allow-print-in-tests
            allow-private-module-inception
            allow-unwrap-in-tests
+           allow-useless-vec-in-tests
            allowed-dotfiles
            allowed-duplicate-crates
            allowed-idents-below-min-chars
@@ -91,6 +92,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            allow-print-in-tests
            allow-private-module-inception
            allow-unwrap-in-tests
+           allow-useless-vec-in-tests
            allowed-dotfiles
            allowed-duplicate-crates
            allowed-idents-below-min-chars
@@ -171,6 +173,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            allow-print-in-tests
            allow-private-module-inception
            allow-unwrap-in-tests
+           allow-useless-vec-in-tests
            allowed-dotfiles
            allowed-duplicate-crates
            allowed-idents-below-min-chars

--- a/tests/ui-toml/useless_vec/clippy.toml
+++ b/tests/ui-toml/useless_vec/clippy.toml
@@ -1,0 +1,1 @@
+allow-useless-vec-in-tests = true

--- a/tests/ui-toml/useless_vec/useless_vec.fixed
+++ b/tests/ui-toml/useless_vec/useless_vec.fixed
@@ -1,0 +1,26 @@
+//@compile-flags: --test
+#![warn(clippy::useless_vec)]
+#![allow(clippy::unnecessary_operation, clippy::no_effect)]
+
+fn foo(_: &[u32]) {}
+
+fn main() {
+    foo(&[1_u32]);
+}
+
+#[test]
+pub fn in_test() {
+    foo(&vec![2_u32]);
+}
+
+#[cfg(test)]
+fn in_cfg_test() {
+    foo(&vec![3_u32]);
+}
+
+#[cfg(test)]
+mod mod1 {
+    fn in_cfg_test_mod() {
+        super::foo(&vec![4_u32]);
+    }
+}

--- a/tests/ui-toml/useless_vec/useless_vec.rs
+++ b/tests/ui-toml/useless_vec/useless_vec.rs
@@ -1,0 +1,26 @@
+//@compile-flags: --test
+#![warn(clippy::useless_vec)]
+#![allow(clippy::unnecessary_operation, clippy::no_effect)]
+
+fn foo(_: &[u32]) {}
+
+fn main() {
+    foo(&vec![1_u32]);
+}
+
+#[test]
+pub fn in_test() {
+    foo(&vec![2_u32]);
+}
+
+#[cfg(test)]
+fn in_cfg_test() {
+    foo(&vec![3_u32]);
+}
+
+#[cfg(test)]
+mod mod1 {
+    fn in_cfg_test_mod() {
+        super::foo(&vec![4_u32]);
+    }
+}

--- a/tests/ui-toml/useless_vec/useless_vec.stderr
+++ b/tests/ui-toml/useless_vec/useless_vec.stderr
@@ -1,0 +1,11 @@
+error: useless use of `vec!`
+  --> tests/ui-toml/useless_vec/useless_vec.rs:8:9
+   |
+LL |     foo(&vec![1_u32]);
+   |         ^^^^^^^^^^^^ help: you can use a slice directly: `&[1_u32]`
+   |
+   = note: `-D clippy::useless-vec` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::useless_vec)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This adds a `àllow-useless-vec-in-test` configuration which, when set to `true` will allow the `useless_vec` lint in `#[test]` functions and code within `#[cfg(test)]`. It also moves a `is_in_test` helper to `clippy_utils`.

---

changelog: configurably allow [`useless_vec`] in test code
