### PR TITLE
`assigning_clones`: move to `pedantic` so it is allow by default

### DIFF
--- a/clippy_lints/src/assigning_clones.rs
+++ b/clippy_lints/src/assigning_clones.rs
@@ -48,7 +48,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.78.0"]
     pub ASSIGNING_CLONES,
-    perf,
+    pedantic,
     "assigning the result of cloning may be inefficient"
 }
 


### PR DESCRIPTION
In a nutshell, the `assigning_clones` lint suggests to make your code less readable for a small performance gain. See #12778 for more motivation.

fixes #12778 

changelog: [`assigning_clones`]: move to the `pedantic` group
