### PR TITLE
Allow one-char de-indent on list items

### DIFF
--- a/clippy_lints/src/doc/lazy_continuation.rs
+++ b/clippy_lints/src/doc/lazy_continuation.rs
@@ -45,7 +45,15 @@ pub(super) fn check(
             }
         })
         .sum();
-    if ccount < blockquote_level || lcount < list_indentation {
+    let list_indentation_less_strict = if list_indentation > 2 && blockquote_level == 0 {
+        // This is technically still a lazy continuation, but it's not very confusing.
+        // To make sure it's not very confusing, we also have to be careful of block quote markers,
+        // because they'll eat a space afterward.
+        list_indentation - 1
+    } else {
+        list_indentation
+    };
+    if ccount < blockquote_level || lcount < list_indentation_less_strict {
         let msg = if ccount < blockquote_level {
             "doc quote line without `>` marker"
         } else {

--- a/tests/ui/doc/doc_lazy_list.fixed
+++ b/tests/ui/doc/doc_lazy_list.fixed
@@ -78,3 +78,70 @@ fn seven() {}
 ///   ]
 //~^ ERROR: doc list item without indentation
 fn eight() {}
+
+// Test the lazy list macro's exact behavior.
+// https://github.com/rust-lang/rust-clippy/issues/13001
+
+#[rustfmt::skip]
+/// List
+///
+///  * Item with some
+///   continuation line that is not ambiguous
+///
+/// List
+///
+///   * Item with some
+///    continuation line that is not ambiguous
+///
+/// List
+///
+///   * Item with some
+///     continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+///
+/// List
+///
+///   - Outer list
+///       * Inner list
+///        continuation line that is not ambiguous
+///
+/// List
+///
+///   - Outer list
+///       * Inner list
+///         continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+fn nine() {}
+
+#[rustfmt::skip]
+/// List
+///
+/// 1.  Item with some
+///    continuation line that is not ambiguous
+///
+/// 1.  Item with some
+///     continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+///
+///  1. Item with some
+///    continuation line that is not ambiguous
+///
+/// List
+///
+///  1.  Item with some
+///      continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+///
+/// List
+///
+///  1.  Outer list
+///      1.  Inner list
+///         continuation line that is not ambiguous
+///
+/// List
+///
+///  1.  Outer list
+///      1.  Inner list
+///          continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+fn ten() {}

--- a/tests/ui/doc/doc_lazy_list.rs
+++ b/tests/ui/doc/doc_lazy_list.rs
@@ -75,3 +75,70 @@ fn seven() {}
 ///  ]
 //~^ ERROR: doc list item without indentation
 fn eight() {}
+
+// Test the lazy list macro's exact behavior.
+// https://github.com/rust-lang/rust-clippy/issues/13001
+
+#[rustfmt::skip]
+/// List
+///
+///  * Item with some
+///   continuation line that is not ambiguous
+///
+/// List
+///
+///   * Item with some
+///    continuation line that is not ambiguous
+///
+/// List
+///
+///   * Item with some
+///   continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+///
+/// List
+///
+///   - Outer list
+///       * Inner list
+///        continuation line that is not ambiguous
+///
+/// List
+///
+///   - Outer list
+///       * Inner list
+///       continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+fn nine() {}
+
+#[rustfmt::skip]
+/// List
+///
+/// 1.  Item with some
+///    continuation line that is not ambiguous
+///
+/// 1.  Item with some
+///   continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+///
+///  1. Item with some
+///    continuation line that is not ambiguous
+///
+/// List
+///
+///  1.  Item with some
+///    continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+///
+/// List
+///
+///  1.  Outer list
+///      1.  Inner list
+///         continuation line that is not ambiguous
+///
+/// List
+///
+///  1.  Outer list
+///      1.  Inner list
+///        continuation line that is not ambiguous
+//~^ ERROR: doc list item without indentation
+fn ten() {}

--- a/tests/ui/doc/doc_lazy_list.stderr
+++ b/tests/ui/doc/doc_lazy_list.stderr
@@ -135,5 +135,65 @@ help: indent this line
 LL | ///   ]
    |      +
 
-error: aborting due to 11 previous errors
+error: doc list item without indentation
+  --> tests/ui/doc/doc_lazy_list.rs:96:5
+   |
+LL | ///   continuation line that is not ambiguous
+   |     ^^
+   |
+   = help: if this is supposed to be its own paragraph, add a blank line
+help: indent this line
+   |
+LL | ///     continuation line that is not ambiguous
+   |       ++
+
+error: doc list item without indentation
+  --> tests/ui/doc/doc_lazy_list.rs:109:5
+   |
+LL | ///       continuation line that is not ambiguous
+   |     ^^^^^^
+   |
+   = help: if this is supposed to be its own paragraph, add a blank line
+help: indent this line
+   |
+LL | ///         continuation line that is not ambiguous
+   |           ++
+
+error: doc list item without indentation
+  --> tests/ui/doc/doc_lazy_list.rs:120:5
+   |
+LL | ///   continuation line that is not ambiguous
+   |     ^^
+   |
+   = help: if this is supposed to be its own paragraph, add a blank line
+help: indent this line
+   |
+LL | ///     continuation line that is not ambiguous
+   |       ++
+
+error: doc list item without indentation
+  --> tests/ui/doc/doc_lazy_list.rs:129:5
+   |
+LL | ///    continuation line that is not ambiguous
+   |     ^^^
+   |
+   = help: if this is supposed to be its own paragraph, add a blank line
+help: indent this line
+   |
+LL | ///      continuation line that is not ambiguous
+   |        ++
+
+error: doc list item without indentation
+  --> tests/ui/doc/doc_lazy_list.rs:142:5
+   |
+LL | ///        continuation line that is not ambiguous
+   |     ^^^^^^^
+   |
+   = help: if this is supposed to be its own paragraph, add a blank line
+help: indent this line
+   |
+LL | ///          continuation line that is not ambiguous
+   |            ++
+
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Fixes #13001

changelog: [`doc_lazy_continuation`]: allow one-char de-indent on list items
