### PR TITLE
remove "Known problems" section for `branches_sharing_code`

### DIFF
--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -129,11 +129,6 @@ declare_clippy_lint! {
     /// ### Why is this bad?
     /// Duplicate code is less maintainable.
     ///
-    /// ### Known problems
-    /// * The lint doesn't check if the moved expressions modify values that are being used in
-    ///   the if condition. The suggestion can in that case modify the behavior of the program.
-    ///   See [rust-clippy#7452](https://github.com/rust-lang/rust-clippy/issues/7452)
-    ///
     /// ### Example
     /// ```ignore
     /// let foo = if … {


### PR DESCRIPTION
This is outdated.

changelog: none
