### PR TITLE
[WIP] add format trailing comma linter skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5617,6 +5617,7 @@ Released 2018-09-13
 [`format_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#format_collect
 [`format_in_format_args`]: https://rust-lang.github.io/rust-clippy/master/index.html#format_in_format_args
 [`format_push_string`]: https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
+[`format_trailing_macro_comma`]: https://rust-lang.github.io/rust-clippy/master/index.html#format_trailing_macro_comma
 [`four_forward_slashes`]: https://rust-lang.github.io/rust-clippy/master/index.html#four_forward_slashes
 [`from_iter_instead_of_collect`]: https://rust-lang.github.io/rust-clippy/master/index.html#from_iter_instead_of_collect
 [`from_over_into`]: https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -196,6 +196,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::format_impl::PRINT_IN_FORMAT_IMPL_INFO,
     crate::format_impl::RECURSIVE_FORMAT_IMPL_INFO,
     crate::format_push_string::FORMAT_PUSH_STRING_INFO,
+    crate::format_trailing_macro_comma::FORMAT_TRAILING_MACRO_COMMA_INFO,
     crate::formatting::POSSIBLE_MISSING_COMMA_INFO,
     crate::formatting::SUSPICIOUS_ASSIGNMENT_FORMATTING_INFO,
     crate::formatting::SUSPICIOUS_ELSE_FORMATTING_INFO,

--- a/clippy_lints/src/format_trailing_macro_comma.rs
+++ b/clippy_lints/src/format_trailing_macro_comma.rs
@@ -1,0 +1,26 @@
+use rustc_ast::ast::*;
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// ### Why is this bad?
+    ///
+    /// ### Example
+    /// ```no_run
+    /// // example code where clippy issues a warning
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// // example code which does not raise clippy warning
+    /// ```
+    #[clippy::version = "1.86.0"]
+    pub FORMAT_TRAILING_MACRO_COMMA,
+    style,
+    "default lint description"
+}
+
+declare_lint_pass!(FormatTrailingMacroComma => [FORMAT_TRAILING_MACRO_COMMA]);
+
+impl EarlyLintPass for FormatTrailingMacroComma {}

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -148,6 +148,7 @@ mod format;
 mod format_args;
 mod format_impl;
 mod format_push_string;
+mod format_trailing_macro_comma;
 mod formatting;
 mod four_forward_slashes;
 mod from_over_into;
@@ -980,5 +981,6 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(move |_| Box::new(non_std_lazy_statics::NonStdLazyStatic::new(conf)));
     store.register_late_pass(|_| Box::new(manual_option_as_slice::ManualOptionAsSlice::new(conf)));
     store.register_late_pass(|_| Box::new(single_option_map::SingleOptionMap));
+    store.register_early_pass(|| Box::new(format_trailing_macro_comma::FormatTrailingMacroComma));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/tests/ui/format_trailing_macro_comma.rs
+++ b/tests/ui/format_trailing_macro_comma.rs
@@ -1,0 +1,5 @@
+#![warn(clippy::format_trailing_macro_comma)]
+
+fn main() {
+    // test code goes here
+}


### PR DESCRIPTION
close #13965 

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
