### PR TITLE
Use a lintcheck specific Clippy configuration file in the CI

### DIFF
--- a/.github/workflows/lintcheck.yml
+++ b/.github/workflows/lintcheck.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Run lintcheck
       if: steps.cache-json.outputs.cache-hit != 'true'
-      run: ./target/debug/lintcheck --format json --all-lints --crates-toml ./lintcheck/ci_crates.toml
+      run: env CLIPPY_CONF_DIR="$PWD/lintcheck/ci-config" ./target/debug/lintcheck --format json --all-lints --crates-toml ./lintcheck/ci_crates.toml
 
     - name: Upload base JSON
       uses: actions/upload-artifact@v4
@@ -97,7 +97,7 @@ jobs:
       run: cargo build --manifest-path=lintcheck/Cargo.toml
 
     - name: Run lintcheck
-      run: ./target/debug/lintcheck --format json --all-lints --crates-toml ./lintcheck/ci_crates.toml
+      run: env CLIPPY_CONF_DIR="$PWD/lintcheck/ci-config" ./target/debug/lintcheck --format json --all-lints --crates-toml ./lintcheck/ci_crates.toml
 
     - name: Upload head JSON
       uses: actions/upload-artifact@v4

--- a/lintcheck/ci-config/clippy.toml
+++ b/lintcheck/ci-config/clippy.toml
@@ -1,0 +1,6 @@
+# Configuration applied when running lintcheck from the CI
+#
+# The CI will set the `CLIPPY_CONF_DIR` environment variable
+# to `$PWD/lintcheck/ci-config`.
+
+avoid-breaking-exported-api = false


### PR DESCRIPTION
By default, lintcheck will use the `clippy.toml` file found at the toplevel of the repository (`CARGO_MANIFEST_DIR`). This file is meant for configuration of Clippy applied to Clippy sources.

This creates a new `lintcheck/ci-config/clippy.toml` file which is used by the CI when running lintcheck. By default this uses the default Clippy configuration.

changelog: none