### PR TITLE
Add xFrednet back to Clippy's reviewer roulette

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -31,6 +31,7 @@ users_on_vacation = [
 "*" = [
     "@Manishearth",
     "@llogiq",
+    "@xFrednet",
     "@Alexendoo",
     "@dswij",
     "@Jarcho",


### PR DESCRIPTION
What the title says.

---

cc: https://github.com/rust-lang/rust-clippy/pull/12947

changelog: none

r? @ghost