### PR TITLE
fix unused_async with macros and sub async block

### DIFF
--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -118,7 +118,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
         span: Span,
         def_id: LocalDefId,
     ) {
-        if fn_kind.asyncness().is_async() && !is_def_id_trait_method(cx, def_id) {
+        if !span.from_expansion() && fn_kind.asyncness().is_async() && !is_def_id_trait_method(cx, def_id) {
             let mut visitor = AsyncFnVisitor {
                 cx,
                 await_in_async_block: None,
@@ -131,13 +131,6 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
                 // Don't lint just yet, but store the necessary information for later.
                 // The actual linting happens in `check_crate_post`, once we've found all
                 // uses of local async functions that do require asyncness to pass typeck
-
-                let mut span = span;
-
-                if let Some(info) = span.macro_backtrace().next() {
-                    span = info.call_site
-                }
-
                 self.unused_async_fns.push(UnusedAsyncFn {
                     await_in_async_block: visitor.await_in_async_block,
                     fn_span: span,

--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -148,13 +148,13 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
     }
 
     fn check_path(&mut self, cx: &LateContext<'tcx>, path: &rustc_hir::Path<'tcx>, hir_id: rustc_hir::HirId) {
-        fn is_node_func_call(node: Node<'_>, expected_receiver: Span) -> bool {
+        fn is_node_func_value(node: Node<'_>, expected_receiver: Span) -> bool {
             matches!(
                 node,
                 Node::Expr(Expr {
                     kind: ExprKind::Call(Expr { span, .. }, _) | ExprKind::MethodCall(_, Expr { span, .. }, ..),
                     ..
-                }) if *span == expected_receiver
+                }) if *span != expected_receiver
             )
         }
 
@@ -166,7 +166,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
             && let Some(local_def_id) = def_id.as_local()
             && cx.tcx.def_kind(def_id) == DefKind::Fn
             && cx.tcx.asyncness(def_id).is_async()
-            && !is_node_func_call(cx.tcx.parent_hir_node(hir_id), path.span)
+            && is_node_func_value(cx.tcx.parent_hir_node(hir_id), path.span)
         {
             self.async_fns_as_value.insert(local_def_id);
         }

--- a/clippy_lints/src/unused_async.rs
+++ b/clippy_lints/src/unused_async.rs
@@ -128,7 +128,6 @@ impl<'tcx> LateLintPass<'tcx> for UnusedAsync {
             walk_fn(&mut visitor, fn_kind, fn_decl, body.id(), def_id);
 
             if !visitor.is_valid {
-                // if !visitor.found_await || !visitor.found_await_in_async_block_all {
                 // Don't lint just yet, but store the necessary information for later.
                 // The actual linting happens in `check_crate_post`, once we've found all
                 // uses of local async functions that do require asyncness to pass typeck

--- a/tests/ui/unused_async.stderr
+++ b/tests/ui/unused_async.stderr
@@ -48,5 +48,5 @@ LL | |     }
    |
    = help: consider removing the `async` from this function
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/unused_async.stderr
+++ b/tests/ui/unused_async.stderr
@@ -19,14 +19,6 @@ LL |             ready(()).await;
    = help: to override `-D warnings` add `#[allow(clippy::unused_async)]`
 
 error: unused `async` for function with no await statements
-  --> tests/ui/unused_async.rs:43:5
-   |
-LL |     async fn f() {}
-   |     ^^^^^^^^^^^^^^^
-   |
-   = help: consider removing the `async` from this function
-
-error: unused `async` for function with no await statements
   --> tests/ui/unused_async.rs:45:5
    |
 LL |     async fn f3() {}

--- a/tests/ui/unused_async.stderr
+++ b/tests/ui/unused_async.stderr
@@ -19,6 +19,14 @@ LL |             ready(()).await;
    = help: to override `-D warnings` add `#[allow(clippy::unused_async)]`
 
 error: unused `async` for function with no await statements
+  --> tests/ui/unused_async.rs:43:5
+   |
+LL |     async fn f() {}
+   |     ^^^^^^^^^^^^^^^
+   |
+   = help: consider removing the `async` from this function
+
+error: unused `async` for function with no await statements
   --> tests/ui/unused_async.rs:45:5
    |
 LL |     async fn f3() {}
@@ -48,5 +56,5 @@ LL | |     }
    |
    = help: consider removing the `async` from this function
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
changelog: [`unused_async`]:
- check after `pro_macro_attribute`
- check inside async block

fixes #13199

I've run the test, but failed with the error that I didn't understand.
```sh
error: actual output differed from expected
Execute `cargo uibless` to update `tests/ui/unused_async.stderr` to the actual output
--- tests/ui/unused_async.stderr
+++ <stderr output>
 error: unused `async` for function with no await statements
   --> tests/ui/unused_async.rs:12:5
... 46 lines skipped ...
    = help: consider removing the `async` from this function

-error: aborting due to 4 previous errors
+error: unused `async` for function with no await statements

+error: aborting due to 5 previous errors
+
```