### PR TITLE
Implement a lint for `.clone().into_iter()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6059,6 +6059,7 @@ Released 2018-09-13
 [`unnecessary_box_returns`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_box_returns
 [`unnecessary_cast`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
 [`unnecessary_clippy_cfg`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_clippy_cfg
+[`unnecessary_collection_clone`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_collection_clone
 [`unnecessary_fallible_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fallible_conversions
 [`unnecessary_filter_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_filter_map
 [`unnecessary_find_map`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_find_map

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -471,6 +471,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::methods::TYPE_ID_ON_BOX_INFO,
     crate::methods::UNINIT_ASSUMED_INIT_INFO,
     crate::methods::UNIT_HASH_INFO,
+    crate::methods::UNNECESSARY_COLLECTION_CLONE_INFO,
     crate::methods::UNNECESSARY_FALLIBLE_CONVERSIONS_INFO,
     crate::methods::UNNECESSARY_FILTER_MAP_INFO,
     crate::methods::UNNECESSARY_FIND_MAP_INFO,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -112,6 +112,7 @@ mod suspicious_to_owned;
 mod type_id_on_box;
 mod uninit_assumed_init;
 mod unit_hash;
+mod unnecessary_collection_clone;
 mod unnecessary_fallible_conversions;
 mod unnecessary_filter_map;
 mod unnecessary_first_then_check;
@@ -4253,6 +4254,36 @@ declare_clippy_lint! {
     "map of a trivial closure (not dependent on parameter) over a range"
 }
 
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Detects when an entire collection is being cloned eagerly, instead of each item lazily.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Cloning a collection requires allocating space for all elements and cloning each element into this new space,
+    /// whereas using `Iterator::cloned` does not allocate any more space and only requires cloning each element as they are consumed.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// fn process_string(val: String) -> String { val }
+    /// fn process_strings(strings: &Vec<String>) -> Vec<String> {
+    ///     strings.clone().into_iter().filter(|s| s.len() < 10).map(process_string).collect()
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// fn process_string(val: String) -> String { val }
+    /// fn process_strings(strings: &Vec<String>) -> Vec<String> {
+    ///     strings.iter().cloned().filter(|s| s.len() < 10).map(process_string).collect()
+    /// }
+    /// ```
+    #[clippy::version = "1.84.0"]
+    pub UNNECESSARY_COLLECTION_CLONE,
+    perf,
+    "calling `.clone().into_iter()` instead of `.iter().cloned()`"
+}
+
 pub struct Methods {
     avoid_breaking_exported_api: bool,
     msrv: Msrv,
@@ -4417,6 +4448,7 @@ impl_lint_pass!(Methods => [
     NEEDLESS_AS_BYTES,
     MAP_ALL_ANY_IDENTITY,
     MAP_WITH_UNUSED_ARGUMENT_OVER_RANGES,
+    UNNECESSARY_COLLECTION_CLONE,
 ]);
 
 /// Extracts a method call name, args, and `Span` of the method name.
@@ -4879,6 +4911,10 @@ impl Methods {
                 ("is_none", []) => check_is_some_is_none(cx, expr, recv, call_span, false),
                 ("is_some", []) => check_is_some_is_none(cx, expr, recv, call_span, true),
                 ("iter" | "iter_mut" | "into_iter", []) => {
+                    if name == "into_iter" {
+                        unnecessary_collection_clone::check(cx, expr, recv);
+                    }
+
                     iter_on_single_or_empty_collections::check(cx, expr, name, recv);
                 },
                 ("join", [join_arg]) => {

--- a/clippy_lints/src/methods/unnecessary_collection_clone.rs
+++ b/clippy_lints/src/methods/unnecessary_collection_clone.rs
@@ -1,0 +1,59 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::is_path_mutable;
+use clippy_utils::source::snippet_with_applicability;
+use clippy_utils::ty::{deref_chain, get_inherent_method, implements_trait, make_normalized_projection};
+use rustc_errors::Applicability;
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, Ty};
+use rustc_span::sym;
+
+use super::{UNNECESSARY_COLLECTION_CLONE, method_call};
+
+// FIXME: This does not check if the iter method is actually compatible with the replacement, but
+// you have to be actively evil to have an `IntoIterator` impl that returns one type and an `iter`
+// method that returns something other than references of that type.... and it is a massive
+// complicated hassle to check this
+fn has_iter_method<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    deref_chain(cx, ty).any(|ty| match ty.kind() {
+        ty::Adt(adt_def, _) => get_inherent_method(cx, adt_def.did(), sym::iter).is_some(),
+        ty::Slice(_) => true,
+        _ => false,
+    })
+}
+
+/// Check for `x.clone().into_iter()` to suggest `x.iter().cloned()`.
+//             ^^^^^^^^^ is recv
+//             ^^^^^^^^^^^^^^^^^^^^^ is expr
+pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, recv: &Expr<'_>) {
+    let typeck_results = cx.typeck_results();
+    let diagnostic_items = cx.tcx.all_diagnostic_items(());
+
+    // If the call before `into_iter` is `.clone()`
+    if let Some(("clone", collection_expr, [], _, _)) = method_call(recv)
+        // and the binding being cloned is not mutable
+        && let Some(false) = is_path_mutable(cx, collection_expr)
+        // and the result of `into_iter` is an Iterator
+        && let Some(&iterator_def_id) = diagnostic_items.name_to_id.get(&sym::Iterator)
+        && let expr_ty = typeck_results.expr_ty(expr)
+        && implements_trait(cx, expr_ty, iterator_def_id, &[])
+        // with an item that implements clone
+        && let Some(&clone_def_id) = diagnostic_items.name_to_id.get(&sym::Clone)
+        && let Some(item_ty) = make_normalized_projection(cx.tcx, cx.param_env, iterator_def_id, sym::Item, [expr_ty])
+        && implements_trait(cx, item_ty, clone_def_id, &[])
+        // and the type has an `iter` method
+        && has_iter_method(cx, typeck_results.expr_ty(collection_expr))
+    {
+        let mut applicability = Applicability::MachineApplicable;
+        let collection_expr_snippet = snippet_with_applicability(cx, collection_expr.span, "...", &mut applicability);
+        span_lint_and_sugg(
+            cx,
+            UNNECESSARY_COLLECTION_CLONE,
+            expr.span,
+            "using clone on collection to own iterated items",
+            "replace with",
+            format!("{collection_expr_snippet}.iter().cloned()"),
+            applicability,
+        );
+    }
+}

