### PR TITLE
docs: remove stray comma

### DIFF
--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -104,7 +104,7 @@ Otherwise, have a great day =^.^=
                                 <li role="separator" class="divider"></li> {# #}
                             </ul> {# #}
                         </div> {# #}
-                        <div class="btn-group", id="lint-applicabilities" tabindex="-1"> {# #}
+                        <div class="btn-group" id="lint-applicabilities" tabindex="-1"> {# #}
                             <button type="button" class="btn btn-default dropdown-toggle"> {# #}
                                 Applicability {#+ #}
                                 <span class="badge">4</span> {#+ #}


### PR DESCRIPTION
changelog: none

the typo was (seemingly) ignored by browsers, so the change isn't visible to users