### PR TITLE
[`implicit_saturating_sub`] Fix suggestion with a less volatile approach

### DIFF
--- a/tests/ui/implicit_saturating_sub.fixed
+++ b/tests/ui/implicit_saturating_sub.fixed
@@ -223,13 +223,8 @@ fn main() {
     };
 }
 
-// https://github.com/rust-lang/rust-clippy/issues/13524
 fn regression_13524(a: usize, b: usize, c: bool) -> usize {
     if c {
         123
-    } else if a >= b {
-        b.saturating_sub(a)
-    } else {
-        b - a
-    }
+    } else { b.saturating_sub(a) }
 }

--- a/tests/ui/implicit_saturating_sub.rs
+++ b/tests/ui/implicit_saturating_sub.rs
@@ -269,7 +269,6 @@ fn main() {
     };
 }
 
-// https://github.com/rust-lang/rust-clippy/issues/13524
 fn regression_13524(a: usize, b: usize, c: bool) -> usize {
     if c {
         123

--- a/tests/ui/implicit_saturating_sub.stderr
+++ b/tests/ui/implicit_saturating_sub.stderr
@@ -186,10 +186,15 @@ LL | |     }
    | |_____^ help: try: `i_64 = i_64.saturating_sub(1);`
 
 error: manual arithmetic check found
-  --> tests/ui/implicit_saturating_sub.rs:277:9
+  --> tests/ui/implicit_saturating_sub.rs:275:12
    |
-LL |         0
-   |         ^ help: replace it with: `b.saturating_sub(a)`
+LL |       } else if a >= b {
+   |  ____________^
+LL | |         0
+LL | |     } else {
+LL | |         b - a
+LL | |     }
+   | |_____^ help: replace it with: `{ b.saturating_sub(a) }`
 
 error: aborting due to 24 previous errors
 

--- a/tests/ui/manual_arithmetic_check.fixed
+++ b/tests/ui/manual_arithmetic_check.fixed
@@ -6,14 +6,14 @@ fn main() {
     let b = 13u32;
     let c = 8u32;
 
-    let result = if a > b { a - b } else { a.saturating_sub(b) };
+    let result = a.saturating_sub(b);
     //~^ ERROR: manual arithmetic check found
-    let result = if b < a { a - b } else { a.saturating_sub(b) };
+    let result = a.saturating_sub(b);
     //~^ ERROR: manual arithmetic check found
 
-    let result = if a < b { a.saturating_sub(b) } else { a - b };
+    let result = a.saturating_sub(b);
     //~^ ERROR: manual arithmetic check found
-    let result = if b > a { a.saturating_sub(b) } else { a - b };
+    let result = a.saturating_sub(b);
     //~^ ERROR: manual arithmetic check found
 
     // Should not warn!

--- a/tests/ui/manual_arithmetic_check.stderr
+++ b/tests/ui/manual_arithmetic_check.stderr
@@ -1,29 +1,29 @@
 error: manual arithmetic check found
-  --> tests/ui/manual_arithmetic_check.rs:9:44
+  --> tests/ui/manual_arithmetic_check.rs:9:18
    |
 LL |     let result = if a > b { a - b } else { 0 };
-   |                                            ^ help: replace it with: `a.saturating_sub(b)`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `a.saturating_sub(b)`
    |
    = note: `-D clippy::implicit-saturating-sub` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::implicit_saturating_sub)]`
 
 error: manual arithmetic check found
-  --> tests/ui/manual_arithmetic_check.rs:11:44
+  --> tests/ui/manual_arithmetic_check.rs:11:18
    |
 LL |     let result = if b < a { a - b } else { 0 };
-   |                                            ^ help: replace it with: `a.saturating_sub(b)`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `a.saturating_sub(b)`
 
 error: manual arithmetic check found
-  --> tests/ui/manual_arithmetic_check.rs:14:29
+  --> tests/ui/manual_arithmetic_check.rs:14:18
    |
 LL |     let result = if a < b { 0 } else { a - b };
-   |                             ^ help: replace it with: `a.saturating_sub(b)`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `a.saturating_sub(b)`
 
 error: manual arithmetic check found
-  --> tests/ui/manual_arithmetic_check.rs:16:29
+  --> tests/ui/manual_arithmetic_check.rs:16:18
    |
 LL |     let result = if b > a { 0 } else { a - b };
-   |                             ^ help: replace it with: `a.saturating_sub(b)`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `a.saturating_sub(b)`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Related to #13533, such and obvious mistake got pass my watch, quite embarassing :/

Revert #13533 and implement a more robust solution.

Revert "Fix span issue on `implicit_saturating_sub`
This reverts commit 140a1275f24ab951ffb0daee568385049de153d5.

changelog: [`lint_name`]: Fix suggestion for `if {} else if {} else {}` cases

r? @y21