### PR TITLE
Make `option_map_or_err_ok` better

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -5044,7 +5044,7 @@ impl Methods {
                 ("map_or", [def, map]) => {
                     option_map_or_none::check(cx, expr, recv, def, map);
                     manual_ok_or::check(cx, expr, recv, def, map);
-                    option_map_or_err_ok::check(cx, expr, recv, def, map);
+                    option_map_or_err_ok::check(cx, expr, recv, def, map, span);
                     unnecessary_map_or::check(cx, expr, recv, def, map, &self.msrv);
                 },
                 ("map_or_else", [def, map]) => {

--- a/clippy_lints/src/methods/option_map_or_err_ok.rs
+++ b/clippy_lints/src/methods/option_map_or_err_ok.rs
@@ -1,13 +1,15 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::is_type_diagnostic_item;
-use clippy_utils::{is_res_lang_ctor, path_res};
+use clippy_utils::{is_lint_allowed, is_res_lang_ctor, path_res, path_to_local};
 use rustc_errors::Applicability;
 use rustc_hir::LangItem::{ResultErr, ResultOk};
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{ClosureKind, Expr, ExprKind, PatKind};
 use rustc_lint::LateContext;
 use rustc_span::Span;
 use rustc_span::symbol::sym;
+
+use crate::eta_reduction::REDUNDANT_CLOSURE;
 
 use super::OPTION_MAP_OR_ERR_OK;
 
@@ -25,7 +27,7 @@ pub(super) fn check<'tcx>(
         && let ExprKind::Call(call, &[arg]) = or_expr.kind
         && is_res_lang_ctor(cx, path_res(cx, call), ResultErr)
         // And finally we check that it is mapped as `Ok`.
-        && is_res_lang_ctor(cx, path_res(cx, map_expr), ResultOk)
+        && is_ok_function(cx, map_expr)
     {
         let mut app = Applicability::MachineApplicable;
         let err_snippet = snippet_with_applicability(cx, arg.span, "_", &mut app);
@@ -43,5 +45,24 @@ pub(super) fn check<'tcx>(
                 );
             },
         );
+    }
+}
+
+fn is_ok_function(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
+    if let ExprKind::Closure(closure) = expr.kind
+        && closure.kind == ClosureKind::Closure
+        // Do not match if `redundant-closure` will be emitted on this closure anyway
+        && is_lint_allowed(cx, REDUNDANT_CLOSURE, expr.hir_id)
+        && let closure_body = cx.tcx.hir().body(closure.body)
+        && let [param] = closure_body.params
+        && let PatKind::Binding(_, var_id, _, _) = param.pat.kind
+        && let closure_expr = closure_body.value
+        && let ExprKind::Call(call, [arg]) = closure_expr.kind
+        && is_res_lang_ctor(cx, path_res(cx, call), ResultOk)
+        && path_to_local(arg) == Some(var_id)
+    {
+        true
+    } else {
+        is_res_lang_ctor(cx, path_res(cx, expr), ResultOk)
     }
 }

--- a/clippy_lints/src/methods/option_map_or_err_ok.rs
+++ b/clippy_lints/src/methods/option_map_or_err_ok.rs
@@ -20,7 +20,7 @@ pub(super) fn check<'tcx>(
     map_or_span: Span,
 ) {
     // We check that it's called on an `Option` type.
-    if is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym::Option)
+    if is_type_diagnostic_item(cx, cx.typeck_results().expr_ty_adjusted(recv), sym::Option)
         // We check that first we pass an `Err`.
         && let ExprKind::Call(call, &[arg]) = or_expr.kind
         && is_res_lang_ctor(cx, path_res(cx, call), ResultErr)

--- a/tests/ui/option_map_or_err_ok.fixed
+++ b/tests/ui/option_map_or_err_ok.fixed
@@ -4,4 +4,7 @@ fn main() {
     let x = Some("a");
     let _ = x.ok_or("a");
     //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
+    let x = &Some("a");
+    let _ = x.ok_or("a");
+    //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
 }

