### PR TITLE
Add the `allow_exact_repetitions` option to the `module_name_repetititions` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6272,6 +6272,7 @@ Released 2018-09-13
 [`accept-comment-above-statement`]: https://doc.rust-lang.org/clippy/lint_configuration.html#accept-comment-above-statement
 [`allow-comparison-to-zero`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-comparison-to-zero
 [`allow-dbg-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-dbg-in-tests
+[`allow-exact-repetitions`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-exact-repetitions
 [`allow-expect-in-consts`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-expect-in-consts
 [`allow-expect-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-expect-in-tests
 [`allow-indexing-slicing-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#allow-indexing-slicing-in-tests

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -71,6 +71,16 @@ Whether `dbg!` should be allowed in test functions or `#[cfg(test)]`
 * [`dbg_macro`](https://rust-lang.github.io/rust-clippy/master/index.html#dbg_macro)
 
 
+## `allow-exact-repetitions`
+Whether an item should be allowed to have the same name as its containing module
+
+**Default Value:** `true`
+
+---
+**Affected lints:**
+* [`module_name_repetitions`](https://rust-lang.github.io/rust-clippy/master/index.html#module_name_repetitions)
+
+
 ## `allow-expect-in-consts`
 Whether `expect` should be allowed in code always evaluated at compile time
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -288,6 +288,9 @@ define_Conf! {
     /// Whether `dbg!` should be allowed in test functions or `#[cfg(test)]`
     #[lints(dbg_macro)]
     allow_dbg_in_tests: bool = false,
+    /// Whether an item should be allowed to have the same name as its containing module
+    #[lints(module_name_repetitions)]
+    allow_exact_repetitions: bool = true,
     /// Whether `expect` should be allowed in code always evaluated at compile time
     #[lints(expect_used)]
     allow_expect_in_consts: bool = true,

--- a/clippy_lints/src/item_name_repetitions.rs
+++ b/clippy_lints/src/item_name_repetitions.rs
@@ -163,6 +163,7 @@ pub struct ItemNameRepetitions {
     enum_threshold: u64,
     struct_threshold: u64,
     avoid_breaking_exported_api: bool,
+    allow_exact_repetitions: bool,
     allow_private_module_inception: bool,
     allowed_prefixes: FxHashSet<String>,
 }
@@ -174,6 +175,7 @@ impl ItemNameRepetitions {
             enum_threshold: conf.enum_variant_name_threshold,
             struct_threshold: conf.struct_field_name_threshold,
             avoid_breaking_exported_api: conf.avoid_breaking_exported_api,
+            allow_exact_repetitions: conf.allow_exact_repetitions,
             allow_private_module_inception: conf.allow_private_module_inception,
             allowed_prefixes: conf.allowed_prefixes.iter().map(|s| to_camel_case(s)).collect(),
         }
@@ -421,12 +423,22 @@ impl LateLintPass<'_> for ItemNameRepetitions {
                         );
                     }
 
-                    // The `module_name_repetitions` lint should only trigger if the item has the module in its
-                    // name. Having the same name is accepted.
-                    if cx.tcx.visibility(item.owner_id).is_public()
-                        && cx.tcx.visibility(mod_owner_id.def_id).is_public()
-                        && item_camel.len() > mod_camel.len()
-                    {
+                    // The `module_name_repetitions` lint should trigger if the item has the module in its
+                    // name. Having the same name is only accepted if `allow_exact_repetition` is set to `true`.
+
+                    let both_are_public = cx.tcx.visibility(item.owner_id).is_public()
+                        && cx.tcx.visibility(mod_owner_id.def_id).is_public();
+
+                    if both_are_public && !self.allow_exact_repetitions && item_camel == *mod_camel {
+                        span_lint(
+                            cx,
+                            MODULE_NAME_REPETITIONS,
+                            item.ident.span,
+                            "item name is the same as its containing module's name",
+                        );
+                    }
+
+                    if both_are_public && item_camel.len() > mod_camel.len() {
                         let matching = count_match_start(mod_camel, &item_camel);
                         let rmatching = count_match_end(mod_camel, &item_camel);
                         let nchars = mod_camel.chars().count();

--- a/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/clippy.toml
+++ b/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/clippy.toml
@@ -1,0 +1,1 @@
+allow-exact-repetitions = false

--- a/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/item_name_repetitions.rs
+++ b/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/item_name_repetitions.rs
@@ -1,0 +1,13 @@
+#![warn(clippy::module_name_repetitions)]
+#![allow(dead_code)]
+
+pub mod foo {
+    // this line should produce a warning:
+    pub fn foo() {}
+    //~^ module_name_repetitions
+
+    // but this line shouldn't
+    pub fn to_foo() {}
+}
+
+fn main() {}

--- a/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/item_name_repetitions.stderr
+++ b/tests/ui-toml/item_name_repetitions/allow_exact_repetitions/item_name_repetitions.stderr
@@ -1,0 +1,11 @@
+error: item name is the same as its containing module's name
+  --> tests/ui-toml/item_name_repetitions/allow_exact_repetitions/item_name_repetitions.rs:6:12
+   |
+LL |     pub fn foo() {}
+   |            ^^^
+   |
+   = note: `-D clippy::module-name-repetitions` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::module_name_repetitions)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -5,6 +5,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            accept-comment-above-statement
            allow-comparison-to-zero
            allow-dbg-in-tests
+           allow-exact-repetitions
            allow-expect-in-consts
            allow-expect-in-tests
            allow-indexing-slicing-in-tests
@@ -96,6 +97,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            accept-comment-above-statement
            allow-comparison-to-zero
            allow-dbg-in-tests
+           allow-exact-repetitions
            allow-expect-in-consts
            allow-expect-in-tests
            allow-indexing-slicing-in-tests
@@ -187,6 +189,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            accept-comment-above-statement
            allow-comparison-to-zero
            allow-dbg-in-tests
+           allow-exact-repetitions
            allow-expect-in-consts
            allow-expect-in-tests
            allow-indexing-slicing-in-tests


### PR DESCRIPTION
changelog: new configuration entry: [`allow_exact_repetitions`]

Closes #14226