### PR TITLE
Add reasons for or remove some `//@no-rustfix` annotations

### DIFF
--- a/tests/ui/as_ptr_cast_mut.rs
+++ b/tests/ui/as_ptr_cast_mut.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 #![warn(clippy::as_ptr_cast_mut)]
 #![allow(clippy::wrong_self_convention, clippy::unnecessary_cast)]
-//@no-rustfix
+//@no-rustfix: incorrect suggestion
 
 struct MutPtrWrapper(Vec<u8>);
 impl MutPtrWrapper {

--- a/tests/ui/borrow_box.fixed
+++ b/tests/ui/borrow_box.fixed
@@ -21,17 +21,17 @@ pub fn test1(foo: &mut Box<bool>) {
 }
 
 pub fn test2() {
-    let foo: &Box<bool>;
+    let foo: &bool;
     //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
 }
 
 struct Test3<'a> {
-    foo: &'a Box<bool>,
+    foo: &'a bool,
     //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
 }
 
 trait Test4 {
-    fn test4(a: &Box<bool>);
+    fn test4(a: &bool);
     //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
 }
 
@@ -92,24 +92,24 @@ pub fn test13(boxed_slice: &mut Box<[i32]>) {
 }
 
 // The suggestion should include proper parentheses to avoid a syntax error.
-pub fn test14(_display: &Box<dyn Display>) {}
+pub fn test14(_display: &dyn Display) {}
 //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-pub fn test15(_display: &Box<dyn Display + Send>) {}
+pub fn test15(_display: &(dyn Display + Send)) {}
 //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-pub fn test16<'a>(_display: &'a Box<dyn Display + 'a>) {}
