### PR TITLE
[draft] lint RefCell late drops

### DIFF
--- a/clippy_lints/src/significant_drop_tightening.rs
+++ b/clippy_lints/src/significant_drop_tightening.rs
@@ -163,6 +163,13 @@ impl<'cx, 'others, 'tcx> AttrChecker<'cx, 'others, 'tcx> {
 
     fn has_sig_drop_attr_uncached(&mut self, ty: Ty<'tcx>) -> bool {
         if let Some(adt) = ty.ty_adt_def() {
+            if matches!(
+                self.cx.tcx.get_diagnostic_name(adt.did()),
+                Some(sym::RefCellRef | sym::RefCellRefMut)
+            ) {
+                return true;
+            }
+
             let mut iter = get_attr(
                 self.cx.sess(),
                 self.cx.tcx.get_attrs_unchecked(adt.did()),


### PR DESCRIPTION
This PR is to observe `significant_drop_tightening` lint behavior on `RefCell` references. See https://github.com/rust-lang/rust-clippy/discussions/13581

The implementation is just to see the effect, so atm it is hacky.