### PR TITLE
Fix `shadow_unrelated`'s behaviour with closures

### DIFF
--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -119,4 +119,18 @@ fn ice_8748() {
     }];
 }
 
+// https://github.com/rust-lang/rust-clippy/issues/10780
+fn shadow_closure() {
+    // These are not shadow_unrelated; but they are correctly shadow_reuse
+    let x = Some(1);
+    #[allow(clippy::shadow_reuse)]
+    let y = x.map(|x| x + 1);
+    let z = x.map(|x| x + 1);
+    let a: Vec<Option<u8>> = [100u8, 120, 140]
+        .iter()
+        .map(|i| i.checked_mul(2))
+        .map(|i| i.map(|i| i - 10))
+        .collect();
+}
+
 fn main() {}

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -280,5 +280,29 @@ note: previous binding is here
 LL |         let x = 1;
    |             ^
 
-error: aborting due to 23 previous errors
+error: `x` is shadowed
+  --> tests/ui/shadow.rs:128:20
+   |
+LL |     let z = x.map(|x| x + 1);
+   |                    ^
+   |
+note: previous binding is here
+  --> tests/ui/shadow.rs:125:9
+   |
+LL |     let x = Some(1);
+   |         ^
+
+error: `i` is shadowed
+  --> tests/ui/shadow.rs:132:25
+   |
+LL |         .map(|i| i.map(|i| i - 10))
+   |                         ^
+   |
+note: previous binding is here
+  --> tests/ui/shadow.rs:132:15
+   |
+LL |         .map(|i| i.map(|i| i - 10))
+   |               ^
+
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/10780

We correctly no longer give a warning when a closure is passed to a method, where one of the arguments to that method uses the variable which would be shadowed by an argument to that closure.
Uses is defined loosely as any expression used in the calling expression mentions the shadowee binding (except for the closure itself):

```rust
#![deny(clippy::shadow_unrelated)]
let x = Some(1);
let y = x.map(|x| x + 1);
```
will now succeed.

See https://github.com/linebender/xilem/pull/745 - without this change, all of the `expect(shadow_unrelated)` in the repository are met; with it, none of them are.

changelog: [`shadow_unrelated`]: Don't treat closures arguments as unrelated when the calling function uses them