### PR TITLE
Fix ICE in manual_map lint

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -3651,7 +3651,10 @@ pub fn expr_requires_coercion<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) -
         ExprKind::Struct(qpath, _, _) => {
             let res = cx.typeck_results().qpath_res(qpath, expr.hir_id);
             if let Some((_, v_def)) = adt_and_variant_of_res(cx, res) {
-                let generic_args = cx.typeck_results().node_args(expr.hir_id);
+                let rustc_ty::Adt(_, generic_args) = cx.typeck_results().expr_ty_adjusted(expr).kind() else {
+                    // This should never happen, but when it does, not linting is the better option.
+                    return true;
+                };
                 v_def
                     .fields
                     .iter()

--- a/tests/ui/crashes/ice-14325.rs
+++ b/tests/ui/crashes/ice-14325.rs
@@ -1,0 +1,17 @@
+//@check-pass
+
+#![allow(clippy::redundant_pattern_matching)]
+
+struct S<'a> {
+    s: &'a str,
+}
+
+fn foo() -> Option<S<'static>> {
+    if let Some(_) = Some(0) {
+        Some(S { s: "xyz" })
+    } else {
+        None
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
node_args doesn't work with struct literals and expr_ty must be used instead

r? @y21 

changelog: none

(No changelog, as this ICE didn't make it to the Rust repo, as it was caught during the sync)

Fixes #14325 