+pub fn test16<'a>(_display: &'a (dyn Display + 'a)) {}
 //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
 
-pub fn test17(_display: &Box<impl Display>) {}
+pub fn test17(_display: &impl Display) {}
 //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-pub fn test18(_display: &Box<impl Display + Send>) {}
+pub fn test18(_display: &(impl Display + Send)) {}
 //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-pub fn test19<'a>(_display: &'a Box<impl Display + 'a>) {}
+pub fn test19<'a>(_display: &'a (impl Display + 'a)) {}
 //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
 
 // This exists only to check what happens when parentheses are already present.
 // Even though the current implementation doesn't put extra parentheses,
 // it's fine that unnecessary parentheses appear in the future for some reason.
-pub fn test20(_display: &Box<(dyn Display + Send)>) {}
+pub fn test20(_display: &(dyn Display + Send)) {}
 //~^ ERROR: you seem to be trying to use `&Box<T>`. Consider using just `&T`
 
 #[allow(clippy::borrowed_box)]

--- a/tests/ui/borrow_box.stderr
+++ b/tests/ui/borrow_box.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:25:14
+  --> tests/ui/borrow_box.rs:24:14
    |
 LL |     let foo: &Box<bool>;
    |              ^^^^^^^^^^ help: try: `&bool`
@@ -11,55 +11,55 @@ LL | #![deny(clippy::borrowed_box)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:30:10
+  --> tests/ui/borrow_box.rs:29:10
    |
 LL |     foo: &'a Box<bool>,
    |          ^^^^^^^^^^^^^ help: try: `&'a bool`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:35:17
+  --> tests/ui/borrow_box.rs:34:17
    |
 LL |     fn test4(a: &Box<bool>);
    |                 ^^^^^^^^^^ help: try: `&bool`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:102:25
+  --> tests/ui/borrow_box.rs:95:25
    |
 LL | pub fn test14(_display: &Box<dyn Display>) {}
    |                         ^^^^^^^^^^^^^^^^^ help: try: `&dyn Display`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:104:25
+  --> tests/ui/borrow_box.rs:97:25
    |
 LL | pub fn test15(_display: &Box<dyn Display + Send>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(dyn Display + Send)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:106:29
+  --> tests/ui/borrow_box.rs:99:29
    |
 LL | pub fn test16<'a>(_display: &'a Box<dyn Display + 'a>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a (dyn Display + 'a)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:109:25
+  --> tests/ui/borrow_box.rs:102:25
    |
 LL | pub fn test17(_display: &Box<impl Display>) {}
    |                         ^^^^^^^^^^^^^^^^^^ help: try: `&impl Display`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:111:25
+  --> tests/ui/borrow_box.rs:104:25
    |
 LL | pub fn test18(_display: &Box<impl Display + Send>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(impl Display + Send)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:113:29
+  --> tests/ui/borrow_box.rs:106:29
    |
 LL | pub fn test19<'a>(_display: &'a Box<impl Display + 'a>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&'a (impl Display + 'a)`
 
 error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
-  --> tests/ui/borrow_box.rs:119:25
+  --> tests/ui/borrow_box.rs:112:25
    |
 LL | pub fn test20(_display: &Box<(dyn Display + Send)>) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&(dyn Display + Send)`

--- a/tests/ui/bytecount.rs
+++ b/tests/ui/bytecount.rs
@@ -1,4 +1,4 @@
-//@no-rustfix
+//@no-rustfix: suggests external crate
 
 #![allow(clippy::needless_borrow, clippy::useless_vec)]
 

--- a/tests/ui/deref_addrof_double_trigger.rs
+++ b/tests/ui/deref_addrof_double_trigger.rs
@@ -1,5 +1,5 @@
-// This test can't work with run-rustfix because it needs two passes of test+fix
-//@no-rustfix
+//@no-rustfix: this test can't work with run-rustfix because it needs two passes of test+fix
+
 #[warn(clippy::deref_addrof)]
 #[allow(unused_variables, unused_mut)]
 fn main() {

--- a/tests/ui/float_cmp.rs
+++ b/tests/ui/float_cmp.rs
@@ -8,7 +8,7 @@
     clippy::unnecessary_operation,
     clippy::cast_lossless
 )]
-//@no-rustfix
+//@no-rustfix: suggestions have an error margin placeholder
 use std::ops::Add;
 
 const ZERO: f32 = 0.0;

--- a/tests/ui/float_cmp_const.rs
+++ b/tests/ui/float_cmp_const.rs
@@ -1,5 +1,4 @@
-// does not test any rustfixable lints
-//@no-rustfix
+//@no-rustfix: suggestions have an error margin placeholder
 #![warn(clippy::float_cmp_const)]
 #![allow(clippy::float_cmp)]
 #![allow(unused, clippy::no_effect, clippy::unnecessary_operation)]

--- a/tests/ui/float_cmp_const.stderr
+++ b/tests/ui/float_cmp_const.stderr
@@ -1,5 +1,5 @@
 error: strict comparison of `f32` or `f64` constant
-  --> tests/ui/float_cmp_const.rs:16:5
+  --> tests/ui/float_cmp_const.rs:15:5
    |
 LL |     1f32 == ONE;
    |     ^^^^^^^^^^^ help: consider comparing them within some margin of error: `(1f32 - ONE).abs() < error_margin`
@@ -8,43 +8,43 @@ LL |     1f32 == ONE;
    = help: to override `-D warnings` add `#[allow(clippy::float_cmp_const)]`
 
 error: strict comparison of `f32` or `f64` constant
-  --> tests/ui/float_cmp_const.rs:18:5
+  --> tests/ui/float_cmp_const.rs:17:5
    |
 LL |     TWO == ONE;
    |     ^^^^^^^^^^ help: consider comparing them within some margin of error: `(TWO - ONE).abs() < error_margin`
 
 error: strict comparison of `f32` or `f64` constant
-  --> tests/ui/float_cmp_const.rs:20:5
+  --> tests/ui/float_cmp_const.rs:19:5
    |
 LL |     TWO != ONE;
    |     ^^^^^^^^^^ help: consider comparing them within some margin of error: `(TWO - ONE).abs() > error_margin`
 
 error: strict comparison of `f32` or `f64` constant
-  --> tests/ui/float_cmp_const.rs:22:5
+  --> tests/ui/float_cmp_const.rs:21:5
    |
 LL |     ONE + ONE == TWO;
    |     ^^^^^^^^^^^^^^^^ help: consider comparing them within some margin of error: `(ONE + ONE - TWO).abs() < error_margin`
 
 error: strict comparison of `f32` or `f64` constant
-  --> tests/ui/float_cmp_const.rs:25:5
+  --> tests/ui/float_cmp_const.rs:24:5
    |
 LL |     x as f32 == ONE;
    |     ^^^^^^^^^^^^^^^ help: consider comparing them within some margin of error: `(x as f32 - ONE).abs() < error_margin`
 
 error: strict comparison of `f32` or `f64` constant
-  --> tests/ui/float_cmp_const.rs:29:5
+  --> tests/ui/float_cmp_const.rs:28:5
    |
 LL |     v == ONE;
    |     ^^^^^^^^ help: consider comparing them within some margin of error: `(v - ONE).abs() < error_margin`
 
 error: strict comparison of `f32` or `f64` constant
-  --> tests/ui/float_cmp_const.rs:31:5
+  --> tests/ui/float_cmp_const.rs:30:5
    |
 LL |     v != ONE;
    |     ^^^^^^^^ help: consider comparing them within some margin of error: `(v - ONE).abs() > error_margin`
 
 error: strict comparison of `f32` or `f64` constant arrays
-  --> tests/ui/float_cmp_const.rs:64:5
+  --> tests/ui/float_cmp_const.rs:63:5
    |
 LL |     NON_ZERO_ARRAY == NON_ZERO_ARRAY2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/float_equality_without_abs.rs
+++ b/tests/ui/float_equality_without_abs.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::float_equality_without_abs)]
-//@no-rustfix
+//@no-rustfix: suggestions cause type ambiguity
 
 // FIXME(f16_f128): add tests for these types when abs is available
 

--- a/tests/ui/unused_format_specs.1.fixed
+++ b/tests/ui/unused_format_specs.1.fixed
@@ -1,0 +1,35 @@
+#![warn(clippy::unused_format_specs)]
+#![allow(unused)]
+
+macro_rules! format_args_from_macro {
+    () => {
+        format_args!("from macro")
+    };
+}
+
+fn main() {
+    // prints `.`, not `     .`
+    println!("{:5}.", format!(""));
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+    //~| NOTE: `-D clippy::unused-format-specs` implied by `-D warnings`
+    //prints `abcde`, not `abc`
+    println!("{:.3}", format!("abcde"));
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+
+    println!("{}.", format_args_from_macro!());
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+
+    let args = format_args!("");
+    println!("{args}");
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+}
+
+fn should_not_lint() {
+    println!("{}", format_args!(""));
+    // Technically the same as `{}`, but the `format_args` docs specifically mention that you can use
+    // debug formatting so allow it
+    println!("{:?}", format_args!(""));
+
+    let args = format_args!("");
+    println!("{args}");
+}

--- a/tests/ui/unused_format_specs.2.fixed
+++ b/tests/ui/unused_format_specs.2.fixed
@@ -1,0 +1,35 @@
+#![warn(clippy::unused_format_specs)]
+#![allow(unused)]
+
+macro_rules! format_args_from_macro {
+    () => {
+        format_args!("from macro")
+    };
+}
+
+fn main() {
+    // prints `.`, not `     .`
+    println!("{}.", format_args!(""));
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+    //~| NOTE: `-D clippy::unused-format-specs` implied by `-D warnings`
+    //prints `abcde`, not `abc`
+    println!("{}", format_args!("abcde"));
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+
+    println!("{}.", format_args_from_macro!());
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+
+    let args = format_args!("");
+    println!("{args}");
+    //~^ ERROR: format specifiers have no effect on `format_args!()`
+}
+
+fn should_not_lint() {
+    println!("{}", format_args!(""));
+    // Technically the same as `{}`, but the `format_args` docs specifically mention that you can use
+    // debug formatting so allow it
+    println!("{:?}", format_args!(""));
+
+    let args = format_args!("");
+    println!("{args}");
+}

--- a/tests/ui/unused_format_specs.rs
+++ b/tests/ui/unused_format_specs.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::unused_format_specs)]
 #![allow(unused)]
