### PR TITLE
Clarify that `modulo_one` only applies to ints

### DIFF
--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -627,7 +627,7 @@ declare_clippy_lint! {
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for getting the remainder of a division by one or minus
+    /// Checks for getting the remainder of integer division by one or minus
     /// one.
     ///
     /// ### Why is this bad?
@@ -646,7 +646,7 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub MODULO_ONE,
     correctness,
-    "taking a number modulo +/-1, which can either panic/overflow or always returns 0"
+    "taking an integer modulo +/-1, which can either panic/overflow or always returns 0"
 }
 
 declare_clippy_lint! {


### PR DESCRIPTION
changelog: [`modulo_one`]: (docs) Clarify that it only applies to integers

This might be nitpicky, but it's more technically correct.

It also helps if a user skims through the docs, because they may believe it also applies to `{float}`s. This doc edit minimizes that possibility