### PR TITLE
Various improvements to the `incompatible_msrv` lint

### DIFF
--- a/clippy_lints/src/incompatible_msrv.rs
+++ b/clippy_lints/src/incompatible_msrv.rs
@@ -33,6 +33,39 @@ declare_clippy_lint! {
     ///
     /// To fix this problem, either increase your MSRV or use another item
     /// available in your current MSRV.
+    ///
+    /// You can also locally change the MSRV that should be checked by Clippy,
+    /// for example if a feature in your crate (e.g., `modern_compiler`) should
+    /// allow you to use an item:
+    ///
+    /// ```no_run
+    /// //! This crate has a MSRV of 1.3.0, but we also have an optional feature
+    /// //! `sleep_well` which requires at least Rust 1.4.0.
+    ///
+    /// // When the `sleep_well` feature is set, do not warn for functions available
+    /// // in Rust 1.4.0 and below.
+    /// #![cfg_attr(feature = "sleep_well", clippy::msrv = "1.4.0")]
+    ///
+    /// use std::time::Duration;
+    ///
+    /// #[cfg(feature = "sleep_well")]
+    /// fn sleep_for_some_time() {
+    ///     std::thread::sleep(Duration::new(1, 0)); // Will not trigger the lint
+    /// }
+    /// ```
+    ///
+    /// You can also increase the MSRV in tests, by using:
+    ///
+    /// ```no_run
+    /// // Use a much higher MSRV for tests while keeping the main one low
+    /// #![cfg_attr(test, clippy::msrv = "1.85.0")]
+    ///
+    /// #[test]
+    /// fn my_test() {
+    ///     // The tests can use items introduced in Rust 1.85.0 and lower
+    ///     // without triggering the `incompatible_msrv` lint.
+    /// }
+    /// ```
     #[clippy::version = "1.78.0"]
     pub INCOMPATIBLE_MSRV,
     suspicious,

--- a/clippy_lints/src/incompatible_msrv.rs
+++ b/clippy_lints/src/incompatible_msrv.rs
@@ -168,6 +168,7 @@ impl IncompatibleMsrv {
 
 impl<'tcx> LateLintPass<'tcx> for IncompatibleMsrv {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        // TODO: check for const stability when in const context
         match expr.kind {
             ExprKind::MethodCall(_, _, _, span) => {
                 if let Some(method_did) = cx.typeck_results().type_dependent_def_id(expr.hir_id) {

--- a/clippy_lints/src/incompatible_msrv.rs
+++ b/clippy_lints/src/incompatible_msrv.rs
@@ -174,14 +174,12 @@ impl<'tcx> LateLintPass<'tcx> for IncompatibleMsrv {
                     self.emit_lint_if_under_msrv(cx, method_did, expr.hir_id, span);
                 }
             },
-            ExprKind::Call(call, _) => {
-                // Desugaring into function calls by the compiler will use `QPath::LangItem` variants. Those should
-                // not be linted as they will not be generated in older compilers if the function is not available,
-                // and the compiler is allowed to call unstable functions.
-                if let ExprKind::Path(qpath @ (QPath::Resolved(..) | QPath::TypeRelative(..))) = call.kind
-                    && let Some(path_def_id) = cx.qpath_res(&qpath, call.hir_id).opt_def_id()
-                {
-                    self.emit_lint_if_under_msrv(cx, path_def_id, expr.hir_id, call.span);
+            // Desugaring into function calls by the compiler will use `QPath::LangItem` variants. Those should
+            // not be linted as they will not be generated in older compilers if the function is not available,
+            // and the compiler is allowed to call unstable functions.
+            ExprKind::Path(qpath @ (QPath::Resolved(..) | QPath::TypeRelative(..))) => {
+                if let Some(path_def_id) = cx.qpath_res(&qpath, expr.hir_id).opt_def_id() {
+                    self.emit_lint_if_under_msrv(cx, path_def_id, expr.hir_id, expr.span);
                 }
             },
             _ => {},

--- a/tests/ui-toml/check_incompatible_msrv_in_tests/check_incompatible_msrv_in_tests.enabled.stderr
+++ b/tests/ui-toml/check_incompatible_msrv_in_tests/check_incompatible_msrv_in_tests.enabled.stderr
@@ -18,6 +18,8 @@ error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is
    |
 LL |         sleep(Duration::new(1, 0));
    |         ^^^^^
+   |
+   = note: you may want to conditionally increase the MSRV considered by Clippy using the `clippy::msrv` attribute
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/checked_conversions.fixed
+++ b/tests/ui/checked_conversions.fixed
@@ -95,7 +95,7 @@ pub const fn issue_8898(i: u32) -> bool {
 #[clippy::msrv = "1.33"]
 fn msrv_1_33() {
     let value: i64 = 33;
-    let _ = value <= (u32::MAX as i64) && value >= 0;
+    let _ = value <= (u32::max_value() as i64) && value >= 0;
 }
 
 #[clippy::msrv = "1.34"]

--- a/tests/ui/checked_conversions.rs
+++ b/tests/ui/checked_conversions.rs
@@ -95,13 +95,13 @@ pub const fn issue_8898(i: u32) -> bool {
 #[clippy::msrv = "1.33"]
 fn msrv_1_33() {
     let value: i64 = 33;
-    let _ = value <= (u32::MAX as i64) && value >= 0;
+    let _ = value <= (u32::max_value() as i64) && value >= 0;
 }
 
 #[clippy::msrv = "1.34"]
 fn msrv_1_34() {
     let value: i64 = 34;
-    let _ = value <= (u32::MAX as i64) && value >= 0;
+    let _ = value <= (u32::max_value() as i64) && value >= 0;
     //~^ checked_conversions
 }
 

--- a/tests/ui/checked_conversions.stderr
+++ b/tests/ui/checked_conversions.stderr
@@ -100,8 +100,8 @@ LL |     let _ = value <= u16::MAX as u32 && value as i32 == 5;
 error: checked cast can be simplified
   --> tests/ui/checked_conversions.rs:104:13
    |
-LL |     let _ = value <= (u32::MAX as i64) && value >= 0;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u32::try_from(value).is_ok()`
+LL |     let _ = value <= (u32::max_value() as i64) && value >= 0;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `u32::try_from(value).is_ok()`
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -13,6 +13,8 @@ fn foo() {
     let mut map: HashMap<&str, u32> = HashMap::new();
     assert_eq!(map.entry("poneyland").key(), &"poneyland");
     //~^ incompatible_msrv
+    //~| NOTE: `-D clippy::incompatible-msrv` implied by `-D warnings`
+    //~| HELP: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
     if let Entry::Vacant(v) = map.entry("poneyland") {
         v.into_key();
@@ -71,6 +73,22 @@ fn lang_items() {
 fn issue14212() {
     let _ = std::iter::repeat_n((), 5);
     //~^ ERROR: is `1.80.0` but this item is stable since `1.82.0`
+}
+
+fn local_msrv_change_suggestion() {
+    let _ = std::iter::repeat_n((), 5);
+    //~^ incompatible_msrv
+
+    #[cfg(any(test, not(test)))]
+    {
+        let _ = std::iter::repeat_n((), 5);
+        //~^ incompatible_msrv
+        //~| NOTE: you may want to conditionally increase the MSRV
+
+        // Emit the additional note only once
+        let _ = std::iter::repeat_n((), 5);
+        //~^ incompatible_msrv
+    }
 }
 
 fn main() {}

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::incompatible_msrv)]
 #![feature(custom_inner_attributes)]
-#![feature(panic_internals)]
 #![clippy::msrv = "1.3.0"]
 
 use std::collections::HashMap;
@@ -45,21 +44,22 @@ fn core_special_treatment(p: bool) {
 
     // But still lint code calling `core` functions directly
     if p {
-        core::panicking::panic("foo");
-        //~^ ERROR: is `1.3.0` but this item is stable since `1.6.0`
+        let _ = core::iter::once_with(|| 0);
+        //~^ incompatible_msrv
     }
 
     // Lint code calling `core` from non-`core` macros
     macro_rules! my_panic {
         ($msg:expr) => {
-            core::panicking::panic($msg)
-        }; //~^ ERROR: is `1.3.0` but this item is stable since `1.6.0`
+            let _ = core::iter::once_with(|| $msg);
+            //~^ incompatible_msrv
+        };
     }
     my_panic!("foo");
 
     // Lint even when the macro comes from `core` and calls `core` functions
-    assert!(core::panicking::panic("out of luck"));
-    //~^ ERROR: is `1.3.0` but this item is stable since `1.6.0`
+    assert!(core::iter::once_with(|| 0).next().is_some());
+    //~^ incompatible_msrv
 }
 
 #[clippy::msrv = "1.26.0"]

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -74,7 +74,7 @@ fn lang_items() {
 #[clippy::msrv = "1.80.0"]
 fn issue14212() {
     let _ = std::iter::repeat_n((), 5);
-    //~^ ERROR: is `1.80.0` but this item is stable since `1.82.0`
+    //~^ incompatible_msrv
 }
 
 fn local_msrv_change_suggestion() {

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::incompatible_msrv)]
 #![feature(custom_inner_attributes)]
+#![allow(stable_features)]
+#![feature(strict_provenance)] // For use in test
 #![clippy::msrv = "1.3.0"]
 
 use std::collections::HashMap;
@@ -89,6 +91,18 @@ fn local_msrv_change_suggestion() {
         let _ = std::iter::repeat_n((), 5);
         //~^ incompatible_msrv
     }
+}
+
+#[clippy::msrv = "1.78.0"]
+fn feature_enable_14425(ptr: *const u8) -> usize {
+    // Do not warn, because it is enabled through a feature even though
+    // it is stabilized only since Rust 1.84.0.
+    let r = ptr.addr();
+
+    // Warn about this which has been introduced in the same Rust version
+    // but is not allowed through a feature.
+    r.isqrt()
+    //~^ incompatible_msrv
 }
 
 fn main() {}

--- a/tests/ui/incompatible_msrv.rs
+++ b/tests/ui/incompatible_msrv.rs
@@ -105,4 +105,9 @@ fn feature_enable_14425(ptr: *const u8) -> usize {
     //~^ incompatible_msrv
 }
 
+fn non_fn_items() {
+    let _ = std::io::ErrorKind::CrossesDevices;
+    //~^ incompatible_msrv
+}
+
 fn main() {}

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -1,5 +1,5 @@
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.10.0`
-  --> tests/ui/incompatible_msrv.rs:14:39
+  --> tests/ui/incompatible_msrv.rs:13:39
    |
 LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    |                                       ^^^^^
@@ -8,39 +8,39 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> tests/ui/incompatible_msrv.rs:20:11
+  --> tests/ui/incompatible_msrv.rs:19:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> tests/ui/incompatible_msrv.rs:24:5
+  --> tests/ui/incompatible_msrv.rs:23:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
-error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:48:9
+error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
+  --> tests/ui/incompatible_msrv.rs:47:17
    |
-LL |         core::panicking::panic("foo");
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _ = core::iter::once_with(|| 0);
+   |                 ^^^^^^^^^^^^^^^^^^^^^
 
-error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:55:13
+error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
+  --> tests/ui/incompatible_msrv.rs:54:21
    |
-LL |             core::panicking::panic($msg)
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL |             let _ = core::iter::once_with(|| $msg);
+   |                     ^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     my_panic!("foo");
    |     ---------------- in this macro invocation
    |
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
+error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
   --> tests/ui/incompatible_msrv.rs:61:13
    |
-LL |     assert!(core::panicking::panic("out of luck"));
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL |     assert!(core::iter::once_with(|| 0).next().is_some());
+   |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
   --> tests/ui/incompatible_msrv.rs:74:13

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -1,5 +1,5 @@
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.10.0`
-  --> tests/ui/incompatible_msrv.rs:13:39
+  --> tests/ui/incompatible_msrv.rs:15:39
    |
 LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    |                                       ^^^^^
@@ -8,25 +8,25 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> tests/ui/incompatible_msrv.rs:19:11
+  --> tests/ui/incompatible_msrv.rs:21:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> tests/ui/incompatible_msrv.rs:23:5
+  --> tests/ui/incompatible_msrv.rs:25:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:47:17
+  --> tests/ui/incompatible_msrv.rs:49:17
    |
 LL |         let _ = core::iter::once_with(|| 0);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:54:21
+  --> tests/ui/incompatible_msrv.rs:56:21
    |
 LL |             let _ = core::iter::once_with(|| $msg);
    |                     ^^^^^^^^^^^^^^^^^^^^^
@@ -37,25 +37,25 @@ LL |     my_panic!("foo");
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.43.0`
-  --> tests/ui/incompatible_msrv.rs:61:13
+  --> tests/ui/incompatible_msrv.rs:63:13
    |
 LL |     assert!(core::iter::once_with(|| 0).next().is_some());
    |             ^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:74:13
+  --> tests/ui/incompatible_msrv.rs:76:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:79:13
+  --> tests/ui/incompatible_msrv.rs:81:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:84:17
+  --> tests/ui/incompatible_msrv.rs:86:17
    |
 LL |         let _ = std::iter::repeat_n((), 5);
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -63,10 +63,16 @@ LL |         let _ = std::iter::repeat_n((), 5);
    = note: you may want to conditionally increase the MSRV considered by Clippy using the `clippy::msrv` attribute
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:89:17
+  --> tests/ui/incompatible_msrv.rs:91:17
    |
 LL |         let _ = std::iter::repeat_n((), 5);
    |                 ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error: current MSRV (Minimum Supported Rust Version) is `1.78.0` but this item is stable since `1.84.0`
+  --> tests/ui/incompatible_msrv.rs:104:7
+   |
+LL |     r.isqrt()
+   |       ^^^^^^^
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -8,25 +8,25 @@ LL |     assert_eq!(map.entry("poneyland").key(), &"poneyland");
    = help: to override `-D warnings` add `#[allow(clippy::incompatible_msrv)]`
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.12.0`
-  --> tests/ui/incompatible_msrv.rs:18:11
+  --> tests/ui/incompatible_msrv.rs:20:11
    |
 LL |         v.into_key();
    |           ^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.4.0`
-  --> tests/ui/incompatible_msrv.rs:22:5
+  --> tests/ui/incompatible_msrv.rs:24:5
    |
 LL |     sleep(Duration::new(1, 0));
    |     ^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:46:9
+  --> tests/ui/incompatible_msrv.rs:48:9
    |
 LL |         core::panicking::panic("foo");
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:53:13
+  --> tests/ui/incompatible_msrv.rs:55:13
    |
 LL |             core::panicking::panic($msg)
    |             ^^^^^^^^^^^^^^^^^^^^^^
@@ -37,16 +37,36 @@ LL |     my_panic!("foo");
    = note: this error originates in the macro `my_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.6.0`
-  --> tests/ui/incompatible_msrv.rs:59:13
+  --> tests/ui/incompatible_msrv.rs:61:13
    |
 LL |     assert!(core::panicking::panic("out of luck"));
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
 error: current MSRV (Minimum Supported Rust Version) is `1.80.0` but this item is stable since `1.82.0`
-  --> tests/ui/incompatible_msrv.rs:72:13
+  --> tests/ui/incompatible_msrv.rs:74:13
    |
 LL |     let _ = std::iter::repeat_n((), 5);
    |             ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
+  --> tests/ui/incompatible_msrv.rs:79:13
+   |
+LL |     let _ = std::iter::repeat_n((), 5);
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
+  --> tests/ui/incompatible_msrv.rs:84:17
+   |
+LL |         let _ = std::iter::repeat_n((), 5);
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: you may want to conditionally increase the MSRV considered by Clippy using the `clippy::msrv` attribute
+
+error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.82.0`
+  --> tests/ui/incompatible_msrv.rs:89:17
+   |
+LL |         let _ = std::iter::repeat_n((), 5);
+   |                 ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/incompatible_msrv.stderr
+++ b/tests/ui/incompatible_msrv.stderr
@@ -74,5 +74,11 @@ error: current MSRV (Minimum Supported Rust Version) is `1.78.0` but this item i
 LL |     r.isqrt()
    |       ^^^^^^^
 
-error: aborting due to 11 previous errors
+error: current MSRV (Minimum Supported Rust Version) is `1.3.0` but this item is stable since `1.85.0`
+  --> tests/ui/incompatible_msrv.rs:109:13
+   |
+LL |     let _ = std::io::ErrorKind::CrossesDevices;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
This PR supersedes #14328 following the [2025-03-18 Clippy meeting discussion](https://rust-lang.zulipchat.com/#narrow/channel/257328-clippy/topic/Meeting.202025-03-18/with/506527762). It uses a simpler approach than what was proposed initially in #14328 and does not add new options.

First, it documents how `cfg_attr` can be used to change the MSRV considered by Clippy to trigger the lint. This allows the MSRV to be feature gated, or to be raised in tests.

Also, the lint stops warning about items which have been explicitly allowed through a rustc feature. This works even if the feature has been stabilized since. It allows using an older compiler with some features turned on, as is done in Rust for Linux. This fixes #14425.

Then, if the lint triggers, and it looks like the code is located below a `cfg` or `cfg_attr` attribute, an additional note is issued, once, to indicate that the `clippy::msrv` attribute can be controlled by an attribute.

Finally, the lint is extended to cover any path, not just method and function calls. For example, enumeration variants, or constants, were not MSRV checked. This required replacing two `u32::MAX` by `u32::max_value()` in MSRV-limited tests.

An extra commit adds a TODO for checking the const stability also, as this is not done right now.

@Centri3 I'll assign this to you because you were assigned #14328 and you were the one who nominated the issue for discussion (thanks!), but of course feel free to reroll!

r? @Centri3 

changelog: [`incompatible_msrv`]: better documentation, honor the `features` attribute, and lint non-function entities as well