### PR TITLE
dogfood: run with `-D clippy::dbg_macro`

### DIFF
--- a/tests/dogfood.rs
+++ b/tests/dogfood.rs
@@ -80,6 +80,7 @@ fn run_clippy_for_package(project: &str, args: &[&str]) -> bool {
 
     command.arg("--").args(args);
     command.arg("-Cdebuginfo=0"); // disable debuginfo to generate less data in the target dir
+    command.args(["-D", "clippy::dbg_macro"]);
 
     if cfg!(feature = "internal") {
         // internal lints only exist if we build with the internal feature


### PR DESCRIPTION
This prevents forgotten `dbg!()` calls from entering Clippy codebase by mistake.

Suggested by @y21 when one of my PR forgot to remove one `dbg!()` call.

changelog: none