### PR TITLE
Rename `inconsistent_struct_constructor` configuration; don't suggest deprecated configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6347,6 +6347,7 @@ Released 2018-09-13
 [`await-holding-invalid-types`]: https://doc.rust-lang.org/clippy/lint_configuration.html#await-holding-invalid-types
 [`cargo-ignore-publish`]: https://doc.rust-lang.org/clippy/lint_configuration.html#cargo-ignore-publish
 [`check-incompatible-msrv-in-tests`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-incompatible-msrv-in-tests
+[`check-inconsistent-struct-field-initializers`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-inconsistent-struct-field-initializers
 [`check-private-items`]: https://doc.rust-lang.org/clippy/lint_configuration.html#check-private-items
 [`cognitive-complexity-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#cognitive-complexity-threshold
 [`disallowed-macros`]: https://doc.rust-lang.org/clippy/lint_configuration.html#disallowed-macros
@@ -6364,7 +6365,6 @@ Released 2018-09-13
 [`ignore-interior-mutability`]: https://doc.rust-lang.org/clippy/lint_configuration.html#ignore-interior-mutability
 [`large-error-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#large-error-threshold
 [`lint-commented-code`]: https://doc.rust-lang.org/clippy/lint_configuration.html#lint-commented-code
-[`lint-inconsistent-struct-field-initializers`]: https://doc.rust-lang.org/clippy/lint_configuration.html#lint-inconsistent-struct-field-initializers
 [`literal-representation-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#literal-representation-threshold
 [`matches-for-let-else`]: https://doc.rust-lang.org/clippy/lint_configuration.html#matches-for-let-else
 [`max-fn-params-bools`]: https://doc.rust-lang.org/clippy/lint_configuration.html#max-fn-params-bools

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -425,6 +425,33 @@ Whether to check MSRV compatibility in `#[test]` and `#[cfg(test)]` code.
 * [`incompatible_msrv`](https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv)
 
 
+## `check-inconsistent-struct-field-initializers`
+Whether to suggest reordering constructor fields when initializers are present.
+
+Warnings produced by this configuration aren't necessarily fixed by just reordering the fields. Even if the
+suggested code would compile, it can change semantics if the initializer expressions have side effects. The
+following example [from rust-clippy#11846] shows how the suggestion can run into borrow check errors:
+
+```rust
+struct MyStruct {
+    vector: Vec<u32>,
+    length: usize
+}
+fn main() {
+    let vector = vec![1,2,3];
+    MyStruct { length: vector.len(), vector};
+}
+```
+
+[from rust-clippy#11846]: https://github.com/rust-lang/rust-clippy/issues/11846#issuecomment-1820747924
+
+**Default Value:** `false`
+
+---
+**Affected lints:**
+* [`inconsistent_struct_constructor`](https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor)
+
+
 ## `check-private-items`
 Whether to also run the listed lints on private items.
 
@@ -622,33 +649,6 @@ that would be collapsed.
 ---
 **Affected lints:**
 * [`collapsible_if`](https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if)
-
-
-## `lint-inconsistent-struct-field-initializers`
-Whether to suggest reordering constructor fields when initializers are present.
-
-Warnings produced by this configuration aren't necessarily fixed by just reordering the fields. Even if the
-suggested code would compile, it can change semantics if the initializer expressions have side effects. The
-following example [from rust-clippy#11846] shows how the suggestion can run into borrow check errors:
-
-```rust
-struct MyStruct {
-    vector: Vec<u32>,
-    length: usize
-}
-fn main() {
-    let vector = vec![1,2,3];
-    MyStruct { length: vector.len(), vector};
-}
-```
-
-[from rust-clippy#11846]: https://github.com/rust-lang/rust-clippy/issues/11846#issuecomment-1820747924
-
-**Default Value:** `false`
-
----
-**Affected lints:**
-* [`inconsistent_struct_constructor`](https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor)
 
 
 ## `literal-representation-threshold`

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,6 @@
 avoid-breaking-exported-api = false
 
-lint-inconsistent-struct-field-initializers = true
+check-inconsistent-struct-field-initializers = true
 
 [[disallowed-methods]]
 path = "rustc_lint::context::LintContext::lint"

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -474,6 +474,26 @@ define_Conf! {
     /// Whether to check MSRV compatibility in `#[test]` and `#[cfg(test)]` code.
     #[lints(incompatible_msrv)]
     check_incompatible_msrv_in_tests: bool = false,
+    /// Whether to suggest reordering constructor fields when initializers are present.
+    ///
+    /// Warnings produced by this configuration aren't necessarily fixed by just reordering the fields. Even if the
+    /// suggested code would compile, it can change semantics if the initializer expressions have side effects. The
+    /// following example [from rust-clippy#11846] shows how the suggestion can run into borrow check errors:
+    ///
+    /// ```rust
+    /// struct MyStruct {
+    ///     vector: Vec<u32>,
+    ///     length: usize
+    /// }
+    /// fn main() {
+    ///     let vector = vec![1,2,3];
+    ///     MyStruct { length: vector.len(), vector};
+    /// }
+    /// ```
+    ///
+    /// [from rust-clippy#11846]: https://github.com/rust-lang/rust-clippy/issues/11846#issuecomment-1820747924
+    #[lints(inconsistent_struct_constructor)]
+    check_inconsistent_struct_field_initializers: bool = false,
     /// Whether to also run the listed lints on private items.
     #[lints(missing_errors_doc, missing_panics_doc, missing_safety_doc, unnecessary_safety_doc)]
     check_private_items: bool = false,
@@ -554,24 +574,10 @@ define_Conf! {
     #[lints(collapsible_if)]
     lint_commented_code: bool = false,
     /// Whether to suggest reordering constructor fields when initializers are present.
+    /// DEPRECATED CONFIGURATION: lint-inconsistent-struct-field-initializers
     ///
-    /// Warnings produced by this configuration aren't necessarily fixed by just reordering the fields. Even if the
-    /// suggested code would compile, it can change semantics if the initializer expressions have side effects. The
-    /// following example [from rust-clippy#11846] shows how the suggestion can run into borrow check errors:
-    ///
-    /// ```rust
-    /// struct MyStruct {
-    ///     vector: Vec<u32>,
-    ///     length: usize
-    /// }
-    /// fn main() {
-    ///     let vector = vec![1,2,3];
-    ///     MyStruct { length: vector.len(), vector};
-    /// }
-    /// ```
-    ///
-    /// [from rust-clippy#11846]: https://github.com/rust-lang/rust-clippy/issues/11846#issuecomment-1820747924
-    #[lints(inconsistent_struct_constructor)]
+    /// Use the `check-inconsistent-struct-field-initializers` configuration instead.
+    #[conf_deprecated("Please use `check-inconsistent-struct-field-initializers` instead", check_inconsistent_struct_field_initializers)]
     lint_inconsistent_struct_field_initializers: bool = false,
     /// The lower bound for linting decimal literals
     #[lints(decimal_literal_representation)]

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -1090,7 +1090,13 @@ mod tests {
     fn configs_are_tested() {
         let mut names: HashSet<String> = crate::get_configuration_metadata()
             .into_iter()
-            .map(|meta| meta.name.replace('_', "-"))
+            .filter_map(|meta| {
+                if meta.deprecation_reason.is_none() {
+                    Some(meta.name.replace('_', "-"))
+                } else {
+                    None
+                }
+            })
             .collect();
 
         let toml_files = WalkDir::new("../tests")

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -991,7 +991,23 @@ impl serde::de::Error for FieldError {
         // set and allows it.
         use fmt::Write;
 
-        let mut expected = expected.to_vec();
+        let metadata = get_configuration_metadata();
+        let deprecated = metadata
+            .iter()
+            .filter_map(|conf| {
+                if conf.deprecation_reason.is_some() {
+                    Some(conf.name.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut expected = expected
+            .iter()
+            .copied()
+            .filter(|name| !deprecated.contains(name))
+            .collect::<Vec<_>>();
         expected.sort_unstable();
 
         let (rows, column_widths) = calculate_dimensions(&expected);

--- a/clippy_lints/src/inconsistent_struct_constructor.rs
+++ b/clippy_lints/src/inconsistent_struct_constructor.rs
@@ -65,13 +65,13 @@ declare_clippy_lint! {
 }
 
 pub struct InconsistentStructConstructor {
-    lint_inconsistent_struct_field_initializers: bool,
+    check_inconsistent_struct_field_initializers: bool,
 }
 
 impl InconsistentStructConstructor {
     pub fn new(conf: &'static Conf) -> Self {
         Self {
-            lint_inconsistent_struct_field_initializers: conf.lint_inconsistent_struct_field_initializers,
+            check_inconsistent_struct_field_initializers: conf.check_inconsistent_struct_field_initializers,
         }
     }
 }
@@ -86,7 +86,7 @@ impl<'tcx> LateLintPass<'tcx> for InconsistentStructConstructor {
         let all_fields_are_shorthand = fields.iter().all(|f| f.is_shorthand);
         let applicability = if all_fields_are_shorthand {
             Applicability::MachineApplicable
-        } else if self.lint_inconsistent_struct_field_initializers {
+        } else if self.check_inconsistent_struct_field_initializers {
             Applicability::MaybeIncorrect
         } else {
             return;

--- a/tests/ui-toml/toml_inconsistent_struct_constructor/clippy.toml
+++ b/tests/ui-toml/toml_inconsistent_struct_constructor/clippy.toml
@@ -1,1 +1,1 @@
-lint-inconsistent-struct-field-initializers = true
+check-inconsistent-struct-field-initializers = true

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -32,6 +32,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            blacklisted-names
            cargo-ignore-publish
            check-incompatible-msrv-in-tests
+           check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold
@@ -126,6 +127,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            blacklisted-names
            cargo-ignore-publish
            check-incompatible-msrv-in-tests
+           check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold
@@ -220,6 +222,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            blacklisted-names
            cargo-ignore-publish
            check-incompatible-msrv-in-tests
+           check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
            cyclomatic-complexity-threshold

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -29,13 +29,11 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            array-size-threshold
            avoid-breaking-exported-api
            await-holding-invalid-types
-           blacklisted-names
            cargo-ignore-publish
            check-incompatible-msrv-in-tests
            check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
-           cyclomatic-complexity-threshold
            disallowed-macros
            disallowed-methods
            disallowed-names
@@ -51,7 +49,6 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            ignore-interior-mutability
            large-error-threshold
            lint-commented-code
-           lint-inconsistent-struct-field-initializers
            literal-representation-threshold
            matches-for-let-else
            max-fn-params-bools
@@ -124,13 +121,11 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            array-size-threshold
            avoid-breaking-exported-api
            await-holding-invalid-types
-           blacklisted-names
            cargo-ignore-publish
            check-incompatible-msrv-in-tests
            check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
-           cyclomatic-complexity-threshold
            disallowed-macros
            disallowed-methods
            disallowed-names
@@ -146,7 +141,6 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            ignore-interior-mutability
            large-error-threshold
            lint-commented-code
-           lint-inconsistent-struct-field-initializers
            literal-representation-threshold
            matches-for-let-else
            max-fn-params-bools
@@ -219,13 +213,11 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            array-size-threshold
            avoid-breaking-exported-api
            await-holding-invalid-types
-           blacklisted-names
            cargo-ignore-publish
            check-incompatible-msrv-in-tests
            check-inconsistent-struct-field-initializers
            check-private-items
            cognitive-complexity-threshold
-           cyclomatic-complexity-threshold
            disallowed-macros
            disallowed-methods
            disallowed-names
@@ -241,7 +233,6 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            ignore-interior-mutability
            large-error-threshold
            lint-commented-code
-           lint-inconsistent-struct-field-initializers
            literal-representation-threshold
            matches-for-let-else
            max-fn-params-bools


### PR DESCRIPTION
This PR does two things:
- It renames `inconsistent_struct_constructor`'s configuration from `lint-inconsistent-struct-field-initializers` to `check-inconsistent-struct-field-initializers`. (I should have suggested `check-...` in [#13737](https://github.com/rust-lang/rust-clippy/pull/13737#discussion_r1875118516).)
- It causes Clippy to no longer suggest deprecated configurations. (Previously, Clippy would suggest `cyclomatic-complexity-threshold`, for example.)

r? @y21

changelog: Rename `lint-inconsistent-struct-field-initializers` to `check-inconsistent-struct-field-initializers`
changelog: No longer suggest deprecated configurations

