### PR TITLE
Improve `needless_pass_by_value` suggestion

### DIFF
--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -275,10 +275,18 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                         }
                     }
 
+                    let suggestion = if is_type_diagnostic_item(cx, ty, sym::Option)
+                        && let snip = snippet(cx, input.span, "_")
+                        && let Some((first, rest)) = snip.split_once('<')
+                    {
+                        format!("{first}<&{rest}")
+                    } else {
+                        format!("&{}", snippet(cx, input.span, "_"))
+                    };
                     diag.span_suggestion(
                         input.span,
                         "consider taking a reference instead",
-                        format!("&{}", snippet(cx, input.span, "_")),
+                        suggestion,
                         Applicability::MaybeIncorrect,
                     );
                 };

--- a/tests/ui/needless_pass_by_value.rs
+++ b/tests/ui/needless_pass_by_value.rs
@@ -182,6 +182,13 @@ struct Obj(String);
 
 fn prefix_test(_unused_with_prefix: Obj) {}
 
+// Regression test for <https://github.com/rust-lang/rust-clippy/issues/13744>.
+// It's more idiomatic to write `Option<&T>` rather than `&Option<T>`.
+fn option_inner_ref(x: Option<String>) {
+    //~^ ERROR: this argument is passed by value, but not consumed in the function body
+    assert!(x.is_some());
+}
+
 fn main() {
     // This should not cause an ICE either
     // https://github.com/rust-lang/rust-clippy/issues/3144

--- a/tests/ui/needless_pass_by_value.stderr
+++ b/tests/ui/needless_pass_by_value.stderr
@@ -29,7 +29,7 @@ error: this argument is passed by value, but not consumed in the function body
   --> tests/ui/needless_pass_by_value.rs:56:18
    |
 LL | fn test_match(x: Option<Option<String>>, y: Option<Option<String>>) {
-   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&Option<Option<String>>`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `Option<&Option<String>>`
 
 error: this argument is passed by value, but not consumed in the function body
   --> tests/ui/needless_pass_by_value.rs:70:24
@@ -175,5 +175,11 @@ error: this argument is passed by value, but not consumed in the function body
 LL | fn more_fun(items: impl Club<'static, i32>) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&impl Club<'static, i32>`
 
-error: aborting due to 22 previous errors
+error: this argument is passed by value, but not consumed in the function body
+  --> tests/ui/needless_pass_by_value.rs:187:24
+   |
+LL | fn option_inner_ref(x: Option<String>) {
+   |                        ^^^^^^^^^^^^^^ help: consider taking a reference instead: `Option<&String>`
+
+error: aborting due to 23 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/13744.

A simple check to check if the type is an `Option` allows to improve the suggestion.

changelog: Improve `needless_pass_by_value` suggestion