### PR TITLE
New lint: `unit_as_impl_trait`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7538,6 +7538,7 @@ Released 2018-09-13
 [`uninit_vec`]: https://rust-lang.github.io/rust-clippy/master/index.html#uninit_vec
 [`uninlined_format_args`]: https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
 [`unit_arg`]: https://rust-lang.github.io/rust-clippy/master/index.html#unit_arg
+[`unit_as_impl_trait`]: https://rust-lang.github.io/rust-clippy/master/index.html#unit_as_impl_trait
 [`unit_cmp`]: https://rust-lang.github.io/rust-clippy/master/index.html#unit_cmp
 [`unit_hash`]: https://rust-lang.github.io/rust-clippy/master/index.html#unit_hash
 [`unit_return_expecting_ord`]: https://rust-lang.github.io/rust-clippy/master/index.html#unit_return_expecting_ord

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -778,6 +778,7 @@ pub static LINTS: &[&::declare_clippy_lint::LintInfo] = &[
     crate::unicode::UNICODE_NOT_NFC_INFO,
     crate::uninhabited_references::UNINHABITED_REFERENCES_INFO,
     crate::uninit_vec::UNINIT_VEC_INFO,
+    crate::unit_as_impl_trait::UNIT_AS_IMPL_TRAIT_INFO,
     crate::unit_return_expecting_ord::UNIT_RETURN_EXPECTING_ORD_INFO,
     crate::unit_types::LET_UNIT_VALUE_INFO,
     crate::unit_types::UNIT_ARG_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -375,6 +375,7 @@ mod undocumented_unsafe_blocks;
 mod unicode;
 mod uninhabited_references;
 mod uninit_vec;
+mod unit_as_impl_trait;
 mod unit_return_expecting_ord;
 mod unit_types;
 mod unnecessary_box_returns;
@@ -870,6 +871,7 @@ rustc_lint::late_lint_methods!(
         RestWhenDestructuringStruct: rest_when_destructuring_struct::RestWhenDestructuringStruct = rest_when_destructuring_struct::RestWhenDestructuringStruct,
         BlockScrutinee: block_scrutinee::BlockScrutinee = block_scrutinee::BlockScrutinee,
         NonnullUncheckedOnBoxPtr: nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr = nonnull_unchecked_on_box_ptr::NonnullUncheckedOnBoxPtr::new(conf),
+        UnitAsImplTrait: unit_as_impl_trait::UnitAsImplTrait = unit_as_impl_trait::UnitAsImplTrait,
         // add late passes here, used by `cargo dev new_lint`
     ]]
 );

