### PR TITLE
Make CI a little bit safer

### DIFF
--- a/.github/workflows/clippy_dev.yml
+++ b/.github/workflows/clippy_dev.yml
@@ -17,6 +17,9 @@ jobs:
     # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     # Run
     - name: Build

--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.ref }}
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     # Run
     - name: Check Changelog
@@ -63,6 +65,8 @@ jobs:
     # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install i686 dependencies
       if: matrix.host == 'i686-unknown-linux-gnu'
@@ -121,6 +125,8 @@ jobs:
      # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install toolchain
       run: rustup show active-toolchain
@@ -136,6 +142,8 @@ jobs:
     # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install toolchain
       run: rustup show active-toolchain
@@ -188,6 +196,8 @@ jobs:
     # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Install toolchain
       run: rustup show active-toolchain

--- a/.github/workflows/clippy_pr.yml
+++ b/.github/workflows/clippy_pr.yml
@@ -25,6 +25,9 @@ jobs:
     # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     - name: Install toolchain
       run: rustup show active-toolchain

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,19 +22,27 @@ jobs:
     # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     - name: Checkout
       uses: actions/checkout@v4
       with:
         ref: ${{ env.TARGET_BRANCH }}
         path: 'out'
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     # Run
     - name: Set tag name
       if: startswith(github.ref, 'refs/tags/')
       run: |
-        TAG=$(basename ${{ github.ref }})
+        TAG=$(basename "${TAGNAME}")
         echo "TAG_NAME=$TAG" >> $GITHUB_ENV
+      env:
+        # Make sure that the reference gets expanded before injecting it
+        TAGNAME: ${{ github.ref }}
     - name: Set beta to true
       if: github.ref == 'refs/heads/beta'
       run: echo "BETA=true" >> $GITHUB_ENV

--- a/.github/workflows/lintcheck.yml
+++ b/.github/workflows/lintcheck.yml
@@ -21,6 +21,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 2
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     # HEAD is the generated merge commit `refs/pull/N/merge` between the PR and `master`, `HEAD^`
     # being the commit from `master` that is the base of the merge
@@ -73,6 +75,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     - name: Cache lintcheck bin
       id: cache-lintcheck-bin
@@ -103,6 +108,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     - name: Restore lintcheck bin
       uses: actions/cache/restore@v4

--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -12,6 +12,9 @@ jobs:
     # Setup
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Unsetting this would make so that any malicious package could get our Github Token
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@v4


### PR DESCRIPTION
This PR fixes two vulnerabilities in our CI, found with [zizmor](https://github.com/woodruffw/zizmor). One could be exploited by someone with tag-pushing permissions to execute arbitrary code in our CI (see`deploy.yml`). The second vulnerability would expose our tokens to a supply chain attack via a `build.rs` in one of the dependencies (See the rest of the files, and https://github.com/actions/checkout/issues/485)

Pre-reviewed by @flip1995 in our DMs.

changelog:none