### PR TITLE
Stop relabelling PRs with merge conflicts

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,9 +10,6 @@ allow-unauthenticated = [
 [shortcut]
 
 [merge-conflicts]
-add = ['S-waiting-on-author']
-remove = ['S-waiting-on-review']
-unless = ['S-blocked', 'S-final-comment-period']
 
 # Have rustbot inform users about the *No Merge Policy*
 [no-merges]


### PR DESCRIPTION
r? @flip1995 

After seeing some PRs get relabelled I think it's probably for the best not to, a conflict doesn't mean it's no longer waiting for review after all

changelog: none
