### PR TITLE
Stop linting manual_bits in any macro invoke

### DIFF
--- a/clippy_lints/src/manual_bits.rs
+++ b/clippy_lints/src/manual_bits.rs
@@ -7,8 +7,7 @@ use rustc_ast::ast::LitKind;
 use rustc_data_structures::packed::Pu128;
 use rustc_errors::Applicability;
 use rustc_hir::{BinOpKind, Expr, ExprKind, GenericArg, QPath};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
-use rustc_middle::lint::in_external_macro;
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::{self, Ty};
 use rustc_session::impl_lint_pass;
 use rustc_span::sym;
@@ -53,7 +52,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualBits {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if let ExprKind::Binary(bin_op, left_expr, right_expr) = expr.kind
             && let BinOpKind::Mul = &bin_op.node
-            && !in_external_macro(cx.sess(), expr.span)
+            && !expr.span.from_expansion()
             && self.msrv.meets(msrvs::MANUAL_BITS)
             && let ctxt = expr.span.ctxt()
             && left_expr.span.ctxt() == ctxt

--- a/tests/ui/manual_bits.fixed
+++ b/tests/ui/manual_bits.fixed
@@ -56,3 +56,14 @@ fn main() {
     let _ = (u128::BITS as usize).pow(5);
     let _ = &(u128::BITS as usize);
 }
+
+fn should_not_lint() {
+    macro_rules! bits_via_macro {
+        ($T: ty) => {
+            size_of::<$T>() * 8;
+        };
+    }
+
+    bits_via_macro!(u8);
+    bits_via_macro!(String);
+}

--- a/tests/ui/manual_bits.rs
+++ b/tests/ui/manual_bits.rs
@@ -56,3 +56,14 @@ fn main() {
     let _ = (size_of::<u128>() * 8).pow(5);
     let _ = &(size_of::<u128>() * 8);
 }
+
+fn should_not_lint() {
+    macro_rules! bits_via_macro {
+        ($T: ty) => {
+            size_of::<$T>() * 8;
+        };
+    }
+
+    bits_via_macro!(u8);
+    bits_via_macro!(String);
+}


### PR DESCRIPTION
Closes #13563.

changelog: [`manual_bits`] No longer lints in macro-generated code