### PR TITLE
Don't lint `implicit_return` on proc macros

### DIFF
--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context, walk_span_to_context};
 use clippy_utils::visitors::for_each_expr_without_closures;
-use clippy_utils::{get_async_fn_body, is_async_fn};
+use clippy_utils::{get_async_fn_body, is_async_fn, is_from_proc_macro};
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
 use rustc_hir::intravisit::FnKind;
@@ -245,6 +245,10 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitReturn {
         } else {
             body.value
         };
+
+        if is_from_proc_macro(cx, expr) {
+            return;
+        }
         lint_implicit_returns(cx, expr, expr.span.ctxt(), None);
     }
 }

--- a/tests/ui/implicit_return.fixed
+++ b/tests/ui/implicit_return.fixed
@@ -1,6 +1,11 @@
+//@aux-build: proc_macros.rs
+
 #![feature(lint_reasons)]
 #![warn(clippy::implicit_return)]
 #![allow(clippy::needless_return, clippy::needless_bool, unused, clippy::never_loop)]
+
+extern crate proc_macros;
+use proc_macros::with_span;
 
 fn test_end_of_fn() -> bool {
     if true {
@@ -137,3 +142,11 @@ fn check_expect() -> bool {
     #[expect(clippy::implicit_return)]
     true
 }
+
+with_span!(
+    span
+
+    fn dont_lint_proc_macro(x: usize) -> usize{
+        x
+    }
+);

--- a/tests/ui/implicit_return.rs
+++ b/tests/ui/implicit_return.rs
@@ -1,6 +1,11 @@
+//@aux-build: proc_macros.rs
+
 #![feature(lint_reasons)]
 #![warn(clippy::implicit_return)]
 #![allow(clippy::needless_return, clippy::needless_bool, unused, clippy::never_loop)]
+
+extern crate proc_macros;
+use proc_macros::with_span;
 
 fn test_end_of_fn() -> bool {
     if true {
@@ -137,3 +142,11 @@ fn check_expect() -> bool {
     #[expect(clippy::implicit_return)]
     true
 }
+
+with_span!(
+    span
+
+    fn dont_lint_proc_macro(x: usize) -> usize{
+        x
+    }
+);

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -1,5 +1,5 @@
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:11:5
+  --> tests/ui/implicit_return.rs:16:5
    |
 LL |     true
    |     ^^^^ help: add `return` as shown: `return true`
@@ -8,85 +8,85 @@ LL |     true
    = help: to override `-D warnings` add `#[allow(clippy::implicit_return)]`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:15:15
+  --> tests/ui/implicit_return.rs:20:15
    |
 LL |     if true { true } else { false }
    |               ^^^^ help: add `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:15:29
+  --> tests/ui/implicit_return.rs:20:29
    |
 LL |     if true { true } else { false }
    |                             ^^^^^ help: add `return` as shown: `return false`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:21:17
+  --> tests/ui/implicit_return.rs:26:17
    |
 LL |         true => false,
    |                 ^^^^^ help: add `return` as shown: `return false`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:22:20
+  --> tests/ui/implicit_return.rs:27:20
    |
 LL |         false => { true },
    |                    ^^^^ help: add `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:35:9
+  --> tests/ui/implicit_return.rs:40:9
    |
 LL |         break true;
    |         ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:42:13
+  --> tests/ui/implicit_return.rs:47:13
    |
 LL |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:50:13
+  --> tests/ui/implicit_return.rs:55:13
    |
 LL |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:68:18
+  --> tests/ui/implicit_return.rs:73:18
    |
 LL |     let _ = || { true };
    |                  ^^^^ help: add `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:69:16
+  --> tests/ui/implicit_return.rs:74:16
    |
 LL |     let _ = || true;
    |                ^^^^ help: add `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:77:5
+  --> tests/ui/implicit_return.rs:82:5
    |
 LL |     format!("test {}", "test")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add `return` as shown: `return format!("test {}", "test")`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:86:5
+  --> tests/ui/implicit_return.rs:91:5
    |
 LL |     m!(true, false)
    |     ^^^^^^^^^^^^^^^ help: add `return` as shown: `return m!(true, false)`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:92:13
+  --> tests/ui/implicit_return.rs:97:13
    |
 LL |             break true;
    |             ^^^^^^^^^^ help: change `break` to `return` as shown: `return true`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:97:17
+  --> tests/ui/implicit_return.rs:102:17
    |
 LL |                 break 'outer false;
    |                 ^^^^^^^^^^^^^^^^^^ help: change `break` to `return` as shown: `return false`
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:112:5
+  --> tests/ui/implicit_return.rs:117:5
    |
 LL | /     loop {
 LL | |         m!(true);
@@ -101,7 +101,7 @@ LL +     }
    |
 
 error: missing `return` statement
-  --> tests/ui/implicit_return.rs:126:5
+  --> tests/ui/implicit_return.rs:131:5
    |
 LL |     true
    |     ^^^^ help: add `return` as shown: `return true`


### PR DESCRIPTION
This pr fixes https://github.com/rust-lang/rust-clippy/issues/12872

changelog: [`implicit_return`]: Don't lint on procedural macros.