### PR TITLE
fix incorrect suggestion for `!(a >= b) as i32 == c`

### DIFF
--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -203,6 +203,21 @@ fn check_simplify_not(cx: &LateContext<'_>, msrv: &Msrv, expr: &Expr<'_>) {
         && let Some(suggestion) = simplify_not(cx, msrv, inner)
         && cx.tcx.lint_level_at_node(NONMINIMAL_BOOL, expr.hir_id).0 != Level::Allow
     {
+        use clippy_utils::sugg::{Sugg, has_enclosing_paren};
+        let maybe_par = if let Some(sug) = Sugg::hir_opt(cx, inner) {
+            match sug {
+                Sugg::BinOp(..) => true,
+                Sugg::MaybeParen(sug) if !has_enclosing_paren(&sug) => true,
+                _ => false,
+            }
+        } else {
+            false
+        };
+        let suggestion = if maybe_par {
+            format!("({suggestion})")
+        } else {
+            suggestion
+        };
         span_lint_and_sugg(
             cx,
             NONMINIMAL_BOOL,

--- a/tests/ui/nonminimal_bool.stderr
+++ b/tests/ui/nonminimal_bool.stderr
@@ -118,25 +118,25 @@ error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:161:8
    |
 LL |     if !(12 == a) {}
-   |        ^^^^^^^^^^ help: try: `12 != a`
+   |        ^^^^^^^^^^ help: try: `(12 != a)`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:162:8
    |
 LL |     if !(a == 12) {}
-   |        ^^^^^^^^^^ help: try: `a != 12`
+   |        ^^^^^^^^^^ help: try: `(a != 12)`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:163:8
    |
 LL |     if !(12 != a) {}
-   |        ^^^^^^^^^^ help: try: `12 == a`
+   |        ^^^^^^^^^^ help: try: `(12 == a)`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:164:8
    |
 LL |     if !(a != 12) {}
-   |        ^^^^^^^^^^ help: try: `a == 12`
+   |        ^^^^^^^^^^ help: try: `(a == 12)`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:168:8

--- a/tests/ui/nonminimal_bool_methods.fixed
+++ b/tests/ui/nonminimal_bool_methods.fixed
@@ -110,9 +110,33 @@ fn dont_warn_for_negated_partial_ord_comparison() {
 fn issue_12625() {
     let a = 0;
     let b = 0;
-    if (a as u64) < b {} //~ ERROR: this boolean expression can be simplified
-    if (a as u64) < b {} //~ ERROR: this boolean expression can be simplified
-    if a as u64 > b {} //~ ERROR: this boolean expression can be simplified
+    if ((a as u64) < b) {} //~ ERROR: this boolean expression can be simplified
+    if ((a as u64) < b) {} //~ ERROR: this boolean expression can be simplified
+    if (a as u64 > b) {} //~ ERROR: this boolean expression can be simplified
+}
+
+fn issue_12761() {
+    let a = 0;
+    let b = 0;
+    let c = 0;
+    if (a < b) as i32 == c {} //~ ERROR: this boolean expression can be simplified
+    if (a < b) | (a > c) {} //~ ERROR: this boolean expression can be simplified
+    let opt: Option<usize> = Some(1);
+    let res: Result<usize, usize> = Ok(1);
+    if res.is_err() as i32 == c {} //~ ERROR: this boolean expression can be simplified
+    if res.is_err() | opt.is_some() {} //~ ERROR: this boolean expression can be simplified
+
+    fn a(a: bool) -> bool {
+        (4 <= 3).b() //~ ERROR: this boolean expression can be simplified
+    }
+
+    trait B {
+        fn b(&self) -> bool {
+            true
+        }
+    }
+
+    impl B for bool {}
 }
 
 fn issue_13436() {

--- a/tests/ui/nonminimal_bool_methods.rs
+++ b/tests/ui/nonminimal_bool_methods.rs
@@ -115,6 +115,30 @@ fn issue_12625() {
     if !(a as u64 <= b) {} //~ ERROR: this boolean expression can be simplified
 }
 
+fn issue_12761() {
+    let a = 0;
+    let b = 0;
+    let c = 0;
+    if !(a >= b) as i32 == c {} //~ ERROR: this boolean expression can be simplified
+    if !(a >= b) | !(a <= c) {} //~ ERROR: this boolean expression can be simplified
+    let opt: Option<usize> = Some(1);
+    let res: Result<usize, usize> = Ok(1);
+    if !res.is_ok() as i32 == c {} //~ ERROR: this boolean expression can be simplified
+    if !res.is_ok() | !opt.is_none() {} //~ ERROR: this boolean expression can be simplified
+
+    fn a(a: bool) -> bool {
+        (!(4 > 3)).b() //~ ERROR: this boolean expression can be simplified
+    }
+
+    trait B {
+        fn b(&self) -> bool {
+            true
+        }
+    }
+
+    impl B for bool {}
+}
+
 fn issue_13436() {
     fn not_zero(x: i32) -> bool {
         x != 0

--- a/tests/ui/nonminimal_bool_methods.stderr
+++ b/tests/ui/nonminimal_bool_methods.stderr
@@ -83,127 +83,169 @@ error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool_methods.rs:113:8
    |
 LL |     if !(a as u64 >= b) {}
-   |        ^^^^^^^^^^^^^^^^ help: try: `(a as u64) < b`
+   |        ^^^^^^^^^^^^^^^^ help: try: `((a as u64) < b)`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool_methods.rs:114:8
    |
 LL |     if !((a as u64) >= b) {}
-   |        ^^^^^^^^^^^^^^^^^^ help: try: `(a as u64) < b`
+   |        ^^^^^^^^^^^^^^^^^^ help: try: `((a as u64) < b)`
 
 error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool_methods.rs:115:8
    |
 LL |     if !(a as u64 <= b) {}
-   |        ^^^^^^^^^^^^^^^^ help: try: `a as u64 > b`
+   |        ^^^^^^^^^^^^^^^^ help: try: `(a as u64 > b)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:131:9
+  --> tests/ui/nonminimal_bool_methods.rs:122:8
+   |
+LL |     if !(a >= b) as i32 == c {}
+   |        ^^^^^^^^^ help: try: `(a < b)`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:123:8
+   |
+LL |     if !(a >= b) | !(a <= c) {}
+   |        ^^^^^^^^^ help: try: `(a < b)`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:123:20
+   |
+LL |     if !(a >= b) | !(a <= c) {}
+   |                    ^^^^^^^^^ help: try: `(a > c)`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:126:8
+   |
+LL |     if !res.is_ok() as i32 == c {}
+   |        ^^^^^^^^^^^^ help: try: `res.is_err()`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:127:8
+   |
+LL |     if !res.is_ok() | !opt.is_none() {}
+   |        ^^^^^^^^^^^^ help: try: `res.is_err()`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:127:23
+   |
+LL |     if !res.is_ok() | !opt.is_none() {}
+   |                       ^^^^^^^^^^^^^^ help: try: `opt.is_some()`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:130:9
+   |
+LL |         (!(4 > 3)).b()
+   |         ^^^^^^^^^^ help: try: `(4 <= 3)`
+
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool_methods.rs:155:9
    |
 LL |     _ = !opt.is_some_and(|x| x < 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x >= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:132:9
+  --> tests/ui/nonminimal_bool_methods.rs:156:9
    |
 LL |     _ = !opt.is_some_and(|x| x <= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x > 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:133:9
+  --> tests/ui/nonminimal_bool_methods.rs:157:9
    |
 LL |     _ = !opt.is_some_and(|x| x > 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x <= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:134:9
+  --> tests/ui/nonminimal_bool_methods.rs:158:9
    |
 LL |     _ = !opt.is_some_and(|x| x >= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x < 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:135:9
+  --> tests/ui/nonminimal_bool_methods.rs:159:9
    |
 LL |     _ = !opt.is_some_and(|x| x == 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x != 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:136:9
+  --> tests/ui/nonminimal_bool_methods.rs:160:9
    |
 LL |     _ = !opt.is_some_and(|x| x != 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x == 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:145:9
+  --> tests/ui/nonminimal_bool_methods.rs:169:9
    |
 LL |     _ = !opt.is_none_or(|x| x < 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x >= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:146:9
+  --> tests/ui/nonminimal_bool_methods.rs:170:9
    |
 LL |     _ = !opt.is_none_or(|x| x <= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x > 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:147:9
+  --> tests/ui/nonminimal_bool_methods.rs:171:9
    |
 LL |     _ = !opt.is_none_or(|x| x > 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x <= 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:148:9
+  --> tests/ui/nonminimal_bool_methods.rs:172:9
    |
 LL |     _ = !opt.is_none_or(|x| x >= 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x < 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:149:9
+  --> tests/ui/nonminimal_bool_methods.rs:173:9
    |
 LL |     _ = !opt.is_none_or(|x| x == 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x != 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:150:9
+  --> tests/ui/nonminimal_bool_methods.rs:174:9
    |
 LL |     _ = !opt.is_none_or(|x| x != 1000);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x == 1000)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:157:9
+  --> tests/ui/nonminimal_bool_methods.rs:181:9
    |
 LL |     _ = !opt.is_some_and(|x| !x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:161:9
+  --> tests/ui/nonminimal_bool_methods.rs:185:9
    |
 LL |     _ = !opt.is_none_or(|x| !x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x)`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:168:9
+  --> tests/ui/nonminimal_bool_methods.rs:192:9
    |
 LL |     _ = !opt.is_some_and(|x| x.is_ok());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x.is_err())`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:169:9
+  --> tests/ui/nonminimal_bool_methods.rs:193:9
    |
 LL |     _ = !opt.is_some_and(|x| x.is_err());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_none_or(|x| x.is_ok())`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:170:9
+  --> tests/ui/nonminimal_bool_methods.rs:194:9
    |
 LL |     _ = !opt.is_none_or(|x| x.is_ok());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x.is_err())`
 
 error: this boolean expression can be simplified
-  --> tests/ui/nonminimal_bool_methods.rs:171:9
+  --> tests/ui/nonminimal_bool_methods.rs:195:9
    |
 LL |     _ = !opt.is_none_or(|x| x.is_err());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.is_some_and(|x| x.is_ok())`
 
-error: aborting due to 34 previous errors
+error: aborting due to 41 previous errors
 


### PR DESCRIPTION
fixes #12761 

The expression `!(a >= b) as i32 == c` got simplified to `a < b as i32 == c`, but this is a syntax error.
The result we want is `(a < b) as i32 == c`.
This is fixed by adding a parenthesis to the suggestion given in `check_simplify_not` when the boolean expression is casted.

changelog: [`nonminimal_bool`]: fix incorrect suggestion for `!(a >= b) as i32 == c`
