### PR TITLE
set concurrency for the `deploy` job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - rust-1.**
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   TARGET_BRANCH: 'gh-pages'
   SHA: '${{ github.sha }}'

--- a/book/src/development/infrastructure/release.md
+++ b/book/src/development/infrastructure/release.md
@@ -88,9 +88,6 @@ git push upstream stable
 After updating the `stable` branch, tag the HEAD commit and push it to the
 Clippy repo.
 
-> Note: Only push the tag once the Deploy GitHub action of the `beta` branch is
-> finished. Otherwise the deploy for the tag might fail.
-
 ```bash
 git tag rust-1.XX.0               # XX should be exchanged with the corresponding version
 git push upstream rust-1.XX.0     # `upstream` is the `rust-lang/rust-clippy` remote


### PR DESCRIPTION
In the current GitHub Actions CI/CD setup, the `deploy` job is not triggered when a PR is enqueued in the merge queue but only when it is merged. Since concurrency is not configured for this job, deployments may fail for later PRs if multiple PRs are merged in quick succession. (e.g. the deployment for [this commit](https://github.com/rust-lang/rust-clippy/commit/c4187145180effa06c87295e44bdf135128866fe) was successful, but the deployment for [this commit](https://github.com/rust-lang/rust-clippy/commit/0a141ab7b882387528eac4140df67e9938e5d257) that was pushed to `main` immediately afterward failed. (edit: the latter deployment seems to be rerun))

changelog: none

r? flip1995