### PR TITLE
`zombie_processes`: consider `wait()` calls in nested bodies

### DIFF
--- a/tests/ui/zombie_processes.rs
+++ b/tests/ui/zombie_processes.rs
@@ -131,6 +131,13 @@ fn main() {
         }
         x.wait().unwrap();
     }
+
+    {
+        let mut x = Command::new("").spawn().unwrap();
+        std::thread::spawn(move || {
+            x.wait().unwrap();
+        });
+    }
 }
 
 fn process_child(c: Child) {


### PR DESCRIPTION
Fixes #13459

Small oversight. We weren't considering uses of the local in closures.

changelog: none