### PR TITLE
Don't trigger `filter_map_identity` with an iterator from an empty array

### DIFF
--- a/clippy_lints/src/methods/filter_map_identity.rs
+++ b/clippy_lints/src/methods/filter_map_identity.rs
@@ -2,6 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::{is_expr_identity_function, is_expr_untyped_identity_function, is_trait_method};
 use rustc_errors::Applicability;
 use rustc_hir as hir;
+use rustc_hir::ExprKind;
 use rustc_lint::LateContext;
 use rustc_span::{Span, sym};
 
@@ -21,6 +22,15 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, filter_map_arg: 
     if is_trait_method(cx, expr, sym::Iterator)
         && let Some(applicability) = is_identity(cx, filter_map_arg)
     {
+        // check if the iterator is from an empty array, see issue #12653
+        if let ExprKind::MethodCall(_, recv, ..) = expr.kind
+            && let ExprKind::MethodCall(_, recv2, ..) = recv.kind
+            && let ExprKind::Array(arr) = recv2.kind
+            && arr.is_empty()
+        {
+            return;
+        }
+
         span_lint_and_sugg(
             cx,
             FILTER_MAP_IDENTITY,

--- a/tests/ui/filter_map_identity.fixed
+++ b/tests/ui/filter_map_identity.fixed
@@ -81,3 +81,8 @@ fn main() {
         //~^ ERROR: use of
     }
 }
+
+fn issue12653() -> impl Iterator<Item = u8> {
+    [].into_iter().filter_map(|x| x)
+    // No lint
+}

--- a/tests/ui/filter_map_identity.rs
+++ b/tests/ui/filter_map_identity.rs
@@ -81,3 +81,8 @@ fn main() {
         //~^ ERROR: use of
     }
 }
+
+fn issue12653() -> impl Iterator<Item = u8> {
+    [].into_iter().filter_map(|x| x)
+    // No lint
+}


### PR DESCRIPTION
fix #12653

changelog: [`filter_map_identity`]: don't lint for creating an iterator from an empty array
