### PR TITLE
use `diag.span_help` if the target is multiline in `map_unwrap_or`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4999,8 +4999,10 @@ impl Methods {
                         Some((arith @ ("checked_add" | "checked_sub" | "checked_mul"), lhs, [rhs], _, _)) => {
                             manual_saturating_arithmetic::check(cx, expr, lhs, rhs, u_arg, &arith["checked_".len()..]);
                         },
-                        Some(("map", m_recv, [m_arg], span, _)) => {
-                            option_map_unwrap_or::check(cx, expr, m_recv, m_arg, recv, u_arg, span, &self.msrv);
+                        Some(("map", m_recv, [m_arg], map_span, _)) => {
+                            option_map_unwrap_or::check(
+                                cx, expr, m_recv, m_arg, recv, u_arg, map_span, span, &self.msrv,
+                            );
                         },
                         Some(("then_some", t_recv, [t_arg], _, _)) => {
                             obfuscated_if_else::check(cx, expr, t_recv, t_arg, u_arg);

--- a/tests/ui/map_unwrap_or.stderr
+++ b/tests/ui/map_unwrap_or.stderr
@@ -7,9 +7,14 @@ LL | |         // Should lint even though this call is on a separate line.
 LL | |         .unwrap_or(0);
    | |_____________________^
    |
+help: remove this `unwrap_or` statement
+  --> tests/ui/map_unwrap_or.rs:19:10
+   |
+LL |         .unwrap_or(0);
+   |          ^^^^^^^^^
    = note: `-D clippy::map-unwrap-or` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::map_unwrap_or)]`
-help: use `map_or(<a>, <f>)` instead
+help: and use `map_or(<a>, <f>)` instead
    |
 LL -     let _ = opt.map(|x| x + 1)
 LL +     let _ = opt.map_or(0, |x| x + 1);
@@ -25,7 +30,12 @@ LL | |     }
 LL | |     ).unwrap_or(0);
    | |__________________^
    |
-help: use `map_or(<a>, <f>)` instead
+help: remove this `unwrap_or` statement
+  --> tests/ui/map_unwrap_or.rs:24:7
+   |
+LL |     ).unwrap_or(0);
+   |       ^^^^^^^^^
+help: and use `map_or(<a>, <f>)` instead
    |
 LL ~     let _ = opt.map_or(0, |x| {
 LL |         x + 1
@@ -43,7 +53,12 @@ LL | |             0
 LL | |         });
    | |__________^
    |
-help: use `map_or(<a>, <f>)` instead
+help: remove this `unwrap_or` statement
+  --> tests/ui/map_unwrap_or.rs:26:10
+   |
+LL |         .unwrap_or({
+   |          ^^^^^^^^^
+help: and use `map_or(<a>, <f>)` instead
    |
 LL ~     let _ = opt.map_or({
 LL +             0
@@ -72,7 +87,12 @@ LL | |     }
 LL | |     ).unwrap_or(None);
    | |_____________________^
    |
-help: use `and_then(<f>)` instead
+help: remove this `unwrap_or` statement
+  --> tests/ui/map_unwrap_or.rs:35:7
+   |
+LL |     ).unwrap_or(None);
+   |       ^^^^^^^^^
+help: and use `and_then(<f>)` instead
    |
 LL ~     let _ = opt.and_then(|x| {
 LL |         Some(x + 1)
@@ -89,7 +109,12 @@ LL | |         .map(|x| Some(x + 1))
 LL | |         .unwrap_or(None);
    | |________________________^
    |
-help: use `and_then(<f>)` instead
+help: remove this `unwrap_or` statement
+  --> tests/ui/map_unwrap_or.rs:38:10
+   |
+LL |         .unwrap_or(None);
+   |          ^^^^^^^^^
+help: and use `and_then(<f>)` instead
    |
 LL -         .map(|x| Some(x + 1))
 LL +         .and_then(|x| Some(x + 1));

--- a/tests/ui/map_unwrap_or_fixable.fixed
+++ b/tests/ui/map_unwrap_or_fixable.fixed
@@ -47,6 +47,15 @@ fn result_methods() {
     let _ = opt_map!(res, |x| x + 1).unwrap_or_else(|_e| 0); // should not lint
 }
 
+#[rustfmt::skip]
+fn issue_13242() {
+    Some(1)
+        .is_some_and(|x| x < 5);
+
+    Some(1)
+        .map_or(1, |x| x + 1);
+}
+
 fn main() {
     option_methods();
     result_methods();

--- a/tests/ui/map_unwrap_or_fixable.rs
+++ b/tests/ui/map_unwrap_or_fixable.rs
@@ -51,6 +51,17 @@ fn result_methods() {
     let _ = opt_map!(res, |x| x + 1).unwrap_or_else(|_e| 0); // should not lint
 }
 
+#[rustfmt::skip]
+fn issue_13242() {
+    Some(1)
+        .map(|x| x < 5)
+        .unwrap_or(false);
+
+    Some(1)
+        .map(|x| x + 1)
+        .unwrap_or(1);
+}
+
 fn main() {
     option_methods();
     result_methods();

--- a/tests/ui/map_unwrap_or_fixable.stderr
+++ b/tests/ui/map_unwrap_or_fixable.stderr
@@ -19,5 +19,43 @@ LL | |         // should lint even though this call is on a separate line
 LL | |         .unwrap_or_else(|_e| 0);
    | |_______________________________^ help: try: `res.map_or_else(|_e| 0, |x| x + 1)`
 
-error: aborting due to 2 previous errors
+error: called `map(<f>).unwrap_or(false)` on an `Option` value
+  --> tests/ui/map_unwrap_or_fixable.rs:56:5
+   |
+LL | /     Some(1)
+LL | |         .map(|x| x < 5)
+LL | |         .unwrap_or(false);
+   | |_________________________^
+   |
+help: remove this `unwrap_or` statement
+  --> tests/ui/map_unwrap_or_fixable.rs:58:10
+   |
+LL |         .unwrap_or(false);
+   |          ^^^^^^^^^
+help: and use `is_some_and(<f>)` instead
+   |
+LL -         .map(|x| x < 5)
+LL +         .is_some_and(|x| x < 5);
+   |
+
+error: called `map(<f>).unwrap_or(<a>)` on an `Option` value
+  --> tests/ui/map_unwrap_or_fixable.rs:60:5
+   |
+LL | /     Some(1)
+LL | |         .map(|x| x + 1)
+LL | |         .unwrap_or(1);
+   | |_____________________^
+   |
+help: remove this `unwrap_or` statement
+  --> tests/ui/map_unwrap_or_fixable.rs:62:10
+   |
+LL |         .unwrap_or(1);
+   |          ^^^^^^^^^
+help: and use `map_or(<a>, <f>)` instead
+   |
+LL -         .map(|x| x + 1)
+LL +         .map_or(1, |x| x + 1);
+   |
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
close https://github.com/rust-lang/rust-clippy/issues/13242

This PR fixes the issue where errors from map_unwrap_or were only partially displayed.
Through discussion on zulip, I changed to using `span_help` to issue change orders rather than inline changes.

https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/Verbose.20suggestion.20missing.20line.20deletions


changelog:
Corrected the error display for map_unwrap_or.