### PR TITLE
Fix `redundant_closure` false positive with closures has return type contains  `'static`

### DIFF
--- a/clippy_lints/src/eta_reduction.rs
+++ b/clippy_lints/src/eta_reduction.rs
@@ -9,8 +9,8 @@ use rustc_hir::{BindingMode, Expr, ExprKind, FnRetTy, Param, PatKind, QPath, Saf
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{
-    self, Binder, ClosureArgs, ClosureKind, FnSig, GenericArg, GenericArgKind, List, Region, RegionKind, Ty, TyCtxt,
-    TypeVisitableExt, TypeckResults,
+    self, Binder, ClosureKind, FnSig, GenericArg, GenericArgKind, List, Region, RegionKind, Ty, TypeVisitableExt,
+    TypeckResults,
 };
 use rustc_session::declare_lint_pass;
 use rustc_span::symbol::sym;
@@ -74,159 +74,173 @@ declare_clippy_lint! {
 declare_lint_pass!(EtaReduction => [REDUNDANT_CLOSURE, REDUNDANT_CLOSURE_FOR_METHOD_CALLS]);
 
 impl<'tcx> LateLintPass<'tcx> for EtaReduction {
-    #[allow(clippy::too_many_lines)]
-    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        let body = if let ExprKind::Closure(c) = expr.kind
-            && c.fn_decl.inputs.iter().all(|ty| matches!(ty.kind, TyKind::Infer))
-            && matches!(c.fn_decl.output, FnRetTy::DefaultReturn(_))
-            && !expr.span.from_expansion()
-        {
-            cx.tcx.hir().body(c.body)
-        } else {
-            return;
-        };
-
-        if body.value.span.from_expansion() {
-            if body.params.is_empty() {
-                if let Some(VecArgs::Vec(&[])) = VecArgs::hir(cx, body.value) {
-                    // replace `|| vec![]` with `Vec::new`
-                    span_lint_and_sugg(
-                        cx,
-                        REDUNDANT_CLOSURE,
-                        expr.span,
-                        "redundant closure",
-                        "replace the closure with `Vec::new`",
-                        "std::vec::Vec::new".into(),
-                        Applicability::MachineApplicable,
-                    );
-                }
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        if let ExprKind::MethodCall(_method, receiver, args, _) = expr.kind {
+            for arg in args {
+                check_clousure(cx, Some(receiver), arg);
             }
-            // skip `foo(|| macro!())`
-            return;
         }
-
-        let typeck = cx.typeck_results();
-        let closure = if let ty::Closure(_, closure_subs) = typeck.expr_ty(expr).kind() {
-            closure_subs.as_closure()
-        } else {
-            return;
-        };
-
-        if is_adjusted(cx, body.value) {
-            return;
+        if let ExprKind::Call(func, args) = expr.kind {
+            check_clousure(cx, None, func);
+            for arg in args {
+                check_clousure(cx, None, arg);
+            }
         }
+    }
+}
 
-        match body.value.kind {
-            ExprKind::Call(callee, args)
-                if matches!(
-                    callee.kind,
-                    ExprKind::Path(QPath::Resolved(..) | QPath::TypeRelative(..))
-                ) =>
+#[allow(clippy::too_many_lines)]
+fn check_clousure<'tcx>(cx: &LateContext<'tcx>, outer_receiver: Option<&Expr<'tcx>>, expr: &Expr<'tcx>) {
+    let body = if let ExprKind::Closure(c) = expr.kind
+        && c.fn_decl.inputs.iter().all(|ty| matches!(ty.kind, TyKind::Infer))
+        && matches!(c.fn_decl.output, FnRetTy::DefaultReturn(_))
+        && !expr.span.from_expansion()
+    {
+        cx.tcx.hir().body(c.body)
+    } else {
+        return;
+    };
+
+    if body.value.span.from_expansion() {
+        if body.params.is_empty() {
+            if let Some(VecArgs::Vec(&[])) = VecArgs::hir(cx, body.value) {
+                // replace `|| vec![]` with `Vec::new`
+                span_lint_and_sugg(
+                    cx,
+                    REDUNDANT_CLOSURE,
+                    expr.span,
+                    "redundant closure",
+                    "replace the closure with `Vec::new`",
+                    "std::vec::Vec::new".into(),
+                    Applicability::MachineApplicable,
+                );
+            }
+        }
+        // skip `foo(|| macro!())`
+        return;
+    }
+
+    if is_adjusted(cx, body.value) {
+        return;
+    }
+
+    let typeck = cx.typeck_results();
+    let closure = if let ty::Closure(_, closure_subs) = typeck.expr_ty(expr).kind() {
+        closure_subs.as_closure()
+    } else {
+        return;
+    };
+    let closure_sig = cx.tcx.signature_unclosure(closure.sig(), Safety::Safe).skip_binder();
+    match body.value.kind {
+        ExprKind::Call(callee, args)
+            if matches!(
+                callee.kind,
+                ExprKind::Path(QPath::Resolved(..) | QPath::TypeRelative(..))
+            ) =>
+        {
+            let callee_ty_raw = typeck.expr_ty(callee);
+            let callee_ty = callee_ty_raw.peel_refs();
+            if matches!(type_diagnostic_name(cx, callee_ty), Some(sym::Arc | sym::Rc))
+                || !check_inputs(typeck, body.params, None, args)
             {
-                let callee_ty_raw = typeck.expr_ty(callee);
-                let callee_ty = callee_ty_raw.peel_refs();
-                if matches!(type_diagnostic_name(cx, callee_ty), Some(sym::Arc | sym::Rc))
-                    || !check_inputs(typeck, body.params, None, args)
-                {
-                    return;
-                }
-                let callee_ty_adjusted = typeck
-                    .expr_adjustments(callee)
-                    .last()
-                    .map_or(callee_ty, |a| a.target.peel_refs());
+                return;
+            }
+            let callee_ty_adjusted = typeck
+                .expr_adjustments(callee)
+                .last()
+                .map_or(callee_ty, |a| a.target.peel_refs());
 
-                let sig = match callee_ty_adjusted.kind() {
-                    ty::FnDef(def, _) => {
-                        // Rewriting `x(|| f())` to `x(f)` where f is marked `#[track_caller]` moves the `Location`
-                        if cx.tcx.has_attr(*def, sym::track_caller) {
-                            return;
-                        }
+            let sig = match callee_ty_adjusted.kind() {
+                ty::FnDef(def, _) => {
+                    // Rewriting `x(|| f())` to `x(f)` where f is marked `#[track_caller]` moves the `Location`
+                    if cx.tcx.has_attr(*def, sym::track_caller) {
+                        return;
+                    }
 
-                        cx.tcx.fn_sig(def).skip_binder().skip_binder()
-                    },
-                    ty::FnPtr(sig) => sig.skip_binder(),
-                    ty::Closure(_, subs) => cx
-                        .tcx
-                        .signature_unclosure(subs.as_closure().sig(), Safety::Safe)
-                        .skip_binder(),
-                    _ => {
-                        if typeck.type_dependent_def_id(body.value.hir_id).is_some()
-                            && let subs = typeck.node_args(body.value.hir_id)
-                            && let output = typeck.expr_ty(body.value)
-                            && let ty::Tuple(tys) = *subs.type_at(1).kind()
-                        {
-                            cx.tcx.mk_fn_sig(tys, output, false, Safety::Safe, Abi::Rust)
-                        } else {
-                            return;
-                        }
-                    },
-                };
-                if check_sig(cx, closure, sig)
-                    && let generic_args = typeck.node_args(callee.hir_id)
-                    // Given some trait fn `fn f() -> ()` and some type `T: Trait`, `T::f` is not
-                    // `'static` unless `T: 'static`. The cast `T::f as fn()` will, however, result
-                    // in a type which is `'static`.
-                    // For now ignore all callee types which reference a type parameter.
-                    && !generic_args.types().any(|t| matches!(t.kind(), ty::Param(_)))
-                {
-                    span_lint_and_then(cx, REDUNDANT_CLOSURE, expr.span, "redundant closure", |diag| {
-                        if let Some(mut snippet) = snippet_opt(cx, callee.span) {
-                            if path_to_local(callee).map_or(false, |l| {
-                                // FIXME: Do we really need this `local_used_in` check?
-                                // Isn't it checking something like... `callee(callee)`?
-                                // If somehow this check is needed, add some test for it,
-                                // 'cuz currently nothing changes after deleting this check.
-                                local_used_in(cx, l, args) || local_used_after_expr(cx, l, expr)
-                            }) {
-                                match cx.tcx.infer_ctxt().build().err_ctxt().type_implements_fn_trait(
-                                    cx.param_env,
-                                    Binder::bind_with_vars(callee_ty_adjusted, List::empty()),
-                                    ty::PredicatePolarity::Positive,
-                                ) {
-                                    // Mutable closure is used after current expr; we cannot consume it.
-                                    Ok((ClosureKind::FnMut, _)) => snippet = format!("&mut {snippet}"),
-                                    Ok((ClosureKind::Fn, _)) if !callee_ty_raw.is_ref() => {
-                                        snippet = format!("&{snippet}");
-                                    },
-                                    _ => (),
-                                }
+                    cx.tcx.fn_sig(def).skip_binder().skip_binder()
+                },
+                ty::FnPtr(sig) => sig.skip_binder(),
+                ty::Closure(_, subs) => cx
+                    .tcx
+                    .signature_unclosure(subs.as_closure().sig(), Safety::Safe)
+                    .skip_binder(),
+                _ => {
+                    if typeck.type_dependent_def_id(body.value.hir_id).is_some()
+                        && let subs = typeck.node_args(body.value.hir_id)
+                        && let output = typeck.expr_ty(body.value)
+                        && let ty::Tuple(tys) = *subs.type_at(1).kind()
+                    {
+                        cx.tcx.mk_fn_sig(tys, output, false, Safety::Safe, Abi::Rust)
+                    } else {
+                        return;
+                    }
+                },
+            };
+            if check_sig(closure_sig, sig)
+                && let generic_args = typeck.node_args(callee.hir_id)
+                // Given some trait fn `fn f() -> ()` and some type `T: Trait`, `T::f` is not
+                // `'static` unless `T: 'static`. The cast `T::f as fn()` will, however, result
+                // in a type which is `'static`.
+                // For now ignore all callee types which reference a type parameter.
+                && !generic_args.types().any(|t| matches!(t.kind(), ty::Param(_)))
+            {
+                span_lint_and_then(cx, REDUNDANT_CLOSURE, expr.span, "redundant closure", |diag| {
+                    if let Some(mut snippet) = snippet_opt(cx, callee.span) {
+                        if path_to_local(callee).map_or(false, |l| {
+                            // FIXME: Do we really need this `local_used_in` check?
+                            // Isn't it checking something like... `callee(callee)`?
+                            // If somehow this check is needed, add some test for it,
+                            // 'cuz currently nothing changes after deleting this check.
+                            local_used_in(cx, l, args) || local_used_after_expr(cx, l, expr)
+                        }) {
+                            match cx.tcx.infer_ctxt().build().err_ctxt().type_implements_fn_trait(
+                                cx.param_env,
+                                Binder::bind_with_vars(callee_ty_adjusted, List::empty()),
+                                ty::PredicatePolarity::Positive,
+                            ) {
+                                // Mutable closure is used after current expr; we cannot consume it.
+                                Ok((ClosureKind::FnMut, _)) => snippet = format!("&mut {snippet}"),
+                                Ok((ClosureKind::Fn, _)) if !callee_ty_raw.is_ref() => {
+                                    snippet = format!("&{snippet}");
+                                },
+                                _ => (),
                             }
-                            diag.span_suggestion(
-                                expr.span,
-                                "replace the closure with the function itself",
-                                snippet,
-                                Applicability::MachineApplicable,
-                            );
                         }
-                    });
-                }
-            },
-            ExprKind::MethodCall(path, self_, args, _) if check_inputs(typeck, body.params, Some(self_), args) => {
-                if let Some(method_def_id) = typeck.type_dependent_def_id(body.value.hir_id)
-                    && !cx.tcx.has_attr(method_def_id, sym::track_caller)
-                    && check_sig(cx, closure, cx.tcx.fn_sig(method_def_id).skip_binder().skip_binder())
-                {
-                    span_lint_and_then(
-                        cx,
-                        REDUNDANT_CLOSURE_FOR_METHOD_CALLS,
-                        expr.span,
-                        "redundant closure",
-                        |diag| {
-                            let args = typeck.node_args(body.value.hir_id);
-                            let caller = self_.hir_id.owner.def_id;
-                            let type_name = get_path_from_caller_to_method_type(cx.tcx, caller, method_def_id, args);
-                            diag.span_suggestion(
-                                expr.span,
-                                "replace the closure with the method itself",
-                                format!("{}::{}", type_name, path.ident.name),
-                                Applicability::MachineApplicable,
-                            );
-                        },
-                    );
-                }
-            },
-            _ => (),
-        }
+                        diag.span_suggestion(
+                            expr.span,
+                            "replace the closure with the function itself",
+                            snippet,
+                            Applicability::MachineApplicable,
+                        );
+                    }
+                });
+            }
+        },
+        ExprKind::MethodCall(path, self_, args, _) if check_inputs(typeck, body.params, Some(self_), args) => {
+            if let Some(method_def_id) = typeck.type_dependent_def_id(body.value.hir_id)
+                && !cx.tcx.has_attr(method_def_id, sym::track_caller)
+                && check_sig(closure_sig, cx.tcx.fn_sig(method_def_id).skip_binder().skip_binder())
+            {
+                span_lint_and_then(
+                    cx,
+                    REDUNDANT_CLOSURE_FOR_METHOD_CALLS,
+                    expr.span,
+                    "redundant closure",
+                    |diag| {
+                        let args = typeck.node_args(body.value.hir_id);
+                        let caller = self_.hir_id.owner.def_id;
+                        let type_name = get_path_from_caller_to_method_type(cx.tcx, caller, method_def_id, args);
+                        diag.span_suggestion(
+                            expr.span,
+                            "replace the closure with the method itself",
+                            format!("{}::{}", type_name, path.ident.name),
+                            Applicability::MachineApplicable,
+                        );
+                    },
+                );
+            }
+        },
+        _ => (),
     }
 }
 
@@ -251,12 +265,8 @@ fn check_inputs(
         })
 }
 
-fn check_sig<'tcx>(cx: &LateContext<'tcx>, closure: ClosureArgs<TyCtxt<'tcx>>, call_sig: FnSig<'_>) -> bool {
-    call_sig.safety == Safety::Safe
-        && !has_late_bound_to_non_late_bound_regions(
-            cx.tcx.signature_unclosure(closure.sig(), Safety::Safe).skip_binder(),
-            call_sig,
-        )
+fn check_sig<'tcx>(closure_sig: FnSig<'tcx>, call_sig: FnSig<'tcx>) -> bool {
+    call_sig.safety == Safety::Safe && !has_late_bound_to_non_late_bound_regions(closure_sig, call_sig)
 }
 
 /// This walks through both signatures and checks for any time a late-bound region is expected by an

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -492,9 +492,9 @@ mod issue_13073 {
     pub fn foo() {
         // shouldn't lint
         let bind: Option<String> = None;
-        let _field = bind.as_deref().or_else(get_default).unwrap();
+        let _field = bind.as_deref().or_else(|| get_default()).unwrap();
         let bind: Option<&'static str> = None;
-        let _field = bind.as_deref().or_else(get_default).unwrap();
+        let _field = bind.as_deref().or_else(|| get_default()).unwrap();
         // should lint
         let _field = bind.or_else(get_default).unwrap();
     }

--- a/tests/ui/eta.fixed
+++ b/tests/ui/eta.fixed
@@ -2,6 +2,7 @@
 #![allow(unused)]
 #![allow(
     clippy::needless_borrow,
+    clippy::needless_option_as_deref,
     clippy::needless_pass_by_value,
     clippy::no_effect,
     clippy::option_map_unit_fn,
@@ -480,5 +481,21 @@ mod issue_12853 {
     fn f_by_ref<F: Fn(u32)>(f: &F) {
         let x = Box::new(|| None.map(f));
         x();
+    }
+}
+
+mod issue_13073 {
+    fn get_default() -> Option<&'static str> {
+        Some("foo")
+    }
+
+    pub fn foo() {
+        // shouldn't lint
+        let bind: Option<String> = None;
+        let _field = bind.as_deref().or_else(get_default).unwrap();
+        let bind: Option<&'static str> = None;
+        let _field = bind.as_deref().or_else(get_default).unwrap();
+        // should lint
+        let _field = bind.or_else(get_default).unwrap();
     }
 }

--- a/tests/ui/eta.rs
+++ b/tests/ui/eta.rs
@@ -2,6 +2,7 @@
 #![allow(unused)]
 #![allow(
     clippy::needless_borrow,
+    clippy::needless_option_as_deref,
     clippy::needless_pass_by_value,
     clippy::no_effect,
     clippy::option_map_unit_fn,
@@ -480,5 +481,21 @@ mod issue_12853 {
     fn f_by_ref<F: Fn(u32)>(f: &F) {
         let x = Box::new(|| None.map(|x| f(x)));
         x();
+    }
+}
+
+mod issue_13073 {
+    fn get_default() -> Option<&'static str> {
+        Some("foo")
+    }
+
+    pub fn foo() {
+        // shouldn't lint
+        let bind: Option<String> = None;
+        let _field = bind.as_deref().or_else(|| get_default()).unwrap();
+        let bind: Option<&'static str> = None;
+        let _field = bind.as_deref().or_else(|| get_default()).unwrap();
+        // should lint
+        let _field = bind.or_else(|| get_default()).unwrap();
     }
 }

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -1,5 +1,5 @@
 error: redundant closure
