### PR TITLE
New lint: `exact_module_name_repetitions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5568,6 +5568,7 @@ Released 2018-09-13
 [`err_expect`]: https://rust-lang.github.io/rust-clippy/master/index.html#err_expect
 [`error_impl_error`]: https://rust-lang.github.io/rust-clippy/master/index.html#error_impl_error
 [`eval_order_dependence`]: https://rust-lang.github.io/rust-clippy/master/index.html#eval_order_dependence
+[`exact_module_name_repetitions`]: https://rust-lang.github.io/rust-clippy/master/index.html#exact_module_name_repetitions
 [`excessive_nesting`]: https://rust-lang.github.io/rust-clippy/master/index.html#excessive_nesting
 [`excessive_precision`]: https://rust-lang.github.io/rust-clippy/master/index.html#excessive_precision
 [`exhaustive_enums`]: https://rust-lang.github.io/rust-clippy/master/index.html#exhaustive_enums

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -248,6 +248,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::integer_division_remainder_used::INTEGER_DIVISION_REMAINDER_USED_INFO,
     crate::invalid_upcast_comparisons::INVALID_UPCAST_COMPARISONS_INFO,
     crate::item_name_repetitions::ENUM_VARIANT_NAMES_INFO,
+    crate::item_name_repetitions::EXACT_MODULE_NAME_REPETITIONS_INFO,
     crate::item_name_repetitions::MODULE_INCEPTION_INFO,
     crate::item_name_repetitions::MODULE_NAME_REPETITIONS_INFO,
     crate::item_name_repetitions::STRUCT_FIELD_NAMES_INFO,

--- a/tests/ui/exact_module_name_repetitions.rs
+++ b/tests/ui/exact_module_name_repetitions.rs
@@ -1,0 +1,32 @@
+//@compile-flags: --test
+
+#![warn(clippy::exact_module_name_repetitions)]
+#![allow(dead_code)]
+
+pub mod foo {
+    pub fn foo() {}
+    //~^ exact_module_name_repetitions
+
+    pub struct Foo;
+    //~^ exact_module_name_repetitions
+}
+
+pub mod bar {
+    // Shouldn't warn when item is declared in a private module...
+    mod baz {
+        pub struct Bar;
+    }
+    // ... but should still warn when the item is reexported to create a *public* path with repetition.
+    pub use baz::Bar;
+    //~^ exact_module_name_repetitions
+}
+
+pub mod baz {
+    // FIXME: This should also warn because it creates the public path `baz::Baz`.
+    mod inner {
+        pub struct Baz;
+    }
+    pub use inner::*;
+}
+
+fn main() {}

--- a/tests/ui/exact_module_name_repetitions.stderr
+++ b/tests/ui/exact_module_name_repetitions.stderr
@@ -1,0 +1,23 @@
+error: item name is the same as its containing module's name
+  --> tests/ui/exact_module_name_repetitions.rs:7:12
+   |
+LL |     pub fn foo() {}
+   |            ^^^
+   |
+   = note: `-D clippy::exact-module-name-repetitions` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::exact_module_name_repetitions)]`
+
+error: item name is the same as its containing module's name
+  --> tests/ui/exact_module_name_repetitions.rs:10:16
+   |
+LL |     pub struct Foo;
+   |                ^^^
+
+error: item name is the same as its containing module's name
+  --> tests/ui/exact_module_name_repetitions.rs:20:18
+   |
+LL |     pub use baz::Bar;
+   |                  ^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
changelog: new lint: [`exact_module_name_repetitions`]

closes #14226
