### PR TITLE
`assigning_clones`: add empty line to doc

### DIFF
--- a/clippy_lints/src/assigning_clones.rs
+++ b/clippy_lints/src/assigning_clones.rs
@@ -36,6 +36,7 @@ declare_clippy_lint! {
     /// Use instead:
     /// ```rust
     /// struct Thing;
+    ///
     /// impl Clone for Thing {
     ///     fn clone(&self) -> Self { todo!() }
     ///     fn clone_from(&mut self, other: &Self) { todo!() }


### PR DESCRIPTION
changelog: none

This PR adds, for consistency reasons, an empty line to the example in the doc of the `assigning_clones` lint.
