### PR TITLE
exclude some directories from `Lintcheck` CI

### DIFF
--- a/.github/workflows/lintcheck.yml
+++ b/.github/workflows/lintcheck.yml
@@ -1,6 +1,12 @@
 name: Lintcheck
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - 'book/**'
+      - 'util/**'
+      - 'tests/**'
+      - '*.md'
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Currently, the CI pipeline triggers `Lintcheck` for all PRs. However, this check takes significant amount of time and seems unnecessary for some certain directories that are frequently updated.

r? flip1995

changelog: none
