### PR TITLE
Move `uninlined_format_args` back to `style`

### DIFF
--- a/clippy_lints/src/format_args.rs
+++ b/clippy_lints/src/format_args.rs
@@ -141,7 +141,7 @@ declare_clippy_lint! {
     /// format!("{var:.prec$}");
     /// ```
     ///
-    /// If allow-mixed-uninlined-format-args is set to false in clippy.toml,
+    /// If `allow-mixed-uninlined-format-args` is set to `false` in clippy.toml,
     /// the following code will also trigger the lint:
     /// ```no_run
     /// # let var = 42;
@@ -159,7 +159,7 @@ declare_clippy_lint! {
     /// nothing will be suggested, e.g. `println!("{0}={1}", var, 1+2)`.
     #[clippy::version = "1.66.0"]
     pub UNINLINED_FORMAT_ARGS,
-    pedantic,
+    style,
     "using non-inlined variables in `format!` calls"
 }
 

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
@@ -1,5 +1,6 @@
-#![deny(clippy::index_refutable_slice)]
 #![allow(clippy::uninlined_format_args)]
+#![deny(clippy::index_refutable_slice)]
+
 fn below_limit() {
     let slice: Option<&[u32]> = Some(&[1, 2, 3]);
     if let Some([_, _, _, _, _, _, _, slice_7, ..]) = slice {

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.fixed
@@ -1,5 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
-
+#![allow(clippy::uninlined_format_args)]
 fn below_limit() {
     let slice: Option<&[u32]> = Some(&[1, 2, 3]);
     if let Some([_, _, _, _, _, _, _, slice_7, ..]) = slice {

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
@@ -1,5 +1,6 @@
-#![deny(clippy::index_refutable_slice)]
 #![allow(clippy::uninlined_format_args)]
+#![deny(clippy::index_refutable_slice)]
+
 fn below_limit() {
     let slice: Option<&[u32]> = Some(&[1, 2, 3]);
     if let Some(slice) = slice {

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::index_refutable_slice)]
-
+#![allow(clippy::uninlined_format_args)]
 fn below_limit() {
     let slice: Option<&[u32]> = Some(&[1, 2, 3]);
     if let Some(slice) = slice {

--- a/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.stderr
+++ b/tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.stderr
@@ -1,11 +1,11 @@
 error: this binding can be a slice pattern to avoid indexing
-  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:5:17
+  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:6:17
    |
 LL |     if let Some(slice) = slice {
    |                 ^^^^^
    |
 note: the lint level is defined here
-  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:1:9
+  --> tests/ui-toml/max_suggested_slice_pattern_length/index_refutable_slice.rs:2:9
    |
 LL | #![deny(clippy::index_refutable_slice)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/author/macro_in_closure.rs
+++ b/tests/ui/author/macro_in_closure.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+
 #![allow(clippy::uninlined_format_args)]
 
 fn main() {

--- a/tests/ui/author/macro_in_closure.rs
+++ b/tests/ui/author/macro_in_closure.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     #[clippy::author]

--- a/tests/ui/author/macro_in_loop.rs
+++ b/tests/ui/author/macro_in_loop.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 
 #![feature(stmt_expr_attributes)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     #[clippy::author]

--- a/tests/ui/dbg_macro/dbg_macro.fixed
+++ b/tests/ui/dbg_macro/dbg_macro.fixed
@@ -1,6 +1,6 @@
 #![warn(clippy::dbg_macro)]
 #![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::unit_arg)]
-
+#![allow(clippy::uninlined_format_args)]
 fn foo(n: u32) -> u32 {
     if let Some(n) = n.checked_sub(4) { n } else { n }
     //~^ dbg_macro

--- a/tests/ui/dbg_macro/dbg_macro.fixed
+++ b/tests/ui/dbg_macro/dbg_macro.fixed
@@ -1,6 +1,11 @@
+#![allow(
+    clippy::no_effect,
+    clippy::uninlined_format_args,
+    clippy::unit_arg,
+    clippy::unnecessary_operation
+)]
 #![warn(clippy::dbg_macro)]
-#![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::unit_arg)]
-#![allow(clippy::uninlined_format_args)]
+
 fn foo(n: u32) -> u32 {
     if let Some(n) = n.checked_sub(4) { n } else { n }
     //~^ dbg_macro

--- a/tests/ui/dbg_macro/dbg_macro.rs
+++ b/tests/ui/dbg_macro/dbg_macro.rs
@@ -1,6 +1,11 @@
+#![allow(
+    clippy::no_effect,
+    clippy::uninlined_format_args,
+    clippy::unit_arg,
+    clippy::unnecessary_operation
+)]
 #![warn(clippy::dbg_macro)]
-#![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::unit_arg)]
-#![allow(clippy::uninlined_format_args)]
+
 fn foo(n: u32) -> u32 {
     if let Some(n) = dbg!(n.checked_sub(4)) { n } else { n }
     //~^ dbg_macro

--- a/tests/ui/dbg_macro/dbg_macro.rs
+++ b/tests/ui/dbg_macro/dbg_macro.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::dbg_macro)]
 #![allow(clippy::unnecessary_operation, clippy::no_effect, clippy::unit_arg)]
-
+#![allow(clippy::uninlined_format_args)]
 fn foo(n: u32) -> u32 {
     if let Some(n) = dbg!(n.checked_sub(4)) { n } else { n }
     //~^ dbg_macro

--- a/tests/ui/dbg_macro/dbg_macro.stderr
+++ b/tests/ui/dbg_macro/dbg_macro.stderr
@@ -1,5 +1,5 @@
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:5:22
+  --> tests/ui/dbg_macro/dbg_macro.rs:10:22
    |
 LL |     if let Some(n) = dbg!(n.checked_sub(4)) { n } else { n }
    |                      ^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     if let Some(n) = n.checked_sub(4) { n } else { n }
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:11:8
+  --> tests/ui/dbg_macro/dbg_macro.rs:16:8
    |
 LL |     if dbg!(n <= 1) {
    |        ^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL +     if n <= 1 {
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:14:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:19:9
    |
 LL |         dbg!(1)
    |         ^^^^^^^
@@ -37,7 +37,7 @@ LL +         1
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:17:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:22:9
    |
 LL |         dbg!(n * factorial(n - 1))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL +         n * factorial(n - 1)
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:23:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:28:5
    |
 LL |     dbg!(42);
    |     ^^^^^^^^
@@ -61,7 +61,7 @@ LL +     42;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:26:14
+  --> tests/ui/dbg_macro/dbg_macro.rs:31:14
    |
 LL |     foo(3) + dbg!(factorial(4));
    |              ^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL +     foo(3) + factorial(4);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:29:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:34:5
    |
 LL |     dbg!(1, 2, 3, 4, 5);
    |     ^^^^^^^^^^^^^^^^^^^
@@ -85,7 +85,7 @@ LL +     (1, 2, 3, 4, 5);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:51:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:56:5
    |
 LL |     dbg!();
    |     ^^^^^^
@@ -96,7 +96,7 @@ LL -     dbg!();
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:55:13
+  --> tests/ui/dbg_macro/dbg_macro.rs:60:13
    |
 LL |     let _ = dbg!();
    |             ^^^^^^
@@ -108,7 +108,7 @@ LL +     let _ = ();
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:58:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:63:9
    |
 LL |     bar(dbg!());
    |         ^^^^^^
@@ -120,7 +120,7 @@ LL +     bar(());
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:61:10
+  --> tests/ui/dbg_macro/dbg_macro.rs:66:10
    |
 LL |     foo!(dbg!());
    |          ^^^^^^
@@ -132,7 +132,7 @@ LL +     foo!(());
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:64:16
+  --> tests/ui/dbg_macro/dbg_macro.rs:69:16
    |
 LL |     foo2!(foo!(dbg!()));
    |                ^^^^^^
@@ -144,7 +144,7 @@ LL +     foo2!(foo!(()));
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:46:13
+  --> tests/ui/dbg_macro/dbg_macro.rs:51:13
    |
 LL |             dbg!();
    |             ^^^^^^
@@ -159,7 +159,7 @@ LL -             dbg!();
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:87:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:92:9
    |
 LL |         dbg!(2);
    |         ^^^^^^^
@@ -171,7 +171,7 @@ LL +         2;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:94:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:99:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
@@ -183,7 +183,7 @@ LL +     1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:100:5
+  --> tests/ui/dbg_macro/dbg_macro.rs:105:5
    |
 LL |     dbg!(1);
    |     ^^^^^^^
@@ -195,7 +195,7 @@ LL +     1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:107:9
+  --> tests/ui/dbg_macro/dbg_macro.rs:112:9
    |
 LL |         dbg!(1);
    |         ^^^^^^^
@@ -207,7 +207,7 @@ LL +         1;
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:114:31
+  --> tests/ui/dbg_macro/dbg_macro.rs:119:31
    |
 LL |         println!("dbg: {:?}", dbg!(s));
    |                               ^^^^^^^
@@ -219,7 +219,7 @@ LL +         println!("dbg: {:?}", s);
    |
 
 error: the `dbg!` macro is intended as a debugging tool
-  --> tests/ui/dbg_macro/dbg_macro.rs:117:22
+  --> tests/ui/dbg_macro/dbg_macro.rs:122:22
    |
 LL |         print!("{}", dbg!(s));
    |                      ^^^^^^^

--- a/tests/ui/large_futures.fixed
+++ b/tests/ui/large_futures.fixed
@@ -1,7 +1,7 @@
 #![warn(clippy::large_futures)]
 #![allow(clippy::never_loop)]
 #![allow(clippy::future_not_send)]
-#![allow(clippy::manual_async_fn)]
+#![allow(clippy::manual_async_fn, clippy::uninlined_format_args)]
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 

--- a/tests/ui/large_futures.fixed
+++ b/tests/ui/large_futures.fixed
@@ -1,7 +1,10 @@
+#![allow(
+    clippy::future_not_send,
+    clippy::manual_async_fn,
+    clippy::never_loop,
+    clippy::uninlined_format_args
+)]
 #![warn(clippy::large_futures)]
-#![allow(clippy::never_loop)]
-#![allow(clippy::future_not_send)]
-#![allow(clippy::manual_async_fn, clippy::uninlined_format_args)]
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 

--- a/tests/ui/large_futures.rs
+++ b/tests/ui/large_futures.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::large_futures)]
 #![allow(clippy::never_loop)]
 #![allow(clippy::future_not_send)]
-#![allow(clippy::manual_async_fn)]
+#![allow(clippy::manual_async_fn, clippy::uninlined_format_args)]
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 

--- a/tests/ui/large_futures.rs
+++ b/tests/ui/large_futures.rs
@@ -1,7 +1,10 @@
+#![allow(
+    clippy::future_not_send,
+    clippy::manual_async_fn,
+    clippy::never_loop,
+    clippy::uninlined_format_args
+)]
 #![warn(clippy::large_futures)]
-#![allow(clippy::never_loop)]
-#![allow(clippy::future_not_send)]
-#![allow(clippy::manual_async_fn, clippy::uninlined_format_args)]
 
 async fn big_fut(_arg: [u8; 1024 * 16]) {}
 

--- a/tests/ui/large_futures.stderr
+++ b/tests/ui/large_futures.stderr
@@ -1,5 +1,5 @@
 error: large future with a size of 16385 bytes
-  --> tests/ui/large_futures.rs:10:9
+  --> tests/ui/large_futures.rs:13:9
    |
 LL |         big_fut([0u8; 1024 * 16]).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(big_fut([0u8; 1024 * 16]))`
@@ -8,37 +8,37 @@ LL |         big_fut([0u8; 1024 * 16]).await;
    = help: to override `-D warnings` add `#[allow(clippy::large_futures)]`
 
 error: large future with a size of 16386 bytes
-  --> tests/ui/large_futures.rs:13:5
+  --> tests/ui/large_futures.rs:16:5
    |
 LL |     f.await
    |     ^ help: consider `Box::pin` on it: `Box::pin(f)`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:18:9
+  --> tests/ui/large_futures.rs:21:9
    |
 LL |         wait().await;
    |         ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 16387 bytes
-  --> tests/ui/large_futures.rs:24:13
+  --> tests/ui/large_futures.rs:27:13
    |
 LL |             wait().await;
    |             ^^^^^^ help: consider `Box::pin` on it: `Box::pin(wait())`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:32:5
+  --> tests/ui/large_futures.rs:35:5
    |
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
 error: large future with a size of 49159 bytes
-  --> tests/ui/large_futures.rs:35:5
+  --> tests/ui/large_futures.rs:38:5
    |
 LL |     calls_fut(fut).await;
    |     ^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(calls_fut(fut))`
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:48:5
+  --> tests/ui/large_futures.rs:51:5
    |
 LL | /     async {
 LL | |
@@ -61,7 +61,7 @@ LL +     })
    |
 
 error: large future with a size of 65540 bytes
-  --> tests/ui/large_futures.rs:61:13
+  --> tests/ui/large_futures.rs:64:13
    |
 LL | /             async {
 LL | |

--- a/tests/ui/manual_inspect.fixed
+++ b/tests/ui/manual_inspect.fixed
@@ -1,5 +1,5 @@
-#![warn(clippy::manual_inspect)]
 #![allow(clippy::no_effect, clippy::op_ref, clippy::uninlined_format_args)]
+#![warn(clippy::manual_inspect)]
 
 fn main() {
     let _ = Some(0).inspect(|&x| {

--- a/tests/ui/manual_inspect.fixed
+++ b/tests/ui/manual_inspect.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_inspect)]
-#![allow(clippy::no_effect, clippy::op_ref)]
+#![allow(clippy::no_effect, clippy::op_ref, clippy::uninlined_format_args)]
 
 fn main() {
     let _ = Some(0).inspect(|&x| {

--- a/tests/ui/manual_inspect.rs
+++ b/tests/ui/manual_inspect.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_inspect)]
-#![allow(clippy::no_effect, clippy::op_ref)]
+#![allow(clippy::no_effect, clippy::op_ref, clippy::uninlined_format_args)]
 
 fn main() {
     let _ = Some(0).map(|x| {

--- a/tests/ui/manual_inspect.rs
+++ b/tests/ui/manual_inspect.rs
@@ -1,5 +1,5 @@
-#![warn(clippy::manual_inspect)]
 #![allow(clippy::no_effect, clippy::op_ref, clippy::uninlined_format_args)]
+#![warn(clippy::manual_inspect)]
 
 fn main() {
     let _ = Some(0).map(|x| {

--- a/tests/ui/manual_strip_fixable.fixed
+++ b/tests/ui/manual_strip_fixable.fixed
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_strip)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let s = "abc";

--- a/tests/ui/manual_strip_fixable.rs
+++ b/tests/ui/manual_strip_fixable.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::manual_strip)]
+#![allow(clippy::uninlined_format_args)]
 
 fn main() {
     let s = "abc";

--- a/tests/ui/manual_strip_fixable.stderr
+++ b/tests/ui/manual_strip_fixable.stderr
@@ -1,11 +1,11 @@
 error: stripping a prefix manually
-  --> tests/ui/manual_strip_fixable.rs:7:24
+  --> tests/ui/manual_strip_fixable.rs:8:24
    |
 LL |         let stripped = &s["ab".len()..];
    |                        ^^^^^^^^^^^^^^^^
    |
 note: the prefix was tested here
-  --> tests/ui/manual_strip_fixable.rs:6:5
+  --> tests/ui/manual_strip_fixable.rs:7:5
    |
 LL |     if s.starts_with("ab") {
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,13 +19,13 @@ LL ~         println!("{stripped}{}", stripped);
    |
 
 error: stripping a suffix manually
-  --> tests/ui/manual_strip_fixable.rs:13:24
+  --> tests/ui/manual_strip_fixable.rs:14:24
    |
 LL |         let stripped = &s[..s.len() - "bc".len()];
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the suffix was tested here
-  --> tests/ui/manual_strip_fixable.rs:12:5
+  --> tests/ui/manual_strip_fixable.rs:13:5
    |
 LL |     if s.ends_with("bc") {
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/needless_pass_by_ref_mut.rs
+++ b/tests/ui/needless_pass_by_ref_mut.rs
@@ -1,13 +1,13 @@
 #![allow(
     clippy::if_same_then_else,
     clippy::no_effect,
+    clippy::ptr_arg,
     clippy::redundant_closure_call,
-    clippy::ptr_arg
+    clippy::uninlined_format_args
 )]
 #![warn(clippy::needless_pass_by_ref_mut)]
 //@no-rustfix
 use std::ptr::NonNull;
-
 fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
     //~^ needless_pass_by_ref_mut
 

--- a/tests/ui/needless_pass_by_ref_mut.rs
+++ b/tests/ui/needless_pass_by_ref_mut.rs
@@ -1,3 +1,5 @@
+//@no-rustfix
+
 #![allow(
     clippy::if_same_then_else,
     clippy::no_effect,
@@ -6,8 +8,9 @@
     clippy::uninlined_format_args
 )]
 #![warn(clippy::needless_pass_by_ref_mut)]
-//@no-rustfix
+
 use std::ptr::NonNull;
+
 fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
     //~^ needless_pass_by_ref_mut
 

--- a/tests/ui/needless_pass_by_ref_mut.rs
+++ b/tests/ui/needless_pass_by_ref_mut.rs
@@ -1,5 +1,3 @@
-//@no-rustfix
-
 #![allow(
     clippy::if_same_then_else,
     clippy::no_effect,
@@ -8,7 +6,7 @@
     clippy::uninlined_format_args
 )]
 #![warn(clippy::needless_pass_by_ref_mut)]
-
+//@no-rustfix
 use std::ptr::NonNull;
 
 fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {

--- a/tests/ui/needless_pass_by_ref_mut.stderr
+++ b/tests/ui/needless_pass_by_ref_mut.stderr
@@ -1,5 +1,5 @@
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:11:11
+  --> tests/ui/needless_pass_by_ref_mut.rs:14:11
    |
 LL | fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
    |           ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
@@ -8,79 +8,79 @@ LL | fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
    = help: to override `-D warnings` add `#[allow(clippy::needless_pass_by_ref_mut)]`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:37:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:40:12
    |
 LL | fn foo6(s: &mut Vec<u32>) {
    |            ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:48:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:51:12
    |
 LL |     fn bar(&mut self) {}
    |            ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:51:29
+  --> tests/ui/needless_pass_by_ref_mut.rs:54:29
    |
 LL |     fn mushroom(&self, vec: &mut Vec<i32>) -> usize {
    |                             ^^^^^^^^^^^^^ help: consider changing to: `&Vec<i32>`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:129:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:132:16
    |
 LL | async fn a1(x: &mut i32) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:134:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:137:16
    |
 LL | async fn a2(x: &mut i32, y: String) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:139:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:142:16
    |
 LL | async fn a3(x: &mut i32, y: String, z: String) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:144:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:147:16
    |
 LL | async fn a4(x: &mut i32, y: i32) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:149:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:152:24
    |
 LL | async fn a5(x: i32, y: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:154:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:157:24
    |
 LL | async fn a6(x: i32, y: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:159:32
+  --> tests/ui/needless_pass_by_ref_mut.rs:162:32
    |
 LL | async fn a7(x: i32, y: i32, z: &mut i32) {
    |                                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:164:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:167:24
    |
 LL | async fn a8(x: i32, a: &mut i32, y: i32, z: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:164:45
+  --> tests/ui/needless_pass_by_ref_mut.rs:167:45
    |
 LL | async fn a8(x: i32, a: &mut i32, y: i32, z: &mut i32) {
    |                                             ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:200:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:203:16
    |
 LL | fn cfg_warn(s: &mut u32) {}
    |                ^^^^^^^^ help: consider changing to: `&u32`
@@ -88,7 +88,7 @@ LL | fn cfg_warn(s: &mut u32) {}
    = note: this is cfg-gated and may require further changes
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:205:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:208:20
    |
 LL |     fn cfg_warn(s: &mut u32) {}
    |                    ^^^^^^^^ help: consider changing to: `&u32`
@@ -96,115 +96,115 @@ LL |     fn cfg_warn(s: &mut u32) {}
    = note: this is cfg-gated and may require further changes
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:218:39
+  --> tests/ui/needless_pass_by_ref_mut.rs:221:39
    |
 LL | async fn inner_async2(x: &mut i32, y: &mut u32) {
    |                                       ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:227:26
+  --> tests/ui/needless_pass_by_ref_mut.rs:230:26
    |
 LL | async fn inner_async3(x: &mut i32, y: &mut u32) {
    |                          ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:247:30
+  --> tests/ui/needless_pass_by_ref_mut.rs:250:30
    |
 LL | async fn call_in_closure1(n: &mut str) {
    |                              ^^^^^^^^ help: consider changing to: `&str`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:267:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:270:16
    |
 LL | fn closure2(n: &mut usize) -> impl '_ + FnMut() -> usize {
    |                ^^^^^^^^^^ help: consider changing to: `&usize`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:279:22
+  --> tests/ui/needless_pass_by_ref_mut.rs:282:22
    |
 LL | async fn closure4(n: &mut usize) {
    |                      ^^^^^^^^^^ help: consider changing to: `&usize`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:334:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:337:12
    |
 LL |     fn bar(&mut self) {}
    |            ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:337:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:340:18
    |
 LL |     async fn foo(&mut self, u: &mut i32, v: &mut u32) {
    |                  ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:337:45
+  --> tests/ui/needless_pass_by_ref_mut.rs:340:45
    |
 LL |     async fn foo(&mut self, u: &mut i32, v: &mut u32) {
    |                                             ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:346:46
+  --> tests/ui/needless_pass_by_ref_mut.rs:349:46
    |
 LL |     async fn foo2(&mut self, u: &mut i32, v: &mut u32) {
    |                                              ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:363:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:366:18
    |
 LL | fn _empty_tup(x: &mut (())) {}
    |                  ^^^^^^^^^ help: consider changing to: `&()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:365:19
+  --> tests/ui/needless_pass_by_ref_mut.rs:368:19
    |
 LL | fn _single_tup(x: &mut ((i32,))) {}
    |                   ^^^^^^^^^^^^^ help: consider changing to: `&(i32,)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:367:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:370:18
    |
 LL | fn _multi_tup(x: &mut ((i32, u32))) {}
    |                  ^^^^^^^^^^^^^^^^^ help: consider changing to: `&(i32, u32)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:369:11
+  --> tests/ui/needless_pass_by_ref_mut.rs:372:11
    |
 LL | fn _fn(x: &mut (fn())) {}
    |           ^^^^^^^^^^^ help: consider changing to: `&fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:372:23
+  --> tests/ui/needless_pass_by_ref_mut.rs:375:23
    |
 LL | fn _extern_rust_fn(x: &mut extern "Rust" fn()) {}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&extern "Rust" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:374:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:377:20
    |
 LL | fn _extern_c_fn(x: &mut extern "C" fn()) {}
    |                    ^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&extern "C" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:376:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:379:18
    |
 LL | fn _unsafe_fn(x: &mut unsafe fn()) {}
    |                  ^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:378:25
+  --> tests/ui/needless_pass_by_ref_mut.rs:381:25
    |
 LL | fn _unsafe_extern_fn(x: &mut unsafe extern "C" fn()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:380:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:383:20
    |
 LL | fn _fn_with_arg(x: &mut unsafe extern "C" fn(i32)) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn(i32)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:382:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:385:20
    |
 LL | fn _fn_with_ret(x: &mut unsafe extern "C" fn() -> (i32)) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn() -> (i32)`

--- a/tests/ui/needless_pass_by_ref_mut.stderr
+++ b/tests/ui/needless_pass_by_ref_mut.stderr
@@ -1,5 +1,5 @@
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:14:11
+  --> tests/ui/needless_pass_by_ref_mut.rs:12:11
    |
 LL | fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
    |           ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
@@ -8,79 +8,79 @@ LL | fn foo(s: &mut Vec<u32>, b: &u32, x: &mut u32) {
    = help: to override `-D warnings` add `#[allow(clippy::needless_pass_by_ref_mut)]`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:40:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:38:12
    |
 LL | fn foo6(s: &mut Vec<u32>) {
    |            ^^^^^^^^^^^^^ help: consider changing to: `&Vec<u32>`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:51:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:49:12
    |
 LL |     fn bar(&mut self) {}
    |            ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:54:29
+  --> tests/ui/needless_pass_by_ref_mut.rs:52:29
    |
 LL |     fn mushroom(&self, vec: &mut Vec<i32>) -> usize {
    |                             ^^^^^^^^^^^^^ help: consider changing to: `&Vec<i32>`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:132:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:130:16
    |
 LL | async fn a1(x: &mut i32) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:137:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:135:16
    |
 LL | async fn a2(x: &mut i32, y: String) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:142:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:140:16
    |
 LL | async fn a3(x: &mut i32, y: String, z: String) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:147:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:145:16
    |
 LL | async fn a4(x: &mut i32, y: i32) {
    |                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:152:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:150:24
    |
 LL | async fn a5(x: i32, y: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:157:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:155:24
    |
 LL | async fn a6(x: i32, y: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:162:32
+  --> tests/ui/needless_pass_by_ref_mut.rs:160:32
    |
 LL | async fn a7(x: i32, y: i32, z: &mut i32) {
    |                                ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:167:24
+  --> tests/ui/needless_pass_by_ref_mut.rs:165:24
    |
 LL | async fn a8(x: i32, a: &mut i32, y: i32, z: &mut i32) {
    |                        ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:167:45
+  --> tests/ui/needless_pass_by_ref_mut.rs:165:45
    |
 LL | async fn a8(x: i32, a: &mut i32, y: i32, z: &mut i32) {
    |                                             ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:203:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:201:16
    |
 LL | fn cfg_warn(s: &mut u32) {}
    |                ^^^^^^^^ help: consider changing to: `&u32`
@@ -88,7 +88,7 @@ LL | fn cfg_warn(s: &mut u32) {}
    = note: this is cfg-gated and may require further changes
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:208:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:206:20
    |
 LL |     fn cfg_warn(s: &mut u32) {}
    |                    ^^^^^^^^ help: consider changing to: `&u32`
@@ -96,115 +96,115 @@ LL |     fn cfg_warn(s: &mut u32) {}
    = note: this is cfg-gated and may require further changes
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:221:39
+  --> tests/ui/needless_pass_by_ref_mut.rs:219:39
    |
 LL | async fn inner_async2(x: &mut i32, y: &mut u32) {
    |                                       ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:230:26
+  --> tests/ui/needless_pass_by_ref_mut.rs:228:26
    |
 LL | async fn inner_async3(x: &mut i32, y: &mut u32) {
    |                          ^^^^^^^^ help: consider changing to: `&i32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:250:30
+  --> tests/ui/needless_pass_by_ref_mut.rs:248:30
    |
 LL | async fn call_in_closure1(n: &mut str) {
    |                              ^^^^^^^^ help: consider changing to: `&str`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:270:16
+  --> tests/ui/needless_pass_by_ref_mut.rs:268:16
    |
 LL | fn closure2(n: &mut usize) -> impl '_ + FnMut() -> usize {
    |                ^^^^^^^^^^ help: consider changing to: `&usize`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:282:22
+  --> tests/ui/needless_pass_by_ref_mut.rs:280:22
    |
 LL | async fn closure4(n: &mut usize) {
    |                      ^^^^^^^^^^ help: consider changing to: `&usize`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:337:12
+  --> tests/ui/needless_pass_by_ref_mut.rs:335:12
    |
 LL |     fn bar(&mut self) {}
    |            ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:340:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:338:18
    |
 LL |     async fn foo(&mut self, u: &mut i32, v: &mut u32) {
    |                  ^^^^^^^^^ help: consider changing to: `&self`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:340:45
+  --> tests/ui/needless_pass_by_ref_mut.rs:338:45
    |
 LL |     async fn foo(&mut self, u: &mut i32, v: &mut u32) {
    |                                             ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:349:46
+  --> tests/ui/needless_pass_by_ref_mut.rs:347:46
    |
 LL |     async fn foo2(&mut self, u: &mut i32, v: &mut u32) {
    |                                              ^^^^^^^^ help: consider changing to: `&u32`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:366:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:364:18
    |
 LL | fn _empty_tup(x: &mut (())) {}
    |                  ^^^^^^^^^ help: consider changing to: `&()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:368:19
+  --> tests/ui/needless_pass_by_ref_mut.rs:366:19
    |
 LL | fn _single_tup(x: &mut ((i32,))) {}
    |                   ^^^^^^^^^^^^^ help: consider changing to: `&(i32,)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:370:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:368:18
    |
 LL | fn _multi_tup(x: &mut ((i32, u32))) {}
    |                  ^^^^^^^^^^^^^^^^^ help: consider changing to: `&(i32, u32)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:372:11
+  --> tests/ui/needless_pass_by_ref_mut.rs:370:11
    |
 LL | fn _fn(x: &mut (fn())) {}
    |           ^^^^^^^^^^^ help: consider changing to: `&fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:375:23
+  --> tests/ui/needless_pass_by_ref_mut.rs:373:23
    |
 LL | fn _extern_rust_fn(x: &mut extern "Rust" fn()) {}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&extern "Rust" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:377:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:375:20
    |
 LL | fn _extern_c_fn(x: &mut extern "C" fn()) {}
    |                    ^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&extern "C" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:379:18
+  --> tests/ui/needless_pass_by_ref_mut.rs:377:18
    |
 LL | fn _unsafe_fn(x: &mut unsafe fn()) {}
    |                  ^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:381:25
+  --> tests/ui/needless_pass_by_ref_mut.rs:379:25
    |
 LL | fn _unsafe_extern_fn(x: &mut unsafe extern "C" fn()) {}
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn()`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:383:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:381:20
    |
 LL | fn _fn_with_arg(x: &mut unsafe extern "C" fn(i32)) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn(i32)`
 
 error: this argument is a mutable reference, but not used mutably
-  --> tests/ui/needless_pass_by_ref_mut.rs:385:20
+  --> tests/ui/needless_pass_by_ref_mut.rs:383:20
    |
 LL | fn _fn_with_ret(x: &mut unsafe extern "C" fn() -> (i32)) {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&unsafe extern "C" fn() -> (i32)`

--- a/tests/ui/to_string_in_format_args_incremental.fixed
+++ b/tests/ui/to_string_in_format_args_incremental.fixed
@@ -1,5 +1,5 @@
 //@compile-flags: -C incremental=target/debug/test/incr
-
+#![allow(clippy::uninlined_format_args)]
 // see https://github.com/rust-lang/rust-clippy/issues/10969
 
 fn main() {

--- a/tests/ui/to_string_in_format_args_incremental.fixed
+++ b/tests/ui/to_string_in_format_args_incremental.fixed
@@ -1,5 +1,7 @@
 //@compile-flags: -C incremental=target/debug/test/incr
+
 #![allow(clippy::uninlined_format_args)]
+
 // see https://github.com/rust-lang/rust-clippy/issues/10969
 
 fn main() {

--- a/tests/ui/to_string_in_format_args_incremental.rs
+++ b/tests/ui/to_string_in_format_args_incremental.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -C incremental=target/debug/test/incr
-
+#![allow(clippy::uninlined_format_args)]
 // see https://github.com/rust-lang/rust-clippy/issues/10969
 
 fn main() {

--- a/tests/ui/to_string_in_format_args_incremental.rs
+++ b/tests/ui/to_string_in_format_args_incremental.rs
@@ -1,5 +1,7 @@
 //@compile-flags: -C incremental=target/debug/test/incr
+
 #![allow(clippy::uninlined_format_args)]
+
 // see https://github.com/rust-lang/rust-clippy/issues/10969
 
 fn main() {

--- a/tests/ui/to_string_in_format_args_incremental.stderr
+++ b/tests/ui/to_string_in_format_args_incremental.stderr
@@ -1,5 +1,5 @@
 error: `to_string` applied to a type that implements `Display` in `println!` args
-  --> tests/ui/to_string_in_format_args_incremental.rs:7:21
+  --> tests/ui/to_string_in_format_args_incremental.rs:9:21
    |
 LL |     println!("{}", s.to_string());
    |                     ^^^^^^^^^^^^ help: remove this

--- a/tests/ui/unnecessary_iter_cloned.fixed
+++ b/tests/ui/unnecessary_iter_cloned.fixed
@@ -1,4 +1,4 @@
-#![allow(unused_assignments)]
+#![allow(unused_assignments, clippy::uninlined_format_args)]
 #![warn(clippy::unnecessary_to_owned)]
 
 #[allow(dead_code)]

--- a/tests/ui/unnecessary_iter_cloned.rs
+++ b/tests/ui/unnecessary_iter_cloned.rs
@@ -1,4 +1,4 @@
-#![allow(unused_assignments)]
+#![allow(unused_assignments, clippy::uninlined_format_args)]
 #![warn(clippy::unnecessary_to_owned)]
 
 #[allow(dead_code)]

--- a/tests/ui/unnecessary_operation.fixed
+++ b/tests/ui/unnecessary_operation.fixed
@@ -1,12 +1,13 @@
 #![allow(
     clippy::deref_addrof,
-    dead_code,
-    unused,
     clippy::no_effect,
-    clippy::unnecessary_struct_initialization
+    clippy::uninlined_format_args,
+    clippy::unnecessary_struct_initialization,
+    dead_code,
+    unused
 )]
 #![warn(clippy::unnecessary_operation)]
-#![allow(clippy::uninlined_format_args)]
+
 use std::fmt::Display;
 use std::ops::Shl;
 

--- a/tests/ui/unnecessary_operation.fixed
+++ b/tests/ui/unnecessary_operation.fixed
@@ -6,7 +6,7 @@
     clippy::unnecessary_struct_initialization
 )]
 #![warn(clippy::unnecessary_operation)]
-
+#![allow(clippy::uninlined_format_args)]
 use std::fmt::Display;
 use std::ops::Shl;
 

--- a/tests/ui/unnecessary_operation.rs
+++ b/tests/ui/unnecessary_operation.rs
@@ -1,12 +1,13 @@
 #![allow(
     clippy::deref_addrof,
-    dead_code,
-    unused,
     clippy::no_effect,
-    clippy::unnecessary_struct_initialization
+    clippy::uninlined_format_args,
+    clippy::unnecessary_struct_initialization,
+    dead_code,
+    unused
 )]
 #![warn(clippy::unnecessary_operation)]
-#![allow(clippy::uninlined_format_args)]
+
 use std::fmt::Display;
 use std::ops::Shl;
 

--- a/tests/ui/unnecessary_operation.rs
+++ b/tests/ui/unnecessary_operation.rs
@@ -6,7 +6,7 @@
     clippy::unnecessary_struct_initialization
 )]
 #![warn(clippy::unnecessary_operation)]
-
+#![allow(clippy::uninlined_format_args)]
 use std::fmt::Display;
 use std::ops::Shl;
 

--- a/tests/ui/unnecessary_operation.stderr
+++ b/tests/ui/unnecessary_operation.stderr
@@ -1,5 +1,5 @@
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:70:5
+  --> tests/ui/unnecessary_operation.rs:71:5
    |
 LL |     Tuple(get_number());
    |     ^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
@@ -8,103 +8,103 @@ LL |     Tuple(get_number());
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_operation)]`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:72:5
+  --> tests/ui/unnecessary_operation.rs:73:5
    |
 LL |     Struct { field: get_number() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:74:5
+  --> tests/ui/unnecessary_operation.rs:75:5
    |
 LL |     Struct { ..get_struct() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_struct();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:76:5
+  --> tests/ui/unnecessary_operation.rs:77:5
    |
 LL |     Enum::Tuple(get_number());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:78:5
+  --> tests/ui/unnecessary_operation.rs:79:5
    |
 LL |     Enum::Struct { field: get_number() };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:80:5
+  --> tests/ui/unnecessary_operation.rs:81:5
    |
 LL |     5 + get_number();
    |     ^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `5;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:82:5
+  --> tests/ui/unnecessary_operation.rs:83:5
    |
 LL |     *&get_number();
    |     ^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:84:5
+  --> tests/ui/unnecessary_operation.rs:85:5
    |
 LL |     &get_number();
    |     ^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:86:5
+  --> tests/ui/unnecessary_operation.rs:87:5
    |
 LL |     (5, 6, get_number());
    |     ^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `5;6;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:88:5
+  --> tests/ui/unnecessary_operation.rs:89:5
    |
 LL |     get_number()..;
    |     ^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:90:5
+  --> tests/ui/unnecessary_operation.rs:91:5
    |
 LL |     ..get_number();
    |     ^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:92:5
+  --> tests/ui/unnecessary_operation.rs:93:5
    |
 LL |     5..get_number();
    |     ^^^^^^^^^^^^^^^^ help: statement can be reduced to: `5;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:94:5
+  --> tests/ui/unnecessary_operation.rs:95:5
    |
 LL |     [42, get_number()];
    |     ^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `42;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:96:5
+  --> tests/ui/unnecessary_operation.rs:97:5
    |
 LL |     [42, 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:98:5
+  --> tests/ui/unnecessary_operation.rs:99:5
    |
 LL |     (42, get_number()).1;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `42;get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:100:5
+  --> tests/ui/unnecessary_operation.rs:101:5
    |
 LL |     [get_number(); 55];
    |     ^^^^^^^^^^^^^^^^^^^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:102:5
+  --> tests/ui/unnecessary_operation.rs:103:5
    |
 LL |     [42; 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42; 55].len() > get_usize());`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:104:5
+  --> tests/ui/unnecessary_operation.rs:105:5
    |
 LL | /     {
 LL | |
@@ -113,7 +113,7 @@ LL | |     };
    | |______^ help: statement can be reduced to: `get_number();`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:108:5
+  --> tests/ui/unnecessary_operation.rs:109:5
    |
 LL | /     FooString {
 LL | |
@@ -122,7 +122,7 @@ LL | |     };
    | |______^ help: statement can be reduced to: `String::from("blah");`
 
 error: unnecessary operation
-  --> tests/ui/unnecessary_operation.rs:149:5
+  --> tests/ui/unnecessary_operation.rs:150:5
    |
 LL |     [42, 55][get_usize()];
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: statement can be written as: `assert!([42, 55].len() > get_usize());`

--- a/tests/ui/unnecessary_os_str_debug_formatting.rs
+++ b/tests/ui/unnecessary_os_str_debug_formatting.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::unnecessary_debug_formatting)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::ffi::{OsStr, OsString};
 

--- a/tests/ui/unnecessary_os_str_debug_formatting.stderr
+++ b/tests/ui/unnecessary_os_str_debug_formatting.stderr
@@ -1,5 +1,5 @@
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_os_str_debug_formatting.rs:14:22
+  --> tests/ui/unnecessary_os_str_debug_formatting.rs:15:22
    |
 LL |     println!("{:?}", os_str);
    |                      ^^^^^^
@@ -10,7 +10,7 @@ LL |     println!("{:?}", os_str);
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_debug_formatting)]`
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_os_str_debug_formatting.rs:15:22
+  --> tests/ui/unnecessary_os_str_debug_formatting.rs:16:22
    |
 LL |     println!("{:?}", os_string);
    |                      ^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     println!("{:?}", os_string);
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_os_str_debug_formatting.rs:17:16
+  --> tests/ui/unnecessary_os_str_debug_formatting.rs:18:16
    |
 LL |     println!("{os_str:?}");
    |                ^^^^^^
@@ -28,7 +28,7 @@ LL |     println!("{os_str:?}");
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_os_str_debug_formatting.rs:18:16
+  --> tests/ui/unnecessary_os_str_debug_formatting.rs:19:16
    |
 LL |     println!("{os_string:?}");
    |                ^^^^^^^^^
@@ -37,7 +37,7 @@ LL |     println!("{os_string:?}");
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `format!` args
-  --> tests/ui/unnecessary_os_str_debug_formatting.rs:20:37
+  --> tests/ui/unnecessary_os_str_debug_formatting.rs:21:37
    |
 LL |     let _: String = format!("{:?}", os_str);
    |                                     ^^^^^^
@@ -46,7 +46,7 @@ LL |     let _: String = format!("{:?}", os_str);
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `format!` args
-  --> tests/ui/unnecessary_os_str_debug_formatting.rs:21:37
+  --> tests/ui/unnecessary_os_str_debug_formatting.rs:22:37
    |
 LL |     let _: String = format!("{:?}", os_string);
    |                                     ^^^^^^^^^

--- a/tests/ui/unnecessary_path_debug_formatting.rs
+++ b/tests/ui/unnecessary_path_debug_formatting.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::unnecessary_debug_formatting)]
+#![allow(clippy::uninlined_format_args)]
 
 use std::ffi::{OsStr, OsString};
 use std::ops::Deref;

--- a/tests/ui/unnecessary_path_debug_formatting.stderr
+++ b/tests/ui/unnecessary_path_debug_formatting.stderr
@@ -1,5 +1,5 @@
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:29:22
+  --> tests/ui/unnecessary_path_debug_formatting.rs:30:22
    |
 LL |     println!("{:?}", os_str);
    |                      ^^^^^^
@@ -10,7 +10,7 @@ LL |     println!("{:?}", os_str);
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_debug_formatting)]`
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:30:22
+  --> tests/ui/unnecessary_path_debug_formatting.rs:31:22
    |
 LL |     println!("{:?}", os_string);
    |                      ^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     println!("{:?}", os_string);
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:32:22
+  --> tests/ui/unnecessary_path_debug_formatting.rs:33:22
    |
 LL |     println!("{:?}", path);
    |                      ^^^^
@@ -28,7 +28,7 @@ LL |     println!("{:?}", path);
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:33:22
+  --> tests/ui/unnecessary_path_debug_formatting.rs:34:22
    |
 LL |     println!("{:?}", path_buf);
    |                      ^^^^^^^^
@@ -37,7 +37,7 @@ LL |     println!("{:?}", path_buf);
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:35:16
+  --> tests/ui/unnecessary_path_debug_formatting.rs:36:16
    |
 LL |     println!("{path:?}");
    |                ^^^^
@@ -46,7 +46,7 @@ LL |     println!("{path:?}");
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:36:16
+  --> tests/ui/unnecessary_path_debug_formatting.rs:37:16
    |
 LL |     println!("{path_buf:?}");
    |                ^^^^^^^^
@@ -55,7 +55,7 @@ LL |     println!("{path_buf:?}");
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `format!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:38:37
+  --> tests/ui/unnecessary_path_debug_formatting.rs:39:37
    |
 LL |     let _: String = format!("{:?}", path);
    |                                     ^^^^
@@ -64,7 +64,7 @@ LL |     let _: String = format!("{:?}", path);
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `format!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:39:37
+  --> tests/ui/unnecessary_path_debug_formatting.rs:40:37
    |
 LL |     let _: String = format!("{:?}", path_buf);
    |                                     ^^^^^^^^
@@ -73,7 +73,7 @@ LL |     let _: String = format!("{:?}", path_buf);
    = note: switching to `Display` formatting will change how the value is shown; escaped characters will no longer be escaped and surrounding quotes will be removed
 
 error: unnecessary `Debug` formatting in `println!` args
-  --> tests/ui/unnecessary_path_debug_formatting.rs:42:22
+  --> tests/ui/unnecessary_path_debug_formatting.rs:43:22
    |
 LL |     println!("{:?}", &*deref_path);
    |                      ^^^^^^^^^^^^

--- a/tests/ui/unnecessary_to_owned.fixed
+++ b/tests/ui/unnecessary_to_owned.fixed
@@ -7,7 +7,7 @@
     clippy::owned_cow
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]
-
+#![allow(clippy::uninlined_format_args)]
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::ops::Deref;

--- a/tests/ui/unnecessary_to_owned.fixed
+++ b/tests/ui/unnecessary_to_owned.fixed
@@ -1,13 +1,14 @@
 #![allow(
+    clippy::manual_async_fn,
     clippy::needless_borrow,
     clippy::needless_borrows_for_generic_args,
-    clippy::ptr_arg,
-    clippy::manual_async_fn,
     clippy::needless_lifetimes,
-    clippy::owned_cow
+    clippy::owned_cow,
+    clippy::ptr_arg,
+    clippy::uninlined_format_args
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]
-#![allow(clippy::uninlined_format_args)]
+
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::ops::Deref;

--- a/tests/ui/unnecessary_to_owned.rs
+++ b/tests/ui/unnecessary_to_owned.rs
@@ -7,7 +7,7 @@
     clippy::owned_cow
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]
-
+#![allow(clippy::uninlined_format_args)]
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::ops::Deref;

--- a/tests/ui/unnecessary_to_owned.rs
+++ b/tests/ui/unnecessary_to_owned.rs
@@ -4,7 +4,8 @@
     clippy::needless_borrows_for_generic_args,
     clippy::needless_lifetimes,
     clippy::owned_cow,
-    clippy::ptr_arg
+    clippy::ptr_arg,
+    clippy::uninlined_format_args
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]
 

--- a/tests/ui/unnecessary_to_owned.rs
+++ b/tests/ui/unnecessary_to_owned.rs
@@ -1,13 +1,13 @@
 #![allow(
+    clippy::manual_async_fn,
     clippy::needless_borrow,
     clippy::needless_borrows_for_generic_args,
-    clippy::ptr_arg,
-    clippy::manual_async_fn,
     clippy::needless_lifetimes,
-    clippy::owned_cow
+    clippy::owned_cow,
+    clippy::ptr_arg
 )]
 #![warn(clippy::unnecessary_to_owned, clippy::redundant_clone)]
-#![allow(clippy::uninlined_format_args)]
+
 use std::borrow::Cow;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::ops::Deref;

--- a/tests/ui/unnecessary_to_owned.stderr
+++ b/tests/ui/unnecessary_to_owned.stderr
@@ -1,11 +1,11 @@
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:217:64
+  --> tests/ui/unnecessary_to_owned.rs:218:64
    |
 LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned());
    |                                                                ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:217:20
+  --> tests/ui/unnecessary_to_owned.rs:218:20
    |
 LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,55 +13,55 @@ LL |     require_c_str(&CString::from_vec_with_nul(vec![0]).unwrap().to_owned())
    = help: to override `-D warnings` add `#[allow(clippy::redundant_clone)]`
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:219:40
+  --> tests/ui/unnecessary_to_owned.rs:220:40
    |
 LL |     require_os_str(&OsString::from("x").to_os_string());
    |                                        ^^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:219:21
+  --> tests/ui/unnecessary_to_owned.rs:220:21
    |
 LL |     require_os_str(&OsString::from("x").to_os_string());
    |                     ^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:221:48
+  --> tests/ui/unnecessary_to_owned.rs:222:48
    |
 LL |     require_path(&std::path::PathBuf::from("x").to_path_buf());
    |                                                ^^^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:221:19
+  --> tests/ui/unnecessary_to_owned.rs:222:19
    |
 LL |     require_path(&std::path::PathBuf::from("x").to_path_buf());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:223:35
+  --> tests/ui/unnecessary_to_owned.rs:224:35
    |
 LL |     require_str(&String::from("x").to_string());
    |                                   ^^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:223:18
+  --> tests/ui/unnecessary_to_owned.rs:224:18
    |
 LL |     require_str(&String::from("x").to_string());
    |                  ^^^^^^^^^^^^^^^^^
 
 error: redundant clone
-  --> tests/ui/unnecessary_to_owned.rs:225:39
+  --> tests/ui/unnecessary_to_owned.rs:226:39
    |
 LL |     require_slice(&[String::from("x")].to_owned());
    |                                       ^^^^^^^^^^^ help: remove this
    |
 note: this value is dropped without further use
-  --> tests/ui/unnecessary_to_owned.rs:225:20
+  --> tests/ui/unnecessary_to_owned.rs:226:20
    |
 LL |     require_slice(&[String::from("x")].to_owned());
    |                    ^^^^^^^^^^^^^^^^^^^
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:65:36
+  --> tests/ui/unnecessary_to_owned.rs:66:36
    |
 LL |     require_c_str(&Cow::from(c_str).into_owned());
    |                                    ^^^^^^^^^^^^^ help: remove this
@@ -70,391 +70,391 @@ LL |     require_c_str(&Cow::from(c_str).into_owned());
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_to_owned)]`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:67:19
+  --> tests/ui/unnecessary_to_owned.rs:68:19
    |
 LL |     require_c_str(&c_str.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_os_string`
-  --> tests/ui/unnecessary_to_owned.rs:70:20
+  --> tests/ui/unnecessary_to_owned.rs:71:20
    |
 LL |     require_os_str(&os_str.to_os_string());
    |                    ^^^^^^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:72:38
+  --> tests/ui/unnecessary_to_owned.rs:73:38
    |
 LL |     require_os_str(&Cow::from(os_str).into_owned());
    |                                      ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:74:20
+  --> tests/ui/unnecessary_to_owned.rs:75:20
    |
 LL |     require_os_str(&os_str.to_owned());
    |                    ^^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_path_buf`
-  --> tests/ui/unnecessary_to_owned.rs:77:18
+  --> tests/ui/unnecessary_to_owned.rs:78:18
    |
 LL |     require_path(&path.to_path_buf());
    |                  ^^^^^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:79:34
+  --> tests/ui/unnecessary_to_owned.rs:80:34
    |
 LL |     require_path(&Cow::from(path).into_owned());
    |                                  ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:81:18
+  --> tests/ui/unnecessary_to_owned.rs:82:18
    |
 LL |     require_path(&path.to_owned());
    |                  ^^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:84:17
+  --> tests/ui/unnecessary_to_owned.rs:85:17
    |
 LL |     require_str(&s.to_string());
    |                 ^^^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:86:30
+  --> tests/ui/unnecessary_to_owned.rs:87:30
    |
 LL |     require_str(&Cow::from(s).into_owned());
    |                              ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:88:17
+  --> tests/ui/unnecessary_to_owned.rs:89:17
    |
 LL |     require_str(&s.to_owned());
    |                 ^^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:90:17
+  --> tests/ui/unnecessary_to_owned.rs:91:17
    |
 LL |     require_str(&x_ref.to_string());
    |                 ^^^^^^^^^^^^^^^^^^ help: use: `x_ref.as_ref()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:93:19
+  --> tests/ui/unnecessary_to_owned.rs:94:19
    |
 LL |     require_slice(&slice.to_vec());
    |                   ^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:95:36
+  --> tests/ui/unnecessary_to_owned.rs:96:36
    |
 LL |     require_slice(&Cow::from(slice).into_owned());
    |                                    ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:97:19
+  --> tests/ui/unnecessary_to_owned.rs:98:19
    |
 LL |     require_slice(&array.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `array.as_ref()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:99:19
+  --> tests/ui/unnecessary_to_owned.rs:100:19
    |
 LL |     require_slice(&array_ref.to_owned());
    |                   ^^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref.as_ref()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:101:19
+  --> tests/ui/unnecessary_to_owned.rs:102:19
    |
 LL |     require_slice(&slice.to_owned());
    |                   ^^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `into_owned`
-  --> tests/ui/unnecessary_to_owned.rs:105:42
+  --> tests/ui/unnecessary_to_owned.rs:106:42
    |
 LL |     require_x(&Cow::<X>::Owned(x.clone()).into_owned());
    |                                          ^^^^^^^^^^^^^ help: remove this
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:109:25
+  --> tests/ui/unnecessary_to_owned.rs:110:25
    |
 LL |     require_deref_c_str(c_str.to_owned());
    |                         ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:111:26
+  --> tests/ui/unnecessary_to_owned.rs:112:26
    |
 LL |     require_deref_os_str(os_str.to_owned());
    |                          ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:113:24
+  --> tests/ui/unnecessary_to_owned.rs:114:24
    |
 LL |     require_deref_path(path.to_owned());
    |                        ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:115:23
+  --> tests/ui/unnecessary_to_owned.rs:116:23
    |
 LL |     require_deref_str(s.to_owned());
    |                       ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:117:25
+  --> tests/ui/unnecessary_to_owned.rs:118:25
    |
 LL |     require_deref_slice(slice.to_owned());
    |                         ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:120:30
+  --> tests/ui/unnecessary_to_owned.rs:121:30
    |
 LL |     require_impl_deref_c_str(c_str.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:122:31
+  --> tests/ui/unnecessary_to_owned.rs:123:31
    |
 LL |     require_impl_deref_os_str(os_str.to_owned());
    |                               ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:124:29
+  --> tests/ui/unnecessary_to_owned.rs:125:29
    |
 LL |     require_impl_deref_path(path.to_owned());
    |                             ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:126:28
+  --> tests/ui/unnecessary_to_owned.rs:127:28
    |
 LL |     require_impl_deref_str(s.to_owned());
    |                            ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:128:30
+  --> tests/ui/unnecessary_to_owned.rs:129:30
    |
 LL |     require_impl_deref_slice(slice.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:131:29
+  --> tests/ui/unnecessary_to_owned.rs:132:29
    |
 LL |     require_deref_str_slice(s.to_owned(), slice.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:131:43
+  --> tests/ui/unnecessary_to_owned.rs:132:43
    |
 LL |     require_deref_str_slice(s.to_owned(), slice.to_owned());
    |                                           ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:134:29
+  --> tests/ui/unnecessary_to_owned.rs:135:29
    |
 LL |     require_deref_slice_str(slice.to_owned(), s.to_owned());
    |                             ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:134:47
+  --> tests/ui/unnecessary_to_owned.rs:135:47
    |
 LL |     require_deref_slice_str(slice.to_owned(), s.to_owned());
    |                                               ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:138:26
+  --> tests/ui/unnecessary_to_owned.rs:139:26
    |
 LL |     require_as_ref_c_str(c_str.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:140:27
+  --> tests/ui/unnecessary_to_owned.rs:141:27
    |
 LL |     require_as_ref_os_str(os_str.to_owned());
    |                           ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:142:25
+  --> tests/ui/unnecessary_to_owned.rs:143:25
    |
 LL |     require_as_ref_path(path.to_owned());
    |                         ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:144:24
+  --> tests/ui/unnecessary_to_owned.rs:145:24
    |
 LL |     require_as_ref_str(s.to_owned());
    |                        ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:146:24
+  --> tests/ui/unnecessary_to_owned.rs:147:24
    |
 LL |     require_as_ref_str(x.to_owned());
    |                        ^^^^^^^^^^^^ help: use: `&x`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:148:26
+  --> tests/ui/unnecessary_to_owned.rs:149:26
    |
 LL |     require_as_ref_slice(array.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:150:26
+  --> tests/ui/unnecessary_to_owned.rs:151:26
    |
 LL |     require_as_ref_slice(array_ref.to_owned());
    |                          ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:152:26
+  --> tests/ui/unnecessary_to_owned.rs:153:26
    |
 LL |     require_as_ref_slice(slice.to_owned());
    |                          ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:155:31
+  --> tests/ui/unnecessary_to_owned.rs:156:31
    |
 LL |     require_impl_as_ref_c_str(c_str.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `c_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:157:32
+  --> tests/ui/unnecessary_to_owned.rs:158:32
    |
 LL |     require_impl_as_ref_os_str(os_str.to_owned());
    |                                ^^^^^^^^^^^^^^^^^ help: use: `os_str`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:159:30
+  --> tests/ui/unnecessary_to_owned.rs:160:30
    |
 LL |     require_impl_as_ref_path(path.to_owned());
    |                              ^^^^^^^^^^^^^^^ help: use: `path`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:161:29
+  --> tests/ui/unnecessary_to_owned.rs:162:29
    |
 LL |     require_impl_as_ref_str(s.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:163:29
+  --> tests/ui/unnecessary_to_owned.rs:164:29
    |
 LL |     require_impl_as_ref_str(x.to_owned());
    |                             ^^^^^^^^^^^^ help: use: `&x`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:165:31
+  --> tests/ui/unnecessary_to_owned.rs:166:31
    |
 LL |     require_impl_as_ref_slice(array.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:167:31
+  --> tests/ui/unnecessary_to_owned.rs:168:31
    |
 LL |     require_impl_as_ref_slice(array_ref.to_owned());
    |                               ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:169:31
+  --> tests/ui/unnecessary_to_owned.rs:170:31
    |
 LL |     require_impl_as_ref_slice(slice.to_owned());
    |                               ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:172:30
+  --> tests/ui/unnecessary_to_owned.rs:173:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:172:44
+  --> tests/ui/unnecessary_to_owned.rs:173:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array.to_owned());
    |                                            ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:175:30
+  --> tests/ui/unnecessary_to_owned.rs:176:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array_ref.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:175:44
+  --> tests/ui/unnecessary_to_owned.rs:176:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), array_ref.to_owned());
    |                                            ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:178:30
+  --> tests/ui/unnecessary_to_owned.rs:179:30
    |
 LL |     require_as_ref_str_slice(s.to_owned(), slice.to_owned());
    |                              ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:178:44
+  --> tests/ui/unnecessary_to_owned.rs:179:44
    |
 LL |     require_as_ref_str_slice(s.to_owned(), slice.to_owned());
    |                                            ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:181:30
+  --> tests/ui/unnecessary_to_owned.rs:182:30
    |
 LL |     require_as_ref_slice_str(array.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `array`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:181:48
+  --> tests/ui/unnecessary_to_owned.rs:182:48
    |
 LL |     require_as_ref_slice_str(array.to_owned(), s.to_owned());
    |                                                ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:184:30
+  --> tests/ui/unnecessary_to_owned.rs:185:30
    |
 LL |     require_as_ref_slice_str(array_ref.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^^^^^ help: use: `array_ref`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:184:52
+  --> tests/ui/unnecessary_to_owned.rs:185:52
    |
 LL |     require_as_ref_slice_str(array_ref.to_owned(), s.to_owned());
    |                                                    ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:187:30
+  --> tests/ui/unnecessary_to_owned.rs:188:30
    |
 LL |     require_as_ref_slice_str(slice.to_owned(), s.to_owned());
    |                              ^^^^^^^^^^^^^^^^ help: use: `slice`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:187:48
+  --> tests/ui/unnecessary_to_owned.rs:188:48
    |
 LL |     require_as_ref_slice_str(slice.to_owned(), s.to_owned());
    |                                                ^^^^^^^^^^^^ help: use: `s`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:191:20
+  --> tests/ui/unnecessary_to_owned.rs:192:20
    |
 LL |     let _ = x.join(&x_ref.to_string());
    |                    ^^^^^^^^^^^^^^^^^^ help: use: `x_ref`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:194:13
+  --> tests/ui/unnecessary_to_owned.rs:195:13
    |
 LL |     let _ = slice.to_vec().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:196:13
+  --> tests/ui/unnecessary_to_owned.rs:197:13
    |
 LL |     let _ = slice.to_owned().into_iter();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:199:13
+  --> tests/ui/unnecessary_to_owned.rs:200:13
    |
 LL |     let _ = IntoIterator::into_iter(slice.to_vec());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:201:13
+  --> tests/ui/unnecessary_to_owned.rs:202:13
    |
 LL |     let _ = IntoIterator::into_iter(slice.to_owned());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `slice.iter().copied()`
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:229:26
+  --> tests/ui/unnecessary_to_owned.rs:230:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(slice.to_vec()).expect("not UTF-8");
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(&slice).expect("not UTF-8");
    |
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:231:26
+  --> tests/ui/unnecessary_to_owned.rs:232:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(b"foo".to_vec()).unwrap();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(b"foo").unwrap();
    |
 
 error: allocating a new `String` only to create a temporary `&str` from it
-  --> tests/ui/unnecessary_to_owned.rs:233:26
+  --> tests/ui/unnecessary_to_owned.rs:234:26
    |
 LL |     let _ref_str: &str = &String::from_utf8(b"foo".as_slice().to_owned()).unwrap();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -490,7 +490,7 @@ LL +     let _ref_str: &str = core::str::from_utf8(b"foo".as_slice()).unwrap();
    |
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:291:14
+  --> tests/ui/unnecessary_to_owned.rs:292:14
    |
 LL |     for t in file_types.to_vec() {
    |              ^^^^^^^^^^^^^^^^^^^
@@ -503,49 +503,49 @@ LL ~         let path = match get_file_path(t) {
    |
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:357:24
+  --> tests/ui/unnecessary_to_owned.rs:358:24
    |
 LL |         Box::new(build(y.to_string()))
    |                        ^^^^^^^^^^^^^ help: use: `y`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:467:12
+  --> tests/ui/unnecessary_to_owned.rs:468:12
    |
 LL |         id("abc".to_string())
    |            ^^^^^^^^^^^^^^^^^ help: use: `"abc"`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:611:37
+  --> tests/ui/unnecessary_to_owned.rs:612:37
    |
 LL |         IntoFuture::into_future(foo([].to_vec(), &0));
    |                                     ^^^^^^^^^^^ help: use: `[]`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:622:18
+  --> tests/ui/unnecessary_to_owned.rs:623:18
    |
 LL |         s.remove(&a.to_vec());
    |                  ^^^^^^^^^^^ help: replace it with: `a`
 
 error: unnecessary use of `to_owned`
-  --> tests/ui/unnecessary_to_owned.rs:627:14
+  --> tests/ui/unnecessary_to_owned.rs:628:14
    |
 LL |     s.remove(&"b".to_owned());
    |              ^^^^^^^^^^^^^^^ help: replace it with: `"b"`
 
 error: unnecessary use of `to_string`
-  --> tests/ui/unnecessary_to_owned.rs:629:14
+  --> tests/ui/unnecessary_to_owned.rs:630:14
    |
 LL |     s.remove(&"b".to_string());
    |              ^^^^^^^^^^^^^^^^ help: replace it with: `"b"`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:635:14
+  --> tests/ui/unnecessary_to_owned.rs:636:14
    |
 LL |     s.remove(&["b"].to_vec());
    |              ^^^^^^^^^^^^^^^ help: replace it with: `["b"].as_slice()`
 
 error: unnecessary use of `to_vec`
-  --> tests/ui/unnecessary_to_owned.rs:637:14
+  --> tests/ui/unnecessary_to_owned.rs:638:14
    |
 LL |     s.remove(&(&["b"]).to_vec());
    |              ^^^^^^^^^^^^^^^^^^ help: replace it with: `(&["b"]).as_slice()`


### PR DESCRIPTION
The `uninlined_format_args` was temporarily downgraded to `pedantic` in part because rust-analyzer was not fully supporting it at the time, per #10087. The support has been added over [a year ago](https://github.com/rust-lang/rust-analyzer/issues/11260), so seems like this should be back to style.

Another source of the initial frustration was fixed since then as well - this lint does not trigger by default in case only some arguments can be inlined.

changelog: [`uninlined_format_args`]: move back to `style`