### PR TITLE
fix(adding_lints): msrv test case distinction

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -498,7 +498,7 @@ for the MSRV version itself.
 
 #[clippy::msrv = "1.44"]
 fn msrv_1_44() {
-    /* something that would trigger the lint */
+    /* something that would not trigger the lint */
 }
 
 #[clippy::msrv = "1.45"]


### PR DESCRIPTION
changelog: none

fix description of test that does not meet msrv and that hence should not lint
