### PR TITLE
Improve display of clippy lints page when JS is disabled

### DIFF
--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -24,7 +24,6 @@ Otherwise, have a great day =^.^=
     <link id="styleNight" rel="stylesheet" href="https://rust-lang.github.io/mdBook/tomorrow-night.css" disabled="true"> {# #}
     <link id="styleAyu" rel="stylesheet" href="https://rust-lang.github.io/mdBook/ayu-highlight.css" disabled="true"> {# #}
     <link rel="stylesheet" href="style.css"> {# #}
-    <noscript><link rel="stylesheet" href="noscript.css"></noscript> {# #}
 </head> {# #}
 <body> {# #}
     <script src="theme.js"></script> {# #}

--- a/util/gh-pages/index_template.html
+++ b/util/gh-pages/index_template.html
@@ -24,6 +24,7 @@ Otherwise, have a great day =^.^=
     <link id="styleNight" rel="stylesheet" href="https://rust-lang.github.io/mdBook/tomorrow-night.css" disabled="true"> {# #}
     <link id="styleAyu" rel="stylesheet" href="https://rust-lang.github.io/mdBook/ayu-highlight.css" disabled="true"> {# #}
     <link rel="stylesheet" href="style.css"> {# #}
+    <noscript><link rel="stylesheet" href="noscript.css"></noscript> {# #}
 </head> {# #}
 <body> {# #}
     <script src="theme.js"></script> {# #}
@@ -52,12 +53,12 @@ Otherwise, have a great day =^.^=
 
         <noscript> {# #}
             <div class="alert alert-danger" role="alert"> {# #}
-                Sorry, this site only works with JavaScript! :( {# #}
+                Lints search and filtering only works with JS enabled. :( {# #}
             </div> {# #}
         </noscript> {# #}
 
         <div> {# #}
-            <div class="panel panel-default"> {# #}
+            <div class="panel panel-default" id="menu-filters"> {# #}
                 <div class="panel-body row"> {# #}
                     <div id="upper-filters" class="col-12 col-md-5"> {# #}
                         <div class="btn-group" id="lint-levels" tabindex="-1"> {# #}

--- a/util/gh-pages/noscript.css
+++ b/util/gh-pages/noscript.css
@@ -1,3 +1,0 @@
-#settings-dropdown, #menu-filters {
-    display: none;
-}

--- a/util/gh-pages/noscript.css
+++ b/util/gh-pages/noscript.css
@@ -1,0 +1,3 @@
+#settings-dropdown, #menu-filters {
+    display: none;
+}

--- a/util/gh-pages/style.css
+++ b/util/gh-pages/style.css
@@ -230,6 +230,11 @@ details[open] {
     }
 }
 
+html:not(.js) #settings-dropdown,
+html:not(.js)#menu-filters {
+    display: none;
+}
+
 #settings-dropdown {
     position: absolute;
     margin: 0.7em;

--- a/util/gh-pages/style.css
+++ b/util/gh-pages/style.css
@@ -204,7 +204,7 @@ details[open] {
 }
 
 /* Expanding the mdBook theme*/
-.light {
+.light, body:not([class]) {
     --inline-code-bg: #f6f7f6;
 }
 .rust {
@@ -218,6 +218,16 @@ details[open] {
 }
 .ayu {
     --inline-code-bg: #191f26;
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not([class]) {
+        /*
+        In case JS is disabled and the user's system is in dark mode, we take "coal" as default
+        dark theme.
+        */
+        --inline-code-bg: #1d1f21;
+    }
 }
 
 #settings-dropdown {

--- a/util/gh-pages/theme.js
+++ b/util/gh-pages/theme.js
@@ -45,6 +45,10 @@ function setTheme(theme, store) {
 }
 
 (function() {
+    // This file is loaded first. If so, we add the `js` class on the `<html>`
+    // element.
+    document.documentElement.classList.add("js");
+
     // loading the theme after the initial load
     const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
     const theme = loadValue("theme");


### PR DESCRIPTION
There is no point in displaying the settings menu and the filters if JS is disabled. So in this case, this PR simply hides it:

![image](https://github.com/user-attachments/assets/e96039a9-e698-49b7-bf2b-70e78442b305)

For the theme handling though, I need to send a fix to mdBook first. But once done, it'll look as expected (dark if system is in dark mode).

changelog: Improve clippy lints page display when JS is disabled.

r? @Alexendoo 