### PR TITLE
Remove extern vectorcall tests

### DIFF
--- a/tests/ui/missing_const_for_fn/could_be_const.fixed
+++ b/tests/ui/missing_const_for_fn/could_be_const.fixed
@@ -1,6 +1,6 @@
 #![warn(clippy::missing_const_for_fn)]
 #![allow(incomplete_features, clippy::let_and_return, clippy::missing_transmute_annotations)]
-#![feature(const_trait_impl, abi_vectorcall)]
+#![feature(const_trait_impl)]
 
 use std::mem::transmute;
 
@@ -210,9 +210,5 @@ mod extern_fn {
     const extern "system" fn system() {}
     //~^ ERROR: this could be a `const fn`
     const extern "system-unwind" fn system_unwind() {}
-    //~^ ERROR: this could be a `const fn`
-    pub const extern "vectorcall" fn std_call() {}
-    //~^ ERROR: this could be a `const fn`
-    pub const extern "vectorcall-unwind" fn std_call_unwind() {}
     //~^ ERROR: this could be a `const fn`
 }

--- a/tests/ui/missing_const_for_fn/could_be_const.rs
+++ b/tests/ui/missing_const_for_fn/could_be_const.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::missing_const_for_fn)]
 #![allow(incomplete_features, clippy::let_and_return, clippy::missing_transmute_annotations)]
-#![feature(const_trait_impl, abi_vectorcall)]
+#![feature(const_trait_impl)]
 
 use std::mem::transmute;
 
@@ -210,9 +210,5 @@ mod extern_fn {
     extern "system" fn system() {}
     //~^ ERROR: this could be a `const fn`
     extern "system-unwind" fn system_unwind() {}
-    //~^ ERROR: this could be a `const fn`
-    pub extern "vectorcall" fn std_call() {}
-    //~^ ERROR: this could be a `const fn`
-    pub extern "vectorcall-unwind" fn std_call_unwind() {}
     //~^ ERROR: this could be a `const fn`
 }

--- a/tests/ui/missing_const_for_fn/could_be_const.stderr
+++ b/tests/ui/missing_const_for_fn/could_be_const.stderr
@@ -316,27 +316,5 @@ help: make the function `const`
 LL |     const extern "system-unwind" fn system_unwind() {}
    |     +++++
 
-error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:214:5
-   |
-LL |     pub extern "vectorcall" fn std_call() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: make the function `const`
-   |
-LL |     pub const extern "vectorcall" fn std_call() {}
-   |         +++++
-
-error: this could be a `const fn`
-  --> tests/ui/missing_const_for_fn/could_be_const.rs:216:5
-   |
-LL |     pub extern "vectorcall-unwind" fn std_call_unwind() {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: make the function `const`
-   |
-LL |     pub const extern "vectorcall-unwind" fn std_call_unwind() {}
-   |         +++++
-
-error: aborting due to 26 previous errors
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
On arm64 I get

```
error[E0570]: `"vectorcall"` is not a supported ABI for the current target
```

We don't seem to be doing any ABI specific handling so it seems fine to just remove this one since there are other tests

changelog: none
