### PR TITLE
change the applicability of `if_then_some_else_none` to `MachineApplicable`

### DIFF
--- a/clippy_lints/src/if_then_some_else_none.rs
+++ b/clippy_lints/src/if_then_some_else_none.rs
@@ -95,7 +95,7 @@ impl<'tcx> LateLintPass<'tcx> for IfThenSomeElseNone {
                 expr.span,
                 format!("this could be simplified with `bool::{method_name}`"),
                 |diag| {
-                    let mut app = Applicability::Unspecified;
+                    let mut app = Applicability::MachineApplicable;
                     let cond_snip = Sugg::hir_with_context(cx, cond, expr.span.ctxt(), "[condition]", &mut app)
                         .maybe_par()
                         .to_string();


### PR DESCRIPTION
`MachineApplicable` is appropriate for the applicability of this lint.

changelog: [`if_then_some_else_none`]: change the applicability to `MachineApplicable`