--- a/clippy_utils/src/ty.rs
+++ b/clippy_utils/src/ty.rs
@@ -1323,20 +1323,27 @@ pub fn deref_chain<'cx, 'tcx>(cx: &'cx LateContext<'tcx>, ty: Ty<'tcx>) -> impl 
 
 /// Checks if a Ty<'_> has some inherent method Symbol.
 ///
-/// This does not look for impls in the type's `Deref::Target` type.
-/// If you need this, you should wrap this call in `clippy_utils::ty::deref_chain().any(...)`.
+/// This is a helper for [`get_inherent_method`].
 pub fn get_adt_inherent_method<'a>(cx: &'a LateContext<'_>, ty: Ty<'_>, method_name: Symbol) -> Option<&'a AssocItem> {
     if let Some(ty_did) = ty.ty_adt_def().map(AdtDef::did) {
-        cx.tcx.inherent_impls(ty_did).iter().find_map(|&did| {
-            cx.tcx
-                .associated_items(did)
-                .filter_by_name_unhygienic(method_name)
-                .next()
-                .filter(|item| item.kind == AssocKind::Fn)
-        })
+        get_inherent_method(cx, ty_did, method_name)
     } else {
         None
     }
+}
+
+/// Checks if the [`DefId`] of a Ty has some inherent method Symbol.
+///
+/// This does not look for impls in the type's `Deref::Target` type.
+/// If you need this, you should wrap this call in `clippy_utils::ty::deref_chain().any(...)`.
+pub fn get_inherent_method<'a>(cx: &'a LateContext<'_>, ty_did: DefId, method_name: Symbol) -> Option<&'a AssocItem> {
+    cx.tcx.inherent_impls(ty_did).iter().find_map(|&did| {
+        cx.tcx
+            .associated_items(did)
+            .filter_by_name_unhygienic(method_name)
+            .next()
+            .filter(|item| item.kind == AssocKind::Fn)
+    })
 }
 
 /// Get's the type of a field by name.

