### PR TITLE
correct "Affected lints" for `allow-one-hash-in-raw-strings`

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -108,7 +108,7 @@ Whether to allow `r#""#` when `r""` can be used
 
 ---
 **Affected lints:**
-* [`unnecessary_raw_string_hashes`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_raw_string_hashes)
+* [`needless_raw_string_hashes`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes)
 
 
 ## `allow-panic-in-tests`

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -298,7 +298,7 @@ define_Conf! {
     #[lints(uninlined_format_args)]
     allow_mixed_uninlined_format_args: bool = true,
     /// Whether to allow `r#""#` when `r""` can be used
-    #[lints(unnecessary_raw_string_hashes)]
+    #[lints(needless_raw_string_hashes)]
     allow_one_hash_in_raw_strings: bool = false,
     /// Whether `panic` should be allowed in test functions or `#[cfg(test)]`
     #[lints(panic)]


### PR DESCRIPTION
The `needless_raw_string_hashes` lint was implemented in #10884. However, the name originally considered might have been `unnecessary_raw_string_hashes`, so this part refers to a non-existent lint.

r? flip1995

changelog: none
