### PR TITLE
`implicit_return`: better handling of asynchronous code

### DIFF
--- a/clippy_lints/src/implicit_return.rs
+++ b/clippy_lints/src/implicit_return.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::{snippet_with_applicability, snippet_with_context, walk_span_to_context};
 use clippy_utils::visitors::for_each_expr_without_closures;
-use clippy_utils::{get_async_fn_body, is_async_fn, is_from_proc_macro};
+use clippy_utils::{desugar_await, get_async_closure_expr, get_async_fn_body, is_async_fn, is_from_proc_macro};
 use core::ops::ControlFlow;
 use rustc_errors::Applicability;
 use rustc_hir::intravisit::FnKind;
@@ -134,6 +134,10 @@ fn lint_implicit_returns(
         },
 
         ExprKind::Match(_, arms, _) => {
+            if let Some(await_expr) = desugar_await(expr) {
+                lint_return(cx, await_expr.hir_id, await_expr.span);
+                return LintLocation::Inner;
+            }
             for arm in arms {
                 let res = lint_implicit_returns(
                     cx,
@@ -241,6 +245,8 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitReturn {
                 Some(e) => e,
                 None => return,
             }
+        } else if let Some(expr) = get_async_closure_expr(cx.tcx, body.value) {
+            expr
         } else {
             body.value
         };

--- a/tests/ui/implicit_return.fixed
+++ b/tests/ui/implicit_return.fixed
@@ -165,3 +165,46 @@ with_span!(
         x
     }
 );
+
+fn desugared_closure_14446() {
+    let _ = async || return 0;
+    //~^ implicit_return
+    #[rustfmt::skip]
+    let _ = async || -> i32 { return 0 };
+    //~^ implicit_return
+    let _ = async |a: i32| return a;
+    //~^ implicit_return
+    #[rustfmt::skip]
+    let _ = async |a: i32| { return a };
+    //~^ implicit_return
+
+    let _ = async || return 0;
+    let _ = async || -> i32 { return 0 };
+    let _ = async |a: i32| return a;
+    #[rustfmt::skip]
+    let _ = async |a: i32| { return a; };
+
+    let _ = async || return foo().await;
+    //~^ implicit_return
+    let _ = async || {
+        foo().await;
+        return foo().await
+    };
+    //~^^ implicit_return
+    #[rustfmt::skip]
+    let _ = async || { return foo().await };
+    //~^ implicit_return
+    let _ = async || -> bool { return foo().await };
+    //~^ implicit_return
+
+    let _ = async || return foo().await;
+    let _ = async || {
+        foo().await;
+        return foo().await;
+    };
+    #[rustfmt::skip]
+    let _ = async || { return foo().await; };
+    let _ = async || -> bool {
+        return foo().await;
+    };
+}

--- a/tests/ui/implicit_return.rs
+++ b/tests/ui/implicit_return.rs
@@ -165,3 +165,46 @@ with_span!(
         x
     }
 );
+
+fn desugared_closure_14446() {
+    let _ = async || 0;
+    //~^ implicit_return
+    #[rustfmt::skip]
+    let _ = async || -> i32 { 0 };
+    //~^ implicit_return
+    let _ = async |a: i32| a;
+    //~^ implicit_return
+    #[rustfmt::skip]
+    let _ = async |a: i32| { a };
+    //~^ implicit_return
+
+    let _ = async || return 0;
+    let _ = async || -> i32 { return 0 };
+    let _ = async |a: i32| return a;
+    #[rustfmt::skip]
+    let _ = async |a: i32| { return a; };
+
+    let _ = async || foo().await;
+    //~^ implicit_return
+    let _ = async || {
+        foo().await;
+        foo().await
+    };
+    //~^^ implicit_return
+    #[rustfmt::skip]
+    let _ = async || { foo().await };
+    //~^ implicit_return
+    let _ = async || -> bool { foo().await };
+    //~^ implicit_return
+
+    let _ = async || return foo().await;
+    let _ = async || {
+        foo().await;
+        return foo().await;
+    };
+    #[rustfmt::skip]
+    let _ = async || { return foo().await; };
+    let _ = async || -> bool {
+        return foo().await;
+    };
+}

--- a/tests/ui/implicit_return.stderr
+++ b/tests/ui/implicit_return.stderr
@@ -183,5 +183,93 @@ help: add `return` as shown
 LL |     return true
    |     ++++++
 
-error: aborting due to 16 previous errors
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:170:22
+   |
+LL |     let _ = async || 0;
+   |                      ^
+   |
+help: add `return` as shown
+   |
+LL |     let _ = async || return 0;
+   |                      ++++++
+
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:173:31
+   |
+LL |     let _ = async || -> i32 { 0 };
+   |                               ^
+   |
+help: add `return` as shown
+   |
+LL |     let _ = async || -> i32 { return 0 };
+   |                               ++++++
+
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:175:28
+   |
+LL |     let _ = async |a: i32| a;
+   |                            ^
+   |
+help: add `return` as shown
+   |
+LL |     let _ = async |a: i32| return a;
+   |                            ++++++
+
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:178:30
+   |
+LL |     let _ = async |a: i32| { a };
+   |                              ^
+   |
+help: add `return` as shown
+   |
+LL |     let _ = async |a: i32| { return a };
+   |                              ++++++
+
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:187:22
+   |
+LL |     let _ = async || foo().await;
+   |                      ^^^^^
+   |
+help: add `return` as shown
+   |
+LL |     let _ = async || return foo().await;
+   |                      ++++++
+
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:191:9
+   |
+LL |         foo().await
+   |         ^^^^^
+   |
+help: add `return` as shown
+   |
+LL |         return foo().await
+   |         ++++++
+
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:195:24
+   |
+LL |     let _ = async || { foo().await };
+   |                        ^^^^^
+   |
+help: add `return` as shown
+   |
+LL |     let _ = async || { return foo().await };
+   |                        ++++++
+
+error: missing `return` statement
+  --> tests/ui/implicit_return.rs:197:32
+   |
+LL |     let _ = async || -> bool { foo().await };
+   |                                ^^^^^
+   |
+help: add `return` as shown
+   |
+LL |     let _ = async || -> bool { return foo().await };
+   |                                ++++++
+
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
Blocks created by desugaring will not contain an explicit `return`. Do not suggest to add it when the user has no control over the desugared code.

Also, ensure that in a `xxx.await` expression, the suggested `return` is emitted before the whole expression, not before the `await` keyword.

Fix #14411

changelog: [`implicit_return`]: fix proposed `return` position in the presence of asynchronous code