### PR TITLE
fulfill expectations in `check_unsafe_derive_deserialize`

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_note, span_lint_and_sugg, span_lint_and_then};
+use clippy_utils::diagnostics::{span_lint_and_note, span_lint_and_sugg, span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::ty::{implements_trait, implements_trait_with_env, is_copy};
 use clippy_utils::{has_non_exhaustive_attr, is_lint_allowed, match_def_path, paths};
 use rustc_errors::Applicability;
@@ -390,13 +390,17 @@ fn check_unsafe_derive_deserialize<'tcx>(
             .map(|imp_did| cx.tcx.hir().expect_item(imp_did.expect_local()))
             .any(|imp| has_unsafe(cx, imp))
     {
-        span_lint_and_help(
+        span_lint_hir_and_then(
             cx,
             UNSAFE_DERIVE_DESERIALIZE,
+            adt_hir_id,
             item.span,
             "you are deriving `serde::Deserialize` on a type that has methods using `unsafe`",
-            None,
-            "consider implementing `serde::Deserialize` manually. See https://serde.rs/impl-deserialize.html",
+            |diag| {
+                diag.help(
+                    "consider implementing `serde::Deserialize` manually. See https://serde.rs/impl-deserialize.html",
+                );
+            },
         );
     }
 }

--- a/tests/ui/unsafe_derive_deserialize.rs
+++ b/tests/ui/unsafe_derive_deserialize.rs
@@ -1,3 +1,4 @@
+#![feature(lint_reasons)]
 #![warn(clippy::unsafe_derive_deserialize)]
 #![allow(unused, clippy::missing_safety_doc)]
 
@@ -66,6 +67,16 @@ pub struct F;
 #[derive(Deserialize)]
 pub struct G;
 impl G {
+    pub fn unsafe_block(&self) {
+        unsafe {}
+    }
+}
+
+// Check that we honor the `expect` attribute on the ADT
+#[expect(clippy::unsafe_derive_deserialize)]
+#[derive(Deserialize)]
+pub struct H;
+impl H {
     pub fn unsafe_block(&self) {
         unsafe {}
     }

--- a/tests/ui/unsafe_derive_deserialize.stderr
+++ b/tests/ui/unsafe_derive_deserialize.stderr
@@ -1,5 +1,5 @@
 error: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
-  --> tests/ui/unsafe_derive_deserialize.rs:8:10
+  --> tests/ui/unsafe_derive_deserialize.rs:9:10
    |
 LL | #[derive(Deserialize)]
    |          ^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | #[derive(Deserialize)]
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
-  --> tests/ui/unsafe_derive_deserialize.rs:17:10
+  --> tests/ui/unsafe_derive_deserialize.rs:18:10
    |
 LL | #[derive(Deserialize)]
    |          ^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | #[derive(Deserialize)]
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
-  --> tests/ui/unsafe_derive_deserialize.rs:24:10
+  --> tests/ui/unsafe_derive_deserialize.rs:25:10
    |
 LL | #[derive(Deserialize)]
    |          ^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL | #[derive(Deserialize)]
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
-  --> tests/ui/unsafe_derive_deserialize.rs:33:10
+  --> tests/ui/unsafe_derive_deserialize.rs:34:10
    |
 LL | #[derive(Deserialize)]
    |          ^^^^^^^^^^^


### PR DESCRIPTION
The utility function `clippy_utils::fulfill_or_allowed` is not used because using it would require to move the check for allowed after the check iterating over all inherent impls of the type, doing possibly unnecessary work.
Instead, `is_lint_allowed` is called as before, but additionally, once certain that the lint should be emitted, `span_lint_hir_and_then` is called instead of `span_lint_and_help` to also fulfill expectations.

Note: as this is my first contribution, please feel free to nitpick or request changes. I am happy to adjust the implementation.

fixes: #12802

changelog: fulfill expectations in [`unsafe_derive_deserialize`]