### PR TITLE
feat: `Quick Fix` for `bare URLs`

### DIFF
--- a/clippy_lints/src/doc/markdown.rs
+++ b/clippy_lints/src/doc/markdown.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::{span_lint, span_lint_and_then};
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::source::snippet_with_applicability;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{Applicability, SuggestionStyle};
@@ -92,13 +92,15 @@ fn check_word(cx: &LateContext<'_>, word: &str, span: Span, code_level: isize, b
     if let Ok(url) = Url::parse(word) {
         // try to get around the fact that `foo::bar` parses as a valid URL
         if !url.cannot_be_a_base() {
-            span_lint(
+            span_lint_and_sugg(
                 cx,
                 DOC_MARKDOWN,
                 span,
                 "you should put bare URLs between `<`/`>` or make a proper Markdown link",
+                "try",
+                format!("<{word}>"),
+                Applicability::MachineApplicable,
             );
-
             return;
         }
     }

--- a/tests/ui/doc/doc-fixable.fixed
+++ b/tests/ui/doc/doc-fixable.fixed
@@ -240,3 +240,6 @@ extern {
     /// `foo()`
     fn in_extern();
 }
+
+/// <https://github.com/rust-lang/rust-clippy/pull/12836>
+fn check_autofix_for_base_urls() {}

--- a/tests/ui/doc/doc-fixable.rs
+++ b/tests/ui/doc/doc-fixable.rs
@@ -240,3 +240,6 @@ extern {
     /// foo()
     fn in_extern();
 }
+
+/// https://github.com/rust-lang/rust-clippy/pull/12836
+fn check_autofix_for_base_urls() {}

--- a/tests/ui/doc/doc-fixable.stderr
+++ b/tests/ui/doc/doc-fixable.stderr
@@ -363,5 +363,11 @@ help: try
 LL |     /// `foo()`
    |         ~~~~~~~
 
-error: aborting due to 33 previous errors
+error: you should put bare URLs between `<`/`>` or make a proper Markdown link
+  --> tests/ui/doc/doc-fixable.rs:244:5
+   |
+LL | /// https://github.com/rust-lang/rust-clippy/pull/12836
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `<https://github.com/rust-lang/rust-clippy/pull/12836>`
+
+error: aborting due to 34 previous errors
 


### PR DESCRIPTION
closes #12835.

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: [`clippy::doc_markdown`]: `Quick Fix` for `bare URLs`