### PR TITLE
Make missing_const_for_fn operate on non-optimized MIR

### DIFF
--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -155,9 +155,9 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
             return;
         }
 
-        let mir = cx.tcx.optimized_mir(def_id);
+        let mir = cx.tcx.mir_drops_elaborated_and_const_checked(def_id);
 
-        if let Ok(()) = is_min_const_fn(cx, mir, self.msrv)
+        if let Ok(()) = is_min_const_fn(cx, &mir.borrow(), self.msrv)
             && let hir::Node::Item(hir::Item { vis_span, .. }) | hir::Node::ImplItem(hir::ImplItem { vis_span, .. }) =
                 cx.tcx.hir_node_by_def_id(def_id)
         {


### PR DESCRIPTION
The main reason for this is that we might transform MIR in the optimization passes in a way that doesn't work with const-eval, but it is irrelevant since const-eval uses another MIR (`mir_for_ctfe`).

Specifically this came up when adding a new check in debug builds (https://github.com/rust-lang/rust/pull/134424), which is added as part of an optimization pass.

changelog: none