### PR TITLE
just_underscores_and_digits: fix false positive in error recovery scenario

### DIFF
--- a/clippy_dev/src/fmt.rs
+++ b/clippy_dev/src/fmt.rs
@@ -290,8 +290,13 @@ fn run_rustfmt(context: &FmtContext) -> Result<(), Error> {
         .filter_map(|entry| {
             let entry = entry.expect("failed to find tests");
             let path = entry.path();
-
-            if path.extension() != Some("rs".as_ref()) || entry.file_name() == "ice-3891.rs" {
+            if path.extension() != Some("rs".as_ref())
+                || path
+                    .components()
+                    .nth_back(1)
+                    .is_some_and(|c| c.as_os_str() == "syntax-error-recovery")
+                || entry.file_name() == "ice-3891.rs"
+            {
                 None
             } else {
                 Some(entry.into_path().into_os_string())

--- a/clippy_lints/src/non_expressive_names.rs
+++ b/clippy_lints/src/non_expressive_names.rs
@@ -208,7 +208,8 @@ impl SimilarNamesNameVisitor<'_, '_, '_> {
 
     fn check_ident(&mut self, ident: Ident) {
         let interned_name = ident.name.as_str();
-        if interned_name.chars().any(char::is_uppercase) {
+        // name can be empty if it comes from recovery
+        if interned_name.chars().any(char::is_uppercase) || interned_name.is_empty() {
             return;
         }
         if interned_name.chars().all(|c| c.is_ascii_digit() || c == '_') {

--- a/tests/ui/syntax-error-recovery/non_expressive_names_error_recovery.fixed
+++ b/tests/ui/syntax-error-recovery/non_expressive_names_error_recovery.fixed
@@ -1,0 +1,8 @@
+// https://github.com/rust-lang/rust-clippy/issues/12302
+use std::marker::PhantomData;
+
+pub struct Aa<T>(PhantomData<T>);
+
+fn aa(a: Aa<String>) {
+
+}

--- a/tests/ui/syntax-error-recovery/non_expressive_names_error_recovery.rs
+++ b/tests/ui/syntax-error-recovery/non_expressive_names_error_recovery.rs
@@ -1,0 +1,8 @@
+// https://github.com/rust-lang/rust-clippy/issues/12302
+use std::marker::PhantomData;
+
+pub struct Aa<T>(PhantomData<T>);
+
+fn aa(a: Aa<String) {
+
+}

--- a/tests/ui/syntax-error-recovery/non_expressive_names_error_recovery.stderr
+++ b/tests/ui/syntax-error-recovery/non_expressive_names_error_recovery.stderr
@@ -1,0 +1,13 @@
+error: expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `)`
+  --> tests/ui/syntax-error-recovery/non_expressive_names_error_recovery.rs:6:19
+   |
+LL | fn aa(a: Aa<String) {
+   |                   ^ expected one of 7 possible tokens
+   |
+help: you might have meant to end the type parameters here
+   |
+LL | fn aa(a: Aa<String>) {
+   |                   +
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #12302

changelog: [`just_underscores_and_digits`]: fix false positive in error recovery scenario
