### PR TITLE
`unnecessary_semicolon`: do not lint if it may cause borrow errors

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -973,6 +973,6 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(|_| Box::new(unnecessary_literal_bound::UnnecessaryLiteralBound));
     store.register_late_pass(move |_| Box::new(arbitrary_source_item_ordering::ArbitrarySourceItemOrdering::new(conf)));
     store.register_late_pass(|_| Box::new(unneeded_struct_pattern::UnneededStructPattern));
-    store.register_late_pass(|_| Box::new(unnecessary_semicolon::UnnecessarySemicolon));
+    store.register_late_pass(|_| Box::<unnecessary_semicolon::UnnecessarySemicolon>::default());
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -1,10 +1,11 @@
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
 use clippy_utils::source::{SpanRangeExt, snippet_with_context};
 use clippy_utils::sugg::has_enclosing_paren;
-use clippy_utils::visitors::{Descend, for_each_expr, for_each_unconsumed_temporary};
+use clippy_utils::visitors::{Descend, for_each_expr};
 use clippy_utils::{
-    binary_expr_needs_parentheses, fn_def_id, is_from_proc_macro, is_inside_let_else, is_res_lang_ctor, path_res,
-    path_to_local_id, span_contains_cfg, span_find_starting_semi,
+    binary_expr_needs_parentheses, fn_def_id, is_from_proc_macro, is_inside_let_else, is_res_lang_ctor,
+    leaks_droppable_temporary_with_limited_lifetime, path_res, path_to_local_id, span_contains_cfg,
+    span_find_starting_semi,
 };
 use core::ops::ControlFlow;
 use rustc_ast::MetaItemInner;
@@ -389,22 +390,8 @@ fn check_final_expr<'tcx>(
                 }
             };
 
