### PR TITLE
fix code blocks in doc comments inconsistently using 3 or 4 spaces of indentation

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -309,7 +309,7 @@ declare_clippy_lint! {
     /// ### Known problems
     /// Inner doc comments can only appear before items, so there are certain cases where the suggestion
     /// made by this lint is not valid code. For example:
-    /// ```rs
+    /// ```rust
     /// fn foo() {}
     /// ///!
     /// fn bar() {}

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -2702,10 +2702,10 @@ declare_clippy_lint! {
     ///             }
     ///         })
     /// }
-    ///  ```
+    /// ```
     ///
-    ///  After:
-    ///  ```rust
+    /// After:
+    /// ```rust
     /// use std::{fmt, num::ParseIntError};
     ///
     /// #[derive(Debug)]

--- a/clippy_lints/src/utils/internal_lints/metadata_collector.rs
+++ b/clippy_lints/src/utils/internal_lints/metadata_collector.rs
@@ -687,10 +687,12 @@ fn cleanup_docs(docs_collection: &Vec<String>) -> String {
                     .trim()
                     .split(',')
                     // remove rustdoc directives
-                    .find(|&s| !matches!(s, "" | "ignore" | "no_run" | "should_panic"))
+                    .find(|&s| !matches!(s, "" | "ignore" | "no_run" | "should_panic" | "compile_fail"))
                     // if no language is present, fill in "rust"
                     .unwrap_or("rust");
-                let len_diff = line.len() - line.trim_start().len();
+                let len_diff = line
+                    .strip_prefix(' ')
+                    .map_or(0, |line| line.len() - line.trim_start().len());
                 if len_diff != 0 {
                     // We put back the indentation.
                     docs.push_str(&line[..len_diff]);


### PR DESCRIPTION
The metadata collector script was treating the space lines all start with as indentation. This caused code block's triple backticks to get a space in front of it, like this:
```
 ```rust
^ this space
```
Code after that that is indented with 4 spaces will only have 3 of those rendered.
Example (taken from [here](https://rust-lang.github.io/rust-clippy/master/index.html#/missing_panics_doc)):
```rust
...
pub fn divide_by(x: i32, y: i32) -> i32 {
   if y == 0 {                      // 3 spaces
       panic!("Cannot divide by 0") // 7 spaces
...
```

Also added 'compile_fail' alongside the other rustdoc directives (second code block [here](https://rust-lang.github.io/rust-clippy/master/index.html#/macro_metavars_in_unsafe) had no highlighting), fixed a doc comment using 'rs' instead of 'rust' and removed some spaces causing an extra missing space of indentation (see second code block [here](https://rust-lang.github.io/rust-clippy/master/index.html#/map_err_ignore)).

changelog: none