### PR TITLE
`useless_asref`: no lint if in a closure to change the ref depth

### DIFF
--- a/tests/ui/useless_asref.fixed
+++ b/tests/ui/useless_asref.fixed
@@ -198,6 +198,11 @@ fn issue_12528() {
     let _ = opt.as_ref().map(RcWeak::clone);
 }
 
+fn issue_14088() {
+    let s = Some("foo");
+    let _: Option<&str> = s.as_ref().map(|x| x.as_ref());
+}
+
 fn main() {
     not_ok();
     ok();

--- a/tests/ui/useless_asref.rs
+++ b/tests/ui/useless_asref.rs
@@ -198,6 +198,11 @@ fn issue_12528() {
     let _ = opt.as_ref().map(RcWeak::clone);
 }
 
+fn issue_14088() {
+    let s = Some("foo");
+    let _: Option<&str> = s.as_ref().map(|x| x.as_ref());
+}
+
 fn main() {
     not_ok();
     ok();


### PR DESCRIPTION
Removing the `.as_ref()` or `.as_mut()` as the top-level expression in a closure may change the type of the result. In this case, it may be better not to lint rather than proposing a fix that would not work.

changelog: [`useless_asref`]: do not remove the `.as_ref()` or `.as_mut()` call if this would change the type of the enclosing closure

Fix #14088