### PR TITLE
doc_lazy_continuation: Correctly count indent with backslashes

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -948,7 +948,12 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                             );
                             refdefrange.start - range.start
                         } else {
-                            next_range.start - range.start
+							let mut start = next_range.start;
+							if start > 0 && doc.as_bytes().get(start - 1) == Some(&b'\\') {
+								// backslashes aren't in the event stream...
+								start -= 1;
+							}
+                            start - range.start
                         }
                     } else {
                         0

--- a/tests/ui/doc/doc_lazy_list.fixed
+++ b/tests/ui/doc/doc_lazy_list.fixed
@@ -75,3 +75,9 @@ fn seven() {}
 ///   ]
 //~^ ERROR: doc list item without indentation
 fn eight() {}
+
+#[rustfmt::skip]
+// https://github.com/rust-lang/rust-clippy/issues/13705
+/// - \[text in square brackets\] with a long following description
+///   that goes over multiple lines
+pub fn backslash_escaped_square_braces() {}

--- a/tests/ui/doc/doc_lazy_list.rs
+++ b/tests/ui/doc/doc_lazy_list.rs
@@ -75,3 +75,9 @@ fn seven() {}
 ///  ]
 //~^ ERROR: doc list item without indentation
 fn eight() {}
+
+#[rustfmt::skip]
+// https://github.com/rust-lang/rust-clippy/issues/13705
+/// - \[text in square brackets\] with a long following description
+///   that goes over multiple lines
+pub fn backslash_escaped_square_braces() {}


### PR DESCRIPTION
changelog: [`doc_lazy_continuation`]: correctly count indent with backslashes

Fixes #13705
