### PR TITLE
Fix broken list for lints config

### DIFF
--- a/clippy_config/src/metadata.rs
+++ b/clippy_config/src/metadata.rs
@@ -13,7 +13,7 @@ impl fmt::Display for ClippyConfiguration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "- `{}`: {}", self.name, self.doc)?;
         if !self.default.is_empty() {
-            write!(f, "\n\n(default: `{}`)", self.default)?;
+            write!(f, "\n\n   (default: `{}`)", self.default)?;
         }
         Ok(())
     }

--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -684,6 +684,11 @@ fn cleanup_docs(docs_collection: &Vec<String>) -> String {
                     .find(|&s| !matches!(s, "" | "ignore" | "no_run" | "should_panic"))
                     // if no language is present, fill in "rust"
                     .unwrap_or("rust");
+                let len_diff = line.len() - line.trim_start().len();
+                if len_diff != 0 {
+                    // We put back the indentation.
+                    docs.push_str(&line[..len_diff]);
+                }
                 docs.push_str("```");
                 docs.push_str(lang);
 


### PR DESCRIPTION
Follow-up of #13166.

Finally figured out that it was a transformation and not the source that was the problem. It now looks like this:

![Screenshot from 2024-07-29 16-29-10](https://github.com/user-attachments/assets/4b89b3fe-8f85-47b8-8d9a-505badeaeac4)

r? @xFrednet 

changelog: none