### PR TITLE
fix [`excessive_precision`] suggestions on floats written in scientific notation

### DIFF
--- a/clippy_utils/src/numeric_literal.rs
+++ b/clippy_utils/src/numeric_literal.rs
@@ -164,6 +164,8 @@ impl<'a> NumericLiteral<'a> {
             if !exponent.is_empty() && exponent != "0" {
                 output.push_str(separator);
                 Self::group_digits(&mut output, exponent, group_size, true, false);
+            } else if exponent == "0" && self.fraction.is_none() && self.suffix.is_none() {
+                output.push_str(".0");
             }
         }
 

--- a/tests/ui/excessive_precision.fixed
+++ b/tests/ui/excessive_precision.fixed
@@ -78,4 +78,8 @@ fn main() {
     const NEG_INF1: f32 = -1.0e+33f32;
     const NEG_INF2: f64 = -1.0e+3300f64;
     const NEG_INF3: f32 = -3.40282357e+38_f32;
+
+    // issue #12954
+    const _: f64 = 3.0;
+    const _: f64 = 3.0000000000000000;
 }

--- a/tests/ui/excessive_precision.rs
+++ b/tests/ui/excessive_precision.rs
@@ -78,4 +78,8 @@ fn main() {
     const NEG_INF1: f32 = -1.0e+33f32;
     const NEG_INF2: f64 = -1.0e+3300f64;
     const NEG_INF3: f32 = -3.40282357e+38_f32;
+
+    // issue #12954
+    const _: f64 = 3.0000000000000000e+00;
+    const _: f64 = 3.0000000000000000;
 }

--- a/tests/ui/excessive_precision.stderr
+++ b/tests/ui/excessive_precision.stderr
@@ -91,5 +91,11 @@ error: float has excessive precision
 LL |     let _ = 1.000_000_000_000_001e-324_f64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0_f64`
 
-error: aborting due to 15 previous errors
+error: float has excessive precision
+  --> tests/ui/excessive_precision.rs:83:20
+   |
+LL |     const _: f64 = 3.0000000000000000e+00;
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `3.0`
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION

fixes #12954

changelog: fix [`excessive_precision`] suggestions on float literal written in scientific notation

