### PR TITLE
needless_continue: check labels consistency before warning

### DIFF
--- a/clippy_lints/src/needless_continue.rs
+++ b/clippy_lints/src/needless_continue.rs
@@ -330,10 +330,11 @@ fn suggestion_snippet_for_continue_inside_else(cx: &EarlyContext<'_>, data: &Lin
 }
 
 fn check_and_warn(cx: &EarlyContext<'_>, expr: &ast::Expr) {
-    if let ast::ExprKind::Loop(loop_block, ..) = &expr.kind
+    if let ast::ExprKind::Loop(loop_block, loop_label, ..) = &expr.kind
         && let Some(last_stmt) = loop_block.stmts.last()
         && let ast::StmtKind::Expr(inner_expr) | ast::StmtKind::Semi(inner_expr) = &last_stmt.kind
-        && let ast::ExprKind::Continue(_) = inner_expr.kind
+        && let ast::ExprKind::Continue(continue_label) = inner_expr.kind
+        && compare_labels(loop_label.as_ref(), continue_label.as_ref())
     {
         span_lint_and_help(
             cx,

--- a/tests/ui/needless_continue.rs
+++ b/tests/ui/needless_continue.rs
@@ -151,3 +151,20 @@ mod issue_2329 {
         }
     }
 }
+
+fn issue_13641() {
+    'a: while std::hint::black_box(true) {
+        #[allow(clippy::never_loop)]
+        loop {
+            continue 'a;
+        }
+    }
+
+    #[allow(clippy::never_loop)]
+    while std::hint::black_box(true) {
+        'b: loop {
+            continue 'b;
+            //~^ ERROR: this `continue` expression is redundant
+        }
+    }
+}

--- a/tests/ui/needless_continue.stderr
+++ b/tests/ui/needless_continue.stderr
@@ -136,5 +136,13 @@ LL | |                 }
                                println!("bar-5");
                            }
 
-error: aborting due to 8 previous errors
+error: this `continue` expression is redundant
+  --> tests/ui/needless_continue.rs:166:13
+   |
+LL |             continue 'b;
+   |             ^^^^^^^^^^^^
+   |
+   = help: consider dropping the `continue` expression
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
changelog: [`needless_continue`]: check labels before warning about `continue` as the last statement in a loop body

Fix #13641