### PR TITLE
Validate paths in `disallowed_*` configurations

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -7,11 +7,14 @@ lint-commented-code = true
 [[disallowed-methods]]
 path = "rustc_lint::context::LintContext::lint"
 reason = "this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint*` functions instead"
+allow-invalid = true
 
 [[disallowed-methods]]
 path = "rustc_lint::context::LintContext::span_lint"
 reason = "this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint*` functions instead"
+allow-invalid = true
 
 [[disallowed-methods]]
 path = "rustc_middle::ty::context::TyCtxt::node_span_lint"
 reason = "this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint_hir*` functions instead"
+allow-invalid = true

--- a/clippy_config/src/lib.rs
+++ b/clippy_config/src/lib.rs
@@ -13,6 +13,7 @@
     rustc::untranslatable_diagnostic
 )]
 
+extern crate rustc_data_structures;
 extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_middle;

--- a/clippy_lints/src/await_holding_invalid.rs
+++ b/clippy_lints/src/await_holding_invalid.rs
@@ -179,9 +179,14 @@ pub struct AwaitHolding {
 
 impl AwaitHolding {
     pub(crate) fn new(tcx: TyCtxt<'_>, conf: &'static Conf) -> Self {
-        Self {
-            def_ids: create_disallowed_map(tcx, &conf.await_holding_invalid_types),
-        }
+        let (def_ids, _) = create_disallowed_map(
+            tcx,
+            &conf.await_holding_invalid_types,
+            crate::disallowed_types::def_kind_predicate,
+            "type",
+            false,
+        );
+        Self { def_ids }
     }
 }
 

--- a/clippy_lints/src/disallowed_macros.rs
+++ b/clippy_lints/src/disallowed_macros.rs
@@ -3,6 +3,7 @@ use clippy_config::types::{DisallowedPath, create_disallowed_map};
 use clippy_utils::diagnostics::{span_lint_and_then, span_lint_hir_and_then};
 use clippy_utils::macros::macro_backtrace;
 use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefIdMap;
 use rustc_hir::{
     AmbigArg, Expr, ExprKind, ForeignItem, HirId, ImplItem, Item, ItemKind, OwnerId, Pat, Path, Stmt, TraitItem, Ty,
@@ -71,8 +72,15 @@ pub struct DisallowedMacros {
 
 impl DisallowedMacros {
     pub fn new(tcx: TyCtxt<'_>, conf: &'static Conf, earlies: AttrStorage) -> Self {
+        let (disallowed, _) = create_disallowed_map(
+            tcx,
+            &conf.disallowed_macros,
+            |def_kind| matches!(def_kind, DefKind::Macro(_)),
+            "macro",
+            false,
+        );
         Self {
-            disallowed: create_disallowed_map(tcx, &conf.disallowed_macros),
+            disallowed,
             seen: FxHashSet::default(),
             derive_src: None,
             earlies,

--- a/clippy_lints/src/disallowed_methods.rs
+++ b/clippy_lints/src/disallowed_methods.rs
@@ -63,9 +63,19 @@ pub struct DisallowedMethods {
 
 impl DisallowedMethods {
     pub fn new(tcx: TyCtxt<'_>, conf: &'static Conf) -> Self {
-        Self {
-            disallowed: create_disallowed_map(tcx, &conf.disallowed_methods),
-        }
+        let (disallowed, _) = create_disallowed_map(
+            tcx,
+            &conf.disallowed_methods,
+            |def_kind| {
+                matches!(
+                    def_kind,
+                    DefKind::Fn | DefKind::Ctor(_, CtorKind::Fn) | DefKind::AssocFn
+                )
+            },
+            "function",
+            false,
+        );
+        Self { disallowed }
     }
 }
 
@@ -74,12 +84,7 @@ impl_lint_pass!(DisallowedMethods => [DISALLOWED_METHODS]);
 impl<'tcx> LateLintPass<'tcx> for DisallowedMethods {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         let (id, span) = match &expr.kind {
-            ExprKind::Path(path)
-                if let Res::Def(DefKind::Fn | DefKind::Ctor(_, CtorKind::Fn) | DefKind::AssocFn, id) =
-                    cx.qpath_res(path, expr.hir_id) =>
-            {
-                (id, expr.span)
-            },
+            ExprKind::Path(path) if let Res::Def(_, id) = cx.qpath_res(path, expr.hir_id) => (id, expr.span),
             ExprKind::MethodCall(name, ..) if let Some(id) = cx.typeck_results().type_dependent_def_id(expr.hir_id) => {
                 (id, name.ident.span)
             },

--- a/tests/ui-toml/await_holding_invalid_type_with_replacement/await_holding_invalid_type.stderr
+++ b/tests/ui-toml/await_holding_invalid_type_with_replacement/await_holding_invalid_type.stderr
@@ -1,11 +1,8 @@
 error: error reading Clippy's configuration file: replacement not allowed for this configuration
-  --> $DIR/tests/ui-toml/await_holding_invalid_type_with_replacement/clippy.toml:1:31
+  --> $DIR/tests/ui-toml/await_holding_invalid_type_with_replacement/clippy.toml:2:5
    |
-LL |   await-holding-invalid-types = [
-   |  _______________________________^
-LL | |     { path = "std::string::String", replacement = "std::net::Ipv4Addr" },
-LL | | ]
-   | |_^
+LL |     { path = "std::string::String", replacement = "std::net::Ipv4Addr" },
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui-toml/toml_invalid_path/clippy.toml
+++ b/tests/ui-toml/toml_invalid_path/clippy.toml
@@ -1,0 +1,14 @@
+[[disallowed-types]]
+path = "std::result::Result::Err"
+
+[[disallowed-macros]]
+path = "bool"
+
+[[disallowed-methods]]
+path = "std::process::current_exe"
+
+# negative test
+
+[[disallowed-methods]]
+path = "std::current_exe"
+allow-invalid = true

--- a/tests/ui-toml/toml_invalid_path/conf_invalid_path.rs
+++ b/tests/ui-toml/toml_invalid_path/conf_invalid_path.rs
@@ -1,0 +1,5 @@
+//@error-in-other-file: expected a macro, found a primitive type
+//@error-in-other-file: `std::process::current_exe` does not refer to an existing function
+//@error-in-other-file: expected a type, found a tuple variant
+
+fn main() {}

--- a/tests/ui-toml/toml_invalid_path/conf_invalid_path.stderr
+++ b/tests/ui-toml/toml_invalid_path/conf_invalid_path.stderr
@@ -1,0 +1,23 @@
+warning: expected a macro, found a primitive type
+  --> $DIR/tests/ui-toml/toml_invalid_path/clippy.toml:4:1
+   |
+LL | / [[disallowed-macros]]
+LL | | path = "bool"
+   | |_____________^
+
+warning: `std::process::current_exe` does not refer to an existing function
+  --> $DIR/tests/ui-toml/toml_invalid_path/clippy.toml:7:1
+   |
+LL | / [[disallowed-methods]]
+LL | | path = "std::process::current_exe"
+   | |__________________________________^
+
+warning: expected a type, found a tuple variant
+  --> $DIR/tests/ui-toml/toml_invalid_path/clippy.toml:1:1
+   |
+LL | / [[disallowed-types]]
+LL | | path = "std::result::Result::Err"
+   | |_________________________________^
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
This PR resolves #11432 by checking that paths resolve in `disallowed_*` configurations.

It also does some lightweight validation of definition kinds. For example, only paths that resolve to `DefKind::Macro` definitions are allowed in `disallowed_macro` configurations.

~The PR is currently two commits. The first is #14376 (cc: @Jarcho), which I submitted just a few days ago. The second commit is everything else.~

Side note: For me, the most difficult part of this PR was getting the spans of the individual `DisallowedPath` configurations. There is some discussion at https://github.com/toml-rs/toml/discussions/840, if interested.

changelog:  validate paths in `disallowed_*` configurations