-//@no-rustfix
+
 macro_rules! format_args_from_macro {
     () => {
         format_args!("from macro")

--- a/tests/ui/unused_format_specs.stderr
+++ b/tests/ui/unused_format_specs.stderr
@@ -1,5 +1,5 @@
 error: format specifiers have no effect on `format_args!()`
-  --> tests/ui/unused_format_specs_unfixable.rs:12:15
+  --> tests/ui/unused_format_specs.rs:12:15
    |
 LL |     println!("{:5}.", format_args!(""));
    |               ^^^^
@@ -17,7 +17,7 @@ LL +     println!("{}.", format_args!(""));
    |
 
 error: format specifiers have no effect on `format_args!()`
-  --> tests/ui/unused_format_specs_unfixable.rs:16:15
+  --> tests/ui/unused_format_specs.rs:16:15
    |
 LL |     println!("{:.3}", format_args!("abcde"));
    |               ^^^^^
@@ -33,7 +33,7 @@ LL +     println!("{}", format_args!("abcde"));
    |
 
 error: format specifiers have no effect on `format_args!()`
-  --> tests/ui/unused_format_specs_unfixable.rs:19:15
+  --> tests/ui/unused_format_specs.rs:19:15
    |
 LL |     println!("{:5}.", format_args_from_macro!());
    |               ^^^^
@@ -46,7 +46,7 @@ LL +     println!("{}.", format_args_from_macro!());
    |
 
 error: format specifiers have no effect on `format_args!()`
-  --> tests/ui/unused_format_specs_unfixable.rs:23:15
+  --> tests/ui/unused_format_specs.rs:23:15
    |
 LL |     println!("{args:5}");
    |               ^^^^^^^^


### PR DESCRIPTION
changelog: none
