### PR TITLE
Fix grammer for the Safety documentation check

### DIFF
--- a/clippy_lints/src/doc/missing_headers.rs
+++ b/clippy_lints/src/doc/missing_headers.rs
@@ -37,7 +37,7 @@ pub fn check(
             cx,
             MISSING_SAFETY_DOC,
             span,
-            "unsafe function's docs miss `# Safety` section",
+            "unsafe function's docs are missing a `# Safety` section",
         ),
         (true, Safety::Safe) => span_lint(
             cx,

--- a/tests/ui-toml/private-doc-errors/doc_lints.rs
+++ b/tests/ui-toml/private-doc-errors/doc_lints.rs
@@ -47,7 +47,7 @@ pub mod __macro {
     pub struct T;
     impl T {
         pub unsafe fn f() {}
-        //~^ ERROR: unsafe function's docs miss `# Safety` section
+        //~^ ERROR: unsafe function's docs are missing a `# Safety` section
     }
 }
 

--- a/tests/ui-toml/private-doc-errors/doc_lints.stderr
+++ b/tests/ui-toml/private-doc-errors/doc_lints.stderr
@@ -51,7 +51,7 @@ note: the lint level is defined here
 LL |     clippy::missing_panics_doc
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unsafe function's docs miss `# Safety` section
+error: unsafe function's docs are missing a `# Safety` section
   --> tests/ui-toml/private-doc-errors/doc_lints.rs:49:9
    |
 LL |         pub unsafe fn f() {}

--- a/tests/ui/doc_unsafe.stderr
+++ b/tests/ui/doc_unsafe.stderr
@@ -1,4 +1,4 @@
-error: unsafe function's docs miss `# Safety` section
+error: unsafe function's docs are missing a `# Safety` section
   --> tests/ui/doc_unsafe.rs:9:1
    |
 LL | pub unsafe fn destroy_the_planet() {
@@ -7,13 +7,13 @@ LL | pub unsafe fn destroy_the_planet() {
    = note: `-D clippy::missing-safety-doc` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::missing_safety_doc)]`
 
-error: unsafe function's docs miss `# Safety` section
+error: unsafe function's docs are missing a `# Safety` section
   --> tests/ui/doc_unsafe.rs:32:5
    |
 LL |     pub unsafe fn republished() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unsafe function's docs miss `# Safety` section
+error: unsafe function's docs are missing a `# Safety` section
   --> tests/ui/doc_unsafe.rs:40:5
    |
 LL |     unsafe fn woefully_underdocumented(self);
@@ -25,13 +25,13 @@ error: docs for unsafe trait missing `# Safety` section
 LL | pub unsafe trait UnsafeTrait {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unsafe function's docs miss `# Safety` section
+error: unsafe function's docs are missing a `# Safety` section
   --> tests/ui/doc_unsafe.rs:76:5
    |
 LL |     pub unsafe fn more_undocumented_unsafe() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unsafe function's docs miss `# Safety` section
+error: unsafe function's docs are missing a `# Safety` section
   --> tests/ui/doc_unsafe.rs:92:9
    |
 LL |         pub unsafe fn whee() {


### PR DESCRIPTION
The original message ("unsafe function's docs miss `# Safety` section") reads quite awkwardly. I've changed it to "unsafe function's docs are missing a `# Safety` section" to have it read better.

```
changelog: [`missing_headers`]: Tweak the grammar in the lint message
```