### PR TITLE
Fix rustc_tools_util's `version.host_compiler` release channel, expose the rustc version, and add tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/driver.rs"
 [dependencies]
 clippy_config = { path = "clippy_config" }
 clippy_lints = { path = "clippy_lints" }
-rustc_tools_util = "0.4.0"
+rustc_tools_util = { path = "rustc_tools_util", version = "0.4.1" }
 tempfile = { version = "3.3", optional = true }
 termize = "0.1"
 color-print = "0.3.4"
@@ -54,7 +54,7 @@ parking_lot = "0.12"
 tokio = { version = "1", features = ["io-util"] }
 
 [build-dependencies]
-rustc_tools_util = "0.4.0"
+rustc_tools_util = { path = "rustc_tools_util", version = "0.4.1" }
 
 [features]
 integration = ["tempfile"]

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc_tools_util"
-version = "0.4.0"
+version = "0.4.1"
 description = "small helper to generate version information for git packages"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"

--- a/rustc_tools_util/README.md
+++ b/rustc_tools_util/README.md
@@ -13,10 +13,10 @@ build = "build.rs"
 List rustc_tools_util as regular AND build dependency.
 ````toml
 [dependencies]
-rustc_tools_util = "0.4.0"
+rustc_tools_util = "0.4.1"
 
 [build-dependencies]
-rustc_tools_util = "0.4.0"
+rustc_tools_util = "0.4.1"
 ````
 
 In `build.rs`, generate the data in your `main()`

--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -28,9 +28,8 @@ macro_rules! get_version_info {
     }};
 }
 
-/// This macro can be used in `build.rs` to automatically set the needed
-/// environment values, namely `GIT_HASH`, `COMMIT_DATE` and
-/// `RUSTC_RELEASE_CHANNEL`
+/// This macro can be used in `build.rs` to automatically set the needed environment values, namely
+/// `GIT_HASH`, `COMMIT_DATE`  and `RUSTC_RELEASE_CHANNEL`
 #[macro_export]
 macro_rules! setup_version_info {
     () => {{
@@ -43,7 +42,11 @@ macro_rules! setup_version_info {
             "cargo:rustc-env=COMMIT_DATE={}",
             $crate::get_commit_date().unwrap_or_default()
         );
-        println!("cargo:rustc-env=RUSTC_RELEASE_CHANNEL={}", $crate::get_channel());
+        let compiler_version = $crate::get_compiler_version();
+        println!(
+            "cargo:rustc-env=RUSTC_RELEASE_CHANNEL={}",
+            $crate::get_channel(compiler_version)
+        );
     }};
 }
 
@@ -87,16 +90,17 @@ impl std::fmt::Debug for VersionInfo {
             "VersionInfo {{ crate_name: \"{}\", major: {}, minor: {}, patch: {}",
             self.crate_name, self.major, self.minor, self.patch,
         )?;
-        if self.commit_hash.is_some() {
-            write!(
-                f,
-                ", commit_hash: \"{}\", commit_date: \"{}\" }}",
-                self.commit_hash.clone().unwrap_or_default().trim(),
-                self.commit_date.clone().unwrap_or_default().trim()
-            )?;
-        } else {
-            write!(f, " }}")?;
+        if let Some(ref commit_hash) = self.commit_hash {
+            write!(f, ", commit_hash: \"{}\"", commit_hash.trim(),)?;
         }
+        if let Some(ref commit_date) = self.commit_date {
+            write!(f, ", commit_date: \"{}\"", commit_date.trim())?;
+        }
+        if let Some(ref host_compiler) = self.host_compiler {
+            write!(f, ", host_compiler: \"{}\"", host_compiler.trim())?;
+        }
+
+        write!(f, " }}")?;
 
         Ok(())
     }
@@ -152,22 +156,27 @@ pub fn get_commit_date() -> Option<String> {
 }
 
 #[must_use]
-pub fn get_channel() -> String {
+pub fn get_compiler_version() -> Option<String> {
+    get_output("rustc", &["-V"])
+}
+
+#[must_use]
+pub fn get_channel(compiler_version: Option<String>) -> String {
     if let Ok(channel) = std::env::var("CFG_RELEASE_CHANNEL") {
         return channel;
     }
 
     // if that failed, try to ask rustc -V, do some parsing and find out
-    if let Some(rustc_output) = get_output("rustc", &["-V"]) {
+    if let Some(rustc_output) = compiler_version {
         if rustc_output.contains("beta") {
             return String::from("beta");
-        } else if rustc_output.contains("stable") {
-            return String::from("stable");
+        } else if rustc_output.contains("nightly") {
+            return String::from("nightly");
         }
     }
 
-    // default to nightly
-    String::from("nightly")
+    // default to stable
+    String::from("stable")
 }
 
 #[cfg(test)]
@@ -179,17 +188,19 @@ mod test {
         let vi = get_version_info!();
         assert_eq!(vi.major, 0);
         assert_eq!(vi.minor, 4);
-        assert_eq!(vi.patch, 0);
+        assert_eq!(vi.patch, 1);
         assert_eq!(vi.crate_name, "rustc_tools_util");
         // hard to make positive tests for these since they will always change
         assert!(vi.commit_hash.is_none());
         assert!(vi.commit_date.is_none());
+
+        assert!(vi.host_compiler.is_none());
     }
 
     #[test]
     fn test_display_local() {
         let vi = get_version_info!();
-        assert_eq!(vi.to_string(), "rustc_tools_util 0.4.0");
+        assert_eq!(vi.to_string(), "rustc_tools_util 0.4.1");
     }
 
     #[test]
@@ -198,7 +209,7 @@ mod test {
         let s = format!("{vi:?}");
         assert_eq!(
             s,
-            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 4, patch: 0 }"
+            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 4, patch: 1 }"
         );
     }
 }

--- a/tests/versioncheck.rs
+++ b/tests/versioncheck.rs
@@ -90,3 +90,9 @@ fn check_that_clippy_has_the_same_major_version_as_rustc() {
         },
     }
 }
+
+#[test]
+fn check_host_compiler() {
+    let version = rustc_tools_util::get_version_info!();
+    assert_eq!(version.host_compiler, Some("nightly".to_string()));
+}


### PR DESCRIPTION
changelog: Fix rustc_tools_util's `version.host_compiler` release channel, expose the rustc version, and add tests.


Previously the host_compiler would be set to "nighly" on the stable channel. Generally, the field felt a bit neglected neither being printed not tested.
