### PR TITLE
[`path_buf_push_overwrite`]: mark suggestion as `MaybeIncorrect`

### DIFF
--- a/clippy_lints/src/methods/path_buf_push_overwrite.rs
+++ b/clippy_lints/src/methods/path_buf_push_overwrite.rs
@@ -28,7 +28,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, arg: &'t
             "calling `push` with '/' or '\\' (file system root) will overwrite the previous path definition",
             "try",
             format!("\"{}\"", pushed_path_lit.trim_start_matches(['/', '\\'])),
-            Applicability::MachineApplicable,
+            Applicability::MaybeIncorrect,
         );
     }
 }


### PR DESCRIPTION
Proposing to replace

```rust
let mut x = PathBuf::from("/foo");
x.push("/bar");
```

by

```rust
let mut x = PathBuf::from("/foo");
x.push("bar");
```

changes the content of `x` (`/bar` ⇒ `/foo/bar`). This is not equivalent and should not be `MachineApplicable`, even if the original code is suspicious.

changelog: none