### PR TITLE
Make it clearer that the suggestion is an alternative one

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -208,7 +208,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                             )
                             .is_ok()
                             {
-                                diag.span_help(span, "consider marking this type as `Copy`");
+                                diag.span_help(span, "or consider marking this type as `Copy`");
                             }
                         }
                     }

--- a/tests/ui/crashes/needless_pass_by_value-w-late-bound.stderr
+++ b/tests/ui/crashes/needless_pass_by_value-w-late-bound.stderr
@@ -4,7 +4,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn test(x: Foo<'_>) {}
    |            ^^^^^^^ help: consider taking a reference instead: `&Foo<'_>`
    |
-help: consider marking this type as `Copy`
+help: or consider marking this type as `Copy`
   --> tests/ui/crashes/needless_pass_by_value-w-late-bound.rs:5:1
    |
 LL | struct Foo<'a>(&'a [(); 100]);

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -121,7 +121,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn bar_copy(x: u32, y: CopyWrapper) {
    |                        ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as `Copy`
+help: or consider marking this type as `Copy`
   --> tests/ui/needless_pass_by_value.rs:141:1
    |
 LL | struct CopyWrapper(u32);
@@ -133,7 +133,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as `Copy`
+help: or consider marking this type as `Copy`
   --> tests/ui/needless_pass_by_value.rs:141:1
    |
 LL | struct CopyWrapper(u32);
@@ -145,7 +145,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as `Copy`
+help: or consider marking this type as `Copy`
   --> tests/ui/needless_pass_by_value.rs:141:1
    |
 LL | struct CopyWrapper(u32);
@@ -157,7 +157,7 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn test_destructure_copy(x: CopyWrapper, y: CopyWrapper, z: CopyWrapper) {
    |                                                             ^^^^^^^^^^^ help: consider taking a reference instead: `&CopyWrapper`
    |
-help: consider marking this type as `Copy`
+help: or consider marking this type as `Copy`
   --> tests/ui/needless_pass_by_value.rs:141:1
    |
 LL | struct CopyWrapper(u32);


### PR DESCRIPTION
`needless_pass_by_value` sometimes suggest marking the concerned type as `Copy`. Adding a `or` before this suggestion makes it clearer that this is not the second part of the original suggestion, but an alternative one.

Inspired by a misunderstanding in #13321 

changelog: none