### PR TITLE
fix: Specifying reason in expect(clippy::needless_return) no longer triggers false positive

### DIFF
--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -421,7 +421,7 @@ fn check_final_expr<'tcx>(
                     if matches!(Level::from_attr(attr), Some(Level::Expect(_)))
                         && let metas = attr.meta_item_list()
                         && let Some(lst) = metas
-                        && let [NestedMetaItem::MetaItem(meta_item)] = lst.as_slice()
+                        && let [NestedMetaItem::MetaItem(meta_item), ..] = lst.as_slice()
                         && let [tool, lint_name] = meta_item.path.segments.as_slice()
                         && tool.ident.name == sym::clippy
                         && matches!(

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -360,3 +360,23 @@ fn issue12907() -> String {
 }
 
 fn main() {}
+
+fn a(x: Option<u8>) -> Option<u8> {
+    match x {
+        Some(_) => None,
+        None => {
+            #[expect(clippy::needless_return, reason = "Use early return for errors.")]
+            return None;
+        },
+    }
+}
+
+fn b(x: Option<u8>) -> Option<u8> {
+    match x {
+        Some(_) => None,
+        None => {
+            #[expect(clippy::needless_return)]
+            return None;
+        },
+    }
+}

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -370,3 +370,23 @@ fn issue12907() -> String {
 }
 
 fn main() {}
+
+fn a(x: Option<u8>) -> Option<u8> {
+    match x {
+        Some(_) => None,
+        None => {
+            #[expect(clippy::needless_return, reason = "Use early return for errors.")]
+            return None;
+        },
+    }
+}
+
+fn b(x: Option<u8>) -> Option<u8> {
+    match x {
+        Some(_) => None,
+        None => {
+            #[expect(clippy::needless_return)]
+            return None;
+        },
+    }
+}


### PR DESCRIPTION
fixes #13366 
changelog: none
