### PR TITLE
Lint `manual_unwrap_or` for it let cases

### DIFF
--- a/clippy_lints/src/matches/manual_unwrap_or.rs
+++ b/clippy_lints/src/matches/manual_unwrap_or.rs
@@ -3,46 +3,78 @@ use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::{indent_of, reindent_multiline, snippet_opt};
 use clippy_utils::ty::is_type_diagnostic_item;
 use clippy_utils::usage::contains_return_break_continue_macro;
-use clippy_utils::{is_res_lang_ctor, path_to_local_id, sugg};
+use clippy_utils::{is_res_lang_ctor, path_to_local_id, peel_blocks, sugg};
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::LangItem::{OptionNone, ResultErr};
-use rustc_hir::{Arm, Expr, PatKind};
+use rustc_hir::{Arm, Expr, Pat, PatKind};
 use rustc_lint::LateContext;
+use rustc_middle::ty::Ty;
 use rustc_span::sym;
 
 use super::MANUAL_UNWRAP_OR;
 
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>, scrutinee: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>]) {
+pub(super) fn check_match<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'tcx>,
+    scrutinee: &'tcx Expr<'_>,
+    arms: &'tcx [Arm<'_>],
+) {
     let ty = cx.typeck_results().expr_ty(scrutinee);
-    if let Some(ty_name) = if is_type_diagnostic_item(cx, ty, sym::Option) {
+    if let Some((or_arm, unwrap_arm)) = applicable_or_arm(cx, arms) {
+        check_and_lint(cx, expr, unwrap_arm.pat, scrutinee, unwrap_arm.body, or_arm.body, ty);
+    }
+}
+
+pub(super) fn check_if_let<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    let_pat: &'tcx Pat<'_>,
+    let_expr: &'tcx Expr<'_>,
+    then_expr: &'tcx Expr<'_>,
+    else_expr: &'tcx Expr<'_>,
+) {
+    let ty = cx.typeck_results().expr_ty(let_expr);
+    check_and_lint(cx, expr, let_pat, let_expr, then_expr, peel_blocks(else_expr), ty);
+}
+
+fn check_and_lint<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &'tcx Expr<'_>,
+    let_pat: &'tcx Pat<'_>,
+    let_expr: &'tcx Expr<'_>,
+    then_expr: &'tcx Expr<'_>,
+    else_expr: &'tcx Expr<'_>,
+    ty: Ty<'tcx>,
+) {
+    if let PatKind::TupleStruct(ref qpath, [unwrap_pat], _) = let_pat.kind
+        && let Res::Def(DefKind::Ctor(..), ctor_id) = cx.qpath_res(qpath, let_pat.hir_id)
+        && let Some(variant_id) = cx.tcx.opt_parent(ctor_id)
+        && (cx.tcx.lang_items().option_some_variant() == Some(variant_id)
+            || cx.tcx.lang_items().result_ok_variant() == Some(variant_id))
+        && let PatKind::Binding(_, binding_hir_id, ..) = unwrap_pat.kind
+        && path_to_local_id(peel_blocks(then_expr), binding_hir_id)
+        && cx.typeck_results().expr_adjustments(then_expr).is_empty()
+        && let Some(ty_name) = find_type_name(cx, ty)
+        && let Some(or_body_snippet) = snippet_opt(cx, else_expr.span)
+        && let Some(indent) = indent_of(cx, expr.span)
+        && constant_simple(cx, cx.typeck_results(), else_expr).is_some()
+    {
+        lint(cx, expr, let_expr, ty_name, or_body_snippet, indent);
+    }
+}
+
+fn find_type_name<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<&'static str> {
+    if is_type_diagnostic_item(cx, ty, sym::Option) {
         Some("Option")
     } else if is_type_diagnostic_item(cx, ty, sym::Result) {
         Some("Result")
     } else {
         None
-    } && let Some(or_arm) = applicable_or_arm(cx, arms)
-        && let Some(or_body_snippet) = snippet_opt(cx, or_arm.body.span)
-        && let Some(indent) = indent_of(cx, expr.span)
-        && constant_simple(cx, cx.typeck_results(), or_arm.body).is_some()
-    {
-        let reindented_or_body = reindent_multiline(or_body_snippet.into(), true, Some(indent));
-
-        let mut app = Applicability::MachineApplicable;
-        let suggestion = sugg::Sugg::hir_with_context(cx, scrutinee, expr.span.ctxt(), "..", &mut app).maybe_par();
-        span_lint_and_sugg(
-            cx,
-            MANUAL_UNWRAP_OR,
-            expr.span,
-            format!("this pattern reimplements `{ty_name}::unwrap_or`"),
-            "replace with",
-            format!("{suggestion}.unwrap_or({reindented_or_body})",),
-            app,
-        );
     }
 }
 
