### PR TITLE
Don't trigger `const_is_empty` lint inside const blocks

### DIFF
--- a/clippy_lints/src/methods/is_empty.rs
+++ b/clippy_lints/src/methods/is_empty.rs
@@ -1,6 +1,6 @@
 use clippy_utils::consts::constant_is_empty;
 use clippy_utils::diagnostics::span_lint;
-use clippy_utils::{find_binding_init, path_to_local};
+use clippy_utils::{find_binding_init, is_inside_always_const_context, path_to_local};
 use rustc_hir::{Expr, HirId};
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::lint::in_external_macro;
@@ -12,6 +12,9 @@ use super::CONST_IS_EMPTY;
 /// not trigger the lint.
 pub(super) fn check(cx: &LateContext<'_>, expr: &'_ Expr<'_>, receiver: &Expr<'_>) {
     if in_external_macro(cx.sess(), expr.span) || !receiver.span.eq_ctxt(expr.span) {
+        return;
+    }
+    if is_inside_always_const_context(cx.tcx, expr.hir_id) {
         return;
     }
     let init_expr = expr_or_init(cx, receiver);

--- a/tests/ui/const_is_empty.rs
+++ b/tests/ui/const_is_empty.rs
@@ -171,3 +171,9 @@ fn constant_from_external_crate() {
     let _ = std::env::consts::EXE_EXTENSION.is_empty();
     // Do not lint, `exe_ext` comes from the `std` crate
 }
+
+fn issue_13106() {
+    const {
+        assert!(!NON_EMPTY_STR.is_empty());
+    }
+}

--- a/tests/ui/const_is_empty.stderr
+++ b/tests/ui/const_is_empty.stderr
@@ -157,11 +157,5 @@ error: this expression always evaluates to true
 LL |     let _ = val.is_empty();
    |             ^^^^^^^^^^^^^^
 
-error: this expression always evaluates to false
-  --> tests/ui/const_is_empty.rs:177:18
-   |
-LL |         assert!(!NON_EMPTY_STR.is_empty());
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 27 previous errors
+error: aborting due to 26 previous errors
 

--- a/tests/ui/const_is_empty.stderr
+++ b/tests/ui/const_is_empty.stderr
@@ -157,5 +157,11 @@ error: this expression always evaluates to true
 LL |     let _ = val.is_empty();
    |             ^^^^^^^^^^^^^^
 
-error: aborting due to 26 previous errors
+error: this expression always evaluates to false
+  --> tests/ui/const_is_empty.rs:177:18
+   |
+LL |         assert!(!NON_EMPTY_STR.is_empty());
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 27 previous errors
 


### PR DESCRIPTION
changelog: [`const_is_empty`] Don't trigger lint inside const blocks
Fixes #13106 .