### PR TITLE
add MSRV check for `manual_flatten`

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -743,6 +743,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`manual_bits`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_bits)
 * [`manual_c_str_literals`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals)
 * [`manual_clamp`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp)
+* [`manual_flatten`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_flatten)
 * [`manual_hash_one`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_hash_one)
 * [`manual_is_ascii_check`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_ascii_check)
 * [`manual_let_else`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_let_else)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -612,6 +612,7 @@ define_Conf! {
         manual_bits,
         manual_c_str_literals,
         manual_clamp,
+        manual_flatten,
         manual_hash_one,
         manual_is_ascii_check,
         manual_let_else,

--- a/clippy_lints/src/loops/manual_flatten.rs
+++ b/clippy_lints/src/loops/manual_flatten.rs
@@ -1,6 +1,7 @@
 use super::MANUAL_FLATTEN;
 use super::utils::make_iterator_snippet;
 use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::msrvs::{self, Msrv};
 use clippy_utils::visitors::is_local_used;
 use clippy_utils::{higher, path_to_local_id, peel_blocks_with_stmt};
 use rustc_errors::Applicability;
@@ -18,6 +19,7 @@ pub(super) fn check<'tcx>(
     arg: &'tcx Expr<'_>,
     body: &'tcx Expr<'_>,
     span: Span,
+    msrv: &Msrv,
 ) {
     let inner_expr = peel_blocks_with_stmt(body);
     if let Some(higher::IfLet { let_pat, let_expr, if_then, if_else: None, .. })
@@ -34,6 +36,7 @@ pub(super) fn check<'tcx>(
         && (some_ctor || ok_ctor)
         // Ensure expr in `if let` is not used afterwards
         && !is_local_used(cx, if_then, pat_hir_id)
+        && msrv.meets(msrvs::ITER_FLATTEN)
     {
         let if_let_type = if some_ctor { "Some" } else { "Ok" };
         // Prepare the error message

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -831,7 +831,7 @@ impl Loops {
         mut_range_bound::check(cx, arg, body);
         single_element_loop::check(cx, pat, arg, body, expr);
         same_item_push::check(cx, pat, arg, body, expr, &self.msrv);
-        manual_flatten::check(cx, pat, arg, body, span);
+        manual_flatten::check(cx, pat, arg, body, span, &self.msrv);
         manual_find::check(cx, pat, arg, body, span, expr);
         unused_enumerate_index::check(cx, pat, arg, body);
     }


### PR DESCRIPTION
`manual_flatten` should respect MSRV.

changelog: [`manual_flatten`]: add MSRV check
