### PR TITLE
correct `single_match` lint suggestion

### DIFF
--- a/clippy_lints/src/matches/single_match.rs
+++ b/clippy_lints/src/matches/single_match.rs
@@ -129,7 +129,7 @@ fn report_single_pattern(cx: &LateContext<'_>, ex: &Expr<'_>, arm: &Arm<'_>, exp
             PatKind::Lit(Expr {
                 kind: ExprKind::Lit(lit),
                 ..
-            }) if lit.node.is_str() => pat_ref_count + 1,
+            }) if lit.node.is_str() || lit.node.is_bytestr() => pat_ref_count + 1,
             _ => pat_ref_count,
         };
         // References are only implicitly added to the pattern, so no overflow here.

--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -303,6 +303,10 @@ fn issue11365() {
     if let Some(A | B) = &Some(A) { println!() }
 }
 
+fn issue12758(s: &[u8]) {
+    if &s[0..3] == b"foo" { println!() }
+}
+
 #[derive(Eq, PartialEq)]
 pub struct Data([u8; 4]);
 

--- a/tests/ui/single_match.rs
+++ b/tests/ui/single_match.rs
@@ -361,6 +361,13 @@ fn issue11365() {
     }
 }
 
+fn issue12758(s: &[u8]) {
+    match &s[0..3] {
+        b"foo" => println!(),
+        _ => {},
+    }
+}
+
 #[derive(Eq, PartialEq)]
 pub struct Data([u8; 4]);
 

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -204,8 +204,17 @@ LL | |         None | Some(_) => {},
 LL | |     }
    | |_____^ help: try: `if let Some(A | B) = &Some(A) { println!() }`
 
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match.rs:365:5
+   |
+LL | /     match &s[0..3] {
+LL | |         b"foo" => println!(),
+LL | |         _ => {},
+LL | |     }
+   | |_____^ help: try: `if &s[0..3] == b"foo" { println!() }`
+
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:371:5
+  --> tests/ui/single_match.rs:378:5
    |
 LL | /     match DATA {
 LL | |         DATA => println!(),
@@ -214,7 +223,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:376:5
+  --> tests/ui/single_match.rs:383:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -223,7 +232,7 @@ LL | |     }
    | |_____^ help: try: `println!();`
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:382:5
+  --> tests/ui/single_match.rs:389:5
    |
 LL | /     match i {
 LL | |         i => {
@@ -243,7 +252,7 @@ LL +     }
    |
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:390:5
+  --> tests/ui/single_match.rs:397:5
    |
 LL | /     match i {
 LL | |         i => {},
@@ -252,7 +261,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:395:5
+  --> tests/ui/single_match.rs:402:5
    |
 LL | /     match i {
 LL | |         i => (),
@@ -261,7 +270,7 @@ LL | |     }
    | |_____^ help: `match` expression can be removed
 
 error: this pattern is irrefutable, `match` is useless
-  --> tests/ui/single_match.rs:400:5
+  --> tests/ui/single_match.rs:407:5
    |
 LL | /     match CONST_I32 {
 LL | |         CONST_I32 => println!(),
@@ -269,5 +278,5 @@ LL | |         _ => {},
 LL | |     }
    | |_____^ help: try: `println!();`
 
-error: aborting due to 25 previous errors
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
fix #12758

The `single_match` lint makes incorrect suggestions when comparing with byte string literals. There seems to be an issue with the logic that calculates the number of refs when creating suggestions.

changelog: [`single_match`]: No longer make incorrect suggestions when comparing with byte string literals.
