### PR TITLE
Change the category of `manual_is_power_of_two` to `pedantic`

### DIFF
--- a/clippy_lints/src/manual_is_power_of_two.rs
+++ b/clippy_lints/src/manual_is_power_of_two.rs
@@ -11,10 +11,12 @@ use rustc_session::declare_lint_pass;
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for expressions like `x.count_ones() == 1` or `x & (x - 1) == 0`, with x and unsigned integer, which are manual
+    /// Checks for expressions like `x.count_ones() == 1` or `x & (x - 1) == 0`, with x and unsigned integer, which may be manual
     /// reimplementations of `x.is_power_of_two()`.
+    ///
     /// ### Why is this bad?
     /// Manual reimplementations of `is_power_of_two` increase code complexity for little benefit.
+    ///
     /// ### Example
     /// ```no_run
     /// let a: u32 = 4;
@@ -27,7 +29,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.82.0"]
     pub MANUAL_IS_POWER_OF_TWO,
-    complexity,
+    pedantic,
     "manually reimplementing `is_power_of_two`"
 }
 


### PR DESCRIPTION
Fixes #13547.

The value being checked might be a bit flag, suggesting `is_power_of_two` for it would make the code unreadable.

changelog: [`manual_is_power_of_two`]: Change the category to `pedantic`