-  --> tests/ui/eta.rs:29:27
+  --> tests/ui/eta.rs:30:27
    |
 LL |     let a = Some(1u8).map(|a| foo(a));
    |                           ^^^^^^^^^^ help: replace the closure with the function itself: `foo`
@@ -8,31 +8,31 @@ LL |     let a = Some(1u8).map(|a| foo(a));
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure)]`
 
 error: redundant closure
-  --> tests/ui/eta.rs:33:40
+  --> tests/ui/eta.rs:34:40
    |
 LL |     let _: Option<Vec<u8>> = true.then(|| vec![]); // special case vec!
    |                                        ^^^^^^^^^ help: replace the closure with `Vec::new`: `std::vec::Vec::new`
 
 error: redundant closure
-  --> tests/ui/eta.rs:34:35
+  --> tests/ui/eta.rs:35:35
    |
 LL |     let d = Some(1u8).map(|a| foo((|b| foo2(b))(a))); //is adjusted?
    |                                   ^^^^^^^^^^^^^ help: replace the closure with the function itself: `foo2`
 
 error: redundant closure
-  --> tests/ui/eta.rs:35:26
+  --> tests/ui/eta.rs:36:26
    |
 LL |     all(&[1, 2, 3], &&2, |x, y| below(x, y)); //is adjusted
    |                          ^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `below`
 
 error: redundant closure
-  --> tests/ui/eta.rs:42:27
+  --> tests/ui/eta.rs:43:27
    |
 LL |     let e = Some(1u8).map(|a| generic(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `generic`
 
 error: redundant closure
-  --> tests/ui/eta.rs:94:51
+  --> tests/ui/eta.rs:95:51
    |
 LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.foo());
    |                                                   ^^^^^^^^^^^ help: replace the closure with the method itself: `TestStruct::foo`
@@ -41,166 +41,184 @@ LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.foo());
    = help: to override `-D warnings` add `#[allow(clippy::redundant_closure_for_method_calls)]`
 
 error: redundant closure
