### PR TITLE
CI: check that new lints use the correct stabilization version

### DIFF
--- a/.github/workflows/versioncheck.yml
+++ b/.github/workflows/versioncheck.yml
@@ -1,0 +1,95 @@
+name: New lint stabilization version check
+
+on:
+  push:
+    branches:
+      - auto
+      - try
+  pull_request:
+    paths:
+    - 'clippy_lints/src/**/*.rs'
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+concurrency:
+  # For a given workflow, if we push to the same PR, cancel all previous builds on that PR.
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number}}"
+  cancel-in-progress: true
+
+jobs:
+  # Collect lint metadata on the PR's target branch and stores the results as an artifact
+  base:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+
+    # HEAD is the generated merge commit `refs/pull/N/merge` between the PR and `master`, `HEAD^`
+    # being the commit from `master` that is the base of the merge
+    - name: Checkout base
+      run: git checkout HEAD^
+
+    - name: Cache metadata
+      id: cache-metadata
+      uses: actions/cache@v4
+      with:
+        path: util/gh-pages/lints.json
+        key: metadata-bin-${{ hashfiles('clippy_lints/**') }}
+
+    - name: Collect metadata
+      if: steps.cache-metadata.outputs.cache-hit != 'true'
+      run: cargo collect-metadata
+
+    - name: Upload base JSON
+      uses: actions/upload-artifact@v4
+      with:
+        name: base
+        path: util/gh-pages/lints.json
+
+  head:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+
+    - name: Cache metadata
+      id: cache-metadata
+      uses: actions/cache@v4
+      with:
+        path: util/gh-pages/lints.json
+        key: metadata-bin-${{ hashfiles('clippy_lints/**') }}
+
+    - name: Collect metadata
+      if: steps.cache-metadata.outputs.cache-hit != 'true'
+      run: cargo collect-metadata
+
+    - name: Upload base JSON
+      uses: actions/upload-artifact@v4
+      with:
+        name: head
+        path: util/gh-pages/lints.json
+
+  # Retrieves the head and base JSON results and prints the diff to the GH actions step summary
+  diff:
+    runs-on: ubuntu-latest
+
+    needs: [base, head]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download JSON
+      uses: actions/download-artifact@v4
+
+    - name: Diff results
+      run: |
+        cargo dev check_new_lints_version base/lints.json head/lints.json

--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -10,6 +10,8 @@ clap = { version = "4.4", features = ["derive"] }
 indoc = "1.0"
 itertools = "0.12"
 opener = "0.6"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
 shell-escape = "0.1"
 walkdir = "2.3"
 

--- a/clippy_dev/src/check_lint_version.rs
+++ b/clippy_dev/src/check_lint_version.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+use std::process;
+
+use crate::new_lint::get_stabilization_version;
+
+#[derive(serde::Deserialize)]
+struct Lint {
+    id: String,
+    version: String,
+}
+
+fn load_metadata(metadata: &Path) -> HashMap<String, String> {
+    let lints: Vec<Lint> = serde_json::from_reader(File::open(metadata).unwrap()).unwrap();
+    lints.into_iter().map(|lint| (lint.id, lint.version)).collect()
+}
+
+pub fn check_lint_version(old_metadata: &Path, new_metadata: &Path) {
+    let stabilization_version = get_stabilization_version();
+    let old_lints = load_metadata(old_metadata);
+    let mut new_lints = load_metadata(new_metadata)
+        .into_iter()
+        .filter(|(name, _)| !old_lints.contains_key(name))
+        .collect::<Vec<_>>();
+    if new_lints.is_empty() {
+        println!("No new lints");
+        return;
+    }
+    new_lints.sort_unstable();
+    let mut error = false;
+    println!("New lints:");
+    for (name, version) in new_lints {
+        if version == stabilization_version {
+            println!("  - {name}");
+        } else {
+            println!("  - {name}: lint declares version {version}, stabilization version is {stabilization_version}");
+            error = true;
+        }
+    }
+    if error {
+        process::exit(1);
+    }
+}

--- a/clippy_dev/src/lib.rs
+++ b/clippy_dev/src/lib.rs
@@ -18,6 +18,7 @@ use std::io;
 use std::path::PathBuf;
 use std::process::{self, ExitStatus};
 
+pub mod check_lint_version;
 pub mod dogfood;
 pub mod fmt;
 pub mod lint;

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -3,8 +3,9 @@
 #![warn(rust_2018_idioms, unused_lifetimes)]
 
 use clap::{Args, Parser, Subcommand};
-use clippy_dev::{dogfood, fmt, lint, new_lint, serve, setup, update_lints};
+use clippy_dev::{check_lint_version, dogfood, fmt, lint, new_lint, serve, setup, update_lints};
 use std::convert::Infallible;
+use std::path::PathBuf;
 
 fn main() {
     let dev = Dev::parse();
@@ -13,6 +14,10 @@ fn main() {
         DevCommand::Bless => {
             eprintln!("use `cargo bless` to automatically replace `.stderr` and `.fixed` files as tests are being run");
         },
+        DevCommand::CheckNewLintsVersion {
+            old_metadata,
+            new_metadata,
+        } => check_lint_version::check_lint_version(&old_metadata, &new_metadata),
         DevCommand::Dogfood {
             fix,
             allow_dirty,
@@ -89,6 +94,14 @@ struct Dev {
 enum DevCommand {
     /// Bless the test output changes
     Bless,
+    /// Check that new lints agree with the stabilization version
+    #[command(name = "check_new_lints_version")]
+    CheckNewLintsVersion {
+        /// Original metadata
+        old_metadata: PathBuf,
+        /// New metadata
+        new_metadata: PathBuf,
+    },
     /// Runs the dogfood test
     Dogfood {
         #[arg(long)]


### PR DESCRIPTION
New lints are found by comparing the metadata with the base one. The declared version must be equal to the stabilization version.

Inspired by #13497.

changelog: none