### PR TITLE
Bump ui_test to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ color-print = "0.3.4"
 anstream = "0.6.0"
 
 [dev-dependencies]
-ui_test = "0.22.2"
+ui_test = "0.23"
 regex = "1.5.5"
 toml = "0.7.3"
 walkdir = "2.3"

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -4,6 +4,7 @@
 #![warn(rust_2018_idioms, unused_lifetimes)]
 #![allow(unused_extern_crates)]
 
+use ui_test::custom_flags::rustfix::RustfixMode;
 use ui_test::spanned::Spanned;
 use ui_test::{status_emitter, Args, CommandBuilder, Config, Match, Mode, OutputConflictHandling};
 
@@ -122,10 +123,11 @@ fn base_config(test_dir: &str) -> (Config, Args) {
         out_dir: target_dir.join("ui_test"),
         ..Config::rustc(Path::new("tests").join(test_dir))
     };
-    config.comment_defaults.base().mode = Some(Spanned::dummy(Mode::Yolo {
-        rustfix: ui_test::RustfixMode::Everything,
-    }))
-    .into();
+    config.comment_defaults.base().mode = Some(Spanned::dummy(Mode::Yolo)).into();
+    config
+        .comment_defaults
+        .base()
+        .set_custom("rustfix", RustfixMode::Everything);
     config.comment_defaults.base().diagnostic_code_prefix = Some(Spanned::dummy("clippy::".into())).into();
     config.with_args(&args);
     let current_exe_path = env::current_exe().unwrap();
@@ -235,13 +237,12 @@ fn run_ui_cargo() {
         .push(("RUSTFLAGS".into(), Some("-Dwarnings".into())));
     // We need to do this while we still have a rustc in the `program` field.
     config.fill_host_and_target().unwrap();
-    config.dependencies_crate_manifest_path = None;
     config.program.program.set_file_name(if cfg!(windows) {
         "cargo-clippy.exe"
     } else {
         "cargo-clippy"
     });
-    config.comment_defaults.base().edition = Default::default();
+    config.comment_defaults.base().custom.clear();
 
     config
         .comment_defaults


### PR DESCRIPTION
Notable changes: more control over run/rustfix/... and other rustc-specific features. All of these can in theory now be implemented entirely out of tree

changelog: none