### PR TITLE
Add `ignore-msrv-check-for` option to `incompatible_msrv` lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6360,6 +6360,7 @@ Released 2018-09-13
 [`excessive-nesting-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#excessive-nesting-threshold
 [`future-size-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#future-size-threshold
 [`ignore-interior-mutability`]: https://doc.rust-lang.org/clippy/lint_configuration.html#ignore-interior-mutability
+[`ignore-msrv-check-for`]: https://doc.rust-lang.org/clippy/lint_configuration.html#ignore-msrv-check-for
 [`large-error-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#large-error-threshold
 [`lint-inconsistent-struct-field-initializers`]: https://doc.rust-lang.org/clippy/lint_configuration.html#lint-inconsistent-struct-field-initializers
 [`literal-representation-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#literal-representation-threshold

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -603,6 +603,24 @@ A list of paths to types that should be treated as if they do not contain interi
 * [`mutable_key_type`](https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type)
 
 
+## `ignore-msrv-check-for`
+A list of path to items that should not be checked for a compatible MSRV. This can be used to ignore
+MSRV checks for code which is gated by a feature which depends on the version of the Rust compiler.
+
+#### Example
+
+```toml
+# Ignore those as we use them only when our `modern_compiler` feature is active.
+ignore-msrv-check-for = [ "str::split_once", "std::option::Option::as_slice" ]
+```
+
+**Default Value:** `[]`
+
+---
+**Affected lints:**
+* [`incompatible_msrv`](https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv)
+
+
 ## `large-error-threshold`
 The maximum size of the `Err`-variant in a `Result` returned from a function
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -539,6 +539,17 @@ define_Conf! {
     /// A list of paths to types that should be treated as if they do not contain interior mutability
     #[lints(borrow_interior_mutable_const, declare_interior_mutable_const, ifs_same_cond, mutable_key_type)]
     ignore_interior_mutability: Vec<String> = Vec::from(["bytes::Bytes".into()]),
+    /// A list of path to items that should not be checked for a compatible MSRV. This can be used to ignore
+    /// MSRV checks for code which is gated by a feature which depends on the version of the Rust compiler.
+    ///
+    /// #### Example
+    ///
+    /// ```toml
+    /// # Ignore those as we use them only when our `modern_compiler` feature is active.
+    /// ignore-msrv-check-for = [ "str::split_once", "std::option::Option::as_slice" ]
+    /// ```
+    #[lints(incompatible_msrv)]
+    ignore_msrv_check_for: Vec<String> = Vec::new(),
     /// The maximum size of the `Err`-variant in a `Result` returned from a function
     #[lints(result_large_err)]
     large_error_threshold: u64 = 128,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -955,7 +955,7 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(|_| Box::<unconditional_recursion::UnconditionalRecursion>::default());
     store.register_late_pass(move |_| Box::new(pub_underscore_fields::PubUnderscoreFields::new(conf)));
     store.register_late_pass(move |_| Box::new(missing_const_for_thread_local::MissingConstForThreadLocal::new(conf)));
-    store.register_late_pass(move |_| Box::new(incompatible_msrv::IncompatibleMsrv::new(conf)));
+    store.register_late_pass(move |tcx| Box::new(incompatible_msrv::IncompatibleMsrv::new(tcx, conf)));
     store.register_late_pass(|_| Box::new(to_string_trait_impl::ToStringTraitImpl));
     store.register_early_pass(|| Box::new(multiple_bound_locations::MultipleBoundLocations));
     store.register_late_pass(move |_| Box::new(assigning_clones::AssigningClones::new(conf)));

--- a/tests/ui-toml/incompatible_msrv/clippy.toml
+++ b/tests/ui-toml/incompatible_msrv/clippy.toml
@@ -1,0 +1,1 @@
+ignore-msrv-check-for = ["str::split_once", "std::option::Option::as_slice"]

--- a/tests/ui-toml/incompatible_msrv/incompatible_msrv.rs
+++ b/tests/ui-toml/incompatible_msrv/incompatible_msrv.rs
@@ -1,0 +1,18 @@
+#![warn(clippy::incompatible_msrv)]
+
+#[clippy::msrv = "1.46"]
+fn main() {
+    if let Some((a, b)) = "foo:bar".split_once(":") {
+        println!("a = {a}, b = {b}");
+    }
+
+    let x: Option<u32> = Some(42u32);
+    for i in x.as_slice() {
+        println!("i = {i}");
+    }
+
+    if x.is_none_or(|x| x + 2 == 17) {
+        //~^ incompatible_msrv
+        println!("impossible");
+    }
+}

--- a/tests/ui-toml/incompatible_msrv/incompatible_msrv.stderr
+++ b/tests/ui-toml/incompatible_msrv/incompatible_msrv.stderr
@@ -1,0 +1,11 @@
+error: current MSRV (Minimum Supported Rust Version) is `1.46.0` but this item is stable since `1.82.0`
+  --> tests/ui-toml/incompatible_msrv/incompatible_msrv.rs:14:10
+   |
+LL |     if x.is_none_or(|x| x + 2 == 17) {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::incompatible-msrv` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -48,6 +48,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           ignore-msrv-check-for
            large-error-threshold
            lint-inconsistent-struct-field-initializers
            literal-representation-threshold
@@ -140,6 +141,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           ignore-msrv-check-for
            large-error-threshold
            lint-inconsistent-struct-field-initializers
            literal-representation-threshold
@@ -232,6 +234,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            excessive-nesting-threshold
            future-size-threshold
            ignore-interior-mutability
+           ignore-msrv-check-for
            large-error-threshold
            lint-inconsistent-struct-field-initializers
            literal-representation-threshold


### PR DESCRIPTION
This option prevents the lint from triggering on entities that may have been feature gated by the user and thus don't need to be warned about.

Another use case would be when a user has enabled an unstable feature and wants to ignore the MSRV check for a given path. Such a false positive MSRV lint in Rust for Linux has been described in #14425. While we could maintain a list of every path created by unstable features, it looks easier to ignore the MSRV check for the specific functions that are used. Most of the time, users of unstable features will use a nightly compiler without specifying a MSRV, so this would not be needed.

This is particularly interesting when #14216 is merged, as its lintcheck output shows that hits are for feature-gated entities. This option will allow the crate authors not to disable the whole lint, or to `#[expect]` everywhere a feature-gated MSRV-incompatible entity is used.

changelog: [`incompatible_msrv`]: add new `ignore-msrv-check-for` option