### PR TITLE
eq_op: allow optionally check fn calls

### DIFF
--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -540,6 +540,9 @@ define_Conf! {
     /// For internal testing only, ignores the current `publish` settings in the Cargo manifest.
     #[lints(cargo_common_metadata)]
     cargo_ignore_publish: bool = false,
+    /// Check fn calls in eq_op lint
+    #[lints(expect_used)]
+    check_fn_call_in_eq_op: bool = false,
     /// Whether to check MSRV compatibility in `#[test]` and `#[cfg(test)]` code.
     #[lints(incompatible_msrv)]
     check_incompatible_msrv_in_tests: bool = false,

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -542,7 +542,7 @@ define_Conf! {
     cargo_ignore_publish: bool = false,
     /// Check fn calls in eq_op lint
     #[lints(expect_used)]
-    check_fn_call_in_eq_op: bool = false,
+    check_fn_call_in_eq_op: bool = true,
     /// Whether to check MSRV compatibility in `#[test]` and `#[cfg(test)]` code.
     #[lints(incompatible_msrv)]
     check_incompatible_msrv_in_tests: bool = false,

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -774,6 +774,11 @@ pub fn eq_expr_value(cx: &LateContext<'_>, left: &Expr<'_>, right: &Expr<'_>) ->
     SpanlessEq::new(cx).deny_side_effects().eq_expr(left, right)
 }
 
+/// Checks if two expressions evaluate to the same value, ignoring side effects.
+pub fn eq_expr_value_with_sideffects(cx: &LateContext<'_>, left: &Expr<'_>, right: &Expr<'_>) -> bool {
+    SpanlessEq::new(cx).eq_expr(left, right)
+}
+
 /// Returns the segments of a path that might have generic parameters.
 /// Usually just the last segment for free items, except for when the path resolves to an associated
 /// item, in which case it is the last two

--- a/clippy_utils/src/hir_utils.rs
+++ b/clippy_utils/src/hir_utils.rs
@@ -771,7 +771,7 @@ pub fn count_eq<X: Sized>(
 
 /// Checks if two expressions evaluate to the same value, and don't contain any side effects.
 pub fn eq_expr_value(cx: &LateContext<'_>, left: &Expr<'_>, right: &Expr<'_>) -> bool {
-    SpanlessEq::new(cx).deny_side_effects().eq_expr(left, right)
+    eq_expr_value_with_sideffects(cx, left, right)
 }
 
 /// Checks if two expressions evaluate to the same value, ignoring side effects.

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -77,7 +77,8 @@ pub mod visitors;
 pub use self::attrs::*;
 pub use self::check_proc_macro::{is_from_proc_macro, is_span_if, is_span_match};
 pub use self::hir_utils::{
-    HirEqInterExpr, SpanlessEq, SpanlessHash, both, count_eq, eq_expr_value, hash_expr, hash_stmt, is_bool, over,
+    HirEqInterExpr, SpanlessEq, SpanlessHash, both, count_eq, eq_expr_value, eq_expr_value_with_sideffects, hash_expr,
+    hash_stmt, is_bool, over,
 };
 
 use core::mem;


### PR DESCRIPTION
Add option to allow `eq_op` lint to check function calls too.

changelog: [`eq_op`]: allow optionally check fn calls too

fixes: #13827

TODO: cleanup test