### PR TITLE
more natural suggestions for `cmp_owned`

### DIFF
--- a/clippy_lints/src/operators/cmp_owned.rs
+++ b/clippy_lints/src/operators/cmp_owned.rs
@@ -98,7 +98,7 @@ fn check_op(cx: &LateContext<'_>, expr: &Expr<'_>, other: &Expr<'_>, left: bool)
             let arg_snip = snippet(cx, arg_span, "..");
             let expr_snip;
             let eq_impl;
-            if with_deref.is_implemented() {
+            if with_deref.is_implemented() && !arg_ty.peel_refs().is_str() {
                 expr_snip = format!("*{arg_snip}");
                 eq_impl = with_deref;
             } else {

--- a/tests/ui/cmp_owned/with_suggestion.fixed
+++ b/tests/ui/cmp_owned/with_suggestion.fixed
@@ -74,3 +74,12 @@ impl ToOwned for Baz {
         Baz
     }
 }
+
+fn issue_8103() {
+    let foo1 = String::from("foo");
+    let _ = foo1 == "foo";
+    //~^ cmp_owned
+    let foo2 = "foo";
+    let _ = foo1 == foo2;
+    //~^ cmp_owned
+}

--- a/tests/ui/cmp_owned/with_suggestion.rs
+++ b/tests/ui/cmp_owned/with_suggestion.rs
@@ -74,3 +74,12 @@ impl ToOwned for Baz {
         Baz
     }
 }
+
+fn issue_8103() {
+    let foo1 = String::from("foo");
+    let _ = foo1 == "foo".to_owned();
+    //~^ cmp_owned
+    let foo2 = "foo";
+    let _ = foo1 == foo2.to_owned();
+    //~^ cmp_owned
+}

--- a/tests/ui/cmp_owned/with_suggestion.stderr
+++ b/tests/ui/cmp_owned/with_suggestion.stderr
@@ -37,5 +37,17 @@ error: this creates an owned instance just for comparison
 LL |     "abc".chars().filter(|c| c.to_owned() != 'X');
    |                              ^^^^^^^^^^^^ help: try: `*c`
 
-error: aborting due to 6 previous errors
+error: this creates an owned instance just for comparison
+  --> tests/ui/cmp_owned/with_suggestion.rs:80:21
+   |
+LL |     let _ = foo1 == "foo".to_owned();
+   |                     ^^^^^^^^^^^^^^^^ help: try: `"foo"`
+
+error: this creates an owned instance just for comparison
+  --> tests/ui/cmp_owned/with_suggestion.rs:83:21
+   |
+LL |     let _ = foo1 == foo2.to_owned();
+   |                     ^^^^^^^^^^^^^^^ help: try: `foo2`
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Dereferencing string literals in suggestions is redundant.

changelog: [`cmp_owned`]: more natural suggestions are provided for string literals now

fixes #8103 