--- a/clippy_lints/src/unit_as_impl_trait.rs
+++ b/clippy_lints/src/unit_as_impl_trait.rs
@@ -1,0 +1,95 @@
+use clippy_utils::diagnostics::span_lint_and_then;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::FnKind;
+use rustc_hir::{Body, ExprKind, FnDecl, FnRetTy, TyKind};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+use rustc_span::{BytePos, Span};
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// Checks for function whose return type is an `impl` trait
+    /// implemented by `()`, and whose `()` return value is implicit.
+    ///
+    /// ### Why is this bad?
+    /// Since the required trait is implemented by `()`, adding an extra `;`
+    /// at the end of the function last expression will compile with no
+    /// indication that the expected value may have been silently swallowed.
+    ///
+    /// ### Example
+    /// ```no_run
+    /// fn key() -> impl Eq {
+    ///     [1, 10, 2, 0].sort_unstable()
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// fn key() -> impl Eq {
+    ///     let mut arr = [1, 10, 2, 0];
+    ///     arr.sort_unstable();
+    ///     arr
+    /// }
+    /// ```
+    /// or
+    /// ```no_run
+    /// fn key() -> impl Eq {
+    ///     [1, 10, 2, 0].sort_unstable();
+    ///     ()
+    /// }
+    /// ```
+    /// if returning `()` is intentional.
+    #[clippy::version = "1.90.0"]
+    pub UNIT_AS_IMPL_TRAIT,
+    suspicious,
+    "`()` which implements the required trait might be returned unexpectedly"
+}
+
+declare_lint_pass!(UnitAsImplTrait => [UNIT_AS_IMPL_TRAIT]);
+
+impl<'tcx> LateLintPass<'tcx> for UnitAsImplTrait {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: FnKind<'tcx>,
+        decl: &'tcx FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        span: Span,
+        _: LocalDefId,
+    ) {
+        if !span.from_expansion()
+            && let FnRetTy::Return(ty) = decl.output
+            && let TyKind::OpaqueDef(_) = ty.kind
+            && cx.typeck_results().expr_ty(body.value).is_unit()
+            && let ExprKind::Block(block, None) = body.value.kind
+            && block.expr.is_none_or(|e| !matches!(e.kind, ExprKind::Tup([])))
+        {
+            let block_end_span = block.span.with_hi(block.span.hi() - BytePos(1)).shrink_to_hi();
+
+            span_lint_and_then(
+                cx,
+                UNIT_AS_IMPL_TRAIT,
+                ty.span,
+                "this function returns `()` which implements the required trait",
+                |diag| {
+                    if let Some(expr) = block.expr {
+                        diag.span_note(expr.span, "this expression evaluates to `()`")
+                            .span_help(
+                                expr.span.shrink_to_hi(),
+                                "consider being explicit, and terminate the body with `()`",
+                            );
+                    } else if let Some(last) = block.stmts.last() {
+                        diag.span_note(last.span, "this statement evaluates to `()` because it ends with `;`")
+                            .span_note(block.span, "therefore the function body evaluates to `()`")
+                            .span_help(
+                                block_end_span,
+                                "if this is intentional, consider being explicit, and terminate the body with `()`",
+                            );
+                    } else {
+                        diag.span_note(block.span, "the empty body evaluates to `()`")
+                            .span_help(block_end_span, "consider being explicit and use `()` in the body");
+                    }
+                },
+            );
+        }
+    }
+}

--- a/tests/ui/crashes/ice-11422.fixed
+++ b/tests/ui/crashes/ice-11422.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::implied_bounds_in_impls)]
+#![allow(clippy::unit_as_impl_trait)]
 
 use std::fmt::Debug;
 use std::ops::*;

--- a/tests/ui/crashes/ice-11422.rs
+++ b/tests/ui/crashes/ice-11422.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::implied_bounds_in_impls)]
+#![allow(clippy::unit_as_impl_trait)]
 
 use std::fmt::Debug;
 use std::ops::*;

--- a/tests/ui/crashes/ice-11422.stderr
+++ b/tests/ui/crashes/ice-11422.stderr
@@ -1,5 +1,5 @@
 error: this bound is already specified as the supertrait of `PartialOrd`
-  --> tests/ui/crashes/ice-11422.rs:6:33
+  --> tests/ui/crashes/ice-11422.rs:7:33
    |
 LL | fn r#gen() -> impl PartialOrd + PartialEq + Debug {}
    |                                 ^^^^^^^^^

--- a/tests/ui/implied_bounds_in_impls.fixed
+++ b/tests/ui/implied_bounds_in_impls.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::implied_bounds_in_impls)]
+#![expect(clippy::unit_as_impl_trait)]
 #![feature(impl_trait_in_assoc_type, type_alias_impl_trait)]
 
 use std::ops::{Deref, DerefMut};

--- a/tests/ui/implied_bounds_in_impls.rs
+++ b/tests/ui/implied_bounds_in_impls.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::implied_bounds_in_impls)]
+#![expect(clippy::unit_as_impl_trait)]
 #![feature(impl_trait_in_assoc_type, type_alias_impl_trait)]
 
 use std::ops::{Deref, DerefMut};

