### PR TITLE
Correctly handle closing parens in `missing_backticks` doc lint

### DIFF
--- a/clippy_lints/src/doc/markdown.rs
+++ b/clippy_lints/src/doc/markdown.rs
@@ -30,6 +30,7 @@ pub fn check(
             word = tmp_word;
         }
 
+        let original_len = word.len();
         word = word.trim_start_matches(trim_pattern);
 
         // Remove leading or trailing single `:` which may be part of a sentence.
@@ -42,6 +43,25 @@ pub fn check(
 
         if valid_idents.contains(word) || word.chars().all(|c| c == ':') {
             continue;
+        }
+
+        // Ensure that all reachable matching closing parens are included as well.
+        let size_diff = original_len - word.len();
+        let mut open_parens = 0;
+        let mut close_parens = 0;
+        for c in word.chars() {
+            if c == '(' {
+                open_parens += 1;
+            } else if c == ')' {
+                close_parens += 1;
+            }
+        }
+        while close_parens < open_parens
+            && let Some(tmp_word) = orig_word.get(size_diff..=(word.len() + size_diff))
+            && tmp_word.ends_with(')')
+        {
+            word = tmp_word;
+            close_parens += 1;
         }
 
         // Adjust for the current word

--- a/tests/ui/doc/issue_12795.fixed
+++ b/tests/ui/doc/issue_12795.fixed
@@ -1,0 +1,9 @@
+#![warn(clippy::doc_markdown)]
+
+//! A comment with `a_b(x)` and `a_c` in it and (`a_b((c))` ) too and (maybe `a_b((c))`)
+//~^ ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+
+pub fn main() {}

--- a/tests/ui/doc/issue_12795.rs
+++ b/tests/ui/doc/issue_12795.rs
@@ -1,0 +1,9 @@
+#![warn(clippy::doc_markdown)]
+
+//! A comment with a_b(x) and a_c in it and (a_b((c)) ) too and (maybe a_b((c)))
+//~^ ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+//~| ERROR: item in documentation is missing backticks
+
+pub fn main() {}

--- a/tests/ui/doc/issue_12795.stderr
+++ b/tests/ui/doc/issue_12795.stderr
@@ -1,0 +1,48 @@
+error: item in documentation is missing backticks
+  --> tests/ui/doc/issue_12795.rs:3:20
+   |
+LL | //! A comment with a_b(x) and a_c in it and (a_b((c)) ) too and (maybe a_b((c)))
+   |                    ^^^^^^
+   |
+   = note: `-D clippy::doc-markdown` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::doc_markdown)]`
+help: try
+   |
+LL | //! A comment with `a_b(x)` and a_c in it and (a_b((c)) ) too and (maybe a_b((c)))
+   |                    ~~~~~~~~
+
+error: item in documentation is missing backticks
+  --> tests/ui/doc/issue_12795.rs:3:31
+   |
+LL | //! A comment with a_b(x) and a_c in it and (a_b((c)) ) too and (maybe a_b((c)))
+   |                               ^^^
+   |
+help: try
+   |
+LL | //! A comment with a_b(x) and `a_c` in it and (a_b((c)) ) too and (maybe a_b((c)))
+   |                               ~~~~~
+
+error: item in documentation is missing backticks
+  --> tests/ui/doc/issue_12795.rs:3:46
+   |
+LL | //! A comment with a_b(x) and a_c in it and (a_b((c)) ) too and (maybe a_b((c)))
+   |                                              ^^^^^^^^
+   |
+help: try
+   |
+LL | //! A comment with a_b(x) and a_c in it and (`a_b((c))` ) too and (maybe a_b((c)))
+   |                                              ~~~~~~~~~~
+
+error: item in documentation is missing backticks
+  --> tests/ui/doc/issue_12795.rs:3:72
+   |
+LL | //! A comment with a_b(x) and a_c in it and (a_b((c)) ) too and (maybe a_b((c)))
+   |                                                                        ^^^^^^^^
+   |
+help: try
+   |
+LL | //! A comment with a_b(x) and a_c in it and (a_b((c)) ) too and (maybe `a_b((c))`)
+   |                                                                        ~~~~~~~~~~
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #12795.

changelog: Correctly handle closing parens in `doc_markdown` lint