### PR TITLE
correct suggestions in `no_std`

### DIFF
--- a/clippy_lints/src/methods/map_with_unused_argument_over_ranges.rs
+++ b/clippy_lints/src/methods/map_with_unused_argument_over_ranges.rs
@@ -3,7 +3,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::sugg::Sugg;
-use clippy_utils::{eager_or_lazy, higher, usage};
+use clippy_utils::{eager_or_lazy, higher, std_or_core, usage};
 use rustc_ast::LitKind;
 use rustc_ast::ast::RangeLimits;
 use rustc_data_structures::packed::Pu128;
@@ -75,6 +75,7 @@ pub(super) fn check(
         } = body_hir
         && !usage::BindingUsageFinder::are_params_used(cx, body_hir)
         && let Some(count) = extract_count_with_applicability(cx, range, &mut applicability)
+        && let Some(exec_context) = std_or_core(cx)
     {
         let method_to_use_name;
         let new_span;
@@ -105,7 +106,7 @@ pub(super) fn check(
         let mut parts = vec![
             (
                 receiver.span.to(method_call_span),
-                format!("std::iter::{method_to_use_name}"),
+                format!("{exec_context}::iter::{method_to_use_name}"),
             ),
             new_span,
         ];

--- a/clippy_lints/src/single_range_in_vec_init.rs
+++ b/clippy_lints/src/single_range_in_vec_init.rs
@@ -1,9 +1,9 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use clippy_utils::get_trait_def_id;
 use clippy_utils::higher::VecArgs;
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::source::SpanRangeExt;
 use clippy_utils::ty::implements_trait;
+use clippy_utils::{get_trait_def_id, is_no_std_crate};
 use rustc_ast::{LitIntType, LitKind, UintTy};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, LangItem, QPath, StructTailExpr};
@@ -125,7 +125,7 @@ impl LateLintPass<'_> for SingleRangeInVecInit {
                     span,
                     format!("{suggested_type} of `Range` that is only one element"),
                     |diag| {
-                        if should_emit_every_value {
+                        if should_emit_every_value && !is_no_std_crate(cx) {
                             diag.span_suggestion(
                                 span,
                                 "if you wanted a `Vec` that contains the entire range, try",

--- a/tests/ui/drain_collect_nostd.fixed
+++ b/tests/ui/drain_collect_nostd.fixed
@@ -1,0 +1,8 @@
+#![warn(clippy::drain_collect)]
+#![no_std]
+extern crate alloc;
+use alloc::vec::Vec;
+
+fn remove_all(v: &mut Vec<i32>) -> Vec<i32> {
+    core::mem::take(v)
+}

--- a/tests/ui/drain_collect_nostd.rs
+++ b/tests/ui/drain_collect_nostd.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::drain_collect)]
+#![no_std]
+extern crate alloc;
+use alloc::vec::Vec;
+
+fn remove_all(v: &mut Vec<i32>) -> Vec<i32> {
+    v.drain(..).collect()
+}

--- a/tests/ui/drain_collect_nostd.stderr
+++ b/tests/ui/drain_collect_nostd.stderr
@@ -1,0 +1,11 @@
+error: you seem to be trying to move all elements into a new `Vec`
+  --> tests/ui/drain_collect_nostd.rs:7:5
+   |
+LL |     v.drain(..).collect()
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using `mem::take`: `core::mem::take(v)`
+   |
+   = note: `-D clippy::drain-collect` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::drain_collect)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/eta_nostd.fixed
+++ b/tests/ui/eta_nostd.fixed
@@ -1,0 +1,10 @@
+#![warn(clippy::redundant_closure)]
+#![no_std]
+
+extern crate alloc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+fn issue_13895() {
+    let _: Option<Vec<u8>> = true.then(alloc::vec::Vec::new);
+}

--- a/tests/ui/eta_nostd.rs
+++ b/tests/ui/eta_nostd.rs
@@ -1,0 +1,10 @@
+#![warn(clippy::redundant_closure)]
+#![no_std]
+
+extern crate alloc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+fn issue_13895() {
+    let _: Option<Vec<u8>> = true.then(|| vec![]);
+}

--- a/tests/ui/eta_nostd.stderr
+++ b/tests/ui/eta_nostd.stderr
@@ -1,0 +1,11 @@
+error: redundant closure
+  --> tests/ui/eta_nostd.rs:9:40
+   |
+LL |     let _: Option<Vec<u8>> = true.then(|| vec![]);
+   |                                        ^^^^^^^^^ help: replace the closure with `Vec::new`: `alloc::vec::Vec::new`
+   |
+   = note: `-D clippy::redundant-closure` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::redundant_closure)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/map_with_unused_argument_over_ranges_nostd.fixed
+++ b/tests/ui/map_with_unused_argument_over_ranges_nostd.fixed
@@ -1,0 +1,8 @@
+#![warn(clippy::map_with_unused_argument_over_ranges)]
+#![no_std]
+extern crate alloc;
+use alloc::vec::Vec;
+
+fn nostd(v: &mut [i32]) {
+    let _: Vec<_> = core::iter::repeat_n(3 + 1, 10).collect();
+}

--- a/tests/ui/map_with_unused_argument_over_ranges_nostd.rs
+++ b/tests/ui/map_with_unused_argument_over_ranges_nostd.rs
@@ -1,0 +1,8 @@
+#![warn(clippy::map_with_unused_argument_over_ranges)]
+#![no_std]
+extern crate alloc;
+use alloc::vec::Vec;
+
+fn nostd(v: &mut [i32]) {
+    let _: Vec<_> = (0..10).map(|_| 3 + 1).collect();
+}

--- a/tests/ui/map_with_unused_argument_over_ranges_nostd.stderr
+++ b/tests/ui/map_with_unused_argument_over_ranges_nostd.stderr
@@ -1,0 +1,15 @@
+error: map of a closure that does not depend on its parameter over a range
+  --> tests/ui/map_with_unused_argument_over_ranges_nostd.rs:7:21
+   |
+LL |     let _: Vec<_> = (0..10).map(|_| 3 + 1).collect();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::map-with-unused-argument-over-ranges` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::map_with_unused_argument_over_ranges)]`
+help: remove the explicit range and use `repeat_n`
+   |
+LL |     let _: Vec<_> = core::iter::repeat_n(3 + 1, 10).collect();
+   |                     ~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/repeat_vec_with_capacity_nostd.fixed
+++ b/tests/ui/repeat_vec_with_capacity_nostd.fixed
@@ -1,0 +1,10 @@
+#![warn(clippy::repeat_vec_with_capacity)]
+#![allow(clippy::manual_repeat_n)]
+#![no_std]
+use core::iter;
+extern crate alloc;
+use alloc::vec::Vec;
+
+fn nostd() {
+    let _: Vec<Vec<u8>> = core::iter::repeat_with(|| Vec::with_capacity(42)).take(123).collect();
+}

--- a/tests/ui/repeat_vec_with_capacity_nostd.rs
+++ b/tests/ui/repeat_vec_with_capacity_nostd.rs
@@ -1,0 +1,10 @@
+#![warn(clippy::repeat_vec_with_capacity)]
+#![allow(clippy::manual_repeat_n)]
+#![no_std]
+use core::iter;
+extern crate alloc;
+use alloc::vec::Vec;
+
+fn nostd() {
+    let _: Vec<Vec<u8>> = iter::repeat(Vec::with_capacity(42)).take(123).collect();
+}

--- a/tests/ui/repeat_vec_with_capacity_nostd.stderr
+++ b/tests/ui/repeat_vec_with_capacity_nostd.stderr
@@ -1,0 +1,16 @@
+error: repeating `Vec::with_capacity` using `iter::repeat`, which does not retain capacity
+  --> tests/ui/repeat_vec_with_capacity_nostd.rs:9:27
+   |
+LL |     let _: Vec<Vec<u8>> = iter::repeat(Vec::with_capacity(42)).take(123).collect();
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: none of the yielded `Vec`s will have the requested capacity
+   = note: `-D clippy::repeat-vec-with-capacity` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::repeat_vec_with_capacity)]`
+help: if you intended to create an iterator that yields `Vec`s with an initial capacity, try
+   |
+LL |     let _: Vec<Vec<u8>> = core::iter::repeat_with(|| Vec::with_capacity(42)).take(123).collect();
+   |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
I opened https://github.com/rust-lang/rust-clippy/pull/13896 before. However, I found that there're more cases where Clippy suggests to use modules that belong to the `std` crate even in a `no_std` environment. Therefore, this PR include the changes I've made in #13896 and new changes to fix cases I found this time to prevent wrong suggestions in `no_std` environments as well.

changelog: [`redundant_closure`]: correct suggestion in `no_std`
changelog: [`repeat_vec_with_capacity`]: correct suggestion in `no_std`
changelog: [`single_range_in_vec_init`]: don't emit suggestion to use `Vec` in `no_std`
changelog: [`drain_collect`]: correct suggestion in `no_std`
changelog: [`map_with_unused_argument_over_ranges`]: correct suggestion in `no_std`

also close #13895 