### PR TITLE
Remove `feature=cargo-clippy` argument

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -270,8 +270,6 @@ pub fn main() {
                 },
                 _ => Some(s.to_string()),
             })
-            // FIXME: remove this line in 1.79 to only keep `--cfg clippy`.
-            .chain(vec!["--cfg".into(), r#"feature="cargo-clippy""#.into()])
             .chain(vec!["--cfg".into(), "clippy".into()])
             .collect::<Vec<String>>();
 


### PR DESCRIPTION
Roses are red,
Violets are blue,
Fixme was written,
And now it's due

---

changelog: **Important Change** Removed the implicit `cargo-clippy` feature set by Clippy as announced here: <https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html>
[#13246](https://github.com/rust-lang/rust-clippy/pull/13246)

Follow-up of: rust-lang/rust-clippy#12292

r? @flip1995 

cc: @GuillaumeGomez 
