### PR TITLE
Do not trigger `redundant_pub_crate` in external macros

### DIFF
--- a/clippy_lints/src/redundant_pub_crate.rs
+++ b/clippy_lints/src/redundant_pub_crate.rs
@@ -1,8 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::source::HasSession;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{Item, ItemKind};
 use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty;
 use rustc_session::impl_lint_pass;
 use rustc_span::def_id::CRATE_DEF_ID;
@@ -49,6 +51,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantPubCrate {
             && !cx.effective_visibilities.is_exported(item.owner_id.def_id)
             && self.is_exported.last() == Some(&false)
             && is_not_macro_export(item)
+            && !in_external_macro(cx.sess(), item.span)
         {
             let span = item.span.with_hi(item.ident.span.hi());
             let descr = cx.tcx.def_kind(item.owner_id).descr(item.owner_id.to_def_id());

--- a/tests/ui/redundant_pub_crate.fixed
+++ b/tests/ui/redundant_pub_crate.fixed
@@ -1,3 +1,4 @@
+//@aux-build:proc_macros.rs
 #![allow(dead_code)]
 #![warn(clippy::redundant_pub_crate)]
 
@@ -111,6 +112,12 @@ mod issue_8732 {
 
     #[allow(unused_imports)]
     pub(crate) use some_macro; // ok: macro exports are exempt
+}
+
+proc_macros::external! {
+    mod priv_mod {
+        pub(crate) fn dummy() {}
+    }
 }
 
 fn main() {}

--- a/tests/ui/redundant_pub_crate.rs
+++ b/tests/ui/redundant_pub_crate.rs
@@ -1,3 +1,4 @@
+//@aux-build:proc_macros.rs
 #![allow(dead_code)]
 #![warn(clippy::redundant_pub_crate)]
 
@@ -111,6 +112,12 @@ mod issue_8732 {
 
     #[allow(unused_imports)]
     pub(crate) use some_macro; // ok: macro exports are exempt
+}
+
+proc_macros::external! {
+    mod priv_mod {
+        pub(crate) fn dummy() {}
+    }
 }
 
 fn main() {}

--- a/tests/ui/redundant_pub_crate.stderr
+++ b/tests/ui/redundant_pub_crate.stderr
@@ -1,5 +1,5 @@
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:6:5
+  --> tests/ui/redundant_pub_crate.rs:7:5
    |
 LL |     pub(crate) fn g() {} // private due to m1
    |     ----------^^^^^
@@ -10,7 +10,7 @@ LL |     pub(crate) fn g() {} // private due to m1
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pub_crate)]`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:11:9
+  --> tests/ui/redundant_pub_crate.rs:12:9
    |
 LL |         pub(crate) fn g() {} // private due to m1_1 and m1
    |         ----------^^^^^
@@ -18,7 +18,7 @@ LL |         pub(crate) fn g() {} // private due to m1_1 and m1
    |         help: consider using: `pub`
 
 error: pub(crate) module inside private module
-  --> tests/ui/redundant_pub_crate.rs:15:5
+  --> tests/ui/redundant_pub_crate.rs:16:5
    |
 LL |     pub(crate) mod m1_2 {
    |     ----------^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     pub(crate) mod m1_2 {
    |     help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:18:9
+  --> tests/ui/redundant_pub_crate.rs:19:9
    |
 LL |         pub(crate) fn g() {} // private due to m1_2 and m1
    |         ----------^^^^^
@@ -34,7 +34,7 @@ LL |         pub(crate) fn g() {} // private due to m1_2 and m1
    |         help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:24:9
+  --> tests/ui/redundant_pub_crate.rs:25:9
    |
 LL |         pub(crate) fn g() {} // private due to m1
    |         ----------^^^^^
@@ -42,7 +42,7 @@ LL |         pub(crate) fn g() {} // private due to m1
    |         help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:31:5
+  --> tests/ui/redundant_pub_crate.rs:32:5
    |
 LL |     pub(crate) fn g() {} // already crate visible due to m2
    |     ----------^^^^^
@@ -50,7 +50,7 @@ LL |     pub(crate) fn g() {} // already crate visible due to m2
    |     help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:36:9
+  --> tests/ui/redundant_pub_crate.rs:37:9
    |
 LL |         pub(crate) fn g() {} // private due to m2_1
    |         ----------^^^^^
@@ -58,7 +58,7 @@ LL |         pub(crate) fn g() {} // private due to m2_1
    |         help: consider using: `pub`
 
 error: pub(crate) module inside private module
-  --> tests/ui/redundant_pub_crate.rs:40:5
+  --> tests/ui/redundant_pub_crate.rs:41:5
    |
 LL |     pub(crate) mod m2_2 {
    |     ----------^^^^^^^^^
@@ -66,7 +66,7 @@ LL |     pub(crate) mod m2_2 {
    |     help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:43:9
+  --> tests/ui/redundant_pub_crate.rs:44:9
    |
 LL |         pub(crate) fn g() {} // already crate visible due to m2_2 and m2
    |         ----------^^^^^
@@ -74,7 +74,7 @@ LL |         pub(crate) fn g() {} // already crate visible due to m2_2 and m2
    |         help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:49:9
+  --> tests/ui/redundant_pub_crate.rs:50:9
    |
 LL |         pub(crate) fn g() {} // already crate visible due to m2
    |         ----------^^^^^
@@ -82,7 +82,7 @@ LL |         pub(crate) fn g() {} // already crate visible due to m2
    |         help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:61:9
+  --> tests/ui/redundant_pub_crate.rs:62:9
    |
 LL |         pub(crate) fn g() {} // private due to m3_1
    |         ----------^^^^^
@@ -90,7 +90,7 @@ LL |         pub(crate) fn g() {} // private due to m3_1
    |         help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:68:9
+  --> tests/ui/redundant_pub_crate.rs:69:9
    |
 LL |         pub(crate) fn g() {} // already crate visible due to m3_2
    |         ----------^^^^^
@@ -98,7 +98,7 @@ LL |         pub(crate) fn g() {} // already crate visible due to m3_2
    |         help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:81:5
+  --> tests/ui/redundant_pub_crate.rs:82:5
    |
 LL |     pub(crate) fn g() {} // private: not re-exported by `pub use m4::*`
    |     ----------^^^^^
@@ -106,7 +106,7 @@ LL |     pub(crate) fn g() {} // private: not re-exported by `pub use m4::*`
    |     help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:86:9
+  --> tests/ui/redundant_pub_crate.rs:87:9
    |
 LL |         pub(crate) fn g() {} // private due to m4_1
    |         ----------^^^^^
@@ -114,7 +114,7 @@ LL |         pub(crate) fn g() {} // private due to m4_1
    |         help: consider using: `pub`
 
 error: pub(crate) module inside private module
-  --> tests/ui/redundant_pub_crate.rs:90:5
+  --> tests/ui/redundant_pub_crate.rs:91:5
    |
 LL |     pub(crate) mod m4_2 {
    |     ----------^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     pub(crate) mod m4_2 {
    |     help: consider using: `pub`
 
 error: pub(crate) function inside private module
-  --> tests/ui/redundant_pub_crate.rs:93:9
+  --> tests/ui/redundant_pub_crate.rs:94:9
    |
 LL |         pub(crate) fn g() {} // private due to m4_2
    |         ----------^^^^^


### PR DESCRIPTION
Some widely used crates, such as `pin-project-lite`, make use of a `pub(crate)` construct in a private module inside a public macro. This makes unrelated project trigger the lint.

There is also an unfortunate situation for Clippy itself: when a new version of `pin-project-lite` or similar lint-trigerring crates is released, those lints which can be found in hundreds of occurrences in dependent crates will change, and appear as diffs in unrelated Clippy PR because the base lintcheck run will be cached with the ancient release of the crates. We currently have the situation [here](https://github.com/rust-lang/rust-clippy/actions/runs/12635410895?pr=13851#user-content-redundant-pub-crate-removed), which 219 lints removed and 219 lints added because of a `pin-project-lite` version change between runs, and the fact that `redundant_pub_crate` triggers on external macros.

Also:
- Fix #10636
- Fix #12213

changelog: [`redundant_pub_crate`]: do not trigger on external macros
