### PR TITLE
Fix `to_string_in_format_args` with macro call receiver

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -424,14 +424,14 @@ impl<'a, 'tcx> FormatArgsExpr<'a, 'tcx> {
                 count_needed_derefs(receiver_ty, cx.typeck_results().expr_adjustments(receiver).iter())
             && implements_trait(cx, target, display_trait_id, &[])
             && let Some(sized_trait_id) = cx.tcx.lang_items().sized_trait()
-            && let Some(receiver_snippet) = snippet_opt(cx, receiver.span)
+            && let Some(receiver_snippet) = snippet_opt(cx, receiver.span.source_callsite())
         {
             let needs_ref = !implements_trait(cx, receiver_ty, sized_trait_id, &[]);
             if n_needed_derefs == 0 && !needs_ref {
                 span_lint_and_sugg(
                     cx,
                     TO_STRING_IN_FORMAT_ARGS,
-                    to_string_span.with_lo(receiver.span.hi()),
+                    to_string_span.with_lo(receiver.span.source_callsite().hi()),
                     format!("`to_string` applied to a type that implements `Display` in `{name}!` args"),
                     "remove this",
                     String::new(),

--- a/tests/ui/format_args.fixed
+++ b/tests/ui/format_args.fixed
@@ -104,6 +104,7 @@ fn main() {
     println!("{foo}{bar}", foo = "foo", bar = "bar");
     println!("{foo}{bar}", bar = "bar", foo = "foo");
     println!("{foo}{bar}", bar = "bar", foo = "foo");
+    println!("{}", my_other_macro!());
 
     // negative tests
     println!("error: something failed at {}", Somewhere.to_string());

--- a/tests/ui/format_args.rs
+++ b/tests/ui/format_args.rs
@@ -104,6 +104,7 @@ fn main() {
     println!("{foo}{bar}", foo = "foo", bar = "bar".to_string());
     println!("{foo}{bar}", bar = "bar".to_string(), foo = "foo");
     println!("{foo}{bar}", bar = "bar", foo = "foo".to_string());
+    println!("{}", my_other_macro!().to_string());
 
     // negative tests
     println!("error: something failed at {}", Somewhere.to_string());

--- a/tests/ui/format_args.stderr
+++ b/tests/ui/format_args.stderr
@@ -127,29 +127,35 @@ error: `to_string` applied to a type that implements `Display` in `println!` arg
 LL |     println!("{foo}{bar}", bar = "bar", foo = "foo".to_string());
    |                                                    ^^^^^^^^^^^^ help: remove this
 
+error: `to_string` applied to a type that implements `Display` in `println!` args
+  --> tests/ui/format_args.rs:107:37
+   |
+LL |     println!("{}", my_other_macro!().to_string());
+   |                                     ^^^^^^^^^^^^ help: remove this
+
 error: `to_string` applied to a type that implements `Display` in `print!` args
-  --> tests/ui/format_args.rs:118:37
+  --> tests/ui/format_args.rs:119:37
    |
 LL |     print!("{}", (Location::caller().to_string()));
    |                                     ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `print!` args
-  --> tests/ui/format_args.rs:119:39
+  --> tests/ui/format_args.rs:120:39
    |
 LL |     print!("{}", ((Location::caller()).to_string()));
    |                                       ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `format!` args
-  --> tests/ui/format_args.rs:147:38
+  --> tests/ui/format_args.rs:148:38
    |
 LL |         let x = format!("{} {}", a, b.to_string());
    |                                      ^^^^^^^^^^^^ help: remove this
 
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/format_args.rs:161:24
+  --> tests/ui/format_args.rs:162:24
    |
 LL |         println!("{}", original[..10].to_string());
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use this: `&original[..10]`
 
-error: aborting due to 25 previous errors
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
Fixes part of #12837

changelog: none
