### PR TITLE
[Minor perf] Avoid unnecessary allocations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,3 +23,6 @@ split-debuginfo = "unpacked"
 rustflags = ["--remap-path-prefix", "=clippy_dev"]
 [profile.dev.package.lintcheck]
 rustflags = ["--remap-path-prefix", "=lintcheck"]
+
+[env]
+MALLOC_CONF = "percpu_arena:phycpu,metadata_thp:always,dirty_decay_ms:300,muzzy_decay_ms:300"

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -579,6 +579,10 @@ fn register_categories(store: &mut rustc_lint::LintStore) {
 /// Used in `./src/driver.rs`.
 #[expect(clippy::too_many_lines)]
 pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
+    // Avoid unnecessary reallocations
+    store.late_passes.reserve(320);
+    store.early_passes.reserve(64);
+
     register_categories(store);
 
     for (old_name, new_name) in deprecated_lints::RENAMED {


### PR DESCRIPTION
**Commits:**

1. Reserve `store.late_passes` with 320 and `store.early_passes` with 64, this leaves us some leeway for adding new passes. Note that there are not as many passes are there lints.
2. Add [env] with some `MALLOC_CONF` for mainly for faster testing, but to also optimize in profiling.

This PR makes it so we avoid unnecessary reallocations, oh and we now use `MALLOC_CONF` for some heap-allocation optimization (I tested manually every config flag and came to this conclusion, see [jemalloc/TUNING.md](https://github.com/jemalloc/jemalloc/blob/dev/TUNING.md)). I'm not sure if this would impact on rustup-distributed binaries, but I'm also taking some measures to make sure that rustup-distributed Clippy binaries (and the Rust compiler overall)) use all of Jemalloc 

The performance gains vary depending on factors outside of the users control, but in `wasmi` (my favourite crate to benchmark due to the 66K LOC) it varies between 100ms to 400ms. Overall a solid optimization. 

**How to test:**

There are two ways to benchmark, either with `cargo lintcheck --perf` in the checkout and in `master`, then `perf diff perf.data perf.data.0`, or with `RUSTFLAGS="-Zself-profile" cargo dev lint <my_crate>`, and [measureme](https://github.com/rust-lang/measureme). Choose whichever one is most comfortable.

changelog: Minor allocation performance improvements.