--- a/tests/ui/option_map_or_err_ok.fixed
+++ b/tests/ui/option_map_or_err_ok.fixed
@@ -6,5 +6,16 @@ fn main() {
     //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
     let x = &Some("a");
     let _ = x.ok_or("a");
-    //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
+
+    #[expect(clippy::redundant_closure)]
+    {
+        // Do not lint because the `redundant-closure` lint will be emitted on
+        // the closure already.
+        let _ = x.map_or(Err("a"), |x| Ok(x));
+    }
+    #[allow(clippy::redundant_closure)]
+    {
+        let _ = x.ok_or("a");
+        //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
+    }
 }

--- a/tests/ui/option_map_or_err_ok.rs
+++ b/tests/ui/option_map_or_err_ok.rs
@@ -6,5 +6,16 @@ fn main() {
     //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
     let x = &Some("a");
     let _ = x.map_or(Err("a"), Ok);
-    //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
+
+    #[expect(clippy::redundant_closure)]
+    {
+        // Do not lint because the `redundant-closure` lint will be emitted on
+        // the closure already.
+        let _ = x.map_or(Err("a"), |x| Ok(x));
+    }
+    #[allow(clippy::redundant_closure)]
+    {
+        let _ = x.map_or(Err("a"), |x| Ok(x));
+        //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
+    }
 }

--- a/tests/ui/option_map_or_err_ok.rs
+++ b/tests/ui/option_map_or_err_ok.rs
@@ -4,4 +4,7 @@ fn main() {
     let x = Some("a");
     let _ = x.map_or(Err("a"), Ok);
     //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
+    let x = &Some("a");
+    let _ = x.map_or(Err("a"), Ok);
+    //~^ ERROR: called `map_or(Err(_), Ok)` on an `Option` value
 }

--- a/tests/ui/option_map_or_err_ok.stderr
+++ b/tests/ui/option_map_or_err_ok.stderr
@@ -11,5 +11,16 @@ help: consider using `ok_or`
 LL |     let _ = x.ok_or("a");
    |               ~~~~~~~~~~
 
-error: aborting due to 1 previous error
+error: called `map_or(Err(_), Ok)` on an `Option` value
+  --> tests/ui/option_map_or_err_ok.rs:8:13
+   |
+LL |     let _ = x.map_or(Err("a"), Ok);
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `ok_or`
+   |
+LL |     let _ = x.ok_or("a");
+   |               ~~~~~~~~~~
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/option_map_or_err_ok.stderr
+++ b/tests/ui/option_map_or_err_ok.stderr
@@ -2,10 +2,14 @@ error: called `map_or(Err(_), Ok)` on an `Option` value
   --> tests/ui/option_map_or_err_ok.rs:5:13
    |
 LL |     let _ = x.map_or(Err("a"), Ok);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ help: consider using `ok_or`: `x.ok_or("a")`
+   |             ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::option-map-or-err-ok` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::option_map_or_err_ok)]`
+help: consider using `ok_or`
+   |
+LL |     let _ = x.ok_or("a");
+   |               ~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/option_map_or_err_ok.stderr
+++ b/tests/ui/option_map_or_err_ok.stderr
@@ -22,5 +22,16 @@ help: consider using `ok_or`
 LL |     let _ = x.ok_or("a");
    |               ~~~~~~~~~~
 
-error: aborting due to 2 previous errors
+error: called `map_or(Err(_), Ok)` on an `Option` value
+  --> tests/ui/option_map_or_err_ok.rs:18:17
+   |
+LL |         let _ = x.map_or(Err("a"), |x| Ok(x));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `ok_or`
+   |
+LL |         let _ = x.ok_or("a");
+   |                   ~~~~~~~~~~
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This PR improve the behavior of `option_map_or_err_ok`:

- Suggestions are now verbose to emphasize the part of the expression that must be rewritten, which makes it easier to apply the change by hand if it is part of a larger expression.
- Recognize the receiver of `Option::map_or` when it dereferences to `Option`
- Recognize the η-expanded form of `Ok`, but do not lint if `redundant-closure` will also apply to the same closure, as the current lint would suggest doing changes to a part that would be modified anyway.

changelog: [`option_map_or_err_ok`]: recognize more forms, and give better suggestions