### PR TITLE
Make restriction lint's use `span_lint_and_then` (i -> p)

### DIFF
--- a/clippy_lints/src/asm_syntax.rs
+++ b/clippy_lints/src/asm_syntax.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::ast::{Expr, ExprKind, InlineAsmOptions};
 use rustc_ast::{InlineAsm, Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, Lint, LintContext};
@@ -49,14 +49,10 @@ fn check_asm_syntax(
         };
 
         if style == check_for {
-            span_lint_and_help(
-                cx,
-                lint,
-                span,
-                format!("{style} x86 assembly syntax used"),
-                None,
-                format!("use {} x86 assembly syntax", !style),
-            );
+            #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+            span_lint_and_then(cx, lint, span, format!("{style} x86 assembly syntax used"), |diag| {
+                diag.help(format!("use {} x86 assembly syntax", !style));
+            });
         }
     }
 }
@@ -98,13 +94,13 @@ declare_lint_pass!(InlineAsmX86IntelSyntax => [INLINE_ASM_X86_INTEL_SYNTAX]);
 impl EarlyLintPass for InlineAsmX86IntelSyntax {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if let ExprKind::InlineAsm(inline_asm) = &expr.kind {
-            check_asm_syntax(Self::get_lints()[0], cx, inline_asm, expr.span, AsmStyle::Intel);
+            check_asm_syntax(INLINE_ASM_X86_INTEL_SYNTAX, cx, inline_asm, expr.span, AsmStyle::Intel);
         }
     }
 
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if let ItemKind::GlobalAsm(inline_asm) = &item.kind {
-            check_asm_syntax(Self::get_lints()[0], cx, inline_asm, item.span, AsmStyle::Intel);
+            check_asm_syntax(INLINE_ASM_X86_INTEL_SYNTAX, cx, inline_asm, item.span, AsmStyle::Intel);
         }
     }
 }
@@ -146,13 +142,13 @@ declare_lint_pass!(InlineAsmX86AttSyntax => [INLINE_ASM_X86_ATT_SYNTAX]);
 impl EarlyLintPass for InlineAsmX86AttSyntax {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
         if let ExprKind::InlineAsm(inline_asm) = &expr.kind {
-            check_asm_syntax(Self::get_lints()[0], cx, inline_asm, expr.span, AsmStyle::Att);
+            check_asm_syntax(INLINE_ASM_X86_ATT_SYNTAX, cx, inline_asm, expr.span, AsmStyle::Att);
         }
     }
 
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
         if let ItemKind::GlobalAsm(inline_asm) = &item.kind {
-            check_asm_syntax(Self::get_lints()[0], cx, inline_asm, item.span, AsmStyle::Att);
+            check_asm_syntax(INLINE_ASM_X86_ATT_SYNTAX, cx, inline_asm, item.span, AsmStyle::Att);
         }
     }
 }

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_note;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_must_use_func_call;
 use clippy_utils::ty::{is_copy, is_must_use_ty, is_type_lang_item};
 use rustc_hir::{Arm, Expr, ExprKind, LangItem, Node};
@@ -126,14 +126,14 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetRef {
                 },
                 _ => return,
             };
-            span_lint_and_note(
-                cx,
-                lint,
-                expr.span,
-                msg,
-                note_span,
-                format!("argument has type `{arg_ty}`"),
-            );
+            span_lint_and_then(cx, lint, expr.span, msg, |diag| {
+                let note = format!("argument has type `{arg_ty}`");
+                if let Some(span) = note_span {
+                    diag.span_note(span, note);
+                } else {
+                    diag.note(note);
+                }
+            });
         }
     }
 }

--- a/clippy_lints/src/float_literal.rs
+++ b/clippy_lints/src/float_literal.rs
@@ -1,7 +1,7 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::numeric_literal;
 use rustc_ast::ast::{self, LitFloatType, LitKind};
