### PR TITLE
Make annotations mandatory for internal ui tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ anstream = "0.6.18"
 
 [dev-dependencies]
 cargo_metadata = "0.18.1"
-ui_test = "0.26.4"
+ui_test = "0.29.2"
 regex = "1.5.5"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.122"

--- a/clippy_lints/src/utils/internal_lints/produce_ice.rs
+++ b/clippy_lints/src/utils/internal_lints/produce_ice.rs
@@ -1,6 +1,6 @@
 use rustc_ast::ast::NodeId;
 use rustc_ast::visit::FnKind;
-use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_session::declare_lint_pass;
 use rustc_span::Span;
 
@@ -24,8 +24,12 @@ declare_clippy_lint! {
 declare_lint_pass!(ProduceIce => [PRODUCE_ICE]);
 
 impl EarlyLintPass for ProduceIce {
-    fn check_fn(&mut self, _: &EarlyContext<'_>, fn_kind: FnKind<'_>, _: Span, _: NodeId) {
-        assert!(!is_trigger_fn(fn_kind), "Would you like some help with that?");
+    fn check_fn(&mut self, ctx: &EarlyContext<'_>, fn_kind: FnKind<'_>, span: Span, _: NodeId) {
+        if is_trigger_fn(fn_kind) {
+            ctx.sess()
+                .dcx()
+                .span_delayed_bug(span, "Would you like some help with that?");
+        }
     }
 }
 

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -220,7 +220,7 @@ fn run_internal_tests(cx: &TestContext) {
     if !RUN_INTERNAL_TESTS {
         return;
     }
-    let mut config = cx.base_config("ui-internal", false);
+    let mut config = cx.base_config("ui-internal", true);
     config.bless_command = Some("cargo uitest --features internal -- -- --bless".into());
 
     ui_test::run_tests_generic(

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -16,7 +16,7 @@ use test_utils::IS_RUSTC_TEST_SUITE;
 use ui_test::custom_flags::Flag;
 use ui_test::custom_flags::rustfix::RustfixMode;
 use ui_test::spanned::Spanned;
-use ui_test::{Args, CommandBuilder, Config, Match, OutputConflictHandling, status_emitter};
+use ui_test::{Args, CommandBuilder, Config, Match, error_on_output_conflict, status_emitter};
 
 use std::collections::{BTreeMap, HashMap};
 use std::env::{self, set_var, var_os};
@@ -142,7 +142,7 @@ impl TestContext {
     fn base_config(&self, test_dir: &str, mandatory_annotations: bool) -> Config {
         let target_dir = PathBuf::from(var_os("CARGO_TARGET_DIR").unwrap_or_else(|| "target".into()));
         let mut config = Config {
-            output_conflict_handling: OutputConflictHandling::Error,
+            output_conflict_handling: error_on_output_conflict,
             filter_files: env::var("TESTNAME")
                 .map(|filters| filters.split(',').map(str::to_string).collect())
                 .unwrap_or_default(),

--- a/tests/lint_message_convention.rs
+++ b/tests/lint_message_convention.rs
@@ -44,6 +44,7 @@ impl Message {
                 ".*AT&T x86 assembly syntax used",
                 "note: Clippy version: .*",
                 "the compiler unexpectedly panicked. this is a bug.",
+                "internal compiler error:",
             ])
             .unwrap()
         });

--- a/tests/ui-internal/custom_ice_message.rs
+++ b/tests/ui-internal/custom_ice_message.rs
@@ -10,5 +10,6 @@
 #![allow(clippy::missing_clippy_version_attribute)]
 
 fn it_looks_like_you_are_trying_to_kill_clippy() {}
+//~^ ice: Would you like some help with that?
 
 fn main() {}

--- a/tests/ui-internal/custom_ice_message.stderr
+++ b/tests/ui-internal/custom_ice_message.stderr
@@ -1,9 +1,18 @@
+note: no errors encountered even though delayed bugs were created
 
-thread '<unnamed>' panicked at clippy_lints/src/utils/internal_lints/produce_ice.rs:
-Would you like some help with that?
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+note: those delayed bugs will now be shown as internal compiler errors
 
-error: the compiler unexpectedly panicked. this is a bug.
+error: internal compiler error: Would you like some help with that?
+  --> tests/ui-internal/custom_ice_message.rs:12:1
+   |
+LL | fn it_looks_like_you_are_trying_to_kill_clippy() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: delayed at clippy_lints/src/utils/internal_lints/produce_ice.rs - disabled backtrace
+  --> tests/ui-internal/custom_ice_message.rs:12:1
+   |
+LL | fn it_looks_like_you_are_trying_to_kill_clippy() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: we would appreciate a bug report: https://github.com/rust-lang/rust-clippy/issues/new?template=ice.yml
 
@@ -13,9 +22,5 @@ note: rustc <version> running on <target>
 
 note: compiler flags: -Z ui-testing -Z deduplicate-diagnostics=no
 
-query stack during panic:
-#0 [early_lint_checks] perform lints prior to AST lowering
-#1 [hir_crate] getting the crate HIR
-... and 3 other queries... use `env RUST_BACKTRACE=1` to see the full query stack
 note: Clippy version: foo
 


### PR DESCRIPTION
Last part of https://github.com/rust-lang/rust-clippy/pull/11421.

Now all ui tests require annotations.

The change in `ui_test` is to add `ICE:` errors.

changelog: Make internals ui tests annotations mandatory

r? @flip1995 