### PR TITLE
build: Skip installing rust-docs with minimal rustup profile

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2024-06-27"
 components = ["cargo", "llvm-tools", "rust-src", "rust-std", "rustc", "rustc-dev", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
r? @flip1995

changelog: none