### PR TITLE
New lint for `as *const _` and `as *mut _` pointer casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5380,6 +5380,7 @@ Released 2018-09-13
 [`arc_with_non_send_sync`]: https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
 [`arithmetic_side_effects`]: https://rust-lang.github.io/rust-clippy/master/index.html#arithmetic_side_effects
 [`as_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_conversions
+[`as_pointer_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_pointer_underscore
 [`as_ptr_cast_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_ptr_cast_mut
 [`as_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_underscore
 [`assertions_on_constants`]: https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

--- a/clippy_lints/src/casts/as_pointer_underscore.rs
+++ b/clippy_lints/src/casts/as_pointer_underscore.rs
@@ -1,0 +1,19 @@
+use rustc_errors::Applicability;
+use rustc_lint::LateContext;
+use rustc_middle::ty::Ty;
+
+pub fn check<'tcx>(cx: &LateContext<'tcx>, ty_into: Ty<'_>, cast_to_hir: &'tcx rustc_hir::Ty<'tcx>) {
+    if let rustc_hir::TyKind::Ptr(rustc_hir::MutTy { ty, .. }) = cast_to_hir.kind
+        && matches!(ty.kind, rustc_hir::TyKind::Infer)
+    {
+        clippy_utils::diagnostics::span_lint_and_sugg(
+            cx,
+            super::AS_POINTER_UNDERSCORE,
+            cast_to_hir.span,
+            "using inferred pointer cast",
+            "use explicit type",
+            ty_into.to_string(),
+            Applicability::MachineApplicable,
+        );
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -75,6 +75,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::cargo::NEGATIVE_FEATURE_NAMES_INFO,
     crate::cargo::REDUNDANT_FEATURE_NAMES_INFO,
     crate::cargo::WILDCARD_DEPENDENCIES_INFO,
+    crate::casts::AS_POINTER_UNDERSCORE_INFO,
     crate::casts::AS_PTR_CAST_MUT_INFO,
     crate::casts::AS_UNDERSCORE_INFO,
     crate::casts::BORROW_AS_PTR_INFO,

--- a/tests/ui/as_pointer_underscore.fixed
+++ b/tests/ui/as_pointer_underscore.fixed
@@ -1,0 +1,15 @@
+#![warn(clippy::as_pointer_underscore)]
+#![crate_type = "lib"]
+#![no_std]
+
+struct S;
+
+fn f(s: &S) -> usize {
+    &s as *const &S as usize
+    //~^ ERROR: using inferred pointer cast
+}
+
+fn g(s: &mut S) -> usize {
+    s as *mut S as usize
+    //~^ ERROR: using inferred pointer cast
+}

--- a/tests/ui/as_pointer_underscore.rs
+++ b/tests/ui/as_pointer_underscore.rs
@@ -1,0 +1,15 @@
+#![warn(clippy::as_pointer_underscore)]
+#![crate_type = "lib"]
+#![no_std]
+
+struct S;
+
+fn f(s: &S) -> usize {
+    &s as *const _ as usize
+    //~^ ERROR: using inferred pointer cast
+}
+
+fn g(s: &mut S) -> usize {
+    s as *mut _ as usize
+    //~^ ERROR: using inferred pointer cast
+}

--- a/tests/ui/as_pointer_underscore.stderr
+++ b/tests/ui/as_pointer_underscore.stderr
@@ -1,0 +1,17 @@
+error: using inferred pointer cast
+  --> tests/ui/as_pointer_underscore.rs:8:11
+   |
+LL |     &s as *const _ as usize
+   |           ^^^^^^^^ help: use explicit type: `*const &S`
+   |
+   = note: `-D clippy::as-pointer-underscore` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::as_pointer_underscore)]`
+
+error: using inferred pointer cast
+  --> tests/ui/as_pointer_underscore.rs:13:10
+   |
+LL |     s as *mut _ as usize
+   |          ^^^^^^ help: use explicit type: `*mut S`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
changelog: New lint for as *const _ and as *mut _ pointer casts

EDIT: lets go with the simpler version
