### PR TITLE
chore: multipart suggestions for let_unit_value lint

### DIFF
--- a/tests/ui/let_unit.fixed
+++ b/tests/ui/let_unit.fixed
@@ -8,7 +8,7 @@ macro_rules! let_and_return {
 }
 
 fn main() {
-    let _x = println!("x");
+    println!("x");
     let _y = 1; // this is fine
     let _z = ((), 1); // this as well
     if true {
@@ -56,7 +56,7 @@ fn consume_units_with_for_loop() {
 fn multiline_sugg() {
     let v: Vec<u8> = vec![2];
 
-    let _ = v
+    v
         .into_iter()
         .map(|i| i * 2)
         .filter(|i| i % 2 == 0)
@@ -105,7 +105,7 @@ fn _returns_generic() {
     let _: () = if true { f() } else { f2(0) };
     let x: () = if true { f() } else { f2(0) };
 
-    let x = match Some(0) {
+    match Some(0) {
         None => f2(1),
         Some(0) => f(),
         Some(1) => f2(3),
@@ -186,9 +186,9 @@ pub fn issue12594() {
 
     fn actual_test() {
         // create first a unit value'd value
-        let res = returns_unit();
-        returns_result(res).unwrap();
-        returns_result(res).unwrap();
+        returns_unit();
+        returns_result(()).unwrap();
+        returns_result(()).unwrap();
         // make sure we replace only the first variable
         let res = 1;
         returns_result(res).unwrap();

--- a/tests/ui/let_unit.stderr
+++ b/tests/ui/let_unit.stderr
@@ -1,5 +1,5 @@
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:13:5
+  --> tests/ui/let_unit.rs:11:5
    |
 LL |     let _x = println!("x");
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: omit the `let` binding: `println!("x");`
@@ -8,7 +8,7 @@ LL |     let _x = println!("x");
    = help: to override `-D warnings` add `#[allow(clippy::let_unit_value)]`
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:61:5
+  --> tests/ui/let_unit.rs:59:5
    |
 LL | /     let _ = v
 LL | |         .into_iter()
@@ -31,7 +31,7 @@ LL +         .unwrap();
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:110:5
+  --> tests/ui/let_unit.rs:108:5
    |
 LL | /     let x = match Some(0) {
 LL | |         None => f2(1),
@@ -52,23 +52,17 @@ LL +     };
    |
 
 error: this let-binding has unit value
-  --> tests/ui/let_unit.rs:191:9
+  --> tests/ui/let_unit.rs:189:9
    |
 LL |         let res = returns_unit();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: omit the `let` binding
+help: omit the `let` binding and replace variable usages with `()`
    |
-LL |         returns_unit();
+LL ~         returns_unit();
+LL ~         returns_result(()).unwrap();
+LL ~         returns_result(()).unwrap();
    |
-help: variable `res` of type `()` can be replaced with explicit `()`
-   |
-LL |         returns_result(()).unwrap();
-   |                        ~~
-help: variable `res` of type `()` can be replaced with explicit `()`
-   |
-LL |         returns_result(()).unwrap();
-   |                        ~~
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This should address #13099 for the let_unit test. 

changelog: [let_unit]: Updated let_unit to use multipart_suggestions where appropriate 