--- a/tests/ui/filter_map_bool_then.fixed
+++ b/tests/ui/filter_map_bool_then.fixed
@@ -4,6 +4,7 @@
     clippy::map_identity,
     clippy::unnecessary_lazy_evaluations,
     clippy::unnecessary_filter_map,
+    clippy::unnecessary_collection_clone,
     unused
 )]
 #![warn(clippy::filter_map_bool_then)]

--- a/tests/ui/filter_map_bool_then.rs
+++ b/tests/ui/filter_map_bool_then.rs
@@ -4,6 +4,7 @@
     clippy::map_identity,
     clippy::unnecessary_lazy_evaluations,
     clippy::unnecessary_filter_map,
+    clippy::unnecessary_collection_clone,
     unused
 )]
 #![warn(clippy::filter_map_bool_then)]

--- a/tests/ui/filter_map_bool_then.stderr
+++ b/tests/ui/filter_map_bool_then.stderr
@@ -1,5 +1,5 @@
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:19:22
+  --> tests/ui/filter_map_bool_then.rs:20:22
    |
 LL |     v.clone().iter().filter_map(|i| (i % 2 == 0).then(|| i + 1));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
@@ -8,55 +8,55 @@ LL |     v.clone().iter().filter_map(|i| (i % 2 == 0).then(|| i + 1));
    = help: to override `-D warnings` add `#[allow(clippy::filter_map_bool_then)]`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:20:27
+  --> tests/ui/filter_map_bool_then.rs:21:27
    |
 LL |     v.clone().into_iter().filter_map(|i| (i % 2 == 0).then(|| i + 1));
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:23:10
+  --> tests/ui/filter_map_bool_then.rs:24:10
    |
 LL |         .filter_map(|i| -> Option<_> { (i % 2 == 0).then(|| i + 1) });
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:27:10
+  --> tests/ui/filter_map_bool_then.rs:28:10
    |
 LL |         .filter_map(|i| (i % 2 == 0).then(|| i + 1));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:31:10
+  --> tests/ui/filter_map_bool_then.rs:32:10
    |
 LL |         .filter_map(|i| (i.clone() % 2 == 0).then(|| i + 1));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i.clone() % 2 == 0)).map(|i| i + 1)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:37:22
+  --> tests/ui/filter_map_bool_then.rs:38:22
    |
 LL |     v.clone().iter().filter_map(|i| (i == &NonCopy).then(|| i));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&i| (i == &NonCopy)).map(|i| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:61:50
+  --> tests/ui/filter_map_bool_then.rs:62:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| *b).map(|(i, b)| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:65:50
+  --> tests/ui/filter_map_bool_then.rs:66:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| ***b).map(|(i, b)| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:69:50
+  --> tests/ui/filter_map_bool_then.rs:70:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| **b).map(|(i, b)| i)`
 
 error: usage of `bool::then` in `filter_map`
-  --> tests/ui/filter_map_bool_then.rs:80:50
+  --> tests/ui/filter_map_bool_then.rs:81:50
    |
 LL |     let _: Vec<usize> = bools.iter().enumerate().filter_map(|(i, b)| b.then(|| i)).collect();
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `filter` then `map` instead: `filter(|&(i, b)| ****b).map(|(i, b)| i)`

--- a/tests/ui/iter_filter_is_ok.fixed
+++ b/tests/ui/iter_filter_is_ok.fixed
@@ -3,7 +3,8 @@
     clippy::map_identity,
     clippy::result_filter_map,
     clippy::needless_borrow,
-    clippy::redundant_closure
+    clippy::redundant_closure,
+    clippy::unnecessary_collection_clone
 )]
 
 fn main() {

--- a/tests/ui/iter_filter_is_ok.rs
+++ b/tests/ui/iter_filter_is_ok.rs
@@ -3,7 +3,8 @@
     clippy::map_identity,
     clippy::result_filter_map,
     clippy::needless_borrow,
-    clippy::redundant_closure
+    clippy::redundant_closure,
+    clippy::unnecessary_collection_clone
 )]
 
 fn main() {

--- a/tests/ui/iter_filter_is_ok.stderr
+++ b/tests/ui/iter_filter_is_ok.stderr
@@ -1,5 +1,5 @@
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:11:56
+  --> tests/ui/iter_filter_is_ok.rs:12:56
    |
 LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(Result::is_ok);
    |                                                        ^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
@@ -8,67 +8,67 @@ LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(Result::is_ok
    = help: to override `-D warnings` add `#[allow(clippy::iter_filter_is_ok)]`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:13:56
