### PR TITLE
pulldown-cmark: don't pull getopts dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ toml = "0.7.3"
 walkdir = "2.3"
 filetime = "0.2.9"
 itertools = "0.12"
-pulldown-cmark = "0.11"
+pulldown-cmark = { version = "0.11", default-features = false, features = ["html"] }
 rinja = { version = "0.3", default-features = false, features = ["config"] }
 
 # UI test dependencies


### PR DESCRIPTION
Don't pull getopts. Noticed in https://github.com/rust-lang/rust/pull/131892

changelog: none