### PR TITLE
add test for ICE

### DIFF
--- a/tests/ui/crashes/ice-10972-tait.rs
+++ b/tests/ui/crashes/ice-10972-tait.rs
@@ -1,0 +1,9 @@
+// ICE: #10972
+// asked to assemble constituent types of unexpected type: Binder(Foo, [])
+#![feature(type_alias_impl_trait)]
+
+use std::fmt::Debug;
+type Foo = impl Debug;
+const FOO2: Foo = 22_u32;
+
+pub fn main() {}


### PR DESCRIPTION
`asked to assemble constituent types of unexpected type: Binder(Foo, [])`

Fixes #10972

changelog: none