### PR TITLE
Modify str_to_string to be machine-applicable

### DIFF
--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -399,13 +399,17 @@ impl<'tcx> LateLintPass<'tcx> for StrToString {
             && let ty::Ref(_, ty, ..) = ty.kind()
             && ty.is_str()
         {
-            span_lint_and_help(
+            let mut applicability = Applicability::MachineApplicable;
+            let snippet = snippet_with_applicability(cx, self_arg.span, "..", &mut applicability);
+
+            span_lint_and_sugg(
                 cx,
                 STR_TO_STRING,
                 expr.span,
                 "`to_string()` called on a `&str`",
-                None,
-                "consider using `.to_owned()`",
+                "try",
+                format!("{snippet}.to_owned()"),
+                applicability,
             );
         }
     }

--- a/tests/ui/str_to_string.fixed
+++ b/tests/ui/str_to_string.fixed
@@ -1,0 +1,9 @@
+#![warn(clippy::str_to_string)]
+
+fn main() {
+    let hello = "hello world".to_owned();
+    //~^ ERROR: `to_string()` called on a `&str`
+    let msg = &hello[..];
+    msg.to_owned();
+    //~^ ERROR: `to_string()` called on a `&str`
+}

--- a/tests/ui/str_to_string.stderr
+++ b/tests/ui/str_to_string.stderr
@@ -2,9 +2,8 @@ error: `to_string()` called on a `&str`
   --> tests/ui/str_to_string.rs:4:17
    |
 LL |     let hello = "hello world".to_string();
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"hello world".to_owned()`
    |
-   = help: consider using `.to_owned()`
    = note: `-D clippy::str-to-string` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::str_to_string)]`
 
@@ -12,9 +11,7 @@ error: `to_string()` called on a `&str`
   --> tests/ui/str_to_string.rs:7:5
    |
 LL |     msg.to_string();
-   |     ^^^^^^^^^^^^^^^
-   |
-   = help: consider using `.to_owned()`
+   |     ^^^^^^^^^^^^^^^ help: try: `msg.to_owned()`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/12768

I'm not sure if there is any potential for edge cases with this - since it only ever acts on `&str` types I can't think of any, and especially since the methods do the same thing anyway.

changelog: allow `str_to_string` lint to be automatically applied