### PR TITLE
Move `large_stack_frames` to suspicious

### DIFF
--- a/clippy_lints/src/large_stack_frames.rs
+++ b/clippy_lints/src/large_stack_frames.rs
@@ -77,7 +77,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.72.0"]
     pub LARGE_STACK_FRAMES,
-    nursery,
+    suspicious,
     "checks for functions that allocate a lot of stack space"
 }
 

--- a/tests/ui/crashes/ice-5389.rs
+++ b/tests/ui/crashes/ice-5389.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::explicit_counter_loop)]
+#![allow(clippy::explicit_counter_loop, clippy::large_stack_frames)]
 
 fn main() {
     let v = vec![1, 2, 3];

--- a/tests/ui/large_stack_arrays.rs
+++ b/tests/ui/large_stack_arrays.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 #![warn(clippy::large_stack_arrays)]
-#![allow(clippy::large_enum_variant)]
+#![allow(clippy::large_enum_variant, clippy::large_stack_frames)]
 
 extern crate proc_macros;
 


### PR DESCRIPTION
This has been in nursery ever since its initial merge, with no FP reports. This lint would have caught https://github.com/rust-lang/rust/issues/132050#issuecomment-2431484012 so I think this could be valuable as a warn-by-default lint.

changelog: Move `large_stack_frames` to suspicious (now warn-by-default)