### PR TITLE
Fix various typos

### DIFF
--- a/clippy_lints/src/manual_is_power_of_two.rs
+++ b/clippy_lints/src/manual_is_power_of_two.rs
@@ -43,21 +43,21 @@ impl LateLintPass<'_> for ManualIsPowerOfTwo {
             && bin_op.node == BinOpKind::Eq
         {
             // a.count_ones() == 1
-            if let ExprKind::MethodCall(method_name, reciever, [], _) = left.kind
+            if let ExprKind::MethodCall(method_name, receiver, [], _) = left.kind
                 && method_name.ident.as_str() == "count_ones"
-                && let &Uint(_) = cx.typeck_results().expr_ty(reciever).kind()
+                && let &Uint(_) = cx.typeck_results().expr_ty(receiver).kind()
                 && check_lit(right, 1)
             {
-                build_sugg(cx, expr, reciever, &mut applicability);
+                build_sugg(cx, expr, receiver, &mut applicability);
             }
 
             // 1 == a.count_ones()
-            if let ExprKind::MethodCall(method_name, reciever, [], _) = right.kind
+            if let ExprKind::MethodCall(method_name, receiver, [], _) = right.kind
                 && method_name.ident.as_str() == "count_ones"
-                && let &Uint(_) = cx.typeck_results().expr_ty(reciever).kind()
+                && let &Uint(_) = cx.typeck_results().expr_ty(receiver).kind()
                 && check_lit(left, 1)
             {
-                build_sugg(cx, expr, reciever, &mut applicability);
+                build_sugg(cx, expr, receiver, &mut applicability);
             }
 
             // a & (a - 1) == 0
@@ -115,8 +115,8 @@ impl LateLintPass<'_> for ManualIsPowerOfTwo {
     }
 }
 
