### PR TITLE
Fix macro name in the Book

### DIFF
--- a/book/src/development/defining_lints.md
+++ b/book/src/development/defining_lints.md
@@ -139,10 +139,10 @@ Untracked files:
 ```
 
 
-## The `define_clippy_lints` macro
+## The `declare_clippy_lint` macro
 
 After `cargo dev new_lint`, you should see a macro with the name
-`define_clippy_lints`. It will be in the same file if you defined a standalone
+`declare_clippy_lint`. It will be in the same file if you defined a standalone
 lint, and it will be in `mod.rs` if you defined a type-specific lint.
 
 The macro looks something like this:


### PR DESCRIPTION
`define_clippy_lints` does not exist, `declare_clippy_lint` exists.

changelog: none
