### PR TITLE
Do not build `tokio-rustls` in the CI for the time being

### DIFF
--- a/.github/workflows/lintcheck.yml
+++ b/.github/workflows/lintcheck.yml
@@ -49,10 +49,6 @@ jobs:
         path: target/debug/lintcheck
         key: lintcheck-bin-${{ hashfiles('lintcheck/**') }}
 
-    # Install cmake to build aws-lc-sys to build tokio-rustls
-    - name: Install cmake
-      run: sudo apt-get install -y cmake
-
     - name: Build lintcheck
       if: steps.cache-lintcheck-bin.outputs.cache-hit != 'true'
       run: cargo build --manifest-path=lintcheck/Cargo.toml
@@ -95,10 +91,6 @@ jobs:
       with:
         path: target/debug/lintcheck
         key: lintcheck-bin-${{ hashfiles('lintcheck/**') }}
-
-    # Install cmake to build aws-lc-sys to build tokio-rustls
-    - name: Install cmake
-      run: sudo apt-get install -y cmake
 
     - name: Build lintcheck
       if: steps.cache-lintcheck-bin.outputs.cache-hit != 'true'

--- a/lintcheck/ci_crates.toml
+++ b/lintcheck/ci_crates.toml
@@ -122,7 +122,8 @@ winnow = { name = 'winnow', version = '0.6.13' }
 cpufeatures = { name = 'cpufeatures', version = '0.2.12' }
 nix = { name = 'nix', version = '0.29.0' }
 fnv = { name = 'fnv', version = '1.0.7' }
-tokio-rustls = { name = 'tokio-rustls', version = '0.26.0' }
+# As of 2025-04-01, one dependency doesn't build because of cmake version discrepancy
+# tokio-rustls = { name = 'tokio-rustls', version = '0.26.0' }
 iana-time-zone = { name = 'iana-time-zone', version = '0.1.60' }
 rustls-webpki = { name = 'rustls-webpki', version = '0.102.5' }
 crc32fast = { name = 'crc32fast', version = '1.4.2' }


### PR DESCRIPTION
A discrepancy between the `cmake` version available on the runners and the one required by the `aws-lc-sys` dependency prevents the crate from building.

changelog: none

r? @flip1995  
cc @Alexendoo  