### PR TITLE
Do not remove identity mapping if mandatory mutability would be lost

### DIFF
--- a/tests/ui/map_identity.fixed
+++ b/tests/ui/map_identity.fixed
@@ -61,3 +61,18 @@ fn issue11764() {
     // no match ergonomics for `(i32, i32)`
     let _ = x.iter().copied();
 }
+
+fn issue13904() {
+    // don't lint: `it.next()` would not be legal as `it` is immutable
+    let it = [1, 2, 3].into_iter();
+    let _ = it.map(|x| x).next();
+
+    // lint
+    #[allow(unused_mut)]
+    let mut it = [1, 2, 3].into_iter();
+    let _ = it.next();
+
+    // lint
+    let it = [1, 2, 3].into_iter();
+    let _ = { it }.next();
+}

--- a/tests/ui/map_identity.rs
+++ b/tests/ui/map_identity.rs
@@ -65,3 +65,18 @@ fn issue11764() {
     // no match ergonomics for `(i32, i32)`
     let _ = x.iter().copied().map(|(x, y)| (x, y));
 }
+
+fn issue13904() {
+    // don't lint: `it.next()` would not be legal as `it` is immutable
+    let it = [1, 2, 3].into_iter();
+    let _ = it.map(|x| x).next();
+
+    // lint
+    #[allow(unused_mut)]
+    let mut it = [1, 2, 3].into_iter();
+    let _ = it.map(|x| x).next();
+
+    // lint
+    let it = [1, 2, 3].into_iter();
+    let _ = { it }.map(|x| x).next();
+}

--- a/tests/ui/map_identity.stderr
+++ b/tests/ui/map_identity.stderr
@@ -73,5 +73,17 @@ error: unnecessary map of the identity function
 LL |     let _ = x.iter().copied().map(|(x, y)| (x, y));
    |                              ^^^^^^^^^^^^^^^^^^^^^ help: remove the call to `map`
 
-error: aborting due to 11 previous errors
+error: unnecessary map of the identity function
+  --> tests/ui/map_identity.rs:77:15
+   |
+LL |     let _ = it.map(|x| x).next();
+   |               ^^^^^^^^^^^ help: remove the call to `map`
+
+error: unnecessary map of the identity function
+  --> tests/ui/map_identity.rs:81:19
+   |
+LL |     let _ = { it }.map(|x| x).next();
+   |                   ^^^^^^^^^^^ help: remove the call to `map`
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Removing `.map(identity)` may result in invalid code if the receiver of `map()` is an immutable binding, and the result of `map()` is used as the receiver of a method call expecting a mutable reference.

Fix #13904

changelog: [`map_identity`]: do not lint if this would cause mandatory mutability to be lost