### PR TITLE
Fix doc_markdown DevOps false positive

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -454,7 +454,7 @@ default configuration of Clippy. By default, any configuration will replace the 
 * `doc-valid-idents = ["ClipPy"]` would replace the default list with `["ClipPy"]`.
 * `doc-valid-idents = ["ClipPy", ".."]` would append `ClipPy` to the default list.
 
-**Default Value:** `["KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "DirectX", "ECMAScript", "GPLv2", "GPLv3", "GitHub", "GitLab", "IPv4", "IPv6", "ClojureScript", "CoffeeScript", "JavaScript", "PureScript", "TypeScript", "WebAssembly", "NaN", "NaNs", "OAuth", "GraphQL", "OCaml", "OpenDNS", "OpenGL", "OpenMP", "OpenSSH", "OpenSSL", "OpenStreetMap", "OpenTelemetry", "WebGL", "WebGL2", "WebGPU", "TensorFlow", "TrueType", "iOS", "macOS", "FreeBSD", "TeX", "LaTeX", "BibTeX", "BibLaTeX", "MinGW", "CamelCase"]`
+**Default Value:** `["KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "DevOps", "DirectX", "ECMAScript", "GPLv2", "GPLv3", "GitHub", "GitLab", "IPv4", "IPv6", "ClojureScript", "CoffeeScript", "JavaScript", "PureScript", "TypeScript", "WebAssembly", "NaN", "NaNs", "OAuth", "GraphQL", "OCaml", "OpenDNS", "OpenGL", "OpenMP", "OpenSSH", "OpenSSL", "OpenStreetMap", "OpenTelemetry", "WebGL", "WebGL2", "WebGPU", "TensorFlow", "TrueType", "iOS", "macOS", "FreeBSD", "TeX", "LaTeX", "BibTeX", "BibLaTeX", "MinGW", "CamelCase"]`
 
 ---
 **Affected lints:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -18,6 +18,7 @@ use std::{cmp, env, fmt, fs, io};
 #[rustfmt::skip]
 const DEFAULT_DOC_VALID_IDENTS: &[&str] = &[
     "KiB", "MiB", "GiB", "TiB", "PiB", "EiB",
+    "DevOps",
     "DirectX",
     "ECMAScript",
     "GPLv2", "GPLv3",


### PR DESCRIPTION
This fixes an issue where the word "DevOps" ends up as a false positive for the `doc_markdown` lint.

In a doc comment like this
```rust
/// Call the Azure DevOps REST API.
pub fn example() {}
```
the word "DevOps" is highlighted as something which should be in backticks.
```
warning: item in documentation is missing backticks
 --> src/lib.rs:1:20
  |
1 | /// Call the Azure DevOps REST API.
  |                    ^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
  = note: requested on the command line with `-W clippy::doc-markdown`
help: try
  |
1 | /// Call the Azure `DevOps` REST API.
  |                    ~~~~~~~~

warning: `example` (lib) generated 1 warning (run `cargo clippy --fix --lib -p example` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.00s
```

This could be overriden with the `doc-valid-idents` configuration parameter as noted by the [documentation](https://rust-lang.github.io/rust-clippy/master/index.html#/doc_markdown), but I believe the word "DevOps" is sufficiently common to belong alongside exceptions like "GitHub" and "GitLab".

changelog: [`doc_markdown`]: Fix DevOps false positive.