### PR TITLE
move `manual_c_str_literals` to complexity

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4025,7 +4025,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.78.0"]
     pub MANUAL_C_STR_LITERALS,
-    pedantic,
+    complexity,
     r#"creating a `CStr` through functions when `c""` literals can be used"#
 }
 


### PR DESCRIPTION
IMO the suggestion to use `c""` literals over a hardcoded `\0` byte string literal has some fairly strong upsides (no need to manually null-terminate it and the compiler checks for intermediary null bytes) that this should just be enabled by default.

It's also written slightly conservatively to only emit a warning when we can be reasonably confident that the lint is *actually* applicable (that is, lint on e.g. `b"foo\0".as_ptr()` but not `b"foo\0"`. The latter looks like a c-string but its type is `&[u8; _]`, and if it's used in a context where a byte slice is needed then you have no nice way to convert to it from a `c"foo"` literal of type `&CStr`).

changelog: move [`manual_c_str_literals`] to complexity (now warn-by-default)