### PR TITLE
Fix `obfuscated_if_else` suggestion on left side of a binary expr

### DIFF
--- a/tests/ui/obfuscated_if_else.fixed
+++ b/tests/ui/obfuscated_if_else.fixed
@@ -22,3 +22,29 @@ fn main() {
     if true { () } else { a += 2 };
     //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 }
+
+fn issue11141() {
+    // Parentheses are required around the left side of a binary expression
+    let _ = (if true { 40 } else { 17 }) | 2;
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are required only for the leftmost expression
+    let _ = (if true { 30 } else { 17 }) | if true { 2 } else { 3 } | if true { 10 } else { 1 };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required around the right side of a binary expression
+    let _ = 2 | if true { 40 } else { 17 };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required for a cast
+    let _ = if true { 42 } else { 17 } as u8;
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required for a deref
+    let _ = *if true { &42 } else { &17 };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required for a deref followed by a cast
+    let _ = *if true { &42 } else { &17 } as u8;
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+}

--- a/tests/ui/obfuscated_if_else.fixed
+++ b/tests/ui/obfuscated_if_else.fixed
@@ -3,16 +3,22 @@
 
 fn main() {
     if true { "a" } else { "b" };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
     if true { "a" } else { "b" };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 
     let a = 1;
     if a == 1 { "a" } else { "b" };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
     if a == 1 { "a" } else { "b" };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 
     let partial = (a == 1).then_some("a");
     partial.unwrap_or("b"); // not lint
 
     let mut a = 0;
     if true { a += 1 } else { () };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
     if true { () } else { a += 2 };
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 }

--- a/tests/ui/obfuscated_if_else.rs
+++ b/tests/ui/obfuscated_if_else.rs
@@ -3,16 +3,22 @@
 
 fn main() {
     true.then_some("a").unwrap_or("b");
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
     true.then(|| "a").unwrap_or("b");
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 
     let a = 1;
     (a == 1).then_some("a").unwrap_or("b");
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
     (a == 1).then(|| "a").unwrap_or("b");
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 
     let partial = (a == 1).then_some("a");
     partial.unwrap_or("b"); // not lint
 
     let mut a = 0;
     true.then_some(a += 1).unwrap_or(());
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
     true.then_some(()).unwrap_or(a += 2);
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 }

--- a/tests/ui/obfuscated_if_else.rs
+++ b/tests/ui/obfuscated_if_else.rs
@@ -22,3 +22,29 @@ fn main() {
     true.then_some(()).unwrap_or(a += 2);
     //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
 }
+
+fn issue11141() {
+    // Parentheses are required around the left side of a binary expression
+    let _ = true.then_some(40).unwrap_or(17) | 2;
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are required only for the leftmost expression
+    let _ = true.then_some(30).unwrap_or(17) | true.then_some(2).unwrap_or(3) | true.then_some(10).unwrap_or(1);
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required around the right side of a binary expression
+    let _ = 2 | true.then_some(40).unwrap_or(17);
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required for a cast
+    let _ = true.then_some(42).unwrap_or(17) as u8;
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required for a deref
+    let _ = *true.then_some(&42).unwrap_or(&17);
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+
+    // Parentheses are not required for a deref followed by a cast
+    let _ = *true.then_some(&42).unwrap_or(&17) as u8;
+    //~^ ERROR: this method chain can be written more clearly with `if .. else ..`
+}

--- a/tests/ui/obfuscated_if_else.stderr
+++ b/tests/ui/obfuscated_if_else.stderr
@@ -8,31 +8,31 @@ LL |     true.then_some("a").unwrap_or("b");
    = help: to override `-D warnings` add `#[allow(clippy::obfuscated_if_else)]`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:6:5
+  --> tests/ui/obfuscated_if_else.rs:7:5
    |
 LL |     true.then(|| "a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { "a" } else { "b" }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:9:5
+  --> tests/ui/obfuscated_if_else.rs:11:5
    |
 LL |     (a == 1).then_some("a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if a == 1 { "a" } else { "b" }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:10:5
+  --> tests/ui/obfuscated_if_else.rs:13:5
    |
 LL |     (a == 1).then(|| "a").unwrap_or("b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if a == 1 { "a" } else { "b" }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:16:5
+  --> tests/ui/obfuscated_if_else.rs:20:5
    |
 LL |     true.then_some(a += 1).unwrap_or(());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { a += 1 } else { () }`
 
 error: this method chain can be written more clearly with `if .. else ..`
-  --> tests/ui/obfuscated_if_else.rs:17:5
+  --> tests/ui/obfuscated_if_else.rs:22:5
    |
 LL |     true.then_some(()).unwrap_or(a += 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { () } else { a += 2 }`

--- a/tests/ui/obfuscated_if_else.stderr
+++ b/tests/ui/obfuscated_if_else.stderr
@@ -37,5 +37,53 @@ error: this method chain can be written more clearly with `if .. else ..`
 LL |     true.then_some(()).unwrap_or(a += 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { () } else { a += 2 }`
 
-error: aborting due to 6 previous errors
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:28:13
+   |
+LL |     let _ = true.then_some(40).unwrap_or(17) | 2;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(if true { 40 } else { 17 })`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:32:13
+   |
+LL |     let _ = true.then_some(30).unwrap_or(17) | true.then_some(2).unwrap_or(3) | true.then_some(10).unwrap_or(1);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(if true { 30 } else { 17 })`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:32:48
+   |
+LL |     let _ = true.then_some(30).unwrap_or(17) | true.then_some(2).unwrap_or(3) | true.then_some(10).unwrap_or(1);
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 2 } else { 3 }`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:32:81
+   |
+LL |     let _ = true.then_some(30).unwrap_or(17) | true.then_some(2).unwrap_or(3) | true.then_some(10).unwrap_or(1);
+   |                                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 10 } else { 1 }`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:36:17
+   |
+LL |     let _ = 2 | true.then_some(40).unwrap_or(17);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 40 } else { 17 }`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:40:13
+   |
+LL |     let _ = true.then_some(42).unwrap_or(17) as u8;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { 42 } else { 17 }`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:44:14
+   |
+LL |     let _ = *true.then_some(&42).unwrap_or(&17);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { &42 } else { &17 }`
+
+error: this method chain can be written more clearly with `if .. else ..`
+  --> tests/ui/obfuscated_if_else.rs:48:14
+   |
+LL |     let _ = *true.then_some(&42).unwrap_or(&17) as u8;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if true { &42 } else { &17 }`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
An `if … { … } else { … }` used as the left operand of a binary expression requires parentheses to be parsed as an expression.

Fix #11141

changelog: [`obfuscated_if_else`]: fix bug in suggestion by issuing required parentheses around the left side of a binary expression