### PR TITLE
Add [`extern_without_abi`] lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5456,6 +5456,7 @@ Released 2018-09-13
 [`explicit_write`]: https://rust-lang.github.io/rust-clippy/master/index.html#explicit_write
 [`extend_from_slice`]: https://rust-lang.github.io/rust-clippy/master/index.html#extend_from_slice
 [`extend_with_drain`]: https://rust-lang.github.io/rust-clippy/master/index.html#extend_with_drain
+[`extern_without_abi`]: https://rust-lang.github.io/rust-clippy/master/index.html#extern_without_abi
 [`extra_unused_lifetimes`]: https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
 [`extra_unused_type_parameters`]: https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_type_parameters
 [`fallible_impl_from`]: https://rust-lang.github.io/rust-clippy/master/index.html#fallible_impl_from

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A collection of lints to catch common mistakes and improve your [Rust](https://github.com/rust-lang/rust) code.
 
-[There are over 700 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are over 750 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 Lints are divided into categories, each with a default [lint level](https://doc.rust-lang.org/rustc/lints/levels.html).
 You can choose how much Clippy is supposed to ~~annoy~~ help you by changing the lint level by category.

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -6,7 +6,7 @@
 A collection of lints to catch common mistakes and improve your
 [Rust](https://github.com/rust-lang/rust) code.
 
-[There are over 700 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
+[There are over 750 lints included in this crate!](https://rust-lang.github.io/rust-clippy/master/index.html)
 
 Lints are divided into categories, each with a default [lint
 level](https://doc.rust-lang.org/rustc/lints/levels.html). You can choose how

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -173,6 +173,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::exhaustive_items::EXHAUSTIVE_STRUCTS_INFO,
     crate::exit::EXIT_INFO,
     crate::explicit_write::EXPLICIT_WRITE_INFO,
+    crate::extern_without_abi::EXTERN_WITHOUT_ABI_INFO,
     crate::extra_unused_type_parameters::EXTRA_UNUSED_TYPE_PARAMETERS_INFO,
     crate::fallible_impl_from::FALLIBLE_IMPL_FROM_INFO,
     crate::field_scoped_visibility_modifiers::FIELD_SCOPED_VISIBILITY_MODIFIERS_INFO,

--- a/clippy_lints/src/extern_without_abi.rs
+++ b/clippy_lints/src/extern_without_abi.rs
@@ -1,0 +1,113 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_from_proc_macro;
+use clippy_utils::source::snippet;
+use rustc_errors::Applicability;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::FnKind;
+use rustc_hir::{Body, FnDecl, FnHeader, Item, ItemKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::lint::in_external_macro;
+use rustc_session::declare_lint_pass;
+use rustc_span::Span;
+use rustc_target::spec::abi::Abi;
+
+const LINT_MSG: &str = "`extern` missing explicit ABI";
+const LINT_HELP_MSG: &str = "consider using";
+
+const EXTERN: &str = "extern";
+const FN: &str = "fn";
+const OPEN_BRACE: &str = "{";
+const ABI: &str = r#""C""#;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for usage of `extern` without an explicit ABI.
+    ///
+    /// ### Why is this bad?
+    /// Explicitly declaring the ABI is the recommended convention. See:
+    /// [Rust Style Guide - `extern` items](https://doc.rust-lang.org/nightly/style-guide/items.html#extern-items)
+    ///
+    /// It's also enforced by `rustfmt` when the `force_explicit_abi` option is enabled. See:
+    /// [Configuring Rustfmt](https://rust-lang.github.io/rustfmt/?version=master&search=#force_explicit_abi)
+    ///
+    /// ### Example
+    /// ```no_run
+    /// extern fn foo() {}
+    ///
+    /// extern {
+    ///     fn bar();
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// extern "C" fn foo() {}
+    ///
+    /// extern "C" {
+    ///     fn bar();
+    /// }
+    /// ```
+    #[clippy::version = "1.83.0"]
+    pub EXTERN_WITHOUT_ABI,
+    style,
+    "`extern` missing explicit ABI"
+}
+
+declare_lint_pass!(ExternWithoutAbi => [EXTERN_WITHOUT_ABI]);
+
+impl<'tcx> LateLintPass<'tcx> for ExternWithoutAbi {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::ForeignMod { abi: Abi::C { .. }, .. } = item.kind
+            && !in_external_macro(cx.sess(), item.span)
+            && let snippet = snippet(cx.sess(), item.span, "").as_ref()
+            && is_extern_followed_by(OPEN_BRACE, snippet)
+            && !is_from_proc_macro(cx, item)
+        {
+            emit_lint(cx, item.span, snippet);
+        }
+    }
+
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        kind: FnKind<'tcx>,
+        _: &'tcx FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        span: Span,
+        _: LocalDefId,
+    ) {
+        if let FnKind::ItemFn(_, _, header) = kind
+            && let FnHeader { abi: Abi::C { .. }, .. } = header
+            && !in_external_macro(cx.sess(), span)
+            && let snippet = snippet(cx.sess(), span, "").as_ref()
+            && is_extern_followed_by(FN, snippet)
+            && let hir_id = cx.tcx.hir().body_owner(body.id())
+            && !is_from_proc_macro(cx, &(&kind, body, hir_id, span))
+        {
+            emit_lint(cx, span, snippet);
+        }
+    }
+}
+
+fn is_extern_followed_by(item: &str, snippet: &str) -> bool {
+    let mut tokens = snippet.split_whitespace();
+
+    if let (Some(EXTERN), Some(i)) = (tokens.next(), tokens.next())
+        && i.starts_with(item)
+    {
+        return true;
+    }
+    false
+}
+
+fn emit_lint(cx: &LateContext<'_>, span: Span, snippet: &str) {
+    let sugg = snippet.replacen(EXTERN, format!("{EXTERN} {ABI}").as_str(), 1);
+    span_lint_and_sugg(
+        cx,
+        EXTERN_WITHOUT_ABI,
+        span,
+        LINT_MSG,
+        LINT_HELP_MSG,
+        sugg,
+        Applicability::MachineApplicable,
+    );
+}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -137,6 +137,7 @@ mod excessive_nesting;
 mod exhaustive_items;
 mod exit;
 mod explicit_write;
+mod extern_without_abi;
 mod extra_unused_type_parameters;
 mod fallible_impl_from;
 mod field_scoped_visibility_modifiers;
@@ -951,5 +952,6 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(move |_| Box::new(unused_trait_names::UnusedTraitNames::new(conf)));
     store.register_late_pass(|_| Box::new(manual_ignore_case_cmp::ManualIgnoreCaseCmp));
     store.register_late_pass(|_| Box::new(unnecessary_literal_bound::UnnecessaryLiteralBound));
+    store.register_late_pass(|_| Box::new(extern_without_abi::ExternWithoutAbi));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/tests/ui/boxed_local.rs
+++ b/tests/ui/boxed_local.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::borrowed_box,
+    clippy::extern_without_abi,
     clippy::needless_pass_by_value,
     clippy::unused_unit,
     clippy::redundant_clone,

--- a/tests/ui/boxed_local.stderr
+++ b/tests/ui/boxed_local.stderr
@@ -1,5 +1,5 @@
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:40:13
+  --> tests/ui/boxed_local.rs:41:13
    |
 LL | fn warn_arg(x: Box<A>) {
    |             ^
@@ -8,19 +8,19 @@ LL | fn warn_arg(x: Box<A>) {
    = help: to override `-D warnings` add `#[allow(clippy::boxed_local)]`
 
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:123:12
+  --> tests/ui/boxed_local.rs:124:12
    |
 LL | pub fn new(_needs_name: Box<PeekableSeekable<&()>>) -> () {}
    |            ^^^^^^^^^^^
 
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:188:44
+  --> tests/ui/boxed_local.rs:189:44
    |
 LL |         fn default_impl_x(self: Box<Self>, x: Box<u32>) -> u32 {
    |                                            ^
 
 error: local variable doesn't need to be boxed here
-  --> tests/ui/boxed_local.rs:196:16
+  --> tests/ui/boxed_local.rs:197:16
    |
 LL |         fn foo(x: Box<u32>) {}
    |                ^

--- a/tests/ui/doc/doc-fixable.fixed
+++ b/tests/ui/doc/doc-fixable.fixed
@@ -1,7 +1,7 @@
 
 //! This file tests for the `DOC_MARKDOWN` lint.
 
-#![allow(dead_code, incomplete_features)]
+#![allow(dead_code, incomplete_features, clippy::extern_without_abi)]
 #![warn(clippy::doc_markdown)]
 #![feature(custom_inner_attributes, generic_const_exprs, const_option)]
 #![rustfmt::skip]

--- a/tests/ui/doc/doc-fixable.rs
+++ b/tests/ui/doc/doc-fixable.rs
@@ -1,7 +1,7 @@
 
 //! This file tests for the `DOC_MARKDOWN` lint.
 
-#![allow(dead_code, incomplete_features)]
+#![allow(dead_code, incomplete_features, clippy::extern_without_abi)]
 #![warn(clippy::doc_markdown)]
 #![feature(custom_inner_attributes, generic_const_exprs, const_option)]
 #![rustfmt::skip]

--- a/tests/ui/extern_without_abi.fixed
+++ b/tests/ui/extern_without_abi.fixed
@@ -1,0 +1,60 @@
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::extern_without_abi)]
+
+extern crate proc_macros;
+use proc_macros::{external, with_span};
+
+#[rustfmt::skip]
+extern "C" fn foo() {}
+//~^ ERROR: `extern` missing explicit ABI
+
+#[rustfmt::skip]
+extern "C" 	
+fn foo_two() {}
+//~^^ ERROR: `extern` missing explicit ABI
+
+extern "C" fn bar() {}
+
+#[rustfmt::skip]
+extern 	
+"C" 
+fn bar_two() {}
+
+extern "system" fn baz() {}
+
+#[rustfmt::skip]
+extern "C" {
+//~^ ERROR: `extern` missing explicit ABI
+    fn qux();
+}
+
+#[rustfmt::skip]
+extern "C" 	
+{
+//~^^ ERROR: `extern` missing explicit ABI
+    fn qux_two();
+}
+
+#[rustfmt::skip]
+extern "C" {fn qux_three();}
+//~^ ERROR: `extern` missing explicit ABI
+
+extern "C" {
+    fn grault();
+}
+
+extern "system" {
+    fn grault_two();
+}
+
+external! {
+    extern fn waldo() {}
+}
+
+with_span! {
+    span
+    extern fn waldo_two() {}
+}
+
+fn main() {}

--- a/tests/ui/extern_without_abi.rs
+++ b/tests/ui/extern_without_abi.rs
@@ -1,0 +1,60 @@
+//@aux-build:proc_macros.rs
+
+#![warn(clippy::extern_without_abi)]
+
+extern crate proc_macros;
+use proc_macros::{external, with_span};
+
+#[rustfmt::skip]
+extern fn foo() {}
+//~^ ERROR: `extern` missing explicit ABI
+
+#[rustfmt::skip]
+extern 	
+fn foo_two() {}
+//~^^ ERROR: `extern` missing explicit ABI
+
+extern "C" fn bar() {}
+
+#[rustfmt::skip]
+extern 	
+"C" 
+fn bar_two() {}
+
+extern "system" fn baz() {}
+
+#[rustfmt::skip]
+extern {
+//~^ ERROR: `extern` missing explicit ABI
+    fn qux();
+}
+
+#[rustfmt::skip]
+extern 	
+{
+//~^^ ERROR: `extern` missing explicit ABI
+    fn qux_two();
+}
+
+#[rustfmt::skip]
+extern {fn qux_three();}
+//~^ ERROR: `extern` missing explicit ABI
+
+extern "C" {
+    fn grault();
+}
+
+extern "system" {
+    fn grault_two();
+}
+
+external! {
+    extern fn waldo() {}
+}
+
+with_span! {
+    span
+    extern fn waldo_two() {}
+}
+
+fn main() {}

--- a/tests/ui/extern_without_abi.stderr
+++ b/tests/ui/extern_without_abi.stderr
@@ -1,0 +1,66 @@
+error: `extern` missing explicit ABI
+  --> tests/ui/extern_without_abi.rs:9:1
+   |
+LL | extern fn foo() {}
+   | ^^^^^^^^^^^^^^^^^^ help: consider using: `extern "C" fn foo() {}`
+   |
+   = note: `-D clippy::extern-without-abi` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::extern_without_abi)]`
+
+error: `extern` missing explicit ABI
+  --> tests/ui/extern_without_abi.rs:13:1
+   |
+LL | / extern     
+LL | | fn foo_two() {}
+   | |_______________^
+   |
+help: consider using
+   |
+LL ~ extern "C"     
+LL + fn foo_two() {}
+   |
+
+error: `extern` missing explicit ABI
+  --> tests/ui/extern_without_abi.rs:27:1
+   |
+LL | / extern {
+LL | |
+LL | |     fn qux();
+LL | | }
+   | |_^
+   |
+help: consider using
+   |
+LL + extern "C" {
+LL +
+LL +     fn qux();
+LL + }
+   |
+
+error: `extern` missing explicit ABI
+  --> tests/ui/extern_without_abi.rs:33:1
+   |
+LL | / extern     
+LL | | {
+LL | |
+LL | |     fn qux_two();
+LL | | }
+   | |_^
+   |
+help: consider using
+   |
+LL ~ extern "C"     
+LL + {
+LL +
+LL +     fn qux_two();
+LL + }
+   |
+
+error: `extern` missing explicit ABI
+  --> tests/ui/extern_without_abi.rs:40:1
+   |
+LL | extern {fn qux_three();}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `extern "C" {fn qux_three();}`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/missing_const_for_fn/could_be_const.fixed
+++ b/tests/ui/missing_const_for_fn/could_be_const.fixed
@@ -1,6 +1,11 @@
 #![warn(clippy::missing_const_for_fn)]
-#![allow(incomplete_features, clippy::let_and_return, clippy::missing_transmute_annotations)]
-#![allow(unsupported_calling_conventions)]
+#![allow(
+    incomplete_features,
+    unsupported_calling_conventions,
+    clippy::extern_without_abi,
+    clippy::let_and_return,
+    clippy::missing_transmute_annotations
+)]
 #![feature(const_trait_impl)]
 
 use std::mem::transmute;

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -1,6 +1,11 @@
 #![warn(clippy::missing_const_for_fn)]
-#![allow(incomplete_features, clippy::let_and_return, clippy::missing_transmute_annotations)]
-#![allow(unsupported_calling_conventions)]
+#![allow(
+    incomplete_features,
+    unsupported_calling_conventions,
+    clippy::extern_without_abi,
+    clippy::let_and_return,
+    clippy::missing_transmute_annotations
+)]
 #![feature(const_trait_impl)]
 
 use std::mem::transmute;

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -1,5 +1,5 @@
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:14:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:19:5
    |
 LL | /     pub fn new() -> Self {
 LL | |
@@ -16,7 +16,7 @@ LL |     pub const fn new() -> Self {
    |         +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:20:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:25:5
    |
 LL | /     fn const_generic_params<'a, T, const N: usize>(&self, b: &'a [T; N]) -> &'a [T; N] {
 LL | |
@@ -30,7 +30,7 @@ LL |     const fn const_generic_params<'a, T, const N: usize>(&self, b: &'a [T; 
    |     +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:27:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:32:1
    |
 LL | / fn one() -> i32 {
 LL | |
@@ -44,7 +44,7 @@ LL | const fn one() -> i32 {
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:33:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:38:1
    |
 LL | / fn two() -> i32 {
 LL | |
@@ -59,7 +59,7 @@ LL | const fn two() -> i32 {
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:40:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:45:1
    |
 LL | / fn string() -> String {
 LL | |
@@ -73,7 +73,7 @@ LL | const fn string() -> String {
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:46:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:51:1
    |
 LL | / unsafe fn four() -> i32 {
 LL | |
@@ -87,7 +87,7 @@ LL | const unsafe fn four() -> i32 {
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:52:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:57:1
    |
 LL | / fn generic<T>(t: T) -> T {
 LL | |
@@ -101,7 +101,7 @@ LL | const fn generic<T>(t: T) -> T {
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:61:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:66:1
    |
 LL | / fn generic_arr<T: Copy>(t: [T; 1]) -> T {
 LL | |
@@ -115,7 +115,7 @@ LL | const fn generic_arr<T: Copy>(t: [T; 1]) -> T {
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:75:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:80:9
    |
 LL | /         pub fn b(self, a: &A) -> B {
 LL | |
@@ -129,7 +129,7 @@ LL |         pub const fn b(self, a: &A) -> B {
    |             +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:85:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:90:5
    |
 LL | /     fn const_fn_stabilized_before_msrv(byte: u8) {
 LL | |
@@ -143,7 +143,7 @@ LL |     const fn const_fn_stabilized_before_msrv(byte: u8) {
    |     +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:97:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:102:1
    |
 LL | / fn msrv_1_46() -> i32 {
 LL | |
@@ -157,7 +157,7 @@ LL | const fn msrv_1_46() -> i32 {
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:117:1
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:122:1
    |
 LL | fn d(this: D) {}
    | ^^^^^^^^^^^^^^^^
@@ -168,7 +168,7 @@ LL | const fn d(this: D) {}
    | +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:125:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:130:9
    |
 LL | /         fn deref_ptr_can_be_const(self) -> usize {
 LL | |
@@ -182,7 +182,7 @@ LL |         const fn deref_ptr_can_be_const(self) -> usize {
    |         +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:130:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:135:9
    |
 LL | /         fn deref_copied_val(self) -> usize {
 LL | |
@@ -196,7 +196,7 @@ LL |         const fn deref_copied_val(self) -> usize {
    |         +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:141:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:146:5
    |
 LL | /     fn union_access_can_be_const() {
 LL | |
@@ -211,7 +211,7 @@ LL |     const fn union_access_can_be_const() {
    |     +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:149:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:154:9
    |
 LL |         extern "C" fn c() {}
    |         ^^^^^^^^^^^^^^^^^^^^
@@ -222,7 +222,7 @@ LL |         const extern "C" fn c() {}
    |         +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:153:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:158:9
    |
 LL |         extern fn implicit_c() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +233,7 @@ LL |         const extern fn implicit_c() {}
    |         +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:170:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:175:9
    |
 LL | /         pub fn new(strings: Vec<String>) -> Self {
 LL | |             Self { strings }
@@ -246,7 +246,7 @@ LL |         pub const fn new(strings: Vec<String>) -> Self {
    |             +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:175:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:180:9
    |
 LL | /         pub fn empty() -> Self {
 LL | |             Self { strings: Vec::new() }
@@ -259,7 +259,7 @@ LL |         pub const fn empty() -> Self {
    |             +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:186:9
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:191:9
    |
 LL | /         pub fn new(text: String) -> Self {
 LL | |             let vec = Vec::new();
@@ -273,7 +273,7 @@ LL |         pub const fn new(text: String) -> Self {
    |             +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:205:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:210:5
    |
 LL |     fn alias_ty_is_projection(bar: <() as FooTrait>::Foo) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -284,7 +284,7 @@ LL |     const fn alias_ty_is_projection(bar: <() as FooTrait>::Foo) {}
    |     +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:209:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:214:5
    |
 LL |     extern "C-unwind" fn c_unwind() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -295,7 +295,7 @@ LL |     const extern "C-unwind" fn c_unwind() {}
    |     +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:211:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:216:5
    |
 LL |     extern "system" fn system() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -306,7 +306,7 @@ LL |     const extern "system" fn system() {}
    |     +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:213:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:218:5
    |
 LL |     extern "system-unwind" fn system_unwind() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -317,7 +317,7 @@ LL |     const extern "system-unwind" fn system_unwind() {}
    |     +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:215:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:220:5
    |
 LL |     pub extern "stdcall" fn std_call() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -328,7 +328,7 @@ LL |     pub const extern "stdcall" fn std_call() {}
    |         +++++
 
 error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:217:5
+  --> tests/ui/missing_const_for_fn/could_be_const.rs:222:5
    |
 LL |     pub extern "stdcall-unwind" fn std_call_unwind() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #13372

The [`extern_without_abi`] lint emits when `extern` is not followed by an ABI.  For example:
```rust
// EMIT
extern fn foo() {}

// EMIT
extern {
    fn bar();
}

// NO EMIT
extern "C" fn baz() {}

// NO EMIT
extern "C" {
    fn foo_bar();
}
```

---

changelog: Add [`extern_without_abi`] lint
