### PR TITLE
Consecutive returns dont decrease cognitive Complexity level anymore

### DIFF
--- a/clippy_lints/src/cognitive_complexity.rs
+++ b/clippy_lints/src/cognitive_complexity.rs
@@ -62,6 +62,7 @@ impl CognitiveComplexity {
 
         let mut cc = 1u64;
         let mut returns = 0u64;
+        let mut prev_expr: Option<&ExprKind<'tcx>> = None;
         let _: Option<!> = for_each_expr_without_closures(expr, |e| {
             match e.kind {
                 ExprKind::If(_, _, _) => {
@@ -73,9 +74,14 @@ impl CognitiveComplexity {
                     }
                     cc += arms.iter().filter(|arm| arm.guard.is_some()).count() as u64;
                 },
-                ExprKind::Ret(_) => returns += 1,
+                ExprKind::Ret(_) => {
+                    if !matches!(prev_expr, Some(ExprKind::Ret(_))) {
+                        returns += 1;
+                    }
+                },
                 _ => {},
             }
+            prev_expr = Some(&e.kind);
             ControlFlow::Continue(())
         });
 

--- a/tests/ui/cognitive_complexity.rs
+++ b/tests/ui/cognitive_complexity.rs
@@ -448,3 +448,20 @@ mod issue9300 {
         }
     }
 }
+
+#[clippy::cognitive_complexity = "2"]
+mod issue14422 {
+    fn foo() {
+        for _ in 0..10 {
+            println!("hello there");
+        }
+    }
+
+    fn bar() {
+        for _ in 0..10 {
+            println!("hello there");
+        }
+        return;
+        return;
+    }
+}


### PR DESCRIPTION
changelog: [`cognitive_complexity`]: Consecutive return calls decreased complexity level of the function by 1.

fixes rust-lang/rust-clippy#14422
