### PR TITLE
`empty_enum_variants_with_brackets`: Do not lint reachable enums and enum variants used as functions in the same crate

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -858,7 +858,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(move |_| Box::new(write::Write::new(conf, format_args.clone())));
     store.register_late_pass(move |_| Box::new(cargo::Cargo::new(conf)));
     store.register_early_pass(|| Box::new(crate_in_macro_def::CrateInMacroDef));
-    store.register_early_pass(|| Box::new(empty_with_brackets::EmptyWithBrackets));
+    store.register_late_pass(|_| Box::new(empty_with_brackets::EmptyWithBrackets::default()));
     store.register_late_pass(|_| Box::new(unnecessary_owned_empty_strings::UnnecessaryOwnedEmptyStrings));
     store.register_early_pass(|| Box::new(pub_use::PubUse));
     store.register_late_pass(|_| Box::new(format_push_string::FormatPushString));

--- a/tests/ui/empty_enum_variants_with_brackets.fixed
+++ b/tests/ui/empty_enum_variants_with_brackets.fixed
@@ -6,8 +6,7 @@ pub enum PublicTestEnum {
     NonEmptyParentheses(i32, i32),     // No error
     EmptyBraces,
     //~^ empty_enum_variants_with_brackets
-    EmptyParentheses,
-    //~^ empty_enum_variants_with_brackets
+    EmptyParentheses(), // No error as enum is pub
 }
 
 enum TestEnum {
@@ -20,12 +19,87 @@ enum TestEnum {
     AnotherEnum, // No error
 }
 
+mod issue12551 {
+    enum EvenOdd {
+        // Used as functions -> no error
+        Even(),
+        Odd(),
+        // Not used as a function
+        Unknown,
+        //~^ empty_enum_variants_with_brackets
+    }
+
+    fn even_odd(x: i32) -> EvenOdd {
+        (x % 2 == 0).then(EvenOdd::Even).unwrap_or_else(EvenOdd::Odd)
+    }
+
+    fn natural_number(x: i32) -> NaturalOrNot {
+        (x > 0)
+            .then(NaturalOrNot::Natural)
+            .unwrap_or_else(NaturalOrNot::NotNatural)
+    }
+
+    enum NaturalOrNot {
+        // Used as functions -> no error
+        Natural(),
+        NotNatural(),
+        // Not used as a function
+        Unknown,
+        //~^ empty_enum_variants_with_brackets
+    }
+
+    enum RedundantParenthesesFunctionCall {
+        // Used as a function call but with redundant parentheses
+        Parentheses,
+        //~^ empty_enum_variants_with_brackets
+        // Not used as a function
+        NoParentheses,
+    }
+
+    #[allow(clippy::no_effect)]
+    fn redundant_parentheses_function_call() {
+        // The parentheses in the below line are redundant.
+        RedundantParenthesesFunctionCall::Parentheses;
+        RedundantParenthesesFunctionCall::NoParentheses;
+    }
+
+    // Same test as above but with usage of the enum occurring before the definition.
+    #[allow(clippy::no_effect)]
+    fn redundant_parentheses_function_call_2() {
+        // The parentheses in the below line are redundant.
+        RedundantParenthesesFunctionCall2::Parentheses;
+        RedundantParenthesesFunctionCall2::NoParentheses;
+    }
+
+    enum RedundantParenthesesFunctionCall2 {
+        // Used as a function call but with redundant parentheses
+        Parentheses,
+        //~^ empty_enum_variants_with_brackets
+        // Not used as a function
+        NoParentheses,
+    }
+}
+
 enum TestEnumWithFeatures {
     NonEmptyBraces {
         #[cfg(feature = "thisisneverenabled")]
         x: i32,
     }, // No error
     NonEmptyParentheses(#[cfg(feature = "thisisneverenabled")] i32), // No error
+}
+
+#[derive(Clone)]
+enum Foo {
+    Variant1(i32),
+    Variant2,
+    Variant3, //~ ERROR: enum variant has empty brackets
+}
+
+#[derive(Clone)]
+pub enum PubFoo {
+    Variant1(i32),
+    Variant2,
+    Variant3(),
 }
 
 fn main() {}

--- a/tests/ui/empty_enum_variants_with_brackets.rs
+++ b/tests/ui/empty_enum_variants_with_brackets.rs
@@ -6,8 +6,7 @@ pub enum PublicTestEnum {
     NonEmptyParentheses(i32, i32),     // No error
     EmptyBraces {},
     //~^ empty_enum_variants_with_brackets
-    EmptyParentheses(),
-    //~^ empty_enum_variants_with_brackets
+    EmptyParentheses(), // No error as enum is pub
 }
 
 enum TestEnum {
@@ -20,12 +19,87 @@ enum TestEnum {
     AnotherEnum, // No error
 }
 
+mod issue12551 {
+    enum EvenOdd {
+        // Used as functions -> no error
+        Even(),
+        Odd(),
+        // Not used as a function
+        Unknown(),
+        //~^ empty_enum_variants_with_brackets
+    }
+
+    fn even_odd(x: i32) -> EvenOdd {
+        (x % 2 == 0).then(EvenOdd::Even).unwrap_or_else(EvenOdd::Odd)
+    }
+
+    fn natural_number(x: i32) -> NaturalOrNot {
+        (x > 0)
+            .then(NaturalOrNot::Natural)
+            .unwrap_or_else(NaturalOrNot::NotNatural)
+    }
+
+    enum NaturalOrNot {
+        // Used as functions -> no error
+        Natural(),
+        NotNatural(),
+        // Not used as a function
+        Unknown(),
+        //~^ empty_enum_variants_with_brackets
+    }
+
+    enum RedundantParenthesesFunctionCall {
+        // Used as a function call but with redundant parentheses
+        Parentheses(),
+        //~^ empty_enum_variants_with_brackets
+        // Not used as a function
+        NoParentheses,
+    }
+
+    #[allow(clippy::no_effect)]
+    fn redundant_parentheses_function_call() {
+        // The parentheses in the below line are redundant.
+        RedundantParenthesesFunctionCall::Parentheses();
+        RedundantParenthesesFunctionCall::NoParentheses;
+    }
+
+    // Same test as above but with usage of the enum occurring before the definition.
+    #[allow(clippy::no_effect)]
+    fn redundant_parentheses_function_call_2() {
+        // The parentheses in the below line are redundant.
+        RedundantParenthesesFunctionCall2::Parentheses();
+        RedundantParenthesesFunctionCall2::NoParentheses;
+    }
+
+    enum RedundantParenthesesFunctionCall2 {
+        // Used as a function call but with redundant parentheses
+        Parentheses(),
+        //~^ empty_enum_variants_with_brackets
+        // Not used as a function
+        NoParentheses,
+    }
+}
+
 enum TestEnumWithFeatures {
     NonEmptyBraces {
         #[cfg(feature = "thisisneverenabled")]
         x: i32,
     }, // No error
     NonEmptyParentheses(#[cfg(feature = "thisisneverenabled")] i32), // No error
+}
+
+#[derive(Clone)]
+enum Foo {
+    Variant1(i32),
+    Variant2,
+    Variant3(), //~ ERROR: enum variant has empty brackets
+}
+
+#[derive(Clone)]
+pub enum PubFoo {
+    Variant1(i32),
+    Variant2,
+    Variant3(),
 }
 
 fn main() {}

--- a/tests/ui/empty_enum_variants_with_brackets.stderr
+++ b/tests/ui/empty_enum_variants_with_brackets.stderr
@@ -9,15 +9,7 @@ LL |     EmptyBraces {},
    = help: remove the brackets
 
 error: enum variant has empty brackets
-  --> tests/ui/empty_enum_variants_with_brackets.rs:9:21
-   |
-LL |     EmptyParentheses(),
-   |                     ^^
-   |
-   = help: remove the brackets
-
-error: enum variant has empty brackets
-  --> tests/ui/empty_enum_variants_with_brackets.rs:16:16
+  --> tests/ui/empty_enum_variants_with_brackets.rs:15:16
    |
 LL |     EmptyBraces {},
    |                ^^^
@@ -25,12 +17,66 @@ LL |     EmptyBraces {},
    = help: remove the brackets
 
 error: enum variant has empty brackets
-  --> tests/ui/empty_enum_variants_with_brackets.rs:18:21
+  --> tests/ui/empty_enum_variants_with_brackets.rs:17:21
    |
 LL |     EmptyParentheses(),
    |                     ^^
    |
    = help: remove the brackets
 
-error: aborting due to 4 previous errors
+error: enum variant has empty brackets
+  --> tests/ui/empty_enum_variants_with_brackets.rs:28:16
+   |
+LL |         Unknown(),
+   |                ^^
+   |
+   = help: remove the brackets
+
+error: enum variant has empty brackets
+  --> tests/ui/empty_enum_variants_with_brackets.rs:47:16
+   |
+LL |         Unknown(),
+   |                ^^
+   |
+   = help: remove the brackets
+
+error: enum variant has empty brackets
+  --> tests/ui/empty_enum_variants_with_brackets.rs:53:20
+   |
+LL |         Parentheses(),
+   |                    ^^
+   |
+help: remove the brackets
+   |
+LL ~         Parentheses,
+LL |
+...
+LL |         // The parentheses in the below line are redundant.
+LL ~         RedundantParenthesesFunctionCall::Parentheses;
+   |
+
+error: enum variant has empty brackets
+  --> tests/ui/empty_enum_variants_with_brackets.rs:76:20
+   |
+LL |         Parentheses(),
+   |                    ^^
+   |
+help: remove the brackets
+   |
+LL ~         RedundantParenthesesFunctionCall2::Parentheses;
+LL |         RedundantParenthesesFunctionCall2::NoParentheses;
+...
+LL |         // Used as a function call but with redundant parentheses
+LL ~         Parentheses,
+   |
+
+error: enum variant has empty brackets
+  --> tests/ui/empty_enum_variants_with_brackets.rs:95:13
+   |
+LL |     Variant3(),
+   |             ^^
+   |
+   = help: remove the brackets
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Fixes #12551 

changelog: [`empty_enum_variants_with_brackets`]: Do not lint reachable enums or enums which are used as functions within the same crate.

r? @xFrednet 