### PR TITLE
set the applicability of `op_ref` to `MachineApplicable`

### DIFF
--- a/clippy_lints/src/operators/op_ref.rs
+++ b/clippy_lints/src/operators/op_ref.rs
@@ -86,7 +86,7 @@ pub(crate) fn check<'tcx>(
                                 left.span,
                                 "use the left value directly",
                                 lsnip,
-                                Applicability::MaybeIncorrect, // FIXME #2597
+                                Applicability::MachineApplicable,
                             );
                         },
                     );
@@ -105,7 +105,7 @@ pub(crate) fn check<'tcx>(
                                 right.span,
                                 "use the right value directly",
                                 rsnip,
-                                Applicability::MaybeIncorrect, // FIXME #2597
+                                Applicability::MachineApplicable,
                             );
                         },
                     );
@@ -137,7 +137,7 @@ pub(crate) fn check<'tcx>(
                                 left.span,
                                 "use the left value directly",
                                 lsnip,
-                                Applicability::MaybeIncorrect, // FIXME #2597
+                                Applicability::MachineApplicable,
                             );
                         },
                     );
@@ -164,7 +164,7 @@ pub(crate) fn check<'tcx>(
                             right.span,
                             "use the right value directly",
                             rsnip,
-                            Applicability::MaybeIncorrect, // FIXME #2597
+                            Applicability::MachineApplicable,
                         );
                     });
                 }

--- a/tests/ui/op_ref.fixed
+++ b/tests/ui/op_ref.fixed
@@ -98,3 +98,15 @@ impl Mul<A> for A {
         self * &rhs
     }
 }
+
+mod issue_2597 {
+    fn ex1() {
+        let a: &str = "abc";
+        let b: String = "abc".to_owned();
+        println!("{}", a > &b);
+    }
+
+    pub fn ex2<T: Ord + PartialOrd>(array: &[T], val: &T, idx: usize) -> bool {
+        &array[idx] < val
+    }
+}

--- a/tests/ui/op_ref.rs
+++ b/tests/ui/op_ref.rs
@@ -98,3 +98,15 @@ impl Mul<A> for A {
         self * &rhs
     }
 }
+
+mod issue_2597 {
+    fn ex1() {
+        let a: &str = "abc";
+        let b: String = "abc".to_owned();
+        println!("{}", a > &b);
+    }
+
+    pub fn ex2<T: Ord + PartialOrd>(array: &[T], val: &T, idx: usize) -> bool {
+        &array[idx] < val
+    }
+}


### PR DESCRIPTION
#2597 appears to be already resolved, so the applicability of `op_ref` can be set to `MachineApplicable`.

close #2597

changelog: [`op_ref`]: set the applicability to `MachineApplicable`
