### PR TITLE
Fix `iter_next_loop.rs` ui test

### DIFF
--- a/tests/ui/iter_next_loop.rs
+++ b/tests/ui/iter_next_loop.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     let x = [1, 2, 3, 4];
-    for _ in vec.iter().next() {}
+    for _ in x.iter().next() {}
 
     struct Unrelated(&'static [u8]);
     impl Unrelated {

--- a/tests/ui/iter_next_loop.stderr
+++ b/tests/ui/iter_next_loop.stderr
@@ -1,9 +1,11 @@
-error[E0423]: expected value, found macro `vec`
+error: you are iterating over `Iterator::next()` which is an Option; this will compile but is probably not what you want
   --> tests/ui/iter_next_loop.rs:6:14
    |
-LL |     for _ in vec.iter().next() {}
-   |              ^^^ not a value
+LL |     for _ in x.iter().next() {}
+   |              ^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::iter-next-loop` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::iter_next_loop)]`
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
I'm uncovering bugs while working on https://github.com/rust-lang/rust-clippy/pull/11421. ^^'

changelog: none