### PR TITLE
Do not propose to auto-derive `Clone` in presence of unsafe fields

### DIFF
--- a/clippy_lints/src/derive.rs
+++ b/clippy_lints/src/derive.rs
@@ -349,6 +349,10 @@ fn check_copy_clone<'tcx>(cx: &LateContext<'tcx>, item: &Item<'_>, trait_ref: &h
     {
         return;
     }
+    // The presence of `unsafe` fields prevents deriving `Clone` automatically
+    if ty_adt.all_fields().any(|f| f.safety.is_unsafe()) {
+        return;
+    }
 
     span_lint_and_note(
         cx,

--- a/tests/ui/derive.rs
+++ b/tests/ui/derive.rs
@@ -6,6 +6,8 @@
     dead_code
 )]
 #![warn(clippy::expl_impl_clone_on_copy)]
+#![expect(incomplete_features)] // `unsafe_fields` is incomplete for the time being
+#![feature(unsafe_fields)] // `clone()` cannot be derived automatically on unsafe fields
 
 #[derive(Copy)]
 struct Qux;
@@ -109,6 +111,21 @@ struct Packed<T>(T);
 impl<T: Copy> Clone for Packed<T> {
     fn clone(&self) -> Self {
         *self
+    }
+}
+
+fn issue14558() {
+    pub struct Valid {
+        pub unsafe actual: (),
+    }
+
+    unsafe impl Copy for Valid {}
+
+    impl Clone for Valid {
+        #[inline]
+        fn clone(&self) -> Self {
+            *self
+        }
     }
 }
 

--- a/tests/ui/derive.stderr
+++ b/tests/ui/derive.stderr
@@ -1,5 +1,5 @@
 error: you are implementing `Clone` explicitly on a `Copy` type
-  --> tests/ui/derive.rs:13:1
+  --> tests/ui/derive.rs:15:1
    |
 LL | / impl Clone for Qux {
 LL | |
@@ -10,7 +10,7 @@ LL | | }
    | |_^
    |
 note: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:13:1
+  --> tests/ui/derive.rs:15:1
    |
 LL | / impl Clone for Qux {
 LL | |
@@ -23,7 +23,7 @@ LL | | }
    = help: to override `-D warnings` add `#[allow(clippy::expl_impl_clone_on_copy)]`
 
 error: you are implementing `Clone` explicitly on a `Copy` type
-  --> tests/ui/derive.rs:39:1
+  --> tests/ui/derive.rs:41:1
    |
 LL | / impl<'a> Clone for Lt<'a> {
 LL | |
@@ -34,7 +34,7 @@ LL | | }
    | |_^
    |
 note: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:39:1
+  --> tests/ui/derive.rs:41:1
    |
 LL | / impl<'a> Clone for Lt<'a> {
 LL | |
@@ -45,7 +45,7 @@ LL | | }
    | |_^
 
 error: you are implementing `Clone` explicitly on a `Copy` type
-  --> tests/ui/derive.rs:52:1
+  --> tests/ui/derive.rs:54:1
    |
 LL | / impl Clone for BigArray {
 LL | |
@@ -56,7 +56,7 @@ LL | | }
    | |_^
    |
 note: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:52:1
+  --> tests/ui/derive.rs:54:1
    |
 LL | / impl Clone for BigArray {
 LL | |
@@ -67,7 +67,7 @@ LL | | }
    | |_^
 
 error: you are implementing `Clone` explicitly on a `Copy` type
-  --> tests/ui/derive.rs:65:1
+  --> tests/ui/derive.rs:67:1
    |
 LL | / impl Clone for FnPtr {
 LL | |
@@ -78,7 +78,7 @@ LL | | }
    | |_^
    |
 note: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:65:1
+  --> tests/ui/derive.rs:67:1
    |
 LL | / impl Clone for FnPtr {
 LL | |
@@ -89,7 +89,7 @@ LL | | }
    | |_^
 
 error: you are implementing `Clone` explicitly on a `Copy` type
-  --> tests/ui/derive.rs:87:1
+  --> tests/ui/derive.rs:89:1
    |
 LL | / impl<T: Clone> Clone for Generic2<T> {
 LL | |
@@ -100,7 +100,7 @@ LL | | }
    | |_^
    |
 note: consider deriving `Clone` or removing `Copy`
-  --> tests/ui/derive.rs:87:1
+  --> tests/ui/derive.rs:89:1
    |
 LL | / impl<T: Clone> Clone for Generic2<T> {
 LL | |


### PR DESCRIPTION
`unsafe_fields` is an incomplete feature; comments have been put near `#![expect(incomplete_features)]` to ensure that we revisit the situation when the feature becomes complete.

changelog: [`expl_impl_clone_on_copy`]: do not lint in the presence of `unsafe` fields

Fixes #14558