### PR TITLE
Make rust_tools_util package compatible with current stable by lowering rust edition to 2021.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/driver.rs"
 [dependencies]
 clippy_config = { path = "clippy_config" }
 clippy_lints = { path = "clippy_lints" }
-rustc_tools_util = { path = "rustc_tools_util", version = "0.4.1" }
+rustc_tools_util = { path = "rustc_tools_util", version = "0.4.2" }
 tempfile = { version = "3.3", optional = true }
 termize = "0.1"
 color-print = "0.3.4"
@@ -54,7 +54,7 @@ parking_lot = "0.12"
 tokio = { version = "1", features = ["io-util"] }
 
 [build-dependencies]
-rustc_tools_util = { path = "rustc_tools_util", version = "0.4.1" }
+rustc_tools_util = { path = "rustc_tools_util", version = "0.4.2" }
 
 [features]
 integration = ["tempfile"]

--- a/rustc_tools_util/Cargo.toml
+++ b/rustc_tools_util/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rustc_tools_util"
-version = "0.4.1"
+version = "0.4.2"
 description = "small helper to generate version information for git packages"
 repository = "https://github.com/rust-lang/rust-clippy"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["rustc", "tool", "git", "version", "hash"]
 categories = ["development-tools"]
-edition = "2024"
+edition = "2021" # Keep this, for this crate's MSRV to stay low
 
 [dependencies]

--- a/rustc_tools_util/README.md
+++ b/rustc_tools_util/README.md
@@ -13,10 +13,10 @@ build = "build.rs"
 List rustc_tools_util as regular AND build dependency.
 ````toml
 [dependencies]
-rustc_tools_util = "0.4.1"
+rustc_tools_util = "0.4.2"
 
 [build-dependencies]
-rustc_tools_util = "0.4.1"
+rustc_tools_util = "0.4.2"
 ````
 
 In `build.rs`, generate the data in your `main()`

--- a/rustc_tools_util/src/lib.rs
+++ b/rustc_tools_util/src/lib.rs
@@ -188,7 +188,7 @@ mod test {
         let vi = get_version_info!();
         assert_eq!(vi.major, 0);
         assert_eq!(vi.minor, 4);
-        assert_eq!(vi.patch, 1);
+        assert_eq!(vi.patch, 2);
         assert_eq!(vi.crate_name, "rustc_tools_util");
         // hard to make positive tests for these since they will always change
         assert!(vi.commit_hash.is_none());
@@ -200,7 +200,7 @@ mod test {
     #[test]
     fn test_display_local() {
         let vi = get_version_info!();
-        assert_eq!(vi.to_string(), "rustc_tools_util 0.4.1");
+        assert_eq!(vi.to_string(), "rustc_tools_util 0.4.2");
     }
 
     #[test]
@@ -209,7 +209,7 @@ mod test {
         let s = format!("{vi:?}");
         assert_eq!(
             s,
-            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 4, patch: 1 }"
+            "VersionInfo { crate_name: \"rustc_tools_util\", major: 0, minor: 4, patch: 2 }"
         );
     }
 }


### PR DESCRIPTION
Between the release of v0.4.0 and v0.4.1 the edition was pushed to 2024 by https://github.com/rust-lang/rust-clippy/commit/a4805ff61049d746b8193ba125af525d9d6165fa

changelog: Use edition=2021 in `rustc_tools_util`