### PR TITLE
fix: enable checking doc attributes on entrypoint function to fix #14491

### DIFF
--- a/clippy_lints/src/doc/mod.rs
+++ b/clippy_lints/src/doc/mod.rs
@@ -7,7 +7,7 @@ use clippy_utils::macros::{is_panic, root_macro_call_first_node};
 use clippy_utils::source::snippet_opt;
 use clippy_utils::ty::is_type_diagnostic_item;
 use clippy_utils::visitors::Visitable;
-use clippy_utils::{is_entrypoint_fn, is_trait_impl_item, method_chain_args};
+use clippy_utils::{is_trait_impl_item, method_chain_args};
 use pulldown_cmark::Event::{
     Code, DisplayMath, End, FootnoteReference, HardBreak, Html, InlineHtml, InlineMath, Rule, SoftBreak, Start,
     TaskListMarker, Text,
@@ -658,9 +658,7 @@ impl<'tcx> LateLintPass<'tcx> for Documentation {
                 );
                 match item.kind {
                     ItemKind::Fn { sig, body: body_id, .. } => {
-                        if !(is_entrypoint_fn(cx, item.owner_id.to_def_id())
-                            || item.span.in_external_macro(cx.tcx.sess.source_map()))
-                        {
+                        if !(item.span.in_external_macro(cx.tcx.sess.source_map())) {
                             let body = cx.tcx.hir_body(body_id);
 
                             let panic_info = FindPanicUnwrap::find_span(cx, cx.tcx.typeck(item.owner_id), body.value);

--- a/tests/ui/issue_14491.rs
+++ b/tests/ui/issue_14491.rs
@@ -1,0 +1,29 @@
+//@aux-build:macro_rules.rs
+#![deny(clippy::missing_panics_doc)]
+#![deny(clippy::missing_errors_doc)]
+#![deny(clippy::allow_attributes)]
+
+use std::env::var;
+
+pub fn f() -> Result<(), &'static str> {
+    //~^ missing_errors_doc
+    match "test" {
+        "hello" => Ok(()),
+        _ => Err("Oh no"),
+    }
+}
+
+pub fn g() {
+    //~^ missing_panics_doc
+    panic!();
+}
+
+#[expect(clippy::missing_panics_doc)]
+#[expect(clippy::missing_errors_doc)]
+pub fn main() -> Result<(), &'static str> {
+    let val = var("Hello").unwrap();
+    match val.as_str() {
+        "hello" => Ok(()),
+        _ => Err("Oh no"),
+    }
+}

--- a/tests/ui/issue_14491.stderr
+++ b/tests/ui/issue_14491.stderr
@@ -1,0 +1,31 @@
+error: docs for function returning `Result` missing `# Errors` section
+  --> tests/ui/issue_14491.rs:8:1
+   |
+LL | pub fn f() -> Result<(), &'static str> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> tests/ui/issue_14491.rs:3:9
+   |
+LL | #![deny(clippy::missing_errors_doc)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: docs for function which may panic missing `# Panics` section
+  --> tests/ui/issue_14491.rs:16:1
+   |
+LL | pub fn g() {
+   | ^^^^^^^^^^
+   |
+note: first possible panic found here
+  --> tests/ui/issue_14491.rs:18:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^
+note: the lint level is defined here
+  --> tests/ui/issue_14491.rs:2:9
+   |
+LL | #![deny(clippy::missing_panics_doc)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #14491 

I'm not so sure about the expected behaviour here, I presume that one **should** document panics and errors on `main`?

So I remove the `is_entrypoint_fn` here.

changelog: [`missing_panics_doc` & `missing_panics_doc`]: enable checking doc attributes on entrypoint function