-fn applicable_or_arm<'a>(cx: &LateContext<'_>, arms: &'a [Arm<'a>]) -> Option<&'a Arm<'a>> {
+fn applicable_or_arm<'a>(cx: &LateContext<'_>, arms: &'a [Arm<'a>]) -> Option<(&'a Arm<'a>, &'a Arm<'a>)> {
     if arms.len() == 2
         && arms.iter().all(|arm| arm.guard.is_none())
         && let Some((idx, or_arm)) = arms.iter().enumerate().find(|(_, arm)| match arm.pat.kind {
@@ -54,18 +86,33 @@ fn applicable_or_arm<'a>(cx: &LateContext<'_>, arms: &'a [Arm<'a>]) -> Option<&'
             _ => false,
         })
         && let unwrap_arm = &arms[1 - idx]
-        && let PatKind::TupleStruct(ref qpath, [unwrap_pat], _) = unwrap_arm.pat.kind
-        && let Res::Def(DefKind::Ctor(..), ctor_id) = cx.qpath_res(qpath, unwrap_arm.pat.hir_id)
-        && let Some(variant_id) = cx.tcx.opt_parent(ctor_id)
-        && (cx.tcx.lang_items().option_some_variant() == Some(variant_id)
-            || cx.tcx.lang_items().result_ok_variant() == Some(variant_id))
-        && let PatKind::Binding(_, binding_hir_id, ..) = unwrap_pat.kind
-        && path_to_local_id(unwrap_arm.body, binding_hir_id)
-        && cx.typeck_results().expr_adjustments(unwrap_arm.body).is_empty()
         && !contains_return_break_continue_macro(or_arm.body)
     {
-        Some(or_arm)
+        Some((or_arm, unwrap_arm))
     } else {
         None
     }
+}
+
+fn lint<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &Expr<'tcx>,
+    scrutinee: &'tcx Expr<'_>,
+    ty_name: &str,
+    or_body_snippet: String,
+    indent: usize,
+) {
+    let reindented_or_body = reindent_multiline(or_body_snippet.into(), true, Some(indent));
+
+    let mut app = Applicability::MachineApplicable;
+    let suggestion = sugg::Sugg::hir_with_context(cx, scrutinee, expr.span.ctxt(), "..", &mut app).maybe_par();
+    span_lint_and_sugg(
+        cx,
+        MANUAL_UNWRAP_OR,
+        expr.span,
+        format!("this pattern reimplements `{ty_name}::unwrap_or`"),
+        "replace with",
+        format!("{suggestion}.unwrap_or({reindented_or_body})",),
+        app,
+    );
 }

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -1069,7 +1069,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                     redundant_guards::check(cx, arms, &self.msrv);
 
                     if !in_constant(cx, expr.hir_id) {
-                        manual_unwrap_or::check(cx, expr, ex, arms);
+                        manual_unwrap_or::check_match(cx, expr, ex, arms);
                         manual_map::check_match(cx, expr, ex, arms);
                         manual_filter::check_match(cx, ex, arms, expr);
                     }
