### PR TITLE
lintcheck: fix table layout

### DIFF
--- a/lintcheck/Cargo.toml
+++ b/lintcheck/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
 strip-ansi-escapes = "0.2.0"
 tar = "0.4"
+tabled = { version = "0.15", default-features = false, features = ["std"] }
 toml = "0.7.3"
 ureq = { version = "2.2", features = ["json"] }
 walkdir = "2.3"


### PR DESCRIPTION
Makes lintcheck output table looks nice. Before:

```
2024-12-12T14:00:30.9043123Z | Lint                                       | Added   | Removed | Changed |
2024-12-12T14:00:30.9044069Z | ------------------------------------------ | ------: | ------: | ------: |
2024-12-12T14:00:30.9049932Z | [`clippy::float_arithmetic`](#user-content-float-arithmetic)   |       0 |      10 |       1 |
```

After https://github.com/rust-lang/rust-clippy/actions/runs/12329727234/job/34414382066?pr=13825:
```
2024-12-14T12:21:42.0455818Z | Lint                                                         | Added | Removed | Changed |
2024-12-14T12:21:42.0456602Z |--------------------------------------------------------------|-------|---------|---------|
2024-12-14T12:21:42.0460656Z | [`clippy::float_arithmetic`](#user-content-float-arithmetic) | 0     | 10      | 1       |
```

Spotted at https://github.com/rust-lang/rust-clippy/actions/runs/12297760099/job/34320221594?pr=13820

changelog: none
