### PR TITLE
Fix `used_underscore_items` lint uses of foreign functions

### DIFF
--- a/clippy_lints/src/misc.rs
+++ b/clippy_lints/src/misc.rs
@@ -7,7 +7,6 @@ use clippy_utils::{
 };
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
-use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{
     BinOpKind, BindingMode, Body, ByRef, Expr, ExprKind, FnDecl, Mutability, PatKind, QPath, Stmt, StmtKind,
@@ -287,7 +286,8 @@ fn used_underscore_items<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
     if name.starts_with('_')
         && !name.starts_with("__")
         && !definition_span.from_expansion()
-        && def_id.krate == LOCAL_CRATE
+        && def_id.is_local()
+        && !cx.tcx.is_foreign_item(def_id)
     {
         span_lint_and_then(
             cx,

--- a/tests/ui/used_underscore_items.rs
+++ b/tests/ui/used_underscore_items.rs
@@ -61,3 +61,13 @@ fn external_item_call() {
 
     external_item::_exernal_foo();
 }
+
+// should not lint foreign functions.
+// issue #14156
+extern "C" {
+    pub fn _exit(code: i32) -> !;
+}
+
+fn _f() {
+    unsafe { _exit(1) }
+}


### PR DESCRIPTION
Fixed #14156

changelog: none
