### PR TITLE
Properly handle expansion in `single_match`

### DIFF
--- a/tests/ui/single_match.fixed
+++ b/tests/ui/single_match.fixed
@@ -366,3 +366,39 @@ fn irrefutable_match() {
     //~^^^^^^^^^ single_match
     //~| NOTE: you might want to preserve the comments from inside the `match`
 }
+
+fn issue_14493() {
+    macro_rules! mac {
+        (some) => {
+            Some(42)
+        };
+        (any) => {
+            _
+        };
+        (str) => {
+            "foo"
+        };
+    }
+
+    if let Some(u) = mac!(some) { println!("{u}") }
+    //~^^^^ single_match
+
+    // When scrutinee comes from macro, do not tell that arm will always match
+    // and suggest an equality check instead.
+    if mac!(str) == "foo" { println!("eq") }
+    //~^^^^ ERROR: for an equality check
+
+    // Do not lint if any match arm come from expansion
+    match Some(0) {
+        mac!(some) => println!("eq"),
+        mac!(any) => println!("neq"),
+    }
+    match Some(0) {
+        Some(42) => println!("eq"),
+        mac!(any) => println!("neq"),
+    }
+    match Some(0) {
+        mac!(some) => println!("eq"),
+        _ => println!("neq"),
+    }
+}

--- a/tests/ui/single_match.stderr
+++ b/tests/ui/single_match.stderr
@@ -321,5 +321,23 @@ LL +         println!("{u}");
 LL +     }
    |
 
-error: aborting due to 29 previous errors
+error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
+  --> tests/ui/single_match.rs:478:5
+   |
+LL | /     match mac!(some) {
+LL | |         Some(u) => println!("{u}"),
+LL | |         _ => (),
+LL | |     }
+   | |_____^ help: try: `if let Some(u) = mac!(some) { println!("{u}") }`
+
+error: you seem to be trying to use `match` for an equality check. Consider using `if`
+  --> tests/ui/single_match.rs:486:5
+   |
+LL | /     match mac!(str) {
+LL | |         "foo" => println!("eq"),
+LL | |         _ => (),
+LL | |     }
+   | |_____^ help: try: `if mac!(str) == "foo" { println!("eq") }`
+
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Having a macro call as the scrutinee is supported. However, the proposed suggestion must use the macro call itself, not its expansion.

When the scrutinee is a macro call, do not complain about an irrefutable match, as the user may not be aware of the result of the macro. A comparaison will be suggested instead, as if we couldn't see the outcome of the macro.

Similarly, do not accept macro calls as arm patterns.

changelog: [`single_match`]: proper suggestions in presence of macros

Fixes #14493 