### PR TITLE
Use a better message for `toplevel_ref_arg` lint

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -169,7 +169,7 @@ impl<'tcx> LateLintPass<'tcx> for LintPass {
                         TOPLEVEL_REF_ARG,
                         arg.hir_id,
                         arg.pat.span,
-                        "`ref` directly on a function argument is ignored. \
+                        "`ref` directly on a function parameter does not prevent taking ownership of the passed argument. \
                         Consider using a reference type instead",
                     );
                 }

--- a/tests/ui/toplevel_ref_arg_non_rustfix.stderr
+++ b/tests/ui/toplevel_ref_arg_non_rustfix.stderr
@@ -1,4 +1,4 @@
-error: `ref` directly on a function argument is ignored. Consider using a reference type instead
+error: `ref` directly on a function parameter does not prevent taking ownership of the passed argument. Consider using a reference type instead
   --> tests/ui/toplevel_ref_arg_non_rustfix.rs:9:15
    |
 LL | fn the_answer(ref mut x: u8) {
@@ -7,7 +7,7 @@ LL | fn the_answer(ref mut x: u8) {
    = note: `-D clippy::toplevel-ref-arg` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::toplevel_ref_arg)]`
 
-error: `ref` directly on a function argument is ignored. Consider using a reference type instead
+error: `ref` directly on a function parameter does not prevent taking ownership of the passed argument. Consider using a reference type instead
   --> tests/ui/toplevel_ref_arg_non_rustfix.rs:20:24
    |
 LL |         fn fun_example(ref _x: usize) {}


### PR DESCRIPTION
A `ref` pattern applied to an argument is not ignored. It creates a reference as expected, but still requires the function to take ownership of the argument given to it.

Fix #14131 

changelog: [`toplevel_ref_arg`]: use a clearer lint message