### PR TITLE
correct suggestion for `unnecessary_sort_by` in `no_std`

### DIFF
--- a/clippy_lints/src/methods/unnecessary_sort_by.rs
+++ b/clippy_lints/src/methods/unnecessary_sort_by.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::is_trait_method;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::ty::implements_trait;
+use clippy_utils::{is_trait_method, std_or_core};
 use rustc_errors::Applicability;
 use rustc_hir::{Closure, Expr, ExprKind, Mutability, Param, Pat, PatKind, Path, PathSegment, QPath};
 use rustc_lint::LateContext;
@@ -212,8 +212,10 @@ pub(super) fn check<'tcx>(
                 trigger.vec_name,
                 if is_unstable { "_unstable" } else { "" },
                 trigger.closure_arg,
-                if trigger.reverse {
-                    format!("std::cmp::Reverse({})", trigger.closure_body)
+                if let Some(std_or_core) = std_or_core(cx)
+                    && trigger.reverse
+                {
+                    format!("{}::cmp::Reverse({})", std_or_core, trigger.closure_body)
                 } else {
                     trigger.closure_body.to_string()
                 },

--- a/tests/ui/unnecessary_sort_by_no_std.fixed
+++ b/tests/ui/unnecessary_sort_by_no_std.fixed
@@ -1,0 +1,20 @@
+#![no_std]
+extern crate alloc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+fn issue_11524() -> Vec<i32> {
+    let mut vec = vec![1, 2, 3];
+
+    // Should lint and suggest `vec.sort_by_key(|a| a + 1);`
+    vec.sort_by_key(|a| a + 1);
+    vec
+}
+
+fn issue_11524_2() -> Vec<i32> {
+    let mut vec = vec![1, 2, 3];
+
+    // Should lint and suggest `vec.sort_by_key(|b| core::cmp::Reverse(b + 1));`
+    vec.sort_by_key(|b| core::cmp::Reverse(b + 1));
+    vec
+}

--- a/tests/ui/unnecessary_sort_by_no_std.rs
+++ b/tests/ui/unnecessary_sort_by_no_std.rs
@@ -1,0 +1,20 @@
+#![no_std]
+extern crate alloc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+fn issue_11524() -> Vec<i32> {
+    let mut vec = vec![1, 2, 3];
+
+    // Should lint and suggest `vec.sort_by_key(|a| a + 1);`
+    vec.sort_by(|a, b| (a + 1).cmp(&(b + 1)));
+    vec
+}
+
+fn issue_11524_2() -> Vec<i32> {
+    let mut vec = vec![1, 2, 3];
+
+    // Should lint and suggest `vec.sort_by_key(|b| core::cmp::Reverse(b + 1));`
+    vec.sort_by(|a, b| (b + 1).cmp(&(a + 1)));
+    vec
+}

--- a/tests/ui/unnecessary_sort_by_no_std.stderr
+++ b/tests/ui/unnecessary_sort_by_no_std.stderr
@@ -1,0 +1,17 @@
+error: consider using `sort_by_key`
+  --> tests/ui/unnecessary_sort_by_no_std.rs:10:5
+   |
+LL |     vec.sort_by(|a, b| (a + 1).cmp(&(b + 1)));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_by_key(|a| a + 1)`
+   |
+   = note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_sort_by)]`
+
+error: consider using `sort_by_key`
+  --> tests/ui/unnecessary_sort_by_no_std.rs:18:5
+   |
+LL |     vec.sort_by(|a, b| (b + 1).cmp(&(a + 1)));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `vec.sort_by_key(|b| core::cmp::Reverse(b + 1))`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
fix #11524 

In a `no_std` environment, we can use `core::cmp::Reverse` instead of `std::cmp::Reverse`.

----

changelog: [`unnecessary_sort_by`]: correct suggestion in `no_std`
