### PR TITLE
Remove `cargo dev fmt` reliance on rustup

### DIFF
--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -3,7 +3,6 @@ use itertools::Itertools;
 use rustc_lexer::{TokenKind, tokenize};
 use shell_escape::escape;
 use std::ffi::{OsStr, OsString};
-use std::io::BufRead;
 use std::ops::ControlFlow;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
@@ -266,42 +265,6 @@ fn fmt_conf(check: bool) -> Result<(), Error> {
     Ok(())
 }
 
-fn find_rustfmt() -> Result<String, Error> {
-    #[cfg(windows)]
-    const WHICH_BIN: &str = "where";
-
-    #[cfg(not(windows))]
-    const WHICH_BIN: &str = "which";
-
-    let output = Command::new("rustup")
-        .args(["which", "rustfmt"])
-        .stderr(Stdio::inherit())
-        .output();
-
-    if let Ok(output) = output {
-        if output.status.success() {
-            return Ok(String::from_utf8(output.stdout).expect("invalid rustfmt path"));
-        }
-    }
-
-    // `rustup which` has failed, fallback to platform-specific built-in command
-    let output = Command::new(WHICH_BIN)
-        .args(["rustfmt"])
-        .stderr(Stdio::inherit())
-        .output();
-
-    if let Ok(output) = output {
-        if output.status.success() {
-            // Since `where` can display multiple results we want to ignore all but one
-            if let Some(Ok(line)) = output.stdout.lines().next() {
-                return Ok(line);
-            }
-        }
-    }
-
-    Err(Error::RustfmtNotInstalled)
-}
-
 fn run_rustfmt(context: &FmtContext) -> Result<(), Error> {
     let project_root = clippy_project_root();
 
@@ -344,14 +307,18 @@ fn run_rustfmt(context: &FmtContext) -> Result<(), Error> {
 
 // the "main" function of cargo dev fmt
 pub fn run(check: bool, verbose: bool) {
-    let mut rustfmt_path;
-    match find_rustfmt() {
-        Ok(path) => rustfmt_path = path,
-        Err(e) => {
-            e.display();
-            process::exit(1);
-        },
-    }
+    let result = Command::new("rustup")
+        .args(["which", "rustfmt"])
+        .stderr(Stdio::inherit())
+        .output();
+
+    let mut rustfmt_path = if let Ok(output) = result
+        && output.status.success()
+    {
+        String::from_utf8(output.stdout).expect("invalid rustfmt path")
+    } else {
+        String::from("rustfmt")
+    };
 
     rustfmt_path.truncate(rustfmt_path.trim_end().len());
 


### PR DESCRIPTION
*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog: none

I hope PRs like this are welcome, it's a small update to the `cargo dev fmt` subcommand. I noticed that it uses `rustup which rustfmt` to get the full command path, and fails if this doesn't work. I think it would be useful to fall back to `which` or `where` if someone is using something other than rustup for toolchain management.