### PR TITLE
fix: Avoid ICE in `doc_nested_refdefs` check by checking range

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -1004,7 +1004,12 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
                                 // backslashes aren't in the event stream...
                                 start -= 1;
                             }
-                            start - range.start
+
+                            if start > range.start {
+                                start - range.start
+                            } else {
+                                0
+                            }
                         }
                     } else {
                         0
@@ -1184,6 +1189,10 @@ impl<'tcx> Visitor<'tcx> for FindPanicUnwrap<'_, 'tcx> {
 
 #[expect(clippy::range_plus_one)] // inclusive ranges aren't the same type
 fn looks_like_refdef(doc: &str, range: Range<usize>) -> Option<Range<usize>> {
+    if range.end < range.start {
+        return None;
+    }
+
     let offset = range.start;
     let mut iterator = doc.as_bytes()[range].iter().copied().enumerate();
     let mut start = None;

--- a/tests/ui/doc/doc_nested_refdef_list_item.fixed
+++ b/tests/ui/doc/doc_nested_refdef_list_item.fixed
@@ -69,3 +69,11 @@ pub struct NotEmpty;
 /// - [link]\: notdef
 ///   inner text
 pub struct NotEmptyTight;
+
+/// ## Heading
+///
+/// - [x][] - Done
+//~^ ERROR: link reference defined in list item
+/// - [ ][] - Not Done
+//~^ ERROR: link reference defined in list item
+pub struct GithubCheckboxes;

--- a/tests/ui/doc/doc_nested_refdef_list_item.rs
+++ b/tests/ui/doc/doc_nested_refdef_list_item.rs
@@ -69,3 +69,11 @@ pub struct NotEmpty;
 /// - [link]\: notdef
 ///   inner text
 pub struct NotEmptyTight;
+
+/// ## Heading
+///
+/// - [x] - Done
+//~^ ERROR: link reference defined in list item
+/// - [ ] - Not Done
+//~^ ERROR: link reference defined in list item
+pub struct GithubCheckboxes;

--- a/tests/ui/doc/doc_nested_refdef_list_item.stderr
+++ b/tests/ui/doc/doc_nested_refdef_list_item.stderr
@@ -144,5 +144,29 @@ help: for an intra-doc link, add `[]` between the label and the colon
 LL | /// - [link][]: def "title"
    |             ++
 
-error: aborting due to 12 previous errors
+error: link reference defined in list item
+  --> tests/ui/doc/doc_nested_refdef_list_item.rs:75:7
+   |
+LL | /// - [x] - Done
+   |       ^^^
+   |
+   = help: link definitions are not shown in rendered documentation
+help: for an intra-doc link, add `[]` between the label and the colon
+   |
+LL | /// - [x][] - Done
+   |          ++
+
+error: link reference defined in list item
+  --> tests/ui/doc/doc_nested_refdef_list_item.rs:77:7
+   |
+LL | /// - [ ] - Not Done
+   |       ^^^
+   |
+   = help: link definitions are not shown in rendered documentation
+help: for an intra-doc link, add `[]` between the label and the colon
+   |
+LL | /// - [ ][] - Not Done
+   |          ++
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
The `looks_like_refdef` function was assuming the range was valid, this just adds a check to ensure that is the case. It also works around a subtraction underflow due to the same invalid range.

changelog: [`doc_nested_refdefs`]: Fix #14287 by avoiding invalid ranges
