### PR TITLE
Add new lint, checking for `.to_string().parse().unwrap()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5945,6 +5945,7 @@ Released 2018-09-13
 [`panic_params`]: https://rust-lang.github.io/rust-clippy/master/index.html#panic_params
 [`panicking_overflow_checks`]: https://rust-lang.github.io/rust-clippy/master/index.html#panicking_overflow_checks
 [`panicking_unwrap`]: https://rust-lang.github.io/rust-clippy/master/index.html#panicking_unwrap
+[`parse_to_string`]: https://rust-lang.github.io/rust-clippy/master/index.html#parse_to_string
 [`partial_pub_fields`]: https://rust-lang.github.io/rust-clippy/master/index.html#partial_pub_fields
 [`partialeq_ne_impl`]: https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_ne_impl
 [`partialeq_to_none`]: https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -456,6 +456,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::methods::OPTION_MAP_OR_NONE_INFO,
     crate::methods::OR_FUN_CALL_INFO,
     crate::methods::OR_THEN_UNWRAP_INFO,
+    crate::methods::PARSE_TO_STRING_INFO,
     crate::methods::PATH_BUF_PUSH_OVERWRITE_INFO,
     crate::methods::PATH_ENDS_WITH_EXT_INFO,
     crate::methods::RANGE_ZIP_WITH_LEN_INFO,

--- a/clippy_lints/src/methods/parse_to_string.rs
+++ b/clippy_lints/src/methods/parse_to_string.rs
@@ -1,0 +1,12 @@
+use rustc_hir::Expr;
+use rustc_lint::LateContext;
+use rustc_span::Span;
+
+pub fn check(cx: &LateContext<'_>, expr: &Expr<'_>, span: Span) {
+    clippy_utils::diagnostics::span_lint(
+        cx,
+        super::PARSE_TO_STRING,
+        expr.span.with_lo(span.lo()),
+        "parsing a the output of `.to_string()`",
+    );
+}

--- a/tests/ui/parse_to_string.rs
+++ b/tests/ui/parse_to_string.rs
@@ -1,0 +1,6 @@
+#![warn(clippy::parse_to_string)]
+
+fn main() {
+    let bad: u64 = 42_u32.to_string().parse().unwrap();
+    //~^ ERROR: parsing
+}

--- a/tests/ui/parse_to_string.stderr
+++ b/tests/ui/parse_to_string.stderr
@@ -1,0 +1,11 @@
+error: parsing a the output of `.to_string()`
+  --> tests/ui/parse_to_string.rs:4:27
+   |
+LL |     let bad: u64 = 42_u32.to_string().parse().unwrap();
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::parse-to-string` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::parse_to_string)]`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Inspired by https://github.com/rust-lang/rust/issues/120048#issuecomment-2641021687

- \[x] Followed [lint naming conventions][lint_naming]
- \[x] Added passing UI tests (including committed `.stderr` file)
- \[x] `cargo test` passes locally
- \[x] Executed `cargo dev update_lints`
- \[x] Added lint documentation
- \[x] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

r? @llogiq

---

changelog: add [`parse_to_string`] lint