### PR TITLE
fix `literal_string_with_formatting_args` FP on format inside assert

### DIFF
--- a/tests/ui/literal_string_with_formatting_arg.rs
+++ b/tests/ui/literal_string_with_formatting_arg.rs
@@ -35,3 +35,9 @@ fn main() {
     let x: Option<usize> = Some(0);
     x.expect("{…}");
 }
+
+fn issue_13885() {
+    let value = 0;
+    dbg!(format!("{value}").is_empty()); // Nothing should happen
+    assert!(format!("{value}").is_empty()); // Nothing should happen
+}


### PR DESCRIPTION
fixes: #13885 

I found that the error message generated by `assert` is put on a root context, not sure if it is a bug on the compiler side (I tested `dbg` and everything went fine, though I do found the generated file name is on a root context too). I simply guarded the lint behind `is_dummy`.

---

changelog: [`literal_string_with_formatting_args`] fix FP on format inside assert
