### PR TITLE
Style: do not defensively use `saturating_sub()`

### DIFF
--- a/clippy_lints/src/loops/infinite_loop.rs
+++ b/clippy_lints/src/loops/infinite_loop.rs
@@ -112,7 +112,7 @@ impl<'hir> Visitor<'hir> for LoopVisitor<'hir, '_> {
             ExprKind::Loop(..) => {
                 self.loop_depth += 1;
                 walk_expr(self, ex);
-                self.loop_depth = self.loop_depth.saturating_sub(1);
+                self.loop_depth -= 1;
             },
             _ => {
                 // Calls to a function that never return


### PR DESCRIPTION
Using `saturating_sub()` here in code which cannot fail brings a false sense of security. If for any reason a logic error was introduced and caused `self.loop_depth` to reach 0 before being decremented, using `saturating_sub(1)` would silently mask the programming error instead of panicking loudly as it should (at least in dev profile).

changelog: none