### PR TITLE
Documentation fixes

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4046,7 +4046,7 @@ declare_clippy_lint! {
     /// Checks the usage of `.get().is_some()` or `.get().is_none()` on std map types.
     ///
     /// ### Why is this bad?
-    /// It can be done in one call with `.contains()`/`.contains_keys()`.
+    /// It can be done in one call with `.contains()`/`.contains_key()`.
     ///
     /// ### Example
     /// ```no_run

--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -186,7 +186,7 @@ Otherwise, have a great day =^.^=
                             {# Jump to source #}
                             {% if let Some(id_location) = lint.id_location %}
                                 <div class="lint-additional-info-item"> {# #}
-                                    <a href="https://github.com/rust-lang/rust-clippy/blob/master/clippy_lints/{{id_location}}">View Source</a> {# #}
+                                    <a href="https://github.com/rust-lang/rust-clippy/blob/master/{{id_location}}">View Source</a> {# #}
                                 </div>
                             {% endif %}
                         </div> {# #}


### PR DESCRIPTION
- In [the page describing the lints](https://rust-lang.github.io/rust-clippy/master/index.html), the View Source links are incorrect. This PR removes the extra segment causing them to fail.
  - Example before: https://github.com/rust-lang/rust-clippy/blob/master/clippy_lints/clippy_lints/src/absolute_paths.rs#L13
  - Example after: https://github.com/rust-lang/rust-clippy/blob/master/clippy_lints/src/absolute_paths.rs#L13
  - I think this was introduced in #13269.
  - I've only checked a few of the lints with the new template, but from what I can tell the metadata is generated in the same way for all of them. The `id_location` contains the full path of the lint declaration in the repository, which is why `clippy_lints` was repeated in the URL.
- Separately, fixing a typo in the explanation of `unnecessary_get_then_check`. 


changelog: none
