### PR TITLE
no_mangle_with_rust_abi: properly position the suggested ABI

### DIFF
--- a/clippy_lints/src/no_mangle_with_rust_abi.rs
+++ b/clippy_lints/src/no_mangle_with_rust_abi.rs
@@ -40,12 +40,12 @@ impl<'tcx> LateLintPass<'tcx> for NoMangleWithRustAbi {
         if let ItemKind::Fn(fn_sig, _, _) = &item.kind {
             let attrs = cx.tcx.hir().attrs(item.hir_id());
             let mut app = Applicability::MaybeIncorrect;
-            let fn_snippet = snippet_with_applicability(cx, fn_sig.span, "..", &mut app);
+            let fn_snippet = snippet_with_applicability(cx, fn_sig.span.with_hi(item.ident.span.lo()), "..", &mut app);
             for attr in attrs {
                 if let Some(ident) = attr.ident()
                     && ident.name == rustc_span::sym::no_mangle
                     && fn_sig.header.abi == Abi::Rust
-                    && let Some((fn_attrs, _)) = fn_snippet.split_once("fn")
+                    && let Some((fn_attrs, _)) = fn_snippet.rsplit_once("fn")
                     && !fn_attrs.contains("extern")
                 {
                     let sugg_span = fn_sig

--- a/tests/ui/no_mangle_with_rust_abi.rs
+++ b/tests/ui/no_mangle_with_rust_abi.rs
@@ -48,6 +48,11 @@ extern "C" {
     fn c_abi_in_block(arg_one: u32, arg_two: usize);
 }
 
+mod r#fn {
+    #[unsafe(no_mangle)]
+    pub(in super::r#fn) fn with_some_fn_around() {}
+}
+
 fn main() {
     // test code goes here
 }

--- a/tests/ui/no_mangle_with_rust_abi.stderr
+++ b/tests/ui/no_mangle_with_rust_abi.stderr
@@ -79,5 +79,20 @@ help: or explicitly set the default
 LL | extern "Rust" fn rust_abi_multiline_function_really_long_name_to_overflow_args_to_multiple_lines(
    | +++++++++++++
 
-error: aborting due to 5 previous errors
+error: `#[unsafe(no_mangle)]` set on a function with the default (`Rust`) ABI
+  --> tests/ui/no_mangle_with_rust_abi.rs:53:5
+   |
+LL |     pub(in super::r#fn) fn with_some_fn_around() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: set an ABI
+   |
+LL |     pub(in super::r#fn) extern "C" fn with_some_fn_around() {}
+   |                         ++++++++++
+help: or explicitly set the default
+   |
+LL |     pub(in super::r#fn) extern "Rust" fn with_some_fn_around() {}
+   |                         +++++++++++++
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Fix #13656

changelog: [`no_mangle_with_rust_abi`]: properly position the suggested ABI
