### PR TITLE
Use `size_of` from the prelude instead of imported

### DIFF
--- a/clippy_lints/src/manual_bits.rs
+++ b/clippy_lints/src/manual_bits.rs
@@ -14,7 +14,7 @@ use rustc_span::{Span, sym};
 
 declare_clippy_lint! {
     /// ### What it does
-    /// Checks for usage of `std::mem::size_of::<T>() * 8` when
+    /// Checks for usage of `size_of::<T>() * 8` when
     /// `T::BITS` is available.
     ///
     /// ### Why is this bad?
@@ -22,7 +22,7 @@ declare_clippy_lint! {
     ///
     /// ### Example
     /// ```no_run
-    /// std::mem::size_of::<usize>() * 8;
+    /// size_of::<usize>() * 8;
     /// ```
     /// Use instead:
     /// ```no_run
@@ -68,7 +68,7 @@ impl<'tcx> LateLintPass<'tcx> for ManualBits {
                 cx,
                 MANUAL_BITS,
                 expr.span,
-                "usage of `mem::size_of::<T>()` to obtain the size of `T` in bits",
+                "usage of `size_of::<T>()` to obtain the size of `T` in bits",
                 "consider using",
                 sugg,
                 app,

--- a/clippy_lints/src/manual_slice_size_calculation.rs
+++ b/clippy_lints/src/manual_slice_size_calculation.rs
@@ -24,12 +24,12 @@ declare_clippy_lint! {
     /// ### Example
     /// ```no_run
     /// # let data : &[i32] = &[1, 2, 3];
-    /// let newlen = data.len() * std::mem::size_of::<i32>();
+    /// let newlen = data.len() * size_of::<i32>();
     /// ```
     /// Use instead:
     /// ```no_run
     /// # let data : &[i32] = &[1, 2, 3];
-    /// let newlen = std::mem::size_of_val(data);
+    /// let newlen = size_of_val(data);
     /// ```
     #[clippy::version = "1.70.0"]
     pub MANUAL_SLICE_SIZE_CALCULATION,

--- a/clippy_lints/src/size_of_in_element_count.rs
+++ b/clippy_lints/src/size_of_in_element_count.rs
@@ -18,7 +18,6 @@ declare_clippy_lint! {
     /// ### Example
     /// ```rust,no_run
     /// # use std::ptr::copy_nonoverlapping;
-    /// # use std::mem::size_of;
     /// const SIZE: usize = 128;
     /// let x = [2u8; SIZE];
     /// let mut y = [2u8; SIZE];

--- a/clippy_lints/src/size_of_ref.rs
+++ b/clippy_lints/src/size_of_ref.rs
@@ -8,7 +8,7 @@ use rustc_span::sym;
 declare_clippy_lint! {
     /// ### What it does
     ///
-    /// Checks for calls to `std::mem::size_of_val()` where the argument is
+    /// Checks for calls to `size_of_val()` where the argument is
     /// a reference to a reference.
     ///
     /// ### Why is this bad?
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     ///         // is already a reference, `&self` is a double-reference.
     ///         // The return value of `size_of_val()` therefore is the
     ///         // size of the reference-type, not the size of `self`.
-    ///         std::mem::size_of_val(&self)
+    ///         size_of_val(&self)
     ///     }
     /// }
     /// ```
@@ -42,14 +42,14 @@ declare_clippy_lint! {
     /// impl Foo {
     ///     fn size(&self) -> usize {
     ///         // Correct
-    ///         std::mem::size_of_val(self)
+    ///         size_of_val(self)
     ///     }
     /// }
     /// ```
     #[clippy::version = "1.68.0"]
     pub SIZE_OF_REF,
     suspicious,
-    "Argument to `std::mem::size_of_val()` is a double-reference, which is almost certainly unintended"
+    "Argument to `size_of_val()` is a double-reference, which is almost certainly unintended"
 }
 declare_lint_pass!(SizeOfRef => [SIZE_OF_REF]);
 
@@ -65,9 +65,9 @@ impl LateLintPass<'_> for SizeOfRef {
                 cx,
                 SIZE_OF_REF,
                 expr.span,
-                "argument to `std::mem::size_of_val()` is a reference to a reference",
+                "argument to `size_of_val()` is a reference to a reference",
                 None,
-                "dereference the argument to `std::mem::size_of_val()` to get the size of the value instead of the size of the reference-type",
+                "dereference the argument to `size_of_val()` to get the size of the value instead of the size of the reference-type",
             );
         }
     }

--- a/tests/ui/manual_bits.stderr
+++ b/tests/ui/manual_bits.stderr
@@ -1,4 +1,4 @@
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:14:5
    |
 LL |     size_of::<i8>() * 8;
@@ -7,169 +7,169 @@ LL |     size_of::<i8>() * 8;
    = note: `-D clippy::manual-bits` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_bits)]`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:16:5
    |
 LL |     size_of::<i16>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i16::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:18:5
    |
 LL |     size_of::<i32>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i32::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:20:5
    |
 LL |     size_of::<i64>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i64::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:22:5
    |
 LL |     size_of::<i128>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `i128::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:24:5
    |
 LL |     size_of::<isize>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `isize::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:27:5
    |
 LL |     size_of::<u8>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `u8::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:29:5
    |
 LL |     size_of::<u16>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u16::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:31:5
    |
 LL |     size_of::<u32>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u32::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:33:5
    |
 LL |     size_of::<u64>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u64::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:35:5
    |
 LL |     size_of::<u128>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:37:5
    |
 LL |     size_of::<usize>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `usize::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:40:5
    |
 LL |     8 * size_of::<i8>();
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `i8::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:42:5
    |
 LL |     8 * size_of::<i16>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i16::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:44:5
    |
 LL |     8 * size_of::<i32>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i32::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:46:5
    |
 LL |     8 * size_of::<i64>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `i64::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:48:5
    |
 LL |     8 * size_of::<i128>();
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `i128::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:50:5
    |
 LL |     8 * size_of::<isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `isize::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:53:5
    |
 LL |     8 * size_of::<u8>();
    |     ^^^^^^^^^^^^^^^^^^^ help: consider using: `u8::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:55:5
    |
 LL |     8 * size_of::<u16>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u16::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:57:5
    |
 LL |     8 * size_of::<u32>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u32::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:59:5
    |
 LL |     8 * size_of::<u64>();
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using: `u64::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:61:5
    |
 LL |     8 * size_of::<u128>();
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:63:5
    |
 LL |     8 * size_of::<usize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `usize::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:74:5
    |
 LL |     size_of::<Word>() * 8;
    |     ^^^^^^^^^^^^^^^^^^^^^ help: consider using: `Word::BITS as usize`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:79:18
    |
 LL |     let _: u32 = (size_of::<u128>() * 8) as u32;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:81:18
    |
 LL |     let _: u32 = (size_of::<u128>() * 8).try_into().unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `u128::BITS`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:83:13
    |
 LL |     let _ = (size_of::<u128>() * 8).pow(5);
    |             ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `(u128::BITS as usize)`
 
-error: usage of `mem::size_of::<T>()` to obtain the size of `T` in bits
+error: usage of `size_of::<T>()` to obtain the size of `T` in bits
   --> tests/ui/manual_bits.rs:85:14
    |
 LL |     let _ = &(size_of::<u128>() * 8);

--- a/tests/ui/size_of_ref.stderr
+++ b/tests/ui/size_of_ref.stderr
@@ -1,28 +1,28 @@
-error: argument to `std::mem::size_of_val()` is a reference to a reference
+error: argument to `size_of_val()` is a reference to a reference
   --> tests/ui/size_of_ref.rs:13:5
    |
 LL |     size_of_val(&&x);
    |     ^^^^^^^^^^^^^^^^
    |
-   = help: dereference the argument to `std::mem::size_of_val()` to get the size of the value instead of the size of the reference-type
+   = help: dereference the argument to `size_of_val()` to get the size of the value instead of the size of the reference-type
    = note: `-D clippy::size-of-ref` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::size_of_ref)]`
 
-error: argument to `std::mem::size_of_val()` is a reference to a reference
+error: argument to `size_of_val()` is a reference to a reference
   --> tests/ui/size_of_ref.rs:16:5
    |
 LL |     size_of_val(&y);
    |     ^^^^^^^^^^^^^^^
    |
-   = help: dereference the argument to `std::mem::size_of_val()` to get the size of the value instead of the size of the reference-type
+   = help: dereference the argument to `size_of_val()` to get the size of the value instead of the size of the reference-type
 
-error: argument to `std::mem::size_of_val()` is a reference to a reference
+error: argument to `size_of_val()` is a reference to a reference
   --> tests/ui/size_of_ref.rs:28:9
    |
 LL |         std::mem::size_of_val(&self) + (std::mem::size_of::<u8>() * self.data.capacity())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: dereference the argument to `std::mem::size_of_val()` to get the size of the value instead of the size of the reference-type
+   = help: dereference the argument to `size_of_val()` to get the size of the value instead of the size of the reference-type
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Use `std::mem::{size_of, size_of_val, align_of, align_of_val}` from the prelude instead of importing or qualifying them.

These functions were added to all preludes in Rust 1.80.

changelog: none