-use rustc_errors::Applicability;
+use rustc_errors::{Applicability, SuggestionStyle};
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, FloatTy};
@@ -109,29 +109,41 @@ impl<'tcx> LateLintPass<'tcx> for FloatLiteral {
                     // If the type suffix is missing the suggestion would be
                     // incorrectly interpreted as an integer so adding a `.0`
                     // suffix to prevent that.
-                    if type_suffix.is_none() {
-                        float_str.push_str(".0");
-                    }
-
-                    span_lint_and_sugg(
+                    
+                    span_lint_and_then(
                         cx,
                         LOSSY_FLOAT_LITERAL,
                         expr.span,
                         "literal cannot be represented as the underlying type without loss of precision",
-                        "consider changing the type or replacing it with",
-                        numeric_literal::format(&float_str, type_suffix, true),
-                        Applicability::MachineApplicable,
+                        |diag| {
+                            if type_suffix.is_none() {
+                                float_str.push_str(".0");
+                            }
+                            diag.span_suggestion_with_style(
+                                expr.span,
+                                "consider changing the type or replacing it with",
+                                numeric_literal::format(&float_str, type_suffix, true),
+                                Applicability::MachineApplicable,
+                                SuggestionStyle::ShowAlways,
+                            );
+                        },
                     );
                 }
             } else if digits > max as usize && float_str.len() < sym_str.len() {
-                span_lint_and_sugg(
+                span_lint_and_then(
                     cx,
                     EXCESSIVE_PRECISION,
                     expr.span,
                     "float has excessive precision",
-                    "consider changing the type or truncating it to",
-                    numeric_literal::format(&float_str, type_suffix, true),
-                    Applicability::MachineApplicable,
+                    |diag| {
+                        diag.span_suggestion_with_style(
+                            expr.span,
+                            "consider changing the type or truncating it to",
+                            numeric_literal::format(&float_str, type_suffix, true),
+                            Applicability::MachineApplicable,
+                            SuggestionStyle::ShowAlways,
+                        );
+                    },
                 );
             }
         }

