### PR TITLE
detect allow_attributes on internal attributes

### DIFF
--- a/clippy_lints/src/attrs/allow_attributes.rs
+++ b/clippy_lints/src/attrs/allow_attributes.rs
@@ -1,7 +1,7 @@
 use super::ALLOW_ATTRIBUTES;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::is_from_proc_macro;
-use rustc_ast::{AttrStyle, Attribute};
+use rustc_ast::Attribute;
 use rustc_errors::Applicability;
 use rustc_lint::{LateContext, LintContext};
 use rustc_middle::lint::in_external_macro;
@@ -9,7 +9,6 @@ use rustc_middle::lint::in_external_macro;
 // Separate each crate's features.
 pub fn check<'cx>(cx: &LateContext<'cx>, attr: &'cx Attribute) {
     if !in_external_macro(cx.sess(), attr.span)
-        && let AttrStyle::Outer = attr.style
         && let Some(ident) = attr.ident()
         && !is_from_proc_macro(cx, attr)
     {

--- a/tests/ui/allow_attributes.fixed
+++ b/tests/ui/allow_attributes.fixed
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 //@aux-build:proc_macro_derive.rs
-#![allow(unused)]
+#![expect(unused)]
 #![warn(clippy::allow_attributes)]
 #![no_main]
 
@@ -45,7 +45,7 @@ fn ignore_proc_macro() {
 }
 
 fn ignore_inner_attr() {
-    #![allow(unused)] // Should not lint
+    #![expect(unused)]
 }
 
 #[clippy::msrv = "1.81"]

--- a/tests/ui/allow_attributes.rs
+++ b/tests/ui/allow_attributes.rs
@@ -45,7 +45,7 @@ fn ignore_proc_macro() {
 }
 
 fn ignore_inner_attr() {
-    #![allow(unused)] // Should not lint
+    #![allow(unused)]
 }
 
 #[clippy::msrv = "1.81"]

--- a/tests/ui/allow_attributes.stderr
+++ b/tests/ui/allow_attributes.stderr
@@ -1,17 +1,29 @@
 error: #[allow] attribute found
+  --> tests/ui/allow_attributes.rs:3:4
+   |
+LL | #![allow(unused)]
+   |    ^^^^^ help: replace it with: `expect`
+   |
+   = note: `-D clippy::allow-attributes` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::allow_attributes)]`
+
+error: #[allow] attribute found
   --> tests/ui/allow_attributes.rs:13:3
    |
 LL | #[allow(dead_code)]
    |   ^^^^^ help: replace it with: `expect`
-   |
-   = note: `-D clippy::allow-attributes` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::allow_attributes)]`
 
 error: #[allow] attribute found
   --> tests/ui/allow_attributes.rs:22:30
    |
 LL | #[cfg_attr(panic = "unwind", allow(dead_code))]
    |                              ^^^^^ help: replace it with: `expect`
+
+error: #[allow] attribute found
+  --> tests/ui/allow_attributes.rs:48:8
+   |
+LL |     #![allow(unused)]
+   |        ^^^^^ help: replace it with: `expect`
 
 error: #[allow] attribute found
   --> tests/ui/allow_attributes.rs:53:7
@@ -27,5 +39,5 @@ LL |     #[allow(unused)]
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
I was working on attributes, part of which is that I might remove AttrStyle here. Don't worry about that, but it meant I was refactoring this and I saw no reason we don't lint on internal attributes. Is there a good reason? Then feel free to close :)

changelog:

changelog: [`allow_attributes`]: lint internal attributes too