### PR TITLE
Remove incorrect "default there is no limit" documentation from trivial_copy_size_limit

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -895,7 +895,7 @@ The order of associated items in traits.
 
 ## `trivial-copy-size-limit`
 The maximum size (in bytes) to consider a `Copy` type for passing by value instead of by
-reference. By default there is no limit
+reference.
 
 **Default Value:** `target_pointer_width * 2`
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -678,7 +678,7 @@ define_Conf! {
     #[lints(arbitrary_source_item_ordering)]
     trait_assoc_item_kinds_order: SourceItemOrderingTraitAssocItemKinds = DEFAULT_TRAIT_ASSOC_ITEM_KINDS_ORDER.into(),
     /// The maximum size (in bytes) to consider a `Copy` type for passing by value instead of by
-    /// reference. By default there is no limit
+    /// reference.
     #[default_text = "target_pointer_width * 2"]
     #[lints(trivially_copy_pass_by_ref)]
     trivial_copy_size_limit: Option<u64> = None,


### PR DESCRIPTION
Remove the documentation incorrectly saying there is no default, followed by the default.

![image](https://github.com/user-attachments/assets/eab54c81-945d-4ce2-b9fb-5cc84f01e68c)


changelog: [`trivially_copy_pass_by_ref`]: Removed incorrect documentation suggesting the default has no limit.