### PR TITLE
Filter from first typed symbol on gh-pages

### DIFF
--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -397,7 +397,7 @@
             $scope.bySearch = function (lint, index, array) {
                 let searchStr = $scope.search;
                 // It can be `null` I haven't missed this value
-                if (searchStr == null || searchStr.length < 3) {
+                if (searchStr == null) {
                     return true;
                 }
                 searchStr = searchStr.toLowerCase();


### PR DESCRIPTION
Cosmetic fix
Don't see the reason that now filter on gh-pages is starting work after 3 symbols typing so remove this condition

Before:

https://github.com/rust-lang/rust-clippy/assets/5480441/fa3b780e-30dc-4fdb-bf2d-5a99337eca4e


After:

https://github.com/rust-lang/rust-clippy/assets/5480441/977e15af-8be5-462c-a703-f10c05e6109c


changelog: gh-pages 
