### PR TITLE
Rework `empty_with_brackets`

### DIFF
--- a/clippy_lints/src/empty_with_brackets.rs
+++ b/clippy_lints/src/empty_with_brackets.rs
@@ -1,17 +1,17 @@
-use clippy_utils::attrs::span_contains_cfg;
-use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
-use clippy_utils::source::SpanExt;
-use clippy_utils::span_contains_non_whitespace;
-use rustc_data_structures::fx::{FxIndexMap, IndexEntry};
-use rustc_errors::Applicability;
-use rustc_hir::def::DefKind::Ctor;
-use rustc_hir::def::Res::Def;
-use rustc_hir::def::{CtorOf, DefKind};
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::in_automatically_derived;
+use clippy_utils::source::{IntoSpan as _, SpanExt as _};
+use core::mem;
+use rustc_errors::{Applicability, SuggestionStyle};
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::LocalDefId;
-use rustc_hir::{Expr, ExprKind, Item, ItemKind, Node, Pat, PatKind, Path, QPath, Variant, VariantData};
-use rustc_lint::{LateContext, LateLintPass, impl_lint_pass};
-use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::{BytePos, Span};
+use rustc_hir::{
+    self as hir, Expr, ExprKind, Generics, HirId, Item, Pat, PatKind, QPath, StructTailExpr, Variant, VariantData,
+};
+use rustc_lexer::is_whitespace;
+use rustc_lint::{LateContext, LateLintPass, Lint, impl_lint_pass};
+use rustc_middle::span_bug;
+use rustc_span::{DUMMY_SP, Span};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -81,255 +81,323 @@ impl_lint_pass!(EmptyWithBrackets => [
     EMPTY_STRUCTS_WITH_BRACKETS,
 ]);
 
