### PR TITLE
Add allow-indexing-slicing-in-tests option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6213,6 +6213,7 @@ Released 2018-09-13
 [`allow-comparison-to-zero`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-comparison-to-zero
 [`allow-dbg-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-dbg-in-tests
 [`allow-expect-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-expect-in-tests
+[`allow-indexing-slicing-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-indexing-slicing-in-tests
 [`allow-mixed-uninlined-format-args`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-mixed-uninlined-format-args
 [`allow-one-hash-in-raw-strings`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-one-hash-in-raw-strings
 [`allow-panic-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-panic-in-tests

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -81,6 +81,16 @@ Whether `expect` should be allowed in test functions or `#[cfg(test)]`
 * [`expect_used`](https://rust-lang.github.io/rust-clippy/master/index.html#expect_used)
 
 
+## `allow-indexing-slicing-in-tests`
+Whether `indexing_slicing` should be allowed in test functions or `#[cfg(test)]`
+
+**Default Value:** `false`
+
+---
+**Affected lints:**
+* [`indexing_slicing`](https://rust-lang.github.io/rust-clippy/master/index.html#indexing_slicing)
+
+
 ## `allow-mixed-uninlined-format-args`
 Whether to allow mixed uninlined format args, e.g. `format!("{} {}", a, foo.bar)`
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -291,6 +291,9 @@ define_Conf! {
     /// Whether `expect` should be allowed in test functions or `#[cfg(test)]`
     #[lints(expect_used)]
     allow_expect_in_tests: bool = false,
+    /// Whether `indexing_slicing` should be allowed in test functions or `#[cfg(test)]`
+    #[lints(indexing_slicing)]
+    allow_indexing_slicing_in_tests: bool = false,
     /// Whether to allow mixed uninlined format args, e.g. `format!("{} {}", a, foo.bar)`
     #[lints(uninlined_format_args)]
     allow_mixed_uninlined_format_args: bool = true,

--- a/tests/ui-toml/indexing_slicing/clippy.toml
+++ b/tests/ui-toml/indexing_slicing/clippy.toml
@@ -1,0 +1,1 @@
+allow-indexing-slicing-in-tests = true

--- a/tests/ui-toml/indexing_slicing/indexing_slicing.rs
+++ b/tests/ui-toml/indexing_slicing/indexing_slicing.rs
@@ -1,0 +1,19 @@
+//@compile-flags: --test
+#![warn(clippy::indexing_slicing)]
+#![allow(clippy::no_effect)]
+
+fn main() {
+    let x = [1, 2, 3, 4];
+    let index: usize = 1;
+    &x[index..];
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_fn() {
+        let x = [1, 2, 3, 4];
+        let index: usize = 1;
+        &x[index..];
+    }
+}

--- a/tests/ui-toml/indexing_slicing/indexing_slicing.stderr
+++ b/tests/ui-toml/indexing_slicing/indexing_slicing.stderr
@@ -1,0 +1,12 @@
+error: slicing may panic
+  --> tests/ui-toml/indexing_slicing/indexing_slicing.rs:8:6
+   |
+LL |     &x[index..];
+   |      ^^^^^^^^^^
+   |
+   = help: consider using `.get(n..)` or .get_mut(n..)` instead
+   = note: `-D clippy::indexing-slicing` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::indexing_slicing)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -6,6 +6,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            allow-comparison-to-zero
            allow-dbg-in-tests
            allow-expect-in-tests
+           allow-indexing-slicing-in-tests
            allow-mixed-uninlined-format-args
            allow-one-hash-in-raw-strings
            allow-panic-in-tests
@@ -93,6 +94,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            allow-comparison-to-zero
            allow-dbg-in-tests
            allow-expect-in-tests
+           allow-indexing-slicing-in-tests
            allow-mixed-uninlined-format-args
            allow-one-hash-in-raw-strings
            allow-panic-in-tests
@@ -180,6 +182,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            allow-comparison-to-zero
            allow-dbg-in-tests
            allow-expect-in-tests
+           allow-indexing-slicing-in-tests
            allow-mixed-uninlined-format-args
            allow-one-hash-in-raw-strings
            allow-panic-in-tests


### PR DESCRIPTION
Close #13842

changelog: [`indexing_slicing`]: add allow-indexing-slicing-in-tests option to be able ignore at test
