### PR TITLE
Use a deterministic number of digits in rustc_tools_util commit hashes

### DIFF
--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -104,10 +104,11 @@ impl std::fmt::Debug for VersionInfo {
 #[must_use]
 pub fn get_commit_hash() -> Option<String> {
     let output = std::process::Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .ok()?;
-    let stdout = output.status.success().then_some(output.stdout)?;
+    let mut stdout = output.status.success().then_some(output.stdout)?;
+    stdout.truncate(10);
     String::from_utf8(stdout).ok()
 }
 


### PR DESCRIPTION
Using `git rev-parse --short` in rustc_tools_util causes nondeterministic compilation of projects that use `setup_version_info!` and `get_version_info!` when built from the exact same source code and git commit. The number of digits printed by `--short` is sensitive to how many other branches and tags in the repository have been fetched so far, what other commits have been worked on in other branches, how recently you had run `git gc`, platform-specific variation in git's default configuration, and platform differences in the sequence of steps performed by the release pipeline. Someone can compile a tool from a particular commit, switch branches to work on a different commit (or simply do a git fetch), go back to the first commit and be unable to reproduce the binary that was built from it previously.

Currently, variation in short commit hashes causes Clippy version strings to be out of sync between different targets. On x86_64-unknown-linux-gnu:

```console
$ clippy-driver +1.80.0 --version
clippy 0.1.80 (0514789 2024-07-21)
```

Whereas on aarch64-apple-darwin:

```console
$ clippy-driver +1.80.0 --version
clippy 0.1.80 (05147895 2024-07-21)
```

---

changelog: none