### PR TITLE
Do not mark attributes with unknown namespace as useless

### DIFF
--- a/tests/ui/useless_attribute.fixed
+++ b/tests/ui/useless_attribute.fixed
@@ -134,3 +134,12 @@ pub mod ambiguous_glob_exports {
     pub use my_prelude::*;
     pub use my_type::*;
 }
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/13764
+pub mod unknown_namespace {
+    pub mod some_module {
+        pub struct SomeType;
+    }
+    #[allow(rustc::non_glob_import_of_type_ir_inherent)]
+    use some_module::SomeType;
+}

--- a/tests/ui/useless_attribute.rs
+++ b/tests/ui/useless_attribute.rs
@@ -134,3 +134,12 @@ pub mod ambiguous_glob_exports {
     pub use my_prelude::*;
     pub use my_type::*;
 }
+
+// Regression test for https://github.com/rust-lang/rust-clippy/issues/13764
+pub mod unknown_namespace {
+    pub mod some_module {
+        pub struct SomeType;
+    }
+    #[allow(rustc::non_glob_import_of_type_ir_inherent)]
+    use some_module::SomeType;
+}


### PR DESCRIPTION
Fixes #13764

changelog: [`useless_attribute`]: do not trigger on attributes with unknown namespace