### PR TITLE
Fix #12964 - false positive with `into_iter_without_iter`

### DIFF
--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -1332,17 +1332,13 @@ pub fn deref_chain<'cx, 'tcx>(cx: &'cx LateContext<'tcx>, ty: Ty<'tcx>) -> impl 
 /// If you need this, you should wrap this call in `clippy_utils::ty::deref_chain().any(...)`.
 pub fn get_adt_inherent_method<'a>(cx: &'a LateContext<'_>, ty: Ty<'_>, method_name: Symbol) -> Option<&'a AssocItem> {
     if let Some(ty_did) = ty.ty_adt_def().map(AdtDef::did) {
-        cx.tcx
-            .inherent_impls(ty_did)
-            .into_iter()
-            .flatten()
-            .find_map(|&did| {
-                cx.tcx
-                    .associated_items(did)
-                    .filter_by_name_unhygienic(method_name)
-                    .next()
-                    .filter(|item| item.kind == AssocKind::Fn)
-            })
+        cx.tcx.inherent_impls(ty_did).into_iter().flatten().find_map(|&did| {
+            cx.tcx
+                .associated_items(did)
+                .filter_by_name_unhygienic(method_name)
+                .next()
+                .filter(|item| item.kind == AssocKind::Fn)
+        })
     } else {
         None
     }

--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -1336,15 +1336,13 @@ pub fn get_adt_inherent_method<'a>(cx: &'a LateContext<'_>, ty: Ty<'_>, method_n
             .inherent_impls(ty_did)
             .into_iter()
             .flatten()
-            .map(|&did| {
+            .find_map(|&did| {
                 cx.tcx
                     .associated_items(did)
                     .filter_by_name_unhygienic(method_name)
                     .next()
                     .filter(|item| item.kind == AssocKind::Fn)
             })
-            .next()
-            .flatten()
     } else {
         None
     }

--- a/tests/ui/into_iter_without_iter.rs
+++ b/tests/ui/into_iter_without_iter.rs
@@ -185,3 +185,42 @@ pub mod issue11635 {
         }
     }
 }
+
+pub mod issue12964 {
+    pub struct MyIter<'a, T: 'a> {
+        iter: std::slice::Iter<'a, T>,
+    }
+
+    impl<'a, T> Iterator for MyIter<'a, T> {
+        type Item = &'a T;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.iter.next()
+        }
+    }
+
+    pub struct MyContainer<T> {
+        inner: Vec<T>,
+    }
+
+    impl<T> MyContainer<T> {}
+
+    impl<T> MyContainer<T> {
+        #[must_use]
+        pub fn iter(&self) -> MyIter<'_, T> {
+            <&Self as IntoIterator>::into_iter(self)
+        }
+    }
+
+    impl<'a, T> IntoIterator for &'a MyContainer<T> {
+        type Item = &'a T;
+
+        type IntoIter = MyIter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            Self::IntoIter {
+                iter: self.inner.as_slice().iter(),
+            }
+        }
+    }
+}


### PR DESCRIPTION
changelog: FP: `into_iter_without_iter`: No longer lints when the `iter` or `iter_mut` implementation is not within the first `impl` block

fixes #12964

---

I'm pretty new to this open-source thing, so hopefully I did everything right. Got a little annoyed this false positive was happening in my code and the issue was inactive for two weeks so I thought I'd fix it myself.

As an aside, maybe `iter.map(...).next()` could be linted against? I don't see that ever being preferred over `iter.next().map(...)`, and it could've prevented the bug here.