### PR TITLE
Don't emit machine applicable `map_flatten` lint if there are code comments

### DIFF
--- a/tests/ui/map_flatten.rs
+++ b/tests/ui/map_flatten.rs
@@ -55,6 +55,18 @@ fn long_span() {
         .collect();
 }
 
+#[allow(clippy::useless_vec)]
+fn no_suggestion_if_comments_present() {
+    let vec = vec![vec![1, 2, 3]];
+    let _ = vec
+        .iter()
+        // a lovely comment explaining the code in very detail
+        .map(|x| x.iter())
+        //~^ ERROR: called `map(..).flatten()` on `Iterator`
+        // the answer to life, the universe and everything could be here
+        .flatten();
+}
+
 fn main() {
     long_span();
 }

--- a/tests/ui/map_flatten.stderr
+++ b/tests/ui/map_flatten.stderr
@@ -102,5 +102,14 @@ LL +             }
 LL +         })
    |
 
-error: aborting due to 4 previous errors
+error: called `map(..).flatten()` on `Iterator`
+  --> tests/ui/map_flatten.rs:64:10
+   |
+LL |           .map(|x| x.iter())
+   |  __________^
+...  |
+LL | |         .flatten();
+   | |__________________^ help: try replacing `map` with `flat_map` and remove the `.flatten()`: `flat_map(|x| x.iter())`
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/8528.

Similar to #13911, if there are code comments, we don't want to remove them automatically.

changelog: Don't emit machine applicable `map_flatten` lint if there are code comments

r? @xFrednet 