### PR TITLE
Add lint for 'toilet closures'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5976,6 +5976,7 @@ Released 2018-09-13
 [`to_string_in_format_args`]: https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args
 [`to_string_trait_impl`]: https://rust-lang.github.io/rust-clippy/master/index.html#to_string_trait_impl
 [`todo`]: https://rust-lang.github.io/rust-clippy/master/index.html#todo
+[`toilet_closures`]: https://rust-lang.github.io/rust-clippy/master/index.html#toilet_closures
 [`too_long_first_doc_paragraph`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
 [`too_many_arguments`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
 [`too_many_lines`]: https://rust-lang.github.io/rust-clippy/master/index.html#too_many_lines

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -692,6 +692,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::tests_outside_test_module::TESTS_OUTSIDE_TEST_MODULE_INFO,
     crate::to_digit_is_some::TO_DIGIT_IS_SOME_INFO,
     crate::to_string_trait_impl::TO_STRING_TRAIT_IMPL_INFO,
+    crate::toilet_closures::TOILET_CLOSURES_INFO,
     crate::trailing_empty_array::TRAILING_EMPTY_ARRAY_INFO,
     crate::trait_bounds::TRAIT_DUPLICATION_IN_BOUNDS_INFO,
     crate::trait_bounds::TYPE_REPETITION_IN_BOUNDS_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -352,6 +352,7 @@ mod temporary_assignment;
 mod tests_outside_test_module;
 mod to_digit_is_some;
 mod to_string_trait_impl;
+mod toilet_closures;
 mod trailing_empty_array;
 mod trait_bounds;
 mod transmute;
@@ -949,5 +950,6 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(|_| Box::new(non_zero_suggestions::NonZeroSuggestions));
     store.register_late_pass(move |_| Box::new(unused_trait_names::UnusedTraitNames::new(conf)));
     store.register_late_pass(|_| Box::new(manual_ignore_case_cmp::ManualIgnoreCaseCmp));
+    store.register_late_pass(|_| Box::new(toilet_closures::ToiletClosures));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -153,7 +153,9 @@ impl RetReplacement<'_> {
     fn applicability(&self) -> Applicability {
         match self {
             Self::Expr(_, ap) | Self::NeedsPar(_, ap) => *ap,
-            _ => Applicability::MachineApplicable,
+            Self::Empty | Self::Unit => Applicability::MachineApplicable,
+            // This should be MachineApplicable, but it can trigger `toilet_closures`.
+            Self::Block => Applicability::MaybeIncorrect,
         }
     }
 }

--- a/clippy_lints/src/toilet_closures.rs
+++ b/clippy_lints/src/toilet_closures.rs
@@ -1,0 +1,90 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::snippet_with_applicability;
+use rustc_errors::Applicability;
+use rustc_hir::{Block, Closure, ClosureKind, Expr, ExprKind, TyKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty;
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Detects a closure which takes one argument and returns unit.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// This is a less clear way to write `drop`.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// fn drop_ok<T, E>(result: Result<T, E>) -> Result<(), E> {
+    ///     result.map(|_| ())
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// fn drop_ok<T, E>(result: Result<T, E>) -> Result<(), E> {
+    ///     result.map(drop)
+    /// }
+    /// ```
+    #[clippy::version = "1.83.0"]
+    pub TOILET_CLOSURES,
+    style,
+    "checks for 'toilet closure' usage"
+}
+
+declare_lint_pass!(ToiletClosures => [TOILET_CLOSURES]);
+
+fn is_empty_expr(expr: &Expr<'_>) -> bool {
+    matches!(
+        expr.kind,
+        ExprKind::Tup([])
+            | ExprKind::Block(
+                Block {
+                    stmts: [],
+                    expr: None,
+                    ..
+                },
+                None,
+            )
+    )
+}
+
+impl<'tcx> LateLintPass<'tcx> for ToiletClosures {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &Expr<'tcx>) {
+        let ExprKind::Closure(Closure {
+            fn_decl,
+            body,
+            kind: ClosureKind::Closure,
+            ..
+        }) = expr.kind
+        else {
+            return;
+        };
+
+        // Check that the closure takes one argument
+        if let [arg_ty] = fn_decl.inputs
+            // and returns `()` or `{}`
+            && is_empty_expr(cx.tcx.hir().body(*body).value)
+            // and the closure is not higher ranked, which `drop` cannot replace
+            && let ty::Closure(_, generic_args) = cx.typeck_results().expr_ty(expr).kind()
+            && generic_args.as_closure().sig().bound_vars().is_empty()
+        {
+            let mut applicability = Applicability::MachineApplicable;
+            span_lint_and_sugg(
+                cx,
+                TOILET_CLOSURES,
+                expr.span,
+                "defined a 'toilet closure'",
+                "replace with",
+                if matches!(arg_ty.kind, TyKind::Infer) {
+                    String::from("drop")
+                } else {
+                    let arg_ty_snippet = snippet_with_applicability(cx, arg_ty.span, "...", &mut applicability);
+                    format!("drop::<{arg_ty_snippet}>",)
+                },
+                applicability,
+            );
+        }
+    }
+}

--- a/tests/ui/crashes/ice-11337.rs
+++ b/tests/ui/crashes/ice-11337.rs
@@ -1,4 +1,5 @@
 #![feature(trait_alias)]
+#![allow(clippy::toilet_closures)]
 
 trait Confusing<F> = Fn(i32) where F: Fn(u32);
 

--- a/tests/ui/explicit_auto_deref.fixed
+++ b/tests/ui/explicit_auto_deref.fixed
@@ -11,7 +11,8 @@
     clippy::too_many_arguments,
     clippy::borrow_deref_ref,
     clippy::let_unit_value,
