### PR TITLE
Update version for unneeded_struct_pattern

### DIFF
--- a/clippy_lints/src/unneeded_struct_pattern.rs
+++ b/clippy_lints/src/unneeded_struct_pattern.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     ///     None => 0,
     /// };
     /// ```
-    #[clippy::version = "1.83.0"]
+    #[clippy::version = "1.86.0"]
     pub UNNEEDED_STRUCT_PATTERN,
     style,
     "using struct pattern to match against unit variant"


### PR DESCRIPTION
This lint was merged recently https://github.com/rust-lang/rust-clippy/pull/13465 and should go with the next version 1.86.0 https://github.com/rust-lang/rust-clippy/tags

changelog: none 
