### PR TITLE
Lint precedence possible ambiguity between closure and method call

### DIFF
--- a/tests/ui/precedence.fixed
+++ b/tests/ui/precedence.fixed
@@ -1,7 +1,12 @@
 #![warn(clippy::precedence)]
-#![allow(unused_must_use, clippy::no_effect, clippy::unnecessary_operation)]
-#![allow(clippy::identity_op)]
-#![allow(clippy::eq_op)]
+#![allow(
+    unused_must_use,
+    clippy::no_effect,
+    clippy::unnecessary_operation,
+    clippy::clone_on_copy,
+    clippy::identity_op,
+    clippy::eq_op
+)]
 
 macro_rules! trip {
     ($a:expr) => {
@@ -34,4 +39,25 @@ fn main() {
 
     let b = 3;
     trip!(b * 8);
+}
+
+struct W(u8);
+impl Clone for W {
+    fn clone(&self) -> Self {
+        W(1)
+    }
+}
+
+fn closure_method_call() {
+    // Do not lint when the method call is applied to the block, both inside the closure
+    let f = |x: W| { x }.clone();
+    assert!(matches!(f(W(0)), W(1)));
+
+    let f = (|x: W| -> _ { x }).clone();
+    assert!(matches!(f(W(0)), W(0)));
+    //~^^ precedence
+
+    let f = (move |x: W| -> _ { x }).clone();
+    assert!(matches!(f(W(0)), W(0)));
+    //~^^ precedence
 }

--- a/tests/ui/precedence.rs
+++ b/tests/ui/precedence.rs
@@ -1,7 +1,12 @@
 #![warn(clippy::precedence)]
-#![allow(unused_must_use, clippy::no_effect, clippy::unnecessary_operation)]
-#![allow(clippy::identity_op)]
-#![allow(clippy::eq_op)]
+#![allow(
+    unused_must_use,
+    clippy::no_effect,
+    clippy::unnecessary_operation,
+    clippy::clone_on_copy,
+    clippy::identity_op,
+    clippy::eq_op
+)]
 
 macro_rules! trip {
     ($a:expr) => {
@@ -34,4 +39,25 @@ fn main() {
 
     let b = 3;
     trip!(b * 8);
+}
+
+struct W(u8);
+impl Clone for W {
+    fn clone(&self) -> Self {
+        W(1)
+    }
+}
+
+fn closure_method_call() {
+    // Do not lint when the method call is applied to the block, both inside the closure
+    let f = |x: W| { x }.clone();
+    assert!(matches!(f(W(0)), W(1)));
+
+    let f = |x: W| -> _ { x }.clone();
+    assert!(matches!(f(W(0)), W(0)));
+    //~^^ precedence
+
+    let f = move |x: W| -> _ { x }.clone();
+    assert!(matches!(f(W(0)), W(0)));
+    //~^^ precedence
 }

--- a/tests/ui/precedence.stderr
+++ b/tests/ui/precedence.stderr
@@ -1,5 +1,5 @@
 error: operator precedence might not be obvious
-  --> tests/ui/precedence.rs:16:5
+  --> tests/ui/precedence.rs:21:5
    |
 LL |     1 << 2 + 3;
    |     ^^^^^^^^^^ help: consider parenthesizing your expression: `1 << (2 + 3)`
@@ -8,40 +8,62 @@ LL |     1 << 2 + 3;
    = help: to override `-D warnings` add `#[allow(clippy::precedence)]`
 
 error: operator precedence might not be obvious
-  --> tests/ui/precedence.rs:18:5
+  --> tests/ui/precedence.rs:23:5
    |
 LL |     1 + 2 << 3;
    |     ^^^^^^^^^^ help: consider parenthesizing your expression: `(1 + 2) << 3`
 
 error: operator precedence might not be obvious
-  --> tests/ui/precedence.rs:20:5
+  --> tests/ui/precedence.rs:25:5
    |
 LL |     4 >> 1 + 1;
    |     ^^^^^^^^^^ help: consider parenthesizing your expression: `4 >> (1 + 1)`
 
 error: operator precedence might not be obvious
-  --> tests/ui/precedence.rs:22:5
+  --> tests/ui/precedence.rs:27:5
    |
 LL |     1 + 3 >> 2;
    |     ^^^^^^^^^^ help: consider parenthesizing your expression: `(1 + 3) >> 2`
 
 error: operator precedence might not be obvious
-  --> tests/ui/precedence.rs:24:5
+  --> tests/ui/precedence.rs:29:5
    |
 LL |     1 ^ 1 - 1;
    |     ^^^^^^^^^ help: consider parenthesizing your expression: `1 ^ (1 - 1)`
 
 error: operator precedence might not be obvious
-  --> tests/ui/precedence.rs:26:5
+  --> tests/ui/precedence.rs:31:5
    |
 LL |     3 | 2 - 1;
    |     ^^^^^^^^^ help: consider parenthesizing your expression: `3 | (2 - 1)`
 
 error: operator precedence might not be obvious
-  --> tests/ui/precedence.rs:28:5
+  --> tests/ui/precedence.rs:33:5
    |
 LL |     3 & 5 - 2;
    |     ^^^^^^^^^ help: consider parenthesizing your expression: `3 & (5 - 2)`
 
-error: aborting due to 7 previous errors
+error: precedence might not be obvious
+  --> tests/ui/precedence.rs:56:13
+   |
+LL |     let f = |x: W| -> _ { x }.clone();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider parenthesizing the closure
+   |
+LL |     let f = (|x: W| -> _ { x }).clone();
+   |             +                 +
+
+error: precedence might not be obvious
+  --> tests/ui/precedence.rs:60:13
+   |
+LL |     let f = move |x: W| -> _ { x }.clone();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider parenthesizing the closure
+   |
+LL |     let f = (move |x: W| -> _ { x }).clone();
+   |             +                      +
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
`|x: String| {x}.clone()` applies `clone()` to `{x}`, while `|x: String| -> String {x}.clone()` applies `.clone()` to the closure because a closure with an explicit return type requires a block as its body.

This extends the `precedence` lint to suggest using parentheses around the closure definition in the second case, when `.clone()` would apply to the whole closure.

changelog: [`precedence`]: warn about ambiguity when a closure is used as a method call receiver

[Related discussion](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Closure.20syntax.20ambiguity/with/504671477)