### PR TITLE
`too_long_first_doc_paragraph` considers rendered output link

### DIFF
--- a/clippy_lints/Cargo.toml
+++ b/clippy_lints/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 tempfile = { version = "3.3.0", optional = true }
 toml = "0.7.3"
-regex = { version = "1.5", optional = true }
+regex = "1.5"
 unicode-normalization = "0.1"
 unicode-script = { version = "0.5", default-features = false }
 semver = "1.0"
@@ -32,7 +32,7 @@ walkdir = "2.3"
 
 [features]
 # build clippy with internal lints enabled, off by default
-internal = ["serde_json", "tempfile", "regex"]
+internal = ["serde_json", "tempfile"]
 
 [package.metadata.rust-analyzer]
 # This crate uses #[feature(rustc_private)]

--- a/tests/ui/too_long_first_doc_paragraph.rs
+++ b/tests/ui/too_long_first_doc_paragraph.rs
@@ -48,6 +48,11 @@ pub union Union2 {
 /// gravida non lacinia at, rhoncus eu lacus.
 fn f() {}
 
+/// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc turpis nunc, lacinia
+/// a dolor in, pellentesque aliquet enim. Cras nec maximus sem.
+/// [this link](https://fooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com)
+pub fn foo() {}
+
 fn main() {
     // test code goes here
 }


### PR DESCRIPTION
Close #13315
As mentioned at #13315 the raw markdown for the link [foo](barbaz) contains 13 bytes, but the rendered output is only 3 bytes. This leads to warnings about short paragraphs with long links.

changelog: [`too_long_first_doc_paragraph`]: considers rendered output link