### PR TITLE
CI: check the presence of the changelog line in every pull request

### DIFF
--- a/.github/workflows/clippy_changelog.yml
+++ b/.github/workflows/clippy_changelog.yml
@@ -1,0 +1,57 @@
+name: Clippy changelog check
+
+on:
+  merge_group:
+  pull_request:
+    types: [opened, reopened, edited]
+
+concurrency:
+  # For a given workflow, if we push to the same PR, cancel all previous builds on that PR.
+  # If the push is not attached to a PR, we will cancel all builds on the same branch.
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    # Run
+    - name: Check Changelog
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        body=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/rust-lang/rust-clippy/pulls/$PR_NUMBER" | \
+          python -c "import sys, json; print(json.load(sys.stdin)['body'])")
+        output=$(grep "^changelog:\s*\S" <<< "$body" | sed "s/changelog:\s*//g") || {
+          echo "ERROR: pull request message must contain 'changelog: ...'. Please add it."
+          exit 1
+        }
+        echo "changelog: $output"
+      env:
+        PYTHONIOENCODING: 'utf-8'
+        PR_NUMBER: '${{ github.event.number }}'
+
+  # We need to have the "conclusion" job also on PR CI, to make it possible
+  # to add PRs to a merge queue.
+  conclusion_changelog:
+    needs: [ changelog ]
+    # We need to ensure this job does *not* get skipped if its dependencies fail,
+    # because a skipped job is considered a success by GitHub. So we have to
+    # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run
+    # when the workflow is canceled manually.
+    #
+    # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      # Manually check the status of all dependencies. `if: failure()` does not work.
+      - name: Conclusion
+        run: |
+          # Print the dependent jobs to see them in the CI log
+          jq -C <<< '${{ toJson(needs) }}'
+          # Check if all jobs that we depend on (in the needs array) were successful.
+          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/clippy_mq.yml
+++ b/.github/workflows/clippy_mq.yml
@@ -15,37 +15,7 @@ defaults:
     shell: bash
 
 jobs:
-  changelog:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.ref }}
-        # Unsetting this would make so that any malicious package could get our Github Token
-        persist-credentials: false
-
-    # Run
-    - name: Check Changelog
-      run: |
-        MESSAGE=$(git log --format=%B -n 1)
-        PR=$(echo "$MESSAGE" | grep -o "#[0-9]*" | head -1 | sed -e 's/^#//')
-        body=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/rust-lang/rust-clippy/pulls/$PR" | \
-          python -c "import sys, json; print(json.load(sys.stdin)['body'])")
-        output=$(grep "^changelog:\s*\S" <<< "$body" | sed "s/changelog:\s*//g") || {
-          echo "ERROR: PR body must contain 'changelog: ...'"
-          exit 1
-        }
-        if [[ "$output" = "none" ]]; then
-          echo "WARNING: changelog is 'none'"
-        else
-          echo "changelog: $output"
-        fi
-      env:
-        PYTHONIOENCODING: 'utf-8'
   base:
-    needs: changelog
     strategy:
       matrix:
         include:
@@ -119,7 +89,6 @@ jobs:
         OS: ${{ runner.os }}
 
   metadata_collection:
-    needs: changelog
     runs-on: ubuntu-latest
 
     steps:
@@ -138,7 +107,6 @@ jobs:
       run: cargo collect-metadata
 
   integration_build:
-    needs: changelog
     runs-on: ubuntu-latest
 
     steps:
@@ -228,7 +196,7 @@ jobs:
         INTEGRATION: ${{ matrix.integration }}
 
   conclusion:
-    needs: [ changelog, base, metadata_collection, integration_build, integration ]
+    needs: [ base, metadata_collection, integration_build, integration ]
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to
     # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run


### PR DESCRIPTION
Checking it only in the merge queue leads to deferred failures once the decision to merge has been taken already.

- [X] Testing first without changelog line
- [x] Now that that has failed, adding the changelog line and force-pushing


changelog: none

