### PR TITLE
[`match_same_arms`]: add a test case with lifetimes

### DIFF
--- a/tests/ui/match_same_arms2.fixed
+++ b/tests/ui/match_same_arms2.fixed
@@ -239,3 +239,20 @@ fn main() {
         _ => false,
     };
 }
+
+// issue #8919, fixed on https://github.com/rust-lang/rust/pull/97312
+mod with_lifetime {
+    enum MaybeStaticStr<'a> {
+        Static(&'static str),
+        Borrowed(&'a str),
+    }
+
+    impl<'a> MaybeStaticStr<'a> {
+        fn get(&self) -> &'a str {
+            match *self {
+                MaybeStaticStr::Borrowed(s) | MaybeStaticStr::Static(s) => s,
+                //~^ ERROR: this match arm has an identical body to another arm
+            }
+        }
+    }
+}

--- a/tests/ui/match_same_arms2.rs
+++ b/tests/ui/match_same_arms2.rs
@@ -262,3 +262,21 @@ fn main() {
         _ => false,
     };
 }
+
+// issue #8919, fixed on https://github.com/rust-lang/rust/pull/97312
+mod with_lifetime {
+    enum MaybeStaticStr<'a> {
+        Static(&'static str),
+        Borrowed(&'a str),
+    }
+
+    impl<'a> MaybeStaticStr<'a> {
+        fn get(&self) -> &'a str {
+            match *self {
+                MaybeStaticStr::Static(s) => s,
+                MaybeStaticStr::Borrowed(s) => s,
+                //~^ ERROR: this match arm has an identical body to another arm
+            }
+        }
+    }
+}

--- a/tests/ui/match_same_arms2.stderr
+++ b/tests/ui/match_same_arms2.stderr
@@ -221,5 +221,21 @@ help: and remove this obsolete arm
 LL -         0 => cfg!(not_enable),
    |
 
-error: aborting due to 13 previous errors
+error: this match arm has an identical body to another arm
+  --> tests/ui/match_same_arms2.rs:277:17
+   |
+LL |                 MaybeStaticStr::Borrowed(s) => s,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try changing either arm body
+help: or try merging the arm patterns
+   |
+LL |                 MaybeStaticStr::Borrowed(s) | MaybeStaticStr::Static(s) => s,
+   |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+help: and remove this obsolete arm
+   |
+LL -                 MaybeStaticStr::Static(s) => s,
+   |
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
as reminded by: #8919 

---

changelog: none
