### PR TITLE
Lintcheck: Cleanup of Lintcheck's CI summery

### DIFF
--- a/lintcheck/src/json.rs
+++ b/lintcheck/src/json.rs
@@ -51,12 +51,16 @@ fn print_warnings(title: &str, warnings: &[LintJson]) {
         return;
     }
 
-    println!("### {title}");
+    //We have to use HTML here to be able to manually add an id.
+    println!(r#"<h3 id="{title}">{title}</h3>"#);
+    println!();
     for warning in warnings {
         println!("{title} `{}` at {}", warning.lint, warning.file_link);
+        println!();
         println!("```");
         print!("{}", warning.rendered);
         println!("```");
+        println!();
     }
 }
 
@@ -65,9 +69,12 @@ fn print_changed_diff(changed: &[(LintJson, LintJson)]) {
         return;
     }
 
-    println!("### Changed");
+    //We have to use HTML here to be able to manually add an id.
+    println!(r#"<h3 id="changed">Changed</h3>"#);
+    println!();
     for (old, new) in changed {
         println!("Changed `{}` at {}", new.lint, new.file_link);
+        println!();
         println!("```diff");
         for change in diff::lines(&old.rendered, &new.rendered) {
             use diff::Result::{Both, Left, Right};
@@ -109,13 +116,30 @@ pub(crate) fn diff(old_path: &Path, new_path: &Path) {
     }
 
     print!(
-        "{} added, {} removed, {} changed\n\n",
-        added.len(),
-        removed.len(),
-        changed.len()
+        r##"{}, {}, {}"##,
+        count_string("added", added.len()),
+        count_string("removed", removed.len()),
+        count_string("changed", changed.len()),
     );
+    println!();
+    println!();
 
     print_warnings("Added", &added);
     print_warnings("Removed", &removed);
     print_changed_diff(&changed);
+}
+
+/// This generates the `x added` string for the start of the job summery.
+/// It linkifies them if possible to jump to the respective heading.
+fn count_string(label: &str, count: usize) -> String {
+    // Headlines are only added, if anything will be displayed under the headline.
+    // We therefore only want to add links to them if they exist
+    if count == 0 {
+        format!("0 {label}")
+    } else {
+        // GitHub's job summaries don't add HTML ids to headings. That's why we
+        // manually have to add them. GitHub prefixes these manual ids with
+        // `user-content-` and that's how we end up with these awesome links :D
+        format!("[{count} {label}](#user-content-{label})")
+    }
 }

--- a/lintcheck/src/json.rs
+++ b/lintcheck/src/json.rs
@@ -58,7 +58,7 @@ fn print_warnings(title: &str, warnings: &[LintJson]) {
         println!("{title} `{}` at {}", warning.lint, warning.file_link);
         println!();
         println!("```");
-        print!("{}", warning.rendered);
+        println!("{}", warning.rendered.trim_end());
         println!("```");
         println!();
     }
@@ -76,7 +76,7 @@ fn print_changed_diff(changed: &[(LintJson, LintJson)]) {
         println!("Changed `{}` at {}", new.lint, new.file_link);
         println!();
         println!("```diff");
-        for change in diff::lines(&old.rendered, &new.rendered) {
+        for change in diff::lines(old.rendered.trim_end(), new.rendered.trim_end()) {
             use diff::Result::{Both, Left, Right};
 
             match change {

--- a/lintcheck/src/main.rs
+++ b/lintcheck/src/main.rs
@@ -189,6 +189,7 @@ impl Crate {
                 Ok(Message::CompilerMessage(message)) => ClippyWarning::new(
                     normalize_diag(message.message, shared_target_dir.to_str().unwrap()),
                     &self.base_url,
+                    &self.name,
                 ),
                 _ => None,
             })

--- a/lintcheck/src/output.rs
+++ b/lintcheck/src/output.rs
@@ -53,12 +53,13 @@ impl RustcIce {
 pub struct ClippyWarning {
     pub lint: String,
     pub diag: Diagnostic,
+    pub krate: String,
     /// The URL that points to the file and line of the lint emission
     pub url: String,
 }
 
 impl ClippyWarning {
-    pub fn new(mut diag: Diagnostic, base_url: &str) -> Option<Self> {
+    pub fn new(mut diag: Diagnostic, base_url: &str, krate: &str) -> Option<Self> {
         let lint = diag.code.clone()?.code;
         if !(lint.contains("clippy") || diag.message.contains("clippy"))
             || diag.message.contains("could not read cargo metadata")
@@ -90,7 +91,12 @@ impl ClippyWarning {
             file.clone()
         };
 
-        Some(Self { lint, diag, url })
+        Some(Self {
+            lint,
+            diag,
+            url,
+            krate: krate.to_string(),
+        })
     }
 
     pub fn span(&self) -> &DiagnosticSpan {

--- a/lintcheck/src/recursive.rs
+++ b/lintcheck/src/recursive.rs
@@ -72,7 +72,7 @@ fn process_stream(
     let messages = stderr
         .lines()
         .filter_map(|json_msg| serde_json::from_str::<Diagnostic>(json_msg).ok())
-        .filter_map(|diag| ClippyWarning::new(diag, &base_url));
+        .filter_map(|diag| ClippyWarning::new(diag, &base_url, &driver_info.package_name));
 
     for message in messages {
         sender.send(message).unwrap();


### PR DESCRIPTION
This PR makes three changes to lintcheck's job summary:
* Adds links to the *Added*, *Removed*, *Changed* sections
* Added the crate name to the warning info
* Removes empty lines from the rendered output

This is what the new output roughly looks like:

![image](https://github.com/user-attachments/assets/3faae0a6-e5ee-4e70-9d4d-d19b18dc6a3a)
![image](https://github.com/user-attachments/assets/028c3a92-98dc-4e00-b7bb-fecf9450f5b1)

[:framed_picture: Old Output :framed_picture:](https://github.com/xFrednet/rust-clippy/actions/runs/10019681444)

[:framed_picture: New Output :framed_picture:](https://github.com/xFrednet/rust-clippy/actions/runs/10019598141)

The links for the sections are a bit weird as you have to click on them twice. I believe this is a bug from GH's side. But it works reasonably well :D

---

changelog: none

r? @Alexendoo 