-    clippy::needless_lifetimes
+    clippy::needless_lifetimes,
+    clippy::toilet_closures
 )]
 
 trait CallableStr {

--- a/tests/ui/explicit_auto_deref.rs
+++ b/tests/ui/explicit_auto_deref.rs
@@ -11,7 +11,8 @@
     clippy::too_many_arguments,
     clippy::borrow_deref_ref,
     clippy::let_unit_value,
-    clippy::needless_lifetimes
+    clippy::needless_lifetimes,
+    clippy::toilet_closures
 )]
 
 trait CallableStr {

--- a/tests/ui/explicit_auto_deref.stderr
+++ b/tests/ui/explicit_auto_deref.stderr
@@ -1,5 +1,5 @@
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:69:19
+  --> tests/ui/explicit_auto_deref.rs:70:19
    |
 LL |     let _: &str = &*s;
    |                   ^^^ help: try: `&s`
@@ -8,271 +8,271 @@ LL |     let _: &str = &*s;
    = help: to override `-D warnings` add `#[allow(clippy::explicit_auto_deref)]`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:70:19
+  --> tests/ui/explicit_auto_deref.rs:71:19
    |
 LL |     let _: &str = &*{ String::new() };
    |                   ^^^^^^^^^^^^^^^^^^^ help: try: `&{ String::new() }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:71:19
+  --> tests/ui/explicit_auto_deref.rs:72:19
    |
 LL |     let _: &str = &mut *{ String::new() };
    |                   ^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&mut { String::new() }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:75:11
+  --> tests/ui/explicit_auto_deref.rs:76:11
    |
 LL |     f_str(&*s);
    |           ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:79:13
+  --> tests/ui/explicit_auto_deref.rs:80:13
    |
 LL |     f_str_t(&*s, &*s); // Don't lint second param.
    |             ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:82:24
+  --> tests/ui/explicit_auto_deref.rs:83:24
    |
 LL |     let _: &Box<i32> = &**b;
    |                        ^^^^ help: try: `&b`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:88:7
+  --> tests/ui/explicit_auto_deref.rs:89:7
    |
 LL |     c(&*s);
    |       ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:94:9
+  --> tests/ui/explicit_auto_deref.rs:95:9
    |
 LL |         &**x
    |         ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:98:11
+  --> tests/ui/explicit_auto_deref.rs:99:11
    |
 LL |         { &**x }
    |           ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:102:9
+  --> tests/ui/explicit_auto_deref.rs:103:9
    |
 LL |         &**{ x }
    |         ^^^^^^^^ help: try: `{ x }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:106:9
+  --> tests/ui/explicit_auto_deref.rs:107:9
    |
 LL |         &***x
    |         ^^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:123:12
+  --> tests/ui/explicit_auto_deref.rs:124:12
    |
 LL |         f1(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:124:12
+  --> tests/ui/explicit_auto_deref.rs:125:12
    |
 LL |         f2(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:125:12
+  --> tests/ui/explicit_auto_deref.rs:126:12
    |
 LL |         f3(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:126:27
+  --> tests/ui/explicit_auto_deref.rs:127:27
    |
 LL |         f4.callable_str()(&*x);
    |                           ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:127:12
+  --> tests/ui/explicit_auto_deref.rs:128:12
    |
 LL |         f5(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:128:12
+  --> tests/ui/explicit_auto_deref.rs:129:12
    |
 LL |         f6(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:129:27
+  --> tests/ui/explicit_auto_deref.rs:130:27
    |
 LL |         f7.callable_str()(&*x);
    |                           ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:130:25
+  --> tests/ui/explicit_auto_deref.rs:131:25
    |
 LL |         f8.callable_t()(&*x);
    |                         ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:131:12
+  --> tests/ui/explicit_auto_deref.rs:132:12
    |
 LL |         f9(&*x);
    |            ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:132:13
+  --> tests/ui/explicit_auto_deref.rs:133:13
    |
 LL |         f10(&*x);
    |             ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:133:26
+  --> tests/ui/explicit_auto_deref.rs:134:26
    |
 LL |         f11.callable_t()(&*x);
    |                          ^^^ help: try: `&x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:137:16
+  --> tests/ui/explicit_auto_deref.rs:138:16
    |
 LL |     let _ = S1(&*s);
    |                ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:142:21
+  --> tests/ui/explicit_auto_deref.rs:143:21
    |
 LL |     let _ = S2 { s: &*s };
    |                     ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:158:30
+  --> tests/ui/explicit_auto_deref.rs:159:30
    |
 LL |             let _ = Self::S1(&**s);
    |                              ^^^^ help: try: `s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:159:35
+  --> tests/ui/explicit_auto_deref.rs:160:35
    |
 LL |             let _ = Self::S2 { s: &**s };
    |                                   ^^^^ help: try: `s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:162:20
+  --> tests/ui/explicit_auto_deref.rs:163:20
    |
 LL |     let _ = E1::S1(&*s);
    |                    ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:163:25
+  --> tests/ui/explicit_auto_deref.rs:164:25
    |
 LL |     let _ = E1::S2 { s: &*s };
    |                         ^^^ help: try: `&s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:181:13
+  --> tests/ui/explicit_auto_deref.rs:182:13
    |
 LL |     let _ = (*b).foo;
    |             ^^^^ help: try: `b`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:182:13
+  --> tests/ui/explicit_auto_deref.rs:183:13
    |
 LL |     let _ = (**b).foo;
    |             ^^^^^ help: try: `b`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:197:19
+  --> tests/ui/explicit_auto_deref.rs:198:19
    |
 LL |     let _ = f_str(*ref_str);
    |                   ^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:199:19
+  --> tests/ui/explicit_auto_deref.rs:200:19
    |
 LL |     let _ = f_str(**ref_ref_str);
    |                   ^^^^^^^^^^^^^ help: try: `ref_ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:209:12
+  --> tests/ui/explicit_auto_deref.rs:210:12
    |
 LL |     f_str(&&*ref_str); // `needless_borrow` will suggest removing both references
    |            ^^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:210:12
+  --> tests/ui/explicit_auto_deref.rs:211:12
    |
 LL |     f_str(&&**ref_str); // `needless_borrow` will suggest removing only one reference
    |            ^^^^^^^^^^ help: try: `ref_str`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:219:41
+  --> tests/ui/explicit_auto_deref.rs:220:41
    |
 LL |     let _ = || -> &'static str { return *s };
    |                                         ^^ help: try: `s`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:238:9
+  --> tests/ui/explicit_auto_deref.rs:239:9
    |
 LL |         &**x
    |         ^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:261:8
+  --> tests/ui/explicit_auto_deref.rs:262:8
    |
 LL |     c1(*x);
    |        ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:264:20
+  --> tests/ui/explicit_auto_deref.rs:265:20
    |
 LL |             return *x;
    |                    ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:266:9
+  --> tests/ui/explicit_auto_deref.rs:267:9
    |
 LL |         *x
    |         ^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:300:20
+  --> tests/ui/explicit_auto_deref.rs:301:20
    |
 LL |         Some(x) => &mut *x,
    |                    ^^^^^^^ help: try: `x`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:333:22
+  --> tests/ui/explicit_auto_deref.rs:334:22
    |
 LL |         let _ = &mut (*{ x.u }).x;
    |                      ^^^^^^^^^^ help: try: `{ x.u }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:339:22
+  --> tests/ui/explicit_auto_deref.rs:340:22
    |
 LL |         let _ = &mut (**x.u).x;
    |                      ^^^^^^^ help: try: `(*x.u)`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:340:22
+  --> tests/ui/explicit_auto_deref.rs:341:22
    |
 LL |         let _ = &mut (**{ x.u }).x;
    |                      ^^^^^^^^^^^ help: try: `{ x.u }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:344:22
+  --> tests/ui/explicit_auto_deref.rs:345:22
    |
 LL |         let _ = &mut (*x.u).x;
    |                      ^^^^^^ help: try: `x.u`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:345:22
+  --> tests/ui/explicit_auto_deref.rs:346:22
    |
 LL |         let _ = &mut (*{ x.u }).x;
    |                      ^^^^^^^^^^ help: try: `{ x.u }`
 
 error: deref which would be done by auto-deref
-  --> tests/ui/explicit_auto_deref.rs:368:13
+  --> tests/ui/explicit_auto_deref.rs:369:13
    |
 LL |         foo(&*wrapped_bar);
    |             ^^^^^^^^^^^^^ help: try: `&wrapped_bar`

--- a/tests/ui/large_futures.fixed
+++ b/tests/ui/large_futures.fixed
@@ -1,7 +1,10 @@
 #![warn(clippy::large_futures)]
-#![allow(clippy::never_loop)]
-#![allow(clippy::future_not_send)]
-#![allow(clippy::manual_async_fn)]
+#![allow(
+    clippy::never_loop,
+    clippy::future_not_send,
+    clippy::manual_async_fn,
+    clippy::toilet_closures
+)]
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 

--- a/tests/ui/large_futures.rs
+++ b/tests/ui/large_futures.rs
@@ -1,7 +1,10 @@
 #![warn(clippy::large_futures)]
-#![allow(clippy::never_loop)]
-#![allow(clippy::future_not_send)]
-#![allow(clippy::manual_async_fn)]
+#![allow(
+    clippy::never_loop,
+    clippy::future_not_send,
+    clippy::manual_async_fn,
+    clippy::toilet_closures
+)]
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 

--- a/tests/ui/large_futures.stderr
+++ b/tests/ui/large_futures.stderr
@@ -1,5 +1,5 @@
 error: large future with a size of 16385 bytes
-  --> tests/ui/large_futures.rs:10:9
+  --> tests/ui/large_futures.rs:13:9
    |
 LL |         big_fut([0u8; 1024 * 16]).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(big_fut([0u8; 1024 * 16]))`
@@ -8,37 +8,37 @@ LL |         big_fut([0u8; 1024 * 16]).await;
    = help: to override `-D warnings` add `#[allow(clippy::large_futures)]`
 
 error: large future with a size of 16386 bytes
-  --> tests/ui/large_futures.rs:14:5
+  --> tests/ui/large_futures.rs:17:5
    |
 LL |     f.await
    |     ^ help: consider `Box::pin` on it: `Box::pin(f)`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:19:9
+  --> tests/ui/large_futures.rs:22:9
    |
 LL |         wait().await;
    |         ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:24:13
+  --> tests/ui/large_futures.rs:27:13
    |
 LL |             wait().await;
    |             ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:32:5
+  --> tests/ui/large_futures.rs:35:5
    |
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
 error: large future with a size of 49159 bytes
-  --> tests/ui/large_futures.rs:34:5
+  --> tests/ui/large_futures.rs:37:5
    |
 LL |     calls_fut(fut).await;
    |     ^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(calls_fut(fut))`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:47:5
+  --> tests/ui/large_futures.rs:50:5
    |
 LL | /     async {
 LL | |
@@ -59,7 +59,7 @@ LL +     })
    |
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:59:13
+  --> tests/ui/large_futures.rs:62:13
    |
 LL | /             async {
 LL | |                 let x = [0i32; 1024 * 16];

--- a/tests/ui/let_underscore_must_use.rs
+++ b/tests/ui/let_underscore_must_use.rs
@@ -96,7 +96,7 @@ fn main() {
     let _ = a.is_ok();
     //~^ ERROR: non-binding `let` on a result of a `#[must_use]` function
 
-    let _ = a.map(|_| ());
+    let _ = a.map(drop);
     //~^ ERROR: non-binding `let` on an expression with `#[must_use]` type
 
     let _ = a;

--- a/tests/ui/let_underscore_must_use.stderr
+++ b/tests/ui/let_underscore_must_use.stderr
@@ -83,8 +83,8 @@ LL |     let _ = a.is_ok();
 error: non-binding `let` on an expression with `#[must_use]` type
   --> tests/ui/let_underscore_must_use.rs:99:5
    |
-LL |     let _ = a.map(|_| ());
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = a.map(drop);
+   |     ^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider explicitly using expression value
 

--- a/tests/ui/let_unit.rs
+++ b/tests/ui/let_unit.rs
@@ -62,7 +62,7 @@ fn multiline_sugg() {
         .into_iter()
         .map(|i| i * 2)
         .filter(|i| i % 2 == 0)
-        .map(|_| ())
+        .map(drop)
         .next()
         .unwrap();
 }

--- a/tests/ui/let_unit.stderr
+++ b/tests/ui/let_unit.stderr
@@ -14,7 +14,7 @@ LL | /     let _ = v
 LL | |         .into_iter()
 LL | |         .map(|i| i * 2)
 LL | |         .filter(|i| i % 2 == 0)
-LL | |         .map(|_| ())
+LL | |         .map(drop)
 LL | |         .next()
 LL | |         .unwrap();
    | |__________________^
@@ -25,7 +25,7 @@ LL ~     v
 LL +         .into_iter()
 LL +         .map(|i| i * 2)
 LL +         .filter(|i| i % 2 == 0)
-LL +         .map(|_| ())
+LL +         .map(drop)
 LL +         .next()
 LL +         .unwrap();
    |

--- a/tests/ui/lines_filter_map_ok.fixed
+++ b/tests/ui/lines_filter_map_ok.fixed
@@ -6,28 +6,28 @@ use std::io::{self, BufRead, BufReader};
 fn main() -> io::Result<()> {
     let f = std::fs::File::open("/")?;
     // Lint
-    BufReader::new(f).lines().map_while(Result::ok).for_each(|_| ());
+    BufReader::new(f).lines().map_while(Result::ok).for_each(drop);
     // Lint
     let f = std::fs::File::open("/")?;
-    BufReader::new(f).lines().map_while(Result::ok).for_each(|_| ());
+    BufReader::new(f).lines().map_while(Result::ok).for_each(drop);
     // Lint
     let f = std::fs::File::open("/")?;
-    BufReader::new(f).lines().map_while(Result::ok).for_each(|_| ());
+    BufReader::new(f).lines().map_while(Result::ok).for_each(drop);
 
     let s = "foo\nbar\nbaz\n";
     // Lint
-    io::stdin().lines().map_while(Result::ok).for_each(|_| ());
+    io::stdin().lines().map_while(Result::ok).for_each(drop);
     // Lint
-    io::stdin().lines().map_while(Result::ok).for_each(|_| ());
+    io::stdin().lines().map_while(Result::ok).for_each(drop);
     // Lint
-    io::stdin().lines().map_while(Result::ok).for_each(|_| ());
+    io::stdin().lines().map_while(Result::ok).for_each(drop);
     // Do not lint (not a `Lines` iterator)
     io::stdin()
         .lines()
         .map(std::convert::identity)
         .filter_map(|x| x.ok())
-        .for_each(|_| ());
+        .for_each(drop);
     // Do not lint (not a `Result::ok()` extractor)
-    io::stdin().lines().filter_map(|x| x.err()).for_each(|_| ());
+    io::stdin().lines().filter_map(|x| x.err()).for_each(drop);
     Ok(())
 }

--- a/tests/ui/lines_filter_map_ok.rs
+++ b/tests/ui/lines_filter_map_ok.rs
@@ -6,28 +6,28 @@ use std::io::{self, BufRead, BufReader};
 fn main() -> io::Result<()> {
     let f = std::fs::File::open("/")?;
     // Lint
-    BufReader::new(f).lines().filter_map(Result::ok).for_each(|_| ());
+    BufReader::new(f).lines().filter_map(Result::ok).for_each(drop);
     // Lint
     let f = std::fs::File::open("/")?;
-    BufReader::new(f).lines().flat_map(Result::ok).for_each(|_| ());
+    BufReader::new(f).lines().flat_map(Result::ok).for_each(drop);
     // Lint
     let f = std::fs::File::open("/")?;
-    BufReader::new(f).lines().flatten().for_each(|_| ());
+    BufReader::new(f).lines().flatten().for_each(drop);
 
     let s = "foo\nbar\nbaz\n";
     // Lint
-    io::stdin().lines().filter_map(Result::ok).for_each(|_| ());
+    io::stdin().lines().filter_map(Result::ok).for_each(drop);
     // Lint
-    io::stdin().lines().filter_map(|x| x.ok()).for_each(|_| ());
+    io::stdin().lines().filter_map(|x| x.ok()).for_each(drop);
     // Lint
-    io::stdin().lines().flatten().for_each(|_| ());
+    io::stdin().lines().flatten().for_each(drop);
     // Do not lint (not a `Lines` iterator)
     io::stdin()
         .lines()
         .map(std::convert::identity)
         .filter_map(|x| x.ok())
-        .for_each(|_| ());
+        .for_each(drop);
     // Do not lint (not a `Result::ok()` extractor)
-    io::stdin().lines().filter_map(|x| x.err()).for_each(|_| ());
+    io::stdin().lines().filter_map(|x| x.err()).for_each(drop);
     Ok(())
 }

--- a/tests/ui/lines_filter_map_ok.stderr
+++ b/tests/ui/lines_filter_map_ok.stderr
@@ -1,13 +1,13 @@
 error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
   --> tests/ui/lines_filter_map_ok.rs:9:31
    |
-LL |     BufReader::new(f).lines().filter_map(Result::ok).for_each(|_| ());
+LL |     BufReader::new(f).lines().filter_map(Result::ok).for_each(drop);
    |                               ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> tests/ui/lines_filter_map_ok.rs:9:5
    |
-LL |     BufReader::new(f).lines().filter_map(Result::ok).for_each(|_| ());
+LL |     BufReader::new(f).lines().filter_map(Result::ok).for_each(drop);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: `-D clippy::lines-filter-map-ok` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::lines_filter_map_ok)]`
@@ -15,61 +15,61 @@ LL |     BufReader::new(f).lines().filter_map(Result::ok).for_each(|_| ());
 error: `flat_map()` will run forever if the iterator repeatedly produces an `Err`
   --> tests/ui/lines_filter_map_ok.rs:12:31
    |
-LL |     BufReader::new(f).lines().flat_map(Result::ok).for_each(|_| ());
+LL |     BufReader::new(f).lines().flat_map(Result::ok).for_each(drop);
    |                               ^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> tests/ui/lines_filter_map_ok.rs:12:5
    |
-LL |     BufReader::new(f).lines().flat_map(Result::ok).for_each(|_| ());
+LL |     BufReader::new(f).lines().flat_map(Result::ok).for_each(drop);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `flatten()` will run forever if the iterator repeatedly produces an `Err`
   --> tests/ui/lines_filter_map_ok.rs:15:31
    |
-LL |     BufReader::new(f).lines().flatten().for_each(|_| ());
+LL |     BufReader::new(f).lines().flatten().for_each(drop);
    |                               ^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> tests/ui/lines_filter_map_ok.rs:15:5
    |
-LL |     BufReader::new(f).lines().flatten().for_each(|_| ());
+LL |     BufReader::new(f).lines().flatten().for_each(drop);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
   --> tests/ui/lines_filter_map_ok.rs:19:25
    |
-LL |     io::stdin().lines().filter_map(Result::ok).for_each(|_| ());
+LL |     io::stdin().lines().filter_map(Result::ok).for_each(drop);
    |                         ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> tests/ui/lines_filter_map_ok.rs:19:5
    |
-LL |     io::stdin().lines().filter_map(Result::ok).for_each(|_| ());
+LL |     io::stdin().lines().filter_map(Result::ok).for_each(drop);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: `filter_map()` will run forever if the iterator repeatedly produces an `Err`
   --> tests/ui/lines_filter_map_ok.rs:21:25
    |
-LL |     io::stdin().lines().filter_map(|x| x.ok()).for_each(|_| ());
+LL |     io::stdin().lines().filter_map(|x| x.ok()).for_each(drop);
    |                         ^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> tests/ui/lines_filter_map_ok.rs:21:5
    |
-LL |     io::stdin().lines().filter_map(|x| x.ok()).for_each(|_| ());
+LL |     io::stdin().lines().filter_map(|x| x.ok()).for_each(drop);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: `flatten()` will run forever if the iterator repeatedly produces an `Err`
   --> tests/ui/lines_filter_map_ok.rs:23:25
    |
-LL |     io::stdin().lines().flatten().for_each(|_| ());
+LL |     io::stdin().lines().flatten().for_each(drop);
    |                         ^^^^^^^^^ help: replace with: `map_while(Result::ok)`
    |
 note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> tests/ui/lines_filter_map_ok.rs:23:5
    |
-LL |     io::stdin().lines().flatten().for_each(|_| ());
+LL |     io::stdin().lines().flatten().for_each(drop);
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors

--- a/tests/ui/manual_let_else_match.fixed
+++ b/tests/ui/manual_let_else_match.fixed
@@ -49,7 +49,7 @@ fn fire() {
     let Ok(v) = f() else { return };
 
     // Err(()) is an allowed pattern
-    let Ok(v) = f().map_err(|_| ()) else { return };
+    let Ok(v) = f().map_err(std::mem::drop) else { return };
 
     let f = Variant::Bar(1);
 

--- a/tests/ui/manual_let_else_match.rs
+++ b/tests/ui/manual_let_else_match.rs
@@ -70,7 +70,7 @@ fn fire() {
     };
 
     // Err(()) is an allowed pattern
-    let v = match f().map_err(|_| ()) {
+    let v = match f().map_err(std::mem::drop) {
         //~^ ERROR: this could be rewritten as `let...else`
         Ok(v) => v,
         Err(()) => return,

--- a/tests/ui/manual_let_else_match.stderr
+++ b/tests/ui/manual_let_else_match.stderr
@@ -55,12 +55,12 @@ LL | |     };
 error: this could be rewritten as `let...else`
   --> tests/ui/manual_let_else_match.rs:73:5
    |
-LL | /     let v = match f().map_err(|_| ()) {
+LL | /     let v = match f().map_err(std::mem::drop) {
 LL | |
 LL | |         Ok(v) => v,
 LL | |         Err(()) => return,
 LL | |     };
-   | |______^ help: consider writing: `let Ok(v) = f().map_err(|_| ()) else { return };`
+   | |______^ help: consider writing: `let Ok(v) = f().map_err(std::mem::drop) else { return };`
 
 error: this could be rewritten as `let...else`
   --> tests/ui/manual_let_else_match.rs:81:5

--- a/tests/ui/needless_lifetimes.fixed
+++ b/tests/ui/needless_lifetimes.fixed
@@ -8,7 +8,8 @@
     clippy::needless_pass_by_value,
     clippy::unnecessary_wraps,
     dyn_drop,
-    clippy::get_first
+    clippy::get_first,
+    clippy::toilet_closures
 )]
 
 extern crate proc_macros;

--- a/tests/ui/needless_lifetimes.rs
+++ b/tests/ui/needless_lifetimes.rs
@@ -8,7 +8,8 @@
     clippy::needless_pass_by_value,
     clippy::unnecessary_wraps,
     dyn_drop,
-    clippy::get_first
+    clippy::get_first,
+    clippy::toilet_closures
 )]
 
 extern crate proc_macros;

--- a/tests/ui/needless_lifetimes.stderr
+++ b/tests/ui/needless_lifetimes.stderr
@@ -1,5 +1,5 @@
 error: elided lifetime has a name
-  --> tests/ui/needless_lifetimes.rs:266:52
+  --> tests/ui/needless_lifetimes.rs:267:52
    |
 LL | fn named_input_elided_output<'a>(_arg: &'a str) -> &str {
    |                              --                    ^ this elided lifetime gets resolved as `'a`
@@ -10,7 +10,7 @@ LL | fn named_input_elided_output<'a>(_arg: &'a str) -> &str {
    = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
 
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/needless_lifetimes.rs:17:23
+  --> tests/ui/needless_lifetimes.rs:18:23
    |
 LL | fn distinct_lifetimes<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: u8) {}
    |                       ^^  ^^       ^^          ^^
@@ -24,7 +24,7 @@ LL + fn distinct_lifetimes(_x: &u8, _y: &u8, _z: u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/needless_lifetimes.rs:19:24
+  --> tests/ui/needless_lifetimes.rs:20:24
    |
 LL | fn distinct_and_static<'a, 'b>(_x: &'a u8, _y: &'b u8, _z: &'static u8) {}
    |                        ^^  ^^       ^^          ^^
@@ -36,7 +36,7 @@ LL + fn distinct_and_static(_x: &u8, _y: &u8, _z: &'static u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:29:15
+  --> tests/ui/needless_lifetimes.rs:30:15
    |
 LL | fn in_and_out<'a>(x: &'a u8, _y: u8) -> &'a u8 {
    |               ^^      ^^                 ^^
@@ -48,7 +48,7 @@ LL + fn in_and_out(x: &u8, _y: u8) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:41:31
+  --> tests/ui/needless_lifetimes.rs:42:31
    |
 LL | fn multiple_in_and_out_2a<'a, 'b>(x: &'a u8, _y: &'b u8) -> &'a u8 {
    |                               ^^                  ^^
@@ -60,7 +60,7 @@ LL + fn multiple_in_and_out_2a<'a>(x: &'a u8, _y: &u8) -> &'a u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:48:27
+  --> tests/ui/needless_lifetimes.rs:49:27
    |
 LL | fn multiple_in_and_out_2b<'a, 'b>(_x: &'a u8, y: &'b u8) -> &'b u8 {
    |                           ^^           ^^
@@ -72,7 +72,7 @@ LL + fn multiple_in_and_out_2b<'b>(_x: &u8, y: &'b u8) -> &'b u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:65:26
+  --> tests/ui/needless_lifetimes.rs:66:26
    |
 LL | fn deep_reference_1a<'a, 'b>(x: &'a u8, _y: &'b u8) -> Result<&'a u8, ()> {
    |                          ^^                  ^^
@@ -84,7 +84,7 @@ LL + fn deep_reference_1a<'a>(x: &'a u8, _y: &u8) -> Result<&'a u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:72:22
+  --> tests/ui/needless_lifetimes.rs:73:22
    |
 LL | fn deep_reference_1b<'a, 'b>(_x: &'a u8, y: &'b u8) -> Result<&'b u8, ()> {
    |                      ^^           ^^
@@ -96,7 +96,7 @@ LL + fn deep_reference_1b<'b>(_x: &u8, y: &'b u8) -> Result<&'b u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:81:21
+  --> tests/ui/needless_lifetimes.rs:82:21
    |
 LL | fn deep_reference_3<'a>(x: &'a u8, _y: u8) -> Result<&'a u8, ()> {
    |                     ^^      ^^                        ^^
