### PR TITLE
Do not remove semicolon if it changes the block type

### DIFF
--- a/tests/ui/unnecessary_semicolon.edition2021.fixed
+++ b/tests/ui/unnecessary_semicolon.edition2021.fixed
@@ -55,3 +55,9 @@ fn no_borrow_issue(a: u32, b: u32) {
         None => {},
     }
 }
+
+fn issue14100() -> bool {
+    // Removing the `;` would make the block type be `()` instead of `!`, and this could no longer be
+    // cast into the `bool` function return type.
+    if return true {};
+}

--- a/tests/ui/unnecessary_semicolon.edition2024.fixed
+++ b/tests/ui/unnecessary_semicolon.edition2024.fixed
@@ -55,3 +55,9 @@ fn no_borrow_issue(a: u32, b: u32) {
         None => {},
     }
 }
+
+fn issue14100() -> bool {
+    // Removing the `;` would make the block type be `()` instead of `!`, and this could no longer be
+    // cast into the `bool` function return type.
+    if return true {};
+}

--- a/tests/ui/unnecessary_semicolon.rs
+++ b/tests/ui/unnecessary_semicolon.rs
@@ -55,3 +55,9 @@ fn no_borrow_issue(a: u32, b: u32) {
         None => {},
     };
 }
+
+fn issue14100() -> bool {
+    // Removing the `;` would make the block type be `()` instead of `!`, and this could no longer be
+    // cast into the `bool` function return type.
+    if return true {};
+}


### PR DESCRIPTION
Removing the semicolon of the last statement of an expressionless block may change the block type even if the statement's type is `()`. If the block type is `!` because of a systematic early return, typing it as `()` may make it incompatible with the expected type for the block (to which `!` is cast).

Fix #14100

changelog: [`unnecessary_semicolon`]: do not remove semicolon if it could change the block type from `!` to `()`