--- a/clippy_lints/src/float_literal.rs
+++ b/clippy_lints/src/float_literal.rs
@@ -106,16 +106,15 @@ impl<'tcx> LateLintPass<'tcx> for FloatLiteral {
             if is_whole && !sym_str.contains(['e', 'E']) {
                 // Normalize the literal by stripping the fractional portion
                 if sym_str.split('.').next().unwrap() != float_str {
-                    // If the type suffix is missing the suggestion would be
-                    // incorrectly interpreted as an integer so adding a `.0`
-                    // suffix to prevent that.
-
                     span_lint_and_then(
                         cx,
                         LOSSY_FLOAT_LITERAL,
                         expr.span,
                         "literal cannot be represented as the underlying type without loss of precision",
                         |diag| {
+                            // If the type suffix is missing the suggestion would be
+                            // incorrectly interpreted as an integer so adding a `.0`
+                            // suffix to prevent that.
                             if type_suffix.is_none() {
                                 float_str.push_str(".0");
                             }

--- a/clippy_lints/src/float_literal.rs
+++ b/clippy_lints/src/float_literal.rs
@@ -109,7 +109,7 @@ impl<'tcx> LateLintPass<'tcx> for FloatLiteral {
                     // If the type suffix is missing the suggestion would be
                     // incorrectly interpreted as an integer so adding a `.0`
                     // suffix to prevent that.
-                    
+
                     span_lint_and_then(
                         cx,
                         LOSSY_FLOAT_LITERAL,

--- a/clippy_lints/src/inherent_impl.rs
+++ b/clippy_lints/src/inherent_impl.rs
@@ -1,6 +1,6 @@
 //! lint on inherent implementations
 
-use clippy_utils::diagnostics::span_lint_and_note;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_lint_allowed;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::LocalDefId;
@@ -106,13 +106,14 @@ impl<'tcx> LateLintPass<'tcx> for MultipleInherentImpl {
         // `TyCtxt::crate_inherent_impls` doesn't have a defined order. Sort the lint output first.
         lint_spans.sort_by_key(|x| x.0.lo());
         for (span, first_span) in lint_spans {
-            span_lint_and_note(
+            span_lint_and_then(
                 cx,
                 MULTIPLE_INHERENT_IMPL,
                 span,
                 "multiple implementations of this structure",
-                Some(first_span),
-                "first implementation here",
+                |diag| {
+                    diag.span_note(first_span, "first implementation here");
+                },
             );
         }
     }

--- a/clippy_lints/src/methods/map_err_ignore.rs
+++ b/clippy_lints/src/methods/map_err_ignore.rs
@@ -30,7 +30,6 @@ pub(super) fn check(cx: &LateContext<'_>, e: &Expr<'_>, arg: &Expr<'_>) {
             "`map_err(|_|...` wildcard pattern discards the original error",
             |diag| {
                 diag.help(
-
                     "consider storing the original error as a source in the new error, or silence this warning using an ignored identifier (`.map_err(|_foo| ...`)",
                 );
             },

--- a/clippy_lints/src/methods/map_err_ignore.rs
+++ b/clippy_lints/src/methods/map_err_ignore.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::ty::is_type_diagnostic_item;
 use rustc_hir::{CaptureBy, Closure, Expr, ExprKind, PatKind};
 use rustc_lint::LateContext;
@@ -22,13 +22,18 @@ pub(super) fn check(cx: &LateContext<'_>, e: &Expr<'_>, arg: &Expr<'_>) {
     {
         // span the area of the closure capture and warn that the
         // original error will be thrown away
-        span_lint_and_help(
+        #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+        span_lint_and_then(
             cx,
             MAP_ERR_IGNORE,
             fn_decl_span,
             "`map_err(|_|...` wildcard pattern discards the original error",
-            None,
-            "consider storing the original error as a source in the new error, or silence this warning using an ignored identifier (`.map_err(|_foo| ...`)",
+            |diag| {
+                diag.help(
+
+                    "consider storing the original error as a source in the new error, or silence this warning using an ignored identifier (`.map_err(|_foo| ...`)",
+                );
+            },
         );
     }
 }

--- a/clippy_lints/src/missing_assert_message.rs
+++ b/clippy_lints/src/missing_assert_message.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_in_test;
 use clippy_utils::macros::{find_assert_args, find_assert_eq_args, root_macro_call_first_node, PanicExpn};
 use rustc_hir::Expr;
@@ -79,13 +79,15 @@ impl<'tcx> LateLintPass<'tcx> for MissingAssertMessage {
         };
 
         if let PanicExpn::Empty = panic_expn {
-            span_lint_and_help(
+            #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+            span_lint_and_then(
                 cx,
                 MISSING_ASSERT_MESSAGE,
                 macro_call.span,
                 "assert without any message",
-                None,
-                "consider describing why the failing assert is problematic",
+                |diag| {
+                    diag.help("consider describing why the failing assert is problematic");
+                },
             );
         }
     }

--- a/clippy_lints/src/missing_trait_methods.rs
+++ b/clippy_lints/src/missing_trait_methods.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_lint_allowed;
 use clippy_utils::macros::span_is_local;
 use rustc_hir::def_id::DefIdMap;
@@ -83,15 +83,15 @@ impl<'tcx> LateLintPass<'tcx> for MissingTraitMethods {
             cx.tcx.with_stable_hashing_context(|hcx| {
                 for assoc in provided.values_sorted(&hcx, true) {
                     let source_map = cx.tcx.sess.source_map();
-                    let definition_span = source_map.guess_head_span(cx.tcx.def_span(assoc.def_id));
-
-                    span_lint_and_help(
+                    span_lint_and_then(
                         cx,
                         MISSING_TRAIT_METHODS,
                         source_map.guess_head_span(item.span),
                         format!("missing trait method provided by default: `{}`", assoc.name),
-                        Some(definition_span),
-                        "implement the method",
+                        |diag| {
+                            let definition_span = source_map.guess_head_span(cx.tcx.def_span(assoc.def_id));
+                            diag.span_help(definition_span, "implement the method");
+                        },
                     );
                 }
             });

--- a/clippy_lints/src/operators/integer_division.rs
+++ b/clippy_lints/src/operators/integer_division.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir as hir;
 use rustc_lint::LateContext;
 
@@ -15,13 +15,9 @@ pub(crate) fn check<'tcx>(
         && cx.typeck_results().expr_ty(left).is_integral()
         && cx.typeck_results().expr_ty(right).is_integral()
     {
-        span_lint_and_help(
-            cx,
-            INTEGER_DIVISION,
-            expr.span,
-            "integer division",
-            None,
-            "division of integers may cause loss of precision. consider using floats",
-        );
+        #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+        span_lint_and_then(cx, INTEGER_DIVISION, expr.span, "integer division", |diag| {
+            diag.help("division of integers may cause loss of precision. consider using floats");
+        });
     }
 }

--- a/clippy_lints/src/partial_pub_fields.rs
+++ b/clippy_lints/src/partial_pub_fields.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::ast::{Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::declare_lint_pass;
@@ -57,24 +57,16 @@ impl EarlyLintPass for PartialPubFields {
 
         for field in fields {
             if all_priv && field.vis.kind.is_pub() {
-                span_lint_and_help(
-                    cx,
-                    PARTIAL_PUB_FIELDS,
-                    field.vis.span,
-                    msg,
-                    None,
-                    "consider using private field here",
-                );
+                #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+                span_lint_and_then(cx, PARTIAL_PUB_FIELDS, field.vis.span, msg, |diag| {
+                    diag.help("consider using private field here");
+                });
                 return;
             } else if all_pub && !field.vis.kind.is_pub() {
-                span_lint_and_help(
-                    cx,
-                    PARTIAL_PUB_FIELDS,
-                    field.vis.span,
-                    msg,
-                    None,
-                    "consider using public field here",
-                );
+                #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+                span_lint_and_then(cx, PARTIAL_PUB_FIELDS, field.vis.span, msg, |diag| {
+                    diag.help("consider using public field here");
+                });
                 return;
             }
         }

--- a/clippy_lints/src/pub_use.rs
+++ b/clippy_lints/src/pub_use.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_help;
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::ast::{Item, ItemKind, VisibilityKind};
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::declare_lint_pass;
@@ -42,14 +42,10 @@ impl EarlyLintPass for PubUse {
         if let ItemKind::Use(_) = item.kind
             && let VisibilityKind::Public = item.vis.kind
         {
-            span_lint_and_help(
-                cx,
-                PUB_USE,
-                item.span,
-                "using `pub use`",
-                None,
-                "move the exported item to a public module instead",
-            );
+            #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+            span_lint_and_then(cx, PUB_USE, item.span, "using `pub use`", |diag| {
+                diag.help("move the exported item to a public module instead");
+            });
         }
     }
 }

--- a/clippy_lints/src/visibility.rs
+++ b/clippy_lints/src/visibility.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::snippet_opt;
 use rustc_ast::ast::{Item, VisibilityKind};
 use rustc_errors::Applicability;
@@ -85,14 +85,19 @@ impl EarlyLintPass for Visibility {
             if **path == kw::SelfLower
                 && let Some(false) = is_from_proc_macro(cx, item.vis.span)
             {
-                span_lint_and_sugg(
+                span_lint_and_then(
                     cx,
                     NEEDLESS_PUB_SELF,
                     item.vis.span,
                     format!("unnecessary `pub({}self)`", if *shorthand { "" } else { "in " }),
-                    "remove it",
-                    String::new(),
-                    Applicability::MachineApplicable,
+                    |diag| {
+                        diag.span_suggestion_hidden(
+                            item.vis.span,
+                            "remove it",
+                            String::new(),
+                            Applicability::MachineApplicable,
+                        );
+                    },
                 );
             }
 
@@ -101,14 +106,20 @@ impl EarlyLintPass for Visibility {
                 && let [.., last] = &*path.segments
                 && let Some(false) = is_from_proc_macro(cx, item.vis.span)
             {
-                span_lint_and_sugg(
+                #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+                span_lint_and_then(
                     cx,
                     PUB_WITHOUT_SHORTHAND,
                     item.vis.span,
                     "usage of `pub` with `in`",
-                    "remove it",
-                    format!("pub({})", last.ident),
-                    Applicability::MachineApplicable,
+                    |diag| {
+                        diag.span_suggestion(
+                            item.vis.span,
+                            "remove it",
+                            format!("pub({})", last.ident),
+                            Applicability::MachineApplicable,
+                        );
+                    },
                 );
             }
 
@@ -116,14 +127,20 @@ impl EarlyLintPass for Visibility {
                 && let [.., last] = &*path.segments
                 && let Some(false) = is_from_proc_macro(cx, item.vis.span)
             {
-                span_lint_and_sugg(
+                #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+                span_lint_and_then(
                     cx,
                     PUB_WITH_SHORTHAND,
                     item.vis.span,
                     "usage of `pub` without `in`",
-                    "add it",
-                    format!("pub(in {})", last.ident),
-                    Applicability::MachineApplicable,
+                    |diag| {
+                        diag.span_suggestion(
+                            item.vis.span,
+                            "add it",
+                            format!("pub(in {})", last.ident),
+                            Applicability::MachineApplicable,
+                        );
+                    },
                 );
             }
         }

--- a/tests/ui/excessive_precision.stderr
+++ b/tests/ui/excessive_precision.stderr
@@ -2,100 +2,179 @@ error: float has excessive precision
   --> tests/ui/excessive_precision.rs:20:26
    |
 LL |     const BAD32_1: f32 = 0.123_456_789_f32;
-   |                          ^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0.123_456_79_f32`
+   |                          ^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::excessive-precision` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::excessive_precision)]`
+help: consider changing the type or truncating it to
+   |
+LL |     const BAD32_1: f32 = 0.123_456_79_f32;
+   |                          ~~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:21:26
    |
 LL |     const BAD32_2: f32 = 0.123_456_789;
-   |                          ^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0.123_456_79`
+   |                          ^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     const BAD32_2: f32 = 0.123_456_79;
+   |                          ~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:22:26
    |
 LL |     const BAD32_3: f32 = 0.100_000_000_000_1;
-   |                          ^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0.1`
+   |                          ^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     const BAD32_3: f32 = 0.1;
+   |                          ~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:23:29
    |
 LL |     const BAD32_EDGE: f32 = 1.000_000_9;
-   |                             ^^^^^^^^^^^ help: consider changing the type or truncating it to: `1.000_001`
+   |                             ^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     const BAD32_EDGE: f32 = 1.000_001;
+   |                             ~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:27:26
    |
 LL |     const BAD64_3: f64 = 0.100_000_000_000_000_000_1;
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0.1`
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     const BAD64_3: f64 = 0.1;
+   |                          ~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:30:22
    |
 LL |     println!("{:?}", 8.888_888_888_888_888_888_888);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `8.888_888_888_888_89`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     println!("{:?}", 8.888_888_888_888_89);
+   |                      ~~~~~~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:41:22
    |
 LL |     let bad32: f32 = 1.123_456_789;
-   |                      ^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `1.123_456_8`
+   |                      ^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let bad32: f32 = 1.123_456_8;
+   |                      ~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:42:26
    |
 LL |     let bad32_suf: f32 = 1.123_456_789_f32;
-   |                          ^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `1.123_456_8_f32`
+   |                          ^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let bad32_suf: f32 = 1.123_456_8_f32;
+   |                          ~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:43:21
    |
 LL |     let bad32_inf = 1.123_456_789_f32;
-   |                     ^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `1.123_456_8_f32`
+   |                     ^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let bad32_inf = 1.123_456_8_f32;
+   |                     ~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:53:36
    |
 LL |     let bad_vec32: Vec<f32> = vec![0.123_456_789];
-   |                                    ^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0.123_456_79`
+   |                                    ^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let bad_vec32: Vec<f32> = vec![0.123_456_79];
+   |                                    ~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:54:36
    |
 LL |     let bad_vec64: Vec<f64> = vec![0.123_456_789_123_456_789];
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0.123_456_789_123_456_78`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let bad_vec64: Vec<f64> = vec![0.123_456_789_123_456_78];
+   |                                    ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:58:24
    |
 LL |     let bad_e32: f32 = 1.123_456_788_888e-10;
-   |                        ^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `1.123_456_8e-10`
+   |                        ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let bad_e32: f32 = 1.123_456_8e-10;
+   |                        ~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:61:27
    |
 LL |     let bad_bige32: f32 = 1.123_456_788_888E-10;
-   |                           ^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `1.123_456_8E-10`
+   |                           ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let bad_bige32: f32 = 1.123_456_8E-10;
+   |                           ~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:70:13
    |
 LL |     let _ = 2.225_073_858_507_201_1e-308_f64;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `2.225_073_858_507_201e-308_f64`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let _ = 2.225_073_858_507_201e-308_f64;
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:73:13
    |
 LL |     let _ = 1.000_000_000_000_001e-324_f64;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `0_f64`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     let _ = 0_f64;
+   |             ~~~~~
 
 error: float has excessive precision
   --> tests/ui/excessive_precision.rs:83:20
    |
 LL |     const _: f64 = 3.0000000000000000e+00;
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or truncating it to: `3.0`
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or truncating it to
+   |
+LL |     const _: f64 = 3.0;
+   |                    ~~~
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/lossy_float_literal.stderr
+++ b/tests/ui/lossy_float_literal.stderr
@@ -2,70 +2,124 @@ error: literal cannot be represented as the underlying type without loss of prec
   --> tests/ui/lossy_float_literal.rs:14:18
    |
 LL |     let _: f32 = 16_777_217.0;
-   |                  ^^^^^^^^^^^^ help: consider changing the type or replacing it with: `16_777_216.0`
+   |                  ^^^^^^^^^^^^
    |
    = note: `-D clippy::lossy-float-literal` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::lossy_float_literal)]`
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f32 = 16_777_216.0;
+   |                  ~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:15:18
    |
 LL |     let _: f32 = 16_777_219.0;
-   |                  ^^^^^^^^^^^^ help: consider changing the type or replacing it with: `16_777_220.0`
+   |                  ^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f32 = 16_777_220.0;
+   |                  ~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:16:18
    |
 LL |     let _: f32 = 16_777_219.;
-   |                  ^^^^^^^^^^^ help: consider changing the type or replacing it with: `16_777_220.0`
+   |                  ^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f32 = 16_777_220.0;
+   |                  ~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:17:18
    |
 LL |     let _: f32 = 16_777_219.000;
-   |                  ^^^^^^^^^^^^^^ help: consider changing the type or replacing it with: `16_777_220.0`
+   |                  ^^^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f32 = 16_777_220.0;
+   |                  ~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:18:13
    |
 LL |     let _ = 16_777_219f32;
-   |             ^^^^^^^^^^^^^ help: consider changing the type or replacing it with: `16_777_220_f32`
+   |             ^^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _ = 16_777_220_f32;
+   |             ~~~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:19:19
    |
 LL |     let _: f32 = -16_777_219.0;
-   |                   ^^^^^^^^^^^^ help: consider changing the type or replacing it with: `16_777_220.0`
+   |                   ^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f32 = -16_777_220.0;
+   |                   ~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:21:18
    |
 LL |     let _: f64 = 9_007_199_254_740_993.0;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or replacing it with: `9_007_199_254_740_992.0`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f64 = 9_007_199_254_740_992.0;
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:22:18
    |
 LL |     let _: f64 = 9_007_199_254_740_993.;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or replacing it with: `9_007_199_254_740_992.0`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f64 = 9_007_199_254_740_992.0;
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:23:18
    |
 LL |     let _: f64 = 9_007_199_254_740_993.00;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or replacing it with: `9_007_199_254_740_992.0`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f64 = 9_007_199_254_740_992.0;
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:24:13
    |
 LL |     let _ = 9_007_199_254_740_993f64;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or replacing it with: `9_007_199_254_740_992_f64`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _ = 9_007_199_254_740_992_f64;
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: literal cannot be represented as the underlying type without loss of precision
   --> tests/ui/lossy_float_literal.rs:25:19
    |
 LL |     let _: f64 = -9_007_199_254_740_993.0;
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing the type or replacing it with: `9_007_199_254_740_992.0`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider changing the type or replacing it with
+   |
+LL |     let _: f64 = -9_007_199_254_740_992.0;
+   |                   ~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/needless_pub_self.stderr
+++ b/tests/ui/needless_pub_self.stderr
@@ -2,22 +2,27 @@ error: unnecessary `pub(self)`
   --> tests/ui/needless_pub_self.rs:13:1
    |
 LL | pub(self) fn a() {}
-   | ^^^^^^^^^ help: remove it
+   | ^^^^^^^^^
    |
    = note: `-D clippy::needless-pub-self` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_pub_self)]`
+   = help: remove it
 
 error: unnecessary `pub(in self)`
   --> tests/ui/needless_pub_self.rs:14:1
    |
 LL | pub(in self) fn b() {}
-   | ^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^
+   |
+   = help: remove it
 
 error: unnecessary `pub(self)`
   --> tests/ui/needless_pub_self.rs:20:5
    |
 LL |     pub(self) fn f() {}
-   |     ^^^^^^^^^ help: remove it
+   |     ^^^^^^^^^
+   |
+   = help: remove it
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This migrates a few restriction lints to use `span_lint_and_then`. This change is motivated by https://github.com/rust-lang/rust-clippy/issues/7797.

I've also cleaned up some lint message. Mostly minor stuff. For example: suggestions with a longer message than `"try"` now use `SuggestionStyle::ShowAlways`

---

cc: https://github.com/rust-lang/rust-clippy/issues/7797

brother PR of: https://github.com/rust-lang/rust-clippy/pull/13136

changelog: none