### PR TITLE
Do not trigger `trailing_empty_array` in tests

### DIFF
--- a/clippy_lints/src/trailing_empty_array.rs
+++ b/clippy_lints/src/trailing_empty_array.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::has_repr_attr;
+use clippy_utils::{has_repr_attr, is_in_test};
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty;
@@ -37,7 +37,10 @@ declare_lint_pass!(TrailingEmptyArray => [TRAILING_EMPTY_ARRAY]);
 
 impl<'tcx> LateLintPass<'tcx> for TrailingEmptyArray {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
-        if is_struct_with_trailing_zero_sized_array(cx, item) && !has_repr_attr(cx, item.hir_id()) {
+        if is_struct_with_trailing_zero_sized_array(cx, item)
+            && !has_repr_attr(cx, item.hir_id())
+            && !is_in_test(cx.tcx, item.hir_id())
+        {
             span_lint_and_help(
                 cx,
                 TRAILING_EMPTY_ARRAY,

--- a/tests/ui/trailing_empty_array.rs
+++ b/tests/ui/trailing_empty_array.rs
@@ -192,3 +192,17 @@ type C = ConstParamNoDefault<0>;
 type D = ConstParamNonZeroDefault<0>;
 
 fn main() {}
+
+#[cfg(test)]
+mod tests {
+    pub struct Friend {
+        age: u8,
+    }
+
+    #[test]
+    fn oldest_empty_is_none() {
+        struct Michael {
+            friends: [Friend; 0],
+        }
+    }
+}


### PR DESCRIPTION
Close #13837

changelog: [`trailing_empty_array`]: do not trigger on tests
