### PR TITLE
Don't trigger `const_is_empty` for inline const assertions

### DIFF
--- a/tests/ui/const_is_empty.rs
+++ b/tests/ui/const_is_empty.rs
@@ -171,3 +171,17 @@ fn constant_from_external_crate() {
     let _ = std::env::consts::EXE_EXTENSION.is_empty();
     // Do not lint, `exe_ext` comes from the `std` crate
 }
+
+fn issue_13106() {
+    const {
+        assert!(!NON_EMPTY_STR.is_empty());
+    }
+
+    const {
+        assert!(EMPTY_STR.is_empty());
+    }
+
+    const {
+        EMPTY_STR.is_empty();
+    }
+}

--- a/tests/ui/const_is_empty.stderr
+++ b/tests/ui/const_is_empty.stderr
@@ -157,5 +157,11 @@ error: this expression always evaluates to true
 LL |     let _ = val.is_empty();
    |             ^^^^^^^^^^^^^^
 
-error: aborting due to 26 previous errors
+error: this expression always evaluates to true
+  --> tests/ui/const_is_empty.rs:185:9
+   |
+LL |         EMPTY_STR.is_empty();
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 27 previous errors
 


### PR DESCRIPTION
Close #13106

Considered case was described [here](https://github.com/rust-lang/rust-clippy/pull/13114#issuecomment-2266629991)

changelog: [`const_is_empty`]: skip const_is_empty for inline const assertions 

