### PR TITLE
Fix `large_include_file` lint being triggered all the time by doc comments

### DIFF
--- a/clippy_lints/src/large_include_file.rs
+++ b/clippy_lints/src/large_include_file.rs
@@ -94,6 +94,8 @@ impl LateLintPass<'_> for LargeIncludeFile {
             // Currently, rustc limits the usage of macro at the top-level of attributes,
             // so we don't need to recurse into each level.
             && let AttrKind::Normal(ref normal) = attr.kind
+            && let Some(doc) = attr.doc_str()
+            && doc.as_str().len() as u64 > self.max_file_size
             && let AttrArgs::Eq(_, AttrArgsEq::Hir(ref meta)) = normal.item.args
             && !attr.span.contains(meta.span)
             // Since the `include_str` is already expanded at this point, we can only take the

--- a/tests/ui-toml/large_include_file/large_include_file.rs
+++ b/tests/ui-toml/large_include_file/large_include_file.rs
@@ -15,5 +15,9 @@ const TOO_BIG_INCLUDE_BYTES: &[u8; 654] = include_bytes!("too_big.txt");
 const TOO_BIG_INCLUDE_STR: &str = include_str!("too_big.txt");
 //~^ large_include_file
 
-#[doc = include_str!("too_big.txt")] //~ large_include_file
+#[doc = include_str!("too_big.txt")]
+//~^ large_include_file
+// Should not lint!
+// Regression test for <https://github.com/rust-lang/rust-clippy/issues/13670>.
+#[doc = include_str!("empty.txt")]
 fn main() {}


### PR DESCRIPTION
Fixes #13670.

Bug was that I forgot to add the comparison with the included file content length...

changelog: Fix `large_include_file` lint being triggered all the time by doc comments