### PR TITLE
Do not intersect spans coming from different contexts

### DIFF
--- a/clippy_lints/src/no_mangle_with_rust_abi.rs
+++ b/clippy_lints/src/no_mangle_with_rust_abi.rs
@@ -37,7 +37,9 @@ declare_lint_pass!(NoMangleWithRustAbi => [NO_MANGLE_WITH_RUST_ABI]);
 
 impl<'tcx> LateLintPass<'tcx> for NoMangleWithRustAbi {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
-        if let ItemKind::Fn { sig: fn_sig, .. } = &item.kind {
+        if let ItemKind::Fn { sig: fn_sig, .. } = &item.kind
+            && !item.span.from_expansion()
+        {
             let attrs = cx.tcx.hir().attrs(item.hir_id());
             let mut app = Applicability::MaybeIncorrect;
             let fn_snippet = snippet_with_applicability(cx, fn_sig.span.with_hi(item.ident.span.lo()), "..", &mut app);


### PR DESCRIPTION
The code should not attempt to obtain a snippet by capping the function signature span with its identifier span without checking that they are in the same context.

This is the only instance I could identify where placeholders were used instead of the real snippet when running the CI lintcheck. Moreover, the placeholders were not even used, as they snippet was obtained prematurely.

Found in the context of #13941 

changelog: none