### PR TITLE
Mention existing labels at CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ currently. Between writing new lints, fixing issues, reviewing pull requests and
 responding to issues there may not always be enough time to stay on top of it
 all.
 
-Our highest priority is fixing [crashes][l-crash] and [bugs][l-bug], for example
+Our highest priority is fixing [ICEs][I-ICE] and [bugs][C-bug], for example
 an ICE in a popular crate that many other crates depend on. We don't
 want Clippy to crash on your code and we want it to be as reliable as the
 suggestions from Rust compiler errors.
@@ -213,8 +213,8 @@ Or rather: before the sync this should be addressed,
 e.g. by removing a lint again, so it doesn't hit beta/stable.
 
 [triage]: https://forge.rust-lang.org/release/triage-procedure.html
-[l-crash]: https://github.com/rust-lang/rust-clippy/labels/L-crash
-[l-bug]: https://github.com/rust-lang/rust-clippy/labels/L-bug
+[I-ICE]: https://github.com/rust-lang/rust-clippy/labels/I-ICE
+[C-bug]: https://github.com/rust-lang/rust-clippy/labels/C-bug
 [p-low]: https://github.com/rust-lang/rust-clippy/labels/P-low
 [p-medium]: https://github.com/rust-lang/rust-clippy/labels/P-medium
 [p-high]: https://github.com/rust-lang/rust-clippy/labels/P-high


### PR DESCRIPTION
At CONTRIBUTING.md there are mentioned [`l-crash`](https://github.com/rust-lang/rust-clippy/issues?q=is%3Aopen+label%3Al-crash) and [`l-bug`](https://github.com/rust-lang/rust-clippy/issues?q=is%3Aopen%20label%3Al-bug) labels which are never used, so correct them to [`I-ICE`](https://github.com/rust-lang/rust-clippy/issues?q=is%3Aopen%20label%3AI-ICE) and  [`C-bug`](https://github.com/rust-lang/rust-clippy/issues?q=is%3Aopen%20label%3AC-bug)

changelog: none
