### PR TITLE
bump strip-ansi-escapes

### DIFF
--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -19,7 +19,7 @@ flate2 = "1.0"
 rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
-strip-ansi-escapes = "0.1.1"
+strip-ansi-escapes = "0.2.0"
 tar = "0.4"
 toml = "0.7.3"
 ureq = { version = "2.2", features = ["json"] }

--- a/lintcheck/src/main.rs
+++ b/lintcheck/src/main.rs
@@ -161,7 +161,7 @@ impl ClippyWarning {
 
         // --recursive bypasses cargo so we have to strip the rendered output ourselves
         let rendered = diag.rendered.as_mut().unwrap();
-        *rendered = String::from_utf8(strip_ansi_escapes::strip(&rendered).unwrap()).unwrap();
+        *rendered = strip_ansi_escapes::strip_str(&rendered);
 
         Some(Self {
             crate_name: crate_name.to_owned(),


### PR DESCRIPTION
This bumps `strip-ansi-escapes` to remove arrayvec from it's deps (https://github.com/luser/strip-ansi-escapes/pull/8)

Should Cargo.lock be commited too to track it's working state?

changelog: none