### PR TITLE
use short message format in integration test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -55,6 +55,7 @@ fn integration_test() {
             "clippy",
             "--all-targets",
             "--all-features",
+            "--message-format=short",
             "--",
             "--cap-lints",
             "warn",


### PR DESCRIPTION
While checking #12983, bors came upon a cargo change that put "E0463" into the standard error (as part of a test case code snippet), which the integration test picked up to fail the build. Talk about unforeseen consequences.

So this PR just changes the integration test to use short message format in order to not include the code snippets in the output. Hopefully that will fix the problem.

r? @Alexendoo 

---

changelog: none
