### PR TITLE
fix: `nonminimal_bool` wrongly showed the macro definition

### DIFF
--- a/tests/ui/nonminimal_bool.rs
+++ b/tests/ui/nonminimal_bool.rs
@@ -216,3 +216,23 @@ fn issue14184(a: f32, b: bool) {
         println!("Hi");
     }
 }
+
+mod issue14404 {
+    enum TyKind {
+        Ref(i32, i32, i32),
+        Other,
+    }
+
+    struct Expr;
+
+    fn is_mutable(expr: &Expr) -> bool {
+        todo!()
+    }
+
+    fn should_not_give_macro(ty: TyKind, expr: Expr) {
+        if !(matches!(ty, TyKind::Ref(_, _, _)) && !is_mutable(&expr)) {
+            //~^ nonminimal_bool
+            todo!()
+        }
+    }
+}

--- a/tests/ui/nonminimal_bool.stderr
+++ b/tests/ui/nonminimal_bool.stderr
@@ -227,7 +227,13 @@ error: this boolean expression can be simplified
   --> tests/ui/nonminimal_bool.rs:214:8
    |
 LL |     if !(a < 2.0 && !b) {
-   |        ^^^^^^^^^^^^^^^^ help: try: `!(a < 2.0) || b`
+   |        ^^^^^^^^^^^^^^^^ help: try: `a >= 2.0 || b`
 
-error: aborting due to 30 previous errors
+error: this boolean expression can be simplified
+  --> tests/ui/nonminimal_bool.rs:233:12
+   |
+LL |         if !(matches!(ty, TyKind::Ref(_, _, _)) && !is_mutable(&expr)) {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `!matches!(ty, TyKind::Ref(_, _, _)) || is_mutable(&expr)`
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Closes #14404 

changelog: [`nonminimal_bool`]: fix macro definition wrongly showed in suggestions.