@@ -108,7 +108,7 @@ LL + fn deep_reference_3(x: &u8, _y: u8) -> Result<&u8, ()> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:86:28
+  --> tests/ui/needless_lifetimes.rs:87:28
    |
 LL | fn where_clause_without_lt<'a, T>(x: &'a u8, _y: u8) -> Result<&'a u8, ()>
    |                            ^^         ^^                        ^^
@@ -120,7 +120,7 @@ LL + fn where_clause_without_lt<T>(x: &u8, _y: u8) -> Result<&u8, ()>
    |
 
 error: the following explicit lifetimes could be elided: 'a, 'b
-  --> tests/ui/needless_lifetimes.rs:98:21
+  --> tests/ui/needless_lifetimes.rs:99:21
    |
 LL | fn lifetime_param_2<'a, 'b>(_x: Ref<'a>, _y: &'b u8) {}
    |                     ^^  ^^          ^^        ^^
@@ -132,7 +132,7 @@ LL + fn lifetime_param_2(_x: Ref<'_>, _y: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:122:15
+  --> tests/ui/needless_lifetimes.rs:123:15
    |
 LL | fn fn_bound_2<'a, F, I>(_m: Lt<'a, I>, _f: F) -> Lt<'a, I>
    |               ^^               ^^                   ^^
