### PR TITLE
Propose to exchange ranges only when it is safe to do so

### DIFF
--- a/clippy_lints/src/cognitive_complexity.rs
+++ b/clippy_lints/src/cognitive_complexity.rs
@@ -103,7 +103,6 @@ impl CognitiveComplexity {
                 FnKind::ItemFn(ident, _, _) | FnKind::Method(ident, _) => ident.span,
                 FnKind::Closure => {
                     let header_span = body_span.with_hi(decl.output.span().lo());
-                    #[expect(clippy::range_plus_one)]
                     if let Some(range) = header_span.map_range(cx, |_, src, range| {
                         let mut idxs = src.get(range.clone())?.match_indices('|');
                         Some(range.start + idxs.next()?.0..range.start + idxs.next()?.0 + 1)

--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -1232,7 +1232,6 @@ fn check_doc<'a, Events: Iterator<Item = (pulldown_cmark::Event<'a>, Range<usize
     headers
 }
 
-#[expect(clippy::range_plus_one)] // inclusive ranges aren't the same type
 fn looks_like_refdef(doc: &str, range: Range<usize>) -> Option<Range<usize>> {
     if range.end < range.start {
         return None;

--- a/clippy_lints/src/methods/manual_inspect.rs
+++ b/clippy_lints/src/methods/manual_inspect.rs
@@ -100,7 +100,6 @@ pub(crate) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, name:
             match x {
                 UseKind::Return(s) => edits.push((s.with_leading_whitespace(cx).with_ctxt(s.ctxt()), String::new())),
                 UseKind::Borrowed(s) => {
-                    #[expect(clippy::range_plus_one)]
                     let range = s.map_range(cx, |_, src, range| {
                         let src = src.get(range.clone())?;
                         let trimmed = src.trim_start_matches([' ', '\t', '\n', '\r', '(']);

--- a/tests/ui/range_plus_minus_one.fixed
+++ b/tests/ui/range_plus_minus_one.fixed
@@ -1,5 +1,10 @@
+#![warn(clippy::range_minus_one)]
+#![warn(clippy::range_plus_one)]
 #![allow(unused_parens)]
 #![allow(clippy::iter_with_drain)]
+
+use std::ops::{Index, IndexMut, Range, RangeBounds, RangeInclusive};
+
 fn f() -> usize {
     42
 }
@@ -20,8 +25,6 @@ macro_rules! macro_minus_one {
     };
 }
 
-#[warn(clippy::range_plus_one)]
-#[warn(clippy::range_minus_one)]
 fn main() {
     for _ in 0..2 {}
     for _ in 0..=2 {}
@@ -45,15 +48,13 @@ fn main() {
     //~^ range_plus_one
     for _ in 0..=(1 + f()) {}
 
+    // Those are not linted, as in the general case we cannot be sure that the exact type won't be
+    // important.
     let _ = ..11 - 1;
-    let _ = ..11;
-    //~^ range_minus_one
-    let _ = ..11;
-    //~^ range_minus_one
-    let _ = (1..=11);
-    //~^ range_plus_one
-    let _ = ((f() + 1)..=f());
-    //~^ range_plus_one
+    let _ = ..=11 - 1;
+    let _ = ..=(11 - 1);
+    let _ = (1..11 + 1);
+    let _ = (f() + 1)..(f() + 1);
 
     const ONE: usize = 1;
     // integer consts are linted, too
@@ -65,4 +66,97 @@ fn main() {
 
     macro_plus_one!(5);
     macro_minus_one!(5);
+
+    // As an instance of `Iterator`
+    (1..=10).for_each(|_| {});
+    //~^ range_plus_one
+
+    // As an instance of `IntoIterator`
+    #[allow(clippy::useless_conversion)]
+    (1..=10).into_iter().for_each(|_| {});
+    //~^ range_plus_one
+
+    // As an instance of `RangeBounds`
+    {
+        let _ = (1..=10).start_bound();
+        //~^ range_plus_one
+    }
+
+    // As a `SliceIndex`
+    let a = [10, 20, 30];
+    let _ = &a[1..=1];
+    //~^ range_plus_one
+
+    // As method call argument
+    vec.drain(2..=3);
+    //~^ range_plus_one
+
+    // As function call argument
+    take_arg(10..=20);
+    //~^ range_plus_one
+
+    // As function call argument inside a block
+    take_arg({ 10..=20 });
+    //~^ range_plus_one
+
+    // Do not lint in case types are unified
+    take_arg(if true { 10..20 } else { 10..20 + 1 });
+
+    // Do not lint, as the same type is used for both parameters
+    take_args(10..20 + 1, 10..21);
+
+    // Do not lint, as the range type is also used indirectly in second parameter
+    take_arg_and_struct(10..20 + 1, S { t: 1..2 });
+
+    // As target of `IndexMut`
+    let mut a = [10, 20, 30];
+    a[0..=2][0] = 1;
+    //~^ range_plus_one
+}
+
+fn take_arg<T: Iterator<Item = u32>>(_: T) {}
+fn take_args<T: Iterator<Item = u32>>(_: T, _: T) {}
+
+struct S<T> {
+    t: T,
+}
+fn take_arg_and_struct<T: Iterator<Item = u32>>(_: T, _: S<T>) {}
+
+fn no_index_by_range_inclusive(a: usize) {
+    struct S;
+
+    impl Index<Range<usize>> for S {
+        type Output = [u32];
+        fn index(&self, _: Range<usize>) -> &Self::Output {
+            &[]
+        }
+    }
+
+    _ = &S[0..a + 1];
+}
+
+fn no_index_mut_with_switched_range(a: usize) {
+    struct S(u32);
+
+    impl Index<Range<usize>> for S {
+        type Output = u32;
+        fn index(&self, _: Range<usize>) -> &Self::Output {
+            &self.0
+        }
+    }
+
+    impl IndexMut<Range<usize>> for S {
+        fn index_mut(&mut self, _: Range<usize>) -> &mut Self::Output {
+            &mut self.0
+        }
+    }
+
+    impl Index<RangeInclusive<usize>> for S {
+        type Output = u32;
+        fn index(&self, _: RangeInclusive<usize>) -> &Self::Output {
+            &self.0
+        }
+    }
+
+    S(2)[0..a + 1] = 3;
 }

--- a/tests/ui/range_plus_minus_one.fixed
+++ b/tests/ui/range_plus_minus_one.fixed
@@ -1,5 +1,4 @@
-#![warn(clippy::range_minus_one)]
-#![warn(clippy::range_plus_one)]
+#![warn(clippy::range_minus_one, clippy::range_plus_one)]
 #![allow(unused_parens)]
 #![allow(clippy::iter_with_drain)]
 
@@ -159,4 +158,25 @@ fn no_index_mut_with_switched_range(a: usize) {
     }
 
     S(2)[0..a + 1] = 3;
+}
+
+fn issue9908() {
+    // Simplified test case
+    let _ = || 0..=1;
+
+    // Original test case
+    let full_length = 1024;
+    let range = {
+        // do some stuff, omit here
+        None
+    };
+
+    let range = range.map(|(s, t)| s..=t).unwrap_or(0..=(full_length - 1));
+
+    assert_eq!(range, 0..=1023);
+}
+
+fn issue9908_2(n: usize) -> usize {
+    (1..n).sum()
+    //~^ range_minus_one
 }

--- a/tests/ui/range_plus_minus_one.rs
+++ b/tests/ui/range_plus_minus_one.rs
@@ -1,5 +1,4 @@
-#![warn(clippy::range_minus_one)]
-#![warn(clippy::range_plus_one)]
+#![warn(clippy::range_minus_one, clippy::range_plus_one)]
 #![allow(unused_parens)]
 #![allow(clippy::iter_with_drain)]
 
@@ -159,4 +158,25 @@ fn no_index_mut_with_switched_range(a: usize) {
     }
 
     S(2)[0..a + 1] = 3;
+}
+
+fn issue9908() {
+    // Simplified test case
+    let _ = || 0..=1;
+
+    // Original test case
+    let full_length = 1024;
+    let range = {
+        // do some stuff, omit here
+        None
+    };
+
+    let range = range.map(|(s, t)| s..=t).unwrap_or(0..=(full_length - 1));
+
+    assert_eq!(range, 0..=1023);
+}
+
+fn issue9908_2(n: usize) -> usize {
+    (1..=n - 1).sum()
+    //~^ range_minus_one
 }

--- a/tests/ui/range_plus_minus_one.rs
+++ b/tests/ui/range_plus_minus_one.rs
@@ -1,5 +1,10 @@
+#![warn(clippy::range_minus_one)]
+#![warn(clippy::range_plus_one)]
 #![allow(unused_parens)]
 #![allow(clippy::iter_with_drain)]
+
+use std::ops::{Index, IndexMut, Range, RangeBounds, RangeInclusive};
+
 fn f() -> usize {
     42
 }
@@ -20,8 +25,6 @@ macro_rules! macro_minus_one {
     };
 }
 
-#[warn(clippy::range_plus_one)]
-#[warn(clippy::range_minus_one)]
 fn main() {
     for _ in 0..2 {}
     for _ in 0..=2 {}
@@ -45,15 +48,13 @@ fn main() {
     //~^ range_plus_one
     for _ in 0..=(1 + f()) {}
 
+    // Those are not linted, as in the general case we cannot be sure that the exact type won't be
+    // important.
     let _ = ..11 - 1;
     let _ = ..=11 - 1;
-    //~^ range_minus_one
     let _ = ..=(11 - 1);
-    //~^ range_minus_one
     let _ = (1..11 + 1);
-    //~^ range_plus_one
     let _ = (f() + 1)..(f() + 1);
-    //~^ range_plus_one
 
     const ONE: usize = 1;
     // integer consts are linted, too
@@ -65,4 +66,97 @@ fn main() {
 
     macro_plus_one!(5);
     macro_minus_one!(5);
+
+    // As an instance of `Iterator`
+    (1..10 + 1).for_each(|_| {});
+    //~^ range_plus_one
+
+    // As an instance of `IntoIterator`
+    #[allow(clippy::useless_conversion)]
+    (1..10 + 1).into_iter().for_each(|_| {});
+    //~^ range_plus_one
+
+    // As an instance of `RangeBounds`
+    {
+        let _ = (1..10 + 1).start_bound();
+        //~^ range_plus_one
+    }
+
+    // As a `SliceIndex`
+    let a = [10, 20, 30];
+    let _ = &a[1..1 + 1];
+    //~^ range_plus_one
+
+    // As method call argument
+    vec.drain(2..3 + 1);
+    //~^ range_plus_one
+
+    // As function call argument
+    take_arg(10..20 + 1);
+    //~^ range_plus_one
+
+    // As function call argument inside a block
+    take_arg({ 10..20 + 1 });
+    //~^ range_plus_one
+
+    // Do not lint in case types are unified
+    take_arg(if true { 10..20 } else { 10..20 + 1 });
+
+    // Do not lint, as the same type is used for both parameters
+    take_args(10..20 + 1, 10..21);
+
+    // Do not lint, as the range type is also used indirectly in second parameter
+    take_arg_and_struct(10..20 + 1, S { t: 1..2 });
+
+    // As target of `IndexMut`
+    let mut a = [10, 20, 30];
+    a[0..2 + 1][0] = 1;
+    //~^ range_plus_one
+}
+
+fn take_arg<T: Iterator<Item = u32>>(_: T) {}
+fn take_args<T: Iterator<Item = u32>>(_: T, _: T) {}
+
+struct S<T> {
+    t: T,
+}
+fn take_arg_and_struct<T: Iterator<Item = u32>>(_: T, _: S<T>) {}
+
+fn no_index_by_range_inclusive(a: usize) {
+    struct S;
+
+    impl Index<Range<usize>> for S {
+        type Output = [u32];
+        fn index(&self, _: Range<usize>) -> &Self::Output {
+            &[]
+        }
+    }
+
+    _ = &S[0..a + 1];
+}
+
+fn no_index_mut_with_switched_range(a: usize) {
+    struct S(u32);
+
+    impl Index<Range<usize>> for S {
+        type Output = u32;
+        fn index(&self, _: Range<usize>) -> &Self::Output {
+            &self.0
+        }
+    }
+
+    impl IndexMut<Range<usize>> for S {
+        fn index_mut(&mut self, _: Range<usize>) -> &mut Self::Output {
+            &mut self.0
+        }
+    }
+
+    impl Index<RangeInclusive<usize>> for S {
+        type Output = u32;
+        fn index(&self, _: RangeInclusive<usize>) -> &Self::Output {
+            &self.0
+        }
+    }
+
+    S(2)[0..a + 1] = 3;
 }

--- a/tests/ui/range_plus_minus_one.stderr
+++ b/tests/ui/range_plus_minus_one.stderr
@@ -1,5 +1,5 @@
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:29:14
+  --> tests/ui/range_plus_minus_one.rs:32:14
    |
 LL |     for _ in 0..3 + 1 {}
    |              ^^^^^^^^ help: use: `0..=3`
@@ -8,55 +8,76 @@ LL |     for _ in 0..3 + 1 {}
    = help: to override `-D warnings` add `#[allow(clippy::range_plus_one)]`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:33:14
+  --> tests/ui/range_plus_minus_one.rs:36:14
    |
 LL |     for _ in 0..1 + 5 {}
    |              ^^^^^^^^ help: use: `0..=5`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:37:14
+  --> tests/ui/range_plus_minus_one.rs:40:14
    |
 LL |     for _ in 1..1 + 1 {}
    |              ^^^^^^^^ help: use: `1..=1`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:44:14
+  --> tests/ui/range_plus_minus_one.rs:47:14
    |
 LL |     for _ in 0..(1 + f()) {}
    |              ^^^^^^^^^^^^ help: use: `0..=f()`
 
-error: an exclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:49:13
-   |
-LL |     let _ = ..=11 - 1;
-   |             ^^^^^^^^^ help: use: `..11`
-   |
-   = note: `-D clippy::range-minus-one` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::range_minus_one)]`
-
-error: an exclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:51:13
-   |
-LL |     let _ = ..=(11 - 1);
-   |             ^^^^^^^^^^^ help: use: `..11`
-
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:53:13
-   |
-LL |     let _ = (1..11 + 1);
-   |             ^^^^^^^^^^^ help: use: `(1..=11)`
-
-error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:55:13
-   |
-LL |     let _ = (f() + 1)..(f() + 1);
-   |             ^^^^^^^^^^^^^^^^^^^^ help: use: `((f() + 1)..=f())`
-
-error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:60:14
+  --> tests/ui/range_plus_minus_one.rs:61:14
    |
 LL |     for _ in 1..ONE + ONE {}
    |              ^^^^^^^^^^^^ help: use: `1..=ONE`
 
-error: aborting due to 9 previous errors
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:71:5
+   |
+LL |     (1..10 + 1).for_each(|_| {});
+   |     ^^^^^^^^^^^ help: use: `(1..=10)`
+
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:76:5
+   |
+LL |     (1..10 + 1).into_iter().for_each(|_| {});
+   |     ^^^^^^^^^^^ help: use: `(1..=10)`
+
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:81:17
+   |
+LL |         let _ = (1..10 + 1).start_bound();
+   |                 ^^^^^^^^^^^ help: use: `(1..=10)`
+
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:87:16
+   |
+LL |     let _ = &a[1..1 + 1];
+   |                ^^^^^^^^ help: use: `1..=1`
+
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:91:15
+   |
+LL |     vec.drain(2..3 + 1);
+   |               ^^^^^^^^ help: use: `2..=3`
+
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:95:14
+   |
+LL |     take_arg(10..20 + 1);
+   |              ^^^^^^^^^^ help: use: `10..=20`
+
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:99:16
+   |
+LL |     take_arg({ 10..20 + 1 });
+   |                ^^^^^^^^^^ help: use: `10..=20`
+
+error: an inclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:113:7
+   |
+LL |     a[0..2 + 1][0] = 1;
+   |       ^^^^^^^^ help: use: `0..=2`
+
+error: aborting due to 13 previous errors
 

--- a/tests/ui/range_plus_minus_one.stderr
+++ b/tests/ui/range_plus_minus_one.stderr
@@ -1,5 +1,5 @@
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:32:14
+  --> tests/ui/range_plus_minus_one.rs:31:14
    |
 LL |     for _ in 0..3 + 1 {}
    |              ^^^^^^^^ help: use: `0..=3`
@@ -8,76 +8,85 @@ LL |     for _ in 0..3 + 1 {}
    = help: to override `-D warnings` add `#[allow(clippy::range_plus_one)]`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:36:14
+  --> tests/ui/range_plus_minus_one.rs:35:14
    |
 LL |     for _ in 0..1 + 5 {}
    |              ^^^^^^^^ help: use: `0..=5`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:40:14
+  --> tests/ui/range_plus_minus_one.rs:39:14
    |
 LL |     for _ in 1..1 + 1 {}
    |              ^^^^^^^^ help: use: `1..=1`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:47:14
+  --> tests/ui/range_plus_minus_one.rs:46:14
    |
 LL |     for _ in 0..(1 + f()) {}
    |              ^^^^^^^^^^^^ help: use: `0..=f()`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:61:14
+  --> tests/ui/range_plus_minus_one.rs:60:14
    |
 LL |     for _ in 1..ONE + ONE {}
    |              ^^^^^^^^^^^^ help: use: `1..=ONE`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:71:5
+  --> tests/ui/range_plus_minus_one.rs:70:5
    |
 LL |     (1..10 + 1).for_each(|_| {});
    |     ^^^^^^^^^^^ help: use: `(1..=10)`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:76:5
+  --> tests/ui/range_plus_minus_one.rs:75:5
    |
 LL |     (1..10 + 1).into_iter().for_each(|_| {});
    |     ^^^^^^^^^^^ help: use: `(1..=10)`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:81:17
+  --> tests/ui/range_plus_minus_one.rs:80:17
    |
 LL |         let _ = (1..10 + 1).start_bound();
    |                 ^^^^^^^^^^^ help: use: `(1..=10)`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:87:16
+  --> tests/ui/range_plus_minus_one.rs:86:16
    |
 LL |     let _ = &a[1..1 + 1];
    |                ^^^^^^^^ help: use: `1..=1`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:91:15
+  --> tests/ui/range_plus_minus_one.rs:90:15
    |
 LL |     vec.drain(2..3 + 1);
    |               ^^^^^^^^ help: use: `2..=3`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:95:14
+  --> tests/ui/range_plus_minus_one.rs:94:14
    |
 LL |     take_arg(10..20 + 1);
    |              ^^^^^^^^^^ help: use: `10..=20`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:99:16
+  --> tests/ui/range_plus_minus_one.rs:98:16
    |
 LL |     take_arg({ 10..20 + 1 });
    |                ^^^^^^^^^^ help: use: `10..=20`
 
 error: an inclusive range would be more readable
-  --> tests/ui/range_plus_minus_one.rs:113:7
+  --> tests/ui/range_plus_minus_one.rs:112:7
    |
 LL |     a[0..2 + 1][0] = 1;
    |       ^^^^^^^^ help: use: `0..=2`
 
-error: aborting due to 13 previous errors
+error: an exclusive range would be more readable
+  --> tests/ui/range_plus_minus_one.rs:180:5
+   |
+LL |     (1..=n - 1).sum()
+   |     ^^^^^^^^^^^ help: use: `(1..n)`
+   |
+   = note: `-D clippy::range-minus-one` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::range_minus_one)]`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
To avoid false positives, the `range_plus_one` and `range_minus_one` lints will restrict themselves to situations where the iterator types can be easily switched from exclusive to inclusive or vice-versa. This includes situations where the range is used as an iterator, or is used for indexing.

On the other hand, assignments of the range to variables, including automatically typed ones or wildcards, will no longer trigger the lint. However, the cases where such an assignment would benefit from the lint are probably rare.

In a second commit, the `range_plus_one` and `range_minus_one` logic are unified, in order to properly emit parentheses around the suggestion when needed.

Fix rust-lang/rust-clippy#3307
Fix rust-lang/rust-clippy#9908

changelog: [`range_plus_one`, `range_minus_one`]: restrict lint to cases where it is safe to switch the range type

*Edit:* as a consequence, this led to the removal of three `#[expect(clippy::range_plus_one)]` in the Clippy sources to avoid those false positives.