### PR TITLE
Do not generate type-indecisive expressions in `unnecessary_cast`

### DIFF
--- a/clippy_utils/src/lib.rs
+++ b/clippy_utils/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(assert_matches)]
 #![feature(unwrap_infallible)]
 #![feature(array_windows)]
+#![feature(try_trait_v2)]
 #![recursion_limit = "512"]
 #![allow(
     clippy::missing_errors_doc,

--- a/clippy_utils/src/ty/type_certainty/mod.rs
+++ b/clippy_utils/src/ty/type_certainty/mod.rs
@@ -110,6 +110,10 @@ fn expr_type_certainty(cx: &LateContext<'_>, expr: &Expr<'_>, in_arg: bool) -> C
 
         ExprKind::Struct(qpath, _, _) => qpath_certainty(cx, qpath, true),
 
+        ExprKind::Block(block, _) => block
+            .expr
+            .map_or(Certainty::Certain(None), |expr| expr_type_certainty(cx, expr, false)),
+
         _ => Certainty::Uncertain,
     };
 

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -6,6 +6,7 @@
     clippy::no_effect,
     clippy::nonstandard_macro_braces,
     clippy::unnecessary_operation,
+    clippy::double_parens,
     nonstandard_style,
     unused
 )]
@@ -281,6 +282,26 @@ mod fixable {
         //~^ unnecessary_cast
 
         let _ = 5i32 as i64;
+        //~^ unnecessary_cast
+    }
+
+    fn issue_14366(i: u32) {
+        // Do not remove the cast if it helps determining the type
+        let _ = ((1.0 / 8.0) as f64).powf(i as f64);
+
+        // But remove useless casts anyway
+        let _ = (((1.0 / 8.0) as f64)).powf(i as f64);
+        //~^ unnecessary_cast
+    }
+
+    fn ambiguity() {
+        pub trait T {}
+        impl T for u32 {}
+        impl T for String {}
+        fn f(_: impl T) {}
+
+        f((1 + 2) as u32);
+        f(((1 + 2u32)));
         //~^ unnecessary_cast
     }
 }

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -310,4 +310,17 @@ mod fixable {
         let _ = threshold;
         //~^ unnecessary_cast
     }
+
+    fn with_prim_ty() {
+        let threshold = 20;
+        let threshold = if threshold == 0 {
+            i64::MAX
+        } else if threshold <= 60 {
+            10
+        } else {
+            0
+        };
+        let _ = threshold;
+        //~^ unnecessary_cast
+    }
 }

--- a/tests/ui/unnecessary_cast.fixed
+++ b/tests/ui/unnecessary_cast.fixed
@@ -304,4 +304,10 @@ mod fixable {
         f(((1 + 2u32)));
         //~^ unnecessary_cast
     }
+
+    fn with_blocks(a: i64, b: i64, c: u64) {
+        let threshold = if c < 10 { a } else { b };
+        let _ = threshold;
+        //~^ unnecessary_cast
+    }
 }

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -310,4 +310,17 @@ mod fixable {
         let _ = threshold as i64;
         //~^ unnecessary_cast
     }
+
+    fn with_prim_ty() {
+        let threshold = 20;
+        let threshold = if threshold == 0 {
+            i64::MAX
+        } else if threshold <= 60 {
+            10
+        } else {
+            0
+        };
+        let _ = threshold as i64;
+        //~^ unnecessary_cast
+    }
 }

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -6,6 +6,7 @@
     clippy::no_effect,
     clippy::nonstandard_macro_braces,
     clippy::unnecessary_operation,
+    clippy::double_parens,
     nonstandard_style,
     unused
 )]
@@ -281,6 +282,26 @@ mod fixable {
         //~^ unnecessary_cast
 
         let _ = 5i32 as i64 as i64;
+        //~^ unnecessary_cast
+    }
+
+    fn issue_14366(i: u32) {
+        // Do not remove the cast if it helps determining the type
+        let _ = ((1.0 / 8.0) as f64).powf(i as f64);
+
+        // But remove useless casts anyway
+        let _ = (((1.0 / 8.0) as f64) as f64).powf(i as f64);
+        //~^ unnecessary_cast
+    }
+
+    fn ambiguity() {
+        pub trait T {}
+        impl T for u32 {}
+        impl T for String {}
+        fn f(_: impl T) {}
+
+        f((1 + 2) as u32);
+        f((1 + 2u32) as u32);
         //~^ unnecessary_cast
     }
 }