@@ -144,7 +144,7 @@ LL + fn fn_bound_2<F, I>(_m: Lt<'_, I>, _f: F) -> Lt<'_, I>
    |
 
 error: the following explicit lifetimes could be elided: 's
-  --> tests/ui/needless_lifetimes.rs:152:21
+  --> tests/ui/needless_lifetimes.rs:153:21
    |
 LL |     fn self_and_out<'s>(&'s self) -> &'s u8 {
    |                     ^^   ^^           ^^
@@ -156,7 +156,7 @@ LL +     fn self_and_out(&self) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 't
-  --> tests/ui/needless_lifetimes.rs:159:30
+  --> tests/ui/needless_lifetimes.rs:160:30
    |
 LL |     fn self_and_in_out_1<'s, 't>(&'s self, _x: &'t u8) -> &'s u8 {
    |                              ^^                 ^^
@@ -168,7 +168,7 @@ LL +     fn self_and_in_out_1<'s>(&'s self, _x: &u8) -> &'s u8 {
    |
 
 error: the following explicit lifetimes could be elided: 's
-  --> tests/ui/needless_lifetimes.rs:166:26
+  --> tests/ui/needless_lifetimes.rs:167:26
    |
 LL |     fn self_and_in_out_2<'s, 't>(&'s self, x: &'t u8) -> &'t u8 {
    |                          ^^       ^^
