### PR TITLE
Don't hardcode repository in changelog CI

### DIFF
--- a/.github/workflows/clippy_changelog.yml
+++ b/.github/workflows/clippy_changelog.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check Changelog
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        body=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/rust-lang/rust-clippy/pulls/$PR_NUMBER" | \
+        body=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -s "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" | \
           python -c "import sys, json; print(json.load(sys.stdin)['body'])")
         output=$(awk '/^changelog:\s*\S/ && !/changelog: \[.*\]: your change/' <<< "$body" | sed "s/changelog:\s*//g")
         if [ -z "$output" ]; then


### PR DESCRIPTION
I sometimes run lintcheck/CI experiments by opening a PR on my own clippy fork. This has recently "stopped" working (as in, fails CI) when the changelog CI was added because the repository is hardcoded as "rust-lang/rust-clippy", where the PR number won't match with the one on my repo.

changelog: none

r? flip1995