### PR TITLE
Walk back to the root context to compute the span

### DIFF
--- a/clippy_lints/src/methods/io_other_error.rs
+++ b/clippy_lints/src/methods/io_other_error.rs
@@ -27,7 +27,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, path: &Expr<'_>, args
                     "use `std::io::Error::other`",
                     vec![
                         (new_segment.ident.span, "other".to_owned()),
-                        (error_kind.span.until(error.span), String::new()),
+                        (error_kind.span.until(error.span.source_callsite()), String::new()),
                     ],
                     Applicability::MachineApplicable,
                 );

--- a/tests/ui/io_other_error.fixed
+++ b/tests/ui/io_other_error.fixed
@@ -53,3 +53,8 @@ mod paths {
 fn under_msrv() {
     let _err = std::io::Error::new(std::io::ErrorKind::Other, E);
 }
+
+pub fn issue14346(x: i32) -> std::io::Error {
+    std::io::Error::other(format!("{x}"))
+    //~^ ERROR: this can be `std::io::Error::other(_)`
+}

--- a/tests/ui/io_other_error.rs
+++ b/tests/ui/io_other_error.rs
@@ -53,3 +53,8 @@ mod paths {
 fn under_msrv() {
     let _err = std::io::Error::new(std::io::ErrorKind::Other, E);
 }
+
+pub fn issue14346(x: i32) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, format!("{x}"))
+    //~^ ERROR: this can be `std::io::Error::other(_)`
+}

--- a/tests/ui/io_other_error.stderr
+++ b/tests/ui/io_other_error.stderr
@@ -48,5 +48,17 @@ LL -         let _err = io::Error::new(io::ErrorKind::Other, super::E);
 LL +         let _err = io::Error::other(super::E);
    |
 
-error: aborting due to 4 previous errors
+error: this can be `std::io::Error::other(_)`
+  --> tests/ui/io_other_error.rs:58:5
+   |
+LL |     std::io::Error::new(std::io::ErrorKind::Other, format!("{x}"))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `std::io::Error::other`
+   |
+LL -     std::io::Error::new(std::io::ErrorKind::Other, format!("{x}"))
+LL +     std::io::Error::other(format!("{x}"))
+   |
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Since the error kind (`io::ErrorKind::other`) is in the root context, the error message must be found in the root context as well to compute the correct span to remove.

Fix #14346 

changelog: [`io_error_other`]: fix non-applicable suggestion

r? @llogiq 