### PR TITLE
Add wildcard_let lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5920,6 +5920,7 @@ Released 2018-09-13
 [`wildcard_enum_match_arm`]: https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_enum_match_arm
 [`wildcard_imports`]: https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_imports
 [`wildcard_in_or_patterns`]: https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_in_or_patterns
+[`wildcard_let`]: https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_let
 [`write_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#write_literal
 [`write_with_newline`]: https://rust-lang.github.io/rust-clippy/master/index.html#write_with_newline
 [`writeln_empty_string`]: https://rust-lang.github.io/rust-clippy/master/index.html#writeln_empty_string

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -749,6 +749,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::visibility::PUB_WITH_SHORTHAND_INFO,
     crate::wildcard_imports::ENUM_GLOB_USE_INFO,
     crate::wildcard_imports::WILDCARD_IMPORTS_INFO,
+    crate::wildcard_let::WILDCARD_LET_INFO,
     crate::write::PRINTLN_EMPTY_STRING_INFO,
     crate::write::PRINT_LITERAL_INFO,
     crate::write::PRINT_STDERR_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1166,7 +1166,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
             ..Default::default()
         })
     });
-	store.register_early_pass(|| Box::new(wildcard_let::WildcardLet{}));
+    store.register_early_pass(|| Box::new(wildcard_let::WildcardLet {}));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -374,6 +374,7 @@ mod vec;
 mod vec_init_then_push;
 mod visibility;
 mod wildcard_imports;
+mod wildcard_let;
 mod write;
 mod zero_div_zero;
 mod zero_repeat_side_effects;
@@ -1165,6 +1166,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
             ..Default::default()
         })
     });
+	store.register_early_pass(|| Box::new(wildcard_let::WildcardLet{}));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/wildcard_let.rs
+++ b/clippy_lints/src/wildcard_let.rs
@@ -1,0 +1,39 @@
+use clippy_config::msrvs::{self, Msrv};
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::source::{trim_span, walk_span_to_context};
+use rustc_ast::ast::{Expr, ExprKind, LitKind, Pat, PatKind, RangeEnd, RangeLimits};
+use rustc_errors::Applicability;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+use rustc_middle::lint::in_external_macro;
+use rustc_session::impl_lint_pass;
+use rustc_span::Span;
+use rustc_ast::ast::Local;
+
+declare_clippy_lint! {
+	/// ### What it does
+	/// check for `let _ = ...`.
+	///
+	/// this may be used by crates that with to force `#[must_use]`
+	/// values to actually used, along with `#[forbid(unused_must_use)]`.
+	pub WILDCARD_LET,
+	restriction,
+	"wildcard let"
+}
+impl_lint_pass!(WildcardLet => [WILDCARD_LET]);
+
+pub struct WildcardLet {}
+
+impl EarlyLintPass for WildcardLet {
+	fn check_local(&mut self, cx: &EarlyContext<'_>, local: &Local) {
+		let span = local.pat.span;
+		if in_external_macro(cx.sess(), span) {
+			return
+		}
+		if let PatKind::Wild =  local.pat.kind {
+			span_lint_and_help(
+				cx, WILDCARD_LET, span, "wildcard let", None,
+				"remove this binding or handle the value");
+		}
+	}
+}

