### PR TITLE
Removed `@no-rustfix annotation and updated suggestions to multipart_suggestion` as required by #13099

### DIFF
--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
@@ -1,7 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 fn below_limit() {
     let slice: Option<&[u32]> = Some(&[1, 2, 3]);
     if let Some(slice) = slice {

--- a/tests/ui/crashes/ice-3717.rs
+++ b/tests/ui/crashes/ice-3717.rs
@@ -1,7 +1,5 @@
 #![deny(clippy::implicit_hasher)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 use std::collections::HashSet;
 
 fn main() {}

--- a/tests/ui/derivable_impls.rs
+++ b/tests/ui/derivable_impls.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 use std::collections::HashMap;
 
 struct FooDefault<'a> {

--- a/tests/ui/index_refutable_slice/if_let_slice_binding.rs
+++ b/tests/ui/index_refutable_slice/if_let_slice_binding.rs
@@ -1,8 +1,6 @@
 #![deny(clippy::index_refutable_slice)]
 #![allow(clippy::uninlined_format_args)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 enum SomeEnum<T> {
     One(T),
     Two(T),

--- a/tests/ui/index_refutable_slice/slice_indexing_in_macro.rs
+++ b/tests/ui/index_refutable_slice/slice_indexing_in_macro.rs
@@ -1,7 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 extern crate if_chain;
 use if_chain::if_chain;
 

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::let_unit_value)]
 #![allow(unused, clippy::no_effect, clippy::needless_late_init, path_statements)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 macro_rules! let_and_return {
     ($n:expr) => {{
         let ret = $n;

--- a/tests/ui/manual_assert.rs
+++ b/tests/ui/manual_assert.rs
@@ -2,8 +2,6 @@
 //@[edition2018] edition:2018
 //@[edition2021] edition:2021
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 #![warn(clippy::manual_assert)]
 #![allow(dead_code, unused_doc_comments)]
 #![allow(clippy::nonminimal_bool, clippy::uninlined_format_args, clippy::useless_vec)]

--- a/tests/ui/manual_async_fn.rs
+++ b/tests/ui/manual_async_fn.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::manual_async_fn)]
 #![allow(clippy::needless_pub_self, unused)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 use std::future::Future;
 
 fn fut() -> impl Future<Output = i32> {

--- a/tests/ui/manual_split_once.rs
+++ b/tests/ui/manual_split_once.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::manual_split_once)]
 #![allow(unused, clippy::iter_skip_next, clippy::iter_nth_zero)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 extern crate itertools;
 
 #[allow(unused_imports)]

--- a/tests/ui/match_same_arms2.rs
+++ b/tests/ui/match_same_arms2.rs
@@ -7,8 +7,6 @@
     clippy::match_like_matches_macro
 )]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 fn bar<T>(_: T) {}
 fn foo() -> bool {
     unimplemented!()

--- a/tests/ui/significant_drop_tightening.rs
+++ b/tests/ui/significant_drop_tightening.rs
@@ -1,7 +1,5 @@
 #![warn(clippy::significant_drop_tightening)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 use std::sync::Mutex;
 
 pub fn complex_return_triggers_the_lint() -> i32 {

--- a/tests/ui/unnecessary_iter_cloned.rs
+++ b/tests/ui/unnecessary_iter_cloned.rs
@@ -1,8 +1,6 @@
 #![allow(unused_assignments)]
 #![warn(clippy::unnecessary_to_owned)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 #[allow(dead_code)]
 #[derive(Clone, Copy)]
 enum FileType {

--- a/tests/ui/unnecessary_to_owned.rs
+++ b/tests/ui/unnecessary_to_owned.rs
@@ -7,8 +7,6 @@
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]
 
-//@no-rustfix: need to change the suggestion to a multipart suggestion
-
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::ops::Deref;


### PR DESCRIPTION
Hey there, I removed the `@no-rustfix annotation and updated suggestions to multipart_suggestion` line from the files that were mentioned in the #13099 issue.  I removed the `@no-rustfix` annotation and mentioned it in the PR also but I didn't understand the 3rd point because I didn't saw any suggestion point except these comments.

Let me know if I am missing anything.

Although there was a test error in the fmt but I didn't modified the `tests/check-fmt.rs` file. Here is the screenshot of it.

![53](https://github.com/user-attachments/assets/e1199efd-4049-437a-9222-d2974d9698be)


- \[x] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
