### PR TITLE
Update book and templates with feature freeze

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_lint.yml
+++ b/.github/ISSUE_TEMPLATE/new_lint.yml
@@ -1,5 +1,7 @@
 name: New lint suggestion
-description: Suggest a new Clippy lint.
+description: |
+  Suggest a new Clippy lint (currently not accepting new lints)
+  Check out the Clippy book for more information about the feature freeze.
 labels: ["A-lint"]
 body:
   - type: markdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,10 @@ order to get feedback.
 
 Delete this line and everything above before opening your PR.
 
+Note taht we are currently not taking in new PRs that add new lints. We are in a
+feature freeze. Check out the book for more information. If you open a
+feature-adding pull request, its review will be delayed.
+
 ---
 
 *Please write a short comment explaining your change (or "none" for internal only changes)*

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -1,5 +1,9 @@
 # Clippy
 
+[### IMPORTANT NOTE FOR CONTRIBUTORS ================](development/feature_freeze.md)
+
+----
+
 [![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/clippy.svg)](https://github.com/rust-lang/rust-clippy#license)
 
 A collection of lints to catch common mistakes and improve your

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
     - [GitLab CI](continuous_integration/gitlab.md)
     - [Travis CI](continuous_integration/travis.md)
 - [Development](development/README.md)
+    - [IMPORTANT: FEATURE FREEZE](development/feature_freeze.md)
     - [Basics](development/basics.md)
     - [Adding Lints](development/adding_lints.md)
     - [Defining Lints](development/defining_lints.md)

--- a/book/src/development/adding_lints.md
+++ b/book/src/development/adding_lints.md
@@ -1,5 +1,8 @@
 # Adding a new lint
 
+[### IMPORTANT NOTE FOR CONTRIBUTORS ================](feature_freeze.md)
+
+
 You are probably here because you want to add a new lint to Clippy. If this is
 the first time you're contributing to Clippy, this document guides you through
 creating an example lint from scratch.

--- a/book/src/development/feature_freeze.md
+++ b/book/src/development/feature_freeze.md
@@ -2,7 +2,7 @@
 
 This is a temporary notice.
 
-From March 28, 2025 to June 20, 2025 we will perform a feature freeze. Only bugfix PRs will be reviewed with the
+From May 9th, 2025 until the 1st of August, 2025 we will perform a feature freeze. Only bugfix PRs will be reviewed with the
 exception of already open ones. Every feature-adding PR open in between those dates will be moved into a milestone
 to be reviewed separately at another time.
 

--- a/book/src/development/feature_freeze.md
+++ b/book/src/development/feature_freeze.md
@@ -1,0 +1,50 @@
+# IMPORTANT: FEATURE FREEZE
+
+This is a temporary notice.
+
+From March 28, 2025 to June 20, 2025 we will perform a feature freeze. Only bugfix PRs will be reviewed with the
+exception of already open ones. Every feature-adding PR open in between those dates will be moved into a milestone
+to be reviewed separately at another time.
+
+We do this because of the long backlog of bugs that need to be addressed
+in order to contiue being the state of the art linter that Clippy has become known for being.
+
+## For contributors
+
+If you are a contributor or are planning to become one, **please do not open a lint-adding PR**, we have lots of open bugs
+of all levels of difficulty that you can address instead!
+
+We currently have about 800 lints, each one posing a maintainability challenge that needs to account to every possible
+usecase of the whole ecosystem. Bugs are natural in every software, but the Clippy team considers that Clippy needs a
+refinement period.
+
+If you open a PR at this time, we will not review it but push it into a milestone until the refinement period ends,
+adding additional load into our reviewing schedules.
+
+## I want to help, what can I do
+
+Thanks a lot to everyone who wants to help Clippy become better software in this feature freeze period!
+If you'd like to help, making a bugfix, making sure that it works, and opening a PR is a great step!
+
+As a general metric and always taking into account your skill and knowledge level, you can use this guide:
+
+- 🟥 [ICEs][search_ice], these are compiler errors that causes Clippy to panic and crash. Usually involves high-level debugging,
+sometimes interacting directly with the upstream compiler. Difficult to fix but a great challenge that improves
+a lot developer workflows!
+
+- 🟧 [Suggestion causes bug][sugg_causes_bug], Clippy suggested code that changed logic in some silent way. Unacceptable, as this may have
+disastreous consequences. Easier to fix than ICEs
+
+- 🟨 [Suggestion causes error][sugg_causes_error], Clippy suggested code snippet that caused a compiler error when applied.
+We need to make sure that Clippy doesn't suggest using a variable twice at the same time or similar
+easy-to-happen occurrences.
+
+- 🟩 [False positives][false_positive], a lint should not have fired, the easiest of them all, as this is "just" identifying the root of a
+the false positive and making an exception for those cases.
+
+Note that false negatives do not have priority unless the case is very clear, as they are a feature-request in a trench coat.
+
+[search_ice]: https://github.com/rust-lang/rust-clippy/issues?q=sort%3Aupdated-desc+state%3Aopen+label%3A%22I-ICE%22
+[sugg_causes_bug]: https://github.com/rust-lang/rust-clippy/issues?q=sort%3Aupdated-desc%20state%3Aopen%20label%3AI-suggestion-causes-bug
+[sugg_causes_error]: https://github.com/rust-lang/rust-clippy/issues?q=sort%3Aupdated-desc%20state%3Aopen%20label%3AI-suggestion-causes-error%20
+[false_positive]: https://github.com/rust-lang/rust-clippy/issues?q=sort%3Aupdated-desc%20state%3Aopen%20label%3AI-false-positive


### PR DESCRIPTION
This PR announces the feature freeze period talked about in https://github.com/rust-lang/rust-clippy/issues/14364

1. Add the page to the book
2. Modify the in-Github templates.
3. The third commit (to be squashed into the first) rolls the date mentioned 6 weeks (so, starting on May 9th and ending on August 20th). This gives us a comfortable buffer to make choices for this period.

We have a pending discussion on the #14364. So having some more time to make choices is very nice. I'm also preparing a Github action for detecting new lints and posting a comment about the feature freeze (being worked on in another branch)

Something I'd like comment on is the date formatting. I'm not sure if "May 9th to the first of August" is the correct way of writing this information in a book :sweat_smile:.

changelog: Announce the feature freeze from May 9th to the first of August
