### PR TITLE
allow `assign_op_pattern` in the test of `string_add`

### DIFF
--- a/tests/ui/string_add.rs
+++ b/tests/ui/string_add.rs
@@ -4,7 +4,7 @@ extern crate proc_macros;
 use proc_macros::external;
 
 #[warn(clippy::string_add)]
-#[allow(clippy::string_add_assign, unused)]
+#[allow(clippy::assign_op_pattern, clippy::string_add_assign, unused)]
 fn main() {
     // ignores assignment distinction
     let mut x = String::new();

--- a/tests/ui/string_add.stderr
+++ b/tests/ui/string_add.stderr
@@ -1,12 +1,3 @@
-error: manual implementation of an assign operation
-  --> tests/ui/string_add.rs:13:9
-   |
-LL |         x = x + ".";
-   |         ^^^^^^^^^^^ help: replace it with: `x += "."`
-   |
-   = note: `-D clippy::assign-op-pattern` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::assign_op_pattern)]`
-
 error: you added something to a string. Consider using `String::push_str()` instead
   --> tests/ui/string_add.rs:13:13
    |
@@ -22,11 +13,5 @@ error: you added something to a string. Consider using `String::push_str()` inst
 LL |     let z = y + "...";
    |             ^^^^^^^^^
 
-error: manual implementation of an assign operation
-  --> tests/ui/string_add.rs:22:5
-   |
-LL |     x = x + 1;
-   |     ^^^^^^^^^ help: replace it with: `x += 1`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Since `assign_op_pattern` is a style lint, not explicitly allowing it can lead to undesirable output in other lint checks.

changelog: none
