### PR TITLE
Fix `let_and_return` with temporary variables, and distinguish between Rust editions

### DIFF
--- a/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
+++ b/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
@@ -199,7 +199,7 @@ impl<'a, 'tcx> SigDropChecker<'a, 'tcx> {
             return false;
         }
 
-        let result = match ty.kind() {
+        match ty.kind() {
             rustc_middle::ty::Adt(adt, args) => {
                 // if some field has significant drop,
                 adt.all_fields()
@@ -223,9 +223,7 @@ impl<'a, 'tcx> SigDropChecker<'a, 'tcx> {
             rustc_middle::ty::Tuple(tys) => tys.iter().any(|ty| self.has_sig_drop_attr_impl(ty)),
             rustc_middle::ty::Array(ty, _) | rustc_middle::ty::Slice(ty) => self.has_sig_drop_attr_impl(*ty),
             _ => false,
-        };
-
-        result
+        }
     }
 }
 

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -21,6 +21,7 @@ use rustc_middle::ty::adjustment::Adjust;
 use rustc_middle::ty::{self, GenericArgKind, Ty};
 use rustc_session::declare_lint_pass;
 use rustc_span::def_id::LocalDefId;
+use rustc_span::edition::Edition;
 use rustc_span::{BytePos, Pos, Span, sym};
 use std::borrow::Cow;
 use std::fmt::Display;
@@ -235,7 +236,7 @@ impl<'tcx> LateLintPass<'tcx> for Return {
             && let Some(initexpr) = &local.init
             && let PatKind::Binding(_, local_id, _, _) = local.pat.kind
             && path_to_local_id(retexpr, local_id)
-            && !last_statement_borrows(cx, initexpr)
+            && (cx.sess().edition() >= Edition::Edition2024 || !last_statement_borrows(cx, initexpr))
             && !initexpr.span.in_external_macro(cx.sess().source_map())
             && !retexpr.span.in_external_macro(cx.sess().source_map())
             && !local.span.from_expansion()

--- a/clippy_lints/src/returns.rs
+++ b/clippy_lints/src/returns.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
 use clippy_utils::source::{SpanRangeExt, snippet_with_context};
 use clippy_utils::sugg::has_enclosing_paren;
-use clippy_utils::visitors::{Descend, for_each_expr};
+use clippy_utils::visitors::for_each_expr;
 use clippy_utils::{
     binary_expr_needs_parentheses, fn_def_id, is_from_proc_macro, is_inside_let_else, is_res_lang_ctor,
     leaks_droppable_temporary_with_limited_lifetime, path_res, path_to_local_id, span_contains_cfg,
@@ -483,7 +483,7 @@ fn last_statement_borrows<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) 
         {
             ControlFlow::Break(())
         } else {
-            ControlFlow::Continue(Descend::from(!e.span.from_expansion()))
+            ControlFlow::Continue(())
         }
     })
     .is_some()

