### PR TITLE
Change the applicability of `obfuscated_if_else`

### DIFF
--- a/clippy_lints/src/methods/obfuscated_if_else.rs
+++ b/clippy_lints/src/methods/obfuscated_if_else.rs
@@ -19,7 +19,7 @@ pub(super) fn check<'tcx>(
     let recv_ty = cx.typeck_results().expr_ty(then_recv);
 
     if recv_ty.is_bool() {
-        let mut applicability = Applicability::MachineApplicable;
+        let mut applicability = Applicability::MaybeIncorrect;
         let sugg = format!(
             "if {} {{ {} }} else {{ {} }}",
             snippet_with_applicability(cx, then_recv.span, "..", &mut applicability),


### PR DESCRIPTION
band-aid of #14034 

The current implementation of `obfuscated_if_else` sometimes makes incorrect suggestion.

changelog: [`obfuscated_if_else`]: the applicability is now `MaybeIncorrect`
