### PR TITLE
fix version attribute for `arbitrary_source_item_ordering` lint

### DIFF
--- a/clippy_lints/src/arbitrary_source_item_ordering.rs
+++ b/clippy_lints/src/arbitrary_source_item_ordering.rs
@@ -126,7 +126,7 @@ declare_clippy_lint! {
     ///
     /// [cargo-pgo]: https://github.com/Kobzol/cargo-pgo/blob/main/README.md
     ///
-    #[clippy::version = "1.82.0"]
+    #[clippy::version = "1.84.0"]
     pub ARBITRARY_SOURCE_ITEM_ORDERING,
     restriction,
     "arbitrary source item ordering"


### PR DESCRIPTION
fix #13818 

The `arbitrary_source_item_ordering` lint does not exist in v1.82.0, so I think it needs to be fixed.

changelog: [`arbitrary_source_item_ordering`]: corrected available version information for this lint
