### PR TITLE
Fix lint source location github link (missing a letter 'L')

### DIFF
--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -310,8 +310,8 @@ declare_clippy_lint! {
     /// ```rust,ignore
     /// #[allow(unused_mut)]
     /// fn foo() -> usize {
-    ///    let mut a = Vec::new();
-    ///    a.len()
+    ///     let mut a = Vec::new();
+    ///     a.len()
     /// }
     /// ```
     /// Use instead:

--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -80,7 +80,7 @@ declare_clippy_lint! {
     /// ```no_run
     /// // `n` can be any number, including `i32::MAX`.
     /// fn foo(n: i32) -> i32 {
-    ///   n + 1
+    ///     n + 1
     /// }
     /// ```
     ///

--- a/declare_clippy_lint/src/lib.rs
+++ b/declare_clippy_lint/src/lib.rs
@@ -156,7 +156,7 @@ pub fn declare_clippy_lint(input: TokenStream) -> TokenStream {
     let category_variant = format_ident!("{category}");
 
     let name_span = name.span().unwrap();
-    let location = format!("{}#{}", name_span.source_file().path().display(), name_span.line());
+    let location = format!("{}#L{}", name_span.source_file().path().display(), name_span.line());
 
     let version = match version {
         Some(version) => quote!(Some(#version)),


### PR DESCRIPTION
Links to github ('View Source') were broken by [pull request 13221](https://github.com/rust-lang/rust-clippy/pull/13221/files#diff-dcd0f8da3873f35e9777182474a9d0f287f478c0c02650a1d3fefffe1c8c1d30R159).

also fixed some indentation in docs

changelog: none