### PR TITLE
Add test case for `missing_errors_doc` at tests with option `check-private-item=true`

### DIFF
--- a/tests/ui-toml/private-doc-errors/doc_lints.rs
+++ b/tests/ui-toml/private-doc-errors/doc_lints.rs
@@ -51,4 +51,10 @@ pub mod __macro {
     }
 }
 
+#[warn(clippy::missing_errors_doc)]
+#[test]
+fn test() -> Result<(), ()> {
+    Ok(())
+}
+
 fn main() {}


### PR DESCRIPTION
Add test case for `missing_errors_doc` at tests with option `check-private-item=true` to proof that rust-lang/rust-clippy#13391 is not an issue anymore

changelog: none

Closes: rust-lang/rust-clippy#13391
