### PR TITLE
Rework `init_numbered_fields`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(f128)]
 #![feature(f16)]
 #![feature(if_let_guard)]
+#![feature(is_sorted)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(never_type)]

--- a/tests/ui/init_numbered_fields.fixed
+++ b/tests/ui/init_numbered_fields.fixed
@@ -14,18 +14,10 @@ fn main() {
     let tuple_struct = TupleStruct::default();
 
     // This should lint
-    let _ = TupleStruct {
-        0: 1u32,
-        1: 42,
-        2: 23u8,
-    };
+    let _ = TupleStruct(1u32, 42, 23u8);
 
     // This should also lint and order the fields correctly
-    let _ = TupleStruct {
-        0: 1u32,
-        2: 2u8,
-        1: 3u32,
-    };
+    let _ = TupleStruct(1u32, 3u32, 2u8);
 
     // Ok because of default initializer
     let _ = TupleStruct { 0: 42, ..tuple_struct };
@@ -46,5 +38,14 @@ fn main() {
     // Issue #12367
     struct TupleStructVec(Vec<usize>);
 
-    let _ = TupleStructVec { 0: vec![0, 1, 2, 3] };
+    let _ = TupleStructVec(vec![0, 1, 2, 3]);
+
+    {
+        struct S(i32, i32);
+        let mut iter = [1i32, 1i32].into_iter();
+        let _ = S {
+            1: iter.next().unwrap(),
+            0: iter.next().unwrap(),
+        };
+    }
 }

--- a/tests/ui/init_numbered_fields.rs
+++ b/tests/ui/init_numbered_fields.rs
@@ -14,10 +14,18 @@ fn main() {
     let tuple_struct = TupleStruct::default();
 
     // This should lint
-    let _ = TupleStruct(1u32, 42, 23u8);
+    let _ = TupleStruct {
+        0: 1u32,
+        1: 42,
+        2: 23u8,
+    };
 
     // This should also lint and order the fields correctly
-    let _ = TupleStruct(1u32, 3u32, 2u8);
+    let _ = TupleStruct {
+        0: 1u32,
+        2: 2u8,
+        1: 3u32,
+    };
 
     // Ok because of default initializer
     let _ = TupleStruct { 0: 42, ..tuple_struct };
@@ -38,5 +46,14 @@ fn main() {
     // Issue #12367
     struct TupleStructVec(Vec<usize>);
 
-    let _ = TupleStructVec(vec![0, 1, 2, 3]);
+    let _ = TupleStructVec { 0: vec![0, 1, 2, 3] };
+
+    {
+        struct S(i32, i32);
+        let mut iter = [1i32, 1i32].into_iter();
+        let _ = S {
+            1: iter.next().unwrap(),
+            0: iter.next().unwrap(),
+        };
+    }
 }

--- a/tests/ui/init_numbered_fields.stderr
+++ b/tests/ui/init_numbered_fields.stderr
@@ -1,5 +1,5 @@
 error: used a field initializer for a tuple struct
-  --> tests/ui/numbered_fields.rs:17:13
+  --> tests/ui/init_numbered_fields.rs:17:13
    |
 LL |       let _ = TupleStruct {
    |  _____________^
@@ -7,13 +7,13 @@ LL | |         0: 1u32,
 LL | |         1: 42,
 LL | |         2: 23u8,
 LL | |     };
-   | |_____^ help: try: `TupleStruct(1u32, 42, 23u8)`
+   | |_____^ help: use tuple initialization: `TupleStruct(1u32, 42, 23u8)`
    |
    = note: `-D clippy::init-numbered-fields` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::init_numbered_fields)]`
 
 error: used a field initializer for a tuple struct
-  --> tests/ui/numbered_fields.rs:24:13
+  --> tests/ui/init_numbered_fields.rs:24:13
    |
 LL |       let _ = TupleStruct {
    |  _____________^
@@ -21,13 +21,13 @@ LL | |         0: 1u32,
 LL | |         2: 2u8,
 LL | |         1: 3u32,
 LL | |     };
-   | |_____^ help: try: `TupleStruct(1u32, 3u32, 2u8)`
+   | |_____^ help: use tuple initialization: `TupleStruct(1u32, 3u32, 2u8)`
 
 error: used a field initializer for a tuple struct
-  --> tests/ui/numbered_fields.rs:49:13
+  --> tests/ui/init_numbered_fields.rs:49:13
    |
 LL |     let _ = TupleStructVec { 0: vec![0, 1, 2, 3] };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `TupleStructVec(vec![0, 1, 2, 3])`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use tuple initialization: `TupleStructVec(vec![0, 1, 2, 3])`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Two behaviour changes:
* Not linting in macros
* Not linting when side effects might be reordered

changelog: `init_numbered_fields`: Don't suggest reordering side effects.
