### PR TITLE
feat: new lint for `and_then` when returning Option or Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6024,6 +6024,7 @@ Released 2018-09-13
 [`result_map_unwrap_or_else`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_map_unwrap_or_else
 [`result_unit_err`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err
 [`result_unwrap_used`]: https://rust-lang.github.io/rust-clippy/master/index.html#result_unwrap_used
+[`return_and_then`]: https://rust-lang.github.io/rust-clippy/master/index.html#return_and_then
 [`return_self_not_must_use`]: https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use
 [`reverse_range_loop`]: https://rust-lang.github.io/rust-clippy/master/index.html#reverse_range_loop
 [`reversed_empty_ranges`]: https://rust-lang.github.io/rust-clippy/master/index.html#reversed_empty_ranges

--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -72,9 +72,8 @@ impl LateLintPass<'_> for CheckedConversions {
                 None => check_upper_bound(lt1, gt1).filter(|cv| cv.cvt == ConversionType::FromUnsigned),
                 Some((lt2, gt2)) => {
                     let upper_lower = |lt1, gt1, lt2, gt2| {
-                        check_upper_bound(lt1, gt1)
-                            .zip(check_lower_bound(lt2, gt2))
-                            .and_then(|(l, r)| l.combine(r, cx))
+                        let (l, r) = check_upper_bound(lt1, gt1).zip(check_lower_bound(lt2, gt2))?;
+                        l.combine(r, cx)
                     };
                     upper_lower(lt1, gt1, lt2, gt2).or_else(|| upper_lower(lt2, gt2, lt1, gt1))
                 },

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -462,6 +462,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::methods::REPEAT_ONCE_INFO,
     crate::methods::RESULT_FILTER_MAP_INFO,
     crate::methods::RESULT_MAP_OR_INTO_OPTION_INFO,
+    crate::methods::RETURN_AND_THEN_INFO,
     crate::methods::SEARCH_IS_SOME_INFO,
     crate::methods::SEEK_FROM_CURRENT_INFO,
     crate::methods::SEEK_TO_START_INSTEAD_OF_REWIND_INFO,

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -95,6 +95,7 @@ mod readonly_write_lock;
 mod redundant_as_str;
 mod repeat_once;
 mod result_map_or_else_none;
+mod return_and_then;
 mod search_is_some;
 mod seek_from_current;
 mod seek_to_start_instead_of_rewind;
@@ -4363,6 +4364,46 @@ declare_clippy_lint! {
     "detect `repeat().take()` that can be replaced with `repeat_n()`"
 }
 
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// Detect functions that end with `Option::and_then` or `Result::and_then`, and suggest using a question mark (`?`) instead.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// The `and_then` method is used to chain a computation that returns an `Option` or a `Result`.
+    /// This can be replaced with the `?` operator, which is more concise and idiomatic.
+    ///
+    /// ### Example
+    ///
+    /// ```no_run
+    /// fn test(opt: Option<i32>) -> Option<i32> {
+    ///     opt.and_then(|n| {
+    ///         if n > 1 {
+    ///             Some(n + 1)
+    ///         } else {
+    ///             None
+    ///        }
+    ///     })
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// fn test(opt: Option<i32>) -> Option<i32> {
+    ///     let n = opt?;
+    ///     if n > 1 {
+    ///         Some(n + 1)
+    ///     } else {
+    ///         None
+    ///     }
+    /// }
+    /// ```
+    #[clippy::version = "1.85.0"]
+    pub RETURN_AND_THEN,
+    style,
+    "using `Option::and_then` or `Result::and_then` to chain a computation that returns an `Option` or a `Result`"
+}
+
 pub struct Methods {
     avoid_breaking_exported_api: bool,
     msrv: Msrv,
@@ -4531,6 +4572,7 @@ impl_lint_pass!(Methods => [
     DOUBLE_ENDED_ITERATOR_LAST,
     USELESS_NONZERO_NEW_UNCHECKED,
     MANUAL_REPEAT_N,
+    RETURN_AND_THEN,
 ]);
 
 /// Extracts a method call name, args, and `Span` of the method name.
@@ -4760,7 +4802,10 @@ impl Methods {
                     let biom_option_linted = bind_instead_of_map::check_and_then_some(cx, expr, recv, arg);
                     let biom_result_linted = bind_instead_of_map::check_and_then_ok(cx, expr, recv, arg);
                     if !biom_option_linted && !biom_result_linted {
-                        unnecessary_lazy_eval::check(cx, expr, recv, arg, "and");
+                        let ule_and_linted = unnecessary_lazy_eval::check(cx, expr, recv, arg, "and");
+                        if !ule_and_linted {
+                            return_and_then::check(cx, expr, recv, arg);
+                        }
                     }
                 },
                 ("any", [arg]) => {
@@ -4973,7 +5018,9 @@ impl Methods {
                     get_first::check(cx, expr, recv, arg);
                     get_last_with_len::check(cx, expr, recv, arg);
                 },
-                ("get_or_insert_with", [arg]) => unnecessary_lazy_eval::check(cx, expr, recv, arg, "get_or_insert"),
+                ("get_or_insert_with", [arg]) => {
+                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "get_or_insert");
+                },
                 ("hash", [arg]) => {
                     unit_hash::check(cx, expr, recv, arg);
                 },
@@ -5114,7 +5161,9 @@ impl Methods {
                     },
                     _ => iter_nth_zero::check(cx, expr, recv, n_arg),
                 },
-                ("ok_or_else", [arg]) => unnecessary_lazy_eval::check(cx, expr, recv, arg, "ok_or"),
+                ("ok_or_else", [arg]) => {
+                    unnecessary_lazy_eval::check(cx, expr, recv, arg, "ok_or");
+                },
                 ("open", [_]) => {
                     open_options::check(cx, expr, recv);
                 },

--- a/clippy_lints/src/methods/return_and_then.rs
+++ b/clippy_lints/src/methods/return_and_then.rs
@@ -1,0 +1,69 @@
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::source::{indent_of, reindent_multiline, snippet};
+use clippy_utils::ty::is_type_diagnostic_item;
+use clippy_utils::{is_expr_final_block_expr, is_expr_used_or_unified, peel_blocks};
+use rustc_errors::Applicability;
+use rustc_hir as hir;
+use rustc_lint::LateContext;
+use rustc_span::sym;
+
+use super::RETURN_AND_THEN;
+
+fn is_final_call(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> bool {
+    if !is_expr_used_or_unified(cx.tcx, expr) {
+        return false;
+    }
+    is_expr_final_block_expr(cx.tcx, expr)
+}
+
+/// lint if `and_then` is the last call in the function
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'_>,
+    expr: &hir::Expr<'_>,
+    recv: &'tcx hir::Expr<'_>,
+    arg: &'tcx hir::Expr<'_>,
+) {
+    if !is_final_call(cx, expr) {
+        return;
+    }
+
+    let is_option = is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym::Option);
+    let is_result = is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym::Result);
+
+    if !is_option && !is_result {
+        return;
+    }
+
+    let hir::ExprKind::Closure(&hir::Closure { body, fn_decl, .. }) = arg.kind else {
+        return;
+    };
+
+    let closure_arg = fn_decl.inputs[0];
+    let closure_body = cx.tcx.hir().body(body);
+    let closure_expr = peel_blocks(closure_body.value);
+
+    let msg = "use the question mark operator instead of an `and_then` call";
+    let body_snip = snippet(cx, closure_expr.span, "..");
+    let inner = if body_snip.starts_with('{') {
+        body_snip[1..body_snip.len() - 1].trim()
+    } else {
+        body_snip.trim()
+    };
+
+    let sugg = format!(
+        "let {} = {}?;\n{}",
+        snippet(cx, closure_arg.span, "_"),
+        snippet(cx, recv.span, ".."),
+        reindent_multiline(inner.into(), false, indent_of(cx, expr.span))
+    );
+
+    span_lint_and_sugg(
+        cx,
+        RETURN_AND_THEN,
+        expr.span,
+        msg,
+        "try",
+        sugg,
+        Applicability::MachineApplicable,
+    );
+}

