### PR TITLE
Fix version for `ref_option`

### DIFF
--- a/clippy_lints/src/functions/mod.rs
+++ b/clippy_lints/src/functions/mod.rs
@@ -441,7 +441,7 @@ declare_clippy_lint! {
     /// fn bar(&self) -> Option<&String> { None }
     /// # }
     /// ```
-    #[clippy::version = "1.82.0"]
+    #[clippy::version = "1.83.0"]
     pub REF_OPTION,
     pedantic,
     "function signature uses `&Option<T>` instead of `Option<&T>`"


### PR DESCRIPTION
Close #13566
As mentioned at #13566 `ref_option` [was merged](https://github.com/rust-lang/rust-clippy/pull/13336) after 1.82.0 so it wasn't include in this version

changelog: none