@@ -180,7 +180,7 @@ LL +     fn self_and_in_out_2<'t>(&self, x: &'t u8) -> &'t u8 {
    |
 
 error: the following explicit lifetimes could be elided: 's, 't
-  --> tests/ui/needless_lifetimes.rs:170:29
+  --> tests/ui/needless_lifetimes.rs:171:29
    |
 LL |     fn distinct_self_and_in<'s, 't>(&'s self, _x: &'t u8) {}
    |                             ^^  ^^   ^^            ^^
@@ -192,7 +192,7 @@ LL +     fn distinct_self_and_in(&self, _x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:189:19
+  --> tests/ui/needless_lifetimes.rs:190:19
    |
 LL | fn struct_with_lt<'a>(_foo: Foo<'a>) -> &'a str {
    |                   ^^            ^^       ^^
@@ -204,7 +204,7 @@ LL + fn struct_with_lt(_foo: Foo<'_>) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:207:25
+  --> tests/ui/needless_lifetimes.rs:208:25
    |
 LL | fn struct_with_lt4a<'a, 'b>(_foo: &'a Foo<'b>) -> &'a str {
    |                         ^^                ^^
@@ -216,7 +216,7 @@ LL + fn struct_with_lt4a<'a>(_foo: &'a Foo<'_>) -> &'a str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:215:21
+  --> tests/ui/needless_lifetimes.rs:216:21
    |
 LL | fn struct_with_lt4b<'a, 'b>(_foo: &'a Foo<'b>) -> &'b str {
    |                     ^^             ^^
@@ -228,7 +228,7 @@ LL + fn struct_with_lt4b<'b>(_foo: &Foo<'b>) -> &'b str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:230:22
+  --> tests/ui/needless_lifetimes.rs:231:22
    |
 LL | fn trait_obj_elided2<'a>(_arg: &'a dyn Drop) -> &'a str {
    |                      ^^         ^^               ^^