--- a/tests/ui/unnecessary_cast.rs
+++ b/tests/ui/unnecessary_cast.rs
@@ -304,4 +304,10 @@ mod fixable {
         f((1 + 2u32) as u32);
         //~^ unnecessary_cast
     }
+
+    fn with_blocks(a: i64, b: i64, c: u64) {
+        let threshold = if c < 10 { a } else { b };
+        let _ = threshold as i64;
+        //~^ unnecessary_cast
+    }
 }

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -1,5 +1,5 @@
 error: casting raw pointers to the same type and constness is unnecessary (`*const T` -> `*const T`)
-  --> tests/ui/unnecessary_cast.rs:19:5
+  --> tests/ui/unnecessary_cast.rs:20:5
    |
 LL |     ptr as *const T
    |     ^^^^^^^^^^^^^^^ help: try: `ptr`
@@ -8,262 +8,274 @@ LL |     ptr as *const T
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_cast)]`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:55:5
+  --> tests/ui/unnecessary_cast.rs:56:5
    |
 LL |     1i32 as i32;
    |     ^^^^^^^^^^^ help: try: `1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:57:5
+  --> tests/ui/unnecessary_cast.rs:58:5
    |
 LL |     1f32 as f32;
    |     ^^^^^^^^^^^ help: try: `1_f32`
 
 error: casting to the same type is unnecessary (`bool` -> `bool`)
-  --> tests/ui/unnecessary_cast.rs:59:5
+  --> tests/ui/unnecessary_cast.rs:60:5
    |
 LL |     false as bool;
    |     ^^^^^^^^^^^^^ help: try: `false`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:63:5
+  --> tests/ui/unnecessary_cast.rs:64:5
    |
 LL |     -1_i32 as i32;
    |     ^^^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:65:5
+  --> tests/ui/unnecessary_cast.rs:66:5
    |
 LL |     - 1_i32 as i32;
    |     ^^^^^^^^^^^^^^ help: try: `- 1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:67:5
+  --> tests/ui/unnecessary_cast.rs:68:5
    |
 LL |     -1f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `-1_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:69:5
+  --> tests/ui/unnecessary_cast.rs:70:5
    |
 LL |     1_i32 as i32;
    |     ^^^^^^^^^^^^ help: try: `1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:71:5
+  --> tests/ui/unnecessary_cast.rs:72:5
    |
 LL |     1_f32 as f32;
    |     ^^^^^^^^^^^^ help: try: `1_f32`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> tests/ui/unnecessary_cast.rs:74:22
+  --> tests/ui/unnecessary_cast.rs:75:22
    |
 LL |     let _: *mut u8 = [1u8, 2].as_ptr() as *const u8 as *mut u8;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> tests/ui/unnecessary_cast.rs:77:5
+  --> tests/ui/unnecessary_cast.rs:78:5
    |
 LL |     [1u8, 2].as_ptr() as *const u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*mut u8` -> `*mut u8`)
-  --> tests/ui/unnecessary_cast.rs:80:5
+  --> tests/ui/unnecessary_cast.rs:81:5
    |
 LL |     [1u8, 2].as_mut_ptr() as *mut u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `[1u8, 2].as_mut_ptr()`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
-  --> tests/ui/unnecessary_cast.rs:92:5
+  --> tests/ui/unnecessary_cast.rs:93:5
    |
 LL |     owo::<u32>([1u32].as_ptr()) as *const u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `owo::<u32>([1u32].as_ptr())`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
-  --> tests/ui/unnecessary_cast.rs:94:5
+  --> tests/ui/unnecessary_cast.rs:95:5
    |
 LL |     uwu::<u32, u8>([1u32].as_ptr()) as *const u8;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u8>([1u32].as_ptr())`
 
 error: casting raw pointers to the same type and constness is unnecessary (`*const u32` -> `*const u32`)
-  --> tests/ui/unnecessary_cast.rs:97:5
+  --> tests/ui/unnecessary_cast.rs:98:5
    |
 LL |     uwu::<u32, u32>([1u32].as_ptr()) as *const u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `uwu::<u32, u32>([1u32].as_ptr())`
 
 error: casting to the same type is unnecessary (`u32` -> `u32`)
-  --> tests/ui/unnecessary_cast.rs:133:5
+  --> tests/ui/unnecessary_cast.rs:134:5
    |
 LL |     aaa() as u32;
    |     ^^^^^^^^^^^^ help: try: `aaa()`
 
 error: casting to the same type is unnecessary (`u32` -> `u32`)
-  --> tests/ui/unnecessary_cast.rs:136:5
+  --> tests/ui/unnecessary_cast.rs:137:5
    |
 LL |     aaa() as u32;
    |     ^^^^^^^^^^^^ help: try: `aaa()`
 
 error: casting integer literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:173:9
+  --> tests/ui/unnecessary_cast.rs:174:9
    |
 LL |         100 as f32;
    |         ^^^^^^^^^^ help: try: `100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:175:9