+  --> tests/ui/iter_filter_is_ok.rs:14:56
    |
 LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(|a| a.is_ok());
    |                                                        ^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:16:49
+  --> tests/ui/iter_filter_is_ok.rs:17:49
    |
 LL |         let _ = vec![Ok(1), Err(2)].into_iter().filter(|o| { o.is_ok() });
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:21:56
+  --> tests/ui/iter_filter_is_ok.rs:22:56
    |
 LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(|&a| a.is_ok());
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:24:56
+  --> tests/ui/iter_filter_is_ok.rs:25:56
    |
 LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(|&a| a.is_ok());
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:28:49
+  --> tests/ui/iter_filter_is_ok.rs:29:49
    |
 LL |         let _ = vec![Ok(1), Err(2)].into_iter().filter(|&o| { o.is_ok() });
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:35:14
+  --> tests/ui/iter_filter_is_ok.rs:36:14
    |
 LL |             .filter(std::result::Result::is_ok);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:40:14
+  --> tests/ui/iter_filter_is_ok.rs:41:14
    |
 LL |             .filter(|a| std::result::Result::is_ok(a));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:43:56
+  --> tests/ui/iter_filter_is_ok.rs:44:56
    |
 LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(|a| { std::result::Result::is_ok(a) });
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:48:56
+  --> tests/ui/iter_filter_is_ok.rs:49:56
    |
 LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(|ref a| a.is_ok());
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:51:56
+  --> tests/ui/iter_filter_is_ok.rs:52:56
    |
 LL |         let _ = vec![Ok(1), Err(2), Ok(3)].into_iter().filter(|ref a| a.is_ok());
    |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_ok` on iterator over `Result`s
-  --> tests/ui/iter_filter_is_ok.rs:55:49
+  --> tests/ui/iter_filter_is_ok.rs:56:49
    |
 LL |         let _ = vec![Ok(1), Err(2)].into_iter().filter(|ref o| { o.is_ok() });
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`

--- a/tests/ui/iter_filter_is_some.fixed
+++ b/tests/ui/iter_filter_is_some.fixed
@@ -5,7 +5,8 @@
     clippy::needless_borrow,
     clippy::option_filter_map,
     clippy::redundant_closure,
-    clippy::unnecessary_get_then_check
+    clippy::unnecessary_get_then_check,
+    clippy::unnecessary_collection_clone
 )]
 
 use std::collections::HashMap;

--- a/tests/ui/iter_filter_is_some.rs
+++ b/tests/ui/iter_filter_is_some.rs
@@ -5,7 +5,8 @@
     clippy::needless_borrow,
     clippy::option_filter_map,
     clippy::redundant_closure,
-    clippy::unnecessary_get_then_check
+    clippy::unnecessary_get_then_check,
+    clippy::unnecessary_collection_clone
 )]
 
 use std::collections::HashMap;

--- a/tests/ui/iter_filter_is_some.stderr
+++ b/tests/ui/iter_filter_is_some.stderr
@@ -1,5 +1,5 @@
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:15:58
+  --> tests/ui/iter_filter_is_some.rs:16:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(Option::is_some);
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
@@ -8,55 +8,55 @@ LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(Option::is_
    = help: to override `-D warnings` add `#[allow(clippy::iter_filter_is_some)]`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:17:58
+  --> tests/ui/iter_filter_is_some.rs:18:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|a| a.is_some());
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:20:58
+  --> tests/ui/iter_filter_is_some.rs:21:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|o| { o.is_some() });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:27:14
+  --> tests/ui/iter_filter_is_some.rs:28:14
    |
 LL |             .filter(std::option::Option::is_some);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:32:14
+  --> tests/ui/iter_filter_is_some.rs:33:14
    |
 LL |             .filter(|a| std::option::Option::is_some(a));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:35:58