--- a/clippy_lints/src/wildcard_let.rs
+++ b/clippy_lints/src/wildcard_let.rs
@@ -1,13 +1,8 @@
-use clippy_config::msrvs::{self, Msrv};
-use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::source::{trim_span, walk_span_to_context};
-use rustc_ast::ast::{Expr, ExprKind, LitKind, Pat, PatKind, RangeEnd, RangeLimits};
-use rustc_errors::Applicability;
+use rustc_ast::ast::PatKind;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_session::impl_lint_pass;
-use rustc_span::Span;
 use rustc_ast::ast::Local;
 
 declare_clippy_lint! {

--- a/clippy_lints/src/wildcard_let.rs
+++ b/clippy_lints/src/wildcard_let.rs
@@ -10,6 +10,7 @@ declare_clippy_lint! {
     ///
     /// this may be used by crates that with to force `#[must_use]`
     /// values to actually used, along with `#[forbid(unused_must_use)]`.
+    #[clippy::version = "1.80.0"]
     pub WILDCARD_LET,
     restriction,
     "wildcard let"

--- a/clippy_lints/src/wildcard_let.rs
+++ b/clippy_lints/src/wildcard_let.rs
@@ -1,34 +1,38 @@
 use clippy_utils::diagnostics::span_lint_and_help;
-use rustc_ast::ast::PatKind;
+use rustc_ast::ast::{Local, PatKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_middle::lint::in_external_macro;
 use rustc_session::impl_lint_pass;
-use rustc_ast::ast::Local;
 
 declare_clippy_lint! {
-	/// ### What it does
-	/// check for `let _ = ...`.
-	///
-	/// this may be used by crates that with to force `#[must_use]`
-	/// values to actually used, along with `#[forbid(unused_must_use)]`.
-	pub WILDCARD_LET,
-	restriction,
-	"wildcard let"
+    /// ### What it does
+    /// check for `let _ = ...`.
+    ///
+    /// this may be used by crates that with to force `#[must_use]`
+    /// values to actually used, along with `#[forbid(unused_must_use)]`.
+    pub WILDCARD_LET,
+    restriction,
+    "wildcard let"
 }
 impl_lint_pass!(WildcardLet => [WILDCARD_LET]);
 
 pub struct WildcardLet {}
 
 impl EarlyLintPass for WildcardLet {
-	fn check_local(&mut self, cx: &EarlyContext<'_>, local: &Local) {
-		let span = local.pat.span;
-		if in_external_macro(cx.sess(), span) {
-			return
-		}
-		if let PatKind::Wild =  local.pat.kind {
-			span_lint_and_help(
-				cx, WILDCARD_LET, span, "wildcard let", None,
-				"remove this binding or handle the value");
-		}
-	}
+    fn check_local(&mut self, cx: &EarlyContext<'_>, local: &Local) {
+        let span = local.pat.span;
+        if in_external_macro(cx.sess(), span) {
+            return;
+        }
+        if let PatKind::Wild = local.pat.kind {
+            span_lint_and_help(
+                cx,
+                WILDCARD_LET,
+                span,
+                "wildcard let",
+                None,
+                "remove this binding or handle the value",
+            );
+        }
+    }
 }

--- a/tests/ui/wildcard_let.rs
+++ b/tests/ui/wildcard_let.rs
@@ -1,5 +1,5 @@
 #![forbid(clippy::wildcard_let)]
 
 fn main() {
-	let _ = 1;
+    let _ = 1;
 }

--- a/tests/ui/wildcard_let.rs
+++ b/tests/ui/wildcard_let.rs
@@ -1,0 +1,5 @@
+#![forbid(clippy::wildcard_let)]
+
+fn main() {
+	let _ = 1;
+}

--- a/tests/ui/wildcard_let.stderr
+++ b/tests/ui/wildcard_let.stderr
@@ -1,0 +1,15 @@
+error: wildcard let
+  --> tests/ui/wildcard_let.rs:4:6
+   |
+LL |     let _ = 1;
+   |         ^
+   |
+   = help: remove this binding or handle the value
+note: the lint level is defined here
+  --> tests/ui/wildcard_let.rs:1:11
+   |
+LL | #![forbid(clippy::wildcard_let)]
+   |           ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/wildcard_let.stderr
+++ b/tests/ui/wildcard_let.stderr
@@ -1,5 +1,5 @@
 error: wildcard let
-  --> tests/ui/wildcard_let.rs:4:6
+  --> tests/ui/wildcard_let.rs:4:9
    |
 LL |     let _ = 1;
    |         ^


### PR DESCRIPTION
Fixes #4090

changelog: [`wildcard_let`]: new restriction lint to forbid use of `let _`
