### PR TITLE
Use contiguous spans for empty_line_after_* suggestion

### DIFF
--- a/tests/ui/empty_line_after/outer_attribute.1.fixed
+++ b/tests/ui/empty_line_after/outer_attribute.1.fixed
@@ -51,6 +51,11 @@ mod foo {}
 // Still lint cases where the empty line does not immediately follow the attribute
 fn comment_before_empty_line() {}
 
+//~v empty_line_after_outer_attr
+#[allow(unused)]
+// This comment is isolated
+pub fn isolated_comment() {}
+
 #[doc = "
 Returns the escaped value of the textual representation of
 

--- a/tests/ui/empty_line_after/outer_attribute.2.fixed
+++ b/tests/ui/empty_line_after/outer_attribute.2.fixed
@@ -54,6 +54,11 @@ mod foo {}
 // Still lint cases where the empty line does not immediately follow the attribute
 fn comment_before_empty_line() {}
 
+//~v empty_line_after_outer_attr
+#[allow(unused)]
+// This comment is isolated
+pub fn isolated_comment() {}
+
 #[doc = "
 Returns the escaped value of the textual representation of
 

--- a/tests/ui/empty_line_after/outer_attribute.rs
+++ b/tests/ui/empty_line_after/outer_attribute.rs
@@ -60,6 +60,13 @@ mod foo {}
 
 fn comment_before_empty_line() {}
 
+//~v empty_line_after_outer_attr
+#[allow(unused)]
+
+// This comment is isolated
+
+pub fn isolated_comment() {}
+
 #[doc = "
 Returns the escaped value of the textual representation of
 

--- a/tests/ui/empty_line_after/outer_attribute.stderr
+++ b/tests/ui/empty_line_after/outer_attribute.stderr
@@ -99,5 +99,18 @@ LL |   fn comment_before_empty_line() {}
    |
    = help: if the empty line is unintentional remove it
 
-error: aborting due to 8 previous errors
+error: empty lines after outer attribute
+  --> tests/ui/empty_line_after/outer_attribute.rs:64:1
+   |
+LL | / #[allow(unused)]
+LL | |
+LL | | // This comment is isolated
+LL | |
+   | |_
+LL |   pub fn isolated_comment() {}
+   |   ------------------------- the attribute applies to this function
+   |
+   = help: if the empty lines are unintentional remove them
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Replacing an empty span (which an empty line is) with an empty string triggers a debug assertion in rustc. This fixes the debug assertion by using contiguous spans, with the same resulting suggestion.

r? @Alexendoo 

This unblocks the sync

changelog: none
