### PR TITLE
Optimise Msrv for common one item case

### DIFF
--- a/clippy_config/src/lib.rs
+++ b/clippy_config/src/lib.rs
@@ -20,6 +20,7 @@ extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate smallvec;
 
 mod conf;
 mod metadata;


### PR DESCRIPTION
Currently, `Msrv` is cloned around a lot in order to handle the `#[clippy::msrv]` attribute. This attribute, however, means `RustcVersion` will be heap allocated if there is only one source of an msrv (eg: `rust-version` in `Cargo.toml`).

This PR optimizes for said case, while keeping the external interface the same by swapping the internal representation to `SmallVec<[RustcVersion; 2]>`.

changelog: none
