### PR TITLE
Not trigger `duplicated_attributes` on duplicate reasons

### DIFF
--- a/clippy_lints/src/attrs/duplicated_attributes.rs
+++ b/clippy_lints/src/attrs/duplicated_attributes.rs
@@ -36,7 +36,7 @@ fn check_duplicated_attr(
     }
     let Some(ident) = attr.ident() else { return };
     let name = ident.name;
-    if name == sym::doc || name == sym::cfg_attr || name == sym::rustc_on_unimplemented {
+    if name == sym::doc || name == sym::cfg_attr || name == sym::rustc_on_unimplemented || name == sym::reason {
         // FIXME: Would be nice to handle `cfg_attr` as well. Only problem is to check that cfg
         // conditions are the same.
         // `#[rustc_on_unimplemented]` contains duplicated subattributes, that's expected.

--- a/tests/ui/duplicated_attributes.rs
+++ b/tests/ui/duplicated_attributes.rs
@@ -27,4 +27,8 @@ trait Abc {}
 #[proc_macro_attr::duplicated_attr()] // Should not warn!
 fn babar() {}
 
+#[allow(missing_docs, reason = "library for internal use only")]
+#[allow(exported_private_dependencies, reason = "library for internal use only")]
+fn duplicate_reason() {}
+
 fn main() {}


### PR DESCRIPTION
As at #13355 we shoudn't  trigger `duplicated_attributes` on duplicate reasons attr
changelog: [`duplicated_attributes`]: not trigger `duplicated_attributes` on duplicate reasons