### PR TITLE
`lint_groups_priority`: ignore lints & groups at the same level

### DIFF
--- a/tests/ui-cargo/lint_groups_priority/fail/Cargo.stderr
+++ b/tests/ui-cargo/lint_groups_priority/fail/Cargo.stderr
@@ -1,17 +1,18 @@
 error: lint group `rust_2018_idioms` has the same priority (0) as a lint
- --> Cargo.toml:7:1
-  |
-7 | rust_2018_idioms = "warn"
-  | ^^^^^^^^^^^^^^^^   ------ has an implicit priority of 0
-8 | bare_trait_objects = "allow"
-  | ------------------ has the same priority as this lint
-  |
-  = note: the order of the lints in the table is ignored by Cargo
-  = note: `#[deny(clippy::lint_groups_priority)]` on by default
+  --> Cargo.toml:7:1
+   |
+7  | rust_2018_idioms = "warn"
+   | ^^^^^^^^^^^^^^^^   ------ has an implicit priority of 0
+...
+12 | unused_attributes = { level = "allow" }
+   | ----------------- has the same priority as this lint
+   |
+   = note: the order of the lints in the table is ignored by Cargo
+   = note: `#[deny(clippy::lint_groups_priority)]` on by default
 help: to have lints override the group set `rust_2018_idioms` to a lower priority
-  |
-7 | rust_2018_idioms = { level = "warn", priority = -1 }
-  |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |
+7  | rust_2018_idioms = { level = "warn", priority = -1 }
+   |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: lint group `unused` has the same priority (0) as a lint
   --> Cargo.toml:10:1
@@ -29,45 +30,45 @@ help: to have lints override the group set `unused` to a lower priority
    |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: lint group `pedantic` has the same priority (-1) as a lint
-  --> Cargo.toml:19:1
+  --> Cargo.toml:15:1
    |
-19 | pedantic = { level = "warn", priority = -1 }
+15 | pedantic = { level = "warn", priority = -1 }
    | ^^^^^^^^
-20 | similar_names = { level = "allow", priority = -1 }
+16 | similar_names = { level = "allow", priority = -1 }
    | ------------- has the same priority as this lint
    |
    = note: the order of the lints in the table is ignored by Cargo
 help: to have lints override the group set `pedantic` to a lower priority
    |
-19 | pedantic = { level = "warn", priority = -2 }
+15 | pedantic = { level = "warn", priority = -2 }
    |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: lint group `rust_2018_idioms` has the same priority (0) as a lint
-  --> Cargo.toml:23:1
+  --> Cargo.toml:19:1
    |
-23 | rust_2018_idioms = "warn"
+19 | rust_2018_idioms = "warn"
    | ^^^^^^^^^^^^^^^^   ------ has an implicit priority of 0
-24 | bare_trait_objects = "allow"
+20 | bare_trait_objects = "allow"
    | ------------------ has the same priority as this lint
    |
    = note: the order of the lints in the table is ignored by Cargo
 help: to have lints override the group set `rust_2018_idioms` to a lower priority
    |
-23 | rust_2018_idioms = { level = "warn", priority = -1 }
+19 | rust_2018_idioms = { level = "warn", priority = -1 }
    |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: lint group `pedantic` has the same priority (0) as a lint
-  --> Cargo.toml:27:1
+  --> Cargo.toml:23:1
    |
-27 | pedantic = "warn"
+23 | pedantic = "warn"
    | ^^^^^^^^   ------ has an implicit priority of 0
-28 | similar_names = "allow"
+24 | similar_names = "allow"
    | ------------- has the same priority as this lint
    |
    = note: the order of the lints in the table is ignored by Cargo
 help: to have lints override the group set `pedantic` to a lower priority
    |
-27 | pedantic = { level = "warn", priority = -1 }
+23 | pedantic = { level = "warn", priority = -1 }
    |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: could not compile `fail` (lib) due to 5 previous errors

--- a/tests/ui-cargo/lint_groups_priority/fail/Cargo.toml
+++ b/tests/ui-cargo/lint_groups_priority/fail/Cargo.toml
@@ -11,10 +11,6 @@ unused = { level = "deny" }
 unused_braces = { level = "allow", priority = 1 }
 unused_attributes = { level = "allow" }
 
-# `warnings` is not a group so the order it is passed does not matter
-warnings = "deny"
-deprecated  = "allow"
-
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 similar_names = { level = "allow", priority = -1 }

--- a/tests/ui-cargo/lint_groups_priority/pass/Cargo.toml
+++ b/tests/ui-cargo/lint_groups_priority/pass/Cargo.toml
@@ -3,6 +3,13 @@ name = "pass"
 version = "0.1.0"
 publish = false
 
+[lints.rust]
+# Warnings does not conflict with any group or lint
+warnings = "deny"
+# Groups & lints at the same level do not conflict
+rust_2018_idioms = "warn"
+unsafe_code = "warn"
+
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 style = { level = "warn", priority = 1 }


### PR DESCRIPTION
Fixes #12270

changelog: none
