### PR TITLE
fix: let non_canonical_impls skip proc marco

### DIFF
--- a/clippy_lints/src/non_canonical_impls.rs
+++ b/clippy_lints/src/non_canonical_impls.rs
@@ -128,6 +128,11 @@ impl LateLintPass<'_> for NonCanonicalImpls {
         let ExprKind::Block(block, ..) = body.value.kind else {
             return;
         };
+        if let Some(expr) = block.expr
+            && expr.span.from_expansion()
+        {
+            return;
+        }
 
         if cx.tcx.is_diagnostic_item(sym::Clone, trait_impl.def_id)
             && let Some(copy_def_id) = cx.tcx.get_diagnostic_item(sym::Copy)

--- a/clippy_lints/src/non_canonical_impls.rs
+++ b/clippy_lints/src/non_canonical_impls.rs
@@ -1,10 +1,11 @@
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::ty::implements_trait;
-use clippy_utils::{is_res_lang_ctor, last_path_segment, path_res, std_or_core};
+use clippy_utils::{is_from_proc_macro, is_res_lang_ctor, last_path_segment, path_res, std_or_core};
 use rustc_errors::Applicability;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::{Expr, ExprKind, ImplItem, ImplItemKind, LangItem, Node, UnOp};
-use rustc_lint::{LateContext, LateLintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::EarlyBinder;
 use rustc_session::declare_lint_pass;
 use rustc_span::sym;
@@ -111,7 +112,7 @@ declare_lint_pass!(NonCanonicalImpls => [NON_CANONICAL_CLONE_IMPL, NON_CANONICAL
 
 impl LateLintPass<'_> for NonCanonicalImpls {
     #[expect(clippy::too_many_lines)]
-    fn check_impl_item(&mut self, cx: &LateContext<'_>, impl_item: &ImplItem<'_>) {
+    fn check_impl_item<'tcx>(&mut self, cx: &LateContext<'tcx>, impl_item: &ImplItem<'tcx>) {
         let Node::Item(item) = cx.tcx.parent_hir_node(impl_item.hir_id()) else {
             return;
         };
@@ -128,9 +129,7 @@ impl LateLintPass<'_> for NonCanonicalImpls {
         let ExprKind::Block(block, ..) = body.value.kind else {
             return;
         };
-        if let Some(expr) = block.expr
-            && expr.span.from_expansion()
-        {
+        if in_external_macro(cx.sess(), block.span) || is_from_proc_macro(cx, impl_item) {
             return;
         }
 

--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -176,8 +176,7 @@ pub fn non_canonical_clone_derive(_: TokenStream) -> TokenStream {
         struct NonCanonicalClone;
         impl Clone for NonCanonicalClone {
             fn clone(&self) -> Self {
-                let a = *self;
-                a
+                todo!()
             }
         }
         impl Copy for NonCanonicalClone {}

--- a/tests/ui/auxiliary/proc_macro_derive.rs
+++ b/tests/ui/auxiliary/proc_macro_derive.rs
@@ -169,3 +169,17 @@ pub fn derive_ignored_unit_pattern(_: TokenStream) -> TokenStream {
         }
     }
 }
+
+#[proc_macro_derive(NonCanonicalClone)]
+pub fn non_canonical_clone_derive(_: TokenStream) -> TokenStream {
+    quote! {
+        struct NonCanonicalClone;
+        impl Clone for NonCanonicalClone {
+            fn clone(&self) -> Self {
+                let a = *self;
+                a
+            }
+        }
+        impl Copy for NonCanonicalClone {}
+    }
+}

--- a/tests/ui/non_canonical_clone_impl.fixed
+++ b/tests/ui/non_canonical_clone_impl.fixed
@@ -1,3 +1,4 @@
+//@aux-build:proc_macro_derive.rs
 #![allow(clippy::clone_on_copy, unused)]
 #![allow(clippy::assigning_clones)]
 #![no_main]
@@ -95,3 +96,7 @@ impl<A: Copy> Clone for Uwu<A> {
 }
 
 impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
+
+// should skip proc macros, see https://github.com/rust-lang/rust-clippy/issues/12788
+#[derive(proc_macro_derive::NonCanonicalClone)]
+pub struct G;

--- a/tests/ui/non_canonical_clone_impl.fixed
+++ b/tests/ui/non_canonical_clone_impl.fixed
@@ -3,6 +3,9 @@
 #![allow(clippy::assigning_clones)]
 #![no_main]
 
+extern crate proc_macros;
+use proc_macros::with_span;
+
 // lint
 
 struct A(u32);
@@ -100,3 +103,15 @@ impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
 // should skip proc macros, see https://github.com/rust-lang/rust-clippy/issues/12788
 #[derive(proc_macro_derive::NonCanonicalClone)]
 pub struct G;
+
+with_span!(
+    span
+
+    #[derive(Copy)]
+    struct H;
+    impl Clone for H {
+        fn clone(&self) -> Self {
+            todo!()
+        }
+    }
+);

--- a/tests/ui/non_canonical_clone_impl.rs
+++ b/tests/ui/non_canonical_clone_impl.rs
@@ -3,6 +3,9 @@
 #![allow(clippy::assigning_clones)]
 #![no_main]
 
+extern crate proc_macros;
+use proc_macros::with_span;
+
 // lint
 
 struct A(u32);
@@ -110,3 +113,15 @@ impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
 // should skip proc macros, see https://github.com/rust-lang/rust-clippy/issues/12788
 #[derive(proc_macro_derive::NonCanonicalClone)]
 pub struct G;
+
+with_span!(
+    span
+
+    #[derive(Copy)]
+    struct H;
+    impl Clone for H {
+        fn clone(&self) -> Self {
+            todo!()
+        }
+    }
+);

--- a/tests/ui/non_canonical_clone_impl.rs
+++ b/tests/ui/non_canonical_clone_impl.rs
@@ -1,3 +1,4 @@
+//@aux-build:proc_macro_derive.rs
 #![allow(clippy::clone_on_copy, unused)]
 #![allow(clippy::assigning_clones)]
 #![no_main]
@@ -105,3 +106,7 @@ impl<A: Copy> Clone for Uwu<A> {
 }
 
 impl<A: std::fmt::Debug + Copy + Clone> Copy for Uwu<A> {}
+
+// should skip proc macros, see https://github.com/rust-lang/rust-clippy/issues/12788
+#[derive(proc_macro_derive::NonCanonicalClone)]
+pub struct G;

--- a/tests/ui/non_canonical_clone_impl.stderr
+++ b/tests/ui/non_canonical_clone_impl.stderr
@@ -1,5 +1,5 @@
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:10:29
+  --> tests/ui/non_canonical_clone_impl.rs:11:29
    |
 LL |       fn clone(&self) -> Self {
    |  _____________________________^
@@ -11,7 +11,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::non_canonical_clone_impl)]`
 
 error: unnecessary implementation of `clone_from` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:14:5
+  --> tests/ui/non_canonical_clone_impl.rs:15:5
    |
 LL | /     fn clone_from(&mut self, source: &Self) {
 LL | |         source.clone();
@@ -20,7 +20,7 @@ LL | |     }
    | |_____^ help: remove it
 
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:81:29
+  --> tests/ui/non_canonical_clone_impl.rs:82:29
    |
 LL |       fn clone(&self) -> Self {
    |  _____________________________^
@@ -29,7 +29,7 @@ LL | |     }
    | |_____^ help: change this to: `{ *self }`
 
 error: unnecessary implementation of `clone_from` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:85:5
+  --> tests/ui/non_canonical_clone_impl.rs:86:5
    |
 LL | /     fn clone_from(&mut self, source: &Self) {
 LL | |         source.clone();

--- a/tests/ui/non_canonical_clone_impl.stderr
+++ b/tests/ui/non_canonical_clone_impl.stderr
@@ -1,5 +1,5 @@
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:11:29
+  --> tests/ui/non_canonical_clone_impl.rs:14:29
    |
 LL |       fn clone(&self) -> Self {
    |  _____________________________^
@@ -11,7 +11,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::non_canonical_clone_impl)]`
 
 error: unnecessary implementation of `clone_from` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:15:5
+  --> tests/ui/non_canonical_clone_impl.rs:18:5
    |
 LL | /     fn clone_from(&mut self, source: &Self) {
 LL | |         source.clone();
@@ -20,7 +20,7 @@ LL | |     }
    | |_____^ help: remove it
 
 error: non-canonical implementation of `clone` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:82:29
+  --> tests/ui/non_canonical_clone_impl.rs:85:29
    |
 LL |       fn clone(&self) -> Self {
    |  _____________________________^
@@ -29,7 +29,7 @@ LL | |     }
    | |_____^ help: change this to: `{ *self }`
 
 error: unnecessary implementation of `clone_from` on a `Copy` type
-  --> tests/ui/non_canonical_clone_impl.rs:86:5
+  --> tests/ui/non_canonical_clone_impl.rs:89:5
    |
 LL | /     fn clone_from(&mut self, source: &Self) {
 LL | |         source.clone();


### PR DESCRIPTION
Fixed #12788

Although the issue only mentions `NON_CANONICAL_CLONE_IMPL`, this fix will also affect `NON_CANONICAL_PARTIAL_ORD_IMPL` because I saw
> Because of these unforeseeable or unstable behaviors, macro expansion should often not be regarded as a part of the stable API.

on Clippy Documentation and these two lints are similar, so I think it might be good, not sure if it's right or not.

--- 

changelog: `NON_CANONICAL_CLONE_IMPL`, `NON_CANONICAL_PARTIAL_ORD_IMPL` will skip proc marco now
