### PR TITLE
Don't use labeled block as top-level blocks

### DIFF
--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -293,7 +293,7 @@ impl SourceFileRange {
     }
 }
 
-/// Like `snippet_block`, but add braces if the expr is not an `ExprKind::Block`.
+/// Like `snippet_block`, but add braces if the expr is not an `ExprKind::Block` with no label.
 pub fn expr_block(
     sess: &impl HasSession,
     expr: &Expr<'_>,
@@ -304,7 +304,7 @@ pub fn expr_block(
 ) -> String {
     let (code, from_macro) = snippet_block_with_context(sess, expr.span, outer, default, indent_relative_to, app);
     if !from_macro
-        && let ExprKind::Block(block, _) = expr.kind
+        && let ExprKind::Block(block, None) = expr.kind
         && block.rules != BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
     {
         format!("{code}")

--- a/tests/ui/match_bool.fixed
+++ b/tests/ui/match_bool.fixed
@@ -55,4 +55,10 @@ fn match_bool() {
     if !(!test && option == 5) { println!("Hello") };
 }
 
+fn issue14099() {
+    if true { 'a: {
+        break 'a;
+    } }
+}
+
 fn main() {}

--- a/tests/ui/match_bool.rs
+++ b/tests/ui/match_bool.rs
@@ -103,4 +103,14 @@ fn match_bool() {
     };
 }
 
+fn issue14099() {
+    match true {
+        //~^ ERROR: `match` on a boolean expression
+        true => 'a: {
+            break 'a;
+        },
+        _ => (),
+    }
+}
+
 fn main() {}

--- a/tests/ui/match_bool.stderr
+++ b/tests/ui/match_bool.stderr
@@ -164,5 +164,24 @@ LL | |         _ => println!("Hello"),
 LL | |     };
    | |_____^ help: consider using an `if`/`else` expression: `if !(!test && option == 5) { println!("Hello") }`
 
-error: aborting due to 12 previous errors
+error: `match` on a boolean expression
+  --> tests/ui/match_bool.rs:107:5
+   |
+LL | /     match true {
+LL | |
+LL | |         true => 'a: {
+LL | |             break 'a;
+LL | |         },
+LL | |         _ => (),
+LL | |     }
+   | |_____^
+   |
+help: consider using an `if`/`else` expression
+   |
+LL ~     if true { 'a: {
+LL +         break 'a;
+LL +     } }
+   |
+
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Labeled blocks cannot be used as-is in the "then" or "else" part of an `if` expression. They must be enclosed in an anonymous block.

Fix #14099

changelog: [`match_bool`]: fix suggestion when the rewritten block has a label