### PR TITLE
fix: `needless_option_as_deref` FP in trait

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -107,7 +107,7 @@ use rustc_hir::{
     self as hir, Arm, BindingMode, Block, BlockCheckMode, Body, ByRef, Closure, ConstArgKind, ConstContext,
     Destination, Expr, ExprField, ExprKind, FnDecl, FnRetTy, GenericArgs, HirId, Impl, ImplItem, ImplItemKind,
     ImplItemRef, Item, ItemKind, LangItem, LetStmt, MatchSource, Mutability, Node, OwnerId, OwnerNode, Param, Pat,
-    PatExpr, PatExprKind, PatKind, Path, PathSegment, PrimTy, QPath, Stmt, StmtKind, TraitItem, TraitItemKind,
+    PatExpr, PatExprKind, PatKind, Path, PathSegment, PrimTy, QPath, Stmt, StmtKind, TraitFn, TraitItem, TraitItemKind,
     TraitItemRef, TraitRef, TyKind, UnOp, def,
 };
 use rustc_lexer::{TokenKind, tokenize};
@@ -1504,6 +1504,10 @@ pub fn get_enclosing_block<'tcx>(cx: &LateContext<'tcx>, hir_id: HirId) -> Optio
         })
         | Node::ImplItem(&ImplItem {
             kind: ImplItemKind::Fn(_, eid),
+            ..
+        })
+        | Node::TraitItem(&TraitItem {
+            kind: TraitItemKind::Fn(_, TraitFn::Provided(eid)),
             ..
         }) => match cx.tcx.hir().body(eid).value.kind {
             ExprKind::Block(block, _) => Some(block),

--- a/tests/ui/needless_option_as_deref.fixed
+++ b/tests/ui/needless_option_as_deref.fixed
@@ -70,3 +70,16 @@ mod issue_non_copy_13077 {
         pub field: (),
     }
 }
+
+mod issue14148 {
+    pub trait SomeTrait {
+        fn something(&self, mut maybe_side_effect: Option<&mut String>) {
+            other(maybe_side_effect.as_deref_mut());
+            other(maybe_side_effect);
+        }
+    }
+
+    fn other(_maybe_side_effect: Option<&mut String>) {
+        unimplemented!()
+    }
+}

--- a/tests/ui/needless_option_as_deref.rs
+++ b/tests/ui/needless_option_as_deref.rs
@@ -70,3 +70,16 @@ mod issue_non_copy_13077 {
         pub field: (),
     }
 }
+
+mod issue14148 {
+    pub trait SomeTrait {
+        fn something(&self, mut maybe_side_effect: Option<&mut String>) {
+            other(maybe_side_effect.as_deref_mut());
+            other(maybe_side_effect);
+        }
+    }
+
+    fn other(_maybe_side_effect: Option<&mut String>) {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
fixes #14148

Another case of #13077 and #8646  

changelog: [`needless_option_as_deref`]: fix FP in trait
