### PR TITLE
fix: `option_if_let_else` suggests wrongly when coercion requires explicit cast

### DIFF
--- a/tests/ui/option_if_let_else.fixed
+++ b/tests/ui/option_if_let_else.fixed
@@ -288,3 +288,17 @@ mod issue13964 {
         };
     }
 }
+
+mod issue11059 {
+    use std::fmt::Debug;
+
+    fn box_coercion_unsize(o: Option<i32>) -> Box<dyn Debug> {
+        if let Some(o) = o { Box::new(o) } else { Box::new("foo") }
+    }
+
+    static S: String = String::new();
+
+    fn deref_with_overload(o: Option<&str>) -> &str {
+        if let Some(o) = o { o } else { &S }
+    }
+}

--- a/tests/ui/option_if_let_else.rs
+++ b/tests/ui/option_if_let_else.rs
@@ -351,3 +351,17 @@ mod issue13964 {
         };
     }
 }
+
+mod issue11059 {
+    use std::fmt::Debug;
+
+    fn box_coercion_unsize(o: Option<i32>) -> Box<dyn Debug> {
+        if let Some(o) = o { Box::new(o) } else { Box::new("foo") }
+    }
+
+    static S: String = String::new();
+
+    fn deref_with_overload(o: Option<&str>) -> &str {
+        if let Some(o) = o { o } else { &S }
+    }
+}


### PR DESCRIPTION
Closes #11059

changelog: `option_if_let_else`: fix wrong suggestion when coersion requires explicit cast