@@ -240,7 +240,7 @@ LL + fn trait_obj_elided2(_arg: &dyn Drop) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:236:18
+  --> tests/ui/needless_lifetimes.rs:237:18
    |
 LL | fn alias_with_lt<'a>(_foo: FooAlias<'a>) -> &'a str {
    |                  ^^                 ^^       ^^
@@ -252,7 +252,7 @@ LL + fn alias_with_lt(_foo: FooAlias<'_>) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'b
-  --> tests/ui/needless_lifetimes.rs:254:24
+  --> tests/ui/needless_lifetimes.rs:255:24
    |
 LL | fn alias_with_lt4a<'a, 'b>(_foo: &'a FooAlias<'b>) -> &'a str {
    |                        ^^                     ^^
@@ -264,7 +264,7 @@ LL + fn alias_with_lt4a<'a>(_foo: &'a FooAlias<'_>) -> &'a str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:262:20
+  --> tests/ui/needless_lifetimes.rs:263:20
    |
 LL | fn alias_with_lt4b<'a, 'b>(_foo: &'a FooAlias<'b>) -> &'b str {
    |                    ^^             ^^
@@ -276,7 +276,7 @@ LL + fn alias_with_lt4b<'b>(_foo: &FooAlias<'b>) -> &'b str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:266:30
+  --> tests/ui/needless_lifetimes.rs:267:30
    |
 LL | fn named_input_elided_output<'a>(_arg: &'a str) -> &str {
    |                              ^^         ^^          ^
@@ -288,7 +288,7 @@ LL + fn named_input_elided_output(_arg: &str) -> &str {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:274:19
+  --> tests/ui/needless_lifetimes.rs:275:19
    |
 LL | fn trait_bound_ok<'a, T: WithLifetime<'static>>(_: &'a u8, _: T) {
    |                   ^^                                ^^
@@ -300,7 +300,7 @@ LL + fn trait_bound_ok<T: WithLifetime<'static>>(_: &u8, _: T) {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:310:24
+  --> tests/ui/needless_lifetimes.rs:311:24
    |
 LL | fn out_return_type_lts<'a>(e: &'a str) -> Cow<'a> {
    |                        ^^      ^^             ^^
@@ -312,7 +312,7 @@ LL + fn out_return_type_lts(e: &str) -> Cow<'_> {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:317:24
+  --> tests/ui/needless_lifetimes.rs:318:24
    |
 LL |         fn needless_lt<'a>(x: &'a u8) {}
    |                        ^^      ^^
@@ -324,7 +324,7 @@ LL +         fn needless_lt(x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:321:24
+  --> tests/ui/needless_lifetimes.rs:322:24
    |
 LL |         fn needless_lt<'a>(_x: &'a u8) {}
    |                        ^^       ^^
@@ -336,7 +336,7 @@ LL +         fn needless_lt(_x: &u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:332:10
+  --> tests/ui/needless_lifetimes.rs:333:10
    |
 LL |     impl<'a> Foo for Baz<'a> {}
    |          ^^              ^^
@@ -348,7 +348,7 @@ LL +     impl Foo for Baz<'_> {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:334:16
+  --> tests/ui/needless_lifetimes.rs:335:16
    |
 LL |         fn baz<'a>(&'a self) -> impl Foo + 'a {
    |                ^^   ^^                     ^^
@@ -360,7 +360,7 @@ LL +         fn baz(&self) -> impl Foo + '_ {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:366:55
+  --> tests/ui/needless_lifetimes.rs:367:55
    |
 LL |     fn impl_trait_elidable_nested_anonymous_lifetimes<'a>(i: &'a i32, f: impl Fn(&i32) -> &i32) -> &'a i32 {
    |                                                       ^^      ^^                                    ^^
@@ -372,7 +372,7 @@ LL +     fn impl_trait_elidable_nested_anonymous_lifetimes(i: &i32, f: impl Fn(&
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:375:26
+  --> tests/ui/needless_lifetimes.rs:376:26
    |
 LL |     fn generics_elidable<'a, T: Fn(&i32) -> &i32>(i: &'a i32, f: T) -> &'a i32 {
    |                          ^^                           ^^                ^^
@@ -384,7 +384,7 @@ LL +     fn generics_elidable<T: Fn(&i32) -> &i32>(i: &i32, f: T) -> &i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:387:30
+  --> tests/ui/needless_lifetimes.rs:388:30
    |
 LL |     fn where_clause_elidable<'a, T>(i: &'a i32, f: T) -> &'a i32
    |                              ^^         ^^                ^^
@@ -396,7 +396,7 @@ LL +     fn where_clause_elidable<T>(i: &i32, f: T) -> &i32
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:402:28
+  --> tests/ui/needless_lifetimes.rs:403:28
    |
 LL |     fn pointer_fn_elidable<'a>(i: &'a i32, f: fn(&i32) -> &i32) -> &'a i32 {
    |                            ^^      ^^                               ^^
@@ -408,7 +408,7 @@ LL +     fn pointer_fn_elidable(i: &i32, f: fn(&i32) -> &i32) -> &i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:415:28
+  --> tests/ui/needless_lifetimes.rs:416:28
    |
 LL |     fn nested_fn_pointer_3<'a>(_: &'a i32) -> fn(fn(&i32) -> &i32) -> i32 {
    |                            ^^      ^^
@@ -420,7 +420,7 @@ LL +     fn nested_fn_pointer_3(_: &i32) -> fn(fn(&i32) -> &i32) -> i32 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:418:28
+  --> tests/ui/needless_lifetimes.rs:419:28
    |
 LL |     fn nested_fn_pointer_4<'a>(_: &'a i32) -> impl Fn(fn(&i32)) {
    |                            ^^      ^^
@@ -432,7 +432,7 @@ LL +     fn nested_fn_pointer_4(_: &i32) -> impl Fn(fn(&i32)) {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:440:21
+  --> tests/ui/needless_lifetimes.rs:441:21
    |
 LL |         fn implicit<'a>(&'a self) -> &'a () {
    |                     ^^   ^^           ^^
@@ -444,7 +444,7 @@ LL +         fn implicit(&self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:443:25
+  --> tests/ui/needless_lifetimes.rs:444:25
    |
 LL |         fn implicit_mut<'a>(&'a mut self) -> &'a () {
    |                         ^^   ^^               ^^
@@ -456,7 +456,7 @@ LL +         fn implicit_mut(&mut self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:454:31
+  --> tests/ui/needless_lifetimes.rs:455:31
    |
 LL |         fn lifetime_elsewhere<'a>(self: Box<Self>, here: &'a ()) -> &'a () {
    |                               ^^                          ^^         ^^
@@ -468,7 +468,7 @@ LL +         fn lifetime_elsewhere(self: Box<Self>, here: &()) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:460:21
+  --> tests/ui/needless_lifetimes.rs:461:21
    |
 LL |         fn implicit<'a>(&'a self) -> &'a ();
    |                     ^^   ^^           ^^
