### PR TITLE
Remove Known problems section for `vec_box`

### DIFF
--- a/clippy_lints/src/types/mod.rs
+++ b/clippy_lints/src/types/mod.rs
@@ -60,10 +60,6 @@ declare_clippy_lint! {
     /// `Vec` already keeps its contents in a separate area on
     /// the heap. So if you `Box` its contents, you just add another level of indirection.
     ///
-    /// ### Known problems
-    /// Vec<Box<T: Sized>> makes sense if T is a large type (see [#3530](https://github.com/rust-lang/rust-clippy/issues/3530),
-    /// 1st comment).
-    ///
     /// ### Example
     /// ```no_run
     /// struct X {


### PR DESCRIPTION
Remove Known problems section for `vec_box` since [issue](https://github.com/rust-lang/rust-clippy/issues/3530#issuecomment-446058452)
> Vec<Box<T: Sized>> makes sense if T is a large type 

can be handled 

> The lint already checks that the type's size is lower than a threshold to avoid linting on large types. 


changelog: none