-  --> tests/ui/eta.rs:95:51
+  --> tests/ui/eta.rs:96:51
    |
 LL |     let e = Some(TestStruct { some_ref: &i }).map(|a| a.trait_foo());
    |                                                   ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `TestTrait::trait_foo`
 
 error: redundant closure
-  --> tests/ui/eta.rs:97:42
+  --> tests/ui/eta.rs:98:42
    |
 LL |     let e = Some(&mut vec![1, 2, 3]).map(|v| v.clear());
    |                                          ^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::vec::Vec::clear`
 
 error: redundant closure
-  --> tests/ui/eta.rs:101:29
+  --> tests/ui/eta.rs:102:29
    |
 LL |     let e = Some("str").map(|s| s.to_string());
    |                             ^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `std::string::ToString::to_string`
 
 error: redundant closure
-  --> tests/ui/eta.rs:102:27
+  --> tests/ui/eta.rs:103:27
    |
 LL |     let e = Some('a').map(|s| s.to_uppercase());
    |                           ^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `char::to_uppercase`
 
 error: redundant closure
-  --> tests/ui/eta.rs:104:65
+  --> tests/ui/eta.rs:105:65
    |
 LL |     let e: std::vec::Vec<char> = vec!['a', 'b', 'c'].iter().map(|c| c.to_ascii_uppercase()).collect();
    |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `char::to_ascii_uppercase`
 
 error: redundant closure
-  --> tests/ui/eta.rs:167:22
+  --> tests/ui/eta.rs:168:22
    |
 LL |     requires_fn_once(|| x());
    |                      ^^^^^^ help: replace the closure with the function itself: `x`
 
 error: redundant closure
-  --> tests/ui/eta.rs:174:27
+  --> tests/ui/eta.rs:175:27
    |
 LL |     let a = Some(1u8).map(|a| foo_ptr(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `foo_ptr`
 
 error: redundant closure
-  --> tests/ui/eta.rs:179:27
+  --> tests/ui/eta.rs:180:27
    |
 LL |     let a = Some(1u8).map(|a| closure(a));
    |                           ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `closure`
 
 error: redundant closure
-  --> tests/ui/eta.rs:211:28
+  --> tests/ui/eta.rs:212:28
    |
 LL |     x.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut add_to_res`
 
 error: redundant closure