+  --> tests/ui/iter_filter_is_some.rs:36:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|a| { std::option::Option::is_some(a) });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:40:58
+  --> tests/ui/iter_filter_is_some.rs:41:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|&a| a.is_some());
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:44:58
+  --> tests/ui/iter_filter_is_some.rs:45:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|&o| { o.is_some() });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:49:58
+  --> tests/ui/iter_filter_is_some.rs:50:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|ref a| a.is_some());
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`
 
 error: `filter` for `is_some` on iterator over `Option`
-  --> tests/ui/iter_filter_is_some.rs:53:58
+  --> tests/ui/iter_filter_is_some.rs:54:58
    |
 LL |         let _ = vec![Some(1), None, Some(3)].into_iter().filter(|ref o| { o.is_some() });
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `flatten` instead: `flatten()`

--- a/tests/ui/iter_kv_map.fixed
+++ b/tests/ui/iter_kv_map.fixed
@@ -1,5 +1,11 @@
 #![warn(clippy::iter_kv_map)]
-#![allow(unused_mut, clippy::redundant_clone, clippy::suspicious_map, clippy::map_identity)]
+#![allow(
+    unused_mut,
+    clippy::redundant_clone,
+    clippy::suspicious_map,
+    clippy::map_identity,
+    clippy::unnecessary_collection_clone
+)]
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/tests/ui/iter_kv_map.rs
+++ b/tests/ui/iter_kv_map.rs
@@ -1,5 +1,11 @@
 #![warn(clippy::iter_kv_map)]
-#![allow(unused_mut, clippy::redundant_clone, clippy::suspicious_map, clippy::map_identity)]
+#![allow(
+    unused_mut,
+    clippy::redundant_clone,
+    clippy::suspicious_map,
+    clippy::map_identity,
+    clippy::unnecessary_collection_clone
+)]
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/tests/ui/iter_kv_map.stderr
+++ b/tests/ui/iter_kv_map.stderr
@@ -1,5 +1,5 @@
 error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:14:13
+  --> tests/ui/iter_kv_map.rs:20:13
    |
 LL |     let _ = map.iter().map(|(key, _)| key).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
@@ -8,173 +8,73 @@ LL |     let _ = map.iter().map(|(key, _)| key).collect::<Vec<_>>();
    = help: to override `-D warnings` add `#[allow(clippy::iter_kv_map)]`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:15:13
+  --> tests/ui/iter_kv_map.rs:21:13
    |
 LL |     let _ = map.iter().map(|(_, value)| value).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values()`
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:16:13
-   |
-LL |     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|v| v + 2)`
-
-error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:18:13
-   |
-LL |     let _ = map.clone().into_iter().map(|(key, _)| key).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys()`
-
-error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:19:13
-   |
-LL |     let _ = map.clone().into_iter().map(|(key, _)| key + 2).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys().map(|key| key + 2)`
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:21:13
-   |
-LL |     let _ = map.clone().into_iter().map(|(_, val)| val).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values()`
 
 error: iterating on a map's values
   --> tests/ui/iter_kv_map.rs:22:13
    |
-LL |     let _ = map.clone().into_iter().map(|(_, val)| val + 2).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values().map(|val| val + 2)`
+LL |     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|v| v + 2)`
 
-error: iterating on a map's values
+error: iterating on a map's keys
   --> tests/ui/iter_kv_map.rs:24:13
    |
-LL |     let _ = map.clone().iter().map(|(_, val)| val).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().values()`
+LL |     let _ = map.clone().into_iter().map(|(key, _)| key).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys()`
 
 error: iterating on a map's keys
   --> tests/ui/iter_kv_map.rs:25:13
    |
-LL |     let _ = map.iter().map(|(key, _)| key).filter(|x| *x % 2 == 0).count();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
-
-error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:35:13
-   |
-LL |     let _ = map.iter().map(|(key, _value)| key * 9).count();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys().map(|key| key * 9)`
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:36:13
-   |
-LL |     let _ = map.iter().map(|(_key, value)| value * 17).count();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|value| value * 17)`
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:39:13
-   |
-LL |     let _ = map.clone().into_iter().map(|(_, ref val)| ref_acceptor(val)).count();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values().map(|ref val| ref_acceptor(val))`
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:42:13
-   |
-LL |       let _ = map
-   |  _____________^
-LL | |         .clone()
-LL | |         .into_iter()
-LL | |         .map(|(_, mut val)| {
-LL | |             val += 2;
-LL | |             val
-LL | |         })
-   | |__________^
-   |
-help: try
-   |
-LL ~     let _ = map
-LL +         .clone().into_values().map(|mut val| {
-LL +             val += 2;
-LL +             val
-LL +         })
-   |
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:52:13
-   |
-LL |     let _ = map.clone().into_iter().map(|(_, mut val)| val).count();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values()`
-
-error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:56:13
-   |
-LL |     let _ = map.iter().map(|(key, _)| key).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:57:13
-   |
-LL |     let _ = map.iter().map(|(_, value)| value).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values()`
-
-error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:58:13
-   |
-LL |     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|v| v + 2)`
-
-error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:60:13
-   |
-LL |     let _ = map.clone().into_iter().map(|(key, _)| key).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys()`
-
-error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:61:13
-   |
 LL |     let _ = map.clone().into_iter().map(|(key, _)| key + 2).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys().map(|key| key + 2)`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:63:13
+  --> tests/ui/iter_kv_map.rs:27:13
    |
 LL |     let _ = map.clone().into_iter().map(|(_, val)| val).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values()`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:64:13
