### PR TITLE
`missing_safety_doc` accept uppercase "SAFETY"

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -917,6 +917,7 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                 }
                 let trimmed_text = text.trim();
                 headers.safety |= in_heading && trimmed_text == "Safety";
+                headers.safety |= in_heading && trimmed_text == "SAFETY";
                 headers.safety |= in_heading && trimmed_text == "Implementation safety";
                 headers.safety |= in_heading && trimmed_text == "Implementation Safety";
                 headers.errors |= in_heading && trimmed_text == "Errors";


### PR DESCRIPTION
changelog: [`missing_safety_doc`]: accept uppercase "SAFETY"

In [Oxc](https://github.com/oxc-project/oxc)'s codebase, we try to draw attention as clearly as possible to the safety constraints of unsafe code by including an uppercase `# SAFETY` doc comment.

Clippy's `missing_safety_doc` lint does not recognise "SAFETY" in upper case, so we also need to include `#[expect(clippy::missing_safety_doc)]` on every unsafe function, to avoid a false positive. Unfortunately this defeats the purpose of the lint, as if someone later removes the safety docs, the lint rule does not trigger.

I don't know how common this style of documenting unsafe functions is, but I don't imagine also supporting `# SAFETY` would disturb other users who prefer `# Safety`.
