### PR TITLE
Lint `zero_repeat_side_effects`  only if array length is a literal zero

### DIFF
--- a/tests/ui/zero_repeat_side_effects.fixed
+++ b/tests/ui/zero_repeat_side_effects.fixed
@@ -60,11 +60,13 @@ fn main() {
 }
 
 macro_rules! LEN {
-    () => {0};
+    () => {
+        0
+    };
 }
 
 fn issue_13110() {
-    f(); let _data: [i32; 0] = [];
+    let _data = [f(); LEN!()];
     const LENGTH: usize = LEN!();
-    f(); let _data: [i32; 0] = [];
+    let _data = [f(); LENGTH];
 }

--- a/tests/ui/zero_repeat_side_effects.fixed
+++ b/tests/ui/zero_repeat_side_effects.fixed
@@ -58,3 +58,13 @@ fn main() {
     // as function param
     drop(vec![f(); 1]);
 }
+
+macro_rules! LEN {
+    () => {0};
+}
+
+fn issue_13110() {
+    f(); let _data: [i32; 0] = [];
+    const LENGTH: usize = LEN!();
+    f(); let _data: [i32; 0] = [];
+}

--- a/tests/ui/zero_repeat_side_effects.fixed
+++ b/tests/ui/zero_repeat_side_effects.fixed
@@ -16,9 +16,7 @@ fn main() {
 
     // on arrays
     f(); let a: [i32; 0] = [];
-    f(); let a: [i32; 0] = [];
     let mut b;
-    f(); b = [] as [i32; 0];
     f(); b = [] as [i32; 0];
 
     // on vecs
@@ -39,9 +37,11 @@ fn main() {
     // when singled out/not part of assignment/local
     { f(); vec![] as std::vec::Vec<i32> };
     { f(); [] as [i32; 0] };
-    { f(); [] as [i32; 0] };
 
     // should not trigger
+    let a = [f(); N];
+    b = [f(); N];
+    [f(); N];
 
     // on arrays with > 0 repeat
     let a = [f(); 1];

--- a/tests/ui/zero_repeat_side_effects.rs
+++ b/tests/ui/zero_repeat_side_effects.rs
@@ -58,3 +58,13 @@ fn main() {
     // as function param
     drop(vec![f(); 1]);
 }
+
+macro_rules! LEN {
+    () => {0};
+}
+
+fn issue_13110() {
+    let _data = [f(); LEN!()];
+    const LENGTH: usize = LEN!();
+    let _data = [f(); LENGTH];
+}

--- a/tests/ui/zero_repeat_side_effects.rs
+++ b/tests/ui/zero_repeat_side_effects.rs
@@ -60,7 +60,9 @@ fn main() {
 }
 
 macro_rules! LEN {
-    () => {0};
+    () => {
+        0
+    };
 }
 
 fn issue_13110() {

--- a/tests/ui/zero_repeat_side_effects.rs
+++ b/tests/ui/zero_repeat_side_effects.rs
@@ -16,10 +16,8 @@ fn main() {
 
     // on arrays
     let a = [f(); 0];
-    let a = [f(); N];
     let mut b;
     b = [f(); 0];
-    b = [f(); N];
 
     // on vecs
     // vecs dont support infering value of consts
@@ -39,9 +37,11 @@ fn main() {
     // when singled out/not part of assignment/local
     vec![f(); 0];
     [f(); 0];
-    [f(); N];
 
     // should not trigger
+    let a = [f(); N];
+    b = [f(); N];
+    [f(); N];
 
     // on arrays with > 0 repeat
     let a = [f(); 1];

--- a/tests/ui/zero_repeat_side_effects.stderr
+++ b/tests/ui/zero_repeat_side_effects.stderr
@@ -8,70 +8,52 @@ LL |     let a = [f(); 0];
    = help: to override `-D warnings` add `#[allow(clippy::zero_repeat_side_effects)]`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:19:5
-   |
-LL |     let a = [f(); N];
-   |     ^^^^^^^^^^^^^^^^^ help: consider using: `f(); let a: [i32; 0] = [];`
-
-error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:21:5
+  --> tests/ui/zero_repeat_side_effects.rs:20:5
    |
 LL |     b = [f(); 0];
    |     ^^^^^^^^^^^^ help: consider using: `f(); b = [] as [i32; 0]`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:22:5
-   |
-LL |     b = [f(); N];
-   |     ^^^^^^^^^^^^ help: consider using: `f(); b = [] as [i32; 0]`
-
-error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:26:5
+  --> tests/ui/zero_repeat_side_effects.rs:24:5
    |
 LL |     let c = vec![f(); 0];
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f(); let c: std::vec::Vec<i32> = vec![];`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:28:5
+  --> tests/ui/zero_repeat_side_effects.rs:26:5
    |
 LL |     d = vec![f(); 0];
    |     ^^^^^^^^^^^^^^^^ help: consider using: `f(); d = vec![] as std::vec::Vec<i32>`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:31:5
+  --> tests/ui/zero_repeat_side_effects.rs:29:5
    |
 LL |     let e = [println!("side effect"); 0];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `println!("side effect"); let e: [(); 0] = [];`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:34:5
+  --> tests/ui/zero_repeat_side_effects.rs:32:5
    |
 LL |     let g = [{ f() }; 0];
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `{ f() }; let g: [i32; 0] = [];`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:37:10
+  --> tests/ui/zero_repeat_side_effects.rs:35:10
    |
 LL |     drop(vec![f(); 0]);
    |          ^^^^^^^^^^^^ help: consider using: `{ f(); vec![] as std::vec::Vec<i32> }`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:40:5
+  --> tests/ui/zero_repeat_side_effects.rs:38:5
    |
 LL |     vec![f(); 0];
    |     ^^^^^^^^^^^^ help: consider using: `{ f(); vec![] as std::vec::Vec<i32> }`
 
 error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:41:5
+  --> tests/ui/zero_repeat_side_effects.rs:39:5
    |
 LL |     [f(); 0];
    |     ^^^^^^^^ help: consider using: `{ f(); [] as [i32; 0] }`
 
-error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:42:5
-   |
-LL |     [f(); N];
-   |     ^^^^^^^^ help: consider using: `{ f(); [] as [i32; 0] }`
-
-error: aborting due to 12 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/zero_repeat_side_effects.stderr
+++ b/tests/ui/zero_repeat_side_effects.stderr
@@ -73,5 +73,17 @@ error: function or method calls as the initial value in zero-sized array initial
 LL |     [f(); N];
    |     ^^^^^^^^ help: consider using: `{ f(); [] as [i32; 0] }`
 
-error: aborting due to 12 previous errors
+error: function or method calls as the initial value in zero-sized array initializers may cause side effects
+  --> tests/ui/zero_repeat_side_effects.rs:67:5
+   |
+LL |     let _data = [f(); LEN!()];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f(); let _data: [i32; 0] = [];`
+
+error: function or method calls as the initial value in zero-sized array initializers may cause side effects
+  --> tests/ui/zero_repeat_side_effects.rs:69:5
+   |
+LL |     let _data = [f(); LENGTH];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f(); let _data: [i32; 0] = [];`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/zero_repeat_side_effects.stderr
+++ b/tests/ui/zero_repeat_side_effects.stderr
@@ -73,17 +73,5 @@ error: function or method calls as the initial value in zero-sized array initial
 LL |     [f(); N];
    |     ^^^^^^^^ help: consider using: `{ f(); [] as [i32; 0] }`
 
-error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:67:5
-   |
-LL |     let _data = [f(); LEN!()];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f(); let _data: [i32; 0] = [];`
-
-error: function or method calls as the initial value in zero-sized array initializers may cause side effects
-  --> tests/ui/zero_repeat_side_effects.rs:69:5
-   |
-LL |     let _data = [f(); LENGTH];
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `f(); let _data: [i32; 0] = [];`
-
-error: aborting due to 14 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
changelog: [`zero_repeat_side_effects` ] Lint only if array length is a literal zero
Fixes #13110 .
r? y21