### PR TITLE
Fixes for `missing_asserts_for_indexing`

### DIFF
--- a/clippy_lints/src/missing_asserts_for_indexing.rs
+++ b/clippy_lints/src/missing_asserts_for_indexing.rs
@@ -244,14 +244,16 @@ fn check_index<'hir>(cx: &LateContext<'_>, expr: &'hir Expr<'hir>, map: &mut Uni
                     assert_span,
                     slice,
                 } => {
-                    *entry = IndexEntry::AssertWithIndex {
-                        highest_index: index,
-                        asserted_len: *asserted_len,
-                        assert_span: *assert_span,
-                        slice,
-                        indexes: vec![expr.span],
-                        comparison: *comparison,
-                    };
+                    if slice.span.lo() > assert_span.lo() {
+                        *entry = IndexEntry::AssertWithIndex {
+                            highest_index: index,
+                            asserted_len: *asserted_len,
+                            assert_span: *assert_span,
+                            slice,
+                            indexes: vec![expr.span],
+                            comparison: *comparison,
+                        };
+                    }
                 },
                 IndexEntry::IndexWithoutAssert {
                     highest_index, indexes, ..
@@ -287,6 +289,7 @@ fn check_assert<'hir>(cx: &LateContext<'_>, expr: &'hir Expr<'hir>, map: &mut Un
                 indexes,
                 slice,
             } = entry
+                && expr.span.lo() <= slice.span.lo()
             {
                 *entry = IndexEntry::AssertWithIndex {
                     highest_index: *highest_index,

--- a/tests/ui/missing_asserts_for_indexing.fixed
+++ b/tests/ui/missing_asserts_for_indexing.fixed
@@ -139,4 +139,14 @@ fn issue11835(v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
     let _ = v4[0] + v4[1] + v4[2];
 }
 
+// ok
+fn same_index_multiple_times(v1: &[u8]) {
+    let _ = v1[0] + v1[0];
+}
+
+// ok
+fn highest_index_first(v1: &[u8]) {
+    let _ = v1[2] + v1[1] + v1[0];
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing.rs
+++ b/tests/ui/missing_asserts_for_indexing.rs
@@ -139,4 +139,14 @@ fn issue11835(v1: &[u8], v2: &[u8], v3: &[u8], v4: &[u8]) {
     let _ = v4[0] + v4[1] + v4[2];
 }
 
+// ok
+fn same_index_multiple_times(v1: &[u8]) {
+    let _ = v1[0] + v1[0];
+}
+
+// ok
+fn highest_index_first(v1: &[u8]) {
+    let _ = v1[2] + v1[1] + v1[0];
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing_unfixable.rs
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.rs
@@ -73,4 +73,10 @@ pub fn issue11856(values: &[i32]) -> usize {
     ascending.len()
 }
 
+fn assert_after_indexing(v1: &[u8]) {
+    let _ = v1[1] + v1[2];
+    //~^ ERROR: indexing into a slice multiple times without an `assert`
+    assert!(v1.len() > 2);
+}
+
 fn main() {}

--- a/tests/ui/missing_asserts_for_indexing_unfixable.stderr
+++ b/tests/ui/missing_asserts_for_indexing_unfixable.stderr
@@ -180,5 +180,24 @@ LL |     let _ = x[0] + x[1];
    |                    ^^^^
    = note: asserting the length before indexing will elide bounds checks
 
-error: aborting due to 8 previous errors
+error: indexing into a slice multiple times without an `assert`
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:77:13
+   |
+LL |     let _ = v1[1] + v1[2];
+   |             ^^^^^^^^^^^^^
+   |
+   = help: consider asserting the length before indexing: `assert!(v1.len() > 2);`
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:77:13
+   |
+LL |     let _ = v1[1] + v1[2];
+   |             ^^^^^
+note: slice indexed here
+  --> tests/ui/missing_asserts_for_indexing_unfixable.rs:77:21
+   |
+LL |     let _ = v1[1] + v1[2];
+   |                     ^^^^^
+   = note: asserting the length before indexing will elide bounds checks
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
This PR fixes issues with the `missing_asserts_for_indexing` lint.
- false positive when the first index is the highest(or equal) value in a list of indexes:
```rust
pub fn foo(slice: &[i32]) -> i32{
	slice[1] * slice[0]
}
```
- false negative when an assert statement if found after the indexing operation.
```rust
pub fn bar(slice: &[i32]) -> i32 {
	let product = slice[0] * slice[1];
	assert!(slice.len() > 1);
	product
}
```

examples: https://godbolt.org/z/s7Y47vKdE

closes: #14079

changelog: [`missing_asserts_for_indexing`]: ignore asserts found after indexing, and do not require asserts if the first index is highest.