### PR TITLE
Add test for `try_err` lint within try blocks.

### DIFF
--- a/tests/ui/try_err.fixed
+++ b/tests/ui/try_err.fixed
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-
+#![feature(try_blocks)]
 #![deny(clippy::try_err)]
 #![allow(
     clippy::unnecessary_wraps,
@@ -151,4 +151,12 @@ pub fn try_return(x: bool) -> Result<i32, i32> {
         return Err(42);
     }
     Ok(0)
+}
+
+// Test that the lint is suppressed in try block.
+pub fn try_block() -> Result<(), i32> {
+    let _: Result<_, i32> = try {
+        Err(1)?;
+    };
+    Ok(())
 }

--- a/tests/ui/try_err.rs
+++ b/tests/ui/try_err.rs
@@ -1,5 +1,5 @@
 //@aux-build:proc_macros.rs
-
+#![feature(try_blocks)]
 #![deny(clippy::try_err)]
 #![allow(
     clippy::unnecessary_wraps,
@@ -151,4 +151,12 @@ pub fn try_return(x: bool) -> Result<i32, i32> {
         return Err(42)?;
     }
     Ok(0)
+}
+
+// Test that the lint is suppressed in try block.
+pub fn try_block() -> Result<(), i32> {
+    let _: Result<_, i32> = try {
+        Err(1)?;
+    };
+    Ok(())
 }


### PR DESCRIPTION
Fixes #5757

Turns out the current `try_err` implementation already skips expressions inside of a try block.

When inside of a try block, `Err(_)?` is desugared to a `break` instead of normal `return` . This makes `find_return_type()` function at [this line](https://github.com/rust-lang/rust-clippy/blob/eb4d88e690c431691bc0fd8eaa9f7096ecc2a723/clippy_lints/src/matches/try_err.rs#L29) always returns `None` and skips the check.

I just added a test case for try block.

changelog: none