-fn build_sugg(cx: &LateContext<'_>, expr: &Expr<'_>, reciever: &Expr<'_>, applicability: &mut Applicability) {
-    let snippet = snippet_with_applicability(cx, reciever.span, "..", applicability);
+fn build_sugg(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, applicability: &mut Applicability) {
+    let snippet = snippet_with_applicability(cx, receiver.span, "..", applicability);
 
     span_lint_and_sugg(
         cx,

--- a/clippy_lints/src/methods/map_with_unused_argument_over_ranges.rs
+++ b/clippy_lints/src/methods/map_with_unused_argument_over_ranges.rs
@@ -19,7 +19,7 @@ fn extract_count_with_applicability(
 ) -> Option<String> {
     let start = range.start?;
     let end = range.end?;
-    // TODO: This doens't handle if either the start or end are negative literals, or if the start is
+    // TODO: This doesn't handle if either the start or end are negative literals, or if the start is
     // not a literal. In the first case, we need to be careful about how we handle computing the
     // count to avoid overflows. In the second, we may need to add parenthesis to make the
     // suggestion correct.

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -3969,7 +3969,7 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     ///
-    /// In the aformentioned cases it is not necessary to call `min()` or `max()`
+    /// In the aforementioned cases it is not necessary to call `min()` or `max()`
     /// to compare values, it may even cause confusion.
     ///
     /// ### Example

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -59,7 +59,7 @@ pub struct QuestionMark {
     /// As for why we need this in the first place: <https://github.com/rust-lang/rust-clippy/issues/8628>
     try_block_depth_stack: Vec<u32>,
     /// Keeps track of the number of inferred return type closures we are inside, to avoid problems
-    /// with the `Err(x.into())` expansion being ambiguious.
+    /// with the `Err(x.into())` expansion being ambiguous.
     inferred_ret_closure_stack: u16,
 }
 

--- a/clippy_lints/src/unit_types/unit_arg.rs
+++ b/clippy_lints/src/unit_types/unit_arg.rs
@@ -25,13 +25,13 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
         return;
     }
 
-    let (reciever, args) = match expr.kind {
+    let (receiver, args) = match expr.kind {
         ExprKind::Call(_, args) => (None, args),
         ExprKind::MethodCall(_, receiver, args, _) => (Some(receiver), args),
         _ => return,
     };
 
-    let args_to_recover = reciever
+    let args_to_recover = receiver
         .into_iter()
         .chain(args)
         .filter(|arg| {

--- a/clippy_lints/src/unnecessary_literal_bound.rs
+++ b/clippy_lints/src/unnecessary_literal_bound.rs
@@ -17,7 +17,7 @@ declare_clippy_lint! {
     ///
     /// ### Why is this bad?
     ///
-    /// This leaves the caller unable to use the `&str` as `&'static str`, causing unneccessary allocations or confusion.
+    /// This leaves the caller unable to use the `&str` as `&'static str`, causing unnecessary allocations or confusion.
     /// This is also most likely what you meant to write.
     ///
     /// ### Example

--- a/clippy_lints/src/utils/internal_lints/slow_symbol_comparisons.rs
+++ b/clippy_lints/src/utils/internal_lints/slow_symbol_comparisons.rs
@@ -12,18 +12,18 @@ use rustc_span::Span;
 declare_clippy_lint! {
     /// ### What it does
     ///
-    /// Detects symbol comparision using `Symbol::intern`.
+    /// Detects symbol comparison using `Symbol::intern`.
     ///
     /// ### Why is this bad?
     ///
-    /// Comparision via `Symbol::as_str()` is faster if the interned symbols are not reused.
+    /// Comparison via `Symbol::as_str()` is faster if the interned symbols are not reused.
     ///
     /// ### Example
     ///
     /// None, see suggestion.
     pub SLOW_SYMBOL_COMPARISONS,
     internal,
-    "detects slow comparisions of symbol"
+    "detects slow comparisons of symbol"
 }
 
 declare_lint_pass!(SlowSymbolComparisons => [SLOW_SYMBOL_COMPARISONS]);

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -284,7 +284,7 @@ pub fn main() {
         let cap_lints_allow = arg_value(&orig_args, "--cap-lints", |val| val == "allow").is_some()
             && arg_value(&orig_args, "--force-warn", |val| val.contains("clippy::")).is_none();
 
-        // If `--no-deps` is enabled only lint the primary pacakge
+        // If `--no-deps` is enabled only lint the primary package
         let relevant_package = !no_deps || env::var("CARGO_PRIMARY_PACKAGE").is_ok();
 
         // Do not run Clippy for Cargo's info queries so that invalid CLIPPY_ARGS are not cached

--- a/util/gh-pages/script.js
+++ b/util/gh-pages/script.js
@@ -232,13 +232,13 @@ const APPLICABILITIES_FILTER_DEFAULT = {
     MaybeIncorrect: true,
     HasPlaceholders: true,
 };
-const URL_PARAMS_CORRESPONDANCE = {
+const URL_PARAMS_CORRESPONDENCE = {
     "groups_filter": "groups",
     "levels_filter": "levels",
     "applicabilities_filter": "applicabilities",
     "version_filter": "versions",
 };
-const VERSIONS_CORRESPONDANCE = {
+const VERSIONS_CORRESPONDENCE = {
     "lte": "≤",
     "gte": "≥",
     "eq": "=",
@@ -285,7 +285,7 @@ window.filters = {
         }
         function updateIfNeeded(filterName, obj2) {
             const obj1 = filters[filterName];
-            const name = URL_PARAMS_CORRESPONDANCE[filterName];
+            const name = URL_PARAMS_CORRESPONDENCE[filterName];
             if (!compareObjects(obj1, obj2)) {
                 urlParams.set(
                     name,
@@ -316,9 +316,9 @@ window.filters = {
             versions.push(`lte:${filters.version_filter["≤"]}`);
         }
         if (versions.length !== 0) {
-            urlParams.set(URL_PARAMS_CORRESPONDANCE["version_filter"], versions.join(","));
+            urlParams.set(URL_PARAMS_CORRESPONDENCE["version_filter"], versions.join(","));
         } else {
-            urlParams.delete(URL_PARAMS_CORRESPONDANCE["version_filter"]);
+            urlParams.delete(URL_PARAMS_CORRESPONDENCE["version_filter"]);
         }
 
         let params = urlParams.toString();
@@ -532,7 +532,7 @@ function parseURLFilters() {
     const urlParams = new URLSearchParams(window.location.search);
 
     for (const [key, value] of urlParams.entries()) {
-        for (const [corres_key, corres_value] of Object.entries(URL_PARAMS_CORRESPONDANCE)) {
+        for (const [corres_key, corres_value] of Object.entries(URL_PARAMS_CORRESPONDENCE)) {
             if (corres_value === key) {
                 if (key !== "versions") {
                     const settings  = new Set(value.split(","));
@@ -545,7 +545,7 @@ function parseURLFilters() {
 
                     for (const [kind, value] of settings) {
                         const elem = document.querySelector(
-                            `#version-filter input[data-value="${VERSIONS_CORRESPONDANCE[kind]}"]`);
+                            `#version-filter input[data-value="${VERSIONS_CORRESPONDENCE[kind]}"]`);
                         elem.value = value;
                         updateVersionFilters(elem, true);
                     }


### PR DESCRIPTION
I ran [Typos](https://github.com/crate-ci/typos) on the project and fixed all of the easy spelling mistakes! I made sure to avoid UI tests, since those changes are more challenging to review due to the changes in `.stderr` files.

```
changelog: Fixed several typos.
```

- \[x] `cargo test` passes locally
- \[x] Run `cargo dev fmt`
