### PR TITLE
[`bad_bit_mask`] Fix FP on proc macros

### DIFF
--- a/clippy_lints/src/operators/bit_mask.rs
+++ b/clippy_lints/src/operators/bit_mask.rs
@@ -1,5 +1,6 @@
 use clippy_utils::consts::{ConstEvalCtxt, Constant};
 use clippy_utils::diagnostics::span_lint;
+use clippy_utils::is_from_proc_macro;
 use rustc_hir::{BinOpKind, Expr, ExprKind};
 use rustc_lint::LateContext;
 use rustc_span::Span;
@@ -35,9 +36,9 @@ fn invert_cmp(cmp: BinOpKind) -> BinOpKind {
     }
 }
 
-fn check_compare(cx: &LateContext<'_>, bit_op: &Expr<'_>, cmp_op: BinOpKind, cmp_value: u128, span: Span) {
+fn check_compare<'a>(cx: &LateContext<'a>, bit_op: &Expr<'a>, cmp_op: BinOpKind, cmp_value: u128, span: Span) {
     if let ExprKind::Binary(op, left, right) = &bit_op.kind {
-        if op.node != BinOpKind::BitAnd && op.node != BinOpKind::BitOr {
+        if op.node != BinOpKind::BitAnd && op.node != BinOpKind::BitOr || is_from_proc_macro(cx, bit_op) {
             return;
         }
         if let Some(mask) = fetch_int_literal(cx, right).or_else(|| fetch_int_literal(cx, left)) {


### PR DESCRIPTION
`clap-3.1.6` was not compiling on the rustc-perf benchmarks because of this lint. Also, the user could not allow the lint on the macro itself because it was checking Exprs, not whatever the input of `bitflags!` is.

```
error: &-masking with zero
   --> src/build/arg_settings.rs:197:1
    |
            (#[allow] here) 
197 | / bitflags! {
198 | |     struct Flags: u32 {
199 | |         const REQUIRED         ...
200 | |         const MULTIPLE_OCC     ...
...   |
226 | |     }
227 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bad_bit_mask
    = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
```

changelog:  [`bad_bit_mask`]: Fix FP on procedural macros