### PR TITLE
better suggestions for `match_on_vec_items`

### DIFF
--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -784,6 +784,7 @@ The minimum rust version that the project supports. Defaults to the `rust-versio
 * [`map_unwrap_or`](https://rust-lang.github.io/rust-clippy/master/index.html#map_unwrap_or)
 * [`map_with_unused_argument_over_ranges`](https://rust-lang.github.io/rust-clippy/master/index.html#map_with_unused_argument_over_ranges)
 * [`match_like_matches_macro`](https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro)
+* [`match_on_vec_items`](https://rust-lang.github.io/rust-clippy/master/index.html#match_on_vec_items)
 * [`mem_replace_option_with_some`](https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_option_with_some)
 * [`mem_replace_with_default`](https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default)
 * [`missing_const_for_fn`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_const_for_fn)

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -639,6 +639,7 @@ define_Conf! {
         map_unwrap_or,
         map_with_unused_argument_over_ranges,
         match_like_matches_macro,
+        match_on_vec_items,
         mem_replace_option_with_some,
         mem_replace_with_default,
         missing_const_for_fn,

--- a/clippy_lints/src/matches/match_on_vec_items.rs
+++ b/clippy_lints/src/matches/match_on_vec_items.rs
@@ -1,27 +1,66 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
-use clippy_utils::source::snippet;
+use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::is_wild;
+use clippy_utils::msrvs::{self, Msrv};
+use clippy_utils::source::{indent_of, snippet, snippet_with_applicability};
 use clippy_utils::ty::{is_type_diagnostic_item, is_type_lang_item};
 use rustc_errors::Applicability;
-use rustc_hir::{Expr, ExprKind, LangItem};
+use rustc_hir::{Arm, Expr, ExprKind, LangItem};
 use rustc_lint::LateContext;
-use rustc_span::sym;
+use rustc_span::{Span, sym};
 
 use super::MATCH_ON_VEC_ITEMS;
 
-pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, scrutinee: &'tcx Expr<'_>) {
+pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, scrutinee: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>], msrv: &Msrv) {
     if let Some(idx_expr) = is_vec_indexing(cx, scrutinee)
         && let ExprKind::Index(vec, idx, _) = idx_expr.kind
     {
-        // FIXME: could be improved to suggest surrounding every pattern with Some(_),
-        // but only when `or_patterns` are stabilized.
-        span_lint_and_sugg(
+        span_lint_and_then(
             cx,
             MATCH_ON_VEC_ITEMS,
             scrutinee.span,
             "indexing into a vector may panic",
-            "try",
-            format!("{}.get({})", snippet(cx, vec.span, ".."), snippet(cx, idx.span, "..")),
-            Applicability::MaybeIncorrect,
+            |diag| {
+                if msrv.meets(msrvs::OR_PATTERNS) {
+                    let mut app = Applicability::MachineApplicable;
+                    let mut suggestions: Vec<(Span, String)> = vec![(
+                        scrutinee.span,
+                        format!(
+                            "{}.get({})",
+                            snippet_with_applicability(cx, vec.span, "_", &mut app),
+                            snippet_with_applicability(cx, idx.span, "_", &mut app)
+                        ),
+                    )];
+
+                    let mut is_wildcard_exist = false;
+                    for arm in arms {
+                        let pat = arm.pat;
+                        if is_wild(pat) {
+                            is_wildcard_exist = true;
+                            continue;
+                        }
+                        let pat_str = snippet_with_applicability(cx, pat.span, "_", &mut app);
+                        let suggestion = format!("Some({pat_str})");
+                        suggestions.push((pat.span, suggestion));
+                    }
+
+                    if !is_wildcard_exist && let Some(last_arm) = arms.last() {
+                        let indent_variant = indent_of(cx, last_arm.span).unwrap_or(0);
+                        suggestions.push((
+                            last_arm.span.shrink_to_hi(),
+                            format!("\n{}None => {{}}", " ".repeat(indent_variant)).to_string(),
+                        ));
+                    }
+
+                    diag.multipart_suggestion("try", suggestions, app);
+                } else {
+                    diag.span_suggestion(
+                        scrutinee.span,
+                        "try",
+                        format!("{}.get({})", snippet(cx, vec.span, ".."), snippet(cx, idx.span, "..")),
+                        Applicability::Unspecified,
+                    );
+                }
+            },
         );
     }
 }

--- a/clippy_lints/src/matches/mod.rs
+++ b/clippy_lints/src/matches/mod.rs
@@ -1118,7 +1118,7 @@ impl<'tcx> LateLintPass<'tcx> for Matches {
                     match_wild_enum::check(cx, ex, arms);
                     match_as_ref::check(cx, ex, arms, expr);
                     needless_match::check_match(cx, ex, arms, expr);
-                    match_on_vec_items::check(cx, ex);
+                    match_on_vec_items::check(cx, ex, arms, &self.msrv);
                     match_str_case_mismatch::check(cx, ex, arms);
                     redundant_guards::check(cx, arms, &self.msrv);
 

--- a/tests/ui/match_on_vec_items.fixed
+++ b/tests/ui/match_on_vec_items.fixed
@@ -7,19 +7,19 @@ fn match_with_wildcard() {
     let idx = 1;
 
     // Lint, may panic
-    match arr[idx] {
+    match arr.get(idx) {
         //~^ ERROR: indexing into a vector may panic
         //~| NOTE: `-D clippy::match-on-vec-items` implied by `-D warnings`
-        0 => println!("0"),
-        1 => println!("1"),
+        Some(0) => println!("0"),
+        Some(1) => println!("1"),
         _ => {},
     }
 
     // Lint, may panic
-    match arr[range] {
+    match arr.get(range) {
         //~^ ERROR: indexing into a vector may panic
-        [0, 1] => println!("0 1"),
-        [1, 2] => println!("1 2"),
+        Some([0, 1]) => println!("0 1"),
+        Some([1, 2]) => println!("1 2"),
         _ => {},
     }
 }
@@ -30,19 +30,21 @@ fn match_without_wildcard() {
     let idx = 2;
 
     // Lint, may panic
-    match arr[idx] {
+    match arr.get(idx) {
         //~^ ERROR: indexing into a vector may panic
-        0 => println!("0"),
-        1 => println!("1"),
-        num => {},
+        Some(0) => println!("0"),
+        Some(1) => println!("1"),
+        Some(num) => {}
+        None => {},
     }
 
     // Lint, may panic
-    match arr[range] {
+    match arr.get(range) {
         //~^ ERROR: indexing into a vector may panic
-        [0, 1] => println!("0 1"),
-        [1, 2] => println!("1 2"),
-        [ref sub @ ..] => {},
+        Some([0, 1]) => println!("0 1"),
+        Some([1, 2]) => println!("1 2"),
+        Some([ref sub @ ..]) => {}
+        None => {},
     }
 }
 
@@ -52,18 +54,18 @@ fn match_wildcard_and_action() {
     let idx = 3;
 
     // Lint, may panic
-    match arr[idx] {
+    match arr.get(idx) {
         //~^ ERROR: indexing into a vector may panic
-        0 => println!("0"),
-        1 => println!("1"),
+        Some(0) => println!("0"),
+        Some(1) => println!("1"),
         _ => println!("Hello, World!"),
     }
 
     // Lint, may panic
-    match arr[range] {
+    match arr.get(range) {
         //~^ ERROR: indexing into a vector may panic
-        [0, 1] => println!("0 1"),
-        [1, 2] => println!("1 2"),
+        Some([0, 1]) => println!("0 1"),
+        Some([1, 2]) => println!("1 2"),
         _ => println!("Hello, World!"),
     }
 }
@@ -74,18 +76,18 @@ fn match_vec_ref() {
     let idx = 3;
 
     // Lint, may panic
-    match arr[idx] {
+    match arr.get(idx) {
         //~^ ERROR: indexing into a vector may panic
-        0 => println!("0"),
-        1 => println!("1"),
+        Some(0) => println!("0"),
+        Some(1) => println!("1"),
         _ => {},
     }
 
     // Lint, may panic
-    match arr[range] {
+    match arr.get(range) {
         //~^ ERROR: indexing into a vector may panic
-        [0, 1] => println!("0 1"),
-        [1, 2] => println!("1 2"),
+        Some([0, 1]) => println!("0 1"),
+        Some([1, 2]) => println!("1 2"),
         _ => {},
     }
 }
@@ -153,9 +155,9 @@ fn match_with_endless_range() {
 
 fn or_patterns() {
     let arr = vec![0, 1, 2, 3];
-    match arr[1] {
+    match arr.get(1) {
         //~^ ERROR: indexing into a vector may panic
-        0 | 1 => println!("0 or 1"),
+        Some(0 | 1) => println!("0 or 1"),
         _ => println!("Hello, World!"),
     }
 }

--- a/tests/ui/match_on_vec_items.stderr
+++ b/tests/ui/match_on_vec_items.stderr
@@ -2,52 +2,133 @@ error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:10:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try: `arr.get(idx)`
+   |           ^^^^^^^^
    |
    = note: `-D clippy::match-on-vec-items` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_on_vec_items)]`
