### PR TITLE
Resolve duplicate diag message for: tests/ui/renamed_builtin_attr.rs

### DIFF
--- a/clippy_utils/Cargo.toml
+++ b/clippy_utils/Cargo.toml
@@ -9,6 +9,8 @@ clippy_config = { path = "../clippy_config" }
 arrayvec = { version = "0.7", default-features = false }
 itertools = "0.12"
 rustc-semver = "1.1"
+rustc-hash = "1.1"
+lazy_static = "1.4"
 
 [features]
 deny-warnings = ["clippy_config/deny-warnings"]

--- a/tests/ui/renamed_builtin_attr.fixed
+++ b/tests/ui/renamed_builtin_attr.fixed
@@ -1,4 +1,3 @@
-//@compile-flags: -Zdeduplicate-diagnostics=yes
 
 #[clippy::cognitive_complexity = "1"]
 fn main() {}

--- a/tests/ui/renamed_builtin_attr.rs
+++ b/tests/ui/renamed_builtin_attr.rs
@@ -1,4 +1,3 @@
-//@compile-flags: -Zdeduplicate-diagnostics=yes
 
 #[clippy::cyclomatic_complexity = "1"]
 fn main() {}

--- a/tests/ui/renamed_builtin_attr.stderr
+++ b/tests/ui/renamed_builtin_attr.stderr
@@ -1,5 +1,5 @@
 error: usage of deprecated attribute
-  --> tests/ui/renamed_builtin_attr.rs:3:11
+  --> tests/ui/renamed_builtin_attr.rs:2:11
    |
 LL | #[clippy::cyclomatic_complexity = "1"]
    |           ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `cognitive_complexity`


### PR DESCRIPTION
This PR is to resolve duplicate diag messages for the renamed_builtin_attr UI test which is related to: #12379 

This was caused by multiple functions calling the get_attr function resulting in the deprecated attribute to be reevaluated. 

I added a state to the attr.rs file to track if the warning has already been emitted and skip the evaluation if the attribute warning has already been emitted.


changelog: [renamed_builtin_attr]: Fix duplicate diagnostics