-  --> tests/ui/eta.rs:212:28
+  --> tests/ui/eta.rs:213:28
    |
 LL |     y.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut add_to_res`
 
 error: redundant closure
-  --> tests/ui/eta.rs:213:28
+  --> tests/ui/eta.rs:214:28
    |
 LL |     z.into_iter().for_each(|x| add_to_res(x));
    |                            ^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `add_to_res`
 
 error: redundant closure
-  --> tests/ui/eta.rs:220:21
+  --> tests/ui/eta.rs:221:21
    |
 LL |         Some(1).map(|n| closure(n));
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut closure`
 
 error: redundant closure
-  --> tests/ui/eta.rs:224:21
+  --> tests/ui/eta.rs:225:21
    |
 LL |         Some(1).map(|n| in_loop(n));
    |                     ^^^^^^^^^^^^^^ help: replace the closure with the function itself: `in_loop`
 
 error: redundant closure
-  --> tests/ui/eta.rs:317:18
+  --> tests/ui/eta.rs:318:18
    |
 LL |     takes_fn_mut(|| f());
    |                  ^^^^^^ help: replace the closure with the function itself: `&mut f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:320:19
+  --> tests/ui/eta.rs:321:19
    |
 LL |     takes_fn_once(|| f());
    |                   ^^^^^^ help: replace the closure with the function itself: `&mut f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:324:26