+help: try
+   |
+LL ~     match arr.get(idx) {
+LL |
+LL |
+LL ~         Some(0) => println!("0"),
+LL ~         Some(1) => println!("1"),
+   |
 
 error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:19:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try: `arr.get(range)`
+   |           ^^^^^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(range) {
+LL |
+LL ~         Some([0, 1]) => println!("0 1"),
+LL ~         Some([1, 2]) => println!("1 2"),
+   |
 
 error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:33:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try: `arr.get(idx)`
+   |           ^^^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(idx) {
+LL |
+LL ~         Some(0) => println!("0"),
+LL ~         Some(1) => println!("1"),
+LL ~         Some(num) => {}
+LL ~         None => {},
+   |
 
 error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:41:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try: `arr.get(range)`
+   |           ^^^^^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(range) {
+LL |
+LL ~         Some([0, 1]) => println!("0 1"),
+LL ~         Some([1, 2]) => println!("1 2"),
+LL ~         Some([ref sub @ ..]) => {}
+LL ~         None => {},
+   |
 
 error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:55:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try: `arr.get(idx)`
+   |           ^^^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(idx) {
+LL |
+LL ~         Some(0) => println!("0"),
+LL ~         Some(1) => println!("1"),
+   |
 
 error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:63:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try: `arr.get(range)`
+   |           ^^^^^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(range) {
+LL |
+LL ~         Some([0, 1]) => println!("0 1"),
+LL ~         Some([1, 2]) => println!("1 2"),
+   |
 
 error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:77:11
    |
 LL |     match arr[idx] {
-   |           ^^^^^^^^ help: try: `arr.get(idx)`
+   |           ^^^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(idx) {
+LL |
+LL ~         Some(0) => println!("0"),
+LL ~         Some(1) => println!("1"),
+   |
 
 error: indexing into a vector may panic
   --> tests/ui/match_on_vec_items.rs:85:11
    |
 LL |     match arr[range] {
-   |           ^^^^^^^^^^ help: try: `arr.get(range)`
+   |           ^^^^^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(range) {
+LL |
+LL ~         Some([0, 1]) => println!("0 1"),
+LL ~         Some([1, 2]) => println!("1 2"),
+   |
 
-error: aborting due to 8 previous errors
+error: indexing into a vector may panic
+  --> tests/ui/match_on_vec_items.rs:156:11
+   |
+LL |     match arr[1] {
+   |           ^^^^^^
+   |
+help: try
+   |
+LL ~     match arr.get(1) {
+LL |
+LL ~         Some(0 | 1) => println!("0 or 1"),
+   |
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/match_on_vec_items_nofix.rs
+++ b/tests/ui/match_on_vec_items_nofix.rs
@@ -1,0 +1,13 @@
+#![warn(clippy::match_on_vec_items)]
+#![allow(clippy::useless_vec)]
+//@no-rustfix
+
+#[clippy::msrv = "1.52.0"]
+fn or_patterns() {
+    let arr = vec![0, 1, 2, 3];
+    match arr[1] {
+        //~^ ERROR: indexing into a vector may panic
+        0 | 1 => println!("0 or 1"),
+        _ => println!("Hello, World!"),
+    }
+}

--- a/tests/ui/match_on_vec_items_nofix.stderr
+++ b/tests/ui/match_on_vec_items_nofix.stderr
@@ -1,0 +1,11 @@
+error: indexing into a vector may panic
+  --> tests/ui/match_on_vec_items_nofix.rs:8:11
+   |
+LL |     match arr[1] {
+   |           ^^^^^^ help: try: `arr.get(1)`
+   |
+   = note: `-D clippy::match-on-vec-items` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::match_on_vec_items)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Since `or_patterns` has been stable since Rust 1.53.0, better suggestions have been possible from this version onward.

changelog: [`match_on_vec_items`]: add autofix for Rust 1.53.0 and later
