### PR TITLE
Update version for doc_include_without_cfg

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -591,7 +591,7 @@ declare_clippy_lint! {
     /// ```no_run
     /// #![cfg_attr(doc, doc = include_str!("some_file.md"))]
     /// ```
-    #[clippy::version = "1.84.0"]
+    #[clippy::version = "1.86.0"]
     pub DOC_INCLUDE_WITHOUT_CFG,
     restriction,
     "check if files included in documentation are behind `cfg(doc)`"


### PR DESCRIPTION
This lint was merged recently https://github.com/rust-lang/rust-clippy/pull/13711 and should go with the next version 1.86.0 https://github.com/rust-lang/rust-clippy/tags

changelog: none