+  --> tests/ui/iter_kv_map.rs:28:13
    |
 LL |     let _ = map.clone().into_iter().map(|(_, val)| val + 2).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values().map(|val| val + 2)`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:66:13
+  --> tests/ui/iter_kv_map.rs:30:13
    |
 LL |     let _ = map.clone().iter().map(|(_, val)| val).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().values()`
 
 error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:67:13
+  --> tests/ui/iter_kv_map.rs:31:13
    |
 LL |     let _ = map.iter().map(|(key, _)| key).filter(|x| *x % 2 == 0).count();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
 
 error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:77:13
+  --> tests/ui/iter_kv_map.rs:41:13
    |
 LL |     let _ = map.iter().map(|(key, _value)| key * 9).count();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys().map(|key| key * 9)`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:78:13
+  --> tests/ui/iter_kv_map.rs:42:13
    |
 LL |     let _ = map.iter().map(|(_key, value)| value * 17).count();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|value| value * 17)`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:81:13
+  --> tests/ui/iter_kv_map.rs:45:13
    |
 LL |     let _ = map.clone().into_iter().map(|(_, ref val)| ref_acceptor(val)).count();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values().map(|ref val| ref_acceptor(val))`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:84:13
+  --> tests/ui/iter_kv_map.rs:48:13
    |
 LL |       let _ = map
    |  _____________^
@@ -196,67 +96,167 @@ LL +         })
    |
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:94:13
+  --> tests/ui/iter_kv_map.rs:58:13
    |
 LL |     let _ = map.clone().into_iter().map(|(_, mut val)| val).count();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values()`
 
 error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:109:13
+  --> tests/ui/iter_kv_map.rs:62:13
    |
 LL |     let _ = map.iter().map(|(key, _)| key).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:111:13
+  --> tests/ui/iter_kv_map.rs:63:13
    |
 LL |     let _ = map.iter().map(|(_, value)| value).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values()`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:113:13
+  --> tests/ui/iter_kv_map.rs:64:13
    |
 LL |     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|v| v + 2)`
 
 error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:122:13
+  --> tests/ui/iter_kv_map.rs:66:13
    |
 LL |     let _ = map.clone().into_iter().map(|(key, _)| key).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys()`
 
 error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:124:13
+  --> tests/ui/iter_kv_map.rs:67:13
    |
 LL |     let _ = map.clone().into_iter().map(|(key, _)| key + 2).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys().map(|key| key + 2)`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:127:13
