### PR TITLE
Show progress while running dogfood test

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@ uibless = "test --test compile-test -- -- --bless"
 bless = "test -- -- --bless"
 dev = "run --package clippy_dev --bin clippy_dev --manifest-path clippy_dev/Cargo.toml --"
 lintcheck = "run --package lintcheck --bin lintcheck --manifest-path lintcheck/Cargo.toml  -- "
-collect-metadata = "test --test dogfood --features internal -- run_metadata_collection_lint --ignored"
+collect-metadata = "test --test dogfood --features internal -- collect_metadata"
 
 [build]
 # -Zbinary-dep-depinfo allows us to track which rlib files to use for compiling UI tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ ui_test = "0.24"
 regex = "1.5.5"
 toml = "0.7.3"
 walkdir = "2.3"
-# This is used by the `collect-metadata` alias.
 filetime = "0.2.9"
 itertools = "0.12"
 
@@ -62,4 +61,8 @@ rustc_private = true
 
 [[test]]
 name = "compile-test"
+harness = false
+
+[[test]]
+name = "dogfood"
 harness = false


### PR DESCRIPTION
Outputs the regular cargo progress in colour when running the dogfood test, helpful to see because it can take a long time to run

changelog: none
