### PR TITLE
new lint: add `call_missing_target_feature` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5417,6 +5417,7 @@ Released 2018-09-13
 [`byte_char_slices`]: https://rust-lang.github.io/rust-clippy/master/index.html#byte_char_slices
 [`bytes_count_to_len`]: https://rust-lang.github.io/rust-clippy/master/index.html#bytes_count_to_len
 [`bytes_nth`]: https://rust-lang.github.io/rust-clippy/master/index.html#bytes_nth
+[`call_missing_target_feature`]: https://rust-lang.github.io/rust-clippy/master/index.html#call_missing_target_feature
 [`cargo_common_metadata`]: https://rust-lang.github.io/rust-clippy/master/index.html#cargo_common_metadata
 [`case_sensitive_file_extension_comparisons`]: https://rust-lang.github.io/rust-clippy/master/index.html#case_sensitive_file_extension_comparisons
 [`cast_abs_to_unsigned`]: https://rust-lang.github.io/rust-clippy/master/index.html#cast_abs_to_unsigned

--- a/clippy_lints/src/call_missing_target_feature.rs
+++ b/clippy_lints/src/call_missing_target_feature.rs
@@ -1,0 +1,141 @@
+#![allow(clippy::similar_names)]
+use clippy_utils::diagnostics::span_lint_and_then;
+use rustc_hir as hir;
+use rustc_hir::def::Res;
+use rustc_hir::def_id::DefId;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::lint::in_external_macro;
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks that the caller enables the target features that the callee requires
+    ///
+    /// ### Why is this bad?
+    /// Not enabling target features can cause UB and limits optimization opportunities.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// #[target_feature(enable = "avx2")]
+    /// unsafe fn f() -> u32 {
+    ///     0
+    /// }
+    ///
+    /// fn g() {
+    ///     unsafe { f() };
+    ///     // g does not enable the target features f requires
+    /// }
+    /// ```
+    #[clippy::version = "1.82.0"]
+    pub CALL_MISSING_TARGET_FEATURE,
+    suspicious,
+    "call requires target features that the surrounding function does not enable"
+}
+
+declare_lint_pass!(CallMissingTargetFeature => [CALL_MISSING_TARGET_FEATURE]);
+
+impl<'tcx> LateLintPass<'tcx> for CallMissingTargetFeature {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &hir::Expr<'tcx>) {
+        let Some(callee_def_id) = callee_def_id(cx, expr) else {
+            return;
+        };
+        let callee_target_features = &cx.tcx.codegen_fn_attrs(callee_def_id).target_features;
+
+        if callee_target_features.is_empty() {
+            return;
+        }
+
+        let Some(caller_body_id) = cx.enclosing_body else {
+            return;
+        };
+        let caller_def_id = cx.tcx.hir().body_owner_def_id(caller_body_id);
+        let caller_target_features = &cx.tcx.codegen_fn_attrs(caller_def_id).target_features;
+
+        if in_external_macro(cx.tcx.sess, expr.span) {
+            return;
+        }
+
+        // target features can imply other target features (e.g. avx2 implies sse4.2). We can safely skip
+        // implied target features and only warn for the more general missing target feature.
+        let missing: Vec<_> = callee_target_features
+            .iter()
+            .filter_map(|target_feature| {
+                if target_feature.implied || caller_target_features.iter().any(|tf| tf.name == target_feature.name) {
+                    None
+                } else {
+                    Some(target_feature.name.as_str())
+                }
+            })
+            .collect();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        let attr = format!("#[target_feature(enable = \"{}\")]", missing.join(","));
+
+        span_lint_and_then(
+            cx,
+            CALL_MISSING_TARGET_FEATURE,
+            expr.span,
+            "this call requires target features that the surrounding function does not enable",
+            |diag| {
+                diag.span_label(
+                    expr.span,
+                    "this function call requires target features to be enabled".to_string(),
+                );
+
+                let fn_sig = cx.tcx.fn_sig(caller_def_id).skip_binder();
+
+                let mut suggestions = Vec::with_capacity(2);
+
+                let hir::Node::Item(caller_item) = cx.tcx.hir_node_by_def_id(caller_def_id) else {
+                    return;
+                };
+
+                let Some(indent) = clippy_utils::source::snippet_indent(cx, caller_item.span) else {
+                    return;
+                };
+
+                let lo_span = caller_item.span.with_hi(caller_item.span.lo());
+
+                match fn_sig.safety() {
+                    hir::Safety::Safe => {
+                        // the `target_feature` attribute can only be applied to unsafe functions
+                        if caller_item.vis_span.is_empty() {
+                            suggestions.push((lo_span, format!("{attr}\n{indent}unsafe ")));
+                        } else {
+                            suggestions.push((lo_span, format!("{attr}\n{indent}")));
+                            suggestions.push((caller_item.vis_span.shrink_to_hi(), " unsafe".to_string()));
+                        }
+                    },
+                    hir::Safety::Unsafe => {
+                        suggestions.push((lo_span, format!("{attr}\n{indent}")));
+                    },
+                }
+
+                diag.multipart_suggestion_verbose(
+                    "add the missing target features to the surrounding function",
+                    suggestions,
+                    rustc_errors::Applicability::MaybeIncorrect,
+                );
+            },
+        );
+    }
+}
+
+fn callee_def_id(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> Option<DefId> {
+    match expr.kind {
+        hir::ExprKind::Call(path, _) => {
+            if let hir::ExprKind::Path(ref qpath) = path.kind
+                && let Res::Def(_, did) = cx.qpath_res(qpath, path.hir_id)
+            {
+                Some(did)
+            } else {
+                None
+            }
+        },
+        hir::ExprKind::MethodCall(..) => cx.typeck_results().type_dependent_def_id(expr.hir_id),
+        _ => None,
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -69,6 +69,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::borrow_deref_ref::BORROW_DEREF_REF_INFO,
     crate::box_default::BOX_DEFAULT_INFO,
     crate::byte_char_slices::BYTE_CHAR_SLICES_INFO,
+    crate::call_missing_target_feature::CALL_MISSING_TARGET_FEATURE_INFO,
     crate::cargo::CARGO_COMMON_METADATA_INFO,
     crate::cargo::LINT_GROUPS_PRIORITY_INFO,
     crate::cargo::MULTIPLE_CRATE_VERSIONS_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -92,6 +92,7 @@ mod booleans;
 mod borrow_deref_ref;
 mod box_default;
 mod byte_char_slices;
+mod call_missing_target_feature;
 mod cargo;
 mod casts;
 mod cfg_not_test;
@@ -784,6 +785,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(|_| Box::new(floating_point_arithmetic::FloatingPointArithmetic));
     store.register_late_pass(|_| Box::new(as_conversions::AsConversions));
     store.register_late_pass(|_| Box::new(let_underscore::LetUnderscore));
+    store.register_late_pass(|_| Box::new(call_missing_target_feature::CallMissingTargetFeature));
     store.register_early_pass(|| Box::<single_component_path_imports::SingleComponentPathImports>::default());
     store.register_late_pass(move |_| Box::new(excessive_bools::ExcessiveBools::new(conf)));
     store.register_early_pass(|| Box::new(option_env_unwrap::OptionEnvUnwrap));

--- a/tests/ui/call_missing_target_feature.fixed
+++ b/tests/ui/call_missing_target_feature.fixed
@@ -1,0 +1,42 @@
+//@only-target: x86_64
+#![allow(clippy::missing_safety_doc)]
+
+#[target_feature(enable = "avx2")]
+pub unsafe fn test_f() {
+    unsafe { f() };
+    //~^ ERROR: this call requires target features
+}
+
+#[target_feature(enable = "avx2,pclmulqdq")]
+pub(crate) unsafe fn test_g() {
+    unsafe { g() };
+    //~^ ERROR: this call requires target features
+}
+
+#[target_feature(enable = "avx2,pclmulqdq")]
+unsafe fn test_h() {
+    unsafe { h() };
+    //~^ ERROR: this call requires target features
+}
+
+#[target_feature(enable = "avx2,pclmulqdq")]
+unsafe fn test_h_unsafe() {
+    unsafe { h() };
+    //~^ ERROR: this call requires target features
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn f() -> u32 {
+    0
+}
+
+#[target_feature(enable = "avx2,pclmulqdq")]
+unsafe fn g() -> u32 {
+    0
+}
+
+#[target_feature(enable = "avx2")]
+#[target_feature(enable = "pclmulqdq")]
+unsafe fn h() -> u32 {
+    0
+}

--- a/tests/ui/call_missing_target_feature.rs
+++ b/tests/ui/call_missing_target_feature.rs
@@ -1,0 +1,38 @@
+//@only-target: x86_64
+#![allow(clippy::missing_safety_doc)]
+
+pub fn test_f() {
+    unsafe { f() };
+    //~^ ERROR: this call requires target features
+}
+
+pub(crate) fn test_g() {
+    unsafe { g() };
+    //~^ ERROR: this call requires target features
+}
+
+fn test_h() {
+    unsafe { h() };
+    //~^ ERROR: this call requires target features
+}
+
+unsafe fn test_h_unsafe() {
+    unsafe { h() };
+    //~^ ERROR: this call requires target features
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn f() -> u32 {
+    0
+}
+
+#[target_feature(enable = "avx2,pclmulqdq")]
+unsafe fn g() -> u32 {
+    0
+}
+
+#[target_feature(enable = "avx2")]
+#[target_feature(enable = "pclmulqdq")]
+unsafe fn h() -> u32 {
+    0
+}

--- a/tests/ui/call_missing_target_feature.stderr
+++ b/tests/ui/call_missing_target_feature.stderr
@@ -1,0 +1,52 @@
+error: this call requires target features that the surrounding function does not enable
+  --> tests/ui/call_missing_target_feature.rs:5:14
+   |
+LL |     unsafe { f() };
+   |              ^^^ this function call requires target features to be enabled
+   |
+   = note: `-D clippy::call-missing-target-feature` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::call_missing_target_feature)]`
+help: add the missing target features to the surrounding function
+   |
+LL + #[target_feature(enable = "avx2")]
+LL ~ pub unsafe fn test_f() {
+   |
+
+error: this call requires target features that the surrounding function does not enable
+  --> tests/ui/call_missing_target_feature.rs:10:14
+   |
+LL |     unsafe { g() };
+   |              ^^^ this function call requires target features to be enabled
+   |
+help: add the missing target features to the surrounding function
+   |
+LL + #[target_feature(enable = "avx2,pclmulqdq")]
+LL ~ pub(crate) unsafe fn test_g() {
+   |
+
+error: this call requires target features that the surrounding function does not enable
+  --> tests/ui/call_missing_target_feature.rs:15:14
+   |
+LL |     unsafe { h() };
+   |              ^^^ this function call requires target features to be enabled
+   |
+help: add the missing target features to the surrounding function
+   |
+LL + #[target_feature(enable = "avx2,pclmulqdq")]
+LL ~ unsafe fn test_h() {
+   |
+
+error: this call requires target features that the surrounding function does not enable
+  --> tests/ui/call_missing_target_feature.rs:20:14
+   |
+LL |     unsafe { h() };
+   |              ^^^ this function call requires target features to be enabled
+   |
+help: add the missing target features to the surrounding function
+   |
+LL + #[target_feature(enable = "avx2,pclmulqdq")]
+LL | unsafe fn test_h_unsafe() {
+   |
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
<!--

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```

```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

-->

changelog: [`call_missing_target_feature`]: was added

This PR adds a lint for missing target features.

## Motivation

A function that requires a target feature (e.g. `#[target_feature(enable = "avx2")]` to indicate that avx2 instructions can be used) must be called from a context where these instructions are actually available. That check is part of the safety contract of the function. For correctness and performance, any function calling a function with a target feature must either

- also declare that target feature
- assert that the target feature is available (e.g. with the [is_x86_feature_detected](https://doc.rust-lang.org/std/macro.is_x86_feature_detected.html) macro, or similar for the current target platform)

However, currently no warning is emitted when the user forgets to correctly annotate target features. My personal experience with [zlib-rs](https://github.com/memorysafety/zlib-rs) is that it's just really easy to forget the annotation on some helper function, and to forget to check for target features in code review. Hence, this check.

## Implementation

The implementation looks for function calls, then looks up if that function (the callee) has any target features, and if so, checks whether the caller also has these target features. Any missing target features are reported.

This lint is not always accurate, and I think should be off by default, but is very useful in e.g. simd-heavy codebases. Some `#[cfg(allow(...)]` are always required though in the function where the feature detection macro is called.

## Questions

- The tests run into 
 
  ```
  error: test got exit status: 1, but expected 0
   --> tests/ui/call_missing_target_feature.fixed:1:1
    |
  1 | #[target_feature(enable = "avx2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ after rustfix is applied, all errors should be gone, but weren't
  ```
    despite the suggestion being `Applicability::MaybeIncorrect`. I must be missing something here. The problem is that the function must also be marked as unsafe in this case. Still I think the suggestion is useful. Also inserting the unsafe seems complicated, but maybe that is possible?

cc @bjorn3 maybe you have phrasing suggestions?