### PR TITLE
Fix large_stack_arrays triggering when nesting const items

### DIFF
--- a/clippy_lints/src/large_stack_arrays.rs
+++ b/clippy_lints/src/large_stack_arrays.rs
@@ -1,3 +1,5 @@
+use std::num::Saturating;
+
 use clippy_config::Conf;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_from_proc_macro;
@@ -30,7 +32,7 @@ declare_clippy_lint! {
 pub struct LargeStackArrays {
     maximum_allowed_size: u64,
     prev_vec_macro_callsite: Option<Span>,
-    is_in_const_item: bool,
+    const_item_counter: Saturating<u16>,
 }
 
 impl LargeStackArrays {
@@ -38,7 +40,7 @@ impl LargeStackArrays {
         Self {
             maximum_allowed_size: conf.array_size_threshold,
             prev_vec_macro_callsite: None,
-            is_in_const_item: false,
+            const_item_counter: Saturating(0),
         }
     }
 
@@ -64,18 +66,18 @@ impl_lint_pass!(LargeStackArrays => [LARGE_STACK_ARRAYS]);
 impl<'tcx> LateLintPass<'tcx> for LargeStackArrays {
     fn check_item(&mut self, _: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
         if matches!(item.kind, ItemKind::Static(..) | ItemKind::Const(..)) {
-            self.is_in_const_item = true;
+            self.const_item_counter += 1;
         }
     }
 
     fn check_item_post(&mut self, _: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
         if matches!(item.kind, ItemKind::Static(..) | ItemKind::Const(..)) {
-            self.is_in_const_item = false;
+            self.const_item_counter -= 1;
         }
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
-        if !self.is_in_const_item
+        if self.const_item_counter.0 == 0
             && let ExprKind::Repeat(_, _) | ExprKind::Array(_) = expr.kind
             && !self.is_from_vec_macro(cx, expr.span)
             && let ty::Array(element_type, cst) = cx.typeck_results().expr_ty(expr).kind()

--- a/tests/ui/large_stack_arrays.rs
+++ b/tests/ui/large_stack_arrays.rs
@@ -16,6 +16,11 @@ enum E {
 }
 
 const STATIC_PROMOTED_LARGE_ARRAY: &[u8; 512001] = &[0; 512001];
+const STATIC_PROMOTED_LARGE_ARRAY_WITH_NESTED: &[u8; 512001] = {
+    const NESTED: () = ();
+    &[0; 512001]
+};
+
 pub static DOESNOTLINT: [u8; 512_001] = [0; 512_001];
 pub static DOESNOTLINT2: [u8; 512_001] = {
     let x = 0;

--- a/tests/ui/large_stack_arrays.stderr
+++ b/tests/ui/large_stack_arrays.stderr
@@ -1,5 +1,5 @@
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:33:14
+  --> tests/ui/large_stack_arrays.rs:38:14
    |
 LL |     let _x = [build(); 3];
    |              ^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let _x = [build(); 3];
    = help: to override `-D warnings` add `#[allow(clippy::large_stack_arrays)]`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:36:14
+  --> tests/ui/large_stack_arrays.rs:41:14
    |
 LL |     let _y = [build(), build(), build()];
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     let _y = [build(), build(), build()];
    = help: consider allocating on the heap with `vec![build(), build(), build()].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:42:9
+  --> tests/ui/large_stack_arrays.rs:47:9
    |
 LL |         [0u32; 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |         [0u32; 20_000_000],
    = help: consider allocating on the heap with `vec![0u32; 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:44:9
+  --> tests/ui/large_stack_arrays.rs:49:9
    |
 LL |         [S { data: [0; 32] }; 5000],
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |         [S { data: [0; 32] }; 5000],
    = help: consider allocating on the heap with `vec![S { data: [0; 32] }; 5000].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:46:9
+  --> tests/ui/large_stack_arrays.rs:51:9
    |
 LL |         [Some(""); 20_000_000],
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |         [Some(""); 20_000_000],
    = help: consider allocating on the heap with `vec![Some(""); 20_000_000].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:48:9
+  --> tests/ui/large_stack_arrays.rs:53:9
    |
 LL |         [E::T(0); 5000],
    |         ^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |         [E::T(0); 5000],
    = help: consider allocating on the heap with `vec![E::T(0); 5000].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:50:9
+  --> tests/ui/large_stack_arrays.rs:55:9
    |
 LL |         [0u8; usize::MAX],
    |         ^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |         [0u8; usize::MAX],
    = help: consider allocating on the heap with `vec![0u8; usize::MAX].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:94:13
+  --> tests/ui/large_stack_arrays.rs:99:13
    |
 LL |     let y = [x, x, dummy!(x), x, x];
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     let y = [x, x, dummy!(x), x, x];
    = help: consider allocating on the heap with `vec![x, x, dummy!(x), x, x].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:71:13
+  --> tests/ui/large_stack_arrays.rs:76:13
    |
 LL |             [$a, $b, $a, $b]
    |             ^^^^^^^^^^^^^^^^
@@ -76,7 +76,7 @@ LL |     let y = dummy![x => x];
    = note: this error originates in the macro `dummy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:99:20
+  --> tests/ui/large_stack_arrays.rs:104:20
    |
 LL |     let y = dummy![[x, x, x, x, x]];
    |                    ^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL |     let y = dummy![[x, x, x, x, x]];
    = help: consider allocating on the heap with `vec![x, x, x, x, x].into_boxed_slice()`
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:102:39
+  --> tests/ui/large_stack_arrays.rs:107:39
    |
 LL |     let y = proc_macros::make_it_big!([x; 1]);
    |                                       ^^^^^^
 
 error: allocating a local array larger than 16384 bytes
-  --> tests/ui/large_stack_arrays.rs:83:23
+  --> tests/ui/large_stack_arrays.rs:88:23
    |
 LL |             let _x_ = [$id; $n];
    |                       ^^^^^^^^^


### PR DESCRIPTION
Fixes #13529.

r? @flip1995

changelog: [`large_stack_arrays`]: No longer triggers in static/const context when using nested items