### PR TITLE
clippy_dev: bump opener

### DIFF
--- a/clippy_dev/Cargo.toml
+++ b/clippy_dev/Cargo.toml
@@ -9,7 +9,7 @@ aho-corasick = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 indoc = "1.0"
 itertools = "0.12"
-opener = "0.6"
+opener = "0.7"
 shell-escape = "0.1"
 walkdir = "2.3"
 


### PR DESCRIPTION
Bump `opener` to sync with rustc repo.

changelog: none

