### PR TITLE
Correct version of `literal_string_with_formatting_args`

### DIFF
--- a/clippy_lints/src/literal_string_with_formatting_args.rs
+++ b/clippy_lints/src/literal_string_with_formatting_args.rs
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// let y = "hello";
     /// x.expect(&format!("{y:?}"));
     /// ```
-    #[clippy::version = "1.83.0"]
+    #[clippy::version = "1.85.0"]
     pub LITERAL_STRING_WITH_FORMATTING_ARGS,
     suspicious,
     "Checks if string literals have formatting arguments"


### PR DESCRIPTION
It claims to be in 1.83 but in fact will not be until 1.85.
 
Evidence: <https://github.com/rust-lang/rust/pull/134788> is where it was merged into rust-lang/rust, and has a milestone of 1.85.

changelog: none