### PR TITLE
`manual_inspect`: fix `clippy::version` from 1.78.0 to 1.81.0

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4121,7 +4121,7 @@ declare_clippy_lint! {
     /// ```no_run
     /// let x = Some(0).inspect(|x| println!("{x}"));
     /// ```
-    #[clippy::version = "1.78.0"]
+    #[clippy::version = "1.81.0"]
     pub MANUAL_INSPECT,
     complexity,
     "use of `map` returning the original item"


### PR DESCRIPTION
Although `manual_inspect`'s PR started some months ago, the lint is only available in the current nightly (1.81.0), rather than 1.78.0.

```
changelog: [`manual_inspect`]: fix `clippy::version` from 1.78.0 to 1.81.0
```