### PR TITLE
Improve `string_to_string` lint in case it is in a map call

### DIFF
--- a/tests/ui/string_to_string.rs
+++ b/tests/ui/string_to_string.rs
@@ -15,7 +15,6 @@ fn main() {
     });
     //~^^ string_to_string
 
-    // Should not lint.
     let x = Some(String::new());
     let _ = x.unwrap_or_else(|| v.to_string());
     //~^ string_to_string

--- a/tests/ui/string_to_string.rs
+++ b/tests/ui/string_to_string.rs
@@ -1,8 +1,22 @@
 #![warn(clippy::string_to_string)]
-#![allow(clippy::redundant_clone)]
+#![allow(clippy::redundant_clone, clippy::unnecessary_literal_unwrap)]
 
 fn main() {
     let mut message = String::from("Hello");
     let mut v = message.to_string();
+    //~^ string_to_string
+
+    let variable1 = String::new();
+    let v = &variable1;
+    let variable2 = Some(v);
+    let _ = variable2.map(|x| {
+        println!();
+        x.to_string()
+    });
+    //~^^ string_to_string
+
+    // Should not lint.
+    let x = Some(String::new());
+    let _ = x.unwrap_or_else(|| v.to_string());
     //~^ string_to_string
 }

--- a/tests/ui/string_to_string.stderr
+++ b/tests/ui/string_to_string.stderr
@@ -17,7 +17,7 @@ LL |         x.to_string()
    = help: consider using `.clone()`
 
 error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string.rs:20:33
+  --> tests/ui/string_to_string.rs:19:33
    |
 LL |     let _ = x.unwrap_or_else(|| v.to_string());
    |                                 ^^^^^^^^^^^^^