--- a/tests/ui/implied_bounds_in_impls.stderr
+++ b/tests/ui/implied_bounds_in_impls.stderr
@@ -1,5 +1,5 @@
 error: this bound is already specified as the supertrait of `DerefMut<Target = T>`
-  --> tests/ui/implied_bounds_in_impls.rs:12:36
+  --> tests/ui/implied_bounds_in_impls.rs:13:36
    |
 LL | fn deref_derefmut<T>(x: T) -> impl Deref<Target = T> + DerefMut<Target = T> {
    |                                    ^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL + fn deref_derefmut<T>(x: T) -> impl DerefMut<Target = T> {
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<U, W, U>`
-  --> tests/ui/implied_bounds_in_impls.rs:30:37
+  --> tests/ui/implied_bounds_in_impls.rs:31:37
    |
 LL | fn generics_implied<U, W>() -> impl GenericTrait<W> + GenericSubtrait<U, W, U>
    |                                     ^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL + fn generics_implied<U, W>() -> impl GenericSubtrait<U, W, U>
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), i32, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:37:40
+  --> tests/ui/implied_bounds_in_impls.rs:38:40
    |
 LL | fn generics_implied_multi<V>() -> impl GenericTrait<i32> + GenericTrait2<V> + GenericSubtrait<(), i32, V> {}
    |                                        ^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL + fn generics_implied_multi<V>() -> impl GenericTrait2<V> + GenericSubtrait<(
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), i32, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:37:60
+  --> tests/ui/implied_bounds_in_impls.rs:38:60
    |
 LL | fn generics_implied_multi<V>() -> impl GenericTrait<i32> + GenericTrait2<V> + GenericSubtrait<(), i32, V> {}
    |                                                            ^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL + fn generics_implied_multi<V>() -> impl GenericTrait<i32> + GenericSubtrait<
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), T, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:41:44
+  --> tests/ui/implied_bounds_in_impls.rs:42:44
    |
 LL | fn generics_implied_multi2<T, V>() -> impl GenericTrait<T> + GenericTrait2<V> + GenericSubtrait<(), T, V>
    |                                            ^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL + fn generics_implied_multi2<T, V>() -> impl GenericTrait2<V> + GenericSubtra
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), T, V>`
-  --> tests/ui/implied_bounds_in_impls.rs:41:62
+  --> tests/ui/implied_bounds_in_impls.rs:42:62
    |
 LL | fn generics_implied_multi2<T, V>() -> impl GenericTrait<T> + GenericTrait2<V> + GenericSubtrait<(), T, V>
    |                                                              ^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL + fn generics_implied_multi2<T, V>() -> impl GenericTrait<T> + GenericSubtrai
    |
 
 error: this bound is already specified as the supertrait of `GenericSubtrait<(), i32, ()>`
-  --> tests/ui/implied_bounds_in_impls.rs:53:28
+  --> tests/ui/implied_bounds_in_impls.rs:54:28
    |
 LL | fn generics_same() -> impl GenericTrait<i32> + GenericSubtrait<(), i32, ()> {}
    |                            ^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL + fn generics_same() -> impl GenericSubtrait<(), i32, ()> {}
    |
 
 error: this bound is already specified as the supertrait of `DerefMut<Target = u8>`
-  --> tests/ui/implied_bounds_in_impls.rs:58:20
+  --> tests/ui/implied_bounds_in_impls.rs:59:20
    |
 LL |     fn f() -> impl Deref + DerefMut<Target = u8>;
    |                    ^^^^^
@@ -97,7 +97,7 @@ LL +     fn f() -> impl DerefMut<Target = u8>;
    |
 
 error: this bound is already specified as the supertrait of `DerefMut<Target = u8>`
-  --> tests/ui/implied_bounds_in_impls.rs:64:20
+  --> tests/ui/implied_bounds_in_impls.rs:65:20
    |
 LL |     fn f() -> impl Deref + DerefMut<Target = u8> {
    |                    ^^^^^
@@ -109,7 +109,7 @@ LL +     fn f() -> impl DerefMut<Target = u8> {
    |
 
 error: this bound is already specified as the supertrait of `DerefMut<Target = u8>`
-  --> tests/ui/implied_bounds_in_impls.rs:71:20
+  --> tests/ui/implied_bounds_in_impls.rs:72:20
    |
 LL |     fn f() -> impl Deref + DerefMut<Target = u8> {
    |                    ^^^^^
@@ -121,7 +121,7 @@ LL +     fn f() -> impl DerefMut<Target = u8> {
    |
 
 error: this bound is already specified as the supertrait of `PartialOrd`
-  --> tests/ui/implied_bounds_in_impls.rs:83:41
+  --> tests/ui/implied_bounds_in_impls.rs:84:41
    |
 LL |     fn default_generic_param1() -> impl PartialEq + PartialOrd + Debug {}
    |                                         ^^^^^^^^^
@@ -133,7 +133,7 @@ LL +     fn default_generic_param1() -> impl PartialOrd + Debug {}
    |
 
 error: this bound is already specified as the supertrait of `PartialOrd`
-  --> tests/ui/implied_bounds_in_impls.rs:85:54
+  --> tests/ui/implied_bounds_in_impls.rs:86:54
    |
 LL |     fn default_generic_param2() -> impl PartialOrd + PartialEq + Debug {}
    |                                                      ^^^^^^^^^
@@ -145,7 +145,7 @@ LL +     fn default_generic_param2() -> impl PartialOrd + Debug {}
    |
 
 error: this bound is already specified as the supertrait of `DoubleEndedIterator`
-  --> tests/ui/implied_bounds_in_impls.rs:99:26
+  --> tests/ui/implied_bounds_in_impls.rs:100:26
    |
 LL |     fn my_iter() -> impl Iterator<Item = u32> + DoubleEndedIterator {
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -157,7 +157,7 @@ LL +     fn my_iter() -> impl DoubleEndedIterator<Item = u32> {
    |
 
 error: this bound is already specified as the supertrait of `Copy`
-  --> tests/ui/implied_bounds_in_impls.rs:105:27
+  --> tests/ui/implied_bounds_in_impls.rs:106:27
    |
 LL |     fn f() -> impl Copy + Clone {
    |                           ^^^^^
@@ -169,7 +169,7 @@ LL +     fn f() -> impl Copy {
    |
 
 error: this bound is already specified as the supertrait of `Trait2<i32>`
-  --> tests/ui/implied_bounds_in_impls.rs:120:21
+  --> tests/ui/implied_bounds_in_impls.rs:121:21
    |
 LL |     fn f2() -> impl Trait1<i32, U = i64> + Trait2<i32> {}
    |                     ^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +181,7 @@ LL +     fn f2() -> impl Trait2<i32, U = i64> {}
    |
 
 error: this bound is already specified as the supertrait of `Trait4<i8, X = i32>`
-  --> tests/ui/implied_bounds_in_impls.rs:136:21
+  --> tests/ui/implied_bounds_in_impls.rs:137:21
    |
 LL |     fn f3() -> impl Trait3<i8, i16, i64, X = i32, Y = i128> + Trait4<i8, X = i32> {}
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +193,7 @@ LL +     fn f3() -> impl Trait4<i8, X = i32, Y = i128> {}
    |
 
 error: this bound is already specified as the supertrait of `Y`
-  --> tests/ui/implied_bounds_in_impls.rs:164:21
+  --> tests/ui/implied_bounds_in_impls.rs:165:21
    |
 LL |     fn f3() -> impl X + Y {}
    |                     ^
@@ -205,7 +205,7 @@ LL +     fn f3() -> impl Y {}
    |
 
 error: this bound is already specified as the supertrait of `Y<T = u32>`
-  --> tests/ui/implied_bounds_in_impls.rs:166:21
+  --> tests/ui/implied_bounds_in_impls.rs:167:21
    |
 LL |     fn f4() -> impl X + Y<T = u32> {}
    |                     ^
@@ -217,7 +217,7 @@ LL +     fn f4() -> impl Y<T = u32> {}
    |
 
 error: this bound is already specified as the supertrait of `Y<T = u32>`
-  --> tests/ui/implied_bounds_in_impls.rs:168:21
+  --> tests/ui/implied_bounds_in_impls.rs:169:21
    |
 LL |     fn f5() -> impl X<U = String> + Y<T = u32> {}
    |                     ^^^^^^^^^^^^^
@@ -229,7 +229,7 @@ LL +     fn f5() -> impl Y<T = u32, U = String> {}
    |
 
 error: this bound is already specified as the supertrait of `DerefMut`
-  --> tests/ui/implied_bounds_in_impls.rs:172:17
+  --> tests/ui/implied_bounds_in_impls.rs:173:17
    |
 LL | fn apit(_: impl Deref + DerefMut) {}
    |                 ^^^^^
@@ -241,7 +241,7 @@ LL + fn apit(_: impl DerefMut) {}
    |
 
 error: this bound is already specified as the supertrait of `DerefMut`
-  --> tests/ui/implied_bounds_in_impls.rs:176:20
+  --> tests/ui/implied_bounds_in_impls.rs:177:20
    |
 LL |     fn f() -> impl Deref + DerefMut;
    |                    ^^^^^
@@ -253,7 +253,7 @@ LL +     fn f() -> impl DerefMut;
    |
 
 error: this bound is already specified as the supertrait of `DerefMut`
-  --> tests/ui/implied_bounds_in_impls.rs:185:23
+  --> tests/ui/implied_bounds_in_impls.rs:186:23
    |
 LL |     type Assoc = impl Deref + DerefMut;
    |                       ^^^^^
@@ -265,7 +265,7 @@ LL +     type Assoc = impl DerefMut;
    |
 
 error: this bound is already specified as the supertrait of `DerefMut`
-  --> tests/ui/implied_bounds_in_impls.rs:192:18
+  --> tests/ui/implied_bounds_in_impls.rs:193:18
    |
 LL | type Tait = impl Deref + DerefMut;
    |                  ^^^^^

--- a/tests/ui/new_ret_no_self.rs
+++ b/tests/ui/new_ret_no_self.rs
@@ -1,5 +1,6 @@
 #![feature(type_alias_impl_trait)]
 #![warn(clippy::new_ret_no_self)]
+#![expect(clippy::unit_as_impl_trait)]
 
 fn main() {}
 

--- a/tests/ui/new_ret_no_self.stderr
+++ b/tests/ui/new_ret_no_self.stderr
@@ -1,5 +1,5 @@
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:49:5
+  --> tests/ui/new_ret_no_self.rs:50:5
    |
 LL | /     pub fn new(_: String) -> impl R<Item = u32> {
 LL | |
@@ -12,7 +12,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::new_ret_no_self)]`
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:83:5
+  --> tests/ui/new_ret_no_self.rs:84:5
    |
 LL | /     pub fn new() -> u32 {
 LL | |
@@ -22,7 +22,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:94:5
+  --> tests/ui/new_ret_no_self.rs:95:5
    |
 LL | /     pub fn new(_: String) -> u32 {
 LL | |
@@ -32,7 +32,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:132:5
+  --> tests/ui/new_ret_no_self.rs:133:5
    |
 LL | /     pub fn new() -> (u32, u32) {
 LL | |
@@ -42,7 +42,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:161:5
+  --> tests/ui/new_ret_no_self.rs:162:5
    |
 LL | /     pub fn new() -> *mut V {
 LL | |
@@ -52,7 +52,7 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:181:5
+  --> tests/ui/new_ret_no_self.rs:182:5
    |
 LL | /     pub fn new() -> Option<u32> {
 LL | |
@@ -62,19 +62,19 @@ LL | |     }
    | |_____^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:236:9
+  --> tests/ui/new_ret_no_self.rs:237:9
    |
 LL |         fn new() -> String;
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:249:9
+  --> tests/ui/new_ret_no_self.rs:250:9
    |
 LL |         fn new(_: String) -> String;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:285:9
+  --> tests/ui/new_ret_no_self.rs:286:9
    |
 LL | /         fn new() -> (u32, u32) {
 LL | |
@@ -84,7 +84,7 @@ LL | |         }
    | |_________^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:314:9
+  --> tests/ui/new_ret_no_self.rs:315:9
    |
 LL | /         fn new() -> *mut V {
 LL | |
@@ -94,7 +94,7 @@ LL | |         }
    | |_________^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:386:9
+  --> tests/ui/new_ret_no_self.rs:387:9
    |
 LL | /         fn new(t: T) -> impl Into<i32> {
 LL | |
@@ -104,7 +104,7 @@ LL | |         }
    | |_________^
 
 error: methods called `new` usually return `Self`
-  --> tests/ui/new_ret_no_self.rs:407:9
+  --> tests/ui/new_ret_no_self.rs:408:9
    |
 LL | /         fn new(t: T) -> impl Trait2<(), i32> {
 LL | |

--- a/tests/ui/unit_as_impl_trait.rs
+++ b/tests/ui/unit_as_impl_trait.rs
@@ -1,0 +1,45 @@
+#![warn(clippy::unit_as_impl_trait)]
+#![allow(clippy::unused_unit)]
+
+fn implicit_unit() -> impl Copy {
+    //~^ ERROR: function returns `()` which implements the required trait
+}
+
+fn explicit_unit() -> impl Copy {
+    ()
+}
+
+fn not_unit(x: u32) -> impl Copy {
+    x
+}
+
+fn never(x: u32) -> impl Copy {
+    panic!();
+}
+
+fn with_generic_param<T: Eq>(x: T) -> impl Eq {
+    //~^ ERROR: function returns `()` which implements the required trait
+    x;
+}
+
+fn non_empty_implicit_unit() -> impl Copy {
+    //~^ ERROR: function returns `()` which implements the required trait
+    println!("foobar");
+}
+
+fn last_expression_returning_unit() -> impl Eq {
+    //~^ ERROR: function returns `()` which implements the required trait
+    [1, 10, 2, 0].sort_unstable()
+}
+
+#[derive(Clone)]
+struct S;
+
+impl S {
+    fn clone(&self) -> impl Clone {
+        //~^ ERROR: function returns `()` which implements the required trait
+        S;
+    }
+}
+
+fn main() {}

--- a/tests/ui/unit_as_impl_trait.stderr
+++ b/tests/ui/unit_as_impl_trait.stderr
@@ -1,0 +1,119 @@
+error: this function returns `()` which implements the required trait
+  --> tests/ui/unit_as_impl_trait.rs:4:23
+   |
+LL | fn implicit_unit() -> impl Copy {
+   |                       ^^^^^^^^^
+   |
+note: the empty body evaluates to `()`
+  --> tests/ui/unit_as_impl_trait.rs:4:33
+   |
+LL |   fn implicit_unit() -> impl Copy {
+   |  _________________________________^
+LL | |
+LL | | }
+   | |_^
+help: consider being explicit and use `()` in the body
+  --> tests/ui/unit_as_impl_trait.rs:6:1
+   |
+LL | }
+   | ^
+   = note: `-D clippy::unit-as-impl-trait` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unit_as_impl_trait)]`
+
+error: this function returns `()` which implements the required trait
+  --> tests/ui/unit_as_impl_trait.rs:20:39
+   |
+LL | fn with_generic_param<T: Eq>(x: T) -> impl Eq {
+   |                                       ^^^^^^^
+   |
+note: this statement evaluates to `()` because it ends with `;`
+  --> tests/ui/unit_as_impl_trait.rs:22:5
+   |
+LL |     x;
+   |     ^^
+note: therefore the function body evaluates to `()`
+  --> tests/ui/unit_as_impl_trait.rs:20:47
+   |
+LL |   fn with_generic_param<T: Eq>(x: T) -> impl Eq {
+   |  _______________________________________________^
+LL | |
+LL | |     x;
+LL | | }
+   | |_^
+help: if this is intentional, consider being explicit, and terminate the body with `()`
+  --> tests/ui/unit_as_impl_trait.rs:23:1
+   |
+LL | }
+   | ^
+
+error: this function returns `()` which implements the required trait
+  --> tests/ui/unit_as_impl_trait.rs:25:33
+   |
+LL | fn non_empty_implicit_unit() -> impl Copy {
+   |                                 ^^^^^^^^^
+   |
+note: this statement evaluates to `()` because it ends with `;`
+  --> tests/ui/unit_as_impl_trait.rs:27:5
+   |
+LL |     println!("foobar");
+   |     ^^^^^^^^^^^^^^^^^^
+note: therefore the function body evaluates to `()`
+  --> tests/ui/unit_as_impl_trait.rs:25:43
+   |
+LL |   fn non_empty_implicit_unit() -> impl Copy {
+   |  ___________________________________________^
+LL | |
+LL | |     println!("foobar");
+LL | | }
+   | |_^
+help: if this is intentional, consider being explicit, and terminate the body with `()`
+  --> tests/ui/unit_as_impl_trait.rs:28:1
+   |
+LL | }
+   | ^
+
+error: this function returns `()` which implements the required trait
+  --> tests/ui/unit_as_impl_trait.rs:30:40
+   |
+LL | fn last_expression_returning_unit() -> impl Eq {
+   |                                        ^^^^^^^
+   |
+note: this expression evaluates to `()`
+  --> tests/ui/unit_as_impl_trait.rs:32:5
+   |
+LL |     [1, 10, 2, 0].sort_unstable()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider being explicit, and terminate the body with `()`
+  --> tests/ui/unit_as_impl_trait.rs:32:34
+   |
+LL |     [1, 10, 2, 0].sort_unstable()
+   |                                  ^
+
+error: this function returns `()` which implements the required trait
+  --> tests/ui/unit_as_impl_trait.rs:39:24
+   |
+LL |     fn clone(&self) -> impl Clone {
+   |                        ^^^^^^^^^^
+   |
+note: this statement evaluates to `()` because it ends with `;`
+  --> tests/ui/unit_as_impl_trait.rs:41:9
+   |
+LL |         S;
+   |         ^^
+note: therefore the function body evaluates to `()`
+  --> tests/ui/unit_as_impl_trait.rs:39:35
+   |
+LL |       fn clone(&self) -> impl Clone {
+   |  ___________________________________^
+LL | |
+LL | |         S;
+LL | |     }
+   | |_____^
+help: if this is intentional, consider being explicit, and terminate the body with `()`
+  --> tests/ui/unit_as_impl_trait.rs:42:5
+   |
+LL |     }
+   |     ^
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust-clippy/pull/13925)*

This lint implements the suggestion from rust-lang/rust-clippy#13909, and requires that an explicit `()` is used when a function returns `()` while declaring an impl trait return type.

I have used specialized messages for three different situations:
- An empty body
- A body ending with a statement
- A body ending with an expression returning `()`

One should note that adding the explicit `()` as suggested will cause the `unused_unit` lint (default: warn) to trigger. This should be possible to silence it inside functions returning impl traits if needed, to avoid having contradictory suggestions. Thoughts?

Close rust-lang/rust-clippy#13909

changelog: [`unit_as_impl_trait`]: new lint