### PR TITLE
Fix `needless_option_as_deref` false-positive on struct literals

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -1407,7 +1407,7 @@ pub fn get_enclosing_loop_or_multi_call_closure<'tcx>(
                 ExprKind::Closure { .. } | ExprKind::Loop(..) => return Some(e),
                 _ => (),
             },
-            Node::Stmt(_) | Node::Block(_) | Node::LetStmt(_) | Node::Arm(_) => (),
+            Node::Stmt(_) | Node::Block(_) | Node::LetStmt(_) | Node::Arm(_) | Node::ExprField(_) => (),
             _ => break,
         }
     }

--- a/tests/ui/needless_option_as_deref.fixed
+++ b/tests/ui/needless_option_as_deref.fixed
@@ -56,7 +56,9 @@ fn from_field<'a>(s: &'a mut S<'a>) -> Option<&'a mut usize> {
 mod issue_non_copy_13077 {
     pub fn something(mut maybe_side_effect: Option<&mut String>) {
         for _ in 0..10 {
-            let _ = S { field: other(maybe_side_effect) };
+            let _ = S {
+                field: other(maybe_side_effect.as_deref_mut()),
+            };
         }
     }
 
@@ -64,5 +66,7 @@ mod issue_non_copy_13077 {
         unimplemented!()
     }
 
-    pub struct S { pub field: () }
+    pub struct S {
+        pub field: (),
+    }
 }

--- a/tests/ui/needless_option_as_deref.fixed
+++ b/tests/ui/needless_option_as_deref.fixed
@@ -52,3 +52,17 @@ struct S<'a> {
 fn from_field<'a>(s: &'a mut S<'a>) -> Option<&'a mut usize> {
     s.opt.as_deref_mut()
 }
+
+mod issue_non_copy_13077 {
+    pub fn something(mut maybe_side_effect: Option<&mut String>) {
+        for _ in 0..10 {
+            let _ = S { field: other(maybe_side_effect) };
+        }
+    }
+
+    fn other(_maybe_side_effect: Option<&mut String>) {
+        unimplemented!()
+    }
+
+    pub struct S { pub field: () }
+}

--- a/tests/ui/needless_option_as_deref.rs
+++ b/tests/ui/needless_option_as_deref.rs
@@ -56,7 +56,9 @@ fn from_field<'a>(s: &'a mut S<'a>) -> Option<&'a mut usize> {
 mod issue_non_copy_13077 {
     pub fn something(mut maybe_side_effect: Option<&mut String>) {
         for _ in 0..10 {
-            let _ = S { field: other(maybe_side_effect.as_deref_mut()) };
+            let _ = S {
+                field: other(maybe_side_effect.as_deref_mut()),
+            };
         }
     }
 
@@ -64,5 +66,7 @@ mod issue_non_copy_13077 {
         unimplemented!()
     }
 
-    pub struct S { pub field: () }
+    pub struct S {
+        pub field: (),
+    }
 }

--- a/tests/ui/needless_option_as_deref.rs
+++ b/tests/ui/needless_option_as_deref.rs
@@ -52,3 +52,17 @@ struct S<'a> {
 fn from_field<'a>(s: &'a mut S<'a>) -> Option<&'a mut usize> {
     s.opt.as_deref_mut()
 }
+
+mod issue_non_copy_13077 {
+    pub fn something(mut maybe_side_effect: Option<&mut String>) {
+        for _ in 0..10 {
+            let _ = S { field: other(maybe_side_effect.as_deref_mut()) };
+        }
+    }
+
+    fn other(_maybe_side_effect: Option<&mut String>) {
+        unimplemented!()
+    }
+
+    pub struct S { pub field: () }
+}

--- a/tests/ui/needless_option_as_deref.stderr
+++ b/tests/ui/needless_option_as_deref.stderr
@@ -19,5 +19,11 @@ error: derefed type is same as origin
 LL |     let _ = x.as_deref_mut();
    |             ^^^^^^^^^^^^^^^^ help: try: `x`
 
-error: aborting due to 3 previous errors
+error: derefed type is same as origin
+  --> tests/ui/needless_option_as_deref.rs:59:38
+   |
+LL |             let _ = S { field: other(maybe_side_effect.as_deref_mut()) };
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_side_effect`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/needless_option_as_deref.stderr
+++ b/tests/ui/needless_option_as_deref.stderr
@@ -19,11 +19,5 @@ error: derefed type is same as origin
 LL |     let _ = x.as_deref_mut();
    |             ^^^^^^^^^^^^^^^^ help: try: `x`
 
-error: derefed type is same as origin
-  --> tests/ui/needless_option_as_deref.rs:59:38
-   |
-LL |             let _ = S { field: other(maybe_side_effect.as_deref_mut()) };
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_side_effect`
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
changelog: [`needless_option_as_deref`] Fix false-positive on struct literals.

Fixes #13077 .

r?  Alexendoo