### PR TITLE
Mark unnecessary_first_then_check and byte_char_slices as Applicable

### DIFF
--- a/clippy_lints/src/byte_char_slices.rs
+++ b/clippy_lints/src/byte_char_slices.rs
@@ -41,7 +41,7 @@ impl EarlyLintPass for ByteCharSlice {
                 "can be more succinctly written as a byte str",
                 "try",
                 format!("b\"{slice}\""),
-                Applicability::MaybeIncorrect,
+                Applicability::MachineApplicable,
             );
         }
     }

--- a/clippy_lints/src/methods/unnecessary_first_then_check.rs
+++ b/clippy_lints/src/methods/unnecessary_first_then_check.rs
@@ -50,7 +50,7 @@ pub(super) fn check(
             ),
             "replace this with",
             suggestion,
-            Applicability::MaybeIncorrect,
+            Applicability::MachineApplicable,
         );
     }
 }


### PR DESCRIPTION
I don't really see situations where this isn't Applicable that aren't weird edge cases where the lint should be disabled.

changelog: none