### PR TITLE
fix: bad indent in doc comments

### DIFF
--- a/clippy_lints/src/ignored_unit_patterns.rs
+++ b/clippy_lints/src/ignored_unit_patterns.rs
@@ -17,15 +17,15 @@ declare_clippy_lint! {
     /// ### Example
     /// ```no_run
     /// match std::fs::create_dir("tmp-work-dir") {
-    ///    Ok(_) => println!("Working directory created"),
-    ///    Err(s) => eprintln!("Could not create directory: {s}"),
+    ///     Ok(_) => println!("Working directory created"),
+    ///     Err(s) => eprintln!("Could not create directory: {s}"),
     /// }
     /// ```
     /// Use instead:
     /// ```no_run
     /// match std::fs::create_dir("tmp-work-dir") {
-    ///    Ok(()) => println!("Working directory created"),
-    ///    Err(s) => eprintln!("Could not create directory: {s}"),
+    ///     Ok(()) => println!("Working directory created"),
+    ///     Err(s) => eprintln!("Could not create directory: {s}"),
     /// }
     /// ```
     #[clippy::version = "1.73.0"]

--- a/clippy_lints/src/iter_not_returning_iterator.rs
+++ b/clippy_lints/src/iter_not_returning_iterator.rs
@@ -28,9 +28,9 @@ declare_clippy_lint! {
     /// use std::str::Chars;
     /// struct Data {}
     /// impl Data {
-    ///    fn iter(&self) -> Chars<'static> {
-    ///        todo!()
-    ///    }
+    ///     fn iter(&self) -> Chars<'static> {
+    ///         todo!()
+    ///     }
     /// }
     /// ```
     #[clippy::version = "1.57.0"]

--- a/clippy_lints/src/loops/mod.rs
+++ b/clippy_lints/src/loops/mod.rs
@@ -469,7 +469,7 @@ declare_clippy_lint! {
     /// let item2 = 3;
     /// let mut vec: Vec<u8> = Vec::new();
     /// for _ in 0..20 {
-    ///    vec.push(item1);
+    ///     vec.push(item1);
     /// }
     /// for _ in 0..30 {
     ///     vec.push(item2);

--- a/clippy_lints/src/manual_ignore_case_cmp.rs
+++ b/clippy_lints/src/manual_ignore_case_cmp.rs
@@ -29,7 +29,7 @@ declare_clippy_lint! {
     /// Use instead:
     /// ```no_run
     /// fn compare(a: &str, b: &str) -> bool {
-    ///    a.eq_ignore_ascii_case(b) || a.eq_ignore_ascii_case("abc")
+    ///     a.eq_ignore_ascii_case(b) || a.eq_ignore_ascii_case("abc")
     /// }
     /// ```
     #[clippy::version = "1.84.0"]

--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -4447,13 +4447,13 @@ declare_clippy_lint! {
     /// ### Example
     /// ```no_run
     /// fn foo(values: &[u8]) -> bool {
-    ///    values.iter().any(|&v| v == 10)
+    ///     values.iter().any(|&v| v == 10)
     /// }
     /// ```
     /// Use instead:
     /// ```no_run
     /// fn foo(values: &[u8]) -> bool {
-    ///    values.contains(&10)
+    ///     values.contains(&10)
     /// }
     /// ```
     #[clippy::version = "1.86.0"]

--- a/clippy_lints/src/missing_inline.rs
+++ b/clippy_lints/src/missing_inline.rs
@@ -37,7 +37,7 @@ declare_clippy_lint! {
     ///
     /// struct Baz;
     /// impl Baz {
-    ///    fn private() {} // ok
+    ///     fn private() {} // ok
     /// }
     ///
     /// impl Bar for Baz {
@@ -46,13 +46,13 @@ declare_clippy_lint! {
     ///
     /// pub struct PubBaz;
     /// impl PubBaz {
-    ///    fn private() {} // ok
-    ///    pub fn not_private() {} // missing #[inline]
+    ///     fn private() {} // ok
+    ///     pub fn not_private() {} // missing #[inline]
     /// }
     ///
     /// impl Bar for PubBaz {
-    ///    fn bar() {} // missing #[inline]
-    ///    fn def_bar() {} // missing #[inline]
+    ///     fn bar() {} // missing #[inline]
+    ///     fn def_bar() {} // missing #[inline]
     /// }
     /// ```
     ///

--- a/clippy_lints/src/needless_question_mark.rs
+++ b/clippy_lints/src/needless_question_mark.rs
@@ -40,7 +40,7 @@ declare_clippy_lint! {
     /// }
     ///
     /// fn f(to: TO) -> Option<usize> {
-    ///    to.magic
+    ///     to.magic
     /// }
     ///
     /// struct TR {

--- a/clippy_lints/src/partialeq_ne_impl.rs
+++ b/clippy_lints/src/partialeq_ne_impl.rs
@@ -19,8 +19,8 @@ declare_clippy_lint! {
     /// struct Foo;
     ///
     /// impl PartialEq for Foo {
-    ///    fn eq(&self, other: &Foo) -> bool { true }
-    ///    fn ne(&self, other: &Foo) -> bool { !(self == other) }
+    ///     fn eq(&self, other: &Foo) -> bool { true }
+    ///     fn ne(&self, other: &Foo) -> bool { !(self == other) }
     /// }
     /// ```
     #[clippy::version = "pre 1.29.0"]

--- a/clippy_lints/src/question_mark.rs
+++ b/clippy_lints/src/question_mark.rs
@@ -230,7 +230,7 @@ fn expr_return_none_or_err(
 ///
 /// ```ignore
 /// if option.is_none() {
-///    return None;
+///     return None;
 /// }
 /// ```
 ///

--- a/clippy_lints/src/redundant_async_block.rs
+++ b/clippy_lints/src/redundant_async_block.rs
@@ -23,7 +23,7 @@ declare_clippy_lint! {
     /// ### Example
     /// ```no_run
     /// let f = async {
-    ///    1 + 2
+    ///     1 + 2
     /// };
     /// let fut = async {
     ///     f.await
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// Use instead:
     /// ```no_run
     /// let f = async {
-    ///    1 + 2
+    ///     1 + 2
     /// };
     /// let fut = f;
     /// ```

--- a/clippy_lints/src/redundant_locals.rs
+++ b/clippy_lints/src/redundant_locals.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// let a = a;
     ///
     /// fn foo(b: i32) {
-    ///    let b = b;
+    ///     let b = b;
     /// }
     /// ```
     /// Use instead:

--- a/clippy_lints/src/unnecessary_semicolon.rs
+++ b/clippy_lints/src/unnecessary_semicolon.rs
@@ -26,7 +26,7 @@ declare_clippy_lint! {
     /// ```no_run
     /// # let a: u32 = 42;
     /// if a > 10 {
-    ///    println!("a is greater than 10");
+    ///     println!("a is greater than 10");
     /// }
     /// ```
     #[clippy::version = "1.86.0"]


### PR DESCRIPTION
TLDR
```diff
- ///    01234
+ ///     01234
     12345
```

Sometimes, in doc comments, there are 3 spaces + 1 instead of 4 spaces + 1.
To make it coherent with the rest of the clippy codebase, I `fd -t f -X sed -E -i 's,///\s{4}(\S),///     \1,g'` and manually verified and fixed the relevant part of code that had bad indentation.

### Example

```rs
/// fn a() {
///    01234
/// }
```
Becomes
```rs
/// fn a() {
///     01234
/// }
```


changelog: none
