### PR TITLE
add index checks for the slice in `manual_slice_fill`

### DIFF
--- a/tests/ui/manual_slice_fill.fixed
+++ b/tests/ui/manual_slice_fill.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_slice_fill)]
-#![allow(clippy::needless_range_loop)]
+#![allow(clippy::needless_range_loop, clippy::useless_vec)]
 
 macro_rules! assign_element {
     ($slice:ident, $index:expr) => {
@@ -97,5 +97,21 @@ fn should_not_lint() {
     // Should not lint because `NoClone` does not have `Clone` trait.
     for i in &mut vec {
         *i = None;
+    }
+}
+
+fn issue_14192() {
+    let mut tmp = vec![0; 3];
+
+    for i in 0..tmp.len() {
+        tmp[i] = i;
+    }
+
+    for i in 0..tmp.len() {
+        tmp[i] = 2 + i;
+    }
+
+    for i in 0..tmp.len() {
+        tmp[0] = i;
     }
 }

--- a/tests/ui/manual_slice_fill.rs
+++ b/tests/ui/manual_slice_fill.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::manual_slice_fill)]
-#![allow(clippy::needless_range_loop)]
+#![allow(clippy::needless_range_loop, clippy::useless_vec)]
 
 macro_rules! assign_element {
     ($slice:ident, $index:expr) => {
@@ -106,5 +106,21 @@ fn should_not_lint() {
     // Should not lint because `NoClone` does not have `Clone` trait.
     for i in &mut vec {
         *i = None;
+    }
+}
+
+fn issue_14192() {
+    let mut tmp = vec![0; 3];
+
+    for i in 0..tmp.len() {
+        tmp[i] = i;
+    }
+
+    for i in 0..tmp.len() {
+        tmp[i] = 2 + i;
+    }
+
+    for i in 0..tmp.len() {
+        tmp[0] = i;
     }
 }


### PR DESCRIPTION
fix #14192 

changelog: [`manual_slice_fill`]: resolve FP caused by missing index checks for the slice