### PR TITLE
`iter_kv_map`: recognize references on maps as well

### DIFF
--- a/clippy_lints/src/methods/iter_kv_map.rs
+++ b/clippy_lints/src/methods/iter_kv_map.rs
@@ -37,7 +37,7 @@ pub(super) fn check<'tcx>(
             (PatKind::Binding(ann, _, key, _), value) if pat_is_wild(cx, value, m_arg) => ("key", ann, key),
             _ => return,
         }
-        && let ty = cx.typeck_results().expr_ty(recv)
+        && let ty = cx.typeck_results().expr_ty_adjusted(recv).peel_refs()
         && (is_type_diagnostic_item(cx, ty, sym::HashMap) || is_type_diagnostic_item(cx, ty, sym::BTreeMap))
     {
         let mut applicability = rustc_errors::Applicability::MachineApplicable;

--- a/tests/ui/iter_kv_map.fixed
+++ b/tests/ui/iter_kv_map.fixed
@@ -166,3 +166,18 @@ fn msrv_1_54() {
     let _ = map.values().map(|v| v + 2).collect::<Vec<_>>();
     //~^ iter_kv_map
 }
+
+fn issue14595() {
+    pub struct Foo(BTreeMap<String, i32>);
+
+    impl AsRef<BTreeMap<String, i32>> for Foo {
+        fn as_ref(&self) -> &BTreeMap<String, i32> {
+            &self.0
+        }
+    }
+
+    let map = Foo(BTreeMap::default());
+
+    let _ = map.as_ref().values().copied().collect::<Vec<_>>();
+    //~^ iter_kv_map
+}

--- a/tests/ui/iter_kv_map.rs
+++ b/tests/ui/iter_kv_map.rs
@@ -170,3 +170,18 @@ fn msrv_1_54() {
     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
     //~^ iter_kv_map
 }
+
+fn issue14595() {
+    pub struct Foo(BTreeMap<String, i32>);
+
+    impl AsRef<BTreeMap<String, i32>> for Foo {
+        fn as_ref(&self) -> &BTreeMap<String, i32> {
+            &self.0
+        }
+    }
+
+    let map = Foo(BTreeMap::default());
+
+    let _ = map.as_ref().iter().map(|(_, v)| v).copied().collect::<Vec<_>>();
+    //~^ iter_kv_map
+}

--- a/tests/ui/iter_kv_map.stderr
+++ b/tests/ui/iter_kv_map.stderr
@@ -263,5 +263,11 @@ error: iterating on a map's values
 LL |     let _ = map.iter().map(|(_, v)| v + 2).collect::<Vec<_>>();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.values().map(|v| v + 2)`
 
-error: aborting due to 38 previous errors
+error: iterating on a map's values
+  --> tests/ui/iter_kv_map.rs:185:13
+   |
+LL |     let _ = map.as_ref().iter().map(|(_, v)| v).copied().collect::<Vec<_>>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `map.as_ref().values()`
+
+error: aborting due to 39 previous errors
 


### PR DESCRIPTION
Fix rust-lang/rust-clippy#14595 

changelog: [`iter_kv_map`]: recognize references on maps as well