### PR TITLE
changelog: new lint: [`split_with_space`]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5826,6 +5826,7 @@ Released 2018-09-13
 [`size_of_ref`]: https://rust-lang.github.io/rust-clippy/master/index.html#size_of_ref
 [`skip_while_next`]: https://rust-lang.github.io/rust-clippy/master/index.html#skip_while_next
 [`slow_vector_initialization`]: https://rust-lang.github.io/rust-clippy/master/index.html#slow_vector_initialization
+[`split_with_space`]: https://rust-lang.github.io/rust-clippy/master/index.html#split_with_space
 [`stable_sort_primitive`]: https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive
 [`std_instead_of_alloc`]: https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_alloc
 [`std_instead_of_core`]: https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_core

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -665,6 +665,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::std_instead_of_core::STD_INSTEAD_OF_CORE_INFO,
     crate::string_patterns::MANUAL_PATTERN_CHAR_COMPARISON_INFO,
     crate::string_patterns::SINGLE_CHAR_PATTERN_INFO,
+    crate::strings::SPLIT_WITH_SPACE_INFO,
     crate::strings::STRING_ADD_INFO,
     crate::strings::STRING_ADD_ASSIGN_INFO,
     crate::strings::STRING_FROM_UTF8_AS_BYTES_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1016,6 +1016,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_early_pass(|| Box::new(pub_use::PubUse));
     store.register_late_pass(|_| Box::new(format_push_string::FormatPushString));
     store.register_late_pass(move |_| Box::new(large_include_file::LargeIncludeFile::new(max_include_file_size)));
+    store.register_late_pass(|_| Box::new(strings::SplitWithSpace));
     store.register_late_pass(|_| Box::new(strings::TrimSplitWhitespace));
     store.register_late_pass(|_| Box::new(rc_clone_in_vec_init::RcCloneInVecInit));
     store.register_early_pass(|| Box::<duplicate_mod::DuplicateMod>::default());

--- a/tests/ui/split_with_space.rs
+++ b/tests/ui/split_with_space.rs
@@ -1,0 +1,16 @@
+//@aux-build:proc_macros.rs
+//@no-rustfix
+
+#[deny(clippy::split_with_space)]
+#[allow(unused)]
+fn main() {
+    let some_space_delimtetered_string = "Hello everyone! How are you doing?";
+
+    for substr in some_space_delimtetered_string.split(' ') {
+        println!("{substr}");
+    }
+
+    for substr in some_space_delimtetered_string.split(" ") {
+        println!("{substr}");
+    }
+}

--- a/tests/ui/split_with_space.stderr
+++ b/tests/ui/split_with_space.stderr
@@ -1,0 +1,20 @@
+error: found call to `str::split` that uses the ASCII space character as an argument
+  --> tests/ui/split_with_space.rs:9:50
+   |
+LL |     for substr in some_space_delimtetered_string.split(' ') {
+   |                                                  ^ help: replace the use of `str::split` with `str::split_whitespace`
+   |
+note: the lint level is defined here
+  --> tests/ui/split_with_space.rs:4:8
+   |
+LL | #[deny(clippy::split_with_space)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: found call to `str::split` that uses the ASCII space character as an argument
+  --> tests/ui/split_with_space.rs:13:50
+   |
+LL |     for substr in some_space_delimtetered_string.split(" ") {
+   |                                                  ^ help: replace the use of `str::split` with `str::split_whitespace`
+
+error: aborting due to 2 previous errors
+

--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![warn(rust_2018_idioms, unused_lifetimes)]
-#![allow(clippy::single_match_else)]
+#![allow(clippy::single_match_else, clippy::split_with_space)]
 
 use std::fs;
 


### PR DESCRIPTION
changelog: new lint: [`split_with_space`]

Adds a new lint for checking whether the `split` method uses ASCII space as an delimiter and if it does so, recommends use of `split_whitespace`.