### PR TITLE
Apply collapsible if to Clippy sources

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -2,6 +2,8 @@ avoid-breaking-exported-api = false
 
 check-inconsistent-struct-field-initializers = true
 
+lint-commented-code = true
+
 [[disallowed-methods]]
 path = "rustc_lint::context::LintContext::lint"
 reason = "this function does not add a link to our documentation, please use the `clippy_utils::diagnostics::span_lint*` functions instead"

--- a/clippy_lints/src/escape.rs
+++ b/clippy_lints/src/escape.rs
@@ -93,12 +93,11 @@ impl<'tcx> LateLintPass<'tcx> for BoxedLocal {
             // find `self` ty for this trait if relevant
             if let ItemKind::Trait(_, _, _, _, _, items) = item.kind {
                 for trait_item in items {
-                    if trait_item.id.owner_id.def_id == fn_def_id {
+                    if trait_item.id.owner_id.def_id == fn_def_id
                         // be sure we have `self` parameter in this function
-                        if trait_item.kind == (AssocItemKind::Fn { has_self: true }) {
-                            trait_self_ty =
-                                Some(TraitRef::identity(cx.tcx, trait_item.id.owner_id.to_def_id()).self_ty());
-                        }
+                        && trait_item.kind == (AssocItemKind::Fn { has_self: true })
+                    {
+                        trait_self_ty = Some(TraitRef::identity(cx.tcx, trait_item.id.owner_id.to_def_id()).self_ty());
                     }
                 }
             }

--- a/clippy_lints/src/item_name_repetitions.rs
+++ b/clippy_lints/src/item_name_repetitions.rs
@@ -377,22 +377,21 @@ impl ItemNameRepetitions {
                         "field name starts with the struct's name",
                     );
                 }
-                if field_words.len() > item_name_words.len() {
+                if field_words.len() > item_name_words.len()
                     // lint only if the end is not covered by the start
-                    if field_words
+                    && field_words
                         .iter()
                         .rev()
                         .zip(item_name_words.iter().rev())
                         .all(|(a, b)| a == b)
-                    {
-                        span_lint_hir(
-                            cx,
-                            STRUCT_FIELD_NAMES,
-                            field.hir_id,
-                            field.span,
-                            "field name ends with the struct's name",
-                        );
-                    }
+                {
+                    span_lint_hir(
+                        cx,
+                        STRUCT_FIELD_NAMES,
+                        field.hir_id,
+                        field.span,
+                        "field name ends with the struct's name",
+                    );
                 }
             }
         }

--- a/clippy_lints/src/mem_replace.rs
+++ b/clippy_lints/src/mem_replace.rs
@@ -304,14 +304,12 @@ impl<'tcx> LateLintPass<'tcx> for MemReplace {
             && let ExprKind::Path(ref func_qpath) = func.kind
             && let Some(def_id) = cx.qpath_res(func_qpath, func.hir_id).opt_def_id()
             && cx.tcx.is_diagnostic_item(sym::mem_replace, def_id)
-        {
             // Check that second argument is `Option::None`
-            if !check_replace_option_with_none(cx, src, dest, expr.span)
-                && !check_replace_option_with_some(cx, src, dest, expr.span, self.msrv)
-                && !check_replace_with_default(cx, src, dest, expr, self.msrv)
-            {
-                check_replace_with_uninit(cx, src, dest, expr.span);
-            }
+            && !check_replace_option_with_none(cx, src, dest, expr.span)
+            && !check_replace_option_with_some(cx, src, dest, expr.span, self.msrv)
+            && !check_replace_with_default(cx, src, dest, expr, self.msrv)
+        {
+            check_replace_with_uninit(cx, src, dest, expr.span);
         }
     }
 }

