### PR TITLE
fix: Fixed incorrect comment form suggestion for too_long_first_doc_paragraph lint

### DIFF
--- a/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
+++ b/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
@@ -79,10 +79,17 @@ pub(super) fn check(
                 && let new_span = first_span.with_hi(second_span.lo()).with_lo(first_span.hi())
                 && let Some(snippet) = snippet_opt(cx, new_span)
             {
+                let Some(first) = snippet_opt(cx, first_span) else {
+                    return;
+                };
+                let Some(comment_form) = first.get(..3) else {
+                    return;
+                };
+
                 diag.span_suggestion(
                     new_span,
                     "add an empty line",
-                    format!("{snippet}///\n"),
+                    format!("{snippet}{comment_form}{snippet}"),
                     Applicability::MachineApplicable,
                 );
             }

--- a/tests/ui/too_long_first_doc_paragraph.rs
+++ b/tests/ui/too_long_first_doc_paragraph.rs
@@ -2,6 +2,16 @@
 
 #![warn(clippy::too_long_first_doc_paragraph)]
 
+pub mod foo {
+
+    // in foo.rs
+    //! A very short summary.
+    //! A much longer explanation that goes into a lot more detail about
+    //! how the thing works, possibly with doclinks and so one,
+    //! and probably spanning a many rows. Blablabla, it needs to be over
+    //! 200 characters so I needed to write something longeeeeeeer.
+}
+
 /// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc turpis nunc, lacinia
 /// a dolor in, pellentesque aliquet enim. Cras nec maximus sem. Mauris arcu libero,
 /// gravida non lacinia at, rhoncus eu lacus.

--- a/tests/ui/too_long_first_doc_paragraph.stderr
+++ b/tests/ui/too_long_first_doc_paragraph.stderr
@@ -1,16 +1,32 @@
 error: first doc comment paragraph is too long
-  --> tests/ui/too_long_first_doc_paragraph.rs:5:1
+  --> tests/ui/too_long_first_doc_paragraph.rs:8:5
+   |
+LL | /     //! A very short summary.
+LL | |     //! A much longer explanation that goes into a lot more detail about
+LL | |     //! how the thing works, possibly with doclinks and so one,
+LL | |     //! and probably spanning a many rows. Blablabla, it needs to be over
+LL | |     //! 200 characters so I needed to write something longeeeeeeer.
+   | |____^
+   |
+   = note: `-D clippy::too-long-first-doc-paragraph` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::too_long_first_doc_paragraph)]`
+help: add an empty line
+   |
+LL ~     //! A very short summary.
+LL +     //!
+LL ~     //! A much longer explanation that goes into a lot more detail about
+   |
+
+error: first doc comment paragraph is too long
+  --> tests/ui/too_long_first_doc_paragraph.rs:15:1
    |
 LL | / /// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc turpis nunc, lacinia
 LL | | /// a dolor in, pellentesque aliquet enim. Cras nec maximus sem. Mauris arcu libero,
 LL | | /// gravida non lacinia at, rhoncus eu lacus.
    | |_
-   |
-   = note: `-D clippy::too-long-first-doc-paragraph` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::too_long_first_doc_paragraph)]`
 
 error: first doc comment paragraph is too long
-  --> tests/ui/too_long_first_doc_paragraph.rs:26:1
+  --> tests/ui/too_long_first_doc_paragraph.rs:36:1
    |
 LL | / /// Lorem
 LL | | /// ipsum dolor sit amet, consectetur adipiscing elit. Nunc turpis nunc, lacinia
@@ -18,5 +34,5 @@ LL | | /// a dolor in, pellentesque aliquet enim. Cras nec maximus sem. Mauris a
 LL | | /// gravida non lacinia at, rhoncus eu lacus.
    | |_
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
fixes #13309 
changelog: none

Comment form is now a variable and a new test for too_long_first_doc_paragraph was added.