### PR TITLE
suggest `is_some_and` instead of `map_or` in `case_sensitive_file_extension_comparions`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4992,7 +4992,7 @@ impl Methods {
                 },
                 ("ends_with", [arg]) => {
                     if let ExprKind::MethodCall(.., span) = expr.kind {
-                        case_sensitive_file_extension_comparisons::check(cx, expr, span, recv, arg);
+                        case_sensitive_file_extension_comparisons::check(cx, expr, span, recv, arg, self.msrv);
                     }
                     path_ends_with_ext::check(cx, recv, arg, expr, self.msrv, &self.allowed_dotfiles);
                 },

--- a/tests/ui/case_sensitive_file_extension_comparisons.fixed
+++ b/tests/ui/case_sensitive_file_extension_comparisons.fixed
@@ -1,5 +1,4 @@
 #![warn(clippy::case_sensitive_file_extension_comparisons)]
-#![allow(clippy::unnecessary_map_or)]
 
 use std::string::String;
 
@@ -13,7 +12,7 @@ impl TestStruct {
 fn is_rust_file(filename: &str) -> bool {
     std::path::Path::new(filename)
         .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("rs"))
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("rs"))
     //~^ case_sensitive_file_extension_comparisons
 }
 
@@ -21,18 +20,18 @@ fn main() {
     // std::string::String and &str should trigger the lint failure with .ext12
     let _ = std::path::Path::new(&String::new())
         .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ext12"));
     //~^ case_sensitive_file_extension_comparisons
     let _ = std::path::Path::new("str")
         .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("ext12"));
     //~^ case_sensitive_file_extension_comparisons
 
     // The fixup should preserve the indentation level
     {
         let _ = std::path::Path::new("str")
             .extension()
-            .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("ext12"));
         //~^ case_sensitive_file_extension_comparisons
     }
 
@@ -42,11 +41,11 @@ fn main() {
     // std::string::String and &str should trigger the lint failure with .EXT12
     let _ = std::path::Path::new(&String::new())
         .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("EXT12"));
     //~^ case_sensitive_file_extension_comparisons
     let _ = std::path::Path::new("str")
         .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("EXT12"));
     //~^ case_sensitive_file_extension_comparisons
 
     // Should not trigger the lint failure because of the calls to to_lowercase and to_uppercase
@@ -75,4 +74,12 @@ fn main() {
     let _ = String::new().ends_with(".123");
     let _ = "str".ends_with(".123");
     TestStruct {}.ends_with(".123");
+}
+
+#[clippy::msrv = "1.69"]
+fn msrv_check() {
+    let _ = std::path::Path::new(&String::new())
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
+    //~^ case_sensitive_file_extension_comparisons
 }

--- a/tests/ui/case_sensitive_file_extension_comparisons.rs
+++ b/tests/ui/case_sensitive_file_extension_comparisons.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::case_sensitive_file_extension_comparisons)]
-#![allow(clippy::unnecessary_map_or)]
 
 use std::string::String;
 
@@ -63,4 +62,10 @@ fn main() {
     let _ = String::new().ends_with(".123");
     let _ = "str".ends_with(".123");
     TestStruct {}.ends_with(".123");
+}
+
+#[clippy::msrv = "1.69"]
+fn msrv_check() {
+    let _ = String::new().ends_with(".ext12");
+    //~^ case_sensitive_file_extension_comparisons
 }

--- a/tests/ui/case_sensitive_file_extension_comparisons.stderr
+++ b/tests/ui/case_sensitive_file_extension_comparisons.stderr
@@ -1,5 +1,5 @@
 error: case-sensitive file extension comparison
-  --> tests/ui/case_sensitive_file_extension_comparisons.rs:14:5
+  --> tests/ui/case_sensitive_file_extension_comparisons.rs:13:5
    |
 LL |     filename.ends_with(".rs")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,11 +11,81 @@ help: use std::path::Path
    |
 LL ~     std::path::Path::new(filename)
 LL +         .extension()
-LL +         .map_or(false, |ext| ext.eq_ignore_ascii_case("rs"))
+LL +         .is_some_and(|ext| ext.eq_ignore_ascii_case("rs"))
    |
 
 error: case-sensitive file extension comparison