-            if let Some(inner) = inner {
-                if for_each_unconsumed_temporary(cx, inner, |temporary_ty| {
-                    if temporary_ty.has_significant_drop(cx.tcx, cx.typing_env())
-                        && temporary_ty
-                            .walk()
-                            .any(|arg| matches!(arg.unpack(), GenericArgKind::Lifetime(re) if !re.is_static()))
-                    {
-                        ControlFlow::Break(())
-                    } else {
-                        ControlFlow::Continue(())
-                    }
-                })
-                .is_break()
-                {
-                    return;
-                }
+            if inner.is_some_and(|inner| leaks_droppable_temporary_with_limited_lifetime(cx, inner)) {
+                return;
             }
 
             if ret_span.from_expansion() || is_from_proc_macro(cx, expr) {

--- a/clippy_lints/src/unnecessary_semicolon.rs
+++ b/clippy_lints/src/unnecessary_semicolon.rs
@@ -1,8 +1,10 @@
 use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::leaks_droppable_temporary_with_limited_lifetime;
 use rustc_errors::Applicability;
-use rustc_hir::{ExprKind, MatchSource, Stmt, StmtKind};
+use rustc_hir::{Block, ExprKind, HirId, MatchSource, Stmt, StmtKind};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_session::declare_lint_pass;
+use rustc_session::impl_lint_pass;
+use rustc_span::edition::Edition::Edition2021;
 
 declare_clippy_lint! {
     /// ### What it does
@@ -33,10 +35,50 @@ declare_clippy_lint! {
     "unnecessary semicolon after expression returning `()`"
 }
 
-declare_lint_pass!(UnnecessarySemicolon => [UNNECESSARY_SEMICOLON]);
+#[derive(Default)]
+pub struct UnnecessarySemicolon {
+    last_statements: Vec<HirId>,
+}
 
-impl LateLintPass<'_> for UnnecessarySemicolon {
-    fn check_stmt(&mut self, cx: &LateContext<'_>, stmt: &Stmt<'_>) {
+impl_lint_pass!(UnnecessarySemicolon => [UNNECESSARY_SEMICOLON]);
+
+impl UnnecessarySemicolon {
+    /// Enter or leave a block, remembering the last statement of the block.
+    fn handle_block(&mut self, cx: &LateContext<'_>, block: &Block<'_>, enter: bool) {
+        // Up to edition 2021, removing the semicolon of the last statement of a block
+        // may result in the scrutinee temporary values to live longer than the block
+        // variables. To avoid this problem, we do not lint the last statement of an
+        // expressionless block.
+        if cx.tcx.sess.edition() <= Edition2021
+            && block.expr.is_none()
+            && let Some(last_stmt) = block.stmts.last()
+        {
+            if enter {
+                self.last_statements.push(last_stmt.hir_id);
+            } else {
+                self.last_statements.pop();
+            }
+        }
+    }
+
+    /// Checks if `stmt` is the last statement in an expressionless block for edition ≤ 2021.
+    fn is_last_in_block(&self, stmt: &Stmt<'_>) -> bool {
+        self.last_statements
+            .last()
+            .is_some_and(|last_stmt_id| last_stmt_id == &stmt.hir_id)
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for UnnecessarySemicolon {
+    fn check_block(&mut self, cx: &LateContext<'_>, block: &Block<'_>) {
+        self.handle_block(cx, block, true);
+    }
+
+    fn check_block_post(&mut self, cx: &LateContext<'_>, block: &Block<'_>) {
+        self.handle_block(cx, block, false);
+    }
+
+    fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &Stmt<'tcx>) {
         // rustfmt already takes care of removing semicolons at the end
         // of loops.
         if let StmtKind::Semi(expr) = stmt.kind
@@ -48,6 +90,10 @@ impl LateLintPass<'_> for UnnecessarySemicolon {
             )
             && cx.typeck_results().expr_ty(expr) == cx.tcx.types.unit
         {
+            if self.is_last_in_block(stmt) && leaks_droppable_temporary_with_limited_lifetime(cx, expr) {
+                return;
+            }
+
             let semi_span = expr.span.shrink_to_hi().to(stmt.span.shrink_to_hi());
             span_lint_and_sugg(
                 cx,

--- a/tests/ui/unnecessary_semicolon.edition2021.fixed
+++ b/tests/ui/unnecessary_semicolon.edition2021.fixed
@@ -26,13 +26,13 @@ fn main() {
     let mut a = 3;
     if a == 2 {
         println!("This is weird");
-    };
+    }
     //~^ ERROR: unnecessary semicolon
 
     a.match {
         3 => println!("three"),
         _ => println!("not three"),
-    };
+    }
     //~^ ERROR: unnecessary semicolon
 }
 
@@ -53,5 +53,5 @@ fn no_borrow_issue(a: u32, b: u32) {
             dbg!(v);
         },
         None => {},
-    };
+    }
 }

--- a/tests/ui/unnecessary_semicolon.edition2021.stderr
+++ b/tests/ui/unnecessary_semicolon.edition2021.stderr
@@ -1,0 +1,23 @@
+error: unnecessary semicolon
+  --> tests/ui/unnecessary_semicolon.rs:29:6
+   |
+LL |     };
+   |      ^ help: remove
+   |
+   = note: `-D clippy::unnecessary-semicolon` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_semicolon)]`
+
+error: unnecessary semicolon
+  --> tests/ui/unnecessary_semicolon.rs:35:6
+   |
+LL |     };
+   |      ^ help: remove
+
+error: unnecessary semicolon
+  --> tests/ui/unnecessary_semicolon.rs:56:6
+   |
+LL |     };
+   |      ^ help: remove
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/unnecessary_semicolon.edition2024.fixed
+++ b/tests/ui/unnecessary_semicolon.edition2024.fixed
@@ -26,13 +26,13 @@ fn main() {
     let mut a = 3;
     if a == 2 {
         println!("This is weird");
-    };
+    }
     //~^ ERROR: unnecessary semicolon
 
     a.match {
         3 => println!("three"),
         _ => println!("not three"),
-    };
+    }
     //~^ ERROR: unnecessary semicolon
 }
 
@@ -44,7 +44,7 @@ fn borrow_issue() {
             dbg!(v);
         },
         None => {},
-    };
+    }
 }
 
 fn no_borrow_issue(a: u32, b: u32) {
@@ -53,5 +53,5 @@ fn no_borrow_issue(a: u32, b: u32) {
             dbg!(v);
         },
         None => {},
-    };
+    }
 }

--- a/tests/ui/unnecessary_semicolon.edition2024.stderr
+++ b/tests/ui/unnecessary_semicolon.edition2024.stderr
@@ -1,0 +1,29 @@
+error: unnecessary semicolon
+  --> tests/ui/unnecessary_semicolon.rs:29:6
+   |
+LL |     };
+   |      ^ help: remove
+   |
+   = note: `-D clippy::unnecessary-semicolon` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_semicolon)]`
+
+error: unnecessary semicolon
+  --> tests/ui/unnecessary_semicolon.rs:35:6
+   |
+LL |     };
+   |      ^ help: remove
+
+error: unnecessary semicolon
+  --> tests/ui/unnecessary_semicolon.rs:47:6
+   |
+LL |     };
+   |      ^ help: remove
+
+error: unnecessary semicolon
+  --> tests/ui/unnecessary_semicolon.rs:56:6
+   |
+LL |     };
+   |      ^ help: remove
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Before edition 2024, some temporaries used in scrutinees of a `match` used as the last expression of a block may outlive some referenced local variables. Prevent those cases from happening by checking that alive temporaries with significant drop do have a static lifetime.

The check is performed only for edition 2021 and earlier, and for the last statement if it would become the last expression of the block.

changelog: [`unnecessary_semicolon`]: prevent borrow errors in editions lower than 2024

r? @y21