### PR TITLE
fix: `redundant_clone` FP on enum cast

### DIFF
--- a/clippy_utils/src/mir/mod.rs
+++ b/clippy_utils/src/mir/mod.rs
@@ -76,7 +76,7 @@ impl<'tcx> Visitor<'tcx> for V<'_> {
                 }
                 if matches!(
                     ctx,
-                    PlaceContext::NonMutatingUse(NonMutatingUseContext::Move)
+                    PlaceContext::NonMutatingUse(NonMutatingUseContext::Move | NonMutatingUseContext::Inspect)
                         | PlaceContext::MutatingUse(MutatingUseContext::Borrow)
                 ) {
                     self.results[i].local_consume_or_mutate_locs.push(loc);

--- a/tests/ui/redundant_clone.fixed
+++ b/tests/ui/redundant_clone.fixed
@@ -259,3 +259,18 @@ fn false_negative_5707() {
     let _z = x.clone(); // pr 7346 can't lint on `x`
     drop(y);
 }
+
+mod issue10074 {
+    #[derive(Debug, Clone)]
+    enum MyEnum {
+        A = 1,
+    }
+
+    fn false_positive_on_as() {
+        let e = MyEnum::A;
+        let v = e.clone() as u16;
+
+        println!("{e:?}");
+        println!("{v}");
+    }
+}

--- a/tests/ui/redundant_clone.rs
+++ b/tests/ui/redundant_clone.rs
@@ -259,3 +259,18 @@ fn false_negative_5707() {
     let _z = x.clone(); // pr 7346 can't lint on `x`
     drop(y);
 }
+
+mod issue10074 {
+    #[derive(Debug, Clone)]
+    enum MyEnum {
+        A = 1,
+    }
+
+    fn false_positive_on_as() {
+        let e = MyEnum::A;
+        let v = e.clone() as u16;
+
+        println!("{e:?}");
+        println!("{v}");
+    }
+}


### PR DESCRIPTION
Closes #10074

changelog: [`redundant_clone`]: fix FP on enum cast
