### PR TITLE
`manual_ok_err`: blockify the replacement of an `else if …`

### DIFF
--- a/tests/ui/manual_ok_err.fixed
+++ b/tests/ui/manual_ok_err.fixed
@@ -89,3 +89,12 @@ const fn cf(x: Result<u32, &'static str>) -> Option<u32> {
         Err(_) => None,
     }
 }
+
+fn issue14239() {
+    let _ = if false {
+        None
+    } else {
+        "1".parse::<u8>().ok()
+    };
+    //~^^^^^ manual_ok_err
+}

--- a/tests/ui/manual_ok_err.rs
+++ b/tests/ui/manual_ok_err.rs
@@ -125,3 +125,14 @@ const fn cf(x: Result<u32, &'static str>) -> Option<u32> {
         Err(_) => None,
     }
 }
+
+fn issue14239() {
+    let _ = if false {
+        None
+    } else if let Ok(n) = "1".parse::<u8>() {
+        Some(n)
+    } else {
+        None
+    };
+    //~^^^^^ manual_ok_err
+}

--- a/tests/ui/manual_ok_err.stderr
+++ b/tests/ui/manual_ok_err.stderr
@@ -93,5 +93,23 @@ LL | |         _ => None,
 LL | |     };
    | |_____^ help: replace with: `(-S).ok()`
 
-error: aborting due to 8 previous errors
+error: manual implementation of `ok`
+  --> tests/ui/manual_ok_err.rs:132:12
+   |
+LL |       } else if let Ok(n) = "1".parse::<u8>() {
+   |  ____________^
+LL | |         Some(n)
+LL | |     } else {
+LL | |         None
+LL | |     };
+   | |_____^
+   |
+help: replace with
+   |
+LL ~     } else {
+LL +         "1".parse::<u8>().ok()
+LL ~     };
+   |
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
If the part being replaced is an `if` expression following an `else`, the replacement expression must be blockified.

Fix #14239

changelog: [`manual_ok_err`]: fix replacement expression if it follows an `else`