### PR TITLE
Don't lint unnamed consts and nested items within functions in `missing_docs_in_private_items`

### DIFF
--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -17,6 +17,7 @@ use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::ty::Visibility;
 use rustc_session::impl_lint_pass;
 use rustc_span::def_id::CRATE_DEF_ID;
+use rustc_span::symbol::kw;
 use rustc_span::{Span, sym};
 
 declare_clippy_lint! {
@@ -184,8 +185,12 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
                     }
                 }
             },
-            hir::ItemKind::Const(..)
-            | hir::ItemKind::Enum(..)
+            hir::ItemKind::Const(..) => {
+                if it.ident.name == kw::Underscore {
+                    note_prev_span_then_ret!(self.prev_span, it.span);
+                }
+            },
+            hir::ItemKind::Enum(..)
             | hir::ItemKind::Macro(..)
             | hir::ItemKind::Mod(..)
             | hir::ItemKind::Static(..)

--- a/tests/ui/missing_doc.rs
+++ b/tests/ui/missing_doc.rs
@@ -116,6 +116,9 @@ with_span!(span pub fn foo_pm() {});
 with_span!(span pub static FOO_PM: u32 = 0;);
 with_span!(span pub const FOO2_PM: u32 = 0;);
 
+// Don't lint unnamed constants
+const _: () = ();
+
 // issue #12197
 // Undocumented field originated inside of spanned proc-macro attribute
 /// Some dox for struct.

--- a/tests/ui/missing_doc.rs
+++ b/tests/ui/missing_doc.rs
@@ -119,6 +119,11 @@ with_span!(span pub const FOO2_PM: u32 = 0;);
 // Don't lint unnamed constants
 const _: () = ();
 
+fn issue13298() {
+    // Rustdoc doesn't generate documentation for items within other items like fns or consts
+    const MSG: &str = "Hello, world!";
+}
+
 // issue #12197
 // Undocumented field originated inside of spanned proc-macro attribute
 /// Some dox for struct.

--- a/tests/ui/missing_doc.stderr
+++ b/tests/ui/missing_doc.stderr
@@ -88,5 +88,14 @@ error: missing documentation for a function
 LL |         fn also_undocumented2() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 13 previous errors
+error: missing documentation for a function
+  --> tests/ui/missing_doc.rs:122:1
+   |
+LL | / fn issue13298() {
+LL | |     // Rustdoc doesn't generate documentation for items within other items like fns or consts
+LL | |     const MSG: &str = "Hello, world!";
+LL | | }
+   | |_^
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
With this change we no longer require doc comments for `const _: ()` items as well as nested items in functions or other bodies. In both of those cases, rustdoc generates no documentation even with `--document-private-items`.

Fixes #13427 (first commit)
Fixes #13298 (second commit)
cc https://github.com/rust-lang/rust-clippy/issues/5736#issuecomment-668524296

changelog: [`missing_docs_in_private_items`]: avoid linting in more cases where rustdoc generates no documentation