@@ -480,7 +480,7 @@ LL +         fn implicit(&self) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:461:30
+  --> tests/ui/needless_lifetimes.rs:462:30
    |
 LL |         fn implicit_provided<'a>(&'a self) -> &'a () {
    |                              ^^   ^^           ^^
@@ -492,7 +492,7 @@ LL +         fn implicit_provided(&self) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:470:31
+  --> tests/ui/needless_lifetimes.rs:471:31
    |
 LL |         fn lifetime_elsewhere<'a>(self: Box<Self>, here: &'a ()) -> &'a ();
    |                               ^^                          ^^         ^^
@@ -504,7 +504,7 @@ LL +         fn lifetime_elsewhere(self: Box<Self>, here: &()) -> &();
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:471:40
+  --> tests/ui/needless_lifetimes.rs:472:40
    |
 LL |         fn lifetime_elsewhere_provided<'a>(self: Box<Self>, here: &'a ()) -> &'a () {
    |                                        ^^                          ^^         ^^
@@ -516,7 +516,7 @@ LL +         fn lifetime_elsewhere_provided(self: Box<Self>, here: &()) -> &() {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:480:12
+  --> tests/ui/needless_lifetimes.rs:481:12
    |
 LL |     fn foo<'a>(x: &'a u8, y: &'_ u8) {}
    |            ^^      ^^
@@ -528,7 +528,7 @@ LL +     fn foo(x: &u8, y: &'_ u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:482:12
+  --> tests/ui/needless_lifetimes.rs:483:12
    |
 LL |     fn bar<'a>(x: &'a u8, y: &'_ u8, z: &'_ u8) {}
    |            ^^      ^^
@@ -540,7 +540,7 @@ LL +     fn bar(x: &u8, y: &'_ u8, z: &'_ u8) {}
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:489:18
+  --> tests/ui/needless_lifetimes.rs:490:18
    |
 LL |     fn one_input<'a>(x: &'a u8) -> &'a u8 {
    |                  ^^      ^^         ^^
