### PR TITLE
Do not warn about shadowing in a destructuring assigment

### DIFF
--- a/tests/ui/shadow.rs
+++ b/tests/ui/shadow.rs
@@ -167,4 +167,19 @@ fn issue13795(value: Issue13795) {
     //~^ shadow_same
 }
 
+fn issue14377() {
+    let a;
+    let b;
+    (a, b) = (0, 1);
+
+    struct S {
+        c: i32,
+        d: i32,
+    }
+
+    let c;
+    let d;
+    S { c, d } = S { c: 1, d: 2 };
+}
+
 fn main() {}


### PR DESCRIPTION
When lowering a destructuring assignment from AST to HIR, the compiler will reuse the same identifier name (namely `sym::lhs`) for all the fields. The desugaring must be checked for to avoid a false positive  of the `shadow_unrelated` lint.

Fix #10279
Fix #14377 

changelog: [`shadow_unrelated`]: prevent false positive in destructuring assignments
