### PR TITLE
Add `todo!` & `unimplemented!` to format macros list

### DIFF
--- a/clippy_utils/src/macros.rs
+++ b/clippy_utils/src/macros.rs
@@ -30,6 +30,8 @@ const FORMAT_MACRO_DIAG_ITEMS: &[Symbol] = &[
     sym::print_macro,
     sym::println_macro,
     sym::std_panic_macro,
+    sym::todo_macro,
+    sym::unimplemented_macro,
     sym::write_macro,
     sym::writeln_macro,
 ];


### PR DESCRIPTION
For some reason, the `todo!` and `unimplemented!` macros were not included in the list of format-supporting macros list. Since they seem to behave exactly the same as all others like `write!` and `assert!`, adding them now.

I wonder if we should delete the `FORMAT_MACRO_DIAG_ITEMS`, and instead tag all macros with the `#[clippy::format_args]`?

changelog: all format-handling lints will now validate `todo!` and `unimplemented!` macros.