@@ -1097,6 +1097,14 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                         );
                     }
                     if !in_constant(cx, expr.hir_id) {
+                        manual_unwrap_or::check_if_let(
+                            cx,
+                            expr,
+                            if_let.let_pat,
+                            if_let.let_expr,
+                            if_let.if_then,
+                            else_expr,
+                        );
                         manual_map::check_if_let(cx, expr, if_let.let_pat, if_let.let_expr, if_let.if_then, else_expr);
                         manual_filter::check_if_let(
                             cx,

--- a/tests/ui/manual_unwrap_or.fixed
+++ b/tests/ui/manual_unwrap_or.fixed
@@ -68,6 +68,32 @@ fn option_unwrap_or() {
         Some(s) => s,
         None => &format!("{} {}!", "hello", "world"),
     };
+
+    Some(1).unwrap_or(42);
+
+    //don't lint
+    if let Some(x) = Some(1) {
+        x + 1
+    } else {
+        42
+    };
+    if let Some(x) = Some(1) {
+        x
+    } else {
+        return;
+    };
+    for j in 0..4 {
+        if let Some(x) = Some(j) {
+            x
+        } else {
+            continue;
+        };
+        if let Some(x) = Some(j) {
+            x
+        } else {
+            break;
+        };
+    }
 }
 
 fn result_unwrap_or() {
@@ -138,6 +164,32 @@ fn result_unwrap_or() {
         Ok(s) => s,
         Err(s) => "Bob",
     };
+
+    Ok::<i32, i32>(1).unwrap_or(42);
+
+    //don't lint
+    if let Ok(x) = Ok::<i32, i32>(1) {
+        x + 1
+    } else {
+        42
+    };
+    if let Ok(x) = Ok::<i32, i32>(1) {
+        x
+    } else {
+        return;
+    };
+    for j in 0..4 {
+        if let Ok(x) = Ok::<i32, i32>(j) {
+            x
+        } else {
+            continue;
+        };
+        if let Ok(x) = Ok::<i32, i32>(j) {
+            x
+        } else {
+            break;
+        };
+    }
 }
 
 // don't lint in const fn

--- a/tests/ui/manual_unwrap_or.rs
+++ b/tests/ui/manual_unwrap_or.rs
@@ -83,6 +83,36 @@ fn option_unwrap_or() {
         Some(s) => s,
         None => &format!("{} {}!", "hello", "world"),
     };
+
+    if let Some(x) = Some(1) {
+        x
+    } else {
+        42
+    };
+
+    //don't lint
+    if let Some(x) = Some(1) {
+        x + 1
+    } else {
+        42
+    };
+    if let Some(x) = Some(1) {
+        x
+    } else {
+        return;
+    };
+    for j in 0..4 {
+        if let Some(x) = Some(j) {
+            x
+        } else {
+            continue;
+        };
+        if let Some(x) = Some(j) {
+            x
+        } else {
+            break;
+        };
+    }
 }
 
 fn result_unwrap_or() {
@@ -177,6 +207,36 @@ fn result_unwrap_or() {
         Ok(s) => s,
         Err(s) => "Bob",
     };
+
+    if let Ok(x) = Ok::<i32, i32>(1) {
+        x
+    } else {
+        42
+    };
+
+    //don't lint
+    if let Ok(x) = Ok::<i32, i32>(1) {
+        x + 1
+    } else {
+        42
+    };
+    if let Ok(x) = Ok::<i32, i32>(1) {
+        x
+    } else {
+        return;
+    };
+    for j in 0..4 {
+        if let Ok(x) = Ok::<i32, i32>(j) {
+            x
+        } else {
+            continue;
+        };
+        if let Ok(x) = Ok::<i32, i32>(j) {
+            x
+        } else {
+            break;
+        };
+    }
 }
 
 // don't lint in const fn

--- a/tests/ui/manual_unwrap_or.stderr
+++ b/tests/ui/manual_unwrap_or.stderr
@@ -58,8 +58,18 @@ LL | |         None => "Alice",
 LL | |     };
    | |_____^ help: replace with: `Some("Bob").unwrap_or("Alice")`
 
+error: this pattern reimplements `Option::unwrap_or`
+  --> tests/ui/manual_unwrap_or.rs:87:5
+   |
+LL | /     if let Some(x) = Some(1) {
+LL | |         x
+LL | |     } else {
+LL | |         42
+LL | |     };
+   | |_____^ help: replace with: `Some(1).unwrap_or(42)`
+
 error: this pattern reimplements `Result::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:90:5
+  --> tests/ui/manual_unwrap_or.rs:120:5
    |
 LL | /     match Ok::<i32, &str>(1) {
 LL | |         Ok(i) => i,
@@ -68,7 +78,7 @@ LL | |     };
    | |_____^ help: replace with: `Ok::<i32, &str>(1).unwrap_or(42)`
 
 error: this pattern reimplements `Result::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:97:5
