### PR TITLE
add allow_unused config to missing_docs_in_private_items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6435,6 +6435,7 @@ Released 2018-09-13
 [`max-suggested-slice-pattern-length`]: https://doc.rust-lang.org/clippy/lint_configuration.html#max-suggested-slice-pattern-length
 [`max-trait-bounds`]: https://doc.rust-lang.org/clippy/lint_configuration.html#max-trait-bounds
 [`min-ident-chars-threshold`]: https://doc.rust-lang.org/clippy/lint_configuration.html#min-ident-chars-threshold
+[`missing-docs-allow-unused`]: https://doc.rust-lang.org/clippy/lint_configuration.html#missing-docs-allow-unused
 [`missing-docs-in-crate-items`]: https://doc.rust-lang.org/clippy/lint_configuration.html#missing-docs-in-crate-items
 [`module-item-order-groupings`]: https://doc.rust-lang.org/clippy/lint_configuration.html#module-item-order-groupings
 [`module-items-ordered-within-groupings`]: https://doc.rust-lang.org/clippy/lint_configuration.html#module-items-ordered-within-groupings

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -734,6 +734,16 @@ Minimum chars an ident can have, anything below or equal to this will be linted.
 * [`min_ident_chars`](https://rust-lang.github.io/rust-clippy/master/index.html#min_ident_chars)
 
 
+## `missing-docs-allow-unused`
+Whether to allow fields starting with underscore to skip documentation requirements
+
+**Default Value:** `false`
+
+---
+**Affected lints:**
+* [`missing_docs_in_private_items`](https://rust-lang.github.io/rust-clippy/master/index.html#missing_docs_in_private_items)
+
+
 ## `missing-docs-in-crate-items`
 Whether to **only** check for missing documentation in items visible within the current
 crate. For example, `pub(crate)` items.

--- a/book/src/lint_configuration.md
+++ b/book/src/lint_configuration.md
@@ -735,7 +735,7 @@ Minimum chars an ident can have, anything below or equal to this will be linted.
 
 
 ## `missing-docs-allow-unused`
-Whether to allow fields starting with underscore to skip documentation requirements
+Whether to allow fields starting with an underscore to skip documentation requirements
 
 **Default Value:** `false`
 

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -675,6 +675,9 @@ define_Conf! {
     /// Minimum chars an ident can have, anything below or equal to this will be linted.
     #[lints(min_ident_chars)]
     min_ident_chars_threshold: u64 = 1,
+    /// Whether to allow fields starting with underscore to skip documentation requirements
+    #[lints(missing_docs_in_private_items)]
+    missing_docs_allow_unused: bool = false,
     /// Whether to **only** check for missing documentation in items visible within the current
     /// crate. For example, `pub(crate)` items.
     #[lints(missing_docs_in_private_items)]

--- a/clippy_config/src/conf.rs
+++ b/clippy_config/src/conf.rs
@@ -675,7 +675,7 @@ define_Conf! {
     /// Minimum chars an ident can have, anything below or equal to this will be linted.
     #[lints(min_ident_chars)]
     min_ident_chars_threshold: u64 = 1,
-    /// Whether to allow fields starting with underscore to skip documentation requirements
+    /// Whether to allow fields starting with an underscore to skip documentation requirements
     #[lints(missing_docs_in_private_items)]
     missing_docs_allow_unused: bool = false,
     /// Whether to **only** check for missing documentation in items visible within the current

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -263,17 +263,12 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
     }
 
     fn check_field_def(&mut self, cx: &LateContext<'tcx>, sf: &'tcx hir::FieldDef<'_>) {
-        if !sf.is_positional() {
-            // Skip checking if the field starts with an underscore and allow_unused is enabled
-            if self.allow_unused && sf.ident.as_str().starts_with('_') {
-                self.prev_span = Some(sf.span);
-                return;
-            }
-
+        if !(sf.is_positional()
+            || is_from_proc_macro(cx, sf)
+            || self.allow_unused && sf.ident.as_str().starts_with('_'))
+        {
             let attrs = cx.tcx.hir_attrs(sf.hir_id);
-            if !is_from_proc_macro(cx, sf) {
-                self.check_missing_docs_attrs(cx, sf.def_id, attrs, sf.span, "a", "struct field");
-            }
+            self.check_missing_docs_attrs(cx, sf.def_id, attrs, sf.span, "a", "struct field");
         }
         self.prev_span = Some(sf.span);
     }

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -91,14 +91,6 @@ impl MissingDoc {
         article: &'static str,
         desc: &'static str,
     ) {
-        // Skip checking if the item starts with underscore and allow_unused is enabled
-        if self.allow_unused {
-            if let Some(name) = cx.tcx.opt_item_name(def_id.to_def_id()) {
-                if name.as_str().starts_with('_') {
-                    return;
-                }
-            }
-        }
         // If we're building a test harness, then warning about
         // documentation is probably not really relevant right now.
         if cx.sess().opts.test {
@@ -272,6 +264,12 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
     fn check_field_def(&mut self, cx: &LateContext<'tcx>, sf: &'tcx hir::FieldDef<'_>) {
         if !sf.is_positional() {
+            // Skip checking if the field starts with underscore and allow_unused is enabled
+            if self.allow_unused && sf.ident.as_str().starts_with('_') {
+                self.prev_span = Some(sf.span);
+                return;
+            }
+
             let attrs = cx.tcx.hir_attrs(sf.hir_id);
             if !is_from_proc_macro(cx, sf) {
                 self.check_missing_docs_attrs(cx, sf.def_id, attrs, sf.span, "a", "struct field");

--- a/clippy_lints/src/missing_doc.rs
+++ b/clippy_lints/src/missing_doc.rs
@@ -48,7 +48,7 @@ pub struct MissingDoc {
     /// Whether to **only** check for missing documentation in items visible within the current
     /// crate. For example, `pub(crate)` items.
     crate_items_only: bool,
-    /// Whether to allow fields starting with underscore to skip documentation requirements
+    /// Whether to allow fields starting with an underscore to skip documentation requirements
     allow_unused: bool,
     /// Stack of whether #[doc(hidden)] is set
     /// at each level which has lint attributes.
@@ -264,7 +264,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
 
     fn check_field_def(&mut self, cx: &LateContext<'tcx>, sf: &'tcx hir::FieldDef<'_>) {
         if !sf.is_positional() {
-            // Skip checking if the field starts with underscore and allow_unused is enabled
+            // Skip checking if the field starts with an underscore and allow_unused is enabled
             if self.allow_unused && sf.ident.as_str().starts_with('_') {
                 self.prev_span = Some(sf.span);
                 return;

--- a/tests/ui-toml/missing_docs_allow_unused/clippy.toml
+++ b/tests/ui-toml/missing_docs_allow_unused/clippy.toml
@@ -1,0 +1,1 @@
+missing-docs-allow-unused = true

--- a/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs
+++ b/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs
@@ -1,0 +1,19 @@
+//! Test file for missing_docs_in_private_items lint with allow_unused configuration
+#![warn(clippy::missing_docs_in_private_items)]
+#![allow(dead_code)]
+
+/// A struct with some documented and undocumented fields
+struct Test {
+    /// This field is documented
+    field1: i32,
+    _unused: i32, // This should not trigger a warning because it starts with underscore
+    field3: i32,  //~ missing_docs_in_private_items
+}
+
+struct Test2 {
+    //~^ missing_docs_in_private_items
+    _field1: i32, // This should not trigger a warning
+    _field2: i32, // This should not trigger a warning
+}
+
+fn main() {}

--- a/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs
+++ b/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs
@@ -16,4 +16,11 @@ struct Test2 {
     _field2: i32, // This should not trigger a warning
 }
 
+struct Test3 {
+    //~^ missing_docs_in_private_items
+    /// This field is documented although this is not mandatory
+    _unused: i32, // This should not trigger a warning because it starts with an underscore
+    field2: i32, //~ missing_docs_in_private_items
+}
+
 fn main() {}

--- a/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs
+++ b/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs
@@ -6,7 +6,7 @@
 struct Test {
     /// This field is documented
     field1: i32,
-    _unused: i32, // This should not trigger a warning because it starts with underscore
+    _unused: i32, // This should not trigger a warning because it starts with an underscore
     field3: i32,  //~ missing_docs_in_private_items
 }
 

--- a/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.stderr
+++ b/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.stderr
@@ -17,5 +17,22 @@ LL | |     _field2: i32, // This should not trigger a warning
 LL | | }
    | |_^
 
-error: aborting due to 2 previous errors
+error: missing documentation for a struct
+  --> tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs:19:1
+   |
+LL | / struct Test3 {
+LL | |
+LL | |     /// This field is documented although this is not mandatory
+LL | |     _unused: i32, // This should not trigger a warning because it starts with an underscore
+LL | |     field2: i32,
+LL | | }
+   | |_^
+
+error: missing documentation for a struct field
+  --> tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs:23:5
+   |
+LL |     field2: i32,
+   |     ^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.stderr
+++ b/tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.stderr
@@ -1,0 +1,21 @@
+error: missing documentation for a struct field
+  --> tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs:10:5
+   |
+LL |     field3: i32,
+   |     ^^^^^^^^^^^
+   |
+   = note: `-D clippy::missing-docs-in-private-items` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_docs_in_private_items)]`
+
+error: missing documentation for a struct
+  --> tests/ui-toml/missing_docs_allow_unused/missing_docs_allow_unused.rs:13:1
+   |
+LL | / struct Test2 {
+LL | |
+LL | |     _field1: i32, // This should not trigger a warning
+LL | |     _field2: i32, // This should not trigger a warning
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
+++ b/tests/ui-toml/toml_unknown_key/conf_unknown_key.stderr
@@ -57,6 +57,7 @@ error: error reading Clippy's configuration file: unknown field `foobar`, expect
            max-suggested-slice-pattern-length
            max-trait-bounds
            min-ident-chars-threshold
+           missing-docs-allow-unused
            missing-docs-in-crate-items
            module-item-order-groupings
            module-items-ordered-within-groupings
@@ -149,6 +150,7 @@ error: error reading Clippy's configuration file: unknown field `barfoo`, expect
            max-suggested-slice-pattern-length
            max-trait-bounds
            min-ident-chars-threshold
+           missing-docs-allow-unused
            missing-docs-in-crate-items
            module-item-order-groupings
            module-items-ordered-within-groupings
@@ -241,6 +243,7 @@ error: error reading Clippy's configuration file: unknown field `allow_mixed_uni
            max-suggested-slice-pattern-length
            max-trait-bounds
            min-ident-chars-threshold
+           missing-docs-allow-unused
            missing-docs-in-crate-items
            module-item-order-groupings
            module-items-ordered-within-groupings


### PR DESCRIPTION
fixes #14413 
add allow_unused config to missing_docs_in_private_items for underscored field

changelog: [`missing_docs_in_private_items`]: add allow_unused config to missing_docs_in_private_items for underscored field


Explaination (quoted from the issue's author): When writing structures that must adhere to a specific format (such as memory mapped I/O structures) there are inevitably fields that are "reserved" by specifications and thus need no documentation. In cases where private docs are preferred but reserved fields need no explanation, having to #[allow/expect] this lint removes the ability to check for otherwise used fields' documentation.
