### PR TITLE
`comparison_chain`: `style` → `pedantic`

### DIFF
--- a/clippy_lints/src/comparison_chain.rs
+++ b/clippy_lints/src/comparison_chain.rs
@@ -53,7 +53,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.40.0"]
     pub COMPARISON_CHAIN,
-    style,
+    pedantic,
     "`if`s that can be rewritten with `match` and `cmp`"
 }
 

--- a/tests/ui/crashes/if_same_then_else.rs
+++ b/tests/ui/crashes/if_same_then_else.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 
-#![allow(clippy::comparison_chain)]
 #![deny(clippy::if_same_then_else)]
 
 // Test for https://github.com/rust-lang/rust-clippy/issues/2426

--- a/tests/ui/ifs_same_cond.rs
+++ b/tests/ui/ifs_same_cond.rs
@@ -1,10 +1,5 @@
 #![warn(clippy::ifs_same_cond)]
-#![allow(
-    clippy::if_same_then_else,
-    clippy::comparison_chain,
-    clippy::needless_if,
-    clippy::needless_else
-)] // all empty blocks
+#![allow(clippy::if_same_then_else, clippy::needless_if, clippy::needless_else)] // all empty blocks
 
 fn ifs_same_cond() {
     let a = 0;

--- a/tests/ui/ifs_same_cond.stderr
+++ b/tests/ui/ifs_same_cond.stderr
@@ -1,11 +1,11 @@
 error: this `if` has the same condition as a previous `if`
-  --> tests/ui/ifs_same_cond.rs:14:15
+  --> tests/ui/ifs_same_cond.rs:9:15
    |
 LL |     } else if b {
    |               ^
    |
 note: same as this
-  --> tests/ui/ifs_same_cond.rs:13:8
+  --> tests/ui/ifs_same_cond.rs:8:8
    |
 LL |     if b {
    |        ^
@@ -13,37 +13,37 @@ LL |     if b {
    = help: to override `-D warnings` add `#[allow(clippy::ifs_same_cond)]`
 
 error: this `if` has the same condition as a previous `if`
-  --> tests/ui/ifs_same_cond.rs:19:15
+  --> tests/ui/ifs_same_cond.rs:14:15
    |
 LL |     } else if a == 1 {
    |               ^^^^^^
    |
 note: same as this
-  --> tests/ui/ifs_same_cond.rs:18:8
+  --> tests/ui/ifs_same_cond.rs:13:8
    |
 LL |     if a == 1 {
    |        ^^^^^^
 
 error: this `if` has the same condition as a previous `if`
-  --> tests/ui/ifs_same_cond.rs:25:15
+  --> tests/ui/ifs_same_cond.rs:20:15
    |
 LL |     } else if 2 * a == 1 {
    |               ^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/ifs_same_cond.rs:23:8
+  --> tests/ui/ifs_same_cond.rs:18:8
    |
 LL |     if 2 * a == 1 {
    |        ^^^^^^^^^^
 
 error: this `if` has the same condition as a previous `if`
-  --> tests/ui/ifs_same_cond.rs:58:15
+  --> tests/ui/ifs_same_cond.rs:53:15
    |
 LL |     } else if a.contains("ah") {
    |               ^^^^^^^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/ifs_same_cond.rs:57:8
+  --> tests/ui/ifs_same_cond.rs:52:8
    |
 LL |     if a.contains("ah") {
    |        ^^^^^^^^^^^^^^^^

--- a/tests/ui/same_functions_in_if_condition.rs
+++ b/tests/ui/same_functions_in_if_condition.rs
@@ -3,12 +3,7 @@
 // ifs_same_cond warning is different from `ifs_same_cond`.
 // clippy::if_same_then_else, clippy::comparison_chain -- all empty blocks
 #![allow(incomplete_features)]
-#![allow(
-    clippy::comparison_chain,
-    clippy::if_same_then_else,
-    clippy::ifs_same_cond,
-    clippy::uninlined_format_args
-)]
+#![allow(clippy::if_same_then_else, clippy::ifs_same_cond, clippy::uninlined_format_args)]
 
 use std::marker::ConstParamTy;
 

--- a/tests/ui/same_functions_in_if_condition.stderr
+++ b/tests/ui/same_functions_in_if_condition.stderr
@@ -1,11 +1,11 @@
 error: this `if` has the same function call as a previous `if`
-  --> tests/ui/same_functions_in_if_condition.rs:39:15
+  --> tests/ui/same_functions_in_if_condition.rs:34:15
    |
 LL |     } else if function() {
    |               ^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/same_functions_in_if_condition.rs:38:8
+  --> tests/ui/same_functions_in_if_condition.rs:33:8
    |
 LL |     if function() {
    |        ^^^^^^^^^^
@@ -16,61 +16,61 @@ LL | #![deny(clippy::same_functions_in_if_condition)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> tests/ui/same_functions_in_if_condition.rs:44:15
+  --> tests/ui/same_functions_in_if_condition.rs:39:15
    |
 LL |     } else if fn_arg(a) {
    |               ^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/same_functions_in_if_condition.rs:43:8
+  --> tests/ui/same_functions_in_if_condition.rs:38:8
    |
 LL |     if fn_arg(a) {
    |        ^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> tests/ui/same_functions_in_if_condition.rs:49:15
+  --> tests/ui/same_functions_in_if_condition.rs:44:15
    |
 LL |     } else if obj.method() {
    |               ^^^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/same_functions_in_if_condition.rs:48:8
+  --> tests/ui/same_functions_in_if_condition.rs:43:8
    |
 LL |     if obj.method() {
    |        ^^^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> tests/ui/same_functions_in_if_condition.rs:54:15
+  --> tests/ui/same_functions_in_if_condition.rs:49:15
    |
 LL |     } else if obj.method_arg(a) {
    |               ^^^^^^^^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/same_functions_in_if_condition.rs:53:8
+  --> tests/ui/same_functions_in_if_condition.rs:48:8
    |
 LL |     if obj.method_arg(a) {
    |        ^^^^^^^^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> tests/ui/same_functions_in_if_condition.rs:60:15
+  --> tests/ui/same_functions_in_if_condition.rs:55:15
    |
 LL |     } else if v.pop().is_none() {
    |               ^^^^^^^^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/same_functions_in_if_condition.rs:59:8
+  --> tests/ui/same_functions_in_if_condition.rs:54:8
    |
 LL |     if v.pop().is_none() {
    |        ^^^^^^^^^^^^^^^^^
 
 error: this `if` has the same function call as a previous `if`
-  --> tests/ui/same_functions_in_if_condition.rs:65:15
+  --> tests/ui/same_functions_in_if_condition.rs:60:15
    |
 LL |     } else if v.len() == 42 {
    |               ^^^^^^^^^^^^^
    |
 note: same as this
-  --> tests/ui/same_functions_in_if_condition.rs:64:8
+  --> tests/ui/same_functions_in_if_condition.rs:59:8
    |
 LL |     if v.len() == 42 {
    |        ^^^^^^^^^^^^^


### PR DESCRIPTION
The `comparison_chain` lint might suggest code which seems less natural to beginners.

[Discussion](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/demote.20some.20lints.20to.20.60pedantic.60)

changelog: [`comparison_chain`]: change lint category to `pedantic`