### PR TITLE
Fix parentheses when replacing `matches!(…, None)` with `.is_none()`

### DIFF
--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -137,3 +137,11 @@ fn issue10803() {
     // Don't lint
     let _ = matches!(x, Some(16));
 }
+
+fn issue13902() {
+    let x = Some(0);
+    let p = &raw const x;
+    unsafe {
+        let _ = (*p).is_none();
+    }
+}

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -164,3 +164,11 @@ fn issue10803() {
     // Don't lint
     let _ = matches!(x, Some(16));
 }
+
+fn issue13902() {
+    let x = Some(0);
+    let p = &raw const x;
+    unsafe {
+        let _ = matches!(*p, None);
+    }
+}

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -209,5 +209,11 @@ error: redundant pattern matching, consider using `is_none()`
 LL |     let _ = matches!(x, None);
    |             ^^^^^^^^^^^^^^^^^ help: try: `x.is_none()`
 
-error: aborting due to 30 previous errors
+error: redundant pattern matching, consider using `is_none()`
+  --> tests/ui/redundant_pattern_matching_option.rs:172:17
+   |
+LL |         let _ = matches!(*p, None);
+   |                 ^^^^^^^^^^^^^^^^^^ help: try: `(*p).is_none()`
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Proper parentheses need to be added to some expressions in receiver position.

Fix #13902 

changelog: [`redundant_pattern_matching`]: use proper parentheses when suggesting replacing `matches!(…, None)` by `.is_none()`