### PR TITLE
Move `too_long_first_doc_paragraph` to `nursery`

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -452,7 +452,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.82.0"]
     pub TOO_LONG_FIRST_DOC_PARAGRAPH,
-    style,
+    nursery,
     "ensure that the first line of a documentation paragraph isn't too long"
 }
 


### PR DESCRIPTION
See: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/too_long_first_doc_paragraph.20to.20nursery.3F/near/476448239

changelog: none

I'll update the changelog as well.
