### PR TITLE
`clippy_utils`: Make `sym_helper` module private

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -53,7 +53,7 @@ extern crate rustc_trait_selection;
 extern crate smallvec;
 
 #[macro_use]
-pub mod sym_helper;
+mod sym_helper;
 
 pub mod ast_utils;
 pub mod attrs;


### PR DESCRIPTION
This is a small PR that makes `clippy_utils::sym_helper` private. Since this module only contains a single macro, `sym!`, which is already re-exported at the root with `#[macro_export]`, there's no need for the module to be public.

changelog: none

- [x] `cargo test` passes locally
- [x] Run `cargo dev fmt`