### PR TITLE
[`missing_panics_doc`] Fix #13381

### DIFF
--- a/clippy_lints/src/panic_in_result_fn.rs
+++ b/clippy_lints/src/panic_in_result_fn.rs
@@ -1,8 +1,8 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::macros::root_macro_call_first_node;
-use clippy_utils::return_ty;
 use clippy_utils::ty::is_type_diagnostic_item;
 use clippy_utils::visitors::{for_each_expr, Descend};
+use clippy_utils::{is_inside_always_const_context, return_ty};
 use core::ops::ControlFlow;
 use rustc_hir as hir;
 use rustc_hir::intravisit::FnKind;
@@ -68,10 +68,12 @@ fn lint_impl_body<'tcx>(cx: &LateContext<'tcx>, impl_span: Span, body: &'tcx hir
         let Some(macro_call) = root_macro_call_first_node(cx, e) else {
             return ControlFlow::Continue(Descend::Yes);
         };
-        if matches!(
-            cx.tcx.item_name(macro_call.def_id).as_str(),
-            "panic" | "assert" | "assert_eq" | "assert_ne"
-        ) {
+        if !is_inside_always_const_context(cx.tcx, e.hir_id)
+            && matches!(
+                cx.tcx.item_name(macro_call.def_id).as_str(),
+                "panic" | "assert" | "assert_eq" | "assert_ne"
+            )
+        {
             panics.push(macro_call.span);
             ControlFlow::Continue(Descend::No)
         } else {

--- a/tests/ui/panic_in_result_fn.rs
+++ b/tests/ui/panic_in_result_fn.rs
@@ -71,6 +71,15 @@ fn function_result_with_custom_todo() -> Result<bool, String> // should not emit
     Ok(true)
 }
 
+fn issue_13381<const N: usize>() -> Result<(), String> {
+    const {
+        if N == 0 {
+            panic!();
+        }
+    }
+    Ok(())
+}
+
 fn main() -> Result<(), String> {
     todo!("finish main method");
     Ok(())


### PR DESCRIPTION
Fix #13381

Makes `missing_panics_doc` act like other "panicking" lints (`unwrap_used`, `panic`, etc) in constant environments.

changelog: Ignore `missing_panics_doc` in constant environments
