### PR TITLE
Reduce default 'large array' threshold

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -329,7 +329,7 @@ arithmetic-side-effects-allowed-unary = ["SomeType", "AnotherType"]
 ## `array-size-threshold`
 The maximum allowed size for arrays on the stack
 
-**Default Value:** `512000`
+**Default Value:** `16384`
 
 ---
 **Affected lints:**

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -366,7 +366,7 @@ define_Conf! {
     arithmetic_side_effects_allowed_unary: Vec<String> = <_>::default(),
     /// The maximum allowed size for arrays on the stack
     #[lints(large_const_arrays, large_stack_arrays)]
-    array_size_threshold: u64 = 512_000,
+    array_size_threshold: u64 = 16 * 1024,
     /// Suppress lints whenever the suggested change would cause breakage for other crates.
     #[lints(
         box_collection,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5182,7 +5182,7 @@ impl ShouldImplTraitCase {
 }
 
 #[rustfmt::skip]
-const TRAIT_METHODS: [ShouldImplTraitCase; 30] = [
+static TRAIT_METHODS: [ShouldImplTraitCase; 30] = [
     ShouldImplTraitCase::new("std::ops::Add", "add",  2,  FN_HEADER,  SelfKind::Value,  OutType::Any, true),
     ShouldImplTraitCase::new("std::convert::AsMut", "as_mut",  1,  FN_HEADER,  SelfKind::RefMut,  OutType::Ref, true),
     ShouldImplTraitCase::new("std::convert::AsRef", "as_ref",  1,  FN_HEADER,  SelfKind::Ref,  OutType::Ref, true),

--- a/tests/ui-toml/array_size_threshold/array_size_threshold.stderr
+++ b/tests/ui-toml/array_size_threshold/array_size_threshold.stderr
@@ -10,22 +10,14 @@ LL | const ABOVE: [u8; 11] = [0; 11];
    = help: to override `-D warnings` add `#[allow(clippy::large_const_arrays)]`
 
 error: allocating a local array larger than 10 bytes
-  --> tests/ui-toml/array_size_threshold/array_size_threshold.rs:4:25
-   |
-LL | const ABOVE: [u8; 11] = [0; 11];
-   |                         ^^^^^^^
-   |
-   = help: consider allocating on the heap with `vec![0; 11].into_boxed_slice()`
-   = note: `-D clippy::large-stack-arrays` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::large_stack_arrays)]`
-
-error: allocating a local array larger than 10 bytes
   --> tests/ui-toml/array_size_threshold/array_size_threshold.rs:8:17
    |
 LL |     let above = [0u8; 11];
    |                 ^^^^^^^^^
    |
    = help: consider allocating on the heap with `vec![0u8; 11].into_boxed_slice()`
+   = note: `-D clippy::large-stack-arrays` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::large_stack_arrays)]`
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/large_const_arrays.fixed
+++ b/tests/ui/large_const_arrays.fixed
@@ -12,9 +12,9 @@ pub static FOO_PUB: [u32; 1_000_000] = [0u32; 1_000_000];
 static FOO: [u32; 1_000_000] = [0u32; 1_000_000];
 
 // Good
-pub(crate) const G_FOO_PUB_CRATE: [u32; 1_000] = [0u32; 1_000];
-pub const G_FOO_PUB: [u32; 1_000] = [0u32; 1_000];
-const G_FOO: [u32; 1_000] = [0u32; 1_000];
+pub(crate) const G_FOO_PUB_CRATE: [u32; 250] = [0u32; 250];
+pub const G_FOO_PUB: [u32; 250] = [0u32; 250];
+const G_FOO: [u32; 250] = [0u32; 250];
 
 fn main() {
     // Should lint
@@ -26,10 +26,10 @@ fn main() {
     static BAR_S: [Option<&str>; 200_000] = [Some("str"); 200_000];
 
     // Good
-    pub const G_BAR_PUB: [u32; 1_000] = [0u32; 1_000];
-    const G_BAR: [u32; 1_000] = [0u32; 1_000];
-    pub const G_BAR_STRUCT_PUB: [S; 500] = [S { data: [0; 32] }; 500];
-    const G_BAR_STRUCT: [S; 500] = [S { data: [0; 32] }; 500];
-    pub const G_BAR_S_PUB: [Option<&str>; 200] = [Some("str"); 200];
-    const G_BAR_S: [Option<&str>; 200] = [Some("str"); 200];
+    pub const G_BAR_PUB: [u32; 250] = [0u32; 250];
+    const G_BAR: [u32; 250] = [0u32; 250];
+    pub const G_BAR_STRUCT_PUB: [S; 4] = [S { data: [0; 32] }; 4];
+    const G_BAR_STRUCT: [S; 4] = [S { data: [0; 32] }; 4];
+    pub const G_BAR_S_PUB: [Option<&str>; 50] = [Some("str"); 50];
+    const G_BAR_S: [Option<&str>; 50] = [Some("str"); 50];
 }

--- a/tests/ui/large_const_arrays.rs
+++ b/tests/ui/large_const_arrays.rs
@@ -12,9 +12,9 @@ pub const FOO_PUB: [u32; 1_000_000] = [0u32; 1_000_000];
 const FOO: [u32; 1_000_000] = [0u32; 1_000_000];
 
 // Good
-pub(crate) const G_FOO_PUB_CRATE: [u32; 1_000] = [0u32; 1_000];
-pub const G_FOO_PUB: [u32; 1_000] = [0u32; 1_000];
-const G_FOO: [u32; 1_000] = [0u32; 1_000];
+pub(crate) const G_FOO_PUB_CRATE: [u32; 250] = [0u32; 250];
+pub const G_FOO_PUB: [u32; 250] = [0u32; 250];
+const G_FOO: [u32; 250] = [0u32; 250];
 
 fn main() {
     // Should lint
@@ -26,10 +26,10 @@ fn main() {
     const BAR_S: [Option<&str>; 200_000] = [Some("str"); 200_000];
 
     // Good
-    pub const G_BAR_PUB: [u32; 1_000] = [0u32; 1_000];
-    const G_BAR: [u32; 1_000] = [0u32; 1_000];
-    pub const G_BAR_STRUCT_PUB: [S; 500] = [S { data: [0; 32] }; 500];
-    const G_BAR_STRUCT: [S; 500] = [S { data: [0; 32] }; 500];
-    pub const G_BAR_S_PUB: [Option<&str>; 200] = [Some("str"); 200];
-    const G_BAR_S: [Option<&str>; 200] = [Some("str"); 200];
+    pub const G_BAR_PUB: [u32; 250] = [0u32; 250];
+    const G_BAR: [u32; 250] = [0u32; 250];
+    pub const G_BAR_STRUCT_PUB: [S; 4] = [S { data: [0; 32] }; 4];
+    const G_BAR_STRUCT: [S; 4] = [S { data: [0; 32] }; 4];
+    pub const G_BAR_S_PUB: [Option<&str>; 50] = [Some("str"); 50];
+    const G_BAR_S: [Option<&str>; 50] = [Some("str"); 50];
 }

--- a/tests/ui/large_stack_arrays.rs
+++ b/tests/ui/large_stack_arrays.rs
@@ -15,6 +15,7 @@ enum E {
     T(u32),
 }
 
+const STATIC_PROMOTED_LARGE_ARRAY: &[u8; 512001] = &[0; 512001];
 pub static DOESNOTLINT: [u8; 512_001] = [0; 512_001];
 pub static DOESNOTLINT2: [u8; 512_001] = {
     let x = 0;

--- a/tests/ui/large_stack_arrays.rs
+++ b/tests/ui/large_stack_arrays.rs
@@ -24,38 +24,38 @@ pub static DOESNOTLINT2: [u8; 512_001] = {
 
 fn issue_10741() {
     #[derive(Copy, Clone)]
-    struct Large([u32; 100_000]);
+    struct Large([u32; 2048]);
 
     fn build() -> Large {
-        Large([0; 100_000])
+        Large([0; 2048])
     }
 
     let _x = [build(); 3];
-    //~^ ERROR: allocating a local array larger than 512000 bytes
+    //~^ ERROR: allocating a local array larger than 16384 bytes
 
     let _y = [build(), build(), build()];
-    //~^ ERROR: allocating a local array larger than 512000 bytes
+    //~^ ERROR: allocating a local array larger than 16384 bytes
 }
 
 fn main() {
     let bad = (
         [0u32; 20_000_000],
-        //~^ ERROR: allocating a local array larger than 512000 bytes
+        //~^ ERROR: allocating a local array larger than 16384 bytes
         [S { data: [0; 32] }; 5000],
-        //~^ ERROR: allocating a local array larger than 512000 bytes
+        //~^ ERROR: allocating a local array larger than 16384 bytes
         [Some(""); 20_000_000],
-        //~^ ERROR: allocating a local array larger than 512000 bytes
+        //~^ ERROR: allocating a local array larger than 16384 bytes
         [E::T(0); 5000],
-        //~^ ERROR: allocating a local array larger than 512000 bytes
+        //~^ ERROR: allocating a local array larger than 16384 bytes
         [0u8; usize::MAX],
-        //~^ ERROR: allocating a local array larger than 512000 bytes
+        //~^ ERROR: allocating a local array larger than 16384 bytes
     );
 
     let good = (
-        [0u32; 1000],
-        [S { data: [0; 32] }; 1000],
-        [Some(""); 1000],
-        [E::T(0); 1000],
+        [0u32; 50],
+        [S { data: [0; 32] }; 4],
+        [Some(""); 50],
+        [E::T(0); 2],
         [(); 20_000_000],
     );
 }
@@ -69,7 +69,7 @@ fn issue_12586() {
         // Weird rule to test help messages.
         ($a:expr => $b:expr) => {
             [$a, $b, $a, $b]
-            //~^ ERROR: allocating a local array larger than 512000 bytes
+            //~^ ERROR: allocating a local array larger than 16384 bytes
         };
         ($id:ident; $n:literal) => {
             dummy!(::std::vec![$id;$n])
@@ -81,26 +81,26 @@ fn issue_12586() {
     macro_rules! create_then_move {
         ($id:ident; $n:literal) => {{
             let _x_ = [$id; $n];
-            //~^ ERROR: allocating a local array larger than 512000 bytes
+            //~^ ERROR: allocating a local array larger than 16384 bytes
             _x_
         }};
     }
 
-    let x = [0u32; 50_000];
+    let x = [0u32; 4096];
     let y = vec![x, x, x, x, x];
     let y = vec![dummy![x, x, x, x, x]];
     let y = vec![dummy![[x, x, x, x, x]]];
     let y = dummy![x, x, x, x, x];
     let y = [x, x, dummy!(x), x, x];
-    //~^ ERROR: allocating a local array larger than 512000 bytes
+    //~^ ERROR: allocating a local array larger than 16384 bytes
     let y = dummy![x => x];
     let y = dummy![x;5];
     let y = dummy!(vec![dummy![x, x, x, x, x]]);
     let y = dummy![[x, x, x, x, x]];
-    //~^ ERROR: allocating a local array larger than 512000 bytes
+    //~^ ERROR: allocating a local array larger than 16384 bytes
 
     let y = proc_macros::make_it_big!([x; 1]);
-    //~^ ERROR: allocating a local array larger than 512000 bytes
+    //~^ ERROR: allocating a local array larger than 16384 bytes
     let y = vec![proc_macros::make_it_big!([x; 10])];
     let y = vec![create_then_move![x; 5]; 5];
 }

--- a/tests/ui/large_stack_arrays.stderr
+++ b/tests/ui/large_stack_arrays.stderr
@@ -1,5 +1,5 @@
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:32:14
+  --> tests/ui/large_stack_arrays.rs:33:14
    |
 LL |     let _x = [build(); 3];
    |              ^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let _x = [build(); 3];
    = help: to override `-D warnings` add `#[allow(clippy::large_stack_arrays)]`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:35:14
+  --> tests/ui/large_stack_arrays.rs:36:14
    |
 LL |     let _y = [build(), build(), build()];
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     let _y = [build(), build(), build()];
    = help: consider allocating on the heap with `vec![build(), build(), build()].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:41:9
+  --> tests/ui/large_stack_arrays.rs:42:9
    |
 LL |         [0u32; 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |         [0u32; 20_000_000],
    = help: consider allocating on the heap with `vec![0u32; 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:43:9
+  --> tests/ui/large_stack_arrays.rs:44:9
    |
 LL |         [S { data: [0; 32] }; 5000],
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |         [S { data: [0; 32] }; 5000],
    = help: consider allocating on the heap with `vec![S { data: [0; 32] }; 5000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:45:9
+  --> tests/ui/large_stack_arrays.rs:46:9
    |
 LL |         [Some(""); 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |         [Some(""); 20_000_000],
    = help: consider allocating on the heap with `vec![Some(""); 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:47:9
+  --> tests/ui/large_stack_arrays.rs:48:9
    |
 LL |         [E::T(0); 5000],
    |         ^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |         [E::T(0); 5000],
    = help: consider allocating on the heap with `vec![E::T(0); 5000].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:49:9
+  --> tests/ui/large_stack_arrays.rs:50:9
    |
 LL |         [0u8; usize::MAX],
    |         ^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |         [0u8; usize::MAX],
    = help: consider allocating on the heap with `vec![0u8; usize::MAX].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:93:13
+  --> tests/ui/large_stack_arrays.rs:94:13
    |
 LL |     let y = [x, x, dummy!(x), x, x];
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     let y = [x, x, dummy!(x), x, x];
    = help: consider allocating on the heap with `vec![x, x, dummy!(x), x, x].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:70:13
+  --> tests/ui/large_stack_arrays.rs:71:13
    |
 LL |             [$a, $b, $a, $b]
    |             ^^^^^^^^^^^^^^^^
@@ -76,7 +76,7 @@ LL |     let y = dummy![x => x];
    = note: this error originates in the macro `dummy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:98:20
+  --> tests/ui/large_stack_arrays.rs:99:20
    |
 LL |     let y = dummy![[x, x, x, x, x]];
    |                    ^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL |     let y = dummy![[x, x, x, x, x]];
    = help: consider allocating on the heap with `vec![x, x, x, x, x].into_boxed_slice()`
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:101:39
+  --> tests/ui/large_stack_arrays.rs:102:39
    |
 LL |     let y = proc_macros::make_it_big!([x; 1]);
    |                                       ^^^^^^
 
 error: allocating a local array larger than 512000 bytes
-  --> tests/ui/large_stack_arrays.rs:82:23
+  --> tests/ui/large_stack_arrays.rs:83:23
    |
 LL |             let _x_ = [$id; $n];
    |                       ^^^^^^^^^

--- a/tests/ui/large_stack_arrays.stderr
+++ b/tests/ui/large_stack_arrays.stderr
@@ -1,4 +1,4 @@
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:33:14
    |
 LL |     let _x = [build(); 3];
@@ -8,7 +8,7 @@ LL |     let _x = [build(); 3];
    = note: `-D clippy::large-stack-arrays` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::large_stack_arrays)]`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:36:14
    |
 LL |     let _y = [build(), build(), build()];
@@ -16,7 +16,7 @@ LL |     let _y = [build(), build(), build()];
    |
    = help: consider allocating on the heap with `vec![build(), build(), build()].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:42:9
    |
 LL |         [0u32; 20_000_000],
@@ -24,7 +24,7 @@ LL |         [0u32; 20_000_000],
    |
    = help: consider allocating on the heap with `vec![0u32; 20_000_000].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:44:9
    |
 LL |         [S { data: [0; 32] }; 5000],
@@ -32,7 +32,7 @@ LL |         [S { data: [0; 32] }; 5000],
    |
    = help: consider allocating on the heap with `vec![S { data: [0; 32] }; 5000].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:46:9
    |
 LL |         [Some(""); 20_000_000],
@@ -40,7 +40,7 @@ LL |         [Some(""); 20_000_000],
    |
    = help: consider allocating on the heap with `vec![Some(""); 20_000_000].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:48:9
    |
 LL |         [E::T(0); 5000],
@@ -48,7 +48,7 @@ LL |         [E::T(0); 5000],
    |
    = help: consider allocating on the heap with `vec![E::T(0); 5000].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:50:9
    |
 LL |         [0u8; usize::MAX],
@@ -56,7 +56,7 @@ LL |         [0u8; usize::MAX],
    |
    = help: consider allocating on the heap with `vec![0u8; usize::MAX].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:94:13
    |
 LL |     let y = [x, x, dummy!(x), x, x];
@@ -64,7 +64,7 @@ LL |     let y = [x, x, dummy!(x), x, x];
    |
    = help: consider allocating on the heap with `vec![x, x, dummy!(x), x, x].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:71:13
    |
 LL |             [$a, $b, $a, $b]
@@ -75,7 +75,7 @@ LL |     let y = dummy![x => x];
    |
    = note: this error originates in the macro `dummy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:99:20
    |
 LL |     let y = dummy![[x, x, x, x, x]];
@@ -83,13 +83,13 @@ LL |     let y = dummy![[x, x, x, x, x]];
    |
    = help: consider allocating on the heap with `vec![x, x, x, x, x].into_boxed_slice()`
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:102:39
    |
 LL |     let y = proc_macros::make_it_big!([x; 1]);
    |                                       ^^^^^^
 
-error: allocating a local array larger than 512000 bytes
+error: allocating a local array larger than 16384 bytes
   --> tests/ui/large_stack_arrays.rs:83:23
    |
 LL |             let _x_ = [$id; $n];


### PR DESCRIPTION
As-is this threshold is `512kb`, but as #9449 points out this is way too high for most people to consider sensible (why would you want to copy `256kb` of data around on the stack or duplicate it via `const`) and didn't get any discussion when originally added. This PR reduces it the threshold to `1kb`, which is higher than the issue says ("a few cpu words") but helps out for actual codebases.

While reducing this, I found that `large_stack_arrays` was triggering for statically promoted arrays in constants/statics, so I also fixed that up as seen in the difference to [array_size_threshold.stderr](https://github.com/rust-lang/rust-clippy/compare/master...GnomedDev:rust-clippy:reduce-large-threshold?expand=1#diff-4c2a2a855d9ff7777f1d385be0c1bede2a3fc8aaab94837cde27a35235233fc7).

Closes #9449.


changelog: [`large_stack_arrays`]: No longer triggers in `static`/`const` context
changelog: [`large_const_arrays`]: Changed the default of [`array-size-threshold`] from `512kb` to `16kb`
