### PR TITLE
Add new case for `question_mark` lint

### DIFF
--- a/tests/ui/question_mark.fixed
+++ b/tests/ui/question_mark.fixed
@@ -373,3 +373,24 @@ fn issue12412(foo: &Foo, bar: &Bar) -> Option<()> {
     let v = bar.foo.owned.clone()?;
     Some(())
 }
+
+mod issue13626 {
+    fn basic_test(x: Option<u32>) -> Option<u32> {
+        let x = x?;
+        dbg!(x);
+        Some(x * 2)
+    }
+
+    fn mut_ref_test(mut x: Option<u32>) -> Option<u32> {
+        let x = x.as_mut()?;
+        dbg!(*x);
+        Some(*x * 2)
+    }
+
+    #[allow(clippy::needless_return)]
+    fn explicit_return_test(x: Option<u32>) -> Option<u32> {
+        let x = x?;
+        dbg!(x);
+        return Some(x * 2);
+    }
+}

--- a/tests/ui/question_mark.rs
+++ b/tests/ui/question_mark.rs
@@ -430,3 +430,33 @@ fn issue12412(foo: &Foo, bar: &Bar) -> Option<()> {
     };
     Some(())
 }
+
+mod issue13626 {
+    fn basic_test(x: Option<u32>) -> Option<u32> {
+        if let Some(x) = x {
+            dbg!(x);
+            Some(x * 2)
+        } else {
+            None
+        }
+    }
+
+    fn mut_ref_test(mut x: Option<u32>) -> Option<u32> {
+        if let Some(ref mut x) = x {
+            dbg!(*x);
+            Some(*x * 2)
+        } else {
+            None
+        }
+    }
+
+    #[allow(clippy::needless_return)]
+    fn explicit_return_test(x: Option<u32>) -> Option<u32> {
+        if let Some(x) = x {
+            dbg!(x);
+            return Some(x * 2);
+        } else {
+            return None;
+        }
+    }
+}

--- a/tests/ui/question_mark.stderr
+++ b/tests/ui/question_mark.stderr
@@ -196,5 +196,59 @@ LL | |         return None;
 LL | |     };
    | |______^ help: replace it with: `let v = bar.foo.owned.clone()?;`
 
-error: aborting due to 22 previous errors
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:436:9
+   |
+LL | /         if let Some(x) = x {
+LL | |             dbg!(x);
+LL | |             Some(x * 2)
+LL | |         } else {
+LL | |             None
+LL | |         }
+   | |_________^
+   |
+help: replace it with
+   |
+LL ~         let x = x?;
+LL +         dbg!(x);
+LL +         Some(x * 2)
+   |
+
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:445:9
+   |
+LL | /         if let Some(ref mut x) = x {
+LL | |             dbg!(*x);
+LL | |             Some(*x * 2)
+LL | |         } else {
+LL | |             None
+LL | |         }
+   | |_________^
+   |
+help: replace it with
+   |
+LL ~         let x = x.as_mut()?;
+LL +         dbg!(*x);
+LL +         Some(*x * 2)
+   |
+
+error: this block may be rewritten with the `?` operator
+  --> tests/ui/question_mark.rs:455:9
+   |
+LL | /         if let Some(x) = x {
+LL | |             dbg!(x);
+LL | |             return Some(x * 2);
+LL | |         } else {
+LL | |             return None;
+LL | |         }
+   | |_________^
+   |
+help: replace it with
+   |
+LL ~         let x = x?;
+LL +         dbg!(x);
+LL +         return Some(x * 2);
+   |
+
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
changelog: [`question_mark`]: suggests rewriting with question mark when returning an if-let-Some expression

fixes #13626

I think it's mostly done unless I've missed an edge case. I could use some pointers on formatting the suggestion though, I think my solution works but it's not very elegant.