### PR TITLE
macro_use_import: Don't check is attribute comes from expansion

### DIFF
--- a/clippy_lints/src/macro_use.rs
+++ b/clippy_lints/src/macro_use.rs
@@ -117,11 +117,6 @@ impl LateLintPass<'_> for MacroUseImports {
             self.push_unique_macro_pat_ty(cx, item.span);
         }
     }
-    fn check_attribute(&mut self, cx: &LateContext<'_>, attr: &hir::Attribute) {
-        if attr.span.from_expansion() {
-            self.push_unique_macro(cx, attr.span);
-        }
-    }
     fn check_expr(&mut self, cx: &LateContext<'_>, expr: &hir::Expr<'_>) {
         if expr.span.from_expansion() {
             self.push_unique_macro(cx, expr.span);

--- a/tests/ui/crashes/ice-14303.rs
+++ b/tests/ui/crashes/ice-14303.rs
@@ -1,0 +1,12 @@
+//@check-pass
+#![warn(clippy::macro_use_imports)]
+
+#[repr(transparent)]
+pub struct X(());
+
+#[repr(u8)]
+pub enum Action {
+    Off = 0,
+}
+
+fn main() {}


### PR DESCRIPTION
It is not possible to write a declarative macro, that produces an attribute w/o
an item attached to it. This means that the `check_item` will already insert the
span in the map, if it came from an expansion. So additionally checking if the
macro came from an expansion doesn't add anything here. So the
`check_attribute` function, and with that the problematic `attr.span()` call can
be completely removed.

Fixes https://github.com/rust-lang/rust-clippy/issues/14303

r? @y21 

cc @jdonszelmann 

changelog: Fix ICE in [`macro_use_import`] lint
