### PR TITLE
chore: use multipart_suggestion in significant_drop_tightening lint

### DIFF
--- a/clippy_lints/src/significant_drop_tightening.rs
+++ b/clippy_lints/src/significant_drop_tightening.rs
@@ -99,16 +99,10 @@ impl<'tcx> LateLintPass<'tcx> for SignificantDropTightening<'tcx> {
                                     snippet(cx, apa.last_bind_ident.span, ".."),
                                 )
                             };
-                            diag.span_suggestion_verbose(
-                                apa.first_stmt_span,
+
+                            diag.multipart_suggestion_verbose(
                                 "merge the temporary construction with its single usage",
-                                stmt,
-                                Applicability::MaybeIncorrect,
-                            );
-                            diag.span_suggestion(
-                                apa.last_stmt_span,
-                                "remove separated single usage",
-                                "",
+                                vec![(apa.first_stmt_span, stmt), (apa.last_stmt_span, String::new())],
                                 Applicability::MaybeIncorrect,
                             );
                         },

--- a/tests/ui/significant_drop_tightening.fixed
+++ b/tests/ui/significant_drop_tightening.fixed
@@ -10,6 +10,7 @@ pub fn complex_return_triggers_the_lint() -> i32 {
     let lock = mutex.lock().unwrap();
     let _ = *lock;
     let _ = *lock;
+    drop(lock);
     foo()
 }
 
@@ -104,6 +105,7 @@ pub fn unnecessary_contention_with_multiple_owned_results() {
         let lock = mutex.lock().unwrap();
         let rslt0 = lock.abs();
         let rslt1 = lock.is_positive();
+        drop(lock);
         do_heavy_computation_that_takes_time((rslt0, rslt1));
     }
 }
@@ -122,14 +124,16 @@ pub fn unnecessary_contention_with_single_owned_results() {
 
     {
         let mutex = Mutex::new(1i32);
-        let lock = mutex.lock().unwrap();
-        let rslt0 = lock.abs();
+        
+        let rslt0 = mutex.lock().unwrap().abs();
+        
         do_heavy_computation_that_takes_time(rslt0);
     }
     {
         let mutex = Mutex::new(vec![1i32]);
-        let mut lock = mutex.lock().unwrap();
-        lock.clear();
+        
+        mutex.lock().unwrap().clear();
+        
         do_heavy_computation_that_takes_time(());
     }
 }

--- a/tests/ui/significant_drop_tightening.stderr
+++ b/tests/ui/significant_drop_tightening.stderr
@@ -1,5 +1,5 @@
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:12:9
+  --> tests/ui/significant_drop_tightening.rs:10:9
    |
 LL |   pub fn complex_return_triggers_the_lint() -> i32 {
    |  __________________________________________________-
@@ -24,7 +24,7 @@ LL +     drop(lock);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:106:13
+  --> tests/ui/significant_drop_tightening.rs:104:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -44,7 +44,7 @@ LL +         drop(lock);
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:127:13
+  --> tests/ui/significant_drop_tightening.rs:125:13
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(1i32);
@@ -60,14 +60,11 @@ help: merge the temporary construction with its single usage
    |
 LL ~         
 LL +         let rslt0 = mutex.lock().unwrap().abs();
-   |
-help: remove separated single usage
-   |
-LL -         let rslt0 = lock.abs();
+LL ~         
    |
 
 error: temporary with significant `Drop` can be early dropped
-  --> tests/ui/significant_drop_tightening.rs:133:17
+  --> tests/ui/significant_drop_tightening.rs:131:17
    |
 LL | /     {
 LL | |         let mutex = Mutex::new(vec![1i32]);
@@ -83,10 +80,7 @@ help: merge the temporary construction with its single usage
    |
 LL ~         
 LL +         mutex.lock().unwrap().clear();
-   |
-help: remove separated single usage
-   |
-LL -         lock.clear();
+LL ~         
    |
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
This addresses https://github.com/rust-lang/rust-clippy/issues/13099 for the significant_drop_tightening lint.

changelog: none