+  --> tests/ui/unnecessary_cast.rs:176:9
    |
 LL |         100 as f64;
    |         ^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:177:9
+  --> tests/ui/unnecessary_cast.rs:178:9
    |
 LL |         100_i32 as f64;
    |         ^^^^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:179:17
+  --> tests/ui/unnecessary_cast.rs:180:17
    |
 LL |         let _ = -100 as f32;
    |                 ^^^^^^^^^^^ help: try: `-100_f32`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:181:17
+  --> tests/ui/unnecessary_cast.rs:182:17
    |
 LL |         let _ = -100 as f64;
    |                 ^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting integer literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:183:17
+  --> tests/ui/unnecessary_cast.rs:184:17
    |
 LL |         let _ = -100_i32 as f64;
    |                 ^^^^^^^^^^^^^^^ help: try: `-100_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:185:9
+  --> tests/ui/unnecessary_cast.rs:186:9
    |
 LL |         100. as f32;
    |         ^^^^^^^^^^^ help: try: `100_f32`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:187:9
+  --> tests/ui/unnecessary_cast.rs:188:9
    |
 LL |         100. as f64;
    |         ^^^^^^^^^^^ help: try: `100_f64`
 
 error: casting integer literal to `u32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:200:9
+  --> tests/ui/unnecessary_cast.rs:201:9
    |
 LL |         1 as u32;
    |         ^^^^^^^^ help: try: `1_u32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:202:9
+  --> tests/ui/unnecessary_cast.rs:203:9
    |
 LL |         0x10 as i32;
    |         ^^^^^^^^^^^ help: try: `0x10_i32`
 
 error: casting integer literal to `usize` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:204:9
+  --> tests/ui/unnecessary_cast.rs:205:9
    |
 LL |         0b10 as usize;
    |         ^^^^^^^^^^^^^ help: try: `0b10_usize`
 
 error: casting integer literal to `u16` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:206:9
+  --> tests/ui/unnecessary_cast.rs:207:9
    |
 LL |         0o73 as u16;
    |         ^^^^^^^^^^^ help: try: `0o73_u16`
 
 error: casting integer literal to `u32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:208:9
+  --> tests/ui/unnecessary_cast.rs:209:9
    |
 LL |         1_000_000_000 as u32;
    |         ^^^^^^^^^^^^^^^^^^^^ help: try: `1_000_000_000_u32`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:211:9
+  --> tests/ui/unnecessary_cast.rs:212:9
    |
 LL |         1.0 as f64;
    |         ^^^^^^^^^^ help: try: `1.0_f64`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:213:9
+  --> tests/ui/unnecessary_cast.rs:214:9
    |
 LL |         0.5 as f32;
    |         ^^^^^^^^^^ help: try: `0.5_f32`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:218:17
+  --> tests/ui/unnecessary_cast.rs:219:17
    |
 LL |         let _ = -1 as i32;
    |                 ^^^^^^^^^ help: try: `-1_i32`
 
 error: casting float literal to `f32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:220:17
+  --> tests/ui/unnecessary_cast.rs:221:17
    |
 LL |         let _ = -1.0 as f32;
    |                 ^^^^^^^^^^^ help: try: `-1.0_f32`
 
 error: casting to the same type is unnecessary (`i32` -> `i32`)
-  --> tests/ui/unnecessary_cast.rs:227:18
+  --> tests/ui/unnecessary_cast.rs:228:18
    |
 LL |         let _ = &(x as i32);
    |                  ^^^^^^^^^^ help: try: `{ x }`
 
 error: casting integer literal to `i32` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:234:22
+  --> tests/ui/unnecessary_cast.rs:235:22
    |
 LL |         let _: i32 = -(1) as i32;
    |                      ^^^^^^^^^^^ help: try: `-1_i32`
 
 error: casting integer literal to `i64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:237:22
+  --> tests/ui/unnecessary_cast.rs:238:22
    |
 LL |         let _: i64 = -(1) as i64;
    |                      ^^^^^^^^^^^ help: try: `-1_i64`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:245:22
+  --> tests/ui/unnecessary_cast.rs:246:22
    |
 LL |         let _: f64 = (-8.0 as f64).exp();
    |                      ^^^^^^^^^^^^^ help: try: `(-8.0_f64)`
 
 error: casting float literal to `f64` is unnecessary
