### PR TITLE
update `rustfix` link in docs

### DIFF
--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -169,7 +169,7 @@ from the lint to the code of the test file and compare that to the contents of a
 Use `cargo bless` to automatically generate the `.fixed` file while running
 the tests.
 
-[rustfix]: https://github.com/rust-lang/rustfix
+[rustfix]: https://github.com/rust-lang/cargo/tree/master/crates/rustfix
 
 ## Testing manually
 

--- a/book/src/development/writing_tests.md
+++ b/book/src/development/writing_tests.md
@@ -203,7 +203,7 @@ We'll talk about suggestions more in depth in a [later chapter](emitting_lints.m
 Use `cargo bless` to automatically generate the `.fixed` file after running
 the tests.
 
-[`rustfix`]: https://github.com/rust-lang/rustfix
+[`rustfix`]: https://github.com/rust-lang/cargo/tree/master/crates/rustfix
 [`span_lint_and_sugg`]: https://doc.rust-lang.org/beta/nightly-rustc/clippy_utils/diagnostics/fn.span_lint_and_sugg.html
 
 ## Testing Manually


### PR DESCRIPTION
Since `rustfix` was moved to `@rust-lang/cargo`, the old link may be confusing for readers.

changelog: none

r? flip1995