### PR TITLE
 Fix type suggestion for manual_is_ascii_check

### DIFF
--- a/clippy_lints/src/manual_is_ascii_check.rs
+++ b/clippy_lints/src/manual_is_ascii_check.rs
@@ -114,7 +114,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualIsAsciiCheck {
             && !matches!(cx.typeck_results().expr_ty(arg).peel_refs().kind(), ty::Param(_))
         {
             let arg = peel_ref_operators(cx, arg);
-            let ty_sugg = get_ty_sugg(cx, arg, start);
+            let ty_sugg = get_ty_sugg(cx, arg);
             let range = check_range(start, end);
             check_is_ascii(cx, expr.span, arg, &range, ty_sugg);
         }
@@ -123,10 +123,9 @@ impl<'tcx> LateLintPass<'tcx> for ManualIsAsciiCheck {
     extract_msrv_attr!(LateContext);
 }
 
-fn get_ty_sugg(cx: &LateContext<'_>, arg: &Expr<'_>, bound_expr: &Expr<'_>) -> Option<(Span, String)> {
-    if let ExprKind::Lit(_) = bound_expr.kind
-        && let local_hid = path_to_local(arg)?
-        && let Node::Param(Param { ty_span, span, .. }) = cx.tcx.parent_hir_node(local_hid)
+fn get_ty_sugg(cx: &LateContext<'_>, arg: &Expr<'_>) -> Option<(Span, String)> {
+    let local_hid = path_to_local(arg)?;
+    if let Node::Param(Param { ty_span, span, .. }) = cx.tcx.parent_hir_node(local_hid)
         // `ty_span` and `span` are the same for inferred type, thus a type suggestion must be given
         && ty_span == span
     {

--- a/tests/ui/manual_is_ascii_check.fixed
+++ b/tests/ui/manual_is_ascii_check.fixed
@@ -82,3 +82,8 @@ fn generics() {
     take_while(|c: u8| c.is_ascii_uppercase());
     take_while(|c: char| c.is_ascii_uppercase());
 }
+
+fn adds_type_reference() {
+    let digits: Vec<&char> = ['1', 'A'].iter().take_while(|c: &&char| c.is_ascii_digit()).collect();
+    let digits: Vec<&mut char> = ['1', 'A'].iter_mut().take_while(|c: &&mut char| c.is_ascii_digit()).collect();
+}

--- a/tests/ui/manual_is_ascii_check.rs
+++ b/tests/ui/manual_is_ascii_check.rs
@@ -82,3 +82,8 @@ fn generics() {
     take_while(|c| (b'A'..=b'Z').contains(&c));
     take_while(|c: char| ('A'..='Z').contains(&c));
 }
+
+fn adds_type_reference() {
+    let digits: Vec<&char> = ['1', 'A'].iter().take_while(|c| ('0'..='9').contains(c)).collect();
+    let digits: Vec<&mut char> = ['1', 'A'].iter_mut().take_while(|c| ('0'..='9').contains(c)).collect();
+}

--- a/tests/ui/manual_is_ascii_check.stderr
+++ b/tests/ui/manual_is_ascii_check.stderr
@@ -173,5 +173,27 @@ error: manual check for common ascii range
 LL |     take_while(|c: char| ('A'..='Z').contains(&c));
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `c.is_ascii_uppercase()`
 
-error: aborting due to 27 previous errors
+error: manual check for common ascii range
+  --> tests/ui/manual_is_ascii_check.rs:87:63
+   |
+LL |     let digits: Vec<&char> = ['1', 'A'].iter().take_while(|c| ('0'..='9').contains(c)).collect();
+   |                                                               ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL |     let digits: Vec<&char> = ['1', 'A'].iter().take_while(|c: &&char| c.is_ascii_digit()).collect();
+   |                                                            ~~~~~~~~~  ~~~~~~~~~~~~~~~~~~
+
+error: manual check for common ascii range
+  --> tests/ui/manual_is_ascii_check.rs:88:71
+   |
+LL |     let digits: Vec<&mut char> = ['1', 'A'].iter_mut().take_while(|c| ('0'..='9').contains(c)).collect();
+   |                                                                       ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL |     let digits: Vec<&mut char> = ['1', 'A'].iter_mut().take_while(|c: &&mut char| c.is_ascii_digit()).collect();
+   |                                                                    ~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 29 previous errors
 


### PR DESCRIPTION
Fixes #13913 .

changelog: [`manual_is_ascii_check`]: fix type suggestions for references

Previously it only derived `char` and `u8` types, now it should always annotate the lambda parameter with the correct type (e.g. `&char`).

I'm quite new to Rust and this is my first contact with clippy, so I'm open for suggetions :)