### PR TITLE
Assign PR touching `triagebot.toml` to Philipp

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -41,6 +41,7 @@ users_on_vacation = [
 
 [assign.owners]
 "/.github" = ["@flip1995"]
+"/triagebot.toml" = ["@flip1995"]
 "/book" = ["@flip1995"]
 "*" = [
     "@Manishearth",


### PR DESCRIPTION
`triagebot.toml` is related to the repo behavior wrt interactions, and must be kept inline with what is done in the CI.

changelog: none

r? @flip1995 