### PR TITLE
change `literal_string_with_formatting_args` lint category to nursery

### DIFF
--- a/clippy_lints/src/literal_string_with_formatting_args.rs
+++ b/clippy_lints/src/literal_string_with_formatting_args.rs
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.85.0"]
     pub LITERAL_STRING_WITH_FORMATTING_ARGS,
-    pedantic,
+    nursery,
     "Checks if string literals have formatting arguments"
 }
 

--- a/clippy_lints/src/literal_string_with_formatting_args.rs
+++ b/clippy_lints/src/literal_string_with_formatting_args.rs
@@ -31,7 +31,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.85.0"]
     pub LITERAL_STRING_WITH_FORMATTING_ARGS,
-    suspicious,
+    pedantic,
     "Checks if string literals have formatting arguments"
 }
 


### PR DESCRIPTION
This PR changes literal_string_with_formatting_args category from `suspicious` to `nursery` since there are thousands of false positive on GitHub.

Closes #13989 since it's no longer problematic with such false positive with ~~`pedantic`~~ `nursery` category.

changelog: [`literal_string_with_formatting_args` ] change category to `nursery` from `suspicious`
