### PR TITLE
docs: fix verbose-bit-mask example

### DIFF
--- a/clippy_lints/src/operators/mod.rs
+++ b/clippy_lints/src/operators/mod.rs
@@ -262,7 +262,7 @@ declare_clippy_lint! {
     /// to `trailing_zeros`
     ///
     /// ### Why is this bad?
-    /// `x.trailing_zeros() > 4` is much clearer than `x & 15
+    /// `x.trailing_zeros() >= 4` is much clearer than `x & 15
     /// == 0`
     ///
     /// ### Known problems
@@ -278,7 +278,7 @@ declare_clippy_lint! {
     ///
     /// ```no_run
     /// # let x: i32 = 1;
-    /// if x.trailing_zeros() > 4 { }
+    /// if x.trailing_zeros() >= 4 { }
     /// ```
     #[clippy::version = "pre 1.29.0"]
     pub VERBOSE_BIT_MASK,


### PR DESCRIPTION
changelog: none

`x & 15 == 0` is not equivalent to `x.trailing_zeros() > 4`, as `x = 0b10000` is true for the former and false for the latter.

In fact, clippy itself suggests the following:

```rust
pub fn src(x: i32) -> bool {
    x & 15 == 0 // ~error: bit mask could be simplified with a call to `trailing_zeros`
    ^^^^^^^^^^^ help: try: `x.trailing_zeros() >= 4`
}
```
