### PR TITLE
Fix possible typo in `ptr_arg` lint

### DIFF
--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -34,7 +34,7 @@ declare_clippy_lint! {
     /// with the appropriate `.to_owned()`/`to_string()` calls.
     ///
     /// ### Why is this bad?
-    /// Requiring the argument to be of the specific size
+    /// Requiring the argument to be of the specific type
     /// makes the function less useful for no benefit; slices in the form of `&[T]`
     /// or `&str` usually suffice and can be obtained from other types, too.
     ///


### PR DESCRIPTION
This fixes a possible typo in the [`ptr_arg`](https://rust-lang.github.io/rust-clippy/master/index.html#/ptr_arg) lint. I'm new to Rust, so apologies if I misunderstood the meaning of this lint.

changelog: [`ptr_arg`]: Fix typo ("size" -> "type")