### PR TITLE
Fix ICE in `upper_case_acronyms`

### DIFF
--- a/tests/ui/crashes/ice-12284.rs
+++ b/tests/ui/crashes/ice-12284.rs
@@ -1,0 +1,10 @@
+#![allow(incomplete_features)]
+#![feature(unnamed_fields)]
+
+#[repr(C)]
+struct Foo {
+    _: struct {
+    },
+}
+
+fn main() {}


### PR DESCRIPTION
fixes #12284

The logic has been rewritten to avoid allocations. The old version allocated multiple vecs and strings for each identifier. The new logic allocates a single string only when the lint triggers.

This also no longer lints on strings which don't start with an uppercase letter (e.g. `something_FOO`).

changelog: none