+  --> tests/ui/eta.rs:325:26
    |
 LL |     move || takes_fn_mut(|| f_used_once())
    |                          ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `&mut f_used_once`
 
 error: redundant closure
-  --> tests/ui/eta.rs:336:19
+  --> tests/ui/eta.rs:337:19
    |
 LL |     array_opt.map(|a| a.as_slice());
    |                   ^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<[u8; 3]>::as_slice`
 
 error: redundant closure
-  --> tests/ui/eta.rs:339:19
+  --> tests/ui/eta.rs:340:19
    |
 LL |     slice_opt.map(|s| s.len());
    |                   ^^^^^^^^^^^ help: replace the closure with the method itself: `<[u8]>::len`
 
 error: redundant closure
-  --> tests/ui/eta.rs:342:17
+  --> tests/ui/eta.rs:343:17
    |
 LL |     ptr_opt.map(|p| p.is_null());
    |                 ^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<*const usize>::is_null`
 
 error: redundant closure
-  --> tests/ui/eta.rs:346:17
+  --> tests/ui/eta.rs:347:17
    |
 LL |     dyn_opt.map(|d| d.method_on_dyn());
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the method itself: `<dyn TestTrait>::method_on_dyn`
 
 error: redundant closure
-  --> tests/ui/eta.rs:406:19
+  --> tests/ui/eta.rs:407:19
    |
 LL |     let _ = f(&0, |x, y| f2(x, y));
    |                   ^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `f2`
 
 error: redundant closure
