### PR TITLE
Add regression tests for `suspicious_doc_comments`

### DIFF
--- a/tests/ui/suspicious_doc_comments.fixed
+++ b/tests/ui/suspicious_doc_comments.fixed
@@ -87,4 +87,8 @@ pub mod useless_outer_doc {
     use std::mem;
 }
 
+// Do not lint, this is not a `///!`
+#[doc = "! here's some docs !"]
+fn issue14265() {}
+
 fn main() {}

--- a/tests/ui/suspicious_doc_comments.rs
+++ b/tests/ui/suspicious_doc_comments.rs
@@ -87,4 +87,8 @@ pub mod useless_outer_doc {
     use std::mem;
 }
 
+// Do not lint, this is not a `///!`
+#[doc = "! here's some docs !"]
+fn issue14265() {}
+
 fn main() {}


### PR DESCRIPTION
Related to #14265 which was fixed automatically by the latest rustup.

changelog: none

*Edit: description, changelog, keep only tests*