### PR TITLE
proper applicability for `obfuscated_if_else`

### DIFF
--- a/tests/ui/obfuscated_if_else.fixed
+++ b/tests/ui/obfuscated_if_else.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::obfuscated_if_else)]
-#![allow(clippy::unnecessary_lazy_evaluations)]
+#![allow(clippy::unnecessary_lazy_evaluations, clippy::unit_arg, clippy::unused_unit)]
 
 fn main() {
     if true { "a" } else { "b" };
@@ -11,4 +11,8 @@ fn main() {
 
     let partial = (a == 1).then_some("a");
     partial.unwrap_or("b"); // not lint
+
+    let mut a = 0;
+    if true { a += 1 } else { () };
+    if true { () } else { a += 2 };
 }

--- a/tests/ui/obfuscated_if_else.rs
+++ b/tests/ui/obfuscated_if_else.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::obfuscated_if_else)]
-#![allow(clippy::unnecessary_lazy_evaluations)]
+#![allow(clippy::unnecessary_lazy_evaluations, clippy::unit_arg, clippy::unused_unit)]
 
 fn main() {
     true.then_some("a").unwrap_or("b");
@@ -11,4 +11,8 @@ fn main() {
 
     let partial = (a == 1).then_some("a");
     partial.unwrap_or("b"); // not lint
+
+    let mut a = 0;
+    true.then_some(a += 1).unwrap_or(());
+    true.then_some(()).unwrap_or(a += 2);
 }

--- a/tests/ui/obfuscated_if_else.stderr
+++ b/tests/ui/obfuscated_if_else.stderr
@@ -25,5 +25,17 @@ error: this method chain can be written more clearly with `if .. else ..`
 LL |     (a == 1).then(|| "a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if a == 1 { "a" } else { "b" }`
 
-error: aborting due to 4 previous errors
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:16:5
+   |
+LL |     true.then_some(a += 1).unwrap_or(());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { a += 1 } else { () }`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:17:5
+   |
+LL |     true.then_some(()).unwrap_or(a += 2);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { () } else { a += 2 }`
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
fix #14034 

The currect implementation of `obfuscated_if_else` sometimes makes incorrect suggestions when the original code have side effects (see the example in the above issue). I think this can be fixed by changing the applicability depending on whether it can have side effects or not.

changelog: [`obfuscated_if_else`]: change applicability when the original code can have side effects
