### PR TITLE
Fix various typos in lint messages, descriptions and comments

### DIFF
--- a/clippy_lints/src/attrs/repr_attributes.rs
+++ b/clippy_lints/src/attrs/repr_attributes.rs
@@ -30,7 +30,7 @@ pub(super) fn check(cx: &LateContext<'_>, item_span: Span, attrs: &[Attribute], 
                     diag.warn(
                         "unqualified `#[repr(packed)]` defaults to `#[repr(Rust, packed)]`, which has no stable ABI",
                     )
-                    .help("qualify the desired ABI explicity via `#[repr(C, packed)]` or `#[repr(Rust, packed)]`")
+                    .help("qualify the desired ABI explicitly via `#[repr(C, packed)]` or `#[repr(Rust, packed)]`")
                     .span_label(packed_span, "`packed` representation set here");
                 },
             );

--- a/clippy_lints/src/copies.rs
+++ b/clippy_lints/src/copies.rs
@@ -256,7 +256,7 @@ fn lint_branches_sharing_code<'tcx>(
         let suggestion = reindent_multiline(&suggestion, true, indent);
 
         let span = span.with_hi(last_block.span.hi());
-        // Improve formatting if the inner block has indention (i.e. normal Rust formatting)
+        // Improve formatting if the inner block has indentation (i.e. normal Rust formatting)
         let span = span
             .map_range(cx, |src, range| {
                 (range.start > 4 && src.get(range.start - 4..range.start)? == "    ")

--- a/clippy_lints/src/methods/unnecessary_map_or.rs
+++ b/clippy_lints/src/methods/unnecessary_map_or.rs
@@ -76,7 +76,7 @@ pub(super) fn check<'a>(
             && ((BinOpKind::Eq == op.node && !def_bool) || (BinOpKind::Ne == op.node && def_bool))
             && let non_binding_location = if path_to_local_id(l, hir_id) { r } else { l }
             && switch_to_eager_eval(cx, non_binding_location)
-            // xor, because if its both then thats a strange edge case and
+            // xor, because if its both then that's a strange edge case and
             // we can just ignore it, since by default clippy will error on this
             && (path_to_local_id(l, hir_id) ^ path_to_local_id(r, hir_id))
             && !is_local_used(cx, non_binding_location, hir_id)
@@ -92,7 +92,7 @@ pub(super) fn check<'a>(
         // we may need to add parens around the suggestion
         // in case the parent expression has additional method calls,
         // since for example `Some(5).map_or(false, |x| x == 5).then(|| 1)`
-        // being converted to `Some(5) == Some(5).then(|| 1)` isnt
+        // being converted to `Some(5) == Some(5).then(|| 1)` isn't
         // the same thing
 
         let inner_non_binding = Sugg::NonParen(Cow::Owned(format!(

--- a/clippy_lints/src/non_std_lazy_statics.rs
+++ b/clippy_lints/src/non_std_lazy_statics.rs
@@ -121,7 +121,7 @@ impl<'hir> LateLintPass<'hir> for NonStdLazyStatic {
                 cx,
                 NON_STD_LAZY_STATICS,
                 macro_call.span,
-                "this macro has been superceded by `std::sync::LazyLock`",
+                "this macro has been superseded by `std::sync::LazyLock`",
             );
             return;
         }
@@ -240,7 +240,7 @@ impl LazyInfo {
             cx,
             NON_STD_LAZY_STATICS,
             self.ty_span_no_args,
-            "this type has been superceded by `LazyLock` in the standard library",
+            "this type has been superseded by `LazyLock` in the standard library",
             |diag| {
                 diag.multipart_suggestion("use `std::sync::LazyLock` instead", suggs, appl);
             },

--- a/clippy_lints/src/shadow.rs
+++ b/clippy_lints/src/shadow.rs
@@ -65,7 +65,7 @@ declare_clippy_lint! {
     #[clippy::version = "pre 1.29.0"]
     pub SHADOW_REUSE,
     restriction,
-    "rebinding a name to an expression that re-uses the original value, e.g., `let x = x + 1`"
+    "rebinding a name to an expression that reuses the original value, e.g., `let x = x + 1`"
 }
 
 declare_clippy_lint! {

--- a/clippy_lints/src/zombie_processes.rs
+++ b/clippy_lints/src/zombie_processes.rs
@@ -131,7 +131,7 @@ struct WaitFinder<'a, 'tcx> {
     local_id: HirId,
     state: VisitorState,
     early_return: Option<Span>,
-    // When joining two if branches where one of them doesn't call `wait()`, stores its span for more targetted help
+    // When joining two if branches where one of them doesn't call `wait()`, stores its span for more targeted help
     // messages
     missing_wait_branch: Option<MissingWaitBranch>,
 }

--- a/clippy_utils/src/str_utils.rs
+++ b/clippy_utils/src/str_utils.rs
@@ -1,4 +1,4 @@
-/// Dealing with sting indices can be hard, this struct ensures that both the
+/// Dealing with string indices can be hard, this struct ensures that both the
 /// character and byte index are provided for correct indexing.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct StrIndex {
@@ -165,7 +165,7 @@ pub fn camel_case_split(s: &str) -> Vec<&str> {
     offsets.windows(2).map(|w| &s[w[0]..w[1]]).collect()
 }
 
-/// Dealing with sting comparison can be complicated, this struct ensures that both the
+/// Dealing with string comparison can be complicated, this struct ensures that both the
 /// character and byte count are provided for correct indexing.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct StrCount {

--- a/clippy_utils/src/ty/mod.rs
+++ b/clippy_utils/src/ty/mod.rs
@@ -1352,7 +1352,7 @@ pub fn get_adt_inherent_method<'a>(cx: &'a LateContext<'_>, ty: Ty<'_>, method_n
     }
 }
 
-/// Get's the type of a field by name.
+/// Gets the type of a field by name.
 pub fn get_field_by_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, name: Symbol) -> Option<Ty<'tcx>> {
     match *ty.kind() {
         ty::Adt(def, args) if def.is_union() || def.is_struct() => def

--- a/lintcheck/src/recursive.rs
+++ b/lintcheck/src/recursive.rs
@@ -64,7 +64,7 @@ fn process_stream(
 
     // It's 99% likely that dependencies compiled with recursive mode are on crates.io
     // and therefore on docs.rs. This links to the sources directly, do avoid invalid
-    // links due to remaped paths. See rust-lang/docs.rs#2551 for more details.
+    // links due to remapped paths. See rust-lang/docs.rs#2551 for more details.
     let base_url = format!(
         "https://docs.rs/crate/{}/{}/source/src/{{file}}#{{line}}",
         driver_info.package_name, driver_info.version

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.fixed
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.fixed
@@ -9,16 +9,16 @@ use once_cell::sync::Lazy;
 fn main() {}
 
 static LAZY_FOO: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| "foo".to_uppercase());
-//~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+//~^ ERROR: this type has been superseded by `LazyLock` in the standard library
 static LAZY_BAR: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     let x = "bar";
     x.to_uppercase()
 });
 static LAZY_BAZ: std::sync::LazyLock<String> = { std::sync::LazyLock::new(|| "baz".to_uppercase()) };
-//~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+//~^ ERROR: this type has been superseded by `LazyLock` in the standard library
 static LAZY_QUX: std::sync::LazyLock<String> = {
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     if "qux".len() == 3 {
         std::sync::LazyLock::new(|| "qux".to_uppercase())
     } else if "qux".is_ascii() {
@@ -39,11 +39,11 @@ mod once_cell_lazy_with_fns {
     use once_cell::sync::Lazy;
 
     static LAZY_FOO: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| "foo".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     static LAZY_BAR: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| "bar".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     static mut LAZY_BAZ: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| "baz".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
 
     fn calling_replaceable_fns() {
         let _ = std::sync::LazyLock::force(&LAZY_FOO);

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs
@@ -9,16 +9,16 @@ use once_cell::sync::Lazy;
 fn main() {}
 
 static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
-//~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+//~^ ERROR: this type has been superseded by `LazyLock` in the standard library
 static LAZY_BAR: Lazy<String> = Lazy::new(|| {
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     let x = "bar";
     x.to_uppercase()
 });
 static LAZY_BAZ: Lazy<String> = { Lazy::new(|| "baz".to_uppercase()) };
-//~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+//~^ ERROR: this type has been superseded by `LazyLock` in the standard library
 static LAZY_QUX: Lazy<String> = {
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     if "qux".len() == 3 {
         Lazy::new(|| "qux".to_uppercase())
     } else if "qux".is_ascii() {
@@ -39,11 +39,11 @@ mod once_cell_lazy_with_fns {
     use once_cell::sync::Lazy;
 
     static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     static LAZY_BAR: Lazy<String> = Lazy::new(|| "bar".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     static mut LAZY_BAZ: Lazy<String> = Lazy::new(|| "baz".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
 
     fn calling_replaceable_fns() {
         let _ = Lazy::force(&LAZY_FOO);

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.stderr
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.stderr
@@ -1,4 +1,4 @@
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs:11:18
    |
 LL | static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
@@ -12,7 +12,7 @@ LL - static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
 LL + static LAZY_FOO: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| "foo".to_uppercase());
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs:13:18
    |
 LL | static LAZY_BAR: Lazy<String> = Lazy::new(|| {
@@ -24,7 +24,7 @@ LL - static LAZY_BAR: Lazy<String> = Lazy::new(|| {
 LL + static LAZY_BAR: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs:18:18
    |
 LL | static LAZY_BAZ: Lazy<String> = { Lazy::new(|| "baz".to_uppercase()) };
@@ -36,7 +36,7 @@ LL - static LAZY_BAZ: Lazy<String> = { Lazy::new(|| "baz".to_uppercase()) };
 LL + static LAZY_BAZ: std::sync::LazyLock<String> = { std::sync::LazyLock::new(|| "baz".to_uppercase()) };
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs:20:18
    |
 LL | static LAZY_QUX: Lazy<String> = {
@@ -54,7 +54,7 @@ LL |     } else {
 LL ~         std::sync::LazyLock::new(|| "qux".to_string())
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs:41:22
    |
 LL |     static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
@@ -69,7 +69,7 @@ LL |     fn calling_replaceable_fns() {
 LL ~         let _ = std::sync::LazyLock::force(&LAZY_FOO);
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs:43:22
    |
 LL |     static LAZY_BAR: Lazy<String> = Lazy::new(|| "bar".to_uppercase());
@@ -84,7 +84,7 @@ LL |         let _ = Lazy::force(&LAZY_FOO);
 LL ~         let _ = std::sync::LazyLock::force(&LAZY_BAR);
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_fixable.rs:45:26
    |
 LL |     static mut LAZY_BAZ: Lazy<String> = Lazy::new(|| "baz".to_uppercase());

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs
@@ -9,11 +9,11 @@ mod once_cell_lazy {
     use once_cell::sync::Lazy;
 
     static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     static mut LAZY_BAR: Lazy<String> = Lazy::new(|| "bar".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
     static mut LAZY_BAZ: Lazy<String> = Lazy::new(|| "baz".to_uppercase());
-    //~^ ERROR: this type has been superceded by `LazyLock` in the standard library
+    //~^ ERROR: this type has been superseded by `LazyLock` in the standard library
 
     fn calling_irreplaceable_fns() {
         let _ = Lazy::get(&LAZY_FOO);
@@ -31,13 +31,13 @@ mod lazy_static_lazy_static {
     lazy_static! {
         static ref LAZY_FOO: String = "foo".to_uppercase();
     }
-    //~^^^ ERROR: this macro has been superceded by `std::sync::LazyLock`
+    //~^^^ ERROR: this macro has been superseded by `std::sync::LazyLock`
     lazy_static! {
         static ref LAZY_BAR: String = "bar".to_uppercase();
         static ref LAZY_BAZ: String = "baz".to_uppercase();
     }
-    //~^^^^ ERROR: this macro has been superceded by `std::sync::LazyLock`
-    //~| ERROR: this macro has been superceded by `std::sync::LazyLock`
+    //~^^^^ ERROR: this macro has been superseded by `std::sync::LazyLock`
+    //~| ERROR: this macro has been superseded by `std::sync::LazyLock`
 }
 
 fn main() {}

--- a/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.stderr
+++ b/tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.stderr
@@ -1,4 +1,4 @@
-error: this macro has been superceded by `std::sync::LazyLock`
+error: this macro has been superseded by `std::sync::LazyLock`
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:31:5
    |
 LL | /     lazy_static! {
@@ -9,7 +9,7 @@ LL | |     }
    = note: `-D clippy::non-std-lazy-statics` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::non_std_lazy_statics)]`
 
-error: this macro has been superceded by `std::sync::LazyLock`
+error: this macro has been superseded by `std::sync::LazyLock`
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:35:5
    |
 LL | /     lazy_static! {
@@ -18,7 +18,7 @@ LL | |         static ref LAZY_BAZ: String = "baz".to_uppercase();
 LL | |     }
    | |_____^
 
-error: this macro has been superceded by `std::sync::LazyLock`
+error: this macro has been superseded by `std::sync::LazyLock`
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:35:5
    |
 LL | /     lazy_static! {
@@ -29,7 +29,7 @@ LL | |     }
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:11:22
    |
 LL |     static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
@@ -41,7 +41,7 @@ LL -     static LAZY_FOO: Lazy<String> = Lazy::new(|| "foo".to_uppercase());
 LL +     static LAZY_FOO: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| "foo".to_uppercase());
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:13:26
    |
 LL |     static mut LAZY_BAR: Lazy<String> = Lazy::new(|| "bar".to_uppercase());
@@ -53,7 +53,7 @@ LL -     static mut LAZY_BAR: Lazy<String> = Lazy::new(|| "bar".to_uppercase());
 LL +     static mut LAZY_BAR: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| "bar".to_uppercase());
    |
 
-error: this type has been superceded by `LazyLock` in the standard library
+error: this type has been superseded by `LazyLock` in the standard library
   --> tests/ui/non_std_lazy_static/non_std_lazy_static_unfixable.rs:15:26
    |
 LL |     static mut LAZY_BAZ: Lazy<String> = Lazy::new(|| "baz".to_uppercase());

--- a/tests/ui/repr_packed_without_abi.stderr
+++ b/tests/ui/repr_packed_without_abi.stderr
@@ -11,7 +11,7 @@ LL | | }
    | |_^
    |
    = warning: unqualified `#[repr(packed)]` defaults to `#[repr(Rust, packed)]`, which has no stable ABI
-   = help: qualify the desired ABI explicity via `#[repr(C, packed)]` or `#[repr(Rust, packed)]`
+   = help: qualify the desired ABI explicitly via `#[repr(C, packed)]` or `#[repr(Rust, packed)]`
 note: the lint level is defined here
   --> tests/ui/repr_packed_without_abi.rs:1:9
    |
@@ -31,7 +31,7 @@ LL | | }
    | |_^
    |
    = warning: unqualified `#[repr(packed)]` defaults to `#[repr(Rust, packed)]`, which has no stable ABI
-   = help: qualify the desired ABI explicity via `#[repr(C, packed)]` or `#[repr(Rust, packed)]`
+   = help: qualify the desired ABI explicitly via `#[repr(C, packed)]` or `#[repr(Rust, packed)]`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
changelog: none