+  --> tests/ui/iter_kv_map.rs:69:13
    |
 LL |     let _ = map.clone().into_iter().map(|(_, val)| val).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values()`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:129:13
+  --> tests/ui/iter_kv_map.rs:70:13
    |
 LL |     let _ = map.clone().into_iter().map(|(_, val)| val + 2).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values().map(|val| val + 2)`
 
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:72:13
+   |
+LL |     let _ = map.clone().iter().map(|(_, val)| val).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().values()`
+
 error: iterating on a map's keys
-  --> tests/ui/iter_kv_map.rs:132:13
+  --> tests/ui/iter_kv_map.rs:73:13
+   |
+LL |     let _ = map.iter().map(|(key, _)| key).filter(|x| *x % 2 == 0).count();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
+
+error: iterating on a map's keys
+  --> tests/ui/iter_kv_map.rs:83:13
+   |
+LL |     let _ = map.iter().map(|(key, _value)| key * 9).count();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys().map(|key| key * 9)`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:84:13
+   |
+LL |     let _ = map.iter().map(|(_key, value)| value * 17).count();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|value| value * 17)`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:87:13
+   |
+LL |     let _ = map.clone().into_iter().map(|(_, ref val)| ref_acceptor(val)).count();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values().map(|ref val| ref_acceptor(val))`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:90:13
+   |
+LL |       let _ = map
+   |  _____________^
+LL | |         .clone()
+LL | |         .into_iter()
+LL | |         .map(|(_, mut val)| {
+LL | |             val += 2;
+LL | |             val
+LL | |         })
+   | |__________^
+   |
+help: try
+   |
+LL ~     let _ = map
+LL +         .clone().into_values().map(|mut val| {
+LL +             val += 2;
+LL +             val
+LL +         })
+   |
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:100:13
+   |
+LL |     let _ = map.clone().into_iter().map(|(_, mut val)| val).count();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values()`
+
+error: iterating on a map's keys
+  --> tests/ui/iter_kv_map.rs:115:13
    |
 LL |     let _ = map.iter().map(|(key, _)| key).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:134:13
+  --> tests/ui/iter_kv_map.rs:117:13
    |
 LL |     let _ = map.iter().map(|(_, value)| value).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values()`
 
 error: iterating on a map's values
-  --> tests/ui/iter_kv_map.rs:136:13
+  --> tests/ui/iter_kv_map.rs:119:13
+   |
+LL |     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|v| v + 2)`
+
+error: iterating on a map's keys
+  --> tests/ui/iter_kv_map.rs:128:13
+   |
+LL |     let _ = map.clone().into_iter().map(|(key, _)| key).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys()`
+
+error: iterating on a map's keys
+  --> tests/ui/iter_kv_map.rs:130:13
+   |
+LL |     let _ = map.clone().into_iter().map(|(key, _)| key + 2).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_keys().map(|key| key + 2)`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:133:13
+   |
+LL |     let _ = map.clone().into_iter().map(|(_, val)| val).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values()`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:135:13
+   |
+LL |     let _ = map.clone().into_iter().map(|(_, val)| val + 2).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.clone().into_values().map(|val| val + 2)`
+
+error: iterating on a map's keys
+  --> tests/ui/iter_kv_map.rs:138:13
+   |
+LL |     let _ = map.iter().map(|(key, _)| key).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.keys()`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:140:13
+   |
+LL |     let _ = map.iter().map(|(_, value)| value).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values()`
+
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:142:13
    |
 LL |     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|v| v + 2)`

