### PR TITLE
Suggest using `Vec::extend()` in `same_item_push`

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -767,6 +767,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`ptr_as_ptr`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_as_ptr)
 * [`redundant_field_names`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names)
 * [`redundant_static_lifetimes`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes)
+* [`same_item_push`](https://rust-lang.github.io/rust-clippy/master/index.html#same_item_push)
 * [`seek_from_current`](https://rust-lang.github.io/rust-clippy/master/index.html#seek_from_current)
 * [`seek_rewind`](https://rust-lang.github.io/rust-clippy/master/index.html#seek_rewind)
 * [`transmute_ptr_to_ref`](https://rust-lang.github.io/rust-clippy/master/index.html#transmute_ptr_to_ref)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -636,6 +636,7 @@ define_Conf! {
         ptr_as_ptr,
         redundant_field_names,
         redundant_static_lifetimes,
+        same_item_push,
         seek_from_current,
         seek_rewind,
         transmute_ptr_to_ref,

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -830,7 +830,7 @@ impl Loops {
         for_kv_map::check(cx, pat, arg, body);
         mut_range_bound::check(cx, arg, body);
         single_element_loop::check(cx, pat, arg, body, expr);
-        same_item_push::check(cx, pat, arg, body, expr);
+        same_item_push::check(cx, pat, arg, body, expr, &self.msrv);
         manual_flatten::check(cx, pat, arg, body, span);
         manual_find::check(cx, pat, arg, body, span, expr);
         unused_enumerate_index::check(cx, pat, arg, body);

--- a/tests/ui/same_item_push.rs
+++ b/tests/ui/same_item_push.rs
@@ -21,33 +21,43 @@ fn main() {
     let item = 2;
     for _ in 5..=20 {
         vec.push(item);
-        //~^ ERROR: it looks like the same item is being pushed into this Vec
+        //~^ ERROR: it looks like the same item is being pushed into this `Vec`
     }
 
     let mut vec: Vec<u8> = Vec::new();
     for _ in 0..15 {
         let item = 2;
         vec.push(item);
-        //~^ ERROR: it looks like the same item is being pushed into this Vec
+        //~^ ERROR: it looks like the same item is being pushed into this `Vec`
     }
 
     let mut vec: Vec<u8> = Vec::new();
     for _ in 0..15 {
         vec.push(13);
-        //~^ ERROR: it looks like the same item is being pushed into this Vec
+        //~^ ERROR: it looks like the same item is being pushed into this `Vec`
     }
 
     let mut vec = Vec::new();
     for _ in 0..20 {
         vec.push(VALUE);
-        //~^ ERROR: it looks like the same item is being pushed into this Vec
+        //~^ ERROR: it looks like the same item is being pushed into this `Vec`
     }
 
     let mut vec = Vec::new();
     let item = VALUE;
     for _ in 0..20 {
         vec.push(item);
-        //~^ ERROR: it looks like the same item is being pushed into this Vec
+        //~^ ERROR: it looks like the same item is being pushed into this `Vec`
+    }
+
+    #[clippy::msrv = "1.81"]
+    fn older_msrv() {
+        let mut vec = Vec::new();
+        let item = VALUE;
+        for _ in 0..20 {
+            vec.push(item);
+            //~^ ERROR: it looks like the same item is being pushed into this `Vec`
+        }
     }
 
     // ** non-linted cases **

--- a/tests/ui/same_item_push.stderr
+++ b/tests/ui/same_item_push.stderr
@@ -1,44 +1,58 @@
-error: it looks like the same item is being pushed into this Vec
+error: it looks like the same item is being pushed into this `Vec`
   --> tests/ui/same_item_push.rs:23:9
    |
 LL |         vec.push(item);
    |         ^^^
    |
-   = help: consider using vec![item;SIZE] or vec.resize(NEW_SIZE, item)
+   = help: consider using `vec![item;SIZE]`
+   = help: or `vec.extend(std::iter::repeat_n(item, SIZE))`
    = note: `-D clippy::same-item-push` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::same_item_push)]`
 
-error: it looks like the same item is being pushed into this Vec
+error: it looks like the same item is being pushed into this `Vec`
   --> tests/ui/same_item_push.rs:30:9
    |
 LL |         vec.push(item);
    |         ^^^
    |
-   = help: consider using vec![item;SIZE] or vec.resize(NEW_SIZE, item)
+   = help: consider using `vec![item;SIZE]`
+   = help: or `vec.extend(std::iter::repeat_n(item, SIZE))`
 
-error: it looks like the same item is being pushed into this Vec
+error: it looks like the same item is being pushed into this `Vec`
   --> tests/ui/same_item_push.rs:36:9
    |
 LL |         vec.push(13);
    |         ^^^
    |
-   = help: consider using vec![13;SIZE] or vec.resize(NEW_SIZE, 13)
+   = help: consider using `vec![13;SIZE]`
+   = help: or `vec.extend(std::iter::repeat_n(13, SIZE))`
 
-error: it looks like the same item is being pushed into this Vec
+error: it looks like the same item is being pushed into this `Vec`
   --> tests/ui/same_item_push.rs:42:9
    |
 LL |         vec.push(VALUE);
    |         ^^^
    |
-   = help: consider using vec![VALUE;SIZE] or vec.resize(NEW_SIZE, VALUE)
+   = help: consider using `vec![VALUE;SIZE]`
+   = help: or `vec.extend(std::iter::repeat_n(VALUE, SIZE))`
 
-error: it looks like the same item is being pushed into this Vec
+error: it looks like the same item is being pushed into this `Vec`
   --> tests/ui/same_item_push.rs:49:9
    |
 LL |         vec.push(item);
    |         ^^^
    |
-   = help: consider using vec![item;SIZE] or vec.resize(NEW_SIZE, item)
+   = help: consider using `vec![item;SIZE]`
+   = help: or `vec.extend(std::iter::repeat_n(item, SIZE))`
 
-error: aborting due to 5 previous errors
+error: it looks like the same item is being pushed into this `Vec`
+  --> tests/ui/same_item_push.rs:58:13
+   |
+LL |             vec.push(item);
+   |             ^^^
+   |
+   = help: consider using `vec![item;SIZE]`
+   = help: or `vec.resize(NEW_SIZE, item)`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Using `Vec::extend(std::iter::repeat_n(item, N))` allows to use the more natural number of elements to add `N`, as is probably done in the original loop, instead of computing the difference between the existing number of elements and the wanted one.

Before MSRV 1.82, the older suggestion to use `Vec::resize()` is still issued.

Inspired by #6156 (which predates `repeat_n()`).

changelog: [`same_item_push`]: recommend using `Vec::extend()` to extend a vector