### PR TITLE
Don't lint `assertions_on_constants` on any const assertions

### DIFF
--- a/clippy_lints/src/assertions_on_constants.rs
+++ b/clippy_lints/src/assertions_on_constants.rs
@@ -1,5 +1,6 @@
 use clippy_utils::consts::{constant_with_source, Constant, ConstantSource};
 use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::is_inside_always_const_context;
 use clippy_utils::macros::{find_assert_args, root_macro_call_first_node, PanicExpn};
 use rustc_hir::{Expr, Item, ItemKind, Node};
 use rustc_lint::{LateContext, LateLintPass};
@@ -31,6 +32,10 @@ declare_lint_pass!(AssertionsOnConstants => [ASSERTIONS_ON_CONSTANTS]);
 
 impl<'tcx> LateLintPass<'tcx> for AssertionsOnConstants {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
+        if is_inside_always_const_context(cx.tcx, e.hir_id) {
+            return;
+        }
+
         let Some(macro_call) = root_macro_call_first_node(cx, e) else {
             return;
         };

--- a/clippy_lints/src/default_numeric_fallback.rs
+++ b/clippy_lints/src/default_numeric_fallback.rs
@@ -50,6 +50,8 @@ declare_lint_pass!(DefaultNumericFallback => [DEFAULT_NUMERIC_FALLBACK]);
 impl<'tcx> LateLintPass<'tcx> for DefaultNumericFallback {
     fn check_body(&mut self, cx: &LateContext<'tcx>, body: &'tcx Body<'_>) {
         let hir = cx.tcx.hir();
+        // NOTE: this is different from `clippy_utils::is_inside_always_const_context`.
+        // Inline const supports type inference.
         let is_parent_const = matches!(
             hir.body_const_context(hir.body_owner_def_id(body.id())),
             Some(ConstContext::Const { inline: false } | ConstContext::Static(_))

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -258,10 +258,10 @@ fn has_no_effect(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
 
 fn check_unnecessary_operation(cx: &LateContext<'_>, stmt: &Stmt<'_>) {
     if let StmtKind::Semi(expr) = stmt.kind
+        && !in_external_macro(cx.sess(), stmt.span)
         && let ctxt = stmt.span.ctxt()
         && expr.span.ctxt() == ctxt
         && let Some(reduced) = reduce_expression(cx, expr)
-        && !in_external_macro(cx.sess(), stmt.span)
         && reduced.iter().all(|e| e.span.ctxt() == ctxt)
     {
         if let ExprKind::Index(..) = &expr.kind {

--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -47,7 +47,6 @@ fn main() {
     assert!(!CFG_FLAG);
 
     const _: () = assert!(true);
-    //~^ ERROR: `assert!(true)` will be optimized out by the compiler
 
     // Don't lint if the value is dependent on a defined constant:
     const N: usize = 1024;

--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -1,4 +1,4 @@
-#![allow(non_fmt_panics, clippy::needless_bool)]
+#![allow(non_fmt_panics, clippy::needless_bool, clippy::eq_op)]
 
 macro_rules! assert_const {
     ($len:expr) => {
@@ -47,14 +47,18 @@ fn main() {
     assert!(!CFG_FLAG);
 
     const _: () = assert!(true);
+    //~^ ERROR: `assert!(true)` will be optimized out by the compiler
+
+    assert!(8 == (7 + 1));
+    //~^ ERROR: `assert!(true)` will be optimized out by the compiler
 
     // Don't lint if the value is dependent on a defined constant:
     const N: usize = 1024;
     const _: () = assert!(N.is_power_of_two());
 }
 
-#[allow(clippy::eq_op)]
 const _: () = {
     assert!(true);
+    //~^ ERROR: `assert!(true)` will be optimized out by the compiler
     assert!(8 == (7 + 1));
 };

--- a/tests/ui/assertions_on_constants.rs
+++ b/tests/ui/assertions_on_constants.rs
@@ -53,3 +53,9 @@ fn main() {
     const N: usize = 1024;
     const _: () = assert!(N.is_power_of_two());
 }
+
+#[allow(clippy::eq_op)]
+const _: () = {
+    assert!(true);
+    assert!(8 == (7 + 1));
+};

--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -72,29 +72,5 @@ LL |     debug_assert!(true);
    |
    = help: remove it
 
-error: `assert!(true)` will be optimized out by the compiler
-  --> tests/ui/assertions_on_constants.rs:49:19
-   |
-LL |     const _: () = assert!(true);
-   |                   ^^^^^^^^^^^^^
-   |
-   = help: remove it
-
-error: `assert!(true)` will be optimized out by the compiler
-  --> tests/ui/assertions_on_constants.rs:59:5
-   |
-LL |     assert!(true);
-   |     ^^^^^^^^^^^^^
-   |
-   = help: remove it
-
-error: `assert!(true)` will be optimized out by the compiler
-  --> tests/ui/assertions_on_constants.rs:60:5
-   |
-LL |     assert!(8 == (7 + 1));
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: remove it
-
-error: aborting due to 12 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -80,5 +80,21 @@ LL |     const _: () = assert!(true);
    |
    = help: remove it
 
-error: aborting due to 10 previous errors
+error: `assert!(true)` will be optimized out by the compiler
+  --> tests/ui/assertions_on_constants.rs:59:5
+   |
+LL |     assert!(true);
+   |     ^^^^^^^^^^^^^
+   |
+   = help: remove it
+
+error: `assert!(true)` will be optimized out by the compiler
+  --> tests/ui/assertions_on_constants.rs:60:5
+   |
+LL |     assert!(8 == (7 + 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove it
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui/assertions_on_constants.stderr
+++ b/tests/ui/assertions_on_constants.stderr
@@ -72,5 +72,29 @@ LL |     debug_assert!(true);
    |
    = help: remove it
 
-error: aborting due to 9 previous errors
+error: `assert!(true)` will be optimized out by the compiler
+  --> tests/ui/assertions_on_constants.rs:49:19
+   |
+LL |     const _: () = assert!(true);
+   |                   ^^^^^^^^^^^^^
+   |
+   = help: remove it
+
+error: `assert!(true)` will be optimized out by the compiler
+  --> tests/ui/assertions_on_constants.rs:52:5
+   |
+LL |     assert!(8 == (7 + 1));
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove it
+
+error: `assert!(true)` will be optimized out by the compiler
+  --> tests/ui/assertions_on_constants.rs:61:5
+   |
+LL |     assert!(true);
+   |     ^^^^^^^^^^^^^
+   |
+   = help: remove it
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui/unnecessary_operation.fixed
+++ b/tests/ui/unnecessary_operation.fixed
@@ -43,7 +43,7 @@ fn get_number() -> i32 {
     0
 }
 
-fn get_usize() -> usize {
+const fn get_usize() -> usize {
     0
 }
 fn get_struct() -> Struct {
@@ -113,4 +113,15 @@ fn main() {
     'label: {
         break 'label
     };
+    let () = const {
+        assert!([42, 55].len() > get_usize());
+    };
+}
+
+const _: () = {
+    assert!([42, 55].len() > get_usize());
+};
+
+const fn foo() {
+    assert!([42, 55].len() > get_usize());
 }

--- a/tests/ui/unnecessary_operation.fixed
+++ b/tests/ui/unnecessary_operation.fixed
@@ -114,12 +114,12 @@ fn main() {
         break 'label
     };
     let () = const {
-        assert!([42, 55].len() > get_usize());
+        [42, 55][get_usize()];
     };
 }
 
 const _: () = {
-    assert!([42, 55].len() > get_usize());
+    [42, 55][get_usize()];
 };
 
 const fn foo() {

--- a/tests/ui/unnecessary_operation.fixed
+++ b/tests/ui/unnecessary_operation.fixed
@@ -124,4 +124,5 @@ const _: () = {
 
 const fn foo() {
     assert!([42, 55].len() > get_usize());
+    //~^ ERROR: unnecessary operation
 }

--- a/tests/ui/unnecessary_operation.rs
+++ b/tests/ui/unnecessary_operation.rs
@@ -43,7 +43,7 @@ fn get_number() -> i32 {
     0
 }
 
-fn get_usize() -> usize {
+const fn get_usize() -> usize {
     0
 }
 fn get_struct() -> Struct {
@@ -117,4 +117,15 @@ fn main() {
     'label: {
         break 'label
     };
+    let () = const {
+        [42, 55][get_usize()];
+    };
+}
+
+const _: () = {
+    [42, 55][get_usize()];
+};
+
+const fn foo() {
+    [42, 55][get_usize()];
 }

--- a/tests/ui/unnecessary_operation.rs
+++ b/tests/ui/unnecessary_operation.rs
@@ -128,4 +128,5 @@ const _: () = {
 
 const fn foo() {
     [42, 55][get_usize()];
+    //~^ ERROR: unnecessary operation
 }

--- a/tests/ui/unnecessary_operation.stderr
+++ b/tests/ui/unnecessary_operation.stderr
@@ -120,22 +120,10 @@ LL | |     };
    | |______^ help: statement can be reduced to: `String::from("blah");`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:121:9
-   |
-LL |         [42, 55][get_usize()];
-   |         ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
-
-error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:126:5
-   |
-LL |     [42, 55][get_usize()];
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
-
-error: unnecessary operation
   --> tests/ui/unnecessary_operation.rs:130:5
    |
 LL |     [42, 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
 
-error: aborting due to 22 previous errors
+error: aborting due to 20 previous errors
 

--- a/tests/ui/unnecessary_operation.stderr
+++ b/tests/ui/unnecessary_operation.stderr
@@ -119,5 +119,23 @@ LL | |         s: String::from("blah"),
 LL | |     };
    | |______^ help: statement can be reduced to: `String::from("blah");`
 
-error: aborting due to 19 previous errors
+error: unnecessary operation
+  --> tests/ui/unnecessary_operation.rs:121:9
+   |
+LL |         [42, 55][get_usize()];
+   |         ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
+
+error: unnecessary operation
+  --> tests/ui/unnecessary_operation.rs:126:5
+   |
+LL |     [42, 55][get_usize()];
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
+
+error: unnecessary operation
+  --> tests/ui/unnecessary_operation.rs:130:5
+   |
+LL |     [42, 55][get_usize()];
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
+
+error: aborting due to 22 previous errors
 


### PR DESCRIPTION
close #12816
close #12847
cc #12817

----

changelog: Fix false positives in consts for `assertions_on_constants` and `unnecessary_operation`.