### PR TITLE
fn_to_numeric_cast_any: Do not warn cast to raw pointer

### DIFF
--- a/clippy_lints/src/casts/fn_to_numeric_cast_any.rs
+++ b/clippy_lints/src/casts/fn_to_numeric_cast_any.rs
@@ -8,11 +8,6 @@ use rustc_middle::ty::Ty;
 use super::FN_TO_NUMERIC_CAST_ANY;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, cast_expr: &Expr<'_>, cast_from: Ty<'_>, cast_to: Ty<'_>) {
-    // We allow casts from any function type to any function type.
-    if cast_to.is_fn() {
-        return;
-    }
-
     if cast_from.is_fn() {
         let mut applicability = Applicability::MaybeIncorrect;
         let from_snippet = snippet_with_applicability(cx, cast_expr.span, "..", &mut applicability);

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -905,10 +905,7 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
             ptr_cast_constness::check(cx, expr, cast_from_expr, cast_from, cast_to, self.msrv);
             ptr_as_ptr::check(cx, expr, cast_from_expr, cast_from, cast_to_hir, cast_to, self.msrv);
             as_ptr_cast_mut::check(cx, expr, cast_from_expr, cast_to);
-            fn_to_numeric_cast_any::check(cx, expr, cast_from_expr, cast_from, cast_to);
             confusing_method_to_numeric_cast::check(cx, expr, cast_from_expr, cast_from, cast_to);
-            fn_to_numeric_cast::check(cx, expr, cast_from_expr, cast_from, cast_to);
-            fn_to_numeric_cast_with_truncation::check(cx, expr, cast_from_expr, cast_from, cast_to);
             zero_ptr::check(cx, expr, cast_from_expr, cast_to_hir, self.msrv);
 
             if self.msrv.meets(cx, msrvs::MANUAL_DANGLING_PTR) {
@@ -926,6 +923,9 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
                 }
                 cast_lossless::check(cx, expr, cast_from_expr, cast_from, cast_to, cast_to_hir, self.msrv);
                 cast_enum_constructor::check(cx, expr, cast_from_expr, cast_from);
+                fn_to_numeric_cast_any::check(cx, expr, cast_from_expr, cast_from, cast_to);
+                fn_to_numeric_cast::check(cx, expr, cast_from_expr, cast_from, cast_to);
+                fn_to_numeric_cast_with_truncation::check(cx, expr, cast_from_expr, cast_from, cast_to);
             }
 
             as_underscore::check(cx, expr, cast_to_hir);

--- a/tests/ui/fn_to_numeric_cast_any.rs
+++ b/tests/ui/fn_to_numeric_cast_any.rs
@@ -82,7 +82,7 @@ fn closure_to_fn_to_integer() {
 
 fn fn_to_raw_ptr() {
     let _ = foo as *const ();
-    //~^ fn_to_numeric_cast_any
+    let _ = foo as *mut ();
 }
 
 fn cast_fn_to_self() {

--- a/tests/ui/fn_to_numeric_cast_any.stderr
+++ b/tests/ui/fn_to_numeric_cast_any.stderr
@@ -176,16 +176,5 @@ help: did you mean to invoke the function?
 LL |     let _ = (clos as fn(u32) -> u32)() as usize;
    |                                     ++
 
-error: casting function pointer `foo` to `*const ()`
-  --> tests/ui/fn_to_numeric_cast_any.rs:84:13
-   |
-LL |     let _ = foo as *const ();
-   |             ^^^^^^^^^^^^^^^^
-   |
-help: did you mean to invoke the function?
-   |
-LL |     let _ = foo() as *const ();
-   |                ++
-
-error: aborting due to 17 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Fixes #12638

changelog: [`fn_to_numeric_cast_any`]: Fix false positive on a cast to raw pointer
