### PR TITLE
Add path prefixes back when compiling `clippy_dev` and `lintcheck`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,13 @@ target-dir = "target"
 
 [unstable]
 binary-dep-depinfo = true
+profile-rustflags = true
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+# Add back the containing directory of the packages we have to refer to using --manifest-path
+[profile.dev.package.clippy_dev]
+rustflags = ["--remap-path-prefix", "=clippy_dev"]
+[profile.dev.package.lintcheck]
+rustflags = ["--remap-path-prefix", "=lintcheck"]


### PR DESCRIPTION
`cargo dev` and `cargo lintcheck` use `--manifest-path` to select the package to compile, with this Cargo changes the CWD to the package's containing directory meaning paths in diagnostics start from e.g. `src/` instead of `clippy_dev/src/`

Lintcheck uses a `--remap-path-prefix` trick when linting crates to re-add the directory name in diagnostics: 

https://github.com/rust-lang/rust-clippy/blob/5ead90f13ae3e03f0c346aea3198f18298960d83/lintcheck/src/main.rs#L93-L94

https://github.com/rust-lang/rust-clippy/blob/5ead90f13ae3e03f0c346aea3198f18298960d83/lintcheck/src/main.rs#L102-L103

It works well as far as I can tell, when absolute paths appear they stay absolute and do not have the prefix added

[`profile-rustflags`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-rustflags-option) allows us to set per package `RUSTFLAGS` in order to use the same trick on the `clippy_dev` and `lintcheck` packages themselves

Now when you run into warnings/errors the filename will be correctly clickable

Before
```
error[E0425]: cannot find value `moo` in this scope
  --> src/lib.rs:41:5
   |
41 |     moo;
   |     ^^^ not found in this scope
```

After
```
error[E0425]: cannot find value `moo` in this scope
  --> clippy_dev/src/lib.rs:41:5
   |
41 |     moo;
   |     ^^^ not found in this scope
```

r? @flip1995

changelog: none