--- a/clippy_lints/src/methods/unnecessary_lazy_eval.rs
+++ b/clippy_lints/src/methods/unnecessary_lazy_eval.rs
@@ -18,7 +18,7 @@ pub(super) fn check<'tcx>(
     recv: &'tcx hir::Expr<'_>,
     arg: &'tcx hir::Expr<'_>,
     simplify_using: &str,
-) {
+) -> bool {
     let is_option = is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym::Option);
     let is_result = is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym::Result);
     let is_bool = cx.typeck_results().expr_ty(recv).is_bool();
@@ -29,7 +29,7 @@ pub(super) fn check<'tcx>(
             let body_expr = &body.value;
 
             if usage::BindingUsageFinder::are_params_used(cx, body) || is_from_proc_macro(cx, expr) {
-                return;
+                return false;
             }
 
             if eager_or_lazy::switch_to_eager_eval(cx, body_expr) {
@@ -71,8 +71,10 @@ pub(super) fn check<'tcx>(
                             applicability,
                         );
                     });
+                    return true;
                 }
             }
         }
     }
+    false
 }

--- a/clippy_lints/src/minmax.rs
+++ b/clippy_lints/src/minmax.rs
@@ -65,14 +65,12 @@ fn min_max<'a, 'tcx>(cx: &LateContext<'tcx>, expr: &'a Expr<'a>) -> Option<(MinM
     match expr.kind {
         ExprKind::Call(path, args) => {
             if let ExprKind::Path(ref qpath) = path.kind {
-                cx.typeck_results()
-                    .qpath_res(qpath, path.hir_id)
-                    .opt_def_id()
-                    .and_then(|def_id| match cx.tcx.get_diagnostic_name(def_id) {
-                        Some(sym::cmp_min) => fetch_const(cx, None, args, MinMax::Min),
-                        Some(sym::cmp_max) => fetch_const(cx, None, args, MinMax::Max),
-                        _ => None,
-                    })
+                let def_id = cx.typeck_results().qpath_res(qpath, path.hir_id).opt_def_id()?;
+                match cx.tcx.get_diagnostic_name(def_id) {
+                    Some(sym::cmp_min) => fetch_const(cx, None, args, MinMax::Min),
+                    Some(sym::cmp_max) => fetch_const(cx, None, args, MinMax::Max),
+                    _ => None,
+                }
             } else {
                 None
             }

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -373,14 +373,13 @@ fn reduce_expression<'a>(cx: &LateContext<'_>, expr: &'a Expr<'a>) -> Option<Vec
         },
         ExprKind::Block(block, _) => {
             if block.stmts.is_empty() && !block.targeted_by_break {
-                block.expr.as_ref().and_then(|e| {
-                    match block.rules {
-                        BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided) => None,
-                        BlockCheckMode::DefaultBlock => Some(vec![&**e]),
-                        // in case of compiler-inserted signaling blocks
-                        BlockCheckMode::UnsafeBlock(_) => reduce_expression(cx, e),
-                    }
-                })
+                let expr = block.expr.as_ref()?;
+                match block.rules {
+                    BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided) => None,
+                    BlockCheckMode::DefaultBlock => Some(vec![&**expr]),
+                    // in case of compiler-inserted signaling blocks
+                    BlockCheckMode::UnsafeBlock(_) => reduce_expression(cx, expr),
+                }
             } else {
                 None
             }

