### PR TITLE
Enable no mentions in commits of triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -13,6 +13,9 @@ allow-unauthenticated = [
 
 [canonicalize-issue-links]
 
+# Prevents mentions in commits to avoid users being spammed
+[no-mentions]
+
 # Have rustbot inform users about the *No Merge Policy*
 [no-merges]
 exclude_titles = ["Rustup"] # exclude syncs from rust-lang/rust


### PR DESCRIPTION
This PR enables the no-mentions in commits handler in triagebot.

Documentation pending at https://github.com/rust-lang/rust-forge/pull/827

Original motivation in https://github.com/rust-lang/rust/issues/137990.

changelog: add `[no-mentions]` in `triagebot.toml`