### PR TITLE
CI: rerun the changelog check on PR synchronization

### DIFF
--- a/.github/workflows/clippy_changelog.yml
+++ b/.github/workflows/clippy_changelog.yml
@@ -3,7 +3,7 @@ name: Clippy changelog check
 on:
   merge_group:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, synchronize, edited]
 
 concurrency:
   # For a given workflow, if we push to the same PR, cancel all previous builds on that PR.


### PR DESCRIPTION
Rerunning the PR checks when a PR is synchronized (new commits added, or force-pushed) seems to remove the changelog checks from the UI while keeping the PR mergeable from the maintainer's interface.

This PR reruns the cheap changelog check when a PR is synchronized.

changelog: none

r? @flip1995 