### PR TITLE
Collapse `if` and `if let` chains in Clippy itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6350,6 +6350,7 @@ Released 2018-09-13
 [`check-inconsistent-struct-field-initializers`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-inconsistent-struct-field-initializers
 [`check-private-items`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-private-items
 [`cognitive-complexity-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#cognitive-complexity-threshold
+[`collapse-let-chains`]: https://doc.rust-lang.org/clippy/lint_configuration.html#collapse-let-chains
 [`disallowed-macros`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-macros
 [`disallowed-methods`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-methods
 [`disallowed-names`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-names

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -475,6 +475,17 @@ The maximum cognitive complexity a function can have
 * [`cognitive_complexity`](https://rust-lang.github.io/rust-clippy/master/index.html#cognitive_complexity)
 
 
+## `collapse-let-chains`
+Whether `if let` chains should be collapsed. This requires the use of the unstable
+`let_chains` rustc feature.
+
+**Default Value:** `false`
+
+---
+**Affected lints:**
+* [`collapsible_if`](https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if)
+
+
 ## `disallowed-macros`
 The list of disallowed macros, written as fully qualified paths.
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,6 +2,8 @@ avoid-breaking-exported-api = false
 
 check-inconsistent-struct-field-initializers = true
 
+collapse-let-chains = true
+
 lint-commented-code = true
 
 [[disallowed-methods]]

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -500,6 +500,10 @@ define_Conf! {
     /// The maximum cognitive complexity a function can have
     #[lints(cognitive_complexity)]
     cognitive_complexity_threshold: u64 = 25,
+    /// Whether `if let` chains should be collapsed. This requires the use of the unstable
+    /// `let_chains` rustc feature.
+    #[lints(collapsible_if)]
+    collapse_let_chains: bool = false,
     /// DEPRECATED LINT: CYCLOMATIC_COMPLEXITY.
     ///
     /// Use the Cognitive Complexity lint instead.

--- a/clippy_dev/src/update_lints.rs
+++ b/clippy_dev/src/update_lints.rs
@@ -402,53 +402,53 @@ fn remove_lint_declaration(name: &str, path: &Path, lints: &mut Vec<Lint>) -> io
         }
     }
 
-    if path.exists() {
-        if let Some(lint) = lints.iter().find(|l| l.name == name) {
-            if lint.module == name {
-                // The lint name is the same as the file, we can just delete the entire file
-                fs::remove_file(path)?;
-            } else {
-                // We can't delete the entire file, just remove the declaration
+    if path.exists()
+        && let Some(lint) = lints.iter().find(|l| l.name == name)
+    {
+        if lint.module == name {
+            // The lint name is the same as the file, we can just delete the entire file
+            fs::remove_file(path)?;
+        } else {
+            // We can't delete the entire file, just remove the declaration
 
-                if let Some(Some("mod.rs")) = path.file_name().map(OsStr::to_str) {
-                    // Remove clippy_lints/src/some_mod/some_lint.rs
-                    let mut lint_mod_path = path.to_path_buf();
-                    lint_mod_path.set_file_name(name);
-                    lint_mod_path.set_extension("rs");
+            if let Some(Some("mod.rs")) = path.file_name().map(OsStr::to_str) {
+                // Remove clippy_lints/src/some_mod/some_lint.rs
+                let mut lint_mod_path = path.to_path_buf();
+                lint_mod_path.set_file_name(name);
+                lint_mod_path.set_extension("rs");
 
-                    let _ = fs::remove_file(lint_mod_path);
-                }
-
-                let mut content =
-                    fs::read_to_string(path).unwrap_or_else(|_| panic!("failed to read `{}`", path.to_string_lossy()));
-
-                eprintln!(
-                    "warn: you will have to manually remove any code related to `{name}` from `{}`",
-                    path.display()
-                );
-
-                assert!(
-                    content[lint.declaration_range.clone()].contains(&name.to_uppercase()),
-                    "error: `{}` does not contain lint `{}`'s declaration",
-                    path.display(),
-                    lint.name
-                );
-
-                // Remove lint declaration (declare_clippy_lint!)
-                content.replace_range(lint.declaration_range.clone(), "");
-
-                // Remove the module declaration (mod xyz;)
-                let mod_decl = format!("\nmod {name};");
-                content = content.replacen(&mod_decl, "", 1);
-
-                remove_impl_lint_pass(&lint.name.to_uppercase(), &mut content);
-                fs::write(path, content).unwrap_or_else(|_| panic!("failed to write to `{}`", path.to_string_lossy()));
+                let _ = fs::remove_file(lint_mod_path);
             }
 
-            remove_test_assets(name);
-            remove_lint(name, lints);
-            return Ok(true);
+            let mut content =
+                fs::read_to_string(path).unwrap_or_else(|_| panic!("failed to read `{}`", path.to_string_lossy()));
+
+            eprintln!(
+                "warn: you will have to manually remove any code related to `{name}` from `{}`",
+                path.display()
+            );
+
+            assert!(
+                content[lint.declaration_range.clone()].contains(&name.to_uppercase()),
+                "error: `{}` does not contain lint `{}`'s declaration",
+                path.display(),
+                lint.name
+            );
+
+            // Remove lint declaration (declare_clippy_lint!)
+            content.replace_range(lint.declaration_range.clone(), "");
+
+            // Remove the module declaration (mod xyz;)
+            let mod_decl = format!("\nmod {name};");
+            content = content.replacen(&mod_decl, "", 1);
+
+            remove_impl_lint_pass(&lint.name.to_uppercase(), &mut content);
+            fs::write(path, content).unwrap_or_else(|_| panic!("failed to write to `{}`", path.to_string_lossy()));
         }
+
+        remove_test_assets(name);
+        remove_lint(name, lints);
+        return Ok(true);
     }
 
     Ok(false)

--- a/clippy_dev/src/utils.rs
+++ b/clippy_dev/src/utils.rs
@@ -30,10 +30,10 @@ pub fn clippy_project_root() -> PathBuf {
     let current_dir = std::env::current_dir().unwrap();
     for path in current_dir.ancestors() {
         let result = fs::read_to_string(path.join("Cargo.toml"));
-        if let Err(err) = &result {
-            if err.kind() == io::ErrorKind::NotFound {
-                continue;
-            }
+        if let Err(err) = &result
+            && err.kind() == io::ErrorKind::NotFound
+        {
+            continue;
         }
 
         let content = result.unwrap();

--- a/clippy_lints/src/arbitrary_source_item_ordering.rs
+++ b/clippy_lints/src/arbitrary_source_item_ordering.rs
@@ -263,10 +263,11 @@ impl<'tcx> LateLintPass<'tcx> for ArbitrarySourceItemOrdering {
                         continue;
                     }
 
-                    if let Some(cur_v) = cur_v {
-                        if cur_v.ident.name.as_str() > variant.ident.name.as_str() && cur_v.span != variant.span {
-                            Self::lint_member_name(cx, &variant.ident, &cur_v.ident);
-                        }
+                    if let Some(cur_v) = cur_v
+                        && cur_v.ident.name.as_str() > variant.ident.name.as_str()
+                        && cur_v.span != variant.span
+                    {
+                        Self::lint_member_name(cx, &variant.ident, &cur_v.ident);
                     }
                     cur_v = Some(variant);
                 }
@@ -278,10 +279,11 @@ impl<'tcx> LateLintPass<'tcx> for ArbitrarySourceItemOrdering {
                         continue;
                     }
 
-                    if let Some(cur_f) = cur_f {
-                        if cur_f.ident.name.as_str() > field.ident.name.as_str() && cur_f.span != field.span {
-                            Self::lint_member_name(cx, &field.ident, &cur_f.ident);
-                        }
+                    if let Some(cur_f) = cur_f
+                        && cur_f.ident.name.as_str() > field.ident.name.as_str()
+                        && cur_f.span != field.span
+                    {
+                        Self::lint_member_name(cx, &field.ident, &cur_f.ident);
                     }
                     cur_f = Some(field);
                 }

--- a/clippy_lints/src/attrs/blanket_clippy_restriction_lints.rs
+++ b/clippy_lints/src/attrs/blanket_clippy_restriction_lints.rs
@@ -8,17 +8,18 @@ use rustc_span::{DUMMY_SP, sym};
 
 pub(super) fn check(cx: &EarlyContext<'_>, name: Symbol, items: &[MetaItemInner]) {
     for lint in items {
-        if let Some(lint_name) = extract_clippy_lint(lint) {
-            if lint_name.as_str() == "restriction" && name != sym::allow {
-                span_lint_and_help(
-                    cx,
-                    BLANKET_CLIPPY_RESTRICTION_LINTS,
-                    lint.span(),
-                    "`clippy::restriction` is not meant to be enabled as a group",
-                    None,
-                    "enable the restriction lints you need individually",
-                );
-            }
+        if let Some(lint_name) = extract_clippy_lint(lint)
+            && lint_name.as_str() == "restriction"
+            && name != sym::allow
+        {
+            span_lint_and_help(
+                cx,
+                BLANKET_CLIPPY_RESTRICTION_LINTS,
+                lint.span(),
+                "`clippy::restriction` is not meant to be enabled as a group",
+                None,
+                "enable the restriction lints you need individually",
+            );
         }
     }
 }

--- a/clippy_lints/src/attrs/deprecated_semver.rs
+++ b/clippy_lints/src/attrs/deprecated_semver.rs
@@ -6,10 +6,10 @@ use rustc_span::Span;
 use semver::Version;
 
 pub(super) fn check(cx: &EarlyContext<'_>, span: Span, lit: &MetaItemLit) {
-    if let LitKind::Str(is, _) = lit.kind {
-        if is.as_str() == "TBD" || Version::parse(is.as_str()).is_ok() {
-            return;
-        }
+    if let LitKind::Str(is, _) = lit.kind
+        && (is.as_str() == "TBD" || Version::parse(is.as_str()).is_ok())
+    {
+        return;
     }
     span_lint(
         cx,

--- a/clippy_lints/src/attrs/useless_attribute.rs
+++ b/clippy_lints/src/attrs/useless_attribute.rs
@@ -14,75 +14,75 @@ pub(super) fn check(cx: &EarlyContext<'_>, item: &Item, attrs: &[Attribute]) {
         if attr.span.in_external_macro(cx.sess().source_map()) {
             return;
         }
-        if let Some(lint_list) = &attr.meta_item_list() {
-            if attr.ident().is_some_and(|ident| is_lint_level(ident.name, attr.id)) {
-                for lint in lint_list {
-                    match item.kind {
-                        ItemKind::Use(..) => {
-                            let (namespace @ (Some(sym::clippy) | None), Some(name)) = namespace_and_lint(lint) else {
-                                return;
-                            };
+        if let Some(lint_list) = &attr.meta_item_list()
+            && attr.ident().is_some_and(|ident| is_lint_level(ident.name, attr.id))
+        {
+            for lint in lint_list {
+                match item.kind {
+                    ItemKind::Use(..) => {
+                        let (namespace @ (Some(sym::clippy) | None), Some(name)) = namespace_and_lint(lint) else {
+                            return;
+                        };
 
-                            if namespace.is_none()
-                                && matches!(
-                                    name.as_str(),
-                                    "ambiguous_glob_reexports"
-                                        | "dead_code"
-                                        | "deprecated"
-                                        | "hidden_glob_reexports"
-                                        | "unreachable_pub"
-                                        | "unused"
-                                        | "unused_braces"
-                                        | "unused_import_braces"
-                                        | "unused_imports"
-                                )
-                            {
-                                return;
-                            }
+                        if namespace.is_none()
+                            && matches!(
+                                name.as_str(),
+                                "ambiguous_glob_reexports"
+                                    | "dead_code"
+                                    | "deprecated"
+                                    | "hidden_glob_reexports"
+                                    | "unreachable_pub"
+                                    | "unused"
+                                    | "unused_braces"
+                                    | "unused_import_braces"
+                                    | "unused_imports"
+                            )
+                        {
+                            return;
+                        }
 
-                            if namespace == Some(sym::clippy)
-                                && matches!(
-                                    name.as_str(),
-                                    "wildcard_imports"
-                                        | "enum_glob_use"
-                                        | "redundant_pub_crate"
-                                        | "macro_use_imports"
-                                        | "unsafe_removed_from_name"
-                                        | "module_name_repetitions"
-                                        | "single_component_path_imports"
-                                        | "disallowed_types"
-                                        | "unused_trait_names"
-                                )
-                            {
-                                return;
-                            }
-                        },
-                        ItemKind::ExternCrate(..) => {
-                            if is_word(lint, sym::unused_imports) && skip_unused_imports {
-                                return;
-                            }
-                            if is_word(lint, sym!(unused_extern_crates)) {
-                                return;
-                            }
-                        },
-                        _ => {},
-                    }
+                        if namespace == Some(sym::clippy)
+                            && matches!(
+                                name.as_str(),
+                                "wildcard_imports"
+                                    | "enum_glob_use"
+                                    | "redundant_pub_crate"
+                                    | "macro_use_imports"
+                                    | "unsafe_removed_from_name"
+                                    | "module_name_repetitions"
+                                    | "single_component_path_imports"
+                                    | "disallowed_types"
+                                    | "unused_trait_names"
+                            )
+                        {
+                            return;
+                        }
+                    },
+                    ItemKind::ExternCrate(..) => {
+                        if is_word(lint, sym::unused_imports) && skip_unused_imports {
+                            return;
+                        }
+                        if is_word(lint, sym!(unused_extern_crates)) {
+                            return;
+                        }
+                    },
+                    _ => {},
                 }
-                let line_span = first_line_of_span(cx, attr.span);
+            }
+            let line_span = first_line_of_span(cx, attr.span);
 
-                if let Some(src) = line_span.get_source_text(cx) {
-                    if src.contains("#[") {
-                        #[expect(clippy::collapsible_span_lint_calls)]
-                        span_lint_and_then(cx, USELESS_ATTRIBUTE, line_span, "useless lint attribute", |diag| {
-                            diag.span_suggestion(
-                                line_span,
-                                "if you just forgot a `!`, use",
-                                src.replacen("#[", "#![", 1),
-                                Applicability::MaybeIncorrect,
-                            );
-                        });
-                    }
-                }
+            if let Some(src) = line_span.get_source_text(cx)
+                && src.contains("#[")
+            {
+                #[expect(clippy::collapsible_span_lint_calls)]
+                span_lint_and_then(cx, USELESS_ATTRIBUTE, line_span, "useless lint attribute", |diag| {
+                    diag.span_suggestion(
+                        line_span,
+                        "if you just forgot a `!`, use",
+                        src.replacen("#[", "#![", 1),
+                        Applicability::MaybeIncorrect,
+                    );
+                });
             }
         }
     }

--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -192,10 +192,9 @@ impl<'tcx> LateLintPass<'tcx> for AwaitHolding {
             def_id,
             ..
         }) = expr.kind
+            && let Some(coroutine_layout) = cx.tcx.mir_coroutine_witnesses(*def_id)
         {
-            if let Some(coroutine_layout) = cx.tcx.mir_coroutine_witnesses(*def_id) {
-                self.check_interior_types(cx, coroutine_layout);
-            }
+            self.check_interior_types(cx, coroutine_layout);
         }
     }
 }

--- a/clippy_lints/src/booleans.rs
+++ b/clippy_lints/src/booleans.rs
@@ -242,11 +242,11 @@ struct Hir2Qmm<'a, 'tcx, 'v> {
 impl<'v> Hir2Qmm<'_, '_, 'v> {
     fn extract(&mut self, op: BinOpKind, a: &[&'v Expr<'_>], mut v: Vec<Bool>) -> Result<Vec<Bool>, String> {
         for a in a {
-            if let ExprKind::Binary(binop, lhs, rhs) = &a.kind {
-                if binop.node == op {
-                    v = self.extract(op, &[lhs, rhs], v)?;
-                    continue;
-                }
+            if let ExprKind::Binary(binop, lhs, rhs) = &a.kind
+                && binop.node == op
+            {
+                v = self.extract(op, &[lhs, rhs], v)?;
+                continue;
             }
             v.push(self.run(a)?);
         }
@@ -418,12 +418,12 @@ fn simplify_not(cx: &LateContext<'_>, curr_msrv: Msrv, expr: &Expr<'_>) -> Optio
                 let lhs_snippet = lhs.span.get_source_text(cx)?;
                 let rhs_snippet = rhs.span.get_source_text(cx)?;
 
-                if !(lhs_snippet.starts_with('(') && lhs_snippet.ends_with(')')) {
-                    if let (ExprKind::Cast(..), BinOpKind::Ge) = (&lhs.kind, binop.node) {
-                        // e.g. `(a as u64) < b`. Without the parens the `<` is
-                        // interpreted as a start of generic arguments for `u64`
-                        return Some(format!("({lhs_snippet}){op}{rhs_snippet}"));
-                    }
+                if !(lhs_snippet.starts_with('(') && lhs_snippet.ends_with(')'))
+                    && let (ExprKind::Cast(..), BinOpKind::Ge) = (&lhs.kind, binop.node)
+                {
+                    // e.g. `(a as u64) < b`. Without the parens the `<` is
+                    // interpreted as a start of generic arguments for `u64`
+                    return Some(format!("({lhs_snippet}){op}{rhs_snippet}"));
                 }
 
                 Some(format!("{lhs_snippet}{op}{rhs_snippet}"))

--- a/clippy_lints/src/borrow_deref_ref.rs
+++ b/clippy_lints/src/borrow_deref_ref.rs
@@ -93,10 +93,10 @@ impl<'tcx> LateLintPass<'tcx> for BorrowDerefRef {
 
                     // has deref trait -> give 2 help
                     // doesn't have deref trait -> give 1 help
-                    if let Some(deref_trait_id) = cx.tcx.lang_items().deref_trait() {
-                        if !implements_trait(cx, *inner_ty, deref_trait_id, &[]) {
-                            return;
-                        }
+                    if let Some(deref_trait_id) = cx.tcx.lang_items().deref_trait()
+                        && !implements_trait(cx, *inner_ty, deref_trait_id, &[])
+                    {
+                        return;
                     }
 
                     diag.span_suggestion(

--- a/clippy_lints/src/casts/cast_possible_truncation.rs
+++ b/clippy_lints/src/casts/cast_possible_truncation.rs
@@ -64,11 +64,11 @@ fn apply_reductions(cx: &LateContext<'_>, nbits: u64, expr: &Expr<'_>, signed: b
             apply_reductions(cx, nbits, left, signed).min(max_bits.unwrap_or(u64::MAX))
         },
         ExprKind::MethodCall(method, _, [lo, hi], _) => {
-            if method.ident.as_str() == "clamp" {
+            if method.ident.as_str() == "clamp"
                 //FIXME: make this a diagnostic item
-                if let (Some(lo_bits), Some(hi_bits)) = (get_constant_bits(cx, lo), get_constant_bits(cx, hi)) {
-                    return lo_bits.max(hi_bits);
-                }
+                && let (Some(lo_bits), Some(hi_bits)) = (get_constant_bits(cx, lo), get_constant_bits(cx, hi))
+            {
+                return lo_bits.max(hi_bits);
             }
             nbits
         },

--- a/clippy_lints/src/casts/cast_ptr_alignment.rs
+++ b/clippy_lints/src/casts/cast_ptr_alignment.rs
@@ -19,16 +19,15 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
             cx.typeck_results().expr_ty(expr),
         );
         lint_cast_ptr_alignment(cx, expr, cast_from, cast_to);
-    } else if let ExprKind::MethodCall(method_path, self_arg, [], _) = &expr.kind {
-        if method_path.ident.name.as_str() == "cast"
+    } else if let ExprKind::MethodCall(method_path, self_arg, [], _) = &expr.kind
+        && method_path.ident.name.as_str() == "cast"
             && let Some(generic_args) = method_path.args
             && let [GenericArg::Type(cast_to)] = generic_args.args
             // There probably is no obvious reason to do this, just to be consistent with `as` cases.
             && !is_hir_ty_cfg_dependant(cx, cast_to.as_unambig_ty())
-        {
-            let (cast_from, cast_to) = (cx.typeck_results().expr_ty(self_arg), cx.typeck_results().expr_ty(expr));
-            lint_cast_ptr_alignment(cx, expr, cast_from, cast_to);
-        }
+    {
+        let (cast_from, cast_to) = (cx.typeck_results().expr_ty(self_arg), cx.typeck_results().expr_ty(expr));
+        lint_cast_ptr_alignment(cx, expr, cast_from, cast_to);
     }
 }
 

--- a/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/clippy_lints/src/casts/unnecessary_cast.rs
@@ -130,11 +130,11 @@ pub(super) fn check<'tcx>(
             | LitKind::Float(_, LitFloatType::Suffixed(_))
                 if cast_from.kind() == cast_to.kind() =>
             {
-                if let Some(src) = cast_expr.span.get_source_text(cx) {
-                    if let Some(num_lit) = NumericLiteral::from_lit_kind(&src, &lit.node) {
-                        lint_unnecessary_cast(cx, expr, num_lit.integer, cast_from, cast_to);
-                        return true;
-                    }
+                if let Some(src) = cast_expr.span.get_source_text(cx)
+                    && let Some(num_lit) = NumericLiteral::from_lit_kind(&src, &lit.node)
+                {
+                    lint_unnecessary_cast(cx, expr, num_lit.integer, cast_from, cast_to);
+                    return true;
                 }
             },
             _ => {},

--- a/clippy_lints/src/checked_conversions.rs
+++ b/clippy_lints/src/checked_conversions.rs
@@ -253,11 +253,11 @@ fn get_types_from_cast<'a>(
         match limit.kind {
             // `from_type::from(_)`
             ExprKind::Call(path, _) => {
-                if let ExprKind::Path(ref path) = path.kind {
+                if let ExprKind::Path(ref path) = path.kind
                     // `to_type`
-                    if let Some(to_type) = get_implementing_type(path, types, func) {
-                        return Some((from_type, to_type));
-                    }
+                    && let Some(to_type) = get_implementing_type(path, types, func)
+                {
+                    return Some((from_type, to_type));
                 }
             },
             // `to_type::MAX`

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -539,10 +539,10 @@ fn check_for_warn_of_moved_symbol(cx: &LateContext<'_>, symbols: &[(HirId, Symbo
                     .filter(|stmt| !ignore_span.overlaps(stmt.span))
                     .try_for_each(|stmt| intravisit::walk_stmt(&mut walker, stmt));
 
-                if let Some(expr) = block.expr {
-                    if res.is_continue() {
-                        res = intravisit::walk_expr(&mut walker, expr);
-                    }
+                if let Some(expr) = block.expr
+                    && res.is_continue()
+                {
+                    res = intravisit::walk_expr(&mut walker, expr);
                 }
 
                 res.is_break()

--- a/clippy_lints/src/dereference.rs
+++ b/clippy_lints/src/dereference.rs
@@ -1133,10 +1133,10 @@ fn report<'tcx>(
 
 impl<'tcx> Dereferencing<'tcx> {
     fn check_local_usage(&mut self, cx: &LateContext<'tcx>, e: &Expr<'tcx>, local: HirId) {
-        if let Some(outer_pat) = self.ref_locals.get_mut(&local) {
-            if let Some(pat) = outer_pat {
+        if let Some(outer_pat) = self.ref_locals.get_mut(&local)
+            && let Some(pat) = outer_pat
                 // Check for auto-deref
-                if !matches!(
+                && !matches!(
                     cx.typeck_results().expr_adjustments(e),
                     [
                         Adjustment {
@@ -1149,45 +1149,44 @@ impl<'tcx> Dereferencing<'tcx> {
                         },
                         ..
                     ]
-                ) {
-                    match get_parent_expr(cx, e) {
-                        // Field accesses are the same no matter the number of references.
-                        Some(Expr {
-                            kind: ExprKind::Field(..),
-                            ..
-                        }) => (),
-                        Some(&Expr {
-                            span,
-                            kind: ExprKind::Unary(UnOp::Deref, _),
-                            ..
-                        }) if !span.from_expansion() => {
-                            // Remove explicit deref.
-                            let snip = snippet_with_context(cx, e.span, span.ctxt(), "..", &mut pat.app).0;
-                            pat.replacements.push((span, snip.into()));
-                        },
-                        Some(parent) if !parent.span.from_expansion() => {
-                            // Double reference might be needed at this point.
-                            if parent.precedence() == ExprPrecedence::Unambiguous {
-                                // Parentheses would be needed here, don't lint.
-                                *outer_pat = None;
-                            } else {
-                                pat.always_deref = false;
-                                let snip = snippet_with_context(cx, e.span, parent.span.ctxt(), "..", &mut pat.app).0;
-                                pat.replacements.push((e.span, format!("&{snip}")));
-                            }
-                        },
-                        _ if !e.span.from_expansion() => {
-                            // Double reference might be needed at this point.
-                            pat.always_deref = false;
-                            let snip = snippet_with_applicability(cx, e.span, "..", &mut pat.app);
-                            pat.replacements.push((e.span, format!("&{snip}")));
-                        },
-                        // Edge case for macros. The span of the identifier will usually match the context of the
-                        // binding, but not if the identifier was created in a macro. e.g. `concat_idents` and proc
-                        // macros
-                        _ => *outer_pat = None,
+                )
+        {
+            match get_parent_expr(cx, e) {
+                // Field accesses are the same no matter the number of references.
+                Some(Expr {
+                    kind: ExprKind::Field(..),
+                    ..
+                }) => (),
+                Some(&Expr {
+                    span,
+                    kind: ExprKind::Unary(UnOp::Deref, _),
+                    ..
+                }) if !span.from_expansion() => {
+                    // Remove explicit deref.
+                    let snip = snippet_with_context(cx, e.span, span.ctxt(), "..", &mut pat.app).0;
+                    pat.replacements.push((span, snip.into()));
+                },
+                Some(parent) if !parent.span.from_expansion() => {
+                    // Double reference might be needed at this point.
+                    if parent.precedence() == ExprPrecedence::Unambiguous {
+                        // Parentheses would be needed here, don't lint.
+                        *outer_pat = None;
+                    } else {
+                        pat.always_deref = false;
+                        let snip = snippet_with_context(cx, e.span, parent.span.ctxt(), "..", &mut pat.app).0;
+                        pat.replacements.push((e.span, format!("&{snip}")));
                     }
-                }
+                },
+                _ if !e.span.from_expansion() => {
+                    // Double reference might be needed at this point.
+                    pat.always_deref = false;
+                    let snip = snippet_with_applicability(cx, e.span, "..", &mut pat.app);
+                    pat.replacements.push((e.span, format!("&{snip}")));
+                },
+                // Edge case for macros. The span of the identifier will usually match the context of the
+                // binding, but not if the identifier was created in a macro. e.g. `concat_idents` and proc
+                // macros
+                _ => *outer_pat = None,
             }
         }
     }

--- a/clippy_lints/src/derivable_impls.rs
+++ b/clippy_lints/src/derivable_impls.rs
@@ -94,18 +94,18 @@ fn check_struct<'tcx>(
     ty_args: GenericArgsRef<'_>,
     typeck_results: &'tcx TypeckResults<'tcx>,
 ) {
-    if let TyKind::Path(QPath::Resolved(_, p)) = self_ty.kind {
-        if let Some(PathSegment { args, .. }) = p.segments.last() {
-            let args = args.map(|a| a.args).unwrap_or(&[]);
+    if let TyKind::Path(QPath::Resolved(_, p)) = self_ty.kind
+        && let Some(PathSegment { args, .. }) = p.segments.last()
+    {
+        let args = args.map(|a| a.args).unwrap_or(&[]);
 
-            // ty_args contains the generic parameters of the type declaration, while args contains the
-            // arguments used at instantiation time. If both len are not equal, it means that some
-            // parameters were not provided (which means that the default values were used); in this
-            // case we will not risk suggesting too broad a rewrite. We won't either if any argument
-            // is a type or a const.
-            if ty_args.len() != args.len() || args.iter().any(|arg| !matches!(arg, GenericArg::Lifetime(_))) {
-                return;
-            }
+        // ty_args contains the generic parameters of the type declaration, while args contains the
+        // arguments used at instantiation time. If both len are not equal, it means that some
+        // parameters were not provided (which means that the default values were used); in this
+        // case we will not risk suggesting too broad a rewrite. We won't either if any argument
+        // is a type or a const.
+        if ty_args.len() != args.len() || args.iter().any(|arg| !matches!(arg, GenericArg::Lifetime(_))) {
+            return;
         }
     }
 

--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -428,10 +428,10 @@ impl<'tcx> Visitor<'tcx> for UnsafeVisitor<'_, 'tcx> {
     }
 
     fn visit_expr(&mut self, expr: &'tcx Expr<'_>) -> Self::Result {
-        if let ExprKind::Block(block, _) = expr.kind {
-            if block.rules == BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided) {
-                return ControlFlow::Break(());
-            }
+        if let ExprKind::Block(block, _) = expr.kind
+            && block.rules == BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
+        {
+            return ControlFlow::Break(());
         }
 
         walk_expr(self, expr)

--- a/clippy_lints/src/doc/markdown.rs
+++ b/clippy_lints/src/doc/markdown.rs
@@ -113,20 +113,20 @@ fn check_word(cx: &LateContext<'_>, word: &str, span: Span, code_level: isize, b
         s != "-" && s.contains('-')
     }
 
-    if let Ok(url) = Url::parse(word) {
+    if let Ok(url) = Url::parse(word)
         // try to get around the fact that `foo::bar` parses as a valid URL
-        if !url.cannot_be_a_base() {
-            span_lint_and_sugg(
-                cx,
-                DOC_MARKDOWN,
-                span,
-                "you should put bare URLs between `<`/`>` or make a proper Markdown link",
-                "try",
-                format!("<{word}>"),
-                Applicability::MachineApplicable,
-            );
-            return;
-        }
+        && !url.cannot_be_a_base()
+    {
+        span_lint_and_sugg(
+            cx,
+            DOC_MARKDOWN,
+            span,
+            "you should put bare URLs between `<`/`>` or make a proper Markdown link",
+            "try",
+            format!("<{word}>"),
+            Applicability::MachineApplicable,
+        );
+        return;
     }
 
     // We assume that mixed-case words are not meant to be put inside backticks. (Issue #2343)

--- a/clippy_lints/src/drop_forget_ref.rs
+++ b/clippy_lints/src/drop_forget_ref.rs
@@ -144,10 +144,10 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetRef {
 //     ..
 // }
 fn is_single_call_in_arm<'tcx>(cx: &LateContext<'tcx>, arg: &'tcx Expr<'_>, drop_expr: &'tcx Expr<'_>) -> bool {
-    if matches!(arg.kind, ExprKind::Call(..) | ExprKind::MethodCall(..)) {
-        if let Node::Arm(Arm { body, .. }) = cx.tcx.parent_hir_node(drop_expr.hir_id) {
-            return body.hir_id == drop_expr.hir_id;
-        }
+    if matches!(arg.kind, ExprKind::Call(..) | ExprKind::MethodCall(..))
+        && let Node::Arm(Arm { body, .. }) = cx.tcx.parent_hir_node(drop_expr.hir_id)
+    {
+        return body.hir_id == drop_expr.hir_id;
     }
     false
 }

--- a/clippy_lints/src/enum_clike.rs
+++ b/clippy_lints/src/enum_clike.rs
@@ -49,10 +49,10 @@ impl<'tcx> LateLintPass<'tcx> for UnportableVariant {
                         .ok()
                         .map(|val| rustc_middle::mir::Const::from_value(val, ty));
                     if let Some(Constant::Int(val)) = constant.and_then(|c| mir_to_const(cx.tcx, c)) {
-                        if let ty::Adt(adt, _) = ty.kind() {
-                            if adt.is_enum() {
-                                ty = adt.repr().discr_type().to_ty(cx.tcx);
-                            }
+                        if let ty::Adt(adt, _) = ty.kind()
+                            && adt.is_enum()
+                        {
+                            ty = adt.repr().discr_type().to_ty(cx.tcx);
                         }
                         match ty.kind() {
                             ty::Int(IntTy::Isize) => {

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -72,10 +72,10 @@ impl<'tcx> LateLintPass<'tcx> for BoxedLocal {
         _: Span,
         fn_def_id: LocalDefId,
     ) {
-        if let Some(header) = fn_kind.header() {
-            if header.abi != ExternAbi::Rust {
-                return;
-            }
+        if let Some(header) = fn_kind.header()
+            && header.abi != ExternAbi::Rust
+        {
+            return;
         }
 
         let parent_id = cx
@@ -141,22 +141,22 @@ fn is_argument(tcx: TyCtxt<'_>, id: HirId) -> bool {
 
 impl<'tcx> Delegate<'tcx> for EscapeDelegate<'_, 'tcx> {
     fn consume(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId) {
-        if cmt.place.projections.is_empty() {
-            if let PlaceBase::Local(lid) = cmt.place.base {
-                // FIXME(rust/#120456) - is `swap_remove` correct?
-                self.set.swap_remove(&lid);
-            }
+        if cmt.place.projections.is_empty()
+            && let PlaceBase::Local(lid) = cmt.place.base
+        {
+            // FIXME(rust/#120456) - is `swap_remove` correct?
+            self.set.swap_remove(&lid);
         }
     }
 
     fn use_cloned(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
 
     fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, _: ty::BorrowKind) {
-        if cmt.place.projections.is_empty() {
-            if let PlaceBase::Local(lid) = cmt.place.base {
-                // FIXME(rust/#120456) - is `swap_remove` correct?
-                self.set.swap_remove(&lid);
-            }
+        if cmt.place.projections.is_empty()
+            && let PlaceBase::Local(lid) = cmt.place.base
+        {
+            // FIXME(rust/#120456) - is `swap_remove` correct?
+            self.set.swap_remove(&lid);
         }
     }
 
@@ -170,10 +170,11 @@ impl<'tcx> Delegate<'tcx> for EscapeDelegate<'_, 'tcx> {
 
             // skip if there is a `self` parameter binding to a type
             // that contains `Self` (i.e.: `self: Box<Self>`), see #4804
-            if let Some(trait_self_ty) = self.trait_self_ty {
-                if self.cx.tcx.hir_name(cmt.hir_id) == kw::SelfLower && cmt.place.ty().contains(trait_self_ty) {
-                    return;
-                }
+            if let Some(trait_self_ty) = self.trait_self_ty
+                && self.cx.tcx.hir_name(cmt.hir_id) == kw::SelfLower
+                && cmt.place.ty().contains(trait_self_ty)
+            {
+                return;
             }
 
             if is_non_trait_box(cmt.place.ty()) && !self.is_large_box(cmt.place.ty()) {

--- a/clippy_lints/src/fallible_impl_from.rs
+++ b/clippy_lints/src/fallible_impl_from.rs
@@ -75,10 +75,10 @@ fn lint_impl_body(cx: &LateContext<'_>, impl_span: Span, impl_items: &[hir::Impl
 
     impl<'tcx> Visitor<'tcx> for FindPanicUnwrap<'_, 'tcx> {
         fn visit_expr(&mut self, expr: &'tcx Expr<'_>) {
-            if let Some(macro_call) = root_macro_call_first_node(self.lcx, expr) {
-                if is_panic(self.lcx, macro_call.def_id) {
-                    self.result.push(expr.span);
-                }
+            if let Some(macro_call) = root_macro_call_first_node(self.lcx, expr)
+                && is_panic(self.lcx, macro_call.def_id)
+            {
+                self.result.push(expr.span);
             }
 
             // check for `unwrap`

--- a/clippy_lints/src/floating_point_arithmetic.rs
+++ b/clippy_lints/src/floating_point_arithmetic.rs
@@ -228,24 +228,24 @@ fn get_integer_from_float_constant(value: &Constant<'_>) -> Option<i32> {
 
 fn check_powf(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, args: &[Expr<'_>]) {
     // Check receiver
-    if let Some(value) = ConstEvalCtxt::new(cx).eval(receiver) {
-        if let Some(method) = if F32(f32_consts::E) == value || F64(f64_consts::E) == value {
+    if let Some(value) = ConstEvalCtxt::new(cx).eval(receiver)
+        && let Some(method) = if F32(f32_consts::E) == value || F64(f64_consts::E) == value {
             Some("exp")
         } else if F32(2.0) == value || F64(2.0) == value {
             Some("exp2")
         } else {
             None
-        } {
-            span_lint_and_sugg(
-                cx,
-                SUBOPTIMAL_FLOPS,
-                expr.span,
-                "exponent for bases 2 and e can be computed more accurately",
-                "consider using",
-                format!("{}.{method}()", prepare_receiver_sugg(cx, &args[0])),
-                Applicability::MachineApplicable,
-            );
         }
+    {
+        span_lint_and_sugg(
+            cx,
+            SUBOPTIMAL_FLOPS,
+            expr.span,
+            "exponent for bases 2 and e can be computed more accurately",
+            "consider using",
+            format!("{}.{method}()", prepare_receiver_sugg(cx, &args[0])),
+            Applicability::MachineApplicable,
+        );
     }
 
     // Check argument
@@ -289,55 +289,53 @@ fn check_powf(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, args: 
 }
 
 fn check_powi(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>, args: &[Expr<'_>]) {
-    if let Some(value) = ConstEvalCtxt::new(cx).eval(&args[0]) {
-        if value == Int(2) {
-            if let Some(parent) = get_parent_expr(cx, expr) {
-                if let Some(grandparent) = get_parent_expr(cx, parent) {
-                    if let ExprKind::MethodCall(PathSegment { ident: method_name, .. }, receiver, ..) = grandparent.kind
-                    {
-                        if method_name.as_str() == "sqrt" && detect_hypot(cx, receiver).is_some() {
-                            return;
-                        }
-                    }
+    if let Some(value) = ConstEvalCtxt::new(cx).eval(&args[0])
+        && value == Int(2)
+        && let Some(parent) = get_parent_expr(cx, expr)
+    {
+        if let Some(grandparent) = get_parent_expr(cx, parent)
+            && let ExprKind::MethodCall(PathSegment { ident: method_name, .. }, receiver, ..) = grandparent.kind
+            && method_name.as_str() == "sqrt"
+            && detect_hypot(cx, receiver).is_some()
+        {
+            return;
+        }
+
+        if let ExprKind::Binary(
+            Spanned {
+                node: op @ (BinOpKind::Add | BinOpKind::Sub),
+                ..
+            },
+            lhs,
+            rhs,
+        ) = parent.kind
+        {
+            let other_addend = if lhs.hir_id == expr.hir_id { rhs } else { lhs };
+
+            // Negate expr if original code has subtraction and expr is on the right side
+            let maybe_neg_sugg = |expr, hir_id| {
+                let sugg = Sugg::hir(cx, expr, "..");
+                if matches!(op, BinOpKind::Sub) && hir_id == rhs.hir_id {
+                    -sugg
+                } else {
+                    sugg
                 }
+            };
 
-                if let ExprKind::Binary(
-                    Spanned {
-                        node: op @ (BinOpKind::Add | BinOpKind::Sub),
-                        ..
-                    },
-                    lhs,
-                    rhs,
-                ) = parent.kind
-                {
-                    let other_addend = if lhs.hir_id == expr.hir_id { rhs } else { lhs };
-
-                    // Negate expr if original code has subtraction and expr is on the right side
-                    let maybe_neg_sugg = |expr, hir_id| {
-                        let sugg = Sugg::hir(cx, expr, "..");
-                        if matches!(op, BinOpKind::Sub) && hir_id == rhs.hir_id {
-                            -sugg
-                        } else {
-                            sugg
-                        }
-                    };
-
-                    span_lint_and_sugg(
-                        cx,
-                        SUBOPTIMAL_FLOPS,
-                        parent.span,
-                        "multiply and add expressions can be calculated more efficiently and accurately",
-                        "consider using",
-                        format!(
-                            "{}.mul_add({}, {})",
-                            Sugg::hir(cx, receiver, "..").maybe_paren(),
-                            maybe_neg_sugg(receiver, expr.hir_id),
-                            maybe_neg_sugg(other_addend, other_addend.hir_id),
-                        ),
-                        Applicability::MachineApplicable,
-                    );
-                }
-            }
+            span_lint_and_sugg(
+                cx,
+                SUBOPTIMAL_FLOPS,
+                parent.span,
+                "multiply and add expressions can be calculated more efficiently and accurately",
+                "consider using",
+                format!(
+                    "{}.mul_add({}, {})",
+                    Sugg::hir(cx, receiver, "..").maybe_paren(),
+                    maybe_neg_sugg(receiver, expr.hir_id),
+                    maybe_neg_sugg(other_addend, other_addend.hir_id),
+                ),
+                Applicability::MachineApplicable,
+            );
         }
     }
 }
@@ -483,12 +481,12 @@ fn check_mul_add(cx: &LateContext<'_>, expr: &Expr<'_>) {
         rhs,
     ) = &expr.kind
     {
-        if let Some(parent) = get_parent_expr(cx, expr) {
-            if let ExprKind::MethodCall(PathSegment { ident: method_name, .. }, receiver, ..) = parent.kind {
-                if method_name.as_str() == "sqrt" && detect_hypot(cx, receiver).is_some() {
-                    return;
-                }
-            }
+        if let Some(parent) = get_parent_expr(cx, expr)
+            && let ExprKind::MethodCall(PathSegment { ident: method_name, .. }, receiver, ..) = parent.kind
+            && method_name.as_str() == "sqrt"
+            && detect_hypot(cx, receiver).is_some()
+        {
+            return;
         }
 
         let maybe_neg_sugg = |expr| {
@@ -566,15 +564,15 @@ fn is_zero(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
 /// If the two expressions are not negations of each other, then it
 /// returns None.
 fn are_negated<'a>(cx: &LateContext<'_>, expr1: &'a Expr<'a>, expr2: &'a Expr<'a>) -> Option<(bool, &'a Expr<'a>)> {
-    if let ExprKind::Unary(UnOp::Neg, expr1_negated) = &expr1.kind {
-        if eq_expr_value(cx, expr1_negated, expr2) {
-            return Some((false, expr2));
-        }
+    if let ExprKind::Unary(UnOp::Neg, expr1_negated) = &expr1.kind
+        && eq_expr_value(cx, expr1_negated, expr2)
+    {
+        return Some((false, expr2));
     }
-    if let ExprKind::Unary(UnOp::Neg, expr2_negated) = &expr2.kind {
-        if eq_expr_value(cx, expr1, expr2_negated) {
-            return Some((true, expr1));
-        }
+    if let ExprKind::Unary(UnOp::Neg, expr2_negated) = &expr2.kind
+        && eq_expr_value(cx, expr1, expr2_negated)
+    {
+        return Some((true, expr1));
     }
     None
 }

--- a/clippy_lints/src/formatting.rs
+++ b/clippy_lints/src/formatting.rs
@@ -138,27 +138,28 @@ impl EarlyLintPass for Formatting {
 
 /// Implementation of the `SUSPICIOUS_ASSIGNMENT_FORMATTING` lint.
 fn check_assign(cx: &EarlyContext<'_>, expr: &Expr) {
-    if let ExprKind::Assign(ref lhs, ref rhs, _) = expr.kind {
-        if !lhs.span.from_expansion() && !rhs.span.from_expansion() {
-            let eq_span = lhs.span.between(rhs.span);
-            if let ExprKind::Unary(op, ref sub_rhs) = rhs.kind {
-                if let Some(eq_snippet) = snippet_opt(cx, eq_span) {
-                    let op = op.as_str();
-                    let eqop_span = lhs.span.between(sub_rhs.span);
-                    if eq_snippet.ends_with('=') {
-                        span_lint_and_note(
-                            cx,
-                            SUSPICIOUS_ASSIGNMENT_FORMATTING,
-                            eqop_span,
-                            format!(
-                                "this looks like you are trying to use `.. {op}= ..`, but you \
+    if let ExprKind::Assign(ref lhs, ref rhs, _) = expr.kind
+        && !lhs.span.from_expansion()
+        && !rhs.span.from_expansion()
+    {
+        let eq_span = lhs.span.between(rhs.span);
+        if let ExprKind::Unary(op, ref sub_rhs) = rhs.kind
+            && let Some(eq_snippet) = snippet_opt(cx, eq_span)
+        {
+            let op = op.as_str();
+            let eqop_span = lhs.span.between(sub_rhs.span);
+            if eq_snippet.ends_with('=') {
+                span_lint_and_note(
+                    cx,
+                    SUSPICIOUS_ASSIGNMENT_FORMATTING,
+                    eqop_span,
+                    format!(
+                        "this looks like you are trying to use `.. {op}= ..`, but you \
                                  really are doing `.. = ({op} ..)`"
-                            ),
-                            None,
-                            format!("to remove this lint, use either `{op}=` or `= {op}`"),
-                        );
-                    }
-                }
+                    ),
+                    None,
+                    format!("to remove this lint, use either `{op}=` or `= {op}`"),
+                );
             }
         }
     }

--- a/clippy_lints/src/functions/too_many_arguments.rs
+++ b/clippy_lints/src/functions/too_many_arguments.rs
@@ -47,16 +47,16 @@ pub(super) fn check_fn(
 }
 
 pub(super) fn check_trait_item(cx: &LateContext<'_>, item: &hir::TraitItem<'_>, too_many_arguments_threshold: u64) {
-    if let hir::TraitItemKind::Fn(ref sig, _) = item.kind {
+    if let hir::TraitItemKind::Fn(ref sig, _) = item.kind
         // don't lint extern functions decls, it's not their fault
-        if sig.header.abi == ExternAbi::Rust {
-            check_arg_number(
-                cx,
-                sig.decl,
-                item.span.with_hi(sig.decl.output.span().hi()),
-                too_many_arguments_threshold,
-            );
-        }
+        && sig.header.abi == ExternAbi::Rust
+    {
+        check_arg_number(
+            cx,
+            sig.decl,
+            item.span.with_hi(sig.decl.output.span().hi()),
+            too_many_arguments_threshold,
+        );
     }
 }
 

--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -153,18 +153,18 @@ fn lint_implicit_returns(
         ExprKind::Loop(block, ..) => {
             let mut add_return = false;
             let _: Option<!> = for_each_expr_without_closures(block, |e| {
-                if let ExprKind::Break(dest, sub_expr) = e.kind {
-                    if dest.target_id.ok() == Some(expr.hir_id) {
-                        if call_site_span.is_none() && e.span.ctxt() == ctxt {
-                            // At this point sub_expr can be `None` in async functions which either diverge, or return
-                            // the unit type.
-                            if let Some(sub_expr) = sub_expr {
-                                lint_break(cx, e.hir_id, e.span, sub_expr.span);
-                            }
-                        } else {
-                            // the break expression is from a macro call, add a return to the loop
-                            add_return = true;
+                if let ExprKind::Break(dest, sub_expr) = e.kind
+                    && dest.target_id.ok() == Some(expr.hir_id)
+                {
+                    if call_site_span.is_none() && e.span.ctxt() == ctxt {
+                        // At this point sub_expr can be `None` in async functions which either diverge, or return
+                        // the unit type.
+                        if let Some(sub_expr) = sub_expr {
+                            lint_break(cx, e.hir_id, e.span, sub_expr.span);
                         }
+                    } else {
+                        // the break expression is from a macro call, add a return to the loop
+                        add_return = true;
                     }
                 }
                 ControlFlow::Continue(())

--- a/clippy_lints/src/indexing_slicing.rs
+++ b/clippy_lints/src/indexing_slicing.rs
@@ -136,28 +136,28 @@ impl<'tcx> LateLintPass<'tcx> for IndexingSlicing {
 
                     let const_range = to_const_range(cx, range, size);
 
-                    if let (Some(start), _) = const_range {
-                        if start > size {
-                            span_lint(
-                                cx,
-                                OUT_OF_BOUNDS_INDEXING,
-                                range.start.map_or(expr.span, |start| start.span),
-                                "range is out of bounds",
-                            );
-                            return;
-                        }
+                    if let (Some(start), _) = const_range
+                        && start > size
+                    {
+                        span_lint(
+                            cx,
+                            OUT_OF_BOUNDS_INDEXING,
+                            range.start.map_or(expr.span, |start| start.span),
+                            "range is out of bounds",
+                        );
+                        return;
                     }
 
-                    if let (_, Some(end)) = const_range {
-                        if end > size {
-                            span_lint(
-                                cx,
-                                OUT_OF_BOUNDS_INDEXING,
-                                range.end.map_or(expr.span, |end| end.span),
-                                "range is out of bounds",
-                            );
-                            return;
-                        }
+                    if let (_, Some(end)) = const_range
+                        && end > size
+                    {
+                        span_lint(
+                            cx,
+                            OUT_OF_BOUNDS_INDEXING,
+                            range.end.map_or(expr.span, |end| end.span),
+                            "range is out of bounds",
+                        );
+                        return;
                     }
 
                     if let (Some(_), Some(_)) = const_range {

--- a/clippy_lints/src/infinite_iter.rs
+++ b/clippy_lints/src/infinite_iter.rs
@@ -156,11 +156,12 @@ fn is_infinite(cx: &LateContext<'_>, expr: &Expr<'_>) -> Finiteness {
                     .and(cap);
                 }
             }
-            if method.ident.name.as_str() == "flat_map" && args.len() == 1 {
-                if let ExprKind::Closure(&Closure { body, .. }) = args[0].kind {
-                    let body = cx.tcx.hir_body(body);
-                    return is_infinite(cx, body.value);
-                }
+            if method.ident.name.as_str() == "flat_map"
+                && args.len() == 1
+                && let ExprKind::Closure(&Closure { body, .. }) = args[0].kind
+            {
+                let body = cx.tcx.hir_body(body);
+                return is_infinite(cx, body.value);
             }
             Finite
         },

--- a/clippy_lints/src/int_plus_one.rs
+++ b/clippy_lints/src/int_plus_one.rs
@@ -130,14 +130,14 @@ impl IntPlusOne {
             BinOpKind::Le => "<",
             _ => return None,
         };
-        if let Some(snippet) = node.span.get_source_text(cx) {
-            if let Some(other_side_snippet) = other_side.span.get_source_text(cx) {
-                let rec = match side {
-                    Side::Lhs => Some(format!("{snippet} {binop_string} {other_side_snippet}")),
-                    Side::Rhs => Some(format!("{other_side_snippet} {binop_string} {snippet}")),
-                };
-                return rec;
-            }
+        if let Some(snippet) = node.span.get_source_text(cx)
+            && let Some(other_side_snippet) = other_side.span.get_source_text(cx)
+        {
+            let rec = match side {
+                Side::Lhs => Some(format!("{snippet} {binop_string} {other_side_snippet}")),
+                Side::Rhs => Some(format!("{other_side_snippet} {binop_string} {snippet}")),
+            };
+            return rec;
         }
         None
     }
@@ -157,10 +157,10 @@ impl IntPlusOne {
 
 impl EarlyLintPass for IntPlusOne {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, item: &Expr) {
-        if let ExprKind::Binary(ref kind, ref lhs, ref rhs) = item.kind {
-            if let Some(rec) = Self::check_binop(cx, kind.node, lhs, rhs) {
-                Self::emit_warning(cx, item, rec);
-            }
+        if let ExprKind::Binary(ref kind, ref lhs, ref rhs) = item.kind
+            && let Some(rec) = Self::check_binop(cx, kind.node, lhs, rhs)
+        {
+            Self::emit_warning(cx, item, rec);
         }
     }
 }

--- a/clippy_lints/src/invalid_upcast_comparisons.rs
+++ b/clippy_lints/src/invalid_upcast_comparisons.rs
@@ -91,49 +91,49 @@ fn upcast_comparison_bounds_err<'tcx>(
     rhs: &'tcx Expr<'_>,
     invert: bool,
 ) {
-    if let Some((lb, ub)) = lhs_bounds {
-        if let Some(norm_rhs_val) = ConstEvalCtxt::new(cx).eval_full_int(rhs) {
-            if rel == Rel::Eq || rel == Rel::Ne {
-                if norm_rhs_val < lb || norm_rhs_val > ub {
-                    err_upcast_comparison(cx, span, lhs, rel == Rel::Ne);
-                }
-            } else if match rel {
-                Rel::Lt => {
-                    if invert {
-                        norm_rhs_val < lb
-                    } else {
-                        ub < norm_rhs_val
-                    }
-                },
-                Rel::Le => {
-                    if invert {
-                        norm_rhs_val <= lb
-                    } else {
-                        ub <= norm_rhs_val
-                    }
-                },
-                Rel::Eq | Rel::Ne => unreachable!(),
-            } {
-                err_upcast_comparison(cx, span, lhs, true);
-            } else if match rel {
-                Rel::Lt => {
-                    if invert {
-                        norm_rhs_val >= ub
-                    } else {
-                        lb >= norm_rhs_val
-                    }
-                },
-                Rel::Le => {
-                    if invert {
-                        norm_rhs_val > ub
-                    } else {
-                        lb > norm_rhs_val
-                    }
-                },
-                Rel::Eq | Rel::Ne => unreachable!(),
-            } {
-                err_upcast_comparison(cx, span, lhs, false);
+    if let Some((lb, ub)) = lhs_bounds
+        && let Some(norm_rhs_val) = ConstEvalCtxt::new(cx).eval_full_int(rhs)
+    {
+        if rel == Rel::Eq || rel == Rel::Ne {
+            if norm_rhs_val < lb || norm_rhs_val > ub {
+                err_upcast_comparison(cx, span, lhs, rel == Rel::Ne);
             }
+        } else if match rel {
+            Rel::Lt => {
+                if invert {
+                    norm_rhs_val < lb
+                } else {
+                    ub < norm_rhs_val
+                }
+            },
+            Rel::Le => {
+                if invert {
+                    norm_rhs_val <= lb
+                } else {
+                    ub <= norm_rhs_val
+                }
+            },
+            Rel::Eq | Rel::Ne => unreachable!(),
+        } {
+            err_upcast_comparison(cx, span, lhs, true);
+        } else if match rel {
+            Rel::Lt => {
+                if invert {
+                    norm_rhs_val >= ub
+                } else {
+                    lb >= norm_rhs_val
+                }
+            },
+            Rel::Le => {
+                if invert {
+                    norm_rhs_val > ub
+                } else {
+                    lb > norm_rhs_val
+                }
+            },
+            Rel::Eq | Rel::Ne => unreachable!(),
+        } {
+            err_upcast_comparison(cx, span, lhs, false);
         }
     }
 }

--- a/clippy_lints/src/item_name_repetitions.rs
+++ b/clippy_lints/src/item_name_repetitions.rs
@@ -444,56 +444,55 @@ impl LateLintPass<'_> for ItemNameRepetitions {
 
         let item_name = ident.name.as_str();
         let item_camel = to_camel_case(item_name);
-        if !item.span.from_expansion() && is_present_in_source(cx, item.span) {
-            if let [.., (mod_name, mod_camel, mod_owner_id)] = &*self.modules {
+        if !item.span.from_expansion() && is_present_in_source(cx, item.span)
+            && let [.., (mod_name, mod_camel, mod_owner_id)] = &*self.modules
                 // constants don't have surrounding modules
-                if !mod_camel.is_empty() {
-                    if mod_name == &ident.name
-                        && let ItemKind::Mod(..) = item.kind
-                        && (!self.allow_private_module_inception || cx.tcx.visibility(mod_owner_id.def_id).is_public())
-                    {
-                        span_lint(
+                && !mod_camel.is_empty()
+        {
+            if mod_name == &ident.name
+                && let ItemKind::Mod(..) = item.kind
+                && (!self.allow_private_module_inception || cx.tcx.visibility(mod_owner_id.def_id).is_public())
+            {
+                span_lint(
+                    cx,
+                    MODULE_INCEPTION,
+                    item.span,
+                    "module has the same name as its containing module",
+                );
+            }
+
+            // The `module_name_repetitions` lint should only trigger if the item has the module in its
+            // name. Having the same name is accepted.
+            if cx.tcx.visibility(item.owner_id).is_public()
+                && cx.tcx.visibility(mod_owner_id.def_id).is_public()
+                && item_camel.len() > mod_camel.len()
+            {
+                let matching = count_match_start(mod_camel, &item_camel);
+                let rmatching = count_match_end(mod_camel, &item_camel);
+                let nchars = mod_camel.chars().count();
+
+                let is_word_beginning = |c: char| c == '_' || c.is_uppercase() || c.is_numeric();
+
+                if matching.char_count == nchars {
+                    match item_camel.chars().nth(nchars) {
+                        Some(c) if is_word_beginning(c) => span_lint(
                             cx,
-                            MODULE_INCEPTION,
-                            item.span,
-                            "module has the same name as its containing module",
-                        );
+                            MODULE_NAME_REPETITIONS,
+                            ident.span,
+                            "item name starts with its containing module's name",
+                        ),
+                        _ => (),
                     }
-
-                    // The `module_name_repetitions` lint should only trigger if the item has the module in its
-                    // name. Having the same name is accepted.
-                    if cx.tcx.visibility(item.owner_id).is_public()
-                        && cx.tcx.visibility(mod_owner_id.def_id).is_public()
-                        && item_camel.len() > mod_camel.len()
-                    {
-                        let matching = count_match_start(mod_camel, &item_camel);
-                        let rmatching = count_match_end(mod_camel, &item_camel);
-                        let nchars = mod_camel.chars().count();
-
-                        let is_word_beginning = |c: char| c == '_' || c.is_uppercase() || c.is_numeric();
-
-                        if matching.char_count == nchars {
-                            match item_camel.chars().nth(nchars) {
-                                Some(c) if is_word_beginning(c) => span_lint(
-                                    cx,
-                                    MODULE_NAME_REPETITIONS,
-                                    ident.span,
-                                    "item name starts with its containing module's name",
-                                ),
-                                _ => (),
-                            }
-                        }
-                        if rmatching.char_count == nchars
-                            && !self.is_allowed_prefix(&item_camel[..item_camel.len() - rmatching.byte_count])
-                        {
-                            span_lint(
-                                cx,
-                                MODULE_NAME_REPETITIONS,
-                                ident.span,
-                                "item name ends with its containing module's name",
-                            );
-                        }
-                    }
+                }
+                if rmatching.char_count == nchars
+                    && !self.is_allowed_prefix(&item_camel[..item_camel.len() - rmatching.byte_count])
+                {
+                    span_lint(
+                        cx,
+                        MODULE_NAME_REPETITIONS,
+                        ident.span,
+                        "item name ends with its containing module's name",
+                    );
                 }
             }
         }

--- a/clippy_lints/src/len_zero.rs
+++ b/clippy_lints/src/len_zero.rs
@@ -523,10 +523,10 @@ fn check_cmp(cx: &LateContext<'_>, span: Span, method: &Expr<'_>, lit: &Expr<'_>
 
     if let (&ExprKind::MethodCall(method_path, receiver, [], _), ExprKind::Lit(lit)) = (&method.kind, &lit.kind) {
         // check if we are in an is_empty() method
-        if let Some(name) = get_item_name(cx, method) {
-            if name.as_str() == "is_empty" {
-                return;
-            }
+        if let Some(name) = get_item_name(cx, method)
+            && name.as_str() == "is_empty"
+        {
+            return;
         }
 
         check_len(cx, span, method_path.ident.name, receiver, &lit.node, op, compare_to);
@@ -588,11 +588,11 @@ fn check_empty_expr(cx: &LateContext<'_>, span: Span, lit1: &Expr<'_>, lit2: &Ex
 }
 
 fn is_empty_string(expr: &Expr<'_>) -> bool {
-    if let ExprKind::Lit(lit) = expr.kind {
-        if let LitKind::Str(lit, _) = lit.node {
-            let lit = lit.as_str();
-            return lit.is_empty();
-        }
+    if let ExprKind::Lit(lit) = expr.kind
+        && let LitKind::Str(lit, _) = lit.node
+    {
+        let lit = lit.as_str();
+        return lit.is_empty();
     }
     false
 }

--- a/clippy_lints/src/lifetimes.rs
+++ b/clippy_lints/src/lifetimes.rs
@@ -150,10 +150,10 @@ impl<'tcx> LateLintPass<'tcx> for Lifetimes {
         } = item.kind
         {
             check_fn_inner(cx, sig, Some(id), None, generics, item.span, true, self.msrv);
-        } else if let ItemKind::Impl(impl_) = item.kind {
-            if !item.span.from_expansion() {
-                report_extra_impl_lifetimes(cx, impl_);
-            }
+        } else if let ItemKind::Impl(impl_) = item.kind
+            && !item.span.from_expansion()
+        {
+            report_extra_impl_lifetimes(cx, impl_);
         }
     }
 

--- a/clippy_lints/src/literal_representation.rs
+++ b/clippy_lints/src/literal_representation.rs
@@ -387,12 +387,11 @@ impl LiteralDigitGrouping {
 
         let first = groups.next().expect("At least one group");
 
-        if radix == Radix::Binary || radix == Radix::Octal || radix == Radix::Hexadecimal {
-            if let Some(second_size) = groups.next() {
-                if !groups.all(|i| i == second_size) || first > second_size {
-                    return Err(WarningType::UnusualByteGroupings);
-                }
-            }
+        if (radix == Radix::Binary || radix == Radix::Octal || radix == Radix::Hexadecimal)
+            && let Some(second_size) = groups.next()
+            && (!groups.all(|i| i == second_size) || first > second_size)
+        {
+            return Err(WarningType::UnusualByteGroupings);
         }
 
         if let Some(second) = groups.next() {

--- a/clippy_lints/src/literal_string_with_formatting_args.rs
+++ b/clippy_lints/src/literal_string_with_formatting_args.rs
@@ -45,15 +45,14 @@ fn emit_lint(cx: &LateContext<'_>, expr: &Expr<'_>, spans: &[(Span, Option<Strin
         let spans = spans
             .iter()
             .filter_map(|(span, name)| {
-                if let Some(name) = name {
+                if let Some(name) = name
                     // We need to check that the name is a local.
-                    if !mir
+                    && !mir
                         .var_debug_info
                         .iter()
                         .any(|local| !local.source_info.span.from_expansion() && local.name.as_str() == name)
-                    {
-                        return None;
-                    }
+                {
+                    return None;
                 }
                 Some(*span)
             })

--- a/clippy_lints/src/loops/for_kv_map.rs
+++ b/clippy_lints/src/loops/for_kv_map.rs
@@ -13,45 +13,45 @@ use rustc_span::sym;
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, pat: &'tcx Pat<'_>, arg: &'tcx Expr<'_>, body: &'tcx Expr<'_>) {
     let pat_span = pat.span;
 
-    if let PatKind::Tuple(pat, _) = pat.kind {
-        if pat.len() == 2 {
-            let arg_span = arg.span;
-            let (new_pat_span, kind, ty, mutbl) = match *cx.typeck_results().expr_ty(arg).kind() {
-                ty::Ref(_, ty, mutbl) => match (&pat[0].kind, &pat[1].kind) {
-                    (key, _) if pat_is_wild(cx, key, body) => (pat[1].span, "value", ty, mutbl),
-                    (_, value) if pat_is_wild(cx, value, body) => (pat[0].span, "key", ty, Mutability::Not),
-                    _ => return,
-                },
+    if let PatKind::Tuple(pat, _) = pat.kind
+        && pat.len() == 2
+    {
+        let arg_span = arg.span;
+        let (new_pat_span, kind, ty, mutbl) = match *cx.typeck_results().expr_ty(arg).kind() {
+            ty::Ref(_, ty, mutbl) => match (&pat[0].kind, &pat[1].kind) {
+                (key, _) if pat_is_wild(cx, key, body) => (pat[1].span, "value", ty, mutbl),
+                (_, value) if pat_is_wild(cx, value, body) => (pat[0].span, "key", ty, Mutability::Not),
                 _ => return,
-            };
-            let mutbl = match mutbl {
-                Mutability::Not => "",
-                Mutability::Mut => "_mut",
-            };
-            let arg = match arg.kind {
-                ExprKind::AddrOf(BorrowKind::Ref, _, expr) => expr,
-                _ => arg,
-            };
+            },
+            _ => return,
+        };
+        let mutbl = match mutbl {
+            Mutability::Not => "",
+            Mutability::Mut => "_mut",
+        };
+        let arg = match arg.kind {
+            ExprKind::AddrOf(BorrowKind::Ref, _, expr) => expr,
+            _ => arg,
+        };
 
-            if is_type_diagnostic_item(cx, ty, sym::HashMap) || is_type_diagnostic_item(cx, ty, sym::BTreeMap) {
-                span_lint_and_then(
-                    cx,
-                    FOR_KV_MAP,
-                    arg_span,
-                    format!("you seem to want to iterate on a map's {kind}s"),
-                    |diag| {
-                        let map = sugg::Sugg::hir(cx, arg, "map");
-                        diag.multipart_suggestion(
-                            "use the corresponding method",
-                            vec![
-                                (pat_span, snippet(cx, new_pat_span, kind).into_owned()),
-                                (arg_span, format!("{}.{kind}s{mutbl}()", map.maybe_paren())),
-                            ],
-                            Applicability::MachineApplicable,
-                        );
-                    },
-                );
-            }
+        if is_type_diagnostic_item(cx, ty, sym::HashMap) || is_type_diagnostic_item(cx, ty, sym::BTreeMap) {
+            span_lint_and_then(
+                cx,
+                FOR_KV_MAP,
+                arg_span,
+                format!("you seem to want to iterate on a map's {kind}s"),
+                |diag| {
+                    let map = sugg::Sugg::hir(cx, arg, "map");
+                    diag.multipart_suggestion(
+                        "use the corresponding method",
+                        vec![
+                            (pat_span, snippet(cx, new_pat_span, kind).into_owned()),
+                            (arg_span, format!("{}.{kind}s{mutbl}()", map.maybe_paren())),
+                        ],
+                        Applicability::MachineApplicable,
+                    );
+                },
+            );
         }
     }
 }

--- a/clippy_lints/src/loops/manual_memcpy.rs
+++ b/clippy_lints/src/loops/manual_memcpy.rs
@@ -28,37 +28,37 @@ pub(super) fn check<'tcx>(
         end: Some(end),
         limits,
     }) = higher::Range::hir(arg)
-    {
         // the var must be a single name
-        if let PatKind::Binding(_, canonical_id, _, _) = pat.kind {
-            let mut starts = vec![Start {
-                id: canonical_id,
-                kind: StartKind::Range,
-            }];
+        && let PatKind::Binding(_, canonical_id, _, _) = pat.kind
+    {
+        let mut starts = vec![Start {
+            id: canonical_id,
+            kind: StartKind::Range,
+        }];
 
-            // This is one of few ways to return different iterators
-            // derived from: https://stackoverflow.com/questions/29760668/conditionally-iterate-over-one-of-several-possible-iterators/52064434#52064434
-            let mut iter_a = None;
-            let mut iter_b = None;
+        // This is one of few ways to return different iterators
+        // derived from: https://stackoverflow.com/questions/29760668/conditionally-iterate-over-one-of-several-possible-iterators/52064434#52064434
+        let mut iter_a = None;
+        let mut iter_b = None;
 
-            if let ExprKind::Block(block, _) = body.kind {
-                if let Some(loop_counters) = get_loop_counters(cx, block, expr) {
-                    starts.extend(loop_counters);
-                }
-                iter_a = Some(get_assignments(block, &starts));
-            } else {
-                iter_b = Some(get_assignment(body));
+        if let ExprKind::Block(block, _) = body.kind {
+            if let Some(loop_counters) = get_loop_counters(cx, block, expr) {
+                starts.extend(loop_counters);
             }
+            iter_a = Some(get_assignments(block, &starts));
+        } else {
+            iter_b = Some(get_assignment(body));
+        }
 
-            let assignments = iter_a.into_iter().flatten().chain(iter_b);
+        let assignments = iter_a.into_iter().flatten().chain(iter_b);
 
-            let big_sugg = assignments
-                // The only statements in the for loops can be indexed assignments from
-                // indexed retrievals (except increments of loop counters).
-                .map(|o| {
-                    o.and_then(|(lhs, rhs)| {
-                        let rhs = fetch_cloned_expr(rhs);
-                        if let ExprKind::Index(base_left, idx_left, _) = lhs.kind
+        let big_sugg = assignments
+            // The only statements in the for loops can be indexed assignments from
+            // indexed retrievals (except increments of loop counters).
+            .map(|o| {
+                o.and_then(|(lhs, rhs)| {
+                    let rhs = fetch_cloned_expr(rhs);
+                    if let ExprKind::Index(base_left, idx_left, _) = lhs.kind
                             && let ExprKind::Index(base_right, idx_right, _) = rhs.kind
                             && let Some(ty) = get_slice_like_element_ty(cx, cx.typeck_results().expr_ty(base_left))
                             && get_slice_like_element_ty(cx, cx.typeck_results().expr_ty(base_right)).is_some()
@@ -68,42 +68,41 @@ pub(super) fn check<'tcx>(
                             && !local_used_in(cx, canonical_id, base_right)
 							// Source and destination must be different
                             && path_to_local(base_left) != path_to_local(base_right)
-                        {
-                            Some((
-                                ty,
-                                IndexExpr {
-                                    base: base_left,
-                                    idx: start_left,
-                                    idx_offset: offset_left,
-                                },
-                                IndexExpr {
-                                    base: base_right,
-                                    idx: start_right,
-                                    idx_offset: offset_right,
-                                },
-                            ))
-                        } else {
-                            None
-                        }
-                    })
+                    {
+                        Some((
+                            ty,
+                            IndexExpr {
+                                base: base_left,
+                                idx: start_left,
+                                idx_offset: offset_left,
+                            },
+                            IndexExpr {
+                                base: base_right,
+                                idx: start_right,
+                                idx_offset: offset_right,
+                            },
+                        ))
+                    } else {
+                        None
+                    }
                 })
-                .map(|o| o.map(|(ty, dst, src)| build_manual_memcpy_suggestion(cx, start, end, limits, ty, &dst, &src)))
-                .collect::<Option<Vec<_>>>()
-                .filter(|v| !v.is_empty())
-                .map(|v| v.join("\n    "));
+            })
+            .map(|o| o.map(|(ty, dst, src)| build_manual_memcpy_suggestion(cx, start, end, limits, ty, &dst, &src)))
+            .collect::<Option<Vec<_>>>()
+            .filter(|v| !v.is_empty())
+            .map(|v| v.join("\n    "));
 
-            if let Some(big_sugg) = big_sugg {
-                span_lint_and_sugg(
-                    cx,
-                    MANUAL_MEMCPY,
-                    expr.span,
-                    "it looks like you're manually copying between slices",
-                    "try replacing the loop by",
-                    big_sugg,
-                    Applicability::Unspecified,
-                );
-                return true;
-            }
+        if let Some(big_sugg) = big_sugg {
+            span_lint_and_sugg(
+                cx,
+                MANUAL_MEMCPY,
+                expr.span,
+                "it looks like you're manually copying between slices",
+                "try replacing the loop by",
+                big_sugg,
+                Applicability::Unspecified,
+            );
+            return true;
         }
     }
     false

--- a/clippy_lints/src/loops/manual_while_let_some.rs
+++ b/clippy_lints/src/loops/manual_while_let_some.rs
@@ -81,15 +81,15 @@ fn check_local(cx: &LateContext<'_>, stmt: &Stmt<'_>, is_empty_recv: &Expr<'_>, 
 }
 
 fn check_call_arguments(cx: &LateContext<'_>, stmt: &Stmt<'_>, is_empty_recv: &Expr<'_>, loop_span: Span) {
-    if let StmtKind::Semi(expr) | StmtKind::Expr(expr) = stmt.kind {
-        if let ExprKind::MethodCall(.., args, _) | ExprKind::Call(_, args) = expr.kind {
-            let offending_arg = args
-                .iter()
-                .find_map(|arg| is_vec_pop_unwrap(cx, arg, is_empty_recv).then_some(arg.span));
+    if let StmtKind::Semi(expr) | StmtKind::Expr(expr) = stmt.kind
+        && let ExprKind::MethodCall(.., args, _) | ExprKind::Call(_, args) = expr.kind
+    {
+        let offending_arg = args
+            .iter()
+            .find_map(|arg| is_vec_pop_unwrap(cx, arg, is_empty_recv).then_some(arg.span));
 
-            if let Some(offending_arg) = offending_arg {
-                report_lint(cx, offending_arg, PopStmt::Anonymous, loop_span, is_empty_recv.span);
-            }
+        if let Some(offending_arg) = offending_arg {
+            report_lint(cx, offending_arg, PopStmt::Anonymous, loop_span, is_empty_recv.span);
         }
     }
 }

--- a/clippy_lints/src/loops/mut_range_bound.rs
+++ b/clippy_lints/src/loops/mut_range_bound.rs
@@ -82,14 +82,14 @@ impl<'tcx> Delegate<'tcx> for MutatePairDelegate<'_, 'tcx> {
     fn use_cloned(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
 
     fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, diag_expr_id: HirId, bk: ty::BorrowKind) {
-        if bk == ty::BorrowKind::Mutable {
-            if let PlaceBase::Local(id) = cmt.place.base {
-                if Some(id) == self.hir_id_low && !BreakAfterExprVisitor::is_found(self.cx, diag_expr_id) {
-                    self.span_low = Some(self.cx.tcx.hir().span(diag_expr_id));
-                }
-                if Some(id) == self.hir_id_high && !BreakAfterExprVisitor::is_found(self.cx, diag_expr_id) {
-                    self.span_high = Some(self.cx.tcx.hir().span(diag_expr_id));
-                }
+        if bk == ty::BorrowKind::Mutable
+            && let PlaceBase::Local(id) = cmt.place.base
+        {
+            if Some(id) == self.hir_id_low && !BreakAfterExprVisitor::is_found(self.cx, diag_expr_id) {
+                self.span_low = Some(self.cx.tcx.hir().span(diag_expr_id));
+            }
+            if Some(id) == self.hir_id_high && !BreakAfterExprVisitor::is_found(self.cx, diag_expr_id) {
+                self.span_high = Some(self.cx.tcx.hir().span(diag_expr_id));
             }
         }
     }

--- a/clippy_lints/src/loops/never_loop.rs
+++ b/clippy_lints/src/loops/never_loop.rs
@@ -244,10 +244,10 @@ fn never_loop_expr<'tcx>(
             });
             combine_seq(first, || {
                 // checks if break targets a block instead of a loop
-                if let ExprKind::Break(Destination { target_id: Ok(t), .. }, _) = expr.kind {
-                    if let Some((_, reachable)) = local_labels.iter_mut().find(|(label, _)| *label == t) {
-                        *reachable = true;
-                    }
+                if let ExprKind::Break(Destination { target_id: Ok(t), .. }, _) = expr.kind
+                    && let Some((_, reachable)) = local_labels.iter_mut().find(|(label, _)| *label == t)
+                {
+                    *reachable = true;
                 }
                 NeverLoopResult::Diverging
             })

--- a/clippy_lints/src/manual_string_new.rs
+++ b/clippy_lints/src/manual_string_new.rs
@@ -113,15 +113,14 @@ fn parse_call(cx: &LateContext<'_>, span: Span, func: &Expr<'_>, arg: &Expr<'_>)
             && is_expr_kind_empty_str(&arg.kind)
         {
             warn_then_suggest(cx, span);
-        } else if let QPath::Resolved(_, path) = qpath {
+        } else if let QPath::Resolved(_, path) = qpath
             // From::from(...) or TryFrom::try_from(...)
-            if let [path_seg1, path_seg2] = path.segments
+            && let [path_seg1, path_seg2] = path.segments
                 && is_expr_kind_empty_str(&arg.kind)
                 && ((path_seg1.ident.name == sym::From && path_seg2.ident.name == sym::from)
                     || (path_seg1.ident.name == sym::TryFrom && path_seg2.ident.name == sym::try_from))
-            {
-                warn_then_suggest(cx, span);
-            }
+        {
+            warn_then_suggest(cx, span);
         }
     }
 }

--- a/clippy_lints/src/map_unit_fn.rs
+++ b/clippy_lints/src/map_unit_fn.rs
@@ -101,10 +101,10 @@ fn is_unit_type(ty: Ty<'_>) -> bool {
 fn is_unit_function(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> bool {
     let ty = cx.typeck_results().expr_ty(expr);
 
-    if let ty::FnDef(id, _) = *ty.kind() {
-        if let Some(fn_type) = cx.tcx.fn_sig(id).instantiate_identity().no_bound_vars() {
-            return is_unit_type(fn_type.output());
-        }
+    if let ty::FnDef(id, _) = *ty.kind()
+        && let Some(fn_type) = cx.tcx.fn_sig(id).instantiate_identity().no_bound_vars()
+    {
+        return is_unit_type(fn_type.output());
     }
     false
 }

--- a/clippy_lints/src/matches/manual_filter.rs
+++ b/clippy_lints/src/matches/manual_filter.rs
@@ -41,10 +41,10 @@ fn get_cond_expr<'tcx>(
 fn peels_blocks_incl_unsafe_opt<'a>(expr: &'a Expr<'a>) -> Option<&'a Expr<'a>> {
     // we don't want to use `peel_blocks` here because we don't care if the block is unsafe, it's
     // checked by `contains_unsafe_block`
-    if let ExprKind::Block(block, None) = expr.kind {
-        if block.stmts.is_empty() {
-            return block.expr;
-        }
+    if let ExprKind::Block(block, None) = expr.kind
+        && block.stmts.is_empty()
+    {
+        return block.expr;
     }
     None
 }
@@ -61,13 +61,13 @@ fn peels_blocks_incl_unsafe<'a>(expr: &'a Expr<'a>) -> &'a Expr<'a> {
 // }
 // Returns true if <expr> resolves to `Some(x)`, `false` otherwise
 fn is_some_expr(cx: &LateContext<'_>, target: HirId, ctxt: SyntaxContext, expr: &Expr<'_>) -> bool {
-    if let Some(inner_expr) = peels_blocks_incl_unsafe_opt(expr) {
+    if let Some(inner_expr) = peels_blocks_incl_unsafe_opt(expr)
         // there can be not statements in the block as they would be removed when switching to `.filter`
-        if let ExprKind::Call(callee, [arg]) = inner_expr.kind {
-            return ctxt == expr.span.ctxt()
-                && is_res_lang_ctor(cx, path_res(cx, callee), OptionSome)
-                && path_to_local_id(arg, target);
-        }
+        && let ExprKind::Call(callee, [arg]) = inner_expr.kind
+    {
+        return ctxt == expr.span.ctxt()
+            && is_res_lang_ctor(cx, path_res(cx, callee), OptionSome)
+            && path_to_local_id(arg, target);
     }
     false
 }

--- a/clippy_lints/src/matches/match_like_matches.rs
+++ b/clippy_lints/src/matches/match_like_matches.rs
@@ -76,17 +76,18 @@ where
         && first_attrs.is_empty()
         && iter.all(|arm| find_bool_lit(&arm.2.kind).is_some_and(|b| b == b0) && arm.3.is_none() && arm.0.is_empty())
     {
-        if let Some(last_pat) = last_pat_opt {
-            if !is_wild(last_pat) {
-                return false;
-            }
+        if let Some(last_pat) = last_pat_opt
+            && !is_wild(last_pat)
+        {
+            return false;
         }
 
         for arm in iter_without_last.clone() {
-            if let Some(pat) = arm.1 {
-                if !is_lint_allowed(cx, REDUNDANT_PATTERN_MATCHING, pat.hir_id) && is_some(pat.kind) {
-                    return false;
-                }
+            if let Some(pat) = arm.1
+                && !is_lint_allowed(cx, REDUNDANT_PATTERN_MATCHING, pat.hir_id)
+                && is_some(pat.kind)
+            {
+                return false;
             }
         }
 
@@ -113,10 +114,10 @@ where
 
         // strip potential borrows (#6503), but only if the type is a reference
         let mut ex_new = ex;
-        if let ExprKind::AddrOf(BorrowKind::Ref, .., ex_inner) = ex.kind {
-            if let ty::Ref(..) = cx.typeck_results().expr_ty(ex_inner).kind() {
-                ex_new = ex_inner;
-            }
+        if let ExprKind::AddrOf(BorrowKind::Ref, .., ex_inner) = ex.kind
+            && let ty::Ref(..) = cx.typeck_results().expr_ty(ex_inner).kind()
+        {
+            ex_new = ex_inner;
         }
         span_lint_and_sugg(
             cx,

--- a/clippy_lints/src/matches/match_single_binding.rs
+++ b/clippy_lints/src/matches/match_single_binding.rs
@@ -178,24 +178,24 @@ fn sugg_with_curlies<'a>(
     let mut indent = " ".repeat(indent_of(cx, ex.span).unwrap_or(0));
 
     let (mut cbrace_start, mut cbrace_end) = (String::new(), String::new());
-    if let Some(parent_expr) = get_parent_expr(cx, match_expr) {
-        if let ExprKind::Closure { .. } = parent_expr.kind {
-            cbrace_end = format!("\n{indent}}}");
-            // Fix body indent due to the closure
-            indent = " ".repeat(indent_of(cx, bind_names).unwrap_or(0));
-            cbrace_start = format!("{{\n{indent}");
-        }
+    if let Some(parent_expr) = get_parent_expr(cx, match_expr)
+        && let ExprKind::Closure { .. } = parent_expr.kind
+    {
+        cbrace_end = format!("\n{indent}}}");
+        // Fix body indent due to the closure
+        indent = " ".repeat(indent_of(cx, bind_names).unwrap_or(0));
+        cbrace_start = format!("{{\n{indent}");
     }
 
     // If the parent is already an arm, and the body is another match statement,
     // we need curly braces around suggestion
-    if let Node::Arm(arm) = &cx.tcx.parent_hir_node(match_expr.hir_id) {
-        if let ExprKind::Match(..) = arm.body.kind {
-            cbrace_end = format!("\n{indent}}}");
-            // Fix body indent due to the match
-            indent = " ".repeat(indent_of(cx, bind_names).unwrap_or(0));
-            cbrace_start = format!("{{\n{indent}");
-        }
+    if let Node::Arm(arm) = &cx.tcx.parent_hir_node(match_expr.hir_id)
+        && let ExprKind::Match(..) = arm.body.kind
+    {
+        cbrace_end = format!("\n{indent}}}");
+        // Fix body indent due to the match
+        indent = " ".repeat(indent_of(cx, bind_names).unwrap_or(0));
+        cbrace_start = format!("{{\n{indent}");
     }
 
     let assignment_str = assignment.map_or_else(String::new, |span| {

--- a/clippy_lints/src/matches/match_str_case_mismatch.rs
+++ b/clippy_lints/src/matches/match_str_case_mismatch.rs
@@ -26,10 +26,10 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, scrutinee: &'tcx Expr<'_>, arm
         && let ty::Str = ty.kind()
     {
         let mut visitor = MatchExprVisitor { cx };
-        if let ControlFlow::Break(case_method) = visitor.visit_expr(scrutinee) {
-            if let Some((bad_case_span, bad_case_sym)) = verify_case(&case_method, arms) {
-                lint(cx, &case_method, bad_case_span, bad_case_sym.as_str());
-            }
+        if let ControlFlow::Break(case_method) = visitor.visit_expr(scrutinee)
+            && let Some((bad_case_span, bad_case_sym)) = verify_case(&case_method, arms)
+        {
+            lint(cx, &case_method, bad_case_span, bad_case_sym.as_str());
         }
     }
 }

--- a/clippy_lints/src/matches/match_wild_enum.rs
+++ b/clippy_lints/src/matches/match_wild_enum.rs
@@ -80,18 +80,20 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>]) {
                     path
                 },
                 PatKind::TupleStruct(path, patterns, ..) => {
-                    if let Some(id) = cx.qpath_res(path, pat.hir_id).opt_def_id() {
-                        if arm.guard.is_none() && patterns.iter().all(|p| !is_refutable(cx, p)) {
-                            missing_variants.retain(|e| e.ctor_def_id() != Some(id));
-                        }
+                    if let Some(id) = cx.qpath_res(path, pat.hir_id).opt_def_id()
+                        && arm.guard.is_none()
+                        && patterns.iter().all(|p| !is_refutable(cx, p))
+                    {
+                        missing_variants.retain(|e| e.ctor_def_id() != Some(id));
                     }
                     path
                 },
                 PatKind::Struct(path, patterns, ..) => {
-                    if let Some(id) = cx.qpath_res(path, pat.hir_id).opt_def_id() {
-                        if arm.guard.is_none() && patterns.iter().all(|p| !is_refutable(cx, p.pat)) {
-                            missing_variants.retain(|e| e.def_id != id);
-                        }
+                    if let Some(id) = cx.qpath_res(path, pat.hir_id).opt_def_id()
+                        && arm.guard.is_none()
+                        && patterns.iter().all(|p| !is_refutable(cx, p.pat))
+                    {
+                        missing_variants.retain(|e| e.def_id != id);
                     }
                     path
                 },

--- a/clippy_lints/src/matches/match_wild_err_arm.rs
+++ b/clippy_lints/src/matches/match_wild_err_arm.rs
@@ -26,11 +26,12 @@ pub(crate) fn check<'tcx>(cx: &LateContext<'tcx>, ex: &Expr<'tcx>, arms: &[Arm<'
                     if !matching_wild {
                         // Looking for unused bindings (i.e.: `_e`)
                         for pat in inner {
-                            if let PatKind::Binding(_, id, ident, None) = pat.kind {
-                                if ident.as_str().starts_with('_') && !is_local_used(cx, arm.body, id) {
-                                    ident_bind_name = ident.name;
-                                    matching_wild = true;
-                                }
+                            if let PatKind::Binding(_, id, ident, None) = pat.kind
+                                && ident.as_str().starts_with('_')
+                                && !is_local_used(cx, arm.body, id)
+                            {
+                                ident_bind_name = ident.name;
+                                matching_wild = true;
                             }
                         }
                     }

--- a/clippy_lints/src/matches/needless_match.rs
+++ b/clippy_lints/src/matches/needless_match.rs
@@ -67,10 +67,10 @@ fn check_all_arms(cx: &LateContext<'_>, match_expr: &Expr<'_>, arms: &[Arm<'_>])
     for arm in arms {
         let arm_expr = peel_blocks_with_stmt(arm.body);
 
-        if let Some(guard_expr) = &arm.guard {
-            if guard_expr.can_have_side_effects() {
-                return false;
-            }
+        if let Some(guard_expr) = &arm.guard
+            && guard_expr.can_have_side_effects()
+        {
+            return false;
         }
 
         if let PatKind::Wild = arm.pat.kind {

--- a/clippy_lints/src/matches/overlapping_arms.rs
+++ b/clippy_lints/src/matches/overlapping_arms.rs
@@ -11,17 +11,17 @@ use super::MATCH_OVERLAPPING_ARM;
 pub(crate) fn check<'tcx>(cx: &LateContext<'tcx>, ex: &'tcx Expr<'_>, arms: &'tcx [Arm<'_>]) {
     if arms.len() >= 2 && cx.typeck_results().expr_ty(ex).is_integral() {
         let ranges = all_ranges(cx, arms, cx.typeck_results().expr_ty(ex));
-        if !ranges.is_empty() {
-            if let Some((start, end)) = overlapping(&ranges) {
-                span_lint_and_note(
-                    cx,
-                    MATCH_OVERLAPPING_ARM,
-                    start.span,
-                    "some ranges overlap",
-                    Some(end.span),
-                    "overlaps with this",
-                );
-            }
+        if !ranges.is_empty()
+            && let Some((start, end)) = overlapping(&ranges)
+        {
+            span_lint_and_note(
+                cx,
+                MATCH_OVERLAPPING_ARM,
+                start.span,
+                "some ranges overlap",
+                Some(end.span),
+                "overlaps with this",
+            );
         }
     }
 }

--- a/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
+++ b/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
@@ -182,17 +182,16 @@ impl<'a, 'tcx> SigDropChecker<'a, 'tcx> {
     }
 
     fn has_sig_drop_attr_impl(&mut self, ty: Ty<'tcx>) -> bool {
-        if let Some(adt) = ty.ty_adt_def() {
-            if get_attr(
+        if let Some(adt) = ty.ty_adt_def()
+            && get_attr(
                 self.cx.sess(),
                 self.cx.tcx.get_attrs_unchecked(adt.did()),
                 "has_significant_drop",
             )
             .count()
                 > 0
-            {
-                return true;
-            }
+        {
+            return true;
         }
 
         if !self.seen_types.insert(ty) {

--- a/clippy_lints/src/matches/wild_in_or_pats.rs
+++ b/clippy_lints/src/matches/wild_in_or_pats.rs
@@ -15,18 +15,18 @@ pub(crate) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, arms: &[Arm<'_>]) {
         return;
     }
     for arm in arms {
-        if let PatKind::Or(fields) = arm.pat.kind {
+        if let PatKind::Or(fields) = arm.pat.kind
             // look for multiple fields in this arm that contains at least one Wild pattern
-            if fields.len() > 1 && fields.iter().any(is_wild) {
-                span_lint_and_help(
-                    cx,
-                    WILDCARD_IN_OR_PATTERNS,
-                    arm.pat.span,
-                    "wildcard pattern covers any other pattern as it will match anyway",
-                    None,
-                    "consider handling `_` separately",
-                );
-            }
+            && fields.len() > 1 && fields.iter().any(is_wild)
+        {
+            span_lint_and_help(
+                cx,
+                WILDCARD_IN_OR_PATTERNS,
+                arm.pat.span,
+                "wildcard pattern covers any other pattern as it will match anyway",
+                None,
+                "consider handling `_` separately",
+            );
         }
     }
 }

--- a/clippy_lints/src/methods/bind_instead_of_map.rs
+++ b/clippy_lints/src/methods/bind_instead_of_map.rs
@@ -192,10 +192,10 @@ impl BindInsteadOfMap {
     }
 
     fn is_variant(&self, cx: &LateContext<'_>, res: Res) -> bool {
-        if let Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Fn), id) = res {
-            if let Some(variant_id) = cx.tcx.lang_items().get(self.variant_lang_item) {
-                return cx.tcx.parent(id) == variant_id;
-            }
+        if let Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Fn), id) = res
+            && let Some(variant_id) = cx.tcx.lang_items().get(self.variant_lang_item)
+        {
+            return cx.tcx.parent(id) == variant_id;
         }
         false
     }

--- a/clippy_lints/src/methods/case_sensitive_file_extension_comparisons.rs
+++ b/clippy_lints/src/methods/case_sensitive_file_extension_comparisons.rs
@@ -19,13 +19,13 @@ pub(super) fn check<'tcx>(
     arg: &'tcx Expr<'_>,
     msrv: Msrv,
 ) {
-    if let ExprKind::MethodCall(path_segment, ..) = recv.kind {
-        if matches!(
+    if let ExprKind::MethodCall(path_segment, ..) = recv.kind
+        && matches!(
             path_segment.ident.name.as_str(),
             "to_lowercase" | "to_uppercase" | "to_ascii_lowercase" | "to_ascii_uppercase"
-        ) {
-            return;
-        }
+        )
+    {
+        return;
     }
 
     if let Some(method_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)

--- a/clippy_lints/src/methods/clone_on_copy.rs
+++ b/clippy_lints/src/methods/clone_on_copy.rs
@@ -40,10 +40,10 @@ pub(super) fn check(
         .map_or_else(|| cx.typeck_results().expr_ty(arg), |a| a.target);
 
     let ty = cx.typeck_results().expr_ty(expr);
-    if let ty::Ref(_, inner, _) = arg_ty.kind() {
-        if let ty::Ref(..) = inner.kind() {
-            return; // don't report clone_on_copy
-        }
+    if let ty::Ref(_, inner, _) = arg_ty.kind()
+        && let ty::Ref(..) = inner.kind()
+    {
+        return; // don't report clone_on_copy
     }
 
     if is_copy(cx, ty) {

--- a/clippy_lints/src/methods/expect_fun_call.rs
+++ b/clippy_lints/src/methods/expect_fun_call.rs
@@ -54,10 +54,11 @@ pub(super) fn check<'tcx>(
         if is_type_lang_item(cx, arg_ty, hir::LangItem::String) {
             return false;
         }
-        if let ty::Ref(_, ty, ..) = arg_ty.kind() {
-            if ty.is_str() && can_be_static_str(cx, arg) {
-                return false;
-            }
+        if let ty::Ref(_, ty, ..) = arg_ty.kind()
+            && ty.is_str()
+            && can_be_static_str(cx, arg)
+        {
+            return false;
         }
         true
     }

--- a/clippy_lints/src/methods/is_empty.rs
+++ b/clippy_lints/src/methods/is_empty.rs
@@ -14,15 +14,13 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &'_ Expr<'_>, receiver: &Expr<'_
     if expr.span.in_external_macro(cx.sess().source_map()) || !receiver.span.eq_ctxt(expr.span) {
         return;
     }
-    if let Some(parent) = get_parent_expr(cx, expr) {
-        if let Some(parent) = get_parent_expr(cx, parent) {
-            if is_inside_always_const_context(cx.tcx, expr.hir_id)
-                && let Some(macro_call) = root_macro_call(parent.span)
-                && is_assert_macro(cx, macro_call.def_id)
-            {
-                return;
-            }
-        }
+    if let Some(parent) = get_parent_expr(cx, expr)
+        && let Some(parent) = get_parent_expr(cx, parent)
+        && is_inside_always_const_context(cx.tcx, expr.hir_id)
+        && let Some(macro_call) = root_macro_call(parent.span)
+        && is_assert_macro(cx, macro_call.def_id)
+    {
+        return;
     }
     let init_expr = expr_or_init(cx, receiver);
     if !receiver.span.eq_ctxt(init_expr.span) {

--- a/clippy_lints/src/methods/iterator_step_by_zero.rs
+++ b/clippy_lints/src/methods/iterator_step_by_zero.rs
@@ -8,14 +8,14 @@ use rustc_span::sym;
 use super::ITERATOR_STEP_BY_ZERO;
 
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &hir::Expr<'_>, arg: &'tcx hir::Expr<'_>) {
-    if is_trait_method(cx, expr, sym::Iterator) {
-        if let Some(Constant::Int(0)) = ConstEvalCtxt::new(cx).eval(arg) {
-            span_lint(
-                cx,
-                ITERATOR_STEP_BY_ZERO,
-                expr.span,
-                "`Iterator::step_by(0)` will panic at runtime",
-            );
-        }
+    if is_trait_method(cx, expr, sym::Iterator)
+        && let Some(Constant::Int(0)) = ConstEvalCtxt::new(cx).eval(arg)
+    {
+        span_lint(
+            cx,
+            ITERATOR_STEP_BY_ZERO,
+            expr.span,
+            "`Iterator::step_by(0)` will panic at runtime",
+        );
     }
 }

--- a/clippy_lints/src/methods/manual_saturating_arithmetic.rs
+++ b/clippy_lints/src/methods/manual_saturating_arithmetic.rs
@@ -106,15 +106,15 @@ fn is_min_or_max(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> Option<MinMax> {
     };
 
     let check_lit = |expr: &hir::Expr<'_>, check_min: bool| {
-        if let hir::ExprKind::Lit(lit) = &expr.kind {
-            if let ast::LitKind::Int(value, _) = lit.node {
-                if value == maxval {
-                    return Some(MinMax::Max);
-                }
+        if let hir::ExprKind::Lit(lit) = &expr.kind
+            && let ast::LitKind::Int(value, _) = lit.node
+        {
+            if value == maxval {
+                return Some(MinMax::Max);
+            }
 
-                if check_min && value == minval {
-                    return Some(MinMax::Min);
-                }
+            if check_min && value == minval {
+                return Some(MinMax::Min);
             }
         }
 
@@ -125,10 +125,10 @@ fn is_min_or_max(cx: &LateContext<'_>, expr: &hir::Expr<'_>) -> Option<MinMax> {
         return r;
     }
 
-    if ty.is_signed() {
-        if let hir::ExprKind::Unary(hir::UnOp::Neg, val) = &expr.kind {
-            return check_lit(val, true);
-        }
+    if ty.is_signed()
+        && let hir::ExprKind::Unary(hir::UnOp::Neg, val) = &expr.kind
+    {
+        return check_lit(val, true);
     }
 
     None

--- a/clippy_lints/src/methods/map_clone.rs
+++ b/clippy_lints/src/methods/map_clone.rs
@@ -51,19 +51,19 @@ pub(super) fn check(cx: &LateContext<'_>, e: &hir::Expr<'_>, recv: &hir::Expr<'_
                 let closure_expr = peel_blocks(closure_body.value);
                 match closure_body.params[0].pat.kind {
                     hir::PatKind::Ref(inner, Mutability::Not) => {
-                        if let hir::PatKind::Binding(hir::BindingMode::NONE, .., name, None) = inner.kind {
-                            if ident_eq(name, closure_expr) {
-                                lint_explicit_closure(cx, e.span, recv.span, true, msrv);
-                            }
+                        if let hir::PatKind::Binding(hir::BindingMode::NONE, .., name, None) = inner.kind
+                            && ident_eq(name, closure_expr)
+                        {
+                            lint_explicit_closure(cx, e.span, recv.span, true, msrv);
                         }
                     },
                     hir::PatKind::Binding(hir::BindingMode::NONE, .., name, None) => {
                         match closure_expr.kind {
                             hir::ExprKind::Unary(hir::UnOp::Deref, inner) => {
-                                if ident_eq(name, inner) {
-                                    if let ty::Ref(.., Mutability::Not) = cx.typeck_results().expr_ty(inner).kind() {
-                                        lint_explicit_closure(cx, e.span, recv.span, true, msrv);
-                                    }
+                                if ident_eq(name, inner)
+                                    && let ty::Ref(.., Mutability::Not) = cx.typeck_results().expr_ty(inner).kind()
+                                {
+                                    lint_explicit_closure(cx, e.span, recv.span, true, msrv);
                                 }
                             },
                             hir::ExprKind::MethodCall(method, obj, [], _) => {

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4667,11 +4667,12 @@ impl_lint_pass!(Methods => [
 pub fn method_call<'tcx>(
     recv: &'tcx Expr<'tcx>,
 ) -> Option<(&'tcx str, &'tcx Expr<'tcx>, &'tcx [Expr<'tcx>], Span, Span)> {
-    if let ExprKind::MethodCall(path, receiver, args, call_span) = recv.kind {
-        if !args.iter().any(|e| e.span.from_expansion()) && !receiver.span.from_expansion() {
-            let name = path.ident.name.as_str();
-            return Some((name, receiver, args, path.ident.span, call_span));
-        }
+    if let ExprKind::MethodCall(path, receiver, args, call_span) = recv.kind
+        && !args.iter().any(|e| e.span.from_expansion())
+        && !receiver.span.from_expansion()
+    {
+        let name = path.ident.name.as_str();
+        return Some((name, receiver, args, path.ident.span, call_span));
     }
     None
 }

--- a/clippy_lints/src/methods/needless_collect.rs
+++ b/clippy_lints/src/methods/needless_collect.rs
@@ -377,20 +377,20 @@ impl<'tcx> Visitor<'tcx> for IterFunctionVisitor<'_, 'tcx> {
                 return;
             }
 
-            if let Some(hir_id) = path_to_local(recv) {
-                if let Some(index) = self.hir_id_uses_map.remove(&hir_id) {
-                    if self
-                        .illegal_mutable_capture_ids
-                        .intersection(&self.current_mutably_captured_ids)
-                        .next()
-                        .is_none()
-                    {
-                        if let Some(hir_id) = self.current_statement_hir_id {
-                            self.hir_id_uses_map.insert(hir_id, index);
-                        }
-                    } else {
-                        self.uses[index] = None;
+            if let Some(hir_id) = path_to_local(recv)
+                && let Some(index) = self.hir_id_uses_map.remove(&hir_id)
+            {
+                if self
+                    .illegal_mutable_capture_ids
+                    .intersection(&self.current_mutably_captured_ids)
+                    .next()
+                    .is_none()
+                {
+                    if let Some(hir_id) = self.current_statement_hir_id {
+                        self.hir_id_uses_map.insert(hir_id, index);
                     }
+                } else {
+                    self.uses[index] = None;
                 }
             }
         }

--- a/clippy_lints/src/methods/seek_from_current.rs
+++ b/clippy_lints/src/methods/seek_from_current.rs
@@ -15,21 +15,22 @@ use super::SEEK_FROM_CURRENT;
 pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'tcx Expr<'_>, arg: &'tcx Expr<'_>) {
     let ty = cx.typeck_results().expr_ty(recv);
 
-    if let Some(def_id) = cx.tcx.get_diagnostic_item(sym::IoSeek) {
-        if implements_trait(cx, ty, def_id, &[]) && arg_is_seek_from_current(cx, arg) {
-            let mut applicability = Applicability::MachineApplicable;
-            let snip = snippet_with_applicability(cx, recv.span, "..", &mut applicability);
+    if let Some(def_id) = cx.tcx.get_diagnostic_item(sym::IoSeek)
+        && implements_trait(cx, ty, def_id, &[])
+        && arg_is_seek_from_current(cx, arg)
+    {
+        let mut applicability = Applicability::MachineApplicable;
+        let snip = snippet_with_applicability(cx, recv.span, "..", &mut applicability);
 
-            span_lint_and_sugg(
-                cx,
-                SEEK_FROM_CURRENT,
-                expr.span,
-                "using `SeekFrom::Current` to start from current position",
-                "replace with",
-                format!("{snip}.stream_position()"),
-                applicability,
-            );
-        }
+        span_lint_and_sugg(
+            cx,
+            SEEK_FROM_CURRENT,
+            expr.span,
+            "using `SeekFrom::Current` to start from current position",
+            "replace with",
+            format!("{snip}.stream_position()"),
+            applicability,
+        );
     }
 }
 

--- a/clippy_lints/src/methods/str_splitn.rs
+++ b/clippy_lints/src/methods/str_splitn.rs
@@ -238,15 +238,14 @@ fn indirect_usage<'tcx>(
             unwrap_kind: Some(unwrap_kind),
             ..
         } = iter_usage
+            && parent_id == local_hir_id
         {
-            if parent_id == local_hir_id {
-                return Some(IndirectUsage {
-                    name: ident.name,
-                    span: stmt.span,
-                    init_expr,
-                    unwrap_kind,
-                });
-            }
+            return Some(IndirectUsage {
+                name: ident.name,
+                span: stmt.span,
+                init_expr,
+                unwrap_kind,
+            });
         }
     }
 

--- a/clippy_lints/src/methods/suspicious_map.rs
+++ b/clippy_lints/src/methods/suspicious_map.rs
@@ -13,11 +13,11 @@ pub fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, count_recv: &hir::Expr<
         && let closure_body = cx.tcx.hir_body(closure.body)
         && !cx.typeck_results().expr_ty(closure_body.value).is_unit()
     {
-        if let Some(map_mutated_vars) = mutated_variables(closure_body.value, cx) {
+        if let Some(map_mutated_vars) = mutated_variables(closure_body.value, cx)
             // A variable is used mutably inside of the closure. Suppress the lint.
-            if !map_mutated_vars.is_empty() {
-                return;
-            }
+            && !map_mutated_vars.is_empty()
+        {
+            return;
         }
         span_lint_and_help(
             cx,

--- a/clippy_lints/src/methods/unnecessary_lazy_eval.rs
+++ b/clippy_lints/src/methods/unnecessary_lazy_eval.rs
@@ -23,56 +23,56 @@ pub(super) fn check<'tcx>(
     let is_result = is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(recv), sym::Result);
     let is_bool = cx.typeck_results().expr_ty(recv).is_bool();
 
-    if is_option || is_result || is_bool {
-        if let hir::ExprKind::Closure(&hir::Closure { body, fn_decl, .. }) = arg.kind {
-            let body = cx.tcx.hir_body(body);
-            let body_expr = &body.value;
+    if (is_option || is_result || is_bool)
+        && let hir::ExprKind::Closure(&hir::Closure { body, fn_decl, .. }) = arg.kind
+    {
+        let body = cx.tcx.hir_body(body);
+        let body_expr = &body.value;
 
-            if usage::BindingUsageFinder::are_params_used(cx, body) || is_from_proc_macro(cx, expr) {
-                return false;
-            }
+        if usage::BindingUsageFinder::are_params_used(cx, body) || is_from_proc_macro(cx, expr) {
+            return false;
+        }
 
-            if eager_or_lazy::switch_to_eager_eval(cx, body_expr) {
-                let msg = if is_option {
-                    "unnecessary closure used to substitute value for `Option::None`"
-                } else if is_result {
-                    "unnecessary closure used to substitute value for `Result::Err`"
-                } else {
-                    "unnecessary closure used with `bool::then`"
-                };
-                let applicability = if body
-                    .params
-                    .iter()
-                    // bindings are checked to be unused above
-                    .all(|param| matches!(param.pat.kind, hir::PatKind::Binding(..) | hir::PatKind::Wild))
-                    && matches!(
-                        fn_decl.output,
-                        FnRetTy::DefaultReturn(_)
-                            | FnRetTy::Return(hir::Ty {
-                                kind: hir::TyKind::Infer(()),
-                                ..
-                            })
-                    ) {
-                    Applicability::MachineApplicable
-                } else {
-                    // replacing the lambda may break type inference
-                    Applicability::MaybeIncorrect
-                };
+        if eager_or_lazy::switch_to_eager_eval(cx, body_expr) {
+            let msg = if is_option {
+                "unnecessary closure used to substitute value for `Option::None`"
+            } else if is_result {
+                "unnecessary closure used to substitute value for `Result::Err`"
+            } else {
+                "unnecessary closure used with `bool::then`"
+            };
+            let applicability = if body
+                .params
+                .iter()
+                // bindings are checked to be unused above
+                .all(|param| matches!(param.pat.kind, hir::PatKind::Binding(..) | hir::PatKind::Wild))
+                && matches!(
+                    fn_decl.output,
+                    FnRetTy::DefaultReturn(_)
+                        | FnRetTy::Return(hir::Ty {
+                            kind: hir::TyKind::Infer(()),
+                            ..
+                        })
+                ) {
+                Applicability::MachineApplicable
+            } else {
+                // replacing the lambda may break type inference
+                Applicability::MaybeIncorrect
+            };
 
-                // This is a duplicate of what's happening in clippy_lints::methods::method_call,
-                // which isn't ideal, We want to get the method call span,
-                // but prefer to avoid changing the signature of the function itself.
-                if let hir::ExprKind::MethodCall(.., span) = expr.kind {
-                    span_lint_and_then(cx, UNNECESSARY_LAZY_EVALUATIONS, expr.span, msg, |diag| {
-                        diag.span_suggestion_verbose(
-                            span,
-                            format!("use `{simplify_using}` instead"),
-                            format!("{simplify_using}({})", snippet(cx, body_expr.span, "..")),
-                            applicability,
-                        );
-                    });
-                    return true;
-                }
+            // This is a duplicate of what's happening in clippy_lints::methods::method_call,
+            // which isn't ideal, We want to get the method call span,
+            // but prefer to avoid changing the signature of the function itself.
+            if let hir::ExprKind::MethodCall(.., span) = expr.kind {
+                span_lint_and_then(cx, UNNECESSARY_LAZY_EVALUATIONS, expr.span, msg, |diag| {
+                    diag.span_suggestion_verbose(
+                        span,
+                        format!("use `{simplify_using}` instead"),
+                        format!("{simplify_using}({})", snippet(cx, body_expr.span, "..")),
+                        applicability,
+                    );
+                });
+                return true;
             }
         }
     }

--- a/clippy_lints/src/misc_early/builtin_type_shadow.rs
+++ b/clippy_lints/src/misc_early/builtin_type_shadow.rs
@@ -6,14 +6,14 @@ use rustc_lint::EarlyContext;
 use super::BUILTIN_TYPE_SHADOW;
 
 pub(super) fn check(cx: &EarlyContext<'_>, param: &GenericParam) {
-    if let GenericParamKind::Type { .. } = param.kind {
-        if let Some(prim_ty) = PrimTy::from_name(param.ident.name) {
-            span_lint(
-                cx,
-                BUILTIN_TYPE_SHADOW,
-                param.ident.span,
-                format!("this generic shadows the built-in type `{}`", prim_ty.name()),
-            );
-        }
+    if let GenericParamKind::Type { .. } = param.kind
+        && let Some(prim_ty) = PrimTy::from_name(param.ident.name)
+    {
+        span_lint(
+            cx,
+            BUILTIN_TYPE_SHADOW,
+            param.ident.span,
+            format!("this generic shadows the built-in type `{}`", prim_ty.name()),
+        );
     }
 }

--- a/clippy_lints/src/misc_early/redundant_pattern.rs
+++ b/clippy_lints/src/misc_early/redundant_pattern.rs
@@ -6,20 +6,20 @@ use rustc_lint::EarlyContext;
 use super::REDUNDANT_PATTERN;
 
 pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
-    if let PatKind::Ident(ann, ident, Some(ref right)) = pat.kind {
-        if let PatKind::Wild = right.kind {
-            span_lint_and_sugg(
-                cx,
-                REDUNDANT_PATTERN,
-                pat.span,
-                format!(
-                    "the `{} @ _` pattern can be written as just `{}`",
-                    ident.name, ident.name,
-                ),
-                "try",
-                format!("{}{}", ann.prefix_str(), ident.name),
-                Applicability::MachineApplicable,
-            );
-        }
+    if let PatKind::Ident(ann, ident, Some(ref right)) = pat.kind
+        && let PatKind::Wild = right.kind
+    {
+        span_lint_and_sugg(
+            cx,
+            REDUNDANT_PATTERN,
+            pat.span,
+            format!(
+                "the `{} @ _` pattern can be written as just `{}`",
+                ident.name, ident.name,
+            ),
+            "try",
+            format!("{}{}", ann.prefix_str(), ident.name),
+            Applicability::MachineApplicable,
+        );
     }
 }

--- a/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
+++ b/clippy_lints/src/misc_early/unneeded_wildcard_pattern.rs
@@ -7,30 +7,30 @@ use rustc_span::Span;
 use super::UNNEEDED_WILDCARD_PATTERN;
 
 pub(super) fn check(cx: &EarlyContext<'_>, pat: &Pat) {
-    if let PatKind::TupleStruct(_, _, ref patterns) | PatKind::Tuple(ref patterns) = pat.kind {
-        if let Some(rest_index) = patterns.iter().position(|pat| pat.is_rest()) {
-            if let Some((left_index, left_pat)) = patterns[..rest_index]
-                .iter()
-                .rev()
-                .take_while(|pat| matches!(pat.kind, PatKind::Wild))
-                .enumerate()
-                .last()
-            {
-                span_lint(cx, left_pat.span.until(patterns[rest_index].span), left_index == 0);
-            }
+    if let PatKind::TupleStruct(_, _, ref patterns) | PatKind::Tuple(ref patterns) = pat.kind
+        && let Some(rest_index) = patterns.iter().position(|pat| pat.is_rest())
+    {
+        if let Some((left_index, left_pat)) = patterns[..rest_index]
+            .iter()
+            .rev()
+            .take_while(|pat| matches!(pat.kind, PatKind::Wild))
+            .enumerate()
+            .last()
+        {
+            span_lint(cx, left_pat.span.until(patterns[rest_index].span), left_index == 0);
+        }
 
-            if let Some((right_index, right_pat)) = patterns[rest_index + 1..]
-                .iter()
-                .take_while(|pat| matches!(pat.kind, PatKind::Wild))
-                .enumerate()
-                .last()
-            {
-                span_lint(
-                    cx,
-                    patterns[rest_index].span.shrink_to_hi().to(right_pat.span),
-                    right_index == 0,
-                );
-            }
+        if let Some((right_index, right_pat)) = patterns[rest_index + 1..]
+            .iter()
+            .take_while(|pat| matches!(pat.kind, PatKind::Wild))
+            .enumerate()
+            .last()
+        {
+            span_lint(
+                cx,
+                patterns[rest_index].span.shrink_to_hi().to(right_pat.span),
+                right_index == 0,
+            );
         }
     }
 }

--- a/clippy_lints/src/mismatching_type_param_order.rs
+++ b/clippy_lints/src/mismatching_type_param_order.rs
@@ -111,10 +111,10 @@ impl<'tcx> LateLintPass<'tcx> for TypeParamMismatch {
 // Checks if impl_param_name is the same as one of type_param_names,
 // and is in a different position
 fn mismatch_param_name(i: usize, impl_param_name: &String, type_param_names: &FxHashMap<&String, usize>) -> bool {
-    if let Some(j) = type_param_names.get(impl_param_name) {
-        if i != *j {
-            return true;
-        }
+    if let Some(j) = type_param_names.get(impl_param_name)
+        && i != *j
+    {
+        return true;
     }
     false
 }

--- a/clippy_lints/src/missing_const_for_fn.rs
+++ b/clippy_lints/src/missing_const_for_fn.rs
@@ -139,12 +139,11 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
         // Const fns are not allowed as methods in a trait.
         {
             let parent = cx.tcx.hir_get_parent_item(hir_id).def_id;
-            if parent != CRATE_DEF_ID {
-                if let hir::Node::Item(item) = cx.tcx.hir_node_by_def_id(parent) {
-                    if let hir::ItemKind::Trait(..) = &item.kind {
-                        return;
-                    }
-                }
+            if parent != CRATE_DEF_ID
+                && let hir::Node::Item(item) = cx.tcx.hir_node_by_def_id(parent)
+                && let hir::ItemKind::Trait(..) = &item.kind
+            {
+                return;
             }
         }
 

--- a/clippy_lints/src/missing_fields_in_debug.rs
+++ b/clippy_lints/src/missing_fields_in_debug.rs
@@ -224,11 +224,10 @@ impl<'tcx> LateLintPass<'tcx> for MissingFieldsInDebug {
             // NB: can't call cx.typeck_results() as we are not in a body
             && let typeck_results = cx.tcx.typeck_body(*body_id)
             && should_lint(cx, typeck_results, block)
-        {
             // we intentionally only lint structs, see lint description
-            if let ItemKind::Struct(_, data, _) = &self_item.kind {
-                check_struct(cx, typeck_results, block, self_ty, item, data);
-            }
+            && let ItemKind::Struct(_, data, _) = &self_item.kind
+        {
+            check_struct(cx, typeck_results, block, self_ty, item, data);
         }
     }
 }

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -160,12 +160,13 @@ impl<'tcx> LateLintPass<'tcx> for MissingInline {
             AssocItemContainer::Impl => cx.tcx.impl_trait_ref(container_id).map(|t| t.skip_binder().def_id),
         };
 
-        if let Some(trait_def_id) = trait_def_id {
-            if trait_def_id.is_local() && !cx.effective_visibilities.is_exported(impl_item.owner_id.def_id) {
-                // If a trait is being implemented for an item, and the
-                // trait is not exported, we don't need #[inline]
-                return;
-            }
+        if let Some(trait_def_id) = trait_def_id
+            && trait_def_id.is_local()
+            && !cx.effective_visibilities.is_exported(impl_item.owner_id.def_id)
+        {
+            // If a trait is being implemented for an item, and the
+            // trait is not exported, we don't need #[inline]
+            return;
         }
 
         let attrs = cx.tcx.hir_attrs(impl_item.hir_id());

--- a/clippy_lints/src/mixed_read_write_in_expression.rs
+++ b/clippy_lints/src/mixed_read_write_in_expression.rs
@@ -135,10 +135,10 @@ impl<'tcx> DivergenceVisitor<'_, 'tcx> {
     }
 
     fn report_diverging_sub_expr(&mut self, e: &Expr<'_>) {
-        if let Some(macro_call) = root_macro_call_first_node(self.cx, e) {
-            if self.cx.tcx.item_name(macro_call.def_id).as_str() == "todo" {
-                return;
-            }
+        if let Some(macro_call) = root_macro_call_first_node(self.cx, e)
+            && self.cx.tcx.item_name(macro_call.def_id).as_str() == "todo"
+        {
+            return;
         }
         span_lint(self.cx, DIVERGING_SUB_EXPRESSION, e.span, "sub-expression diverges");
     }
@@ -372,10 +372,10 @@ impl<'tcx> Visitor<'tcx> for ReadVisitor<'_, 'tcx> {
 
 /// Returns `true` if `expr` is the LHS of an assignment, like `expr = ...`.
 fn is_in_assignment_position(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    if let Some(parent) = get_parent_expr(cx, expr) {
-        if let ExprKind::Assign(lhs, ..) = parent.kind {
-            return lhs.hir_id == expr.hir_id;
-        }
+    if let Some(parent) = get_parent_expr(cx, expr)
+        && let ExprKind::Assign(lhs, ..) = parent.kind
+    {
+        return lhs.hir_id == expr.hir_id;
     }
     false
 }

--- a/clippy_lints/src/module_style.rs
+++ b/clippy_lints/src/module_style.rs
@@ -119,22 +119,22 @@ impl EarlyLintPass for ModStyle {
         }
 
         for folder in &folder_segments {
-            if !mod_folders.contains(folder) {
-                if let Some((file, path)) = file_map.get(folder) {
-                    span_lint_and_then(
-                        cx,
-                        SELF_NAMED_MODULE_FILES,
-                        Span::new(file.start_pos, file.start_pos, SyntaxContext::root(), None),
-                        format!("`mod.rs` files are required, found `{}`", path.display()),
-                        |diag| {
-                            let mut correct = path.to_path_buf();
-                            correct.pop();
-                            correct.push(folder);
-                            correct.push("mod.rs");
-                            diag.help(format!("move `{}` to `{}`", path.display(), correct.display(),));
-                        },
-                    );
-                }
+            if !mod_folders.contains(folder)
+                && let Some((file, path)) = file_map.get(folder)
+            {
+                span_lint_and_then(
+                    cx,
+                    SELF_NAMED_MODULE_FILES,
+                    Span::new(file.start_pos, file.start_pos, SyntaxContext::root(), None),
+                    format!("`mod.rs` files are required, found `{}`", path.display()),
+                    |diag| {
+                        let mut correct = path.to_path_buf();
+                        correct.pop();
+                        correct.push(folder);
+                        correct.push("mod.rs");
+                        diag.help(format!("move `{}` to `{}`", path.display(), correct.display(),));
+                    },
+                );
             }
         }
     }

--- a/clippy_lints/src/multiple_unsafe_ops_per_block.rs
+++ b/clippy_lints/src/multiple_unsafe_ops_per_block.rs
@@ -142,10 +142,9 @@ fn collect_unsafe_exprs<'tcx>(
                     .typeck_results()
                     .type_dependent_def_id(expr.hir_id)
                     .map(|def_id| cx.tcx.fn_sig(def_id))
+                    && sig.skip_binder().safety().is_unsafe()
                 {
-                    if sig.skip_binder().safety().is_unsafe() {
-                        unsafe_ops.push(("unsafe method call occurs here", expr.span));
-                    }
+                    unsafe_ops.push(("unsafe method call occurs here", expr.span));
                 }
             },
 

--- a/clippy_lints/src/mut_key.rs
+++ b/clippy_lints/src/mut_key.rs
@@ -82,10 +82,10 @@ impl<'tcx> LateLintPass<'tcx> for MutableKeyType<'tcx> {
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::ImplItem<'tcx>) {
-        if let hir::ImplItemKind::Fn(ref sig, ..) = item.kind {
-            if trait_ref_of_method(cx, item.owner_id.def_id).is_none() {
-                self.check_sig(cx, item.owner_id.def_id, sig.decl);
-            }
+        if let hir::ImplItemKind::Fn(ref sig, ..) = item.kind
+            && trait_ref_of_method(cx, item.owner_id.def_id).is_none()
+        {
+            self.check_sig(cx, item.owner_id.def_id, sig.decl);
         }
     }
 

--- a/clippy_lints/src/mut_mut.rs
+++ b/clippy_lints/src/mut_mut.rs
@@ -77,16 +77,16 @@ impl<'tcx> intravisit::Visitor<'tcx> for MutVisitor<'_, 'tcx> {
                     expr.span,
                     "generally you want to avoid `&mut &mut _` if possible",
                 );
-            } else if let ty::Ref(_, ty, hir::Mutability::Mut) = self.cx.typeck_results().expr_ty(e).kind() {
-                if ty.peel_refs().is_sized(self.cx.tcx, self.cx.typing_env()) {
-                    span_lint_hir(
-                        self.cx,
-                        MUT_MUT,
-                        expr.hir_id,
-                        expr.span,
-                        "this expression mutably borrows a mutable reference. Consider reborrowing",
-                    );
-                }
+            } else if let ty::Ref(_, ty, hir::Mutability::Mut) = self.cx.typeck_results().expr_ty(e).kind()
+                && ty.peel_refs().is_sized(self.cx.tcx, self.cx.typing_env())
+            {
+                span_lint_hir(
+                    self.cx,
+                    MUT_MUT,
+                    expr.hir_id,
+                    expr.span,
+                    "this expression mutably borrows a mutable reference. Consider reborrowing",
+                );
             }
         }
     }

--- a/clippy_lints/src/mutable_debug_assertion.rs
+++ b/clippy_lints/src/mutable_debug_assertion.rs
@@ -97,14 +97,13 @@ impl<'tcx> Visitor<'tcx> for MutArgVisitor<'_, 'tcx> {
                 return;
             },
             ExprKind::Path(_) => {
-                if let Some(adj) = self.cx.typeck_results().adjustments().get(expr.hir_id) {
-                    if adj
+                if let Some(adj) = self.cx.typeck_results().adjustments().get(expr.hir_id)
+                    && adj
                         .iter()
                         .any(|a| matches!(a.target.kind(), ty::Ref(_, _, Mutability::Mut)))
-                    {
-                        self.found = true;
-                        return;
-                    }
+                {
+                    self.found = true;
+                    return;
                 }
             },
             // Don't check await desugars

--- a/clippy_lints/src/mutex_atomic.rs
+++ b/clippy_lints/src/mutex_atomic.rs
@@ -91,19 +91,19 @@ declare_lint_pass!(Mutex => [MUTEX_ATOMIC, MUTEX_INTEGER]);
 impl<'tcx> LateLintPass<'tcx> for Mutex {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         let ty = cx.typeck_results().expr_ty(expr);
-        if let ty::Adt(_, subst) = ty.kind() {
-            if is_type_diagnostic_item(cx, ty, sym::Mutex) {
-                let mutex_param = subst.type_at(0);
-                if let Some(atomic_name) = get_atomic_name(mutex_param) {
-                    let msg = format!(
-                        "consider using an `{atomic_name}` instead of a `Mutex` here; if you just want the locking \
+        if let ty::Adt(_, subst) = ty.kind()
+            && is_type_diagnostic_item(cx, ty, sym::Mutex)
+        {
+            let mutex_param = subst.type_at(0);
+            if let Some(atomic_name) = get_atomic_name(mutex_param) {
+                let msg = format!(
+                    "consider using an `{atomic_name}` instead of a `Mutex` here; if you just want the locking \
                          behavior and not the internal type, consider using `Mutex<()>`"
-                    );
-                    match *mutex_param.kind() {
-                        ty::Uint(t) if t != UintTy::Usize => span_lint(cx, MUTEX_INTEGER, expr.span, msg),
-                        ty::Int(t) if t != IntTy::Isize => span_lint(cx, MUTEX_INTEGER, expr.span, msg),
-                        _ => span_lint(cx, MUTEX_ATOMIC, expr.span, msg),
-                    }
+                );
+                match *mutex_param.kind() {
+                    ty::Uint(t) if t != UintTy::Usize => span_lint(cx, MUTEX_INTEGER, expr.span, msg),
+                    ty::Int(t) if t != IntTy::Isize => span_lint(cx, MUTEX_INTEGER, expr.span, msg),
+                    _ => span_lint(cx, MUTEX_ATOMIC, expr.span, msg),
                 }
             }
         }

--- a/clippy_lints/src/needless_bool.rs
+++ b/clippy_lints/src/needless_bool.rs
@@ -426,10 +426,10 @@ fn fetch_bool_block(expr: &Expr<'_>) -> Option<Expression> {
 }
 
 fn fetch_bool_expr(expr: &Expr<'_>) -> Option<bool> {
-    if let ExprKind::Lit(lit_ptr) = peel_blocks(expr).kind {
-        if let LitKind::Bool(value) = lit_ptr.node {
-            return Some(value);
-        }
+    if let ExprKind::Lit(lit_ptr) = peel_blocks(expr).kind
+        && let LitKind::Bool(value) = lit_ptr.node
+    {
+        return Some(value);
     }
     None
 }

--- a/clippy_lints/src/needless_pass_by_value.rs
+++ b/clippy_lints/src/needless_pass_by_value.rs
@@ -98,13 +98,13 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
         }
 
         // Exclude non-inherent impls
-        if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id) {
-            if matches!(
+        if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id)
+            && matches!(
                 item.kind,
                 ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait(..)
-            ) {
-                return;
-            }
+            )
+        {
+            return;
         }
 
         // Allow `Borrow` or functions to be taken by value
@@ -197,20 +197,18 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
             {
                 // Dereference suggestion
                 let sugg = |diag: &mut Diag<'_, ()>| {
-                    if let ty::Adt(def, ..) = ty.kind() {
-                        if let Some(span) = cx.tcx.hir().span_if_local(def.did()) {
-                            if type_allowed_to_implement_copy(
-                                cx.tcx,
-                                cx.param_env,
-                                ty,
-                                traits::ObligationCause::dummy_with_span(span),
-                                rustc_hir::Safety::Safe,
-                            )
-                            .is_ok()
-                            {
-                                diag.span_help(span, "or consider marking this type as `Copy`");
-                            }
-                        }
+                    if let ty::Adt(def, ..) = ty.kind()
+                        && let Some(span) = cx.tcx.hir().span_if_local(def.did())
+                        && type_allowed_to_implement_copy(
+                            cx.tcx,
+                            cx.param_env,
+                            ty,
+                            traits::ObligationCause::dummy_with_span(span),
+                            rustc_hir::Safety::Safe,
+                        )
+                        .is_ok()
+                    {
+                        diag.span_help(span, "or consider marking this type as `Copy`");
                     }
 
                     if is_type_diagnostic_item(cx, ty, sym::Vec)
@@ -254,29 +252,28 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                         return;
                     }
 
-                    if is_type_lang_item(cx, ty, LangItem::String) {
-                        if let Some(clone_spans) =
+                    if is_type_lang_item(cx, ty, LangItem::String)
+                        && let Some(clone_spans) =
                             get_spans(cx, Some(body.id()), idx, &[("clone", ".to_string()"), ("as_str", "")])
-                        {
+                    {
+                        diag.span_suggestion(
+                            input.span,
+                            "consider changing the type to",
+                            "&str",
+                            Applicability::Unspecified,
+                        );
+
+                        for (span, suggestion) in clone_spans {
                             diag.span_suggestion(
-                                input.span,
-                                "consider changing the type to",
-                                "&str",
+                                span,
+                                span.get_source_text(cx)
+                                    .map_or("change the call to".to_owned(), |src| format!("change `{src}` to")),
+                                suggestion,
                                 Applicability::Unspecified,
                             );
-
-                            for (span, suggestion) in clone_spans {
-                                diag.span_suggestion(
-                                    span,
-                                    span.get_source_text(cx)
-                                        .map_or("change the call to".to_owned(), |src| format!("change `{src}` to")),
-                                    suggestion,
-                                    Applicability::Unspecified,
-                                );
-                            }
-
-                            return;
                         }
+
+                        return;
                     }
 
                     diag.span_suggestion_verbose(

--- a/clippy_lints/src/needless_update.rs
+++ b/clippy_lints/src/needless_update.rs
@@ -53,17 +53,16 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessUpdate {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if let ExprKind::Struct(_, fields, StructTailExpr::Base(base)) = expr.kind {
             let ty = cx.typeck_results().expr_ty(expr);
-            if let ty::Adt(def, _) = ty.kind() {
-                if fields.len() == def.non_enum_variant().fields.len()
-                    && !def.variant(0_usize.into()).is_field_list_non_exhaustive()
-                {
-                    span_lint(
-                        cx,
-                        NEEDLESS_UPDATE,
-                        base.span,
-                        "struct update has no effect, all the fields in the struct have already been specified",
-                    );
-                }
+            if let ty::Adt(def, _) = ty.kind()
+                && fields.len() == def.non_enum_variant().fields.len()
+                && !def.variant(0_usize.into()).is_field_list_non_exhaustive()
+            {
+                span_lint(
+                    cx,
+                    NEEDLESS_UPDATE,
+                    base.span,
+                    "struct update has no effect, all the fields in the struct have already been specified",
+                );
             }
         }
     }

--- a/clippy_lints/src/neg_multiply.rs
+++ b/clippy_lints/src/neg_multiply.rs
@@ -35,14 +35,14 @@ declare_lint_pass!(NegMultiply => [NEG_MULTIPLY]);
 
 impl<'tcx> LateLintPass<'tcx> for NegMultiply {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) {
-        if let ExprKind::Binary(ref op, left, right) = e.kind {
-            if BinOpKind::Mul == op.node {
-                match (&left.kind, &right.kind) {
-                    (&ExprKind::Unary(..), &ExprKind::Unary(..)) => {},
-                    (&ExprKind::Unary(UnOp::Neg, lit), _) => check_mul(cx, e.span, lit, right),
-                    (_, &ExprKind::Unary(UnOp::Neg, lit)) => check_mul(cx, e.span, lit, left),
-                    _ => {},
-                }
+        if let ExprKind::Binary(ref op, left, right) = e.kind
+            && BinOpKind::Mul == op.node
+        {
+            match (&left.kind, &right.kind) {
+                (&ExprKind::Unary(..), &ExprKind::Unary(..)) => {},
+                (&ExprKind::Unary(UnOp::Neg, lit), _) => check_mul(cx, e.span, lit, right),
+                (_, &ExprKind::Unary(UnOp::Neg, lit)) => check_mul(cx, e.span, lit, left),
+                _ => {},
             }
         }
     }

--- a/clippy_lints/src/new_without_default.rs
+++ b/clippy_lints/src/new_without_default.rs
@@ -99,10 +99,10 @@ impl<'tcx> LateLintPass<'tcx> for NewWithoutDefault {
                                 let mut impls = HirIdSet::default();
                                 cx.tcx.for_each_impl(default_trait_id, |d| {
                                     let ty = cx.tcx.type_of(d).instantiate_identity();
-                                    if let Some(ty_def) = ty.ty_adt_def() {
-                                        if let Some(local_def_id) = ty_def.did().as_local() {
-                                            impls.insert(cx.tcx.local_def_id_to_hir_id(local_def_id));
-                                        }
+                                    if let Some(ty_def) = ty.ty_adt_def()
+                                        && let Some(local_def_id) = ty_def.did().as_local()
+                                    {
+                                        impls.insert(cx.tcx.local_def_id_to_hir_id(local_def_id));
                                     }
                                 });
                                 self.impling_types = Some(impls);

--- a/clippy_lints/src/no_effect.rs
+++ b/clippy_lints/src/no_effect.rs
@@ -182,23 +182,22 @@ impl NoEffect {
                 );
                 return true;
             }
-        } else if let StmtKind::Let(local) = stmt.kind {
-            if !is_lint_allowed(cx, NO_EFFECT_UNDERSCORE_BINDING, local.hir_id)
-                && !matches!(local.source, LocalSource::AsyncFn)
-                && let Some(init) = local.init
-                && local.els.is_none()
-                && !local.pat.span.from_expansion()
-                && has_no_effect(cx, init)
-                && let PatKind::Binding(_, hir_id, ident, _) = local.pat.kind
-                && ident.name.to_ident_string().starts_with('_')
-                && !in_automatically_derived(cx.tcx, local.hir_id)
-            {
-                if let Some(l) = self.local_bindings.last_mut() {
-                    l.push(hir_id);
-                    self.underscore_bindings.insert(hir_id, ident.span);
-                }
-                return true;
+        } else if let StmtKind::Let(local) = stmt.kind
+            && !is_lint_allowed(cx, NO_EFFECT_UNDERSCORE_BINDING, local.hir_id)
+            && !matches!(local.source, LocalSource::AsyncFn)
+            && let Some(init) = local.init
+            && local.els.is_none()
+            && !local.pat.span.from_expansion()
+            && has_no_effect(cx, init)
+            && let PatKind::Binding(_, hir_id, ident, _) = local.pat.kind
+            && ident.name.to_ident_string().starts_with('_')
+            && !in_automatically_derived(cx.tcx, local.hir_id)
+        {
+            if let Some(l) = self.local_bindings.last_mut() {
+                l.push(hir_id);
+                self.underscore_bindings.insert(hir_id, ident.span);
             }
+            return true;
         }
         false
     }

--- a/clippy_lints/src/non_zero_suggestions.rs
+++ b/clippy_lints/src/non_zero_suggestions.rs
@@ -82,11 +82,10 @@ fn check_non_zero_conversion(cx: &LateContext<'_>, expr: &Expr<'_>, applicabilit
         if let ty::Adt(adt_def, _) = receiver_ty.kind()
             && adt_def.is_struct()
             && cx.tcx.get_diagnostic_name(adt_def.did()) == Some(sym::NonZero)
+            && let Some(target_non_zero_type) = get_target_non_zero_type(target_ty)
         {
-            if let Some(target_non_zero_type) = get_target_non_zero_type(target_ty) {
-                let arg_snippet = get_arg_snippet(cx, arg, rcv_path);
-                suggest_non_zero_conversion(cx, expr, fn_name, target_non_zero_type, &arg_snippet, applicability);
-            }
+            let arg_snippet = get_arg_snippet(cx, arg, rcv_path);
+            suggest_non_zero_conversion(cx, expr, fn_name, target_non_zero_type, &arg_snippet, applicability);
         }
     }
 }

--- a/clippy_lints/src/operators/modulo_one.rs
+++ b/clippy_lints/src/operators/modulo_one.rs
@@ -12,15 +12,15 @@ pub(crate) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, op: BinOpKind, right:
             span_lint(cx, MODULO_ONE, expr.span, "any number modulo 1 will be 0");
         }
 
-        if let ty::Int(ity) = cx.typeck_results().expr_ty(right).kind() {
-            if is_integer_const(cx, right, unsext(cx.tcx, -1, *ity)) {
-                span_lint(
-                    cx,
-                    MODULO_ONE,
-                    expr.span,
-                    "any number modulo -1 will panic/overflow or result in 0",
-                );
-            }
+        if let ty::Int(ity) = cx.typeck_results().expr_ty(right).kind()
+            && is_integer_const(cx, right, unsext(cx.tcx, -1, *ity))
+        {
+            span_lint(
+                cx,
+                MODULO_ONE,
+                expr.span,
+                "any number modulo -1 will panic/overflow or result in 0",
+            );
         }
     }
 }

--- a/clippy_lints/src/operators/numeric_arithmetic.rs
+++ b/clippy_lints/src/operators/numeric_arithmetic.rs
@@ -75,10 +75,10 @@ impl Context {
             hir::BodyOwnerKind::Static(_) | hir::BodyOwnerKind::Const { .. } => {
                 let body_span = cx.tcx.hir().span_with_body(body_owner);
 
-                if let Some(span) = self.const_span {
-                    if span.contains(body_span) {
-                        return;
-                    }
+                if let Some(span) = self.const_span
+                    && span.contains(body_span)
+                {
+                    return;
                 }
                 self.const_span = Some(body_span);
             },
@@ -90,10 +90,10 @@ impl Context {
         let body_owner = cx.tcx.hir_body_owner(body.id());
         let body_span = cx.tcx.hir().span_with_body(body_owner);
 
-        if let Some(span) = self.const_span {
-            if span.contains(body_span) {
-                return;
-            }
+        if let Some(span) = self.const_span
+            && span.contains(body_span)
+        {
+            return;
         }
         self.const_span = None;
     }

--- a/clippy_lints/src/operators/op_ref.rs
+++ b/clippy_lints/src/operators/op_ref.rs
@@ -47,12 +47,11 @@ pub(crate) fn check<'tcx>(
                 let rty = cx.typeck_results().expr_ty(r);
                 let lcpy = is_copy(cx, lty);
                 let rcpy = is_copy(cx, rty);
-                if let Some((self_ty, other_ty)) = in_impl(cx, e, trait_id) {
-                    if (are_equal(cx, rty, self_ty) && are_equal(cx, lty, other_ty))
-                        || (are_equal(cx, rty, other_ty) && are_equal(cx, lty, self_ty))
-                    {
-                        return; // Don't lint
-                    }
+                if let Some((self_ty, other_ty)) = in_impl(cx, e, trait_id)
+                    && ((are_equal(cx, rty, self_ty) && are_equal(cx, lty, other_ty))
+                        || (are_equal(cx, rty, other_ty) && are_equal(cx, lty, self_ty)))
+                {
+                    return; // Don't lint
                 }
                 // either operator autorefs or both args are copyable
                 if (requires_ref || (lcpy && rcpy)) && implements_trait(cx, lty, trait_id, &[rty.into()]) {

--- a/clippy_lints/src/pathbuf_init_then_push.rs
+++ b/clippy_lints/src/pathbuf_init_then_push.rs
@@ -173,16 +173,15 @@ impl<'tcx> LateLintPass<'tcx> for PathbufThenPush<'tcx> {
     }
 
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
-        if let Some(mut searcher) = self.searcher.take() {
-            if let StmtKind::Expr(expr) | StmtKind::Semi(expr) = stmt.kind
-                && let ExprKind::MethodCall(name, self_arg, [arg_expr], _) = expr.kind
-                && path_to_local_id(self_arg, searcher.local_id)
-                && name.ident.as_str() == "push"
-            {
-                searcher.err_span = searcher.err_span.to(stmt.span);
-                searcher.arg = Some(*arg_expr);
-                searcher.display_err(cx);
-            }
+        if let Some(mut searcher) = self.searcher.take()
+            && let StmtKind::Expr(expr) | StmtKind::Semi(expr) = stmt.kind
+            && let ExprKind::MethodCall(name, self_arg, [arg_expr], _) = expr.kind
+            && path_to_local_id(self_arg, searcher.local_id)
+            && name.ident.as_str() == "push"
+        {
+            searcher.err_span = searcher.err_span.to(stmt.span);
+            searcher.arg = Some(*arg_expr);
+            searcher.display_err(cx);
         }
     }
 

--- a/clippy_lints/src/pattern_type_mismatch.rs
+++ b/clippy_lints/src/pattern_type_mismatch.rs
@@ -177,17 +177,16 @@ fn find_first_mismatch(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<(Span, Mut
             PatKind::Or([p, ..]) => p,
             _ => p,
         };
-        if let Some(adjustments) = cx.typeck_results().pat_adjustments().get(adjust_pat.hir_id) {
-            if let [first, ..] = **adjustments {
-                if let ty::Ref(.., mutability) = *first.kind() {
-                    let level = if p.hir_id == pat.hir_id {
-                        Level::Top
-                    } else {
-                        Level::Lower
-                    };
-                    result = Some((p.span, mutability, level));
-                }
-            }
+        if let Some(adjustments) = cx.typeck_results().pat_adjustments().get(adjust_pat.hir_id)
+            && let [first, ..] = **adjustments
+            && let ty::Ref(.., mutability) = *first.kind()
+        {
+            let level = if p.hir_id == pat.hir_id {
+                Level::Top
+            } else {
+                Level::Lower
+            };
+            result = Some((p.span, mutability, level));
         }
         result.is_none()
     });

--- a/clippy_lints/src/ptr_offset_with_cast.rs
+++ b/clippy_lints/src/ptr_offset_with_cast.rs
@@ -77,10 +77,10 @@ impl<'tcx> LateLintPass<'tcx> for PtrOffsetWithCast {
 
 // If the given expression is a cast from a usize, return the lhs of the cast
 fn expr_as_cast_from_usize<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) -> Option<&'tcx Expr<'tcx>> {
-    if let ExprKind::Cast(cast_lhs_expr, _) = expr.kind {
-        if is_expr_ty_usize(cx, cast_lhs_expr) {
-            return Some(cast_lhs_expr);
-        }
+    if let ExprKind::Cast(cast_lhs_expr, _) = expr.kind
+        && is_expr_ty_usize(cx, cast_lhs_expr)
+    {
+        return Some(cast_lhs_expr);
     }
     None
 }
@@ -91,14 +91,14 @@ fn expr_as_ptr_offset_call<'tcx>(
     cx: &LateContext<'tcx>,
     expr: &'tcx Expr<'_>,
 ) -> Option<(&'tcx Expr<'tcx>, &'tcx Expr<'tcx>, Method)> {
-    if let ExprKind::MethodCall(path_segment, arg_0, [arg_1], _) = &expr.kind {
-        if is_expr_ty_raw_ptr(cx, arg_0) {
-            if path_segment.ident.name == sym::offset {
-                return Some((arg_0, arg_1, Method::Offset));
-            }
-            if path_segment.ident.name.as_str() == "wrapping_offset" {
-                return Some((arg_0, arg_1, Method::WrappingOffset));
-            }
+    if let ExprKind::MethodCall(path_segment, arg_0, [arg_1], _) = &expr.kind
+        && is_expr_ty_raw_ptr(cx, arg_0)
+    {
+        if path_segment.ident.name == sym::offset {
+            return Some((arg_0, arg_1, Method::Offset));
+        }
+        if path_segment.ident.name.as_str() == "wrapping_offset" {
+            return Some((arg_0, arg_1, Method::WrappingOffset));
         }
     }
     None

--- a/clippy_lints/src/ranges.rs
+++ b/clippy_lints/src/ranges.rs
@@ -179,10 +179,10 @@ impl_lint_pass!(Ranges => [
 
 impl<'tcx> LateLintPass<'tcx> for Ranges {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
-        if let ExprKind::Binary(ref op, l, r) = expr.kind {
-            if self.msrv.meets(cx, msrvs::RANGE_CONTAINS) {
-                check_possible_range_contains(cx, op.node, l, r, expr, expr.span);
-            }
+        if let ExprKind::Binary(ref op, l, r) = expr.kind
+            && self.msrv.meets(cx, msrvs::RANGE_CONTAINS)
+        {
+            check_possible_range_contains(cx, op.node, l, r, expr, expr.span);
         }
 
         check_exclusive_range_plus_one(cx, expr);
@@ -327,18 +327,18 @@ fn check_range_bounds<'a, 'tcx>(cx: &'a LateContext<'tcx>, ex: &'a Expr<'_>) -> 
                     inc: inclusive,
                 });
             }
-        } else if let Some(id) = path_to_local(r) {
-            if let Some(c) = ConstEvalCtxt::new(cx).eval(l) {
-                return Some(RangeBounds {
-                    val: c,
-                    expr: l,
-                    id,
-                    name_span: r.span,
-                    val_span: l.span,
-                    ord: ordering.reverse(),
-                    inc: inclusive,
-                });
-            }
+        } else if let Some(id) = path_to_local(r)
+            && let Some(c) = ConstEvalCtxt::new(cx).eval(l)
+        {
+            return Some(RangeBounds {
+                val: c,
+                expr: l,
+                id,
+                name_span: r.span,
+                val_span: l.span,
+                ord: ordering.reverse(),
+                inc: inclusive,
+            });
         }
     }
     None

--- a/clippy_lints/src/redundant_clone.rs
+++ b/clippy_lints/src/redundant_clone.rs
@@ -109,10 +109,10 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
                 continue;
             }
 
-            if let ty::Adt(def, _) = arg_ty.kind() {
-                if def.is_manually_drop() {
-                    continue;
-                }
+            if let ty::Adt(def, _) = arg_ty.kind()
+                && def.is_manually_drop()
+            {
+                continue;
             }
 
             // `{ arg = &cloned; clone(move arg); }` or `{ arg = &cloned; to_path_buf(arg); }`
@@ -191,11 +191,11 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
                 if clone_usage.cloned_used && clone_usage.clone_consumed_or_mutated {
                     // cloned value is used, and the clone is modified or moved
                     continue;
-                } else if let Some(loc) = clone_usage.cloned_consume_or_mutate_loc {
+                } else if let Some(loc) = clone_usage.cloned_consume_or_mutate_loc
                     // cloned value is mutated, and the clone is alive.
-                    if possible_borrower.local_is_alive_at(ret_local, loc) {
-                        continue;
-                    }
+                    && possible_borrower.local_is_alive_at(ret_local, loc)
+                {
+                    continue;
                 }
                 clone_usage
             };
@@ -216,14 +216,13 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
 
                 let call_snip = &snip[dot + 1..];
                 // Machine applicable when `call_snip` looks like `foobar()`
-                if let Some(call_snip) = call_snip.strip_suffix("()").map(str::trim) {
-                    if call_snip
+                if let Some(call_snip) = call_snip.strip_suffix("()").map(str::trim)
+                    && call_snip
                         .as_bytes()
                         .iter()
                         .all(|b| b.is_ascii_alphabetic() || *b == b'_')
-                    {
-                        app = Applicability::MachineApplicable;
-                    }
+                {
+                    app = Applicability::MachineApplicable;
                 }
 
                 span_lint_hir_and_then(cx, REDUNDANT_CLONE, node, sugg_span, "redundant clone", |diag| {

--- a/clippy_lints/src/serde_api.rs
+++ b/clippy_lints/src/serde_api.rs
@@ -32,27 +32,27 @@ impl<'tcx> LateLintPass<'tcx> for SerdeApi {
         }) = item.kind
         {
             let did = trait_ref.path.res.def_id();
-            if let Some(visit_did) = get_trait_def_id(cx.tcx, &paths::SERDE_DE_VISITOR) {
-                if did == visit_did {
-                    let mut seen_str = None;
-                    let mut seen_string = None;
-                    for item in *items {
-                        match item.ident.as_str() {
-                            "visit_str" => seen_str = Some(item.span),
-                            "visit_string" => seen_string = Some(item.span),
-                            _ => {},
-                        }
+            if let Some(visit_did) = get_trait_def_id(cx.tcx, &paths::SERDE_DE_VISITOR)
+                && did == visit_did
+            {
+                let mut seen_str = None;
+                let mut seen_string = None;
+                for item in *items {
+                    match item.ident.as_str() {
+                        "visit_str" => seen_str = Some(item.span),
+                        "visit_string" => seen_string = Some(item.span),
+                        _ => {},
                     }
-                    if let Some(span) = seen_string {
-                        if seen_str.is_none() {
-                            span_lint(
-                                cx,
-                                SERDE_API_MISUSE,
-                                span,
-                                "you should not implement `visit_string` without also implementing `visit_str`",
-                            );
-                        }
-                    }
+                }
+                if let Some(span) = seen_string
+                    && seen_str.is_none()
+                {
+                    span_lint(
+                        cx,
+                        SERDE_API_MISUSE,
+                        span,
+                        "you should not implement `visit_string` without also implementing `visit_str`",
+                    );
                 }
             }
         }

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -167,10 +167,10 @@ impl<'tcx> LateLintPass<'tcx> for Shadow {
 
 fn is_shadow(cx: &LateContext<'_>, owner: LocalDefId, first: ItemLocalId, second: ItemLocalId) -> bool {
     let scope_tree = cx.tcx.region_scope_tree(owner.to_def_id());
-    if let Some(first_scope) = scope_tree.var_scope(first) {
-        if let Some(second_scope) = scope_tree.var_scope(second) {
-            return scope_tree.is_subscope_of(second_scope, first_scope);
-        }
+    if let Some(first_scope) = scope_tree.var_scope(first)
+        && let Some(second_scope) = scope_tree.var_scope(second)
+    {
+        return scope_tree.is_subscope_of(second_scope, first_scope);
     }
 
     false

--- a/clippy_lints/src/significant_drop_tightening.rs
+++ b/clippy_lints/src/significant_drop_tightening.rs
@@ -181,10 +181,10 @@ impl<'cx, 'others, 'tcx> AttrChecker<'cx, 'others, 'tcx> {
                     }
                 }
                 for generic_arg in *b {
-                    if let GenericArgKind::Type(ty) = generic_arg.unpack() {
-                        if self.has_sig_drop_attr(ty) {
-                            return true;
-                        }
+                    if let GenericArgKind::Type(ty) = generic_arg.unpack()
+                        && self.has_sig_drop_attr(ty)
+                    {
+                        return true;
                     }
                 }
                 false

--- a/clippy_lints/src/single_char_lifetime_names.rs
+++ b/clippy_lints/src/single_char_lifetime_names.rs
@@ -45,19 +45,20 @@ impl EarlyLintPass for SingleCharLifetimeNames {
             return;
         }
 
-        if let GenericParamKind::Lifetime = param.kind {
-            if !param.is_placeholder && param.ident.as_str().len() <= 2 {
-                #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
-                span_lint_and_then(
-                    ctx,
-                    SINGLE_CHAR_LIFETIME_NAMES,
-                    param.ident.span,
-                    "single-character lifetime names are likely uninformative",
-                    |diag| {
-                        diag.help("use a more informative name");
-                    },
-                );
-            }
+        if let GenericParamKind::Lifetime = param.kind
+            && !param.is_placeholder
+            && param.ident.as_str().len() <= 2
+        {
+            #[expect(clippy::collapsible_span_lint_calls, reason = "rust-clippy#7797")]
+            span_lint_and_then(
+                ctx,
+                SINGLE_CHAR_LIFETIME_NAMES,
+                param.ident.span,
+                "single-character lifetime names are likely uninformative",
+                |diag| {
+                    diag.help("use a more informative name");
+                },
+            );
         }
     }
 }

--- a/clippy_lints/src/single_component_path_imports.rs
+++ b/clippy_lints/src/single_component_path_imports.rs
@@ -204,17 +204,17 @@ impl SingleComponentPathImports {
                     if let UseTreeKind::Nested { items, .. } = &use_tree.kind {
                         for tree in items {
                             let segments = &tree.0.prefix.segments;
-                            if segments.len() == 1 {
-                                if let UseTreeKind::Simple(None) = tree.0.kind {
-                                    let name = segments[0].ident.name;
-                                    if !macros.contains(&name) {
-                                        single_use_usages.push(SingleUse {
-                                            name,
-                                            span: tree.0.span,
-                                            item_id: item.id,
-                                            can_suggest: false,
-                                        });
-                                    }
+                            if segments.len() == 1
+                                && let UseTreeKind::Simple(None) = tree.0.kind
+                            {
+                                let name = segments[0].ident.name;
+                                if !macros.contains(&name) {
+                                    single_use_usages.push(SingleUse {
+                                        name,
+                                        span: tree.0.span,
+                                        item_id: item.id,
+                                        can_suggest: false,
+                                    });
                                 }
                             }
                         }

--- a/clippy_lints/src/strings.rs
+++ b/clippy_lints/src/strings.rs
@@ -162,13 +162,12 @@ impl<'tcx> LateLintPass<'tcx> for StringAdd {
                 if is_string(cx, left) {
                     if !is_lint_allowed(cx, STRING_ADD_ASSIGN, e.hir_id) {
                         let parent = get_parent_expr(cx, e);
-                        if let Some(p) = parent {
-                            if let ExprKind::Assign(target, _, _) = p.kind {
+                        if let Some(p) = parent
+                            && let ExprKind::Assign(target, _, _) = p.kind
                                 // avoid duplicate matches
-                                if SpanlessEq::new(cx).eq_expr(target, left) {
-                                    return;
-                                }
-                            }
+                                && SpanlessEq::new(cx).eq_expr(target, left)
+                        {
+                            return;
                         }
                     }
                     span_lint(

--- a/clippy_lints/src/swap.rs
+++ b/clippy_lints/src/swap.rs
@@ -269,12 +269,11 @@ fn parse<'a, 'hir>(stmt: &'a Stmt<'hir>) -> Option<(ExprOrIdent<'hir>, &'a Expr<
         if let ExprKind::Assign(lhs, rhs, _) = expr.kind {
             return Some((ExprOrIdent::Expr(lhs), rhs));
         }
-    } else if let StmtKind::Let(expr) = stmt.kind {
-        if let Some(rhs) = expr.init {
-            if let PatKind::Binding(_, _, ident_l, _) = expr.pat.kind {
-                return Some((ExprOrIdent::Ident(ident_l), rhs));
-            }
-        }
+    } else if let StmtKind::Let(expr) = stmt.kind
+        && let Some(rhs) = expr.init
+        && let PatKind::Binding(_, _, ident_l, _) = expr.pat.kind
+    {
+        return Some((ExprOrIdent::Ident(ident_l), rhs));
     }
     None
 }

--- a/clippy_lints/src/trait_bounds.rs
+++ b/clippy_lints/src/trait_bounds.rs
@@ -151,20 +151,19 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                     .iter()
                     .filter_map(get_trait_info_from_bound)
                     .for_each(|(trait_item_res, trait_item_segments, span)| {
-                        if let Some(self_segments) = self_bounds_map.get(&trait_item_res) {
-                            if SpanlessEq::new(cx)
+                        if let Some(self_segments) = self_bounds_map.get(&trait_item_res)
+                            && SpanlessEq::new(cx)
                                 .paths_by_resolution()
                                 .eq_path_segments(self_segments, trait_item_segments)
-                            {
-                                span_lint_and_help(
-                                    cx,
-                                    TRAIT_DUPLICATION_IN_BOUNDS,
-                                    span,
-                                    "this trait bound is already specified in trait declaration",
-                                    None,
-                                    "consider removing this trait bound",
-                                );
-                            }
+                        {
+                            span_lint_and_help(
+                                cx,
+                                TRAIT_DUPLICATION_IN_BOUNDS,
+                                span,
+                                "this trait bound is already specified in trait declaration",
+                                None,
+                                "consider removing this trait bound",
+                            );
                         }
                     });
             }

--- a/clippy_lints/src/types/mod.rs
+++ b/clippy_lints/src/types/mod.rs
@@ -591,26 +591,26 @@ impl Types {
             TyKind::Path(ref qpath) if !context.in_body => {
                 let hir_id = hir_ty.hir_id;
                 let res = cx.qpath_res(qpath, hir_id);
-                if let Some(def_id) = res.opt_def_id() {
-                    if self.is_type_change_allowed(context) {
-                        // All lints that are being checked in this block are guarded by
-                        // the `avoid_breaking_exported_api` configuration. When adding a
-                        // new lint, please also add the name to the configuration documentation
-                        // in `clippy_config::conf`
+                if let Some(def_id) = res.opt_def_id()
+                    && self.is_type_change_allowed(context)
+                {
+                    // All lints that are being checked in this block are guarded by
+                    // the `avoid_breaking_exported_api` configuration. When adding a
+                    // new lint, please also add the name to the configuration documentation
+                    // in `clippy_config::conf`
 
-                        let mut triggered = false;
-                        triggered |= box_collection::check(cx, hir_ty, qpath, def_id);
-                        triggered |= redundant_allocation::check(cx, hir_ty, qpath, def_id);
-                        triggered |= rc_buffer::check(cx, hir_ty, qpath, def_id);
-                        triggered |= vec_box::check(cx, hir_ty, qpath, def_id, self.vec_box_size_threshold);
-                        triggered |= option_option::check(cx, hir_ty, qpath, def_id);
-                        triggered |= linked_list::check(cx, hir_ty, def_id);
-                        triggered |= rc_mutex::check(cx, hir_ty, qpath, def_id);
-                        triggered |= owned_cow::check(cx, qpath, def_id);
+                    let mut triggered = false;
+                    triggered |= box_collection::check(cx, hir_ty, qpath, def_id);
+                    triggered |= redundant_allocation::check(cx, hir_ty, qpath, def_id);
+                    triggered |= rc_buffer::check(cx, hir_ty, qpath, def_id);
+                    triggered |= vec_box::check(cx, hir_ty, qpath, def_id, self.vec_box_size_threshold);
+                    triggered |= option_option::check(cx, hir_ty, qpath, def_id);
+                    triggered |= linked_list::check(cx, hir_ty, def_id);
+                    triggered |= rc_mutex::check(cx, hir_ty, qpath, def_id);
+                    triggered |= owned_cow::check(cx, qpath, def_id);
 
-                        if triggered {
-                            return;
-                        }
+                    if triggered {
+                        return;
                     }
                 }
                 match *qpath {

--- a/clippy_lints/src/unicode.rs
+++ b/clippy_lints/src/unicode.rs
@@ -76,10 +76,10 @@ declare_lint_pass!(Unicode => [INVISIBLE_CHARACTERS, NON_ASCII_LITERAL, UNICODE_
 
 impl LateLintPass<'_> for Unicode {
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &'_ Expr<'_>) {
-        if let ExprKind::Lit(lit) = expr.kind {
-            if let LitKind::Str(_, _) | LitKind::Char(_) = lit.node {
-                check_str(cx, lit.span, expr.hir_id);
-            }
+        if let ExprKind::Lit(lit) = expr.kind
+            && let LitKind::Str(_, _) | LitKind::Char(_) = lit.node
+        {
+            check_str(cx, lit.span, expr.hir_id);
         }
     }
 }

--- a/clippy_lints/src/unnecessary_wraps.rs
+++ b/clippy_lints/src/unnecessary_wraps.rs
@@ -93,13 +93,13 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
 
         // Abort if the method is implementing a trait or of it a trait method.
         let hir_id = cx.tcx.local_def_id_to_hir_id(def_id);
-        if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id) {
-            if matches!(
+        if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id)
+            && matches!(
                 item.kind,
                 ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait(..)
-            ) {
-                return;
-            }
+            )
+        {
+            return;
         }
 
         // Get the wrapper and inner types, if can't, abort.

--- a/clippy_lints/src/unnested_or_patterns.rs
+++ b/clippy_lints/src/unnested_or_patterns.rs
@@ -69,10 +69,10 @@ impl EarlyLintPass for UnnestedOrPatterns {
     }
 
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
-        if self.msrv.meets(msrvs::OR_PATTERNS) {
-            if let ast::ExprKind::Let(pat, _, _, _) = &e.kind {
-                lint_unnested_or_patterns(cx, pat);
-            }
+        if self.msrv.meets(msrvs::OR_PATTERNS)
+            && let ast::ExprKind::Let(pat, _, _, _) = &e.kind
+        {
+            lint_unnested_or_patterns(cx, pat);
         }
     }
 

--- a/clippy_lints/src/unused_io_amount.rs
+++ b/clippy_lints/src/unused_io_amount.rs
@@ -265,15 +265,14 @@ fn unpack_match<'a>(mut expr: &'a hir::Expr<'a>) -> &'a hir::Expr<'a> {
 /// If `expr` is an (e).await, return the inner expression "e" that's being
 /// waited on.  Otherwise return None.
 fn unpack_await<'a>(expr: &'a hir::Expr<'a>) -> &'a hir::Expr<'a> {
-    if let ExprKind::Match(expr, _, hir::MatchSource::AwaitDesugar) = expr.kind {
-        if let ExprKind::Call(func, [arg_0]) = expr.kind {
-            if matches!(
-                func.kind,
-                ExprKind::Path(hir::QPath::LangItem(hir::LangItem::IntoFutureIntoFuture, ..))
-            ) {
-                return arg_0;
-            }
-        }
+    if let ExprKind::Match(expr, _, hir::MatchSource::AwaitDesugar) = expr.kind
+        && let ExprKind::Call(func, [arg_0]) = expr.kind
+        && matches!(
+            func.kind,
+            ExprKind::Path(hir::QPath::LangItem(hir::LangItem::IntoFutureIntoFuture, ..))
+        )
+    {
+        return arg_0;
     }
     expr
 }

--- a/clippy_lints/src/useless_conversion.rs
+++ b/clippy_lints/src/useless_conversion.rs
@@ -92,36 +92,36 @@ fn into_iter_bound<'tcx>(
     let mut into_iter_span = None;
 
     for (pred, span) in cx.tcx.explicit_predicates_of(fn_did).predicates {
-        if let ty::ClauseKind::Trait(tr) = pred.kind().skip_binder() {
-            if tr.self_ty().is_param(param_index) {
-                if tr.def_id() == into_iter_did {
-                    into_iter_span = Some(*span);
-                } else {
-                    let tr = cx.tcx.erase_regions(tr);
-                    if tr.has_escaping_bound_vars() {
-                        return None;
-                    }
+        if let ty::ClauseKind::Trait(tr) = pred.kind().skip_binder()
+            && tr.self_ty().is_param(param_index)
+        {
+            if tr.def_id() == into_iter_did {
+                into_iter_span = Some(*span);
+            } else {
+                let tr = cx.tcx.erase_regions(tr);
+                if tr.has_escaping_bound_vars() {
+                    return None;
+                }
 
-                    // Substitute generics in the predicate and replace the IntoIterator type parameter with the
-                    // `.into_iter()` receiver to see if the bound also holds for that type.
-                    let args = cx.tcx.mk_args_from_iter(node_args.iter().enumerate().map(|(i, arg)| {
-                        if i == param_index as usize {
-                            GenericArg::from(into_iter_receiver)
-                        } else {
-                            arg
-                        }
-                    }));
-
-                    let predicate = EarlyBinder::bind(tr).instantiate(cx.tcx, args);
-                    let obligation = Obligation::new(cx.tcx, ObligationCause::dummy(), cx.param_env, predicate);
-                    if !cx
-                        .tcx
-                        .infer_ctxt()
-                        .build(cx.typing_mode())
-                        .predicate_must_hold_modulo_regions(&obligation)
-                    {
-                        return None;
+                // Substitute generics in the predicate and replace the IntoIterator type parameter with the
+                // `.into_iter()` receiver to see if the bound also holds for that type.
+                let args = cx.tcx.mk_args_from_iter(node_args.iter().enumerate().map(|(i, arg)| {
+                    if i == param_index as usize {
+                        GenericArg::from(into_iter_receiver)
+                    } else {
+                        arg
                     }
+                }));
+
+                let predicate = EarlyBinder::bind(tr).instantiate(cx.tcx, args);
+                let obligation = Obligation::new(cx.tcx, ObligationCause::dummy(), cx.param_env, predicate);
+                if !cx
+                    .tcx
+                    .infer_ctxt()
+                    .build(cx.typing_mode())
+                    .predicate_must_hold_modulo_regions(&obligation)
+                {
+                    return None;
                 }
             }
         }

--- a/clippy_lints/src/utils/internal_lints/invalid_paths.rs
+++ b/clippy_lints/src/utils/internal_lints/invalid_paths.rs
@@ -80,22 +80,22 @@ pub fn check_path(cx: &LateContext<'_>, path: &[&str]) -> bool {
     .copied();
     for item_def_id in lang_items.iter().map(|(_, def_id)| def_id).chain(incoherent_impls) {
         let lang_item_path = cx.get_def_path(item_def_id);
-        if path_syms.starts_with(&lang_item_path) {
-            if let [item] = &path_syms[lang_item_path.len()..] {
-                if matches!(
-                    cx.tcx.def_kind(item_def_id),
-                    DefKind::Mod | DefKind::Enum | DefKind::Trait
-                ) {
-                    for child in cx.tcx.module_children(item_def_id) {
-                        if child.ident.name == *item {
-                            return true;
-                        }
+        if path_syms.starts_with(&lang_item_path)
+            && let [item] = &path_syms[lang_item_path.len()..]
+        {
+            if matches!(
+                cx.tcx.def_kind(item_def_id),
+                DefKind::Mod | DefKind::Enum | DefKind::Trait
+            ) {
+                for child in cx.tcx.module_children(item_def_id) {
+                    if child.ident.name == *item {
+                        return true;
                     }
-                } else {
-                    for child in cx.tcx.associated_item_def_ids(item_def_id) {
-                        if cx.tcx.item_name(*child) == *item {
-                            return true;
-                        }
+                }
+            } else {
+                for child in cx.tcx.associated_item_def_ids(item_def_id) {
+                    if cx.tcx.item_name(*child) == *item {
+                        return true;
                     }
                 }
             }

--- a/clippy_lints/src/utils/internal_lints/lint_without_lint_pass.rs
+++ b/clippy_lints/src/utils/internal_lints/lint_without_lint_pass.rs
@@ -205,12 +205,10 @@ pub(super) fn is_lint_ref_type(cx: &LateContext<'_>, ty: &hir::Ty<'_>) -> bool {
             mutbl: Mutability::Not,
         },
     ) = ty.kind
+        && let TyKind::Path(ref path) = inner.kind
+        && let Res::Def(DefKind::Struct, def_id) = cx.qpath_res(path, inner.hir_id)
     {
-        if let TyKind::Path(ref path) = inner.kind {
-            if let Res::Def(DefKind::Struct, def_id) = cx.qpath_res(path, inner.hir_id) {
-                return match_def_path(cx, def_id, &paths::LINT);
-            }
-        }
+        return match_def_path(cx, def_id, &paths::LINT);
     }
 
     false

--- a/clippy_lints/src/utils/internal_lints/unnecessary_def_path.rs
+++ b/clippy_lints/src/utils/internal_lints/unnecessary_def_path.rs
@@ -281,10 +281,10 @@ fn path_from_array(exprs: &[Expr<'_>]) -> Option<Vec<String>> {
     exprs
         .iter()
         .map(|expr| {
-            if let ExprKind::Lit(lit) = &expr.kind {
-                if let LitKind::Str(sym, _) = lit.node {
-                    return Some((*sym.as_str()).to_owned());
-                }
+            if let ExprKind::Lit(lit) = &expr.kind
+                && let LitKind::Str(sym, _) = lit.node
+            {
+                return Some((*sym.as_str()).to_owned());
             }
 
             None

--- a/clippy_lints/src/utils/internal_lints/unsorted_clippy_utils_paths.rs
+++ b/clippy_lints/src/utils/internal_lints/unsorted_clippy_utils_paths.rs
@@ -21,28 +21,26 @@ declare_lint_pass!(UnsortedClippyUtilsPaths => [UNSORTED_CLIPPY_UTILS_PATHS]);
 
 impl EarlyLintPass for UnsortedClippyUtilsPaths {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, krate: &Crate) {
-        if let Some(utils) = krate.items.iter().find(|item| item.ident.name.as_str() == "utils") {
-            if let ItemKind::Mod(_, ModKind::Loaded(ref items, ..)) = utils.kind {
-                if let Some(paths) = items.iter().find(|item| item.ident.name.as_str() == "paths") {
-                    if let ItemKind::Mod(_, ModKind::Loaded(ref items, ..)) = paths.kind {
-                        let mut last_name: Option<&str> = None;
-                        for item in items {
-                            let name = item.ident.as_str();
-                            if let Some(last_name) = last_name {
-                                if *last_name > *name {
-                                    span_lint(
-                                        cx,
-                                        UNSORTED_CLIPPY_UTILS_PATHS,
-                                        item.span,
-                                        "this constant should be before the previous constant due to lexical \
+        if let Some(utils) = krate.items.iter().find(|item| item.ident.name.as_str() == "utils")
+            && let ItemKind::Mod(_, ModKind::Loaded(ref items, ..)) = utils.kind
+            && let Some(paths) = items.iter().find(|item| item.ident.name.as_str() == "paths")
+            && let ItemKind::Mod(_, ModKind::Loaded(ref items, ..)) = paths.kind
+        {
+            let mut last_name: Option<&str> = None;
+            for item in items {
+                let name = item.ident.as_str();
+                if let Some(last_name) = last_name
+                    && *last_name > *name
+                {
+                    span_lint(
+                        cx,
+                        UNSORTED_CLIPPY_UTILS_PATHS,
+                        item.span,
+                        "this constant should be before the previous constant due to lexical \
                                          ordering",
-                                    );
-                                }
-                            }
-                            last_name = Some(name);
-                        }
-                    }
+                    );
                 }
+                last_name = Some(name);
             }
         }
     }

--- a/clippy_lints/src/zero_sized_map_values.rs
+++ b/clippy_lints/src/zero_sized_map_values.rs
@@ -74,10 +74,10 @@ impl LateLintPass<'_> for ZeroSizedMapValues {
 fn in_trait_impl(cx: &LateContext<'_>, hir_id: HirId) -> bool {
     let parent_id = cx.tcx.hir_get_parent_item(hir_id);
     let second_parent_id = cx.tcx.hir_get_parent_item(parent_id.into()).def_id;
-    if let Node::Item(item) = cx.tcx.hir_node_by_def_id(second_parent_id) {
-        if let ItemKind::Impl(hir::Impl { of_trait: Some(_), .. }) = item.kind {
-            return true;
-        }
+    if let Node::Item(item) = cx.tcx.hir_node_by_def_id(second_parent_id)
+        && let ItemKind::Impl(hir::Impl { of_trait: Some(_), .. }) = item.kind
+    {
+        return true;
     }
     false
 }

--- a/clippy_utils/src/diagnostics.rs
+++ b/clippy_utils/src/diagnostics.rs
@@ -17,16 +17,16 @@ use rustc_span::Span;
 use std::env;
 
 fn docs_link(diag: &mut Diag<'_, ()>, lint: &'static Lint) {
-    if env::var("CLIPPY_DISABLE_DOCS_LINKS").is_err() {
-        if let Some(lint) = lint.name_lower().strip_prefix("clippy::") {
-            diag.help(format!(
-                "for further information visit https://rust-lang.github.io/rust-clippy/{}/index.html#{lint}",
-                &option_env!("RUST_RELEASE_NUM").map_or("master".to_string(), |n| {
-                    // extract just major + minor version and ignore patch versions
-                    format!("rust-{}", n.rsplit_once('.').unwrap().1)
-                })
-            ));
-        }
+    if env::var("CLIPPY_DISABLE_DOCS_LINKS").is_err()
+        && let Some(lint) = lint.name_lower().strip_prefix("clippy::")
+    {
+        diag.help(format!(
+            "for further information visit https://rust-lang.github.io/rust-clippy/{}/index.html#{lint}",
+            &option_env!("RUST_RELEASE_NUM").map_or("master".to_string(), |n| {
+                // extract just major + minor version and ignore patch versions
+                format!("rust-{}", n.rsplit_once('.').unwrap().1)
+            })
+        ));
     }
 }
 

--- a/clippy_utils/src/higher.rs
+++ b/clippy_utils/src/higher.rs
@@ -118,18 +118,17 @@ impl<'hir> IfLet<'hir> {
         ) = expr.kind
         {
             let mut iter = cx.tcx.hir_parent_iter(expr.hir_id);
-            if let Some((_, Node::Block(Block { stmts: [], .. }))) = iter.next() {
-                if let Some((
+            if let Some((_, Node::Block(Block { stmts: [], .. }))) = iter.next()
+                && let Some((
                     _,
                     Node::Expr(Expr {
                         kind: ExprKind::Loop(_, _, LoopSource::While, _),
                         ..
                     }),
                 )) = iter.next()
-                {
-                    // while loop desugar
-                    return None;
-                }
+            {
+                // while loop desugar
+                return None;
             }
             return Some(Self {
                 let_pat,

--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -367,10 +367,10 @@ pub fn is_inherent_method_call(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
 
 /// Checks if a method is defined in an impl of a diagnostic item
 pub fn is_diag_item_method(cx: &LateContext<'_>, def_id: DefId, diag_item: Symbol) -> bool {
-    if let Some(impl_did) = cx.tcx.impl_of_method(def_id) {
-        if let Some(adt) = cx.tcx.type_of(impl_did).instantiate_identity().ty_adt_def() {
-            return cx.tcx.is_diagnostic_item(diag_item, adt.did());
-        }
+    if let Some(impl_did) = cx.tcx.impl_of_method(def_id)
+        && let Some(adt) = cx.tcx.type_of(impl_did).instantiate_identity().ty_adt_def()
+    {
+        return cx.tcx.is_diagnostic_item(diag_item, adt.did());
     }
     false
 }
@@ -457,10 +457,10 @@ pub fn match_qpath(path: &QPath<'_>, segments: &[&str]) -> bool {
         QPath::Resolved(_, path) => match_path(path, segments),
         QPath::TypeRelative(ty, segment) => match ty.kind {
             TyKind::Path(ref inner_path) => {
-                if let [prefix @ .., end] = segments {
-                    if match_qpath(inner_path, prefix) {
-                        return segment.ident.name.as_str() == *end;
-                    }
+                if let [prefix @ .., end] = segments
+                    && match_qpath(inner_path, prefix)
+                {
+                    return segment.ident.name.as_str() == *end;
                 }
                 false
             },
@@ -523,10 +523,10 @@ pub fn match_path(path: &Path<'_>, segments: &[&str]) -> bool {
 
 /// If the expression is a path to a local, returns the canonical `HirId` of the local.
 pub fn path_to_local(expr: &Expr<'_>) -> Option<HirId> {
-    if let ExprKind::Path(QPath::Resolved(None, path)) = expr.kind {
-        if let Res::Local(id) = path.res {
-            return Some(id);
-        }
+    if let ExprKind::Path(QPath::Resolved(None, path)) = expr.kind
+        && let Res::Local(id) = path.res
+    {
+        return Some(id);
     }
     None
 }
@@ -893,16 +893,14 @@ fn is_default_equivalent_ctor(cx: &LateContext<'_>, def_id: DefId, path: &QPath<
         sym::BinaryHeap,
     ];
 
-    if let QPath::TypeRelative(_, method) = path {
-        if method.ident.name == sym::new {
-            if let Some(impl_did) = cx.tcx.impl_of_method(def_id) {
-                if let Some(adt) = cx.tcx.type_of(impl_did).instantiate_identity().ty_adt_def() {
-                    return std_types_symbols.iter().any(|&symbol| {
-                        cx.tcx.is_diagnostic_item(symbol, adt.did()) || Some(adt.did()) == cx.tcx.lang_items().string()
-                    });
-                }
-            }
-        }
+    if let QPath::TypeRelative(_, method) = path
+        && method.ident.name == sym::new
+        && let Some(impl_did) = cx.tcx.impl_of_method(def_id)
+        && let Some(adt) = cx.tcx.type_of(impl_did).instantiate_identity().ty_adt_def()
+    {
+        return std_types_symbols.iter().any(|&symbol| {
+            cx.tcx.is_diagnostic_item(symbol, adt.did()) || Some(adt.did()) == cx.tcx.lang_items().string()
+        });
     }
     false
 }
@@ -1204,12 +1202,10 @@ pub fn capture_local_usage(cx: &LateContext<'_>, e: &Expr<'_>) -> CaptureKind {
             .adjustments()
             .get(child_id)
             .map_or(&[][..], |x| &**x)
-        {
-            if let rustc_ty::RawPtr(_, mutability) | rustc_ty::Ref(_, _, mutability) =
+            && let rustc_ty::RawPtr(_, mutability) | rustc_ty::Ref(_, _, mutability) =
                 *adjust.last().map_or(target, |a| a.target).kind()
-            {
-                return CaptureKind::Ref(mutability);
-            }
+        {
+            return CaptureKind::Ref(mutability);
         }
 
         match parent {
@@ -1737,10 +1733,10 @@ pub fn is_integer_const(cx: &LateContext<'_>, e: &Expr<'_>, value: u128) -> bool
 /// Checks whether the given expression is a constant literal of the given value.
 pub fn is_integer_literal(expr: &Expr<'_>, value: u128) -> bool {
     // FIXME: use constant folding
-    if let ExprKind::Lit(spanned) = expr.kind {
-        if let LitKind::Int(v, _) = spanned.node {
-            return v == value;
-        }
+    if let ExprKind::Lit(spanned) = expr.kind
+        && let LitKind::Int(v, _) = spanned.node
+    {
+        return v == value;
     }
     false
 }
@@ -1777,10 +1773,10 @@ pub fn is_expn_of(mut span: Span, name: &str) -> Option<Span> {
             let data = span.ctxt().outer_expn_data();
             let new_span = data.call_site;
 
-            if let ExpnKind::Macro(MacroKind::Bang, mac_name) = data.kind {
-                if mac_name.as_str() == name {
-                    return Some(new_span);
-                }
+            if let ExpnKind::Macro(MacroKind::Bang, mac_name) = data.kind
+                && mac_name.as_str() == name
+            {
+                return Some(new_span);
             }
 
             span = new_span;
@@ -1806,10 +1802,10 @@ pub fn is_direct_expn_of(span: Span, name: &str) -> Option<Span> {
         let data = span.ctxt().outer_expn_data();
         let new_span = data.call_site;
 
-        if let ExpnKind::Macro(MacroKind::Bang, mac_name) = data.kind {
-            if mac_name.as_str() == name {
-                return Some(new_span);
-            }
+        if let ExpnKind::Macro(MacroKind::Bang, mac_name) = data.kind
+            && mac_name.as_str() == name
+        {
+            return Some(new_span);
         }
     }
 
@@ -1830,15 +1826,15 @@ pub fn nth_arg<'tcx>(cx: &LateContext<'tcx>, fn_def_id: OwnerId, nth: usize) -> 
 
 /// Checks if an expression is constructing a tuple-like enum variant or struct
 pub fn is_ctor_or_promotable_const_function(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
-    if let ExprKind::Call(fun, _) = expr.kind {
-        if let ExprKind::Path(ref qp) = fun.kind {
-            let res = cx.qpath_res(qp, fun.hir_id);
-            return match res {
-                Res::Def(DefKind::Variant | DefKind::Ctor(..), ..) => true,
-                Res::Def(_, def_id) => cx.tcx.is_promotable_const_fn(def_id),
-                _ => false,
-            };
-        }
+    if let ExprKind::Call(fun, _) = expr.kind
+        && let ExprKind::Path(ref qp) = fun.kind
+    {
+        let res = cx.qpath_res(qp, fun.hir_id);
+        return match res {
+            Res::Def(DefKind::Variant | DefKind::Ctor(..), ..) => true,
+            Res::Def(_, def_id) => cx.tcx.is_promotable_const_fn(def_id),
+            _ => false,
+        };
     }
     false
 }
@@ -1911,10 +1907,10 @@ pub fn is_self(slf: &Param<'_>) -> bool {
 }
 
 pub fn is_self_ty(slf: &hir::Ty<'_>) -> bool {
-    if let TyKind::Path(QPath::Resolved(None, path)) = slf.kind {
-        if let Res::SelfTyParam { .. } | Res::SelfTyAlias { .. } = path.res {
-            return true;
-        }
+    if let TyKind::Path(QPath::Resolved(None, path)) = slf.kind
+        && let Res::SelfTyParam { .. } | Res::SelfTyAlias { .. } = path.res
+    {
+        return true;
     }
     false
 }
@@ -2119,10 +2115,10 @@ pub fn if_sequence<'tcx>(mut expr: &'tcx Expr<'tcx>) -> (Vec<&'tcx Expr<'tcx>>, 
     }
 
     // final `else {..}`
-    if !blocks.is_empty() {
-        if let ExprKind::Block(block, _) = expr.kind {
-            blocks.push(block);
-        }
+    if !blocks.is_empty()
+        && let ExprKind::Block(block, _) = expr.kind
+    {
+        blocks.push(block);
     }
 
     (conds, blocks)
@@ -2139,8 +2135,8 @@ pub fn is_async_fn(kind: FnKind<'_>) -> bool {
 
 /// Peels away all the compiler generated code surrounding the body of an async function,
 pub fn get_async_fn_body<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'_>) -> Option<&'tcx Expr<'tcx>> {
-    if let ExprKind::Closure(&Closure { body, .. }) = body.value.kind {
-        if let ExprKind::Block(
+    if let ExprKind::Closure(&Closure { body, .. }) = body.value.kind
+        && let ExprKind::Block(
             Block {
                 stmts: [],
                 expr:
@@ -2152,9 +2148,8 @@ pub fn get_async_fn_body<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'_>) -> Option<&'t
             },
             _,
         ) = tcx.hir_body(body).value.kind
-        {
-            return Some(expr);
-        }
+    {
+        return Some(expr);
     }
     None
 }
@@ -2628,10 +2623,10 @@ pub fn peel_ref_operators<'hir>(cx: &LateContext<'_>, mut expr: &'hir Expr<'hir>
 }
 
 pub fn is_hir_ty_cfg_dependant(cx: &LateContext<'_>, ty: &hir::Ty<'_>) -> bool {
-    if let TyKind::Path(QPath::Resolved(_, path)) = ty.kind {
-        if let Res::Def(_, def_id) = path.res {
-            return cx.tcx.has_attr(def_id, sym::cfg) || cx.tcx.has_attr(def_id, sym::cfg_attr);
-        }
+    if let TyKind::Path(QPath::Resolved(_, path)) = ty.kind
+        && let Res::Def(_, def_id) = path.res
+    {
+        return cx.tcx.has_attr(def_id, sym::cfg) || cx.tcx.has_attr(def_id, sym::cfg_attr);
     }
     false
 }
@@ -2650,18 +2645,16 @@ fn with_test_item_names(tcx: TyCtxt<'_>, module: LocalModDefId, f: impl Fn(&[Sym
                 if matches!(tcx.def_kind(id.owner_id), DefKind::Const)
                     && let item = tcx.hir_item(id)
                     && let ItemKind::Const(ident, ty, _generics, _body) = item.kind
-                {
-                    if let TyKind::Path(QPath::Resolved(_, path)) = ty.kind {
+                    && let TyKind::Path(QPath::Resolved(_, path)) = ty.kind
                         // We could also check for the type name `test::TestDescAndFn`
-                        if let Res::Def(DefKind::Struct, _) = path.res {
-                            let has_test_marker = tcx
-                                .hir_attrs(item.hir_id())
-                                .iter()
-                                .any(|a| a.has_name(sym::rustc_test_marker));
-                            if has_test_marker {
-                                names.push(ident.name);
-                            }
-                        }
+                        && let Res::Def(DefKind::Struct, _) = path.res
+                {
+                    let has_test_marker = tcx
+                        .hir_attrs(item.hir_id())
+                        .iter()
+                        .any(|a| a.has_name(sym::rustc_test_marker));
+                    if has_test_marker {
+                        names.push(ident.name);
                     }
                 }
             }
@@ -2682,12 +2675,12 @@ pub fn is_in_test_function(tcx: TyCtxt<'_>, id: HirId) -> bool {
             // Since you can nest functions we need to collect all until we leave
             // function scope
             .any(|(_id, node)| {
-                if let Node::Item(item) = node {
-                    if let ItemKind::Fn { ident, .. } = item.kind {
-                        // Note that we have sorted the item names in the visitor,
-                        // so the binary_search gets the same as `contains`, but faster.
-                        return names.binary_search(&ident.name).is_ok();
-                    }
+                if let Node::Item(item) = node
+                    && let ItemKind::Fn { ident, .. } = item.kind
+                {
+                    // Note that we have sorted the item names in the visitor,
+                    // so the binary_search gets the same as `contains`, but faster.
+                    return names.binary_search(&ident.name).is_ok();
                 }
                 false
             })

--- a/clippy_utils/src/source.rs
+++ b/clippy_utils/src/source.rs
@@ -384,10 +384,10 @@ pub fn snippet_indent(sess: &impl HasSession, span: Span) -> Option<String> {
 // For some reason these attributes don't have any expansion info on them, so
 // we have to check it this way until there is a better way.
 pub fn is_present_in_source(sess: &impl HasSession, span: Span) -> bool {
-    if let Some(snippet) = snippet_opt(sess, span) {
-        if snippet.is_empty() {
-            return false;
-        }
+    if let Some(snippet) = snippet_opt(sess, span)
+        && snippet.is_empty()
+    {
+        return false;
     }
     true
 }
@@ -408,11 +408,11 @@ pub fn position_before_rarrow(s: &str) -> Option<usize> {
         let mut rpos = rpos;
         let chars: Vec<char> = s.chars().collect();
         while rpos > 1 {
-            if let Some(c) = chars.get(rpos - 1) {
-                if c.is_whitespace() {
-                    rpos -= 1;
-                    continue;
-                }
+            if let Some(c) = chars.get(rpos - 1)
+                && c.is_whitespace()
+            {
+                rpos -= 1;
+                continue;
             }
             break;
         }

--- a/clippy_utils/src/sugg.rs
+++ b/clippy_utils/src/sugg.rs
@@ -947,11 +947,10 @@ impl<'tcx> Delegate<'tcx> for DerefDelegate<'_, 'tcx> {
                             // some items do not need explicit deref, such as array accesses,
                             // so we mark them as already processed
                             // i.e.: don't suggest `*sub[1..4].len()` for `|sub| sub[1..4].len() == 3`
-                            if let ty::Ref(_, inner, _) = cmt.place.ty_before_projection(i).kind() {
-                                if matches!(inner.kind(), ty::Ref(_, innermost, _) if innermost.is_array()) {
+                            if let ty::Ref(_, inner, _) = cmt.place.ty_before_projection(i).kind()
+                                && matches!(inner.kind(), ty::Ref(_, innermost, _) if innermost.is_array()) {
                                     projections_handled = true;
                                 }
-                            }
                         },
                     }
                 });

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -128,10 +128,10 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
                             // For `impl Trait<Assoc=U>`, it will register a predicate of `<T as Trait>::Assoc = U`,
                             // so we check the term for `U`.
                             ty::ClauseKind::Projection(projection_predicate) => {
-                                if let ty::TermKind::Ty(ty) = projection_predicate.term.unpack() {
-                                    if contains_ty_adt_constructor_opaque_inner(cx, ty, needle, seen) {
-                                        return true;
-                                    }
+                                if let ty::TermKind::Ty(ty) = projection_predicate.term.unpack()
+                                    && contains_ty_adt_constructor_opaque_inner(cx, ty, needle, seen)
+                                {
+                                    return true;
                                 }
                             },
                             _ => (),
@@ -337,20 +337,20 @@ pub fn is_must_use_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
         ty::Tuple(args) => args.iter().any(|ty| is_must_use_ty(cx, ty)),
         ty::Alias(ty::Opaque, AliasTy { def_id, .. }) => {
             for (predicate, _) in cx.tcx.explicit_item_self_bounds(def_id).skip_binder() {
-                if let ty::ClauseKind::Trait(trait_predicate) = predicate.kind().skip_binder() {
-                    if cx.tcx.has_attr(trait_predicate.trait_ref.def_id, sym::must_use) {
-                        return true;
-                    }
+                if let ty::ClauseKind::Trait(trait_predicate) = predicate.kind().skip_binder()
+                    && cx.tcx.has_attr(trait_predicate.trait_ref.def_id, sym::must_use)
+                {
+                    return true;
                 }
             }
             false
         },
         ty::Dynamic(binder, _, _) => {
             for predicate in *binder {
-                if let ty::ExistentialPredicate::Trait(ref trait_ref) = predicate.skip_binder() {
-                    if cx.tcx.has_attr(trait_ref.def_id, sym::must_use) {
-                        return true;
-                    }
+                if let ty::ExistentialPredicate::Trait(ref trait_ref) = predicate.skip_binder()
+                    && cx.tcx.has_attr(trait_ref.def_id, sym::must_use)
+                {
+                    return true;
                 }
             }
             false

--- a/clippy_utils/src/usage.rs
+++ b/clippy_utils/src/usage.rs
@@ -126,10 +126,10 @@ impl<'tcx> Visitor<'tcx> for BindingUsageFinder<'_, 'tcx> {
     type NestedFilter = nested_filter::OnlyBodies;
 
     fn visit_path(&mut self, path: &hir::Path<'tcx>, _: HirId) -> Self::Result {
-        if let Res::Local(id) = path.res {
-            if self.binding_ids.contains(&id) {
-                return ControlFlow::Break(());
-            }
+        if let Res::Local(id) = path.res
+            && self.binding_ids.contains(&id)
+        {
+            return ControlFlow::Break(());
         }
 
         ControlFlow::Continue(())

--- a/clippy_utils/src/visitors.rs
+++ b/clippy_utils/src/visitors.rs
@@ -297,10 +297,10 @@ where
 /// Checks if the given resolved path is used in the given body.
 pub fn is_res_used(cx: &LateContext<'_>, res: Res, body: BodyId) -> bool {
     for_each_expr(cx, cx.tcx.hir_body(body).value, |e| {
-        if let ExprKind::Path(p) = &e.kind {
-            if cx.qpath_res(p, e.hir_id) == res {
-                return ControlFlow::Break(());
-            }
+        if let ExprKind::Path(p) = &e.kind
+            && cx.qpath_res(p, e.hir_id) == res
+        {
+            return ControlFlow::Break(());
         }
         ControlFlow::Continue(())
     })

--- a/lintcheck/ci-config/clippy.toml
+++ b/lintcheck/ci-config/clippy.toml
@@ -4,4 +4,5 @@
 # to `$PWD/lintcheck/ci-config`.
 
 avoid-breaking-exported-api = false
+collapse-let-chains = false
 lint-commented-code = false

--- a/lintcheck/src/main.rs
+++ b/lintcheck/src/main.rs
@@ -467,10 +467,10 @@ fn get_perf_data_filename(source_path: &Path) -> String {
             .for_each(|path| {
                 let file_name = path.file_name();
                 let file_name = file_name.as_os_str().to_str().unwrap().split('.').next_back().unwrap();
-                if let Ok(parsed_file_name) = file_name.parse::<usize>() {
-                    if parsed_file_name >= max_number {
-                        max_number = parsed_file_name + 1;
-                    }
+                if let Ok(parsed_file_name) = file_name.parse::<usize>()
+                    && parsed_file_name >= max_number
+                {
+                    max_number = parsed_file_name + 1;
                 }
             });
         return format!("perf.data.{max_number}");

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -207,12 +207,12 @@ pub fn main() {
             // Beside checking for existence of `--sysroot` on the command line, we need to
             // check for the arg files that are prefixed with @ as well to be consistent with rustc
             for arg in args.iter() {
-                if let Some(arg_file_path) = arg.strip_prefix('@') {
-                    if let Ok(arg_file) = read_to_string(arg_file_path) {
-                        let split_arg_file: Vec<String> = arg_file.lines().map(ToString::to_string).collect();
-                        if has_arg(&split_arg_file, "--sysroot") {
-                            return true;
-                        }
+                if let Some(arg_file_path) = arg.strip_prefix('@')
+                    && let Ok(arg_file) = read_to_string(arg_file_path)
+                {
+                    let split_arg_file: Vec<String> = arg_file.lines().map(ToString::to_string).collect();
+                    if has_arg(&split_arg_file, "--sysroot") {
+                        return true;
                     }
                 }
             }
@@ -221,10 +221,10 @@ pub fn main() {
 
         let sys_root_env = std::env::var("SYSROOT").ok();
         let pass_sysroot_env_if_given = |args: &mut Vec<String>, sys_root_env| {
-            if let Some(sys_root) = sys_root_env {
-                if !has_sysroot_arg(args) {
-                    args.extend(vec!["--sysroot".into(), sys_root]);
-                }
+            if let Some(sys_root) = sys_root_env
+                && !has_sysroot_arg(args)
+            {
+                args.extend(vec!["--sysroot".into(), sys_root]);
             }
         };
 

--- a/tests/clippy.toml
+++ b/tests/clippy.toml
@@ -1,2 +1,3 @@
 # default config for tests, overrides clippy.toml at the project root
+collapse-let-chains = false
 lint-commented-code = false

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -86,13 +86,13 @@ fn extern_flags() -> Vec<String> {
             let name = name.strip_prefix("lib").unwrap_or(name);
             Some((name, path_str))
         };
-        if let Some((name, path)) = parse_name_path() {
-            if TEST_DEPENDENCIES.contains(&name) {
-                // A dependency may be listed twice if it is available in sysroot,
-                // and the sysroot dependencies are listed first. As of the writing,
-                // this only seems to apply to if_chain.
-                crates.insert(name, path);
-            }
+        if let Some((name, path)) = parse_name_path()
+            && TEST_DEPENDENCIES.contains(&name)
+        {
+            // A dependency may be listed twice if it is available in sysroot,
+            // and the sysroot dependencies are listed first. As of the writing,
+            // this only seems to apply to if_chain.
+            crates.insert(name, path);
         }
     }
     let not_found: Vec<&str> = TEST_DEPENDENCIES

--- a/tests/ui-toml/collapsible_if/clippy.toml
+++ b/tests/ui-toml/collapsible_if/clippy.toml
@@ -1,1 +1,2 @@
+collapse-let-chains = true
 lint-commented-code = true

--- a/tests/ui-toml/collapsible_if/collapsible_if.fixed
+++ b/tests/ui-toml/collapsible_if/collapsible_if.fixed
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 #![allow(clippy::eq_op, clippy::nonminimal_bool)]
 
 #[rustfmt::skip]
@@ -29,6 +30,30 @@ fn main() {
     if x == "hello" /* Inner comment */
         && y == "world" {
             println!("Hello world!");
+        }
+    //~^^^^^ collapsible_if
+
+    if true
+         && true {
+             println!("No comment, linted");
+         }
+     //~^^^^^ collapsible_if
+
+    if let Some(a) = Some(3)
+        && let Some(b) = Some(4) {
+            let _ = a + b;
+        }
+    //~^^^^^ collapsible_if
+
+    if let Some(a) = Some(3)
+        && a + 1 == 4 {
+            let _ = a;
+        }
+    //~^^^^^ collapsible_if
+
+    if Some(3) == Some(4).map(|x| x - 1)
+        && let Some(b) = Some(4) {
+            let _ = b;
         }
     //~^^^^^ collapsible_if
 }

--- a/tests/ui-toml/collapsible_if/collapsible_if.rs
+++ b/tests/ui-toml/collapsible_if/collapsible_if.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 #![allow(clippy::eq_op, clippy::nonminimal_bool)]
 
 #[rustfmt::skip]
@@ -32,6 +33,34 @@ fn main() {
     if x == "hello" { /* Inner comment */
         if y == "world" {
             println!("Hello world!");
+        }
+    }
+    //~^^^^^ collapsible_if
+
+    if true {
+         if true {
+             println!("No comment, linted");
+         }
+     }
+     //~^^^^^ collapsible_if
+
+    if let Some(a) = Some(3) {
+        if let Some(b) = Some(4) {
+            let _ = a + b;
+        }
+    }
+    //~^^^^^ collapsible_if
+
+    if let Some(a) = Some(3) {
+        if a + 1 == 4 {
+            let _ = a;
+        }
+    }
+    //~^^^^^ collapsible_if
+
+    if Some(3) == Some(4).map(|x| x - 1) {
+        if let Some(b) = Some(4) {
+            let _ = b;
         }
     }
     //~^^^^^ collapsible_if

--- a/tests/ui-toml/collapsible_if/collapsible_if.stderr
+++ b/tests/ui-toml/collapsible_if/collapsible_if.stderr
@@ -1,5 +1,5 @@
 error: this `if` statement can be collapsed
-  --> tests/ui-toml/collapsible_if/collapsible_if.rs:8:5
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:9:5
    |
 LL | /     if x == "hello" {
 LL | |         // Comment must be kept
@@ -21,7 +21,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui-toml/collapsible_if/collapsible_if.rs:17:5
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:18:5
    |
 LL | /     if x == "hello" { // Inner comment
 LL | |         if y == "world" {
@@ -39,7 +39,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui-toml/collapsible_if/collapsible_if.rs:24:5
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:25:5
    |
 LL | /     if x == "hello" {
 LL | |         /* Inner comment */
@@ -59,7 +59,7 @@ LL ~         }
    |
 
 error: this `if` statement can be collapsed
-  --> tests/ui-toml/collapsible_if/collapsible_if.rs:32:5
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:33:5
    |
 LL | /     if x == "hello" { /* Inner comment */
 LL | |         if y == "world" {
@@ -76,5 +76,77 @@ LL |             println!("Hello world!");
 LL ~         }
    |
 
-error: aborting due to 4 previous errors
+error: this `if` statement can be collapsed
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:40:5
+   |
+LL | /     if true {
+LL | |          if true {
+LL | |              println!("No comment, linted");
+LL | |          }
+LL | |      }
+   | |______^
+   |
+help: collapse nested if block
+   |
+LL ~     if true
+LL ~          && true {
+LL |              println!("No comment, linted");
+LL ~          }
+   |
+
+error: this `if` statement can be collapsed
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:47:5
+   |
+LL | /     if let Some(a) = Some(3) {
+LL | |         if let Some(b) = Some(4) {
+LL | |             let _ = a + b;
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+help: collapse nested if block
+   |
+LL ~     if let Some(a) = Some(3)
+LL ~         && let Some(b) = Some(4) {
+LL |             let _ = a + b;
+LL ~         }
+   |
+
+error: this `if` statement can be collapsed
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:54:5
+   |
+LL | /     if let Some(a) = Some(3) {
+LL | |         if a + 1 == 4 {
+LL | |             let _ = a;
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+help: collapse nested if block
+   |
+LL ~     if let Some(a) = Some(3)
+LL ~         && a + 1 == 4 {
+LL |             let _ = a;
+LL ~         }
+   |
+
+error: this `if` statement can be collapsed
+  --> tests/ui-toml/collapsible_if/collapsible_if.rs:61:5
+   |
+LL | /     if Some(3) == Some(4).map(|x| x - 1) {
+LL | |         if let Some(b) = Some(4) {
+LL | |             let _ = b;
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+help: collapse nested if block
+   |
+LL ~     if Some(3) == Some(4).map(|x| x - 1)
+LL ~         && let Some(b) = Some(4) {
+LL |             let _ = b;
+LL ~         }
+   |
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -34,6 +34,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
+           collapse-let-chains
            disallowed-macros
            disallowed-methods
            disallowed-names
@@ -126,6 +127,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
+           collapse-let-chains
            disallowed-macros
            disallowed-methods
            disallowed-names
@@ -218,6 +220,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
+           collapse-let-chains
            disallowed-macros
            disallowed-methods
            disallowed-names

--- a/tests/ui/auxiliary/proc_macros.rs
+++ b/tests/ui/auxiliary/proc_macros.rs
@@ -131,12 +131,12 @@ fn write_with_span(s: Span, mut input: IntoIter, out: &mut TokenStream) -> Resul
 pub fn make_it_big(input: TokenStream) -> TokenStream {
     let mut expr_repeat = syn::parse_macro_input!(input as syn::ExprRepeat);
     let len_span = expr_repeat.len.span();
-    if let syn::Expr::Lit(expr_lit) = &mut *expr_repeat.len {
-        if let syn::Lit::Int(lit_int) = &expr_lit.lit {
-            let orig_val = lit_int.base10_parse::<usize>().expect("not a valid length parameter");
-            let new_val = orig_val.saturating_mul(10);
-            expr_lit.lit = syn::parse_quote_spanned!( len_span => #new_val);
-        }
+    if let syn::Expr::Lit(expr_lit) = &mut *expr_repeat.len
+        && let syn::Lit::Int(lit_int) = &expr_lit.lit
+    {
+        let orig_val = lit_int.base10_parse::<usize>().expect("not a valid length parameter");
+        let new_val = orig_val.saturating_mul(10);
+        expr_lit.lit = syn::parse_quote_spanned!( len_span => #new_val);
     }
     quote::quote!(#expr_repeat).into()
 }


### PR DESCRIPTION
This adds a `collapse_let_chains` config option to the `collapsible_if` lint. This lint is then applies to Clippy itself. This reduces the level of indentation in Clippy source code in many locations.

The first two commits are from PR #14231, the third one from PR #14233. They must be merged first (or as part of this PR).

If reviewed on GitHub, the last three commits of this PR are best looked at side by side, with whitespace differences turned off.

changelog: none