### PR TITLE
ignore array from `deref_addrof` lint

### DIFF
--- a/clippy_lints/src/reference.rs
+++ b/clippy_lints/src/reference.rs
@@ -48,6 +48,9 @@ impl EarlyLintPass for DerefAddrOf {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &Expr) {
         if let ExprKind::Unary(UnOp::Deref, ref deref_target) = e.kind
             && let ExprKind::AddrOf(_, ref mutability, ref addrof_target) = without_parens(deref_target).kind
+            // NOTE(tesuji): `*&` forces rustc to const-promote the array to `.rodata` section.
+            // See #12854 for details.
+            && !matches!(addrof_target.kind, ExprKind::Array(_))
             && deref_target.span.eq_ctxt(e.span)
             && !addrof_target.span.from_expansion()
         {

--- a/tests/ui/deref_addrof.fixed
+++ b/tests/ui/deref_addrof.fixed
@@ -44,9 +44,9 @@ fn main() {
 
     let _ = unsafe { *core::ptr::addr_of!(a) };
 
-    // do NOT lint for array as sematic differences with/out `*&`.
     let _repeat = [0; 64];
-    let _arr = [0, 1, 2, 3, 4];
+    // do NOT lint for array as sematic differences with/out `*&`.
+    let _arr = *&[0, 1, 2, 3, 4];
 }
 
 #[derive(Copy, Clone)]

--- a/tests/ui/deref_addrof.fixed
+++ b/tests/ui/deref_addrof.fixed
@@ -43,6 +43,10 @@ fn main() {
     let b = *aref;
 
     let _ = unsafe { *core::ptr::addr_of!(a) };
+
+    // do NOT lint for array as sematic differences with/out `*&`.
+    let _repeat = [0; 64];
+    let _arr = [0, 1, 2, 3, 4];
 }
 
 #[derive(Copy, Clone)]

--- a/tests/ui/deref_addrof.rs
+++ b/tests/ui/deref_addrof.rs
@@ -44,8 +44,8 @@ fn main() {
 
     let _ = unsafe { *core::ptr::addr_of!(a) };
 
-    // do NOT lint for array as sematic differences with/out `*&`.
     let _repeat = *&[0; 64];
+    // do NOT lint for array as sematic differences with/out `*&`.
     let _arr = *&[0, 1, 2, 3, 4];
 }
 

--- a/tests/ui/deref_addrof.rs
+++ b/tests/ui/deref_addrof.rs
@@ -43,6 +43,10 @@ fn main() {
     let b = **&aref;
 
     let _ = unsafe { *core::ptr::addr_of!(a) };
+
+    // do NOT lint for array as sematic differences with/out `*&`.
+    let _repeat = *&[0; 64];
+    let _arr = *&[0, 1, 2, 3, 4];
 }
 
 #[derive(Copy, Clone)]

--- a/tests/ui/deref_addrof.stderr
+++ b/tests/ui/deref_addrof.stderr
@@ -50,7 +50,19 @@ LL |     let b = **&aref;
    |              ^^^^^^ help: try: `aref`
 
 error: immediately dereferencing a reference
-  --> tests/ui/deref_addrof.rs:53:17
+  --> tests/ui/deref_addrof.rs:48:19
+   |
+LL |     let _repeat = *&[0; 64];
+   |                   ^^^^^^^^^ help: try: `[0; 64]`
+
+error: immediately dereferencing a reference
+  --> tests/ui/deref_addrof.rs:49:16
+   |
+LL |     let _arr = *&[0, 1, 2, 3, 4];
+   |                ^^^^^^^^^^^^^^^^^ help: try: `[0, 1, 2, 3, 4]`
+
+error: immediately dereferencing a reference
+  --> tests/ui/deref_addrof.rs:57:17
    |
 LL |         inline!(*& $(@expr self))
    |                 ^^^^^^^^^^^^^^^^ help: try: `$(@expr self)`
@@ -58,12 +70,12 @@ LL |         inline!(*& $(@expr self))
    = note: this error originates in the macro `__inline_mac_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: immediately dereferencing a reference
-  --> tests/ui/deref_addrof.rs:57:17
+  --> tests/ui/deref_addrof.rs:61:17
    |
 LL |         inline!(*&mut $(@expr self))
    |                 ^^^^^^^^^^^^^^^^^^^ help: try: `$(@expr self)`
    |
    = note: this error originates in the macro `__inline_mac_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 

--- a/tests/ui/deref_addrof.stderr
+++ b/tests/ui/deref_addrof.stderr
@@ -50,16 +50,10 @@ LL |     let b = **&aref;
    |              ^^^^^^ help: try: `aref`
 
 error: immediately dereferencing a reference
-  --> tests/ui/deref_addrof.rs:48:19
+  --> tests/ui/deref_addrof.rs:47:19
    |
 LL |     let _repeat = *&[0; 64];
    |                   ^^^^^^^^^ help: try: `[0; 64]`
-
-error: immediately dereferencing a reference
-  --> tests/ui/deref_addrof.rs:49:16
-   |
-LL |     let _arr = *&[0, 1, 2, 3, 4];
-   |                ^^^^^^^^^^^^^^^^^ help: try: `[0, 1, 2, 3, 4]`
 
 error: immediately dereferencing a reference
   --> tests/ui/deref_addrof.rs:57:17
@@ -77,5 +71,5 @@ LL |         inline!(*&mut $(@expr self))
    |
    = note: this error originates in the macro `__inline_mac_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 12 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Split from https://github.com/rust-lang/rust-clippy/pull/12854

changelog: ignore array from `deref_addrof` lint

r? y21 