-  --> tests/ui/unnecessary_cast.rs:248:23
+  --> tests/ui/unnecessary_cast.rs:249:23
    |
 LL |         let _: f64 = -(8.0 as f64).exp(); // should suggest `-8.0_f64.exp()` here not to change code behavior
    |                       ^^^^^^^^^^^^ help: try: `8.0_f64`
 
 error: casting to the same type is unnecessary (`f32` -> `f32`)
-  --> tests/ui/unnecessary_cast.rs:258:20
+  --> tests/ui/unnecessary_cast.rs:259:20
    |
 LL |         let _num = foo() as f32;
    |                    ^^^^^^^^^^^^ help: try: `foo()`
 
 error: casting to the same type is unnecessary (`usize` -> `usize`)
-  --> tests/ui/unnecessary_cast.rs:269:9
+  --> tests/ui/unnecessary_cast.rs:270:9
    |
 LL |         (*x as usize).pow(2)
    |         ^^^^^^^^^^^^^ help: try: `(*x)`
 
 error: casting to the same type is unnecessary (`usize` -> `usize`)
-  --> tests/ui/unnecessary_cast.rs:277:31
+  --> tests/ui/unnecessary_cast.rs:278:31
    |
 LL |         assert_eq!(vec.len(), x as usize);
    |                               ^^^^^^^^^^ help: try: `x`
 
 error: casting to the same type is unnecessary (`i64` -> `i64`)
-  --> tests/ui/unnecessary_cast.rs:280:17
+  --> tests/ui/unnecessary_cast.rs:281:17
    |
 LL |         let _ = (5i32 as i64 as i64).abs();
    |                 ^^^^^^^^^^^^^^^^^^^^ help: try: `(5i32 as i64)`
 
 error: casting to the same type is unnecessary (`i64` -> `i64`)
-  --> tests/ui/unnecessary_cast.rs:283:17
+  --> tests/ui/unnecessary_cast.rs:284:17
    |
 LL |         let _ = 5i32 as i64 as i64;
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `5i32 as i64`
 
-error: aborting due to 44 previous errors
+error: casting to the same type is unnecessary (`f64` -> `f64`)
+  --> tests/ui/unnecessary_cast.rs:293:17
+   |
+LL |         let _ = (((1.0 / 8.0) as f64) as f64).powf(i as f64);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(((1.0 / 8.0) as f64))`
+
+error: casting to the same type is unnecessary (`u32` -> `u32`)
+  --> tests/ui/unnecessary_cast.rs:304:11
+   |
+LL |         f((1 + 2u32) as u32);
+   |           ^^^^^^^^^^^^^^^^^ help: try: `((1 + 2u32))`
+
+error: aborting due to 46 previous errors
 

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -283,5 +283,11 @@ error: casting to the same type is unnecessary (`i64` -> `i64`)
 LL |         let _ = threshold as i64;
    |                 ^^^^^^^^^^^^^^^^ help: try: `threshold`
 
-error: aborting due to 47 previous errors
+error: casting to the same type is unnecessary (`i64` -> `i64`)
+  --> tests/ui/unnecessary_cast.rs:323:17
+   |
+LL |         let _ = threshold as i64;
+   |                 ^^^^^^^^^^^^^^^^ help: try: `threshold`
+
+error: aborting due to 48 previous errors
 

--- a/tests/ui/unnecessary_cast.stderr
+++ b/tests/ui/unnecessary_cast.stderr
@@ -277,5 +277,11 @@ error: casting to the same type is unnecessary (`u32` -> `u32`)
 LL |         f((1 + 2u32) as u32);
    |           ^^^^^^^^^^^^^^^^^ help: try: `((1 + 2u32))`
 
-error: aborting due to 46 previous errors
+error: casting to the same type is unnecessary (`i64` -> `i64`)
+  --> tests/ui/unnecessary_cast.rs:310:17
+   |
+LL |         let _ = threshold as i64;
+   |                 ^^^^^^^^^^^^^^^^ help: try: `threshold`
+
+error: aborting due to 47 previous errors
 


### PR DESCRIPTION
This change requires fixing the type certainty evaluation:

- unsuffixed integral or floating-point literals are considered of unknown type unless their type is constrained or they are used as a function or method argument
- if the type of one argument in a binary expression is certain and the other is not, consider the type of the binary expression as being known as well (without more precisions)

This might be to be refined further, but this does not break any existing test, and allows for new fixes such as this one.

Fix #14366

changelog: [`unnecessary_cast`]: do not remove casts if the expression would become type-indecisive