### PR TITLE
fix: `manual_find` suggests wrongly when early return

### DIFF
--- a/clippy_lints/src/loops/manual_find.rs
+++ b/clippy_lints/src/loops/manual_find.rs
@@ -3,6 +3,7 @@ use super::utils::make_iterator_snippet;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::implements_trait;
+use clippy_utils::usage::contains_return_break_continue_macro;
 use clippy_utils::{higher, is_res_lang_ctor, path_res, peel_blocks_with_stmt};
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
@@ -35,6 +36,7 @@ pub(super) fn check<'tcx>(
         && let ExprKind::Call(ctor, [inner_ret]) = ret_value.kind
         && is_res_lang_ctor(cx, path_res(cx, ctor), LangItem::OptionSome)
         && path_res(cx, inner_ret) == Res::Local(binding_id)
+        && !contains_return_break_continue_macro(cond)
         && let Some((last_stmt, last_ret)) = last_stmt_and_ret(cx, expr)
     {
         let mut applicability = Applicability::MachineApplicable;

--- a/tests/ui/manual_find.rs
+++ b/tests/ui/manual_find.rs
@@ -23,4 +23,32 @@ fn tuple(arr: Vec<(String, i32)>) -> Option<String> {
     None
 }
 
+mod issue9521 {
+    fn condition(x: u32, y: u32) -> Result<bool, ()> {
+        todo!()
+    }
+
+    fn find_with_early_return(v: Vec<u32>) -> Option<u32> {
+        for x in v {
+            if condition(x, 10).ok()? {
+                return Some(x);
+            }
+        }
+        None
+    }
+
+    fn find_with_early_break(v: Vec<u32>) -> Option<u32> {
+        for x in v {
+            if if x < 3 {
+                break;
+            } else {
+                x < 10
+            } {
+                return Some(x);
+            }
+        }
+        None
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Closes #9521 

changelog: [`manual_find`]: fix wrong suggestions when early return
