### PR TITLE
Watch `tests/compile-test.rs` in `cargo dev serve`

### DIFF
--- a/clippy_dev/src/serve.rs
+++ b/clippy_dev/src/serve.rs
@@ -20,8 +20,14 @@ pub fn run(port: u16, lint: Option<String>) -> ! {
 
     loop {
         let index_time = mtime("util/gh-pages/index.html");
+        let times = [
+            "clippy_lints/src",
+            "util/gh-pages/index_template.html",
+            "tests/compile-test.rs",
+        ]
+        .map(mtime);
 
-        if index_time < mtime("clippy_lints/src") || index_time < mtime("util/gh-pages/index_template.html") {
+        if times.iter().any(|&time| index_time < time) {
             Command::new(env::var("CARGO").unwrap_or("cargo".into()))
                 .arg("collect-metadata")
                 .spawn()


### PR DESCRIPTION
Changes to `compile-test.rs` will also need a rerun of `collect-metadata`

changelog: none
