### PR TITLE
Fix the primary span of `redundant_pub_crate` when flagging nameless items

### DIFF
--- a/clippy_lints/src/redundant_pub_crate.rs
+++ b/clippy_lints/src/redundant_pub_crate.rs
@@ -52,13 +52,10 @@ impl<'tcx> LateLintPass<'tcx> for RedundantPubCrate {
             && is_not_macro_export(item)
             && !item.span.in_external_macro(cx.sess().source_map())
         {
-            // FIXME: `DUMMY_SP` isn't right here, because it causes the
-            // resulting span to begin at the start of the file.
-            let span = item.span.with_hi(
-                item.kind
-                    .ident()
-                    .map_or(rustc_span::DUMMY_SP.hi(), |ident| ident.span.hi()),
-            );
+            let span = item
+                .kind
+                .ident()
+                .map_or(item.span, |ident| item.span.with_hi(ident.span.hi()));
             let descr = cx.tcx.def_kind(item.owner_id).descr(item.owner_id.to_def_id());
             span_lint_and_then(
                 cx,

--- a/tests/ui/redundant_pub_crate.fixed
+++ b/tests/ui/redundant_pub_crate.fixed
@@ -131,6 +131,14 @@ mod m4 {
     }
 }
 
+mod m5 {
+    pub mod m5_1 {}
+    // Test that the primary span isn't butchered for item kinds that don't have an ident.
+    pub use m5_1::*; //~ redundant_pub_crate
+    #[rustfmt::skip]
+    pub use m5_1::{*}; //~ redundant_pub_crate
+}
+
 pub use m4::*;
 
 mod issue_8732 {

--- a/tests/ui/redundant_pub_crate.rs
+++ b/tests/ui/redundant_pub_crate.rs
@@ -131,6 +131,14 @@ mod m4 {
     }
 }
 
+mod m5 {
+    pub mod m5_1 {}
+    // Test that the primary span isn't butchered for item kinds that don't have an ident.
+    pub(crate) use m5_1::*; //~ redundant_pub_crate
+    #[rustfmt::skip]
+    pub(crate) use m5_1::{*}; //~ redundant_pub_crate
+}
+
 pub use m4::*;
 
 mod issue_8732 {

--- a/tests/ui/redundant_pub_crate.stderr
+++ b/tests/ui/redundant_pub_crate.stderr
@@ -129,5 +129,21 @@ LL |         pub(crate) fn g() {} // private due to m4_2
    |         |
    |         help: consider using: `pub`
 
-error: aborting due to 16 previous errors
+error: pub(crate) import inside private module
+  --> tests/ui/redundant_pub_crate.rs:137:5
+   |
+LL |     pub(crate) use m5_1::*;
+   |     ----------^^^^^^^^^^^^^
+   |     |
+   |     help: consider using: `pub`
+
+error: pub(crate) import inside private module
+  --> tests/ui/redundant_pub_crate.rs:139:27
+   |
+LL |     pub(crate) use m5_1::{*};
+   |     ----------            ^
+   |     |
+   |     help: consider using: `pub`
+
+error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Found this while reviewing PR https://github.com/rust-lang/rust/pull/138384: See https://github.com/rust-lang/rust/pull/138384#discussion_r1996111087 in which I suggested a FIXME to be added that I'm now fixing in this PR.

---

Before this PR, `redundant_pub_crate` computed a broken primary Span when flagging items (`hir::Item`s) that never bear a name (`ForeignMod`, `GlobalAsm`, `Impl`, `Use(UseKind::Glob)`, `Use(UseKind::ListStem)`). Namely, it created a span whose high byte index is `DUMMY_SP.hi()` which is quite broken (`DUMMY_SP` is synonymous with `0..0` wrt. the entire `SourceMap` meaning it points at the start of the very first source file in the `SourceMap`).

Why did this happen? Before PR https://github.com/rust-lang/rust/pull/138384, the offending line looked like `let span = item.span.with_hi(item.ident.span.hi());`. For nameless items, `item.ident` used to be set to `Ident(sym::empty, DUMMY_SP)`. This is where the `DUMMY_SP` came from.

The code means to compute a "shorter item span" that doesn't include the "body" of items, only the "head" (similar to `TyCtxt::def_span`).

<details><summary>Examples of Clippy's butchered output on master</summary>

```rs
#![deny(clippy::redundant_pub_crate)]

mod m5 {
    pub mod m5_1 {}
    pub(crate) use m5_1::*;
}
```

```
error: pub(crate) import inside private module
 --> file.rs:1:1
  |
1 | / #![deny(clippy::redundant_pub_crate)]
2 | |
3 | | mod m5 {
4 | |     pub mod m5_1 {}
5 | |     pub(crate) use m5_1::*;
  | |    ^---------- help: consider using: `pub`
  | |____|
  |
```

Or if the `SourceMap` contains multiple files (notice how it leaks `clippy.toml`!):

```
error: pub(crate) import inside private module
 --> /home/fmease/programming/rust/clippy/clippy.toml:1:1
  |
1 | / avoid-breaking-exported-api = false
2 | |
3 | | check-inconsistent-struct-field-initializers = true
... |
6 | |
  | |_^
  |
 ::: file.rs:6:5
  |
6 |       pub(crate) use m5_1::{*}; // Glob
  |       ---------- help: consider using: `pub`
  |
```

</details>

---

**Note**: Currently, the only nameless item kind that can also have a visibility is `Use(UseKind::{Glob,ListStem})`. Thus I'm just falling back to the entire item's Span which wouldn't be that verbose. However, in the future Rust will feature impl restrictions (like `pub(crate) impl Trait for Type {}`, see [RFC 3323](https://rust-lang.github.io/rfcs/3323-restrictions.html) and https://github.com/rust-lang/rust/pull/106074). Using `item.span` for these would be quite bad (it would include all associated items). Should I add a FIXME?

---

changelog: [`redundant_pub_crate`]: Fix the code highlighting for nameless items.