-  --> tests/ui/eta.rs:434:22
+  --> tests/ui/eta.rs:435:22
    |
 LL |             test.map(|t| t.method())
    |                      ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `Test::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:438:22
+  --> tests/ui/eta.rs:439:22
    |
 LL |             test.map(|t| t.method())
    |                      ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `super::Outer::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:451:18
+  --> tests/ui/eta.rs:452:18
    |
 LL |         test.map(|t| t.method())
    |                  ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `test_mod::Test::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:458:30
+  --> tests/ui/eta.rs:459:30
    |
 LL |                     test.map(|t| t.method())
    |                              ^^^^^^^^^^^^^^ help: replace the closure with the method itself: `crate::issue_10854::d::Test::method`
 
 error: redundant closure
-  --> tests/ui/eta.rs:477:38
+  --> tests/ui/eta.rs:478:38
    |
 LL |         let x = Box::new(|| None.map(|x| f(x)));
    |                                      ^^^^^^^^ help: replace the closure with the function itself: `&f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:481:38
+  --> tests/ui/eta.rs:482:38
    |
 LL |         let x = Box::new(|| None.map(|x| f(x)));
    |                                      ^^^^^^^^ help: replace the closure with the function itself: `f`
 
-error: aborting due to 33 previous errors
+error: redundant closure
+  --> tests/ui/eta.rs:495:46
+   |
+LL |         let _field = bind.as_deref().or_else(|| get_default()).unwrap();
+   |                                              ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `get_default`
+
+error: redundant closure
+  --> tests/ui/eta.rs:497:46
+   |
+LL |         let _field = bind.as_deref().or_else(|| get_default()).unwrap();
+   |                                              ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `get_default`
+
+error: redundant closure
+  --> tests/ui/eta.rs:499:35
+   |
+LL |         let _field = bind.or_else(|| get_default()).unwrap();
+   |                                   ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `get_default`
+
+error: aborting due to 36 previous errors
 

