### PR TITLE
checkout only needed files in the remark CI

### DIFF
--- a/.github/workflows/remark.yml
+++ b/.github/workflows/remark.yml
@@ -13,6 +13,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
+        sparse-checkout: |
+            book
+        sparse-checkout-cone-mode: false
         # Unsetting this would make so that any malicious package could get our Github Token
         persist-credentials: false
 


### PR DESCRIPTION
Currently, the remark CI requires a specific nightly toolchain for link checking, which is causing all remark jobs to fail.

This issue occurs because the `rust-toolchain` file [specifies](https://github.com/rust-lang/rust-clippy/blob/a9c61ec1e1445d4eb8a8eabf0bb858ac220bd345/rust-toolchain#L3) the nightly build from 2/27. However, when the `linkcheck` script installs nightly, for some reason, it is not overridden to the version, causing an error. I suspect this is due to a recent sync mismatch, but I’m not entirely sure.

In any case, since only the `book` directory needs to be checked out to run the remark CI, this issue can be resolved by performing a sparse checkout.

changelog: none
