### PR TITLE
don't emit suggestion inside macro in `manual_async_fn`

### DIFF
--- a/clippy_lints/src/manual_async_fn.rs
+++ b/clippy_lints/src/manual_async_fn.rs
@@ -62,6 +62,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualAsyncFn {
             && let Some(closure_body) = desugared_async_block(cx, block)
             && let Node::Item(Item {vis_span, ..}) | Node::ImplItem(ImplItem {vis_span, ..}) =
                 cx.tcx.hir_node_by_def_id(fn_def_id)
+            && !span.from_expansion()
         {
             let header_span = span.with_hi(ret_ty.span.hi());
 

--- a/tests/ui/manual_async_fn.fixed
+++ b/tests/ui/manual_async_fn.fixed
@@ -113,4 +113,30 @@ pub(crate) async fn issue_10450_2() -> i32 { 42 }
 
 pub(self) async fn issue_10450_3() -> i32 { 42 }
 
+macro_rules! issue_12407 {
+    (
+        $(
+            $(#[$m:meta])*
+            $v:vis $(override($($overrides:tt),* $(,)?))? fn $name:ident $([$($params:tt)*])? (
+                $($arg_name:ident: $arg_typ:ty),* $(,)?
+            ) $(-> $ret_ty:ty)? = $e:expr;
+        )*
+    ) => {
+        $(
+            $(#[$m])*
+            $v $($($overrides)*)? fn $name$(<$($params)*>)?(
+                $($arg_name: $arg_typ),*
+            ) $(-> $ret_ty)? {
+                $e
+            }
+        )*
+    };
+}
+
+issue_12407! {
+    fn _hello() -> impl Future<Output = ()> = async {};
+    fn non_async() = println!("hello");
+    fn foo() = non_async();
+}
+
 fn main() {}

--- a/tests/ui/manual_async_fn.rs
+++ b/tests/ui/manual_async_fn.rs
@@ -139,4 +139,30 @@ pub(self) fn issue_10450_3() -> impl Future<Output = i32> {
     async { 42 }
 }
 
+macro_rules! issue_12407 {
+    (
+        $(
+            $(#[$m:meta])*
+            $v:vis $(override($($overrides:tt),* $(,)?))? fn $name:ident $([$($params:tt)*])? (
+                $($arg_name:ident: $arg_typ:ty),* $(,)?
+            ) $(-> $ret_ty:ty)? = $e:expr;
+        )*
+    ) => {
+        $(
+            $(#[$m])*
+            $v $($($overrides)*)? fn $name$(<$($params)*>)?(
+                $($arg_name: $arg_typ),*
+            ) $(-> $ret_ty)? {
+                $e
+            }
+        )*
+    };
+}
+
+issue_12407! {
+    fn _hello() -> impl Future<Output = ()> = async {};
+    fn non_async() = println!("hello");
+    fn foo() = non_async();
+}
+
 fn main() {}


### PR DESCRIPTION
fixes #12407 

I think it is meaningful to emit a warning even if the span is in a macro.

changelog: [`manual_async_fn`]: don't emit suggestion inside macro
