### PR TITLE
chore: replace tabs with spaces for indentations

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -948,11 +948,11 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                             );
                             refdefrange.start - range.start
                         } else {
-							let mut start = next_range.start;
-							if start > 0 && doc.as_bytes().get(start - 1) == Some(&b'\\') {
-								// backslashes aren't in the event stream...
-								start -= 1;
-							}
+                            let mut start = next_range.start;
+                            if start > 0 && doc.as_bytes().get(start - 1) == Some(&b'\\') {
+                                // backslashes aren't in the event stream...
+                                start -= 1;
+                            }
                             start - range.start
                         }
                     } else {


### PR DESCRIPTION
A minor style fix. This replaces tab characters with spaces for indentations.

changelog: none