### PR TITLE
Remove obsolete comment and simplify code

### DIFF
--- a/clippy_lints/src/methods/unbuffered_bytes.rs
+++ b/clippy_lints/src/methods/unbuffered_bytes.rs
@@ -7,25 +7,19 @@ use rustc_lint::LateContext;
 use rustc_span::sym;
 
 pub(super) fn check(cx: &LateContext<'_>, expr: &hir::Expr<'_>, recv: &hir::Expr<'_>) {
-    let ty = cx.typeck_results().expr_ty_adjusted(recv);
-
-    // If the .bytes() call is a call from the Read trait
-    if is_trait_method(cx, expr, sym::IoRead) {
-        // Retrieve the DefId of the BufRead trait
-        // FIXME: add a diagnostic item for `BufRead`
-        let Some(buf_read) = cx.tcx.get_diagnostic_item(sym::IoBufRead) else {
-            return;
-        };
-        // And the implementor of the trait is not buffered
-        if !implements_trait(cx, ty, buf_read, &[]) {
-            span_lint_and_help(
-                cx,
-                UNBUFFERED_BYTES,
-                expr.span,
-                "calling .bytes() is very inefficient when data is not in memory",
-                None,
-                "consider using `BufReader`",
-            );
-        }
+    // Lint if the `.bytes()` call is from the `Read` trait and the implementor is not buffered.
+    if is_trait_method(cx, expr, sym::IoRead)
+        && let Some(buf_read) = cx.tcx.get_diagnostic_item(sym::IoBufRead)
+        && let ty = cx.typeck_results().expr_ty_adjusted(recv)
+        && !implements_trait(cx, ty, buf_read, &[])
+    {
+        span_lint_and_help(
+            cx,
+            UNBUFFERED_BYTES,
+            expr.span,
+            "calling .bytes() is very inefficient when data is not in memory",
+            None,
+            "consider using `BufReader`",
+        );
     }
 }


### PR DESCRIPTION
The `IoBufRead` diagnostic has been added during the latest rustup.

changelog: none