### PR TITLE
fix typo in `numeric_arithmetic` logic

### DIFF
--- a/clippy_lints/src/operators/numeric_arithmetic.rs
+++ b/clippy_lints/src/operators/numeric_arithmetic.rs
@@ -43,8 +43,8 @@ impl Context {
             _ => (),
         }
 
-        let (_, r_ty) = (cx.typeck_results().expr_ty(l), cx.typeck_results().expr_ty(r));
-        if r_ty.peel_refs().is_floating_point() && r_ty.peel_refs().is_floating_point() {
+        let (l_ty, r_ty) = (cx.typeck_results().expr_ty(l), cx.typeck_results().expr_ty(r));
+        if l_ty.peel_refs().is_floating_point() && r_ty.peel_refs().is_floating_point() {
             span_lint(cx, FLOAT_ARITHMETIC, expr.span, "floating-point arithmetic detected");
             self.expr_id = Some(expr.hir_id);
         }


### PR DESCRIPTION
Looks like typo for me.

Looking at blame https://github.com/rust-lang/rust-clippy/commit/b76b0aeb63948fecca6d6f603f47c6648059048a#diff-ac15e787d7d276b24f251f4f5bdedf1e6ac81aa1e2ea0db27219e9a7fa8b0b30L66 the same typo was before.

Is logic here actually correct? Tests passed locally, but i expected some changes.

changelog: none