+  --> tests/ui/manual_unwrap_or.rs:127:5
    |
 LL | /     match a {
 LL | |         Ok(i) => i,
@@ -77,7 +87,7 @@ LL | |     };
    | |_____^ help: replace with: `a.unwrap_or(42)`
 
 error: this pattern reimplements `Result::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:103:5
+  --> tests/ui/manual_unwrap_or.rs:133:5
    |
 LL | /     match Ok(1) as Result<i32, &str> {
 LL | |         Ok(i) => i,
@@ -86,7 +96,7 @@ LL | |     };
    | |_____^ help: replace with: `(Ok(1) as Result<i32, &str>).unwrap_or(42)`
 
 error: this pattern reimplements `Option::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:116:5
+  --> tests/ui/manual_unwrap_or.rs:146:5
    |
 LL | /     match s.method() {
 LL | |         Some(i) => i,
@@ -95,7 +105,7 @@ LL | |     };
    | |_____^ help: replace with: `s.method().unwrap_or(42)`
 
 error: this pattern reimplements `Result::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:122:5
+  --> tests/ui/manual_unwrap_or.rs:152:5
    |
 LL | /     match Ok::<i32, &str>(1) {
 LL | |         Err(_) => 42,
@@ -104,7 +114,7 @@ LL | |     };
    | |_____^ help: replace with: `Ok::<i32, &str>(1).unwrap_or(42)`
 
 error: this pattern reimplements `Result::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:128:5
+  --> tests/ui/manual_unwrap_or.rs:158:5
    |
 LL | /     match Ok::<i32, &str>(1) {
 LL | |         Ok(i) => i,
@@ -113,7 +123,7 @@ LL | |     };
    | |_____^ help: replace with: `Ok::<i32, &str>(1).unwrap_or(1 + 42)`
 
 error: this pattern reimplements `Result::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:135:5
+  --> tests/ui/manual_unwrap_or.rs:165:5
    |
 LL | /     match Ok::<i32, &str>(1) {
 LL | |         Ok(i) => i,
@@ -134,7 +144,7 @@ LL ~     });
    |
 
 error: this pattern reimplements `Result::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:145:5
+  --> tests/ui/manual_unwrap_or.rs:175:5
    |
 LL | /     match Ok::<&str, &str>("Bob") {
 LL | |         Ok(i) => i,
@@ -142,8 +152,18 @@ LL | |         Err(_) => "Alice",
 LL | |     };
    | |_____^ help: replace with: `Ok::<&str, &str>("Bob").unwrap_or("Alice")`
 
