### PR TITLE
Generate versions HTML directly

### DIFF
--- a/.github/deploy.sh
+++ b/.github/deploy.sh
@@ -25,15 +25,14 @@ if [[ $BETA = "true" ]]; then
 fi
 
 # Generate version index that is shown as root index page
-cp util/gh-pages/versions.html out/index.html
-
-echo "Making the versions.json file"
-python3 ./util/versions.py out
+python3 ./util/versions.py ./util/gh-pages/versions.html out
 
 # Now let's go have some fun with the cloned repo
 cd out
 git config user.name "GHA CI"
 git config user.email "gha@ci.invalid"
+
+git status
 
 if [[ -n $TAG_NAME ]]; then
   # track files, so that the following check works
@@ -46,8 +45,6 @@ if [[ -n $TAG_NAME ]]; then
   git add "$TAG_NAME"
   # Update the symlink
   git add stable
-  # Update versions file
-  git add versions.json
   git commit -m "Add documentation for ${TAG_NAME} release: ${SHA}"
 elif [[ $BETA = "true" ]]; then
   if git diff --exit-code --quiet -- beta/; then

--- a/util/gh-pages/versions.html
+++ b/util/gh-pages/versions.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Expanded by util/versions.py into the HTML file seen at https://rust-lang.github.io/rust-clippy/ -->
 <html lang="en">
 <head>
     <meta charset="UTF-8"/>
@@ -7,26 +8,15 @@
     <title>Clippy lints documentation</title>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css"/>
-    <style>
-        [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak { display: none !important; }
-    </style>
 </head>
 <body>
-    <div class="container" ng-app="clippy" ng-controller="docVersions">
+    <div class="container">
         <div class="page-header">
             <h1>Clippy lints documentation</h1>
         </div>
 
-        <div ng-cloak>
-            <div class="alert alert-info" role="alert" ng-if="loading">
-                Loading&#x2026;
-            </div>
-            <div class="alert alert-danger" role="alert" ng-if="error">
-                Error loading versions!<br/>
-                You can always try to get <a href="master/index.html">the master branch docs</a>.
-            </div>
-
-            <article class="panel panel-default" ng-show="data">
+        <div>
+            <article class="panel panel-default">
                 <div class="panel-heading">
                     <h3 class="panel-title">
                         Available versions
@@ -34,55 +24,70 @@
                 </div>
 
                 <ul class="list-group">
-                    <a class="list-group-item" ng-repeat="version in data | orderBy:versionOrder:true"
-                       href="./{{version}}/index.html">
-                        {{version}}
-                    </a>
+                    $list
                 </ul>
             </article>
         </div>
     </div>
 
-    <a href="https://github.com/rust-lang/rust-clippy">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"/>
-    </a>
-
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.12/angular.min.js"></script>
-    <script>
-        angular.module('clippy', [])
-        .controller('docVersions', function ($scope, $http) {
-            $scope.loading = true;
-
-            $scope.normalizeVersion = function(v) {
-                return v.replace(/^rust-/, '');
-            };
-
-            $scope.versionOrder = function(v) {
-                if (v === 'master') { return Infinity; }
-                if (v === 'stable') { return Number.MAX_VALUE; }
-                if (v === 'beta') { return Number.MAX_VALUE - 1; }
-                if (v === 'pre-1.29.0') { return Number.MIN_VALUE; }
-
-                return $scope.normalizeVersion(v)
-                    .split('.')
-                    .reverse()
-                    .reduce(function(acc, val, index) {
-                        return acc + (val * Math.pow(100, index));
-                    }, 0);
+    <a
+        aria-label="View source on GitHub"
+        class="github-corner"
+        href="https://github.com/rust-lang/rust-clippy"
+        rel="noopener noreferrer"
+        target="_blank"
+    >
+        <svg
+            width="80"
+            height="80"
+            viewBox="0 0 250 250"
+            style="position: absolute; top: 0; border: 0; right: 0"
+            aria-hidden="true"
+        >
+            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" fill="var(--theme-color)"></path>
+            <path
+                d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+                fill="currentColor"
+                style="transform-origin: 130px 106px"
+                class="octo-arm"
+            ></path>
+            <path
+                d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+                fill="currentColor"
+                class="octo-body"
+            ></path>
+        </svg>
+        <style>
+            .github-corner svg {
+                fill: black;
+                color: white;
             }
-
-            $http.get('./versions.json')
-            .success(function (data) {
-                $scope.data = data;
-                $scope.loading = false;
-            })
-            .error(function (data) {
-                $scope.error = data;
-                $scope.loading = false;
-            });
-        })
-        ;
-    </script>
+            .github-corner:hover .octo-arm {
+                animation: octocat-wave 560ms ease-in-out;
+            }
+            @keyframes octocat-wave {
+                0%,
+                100% {
+                    transform: rotate(0);
+                }
+                20%,
+                60% {
+                    transform: rotate(-25deg);
+                }
+                40%,
+                80% {
+                    transform: rotate(10deg);
+                }
+            }
+            @media (max-width: 500px) {
+                .github-corner:hover .octo-arm {
+                    animation: none;
+                }
+                .github-corner .octo-arm {
+                    animation: octocat-wave 560ms ease-in-out;
+                }
+            }
+        </style>
+    </a>
 </body>
 </html>

--- a/util/versions.py
+++ b/util/versions.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
 
+from string import Template
+import argparse
 import json
-import logging as log
 import os
 import sys
 
-log.basicConfig(level=log.INFO, format="%(levelname)s: %(message)s")
-
-
 def key(v):
     if v == "master":
-        return float("inf")
-    if v == "stable":
         return sys.maxsize
-    if v == "beta":
+    if v == "stable":
         return sys.maxsize - 1
+    if v == "beta":
+        return sys.maxsize - 2
     if v == "pre-1.29.0":
         return -1
+    if not v.startswith("rust-"):
+        return None
 
     v = v.replace("rust-", "")
 
@@ -26,26 +26,27 @@ def key(v):
 
     return s
 
-
 def main():
-    if len(sys.argv) < 2:
-        log.error("specify output directory")
-        return
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="path to the versions.html template", type=argparse.FileType("r"))
+    parser.add_argument("outdir", help="path to write the output HTML")
+    args = parser.parse_args()
 
-    outdir = sys.argv[1]
     versions = [
         dir
-        for dir in os.listdir(outdir)
-        if not dir.startswith(".")
-        and not dir.startswith("v")
-        and os.path.isdir(os.path.join(outdir, dir))
+        for dir in os.listdir(args.outdir)
+        if key(dir) is not None
     ]
-    versions.sort(key=key)
+    versions.sort(key=key, reverse=True)
+    links = [f'<a class="list-group-item" href="./{version}/index.html">{version}</a>' for version in versions]
 
-    with open(os.path.join(outdir, "versions.json"), "w") as fp:
-        json.dump(versions, fp, indent=2)
-        log.info("wrote JSON for great justice")
+    template = Template(args.input.read())
+    html = template.substitute(list="\n".join(links))
 
+    path = os.path.join(args.outdir, "index.html")
+    with open(path, "w") as out:
+        out.write(html)
+        print(f"wrote HTML to {path}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Generates the page at https://rust-lang.github.io/rust-clippy/ directly rather than creating a JSON file to load

Also fixes https://github.com/rust-lang/rust-clippy/issues/13413

r? @flip1995

changelog: none
