### PR TITLE
Improve `slow_vector_initialization` suggestion

### DIFF
--- a/clippy_lints/src/slow_vector_initialization.rs
+++ b/clippy_lints/src/slow_vector_initialization.rs
@@ -1,4 +1,4 @@
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::macros::matching_root_macro_call;
 use clippy_utils::sugg::Sugg;
 use clippy_utils::{
@@ -203,14 +203,18 @@ impl SlowVectorInit {
             "len",
         );
 
-        span_lint_and_then(cx, SLOW_VECTOR_INITIALIZATION, slow_fill.span, msg, |diag| {
-            diag.span_suggestion(
-                vec_alloc.allocation_expr.span.source_callsite(),
-                "consider replacing this with",
-                format!("vec![0; {len_expr}]"),
-                Applicability::Unspecified,
-            );
-        });
+        let span_to_replace = slow_fill
+            .span
+            .with_lo(vec_alloc.allocation_expr.span.source_callsite().lo());
+        span_lint_and_sugg(
+            cx,
+            SLOW_VECTOR_INITIALIZATION,
+            span_to_replace,
+            msg,
+            "consider replacing this with",
+            format!("vec![0; {len_expr}]"),
+            Applicability::Unspecified,
+        );
     }
 }
 

--- a/tests/ui/slow_vector_initialization.rs
+++ b/tests/ui/slow_vector_initialization.rs
@@ -11,22 +11,22 @@ fn extend_vector() {
     // Extend with constant expression
     let len = 300;
     let mut vec1 = Vec::with_capacity(len);
-    vec1.extend(repeat(0).take(len));
     //~^ ERROR: slow zero-filling initialization
     //~| NOTE: `-D clippy::slow-vector-initialization` implied by `-D warnings`
+    vec1.extend(repeat(0).take(len));
 
     // Extend with len expression
     let mut vec2 = Vec::with_capacity(len - 10);
-    vec2.extend(repeat(0).take(len - 10));
     //~^ ERROR: slow zero-filling initialization
+    vec2.extend(repeat(0).take(len - 10));
 
     // Extend with mismatching expression should not be warned
     let mut vec3 = Vec::with_capacity(24322);
     vec3.extend(repeat(0).take(2));
 
     let mut vec4 = Vec::with_capacity(len);
-    vec4.extend(repeat(0).take(vec4.capacity()));
     //~^ ERROR: slow zero-filling initialization
+    vec4.extend(repeat(0).take(vec4.capacity()));
 }
 
 fn mixed_extend_resize_vector() {
@@ -36,20 +36,20 @@ fn mixed_extend_resize_vector() {
 
     // Slow initialization
     let mut resized_vec = Vec::with_capacity(30);
-    resized_vec.resize(30, 0);
     //~^ ERROR: slow zero-filling initialization
+    resized_vec.resize(30, 0);
 
     let mut extend_vec = Vec::with_capacity(30);
-    extend_vec.extend(repeat(0).take(30));
     //~^ ERROR: slow zero-filling initialization
+    extend_vec.extend(repeat(0).take(30));
 }
 
 fn resize_vector() {
     // Resize with constant expression
     let len = 300;
     let mut vec1 = Vec::with_capacity(len);
-    vec1.resize(len, 0);
     //~^ ERROR: slow zero-filling initialization
+    vec1.resize(len, 0);
 
     // Resize mismatch len
     let mut vec2 = Vec::with_capacity(200);
@@ -57,39 +57,39 @@ fn resize_vector() {
 
     // Resize with len expression
     let mut vec3 = Vec::with_capacity(len - 10);
-    vec3.resize(len - 10, 0);
     //~^ ERROR: slow zero-filling initialization
+    vec3.resize(len - 10, 0);
 
     let mut vec4 = Vec::with_capacity(len);
-    vec4.resize(vec4.capacity(), 0);
     //~^ ERROR: slow zero-filling initialization
+    vec4.resize(vec4.capacity(), 0);
 
     // Reinitialization should be warned
     vec1 = Vec::with_capacity(10);
-    vec1.resize(10, 0);
     //~^ ERROR: slow zero-filling initialization
+    vec1.resize(10, 0);
 }
 
 fn from_empty_vec() {
     // Resize with constant expression
     let len = 300;
     let mut vec1 = Vec::new();
-    vec1.resize(len, 0);
     //~^ ERROR: slow zero-filling initialization
+    vec1.resize(len, 0);
 
     // Resize with len expression
     let mut vec3 = Vec::new();
-    vec3.resize(len - 10, 0);
     //~^ ERROR: slow zero-filling initialization
+    vec3.resize(len - 10, 0);
 
     // Reinitialization should be warned
     vec1 = Vec::new();
-    vec1.resize(10, 0);
     //~^ ERROR: slow zero-filling initialization
+    vec1.resize(10, 0);
 
     vec1 = vec![];
-    vec1.resize(10, 0);
     //~^ ERROR: slow zero-filling initialization
+    vec1.resize(10, 0);
 
     macro_rules! x {
         () => {

--- a/tests/ui/slow_vector_initialization.stderr
+++ b/tests/ui/slow_vector_initialization.stderr
@@ -1,109 +1,122 @@
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:14:5
+  --> tests/ui/slow_vector_initialization.rs:13:20
    |
-LL |     let mut vec1 = Vec::with_capacity(len);
-   |                    ----------------------- help: consider replacing this with: `vec![0; len]`
-LL |     vec1.extend(repeat(0).take(len));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec1 = Vec::with_capacity(len);
+   |  ____________________^
+...  |
+LL | |     vec1.extend(repeat(0).take(len));
+   | |____________________________________^ help: consider replacing this with: `vec![0; len]`
    |
    = note: `-D clippy::slow-vector-initialization` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::slow_vector_initialization)]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:20:5
+  --> tests/ui/slow_vector_initialization.rs:19:20
    |
-LL |     let mut vec2 = Vec::with_capacity(len - 10);
-   |                    ---------------------------- help: consider replacing this with: `vec![0; len - 10]`
-LL |     vec2.extend(repeat(0).take(len - 10));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec2 = Vec::with_capacity(len - 10);
+   |  ____________________^
+LL | |
+LL | |     vec2.extend(repeat(0).take(len - 10));
+   | |_________________________________________^ help: consider replacing this with: `vec![0; len - 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:28:5
+  --> tests/ui/slow_vector_initialization.rs:27:20
    |
-LL |     let mut vec4 = Vec::with_capacity(len);
-   |                    ----------------------- help: consider replacing this with: `vec![0; len]`
-LL |     vec4.extend(repeat(0).take(vec4.capacity()));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec4 = Vec::with_capacity(len);
+   |  ____________________^
+LL | |
+LL | |     vec4.extend(repeat(0).take(vec4.capacity()));
+   | |________________________________________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:39:5
+  --> tests/ui/slow_vector_initialization.rs:38:27
    |
-LL |     let mut resized_vec = Vec::with_capacity(30);
-   |                           ---------------------- help: consider replacing this with: `vec![0; 30]`
-LL |     resized_vec.resize(30, 0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut resized_vec = Vec::with_capacity(30);
+   |  ___________________________^
+LL | |
+LL | |     resized_vec.resize(30, 0);
+   | |_____________________________^ help: consider replacing this with: `vec![0; 30]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:43:5
+  --> tests/ui/slow_vector_initialization.rs:42:26
    |
-LL |     let mut extend_vec = Vec::with_capacity(30);
-   |                          ---------------------- help: consider replacing this with: `vec![0; 30]`
-LL |     extend_vec.extend(repeat(0).take(30));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut extend_vec = Vec::with_capacity(30);
+   |  __________________________^
+LL | |
+LL | |     extend_vec.extend(repeat(0).take(30));
+   | |_________________________________________^ help: consider replacing this with: `vec![0; 30]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:51:5
+  --> tests/ui/slow_vector_initialization.rs:50:20
    |
-LL |     let mut vec1 = Vec::with_capacity(len);
-   |                    ----------------------- help: consider replacing this with: `vec![0; len]`
-LL |     vec1.resize(len, 0);
-   |     ^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec1 = Vec::with_capacity(len);
+   |  ____________________^
+LL | |
+LL | |     vec1.resize(len, 0);
+   | |_______________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:60:5
+  --> tests/ui/slow_vector_initialization.rs:59:20
    |
-LL |     let mut vec3 = Vec::with_capacity(len - 10);
-   |                    ---------------------------- help: consider replacing this with: `vec![0; len - 10]`
-LL |     vec3.resize(len - 10, 0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec3 = Vec::with_capacity(len - 10);
+   |  ____________________^
+LL | |
+LL | |     vec3.resize(len - 10, 0);
+   | |____________________________^ help: consider replacing this with: `vec![0; len - 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:64:5
+  --> tests/ui/slow_vector_initialization.rs:63:20
    |
-LL |     let mut vec4 = Vec::with_capacity(len);
-   |                    ----------------------- help: consider replacing this with: `vec![0; len]`
-LL |     vec4.resize(vec4.capacity(), 0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec4 = Vec::with_capacity(len);
+   |  ____________________^
+LL | |
+LL | |     vec4.resize(vec4.capacity(), 0);
+   | |___________________________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:69:5
+  --> tests/ui/slow_vector_initialization.rs:68:12
    |
-LL |     vec1 = Vec::with_capacity(10);
-   |            ---------------------- help: consider replacing this with: `vec![0; 10]`
-LL |     vec1.resize(10, 0);
-   |     ^^^^^^^^^^^^^^^^^^
+LL |       vec1 = Vec::with_capacity(10);
+   |  ____________^
+LL | |
+LL | |     vec1.resize(10, 0);
+   | |______________________^ help: consider replacing this with: `vec![0; 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:77:5
+  --> tests/ui/slow_vector_initialization.rs:76:20
    |
-LL |     let mut vec1 = Vec::new();
-   |                    ---------- help: consider replacing this with: `vec![0; len]`
-LL |     vec1.resize(len, 0);
-   |     ^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec1 = Vec::new();
+   |  ____________________^
+LL | |
+LL | |     vec1.resize(len, 0);
+   | |_______________________^ help: consider replacing this with: `vec![0; len]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:82:5
+  --> tests/ui/slow_vector_initialization.rs:81:20
    |
-LL |     let mut vec3 = Vec::new();
-   |                    ---------- help: consider replacing this with: `vec![0; len - 10]`
-LL |     vec3.resize(len - 10, 0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       let mut vec3 = Vec::new();
+   |  ____________________^
+LL | |
+LL | |     vec3.resize(len - 10, 0);
+   | |____________________________^ help: consider replacing this with: `vec![0; len - 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:87:5
+  --> tests/ui/slow_vector_initialization.rs:86:12
    |
-LL |     vec1 = Vec::new();
-   |            ---------- help: consider replacing this with: `vec![0; 10]`
-LL |     vec1.resize(10, 0);
-   |     ^^^^^^^^^^^^^^^^^^
+LL |       vec1 = Vec::new();
+   |  ____________^
+LL | |
+LL | |     vec1.resize(10, 0);
+   | |______________________^ help: consider replacing this with: `vec![0; 10]`
 
 error: slow zero-filling initialization
-  --> tests/ui/slow_vector_initialization.rs:91:5
+  --> tests/ui/slow_vector_initialization.rs:90:12
    |
-LL |     vec1 = vec![];
-   |            ------ help: consider replacing this with: `vec![0; 10]`
-LL |     vec1.resize(10, 0);
-   |     ^^^^^^^^^^^^^^^^^^
+LL |       vec1 = vec![];
+   |  ____________^
+LL | |
+LL | |     vec1.resize(10, 0);
+   | |______________________^ help: consider replacing this with: `vec![0; 10]`
 
 error: aborting due to 13 previous errors
 


### PR DESCRIPTION
close #13781

The `slow_vector_initialization` lint currently only suggests using the `vec!` macro with size, but it does not suggest removing the `resize` method call.

changelog: [`slow_vector_initialization`]: improve `slow_vector_initialization` suggestion