-  --> tests/ui/case_sensitive_file_extension_comparisons.rs:20:13
+  --> tests/ui/case_sensitive_file_extension_comparisons.rs:19:13
+   |
+LL |     let _ = String::new().ends_with(".ext12");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new(&String::new())
+LL +         .extension()
+LL ~         .is_some_and(|ext| ext.eq_ignore_ascii_case("ext12"));
+   |
+
+error: case-sensitive file extension comparison
+  --> tests/ui/case_sensitive_file_extension_comparisons.rs:21:13
+   |
+LL |     let _ = "str".ends_with(".ext12");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new("str")
+LL +         .extension()
+LL ~         .is_some_and(|ext| ext.eq_ignore_ascii_case("ext12"));
+   |
+
+error: case-sensitive file extension comparison
+  --> tests/ui/case_sensitive_file_extension_comparisons.rs:26:17
+   |
+LL |         let _ = "str".ends_with(".ext12");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~         let _ = std::path::Path::new("str")
+LL +             .extension()
+LL ~             .is_some_and(|ext| ext.eq_ignore_ascii_case("ext12"));
+   |
+
+error: case-sensitive file extension comparison
+  --> tests/ui/case_sensitive_file_extension_comparisons.rs:34:13
+   |
+LL |     let _ = String::new().ends_with(".EXT12");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new(&String::new())
+LL +         .extension()
+LL ~         .is_some_and(|ext| ext.eq_ignore_ascii_case("EXT12"));
+   |
+
+error: case-sensitive file extension comparison
+  --> tests/ui/case_sensitive_file_extension_comparisons.rs:36:13
+   |
+LL |     let _ = "str".ends_with(".EXT12");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using a case-insensitive comparison instead
+help: use std::path::Path
+   |
+LL ~     let _ = std::path::Path::new("str")
+LL +         .extension()
+LL ~         .is_some_and(|ext| ext.eq_ignore_ascii_case("EXT12"));
+   |
+
+error: case-sensitive file extension comparison
+  --> tests/ui/case_sensitive_file_extension_comparisons.rs:69:13
    |
 LL |     let _ = String::new().ends_with(".ext12");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,61 +98,5 @@ LL +         .extension()
 LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
    |
 
-error: case-sensitive file extension comparison
-  --> tests/ui/case_sensitive_file_extension_comparisons.rs:22:13
-   |
-LL |     let _ = "str".ends_with(".ext12");
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using a case-insensitive comparison instead
-help: use std::path::Path
-   |
-LL ~     let _ = std::path::Path::new("str")
-LL +         .extension()
-LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
-   |
-
-error: case-sensitive file extension comparison
-  --> tests/ui/case_sensitive_file_extension_comparisons.rs:27:17
-   |
-LL |         let _ = "str".ends_with(".ext12");
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using a case-insensitive comparison instead
-help: use std::path::Path
-   |
-LL ~         let _ = std::path::Path::new("str")
-LL +             .extension()
-LL ~             .map_or(false, |ext| ext.eq_ignore_ascii_case("ext12"));
-   |
-
-error: case-sensitive file extension comparison
-  --> tests/ui/case_sensitive_file_extension_comparisons.rs:35:13
-   |
-LL |     let _ = String::new().ends_with(".EXT12");
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using a case-insensitive comparison instead
-help: use std::path::Path
-   |
-LL ~     let _ = std::path::Path::new(&String::new())
-LL +         .extension()
-LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
-   |
-
-error: case-sensitive file extension comparison
-  --> tests/ui/case_sensitive_file_extension_comparisons.rs:37:13
-   |
-LL |     let _ = "str".ends_with(".EXT12");
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using a case-insensitive comparison instead
-help: use std::path::Path
-   |
-LL ~     let _ = std::path::Path::new("str")
-LL +         .extension()
-LL ~         .map_or(false, |ext| ext.eq_ignore_ascii_case("EXT12"));
-   |
-
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
close #14357

changelog: [`case_sensitive_file_extension_comparisons`]: suggest `is_some_and` to suppress other lint warnings