--- a/tests/ui/let_and_return.edition2021.fixed
+++ b/tests/ui/let_and_return.edition2021.fixed
@@ -9,16 +9,16 @@ use std::cell::RefCell;
 
 fn test() -> i32 {
     let _y = 0; // no warning
-    let x = 5;
-    x
+    
+    5
     //~^ ERROR: returning the result of a `let` binding from a block
     //~| NOTE: `-D clippy::let-and-return` implied by `-D warnings`
 }
 
 fn test_inner() -> i32 {
     if true {
-        let x = 5;
-        x
+        
+        5
         //~^ ERROR: returning the result of a `let` binding from a block
     } else {
         0
@@ -80,8 +80,8 @@ fn issue_3792() -> String {
     let stdin = io::stdin();
     // `Stdin::lock` returns `StdinLock<'static>` so `line` doesn't borrow from `stdin`
     // https://github.com/rust-lang/rust/pull/93965
-    let line = stdin.lock().lines().next().unwrap().unwrap();
-    line
+    
+    stdin.lock().lines().next().unwrap().unwrap()
     //~^ ERROR: returning the result of a `let` binding from a block
 }
 
@@ -175,8 +175,8 @@ mod issue_5729 {
 
     impl<T: Foo + 'static> FooStorage for FooStorageImpl<T> {
         fn foo_cloned(&self) -> Arc<dyn Foo> {
-            let clone = Arc::clone(&self.foo);
-            clone
+            
+            (Arc::clone(&self.foo)) as _
             //~^ ERROR: returning the result of a `let` binding from a block
         }
     }
@@ -190,12 +190,12 @@ mod issue_11335 {
 
     impl<T> E<T> {
         pub fn inner(&self) -> &T {
-            let result = match self {
+            
+
+            (match self {
                 E::A(x) => x,
                 E::B(x) => x,
-            };
-
-            result
+            }) as _
             //~^ ERROR: returning the result of a `let` binding from a block
         }
     }
@@ -220,33 +220,33 @@ fn issue9150() -> usize {
 
 fn issue12801() {
     fn left_is_if() -> String {
-        let s = if true { "a".to_string() } else { "b".to_string() } + "c";
-        s
+        
+        (if true { "a".to_string() } else { "b".to_string() } + "c")
         //~^ ERROR: returning the result of a `let` binding from a block
     }
 
     fn no_par_needed() -> String {
-        let s = "c".to_string() + if true { "a" } else { "b" };
-        s
+        
+        "c".to_string() + if true { "a" } else { "b" }
         //~^ ERROR: returning the result of a `let` binding from a block
     }
 
     fn conjunctive_blocks() -> String {
-        let s = { "a".to_string() } + "b" + { "c" } + "d";
-        s
+        
+        ({ "a".to_string() } + "b" + { "c" } + "d")
         //~^ ERROR: returning the result of a `let` binding from a block
     }
 
     #[allow(clippy::overly_complex_bool_expr)]
     fn other_ops() {
         let _ = || {
-            let s = if true { 2 } else { 3 } << 4;
-            s
+            
+            (if true { 2 } else { 3 } << 4)
             //~^ ERROR: returning the result of a `let` binding from a block
         };
         let _ = || {
-            let s = { true } || { false } && { 2 <= 3 };
-            s
+            
+            ({ true } || { false } && { 2 <= 3 })
             //~^ ERROR: returning the result of a `let` binding from a block
         };
     }

--- a/tests/ui/let_and_return.edition2021.stderr
+++ b/tests/ui/let_and_return.edition2021.stderr
@@ -1,0 +1,152 @@
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:13:5
+   |
+LL |     let x = 5;
+   |     ---------- unnecessary `let` binding
+LL |     x
+   |     ^
+   |
+   = note: `-D clippy::let-and-return` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::let_and_return)]`
+help: return the expression directly
+   |
+LL ~     
+LL ~     5
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:21:9
+   |
+LL |         let x = 5;
+   |         ---------- unnecessary `let` binding
+LL |         x
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         5
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:84:5
+   |
+LL |     let line = stdin.lock().lines().next().unwrap().unwrap();
+   |     --------------------------------------------------------- unnecessary `let` binding
+LL |     line
+   |     ^^^^
+   |
+help: return the expression directly
+   |
+LL ~     
+LL ~     stdin.lock().lines().next().unwrap().unwrap()
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:179:13
+   |
+LL |             let clone = Arc::clone(&self.foo);
+   |             ---------------------------------- unnecessary `let` binding
+LL |             clone
+   |             ^^^^^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             (Arc::clone(&self.foo)) as _
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:198:13
+   |
+LL | /             let result = match self {
+LL | |                 E::A(x) => x,
+LL | |                 E::B(x) => x,
+LL | |             };
+   | |______________- unnecessary `let` binding
+LL |
+LL |               result
+   |               ^^^^^^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL |
+LL ~             (match self {
+LL +                 E::A(x) => x,
+LL +                 E::B(x) => x,
+LL +             }) as _
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:224:9
+   |
+LL |         let s = if true { "a".to_string() } else { "b".to_string() } + "c";
+   |         ------------------------------------------------------------------- unnecessary `let` binding
+LL |         s
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         (if true { "a".to_string() } else { "b".to_string() } + "c")
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:230:9
+   |
+LL |         let s = "c".to_string() + if true { "a" } else { "b" };
+   |         ------------------------------------------------------- unnecessary `let` binding
+LL |         s
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         "c".to_string() + if true { "a" } else { "b" }
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:236:9
+   |
+LL |         let s = { "a".to_string() } + "b" + { "c" } + "d";
+   |         -------------------------------------------------- unnecessary `let` binding
+LL |         s
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         ({ "a".to_string() } + "b" + { "c" } + "d")
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:244:13
+   |
+LL |             let s = if true { 2 } else { 3 } << 4;
+   |             -------------------------------------- unnecessary `let` binding
+LL |             s
+   |             ^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             (if true { 2 } else { 3 } << 4)
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:249:13
+   |
+LL |             let s = { true } || { false } && { 2 <= 3 };
+   |             -------------------------------------------- unnecessary `let` binding
+LL |             s
+   |             ^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             ({ true } || { false } && { 2 <= 3 })
+   |
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/let_and_return.edition2024.fixed
+++ b/tests/ui/let_and_return.edition2024.fixed
@@ -9,16 +9,16 @@ use std::cell::RefCell;
 
 fn test() -> i32 {
     let _y = 0; // no warning
-    let x = 5;
-    x
+    
+    5
     //~^ ERROR: returning the result of a `let` binding from a block
     //~| NOTE: `-D clippy::let-and-return` implied by `-D warnings`
 }
 
 fn test_inner() -> i32 {
     if true {
-        let x = 5;
-        x
+        
+        5
         //~^ ERROR: returning the result of a `let` binding from a block
     } else {
         0
@@ -80,8 +80,8 @@ fn issue_3792() -> String {
     let stdin = io::stdin();
     // `Stdin::lock` returns `StdinLock<'static>` so `line` doesn't borrow from `stdin`
     // https://github.com/rust-lang/rust/pull/93965
-    let line = stdin.lock().lines().next().unwrap().unwrap();
-    line
+    
+    stdin.lock().lines().next().unwrap().unwrap()
     //~^ ERROR: returning the result of a `let` binding from a block
 }
 
@@ -103,8 +103,8 @@ mod no_lint_if_stmt_borrows {
 
     fn issue_3324(value: Weak<RefCell<Bar>>) -> u32 {
         let value = value.upgrade().unwrap();
-        let ret = value.borrow().baz();
-        ret
+        
+        value.borrow().baz()
         //~[edition2024]^ ERROR: returning the result of a `let` binding from a block
     }
 
@@ -114,8 +114,8 @@ mod no_lint_if_stmt_borrows {
         }
 
         let value = value.upgrade().unwrap();
-        let ret = f(|| value.borrow().baz())();
-        ret
+        
+        f(|| value.borrow().baz())()
         //~[edition2024]^ ERROR: returning the result of a `let` binding from a block
     }
 
@@ -146,15 +146,15 @@ mod no_lint_if_stmt_borrows {
 
         fn test() -> i32 {
             let x = Inner {};
-            let value = some_foo(&x).value();
-            value
+            
+            some_foo(&x).value()
             //~[edition2024]^ ERROR: returning the result of a `let` binding from a block
         }
 
         fn test2() -> i32 {
             let x = Inner {};
-            let value = Foo::new(&x).value();
-            value
+            
+            Foo::new(&x).value()
             //~[edition2024]^ ERROR: returning the result of a `let` binding from a block
         }
     }
@@ -175,8 +175,8 @@ mod issue_5729 {
 
     impl<T: Foo + 'static> FooStorage for FooStorageImpl<T> {
         fn foo_cloned(&self) -> Arc<dyn Foo> {
-            let clone = Arc::clone(&self.foo);
-            clone
+            
+            (Arc::clone(&self.foo)) as _
             //~^ ERROR: returning the result of a `let` binding from a block
         }
     }
@@ -190,12 +190,12 @@ mod issue_11335 {
 
     impl<T> E<T> {
         pub fn inner(&self) -> &T {
-            let result = match self {
+            
+
+            (match self {
                 E::A(x) => x,
                 E::B(x) => x,
-            };
-
-            result
+            }) as _
             //~^ ERROR: returning the result of a `let` binding from a block
         }
     }
@@ -220,33 +220,33 @@ fn issue9150() -> usize {
 
 fn issue12801() {
     fn left_is_if() -> String {
-        let s = if true { "a".to_string() } else { "b".to_string() } + "c";
-        s
+        
+        (if true { "a".to_string() } else { "b".to_string() } + "c")
         //~^ ERROR: returning the result of a `let` binding from a block
     }
 
     fn no_par_needed() -> String {
-        let s = "c".to_string() + if true { "a" } else { "b" };
-        s
+        
+        "c".to_string() + if true { "a" } else { "b" }
         //~^ ERROR: returning the result of a `let` binding from a block
     }
 
     fn conjunctive_blocks() -> String {
-        let s = { "a".to_string() } + "b" + { "c" } + "d";
-        s
+        
+        ({ "a".to_string() } + "b" + { "c" } + "d")
         //~^ ERROR: returning the result of a `let` binding from a block
     }
 
     #[allow(clippy::overly_complex_bool_expr)]
     fn other_ops() {
         let _ = || {
-            let s = if true { 2 } else { 3 } << 4;
-            s
+            
+            (if true { 2 } else { 3 } << 4)
             //~^ ERROR: returning the result of a `let` binding from a block
         };
         let _ = || {
-            let s = { true } || { false } && { 2 <= 3 };
-            s
+            
+            ({ true } || { false } && { 2 <= 3 })
             //~^ ERROR: returning the result of a `let` binding from a block
         };
     }
@@ -254,11 +254,11 @@ fn issue12801() {
 
 fn issue14164() -> Result<u32, ()> {
     let v = std::cell::RefCell::new(Some(vec![1]));
-    let r = match &*v.borrow() {
+    
+    match &*v.borrow() {
         Some(v) => Ok(Ok(v[0])),
         None => Ok(Ok(0)),
-    }?;
-    r
+    }?
     //~[edition2024]^ ERROR: returning the result of a `let` binding from a block
 }
 

--- a/tests/ui/let_and_return.edition2024.stderr
+++ b/tests/ui/let_and_return.edition2024.stderr
@@ -1,0 +1,228 @@
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:13:5
+   |
+LL |     let x = 5;
+   |     ---------- unnecessary `let` binding
+LL |     x
+   |     ^
+   |
+   = note: `-D clippy::let-and-return` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::let_and_return)]`
+help: return the expression directly
+   |
+LL ~     
+LL ~     5
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:21:9
+   |
+LL |         let x = 5;
+   |         ---------- unnecessary `let` binding
+LL |         x
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         5
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:84:5
+   |
+LL |     let line = stdin.lock().lines().next().unwrap().unwrap();
+   |     --------------------------------------------------------- unnecessary `let` binding
+LL |     line
+   |     ^^^^
+   |
+help: return the expression directly
+   |
+LL ~     
+LL ~     stdin.lock().lines().next().unwrap().unwrap()
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:107:9
+   |
+LL |         let ret = value.borrow().baz();
+   |         ------------------------------- unnecessary `let` binding
+LL |         ret
+   |         ^^^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         value.borrow().baz()
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:118:9
+   |
+LL |         let ret = f(|| value.borrow().baz())();
+   |         --------------------------------------- unnecessary `let` binding
+LL |         ret
+   |         ^^^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         f(|| value.borrow().baz())()
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:150:13
+   |
+LL |             let value = some_foo(&x).value();
+   |             --------------------------------- unnecessary `let` binding
+LL |             value
+   |             ^^^^^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             some_foo(&x).value()
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:157:13
+   |
+LL |             let value = Foo::new(&x).value();
+   |             --------------------------------- unnecessary `let` binding
+LL |             value
+   |             ^^^^^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             Foo::new(&x).value()
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:179:13
+   |
+LL |             let clone = Arc::clone(&self.foo);
+   |             ---------------------------------- unnecessary `let` binding
+LL |             clone
+   |             ^^^^^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             (Arc::clone(&self.foo)) as _
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:198:13
+   |
+LL | /             let result = match self {
+LL | |                 E::A(x) => x,
+LL | |                 E::B(x) => x,
+LL | |             };
+   | |______________- unnecessary `let` binding
+LL |
+LL |               result
+   |               ^^^^^^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL |
+LL ~             (match self {
+LL +                 E::A(x) => x,
+LL +                 E::B(x) => x,
+LL +             }) as _
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:224:9
+   |
+LL |         let s = if true { "a".to_string() } else { "b".to_string() } + "c";
+   |         ------------------------------------------------------------------- unnecessary `let` binding
+LL |         s
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         (if true { "a".to_string() } else { "b".to_string() } + "c")
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:230:9
+   |
+LL |         let s = "c".to_string() + if true { "a" } else { "b" };
+   |         ------------------------------------------------------- unnecessary `let` binding
+LL |         s
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         "c".to_string() + if true { "a" } else { "b" }
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:236:9
+   |
+LL |         let s = { "a".to_string() } + "b" + { "c" } + "d";
+   |         -------------------------------------------------- unnecessary `let` binding
+LL |         s
+   |         ^
+   |
+help: return the expression directly
+   |
+LL ~         
+LL ~         ({ "a".to_string() } + "b" + { "c" } + "d")
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:244:13
+   |
+LL |             let s = if true { 2 } else { 3 } << 4;
+   |             -------------------------------------- unnecessary `let` binding
+LL |             s
+   |             ^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             (if true { 2 } else { 3 } << 4)
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:249:13
+   |
+LL |             let s = { true } || { false } && { 2 <= 3 };
+   |             -------------------------------------------- unnecessary `let` binding
+LL |             s
+   |             ^
+   |
+help: return the expression directly
+   |
+LL ~             
+LL ~             ({ true } || { false } && { 2 <= 3 })
+   |
+
+error: returning the result of a `let` binding from a block
+  --> tests/ui/let_and_return.rs:261:5
+   |
+LL | /     let r = match &*v.borrow() {
+LL | |         Some(v) => Ok(Ok(v[0])),
+LL | |         None => Ok(Ok(0)),
+LL | |     }?;
+   | |_______- unnecessary `let` binding
+LL |       r
+   |       ^
+   |
+help: return the expression directly
+   |
+LL ~     
+LL ~     match &*v.borrow() {
+LL +         Some(v) => Ok(Ok(v[0])),
+LL +         None => Ok(Ok(0)),
+LL +     }?
+   |
+
+error: aborting due to 15 previous errors
+

--- a/tests/ui/let_and_return.fixed
+++ b/tests/ui/let_and_return.fixed
@@ -244,4 +244,14 @@ fn issue12801() {
     }
 }
 
+// Do not lint
+fn issue14164() -> Result<u32, ()> {
+    let v = std::cell::RefCell::new(Some(vec![1]));
+    let r = match &*v.borrow() {
+        Some(v) => Ok(Ok(v[0])),
+        None => Ok(Ok(0)),
+    }?;
+    r
+}
+
 fn main() {}

--- a/tests/ui/let_and_return.rs
+++ b/tests/ui/let_and_return.rs
@@ -244,4 +244,14 @@ fn issue12801() {
     }
 }
 
+// Do not lint
+fn issue14164() -> Result<u32, ()> {
+    let v = std::cell::RefCell::new(Some(vec![1]));
+    let r = match &*v.borrow() {
+        Some(v) => Ok(Ok(v[0])),
+        None => Ok(Ok(0)),
+    }?;
+    r
+}
+
 fn main() {}


### PR DESCRIPTION
The first commit fixes #14164 by making sure that temporaries with non-static references are also looked for in expressions coming from expansion. The shortcut that was done skipped those parts and reported an absence of short-lived temporaries, which was incorrect.

The second commit distinguishes between edition 2024 and earlier ones. Starting from edition 2024, the problematic drop order has been fixed, and block variables, which might be referenced in a block expression, are freed after the block expression itself. This allows more `let_and_return` cases to be reported starting with edition 2024, whereas in earlier editions an intermediary variable was necessary to reorder the drops.

Incidentally, since Clippy is compiled in edition 2024 mode, the second commit has led to a fix in `clippy_lints/src/matches/significant_drop_in_scrutinee.rs`.

changelog: [`let_and_return`]: lint more cases in edition 2024, and fix a false positive involving short-lived block temporary variables in earlier editions.