### PR TITLE
fix: `map_entry` FP on struct member

### DIFF
--- a/tests/ui/entry.fixed
+++ b/tests/ui/entry.fixed
@@ -195,4 +195,27 @@ fn issue12489(map: &mut HashMap<u64, u64>) -> Option<()> {
     Some(())
 }
 
+mod issue13934 {
+    use std::collections::HashMap;
+
+    struct Member {}
+
+    pub struct Foo {
+        members: HashMap<u8, Member>,
+    }
+
+    impl Foo {
+        pub fn should_also_not_cause_lint(&mut self, input: u8) {
+            if self.members.contains_key(&input) {
+                todo!();
+            } else {
+                self.other();
+                self.members.insert(input, Member {});
+            }
+        }
+
+        fn other(&self) {}
+    }
+}
+
 fn main() {}

--- a/tests/ui/entry.rs
+++ b/tests/ui/entry.rs
@@ -201,4 +201,27 @@ fn issue12489(map: &mut HashMap<u64, u64>) -> Option<()> {
     Some(())
 }
 
+mod issue13934 {
+    use std::collections::HashMap;
+
+    struct Member {}
+
+    pub struct Foo {
+        members: HashMap<u8, Member>,
+    }
+
+    impl Foo {
+        pub fn should_also_not_cause_lint(&mut self, input: u8) {
+            if self.members.contains_key(&input) {
+                todo!();
+            } else {
+                self.other();
+                self.members.insert(input, Member {});
+            }
+        }
+
+        fn other(&self) {}
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
fixes #13934 

I modified the part for checking if the map is used so that it can check field and index exprs.

changelog: [`map_entry`]: fix FP on struct member
