### PR TITLE
Add missing tests annotations for `ui-internal`

### DIFF
--- a/tests/ui-internal/check_clippy_version_attribute.rs
+++ b/tests/ui-internal/check_clippy_version_attribute.rs
@@ -38,6 +38,7 @@ declare_tool_lint! {
 // Invalid attributes
 ///////////////////////
 declare_tool_lint! {
+//~^ invalid_clippy_version_attribute
     #[clippy::version = "1.2.3.4.5.6"]
     pub clippy::INVALID_ONE,
     Warn,
@@ -46,6 +47,7 @@ declare_tool_lint! {
 }
 
 declare_tool_lint! {
+//~^ invalid_clippy_version_attribute
     #[clippy::version = "I'm a string"]
     pub clippy::INVALID_TWO,
     Warn,
@@ -57,6 +59,7 @@ declare_tool_lint! {
 // Missing attribute test
 ///////////////////////
 declare_tool_lint! {
+//~^ missing_clippy_version_attribute
     #[clippy::version]
     pub clippy::MISSING_ATTRIBUTE_ONE,
     Warn,
@@ -65,6 +68,7 @@ declare_tool_lint! {
 }
 
 declare_tool_lint! {
+//~^ missing_clippy_version_attribute
     pub clippy::MISSING_ATTRIBUTE_TWO,
     Warn,
     "Two",

--- a/tests/ui-internal/check_clippy_version_attribute.stderr
+++ b/tests/ui-internal/check_clippy_version_attribute.stderr
@@ -2,10 +2,10 @@ error: this item has an invalid `clippy::version` attribute
   --> tests/ui-internal/check_clippy_version_attribute.rs:40:1
    |
 LL | / declare_tool_lint! {
+LL | |
 LL | |     #[clippy::version = "1.2.3.4.5.6"]
 LL | |     pub clippy::INVALID_ONE,
-LL | |     Warn,
-LL | |     "One",
+...  |
 LL | |     report_in_external_macro: true
 LL | | }
    | |_^
@@ -20,13 +20,13 @@ LL | #![deny(clippy::internal)]
    = note: this error originates in the macro `$crate::declare_tool_lint` which comes from the expansion of the macro `declare_tool_lint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this item has an invalid `clippy::version` attribute
-  --> tests/ui-internal/check_clippy_version_attribute.rs:48:1
+  --> tests/ui-internal/check_clippy_version_attribute.rs:49:1
    |
 LL | / declare_tool_lint! {
+LL | |
 LL | |     #[clippy::version = "I'm a string"]
 LL | |     pub clippy::INVALID_TWO,
-LL | |     Warn,
-LL | |     "Two",
+...  |
 LL | |     report_in_external_macro: true
 LL | | }
    | |_^
@@ -35,13 +35,13 @@ LL | | }
    = note: this error originates in the macro `$crate::declare_tool_lint` which comes from the expansion of the macro `declare_tool_lint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this lint is missing the `clippy::version` attribute or version value
-  --> tests/ui-internal/check_clippy_version_attribute.rs:59:1
+  --> tests/ui-internal/check_clippy_version_attribute.rs:61:1
    |
 LL | / declare_tool_lint! {
+LL | |
 LL | |     #[clippy::version]
 LL | |     pub clippy::MISSING_ATTRIBUTE_ONE,
-LL | |     Warn,
-LL | |     "Two",
+...  |
 LL | |     report_in_external_macro: true
 LL | | }
    | |_^
@@ -51,9 +51,10 @@ LL | | }
    = note: this error originates in the macro `$crate::declare_tool_lint` which comes from the expansion of the macro `declare_tool_lint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this lint is missing the `clippy::version` attribute or version value
-  --> tests/ui-internal/check_clippy_version_attribute.rs:67:1
+  --> tests/ui-internal/check_clippy_version_attribute.rs:70:1
    |
 LL | / declare_tool_lint! {
+LL | |
 LL | |     pub clippy::MISSING_ATTRIBUTE_TWO,
 LL | |     Warn,
 LL | |     "Two",

--- a/tests/ui-internal/check_formulation.rs
+++ b/tests/ui-internal/check_formulation.rs
@@ -21,6 +21,7 @@ declare_tool_lint! {
 declare_tool_lint! {
     /// # What it does
     /// Check for lint formulations that are correct
+    //~^ almost_standard_lint_formulation
     #[clippy::version = "pre 1.29.0"]
     pub clippy::INVALID1,
     Warn,
@@ -31,6 +32,7 @@ declare_tool_lint! {
 declare_tool_lint! {
     /// # What it does
     /// Detects uses of incorrect formulations
+    //~^ almost_standard_lint_formulation
     #[clippy::version = "pre 1.29.0"]
     pub clippy::INVALID2,
     Warn,

--- a/tests/ui-internal/check_formulation.stderr
+++ b/tests/ui-internal/check_formulation.stderr
@@ -9,7 +9,7 @@ LL |     /// Check for lint formulations that are correct
    = help: to override `-D warnings` add `#[allow(clippy::almost_standard_lint_formulation)]`
 
 error: non-standard lint formulation
-  --> tests/ui-internal/check_formulation.rs:33:5
+  --> tests/ui-internal/check_formulation.rs:34:5
    |
 LL |     /// Detects uses of incorrect formulations
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-internal/collapsible_span_lint_calls.rs
+++ b/tests/ui-internal/collapsible_span_lint_calls.rs
@@ -33,18 +33,23 @@ impl EarlyLintPass for Pass {
         let predicate = true;
 
         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+            //~^ collapsible_span_lint_calls
             db.span_suggestion(expr.span, help_msg, sugg.to_string(), Applicability::MachineApplicable);
         });
         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+            //~^ collapsible_span_lint_calls
             db.span_help(expr.span, help_msg);
         });
         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+            //~^ collapsible_span_lint_calls
             db.help(help_msg);
         });
         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+            //~^ collapsible_span_lint_calls
             db.span_note(expr.span, note_msg);
         });
         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+            //~^ collapsible_span_lint_calls
             db.note(note_msg);
         });
 

