### PR TITLE
cast_possible_truncation: Fix some false-positive cases

### DIFF
--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -40,8 +40,8 @@ fn apply_reductions(cx: &LateContext<'_>, nbits: u64, expr: &Expr<'_>, signed: b
                     get_constant_bits(cx, right).map_or(0, |b| b.saturating_sub(1))
                 })
             },
-            BinOpKind::Rem => get_constant_bits(cx, right)
-                .unwrap_or(u64::MAX)
+            BinOpKind::Rem => constant_int(cx, right)
+                .map_or(u64::MAX, |c| c.next_power_of_two().trailing_zeros().into())
                 .min(apply_reductions(cx, nbits, left, signed)),
             BinOpKind::BitAnd => get_constant_bits(cx, right)
                 .unwrap_or(u64::MAX)

--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -79,6 +79,7 @@ fn apply_reductions(cx: &LateContext<'_>, nbits: u64, expr: &Expr<'_>, signed: b
                 nbits
             }
         },
+        ExprKind::Path(ref _qpath) => get_constant_bits(cx, expr).unwrap_or(nbits),
         _ => nbits,
     }
 }
@@ -104,7 +105,7 @@ pub(super) fn check(
             let (should_lint, suffix) = match (is_isize_or_usize(cast_from), is_isize_or_usize(cast_to)) {
                 (true, true) | (false, false) => (to_nbits < from_nbits, ""),
                 (true, false) => (
-                    to_nbits <= 32,
+                    to_nbits < from_nbits && to_nbits <= 32,
                     if to_nbits == 32 {
                         " on targets with 64-bit wide pointers"
                     } else {

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -511,5 +511,11 @@ pub fn issue_9613() {
     CHUNK as u32;
     u64::MIN as u32;
     //~^ ERROR: casting `u64` to `u32` may truncate the value
+    struct Foo(usize, u32);
+    struct Bar(usize, String);
+    core::mem::size_of::<Foo>() as u32;
+    core::mem::size_of::<Bar>() as u32;
+    //~^ ERROR: casting `usize` to `u32` may truncate
     core::mem::size_of::<String>() as u32;
+    //~^ ERROR: casting `usize` to `u32` may truncate
 }

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -509,4 +509,5 @@ pub fn issue_7486() -> u8 {
 pub fn issue_9613() {
     const CHUNK: usize = 64;
     CHUNK as u32;
+    core::mem::size_of::<String>() as u32;
 }

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -505,3 +505,8 @@ fn issue12721() {
 pub fn issue_7486() -> u8 {
     (2u16 % 256) as u8
 }
+
+pub fn issue_9613() {
+    const CHUNK: usize = 64;
+    CHUNK as u32;
+}

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -501,3 +501,7 @@ fn issue12721() {
     (255 % 999999u64) as u8;
     //~^ ERROR: casting `u64` to `u8` may truncate the value
 }
+
+pub fn issue_7486() -> u8 {
+    (2u16 % 256) as u8
+}

--- a/tests/ui/cast.rs
+++ b/tests/ui/cast.rs
@@ -509,5 +509,7 @@ pub fn issue_7486() -> u8 {
 pub fn issue_9613() {
     const CHUNK: usize = 64;
     CHUNK as u32;
+    u64::MIN as u32;
+    //~^ ERROR: casting `u64` to `u32` may truncate the value
     core::mem::size_of::<String>() as u32;
 }

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -732,7 +732,7 @@ LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: casting `u64` to `u32` may truncate the value
-  --> tests/ui/cast.rs:510:5
+  --> tests/ui/cast.rs:512:5
    |
 LL |     u64::MIN as u32;
    |     ^^^^^^^^^^^^^^^
@@ -743,5 +743,29 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u32::try_from(u64::MIN);
    |     ~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 93 previous errors
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
+  --> tests/ui/cast.rs:517:5
+   |
+LL |     core::mem::size_of::<Bar>() as u32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL |     u32::try_from(core::mem::size_of::<Bar>());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
+  --> tests/ui/cast.rs:519:5
+   |
+LL |     core::mem::size_of::<String>() as u32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL |     u32::try_from(core::mem::size_of::<String>());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 95 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -731,17 +731,5 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:509:5
-   |
-LL |     core::mem::size_of::<String>() as u32;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
-help: ... or use `try_from` and handle the error accordingly
-   |
-LL |     u32::try_from(core::mem::size_of::<String>());
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-error: aborting due to 93 previous errors
+error: aborting due to 92 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -731,5 +731,17 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 92 previous errors
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
+  --> tests/ui/cast.rs:508:5
+   |
+LL |     CHUNK as u32;
+   |     ^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL |     u32::try_from(CHUNK);
+   |     ~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 93 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -731,17 +731,5 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: casting `u16` to `u8` may truncate the value
-  --> tests/ui/cast.rs:503:5
-   |
-LL |     (2u16 % 256) as u8
-   |     ^^^^^^^^^^^^^^^^^^
-   |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
-help: ... or use `try_from` and handle the error accordingly
-   |
-LL |     u8::try_from(2u16 % 256)
-   |
-
-error: aborting due to 93 previous errors
+error: aborting due to 92 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -731,5 +731,17 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 92 previous errors
+error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
+  --> tests/ui/cast.rs:509:5
+   |
+LL |     core::mem::size_of::<String>() as u32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL |     u32::try_from(core::mem::size_of::<String>());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 93 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -731,5 +731,17 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 92 previous errors
+error: casting `u16` to `u8` may truncate the value
+  --> tests/ui/cast.rs:503:5
+   |
+LL |     (2u16 % 256) as u8
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL |     u8::try_from(2u16 % 256)
+   |
+
+error: aborting due to 93 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -731,5 +731,17 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 92 previous errors
+error: casting `u64` to `u32` may truncate the value
+  --> tests/ui/cast.rs:510:5
+   |
+LL |     u64::MIN as u32;
+   |     ^^^^^^^^^^^^^^^
+   |
+   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
+help: ... or use `try_from` and handle the error accordingly
+   |
+LL |     u32::try_from(u64::MIN);
+   |     ~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 93 previous errors
 

--- a/tests/ui/cast.stderr
+++ b/tests/ui/cast.stderr
@@ -731,17 +731,5 @@ help: ... or use `try_from` and handle the error accordingly
 LL |     u8::try_from(255 % 999999u64);
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: casting `usize` to `u32` may truncate the value on targets with 64-bit wide pointers
-  --> tests/ui/cast.rs:508:5
-   |
-LL |     CHUNK as u32;
-   |     ^^^^^^^^^^^^
-   |
-   = help: if this is intentional allow the lint with `#[allow(clippy::cast_possible_truncation)]` ...
-help: ... or use `try_from` and handle the error accordingly
-   |
-LL |     u32::try_from(CHUNK);
-   |     ~~~~~~~~~~~~~~~~~~~~
-
-error: aborting due to 93 previous errors
+error: aborting due to 92 previous errors
 


### PR DESCRIPTION
Fix partially  https://github.com/rust-lang/rust-clippy/issues/7486#issuecomment-1843248881.
Fix #9613.
changelog: [`cast_possible_truncation`]: fix some false-positive on % operator, valid constants, and size_of