### PR TITLE
Enable triagebot's merge conflict notifications

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -9,6 +9,11 @@ allow-unauthenticated = [
 # See https://forge.rust-lang.org/triagebot/shortcuts.html
 [shortcut]
 
+[merge-conflicts]
+add = ['S-waiting-on-author']
+remove = ['S-waiting-on-review']
+unless = ['S-blocked', 'S-final-comment-period']
+
 # Have rustbot inform users about the *No Merge Policy*
 [no-merges]
 exclude_titles = ["Rustup"] # exclude syncs from rust-lang/rust


### PR DESCRIPTION
Since we migrated away from bors I've missed this feature, fortunately triagebot supports it too - https://forge.rust-lang.org/triagebot/merge-conflicts.html 

r? @flip1995

changelog: none
