### PR TITLE
Fix running compile-test under cargo nextest

### DIFF
--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -268,15 +268,6 @@ fn run_ui_cargo() {
 }
 
 fn main() {
-    // Support being run by cargo nextest - https://nexte.st/book/custom-test-harnesses.html
-    if env::args().any(|arg| arg == "--list") {
-        if !env::args().any(|arg| arg == "--ignored") {
-            println!("compile_test: test");
-        }
-
-        return;
-    }
-
     set_var("CLIPPY_DISABLE_DOCS_LINKS", "true");
     // The SPEEDTEST_* env variables can be used to check Clippy's performance on your PR. It runs the
     // affected test 1000 times and gets the average.


### PR DESCRIPTION
`ui_test` itself has `cargo nextest` support which we now use - https://github.com/oli-obk/ui_test/pull/161

It prints `ui_test` as its test name whereas we printed `compile_test`, this ended up being treated as a test name filter causing all the tests to be filtered out

changelog: none
