### PR TITLE
Add `--allow-no-vcs` to `cargo dev dogfood --fix`

### DIFF
--- a/clippy_dev/src/dogfood.rs
+++ b/clippy_dev/src/dogfood.rs
@@ -4,7 +4,8 @@ use std::process::Command;
 /// # Panics
 ///
 /// Panics if unable to run the dogfood test
-pub fn dogfood(fix: bool, allow_dirty: bool, allow_staged: bool) {
+#[allow(clippy::fn_params_excessive_bools)]
+pub fn dogfood(fix: bool, allow_dirty: bool, allow_staged: bool, allow_no_vcs: bool) {
     let mut cmd = Command::new("cargo");
 
     cmd.current_dir(clippy_project_root())
@@ -23,6 +24,10 @@ pub fn dogfood(fix: bool, allow_dirty: bool, allow_staged: bool) {
 
     if allow_staged {
         dogfood_args.push("--allow-staged");
+    }
+
+    if allow_no_vcs {
+        dogfood_args.push("--allow-no-vcs");
     }
 
     cmd.env("__CLIPPY_DOGFOOD_ARGS", dogfood_args.join(" "));

--- a/clippy_dev/src/main.rs
+++ b/clippy_dev/src/main.rs
@@ -17,7 +17,8 @@ fn main() {
             fix,
             allow_dirty,
             allow_staged,
-        } => dogfood::dogfood(fix, allow_dirty, allow_staged),
+            allow_no_vcs,
+        } => dogfood::dogfood(fix, allow_dirty, allow_staged, allow_no_vcs),
         DevCommand::Fmt { check, verbose } => fmt::run(check, verbose),
         DevCommand::UpdateLints { print_only, check } => {
             if print_only {
@@ -106,6 +107,9 @@ enum DevCommand {
         #[arg(long, requires = "fix")]
         /// Fix code even if the working directory has staged changes
         allow_staged: bool,
+        #[arg(long, requires = "fix")]
+        /// Fix code even if a VCS was not detected
+        allow_no_vcs: bool,
     },
     /// Run rustfmt on all projects and tests
     Fmt {


### PR DESCRIPTION
Some developers might prefer to use alternate VCS, such as Jujutsu, which are not detected by `cargo fix`. This forwards the `--allow-no-vcs` command line argument to `cargo fix`.

changelog: none