--- a/clippy_lints/src/option_if_let_else.rs
+++ b/clippy_lints/src/option_if_let_else.rs
@@ -171,9 +171,8 @@ fn try_get_option_occurrence<'tcx>(
             )) = e.kind
             {
                 match some_captures.get(local_id).or_else(|| {
-                    (method_sugg == "map_or_else")
-                        .then_some(())
-                        .and_then(|()| none_captures.get(local_id))
+                    (method_sugg == "map_or_else").then_some(())?;
+                    none_captures.get(local_id)
                 }) {
                     Some(CaptureKind::Value | CaptureKind::Ref(Mutability::Mut)) => return None,
                     Some(CaptureKind::Ref(Mutability::Not)) if as_mut => return None,

--- a/clippy_lints/src/ptr.rs
+++ b/clippy_lints/src/ptr.rs
@@ -414,6 +414,7 @@ impl<'tcx> DerefTy<'tcx> {
     }
 }
 
+#[expect(clippy::too_many_lines)]
 fn check_fn_args<'cx, 'tcx: 'cx>(
     cx: &'cx LateContext<'tcx>,
     fn_sig: ty::FnSig<'tcx>,
@@ -467,7 +468,8 @@ fn check_fn_args<'cx, 'tcx: 'cx>(
                                     .output()
                                     .walk()
                                     .filter_map(|arg| {
-                                        arg.as_region().and_then(|lifetime| match lifetime.kind() {
+                                        let lifetime = arg.as_region()?;
+                                        match lifetime.kind() {
                                             ty::ReEarlyParam(r) => Some(
                                                 cx.tcx
                                                     .generics_of(cx.tcx.parent(param_def_id.to_def_id()))
@@ -481,7 +483,7 @@ fn check_fn_args<'cx, 'tcx: 'cx>(
                                             | ty::RePlaceholder(_)
                                             | ty::ReErased
                                             | ty::ReError(_) => None,
-                                        })
+                                        }
                                     })
                                     .any(|def_id| def_id.as_local().is_some_and(|def_id| def_id == param_def_id))
                             {

--- a/clippy_lints/src/regex.rs
+++ b/clippy_lints/src/regex.rs
@@ -222,10 +222,11 @@ fn lint_syntax_error(cx: &LateContext<'_>, error: &regex_syntax::Error, unescape
 }
 
 fn const_str<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<String> {
-    ConstEvalCtxt::new(cx).eval(e).and_then(|c| match c {
+    let constant = ConstEvalCtxt::new(cx).eval(e)?;
+    match constant {
         Constant::Str(s) => Some(s),
         _ => None,
-    })
+    }
 }
 
 fn is_trivial_regex(s: &regex_syntax::hir::Hir) -> Option<&'static str> {

--- a/clippy_lints/src/suspicious_operation_groupings.rs
+++ b/clippy_lints/src/suspicious_operation_groupings.rs
@@ -635,18 +635,17 @@ fn suggestion_with_swapped_ident(
     new_ident: Ident,
     applicability: &mut Applicability,
 ) -> Option<String> {
-    get_ident(expr, location).and_then(|current_ident| {
-        if eq_id(current_ident, new_ident) {
-            // We never want to suggest a non-change
-            return None;
-        }
+    let current_ident = get_ident(expr, location)?;
+    if eq_id(current_ident, new_ident) {
+        // We never want to suggest a non-change
+        return None;
+    }
 
-        Some(format!(
-            "{}{new_ident}{}",
-            snippet_with_applicability(cx, expr.span.with_hi(current_ident.span.lo()), "..", applicability),
-            snippet_with_applicability(cx, expr.span.with_lo(current_ident.span.hi()), "..", applicability),
-        ))
-    })
+    Some(format!(
+        "{}{new_ident}{}",
+        snippet_with_applicability(cx, expr.span.with_hi(current_ident.span.lo()), "..", applicability),
+        snippet_with_applicability(cx, expr.span.with_lo(current_ident.span.hi()), "..", applicability),
+    ))
 }
 
 fn skip_index<A, Iter>(iter: Iter, index: usize) -> impl Iterator<Item = A>

--- a/clippy_utils/src/consts.rs
+++ b/clippy_utils/src/consts.rs
@@ -720,7 +720,8 @@ impl<'tcx> ConstEvalCtxt<'tcx> {
             if b {
                 self.expr(then)
             } else {
-                otherwise.as_ref().and_then(|expr| self.expr(expr))
+                let expr = otherwise.as_ref()?;
+                self.expr(expr)
             }
         } else {
             None

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -827,11 +827,9 @@ pub fn expr_custom_deref_adjustment(cx: &LateContext<'_>, e: &Expr<'_>) -> Optio
         .expr_adjustments(e)
         .iter()
         .find_map(|a| match a.kind {
-            Adjust::Deref(Some(d)) => Some(Some(d.mutbl)),
-            Adjust::Deref(None) => None,
-            _ => Some(None),
+            Adjust::Deref(Some(d)) => Some(d.mutbl),
+            _ => None,
         })
-        .and_then(|x| x)
 }
 
 /// Checks if two expressions can be mutably borrowed simultaneously
@@ -1390,11 +1388,9 @@ pub fn get_parent_expr_for_hir<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> O
 
 /// Gets the enclosing block, if any.
 pub fn get_enclosing_block<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Option<&'tcx Block<'tcx>> {
-    let map = &cx.tcx.hir();
-    let enclosing_node = map
-        .get_enclosing_scope(hir_id)
-        .map(|enclosing_id| cx.tcx.hir_node(enclosing_id));
-    enclosing_node.and_then(|node| match node {
+    let enclosing_id = cx.tcx.hir().get_enclosing_scope(hir_id)?;
+    let node = cx.tcx.hir_node(enclosing_id);
+    match node {
         Node::Block(block) => Some(block),
         Node::Item(&Item {
             kind: ItemKind::Fn { body: eid, .. },
@@ -1408,7 +1404,7 @@ pub fn get_enclosing_block<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Optio
             _ => None,
         },
         _ => None,
-    })
+    }
 }
 
 /// Gets the loop or closure enclosing the given expression, if any.

--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -143,14 +143,13 @@ pub fn enclosing_mir(tcx: TyCtxt<'_>, hir_id: HirId) -> Option<&Body<'_>> {
 /// Tries to determine the `Local` corresponding to `expr`, if any.
 /// This function is expensive and should be used sparingly.
 pub fn expr_local(tcx: TyCtxt<'_>, expr: &Expr<'_>) -> Option<Local> {
-    enclosing_mir(tcx, expr.hir_id).and_then(|mir| {
-        mir.local_decls.iter_enumerated().find_map(|(local, local_decl)| {
-            if local_decl.source_info.span == expr.span {
-                Some(local)
-            } else {
-                None
-            }
-        })
+    let mir = enclosing_mir(tcx, expr.hir_id)?;
+    mir.local_decls.iter_enumerated().find_map(|(local, local_decl)| {
+        if local_decl.source_info.span == expr.span {
+            Some(local)
+        } else {
+            None
+        }
     })
 }
 

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -284,12 +284,13 @@ impl SourceFileRange {
     /// Attempts to get the text from the source file. This can fail if the source text isn't
     /// loaded.
     pub fn as_str(&self) -> Option<&str> {
-        self.sf
+        let x = self
+            .sf
             .src
             .as_ref()
             .map(|src| src.as_str())
-            .or_else(|| self.sf.external_src.get().and_then(|src| src.get_source()))
-            .and_then(|x| x.get(self.range.clone()))
+            .or_else(|| self.sf.external_src.get().and_then(|src| src.get_source()))?;
+        x.get(self.range.clone())
     }
 }
 
@@ -333,10 +334,9 @@ pub fn first_line_of_span(sess: &impl HasSession, span: Span) -> Span {
 
 fn first_char_in_first_line(sess: &impl HasSession, span: Span) -> Option<BytePos> {
     let line_span = line_span(sess, span);
-    snippet_opt(sess, line_span).and_then(|snip| {
-        snip.find(|c: char| !c.is_whitespace())
-            .map(|pos| line_span.lo() + BytePos::from_usize(pos))
-    })
+    let snip = snippet_opt(sess, line_span)?;
+    snip.find(|c: char| !c.is_whitespace())
+        .map(|pos| line_span.lo() + BytePos::from_usize(pos))
 }
 
 /// Extends the span to the beginning of the spans line, incl. whitespaces.
@@ -365,7 +365,8 @@ fn line_span(sess: &impl HasSession, span: Span) -> Span {
 /// //          ^^ -- will return 4
 /// ```
 pub fn indent_of(sess: &impl HasSession, span: Span) -> Option<usize> {
-    snippet_opt(sess, line_span(sess, span)).and_then(|snip| snip.find(|c: char| !c.is_whitespace()))
+    let snip = snippet_opt(sess, line_span(sess, span))?;
+    snip.find(|c: char| !c.is_whitespace())
 }
 
 /// Gets a snippet of the indentation of the line of a span

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -672,20 +672,17 @@ fn astbinop2assignop(op: ast::BinOp) -> AssocOp {
 /// before it on its line.
 fn indentation<T: LintContext>(cx: &T, span: Span) -> Option<String> {
     let lo = cx.sess().source_map().lookup_char_pos(span.lo());
-    lo.file
-        .get_line(lo.line - 1 /* line numbers in `Loc` are 1-based */)
-        .and_then(|line| {
-            if let Some((pos, _)) = line.char_indices().find(|&(_, c)| c != ' ' && c != '\t') {
-                // We can mix char and byte positions here because we only consider `[ \t]`.
-                if lo.col == CharPos(pos) {
-                    Some(line[..pos].into())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
+    let line = lo.file.get_line(lo.line - 1 /* line numbers in `Loc` are 1-based */)?;
+    if let Some((pos, _)) = line.char_indices().find(|&(_, c)| c != ' ' && c != '\t') {
+        // We can mix char and byte positions here because we only consider `[ \t]`.
+        if lo.col == CharPos(pos) {
+            Some(line[..pos].into())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
 }
 
 /// Convenience extension trait for `Diag`.

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -140,9 +140,8 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
 /// Resolves `<T as Iterator>::Item` for `T`
 /// Do not invoke without first verifying that the type implements `Iterator`
 pub fn get_iterator_item_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> Option<Ty<'tcx>> {
-    cx.tcx
-        .get_diagnostic_item(sym::Iterator)
-        .and_then(|iter_did| cx.get_associated_type(ty, iter_did, "Item"))
+    let iter_did = cx.tcx.get_diagnostic_item(sym::Iterator)?;
+    cx.get_associated_type(ty, iter_did, "Item")
 }
 
 /// Get the diagnostic name of a type, e.g. `sym::HashMap`. To check if a type
@@ -1337,7 +1336,10 @@ pub fn get_field_by_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, name: Symbol) ->
             .iter()
             .find(|f| f.name == name)
             .map(|f| f.ty(tcx, args)),
-        ty::Tuple(args) => name.as_str().parse::<usize>().ok().and_then(|i| args.get(i).copied()),
+        ty::Tuple(args) => {
+            let i = name.as_str().parse::<usize>().ok()?;
+            args.get(i).copied()
+        },
         _ => None,
     }
 }

--- a/tests/ui/bind_instead_of_map.fixed
+++ b/tests/ui/bind_instead_of_map.fixed
@@ -17,9 +17,11 @@ pub fn main() {
 
 pub fn foo() -> Option<String> {
     let x = Some(String::from("hello"));
-    Some("hello".to_owned()).and_then(|s| Some(format!("{}{}", s, x?)))
+    let s = Some("hello".to_owned())?;
+    Some(format!("{}{}", s, x?))
 }
 
 pub fn example2(x: bool) -> Option<&'static str> {
-    Some("a").and_then(|s| Some(if x { s } else { return None }))
+    let s = Some("a")?;
+    Some(if x { s } else { return None })
 }

--- a/tests/ui/bind_instead_of_map.rs
+++ b/tests/ui/bind_instead_of_map.rs
@@ -17,9 +17,11 @@ pub fn main() {
 
 pub fn foo() -> Option<String> {
     let x = Some(String::from("hello"));
-    Some("hello".to_owned()).and_then(|s| Some(format!("{}{}", s, x?)))
+    let s = Some("hello".to_owned())?;
+    Some(format!("{}{}", s, x?))
 }
 
 pub fn example2(x: bool) -> Option<&'static str> {
-    Some("a").and_then(|s| Some(if x { s } else { return None }))
+    let s = Some("a")?;
+    Some(if x { s } else { return None })
 }

--- a/tests/ui/needless_question_mark.fixed
+++ b/tests/ui/needless_question_mark.fixed
@@ -35,7 +35,8 @@ fn simple_option_bad3(to: TO) -> Option<usize> {
 
 fn simple_option_bad4(to: Option<TO>) -> Option<usize> {
     // single line closure
-    to.and_then(|t| t.magic)
+    let t = to?;
+    t.magic
 }
 
 // formatting this will remove the block brackets, making
@@ -43,9 +44,8 @@ fn simple_option_bad4(to: Option<TO>) -> Option<usize> {
 #[rustfmt::skip]
 fn simple_option_bad5(to: Option<TO>) -> Option<usize> {
     // closure with body
-    to.and_then(|t| {
-        t.magic
-    })
+    let t = to?;
+    t.magic
 }
 
 fn simple_result_bad1(tr: TR) -> Result<usize, bool> {
@@ -64,16 +64,16 @@ fn simple_result_bad3(tr: TR) -> Result<usize, bool> {
 }
 
 fn simple_result_bad4(tr: Result<TR, bool>) -> Result<usize, bool> {
-    tr.and_then(|t| t.magic)
+    let t = tr?;
+    t.magic
 }
 
 // formatting this will remove the block brackets, making
 // this test identical to the one above
 #[rustfmt::skip]
 fn simple_result_bad5(tr: Result<TR, bool>) -> Result<usize, bool> {
-    tr.and_then(|t| {
-        t.magic
-    })
+    let t = tr?;
+    t.magic
 }
 
 fn also_bad(tr: Result<TR, bool>) -> Result<usize, bool> {

--- a/tests/ui/needless_question_mark.rs
+++ b/tests/ui/needless_question_mark.rs
@@ -35,7 +35,8 @@ fn simple_option_bad3(to: TO) -> Option<usize> {
 
 fn simple_option_bad4(to: Option<TO>) -> Option<usize> {
     // single line closure
-    to.and_then(|t| Some(t.magic?))
+    let t = to?;
+    Some(t.magic?)
 }
 
 // formatting this will remove the block brackets, making
@@ -43,9 +44,8 @@ fn simple_option_bad4(to: Option<TO>) -> Option<usize> {
 #[rustfmt::skip]
 fn simple_option_bad5(to: Option<TO>) -> Option<usize> {
     // closure with body
-    to.and_then(|t| {
-        Some(t.magic?)
-    })
+    let t = to?;
+    Some(t.magic?)
 }
 
 fn simple_result_bad1(tr: TR) -> Result<usize, bool> {
@@ -64,16 +64,16 @@ fn simple_result_bad3(tr: TR) -> Result<usize, bool> {
 }
 
 fn simple_result_bad4(tr: Result<TR, bool>) -> Result<usize, bool> {
-    tr.and_then(|t| Ok(t.magic?))
+    let t = tr?;
+    Ok(t.magic?)
 }
 
 // formatting this will remove the block brackets, making
 // this test identical to the one above
 #[rustfmt::skip]
 fn simple_result_bad5(tr: Result<TR, bool>) -> Result<usize, bool> {
-    tr.and_then(|t| {
-        Ok(t.magic?)
-    })
+    let t = tr?;
+    Ok(t.magic?)
 }
 
 fn also_bad(tr: Result<TR, bool>) -> Result<usize, bool> {

--- a/tests/ui/needless_question_mark.stderr
+++ b/tests/ui/needless_question_mark.stderr
@@ -20,16 +20,16 @@ LL |     Some(to.magic?)
    |     ^^^^^^^^^^^^^^^ help: try removing question mark and `Some()`: `to.magic`
 
 error: question mark operator is useless here
-  --> tests/ui/needless_question_mark.rs:38:21
+  --> tests/ui/needless_question_mark.rs:39:5
    |
-LL |     to.and_then(|t| Some(t.magic?))
-   |                     ^^^^^^^^^^^^^^ help: try removing question mark and `Some()`: `t.magic`
+LL |     Some(t.magic?)
+   |     ^^^^^^^^^^^^^^ help: try removing question mark and `Some()`: `t.magic`
 
 error: question mark operator is useless here
-  --> tests/ui/needless_question_mark.rs:47:9
+  --> tests/ui/needless_question_mark.rs:48:5
    |
-LL |         Some(t.magic?)
-   |         ^^^^^^^^^^^^^^ help: try removing question mark and `Some()`: `t.magic`
+LL |     Some(t.magic?)
+   |     ^^^^^^^^^^^^^^ help: try removing question mark and `Some()`: `t.magic`
 
 error: question mark operator is useless here
   --> tests/ui/needless_question_mark.rs:52:12
@@ -50,16 +50,16 @@ LL |     Ok(tr.magic?)
    |     ^^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `tr.magic`
 
 error: question mark operator is useless here
-  --> tests/ui/needless_question_mark.rs:67:21
+  --> tests/ui/needless_question_mark.rs:68:5
    |
-LL |     tr.and_then(|t| Ok(t.magic?))
-   |                     ^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `t.magic`
+LL |     Ok(t.magic?)
+   |     ^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `t.magic`
 
 error: question mark operator is useless here
-  --> tests/ui/needless_question_mark.rs:75:9
+  --> tests/ui/needless_question_mark.rs:76:5
    |
-LL |         Ok(t.magic?)
-   |         ^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `t.magic`
+LL |     Ok(t.magic?)
+   |     ^^^^^^^^^^^^ help: try removing question mark and `Ok()`: `t.magic`
 
 error: question mark operator is useless here
   --> tests/ui/needless_question_mark.rs:82:16

--- a/tests/ui/return_and_then.fixed
+++ b/tests/ui/return_and_then.fixed
@@ -1,0 +1,34 @@
+#![warn(clippy::return_and_then)]
+
+fn main() {
+    fn test_opt_block(opt: Option<i32>) -> Option<i32> {
+        let n = opt?;
+        let mut ret = n + 1;
+                    ret += n;
+                    if n > 1 { Some(ret) } else { None }
+    }
+
+    fn test_opt_func(opt: Option<i32>) -> Option<i32> {
+        let n = opt?;
+        test_opt_block(Some(n))
+    }
+
+    fn test_call_chain() -> Option<i32> {
+        let n = gen_option(1)?;
+        test_opt_func(Some(n))
+    }
+
+    fn test_res_block(opt: Result<i32, i32>) -> Result<i32, i32> {
+        let n = opt?;
+        if n > 1 { Ok(n + 1) } else { Err(n) }
+    }
+
+    fn test_res_func(opt: Result<i32, i32>) -> Result<i32, i32> {
+        let n = opt?;
+        test_res_block(Ok(n))
+    }
+}
+
+fn gen_option(n: i32) -> Option<i32> {
+    Some(n)
+}

--- a/tests/ui/return_and_then.rs
+++ b/tests/ui/return_and_then.rs
@@ -1,0 +1,31 @@
+#![warn(clippy::return_and_then)]
+
+fn main() {
+    fn test_opt_block(opt: Option<i32>) -> Option<i32> {
+        opt.and_then(|n| {
+            let mut ret = n + 1;
+            ret += n;
+            if n > 1 { Some(ret) } else { None }
+        })
+    }
+
+    fn test_opt_func(opt: Option<i32>) -> Option<i32> {
+        opt.and_then(|n| test_opt_block(Some(n)))
+    }
+
+    fn test_call_chain() -> Option<i32> {
+        gen_option(1).and_then(|n| test_opt_func(Some(n)))
+    }
+
+    fn test_res_block(opt: Result<i32, i32>) -> Result<i32, i32> {
+        opt.and_then(|n| if n > 1 { Ok(n + 1) } else { Err(n) })
+    }
+
+    fn test_res_func(opt: Result<i32, i32>) -> Result<i32, i32> {
+        opt.and_then(|n| test_res_block(Ok(n)))
+    }
+}
+
+fn gen_option(n: i32) -> Option<i32> {
+    Some(n)
+}

--- a/tests/ui/return_and_then.stderr
+++ b/tests/ui/return_and_then.stderr
@@ -1,0 +1,70 @@
+error: use the question mark operator instead of an `and_then` call
+  --> tests/ui/return_and_then.rs:5:9
+   |
+LL | /         opt.and_then(|n| {
+LL | |             let mut ret = n + 1;
+LL | |             ret += n;
+LL | |             if n > 1 { Some(ret) } else { None }
+LL | |         })
+   | |__________^
+   |
+   = note: `-D clippy::return-and-then` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::return_and_then)]`
+help: try
+   |
+LL ~         let n = opt?;
+LL +         let mut ret = n + 1;
+LL +                     ret += n;
+LL +                     if n > 1 { Some(ret) } else { None }
+   |
+
+error: use the question mark operator instead of an `and_then` call
+  --> tests/ui/return_and_then.rs:13:9
+   |
+LL |         opt.and_then(|n| test_opt_block(Some(n)))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL ~         let n = opt?;
+LL +         test_opt_block(Some(n))
+   |
+
+error: use the question mark operator instead of an `and_then` call
+  --> tests/ui/return_and_then.rs:17:9
+   |
+LL |         gen_option(1).and_then(|n| test_opt_func(Some(n)))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL ~         let n = gen_option(1)?;
+LL +         test_opt_func(Some(n))
+   |
+
+error: use the question mark operator instead of an `and_then` call
+  --> tests/ui/return_and_then.rs:21:9
+   |
+LL |         opt.and_then(|n| if n > 1 { Ok(n + 1) } else { Err(n) })
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL ~         let n = opt?;
+LL +         if n > 1 { Ok(n + 1) } else { Err(n) }
+   |
+
+error: use the question mark operator instead of an `and_then` call
+  --> tests/ui/return_and_then.rs:25:9
+   |
+LL |         opt.and_then(|n| test_res_block(Ok(n)))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: try
+   |
+LL ~         let n = opt?;
+LL +         test_res_block(Ok(n))
+   |
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
close #6436

changelog: add new `return_and_then` lint

Additional src files changed to reflect the lint.