+error: this pattern reimplements `Result::unwrap_or`
+  --> tests/ui/manual_unwrap_or.rs:211:5
+   |
+LL | /     if let Ok(x) = Ok::<i32, i32>(1) {
+LL | |         x
+LL | |     } else {
+LL | |         42
+LL | |     };
+   | |_____^ help: replace with: `Ok::<i32, i32>(1).unwrap_or(42)`
+
 error: this pattern reimplements `Option::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:205:17
+  --> tests/ui/manual_unwrap_or.rs:265:17
    |
 LL |           let _ = match some_macro!() {
    |  _________________^
@@ -152,5 +172,5 @@ LL | |             None => 0,
 LL | |         };
    | |_________^ help: replace with: `some_macro!().unwrap_or(0)`
 
-error: aborting due to 14 previous errors
+error: aborting due to 16 previous errors
 

--- a/tests/ui/manual_unwrap_or_default.fixed
+++ b/tests/ui/manual_unwrap_or_default.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_unwrap_or_default)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::manual_unwrap_or)]
 
 fn main() {
     let x: Option<Vec<String>> = None;

--- a/tests/ui/manual_unwrap_or_default.rs
+++ b/tests/ui/manual_unwrap_or_default.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_unwrap_or_default)]
-#![allow(clippy::unnecessary_literal_unwrap)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::manual_unwrap_or)]
 
 fn main() {
     let x: Option<Vec<String>> = None;

--- a/tests/ui/match_result_ok.fixed
+++ b/tests/ui/match_result_ok.fixed
@@ -1,6 +1,11 @@
 #![warn(clippy::match_result_ok)]
 #![allow(dead_code)]
-#![allow(clippy::boxed_local, clippy::uninlined_format_args, clippy::manual_unwrap_or_default)]
+#![allow(
+    clippy::boxed_local,
+    clippy::uninlined_format_args,
+    clippy::manual_unwrap_or_default,
+    clippy::manual_unwrap_or
+)]
 
 // Checking `if` cases
 

--- a/tests/ui/match_result_ok.rs
+++ b/tests/ui/match_result_ok.rs
@@ -1,6 +1,11 @@
 #![warn(clippy::match_result_ok)]
 #![allow(dead_code)]
-#![allow(clippy::boxed_local, clippy::uninlined_format_args, clippy::manual_unwrap_or_default)]
+#![allow(
+    clippy::boxed_local,
+    clippy::uninlined_format_args,
+    clippy::manual_unwrap_or_default,
+    clippy::manual_unwrap_or
+)]
 
 // Checking `if` cases
 

--- a/tests/ui/match_result_ok.stderr
+++ b/tests/ui/match_result_ok.stderr
@@ -1,5 +1,5 @@
 error: matching on `Some` with `ok()` is redundant
-  --> tests/ui/match_result_ok.rs:8:5
+  --> tests/ui/match_result_ok.rs:13:5
    |
 LL |     if let Some(y) = x.parse().ok() { y } else { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL |     if let Ok(y) = x.parse() { y } else { 0 }
    |     ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: matching on `Some` with `ok()` is redundant
-  --> tests/ui/match_result_ok.rs:18:9
+  --> tests/ui/match_result_ok.rs:23:9
    |
 LL |         if let Some(y) = x   .   parse()   .   ok   ()    {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |         if let Ok(y) = x   .   parse()    {
    |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: matching on `Some` with `ok()` is redundant
-  --> tests/ui/match_result_ok.rs:44:5
+  --> tests/ui/match_result_ok.rs:49:5
    |
 LL |     while let Some(a) = wat.next().ok() {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -4,7 +4,8 @@
     clippy::equatable_if_let,
     clippy::let_unit_value,
     clippy::redundant_locals,
-    clippy::manual_unwrap_or_default
+    clippy::manual_unwrap_or_default,
+    clippy::manual_unwrap_or
 )]
 
 fn bad1(string: Option<&str>) -> (bool, &str) {

--- a/tests/ui/option_if_let_else.rs
+++ b/tests/ui/option_if_let_else.rs
@@ -4,7 +4,8 @@
     clippy::equatable_if_let,
     clippy::let_unit_value,
     clippy::redundant_locals,
-    clippy::manual_unwrap_or_default
+    clippy::manual_unwrap_or_default,
+    clippy::manual_unwrap_or
 )]
 
 fn bad1(string: Option<&str>) -> (bool, &str) {

--- a/tests/ui/option_if_let_else.stderr
+++ b/tests/ui/option_if_let_else.stderr
@@ -1,5 +1,5 @@
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:11:5
+  --> tests/ui/option_if_let_else.rs:12:5
    |
 LL | /     if let Some(x) = string {
 LL | |         (true, x)
@@ -12,19 +12,19 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::option_if_let_else)]`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:29:13
+  --> tests/ui/option_if_let_else.rs:30:13
    |
 LL |     let _ = if let Some(s) = *string { s.len() } else { 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.map_or(0, |s| s.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:30:13
+  --> tests/ui/option_if_let_else.rs:31:13
    |
 LL |     let _ = if let Some(s) = &num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:31:13
+  --> tests/ui/option_if_let_else.rs:32:13
    |
 LL |       let _ = if let Some(s) = &mut num {
    |  _____________^
@@ -44,13 +44,13 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:37:13
+  --> tests/ui/option_if_let_else.rs:38:13
    |
 LL |     let _ = if let Some(ref s) = num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:38:13
+  --> tests/ui/option_if_let_else.rs:39:13
    |
 LL |       let _ = if let Some(mut s) = num {
    |  _____________^
@@ -70,7 +70,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:44:13
+  --> tests/ui/option_if_let_else.rs:45:13
    |
 LL |       let _ = if let Some(ref mut s) = num {
    |  _____________^
@@ -90,7 +90,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:53:5
+  --> tests/ui/option_if_let_else.rs:54:5
    |
 LL | /     if let Some(x) = arg {
 LL | |         let y = x * x;
@@ -109,7 +109,7 @@ LL +     })
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:66:13
+  --> tests/ui/option_if_let_else.rs:67:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -121,7 +121,7 @@ LL | |     };
    | |_____^ help: try: `arg.map_or_else(side_effect, |x| x)`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:75:13
+  --> tests/ui/option_if_let_else.rs:76:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -144,7 +144,7 @@ LL ~     }, |x| x * x * x * x);
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:108:13
+  --> tests/ui/option_if_let_else.rs:109:13
    |
 LL | /             if let Some(idx) = s.find('.') {
 LL | |                 vec![s[..idx].to_string(), s[idx..].to_string()]
@@ -154,7 +154,7 @@ LL | |             }
    | |_____________^ help: try: `s.find('.').map_or_else(|| vec![s.to_string()], |idx| vec![s[..idx].to_string(), s[idx..].to_string()])`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:119:5
+  --> tests/ui/option_if_let_else.rs:120:5
    |
 LL | /     if let Ok(binding) = variable {
 LL | |         println!("Ok {binding}");
@@ -177,13 +177,13 @@ LL +     })
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:143:13
+  --> tests/ui/option_if_let_else.rs:144:13
    |
 LL |     let _ = if let Some(x) = optional { x + 2 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `optional.map_or(5, |x| x + 2)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:153:13
+  --> tests/ui/option_if_let_else.rs:154:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -205,13 +205,13 @@ LL ~         });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:181:13
+  --> tests/ui/option_if_let_else.rs:182:13
    |
 LL |     let _ = if let Some(x) = Some(0) { s.len() + x } else { s.len() };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(0).map_or(s.len(), |x| s.len() + x)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:185:13
+  --> tests/ui/option_if_let_else.rs:186:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -231,7 +231,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:224:13
+  --> tests/ui/option_if_let_else.rs:225:13
    |
 LL |       let _ = match s {
    |  _____________^
@@ -241,7 +241,7 @@ LL | |     };
    | |_____^ help: try: `s.map_or(1, |string| string.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:228:13
+  --> tests/ui/option_if_let_else.rs:229:13
    |
 LL |       let _ = match Some(10) {
    |  _____________^
@@ -251,7 +251,7 @@ LL | |     };
    | |_____^ help: try: `Some(10).map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:234:13
+  --> tests/ui/option_if_let_else.rs:235:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -261,7 +261,7 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:238:13
+  --> tests/ui/option_if_let_else.rs:239:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -271,13 +271,13 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:242:13
+  --> tests/ui/option_if_let_else.rs:243:13
    |
 LL |     let _ = if let Ok(a) = res { a + 1 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:259:17
+  --> tests/ui/option_if_let_else.rs:260:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -287,7 +287,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_ref().map_or(42, |value| do_something(value))`
 
 error: use Option::map_or instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:266:17
+  --> tests/ui/option_if_let_else.rs:267:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -297,7 +297,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_mut().map_or(42, |value| do_something2(value))`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:289:24
+  --> tests/ui/option_if_let_else.rs:290:24
    |
 LL |       let mut _hashmap = if let Some(hm) = &opt {
    |  ________________________^
@@ -308,7 +308,7 @@ LL | |     };
    | |_____^ help: try: `opt.as_ref().map_or_else(HashMap::new, |hm| hm.clone())`
 
 error: use Option::map_or_else instead of an if let/else
-  --> tests/ui/option_if_let_else.rs:295:19
+  --> tests/ui/option_if_let_else.rs:296:19
    |
 LL |     let mut _hm = if let Some(hm) = &opt { hm.clone() } else { new_map!() };
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.as_ref().map_or_else(|| new_map!(), |hm| hm.clone())`


### PR DESCRIPTION
This PR modifies `manual_unwrap_or` to lint for `if let` cases as well. This effort is part of the fixes desired by https://github.com/rust-lang/rust-clippy/issues/12618

changelog:[`manual_unwrap_or`]: Lint for `if let` cases.
