### PR TITLE
Check if dropping an expression may have indirect side-effects

### DIFF
--- a/tests/ui/single_range_in_vec_init.rs
+++ b/tests/ui/single_range_in_vec_init.rs
@@ -1,6 +1,6 @@
 //@aux-build:proc_macros.rs
 //@no-rustfix: overlapping suggestions
-#![allow(clippy::no_effect, clippy::useless_vec, unused)]
+#![allow(clippy::no_effect, clippy::unnecessary_operation, clippy::useless_vec, unused)]
 #![warn(clippy::single_range_in_vec_init)]
 #![feature(generic_arg_infer)]
 


### PR DESCRIPTION
It is not enough to check if an expression type implements `Drop` to determine whether it can have a significant side-effect.

Also, add tests for unchecked cases which were explicitly handled in the code, such as checking for side effect in a `struct`'s fields, or in its base expression.

Fix rust-lang/rust-clippy#14592 

changelog: [`no_effect_underscore_binding`]: do not propose to remove the assignment of an object if dropping it might indirectly have a visible side effect