### PR TITLE
Detect shadowing in pattern field

### DIFF
--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -263,7 +263,7 @@ fn is_self_shadow(cx: &LateContext<'_>, pat: &Pat<'_>, mut expr: &Expr<'_>, hir_
 fn find_init<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<(&'tcx Expr<'tcx>, Option<HirId>)> {
     for (hir_id, node) in cx.tcx.hir().parent_iter(hir_id) {
         let init = match node {
-            Node::Arm(_) | Node::Pat(_) | Node::Param(_) => continue,
+            Node::Arm(_) | Node::Pat(_) | Node::PatField(_) | Node::Param(_) => continue,
             Node::Expr(expr) => match expr.kind {
                 ExprKind::Match(e, _, _) | ExprKind::Let(&LetExpr { init: e, .. }) => Some((e, None)),
                 // If we're a closure argument, then a parent call is also an associated item.

--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -133,4 +133,12 @@ fn shadow_closure() {
         .collect();
 }
 
+struct Issue13795 {
+    value: i32,
+}
+
+fn issue13795(value: Issue13795) {
+    let Issue13795 { value, .. } = value;
+}
+
 fn main() {}

--- a/tests/ui/shadow.stderr
+++ b/tests/ui/shadow.stderr
@@ -304,5 +304,17 @@ note: previous binding is here
 LL |         .map(|i| i.map(|i| i - 10))
    |               ^
 
-error: aborting due to 25 previous errors
+error: `value` is shadowed by itself in `value`
+  --> tests/ui/shadow.rs:141:22
+   |
+LL |     let Issue13795 { value, .. } = value;
+   |                      ^^^^^
+   |
+note: previous binding is here
+  --> tests/ui/shadow.rs:140:15
+   |
+LL | fn issue13795(value: Issue13795) {
+   |               ^^^^^
+
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
Fix #13795

changelog: [`shadow_same`]: detect shadowing as a pattern field