--- a/tests/ui-internal/collapsible_span_lint_calls.stderr
+++ b/tests/ui-internal/collapsible_span_lint_calls.stderr
@@ -2,6 +2,7 @@ error: this call is collapsible
   --> tests/ui-internal/collapsible_span_lint_calls.rs:35:9
    |
 LL | /         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+LL | |
 LL | |             db.span_suggestion(expr.span, help_msg, sugg.to_string(), Applicability::MachineApplicable);
 LL | |         });
    | |__________^ help: collapse into: `span_lint_and_sugg(cx, TEST_LINT, expr.span, lint_msg, help_msg, sugg.to_string(), Applicability::MachineApplicable)`
@@ -14,33 +15,37 @@ LL | #![deny(clippy::internal)]
    = note: `#[deny(clippy::collapsible_span_lint_calls)]` implied by `#[deny(clippy::internal)]`
 
 error: this call is collapsible
-  --> tests/ui-internal/collapsible_span_lint_calls.rs:38:9
+  --> tests/ui-internal/collapsible_span_lint_calls.rs:39:9
    |
 LL | /         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+LL | |
 LL | |             db.span_help(expr.span, help_msg);
 LL | |         });
    | |__________^ help: collapse into: `span_lint_and_help(cx, TEST_LINT, expr.span, lint_msg, Some(expr.span), help_msg)`
 
 error: this call is collapsible
-  --> tests/ui-internal/collapsible_span_lint_calls.rs:41:9
+  --> tests/ui-internal/collapsible_span_lint_calls.rs:43:9
    |
 LL | /         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+LL | |
 LL | |             db.help(help_msg);
 LL | |         });
    | |__________^ help: collapse into: `span_lint_and_help(cx, TEST_LINT, expr.span, lint_msg, None, help_msg)`
 
 error: this call is collapsible
-  --> tests/ui-internal/collapsible_span_lint_calls.rs:44:9
+  --> tests/ui-internal/collapsible_span_lint_calls.rs:47:9
    |
 LL | /         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+LL | |
 LL | |             db.span_note(expr.span, note_msg);
 LL | |         });
    | |__________^ help: collapse into: `span_lint_and_note(cx, TEST_LINT, expr.span, lint_msg, Some(expr.span), note_msg)`
 
 error: this call is collapsible
