### PR TITLE
detect redundant nested match

### DIFF
--- a/tests/ui/collapsible_match.rs
+++ b/tests/ui/collapsible_match.rs
@@ -112,6 +112,18 @@ fn lint_cases(opt_opt: Option<Option<u32>>, res_opt: Result<Option<u32>, String>
         },
         None => return,
     }
+
+    match res_opt {
+        Ok(val) => match res_opt {
+            Ok(val) => match val {
+                //~^ ERROR: this `match` can be collapsed into the outer `match`
+                Some(n) => foo(n),
+                _ => return,
+            },
+            _ => return,
+        },
+        _ => return,
+    }
 }
 
 fn negative_cases(res_opt: Result<Option<u32>, String>, res_res: Result<Result<u32, String>, String>) {

--- a/tests/ui/collapsible_match.stderr
+++ b/tests/ui/collapsible_match.stderr
@@ -191,7 +191,27 @@ LL |             Some(n) => foo(n),
    |             ^^^^^^^ with this pattern
 
 error: this `match` can be collapsed into the outer `match`
-  --> tests/ui/collapsible_match.rs:252:22
+  --> tests/ui/collapsible_match.rs:118:24
+   |
+LL |               Ok(val) => match val {
+   |  ________________________^
+LL | |
+LL | |                 Some(n) => foo(n),
+LL | |                 _ => return,
+LL | |             },
+   | |_____________^
+   |
+help: the outer pattern can be modified to include the inner pattern
+  --> tests/ui/collapsible_match.rs:118:16
+   |
+LL |             Ok(val) => match val {
+   |                ^^^ replace this binding
+LL |
+LL |                 Some(n) => foo(n),
+   |                 ^^^^^^^ with this pattern
+
+error: this `match` can be collapsed into the outer `match`
+  --> tests/ui/collapsible_match.rs:264:22
    |
 LL |           Some(val) => match val {
    |  ______________________^
@@ -201,7 +221,7 @@ LL | |         },
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:252:14
+  --> tests/ui/collapsible_match.rs:264:14
    |
 LL |         Some(val) => match val {
    |              ^^^ replace this binding
@@ -209,7 +229,7 @@ LL |             E::A(val) | E::B(val) => foo(val),
    |             ^^^^^^^^^^^^^^^^^^^^^ with this pattern
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:283:9
+  --> tests/ui/collapsible_match.rs:295:9
    |
 LL | /         if let Some(u) = a {
 LL | |
@@ -218,7 +238,7 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:282:27
+  --> tests/ui/collapsible_match.rs:294:27
    |
 LL |     if let Issue9647::A { a, .. } = x {
    |                           ^ replace this binding
@@ -226,7 +246,7 @@ LL |         if let Some(u) = a {
    |                ^^^^^^^ with this pattern, prefixed by `a`:
 
 error: this `if let` can be collapsed into the outer `if let`
-  --> tests/ui/collapsible_match.rs:292:9
+  --> tests/ui/collapsible_match.rs:304:9
    |
 LL | /         if let Some(u) = a {
 LL | |
@@ -235,12 +255,12 @@ LL | |         }
    | |_________^
    |
 help: the outer pattern can be modified to include the inner pattern
-  --> tests/ui/collapsible_match.rs:291:35
+  --> tests/ui/collapsible_match.rs:303:35
    |
 LL |     if let Issue9647::A { a: Some(a), .. } = x {
    |                                   ^ replace this binding
 LL |         if let Some(u) = a {
    |                ^^^^^^^ with this pattern
 
-error: aborting due to 13 previous errors
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
fix #13773 

`match` statements that refer to the same binding inside and outside can be combined.

changelog: [`collapsible_match`]: detect redundant nested match
