### PR TITLE
Refactor `disallowed_methods` and narrow span

### DIFF
--- a/tests/ui-internal/disallow_span_lint.stderr
+++ b/tests/ui-internal/disallow_span_lint.stderr
@@ -1,22 +1,18 @@
 error: use of a disallowed method `rustc_lint::context::LintContext::span_lint`
-  --> tests/ui-internal/disallow_span_lint.rs:14:5
+  --> tests/ui-internal/disallow_span_lint.rs:14:8
    |
-LL | /     cx.span_lint(lint, span, |lint| {
-LL | |         lint.primary_message(msg);
-LL | |     });
-   | |______^
+LL |     cx.span_lint(lint, span, |lint| {
+   |        ^^^^^^^^^
    |
    = note: this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint*` functions instead (from clippy.toml)
    = note: `-D clippy::disallowed-methods` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
 
 error: use of a disallowed method `rustc_middle::ty::context::TyCtxt::node_span_lint`
-  --> tests/ui-internal/disallow_span_lint.rs:20:5
+  --> tests/ui-internal/disallow_span_lint.rs:20:9
    |
-LL | /     tcx.node_span_lint(lint, hir_id, span, |lint| {
-LL | |         lint.primary_message(msg);
-LL | |     });
-   | |______^
+LL |     tcx.node_span_lint(lint, hir_id, span, |lint| {
+   |         ^^^^^^^^^^^^^^
    |
    = note: this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint_hir*` functions instead (from clippy.toml)
 

--- a/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
+++ b/tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.stderr
@@ -2,36 +2,36 @@ error: use of a disallowed method `regex::Regex::new`
   --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:35:14
    |
 LL |     let re = Regex::new(r"ab.*c").unwrap();
-   |              ^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^
    |
    = note: `-D clippy::disallowed-methods` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
 
 error: use of a disallowed method `regex::Regex::is_match`
-  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:36:5
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:36:8
    |
 LL |     re.is_match("abc");
-   |     ^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^
    |
    = note: no matching allowed (from clippy.toml)
 
 error: use of a disallowed method `std::iter::Iterator::sum`
-  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:39:5
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:39:14
    |
 LL |     a.iter().sum::<i32>();
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^
 
 error: use of a disallowed method `slice::sort_unstable`
-  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:41:5
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:41:7
    |
 LL |     a.sort_unstable();
-   |     ^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^
 
 error: use of a disallowed method `f32::clamp`
-  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:44:13
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:44:20
    |
 LL |     let _ = 2.0f32.clamp(3.0f32, 4.0f32);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^
 
 error: use of a disallowed method `regex::Regex::new`
   --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:47:61
@@ -55,37 +55,37 @@ error: use of a disallowed method `futures::stream::select_all`
   --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:54:31
    |
 LL |     let same_name_as_module = select_all(vec![empty::<()>()]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_fn`
   --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:56:5
    |
 LL |     local_fn();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::local_mod::f`
   --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:57:5
    |
 LL |     local_mod::f();
-   |     ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Struct::method`
-  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:59:5
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:59:7
    |
 LL |     s.method();
-   |     ^^^^^^^^^^
+   |       ^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::provided_method`
-  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:60:5
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:60:7
    |
 LL |     s.provided_method();
-   |     ^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^
 
 error: use of a disallowed method `conf_disallowed_methods::Trait::implemented_method`
-  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:61:5
+  --> tests/ui-toml/toml_disallowed_methods/conf_disallowed_methods.rs:61:7
    |
 LL |     s.implemented_method();
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Using the span of the call site just produces noisy diagnostics for long calls. Especially multi-line calls.

changelog: none
