### PR TITLE
remove obsolete "Known Problems" in `ok_expect`

### DIFF
--- a/clippy_lints/src/methods/mod.rs
+++ b/clippy_lints/src/methods/mod.rs
@@ -478,9 +478,6 @@ declare_clippy_lint! {
     /// Because you usually call `expect()` on the `Result`
     /// directly to get a better error message.
     ///
-    /// ### Known problems
-    /// The error type needs to implement `Debug`
-    ///
     /// ### Example
     /// ```no_run
     /// # let x = Ok::<_, ()>(());


### PR DESCRIPTION
It looks like `ok_expect` already [checks](https://github.com/rust-lang/rust-clippy/blob/b27a2bbe26b5d4499ca71091e955e7bc7b8b1a4a/clippy_lints/src/methods/ok_expect.rs#L16) for the presence of the `Debug`.

changelog: none