--- a/tests/ui/eta.stderr
+++ b/tests/ui/eta.stderr
@@ -203,22 +203,10 @@ LL |         let x = Box::new(|| None.map(|x| f(x)));
    |                                      ^^^^^^^^ help: replace the closure with the function itself: `f`
 
 error: redundant closure
-  --> tests/ui/eta.rs:495:46
-   |
-LL |         let _field = bind.as_deref().or_else(|| get_default()).unwrap();
-   |                                              ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `get_default`
-
-error: redundant closure
-  --> tests/ui/eta.rs:497:46
-   |
-LL |         let _field = bind.as_deref().or_else(|| get_default()).unwrap();
-   |                                              ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `get_default`
-
-error: redundant closure
   --> tests/ui/eta.rs:499:35
    |
 LL |         let _field = bind.or_else(|| get_default()).unwrap();
    |                                   ^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `get_default`
 
-error: aborting due to 36 previous errors
+error: aborting due to 34 previous errors
 


### PR DESCRIPTION
Fix #13073 .

Please enable "ignore white-space change" settings in github UI for easy reviewing.

HACK: The third commit contains a hack to check if a type `T: 'static` when `fn() -> U where U: 'static`.
I don't have a clean way to check for it.

changelog: [`redundant_closure`] Fix false positive with closures has return type contains  `'static`
