### PR TITLE
Only emit `useless_vec` suggestion if the macro does not contain code comments

### DIFF
--- a/tests/ui/useless_vec.rs
+++ b/tests/ui/useless_vec.rs
@@ -1,0 +1,15 @@
+//@no-rustfix: no suggestions
+
+#![warn(clippy::useless_vec)]
+
+// Regression test for <https://github.com/rust-lang/rust-clippy/issues/13692>.
+fn foo() {
+    // There should be no suggestion in this case.
+    let _some_variable = vec![
+        //~^ useless_vec
+        1, 2, // i'm here to stay
+        3, 4, // but this one going away ;-;
+    ]; // that is life anyways
+}
+
+fn main() {}

--- a/tests/ui/useless_vec.stderr
+++ b/tests/ui/useless_vec.stderr
@@ -1,0 +1,21 @@
+error: useless use of `vec!`
+  --> tests/ui/useless_vec.rs:8:26
+   |
+LL |       let _some_variable = vec![
+   |  __________________________^
+LL | |
+LL | |         1, 2, // i'm here to stay
+LL | |         3, 4, // but this one going away ;-;
+LL | |     ]; // that is life anyways
+   | |_____^
+   |
+   = note: `-D clippy::useless-vec` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::useless_vec)]`
+help: you can use an array directly
+   |
+LL ~     let _some_variable = [1, 2, // i'm here to stay
+LL ~         3, 4]; // that is life anyways
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #13692.

If the `vec!` macro call contains comments, we should not provide suggestions and let users handle it however they see fit.

changelog: Only emit `useless_vec` suggestion if the macro does not contain code comments