-  --> tests/ui-internal/collapsible_span_lint_calls.rs:47:9
+  --> tests/ui-internal/collapsible_span_lint_calls.rs:51:9
    |
 LL | /         span_lint_and_then(cx, TEST_LINT, expr.span, lint_msg, |db| {
+LL | |
 LL | |             db.note(note_msg);
 LL | |         });
    | |__________^ help: collapse into: `span_lint_and_note(cx, TEST_LINT, expr.span, lint_msg, None, note_msg)`

--- a/tests/ui-internal/default_lint.rs
+++ b/tests/ui-internal/default_lint.rs
@@ -16,6 +16,7 @@ declare_tool_lint! {
 }
 
 declare_tool_lint! {
+//~^ default_lint
     pub clippy::TEST_LINT_DEFAULT,
     Warn,
     "default lint description",

--- a/tests/ui-internal/default_lint.stderr
+++ b/tests/ui-internal/default_lint.stderr
@@ -2,6 +2,7 @@ error: the lint `TEST_LINT_DEFAULT` has the default lint description
   --> tests/ui-internal/default_lint.rs:18:1
    |
 LL | / declare_tool_lint! {
+LL | |
 LL | |     pub clippy::TEST_LINT_DEFAULT,
 LL | |     Warn,
 LL | |     "default lint description",

--- a/tests/ui-internal/disallow_span_lint.rs
+++ b/tests/ui-internal/disallow_span_lint.rs
@@ -12,12 +12,14 @@ use rustc_middle::ty::TyCtxt;
 
 pub fn a(cx: impl LintContext, lint: &'static Lint, span: impl Into<MultiSpan>, msg: impl Into<DiagMessage>) {
     cx.span_lint(lint, span, |lint| {
+        //~^ disallowed_methods
         lint.primary_message(msg);
     });
 }
 
 pub fn b(tcx: TyCtxt<'_>, lint: &'static Lint, hir_id: HirId, span: impl Into<MultiSpan>, msg: impl Into<DiagMessage>) {
     tcx.node_span_lint(lint, hir_id, span, |lint| {
+        //~^ disallowed_methods
         lint.primary_message(msg);
     });
 }

--- a/tests/ui-internal/disallow_span_lint.stderr
+++ b/tests/ui-internal/disallow_span_lint.stderr
@@ -9,7 +9,7 @@ LL |     cx.span_lint(lint, span, |lint| {
    = help: to override `-D warnings` add `#[allow(clippy::disallowed_methods)]`
 
 error: use of a disallowed method `rustc_middle::ty::context::TyCtxt::node_span_lint`
-  --> tests/ui-internal/disallow_span_lint.rs:20:9
+  --> tests/ui-internal/disallow_span_lint.rs:21:9
    |
 LL |     tcx.node_span_lint(lint, hir_id, span, |lint| {
    |         ^^^^^^^^^^^^^^

--- a/tests/ui-internal/interning_defined_symbol.fixed
+++ b/tests/ui-internal/interning_defined_symbol.fixed
@@ -15,15 +15,19 @@ macro_rules! sym {
 fn main() {
     // Direct use of Symbol::intern
     let _ = rustc_span::sym::f32;
+    //~^ interning_defined_symbol
 
     // Using a sym macro
     let _ = rustc_span::sym::f32;
+    //~^ interning_defined_symbol
 
     // Correct suggestion when symbol isn't stringified constant name
     let _ = rustc_span::sym::proc_dash_macro;
+    //~^ interning_defined_symbol
 
     // interning a keyword
     let _ = rustc_span::kw::SelfLower;
+    //~^ interning_defined_symbol
 
     // Interning a symbol that is not defined
     let _ = Symbol::intern("xyz123");

--- a/tests/ui-internal/interning_defined_symbol.rs
+++ b/tests/ui-internal/interning_defined_symbol.rs
@@ -15,15 +15,19 @@ macro_rules! sym {
 fn main() {
     // Direct use of Symbol::intern
     let _ = Symbol::intern("f32");
+    //~^ interning_defined_symbol
 
     // Using a sym macro
     let _ = sym!(f32);
+    //~^ interning_defined_symbol
 
     // Correct suggestion when symbol isn't stringified constant name
     let _ = Symbol::intern("proc-macro");
+    //~^ interning_defined_symbol
 
     // interning a keyword
     let _ = Symbol::intern("self");
+    //~^ interning_defined_symbol
 
     // Interning a symbol that is not defined
     let _ = Symbol::intern("xyz123");

--- a/tests/ui-internal/interning_defined_symbol.stderr
+++ b/tests/ui-internal/interning_defined_symbol.stderr
@@ -12,19 +12,19 @@ LL | #![deny(clippy::internal)]
    = note: `#[deny(clippy::interning_defined_symbol)]` implied by `#[deny(clippy::internal)]`
 
 error: interning a defined symbol
-  --> tests/ui-internal/interning_defined_symbol.rs:20:13
+  --> tests/ui-internal/interning_defined_symbol.rs:21:13
    |
 LL |     let _ = sym!(f32);
    |             ^^^^^^^^^ help: try: `rustc_span::sym::f32`
 
 error: interning a defined symbol
-  --> tests/ui-internal/interning_defined_symbol.rs:23:13
+  --> tests/ui-internal/interning_defined_symbol.rs:25:13
    |
 LL |     let _ = Symbol::intern("proc-macro");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `rustc_span::sym::proc_dash_macro`
 
 error: interning a defined symbol
-  --> tests/ui-internal/interning_defined_symbol.rs:26:13
+  --> tests/ui-internal/interning_defined_symbol.rs:29:13
    |
 LL |     let _ = Symbol::intern("self");
    |             ^^^^^^^^^^^^^^^^^^^^^^ help: try: `rustc_span::kw::SelfLower`

--- a/tests/ui-internal/invalid_msrv_attr_impl.fixed
+++ b/tests/ui-internal/invalid_msrv_attr_impl.fixed
@@ -27,6 +27,7 @@ impl_lint_pass!(Pass => [TEST_LINT]);
 
 impl EarlyLintPass for Pass {
     extract_msrv_attr!();
+    //~^ missing_msrv_attr_impl
     fn check_expr(&mut self, _: &EarlyContext<'_>, _: &rustc_ast::Expr) {}
 }
 

--- a/tests/ui-internal/invalid_msrv_attr_impl.rs
+++ b/tests/ui-internal/invalid_msrv_attr_impl.rs
@@ -26,6 +26,7 @@ struct Pass {
 impl_lint_pass!(Pass => [TEST_LINT]);
 
 impl EarlyLintPass for Pass {
+    //~^ missing_msrv_attr_impl
     fn check_expr(&mut self, _: &EarlyContext<'_>, _: &rustc_ast::Expr) {}
 }
 

--- a/tests/ui-internal/invalid_paths.rs
+++ b/tests/ui-internal/invalid_paths.rs
@@ -13,12 +13,15 @@ mod paths {
 
     // Path with empty segment
     pub const TRANSMUTE: [&str; 4] = ["core", "intrinsics", "", "transmute"];
+    //~^ invalid_paths
 
     // Path with bad crate
     pub const BAD_CRATE_PATH: [&str; 2] = ["bad", "path"];
+    //~^ invalid_paths
 
     // Path with bad module
     pub const BAD_MOD_PATH: [&str; 2] = ["std", "xxx"];
+    //~^ invalid_paths
 
     // Path to method on an enum inherent impl
     pub const OPTION_IS_SOME: [&str; 4] = ["core", "option", "Option", "is_some"];

--- a/tests/ui-internal/invalid_paths.stderr
+++ b/tests/ui-internal/invalid_paths.stderr
@@ -8,13 +8,13 @@ LL |     pub const TRANSMUTE: [&str; 4] = ["core", "intrinsics", "", "transmute"
    = help: to override `-D warnings` add `#[allow(clippy::invalid_paths)]`
 
 error: invalid path
-  --> tests/ui-internal/invalid_paths.rs:18:5
+  --> tests/ui-internal/invalid_paths.rs:19:5
    |
 LL |     pub const BAD_CRATE_PATH: [&str; 2] = ["bad", "path"];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid path
-  --> tests/ui-internal/invalid_paths.rs:21:5
+  --> tests/ui-internal/invalid_paths.rs:23:5
    |
 LL |     pub const BAD_MOD_PATH: [&str; 2] = ["std", "xxx"];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-internal/lint_without_lint_pass.rs
+++ b/tests/ui-internal/lint_without_lint_pass.rs
@@ -10,6 +10,7 @@ extern crate rustc_lint;
 use rustc_lint::{LintPass, LintVec};
 
 declare_tool_lint! {
+//~^ lint_without_lint_pass
     pub clippy::TEST_LINT,
     Warn,
     "",

--- a/tests/ui-internal/lint_without_lint_pass.stderr
+++ b/tests/ui-internal/lint_without_lint_pass.stderr
@@ -2,6 +2,7 @@ error: the lint `TEST_LINT` is not added to any `LintPass`
   --> tests/ui-internal/lint_without_lint_pass.rs:12:1
    |
 LL | / declare_tool_lint! {
+LL | |
 LL | |     pub clippy::TEST_LINT,
 LL | |     Warn,
 LL | |     "",

--- a/tests/ui-internal/outer_expn_data.fixed
+++ b/tests/ui-internal/outer_expn_data.fixed
@@ -21,6 +21,7 @@ declare_lint_pass!(Pass => [TEST_LINT]);
 impl<'tcx> LateLintPass<'tcx> for Pass {
     fn check_expr(&mut self, _cx: &LateContext<'tcx>, expr: &'tcx Expr) {
         let _ = expr.span.ctxt().outer_expn_data();
+        //~^ outer_expn_expn_data
     }
 }
 

--- a/tests/ui-internal/outer_expn_data.rs
+++ b/tests/ui-internal/outer_expn_data.rs
@@ -21,6 +21,7 @@ declare_lint_pass!(Pass => [TEST_LINT]);
 impl<'tcx> LateLintPass<'tcx> for Pass {
     fn check_expr(&mut self, _cx: &LateContext<'tcx>, expr: &'tcx Expr) {
         let _ = expr.span.ctxt().outer_expn().expn_data();
+        //~^ outer_expn_expn_data
     }
 }
 

--- a/tests/ui-internal/unnecessary_def_path.fixed
+++ b/tests/ui-internal/unnecessary_def_path.fixed
@@ -35,28 +35,43 @@ const RESULT: &[&str] = &["core", "result", "Result"];
 
 fn _f<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, did: DefId, expr: &Expr<'_>) {
     let _ = is_type_diagnostic_item(cx, ty, sym::Option);
+    //~^ unnecessary_def_path
     let _ = is_type_diagnostic_item(cx, ty, sym::Result);
+    //~^ unnecessary_def_path
     let _ = is_type_diagnostic_item(cx, ty, sym::Result);
+    //~^ unnecessary_def_path
 
     #[allow(unused, clippy::unnecessary_def_path)]
     let rc_path = &["alloc", "rc", "Rc"];
     let _ = is_type_diagnostic_item(cx, ty, sym::Rc);
+    //~^ unnecessary_def_path
 
     let _ = is_type_diagnostic_item(cx, ty, sym::Option);
+    //~^ unnecessary_def_path
     let _ = is_type_diagnostic_item(cx, ty, sym::Result);
+    //~^ unnecessary_def_path
 
     let _ = is_type_lang_item(cx, ty, LangItem::OwnedBox);
+    //~^ unnecessary_def_path
     let _ = is_type_diagnostic_item(cx, ty, sym::maybe_uninit_uninit);
+    //~^ unnecessary_def_path
 
     let _ = cx.tcx.lang_items().get(LangItem::OwnedBox) == Some(did);
+    //~^ unnecessary_def_path
     let _ = cx.tcx.is_diagnostic_item(sym::Option, did);
+    //~^ unnecessary_def_path
     let _ = cx.tcx.lang_items().get(LangItem::OptionSome) == Some(did);
+    //~^ unnecessary_def_path
 
     let _ = is_trait_method(cx, expr, sym::AsRef);
+    //~^ unnecessary_def_path
 
     let _ = is_path_diagnostic_item(cx, expr, sym::Option);
+    //~^ unnecessary_def_path
     let _ = path_res(cx, expr).opt_def_id().map_or(false, |id| cx.tcx.lang_items().get(LangItem::IteratorNext) == Some(id));
+    //~^ unnecessary_def_path
     let _ = is_res_lang_ctor(cx, path_res(cx, expr), LangItem::OptionSome);
+    //~^ unnecessary_def_path
 }
 
 fn main() {}

--- a/tests/ui-internal/unnecessary_def_path.rs
+++ b/tests/ui-internal/unnecessary_def_path.rs
@@ -35,28 +35,43 @@ const RESULT: &[&str] = &["core", "result", "Result"];
 
 fn _f<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>, did: DefId, expr: &Expr<'_>) {
     let _ = match_type(cx, ty, &OPTION);
+    //~^ unnecessary_def_path
     let _ = match_type(cx, ty, RESULT);
+    //~^ unnecessary_def_path
     let _ = match_type(cx, ty, &["core", "result", "Result"]);
+    //~^ unnecessary_def_path
 
     #[allow(unused, clippy::unnecessary_def_path)]
     let rc_path = &["alloc", "rc", "Rc"];
     let _ = clippy_utils::ty::match_type(cx, ty, rc_path);
+    //~^ unnecessary_def_path
 
     let _ = match_type(cx, ty, &paths::OPTION);
+    //~^ unnecessary_def_path
     let _ = match_type(cx, ty, paths::RESULT);
+    //~^ unnecessary_def_path
 
     let _ = match_type(cx, ty, &["alloc", "boxed", "Box"]);
+    //~^ unnecessary_def_path
     let _ = match_type(cx, ty, &["core", "mem", "maybe_uninit", "MaybeUninit", "uninit"]);
+    //~^ unnecessary_def_path
 
     let _ = match_def_path(cx, did, &["alloc", "boxed", "Box"]);
+    //~^ unnecessary_def_path
     let _ = match_def_path(cx, did, &["core", "option", "Option"]);
+    //~^ unnecessary_def_path
     let _ = match_def_path(cx, did, &["core", "option", "Option", "Some"]);
+    //~^ unnecessary_def_path
 
     let _ = match_trait_method(cx, expr, &["core", "convert", "AsRef"]);
+    //~^ unnecessary_def_path
 
     let _ = is_expr_path_def_path(cx, expr, &["core", "option", "Option"]);
+    //~^ unnecessary_def_path
     let _ = is_expr_path_def_path(cx, expr, &["core", "iter", "traits", "Iterator", "next"]);
+    //~^ unnecessary_def_path
     let _ = is_expr_path_def_path(cx, expr, &["core", "option", "Option", "Some"]);
+    //~^ unnecessary_def_path
 }
 
 fn main() {}

--- a/tests/ui-internal/unnecessary_def_path.stderr
+++ b/tests/ui-internal/unnecessary_def_path.stderr
@@ -12,61 +12,61 @@ LL | #![deny(clippy::internal)]
    = note: `#[deny(clippy::unnecessary_def_path)]` implied by `#[deny(clippy::internal)]`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:38:13
+  --> tests/ui-internal/unnecessary_def_path.rs:39:13
    |
 LL |     let _ = match_type(cx, ty, RESULT);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_type_diagnostic_item(cx, ty, sym::Result)`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:39:13
+  --> tests/ui-internal/unnecessary_def_path.rs:41:13
    |
 LL |     let _ = match_type(cx, ty, &["core", "result", "Result"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_type_diagnostic_item(cx, ty, sym::Result)`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:43:13
+  --> tests/ui-internal/unnecessary_def_path.rs:46:13
    |
 LL |     let _ = clippy_utils::ty::match_type(cx, ty, rc_path);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_type_diagnostic_item(cx, ty, sym::Rc)`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:45:13
+  --> tests/ui-internal/unnecessary_def_path.rs:49:13
    |
 LL |     let _ = match_type(cx, ty, &paths::OPTION);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_type_diagnostic_item(cx, ty, sym::Option)`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:46:13
+  --> tests/ui-internal/unnecessary_def_path.rs:51:13
    |
 LL |     let _ = match_type(cx, ty, paths::RESULT);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_type_diagnostic_item(cx, ty, sym::Result)`
 
 error: use of a def path to a `LangItem`
-  --> tests/ui-internal/unnecessary_def_path.rs:48:13
+  --> tests/ui-internal/unnecessary_def_path.rs:54:13
    |
 LL |     let _ = match_type(cx, ty, &["alloc", "boxed", "Box"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_type_lang_item(cx, ty, LangItem::OwnedBox)`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:49:13
+  --> tests/ui-internal/unnecessary_def_path.rs:56:13
    |
 LL |     let _ = match_type(cx, ty, &["core", "mem", "maybe_uninit", "MaybeUninit", "uninit"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_type_diagnostic_item(cx, ty, sym::maybe_uninit_uninit)`
 
 error: use of a def path to a `LangItem`
-  --> tests/ui-internal/unnecessary_def_path.rs:51:13
+  --> tests/ui-internal/unnecessary_def_path.rs:59:13
    |
 LL |     let _ = match_def_path(cx, did, &["alloc", "boxed", "Box"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cx.tcx.lang_items().get(LangItem::OwnedBox) == Some(did)`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:52:13
+  --> tests/ui-internal/unnecessary_def_path.rs:61:13
    |
 LL |     let _ = match_def_path(cx, did, &["core", "option", "Option"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cx.tcx.is_diagnostic_item(sym::Option, did)`
 
 error: use of a def path to a `LangItem`
-  --> tests/ui-internal/unnecessary_def_path.rs:53:13
+  --> tests/ui-internal/unnecessary_def_path.rs:63:13
    |
 LL |     let _ = match_def_path(cx, did, &["core", "option", "Option", "Some"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cx.tcx.lang_items().get(LangItem::OptionSome) == Some(did)`
@@ -74,25 +74,25 @@ LL |     let _ = match_def_path(cx, did, &["core", "option", "Option", "Some"]);
    = help: if this `DefId` came from a constructor expression or pattern then the parent `DefId` should be used instead
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:55:13
+  --> tests/ui-internal/unnecessary_def_path.rs:66:13
    |
 LL |     let _ = match_trait_method(cx, expr, &["core", "convert", "AsRef"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_trait_method(cx, expr, sym::AsRef)`
 
 error: use of a def path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path.rs:57:13
+  --> tests/ui-internal/unnecessary_def_path.rs:69:13
    |
 LL |     let _ = is_expr_path_def_path(cx, expr, &["core", "option", "Option"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_path_diagnostic_item(cx, expr, sym::Option)`
 
 error: use of a def path to a `LangItem`
-  --> tests/ui-internal/unnecessary_def_path.rs:58:13
+  --> tests/ui-internal/unnecessary_def_path.rs:71:13
    |
 LL |     let _ = is_expr_path_def_path(cx, expr, &["core", "iter", "traits", "Iterator", "next"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `path_res(cx, expr).opt_def_id().map_or(false, |id| cx.tcx.lang_items().get(LangItem::IteratorNext) == Some(id))`
 
 error: use of a def path to a `LangItem`
-  --> tests/ui-internal/unnecessary_def_path.rs:59:13
+  --> tests/ui-internal/unnecessary_def_path.rs:73:13
    |
 LL |     let _ = is_expr_path_def_path(cx, expr, &["core", "option", "Option", "Some"]);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `is_res_lang_ctor(cx, path_res(cx, expr), LangItem::OptionSome)`

--- a/tests/ui-internal/unnecessary_def_path_hardcoded_path.rs
+++ b/tests/ui-internal/unnecessary_def_path_hardcoded_path.rs
@@ -8,8 +8,11 @@ use rustc_hir::LangItem;
 
 fn main() {
     const DEREF_TRAIT: [&str; 4] = ["core", "ops", "deref", "Deref"];
+    //~^ unnecessary_def_path
     const DEREF_MUT_TRAIT: [&str; 4] = ["core", "ops", "deref", "DerefMut"];
+    //~^ unnecessary_def_path
     const DEREF_TRAIT_METHOD: [&str; 5] = ["core", "ops", "deref", "Deref", "deref"];
+    //~^ unnecessary_def_path
 
     // Don't lint, not a diagnostic or language item
     const OPS_MOD: [&str; 2] = ["core", "ops"];

--- a/tests/ui-internal/unnecessary_def_path_hardcoded_path.stderr
+++ b/tests/ui-internal/unnecessary_def_path_hardcoded_path.stderr
@@ -9,7 +9,7 @@ LL |     const DEREF_TRAIT: [&str; 4] = ["core", "ops", "deref", "Deref"];
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_def_path)]`
 
 error: hardcoded path to a language item
-  --> tests/ui-internal/unnecessary_def_path_hardcoded_path.rs:11:40
+  --> tests/ui-internal/unnecessary_def_path_hardcoded_path.rs:12:40
    |
 LL |     const DEREF_MUT_TRAIT: [&str; 4] = ["core", "ops", "deref", "DerefMut"];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     const DEREF_MUT_TRAIT: [&str; 4] = ["core", "ops", "deref", "DerefMut"]
    = help: convert all references to use `LangItem::DerefMut`
 
 error: hardcoded path to a diagnostic item
-  --> tests/ui-internal/unnecessary_def_path_hardcoded_path.rs:12:43
+  --> tests/ui-internal/unnecessary_def_path_hardcoded_path.rs:14:43
    |
 LL |     const DEREF_TRAIT_METHOD: [&str; 5] = ["core", "ops", "deref", "Deref", "deref"];
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-internal/unnecessary_symbol_str.fixed
+++ b/tests/ui-internal/unnecessary_symbol_str.fixed
@@ -14,8 +14,13 @@ use rustc_span::symbol::{Ident, Symbol};
 
 fn main() {
     Symbol::intern("foo") == rustc_span::sym::clippy;
+    //~^ unnecessary_symbol_str
     Symbol::intern("foo") == rustc_span::kw::SelfLower;
+    //~^ unnecessary_symbol_str
     Symbol::intern("foo") != rustc_span::kw::SelfUpper;
+    //~^ unnecessary_symbol_str
     Ident::empty().name == rustc_span::sym::clippy;
+    //~^ unnecessary_symbol_str
     rustc_span::sym::clippy == Ident::empty().name;
+    //~^ unnecessary_symbol_str
 }

--- a/tests/ui-internal/unnecessary_symbol_str.rs
+++ b/tests/ui-internal/unnecessary_symbol_str.rs
@@ -14,8 +14,13 @@ use rustc_span::symbol::{Ident, Symbol};
 
 fn main() {
     Symbol::intern("foo").as_str() == "clippy";
+    //~^ unnecessary_symbol_str
     Symbol::intern("foo").to_string() == "self";
+    //~^ unnecessary_symbol_str
     Symbol::intern("foo").to_ident_string() != "Self";
+    //~^ unnecessary_symbol_str
     &*Ident::empty().as_str() == "clippy";
+    //~^ unnecessary_symbol_str
     "clippy" == Ident::empty().to_string();
+    //~^ unnecessary_symbol_str
 }

--- a/tests/ui-internal/unnecessary_symbol_str.stderr
+++ b/tests/ui-internal/unnecessary_symbol_str.stderr
@@ -12,25 +12,25 @@ LL | #![deny(clippy::internal)]
    = note: `#[deny(clippy::unnecessary_symbol_str)]` implied by `#[deny(clippy::internal)]`
 
 error: unnecessary `Symbol` to string conversion
-  --> tests/ui-internal/unnecessary_symbol_str.rs:17:5
+  --> tests/ui-internal/unnecessary_symbol_str.rs:18:5
    |
 LL |     Symbol::intern("foo").to_string() == "self";
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Symbol::intern("foo") == rustc_span::kw::SelfLower`
 
 error: unnecessary `Symbol` to string conversion
-  --> tests/ui-internal/unnecessary_symbol_str.rs:18:5
+  --> tests/ui-internal/unnecessary_symbol_str.rs:20:5
    |
 LL |     Symbol::intern("foo").to_ident_string() != "Self";
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Symbol::intern("foo") != rustc_span::kw::SelfUpper`
 
 error: unnecessary `Symbol` to string conversion
-  --> tests/ui-internal/unnecessary_symbol_str.rs:19:5
+  --> tests/ui-internal/unnecessary_symbol_str.rs:22:5
    |
 LL |     &*Ident::empty().as_str() == "clippy";
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Ident::empty().name == rustc_span::sym::clippy`
 
 error: unnecessary `Symbol` to string conversion
-  --> tests/ui-internal/unnecessary_symbol_str.rs:20:5
+  --> tests/ui-internal/unnecessary_symbol_str.rs:24:5
    |
 LL |     "clippy" == Ident::empty().to_string();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `rustc_span::sym::clippy == Ident::empty().name`


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust-clippy/pull/11421.

I can't yet make the annotations mandatory because there is an issue with `tests/ui-internal/custom_ice_message.rs`: the error message is not emitted as JSON, meaning that we can't match it with `ui_test`. I need to check if it's a bug in rustc or if `ui_test` needs to handle this case somehow.

changelog: Add missing tests annotations for `ui-internal`

r? @flip1995 