@@ -552,7 +552,7 @@ LL +     fn one_input(x: &u8) -> &u8 {
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:494:42
+  --> tests/ui/needless_lifetimes.rs:495:42
    |
 LL |     fn multiple_inputs_output_not_elided<'a, 'b>(x: &'a u8, y: &'b u8, z: &'b u8) -> &'b u8 {
    |                                          ^^          ^^
@@ -564,7 +564,7 @@ LL +     fn multiple_inputs_output_not_elided<'b>(x: &u8, y: &'b u8, z: &'b u8) 
    |
 
 error: the following explicit lifetimes could be elided: 'a
-  --> tests/ui/needless_lifetimes.rs:510:22
+  --> tests/ui/needless_lifetimes.rs:511:22
    |
 LL |         fn one_input<'a>(x: &'a u8) -> &'a u8 {
    |                      ^^      ^^         ^^

--- a/tests/ui/needless_return.fixed
+++ b/tests/ui/needless_return.fixed
@@ -128,7 +128,7 @@ fn test_return_in_macro() {
 }
 
 mod issue6501 {
-    #[allow(clippy::unnecessary_lazy_evaluations)]
+    #[allow(clippy::unnecessary_lazy_evaluations, clippy::toilet_closures)]
     fn foo(bar: Result<(), ()>) {
         bar.unwrap_or_else(|_| {})
     }

--- a/tests/ui/needless_return.rs
+++ b/tests/ui/needless_return.rs
@@ -132,7 +132,7 @@ fn test_return_in_macro() {
 }
 
 mod issue6501 {
-    #[allow(clippy::unnecessary_lazy_evaluations)]
+    #[allow(clippy::unnecessary_lazy_evaluations, clippy::toilet_closures)]
     fn foo(bar: Result<(), ()>) {
         bar.unwrap_or_else(|_| return)
     }

--- a/tests/ui/redundant_allocation.rs
+++ b/tests/ui/redundant_allocation.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::all)]
-#![allow(clippy::boxed_local, clippy::disallowed_names)]
+#![allow(clippy::boxed_local, clippy::disallowed_names, clippy::toilet_closures)]
 
 pub struct MyStruct;
 

--- a/tests/ui/ref_option/ref_option.all.fixed
+++ b/tests/ui/ref_option/ref_option.all.fixed
@@ -2,7 +2,7 @@
 //@[private] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/private
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/all
 
-#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box)]
+#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box, clippy::toilet_closures)]
 #![warn(clippy::ref_option)]
 
 fn opt_u8(a: Option<&u8>) {}

--- a/tests/ui/ref_option/ref_option.private.fixed
+++ b/tests/ui/ref_option/ref_option.private.fixed
@@ -2,7 +2,7 @@
 //@[private] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/private
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/all
 
-#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box)]
+#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box, clippy::toilet_closures)]
 #![warn(clippy::ref_option)]
 
 fn opt_u8(a: Option<&u8>) {}

--- a/tests/ui/ref_option/ref_option.rs
+++ b/tests/ui/ref_option/ref_option.rs
@@ -2,7 +2,7 @@
 //@[private] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/private
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/all
 
-#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box)]
+#![allow(unused, clippy::needless_lifetimes, clippy::borrowed_box, clippy::toilet_closures)]
 #![warn(clippy::ref_option)]
 
 fn opt_u8(a: &Option<u8>) {}

--- a/tests/ui/suspicious_map.rs
+++ b/tests/ui/suspicious_map.rs
@@ -19,11 +19,7 @@ fn negative() {
     let _ = (0..3).map(ext_closure).count();
 
     // closure that returns unit
-    let _ = (0..3)
-        .map(|x| {
-            // do nothing
-        })
-        .count();
+    let _ = (0..3).map(std::mem::drop).count();
 
     // external function
     let _ = (0..3).map(do_something).count();

--- a/tests/ui/toilet_closures.fixed
+++ b/tests/ui/toilet_closures.fixed
@@ -1,0 +1,18 @@
+#![warn(clippy::toilet_closures)]
+
+fn main() {
+    // Should lint
+    let toliet: fn(u8) = drop;
+    //~^ error: defined a 'toilet closure'
+    let toliet_with_arg: fn(u8) = drop;
+    //~^ error: defined a 'toilet closure'
+    let toliet_with_typed_arg: fn(u8) = drop::<u8>;
+    //~^ error: defined a 'toilet closure'
+    let toliet_with_braces: fn(u8) = drop;
+    //~^ error: defined a 'toilet closure'
+
+    // Should not lint
+    let toilet_higher_ranked: fn(&u8) = |_| ();
+    let closure_multi_arg: fn(u8, u8) = |_, _| ();
+    let closure_does_stuff: fn(u8) = |_| println!("Stuff!");
+}

--- a/tests/ui/toilet_closures.rs
+++ b/tests/ui/toilet_closures.rs
@@ -1,0 +1,18 @@
+#![warn(clippy::toilet_closures)]
+
+fn main() {
+    // Should lint
+    let toliet: fn(u8) = |_| ();
+    //~^ error: defined a 'toilet closure'
+    let toliet_with_arg: fn(u8) = |_to_drop| ();
+    //~^ error: defined a 'toilet closure'
+    let toliet_with_typed_arg: fn(u8) = |_to_drop: u8| ();
+    //~^ error: defined a 'toilet closure'
+    let toliet_with_braces: fn(u8) = |_| {};
+    //~^ error: defined a 'toilet closure'
+
+    // Should not lint
+    let toilet_higher_ranked: fn(&u8) = |_| ();
+    let closure_multi_arg: fn(u8, u8) = |_, _| ();
+    let closure_does_stuff: fn(u8) = |_| println!("Stuff!");
+}

--- a/tests/ui/toilet_closures.stderr
+++ b/tests/ui/toilet_closures.stderr
@@ -1,0 +1,29 @@
+error: defined a 'toilet closure'
+  --> tests/ui/toilet_closures.rs:5:26
+   |
+LL |     let toliet: fn(u8) = |_| ();
+   |                          ^^^^^^ help: replace with: `drop`
+   |
+   = note: `-D clippy::toilet-closures` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::toilet_closures)]`
+
+error: defined a 'toilet closure'
+  --> tests/ui/toilet_closures.rs:7:35
+   |
+LL |     let toliet_with_arg: fn(u8) = |_to_drop| ();
+   |                                   ^^^^^^^^^^^^^ help: replace with: `drop`
+
+error: defined a 'toilet closure'
+  --> tests/ui/toilet_closures.rs:9:41
+   |
+LL |     let toliet_with_typed_arg: fn(u8) = |_to_drop: u8| ();
+   |                                         ^^^^^^^^^^^^^^^^^ help: replace with: `drop::<u8>`
+
+error: defined a 'toilet closure'
+  --> tests/ui/toilet_closures.rs:11:38
+   |
+LL |     let toliet_with_braces: fn(u8) = |_| {};
+   |                                      ^^^^^^ help: replace with: `drop`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/unused_enumerate_index.fixed
+++ b/tests/ui/unused_enumerate_index.fixed
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::map_identity)]
+#![allow(unused, clippy::map_identity, clippy::toilet_closures)]
 #![warn(clippy::unused_enumerate_index)]
 
 use std::iter::Enumerate;

--- a/tests/ui/unused_enumerate_index.rs
+++ b/tests/ui/unused_enumerate_index.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::map_identity)]
+#![allow(unused, clippy::map_identity, clippy::toilet_closures)]
 #![warn(clippy::unused_enumerate_index)]
 
 use std::iter::Enumerate;

--- a/tests/ui/unused_unit.fixed
+++ b/tests/ui/unused_unit.fixed
@@ -11,8 +11,7 @@
 #![rustfmt::skip]
 
 #![deny(clippy::unused_unit)]
-#![allow(dead_code)]
-#![allow(clippy::from_over_into)]
+#![allow(dead_code, clippy::from_over_into, clippy::toilet_closures)]
 
 struct Unitter;
 impl Unitter {

--- a/tests/ui/unused_unit.rs
+++ b/tests/ui/unused_unit.rs
@@ -11,8 +11,7 @@
 #![rustfmt::skip]
 
 #![deny(clippy::unused_unit)]
-#![allow(dead_code)]
-#![allow(clippy::from_over_into)]
+#![allow(dead_code, clippy::from_over_into, clippy::toilet_closures)]
 
 struct Unitter;
 impl Unitter {

--- a/tests/ui/unused_unit.stderr
+++ b/tests/ui/unused_unit.stderr
@@ -1,5 +1,5 @@
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:20:58
+  --> tests/ui/unused_unit.rs:19:58
    |
 LL |     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) -> ()
    |                                                          ^^^^^^ help: remove the `-> ()`
@@ -11,109 +11,109 @@ LL | #![deny(clippy::unused_unit)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:20:28
+  --> tests/ui/unused_unit.rs:19:28
    |
 LL |     pub fn get_unit<F: Fn() -> (), G>(&self, f: F, _g: G) -> ()
    |                            ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:21:18
+  --> tests/ui/unused_unit.rs:20:18
    |
 LL |     where G: Fn() -> () {
    |                  ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:22:26
+  --> tests/ui/unused_unit.rs:21:26
    |
 LL |         let _y: &dyn Fn() -> () = &f;
    |                          ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:29:18
+  --> tests/ui/unused_unit.rs:28:18
    |
 LL |     fn into(self) -> () {
    |                  ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
-  --> tests/ui/unused_unit.rs:30:9
+  --> tests/ui/unused_unit.rs:29:9
    |
 LL |         ()
    |         ^^ help: remove the final `()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:35:29
+  --> tests/ui/unused_unit.rs:34:29
    |
 LL |     fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
    |                             ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:37:19
+  --> tests/ui/unused_unit.rs:36:19
    |
 LL |         G: FnMut() -> (),
    |                   ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:38:16
+  --> tests/ui/unused_unit.rs:37:16
    |
 LL |         H: Fn() -> ();
    |                ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:42:29
+  --> tests/ui/unused_unit.rs:41:29
    |
 LL |     fn redundant<F: FnOnce() -> (), G, H>(&self, _f: F, _g: G, _h: H)
    |                             ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:44:19
+  --> tests/ui/unused_unit.rs:43:19
    |
 LL |         G: FnMut() -> (),
    |                   ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:45:16
+  --> tests/ui/unused_unit.rs:44:16
    |
 LL |         H: Fn() -> () {}
    |                ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:48:17
+  --> tests/ui/unused_unit.rs:47:17
    |
 LL | fn return_unit() -> () { () }
    |                 ^^^^^^ help: remove the `-> ()`
 
 error: unneeded unit expression
-  --> tests/ui/unused_unit.rs:48:26
+  --> tests/ui/unused_unit.rs:47:26
    |
 LL | fn return_unit() -> () { () }
    |                          ^^ help: remove the final `()`
 
 error: unneeded `()`
-  --> tests/ui/unused_unit.rs:58:14
+  --> tests/ui/unused_unit.rs:57:14
    |
 LL |         break();
    |              ^^ help: remove the `()`
 
 error: unneeded `()`
-  --> tests/ui/unused_unit.rs:60:11
+  --> tests/ui/unused_unit.rs:59:11
    |
 LL |     return();
    |           ^^ help: remove the `()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:77:10
+  --> tests/ui/unused_unit.rs:76:10
    |
 LL | fn test()->(){}
    |          ^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:80:11
+  --> tests/ui/unused_unit.rs:79:11
    |
 LL | fn test2() ->(){}
    |           ^^^^^ help: remove the `-> ()`
 
 error: unneeded unit return type
-  --> tests/ui/unused_unit.rs:83:11
+  --> tests/ui/unused_unit.rs:82:11
    |
 LL | fn test3()-> (){}
    |           ^^^^^ help: remove the `-> ()`

--- a/tests/ui/vec_box_sized.rs
+++ b/tests/ui/vec_box_sized.rs
@@ -83,6 +83,7 @@ mod inner_mod {
 }
 
 // https://github.com/rust-lang/rust-clippy/issues/11417
+#[allow(clippy::toilet_closures)]
 fn in_closure() {
     let _ = |_: Vec<Box<dyn ToString>>| {};
 }


### PR DESCRIPTION
Closes #2523

This name is a little silly, but is also a widely used term and I don't think there is a funnier name we could use.

I feel like the discussion in that issue thread has come to a settle, with most people preferring `drop` to `|_| ()` or suggesting those do not to implement their own `fn ignore<T>(_: T) {}` which would not fire this lint. It is also always possible to disagree with the agreed style of clippy with a simply `allow` attribute.

changelog: [`toilet_closures`]: Implemented lint for replacing `|_| ()` with `drop`