--- a/clippy_lints/src/methods/map_clone.rs
+++ b/clippy_lints/src/methods/map_clone.rs
@@ -114,19 +114,17 @@ fn handle_path(
 ) {
     if let Some(path_def_id) = cx.qpath_res(qpath, arg.hir_id).opt_def_id()
         && cx.tcx.lang_items().get(LangItem::CloneFn) == Some(path_def_id)
-    {
         // The `copied` and `cloned` methods are only available on `&T` and `&mut T` in `Option`
         // and `Result`.
-        if let ty::Adt(_, args) = cx.typeck_results().expr_ty(recv).kind()
-            && let args = args.as_slice()
-            && let Some(ty) = args.iter().find_map(|generic_arg| generic_arg.as_type())
-            && let ty::Ref(_, ty, Mutability::Not) = ty.kind()
-            && let ty::FnDef(_, lst) = cx.typeck_results().expr_ty(arg).kind()
-            && lst.iter().all(|l| l.as_type() == Some(*ty))
-            && !should_call_clone_as_function(cx, *ty)
-        {
-            lint_path(cx, e.span, recv.span, is_copy(cx, ty.peel_refs()));
-        }
+        && let ty::Adt(_, args) = cx.typeck_results().expr_ty(recv).kind()
+        && let args = args.as_slice()
+        && let Some(ty) = args.iter().find_map(|generic_arg| generic_arg.as_type())
+        && let ty::Ref(_, ty, Mutability::Not) = ty.kind()
+        && let ty::FnDef(_, lst) = cx.typeck_results().expr_ty(arg).kind()
+        && lst.iter().all(|l| l.as_type() == Some(*ty))
+        && !should_call_clone_as_function(cx, *ty)
+    {
+        lint_path(cx, e.span, recv.span, is_copy(cx, ty.peel_refs()));
     }
 }
 

--- a/clippy_lints/src/methods/seek_from_current.rs
+++ b/clippy_lints/src/methods/seek_from_current.rs
@@ -38,13 +38,11 @@ fn arg_is_seek_from_current<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) 
         && let ExprKind::Path(ref path) = f.kind
         && let Some(ctor_call_id) = cx.qpath_res(path, f.hir_id).opt_def_id()
         && is_enum_variant_ctor(cx, sym::SeekFrom, sym!(Current), ctor_call_id)
-    {
         // check if argument of `SeekFrom::Current` is `0`
-        if let ExprKind::Lit(lit) = arg.kind
-            && let LitKind::Int(Pu128(0), LitIntType::Unsuffixed) = lit.node
-        {
-            return true;
-        }
+        && let ExprKind::Lit(lit) = arg.kind
+        && let LitKind::Int(Pu128(0), LitIntType::Unsuffixed) = lit.node
+    {
+        return true;
     }
 
     false

--- a/clippy_lints/src/mixed_read_write_in_expression.rs
+++ b/clippy_lints/src/mixed_read_write_in_expression.rs
@@ -327,22 +327,22 @@ impl<'tcx> Visitor<'tcx> for ReadVisitor<'_, 'tcx> {
             return;
         }
 
-        if path_to_local_id(expr, self.var) {
+        if path_to_local_id(expr, self.var)
             // Check that this is a read, not a write.
-            if !is_in_assignment_position(self.cx, expr) {
-                span_lint_and_then(
-                    self.cx,
-                    MIXED_READ_WRITE_IN_EXPRESSION,
-                    expr.span,
-                    format!("unsequenced read of `{}`", self.cx.tcx.hir_name(self.var)),
-                    |diag| {
-                        diag.span_note(
-                            self.write_expr.span,
-                            "whether read occurs before this write depends on evaluation order",
-                        );
-                    },
-                );
-            }
+            && !is_in_assignment_position(self.cx, expr)
+        {
+            span_lint_and_then(
+                self.cx,
+                MIXED_READ_WRITE_IN_EXPRESSION,
+                expr.span,
+                format!("unsequenced read of `{}`", self.cx.tcx.hir_name(self.var)),
+                |diag| {
+                    diag.span_note(
+                        self.write_expr.span,
+                        "whether read occurs before this write depends on evaluation order",
+                    );
+                },
+            );
         }
         match expr.kind {
             // We're about to descend a closure. Since we don't know when (or

--- a/lintcheck/ci-config/clippy.toml
+++ b/lintcheck/ci-config/clippy.toml
@@ -4,3 +4,4 @@
 # to `$PWD/lintcheck/ci-config`.
 
 avoid-breaking-exported-api = false
+lint-commented-code = false

--- a/tests/clippy.toml
+++ b/tests/clippy.toml
@@ -1,1 +1,2 @@
 # default config for tests, overrides clippy.toml at the project root
+lint-commented-code = false


### PR DESCRIPTION
This PR enables the new ability to collapse `if` statements containing comments (without losing them) in Clippy sources, excluding tests and lintcheck, where the default behaviour (no collapsing in presence of comments) is preserved.

To be applied after #14231. When it is applied, #14455 will be marked as ready for review, then #14228 afterwards.

changelog: none

r? ghost