-#[derive(Debug)]
-enum Usage {
-    Unused { redundant_use_sites: Vec<Span> },
-    Used,
-    NoDefinition { redundant_use_sites: Vec<Span> },
+struct Def {
+    did: LocalDefId,
+    lint_sp: Span,
+    edit_sp: Span,
+    needs_semi: bool,
+    item_kind: ItemKind,
+    var_kind: VarKind,
+}
+
+struct Use {
+    did: LocalDefId,
+    /// The span of the call parenthesis, or `DUMMY_SP` if this use can't be changed.
+    edit_sp: Span,
+}
+
+#[derive(Clone, Copy)]
+enum VarKind {
+    Tuple,
+    Struct,
+}
+impl VarKind {
+    fn chars(self) -> (char, char) {
+        match self {
+            Self::Tuple => ('(', ')'),
+            Self::Struct => ('{', '}'),
+        }
+    }
+
+    fn is_parens(self, s: &str) -> bool {
+        let (start, end) = self.chars();
+        if let Some(s) = s.strip_prefix(start)
+            && let Some(s) = s.strip_suffix(end)
+        {
+            s.chars().all(is_whitespace)
+        } else {
+            false
+        }
+    }
+
+    fn strip_leading_parens(self, s: &str) -> Option<&str> {
+        let (start, end) = match self {
+            Self::Tuple => ('(', ')'),
+            Self::Struct => ('{', '}'),
+        };
+        let s = s
+            .trim_start_matches(is_whitespace)
+            .strip_prefix(start)?
+            .trim_start_matches(is_whitespace);
+        s.strip_prefix("..")
+            .map_or(s, |s| s.trim_start_matches(is_whitespace))
+            .strip_prefix(end)
+    }
+
+    fn sugg_msg(self) -> &'static str {
+        match self {
+            Self::Tuple => "remove the parenthesis",
+            Self::Struct => "remove the brackets",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ItemKind {
+    Struct,
+    Enum,
+}
+impl ItemKind {
+    fn lint(self) -> &'static Lint {
+        match self {
+            Self::Struct => EMPTY_STRUCTS_WITH_BRACKETS,
+            Self::Enum => EMPTY_ENUM_VARIANTS_WITH_BRACKETS,
+        }
+    }
+
+    fn msg(self) -> &'static str {
+        match self {
+            Self::Struct => "non-unit struct contains no fields",
+            Self::Enum => "non-unit variant contains no fields",
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct EmptyWithBrackets {
-    // Value holds `Usage::Used` if the empty tuple variant was used as a function
-    empty_tuple_enum_variants: FxIndexMap<LocalDefId, Usage>,
+    defs: Vec<Def>,
+    uses: Vec<Use>,
+    // Used to skip over constructor path expressions when they've already been seen as a
+    // call expression.
+    skip_next_expr: bool,
 }
 
-impl LateLintPass<'_> for EmptyWithBrackets {
+impl<'tcx> LateLintPass<'tcx> for EmptyWithBrackets {
     fn check_item(&mut self, cx: &LateContext<'_>, item: &Item<'_>) {
-        // FIXME: handle `struct $name {}`
-        if let ItemKind::Struct(ident, generics, var_data) = &item.kind
-            && !item.span.from_expansion()
-            && !ident.span.from_expansion()
-            && has_brackets(var_data)
-            && let span_after_ident = item.span.with_lo(generics.span.hi())
-            && has_no_fields(cx, var_data, span_after_ident)
-        {
-            span_lint_and_then(
+        if let hir::ItemKind::Struct(ident, generics, ref var_data) = item.kind {
+            self.check_def(
                 cx,
-                EMPTY_STRUCTS_WITH_BRACKETS,
-                span_after_ident,
-                "found empty brackets on struct declaration",
-                |diagnostic| {
-                    diagnostic.span_suggestion_hidden(
-                        span_after_ident,
-                        "remove the brackets",
-                        ";",
-                        Applicability::Unspecified,
-                    );
-                },
+                var_data,
+                item.owner_id.def_id,
+                item.span,
+                ident.span,
+                Some(generics),
             );
         }
     }
 
     fn check_variant(&mut self, cx: &LateContext<'_>, variant: &Variant<'_>) {
-        if !variant.span.from_expansion()
-            && !variant.ident.span.from_expansion()
-            && let span_after_ident = variant.span.with_lo(variant.ident.span.hi())
-            && has_no_fields(cx, &variant.data, span_after_ident)
-        {
-            match variant.data {
-                VariantData::Struct { .. } => {
-                    self.add_enum_variant(variant.def_id);
-                },
-                VariantData::Tuple(.., local_def_id) => {
-                    // Don't lint reachable tuple enums
-                    if cx.effective_visibilities.is_reachable(variant.def_id) {
-                        return;
-                    }
-                    self.add_enum_variant(local_def_id);
-                },
-                VariantData::Unit(..) => {},
-            }
-        }
+        self.check_def(
+            cx,
+            &variant.data,
+            variant.def_id,
+            variant.span,
+            variant.ident.span,
+            None,
+        );
     }
 
-    fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
-        if let Some((def_id, mut span)) = check_expr_for_enum_as_function(cx, expr) {
-            if span.is_empty()
-                && let Some(parentheses_span) = call_parentheses_span(cx.tcx, expr)
+    fn check_expr(&mut self, cx: &LateContext<'_>, e: &Expr<'_>) {
+        match e.kind {
+            ExprKind::Call(callee, []) if let ExprKind::Path(qpath) = &callee.kind => {
+                // The next visited expression will be `callee`. Make sure we don't add it
+                // as a tuple use.
+                self.skip_next_expr = true;
+                self.push_use(cx, VarKind::Tuple, e.span, qpath, callee.hir_id);
+            },
+            ExprKind::Path(ref qpath)
+                if !mem::replace(&mut self.skip_next_expr, false)
+                    && let Res::Def(DefKind::Ctor(..), did) = cx.typeck_results().qpath_res(qpath, e.hir_id)
+                    && let Some(did) = did.as_local()
+                    && cx.tcx.fn_sig(did).skip_binder().skip_binder().inputs_and_output.len() == 1
+                    && let Some(did) = cx.tcx.opt_local_parent(did) =>
             {
-                span = parentheses_span;
-            }
-
-            if span.is_empty() {
-                // The parentheses are not redundant.
-                self.empty_tuple_enum_variants.insert(def_id, Usage::Used);
-            } else {
-                // Do not count expressions from macro expansion as a redundant use site.
-                if expr.span.from_expansion() {
-                    return;
-                }
-                self.update_enum_variant_usage(def_id, span);
-            }
+                self.uses.push(Use { did, edit_sp: DUMMY_SP });
+            },
+            ExprKind::Struct(qpath, [], StructTailExpr::None | StructTailExpr::DefaultFields(_)) => {
+                self.push_use(cx, VarKind::Struct, e.span, qpath, e.hir_id);
+            },
+            _ => {},
         }
     }
 
-    fn check_pat(&mut self, cx: &LateContext<'_>, pat: &Pat<'_>) {
-        if !pat.span.from_expansion()
-            && let Some((def_id, span)) = check_pat_for_enum_as_function(cx, pat)
-        {
-            self.update_enum_variant_usage(def_id, span);
+    fn check_pat(&mut self, cx: &LateContext<'_>, p: &Pat<'tcx>) {
+        match p.kind {
+            PatKind::TupleStruct(ref qpath, [], _) => {
+                self.push_use(cx, VarKind::Tuple, p.span, qpath, p.hir_id);
+            },
+            PatKind::Struct(ref qpath, [], _) => {
+                self.push_use(cx, VarKind::Struct, p.span, qpath, p.hir_id);
+            },
+            _ => {},
         }
     }
 
-    fn check_crate_post(&mut self, cx: &LateContext<'_>) {
-        for (&local_def_id, usage) in &self.empty_tuple_enum_variants {
-            // Ignore all variants with Usage::Used or Usage::NoDefinition
-            let Usage::Unused { redundant_use_sites } = usage else {
-                continue;
-            };
+    fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
+        if self.defs.is_empty() {
+            return;
+        }
+        self.uses.sort_unstable_by_key(|x| x.did.local_def_index);
 
-            // Attempt to fetch the Variant from LocalDefId.
-            let variant = if let Node::Variant(variant) = cx.tcx.hir_node_by_def_id(local_def_id) {
-                variant
-            } else if let Node::Variant(variant) = cx.tcx.hir_node_by_def_id(cx.tcx.local_parent(local_def_id)) {
-                variant
-            } else {
-                continue;
-            };
-
-            // Span of the parentheses in variant definition
-            let span = variant.span.with_lo(variant.ident.span.hi());
-            let span_inner = span
-                .with_lo(SpanExt::trim_start(span, cx).start + BytePos(1))
-                .with_hi(span.hi() - BytePos(1));
-            if span_contains_non_whitespace(cx, span_inner, false) {
-                continue;
-            }
-            span_lint_hir_and_then(
-                cx,
-                EMPTY_ENUM_VARIANTS_WITH_BRACKETS,
-                variant.hir_id,
-                span,
-                "enum variant has empty brackets",
-                |diagnostic| {
-                    if redundant_use_sites.is_empty() {
-                        // If there's no redundant use sites, the definition is the only place to modify.
-                        diagnostic.span_suggestion_hidden(
-                            span,
-                            "remove the brackets",
-                            "",
-                            Applicability::MaybeIncorrect,
-                        );
-                    } else {
-                        let mut parentheses_spans: Vec<_> =
-                            redundant_use_sites.iter().map(|span| (*span, String::new())).collect();
-                        parentheses_spans.push((span, String::new()));
-                        diagnostic.multipart_suggestion(
-                            "remove the brackets",
-                            parentheses_spans,
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
+        let mut replacements = Vec::with_capacity(16);
+        'def_loop: for def in &self.defs {
+            replacements.clear();
+            replacements.push((
+                def.edit_sp,
+                if def.needs_semi {
+                    String::from(";")
+                } else {
+                    String::new()
                 },
-            );
+            ));
+            let mut app = if def.lint_sp.from_expansion() {
+                Applicability::MaybeIncorrect
+            } else {
+                Applicability::MachineApplicable
+            };
+
+            let start = self
+                .uses
+                .partition_point(|x| x.did.local_def_index < def.did.local_def_index);
+            for u in &self.uses[start..] {
+                if u.did != def.did {
+                    break;
+                }
+                if u.edit_sp == DUMMY_SP {
+                    continue 'def_loop;
+                }
+                if u.edit_sp.from_expansion() {
+                    app = Applicability::MaybeIncorrect;
+                }
+                replacements.push((u.edit_sp, String::new()));
+            }
+
+            span_lint_and_then(cx, def.item_kind.lint(), def.lint_sp, def.item_kind.msg(), |diag| {
+                diag.multipart_suggestion_with_style(
+                    def.var_kind.sugg_msg(),
+                    replacements.clone(),
+                    app,
+                    SuggestionStyle::HideCodeAlways,
+                );
+            });
         }
     }
 }
 
 impl EmptyWithBrackets {
-    fn add_enum_variant(&mut self, local_def_id: LocalDefId) {
-        self.empty_tuple_enum_variants
-            .entry(local_def_id)
-            .and_modify(|entry| {
-                // empty_tuple_enum_variants contains Usage::NoDefinition if the variant was called before
-                // the definition was encountered. Now that there's a
-                // definition, convert it to Usage::Unused.
-                if let Usage::NoDefinition { redundant_use_sites } = entry {
-                    *entry = Usage::Unused {
-                        redundant_use_sites: redundant_use_sites.clone(),
-                    };
+    fn check_def(
+        &mut self,
+        cx: &LateContext<'_>,
+        data: &VariantData<'_>,
+        did: LocalDefId,
+        item_sp: Span,
+        name_sp: Span,
+        struct_generics: Option<&Generics<'_>>,
+    ) {
+        // Start by normalizing the various variant forms into:
+        // * Does the replacement need a semicolon.
+        // * What kind of variant it is.
+        // * The span that should only contain braces and whitespace.
+        let (needs_semi, var_kind, start_sp, end_pos, ctxt) = match *data {
+            VariantData::Struct { fields: [], .. } => {
+                let data = item_sp.data();
+                if let Some(g) = struct_generics {
+                    // `struct Name<generics> where {}`
+                    (true, VarKind::Struct, g.where_clause_span, data.hi, data.ctxt)
+                } else {
+                    // `Variant {}`
+                    (false, VarKind::Struct, name_sp, data.hi, data.ctxt)
                 }
-            })
-            .or_insert_with(|| Usage::Unused {
-                redundant_use_sites: vec![],
-            });
-    }
+            },
+            VariantData::Tuple([], _, _) => {
+                if let Some(g) = struct_generics {
+                    // `struct Name<generics>() where;`
+                    let data = g.where_clause_span.data();
+                    (false, VarKind::Tuple, g.span, data.lo, data.ctxt)
+                } else {
+                    // `Variant()`
+                    let data = item_sp.data();
+                    (false, VarKind::Tuple, name_sp, data.hi, data.ctxt)
+                }
+            },
+            VariantData::Struct { .. } | VariantData::Tuple(..) | VariantData::Unit(..) => return,
+        };
 
-    fn update_enum_variant_usage(&mut self, def_id: LocalDefId, parentheses_span: Span) {
-        match self.empty_tuple_enum_variants.entry(def_id) {
-            IndexEntry::Occupied(mut e) => {
-                if let Usage::Unused { redundant_use_sites } | Usage::NoDefinition { redundant_use_sites } = e.get_mut()
-                {
-                    redundant_use_sites.push(parentheses_span);
-                }
-            },
-            IndexEntry::Vacant(e) => {
-                // The variant isn't in the IndexMap which means its definition wasn't encountered yet.
-                e.insert(Usage::NoDefinition {
-                    redundant_use_sites: vec![parentheses_span],
+        let start_data = start_sp.data();
+        if start_data.ctxt == ctxt
+            && name_sp.ctxt() == ctxt
+            && !ctxt.in_external_macro(cx.tcx.sess.source_map())
+            && let Some(lint_range) = (start_data.hi..end_pos).clone().map_range(cx, |_, src, range| {
+                // Check that the source text only contains whitespace and the braces.
+                // Anything else (e.g. comments, cfgs, macro vars, etc.) should stop this
+                // lint from triggering.
+                let src = src.get(range.clone())?;
+                let src_trimmed = src.trim_matches(is_whitespace);
+                var_kind.is_parens(src_trimmed).then(|| {
+                    let offset = src_trimmed.as_ptr().addr() - src.as_ptr().addr();
+                    range.start + offset..range.start + offset + src_trimmed.len()
+                })
+            })
+        {
+            // Don't edit the out any trailing whitespace to avoid problems with
+            // where clauses.
+            let edit_sp = Span::new(start_data.hi, lint_range.end, ctxt, None);
+            let lint_sp = Span::new(lint_range.start, lint_range.end, ctxt, None);
+            if matches!(var_kind, VarKind::Struct) || !cx.effective_visibilities.is_exported(did) {
+                self.defs.push(Def {
+                    did,
+                    lint_sp,
+                    edit_sp,
+                    needs_semi,
+                    item_kind: if struct_generics.is_some() {
+                        ItemKind::Struct
+                    } else {
+                        ItemKind::Enum
+                    },
+                    var_kind,
                 });
-            },
+            }
         }
     }
-}
 
-fn has_brackets(var_data: &VariantData<'_>) -> bool {
-    !matches!(var_data, VariantData::Unit(..))
-}
-
-fn has_no_fields(cx: &LateContext<'_>, var_data: &VariantData<'_>, braces_span: Span) -> bool {
-    var_data.fields().is_empty() &&
-    // there might still be field declarations hidden from the AST
-    // (conditionally compiled code using #[cfg(..)])
-    !span_contains_cfg(cx, braces_span)
-}
-
-// If expression HIR ID and callee HIR ID are same, returns the span of the parentheses, else,
-// returns None.
-fn call_parentheses_span(tcx: TyCtxt<'_>, expr: &Expr<'_>) -> Option<Span> {
-    if let Node::Expr(parent) = tcx.parent_hir_node(expr.hir_id)
-        && let ExprKind::Call(callee, ..) = parent.kind
-        && callee.hir_id == expr.hir_id
-    {
-        Some(parent.span.with_lo(expr.span.hi()))
-    } else {
-        None
-    }
-}
-
-// Returns the LocalDefId of the variant being called as a function if it exists.
-fn check_expr_for_enum_as_function(cx: &LateContext<'_>, expr: &Expr<'_>) -> Option<(LocalDefId, Span)> {
-    match expr.kind {
-        ExprKind::Path(QPath::Resolved(
-            _,
-            Path {
-                res: Def(Ctor(CtorOf::Variant, _), def_id),
-                span,
-                ..
-            },
-        )) => def_id.as_local().map(|id| (id, span.with_lo(expr.span.hi()))),
-        ExprKind::Struct(qpath, ..)
-            if let Def(DefKind::Variant, mut def_id) = cx.typeck_results().qpath_res(qpath, expr.hir_id) =>
+    fn push_use(&mut self, cx: &LateContext<'_>, kind: VarKind, sp: Span, qpath: &QPath<'_>, hir_id: HirId) {
+        if let Res::Def(def_kind, did) = cx.typeck_results().qpath_res(qpath, hir_id)
+            && let Some(did) = did.as_local()
         {
-            let ty = cx.tcx.type_of(def_id).instantiate_identity().skip_norm_wip();
-            if let ty::FnDef(ctor_def_id, _) = ty.kind() {
-                def_id = *ctor_def_id;
-            }
-
-            def_id.as_local().map(|id| (id, qpath.span().with_lo(expr.span.hi())))
-        },
-        _ => None,
-    }
-}
-
-fn check_pat_for_enum_as_function(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<(LocalDefId, Span)> {
-    match pat.kind {
-        PatKind::TupleStruct(qpath, ..)
-            if let Def(Ctor(CtorOf::Variant, _), def_id) = cx.typeck_results().qpath_res(&qpath, pat.hir_id) =>
-        {
-            def_id.as_local().map(|id| (id, qpath.span().with_lo(pat.span.hi())))
-        },
-        PatKind::Struct(qpath, ..)
-            if let Def(DefKind::Variant, mut def_id) = cx.typeck_results().qpath_res(&qpath, pat.hir_id) =>
-        {
-            let ty = cx.tcx.type_of(def_id).instantiate_identity().skip_norm_wip();
-            if let ty::FnDef(ctor_def_id, _) = ty.kind() {
-                def_id = *ctor_def_id;
-            }
-
-            def_id.as_local().map(|id| (id, qpath.span().with_lo(pat.span.hi())))
-        },
-        _ => None,
+            let did = match def_kind {
+                DefKind::Ctor(..) => cx.tcx.local_parent(did),
+                // 2026-08-20: `<T>::X {}` incorrectly resolves to the variant.
+                DefKind::Variant | DefKind::Struct => did,
+                _ => return,
+            };
+            let sp_data = sp.data();
+            let (in_ctxt, path_sp) = match *qpath {
+                QPath::Resolved(_, path) if let [.., seg] = path.segments => {
+                    (seg.ident.span.ctxt() == sp_data.ctxt, path.span)
+                },
+                QPath::TypeRelative(ty, seg) => (ty.span.ctxt() == sp_data.ctxt, seg.ident.span),
+                QPath::Resolved(_, path) => span_bug!(path.span, "path with no segments"),
+            };
+            let path_data = path_sp.data();
+            let edit_sp = if in_ctxt
+                && sp_data.ctxt == path_data.ctxt
+                && let Some(edit_range) = (path_data.hi..sp_data.hi).map_range(cx, |_, src, range| {
+                    let s = kind.strip_leading_parens(src.get(range.clone())?)?;
+                    s.chars()
+                        .all(|c| c == ')' || is_whitespace(c))
+                        .then_some(range.start..range.end - s.len())
+                }) {
+                edit_range.with_ctxt(sp_data.ctxt)
+            } else if let VarKind::Tuple = kind
+                && !in_automatically_derived(cx.tcx, hir_id)
+            {
+                // Parenthesis have to be removed for the suggestion to be valid.
+                // Use the dummy span to mark this as unfixable.
+                DUMMY_SP
+            } else {
+                return;
+            };
+            self.uses.push(Use { did, edit_sp });
+        }
     }
 }

--- a/tests/ui/empty_enum_variants_with_brackets.fixed
+++ b/tests/ui/empty_enum_variants_with_brackets.fixed
@@ -1,163 +1,139 @@
-#![warn(clippy::empty_enum_variants_with_brackets)]
+//@aux-build:proc_macros.rs
 #![feature(more_qualified_paths)]
+#![deny(clippy::empty_enum_variants_with_brackets)]
+#![expect(clippy::no_effect)]
+#![allow(clippy::unneeded_struct_pattern)] // FP removed after rustfix
 
-pub enum PublicTestEnum {
-    NonEmptyBraces { x: i32, y: i32 }, // No error
-    NonEmptyParentheses(i32, i32),     // No error
-    EmptyBraces,
-    //~^ empty_enum_variants_with_brackets
-    EmptyParentheses(), // No error as enum is pub
+extern crate proc_macros;
+
+use core::hint::black_box;
+use proc_macros::{external, inline_macros, with_span};
+
+pub enum Pub1 {
+    V1(),
+    V2, //~ empty_enum_variants_with_brackets
 }
 
-enum TestEnum {
-    NonEmptyBraces { x: i32, y: i32 }, // No error
-    NonEmptyParentheses(i32, i32),     // No error
-    EmptyBraces,
-    //~^ empty_enum_variants_with_brackets
-    EmptyParentheses,
-    //~^ empty_enum_variants_with_brackets
-    AnotherEnum, // No error
+#[inline_macros]
+fn main() {
+    // Tuple variants
+    {
+        enum E1 {
+            V1, //~ empty_enum_variants_with_brackets
+            V2(u32),
+            V3(),
+            V4(),
+        }
+        enum E2 {
+            V1, //~ empty_enum_variants_with_brackets
+        }
+
+        let E2::V1 = E2::V1;
+        let <E2>::V1 = <E2>::V1;
+        let E2::V1 = E2::V1;
+        let <E2>::V1 = <E2>::V1;
+        E2::V1 = E2::V1;
+        <E2>::V1 = <E2>::V1;
+        E2::V1 = E2::V1;
+        <E2>::V1 = <E2>::V1;
+
+        black_box(E1::V3);
+        black_box(<E1>::V4);
+    }
+    // Struct variants
+    {
+        enum E1 {
+            V1, //~ empty_enum_variants_with_brackets
+            V2 { x: u32 },
+        }
+        enum E2 {
+            V1, //~ empty_enum_variants_with_brackets
+        }
+
+        let E2::V1 = E2::V1;
+        let <E2>::V1 = <E2>::V1;
+        E2::V1 = E2::V1;
+        <E2>::V1 = <E2>::V1;
+    }
+    // Cfg fields and comments
+    {
+        enum E {
+            V1 {
+                #[cfg(any())]
+                x: u32,
+            },
+            V2(#[cfg(any())] u32),
+            V3 {
+                // intentionally empty
+            },
+            V4(/* intentionally empty */),
+        }
+    }
+    // External macro declarations
+    {
+        external! {
+            enum E1 {
+                V1(),
+                V2 {},
+            }
+        }
+        with_span! {
+            sp
+            enum E2 {
+                V1(),
+                V2 {},
+            }
+        }
+    }
+    // External macro uses
+    {
+        enum E {
+            V1(),
+            V2(),
+            V3,  //~ empty_enum_variants_with_brackets
+            V4, //~ empty_enum_variants_with_brackets
+        }
+
+        external!({
+            E::V1();
+            E::V3 {};
+            E::V4 {};
+        });
+        with_span!(sp {
+            E::V2();
+            E::V3 {};
+            E::V4 {};
+        });
+    }
+    // Macro declarations
+    {
+        inline! {
+            enum E {
+                V1, //~ empty_enum_variants_with_brackets
+                V2, //~ empty_enum_variants_with_brackets
+                $V3(),
+                $V4 {},
+                V5($()),
+            }
+        }
+    }
+    // Macro uses
+    {
+        enum E1 {
+            V1(),
+            V2(),
+            V3, //~ empty_enum_variants_with_brackets
+        }
+        enum E2 {
+            V1, //~ empty_enum_variants_with_brackets
+        }
+
+        inline!({
+            $(E1::V1)();
+            E1::V2($());
+            E2::V1;
+            $(E1::V3) {};
+            let $(E2::V1) {} = $(E2::V1) {};
+        });
+    }
 }
-
-mod issue12551 {
-    enum EvenOdd {
-        // Used as functions -> no error
-        Even(),
-        Odd(),
-        // Not used as a function
-        Unknown,
-        //~^ empty_enum_variants_with_brackets
-    }
-
-    fn even_odd(x: i32) -> EvenOdd {
-        (x % 2 == 0).then(EvenOdd::Even).unwrap_or_else(EvenOdd::Odd)
-    }
-
-    fn natural_number(x: i32) -> NaturalOrNot {
-        (x > 0)
-            .then(NaturalOrNot::Natural)
-            .unwrap_or_else(NaturalOrNot::NotNatural)
-    }
-
-    enum NaturalOrNot {
-        // Used as functions -> no error
-        Natural(),
-        NotNatural(),
-        // Not used as a function
-        Unknown,
-        //~^ empty_enum_variants_with_brackets
-    }
-
-    enum RedundantParenthesesFunctionCall {
-        // Used as a function call but with redundant parentheses
-        Parentheses,
-        //~^ empty_enum_variants_with_brackets
-        // Not used as a function
-        NoParentheses,
-    }
-
-    #[allow(clippy::no_effect)]
-    fn redundant_parentheses_function_call() {
-        // The parentheses in the below line are redundant.
-        RedundantParenthesesFunctionCall::Parentheses;
-        RedundantParenthesesFunctionCall::NoParentheses;
-    }
-
-    // Same test as above but with usage of the enum occurring before the definition.
-    #[allow(clippy::no_effect)]
-    fn redundant_parentheses_function_call_2() {
-        // The parentheses in the below line are redundant.
-        RedundantParenthesesFunctionCall2::Parentheses;
-        RedundantParenthesesFunctionCall2::NoParentheses;
-    }
-
-    enum RedundantParenthesesFunctionCall2 {
-        // Used as a function call but with redundant parentheses
-        Parentheses,
-        //~^ empty_enum_variants_with_brackets
-        // Not used as a function
-        NoParentheses,
-    }
-}
-
-enum TestEnumWithFeatures {
-    NonEmptyBraces {
-        #[cfg(feature = "thisisneverenabled")]
-        x: i32,
-    }, // No error
-    NonEmptyParentheses(#[cfg(feature = "thisisneverenabled")] i32), // No error
-}
-
-#[derive(Clone)]
-enum Foo {
-    Variant1(i32),
-    Variant2,
-    Variant3, //~ empty_enum_variants_with_brackets
-}
-
-#[derive(Clone)]
-pub enum PubFoo {
-    Variant1(i32),
-    Variant2,
-    Variant3(),
-}
-
-fn issue16157() {
-    enum E {
-        V,
-        //~^ empty_enum_variants_with_brackets
-    }
-
-    let E::V = E::V;
-
-    <E>::V = E::V;
-    <E>::V = E::V;
-}
-
-fn variant_with_braces() {
-    enum E {
-        V,
-        //~^ empty_enum_variants_with_brackets
-    }
-    E::V = E::V;
-    E::V = E::V;
-    <E>::V = <E>::V;
-
-    enum F {
-        U,
-        //~^ empty_enum_variants_with_brackets
-    }
-    F::U = F::U;
-    <F>::U = F::U;
-}
-
-fn variant_with_comments_and_cfg() {
-    enum E {
-        V(
-            // This is a comment
-        ),
-    }
-    E::V() = E::V();
-
-    enum F {
-        U {
-            // This is a comment
-        },
-    }
-    F::U {} = F::U {};
-
-    enum G {
-        V(#[cfg(target_os = "cuda")] String),
-    }
-    G::V() = G::V();
-
-    enum H {
-        U {
-            #[cfg(target_os = "cuda")]
-            value: String,
-        },
-    }
-    H::U {} = H::U {};
-}
-
-fn main() {}

--- a/tests/ui/empty_enum_variants_with_brackets.rs
+++ b/tests/ui/empty_enum_variants_with_brackets.rs
@@ -1,163 +1,139 @@
-#![warn(clippy::empty_enum_variants_with_brackets)]
+//@aux-build:proc_macros.rs
 #![feature(more_qualified_paths)]
+#![deny(clippy::empty_enum_variants_with_brackets)]
+#![expect(clippy::no_effect)]
+#![allow(clippy::unneeded_struct_pattern)] // FP removed after rustfix
 
-pub enum PublicTestEnum {
-    NonEmptyBraces { x: i32, y: i32 }, // No error
-    NonEmptyParentheses(i32, i32),     // No error
-    EmptyBraces {},
-    //~^ empty_enum_variants_with_brackets
-    EmptyParentheses(), // No error as enum is pub
+extern crate proc_macros;
+
+use core::hint::black_box;
+use proc_macros::{external, inline_macros, with_span};
+
+pub enum Pub1 {
+    V1(),
+    V2 {}, //~ empty_enum_variants_with_brackets
 }
 
-enum TestEnum {
-    NonEmptyBraces { x: i32, y: i32 }, // No error
-    NonEmptyParentheses(i32, i32),     // No error
-    EmptyBraces {},
-    //~^ empty_enum_variants_with_brackets
-    EmptyParentheses(),
-    //~^ empty_enum_variants_with_brackets
-    AnotherEnum, // No error
+#[inline_macros]
+fn main() {
+    // Tuple variants
+    {
+        enum E1 {
+            V1(), //~ empty_enum_variants_with_brackets
+            V2(u32),
+            V3(),
+            V4(),
+        }
+        enum E2 {
+            V1(), //~ empty_enum_variants_with_brackets
+        }
+
+        let E2::V1() = E2::V1();
+        let <E2>::V1() = <E2>::V1();
+        let E2::V1 {} = E2::V1 {};
+        let <E2>::V1 {} = <E2>::V1 {};
+        E2::V1() = E2::V1();
+        <E2>::V1() = <E2>::V1();
+        E2::V1 {} = E2::V1 {};
+        <E2>::V1 {} = <E2>::V1 {};
+
+        black_box(E1::V3);
+        black_box(<E1>::V4);
+    }
+    // Struct variants
+    {
+        enum E1 {
+            V1 {}, //~ empty_enum_variants_with_brackets
+            V2 { x: u32 },
+        }
+        enum E2 {
+            V1 {}, //~ empty_enum_variants_with_brackets
+        }
+
+        let E2::V1 {} = E2::V1 {};
+        let <E2>::V1 {} = <E2>::V1 {};
+        E2::V1 {} = E2::V1 {};
+        <E2>::V1 {} = <E2>::V1 {};
+    }
+    // Cfg fields and comments
+    {
+        enum E {
+            V1 {
+                #[cfg(any())]
+                x: u32,
+            },
+            V2(#[cfg(any())] u32),
+            V3 {
+                // intentionally empty
+            },
+            V4(/* intentionally empty */),
+        }
+    }
+    // External macro declarations
+    {
+        external! {
+            enum E1 {
+                V1(),
+                V2 {},
+            }
+        }
+        with_span! {
+            sp
+            enum E2 {
+                V1(),
+                V2 {},
+            }
+        }
+    }
+    // External macro uses
+    {
+        enum E {
+            V1(),
+            V2(),
+            V3(),  //~ empty_enum_variants_with_brackets
+            V4 {}, //~ empty_enum_variants_with_brackets
+        }
+
+        external!({
+            E::V1();
+            E::V3 {};
+            E::V4 {};
+        });
+        with_span!(sp {
+            E::V2();
+            E::V3 {};
+            E::V4 {};
+        });
+    }
+    // Macro declarations
+    {
+        inline! {
+            enum E {
+                V1(), //~ empty_enum_variants_with_brackets
+                V2 {}, //~ empty_enum_variants_with_brackets
+                $V3(),
+                $V4 {},
+                V5($()),
+            }
+        }
+    }
+    // Macro uses
+    {
+        enum E1 {
+            V1(),
+            V2(),
+            V3 {}, //~ empty_enum_variants_with_brackets
+        }
+        enum E2 {
+            V1(), //~ empty_enum_variants_with_brackets
+        }
+
+        inline!({
+            $(E1::V1)();
+            E1::V2($());
+            E2::V1();
+            $(E1::V3) {};
+            let $(E2::V1) {} = $(E2::V1) {};
+        });
+    }
 }
-
-mod issue12551 {
-    enum EvenOdd {
-        // Used as functions -> no error
-        Even(),
-        Odd(),
-        // Not used as a function
-        Unknown(),
-        //~^ empty_enum_variants_with_brackets
-    }
-
-    fn even_odd(x: i32) -> EvenOdd {
-        (x % 2 == 0).then(EvenOdd::Even).unwrap_or_else(EvenOdd::Odd)
-    }
-
-    fn natural_number(x: i32) -> NaturalOrNot {
-        (x > 0)
-            .then(NaturalOrNot::Natural)
-            .unwrap_or_else(NaturalOrNot::NotNatural)
-    }
-
-    enum NaturalOrNot {
-        // Used as functions -> no error
-        Natural(),
-        NotNatural(),
-        // Not used as a function
-        Unknown(),
-        //~^ empty_enum_variants_with_brackets
-    }
-
-    enum RedundantParenthesesFunctionCall {
-        // Used as a function call but with redundant parentheses
-        Parentheses(),
-        //~^ empty_enum_variants_with_brackets
-        // Not used as a function
-        NoParentheses,
-    }
-
-    #[allow(clippy::no_effect)]
-    fn redundant_parentheses_function_call() {
-        // The parentheses in the below line are redundant.
-        RedundantParenthesesFunctionCall::Parentheses();
-        RedundantParenthesesFunctionCall::NoParentheses;
-    }
-
-    // Same test as above but with usage of the enum occurring before the definition.
-    #[allow(clippy::no_effect)]
-    fn redundant_parentheses_function_call_2() {
-        // The parentheses in the below line are redundant.
-        RedundantParenthesesFunctionCall2::Parentheses();
-        RedundantParenthesesFunctionCall2::NoParentheses;
-    }
-
-    enum RedundantParenthesesFunctionCall2 {
-        // Used as a function call but with redundant parentheses
-        Parentheses(),
-        //~^ empty_enum_variants_with_brackets
-        // Not used as a function
-        NoParentheses,
-    }
-}
-
-enum TestEnumWithFeatures {
-    NonEmptyBraces {
-        #[cfg(feature = "thisisneverenabled")]
-        x: i32,
-    }, // No error
-    NonEmptyParentheses(#[cfg(feature = "thisisneverenabled")] i32), // No error
-}
-
-#[derive(Clone)]
-enum Foo {
-    Variant1(i32),
-    Variant2,
-    Variant3(), //~ empty_enum_variants_with_brackets
-}
-
-#[derive(Clone)]
-pub enum PubFoo {
-    Variant1(i32),
-    Variant2,
-    Variant3(),
-}
-
-fn issue16157() {
-    enum E {
-        V(),
-        //~^ empty_enum_variants_with_brackets
-    }
-
-    let E::V() = E::V();
-
-    <E>::V() = E::V();
-    <E>::V {} = E::V();
-}
-
-fn variant_with_braces() {
-    enum E {
-        V(),
-        //~^ empty_enum_variants_with_brackets
-    }
-    E::V() = E::V();
-    E::V() = E::V {};
-    <E>::V {} = <E>::V {};
-
-    enum F {
-        U {},
-        //~^ empty_enum_variants_with_brackets
-    }
-    F::U {} = F::U {};
-    <F>::U {} = F::U {};
-}
-
-fn variant_with_comments_and_cfg() {
-    enum E {
-        V(
-            // This is a comment
-        ),
-    }
-    E::V() = E::V();
-
-    enum F {
-        U {
-            // This is a comment
-        },
-    }
-    F::U {} = F::U {};
-
-    enum G {
-        V(#[cfg(target_os = "cuda")] String),
-    }
-    G::V() = G::V();
-
-    enum H {
-        U {
-            #[cfg(target_os = "cuda")]
-            value: String,
-        },
-    }
-    H::U {} = H::U {};
-}
-
-fn main() {}

--- a/tests/ui/empty_enum_variants_with_brackets.stderr
+++ b/tests/ui/empty_enum_variants_with_brackets.stderr
@@ -1,131 +1,92 @@
-error: enum variant has empty brackets
-  --> tests/ui/empty_enum_variants_with_brackets.rs:7:16
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:7:17
    |
 LL |     EmptyBraces {},
-   |                ^^^
+   |                 ^^
    |
    = note: `-D clippy::empty-enum-variants-with-brackets` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::empty_enum_variants_with_brackets)]`
    = help: remove the brackets
 
-error: enum variant has empty brackets
-  --> tests/ui/empty_enum_variants_with_brackets.rs:15:16
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:15:17
    |
 LL |     EmptyBraces {},
-   |                ^^^
+   |                 ^^
    |
    = help: remove the brackets
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:17:21
    |
 LL |     EmptyParentheses(),
    |                     ^^
    |
-   = help: remove the brackets
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:28:16
    |
 LL |         Unknown(),
    |                ^^
    |
-   = help: remove the brackets
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:47:16
    |
 LL |         Unknown(),
    |                ^^
    |
-   = help: remove the brackets
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:53:20
    |
 LL |         Parentheses(),
    |                    ^^
    |
-help: remove the brackets
-   |
-LL ~         Parentheses,
-LL |
-...
-LL |         // The parentheses in the below line are redundant.
-LL ~         RedundantParenthesesFunctionCall::Parentheses;
-   |
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:76:20
    |
 LL |         Parentheses(),
    |                    ^^
    |
-help: remove the brackets
-   |
-LL ~         RedundantParenthesesFunctionCall2::Parentheses;
-LL |         RedundantParenthesesFunctionCall2::NoParentheses;
-...
-LL |         // Used as a function call but with redundant parentheses
-LL ~         Parentheses,
-   |
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:95:13
    |
 LL |     Variant3(),
    |             ^^
    |
-   = help: remove the brackets
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:107:10
    |
 LL |         V(),
    |          ^^
    |
-help: remove the brackets
-   |
-LL ~         V,
-LL |
-LL |     }
-LL |
-LL ~     let E::V = E::V;
-LL |
-LL ~     <E>::V = E::V;
-LL ~     <E>::V = E::V;
-   |
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
+error: non-unit variant contains no fields
   --> tests/ui/empty_enum_variants_with_brackets.rs:119:10
    |
 LL |         V(),
    |          ^^
    |
-help: remove the brackets
-   |
-LL ~         V,
-LL |
-LL |     }
-LL ~     E::V = E::V;
-LL ~     E::V = E::V;
-LL ~     <E>::V = <E>::V;
-   |
+   = help: remove the parenthesis
 
-error: enum variant has empty brackets
-  --> tests/ui/empty_enum_variants_with_brackets.rs:127:10
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:127:11
    |
 LL |         U {},
-   |          ^^^
+   |           ^^
    |
-help: remove the brackets
-   |
-LL ~         U,
-LL |
-LL |     }
-LL ~     F::U = F::U;
-LL ~     <F>::U = F::U;
-   |
+   = help: remove the brackets
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/empty_enum_variants_with_brackets.stderr
+++ b/tests/ui/empty_enum_variants_with_brackets.stderr
@@ -1,92 +1,97 @@
 error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:7:17
+  --> tests/ui/empty_enum_variants_with_brackets.rs:14:8
    |
-LL |     EmptyBraces {},
-   |                 ^^
+LL |     V2 {},
+   |        ^^
    |
-   = note: `-D clippy::empty-enum-variants-with-brackets` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::empty_enum_variants_with_brackets)]`
+note: the lint level is defined here
+  --> tests/ui/empty_enum_variants_with_brackets.rs:3:9
+   |
+LL | #![deny(clippy::empty_enum_variants_with_brackets)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: remove the brackets
 
 error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:15:17
+  --> tests/ui/empty_enum_variants_with_brackets.rs:22:15
    |
-LL |     EmptyBraces {},
-   |                 ^^
-   |
-   = help: remove the brackets
-
-error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:17:21
-   |
-LL |     EmptyParentheses(),
-   |                     ^^
+LL |             V1(),
+   |               ^^
    |
    = help: remove the parenthesis
 
 error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:28:16
+  --> tests/ui/empty_enum_variants_with_brackets.rs:28:15
    |
-LL |         Unknown(),
+LL |             V1(),
+   |               ^^
+   |
+   = help: remove the parenthesis
+
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:46:16
+   |
+LL |             V1 {},
    |                ^^
    |
-   = help: remove the parenthesis
+   = help: remove the brackets
 
 error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:47:16
+  --> tests/ui/empty_enum_variants_with_brackets.rs:50:16
    |
-LL |         Unknown(),
+LL |             V1 {},
    |                ^^
    |
-   = help: remove the parenthesis
+   = help: remove the brackets
 
 error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:53:20
+  --> tests/ui/empty_enum_variants_with_brackets.rs:93:15
    |
-LL |         Parentheses(),
-   |                    ^^
-   |
-   = help: remove the parenthesis
-
-error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:76:20
-   |
-LL |         Parentheses(),
-   |                    ^^
+LL |             V3(),
+   |               ^^
    |
    = help: remove the parenthesis
 
 error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:95:13
+  --> tests/ui/empty_enum_variants_with_brackets.rs:94:16
    |
-LL |     Variant3(),
-   |             ^^
-   |
-   = help: remove the parenthesis
-
-error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:107:10
-   |
-LL |         V(),
-   |          ^^
-   |
-   = help: remove the parenthesis
-
-error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:119:10
-   |
-LL |         V(),
-   |          ^^
-   |
-   = help: remove the parenthesis
-
-error: non-unit variant contains no fields
-  --> tests/ui/empty_enum_variants_with_brackets.rs:127:11
-   |
-LL |         U {},
-   |           ^^
+LL |             V4 {},
+   |                ^^
    |
    = help: remove the brackets
+
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:112:19
+   |
+LL |                 V1(),
+   |                   ^^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: remove the parenthesis
+
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:113:20
+   |
+LL |                 V2 {},
+   |                    ^^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: remove the brackets
+
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:125:16
+   |
+LL |             V3 {},
+   |                ^^
+   |
+   = help: remove the brackets
+
+error: non-unit variant contains no fields
+  --> tests/ui/empty_enum_variants_with_brackets.rs:128:15
+   |
+LL |             V1(),
+   |               ^^
+   |
+   = help: remove the parenthesis
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/empty_structs_with_brackets.fixed
+++ b/tests/ui/empty_structs_with_brackets.fixed
@@ -1,47 +1,135 @@
-#![warn(clippy::empty_structs_with_brackets)]
+//@aux-build:proc_macros.rs
+#![deny(clippy::empty_structs_with_brackets)]
+#![expect(clippy::no_effect)]
 
-pub struct MyEmptyStruct; // should trigger lint
-//~^ empty_structs_with_brackets
-struct MyEmptyTupleStruct; // should trigger lint
-//~^ empty_structs_with_brackets
+extern crate proc_macros;
 
-// should not trigger lint
-struct MyCfgStruct {
-    #[cfg(feature = "thisisneverenabled")]
-    field: u8,
-}
+use core::hint::black_box;
+use proc_macros::{external, inline_macros, with_span};
 
-// should not trigger lint
-struct MyCfgTupleStruct(#[cfg(feature = "thisisneverenabled")] u8);
+pub struct Pub1();
+pub struct Pub2; //~ empty_structs_with_brackets
+#[non_exhaustive]
+pub struct Pub3; //~ empty_structs_with_brackets
 
-// should not trigger lint
-struct MyStruct {
-    field: u8,
-}
-struct MyTupleStruct(usize, String); // should not trigger lint
-struct MySingleTupleStruct(usize); // should not trigger lint
-struct MyUnitLikeStruct; // should not trigger lint
-
-macro_rules! empty_struct {
-    ($s:ident) => {
-        struct $s {}
-    };
-}
-
-empty_struct!(FromMacro);
-
-fn main() {}
-
-mod issue15349 {
-    trait Bar<T> {}
-    impl<T> Bar<T> for [u8; 7] {}
-
-    struct Foo<const N: usize>;
-    //~^ empty_structs_with_brackets
-    impl<const N: usize> Foo<N>
-    where
-        [u8; N]: Bar<[(); N]>,
+#[inline_macros]
+fn main() {
+    // Tuple struct
     {
-        fn foo() {}
+        struct S1; //~ empty_structs_with_brackets
+        struct S2(u32);
+        struct S3; //~ empty_structs_with_brackets
+        struct S4();
+
+        let S3 = S3;
+        let S3 = S3;
+        S3 = S3;
+        S3 = S3;
+
+        black_box(S4);
+    }
+    // Structs
+    {
+        struct S1; //~ empty_structs_with_brackets
+        struct S2 {
+            x: u32,
+        }
+        struct S3; //~ empty_structs_with_brackets
+
+        let S3 = S3;
+        S3 = S3;
+    }
+    // Cfg fields and comments
+    {
+        struct S1 {
+            #[cfg(any())]
+            x: u32,
+        }
+        struct S2(#[cfg(any())] u32);
+        struct S3 {
+            // intentionally empty
+        }
+        struct S4(/* intentionally empty */);
+    }
+    // With generics
+    {
+        //~v empty_structs_with_brackets
+        struct S1
+        where
+            u32: Sized;
+        //~v empty_structs_with_brackets
+        struct S2<const N: usize>;
+        //~v empty_structs_with_brackets
+        struct S3<const N: usize>
+        where
+            u32: Sized;
+
+        //~vvv empty_structs_with_brackets
+        struct S4
+        where
+            u32: Sized,;
+        //~v empty_structs_with_brackets
+        struct S5<const N: usize>;
+        //~vvv empty_structs_with_brackets
+        struct S6<const N: usize>
+        where
+            u32: Sized,;
+    }
+    // External macro declarations
+    {
+        external! {
+            struct S1();
+            struct S2 {}
+        }
+        with_span! {
+            sp
+            struct S3();
+            struct S4 {}
+        }
+    }
+    // External macro uses
+    {
+        struct S1();
+        struct S2();
+        struct S3; //~ empty_structs_with_brackets
+        struct S4; //~ empty_structs_with_brackets
+
+        external!({
+            S1();
+            S3 {};
+            S4 {};
+        });
+        with_span!(sp {
+            S2();
+            S3 {};
+            S4 {};
+        });
+    }
+    // Macro declarations
+    {
+        inline! {
+            struct S1; //~ empty_structs_with_brackets
+            struct S2; //~ empty_structs_with_brackets
+            struct $S3();
+            struct $S4 {};
+            struct S5$(<const N: usize>)();
+            struct S6() $(where u32: Sized);
+            struct S7($());
+        }
+    }
+    // Macro uses
+    {
+        struct S1();
+        struct S2();
+        struct S3; //~ empty_structs_with_brackets
+        struct S4; //~ empty_structs_with_brackets
+
+        inline!({
+            $S1();
+            S2($());
+            S3;
+            let $S3 {} = $S3 {};
+            $S4 {};
+        });
     }
 }

--- a/tests/ui/empty_structs_with_brackets.rs
+++ b/tests/ui/empty_structs_with_brackets.rs
@@ -1,47 +1,135 @@
-#![warn(clippy::empty_structs_with_brackets)]
+//@aux-build:proc_macros.rs
+#![deny(clippy::empty_structs_with_brackets)]
+#![expect(clippy::no_effect)]
 
-pub struct MyEmptyStruct {} // should trigger lint
-//~^ empty_structs_with_brackets
-struct MyEmptyTupleStruct(); // should trigger lint
-//~^ empty_structs_with_brackets
+extern crate proc_macros;
 
-// should not trigger lint
-struct MyCfgStruct {
-    #[cfg(feature = "thisisneverenabled")]
-    field: u8,
-}
+use core::hint::black_box;
+use proc_macros::{external, inline_macros, with_span};
 
-// should not trigger lint
-struct MyCfgTupleStruct(#[cfg(feature = "thisisneverenabled")] u8);
+pub struct Pub1();
+pub struct Pub2 {} //~ empty_structs_with_brackets
+#[non_exhaustive]
+pub struct Pub3 {} //~ empty_structs_with_brackets
 
-// should not trigger lint
-struct MyStruct {
-    field: u8,
-}
-struct MyTupleStruct(usize, String); // should not trigger lint
-struct MySingleTupleStruct(usize); // should not trigger lint
-struct MyUnitLikeStruct; // should not trigger lint
-
-macro_rules! empty_struct {
-    ($s:ident) => {
-        struct $s {}
-    };
-}
-
-empty_struct!(FromMacro);
-
-fn main() {}
-
-mod issue15349 {
-    trait Bar<T> {}
-    impl<T> Bar<T> for [u8; 7] {}
-
-    struct Foo<const N: usize> {}
-    //~^ empty_structs_with_brackets
-    impl<const N: usize> Foo<N>
-    where
-        [u8; N]: Bar<[(); N]>,
+#[inline_macros]
+fn main() {
+    // Tuple struct
     {
-        fn foo() {}
+        struct S1(); //~ empty_structs_with_brackets
+        struct S2(u32);
+        struct S3(); //~ empty_structs_with_brackets
+        struct S4();
+
+        let S3() = S3();
+        let S3 {} = S3 {};
+        S3() = S3();
+        S3 {} = S3 {};
+
+        black_box(S4);
+    }
+    // Structs
+    {
+        struct S1 {} //~ empty_structs_with_brackets
+        struct S2 {
+            x: u32,
+        }
+        struct S3 {} //~ empty_structs_with_brackets
+
+        let S3 {} = S3 {};
+        S3 {} = S3 {};
+    }
+    // Cfg fields and comments
+    {
+        struct S1 {
+            #[cfg(any())]
+            x: u32,
+        }
+        struct S2(#[cfg(any())] u32);
+        struct S3 {
+            // intentionally empty
+        }
+        struct S4(/* intentionally empty */);
+    }
+    // With generics
+    {
+        //~v empty_structs_with_brackets
+        struct S1()
+        where
+            u32: Sized;
+        //~v empty_structs_with_brackets
+        struct S2<const N: usize>();
+        //~v empty_structs_with_brackets
+        struct S3<const N: usize>()
+        where
+            u32: Sized;
+
+        //~vvv empty_structs_with_brackets
+        struct S4
+        where
+            u32: Sized, {}
+        //~v empty_structs_with_brackets
+        struct S5<const N: usize> {}
+        //~vvv empty_structs_with_brackets
+        struct S6<const N: usize>
+        where
+            u32: Sized, {}
+    }
+    // External macro declarations
+    {
+        external! {
+            struct S1();
+            struct S2 {}
+        }
+        with_span! {
+            sp
+            struct S3();
+            struct S4 {}
+        }
+    }
+    // External macro uses
+    {
+        struct S1();
+        struct S2();
+        struct S3(); //~ empty_structs_with_brackets
+        struct S4 {} //~ empty_structs_with_brackets
+
+        external!({
+            S1();
+            S3 {};
+            S4 {};
+        });
+        with_span!(sp {
+            S2();
+            S3 {};
+            S4 {};
+        });
+    }
+    // Macro declarations
+    {
+        inline! {
+            struct S1(); //~ empty_structs_with_brackets
+            struct S2 {} //~ empty_structs_with_brackets
+            struct $S3();
+            struct $S4 {};
+            struct S5$(<const N: usize>)();
+            struct S6() $(where u32: Sized);
+            struct S7($());
+        }
+    }
+    // Macro uses
+    {
+        struct S1();
+        struct S2();
+        struct S3(); //~ empty_structs_with_brackets
+        struct S4 {} //~ empty_structs_with_brackets
+
+        inline!({
+            $S1();
+            S2($());
+            S3();
+            let $S3 {} = $S3 {};
+            $S4 {};
+        });
     }
 }

--- a/tests/ui/empty_structs_with_brackets.stderr
+++ b/tests/ui/empty_structs_with_brackets.stderr
@@ -1,28 +1,153 @@
 error: non-unit struct contains no fields
-  --> tests/ui/empty_structs_with_brackets.rs:3:26
+  --> tests/ui/empty_structs_with_brackets.rs:11:17
    |
-LL | pub struct MyEmptyStruct {} // should trigger lint
-   |                          ^^
+LL | pub struct Pub2 {}
+   |                 ^^
    |
-   = note: `-D clippy::empty-structs-with-brackets` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::empty_structs_with_brackets)]`
+note: the lint level is defined here
+  --> tests/ui/empty_structs_with_brackets.rs:2:9
+   |
+LL | #![deny(clippy::empty_structs_with_brackets)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: remove the brackets
 
 error: non-unit struct contains no fields
-  --> tests/ui/empty_structs_with_brackets.rs:5:26
+  --> tests/ui/empty_structs_with_brackets.rs:13:17
    |
-LL | struct MyEmptyTupleStruct(); // should trigger lint
-   |                          ^^
+LL | pub struct Pub3 {}
+   |                 ^^
+   |
+   = help: remove the brackets
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:19:18
+   |
+LL |         struct S1();
+   |                  ^^
    |
    = help: remove the parenthesis
 
 error: non-unit struct contains no fields
-  --> tests/ui/empty_structs_with_brackets.rs:39:32
+  --> tests/ui/empty_structs_with_brackets.rs:21:18
    |
-LL |     struct Foo<const N: usize> {}
-   |                                ^^
+LL |         struct S3();
+   |                  ^^
+   |
+   = help: remove the parenthesis
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:33:19
+   |
+LL |         struct S1 {}
+   |                   ^^
    |
    = help: remove the brackets
 
-error: aborting due to 3 previous errors
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:37:19
+   |
+LL |         struct S3 {}
+   |                   ^^
+   |
+   = help: remove the brackets
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:57:18
+   |
+LL |         struct S1()
+   |                  ^^
+   |
+   = help: remove the parenthesis
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:61:34
+   |
+LL |         struct S2<const N: usize>();
+   |                                  ^^
+   |
+   = help: remove the parenthesis
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:63:34
+   |
+LL |         struct S3<const N: usize>()
+   |                                  ^^
+   |
+   = help: remove the parenthesis
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:70:25
+   |
+LL |             u32: Sized, {}
+   |                         ^^
+   |
+   = help: remove the brackets
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:72:35
+   |
+LL |         struct S5<const N: usize> {}
+   |                                   ^^
+   |
+   = help: remove the brackets
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:76:25
+   |
+LL |             u32: Sized, {}
+   |                         ^^
+   |
+   = help: remove the brackets
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:94:18
+   |
+LL |         struct S3();
+   |                  ^^
+   |
+   = help: remove the parenthesis
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:95:19
+   |
+LL |         struct S4 {}
+   |                   ^^
+   |
+   = help: remove the brackets
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:111:22
+   |
+LL |             struct S1();
+   |                      ^^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: remove the parenthesis
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:112:23
+   |
+LL |             struct S2 {}
+   |                       ^^
+   |
+   = note: this error originates in the macro `__inline_mac_fn_main` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: remove the brackets
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:124:18
+   |
+LL |         struct S3();
+   |                  ^^
+   |
+   = help: remove the parenthesis
+
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:125:19
+   |
+LL |         struct S4 {}
+   |                   ^^
+   |
+   = help: remove the brackets
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/empty_structs_with_brackets.stderr
+++ b/tests/ui/empty_structs_with_brackets.stderr
@@ -1,26 +1,26 @@
-error: found empty brackets on struct declaration
-  --> tests/ui/empty_structs_with_brackets.rs:3:25
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:3:26
    |
 LL | pub struct MyEmptyStruct {} // should trigger lint
-   |                         ^^^
+   |                          ^^
    |
    = note: `-D clippy::empty-structs-with-brackets` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::empty_structs_with_brackets)]`
    = help: remove the brackets
 
-error: found empty brackets on struct declaration
+error: non-unit struct contains no fields
   --> tests/ui/empty_structs_with_brackets.rs:5:26
    |
 LL | struct MyEmptyTupleStruct(); // should trigger lint
-   |                          ^^^
+   |                          ^^
    |
-   = help: remove the brackets
+   = help: remove the parenthesis
 
-error: found empty brackets on struct declaration
-  --> tests/ui/empty_structs_with_brackets.rs:39:31
+error: non-unit struct contains no fields
+  --> tests/ui/empty_structs_with_brackets.rs:39:32
    |
 LL |     struct Foo<const N: usize> {}
-   |                               ^^^
+   |                                ^^
    |
    = help: remove the brackets
 


### PR DESCRIPTION
* Merge code paths for struct and variants.
* Merge code paths for pattern and expression forms.
* Adjust the span to not include leading whitespace.
* Add proc macro detection.
* Don't lint if there are comments inside the brackets.
* Don't lint if parenthesis are required due to a macro.
* Attempt to remove braces from use sites.

changelog: [`empty_struct_with_brackets`]: Don't lint when a macro expansion requires the parenthesis.
changelog: [`empty_struct_with_brackets`]: Don't lint there is a comment inside the brackets.

changelog: [`empty_enum_variants_with_brackets`]: Don't lint when a macro expansion requires the parenthesis.
changelog: [`empty_enum_variants_with_brackets`]: Don't lint when there is a comment inside the brackets.