--- a/tests/ui/unnecessary_collection_clone.fixed
+++ b/tests/ui/unnecessary_collection_clone.fixed
@@ -1,0 +1,55 @@
+#![warn(clippy::unnecessary_collection_clone)]
+#![allow(clippy::iter_cloned_collect)]
+
+use std::collections::LinkedList;
+use std::marker::PhantomData;
+
+fn basic(val: Vec<u8>) -> Vec<u8> {
+    val.iter().cloned().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn non_deref_to_slice(val: LinkedList<u8>) -> Vec<u8> {
+    val.iter().cloned().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn partial_borrow(vals: (Vec<u8>,)) -> Vec<u8> {
+    vals.0.iter().cloned().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn generic<T: Clone>(val: Vec<T>) -> Vec<T> {
+    val.iter().cloned().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn use_mutable<T>(_: &mut T) {}
+
+// Should not lint, as the replacement causes the mutable borrow to overlap
+fn used_mutably<T: Clone>(mut vals: Vec<T>) {
+    for val in vals.clone().into_iter() {
+        use_mutable(&mut vals)
+    }
+}
+
+// Should not lint, as the replacement causes the mutable borrow to overlap
+fn used_mutably_chain<T: Clone>(mut vals: Vec<T>) {
+    vals.clone().into_iter().for_each(|_| use_mutable(&mut vals));
+}
+
+// Should not lint, as the replacement causes the mutable borrow to overlap
+fn used_mutably_partial_borrow<T: Clone>(mut vals: (Vec<T>,)) {
+    vals.0.clone().into_iter().for_each(|_| use_mutable(&mut vals.0))
+}
+
+// Should not lint, as `Src` has no `iter` method to use.
+fn too_generic<Src, Dst, T: Clone>(val: Src) -> Dst
+where
+    Src: IntoIterator<Item = T> + Clone,
+    Dst: FromIterator<T>,
+{
+    val.clone().into_iter().collect()
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_collection_clone.rs
+++ b/tests/ui/unnecessary_collection_clone.rs
@@ -1,0 +1,55 @@
+#![warn(clippy::unnecessary_collection_clone)]
+#![allow(clippy::iter_cloned_collect)]
+
+use std::collections::LinkedList;
+use std::marker::PhantomData;
+
+fn basic(val: Vec<u8>) -> Vec<u8> {
+    val.clone().into_iter().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn non_deref_to_slice(val: LinkedList<u8>) -> Vec<u8> {
+    val.clone().into_iter().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn partial_borrow(vals: (Vec<u8>,)) -> Vec<u8> {
+    vals.0.clone().into_iter().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn generic<T: Clone>(val: Vec<T>) -> Vec<T> {
+    val.clone().into_iter().collect()
+    //~^ error: using clone on collection to own iterated items
+}
+
+fn use_mutable<T>(_: &mut T) {}
+
+// Should not lint, as the replacement causes the mutable borrow to overlap
+fn used_mutably<T: Clone>(mut vals: Vec<T>) {
+    for val in vals.clone().into_iter() {
+        use_mutable(&mut vals)
+    }
+}
+
+// Should not lint, as the replacement causes the mutable borrow to overlap
+fn used_mutably_chain<T: Clone>(mut vals: Vec<T>) {
+    vals.clone().into_iter().for_each(|_| use_mutable(&mut vals));
+}
+
+// Should not lint, as the replacement causes the mutable borrow to overlap
+fn used_mutably_partial_borrow<T: Clone>(mut vals: (Vec<T>,)) {
+    vals.0.clone().into_iter().for_each(|_| use_mutable(&mut vals.0))
+}
+
+// Should not lint, as `Src` has no `iter` method to use.
+fn too_generic<Src, Dst, T: Clone>(val: Src) -> Dst
+where
+    Src: IntoIterator<Item = T> + Clone,
+    Dst: FromIterator<T>,
+{
+    val.clone().into_iter().collect()
+}
+
+fn main() {}

--- a/tests/ui/unnecessary_collection_clone.stderr
+++ b/tests/ui/unnecessary_collection_clone.stderr
@@ -1,0 +1,29 @@
+error: using clone on collection to own iterated items
+  --> tests/ui/unnecessary_collection_clone.rs:8:5
+   |
+LL |     val.clone().into_iter().collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `val.iter().cloned()`
+   |
+   = note: `-D clippy::unnecessary-collection-clone` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_collection_clone)]`
+
+error: using clone on collection to own iterated items
+  --> tests/ui/unnecessary_collection_clone.rs:13:5
+   |
+LL |     val.clone().into_iter().collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `val.iter().cloned()`
+
+error: using clone on collection to own iterated items
+  --> tests/ui/unnecessary_collection_clone.rs:18:5
+   |
+LL |     vals.0.clone().into_iter().collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `vals.0.iter().cloned()`
+
+error: using clone on collection to own iterated items
+  --> tests/ui/unnecessary_collection_clone.rs:23:5
+   |
+LL |     val.clone().into_iter().collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `val.iter().cloned()`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Closes #3302

changelog: [`unnecessary_collection_clone`] Add a lint for `.clone().into_iter()`.