### PR TITLE
suppress `readonly_write_lock` for underscore-prefixed bindings

### DIFF
--- a/clippy_lints/src/methods/readonly_write_lock.rs
+++ b/clippy_lints/src/methods/readonly_write_lock.rs
@@ -4,7 +4,7 @@ use clippy_utils::mir::{enclosing_mir, visit_local_usage};
 use clippy_utils::source::snippet;
 use clippy_utils::ty::is_type_diagnostic_item;
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, Node};
+use rustc_hir::{Expr, ExprKind, Node, PatKind};
 use rustc_lint::LateContext;
 use rustc_middle::mir::{Location, START_BLOCK};
 use rustc_span::sym;
@@ -25,6 +25,11 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, receiver
         && is_unwrap_call(cx, unwrap_call_expr)
         && let parent = cx.tcx.parent_hir_node(unwrap_call_expr.hir_id)
         && let Node::LetStmt(local) = parent
+        && let PatKind::Binding(.., ident, _) = local.pat.kind
+        // if the binding is prefixed with `_`, it typically means
+        // that this guard only exists to protect a section of code
+        // rather than the contained data
+        && !ident.as_str().starts_with('_')
         && let Some(mir) = enclosing_mir(cx.tcx, expr.hir_id)
         && let Some((local, _)) = mir
             .local_decls

--- a/tests/ui/readonly_write_lock.fixed
+++ b/tests/ui/readonly_write_lock.fixed
@@ -43,3 +43,7 @@ fn main() {
         *writer1 = *writer2;
     }
 }
+
+fn issue12733(rw: &RwLock<()>) {
+    let _write_guard = rw.write().unwrap();
+}

--- a/tests/ui/readonly_write_lock.rs
+++ b/tests/ui/readonly_write_lock.rs
@@ -43,3 +43,7 @@ fn main() {
         *writer1 = *writer2;
     }
 }
+
+fn issue12733(rw: &RwLock<()>) {
+    let _write_guard = rw.write().unwrap();
+}


### PR DESCRIPTION
Fixes #12733 

Unsure if there's a better way to prevent this kind of false positive but this is the one that made most sense to me.
In my experience, prefixing bindings with an underscore is the usual way to name variables that aren't used and that exist purely for executing drop code at the end of the scope.

-------

changelog: suppress [`readonly_write_lock`] for underscore-prefixed bindings