### PR TITLE
show message with try block in `map_unwrap_or`

### DIFF
--- a/tests/ui/map_unwrap_or.stderr
+++ b/tests/ui/map_unwrap_or.stderr
@@ -5,15 +5,10 @@ LL |       let _ = opt.map(|x| x + 1)
    |  _____________^
 LL | |         // Should lint even though this call is on a separate line.
 LL | |         .unwrap_or(0);
-   | |_____________________^
+   | |_____________________^ help: try: `opt.map_or(0, |x| x + 1)`
    |
    = note: `-D clippy::map-unwrap-or` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::map_unwrap_or)]`
-help: use `map_or(<a>, <f>)` instead
-   |
-LL -     let _ = opt.map(|x| x + 1)
-LL +     let _ = opt.map_or(0, |x| x + 1);
-   |
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:21:13
@@ -54,13 +49,7 @@ error: called `map(<f>).unwrap_or(None)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:30:13
    |
 LL |     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `and_then(<f>)` instead
-   |
-LL -     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
-LL +     let _ = opt.and_then(|x| Some(x + 1));
-   |
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.and_then(|x| Some(x + 1))`
 
 error: called `map(<f>).unwrap_or(None)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:32:13
@@ -87,25 +76,13 @@ LL |       let _ = opt
    |  _____________^
 LL | |         .map(|x| Some(x + 1))
 LL | |         .unwrap_or(None);
-   | |________________________^
-   |
-help: use `and_then(<f>)` instead
-   |
-LL -         .map(|x| Some(x + 1))
-LL +         .and_then(|x| Some(x + 1));
-   |
+   | |________________________^ help: try: `opt.and_then(|x| Some(x + 1))`
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:47:13
    |
 LL |     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `map_or(<a>, <f>)` instead
-   |
-LL -     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
-LL +     let _ = Some("prefix").map_or(id, |p| format!("{}.", p));
-   |
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some("prefix").map_or(id, |p| format!("{}.", p))`
 
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:51:13
@@ -131,13 +108,7 @@ error: called `map(<f>).unwrap_or(false)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:61:13
    |
 LL |     let _ = opt.map(|x| x > 5).unwrap_or(false);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and(<f>)` instead
-   |
-LL -     let _ = opt.map(|x| x > 5).unwrap_or(false);
-LL +     let _ = opt.is_some_and(|x| x > 5);
-   |
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x > 5)`
 
 error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
   --> tests/ui/map_unwrap_or.rs:71:13
@@ -169,25 +140,13 @@ error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:106:13
    |
 LL |     let _ = opt.map(|x| x > 5).unwrap_or(false);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `map_or(<a>, <f>)` instead
-   |
-LL -     let _ = opt.map(|x| x > 5).unwrap_or(false);
-LL +     let _ = opt.map_or(false, |x| x > 5);
-   |
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.map_or(false, |x| x > 5)`
 
 error: called `map(<f>).unwrap_or(false)` on an `Option` value
   --> tests/ui/map_unwrap_or.rs:113:13
    |
 LL |     let _ = opt.map(|x| x > 5).unwrap_or(false);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: use `is_some_and(<f>)` instead
-   |
-LL -     let _ = opt.map(|x| x > 5).unwrap_or(false);
-LL +     let _ = opt.is_some_and(|x| x > 5);
-   |
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x > 5)`
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/map_unwrap_or_fixable.fixed
+++ b/tests/ui/map_unwrap_or_fixable.fixed
@@ -47,6 +47,15 @@ fn result_methods() {
     let _ = opt_map!(res, |x| x + 1).unwrap_or_else(|_e| 0); // should not lint
 }
 
+#[rustfmt::skip]
+fn issue_13242() {
+    Some(1).is_some_and(|x| x < 5);
+
+    Some(1).map_or(1, |x| x + 1);
+
+    Ok(1).map_or_else(|_: usize| {1}, |x| x + 1);
+}
+
 fn main() {
     option_methods();
     result_methods();

--- a/tests/ui/map_unwrap_or_fixable.rs
+++ b/tests/ui/map_unwrap_or_fixable.rs
@@ -51,6 +51,21 @@ fn result_methods() {
     let _ = opt_map!(res, |x| x + 1).unwrap_or_else(|_e| 0); // should not lint
 }
 
+#[rustfmt::skip]
+fn issue_13242() {
+    Some(1)
+        .map(|x| x < 5)
+        .unwrap_or(false);
+
+    Some(1)
+        .map(|x| x + 1)
+        .unwrap_or(1);
+
+    Ok(1)
+        .map(|x| x + 1)
+        .unwrap_or_else(|_: usize| {1});
+}
+
 fn main() {
     option_methods();
     result_methods();

--- a/tests/ui/map_unwrap_or_fixable.stderr
+++ b/tests/ui/map_unwrap_or_fixable.stderr
@@ -19,5 +19,29 @@ LL | |         // should lint even though this call is on a separate line
 LL | |         .unwrap_or_else(|_e| 0);
    | |_______________________________^ help: try: `res.map_or_else(|_e| 0, |x| x + 1)`
 
-error: aborting due to 2 previous errors
+error: called `map(<f>).unwrap_or(false)` on an `Option` value
+  --> tests/ui/map_unwrap_or_fixable.rs:56:5
+   |
+LL | /     Some(1)
+LL | |         .map(|x| x < 5)
+LL | |         .unwrap_or(false);
+   | |_________________________^ help: try: `Some(1).is_some_and(|x| x < 5)`
+
+error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
+  --> tests/ui/map_unwrap_or_fixable.rs:60:5
+   |
+LL | /     Some(1)
+LL | |         .map(|x| x + 1)
+LL | |         .unwrap_or(1);
+   | |_____________________^ help: try: `Some(1).map_or(1, |x| x + 1)`
+
+error: called `map(<f>).unwrap_or_else(<g>)` on a `Result` value
+  --> tests/ui/map_unwrap_or_fixable.rs:64:5
+   |
+LL | /     Ok(1)
+LL | |         .map(|x| x + 1)
+LL | |         .unwrap_or_else(|_: usize| {1});
+   | |_______________________________________^ help: try: `Ok(1).map_or_else(|_: usize| {1}, |x| x + 1)`
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
close https://github.com/rust-lang/rust-clippy/issues/13242

This PR fixes the issue where errors from map_unwrap_or were only partially displayed. When the error spans multiple lines, it needs to be shown in a block format.

changelog:
Corrected the error display for map_unwrap_or.