### PR TITLE
Make `borrow_as_ptr` flag implicit casts as well

### DIFF
--- a/clippy_lints/src/casts/borrow_as_ptr.rs
+++ b/clippy_lints/src/casts/borrow_as_ptr.rs
@@ -29,10 +29,6 @@ pub(super) fn check<'tcx>(
         }
 
         let (suggestion, span) = if msrv.meets(cx, msrvs::RAW_REF_OP) {
-            let operator_kind = match mutability {
-                Mutability::Not => "const",
-                Mutability::Mut => "mut",
-            };
             // Make sure that the span to be replaced doesn't include parentheses, that could break the
             // suggestion.
             let span = if has_enclosing_paren(snippet_with_applicability(cx, expr.span, "", &mut app)) {
@@ -42,7 +38,7 @@ pub(super) fn check<'tcx>(
             } else {
                 expr.span
             };
-            (format!("&raw {operator_kind} {snip}"), span)
+            (format!("&raw {} {snip}", mutability.ptr_str()), span)
         } else {
             let Some(std_or_core) = std_or_core(cx) else {
                 return false;

--- a/clippy_lints/src/casts/mod.rs
+++ b/clippy_lints/src/casts/mod.rs
@@ -846,6 +846,9 @@ impl<'tcx> LateLintPass<'tcx> for Casts {
             }
         }
 
+        if self.msrv.meets(cx, msrvs::RAW_REF_OP) {
+            borrow_as_ptr::check_implicit_cast(cx, expr);
+        }
         cast_ptr_alignment::check(cx, expr);
         char_lit_as_u8::check(cx, expr);
         ptr_as_ptr::check(cx, expr, self.msrv);

--- a/clippy_lints/src/non_copy_const.rs
+++ b/clippy_lints/src/non_copy_const.rs
@@ -449,7 +449,7 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst<'tcx> {
 
                             dereferenced_expr = parent_expr;
                         },
-                        ExprKind::Index(e, _, _) if ptr::eq(&**e, cur_expr) => {
+                        ExprKind::Index(e, _, _) if ptr::eq(&raw const **e, cur_expr) => {
                             // `e[i]` => desugared to `*Index::index(&e, i)`,
                             // meaning `e` must be referenced.
                             // no need to go further up since a method call is involved now.

--- a/tests/ui/borrow_as_ptr.fixed
+++ b/tests/ui/borrow_as_ptr.fixed
@@ -29,3 +29,21 @@ fn issue_13882() {
     let _raw = (&raw mut x[1]).wrapping_offset(-1);
     //~^ borrow_as_ptr
 }
+
+fn implicit_cast() {
+    let val = 1;
+    let p: *const i32 = &raw const val;
+    //~^ borrow_as_ptr
+
+    let mut val = 1;
+    let p: *mut i32 = &raw mut val;
+    //~^ borrow_as_ptr
+
+    let mut val = 1;
+    // Only lint the leftmost argument, the rightmost is ref to a temporary
+    core::ptr::eq(&raw const val, &1);
+    //~^ borrow_as_ptr
+
+    // Do not lint references to temporaries
+    core::ptr::eq(&0i32, &1i32);
+}

--- a/tests/ui/borrow_as_ptr.rs
+++ b/tests/ui/borrow_as_ptr.rs
@@ -29,3 +29,21 @@ fn issue_13882() {
     let _raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
     //~^ borrow_as_ptr
 }
+
+fn implicit_cast() {
+    let val = 1;
+    let p: *const i32 = &val;
+    //~^ borrow_as_ptr
+
+    let mut val = 1;
+    let p: *mut i32 = &mut val;
+    //~^ borrow_as_ptr
+
+    let mut val = 1;
+    // Only lint the leftmost argument, the rightmost is ref to a temporary
+    core::ptr::eq(&val, &1);
+    //~^ borrow_as_ptr
+
+    // Do not lint references to temporaries
+    core::ptr::eq(&0i32, &1i32);
+}

--- a/tests/ui/borrow_as_ptr.stderr
+++ b/tests/ui/borrow_as_ptr.stderr
@@ -25,5 +25,38 @@ error: borrow as raw pointer
 LL |     let _raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
    |                 ^^^^^^^^^^^^^^^^^^^^^ help: try: `&raw mut x[1]`
 
-error: aborting due to 4 previous errors
+error: implicit borrow as raw pointer
+  --> tests/ui/borrow_as_ptr.rs:35:25
+   |
+LL |     let p: *const i32 = &val;
+   |                         ^^^^
+   |
+help: use a raw pointer instead
+   |
+LL |     let p: *const i32 = &raw const val;
+   |                          +++++++++
+
+error: implicit borrow as raw pointer
+  --> tests/ui/borrow_as_ptr.rs:39:23
+   |
+LL |     let p: *mut i32 = &mut val;
+   |                       ^^^^^^^^
+   |
+help: use a raw pointer instead
+   |
+LL |     let p: *mut i32 = &raw mut val;
+   |                        +++
+
+error: implicit borrow as raw pointer
+  --> tests/ui/borrow_as_ptr.rs:44:19
+   |
+LL |     core::ptr::eq(&val, &1);
+   |                   ^^^^
+   |
+help: use a raw pointer instead
+   |
+LL |     core::ptr::eq(&raw const val, &1);
+   |                    +++++++++
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
While I like replacing `&x` by `&raw const x` and `&mut x` by `&raw mut x`, I'm less sure I like the suggested reborrows such as `&raw const *p`. There was one in Clippy sources, see the PR diff.

@RalfJung, any opinion on this?

Fix #14406

changelog: [`borrow_as_ptr`]: lint implicit casts as well