### PR TITLE
remove an unneeded `#![feature]`

### DIFF
--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(array_windows)]
-#![feature(binary_heap_into_iter_sorted)]
 #![feature(box_patterns)]
 #![feature(macro_metavar_expr_concat)]
 #![feature(f128)]


### PR DESCRIPTION
It seems as if `#![feature(binary_heap_into_iter_sorted)]` is not required anymore.

changelog: none
