### PR TITLE
Correct version of `doc_overindented_list_items`

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -455,7 +455,7 @@ declare_clippy_lint! {
     /// ///   and this line is overindented.
     /// # fn foo() {}
     /// ```
-    #[clippy::version = "1.80.0"]
+    #[clippy::version = "1.86.0"]
     pub DOC_OVERINDENTED_LIST_ITEMS,
     style,
     "ensure list items are not overindented"


### PR DESCRIPTION
Fix the version of `doc_overindented_list_items`. It actually will be in 1.86.0, not 1.80.0.
(https://github.com/rust-lang/rust/pull/136209 has a milestone of 1.86.0)

changelog: none