### PR TITLE
fix: `too_long_first_doc_paragraph` suggests wrongly when first line too long

### DIFF
--- a/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
+++ b/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
@@ -51,7 +51,11 @@ pub(super) fn check(
                 // We make this suggestion only if the first doc line ends with a punctuation
                 // because it might just need to add an empty line with `///`.
                 should_suggest_empty_doc = doc.ends_with('.') || doc.ends_with('!') || doc.ends_with('?');
+            } else if spans.len() == 2 {
+                // We make this suggestion only if the second doc line is not empty.
+                should_suggest_empty_doc &= !doc.is_empty();
             }
+
             let len = doc.chars().count();
             if len >= first_paragraph_len {
                 break;

--- a/tests/ui/too_long_first_doc_paragraph.rs
+++ b/tests/ui/too_long_first_doc_paragraph.rs
@@ -61,6 +61,13 @@ pub union Union2 {
 /// gravida non lacinia at, rhoncus eu lacus.
 fn f() {}
 
+#[rustfmt::skip]
+/// Some function. This doc-string paragraph is too long. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+//~^ too_long_first_doc_paragraph
+///
+/// Here's a second paragraph. It would be preferable to put the details here.
+pub fn issue_14274() {}
+
 fn main() {
     // test code goes here
 }

--- a/tests/ui/too_long_first_doc_paragraph.stderr
+++ b/tests/ui/too_long_first_doc_paragraph.stderr
@@ -39,5 +39,14 @@ LL | | /// a dolor in, pellentesque aliquet enim. Cras nec maximus sem. Mauris a
 LL | | /// gravida non lacinia at, rhoncus eu lacus.
    | |_^
 
-error: aborting due to 3 previous errors
+error: first doc comment paragraph is too long
+  --> tests/ui/too_long_first_doc_paragraph.rs:65:1
+   |
+LL | / /// Some function. This doc-string paragraph is too long. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lore...
+LL | |
+LL | | ///
+LL | | /// Here's a second paragraph. It would be preferable to put the details here.
+   | |_^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes #14274

changelog: [`too_long_first_doc_paragraph`]: fix wrong suggestion when first line too long
