### PR TITLE
Fix `manual_unwrap_or` false positive

### DIFF
--- a/tests/ui/manual_unwrap_or.fixed
+++ b/tests/ui/manual_unwrap_or.fixed
@@ -234,4 +234,13 @@ fn implicit_deref_ref() {
     };
 }
 
+mod issue_13018 {
+    use std::collections::HashMap;
+
+    type RefName = i32;
+    pub fn get(index: &HashMap<usize, Vec<RefName>>, id: usize) -> &[RefName] {
+        index.get(&id).unwrap_or(&[])
+    }
+}
+
 fn main() {}

--- a/tests/ui/manual_unwrap_or.fixed
+++ b/tests/ui/manual_unwrap_or.fixed
@@ -239,7 +239,14 @@ mod issue_13018 {
 
     type RefName = i32;
     pub fn get(index: &HashMap<usize, Vec<RefName>>, id: usize) -> &[RefName] {
-        index.get(&id).unwrap_or(&[])
+        if let Some(names) = index.get(&id) { names } else { &[] }
+    }
+
+    pub fn get_match(index: &HashMap<usize, Vec<RefName>>, id: usize) -> &[RefName] {
+        match index.get(&id) {
+            Some(names) => names,
+            None => &[],
+        }
     }
 }
 

--- a/tests/ui/manual_unwrap_or.rs
+++ b/tests/ui/manual_unwrap_or.rs
@@ -284,4 +284,17 @@ fn implicit_deref_ref() {
     };
 }
 
+mod issue_13018 {
+    use std::collections::HashMap;
+
+    type RefName = i32;
+    pub fn get(index: &HashMap<usize, Vec<RefName>>, id: usize) -> &[RefName] {
+        if let Some(names) = index.get(&id) {
+            names
+        } else {
+            &[]
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/manual_unwrap_or.rs
+++ b/tests/ui/manual_unwrap_or.rs
@@ -289,10 +289,13 @@ mod issue_13018 {
 
     type RefName = i32;
     pub fn get(index: &HashMap<usize, Vec<RefName>>, id: usize) -> &[RefName] {
-        if let Some(names) = index.get(&id) {
-            names
-        } else {
-            &[]
+        if let Some(names) = index.get(&id) { names } else { &[] }
+    }
+
+    pub fn get_match(index: &HashMap<usize, Vec<RefName>>, id: usize) -> &[RefName] {
+        match index.get(&id) {
+            Some(names) => names,
+            None => &[],
         }
     }
 }

--- a/tests/ui/manual_unwrap_or.stderr
+++ b/tests/ui/manual_unwrap_or.stderr
@@ -172,5 +172,15 @@ LL | |             None => 0,
 LL | |         };
    | |_________^ help: replace with: `some_macro!().unwrap_or(0)`
 
-error: aborting due to 16 previous errors
+error: this pattern reimplements `Option::unwrap_or`
+  --> tests/ui/manual_unwrap_or.rs:292:9
+   |
+LL | /         if let Some(names) = index.get(&id) {
+LL | |             names
+LL | |         } else {
+LL | |             &[]
+LL | |         }
+   | |_________^ help: replace with: `index.get(&id).unwrap_or(&[])`
+
+error: aborting due to 17 previous errors
 

--- a/tests/ui/manual_unwrap_or.stderr
+++ b/tests/ui/manual_unwrap_or.stderr
@@ -172,15 +172,5 @@ LL | |             None => 0,
 LL | |         };
    | |_________^ help: replace with: `some_macro!().unwrap_or(0)`
 
-error: this pattern reimplements `Option::unwrap_or`
-  --> tests/ui/manual_unwrap_or.rs:292:9
-   |
-LL | /         if let Some(names) = index.get(&id) {
-LL | |             names
-LL | |         } else {
-LL | |             &[]
-LL | |         }
-   | |_________^ help: replace with: `index.get(&id).unwrap_or(&[])`
-
-error: aborting due to 17 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
changelog: [`manual_unwrap_or`]: fix false positive of `if let Option<T>`

Closes #13018