### PR TITLE
Improve `needless_as_bytes` to also detect `str::bytes()`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4924,8 +4924,8 @@ impl Methods {
                 },
                 ("is_empty", []) => {
                     match method_call(recv) {
-                        Some(("as_bytes", prev_recv, [], _, _)) => {
-                            needless_as_bytes::check(cx, "is_empty", prev_recv, expr.span);
+                        Some((prev_method @ ("as_bytes" | "bytes"), prev_recv, [], _, _)) => {
+                            needless_as_bytes::check(cx, prev_method, "is_empty", prev_recv, expr.span);
                         },
                         Some(("as_str", recv, [], as_str_span, _)) => {
                             redundant_as_str::check(cx, expr, recv, as_str_span, span);
@@ -4962,8 +4962,8 @@ impl Methods {
                     double_ended_iterator_last::check(cx, expr, recv, call_span);
                 },
                 ("len", []) => {
-                    if let Some(("as_bytes", prev_recv, [], _, _)) = method_call(recv) {
-                        needless_as_bytes::check(cx, "len", prev_recv, expr.span);
+                    if let Some((prev_method @ ("as_bytes" | "bytes"), prev_recv, [], _, _)) = method_call(recv) {
+                        needless_as_bytes::check(cx, prev_method, "len", prev_recv, expr.span);
                     }
                 },
                 ("lock", []) => {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4925,7 +4925,7 @@ impl Methods {
                 ("is_empty", []) => {
                     match method_call(recv) {
                         Some(("as_bytes", prev_recv, [], _, _)) => {
-                            needless_as_bytes::check(cx, "is_empty", recv, prev_recv, expr.span);
+                            needless_as_bytes::check(cx, "is_empty", prev_recv, expr.span);
                         },
                         Some(("as_str", recv, [], as_str_span, _)) => {
                             redundant_as_str::check(cx, expr, recv, as_str_span, span);
@@ -4963,7 +4963,7 @@ impl Methods {
                 },
                 ("len", []) => {
                     if let Some(("as_bytes", prev_recv, [], _, _)) = method_call(recv) {
-                        needless_as_bytes::check(cx, "len", recv, prev_recv, expr.span);
+                        needless_as_bytes::check(cx, "len", prev_recv, expr.span);
                     }
                 },
                 ("lock", []) => {

--- a/clippy_lints/src/methods/needless_as_bytes.rs
+++ b/clippy_lints/src/methods/needless_as_bytes.rs
@@ -8,7 +8,7 @@ use rustc_span::Span;
 
 use super::NEEDLESS_AS_BYTES;
 
-pub fn check(cx: &LateContext<'_>, method: &str, prev_recv: &Expr<'_>, span: Span) {
+pub fn check(cx: &LateContext<'_>, prev_method: &str, method: &str, prev_recv: &Expr<'_>, span: Span) {
     let ty1 = cx.typeck_results().expr_ty_adjusted(prev_recv).peel_refs();
     if is_type_lang_item(cx, ty1, LangItem::String) || ty1.is_str() {
         let mut app = Applicability::MachineApplicable;
@@ -17,7 +17,7 @@ pub fn check(cx: &LateContext<'_>, method: &str, prev_recv: &Expr<'_>, span: Spa
             cx,
             NEEDLESS_AS_BYTES,
             span,
-            "needless call to `as_bytes()`",
+            format!("needless call to `{prev_method}`"),
             format!("`{method}()` can be called directly on strings"),
             format!("{sugg}.{method}()"),
             app,

--- a/clippy_lints/src/methods/needless_as_bytes.rs
+++ b/clippy_lints/src/methods/needless_as_bytes.rs
@@ -8,11 +8,9 @@ use rustc_span::Span;
 
 use super::NEEDLESS_AS_BYTES;
 
-pub fn check(cx: &LateContext<'_>, method: &str, recv: &Expr<'_>, prev_recv: &Expr<'_>, span: Span) {
-    if cx.typeck_results().expr_ty_adjusted(recv).peel_refs().is_slice()
-        && let ty1 = cx.typeck_results().expr_ty_adjusted(prev_recv).peel_refs()
-        && (is_type_lang_item(cx, ty1, LangItem::String) || ty1.is_str())
-    {
+pub fn check(cx: &LateContext<'_>, method: &str, prev_recv: &Expr<'_>, span: Span) {
+    let ty1 = cx.typeck_results().expr_ty_adjusted(prev_recv).peel_refs();
+    if is_type_lang_item(cx, ty1, LangItem::String) || ty1.is_str() {
         let mut app = Applicability::MachineApplicable;
         let sugg = Sugg::hir_with_context(cx, prev_recv, span.ctxt(), "..", &mut app);
         span_lint_and_sugg(

--- a/tests/ui/needless_as_bytes.fixed
+++ b/tests/ui/needless_as_bytes.fixed
@@ -1,10 +1,14 @@
 #![warn(clippy::needless_as_bytes)]
 #![allow(clippy::const_is_empty)]
+#![feature(exact_size_is_empty)]
 
 struct S;
 
 impl S {
     fn as_bytes(&self) -> &[u8] {
+        &[]
+    }
+    fn bytes(&self) -> &[u8] {
         &[]
     }
 }
@@ -15,8 +19,18 @@ fn main() {
         println!("len = {}", "some string".len());
         //~^ needless_as_bytes
     }
+    if "some string".is_empty() {
+        //~^ needless_as_bytes
+        println!("len = {}", "some string".len());
+        //~^ needless_as_bytes
+    }
 
     let s = String::from("yet another string");
+    if s.is_empty() {
+        //~^ needless_as_bytes
+        println!("len = {}", s.len());
+        //~^ needless_as_bytes
+    }
     if s.is_empty() {
         //~^ needless_as_bytes
         println!("len = {}", s.len());
@@ -36,6 +50,18 @@ fn main() {
         };
     }
     m!(1).as_bytes().len();
+    let _ = S.bytes().is_empty();
+    let _ = S.bytes().len();
+    let _ = (&String::new() as &dyn Bytes).bytes().len();
+    macro_rules! m {
+        (1) => {
+            ""
+        };
+        (2) => {
+            "".bytes()
+        };
+    }
+    m!(1).bytes().len();
     m!(2).len();
 }
 
@@ -45,6 +71,16 @@ pub trait AsBytes {
 
 impl AsBytes for String {
     fn as_bytes(&self) -> &[u8] {
+        &[]
+    }
+}
+
+pub trait Bytes {
+    fn bytes(&self) -> &[u8];
+}
+
+impl Bytes for String {
+    fn bytes(&self) -> &[u8] {
         &[]
     }
 }

--- a/tests/ui/needless_as_bytes.rs
+++ b/tests/ui/needless_as_bytes.rs
@@ -1,10 +1,14 @@
 #![warn(clippy::needless_as_bytes)]
 #![allow(clippy::const_is_empty)]
+#![feature(exact_size_is_empty)]
 
 struct S;
 
 impl S {
     fn as_bytes(&self) -> &[u8] {
+        &[]
+    }
+    fn bytes(&self) -> &[u8] {
         &[]
     }
 }
@@ -15,11 +19,21 @@ fn main() {
         println!("len = {}", "some string".as_bytes().len());
         //~^ needless_as_bytes
     }
+    if "some string".bytes().is_empty() {
+        //~^ needless_as_bytes
+        println!("len = {}", "some string".bytes().len());
+        //~^ needless_as_bytes
+    }
 
     let s = String::from("yet another string");
     if s.as_bytes().is_empty() {
         //~^ needless_as_bytes
         println!("len = {}", s.as_bytes().len());
+        //~^ needless_as_bytes
+    }
+    if s.bytes().is_empty() {
+        //~^ needless_as_bytes
+        println!("len = {}", s.bytes().len());
         //~^ needless_as_bytes
     }
 
@@ -36,6 +50,18 @@ fn main() {
         };
     }
     m!(1).as_bytes().len();
+    let _ = S.bytes().is_empty();
+    let _ = S.bytes().len();
+    let _ = (&String::new() as &dyn Bytes).bytes().len();
+    macro_rules! m {
+        (1) => {
+            ""
+        };
+        (2) => {
+            "".bytes()
+        };
+    }
+    m!(1).bytes().len();
     m!(2).len();
 }
 
@@ -45,6 +71,16 @@ pub trait AsBytes {
 
 impl AsBytes for String {
     fn as_bytes(&self) -> &[u8] {
+        &[]
+    }
+}
+
+pub trait Bytes {
+    fn bytes(&self) -> &[u8];
+}
+
+impl Bytes for String {
+    fn bytes(&self) -> &[u8] {
         &[]
     }
 }

--- a/tests/ui/needless_as_bytes.stderr
+++ b/tests/ui/needless_as_bytes.stderr
@@ -1,5 +1,5 @@
-error: needless call to `as_bytes()`
-  --> tests/ui/needless_as_bytes.rs:13:8
+error: needless call to `as_bytes`
+  --> tests/ui/needless_as_bytes.rs:17:8
    |
 LL |     if "some string".as_bytes().is_empty() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `is_empty()` can be called directly on strings: `"some string".is_empty()`
@@ -7,23 +7,47 @@ LL |     if "some string".as_bytes().is_empty() {
    = note: `-D clippy::needless-as-bytes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_as_bytes)]`
 
-error: needless call to `as_bytes()`
-  --> tests/ui/needless_as_bytes.rs:15:30
+error: needless call to `as_bytes`
+  --> tests/ui/needless_as_bytes.rs:19:30
    |
 LL |         println!("len = {}", "some string".as_bytes().len());
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `len()` can be called directly on strings: `"some string".len()`
 
-error: needless call to `as_bytes()`
-  --> tests/ui/needless_as_bytes.rs:20:8
+error: needless call to `bytes`
+  --> tests/ui/needless_as_bytes.rs:22:8
+   |
+LL |     if "some string".bytes().is_empty() {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `is_empty()` can be called directly on strings: `"some string".is_empty()`
+
+error: needless call to `bytes`
+  --> tests/ui/needless_as_bytes.rs:24:30
+   |
+LL |         println!("len = {}", "some string".bytes().len());
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `len()` can be called directly on strings: `"some string".len()`
+
+error: needless call to `as_bytes`
+  --> tests/ui/needless_as_bytes.rs:29:8
    |
 LL |     if s.as_bytes().is_empty() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^ help: `is_empty()` can be called directly on strings: `s.is_empty()`
 
-error: needless call to `as_bytes()`
-  --> tests/ui/needless_as_bytes.rs:22:30
+error: needless call to `as_bytes`
+  --> tests/ui/needless_as_bytes.rs:31:30
    |
 LL |         println!("len = {}", s.as_bytes().len());
    |                              ^^^^^^^^^^^^^^^^^^ help: `len()` can be called directly on strings: `s.len()`
 
-error: aborting due to 4 previous errors
+error: needless call to `bytes`
+  --> tests/ui/needless_as_bytes.rs:34:8
+   |
+LL |     if s.bytes().is_empty() {
+   |        ^^^^^^^^^^^^^^^^^^^^ help: `is_empty()` can be called directly on strings: `s.is_empty()`
+
+error: needless call to `bytes`
+  --> tests/ui/needless_as_bytes.rs:36:30
+   |
+LL |         println!("len = {}", s.bytes().len());
+   |                              ^^^^^^^^^^^^^^^ help: `len()` can be called directly on strings: `s.len()`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
I ran Clippy on some projects after upgrading to 1.84, which found a [needless use of `as_bytes()`](https://github.com/rust-lang/rust-clippy/pull/13437). It made me notice that the code was also using `bytes()` needlessly in other places. This PR improves on the `as_bytes()` lint to also lint `bytes()`.

----

changelog: none
