### PR TITLE
Fix display of configs in clippy doc page

### DIFF
--- a/clippy_config/src/metadata.rs
+++ b/clippy_config/src/metadata.rs
@@ -13,7 +13,7 @@ impl fmt::Display for ClippyConfiguration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "- `{}`: {}", self.name, self.doc)?;
         if !self.default.is_empty() {
-            write!(f, " (default: `{}`)", self.default)?;
+            write!(f, "\n\n(default: `{}`)", self.default)?;
         }
         Ok(())
     }

--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -167,7 +167,7 @@ impl MetadataCollector {
             .iter()
             .filter(|config| config.lints.iter().any(|lint| lint == lint_name))
             .map(ToString::to_string)
-            .reduce(|acc, x| acc + &x)
+            .reduce(|acc, x| acc + "\n\n" + &x)
             .map(|configurations| {
                 format!(
                     r#"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/13051.

It was simply some empty lines missing between configs. With this fix it looks like expected:

![image](https://github.com/user-attachments/assets/89c609b4-e24a-4f4a-91c1-3b49fc83584c)

r? @xFrednet 

changelog: Fix display of configs in clippy doc page