### PR TITLE
Changelog for Clippy 1.85 🦜

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,53 @@ document.
 
 ## Unreleased / Beta / In Rust Nightly
 
-[786fbd6d...master](https://github.com/rust-lang/rust-clippy/compare/786fbd6d...master)
+[609cd310...master](https://github.com/rust-lang/rust-clippy/compare/609cd310...master)
+
+## Rust 1.85
+
+Current stable, released 2025-02-20
+
+[View all 72 merged pull requests](https://github.com/rust-lang/rust-clippy/pulls?q=merged%3A2024-11-15T19%3A31%3A08Z..2024-12-26T13%3A59%3A48Z+base%3Amaster)
+
+### New Lints
+
+* Added [`repr_packed_without_abi`] to `suspicious`
+  [#13398](https://github.com/rust-lang/rust-clippy/pull/13398)
+* Added [`as_pointer_underscore`] to `restriction`
+  [#13251](https://github.com/rust-lang/rust-clippy/pull/13251)
+* Added [`doc_nested_refdefs`] to `suspicious`
+  [#13707](https://github.com/rust-lang/rust-clippy/pull/13707)
+* Added [`literal_string_with_formatting_args`] to `nursery`
+  [#13410](https://github.com/rust-lang/rust-clippy/pull/13410)
+* Added [`doc_include_without_cfg`] to `restriction`
+  [#13625](https://github.com/rust-lang/rust-clippy/pull/13625)
+
+### Enhancements
+
+* [`indexing_slicing`]: Can now be allowed in tests using the [`allow-indexing-slicing-in-tests`]
+  configuration
+  [#13854](https://github.com/rust-lang/rust-clippy/pull/13854)
+* [`if_let_mutex`]: disable lint from Edition 2024 since
+  [if_let_rescope](https://github.com/rust-lang/rust/issues/131154) was stabilized
+  [#13695](https://github.com/rust-lang/rust-clippy/pull/13695)
+* [`format_in_format_args`], [`recursive_format_impl`], [`to_string_in_format_args`],
+  [`uninlined_format_args`], [`unused_format_specs`]: Can now support 3er party format macros
+  if they're marked with the `#[clippy::format_args]` attribute
+  [#9948](https://github.com/rust-lang/rust-clippy/pull/9948)
+
+### ICE Fixes
+
+* [`trait_duplication_in_bounds`]: fix ICE on duplicate type or constant bound
+  [#13722](https://github.com/rust-lang/rust-clippy/pull/13722)
+
+### Others
+
+* `clippy_utils` is now published to crates.io. Note that this crate is and will remain unstable.
+  [#13700](https://github.com/rust-lang/rust-clippy/pull/13700)
 
 ## Rust 1.84
 
-Current stable, released 2025-01-09
+Released 2025-01-09
 
 [View all 84 merged pull requests](https://github.com/rust-lang/rust-clippy/pulls?q=merged%3A2024-10-03T21%3A23%3A58Z..2024-11-14T17%3A41%3A37Z+base%3Amaster)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Current stable, released 2025-02-20
   [if_let_rescope](https://github.com/rust-lang/rust/issues/131154) was stabilized
   [#13695](https://github.com/rust-lang/rust-clippy/pull/13695)
 * [`format_in_format_args`], [`recursive_format_impl`], [`to_string_in_format_args`],
-  [`uninlined_format_args`], [`unused_format_specs`]: Can now support 3er party format macros
+  [`uninlined_format_args`], [`unused_format_specs`]: Can now support 3rd party format macros
   if they're marked with the `#[clippy::format_args]` attribute
   [#9948](https://github.com/rust-lang/rust-clippy/pull/9948)
 

--- a/clippy_lints/src/attrs/mod.rs
+++ b/clippy_lints/src/attrs/mod.rs
@@ -305,7 +305,7 @@ declare_clippy_lint! {
     ///     header_version: u16
     /// }
     /// ```
-    #[clippy::version = "1.84.0"]
+    #[clippy::version = "1.85.0"]
     pub REPR_PACKED_WITHOUT_ABI,
     suspicious,
     "ensures that `repr(packed)` always comes with a qualified ABI"

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -747,7 +747,7 @@ declare_clippy_lint! {
     ///     t as *const T as usize
     /// }
     /// ```
-    #[clippy::version = "1.81.0"]
+    #[clippy::version = "1.85.0"]
     pub AS_POINTER_UNDERSCORE,
     restriction,
     "detects `as *mut _` and `as *const _` conversion"

--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -612,7 +612,7 @@ declare_clippy_lint! {
     /// ```no_run
     /// #![cfg_attr(doc, doc = include_str!("some_file.md"))]
     /// ```
-    #[clippy::version = "1.84.0"]
+    #[clippy::version = "1.85.0"]
     pub DOC_INCLUDE_WITHOUT_CFG,
     restriction,
     "check if files included in documentation are behind `cfg(doc)`"
@@ -638,7 +638,7 @@ declare_clippy_lint! {
     /// //!
     /// //! [link]: destination (for link reference definition)
     /// ```
-    #[clippy::version = "1.84.0"]
+    #[clippy::version = "1.85.0"]
     pub DOC_NESTED_REFDEFS,
     suspicious,
     "link reference defined in list item or quote"


### PR DESCRIPTION
Roses are red,
Biolets are blue,
A typo happened,
too late now

You might be asking,
what are Biolets now?
And to be honest,
I have no clue

---

The cat of this release is `Vera` nominated by @and-reas-se

<img height=500 src="https://github.com/user-attachments/assets/82e6fccc-1f6d-4d29-b6bb-0bd4f3584593" alt="The cats of this Clippy release" />

Cats for the next release can be nominated in the comments :D

---

changelog: none