### PR TITLE
chore: use multipart_suggestions for str_splitn

### DIFF
--- a/tests/ui/manual_split_once.fixed
+++ b/tests/ui/manual_split_once.fixed
@@ -8,24 +8,24 @@ use itertools::Itertools;
 
 fn main() {
     let _ = "key=value".splitn(2, '=').nth(2);
-    let _ = "key=value".splitn(2, '=').nth(1).unwrap();
-    let _ = "key=value".splitn(2, '=').skip(1).next().unwrap();
-    let (_, _) = "key=value".splitn(2, '=').next_tuple().unwrap();
+    let _ = "key=value".split_once('=').unwrap().1;
+    let _ = "key=value".split_once('=').unwrap().1;
+    let (_, _) = "key=value".split_once('=').unwrap();
 
     let s = String::from("key=value");
-    let _ = s.splitn(2, '=').nth(1).unwrap();
+    let _ = s.split_once('=').unwrap().1;
 
     let s = Box::<str>::from("key=value");
-    let _ = s.splitn(2, '=').nth(1).unwrap();
+    let _ = s.split_once('=').unwrap().1;
 
     let s = &"key=value";
-    let _ = s.splitn(2, '=').skip(1).next().unwrap();
+    let _ = s.split_once('=').unwrap().1;
 
     fn _f(s: &str) -> Option<&str> {
-        let _ = s.splitn(2, '=').nth(1)?;
-        let _ = s.splitn(2, '=').skip(1).next()?;
-        let _ = s.rsplitn(2, '=').nth(1)?;
-        let _ = s.rsplitn(2, '=').skip(1).next()?;
+        let _ = s.split_once('=')?.1;
+        let _ = s.split_once('=')?.1;
+        let _ = s.rsplit_once('=')?.0;
+        let _ = s.rsplit_once('=')?.0;
         None
     }
 
@@ -33,27 +33,27 @@ fn main() {
     let _ = [0, 1, 2].splitn(2, |&x| x == 1).nth(1).unwrap();
 
     // `rsplitn` gives the results in the reverse order of `rsplit_once`
-    let _ = "key=value".rsplitn(2, '=').nth(1).unwrap();
-    let (_, _) = "key=value".rsplitn(2, '=').next_tuple().unwrap();
-    let _ = s.rsplitn(2, '=').nth(1);
+    let _ = "key=value".rsplit_once('=').unwrap().0;
+    let (_, _) = "key=value".rsplit_once('=').map(|(x, y)| (y, x)).unwrap();
+    let _ = s.rsplit_once('=').map(|x| x.0);
 }
 
 fn indirect() -> Option<()> {
-    let mut iter = "a.b.c".splitn(2, '.');
-    let l = iter.next().unwrap();
-    let r = iter.next().unwrap();
+    let (l, r) = "a.b.c".split_once('.').unwrap();
+    
+    
 
-    let mut iter = "a.b.c".splitn(2, '.');
-    let l = iter.next()?;
-    let r = iter.next()?;
+    let (l, r) = "a.b.c".split_once('.')?;
+    
+    
 
-    let mut iter = "a.b.c".rsplitn(2, '.');
-    let r = iter.next().unwrap();
-    let l = iter.next().unwrap();
+    let (l, r) = "a.b.c".rsplit_once('.').unwrap();
+    
+    
 
-    let mut iter = "a.b.c".rsplitn(2, '.');
-    let r = iter.next()?;
-    let l = iter.next()?;
+    let (l, r) = "a.b.c".rsplit_once('.')?;
+    
+    
 
     // could lint, currently doesn't
 
@@ -136,9 +136,9 @@ fn _msrv_1_51() {
 
 #[clippy::msrv = "1.52"]
 fn _msrv_1_52() {
-    let _ = "key=value".splitn(2, '=').nth(1).unwrap();
+    let _ = "key=value".split_once('=').unwrap().1;
 
-    let mut iter = "a.b.c".splitn(2, '.');
-    let a = iter.next().unwrap();
-    let b = iter.next().unwrap();
+    let (a, b) = "a.b.c".split_once('.').unwrap();
+    
+    
 }

--- a/tests/ui/manual_split_once.stderr
+++ b/tests/ui/manual_split_once.stderr
@@ -1,5 +1,5 @@
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:13:13
+  --> tests/ui/manual_split_once.rs:11:13
    |
 LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=').unwrap().1`
@@ -8,79 +8,79 @@ LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
    = help: to override `-D warnings` add `#[allow(clippy::manual_split_once)]`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:14:13
+  --> tests/ui/manual_split_once.rs:12:13
    |
 LL |     let _ = "key=value".splitn(2, '=').skip(1).next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:15:18
+  --> tests/ui/manual_split_once.rs:13:18
    |
 LL |     let (_, _) = "key=value".splitn(2, '=').next_tuple().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=')`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:18:13
+  --> tests/ui/manual_split_once.rs:16:13
    |
 LL |     let _ = s.splitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:21:13
+  --> tests/ui/manual_split_once.rs:19:13
    |
 LL |     let _ = s.splitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:24:13
+  --> tests/ui/manual_split_once.rs:22:13
    |
 LL |     let _ = s.splitn(2, '=').skip(1).next().unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:27:17
+  --> tests/ui/manual_split_once.rs:25:17
    |
 LL |         let _ = s.splitn(2, '=').nth(1)?;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=')?.1`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:28:17
+  --> tests/ui/manual_split_once.rs:26:17
    |
 LL |         let _ = s.splitn(2, '=').skip(1).next()?;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.split_once('=')?.1`
 
 error: manual implementation of `rsplit_once`
-  --> tests/ui/manual_split_once.rs:29:17
+  --> tests/ui/manual_split_once.rs:27:17
    |
 LL |         let _ = s.rsplitn(2, '=').nth(1)?;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.rsplit_once('=')?.0`
 
 error: manual implementation of `rsplit_once`
-  --> tests/ui/manual_split_once.rs:30:17
+  --> tests/ui/manual_split_once.rs:28:17
    |
 LL |         let _ = s.rsplitn(2, '=').skip(1).next()?;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.rsplit_once('=')?.0`
 
 error: manual implementation of `rsplit_once`
-  --> tests/ui/manual_split_once.rs:38:13
+  --> tests/ui/manual_split_once.rs:36:13
    |
 LL |     let _ = "key=value".rsplitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".rsplit_once('=').unwrap().0`
 
 error: manual implementation of `rsplit_once`
-  --> tests/ui/manual_split_once.rs:39:18
+  --> tests/ui/manual_split_once.rs:37:18
    |
 LL |     let (_, _) = "key=value".rsplitn(2, '=').next_tuple().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".rsplit_once('=').map(|(x, y)| (y, x))`
 
 error: manual implementation of `rsplit_once`
-  --> tests/ui/manual_split_once.rs:40:13
+  --> tests/ui/manual_split_once.rs:38:13
    |
 LL |     let _ = s.rsplitn(2, '=').nth(1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `s.rsplit_once('=').map(|x| x.0)`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:44:5
+  --> tests/ui/manual_split_once.rs:42:5
    |
 LL |     let mut iter = "a.b.c".splitn(2, '.');
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,21 +89,15 @@ LL |     let l = iter.next().unwrap();
 LL |     let r = iter.next().unwrap();
    |     ----------------------------- second usage here
    |
-help: try `split_once`
+help: replace with `split_once`
    |
-LL |     let (l, r) = "a.b.c".split_once('.').unwrap();
-   |
-help: remove the `iter` usages
-   |
-LL -     let l = iter.next().unwrap();
-   |
-help: remove the `iter` usages
-   |
-LL -     let r = iter.next().unwrap();
+LL ~     let (l, r) = "a.b.c".split_once('.').unwrap();
+LL ~     
+LL ~     
    |
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:48:5
+  --> tests/ui/manual_split_once.rs:46:5
    |
 LL |     let mut iter = "a.b.c".splitn(2, '.');
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,21 +106,15 @@ LL |     let l = iter.next()?;
 LL |     let r = iter.next()?;
    |     --------------------- second usage here
    |
-help: try `split_once`
+help: replace with `split_once`
    |
-LL |     let (l, r) = "a.b.c".split_once('.')?;
-   |
-help: remove the `iter` usages
-   |
-LL -     let l = iter.next()?;
-   |
-help: remove the `iter` usages
-   |
-LL -     let r = iter.next()?;
+LL ~     let (l, r) = "a.b.c".split_once('.')?;
+LL ~     
+LL ~     
    |
 
 error: manual implementation of `rsplit_once`
-  --> tests/ui/manual_split_once.rs:52:5
+  --> tests/ui/manual_split_once.rs:50:5
    |
 LL |     let mut iter = "a.b.c".rsplitn(2, '.');
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -135,21 +123,15 @@ LL |     let r = iter.next().unwrap();
 LL |     let l = iter.next().unwrap();
    |     ----------------------------- second usage here
    |
-help: try `rsplit_once`
+help: replace with `rsplit_once`
    |
-LL |     let (l, r) = "a.b.c".rsplit_once('.').unwrap();
-   |
-help: remove the `iter` usages
-   |
-LL -     let r = iter.next().unwrap();
-   |
-help: remove the `iter` usages
-   |
-LL -     let l = iter.next().unwrap();
+LL ~     let (l, r) = "a.b.c".rsplit_once('.').unwrap();
+LL ~     
+LL ~     
    |
 
 error: manual implementation of `rsplit_once`
-  --> tests/ui/manual_split_once.rs:56:5
+  --> tests/ui/manual_split_once.rs:54:5
    |
 LL |     let mut iter = "a.b.c".rsplitn(2, '.');
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,27 +140,21 @@ LL |     let r = iter.next()?;
 LL |     let l = iter.next()?;
    |     --------------------- second usage here
    |
-help: try `rsplit_once`
+help: replace with `rsplit_once`
    |
-LL |     let (l, r) = "a.b.c".rsplit_once('.')?;
-   |
-help: remove the `iter` usages
-   |
-LL -     let r = iter.next()?;
-   |
-help: remove the `iter` usages
-   |
-LL -     let l = iter.next()?;
+LL ~     let (l, r) = "a.b.c".rsplit_once('.')?;
+LL ~     
+LL ~     
    |
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:141:13
+  --> tests/ui/manual_split_once.rs:139:13
    |
 LL |     let _ = "key=value".splitn(2, '=').nth(1).unwrap();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `"key=value".split_once('=').unwrap().1`
 
 error: manual implementation of `split_once`
-  --> tests/ui/manual_split_once.rs:143:5
+  --> tests/ui/manual_split_once.rs:141:5
    |
 LL |     let mut iter = "a.b.c".splitn(2, '.');
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -187,17 +163,11 @@ LL |     let a = iter.next().unwrap();
 LL |     let b = iter.next().unwrap();
    |     ----------------------------- second usage here
    |
-help: try `split_once`
+help: replace with `split_once`
    |
-LL |     let (a, b) = "a.b.c".split_once('.').unwrap();
-   |
-help: remove the `iter` usages
-   |
-LL -     let a = iter.next().unwrap();
-   |
-help: remove the `iter` usages
-   |
-LL -     let b = iter.next().unwrap();
+LL ~     let (a, b) = "a.b.c".split_once('.').unwrap();
+LL ~     
+LL ~     
    |
 
 error: aborting due to 19 previous errors


### PR DESCRIPTION
This addresses #13099 for the manual_split_once test, using the str_splitn lint. 

changelog: [str_splitn]: Updated str_splitn to use multipart_suggestions where appropriate