--- a/tests/ui/string_to_string.stderr
+++ b/tests/ui/string_to_string.stderr
@@ -8,5 +8,21 @@ LL |     let mut v = message.to_string();
    = note: `-D clippy::string-to-string` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::string_to_string)]`
 
-error: aborting due to 1 previous error
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string.rs:14:9
+   |
+LL |         x.to_string()
+   |         ^^^^^^^^^^^^^
+   |
+   = help: consider using `.clone()`
+
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string.rs:20:33
+   |
+LL |     let _ = x.unwrap_or_else(|| v.to_string());
+   |                                 ^^^^^^^^^^^^^
+   |
+   = help: consider using `.clone()`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/string_to_string_in_map.fixed
+++ b/tests/ui/string_to_string_in_map.fixed
@@ -5,13 +5,13 @@ fn main() {
     let variable1 = String::new();
     let v = &variable1;
     let variable2 = Some(v);
-    let _ = variable2.map(String::to_string);
+    let _ = variable2.cloned();
     //~^ string_to_string
-    let _ = variable2.map(|x| x.to_string());
+    let _ = variable2.cloned();
     //~^ string_to_string
 
-    let _ = vec![String::new()].iter().map(String::to_string).collect::<Vec<_>>();
+    let _ = vec![String::new()].iter().cloned().collect::<Vec<_>>();
     //~^ string_to_string
-    let _ = vec![String::new()].iter().map(|x| x.to_string()).collect::<Vec<_>>();
+    let _ = vec![String::new()].iter().cloned().collect::<Vec<_>>();
     //~^ string_to_string
 }

--- a/tests/ui/string_to_string_in_map.fixed
+++ b/tests/ui/string_to_string_in_map.fixed
@@ -9,6 +9,9 @@ fn main() {
     //~^ string_to_string
     let _ = variable2.cloned();
     //~^ string_to_string
+    #[rustfmt::skip]
+    let _ = variable2.cloned();
+    //~^ string_to_string
 
     let _ = vec![String::new()].iter().cloned().collect::<Vec<_>>();
     //~^ string_to_string

--- a/tests/ui/string_to_string_in_map.rs
+++ b/tests/ui/string_to_string_in_map.rs
@@ -9,6 +9,9 @@ fn main() {
     //~^ string_to_string
     let _ = variable2.map(|x| x.to_string());
     //~^ string_to_string
+    #[rustfmt::skip]
+    let _ = variable2.map(|x| { x.to_string() });
+    //~^ string_to_string
 
     let _ = vec![String::new()].iter().map(String::to_string).collect::<Vec<_>>();
     //~^ string_to_string

--- a/tests/ui/string_to_string_in_map.rs
+++ b/tests/ui/string_to_string_in_map.rs
@@ -1,0 +1,25 @@
+#![deny(clippy::string_to_string)]
+#![allow(clippy::unnecessary_literal_unwrap, clippy::useless_vec)]
+
+fn main() {
+    let variable1 = String::new();
+    let v = &variable1;
+    let variable2 = Some(v);
+    let _ = variable2.map(String::to_string);
+    //~^ string_to_string
+    let _ = variable2.map(|x| {
+        println!();
+        x.to_string()
+    });
+    //~^^ string_to_string
+    let _ = variable2.map(|x| x.to_string());
+    //~^ string_to_string
+    let x = Some(String::new());
+    let _ = x.unwrap_or_else(|| v.to_string());
+    //~^ string_to_string
+
+    let _ = vec![String::new()].iter().map(String::to_string).collect::<Vec<_>>();
+    //~^ string_to_string
+    let _ = vec![String::new()].iter().map(|x| x.to_string()).collect::<Vec<_>>();
+    //~^ string_to_string
+}

--- a/tests/ui/string_to_string_in_map.stderr
+++ b/tests/ui/string_to_string_in_map.stderr
@@ -1,0 +1,55 @@
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string_in_map.rs:8:13
+   |
+LL |     let _ = variable2.map(String::to_string);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `.cloned()`
+note: the lint level is defined here
+  --> tests/ui/string_to_string_in_map.rs:1:9
+   |
+LL | #![deny(clippy::string_to_string)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string_in_map.rs:12:9
+   |
+LL |         x.to_string()
+   |         ^^^^^^^^^^^^^
+   |
+   = help: consider using `.clone()`
+
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string_in_map.rs:15:13
+   |
+LL |     let _ = variable2.map(|x| x.to_string());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `.cloned()`
+
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string_in_map.rs:18:33
+   |
+LL |     let _ = x.unwrap_or_else(|| v.to_string());
+   |                                 ^^^^^^^^^^^^^
+   |
+   = help: consider using `.clone()`
+
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string_in_map.rs:21:13
+   |
+LL |     let _ = vec![String::new()].iter().map(String::to_string).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `.cloned()`
+
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string_in_map.rs:23:13
+   |
+LL |     let _ = vec![String::new()].iter().map(|x| x.to_string()).collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider using `.cloned()`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/string_to_string_in_map.stderr
+++ b/tests/ui/string_to_string_in_map.stderr
@@ -1,10 +1,9 @@
 error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:8:13
+  --> tests/ui/string_to_string_in_map.rs:8:23
    |
 LL |     let _ = variable2.map(String::to_string);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
    |
-   = help: consider using `.cloned()`
 note: the lint level is defined here
   --> tests/ui/string_to_string_in_map.rs:1:9
    |
@@ -12,44 +11,22 @@ LL | #![deny(clippy::string_to_string)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:12:9
-   |
-LL |         x.to_string()
-   |         ^^^^^^^^^^^^^
-   |
-   = help: consider using `.clone()`
-
-error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:15:13
+  --> tests/ui/string_to_string_in_map.rs:10:23
    |
 LL |     let _ = variable2.map(|x| x.to_string());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using `.cloned()`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
 
 error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:18:33
-   |
-LL |     let _ = x.unwrap_or_else(|| v.to_string());
-   |                                 ^^^^^^^^^^^^^
-   |
-   = help: consider using `.clone()`
-
-error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:21:13
+  --> tests/ui/string_to_string_in_map.rs:13:40
    |
 LL |     let _ = vec![String::new()].iter().map(String::to_string).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using `.cloned()`
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
 
 error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:23:13
+  --> tests/ui/string_to_string_in_map.rs:15:40
    |
 LL |     let _ = vec![String::new()].iter().map(|x| x.to_string()).collect::<Vec<_>>();
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider using `.cloned()`
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/string_to_string_in_map.stderr
+++ b/tests/ui/string_to_string_in_map.stderr
@@ -17,16 +17,22 @@ LL |     let _ = variable2.map(|x| x.to_string());
    |                       ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
 
 error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:13:40
+  --> tests/ui/string_to_string_in_map.rs:13:23
+   |
+LL |     let _ = variable2.map(|x| { x.to_string() });
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
+
+error: `to_string()` called on a `String`
+  --> tests/ui/string_to_string_in_map.rs:16:40
    |
 LL |     let _ = vec![String::new()].iter().map(String::to_string).collect::<Vec<_>>();
    |                                        ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
 
 error: `to_string()` called on a `String`
-  --> tests/ui/string_to_string_in_map.rs:15:40
+  --> tests/ui/string_to_string_in_map.rs:18:40
    |
 LL |     let _ = vec![String::new()].iter().map(|x| x.to_string()).collect::<Vec<_>>();
    |                                        ^^^^^^^^^^^^^^^^^^^^^^ help: try: `cloned()`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-clippy/issues/14175.

There are two "big" cases to handle: `.map(|x| x.to_string())` and `.map(String::to_string)`. If the closure has more than one expression, we should not suggest `.cloned()`.

changelog: Improve `string_to_string` lint in case it is in a map call

r? @samueltardieu 