### PR TITLE
Enable canonicalization of issue links in triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -11,6 +11,8 @@ allow-unauthenticated = [
 
 [merge-conflicts]
 
+[canonicalize-issue-links]
+
 # Have rustbot inform users about the *No Merge Policy*
 [no-merges]
 exclude_titles = ["Rustup"] # exclude syncs from rust-lang/rust


### PR DESCRIPTION
This PR enables to the canonicalization of issue links in triagebot.

Documentation pending at https://github.com/rust-lang/rust-forge/pull/825

changelog: add `[canonicalize-issue-links]` in `triagebot.toml`