### PR TITLE
Remove some `clippy::all` uses from UI tests

### DIFF
--- a/tests/ui/author/if.rs
+++ b/tests/ui/author/if.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#[allow(clippy::all)]
+#![allow(clippy::all)]
 
 fn main() {
     #[clippy::author]

--- a/tests/ui/box_collection.rs
+++ b/tests/ui/box_collection.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::all)]
 #![allow(
     clippy::boxed_local,
     clippy::needless_pass_by_value,

--- a/tests/ui/box_collection.stderr
+++ b/tests/ui/box_collection.stderr
@@ -1,5 +1,5 @@
 error: you seem to be trying to use `Box<Vec<..>>`. Consider using just `Vec<..>`
-  --> tests/ui/box_collection.rs:21:15
+  --> tests/ui/box_collection.rs:20:15
    |
 LL | fn test1(foo: Box<Vec<bool>>) {}
    |               ^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | fn test1(foo: Box<Vec<bool>>) {}
    = help: to override `-D warnings` add `#[allow(clippy::box_collection)]`
 
 error: you seem to be trying to use `Box<String>`. Consider using just `String`
-  --> tests/ui/box_collection.rs:29:15
+  --> tests/ui/box_collection.rs:28:15
    |
 LL | fn test3(foo: Box<String>) {}
    |               ^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | fn test3(foo: Box<String>) {}
    = help: `String` is already on the heap, `Box<String>` makes an extra allocation
 
 error: you seem to be trying to use `Box<HashMap<..>>`. Consider using just `HashMap<..>`
-  --> tests/ui/box_collection.rs:32:15
+  --> tests/ui/box_collection.rs:31:15
    |
 LL | fn test4(foo: Box<HashMap<String, String>>) {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | fn test4(foo: Box<HashMap<String, String>>) {}
    = help: `HashMap<..>` is already on the heap, `Box<HashMap<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<HashSet<..>>`. Consider using just `HashSet<..>`
-  --> tests/ui/box_collection.rs:35:15
+  --> tests/ui/box_collection.rs:34:15
    |
 LL | fn test5(foo: Box<HashSet<i64>>) {}
    |               ^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL | fn test5(foo: Box<HashSet<i64>>) {}
    = help: `HashSet<..>` is already on the heap, `Box<HashSet<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<VecDeque<..>>`. Consider using just `VecDeque<..>`
-  --> tests/ui/box_collection.rs:38:15
+  --> tests/ui/box_collection.rs:37:15
    |
 LL | fn test6(foo: Box<VecDeque<i32>>) {}
    |               ^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL | fn test6(foo: Box<VecDeque<i32>>) {}
    = help: `VecDeque<..>` is already on the heap, `Box<VecDeque<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<LinkedList<..>>`. Consider using just `LinkedList<..>`
-  --> tests/ui/box_collection.rs:41:15
+  --> tests/ui/box_collection.rs:40:15
    |
 LL | fn test7(foo: Box<LinkedList<i16>>) {}
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL | fn test7(foo: Box<LinkedList<i16>>) {}
    = help: `LinkedList<..>` is already on the heap, `Box<LinkedList<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<BTreeMap<..>>`. Consider using just `BTreeMap<..>`
-  --> tests/ui/box_collection.rs:44:15
+  --> tests/ui/box_collection.rs:43:15
    |
 LL | fn test8(foo: Box<BTreeMap<i8, String>>) {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL | fn test8(foo: Box<BTreeMap<i8, String>>) {}
    = help: `BTreeMap<..>` is already on the heap, `Box<BTreeMap<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<BTreeSet<..>>`. Consider using just `BTreeSet<..>`
-  --> tests/ui/box_collection.rs:47:15
+  --> tests/ui/box_collection.rs:46:15
    |
 LL | fn test9(foo: Box<BTreeSet<u64>>) {}
    |               ^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL | fn test9(foo: Box<BTreeSet<u64>>) {}
    = help: `BTreeSet<..>` is already on the heap, `Box<BTreeSet<..>>` makes an extra allocation
 
 error: you seem to be trying to use `Box<BinaryHeap<..>>`. Consider using just `BinaryHeap<..>`
-  --> tests/ui/box_collection.rs:50:16
+  --> tests/ui/box_collection.rs:49:16
    |
 LL | fn test10(foo: Box<BinaryHeap<u32>>) {}
    |                ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cognitive_complexity.rs
+++ b/tests/ui/cognitive_complexity.rs
@@ -1,6 +1,11 @@
-#![allow(clippy::all)]
 #![warn(clippy::cognitive_complexity)]
-#![allow(unused, unused_crate_dependencies)]
+#![allow(
+    clippy::eq_op,
+    clippy::needless_borrows_for_generic_args,
+    clippy::needless_return,
+    clippy::nonminimal_bool,
+    clippy::uninlined_format_args
+)]
 
 #[rustfmt::skip]
 fn main() {

--- a/tests/ui/cognitive_complexity.stderr
+++ b/tests/ui/cognitive_complexity.stderr
@@ -1,5 +1,5 @@
 error: the function has a cognitive complexity of (28/25)
-  --> tests/ui/cognitive_complexity.rs:6:4
+  --> tests/ui/cognitive_complexity.rs:11:4
    |
 LL | fn main() {
    |    ^^^^
@@ -9,7 +9,7 @@ LL | fn main() {
    = help: to override `-D warnings` add `#[allow(clippy::cognitive_complexity)]`
 
 error: the function has a cognitive complexity of (7/1)
-  --> tests/ui/cognitive_complexity.rs:93:4
+  --> tests/ui/cognitive_complexity.rs:98:4
    |
 LL | fn kaboom() {
    |    ^^^^^^
@@ -17,7 +17,7 @@ LL | fn kaboom() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:153:4
+  --> tests/ui/cognitive_complexity.rs:158:4
    |
 LL | fn baa() {
    |    ^^^
@@ -25,7 +25,7 @@ LL | fn baa() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:156:13
+  --> tests/ui/cognitive_complexity.rs:161:13
    |
 LL |     let x = || match 99 {
    |             ^^
@@ -33,7 +33,7 @@ LL |     let x = || match 99 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:174:4
+  --> tests/ui/cognitive_complexity.rs:179:4
    |
 LL | fn bar() {
    |    ^^^
@@ -41,7 +41,7 @@ LL | fn bar() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:187:4
+  --> tests/ui/cognitive_complexity.rs:192:4
    |
 LL | fn dont_warn_on_tests() {
    |    ^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL | fn dont_warn_on_tests() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:197:4
+  --> tests/ui/cognitive_complexity.rs:202:4
    |
 LL | fn barr() {
    |    ^^^^
@@ -57,7 +57,7 @@ LL | fn barr() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (3/1)
-  --> tests/ui/cognitive_complexity.rs:209:4
+  --> tests/ui/cognitive_complexity.rs:214:4
    |
 LL | fn barr2() {
    |    ^^^^^
@@ -65,7 +65,7 @@ LL | fn barr2() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:227:4
+  --> tests/ui/cognitive_complexity.rs:232:4
    |
 LL | fn barrr() {
    |    ^^^^^
@@ -73,7 +73,7 @@ LL | fn barrr() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (3/1)
-  --> tests/ui/cognitive_complexity.rs:239:4
+  --> tests/ui/cognitive_complexity.rs:244:4
    |
 LL | fn barrr2() {
    |    ^^^^^^
@@ -81,7 +81,7 @@ LL | fn barrr2() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:257:4
+  --> tests/ui/cognitive_complexity.rs:262:4
    |
 LL | fn barrrr() {
    |    ^^^^^^
@@ -89,7 +89,7 @@ LL | fn barrrr() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (3/1)
-  --> tests/ui/cognitive_complexity.rs:269:4
+  --> tests/ui/cognitive_complexity.rs:274:4
    |
 LL | fn barrrr2() {
    |    ^^^^^^^
@@ -97,7 +97,7 @@ LL | fn barrrr2() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:287:4
+  --> tests/ui/cognitive_complexity.rs:292:4
    |
 LL | fn cake() {
    |    ^^^^
@@ -105,7 +105,7 @@ LL | fn cake() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (4/1)
-  --> tests/ui/cognitive_complexity.rs:299:8
+  --> tests/ui/cognitive_complexity.rs:304:8
    |
 LL | pub fn read_file(input_path: &str) -> String {
    |        ^^^^^^^^^
@@ -113,7 +113,7 @@ LL | pub fn read_file(input_path: &str) -> String {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:332:4
+  --> tests/ui/cognitive_complexity.rs:337:4
    |
 LL | fn void(void: Void) {
    |    ^^^^
@@ -121,7 +121,7 @@ LL | fn void(void: Void) {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (8/1)
-  --> tests/ui/cognitive_complexity.rs:385:4
+  --> tests/ui/cognitive_complexity.rs:390:4
    |
 LL | fn early_ret() -> i32 {
    |    ^^^^^^^^^
@@ -129,7 +129,7 @@ LL | fn early_ret() -> i32 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:408:13
+  --> tests/ui/cognitive_complexity.rs:413:13
    |
 LL |     let x = |a: i32, b: i32| -> i32 {
    |             ^^^^^^^^^^^^^^^^
@@ -137,7 +137,7 @@ LL |     let x = |a: i32, b: i32| -> i32 {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:423:8
+  --> tests/ui/cognitive_complexity.rs:428:8
    |
 LL |     fn moo(&self) {
    |        ^^^
@@ -145,7 +145,7 @@ LL |     fn moo(&self) {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:434:14
+  --> tests/ui/cognitive_complexity.rs:439:14
    |
 LL |     async fn a() {
    |              ^
@@ -153,7 +153,7 @@ LL |     async fn a() {
    = help: you could split it up into multiple smaller functions
 
 error: the function has a cognitive complexity of (2/1)
-  --> tests/ui/cognitive_complexity.rs:443:22
+  --> tests/ui/cognitive_complexity.rs:448:22
    |
 LL |         pub async fn async_method() {
    |                      ^^^^^^^^^^^^

--- a/tests/ui/crashes/enum-glob-import-crate.rs
+++ b/tests/ui/crashes/enum-glob-import-crate.rs
@@ -1,8 +1,5 @@
 //@ check-pass
 
-#![deny(clippy::all)]
-#![allow(unused_imports)]
-
 use std::*;
 
 fn main() {}

--- a/tests/ui/crashes/ice-1588.rs
+++ b/tests/ui/crashes/ice-1588.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![allow(clippy::all)]
+#![expect(clippy::no_effect)]
 
 // Test for https://github.com/rust-lang/rust-clippy/issues/1588
 

--- a/tests/ui/crashes/ice-1969.rs
+++ b/tests/ui/crashes/ice-1969.rs
@@ -1,7 +1,5 @@
 //@ check-pass
 
-#![allow(clippy::all)]
-
 // Test for https://github.com/rust-lang/rust-clippy/issues/1969
 
 fn main() {}

--- a/tests/ui/crashes/ice-3462.rs
+++ b/tests/ui/crashes/ice-3462.rs
@@ -1,8 +1,6 @@
 //@ check-pass
 
-#![warn(clippy::all)]
-#![allow(clippy::disallowed_names, clippy::equatable_if_let, clippy::needless_if)]
-#![allow(unused)]
+#![expect(clippy::disallowed_names)]
 
 // Test for https://github.com/rust-lang/rust-clippy/issues/3462
 

--- a/tests/ui/crashes/ice-700.rs
+++ b/tests/ui/crashes/ice-700.rs
@@ -1,7 +1,5 @@
 //@ check-pass
 
-#![deny(clippy::all)]
-
 // Test for https://github.com/rust-lang/rust-clippy/issues/700
 
 fn core() {}

--- a/tests/ui/crashes/ice-7012.rs
+++ b/tests/ui/crashes/ice-7012.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 
-#![allow(clippy::all)]
+#![expect(clippy::single_match)]
 
 enum _MyOption {
     None,

--- a/tests/ui/crashes/ice_exact_size.rs
+++ b/tests/ui/crashes/ice_exact_size.rs
@@ -1,10 +1,7 @@
 //@ check-pass
 
-#![deny(clippy::all)]
-
 // Test for https://github.com/rust-lang/rust-clippy/issues/1336
 
-#[allow(dead_code)]
 struct Foo;
 
 impl Iterator for Foo {

--- a/tests/ui/crashes/needless_borrow_fp.rs
+++ b/tests/ui/crashes/needless_borrow_fp.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 
-#[deny(clippy::all)]
 #[derive(Debug)]
 pub enum Error {
     Type(&'static str),

--- a/tests/ui/crate_level_checks/no_std_swap.fixed
+++ b/tests/ui/crate_level_checks/no_std_swap.fixed
@@ -3,7 +3,6 @@
 
 use core::panic::PanicInfo;
 
-#[warn(clippy::all)]
 pub fn main() {
     let mut a = 42;
     let mut b = 1337;

--- a/tests/ui/crate_level_checks/no_std_swap.rs
+++ b/tests/ui/crate_level_checks/no_std_swap.rs
@@ -3,7 +3,6 @@
 
 use core::panic::PanicInfo;
 
-#[warn(clippy::all)]
 pub fn main() {
     let mut a = 42;
     let mut b = 1337;

--- a/tests/ui/crate_level_checks/no_std_swap.stderr
+++ b/tests/ui/crate_level_checks/no_std_swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are trying to swap `a` and `b`
-  --> tests/ui/crate_level_checks/no_std_swap.rs:11:5
+  --> tests/ui/crate_level_checks/no_std_swap.rs:10:5
    |
 LL | /     a = b;
 ...  |
@@ -7,8 +7,7 @@ LL | |     b = a;
    | |_________^ help: try: `core::mem::swap(&mut a, &mut b)`
    |
    = note: or maybe you should use `core::mem::replace`?
-   = note: `-D clippy::almost-swapped` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::almost_swapped)]`
+   = note: `#[deny(clippy::almost_swapped)]` on by default
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/filter_map_next.rs
+++ b/tests/ui/filter_map_next.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::all, clippy::pedantic)]
+#![warn(clippy::filter_map_next)]
 
 fn main() {
     let a = ["1", "lol", "3", "NaN", "5"];

--- a/tests/ui/filter_map_next_fixable.fixed
+++ b/tests/ui/filter_map_next_fixable.fixed
@@ -1,5 +1,4 @@
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(unused)]
+#![warn(clippy::filter_map_next)]
 
 fn main() {
     let a = ["1", "lol", "3", "NaN", "5"];

--- a/tests/ui/filter_map_next_fixable.rs
+++ b/tests/ui/filter_map_next_fixable.rs
@@ -1,5 +1,4 @@
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(unused)]
+#![warn(clippy::filter_map_next)]
 
 fn main() {
     let a = ["1", "lol", "3", "NaN", "5"];

--- a/tests/ui/filter_map_next_fixable.stderr
+++ b/tests/ui/filter_map_next_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `filter_map(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find_map(..)` instead
-  --> tests/ui/filter_map_next_fixable.rs:7:32
+  --> tests/ui/filter_map_next_fixable.rs:6:32
    |
 LL |     let element: Option<i32> = a.iter().filter_map(|s| s.parse().ok()).next();
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.iter().find_map(|s| s.parse().ok())`
@@ -8,7 +8,7 @@ LL |     let element: Option<i32> = a.iter().filter_map(|s| s.parse().ok()).next
    = help: to override `-D warnings` add `#[allow(clippy::filter_map_next)]`
 
 error: called `filter_map(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find_map(..)` instead
-  --> tests/ui/filter_map_next_fixable.rs:21:26
+  --> tests/ui/filter_map_next_fixable.rs:20:26
    |
 LL |     let _: Option<i32> = a.iter().filter_map(|s| s.parse().ok()).next();
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `a.iter().find_map(|s| s.parse().ok())`

--- a/tests/ui/find_map.rs
+++ b/tests/ui/find_map.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 
-#![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::useless_vec)]
 
 #[derive(Debug, Copy, Clone)]

--- a/tests/ui/formatting.rs
+++ b/tests/ui/formatting.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::all)]
-#![allow(unused_variables)]
-#![allow(unused_assignments)]
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::deref_addrof)]
 #![allow(clippy::nonminimal_bool)]

--- a/tests/ui/formatting.stderr
+++ b/tests/ui/formatting.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are trying to use `.. -= ..`, but you really are doing `.. = (- ..)`
-  --> tests/ui/formatting.rs:16:6
+  --> tests/ui/formatting.rs:13:6
    |
 LL |     a =- 35;
    |      ^^^^
@@ -9,7 +9,7 @@ LL |     a =- 35;
    = help: to override `-D warnings` add `#[allow(clippy::suspicious_assignment_formatting)]`
 
 error: this looks like you are trying to use `.. *= ..`, but you really are doing `.. = (* ..)`
-  --> tests/ui/formatting.rs:20:6
+  --> tests/ui/formatting.rs:17:6
    |
 LL |     a =* &191;
    |      ^^^^
@@ -17,7 +17,7 @@ LL |     a =* &191;
    = note: to remove this lint, use either `*=` or `= *`
 
 error: this looks like you are trying to use `.. != ..`, but you really are doing `.. = (! ..)`
-  --> tests/ui/formatting.rs:26:6
+  --> tests/ui/formatting.rs:23:6
    |
 LL |     b =! false;
    |      ^^^^
@@ -25,17 +25,16 @@ LL |     b =! false;
    = note: to remove this lint, use either `!=` or `= !`
 
 error: possibly missing a comma here
-  --> tests/ui/formatting.rs:38:19
+  --> tests/ui/formatting.rs:35:19
    |
 LL |         -1, -2, -3 // <= no comma here
    |                   ^
    |
    = note: to remove this lint, add a comma or write the expr in a single line
-   = note: `-D clippy::possible-missing-comma` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::possible_missing_comma)]`
+   = note: `#[deny(clippy::possible_missing_comma)]` on by default
 
 error: possibly missing a comma here
-  --> tests/ui/formatting.rs:45:19
+  --> tests/ui/formatting.rs:42:19
    |
 LL |         -1, -2, -3 // <= no comma here
    |                   ^
@@ -43,7 +42,7 @@ LL |         -1, -2, -3 // <= no comma here
    = note: to remove this lint, add a comma or write the expr in a single line
 
 error: possibly missing a comma here
-  --> tests/ui/formatting.rs:85:11
+  --> tests/ui/formatting.rs:82:11
    |
 LL |         -1
    |           ^

--- a/tests/ui/functions.rs
+++ b/tests/ui/functions.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::all)]
-#![allow(dead_code, unused_unsafe)]
 #![allow(clippy::missing_safety_doc, clippy::uninlined_format_args)]
 
 // TOO_MANY_ARGUMENTS

--- a/tests/ui/functions.stderr
+++ b/tests/ui/functions.stderr
@@ -1,5 +1,5 @@
 error: this function has too many arguments (8/7)
-  --> tests/ui/functions.rs:8:1
+  --> tests/ui/functions.rs:6:1
    |
 LL | fn bad(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f32, _seven: bool, _eight: ()) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | fn bad(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f
    = help: to override `-D warnings` add `#[allow(clippy::too_many_arguments)]`
 
 error: this function has too many arguments (8/7)
-  --> tests/ui/functions.rs:12:1
+  --> tests/ui/functions.rs:10:1
    |
 LL | / fn bad_multiline(
 LL | |
@@ -20,88 +20,87 @@ LL | | ) {
    | |_^
 
 error: this function has too many arguments (8/7)
-  --> tests/ui/functions.rs:48:5
+  --> tests/ui/functions.rs:46:5
    |
 LL |     fn bad(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f32, _seven: bool, _eight: ());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this function has too many arguments (8/7)
-  --> tests/ui/functions.rs:58:5
+  --> tests/ui/functions.rs:56:5
    |
 LL |     fn bad_method(_one: u32, _two: u32, _three: &str, _four: bool, _five: f32, _six: f32, _seven: bool, _eight: ()) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:68:34
+  --> tests/ui/functions.rs:66:34
    |
 LL |         println!("{}", unsafe { *p });
    |                                  ^
    |
-   = note: `-D clippy::not-unsafe-ptr-arg-deref` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::not_unsafe_ptr_arg_deref)]`
+   = note: `#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:71:35
+  --> tests/ui/functions.rs:69:35
    |
 LL |         println!("{:?}", unsafe { p.as_ref() });
    |                                   ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:74:33
+  --> tests/ui/functions.rs:72:33
    |
 LL |         unsafe { std::ptr::read(p) };
    |                                 ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:86:30
+  --> tests/ui/functions.rs:84:30
    |
 LL |     println!("{}", unsafe { *p });
    |                              ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:89:31
+  --> tests/ui/functions.rs:87:31
    |
 LL |     println!("{:?}", unsafe { p.as_ref() });
    |                               ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:92:29
+  --> tests/ui/functions.rs:90:29
    |
 LL |     unsafe { std::ptr::read(p) };
    |                             ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:99:30
+  --> tests/ui/functions.rs:97:30
    |
 LL |     println!("{}", unsafe { *p });
    |                              ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:102:31
+  --> tests/ui/functions.rs:100:31
    |
 LL |     println!("{:?}", unsafe { p.as_ref() });
    |                               ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:105:29
+  --> tests/ui/functions.rs:103:29
    |
 LL |     unsafe { std::ptr::read(p) };
    |                             ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:115:34
+  --> tests/ui/functions.rs:113:34
    |
 LL |         println!("{}", unsafe { *p });
    |                                  ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:118:35
+  --> tests/ui/functions.rs:116:35
    |
 LL |         println!("{:?}", unsafe { p.as_ref() });
    |                                   ^
 
 error: this public function might dereference a raw pointer but is not marked `unsafe`
-  --> tests/ui/functions.rs:121:33
+  --> tests/ui/functions.rs:119:33
    |
 LL |         unsafe { std::ptr::read(p) };
    |                                 ^

--- a/tests/ui/if_not_else.fixed
+++ b/tests/ui/if_not_else.fixed
@@ -1,4 +1,3 @@
-#![warn(clippy::all)]
 #![warn(clippy::if_not_else)]
 
 fn foo() -> bool {

--- a/tests/ui/if_not_else.rs
+++ b/tests/ui/if_not_else.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::all)]
 #![warn(clippy::if_not_else)]
 
 fn foo() -> bool {

--- a/tests/ui/if_not_else.stderr
+++ b/tests/ui/if_not_else.stderr
@@ -1,5 +1,5 @@
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:12:5
+  --> tests/ui/if_not_else.rs:11:5
    |
 LL | /     if !bla() {
 LL | |
@@ -24,7 +24,7 @@ LL +     }
    |
 
 error: unnecessary `!=` operation
-  --> tests/ui/if_not_else.rs:19:5
+  --> tests/ui/if_not_else.rs:18:5
    |
 LL | /     if 4 != 5 {
 LL | |
@@ -47,7 +47,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:34:5
+  --> tests/ui/if_not_else.rs:33:5
    |
 LL | /     if !(foo() && bla()) {
 LL | |
@@ -79,7 +79,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:53:5
+  --> tests/ui/if_not_else.rs:52:5
    |
 LL | /     if !foo() {
 LL | |
@@ -102,7 +102,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:61:5
+  --> tests/ui/if_not_else.rs:60:5
    |
 LL | /     if !bla() {
 LL | |
@@ -125,7 +125,7 @@ LL +     }
    |
 
 error: unnecessary boolean `not` operation
-  --> tests/ui/if_not_else.rs:72:5
+  --> tests/ui/if_not_else.rs:71:5
    |
 LL | /     if !foo() {
 LL | |

--- a/tests/ui/items_after_test_module/root_module.fixed
+++ b/tests/ui/items_after_test_module/root_module.fixed
@@ -1,4 +1,3 @@
-#![allow(unused)]
 #![warn(clippy::items_after_test_module)]
 
 fn main() {}

--- a/tests/ui/items_after_test_module/root_module.rs
+++ b/tests/ui/items_after_test_module/root_module.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 #![warn(clippy::items_after_test_module)]
 
 fn main() {}

--- a/tests/ui/items_after_test_module/root_module.stderr
+++ b/tests/ui/items_after_test_module/root_module.stderr
@@ -1,5 +1,5 @@
 error: items after a test module
-  --> tests/ui/items_after_test_module/root_module.rs:12:1
+  --> tests/ui/items_after_test_module/root_module.rs:11:1
    |
 LL | mod tests {
    | ^^^^^^^^^

--- a/tests/ui/manual_ignore_case_cmp.fixed
+++ b/tests/ui/manual_ignore_case_cmp.fixed
@@ -1,5 +1,11 @@
-#![allow(clippy::all)]
-#![deny(clippy::manual_ignore_case_cmp)]
+#![warn(clippy::manual_ignore_case_cmp)]
+#![allow(
+    clippy::deref_addrof,
+    clippy::op_ref,
+    clippy::ptr_arg,
+    clippy::short_circuit_statement,
+    clippy::unnecessary_operation
+)]
 
 use std::ffi::{OsStr, OsString};
 

--- a/tests/ui/manual_ignore_case_cmp.rs
+++ b/tests/ui/manual_ignore_case_cmp.rs
@@ -1,5 +1,11 @@
-#![allow(clippy::all)]
-#![deny(clippy::manual_ignore_case_cmp)]
+#![warn(clippy::manual_ignore_case_cmp)]
+#![allow(
+    clippy::deref_addrof,
+    clippy::op_ref,
+    clippy::ptr_arg,
+    clippy::short_circuit_statement,
+    clippy::unnecessary_operation
+)]
 
 use std::ffi::{OsStr, OsString};
 

--- a/tests/ui/manual_ignore_case_cmp.stderr
+++ b/tests/ui/manual_ignore_case_cmp.stderr
@@ -1,14 +1,11 @@
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:9:8
+  --> tests/ui/manual_ignore_case_cmp.rs:15:8
    |
 LL |     if a.to_ascii_lowercase() == b.to_ascii_lowercase() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the lint level is defined here
-  --> tests/ui/manual_ignore_case_cmp.rs:2:9
-   |
-LL | #![deny(clippy::manual_ignore_case_cmp)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `-D clippy::manual-ignore-case-cmp` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::manual_ignore_case_cmp)]`
 help: consider using `.eq_ignore_ascii_case()` instead
    |
 LL -     if a.to_ascii_lowercase() == b.to_ascii_lowercase() {
@@ -16,7 +13,7 @@ LL +     if a.eq_ignore_ascii_case(b) {
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:13:8
+  --> tests/ui/manual_ignore_case_cmp.rs:19:8
    |
 LL |     if a.to_ascii_uppercase() == b.to_ascii_uppercase() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +25,7 @@ LL +     if a.eq_ignore_ascii_case(b) {
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:17:13
+  --> tests/ui/manual_ignore_case_cmp.rs:23:13
    |
 LL |     let r = a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,7 +37,7 @@ LL +     let r = a.eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:19:18
+  --> tests/ui/manual_ignore_case_cmp.rs:25:18
    |
 LL |     let r = r || a.to_ascii_uppercase() == b.to_ascii_uppercase();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +49,7 @@ LL +     let r = r || a.eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:21:10
+  --> tests/ui/manual_ignore_case_cmp.rs:27:10
    |
 LL |     r && a.to_ascii_lowercase() == b.to_uppercase().to_ascii_lowercase();
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +61,7 @@ LL +     r && a.eq_ignore_ascii_case(&b.to_uppercase());
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:24:8
+  --> tests/ui/manual_ignore_case_cmp.rs:30:8
    |
 LL |     if a.to_ascii_lowercase() != b.to_ascii_lowercase() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,7 +73,7 @@ LL +     if !a.eq_ignore_ascii_case(b) {
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:28:8
+  --> tests/ui/manual_ignore_case_cmp.rs:34:8
    |
 LL |     if a.to_ascii_uppercase() != b.to_ascii_uppercase() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +85,7 @@ LL +     if !a.eq_ignore_ascii_case(b) {
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:32:13
+  --> tests/ui/manual_ignore_case_cmp.rs:38:13
    |
 LL |     let r = a.to_ascii_lowercase() != b.to_ascii_lowercase();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +97,7 @@ LL +     let r = !a.eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:34:18
+  --> tests/ui/manual_ignore_case_cmp.rs:40:18
    |
 LL |     let r = r || a.to_ascii_uppercase() != b.to_ascii_uppercase();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +109,7 @@ LL +     let r = r || !a.eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:36:10
+  --> tests/ui/manual_ignore_case_cmp.rs:42:10
    |
 LL |     r && a.to_ascii_lowercase() != b.to_uppercase().to_ascii_lowercase();
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,7 +121,7 @@ LL +     r && !a.eq_ignore_ascii_case(&b.to_uppercase());
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:48:5
+  --> tests/ui/manual_ignore_case_cmp.rs:54:5
    |
 LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +133,7 @@ LL +     a.eq_ignore_ascii_case(&b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:52:5
+  --> tests/ui/manual_ignore_case_cmp.rs:58:5
    |
 LL |     a.to_ascii_lowercase() == 'a';
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -148,7 +145,7 @@ LL +     a.eq_ignore_ascii_case(&'a');
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:54:5
+  --> tests/ui/manual_ignore_case_cmp.rs:60:5
    |
 LL |     'a' == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -160,7 +157,7 @@ LL +     'a'.eq_ignore_ascii_case(&b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:58:5
+  --> tests/ui/manual_ignore_case_cmp.rs:64:5
    |
 LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,7 +169,7 @@ LL +     a.eq_ignore_ascii_case(&b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:60:5
+  --> tests/ui/manual_ignore_case_cmp.rs:66:5
    |
 LL |     a.to_ascii_lowercase() == b'a';
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +181,7 @@ LL +     a.eq_ignore_ascii_case(&b'a');
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:62:5
+  --> tests/ui/manual_ignore_case_cmp.rs:68:5
    |
 LL |     b'a' == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -196,7 +193,7 @@ LL +     b'a'.eq_ignore_ascii_case(&b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:66:5
+  --> tests/ui/manual_ignore_case_cmp.rs:72:5
    |
 LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +205,7 @@ LL +     a.eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:68:5
+  --> tests/ui/manual_ignore_case_cmp.rs:74:5
    |
 LL |     a.to_uppercase().to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -217,59 +214,11 @@ help: consider using `.eq_ignore_ascii_case()` instead
    |
 LL -     a.to_uppercase().to_ascii_lowercase() == b.to_ascii_lowercase();
 LL +     a.to_uppercase().eq_ignore_ascii_case(b);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:70:5
-   |
-LL |     a.to_ascii_lowercase() == "a";
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     a.to_ascii_lowercase() == "a";
-LL +     a.eq_ignore_ascii_case("a");
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:72:5
-   |
-LL |     "a" == b.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     "a" == b.to_ascii_lowercase();
-LL +     "a".eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
   --> tests/ui/manual_ignore_case_cmp.rs:76:5
    |
-LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-LL +     a.eq_ignore_ascii_case(b);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:78:5
-   |
-LL |     a.to_uppercase().to_ascii_lowercase() == b.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     a.to_uppercase().to_ascii_lowercase() == b.to_ascii_lowercase();
-LL +     a.to_uppercase().eq_ignore_ascii_case(b);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:80:5
-   |
 LL |     a.to_ascii_lowercase() == "a";
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -280,7 +229,7 @@ LL +     a.eq_ignore_ascii_case("a");
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:82:5
+  --> tests/ui/manual_ignore_case_cmp.rs:78:5
    |
 LL |     "a" == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -292,7 +241,55 @@ LL +     "a".eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:82:5
+   |
+LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+LL +     a.eq_ignore_ascii_case(b);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:84:5
+   |
+LL |     a.to_uppercase().to_ascii_lowercase() == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     a.to_uppercase().to_ascii_lowercase() == b.to_ascii_lowercase();
+LL +     a.to_uppercase().eq_ignore_ascii_case(b);
+   |
+
+error: manual case-insensitive ASCII comparison
   --> tests/ui/manual_ignore_case_cmp.rs:86:5
+   |
+LL |     a.to_ascii_lowercase() == "a";
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     a.to_ascii_lowercase() == "a";
+LL +     a.eq_ignore_ascii_case("a");
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:88:5
+   |
+LL |     "a" == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     "a" == b.to_ascii_lowercase();
+LL +     "a".eq_ignore_ascii_case(b);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:92:5
    |
 LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -301,30 +298,6 @@ help: consider using `.eq_ignore_ascii_case()` instead
    |
 LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
 LL +     a.eq_ignore_ascii_case(&b);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:88:5
-   |
-LL |     a.to_ascii_lowercase() == "a";
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     a.to_ascii_lowercase() == "a";
-LL +     a.eq_ignore_ascii_case("a");
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:90:5
-   |
-LL |     "a" == b.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     "a" == b.to_ascii_lowercase();
-LL +     "a".eq_ignore_ascii_case(&b);
    |
 
 error: manual case-insensitive ASCII comparison
@@ -354,18 +327,42 @@ LL +     "a".eq_ignore_ascii_case(&b);
 error: manual case-insensitive ASCII comparison
   --> tests/ui/manual_ignore_case_cmp.rs:100:5
    |
-LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     a.to_ascii_lowercase() == "a";
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider using `.eq_ignore_ascii_case()` instead
    |
-LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-LL +     a.eq_ignore_ascii_case(b);
+LL -     a.to_ascii_lowercase() == "a";
+LL +     a.eq_ignore_ascii_case("a");
    |
 
 error: manual case-insensitive ASCII comparison
   --> tests/ui/manual_ignore_case_cmp.rs:102:5
    |
+LL |     "a" == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     "a" == b.to_ascii_lowercase();
+LL +     "a".eq_ignore_ascii_case(&b);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:106:5
+   |
+LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+LL +     a.eq_ignore_ascii_case(b);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:108:5
+   |
 LL |     a.to_ascii_lowercase() == "a";
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -376,7 +373,7 @@ LL +     a.eq_ignore_ascii_case("a");
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:104:5
+  --> tests/ui/manual_ignore_case_cmp.rs:110:5
    |
 LL |     "a" == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -388,7 +385,7 @@ LL +     "a".eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:107:5
+  --> tests/ui/manual_ignore_case_cmp.rs:113:5
    |
 LL |     b.to_ascii_lowercase() == a.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -397,83 +394,11 @@ help: consider using `.eq_ignore_ascii_case()` instead
    |
 LL -     b.to_ascii_lowercase() == a.to_ascii_lowercase();
 LL +     b.eq_ignore_ascii_case(&a);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:109:5
-   |
-LL |     b.to_ascii_lowercase() == "a";
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     b.to_ascii_lowercase() == "a";
-LL +     b.eq_ignore_ascii_case("a");
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:111:5
-   |
-LL |     "a" == a.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     "a" == a.to_ascii_lowercase();
-LL +     "a".eq_ignore_ascii_case(&a);
    |
 
 error: manual case-insensitive ASCII comparison
   --> tests/ui/manual_ignore_case_cmp.rs:115:5
    |
-LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-LL +     a.eq_ignore_ascii_case(b);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:117:5
-   |
-LL |     a.to_ascii_lowercase() == "a";
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     a.to_ascii_lowercase() == "a";
-LL +     a.eq_ignore_ascii_case("a");
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:119:5
-   |
-LL |     "a" == b.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     "a" == b.to_ascii_lowercase();
-LL +     "a".eq_ignore_ascii_case(b);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:122:5
-   |
-LL |     b.to_ascii_lowercase() == a.to_ascii_lowercase();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using `.eq_ignore_ascii_case()` instead
-   |
-LL -     b.to_ascii_lowercase() == a.to_ascii_lowercase();
-LL +     b.eq_ignore_ascii_case(&a);
-   |
-
-error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:124:5
-   |
 LL |     b.to_ascii_lowercase() == "a";
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -484,7 +409,7 @@ LL +     b.eq_ignore_ascii_case("a");
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:126:5
+  --> tests/ui/manual_ignore_case_cmp.rs:117:5
    |
 LL |     "a" == a.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -496,7 +421,7 @@ LL +     "a".eq_ignore_ascii_case(&a);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:130:5
+  --> tests/ui/manual_ignore_case_cmp.rs:121:5
    |
 LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -508,19 +433,67 @@ LL +     a.eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:134:5
+  --> tests/ui/manual_ignore_case_cmp.rs:123:5
    |
-LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+LL |     a.to_ascii_lowercase() == "a";
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     a.to_ascii_lowercase() == "a";
+LL +     a.eq_ignore_ascii_case("a");
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:125:5
+   |
+LL |     "a" == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     "a" == b.to_ascii_lowercase();
+LL +     "a".eq_ignore_ascii_case(b);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:128:5
+   |
+LL |     b.to_ascii_lowercase() == a.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider using `.eq_ignore_ascii_case()` instead
    |
-LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-LL +     a.eq_ignore_ascii_case(&b);
+LL -     b.to_ascii_lowercase() == a.to_ascii_lowercase();
+LL +     b.eq_ignore_ascii_case(&a);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:138:5
+  --> tests/ui/manual_ignore_case_cmp.rs:130:5
+   |
+LL |     b.to_ascii_lowercase() == "a";
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     b.to_ascii_lowercase() == "a";
+LL +     b.eq_ignore_ascii_case("a");
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:132:5
+   |
+LL |     "a" == a.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     "a" == a.to_ascii_lowercase();
+LL +     "a".eq_ignore_ascii_case(&a);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:136:5
    |
 LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -534,13 +507,13 @@ LL +     a.eq_ignore_ascii_case(b);
 error: manual case-insensitive ASCII comparison
   --> tests/ui/manual_ignore_case_cmp.rs:140:5
    |
-LL |     b.to_ascii_lowercase() == a.to_ascii_lowercase();
+LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider using `.eq_ignore_ascii_case()` instead
    |
-LL -     b.to_ascii_lowercase() == a.to_ascii_lowercase();
-LL +     b.eq_ignore_ascii_case(&a);
+LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+LL +     a.eq_ignore_ascii_case(&b);
    |
 
 error: manual case-insensitive ASCII comparison
@@ -556,19 +529,19 @@ LL +     a.eq_ignore_ascii_case(b);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:148:5
+  --> tests/ui/manual_ignore_case_cmp.rs:146:5
    |
-LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+LL |     b.to_ascii_lowercase() == a.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider using `.eq_ignore_ascii_case()` instead
    |
-LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
-LL +     a.eq_ignore_ascii_case(b);
+LL -     b.to_ascii_lowercase() == a.to_ascii_lowercase();
+LL +     b.eq_ignore_ascii_case(&a);
    |
 
 error: manual case-insensitive ASCII comparison
-  --> tests/ui/manual_ignore_case_cmp.rs:152:5
+  --> tests/ui/manual_ignore_case_cmp.rs:150:5
    |
 LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -581,6 +554,30 @@ LL +     a.eq_ignore_ascii_case(b);
 
 error: manual case-insensitive ASCII comparison
   --> tests/ui/manual_ignore_case_cmp.rs:154:5
+   |
+LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+LL +     a.eq_ignore_ascii_case(b);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:158:5
+   |
+LL |     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider using `.eq_ignore_ascii_case()` instead
+   |
+LL -     a.to_ascii_lowercase() == b.to_ascii_lowercase();
+LL +     a.eq_ignore_ascii_case(b);
+   |
+
+error: manual case-insensitive ASCII comparison
+  --> tests/ui/manual_ignore_case_cmp.rs:160:5
    |
 LL |     b.to_ascii_lowercase() == a.to_ascii_lowercase();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/map_flatten_fixable.fixed
+++ b/tests/ui/map_flatten_fixable.fixed
@@ -1,10 +1,11 @@
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped)]
-#![allow(clippy::missing_docs_in_private_items)]
-#![allow(clippy::map_identity)]
-#![allow(clippy::redundant_closure)]
-#![allow(clippy::unnecessary_wraps)]
 #![feature(result_flattening)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::missing_docs_in_private_items,
+    clippy::map_identity,
+    clippy::redundant_closure,
+    clippy::unnecessary_wraps
+)]
 
 fn main() {
     // mapping to Option on Iterator

--- a/tests/ui/map_flatten_fixable.rs
+++ b/tests/ui/map_flatten_fixable.rs
@@ -1,10 +1,11 @@
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped)]
-#![allow(clippy::missing_docs_in_private_items)]
-#![allow(clippy::map_identity)]
-#![allow(clippy::redundant_closure)]
-#![allow(clippy::unnecessary_wraps)]
 #![feature(result_flattening)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::missing_docs_in_private_items,
+    clippy::map_identity,
+    clippy::redundant_closure,
+    clippy::unnecessary_wraps
+)]
 
 fn main() {
     // mapping to Option on Iterator

--- a/tests/ui/map_flatten_fixable.stderr
+++ b/tests/ui/map_flatten_fixable.stderr
@@ -1,5 +1,5 @@
 error: called `map(..).flatten()` on `Iterator`
-  --> tests/ui/map_flatten_fixable.rs:16:47
+  --> tests/ui/map_flatten_fixable.rs:17:47
    |
 LL |     let _: Vec<_> = vec![5_i8; 6].into_iter().map(option_id).flatten().collect();
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^ help: try replacing `map` with `filter_map` and remove the `.flatten()`: `filter_map(option_id)`
@@ -8,43 +8,43 @@ LL |     let _: Vec<_> = vec![5_i8; 6].into_iter().map(option_id).flatten().coll
    = help: to override `-D warnings` add `#[allow(clippy::map_flatten)]`
 
 error: called `map(..).flatten()` on `Iterator`
-  --> tests/ui/map_flatten_fixable.rs:18:47
+  --> tests/ui/map_flatten_fixable.rs:19:47
    |
 LL |     let _: Vec<_> = vec![5_i8; 6].into_iter().map(option_id_ref).flatten().collect();
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try replacing `map` with `filter_map` and remove the `.flatten()`: `filter_map(option_id_ref)`
 
 error: called `map(..).flatten()` on `Iterator`
-  --> tests/ui/map_flatten_fixable.rs:20:47
+  --> tests/ui/map_flatten_fixable.rs:21:47
    |
 LL |     let _: Vec<_> = vec![5_i8; 6].into_iter().map(option_id_closure).flatten().collect();
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try replacing `map` with `filter_map` and remove the `.flatten()`: `filter_map(option_id_closure)`
 
 error: called `map(..).flatten()` on `Iterator`
-  --> tests/ui/map_flatten_fixable.rs:22:47
+  --> tests/ui/map_flatten_fixable.rs:23:47
    |
 LL |     let _: Vec<_> = vec![5_i8; 6].into_iter().map(|x| x.checked_add(1)).flatten().collect();
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try replacing `map` with `filter_map` and remove the `.flatten()`: `filter_map(|x| x.checked_add(1))`
 
 error: called `map(..).flatten()` on `Iterator`
-  --> tests/ui/map_flatten_fixable.rs:26:47
+  --> tests/ui/map_flatten_fixable.rs:27:47
    |
 LL |     let _: Vec<_> = vec![5_i8; 6].into_iter().map(|x| 0..x).flatten().collect();
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^ help: try replacing `map` with `flat_map` and remove the `.flatten()`: `flat_map(|x| 0..x)`
 
 error: called `map(..).flatten()` on `Option`
-  --> tests/ui/map_flatten_fixable.rs:30:40
+  --> tests/ui/map_flatten_fixable.rs:31:40
    |
 LL |     let _: Option<_> = (Some(Some(1))).map(|x| x).flatten();
    |                                        ^^^^^^^^^^^^^^^^^^^^ help: try replacing `map` with `and_then` and remove the `.flatten()`: `and_then(|x| x)`
 
 error: called `map(..).flatten()` on `Result`
-  --> tests/ui/map_flatten_fixable.rs:34:42
+  --> tests/ui/map_flatten_fixable.rs:35:42
    |
 LL |     let _: Result<_, &str> = (Ok(Ok(1))).map(|x| x).flatten();
    |                                          ^^^^^^^^^^^^^^^^^^^^ help: try replacing `map` with `and_then` and remove the `.flatten()`: `and_then(|x| x)`
 
 error: called `map(..).flatten()` on `Iterator`
-  --> tests/ui/map_flatten_fixable.rs:44:10
+  --> tests/ui/map_flatten_fixable.rs:45:10
    |
 LL |           .map(|n| match n {
    |  __________^
@@ -74,7 +74,7 @@ LL ~         });
    |
 
 error: called `map(..).flatten()` on `Option`
-  --> tests/ui/map_flatten_fixable.rs:65:10
+  --> tests/ui/map_flatten_fixable.rs:66:10
    |
 LL |           .map(|_| {
    |  __________^

--- a/tests/ui/methods.rs
+++ b/tests/ui/methods.rs
@@ -1,6 +1,5 @@
 //@aux-build:option_helpers.rs
 
-#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::disallowed_names,
     clippy::default_trait_access,
@@ -19,8 +18,7 @@
     clippy::wrong_self_convention,
     clippy::unused_async,
     clippy::unused_self,
-    clippy::useless_vec,
-    unused
+    clippy::useless_vec
 )]
 
 #[macro_use]

--- a/tests/ui/methods.stderr
+++ b/tests/ui/methods.stderr
@@ -1,5 +1,5 @@
 error: methods called `new` usually return `Self`
-  --> tests/ui/methods.rs:104:5
+  --> tests/ui/methods.rs:102:5
    |
 LL | /     fn new() -> i32 {
 LL | |
@@ -11,7 +11,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::new_ret_no_self)]`
 
 error: called `filter(..).next()` on an `Iterator`. This is more succinctly expressed by calling `.find(..)` instead
-  --> tests/ui/methods.rs:126:13
+  --> tests/ui/methods.rs:124:13
    |
 LL |       let _ = v.iter().filter(|&x| {
    |  _____________^

--- a/tests/ui/min_max.rs
+++ b/tests/ui/min_max.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::all)]
 #![allow(clippy::manual_clamp)]
 
 use std::cmp::{max as my_max, max, min as my_min, min};

--- a/tests/ui/min_max.stderr
+++ b/tests/ui/min_max.stderr
@@ -1,80 +1,79 @@
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:22:5
+  --> tests/ui/min_max.rs:21:5
    |
 LL |     min(1, max(3, x));
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: `-D clippy::min-max` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::min_max)]`
+   = note: `#[deny(clippy::min_max)]` on by default
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:25:5
+  --> tests/ui/min_max.rs:24:5
    |
 LL |     min(max(3, x), 1);
    |     ^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:28:5
+  --> tests/ui/min_max.rs:27:5
    |
 LL |     max(min(x, 1), 3);
    |     ^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:31:5
+  --> tests/ui/min_max.rs:30:5
    |
 LL |     max(3, min(x, 1));
    |     ^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:34:5
+  --> tests/ui/min_max.rs:33:5
    |
 LL |     my_max(3, my_min(x, 1));
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:45:5
+  --> tests/ui/min_max.rs:44:5
    |
 LL |     min("Apple", max("Zoo", s));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:48:5
+  --> tests/ui/min_max.rs:47:5
    |
 LL |     max(min(s, "Apple"), "Zoo");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:54:5
+  --> tests/ui/min_max.rs:53:5
    |
 LL |     x.min(1).max(3);
    |     ^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:57:5
+  --> tests/ui/min_max.rs:56:5
    |
 LL |     x.max(3).min(1);
    |     ^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:60:5
+  --> tests/ui/min_max.rs:59:5
    |
 LL |     f.max(3f32).min(1f32);
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:67:5
+  --> tests/ui/min_max.rs:66:5
    |
 LL |     max(x.min(1), 3);
    |     ^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:72:5
+  --> tests/ui/min_max.rs:71:5
    |
 LL |     s.max("Zoo").min("Apple");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this `min`/`max` combination leads to constant result
-  --> tests/ui/min_max.rs:75:5
+  --> tests/ui/min_max.rs:74:5
    |
 LL |     s.min("Apple").max("Zoo");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/mutex_atomic.rs
+++ b/tests/ui/mutex_atomic.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::all)]
 #![warn(clippy::mutex_integer)]
 #![warn(clippy::mutex_atomic)]
 #![allow(clippy::borrow_as_ptr)]

--- a/tests/ui/mutex_atomic.stderr
+++ b/tests/ui/mutex_atomic.stderr
@@ -1,5 +1,5 @@
 error: consider using an `AtomicBool` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:8:5
+  --> tests/ui/mutex_atomic.rs:7:5
    |
 LL |     Mutex::new(true);
    |     ^^^^^^^^^^^^^^^^
@@ -8,31 +8,31 @@ LL |     Mutex::new(true);
    = help: to override `-D warnings` add `#[allow(clippy::mutex_atomic)]`
 
 error: consider using an `AtomicUsize` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:11:5
+  --> tests/ui/mutex_atomic.rs:10:5
    |
 LL |     Mutex::new(5usize);
    |     ^^^^^^^^^^^^^^^^^^
 
 error: consider using an `AtomicIsize` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:14:5
+  --> tests/ui/mutex_atomic.rs:13:5
    |
 LL |     Mutex::new(9isize);
    |     ^^^^^^^^^^^^^^^^^^
 
 error: consider using an `AtomicPtr` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:18:5
+  --> tests/ui/mutex_atomic.rs:17:5
    |
 LL |     Mutex::new(&x as *const u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider using an `AtomicPtr` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:21:5
+  --> tests/ui/mutex_atomic.rs:20:5
    |
 LL |     Mutex::new(&mut x as *mut u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider using an `AtomicU32` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:24:5
+  --> tests/ui/mutex_atomic.rs:23:5
    |
 LL |     Mutex::new(0u32);
    |     ^^^^^^^^^^^^^^^^
@@ -41,31 +41,31 @@ LL |     Mutex::new(0u32);
    = help: to override `-D warnings` add `#[allow(clippy::mutex_integer)]`
 
 error: consider using an `AtomicI32` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:27:5
+  --> tests/ui/mutex_atomic.rs:26:5
    |
 LL |     Mutex::new(0i32);
    |     ^^^^^^^^^^^^^^^^
 
 error: consider using an `AtomicU8` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:31:5
+  --> tests/ui/mutex_atomic.rs:30:5
    |
 LL |     Mutex::new(0u8);
    |     ^^^^^^^^^^^^^^^
 
 error: consider using an `AtomicI16` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:34:5
+  --> tests/ui/mutex_atomic.rs:33:5
    |
 LL |     Mutex::new(0i16);
    |     ^^^^^^^^^^^^^^^^
 
 error: consider using an `AtomicI8` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:37:25
+  --> tests/ui/mutex_atomic.rs:36:25
    |
 LL |     let _x: Mutex<i8> = Mutex::new(0);
    |                         ^^^^^^^^^^^^^
 
 error: consider using an `AtomicI64` instead of a `Mutex` here; if you just want the locking behavior and not the internal type, consider using `Mutex<()>`
-  --> tests/ui/mutex_atomic.rs:41:5
+  --> tests/ui/mutex_atomic.rs:40:5
    |
 LL |     Mutex::new(X);
    |     ^^^^^^^^^^^^^

--- a/tests/ui/non_expressive_names.rs
+++ b/tests/ui/non_expressive_names.rs
@@ -1,5 +1,4 @@
-#![warn(clippy::all)]
-#![allow(unused, clippy::println_empty_string, non_snake_case, clippy::let_unit_value)]
+#![allow(clippy::println_empty_string, non_snake_case, clippy::let_unit_value)]
 
 #[derive(Clone, Debug)]
 enum MaybeInst {

--- a/tests/ui/non_expressive_names.stderr
+++ b/tests/ui/non_expressive_names.stderr
@@ -1,5 +1,5 @@
 error: consider choosing a more descriptive name
-  --> tests/ui/non_expressive_names.rs:28:9
+  --> tests/ui/non_expressive_names.rs:27:9
    |
 LL |     let _1 = 1;
    |         ^^
@@ -8,31 +8,31 @@ LL |     let _1 = 1;
    = help: to override `-D warnings` add `#[allow(clippy::just_underscores_and_digits)]`
 
 error: consider choosing a more descriptive name
-  --> tests/ui/non_expressive_names.rs:30:9
+  --> tests/ui/non_expressive_names.rs:29:9
    |
 LL |     let ____1 = 1;
    |         ^^^^^
 
 error: consider choosing a more descriptive name
-  --> tests/ui/non_expressive_names.rs:32:9
+  --> tests/ui/non_expressive_names.rs:31:9
    |
 LL |     let __1___2 = 12;
    |         ^^^^^^^
 
 error: consider choosing a more descriptive name
-  --> tests/ui/non_expressive_names.rs:54:13
+  --> tests/ui/non_expressive_names.rs:53:13
    |
 LL |         let _1 = 1;
    |             ^^
 
 error: consider choosing a more descriptive name
-  --> tests/ui/non_expressive_names.rs:56:13
+  --> tests/ui/non_expressive_names.rs:55:13
    |
 LL |         let ____1 = 1;
    |             ^^^^^
 
 error: consider choosing a more descriptive name
-  --> tests/ui/non_expressive_names.rs:58:13
+  --> tests/ui/non_expressive_names.rs:57:13
    |
 LL |         let __1___2 = 12;
    |             ^^^^^^^

--- a/tests/ui/pattern_type_mismatch/mutability.rs
+++ b/tests/ui/pattern_type_mismatch/mutability.rs
@@ -1,5 +1,5 @@
-#![allow(clippy::all)]
 #![warn(clippy::pattern_type_mismatch)]
+#![allow(clippy::single_match)]
 
 fn main() {}
 

--- a/tests/ui/pattern_type_mismatch/pattern_alternatives.rs
+++ b/tests/ui/pattern_type_mismatch/pattern_alternatives.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::all)]
 #![warn(clippy::pattern_type_mismatch)]
 
 fn main() {}

--- a/tests/ui/pattern_type_mismatch/pattern_alternatives.stderr
+++ b/tests/ui/pattern_type_mismatch/pattern_alternatives.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:15:12
+  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:14:12
    |
 LL |     if let Value::B | Value::A(_) = ref_value {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     if let Value::B | Value::A(_) = ref_value {}
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:18:34
+  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:17:34
    |
 LL |     if let &Value::B | &Value::A(Some(_)) = ref_value {}
    |                                  ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let &Value::B | &Value::A(Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:21:32
+  --> tests/ui/pattern_type_mismatch/pattern_alternatives.rs:20:32
    |
 LL |     if let Value::B | Value::A(Some(_)) = *ref_value {}
    |                                ^^^^^^^

--- a/tests/ui/pattern_type_mismatch/pattern_structs.rs
+++ b/tests/ui/pattern_type_mismatch/pattern_structs.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::all)]
 #![warn(clippy::pattern_type_mismatch)]
 
 fn main() {}

--- a/tests/ui/pattern_type_mismatch/pattern_structs.stderr
+++ b/tests/ui/pattern_type_mismatch/pattern_structs.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:13:9
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:12:9
    |
 LL |     let Struct { .. } = ref_value;
    |         ^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let Struct { .. } = ref_value;
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:16:33
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:15:33
    |
 LL |     if let &Struct { ref_inner: Some(_) } = ref_value {}
    |                                 ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let &Struct { ref_inner: Some(_) } = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:19:32
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:18:32
    |
 LL |     if let Struct { ref_inner: Some(_) } = *ref_value {}
    |                                ^^^^^^^
@@ -25,7 +25,7 @@ LL |     if let Struct { ref_inner: Some(_) } = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:37:12
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:36:12
    |
 LL |     if let StructEnum::Var { .. } = ref_value {}
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     if let StructEnum::Var { .. } = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:40:12
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:39:12
    |
 LL |     if let StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     if let StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:43:42
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:42:42
    |
 LL |     if let &StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    |                                          ^^^^^^^
@@ -49,7 +49,7 @@ LL |     if let &StructEnum::Var { inner_ref: Some(_) } = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:46:41
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:45:41
    |
 LL |     if let StructEnum::Var { inner_ref: Some(_) } = *ref_value {}
    |                                         ^^^^^^^
@@ -57,7 +57,7 @@ LL |     if let StructEnum::Var { inner_ref: Some(_) } = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:49:12
+  --> tests/ui/pattern_type_mismatch/pattern_structs.rs:48:12
    |
 LL |     if let StructEnum::Empty = ref_value {}
    |            ^^^^^^^^^^^^^^^^^

--- a/tests/ui/pattern_type_mismatch/pattern_tuples.rs
+++ b/tests/ui/pattern_type_mismatch/pattern_tuples.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::all)]
 #![warn(clippy::pattern_type_mismatch)]
 
 fn main() {}

--- a/tests/ui/pattern_type_mismatch/pattern_tuples.stderr
+++ b/tests/ui/pattern_type_mismatch/pattern_tuples.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:11:9
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:10:9
    |
 LL |     let TupleStruct(_) = ref_value;
    |         ^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     let TupleStruct(_) = ref_value;
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:14:25
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:13:25
    |
 LL |     if let &TupleStruct(Some(_)) = ref_value {}
    |                         ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let &TupleStruct(Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:17:24
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:16:24
    |
 LL |     if let TupleStruct(Some(_)) = *ref_value {}
    |                        ^^^^^^^
@@ -25,7 +25,7 @@ LL |     if let TupleStruct(Some(_)) = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:35:12
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:34:12
    |
 LL |     if let TupleEnum::Var(_) = ref_value {}
    |            ^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     if let TupleEnum::Var(_) = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:38:28
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:37:28
    |
 LL |     if let &TupleEnum::Var(Some(_)) = ref_value {}
    |                            ^^^^^^^
@@ -41,7 +41,7 @@ LL |     if let &TupleEnum::Var(Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:41:27
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:40:27
    |
 LL |     if let TupleEnum::Var(Some(_)) = *ref_value {}
    |                           ^^^^^^^
@@ -49,7 +49,7 @@ LL |     if let TupleEnum::Var(Some(_)) = *ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:44:12
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:43:12
    |
 LL |     if let TupleEnum::Empty = ref_value {}
    |            ^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     if let TupleEnum::Empty = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:60:9
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:59:9
    |
 LL |     let (_a, _b) = ref_value;
    |         ^^^^^^^^
@@ -65,7 +65,7 @@ LL |     let (_a, _b) = ref_value;
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:63:18
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:62:18
    |
 LL |     if let &(_a, Some(_)) = ref_value {}
    |                  ^^^^^^^
@@ -73,7 +73,7 @@ LL |     if let &(_a, Some(_)) = ref_value {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:66:17
+  --> tests/ui/pattern_type_mismatch/pattern_tuples.rs:65:17
    |
 LL |     if let (_a, Some(_)) = *ref_value {}
    |                 ^^^^^^^

--- a/tests/ui/pattern_type_mismatch/syntax.rs
+++ b/tests/ui/pattern_type_mismatch/syntax.rs
@@ -1,5 +1,10 @@
-#![allow(clippy::all)]
 #![warn(clippy::pattern_type_mismatch)]
+#![allow(
+    clippy::match_ref_pats,
+    clippy::never_loop,
+    clippy::redundant_pattern_matching,
+    clippy::single_match
+)]
 
 fn main() {}
 

--- a/tests/ui/pattern_type_mismatch/syntax.stderr
+++ b/tests/ui/pattern_type_mismatch/syntax.stderr
@@ -1,5 +1,5 @@
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:11:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:16:9
    |
 LL |         Some(_) => (),
    |         ^^^^^^^
@@ -9,7 +9,7 @@ LL |         Some(_) => (),
    = help: to override `-D warnings` add `#[allow(clippy::pattern_type_mismatch)]`
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:31:12
+  --> tests/ui/pattern_type_mismatch/syntax.rs:36:12
    |
 LL |     if let Some(_) = ref_value {}
    |            ^^^^^^^
@@ -17,7 +17,7 @@ LL |     if let Some(_) = ref_value {}
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:43:15
+  --> tests/ui/pattern_type_mismatch/syntax.rs:48:15
    |
 LL |     while let Some(_) = ref_value {
    |               ^^^^^^^
@@ -25,7 +25,7 @@ LL |     while let Some(_) = ref_value {
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:63:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:68:9
    |
 LL |     for (_a, _b) in slice.iter() {}
    |         ^^^^^^^^
@@ -33,7 +33,7 @@ LL |     for (_a, _b) in slice.iter() {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:74:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:79:9
    |
 LL |     let (_n, _m) = ref_value;
    |         ^^^^^^^^
@@ -41,7 +41,7 @@ LL |     let (_n, _m) = ref_value;
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:84:12
+  --> tests/ui/pattern_type_mismatch/syntax.rs:89:12
    |
 LL |     fn foo((_a, _b): &(i32, i32)) {}
    |            ^^^^^^^^
@@ -49,7 +49,7 @@ LL |     fn foo((_a, _b): &(i32, i32)) {}
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:99:10
+  --> tests/ui/pattern_type_mismatch/syntax.rs:104:10
    |
 LL |     foo(|(_a, _b)| ());
    |          ^^^^^^^^
@@ -57,7 +57,7 @@ LL |     foo(|(_a, _b)| ());
    = help: explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:116:9
+  --> tests/ui/pattern_type_mismatch/syntax.rs:121:9
    |
 LL |         Some(_) => (),
    |         ^^^^^^^
@@ -65,7 +65,7 @@ LL |         Some(_) => (),
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
 
 error: type of pattern does not match the expression type
-  --> tests/ui/pattern_type_mismatch/syntax.rs:137:17
+  --> tests/ui/pattern_type_mismatch/syntax.rs:142:17
    |
 LL |                 Some(_) => (),
    |                 ^^^^^^^

--- a/tests/ui/patterns.fixed
+++ b/tests/ui/patterns.fixed
@@ -1,6 +1,4 @@
 //@aux-build:proc_macros.rs
-#![warn(clippy::all)]
-#![allow(unused)]
 #![allow(clippy::uninlined_format_args, clippy::single_match)]
 
 #[macro_use]

--- a/tests/ui/patterns.rs
+++ b/tests/ui/patterns.rs
@@ -1,6 +1,4 @@
 //@aux-build:proc_macros.rs
-#![warn(clippy::all)]
-#![allow(unused)]
 #![allow(clippy::uninlined_format_args, clippy::single_match)]
 
 #[macro_use]

--- a/tests/ui/patterns.stderr
+++ b/tests/ui/patterns.stderr
@@ -1,5 +1,5 @@
 error: the `y @ _` pattern can be written as just `y`
-  --> tests/ui/patterns.rs:14:9
+  --> tests/ui/patterns.rs:12:9
    |
 LL |         y @ _ => (),
    |         ^^^^^ help: try: `y`
@@ -8,13 +8,13 @@ LL |         y @ _ => (),
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern)]`
 
 error: the `x @ _` pattern can be written as just `x`
-  --> tests/ui/patterns.rs:30:9
+  --> tests/ui/patterns.rs:28:9
    |
 LL |         ref mut x @ _ => {
    |         ^^^^^^^^^^^^^ help: try: `ref mut x`
 
 error: the `x @ _` pattern can be written as just `x`
-  --> tests/ui/patterns.rs:39:9
+  --> tests/ui/patterns.rs:37:9
    |
 LL |         ref x @ _ => println!("vec: {:?}", x),
    |         ^^^^^^^^^ help: try: `ref x`

--- a/tests/ui/redundant_allocation.rs
+++ b/tests/ui/redundant_allocation.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::all)]
 #![allow(clippy::boxed_local, clippy::disallowed_names)]
 
 pub struct MyStruct;

--- a/tests/ui/redundant_allocation.stderr
+++ b/tests/ui/redundant_allocation.stderr
@@ -1,5 +1,5 @@
 error: usage of `Box<Rc<T>>`
-  --> tests/ui/redundant_allocation.rs:16:30
+  --> tests/ui/redundant_allocation.rs:15:30
    |
 LL |     pub fn box_test6<T>(foo: Box<Rc<T>>) {}
    |                              ^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     pub fn box_test6<T>(foo: Box<Rc<T>>) {}
    = help: to override `-D warnings` add `#[allow(clippy::redundant_allocation)]`
 
 error: usage of `Box<Arc<T>>`
-  --> tests/ui/redundant_allocation.rs:19:30
+  --> tests/ui/redundant_allocation.rs:18:30
    |
 LL |     pub fn box_test7<T>(foo: Box<Arc<T>>) {}
    |                              ^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     pub fn box_test7<T>(foo: Box<Arc<T>>) {}
    = help: consider using just `Box<T>` or `Arc<T>`
 
 error: usage of `Box<Rc<SubT<usize>>>`
-  --> tests/ui/redundant_allocation.rs:22:27
+  --> tests/ui/redundant_allocation.rs:21:27
    |
 LL |     pub fn box_test8() -> Box<Rc<SubT<usize>>> {
    |                           ^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |     pub fn box_test8() -> Box<Rc<SubT<usize>>> {
    = help: consider using just `Box<SubT<usize>>` or `Rc<SubT<usize>>`
 
 error: usage of `Box<Arc<T>>`
-  --> tests/ui/redundant_allocation.rs:28:30
+  --> tests/ui/redundant_allocation.rs:27:30
    |
 LL |     pub fn box_test9<T>(foo: Box<Arc<T>>) -> Box<Arc<SubT<T>>> {
    |                              ^^^^^^^^^^^
@@ -37,7 +37,7 @@ LL |     pub fn box_test9<T>(foo: Box<Arc<T>>) -> Box<Arc<SubT<T>>> {
    = help: consider using just `Box<T>` or `Arc<T>`
 
 error: usage of `Box<Arc<SubT<T>>>`
-  --> tests/ui/redundant_allocation.rs:28:46
+  --> tests/ui/redundant_allocation.rs:27:46
    |
 LL |     pub fn box_test9<T>(foo: Box<Arc<T>>) -> Box<Arc<SubT<T>>> {
    |                                              ^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ LL |     pub fn box_test9<T>(foo: Box<Arc<T>>) -> Box<Arc<SubT<T>>> {
    = help: consider using just `Box<SubT<T>>` or `Arc<SubT<T>>`
 
 error: usage of `Rc<Box<bool>>`
-  --> tests/ui/redundant_allocation.rs:42:24
+  --> tests/ui/redundant_allocation.rs:41:24
    |
 LL |     pub fn rc_test5(a: Rc<Box<bool>>) {}
    |                        ^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     pub fn rc_test5(a: Rc<Box<bool>>) {}
    = help: consider using just `Rc<bool>` or `Box<bool>`
 
 error: usage of `Rc<Arc<bool>>`
-  --> tests/ui/redundant_allocation.rs:45:24
+  --> tests/ui/redundant_allocation.rs:44:24
    |
 LL |     pub fn rc_test7(a: Rc<Arc<bool>>) {}
    |                        ^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL |     pub fn rc_test7(a: Rc<Arc<bool>>) {}
    = help: consider using just `Rc<bool>` or `Arc<bool>`
 
 error: usage of `Rc<Box<SubT<usize>>>`
-  --> tests/ui/redundant_allocation.rs:48:26
+  --> tests/ui/redundant_allocation.rs:47:26
    |
 LL |     pub fn rc_test8() -> Rc<Box<SubT<usize>>> {
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +73,7 @@ LL |     pub fn rc_test8() -> Rc<Box<SubT<usize>>> {
    = help: consider using just `Rc<SubT<usize>>` or `Box<SubT<usize>>`
 
 error: usage of `Rc<Arc<T>>`
-  --> tests/ui/redundant_allocation.rs:54:29
+  --> tests/ui/redundant_allocation.rs:53:29
    |
 LL |     pub fn rc_test9<T>(foo: Rc<Arc<T>>) -> Rc<Arc<SubT<T>>> {
    |                             ^^^^^^^^^^
@@ -82,7 +82,7 @@ LL |     pub fn rc_test9<T>(foo: Rc<Arc<T>>) -> Rc<Arc<SubT<T>>> {
    = help: consider using just `Rc<T>` or `Arc<T>`
 
 error: usage of `Rc<Arc<SubT<T>>>`
-  --> tests/ui/redundant_allocation.rs:54:44
+  --> tests/ui/redundant_allocation.rs:53:44
    |
 LL |     pub fn rc_test9<T>(foo: Rc<Arc<T>>) -> Rc<Arc<SubT<T>>> {
    |                                            ^^^^^^^^^^^^^^^^
@@ -91,7 +91,7 @@ LL |     pub fn rc_test9<T>(foo: Rc<Arc<T>>) -> Rc<Arc<SubT<T>>> {
    = help: consider using just `Rc<SubT<T>>` or `Arc<SubT<T>>`
 
 error: usage of `Arc<Box<bool>>`
-  --> tests/ui/redundant_allocation.rs:68:25
+  --> tests/ui/redundant_allocation.rs:67:25
    |
 LL |     pub fn arc_test5(a: Arc<Box<bool>>) {}
    |                         ^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ LL |     pub fn arc_test5(a: Arc<Box<bool>>) {}
    = help: consider using just `Arc<bool>` or `Box<bool>`
 
 error: usage of `Arc<Rc<bool>>`
-  --> tests/ui/redundant_allocation.rs:71:25
+  --> tests/ui/redundant_allocation.rs:70:25
    |
 LL |     pub fn arc_test6(a: Arc<Rc<bool>>) {}
    |                         ^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     pub fn arc_test6(a: Arc<Rc<bool>>) {}
    = help: consider using just `Arc<bool>` or `Rc<bool>`
 
 error: usage of `Arc<Box<SubT<usize>>>`
-  --> tests/ui/redundant_allocation.rs:74:27
+  --> tests/ui/redundant_allocation.rs:73:27
    |
 LL |     pub fn arc_test8() -> Arc<Box<SubT<usize>>> {
    |                           ^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL |     pub fn arc_test8() -> Arc<Box<SubT<usize>>> {
    = help: consider using just `Arc<SubT<usize>>` or `Box<SubT<usize>>`
 
 error: usage of `Arc<Rc<T>>`
-  --> tests/ui/redundant_allocation.rs:80:30
+  --> tests/ui/redundant_allocation.rs:79:30
    |
 LL |     pub fn arc_test9<T>(foo: Arc<Rc<T>>) -> Arc<Rc<SubT<T>>> {
    |                              ^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |     pub fn arc_test9<T>(foo: Arc<Rc<T>>) -> Arc<Rc<SubT<T>>> {
    = help: consider using just `Arc<T>` or `Rc<T>`
 
 error: usage of `Arc<Rc<SubT<T>>>`
-  --> tests/ui/redundant_allocation.rs:80:45
+  --> tests/ui/redundant_allocation.rs:79:45
    |
 LL |     pub fn arc_test9<T>(foo: Arc<Rc<T>>) -> Arc<Rc<SubT<T>>> {
    |                                             ^^^^^^^^^^^^^^^^
@@ -136,7 +136,7 @@ LL |     pub fn arc_test9<T>(foo: Arc<Rc<T>>) -> Arc<Rc<SubT<T>>> {
    = help: consider using just `Arc<SubT<T>>` or `Rc<SubT<T>>`
 
 error: usage of `Rc<Box<Box<dyn T>>>`
-  --> tests/ui/redundant_allocation.rs:105:27
+  --> tests/ui/redundant_allocation.rs:104:27
    |
 LL |     pub fn test_rc_box(_: Rc<Box<Box<dyn T>>>) {}
    |                           ^^^^^^^^^^^^^^^^^^^
@@ -145,7 +145,7 @@ LL |     pub fn test_rc_box(_: Rc<Box<Box<dyn T>>>) {}
    = help: consider using just `Rc<Box<dyn T>>` or `Box<Box<dyn T>>`
 
 error: usage of `Rc<Box<Box<str>>>`
-  --> tests/ui/redundant_allocation.rs:138:31
+  --> tests/ui/redundant_allocation.rs:137:31
    |
 LL |     pub fn test_rc_box_str(_: Rc<Box<Box<str>>>) {}
    |                               ^^^^^^^^^^^^^^^^^
@@ -154,7 +154,7 @@ LL |     pub fn test_rc_box_str(_: Rc<Box<Box<str>>>) {}
    = help: consider using just `Rc<Box<str>>` or `Box<Box<str>>`
 
 error: usage of `Rc<Box<Box<[usize]>>>`
-  --> tests/ui/redundant_allocation.rs:141:33
+  --> tests/ui/redundant_allocation.rs:140:33
    |
 LL |     pub fn test_rc_box_slice(_: Rc<Box<Box<[usize]>>>) {}
    |                                 ^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +163,7 @@ LL |     pub fn test_rc_box_slice(_: Rc<Box<Box<[usize]>>>) {}
    = help: consider using just `Rc<Box<[usize]>>` or `Box<Box<[usize]>>`
 
 error: usage of `Rc<Box<Box<Path>>>`
-  --> tests/ui/redundant_allocation.rs:144:32
+  --> tests/ui/redundant_allocation.rs:143:32
    |
 LL |     pub fn test_rc_box_path(_: Rc<Box<Box<Path>>>) {}
    |                                ^^^^^^^^^^^^^^^^^^
@@ -172,7 +172,7 @@ LL |     pub fn test_rc_box_path(_: Rc<Box<Box<Path>>>) {}
    = help: consider using just `Rc<Box<Path>>` or `Box<Box<Path>>`
 
 error: usage of `Rc<Box<Box<DynSized>>>`
-  --> tests/ui/redundant_allocation.rs:147:34
+  --> tests/ui/redundant_allocation.rs:146:34
    |
 LL |     pub fn test_rc_box_custom(_: Rc<Box<Box<DynSized>>>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/redundant_allocation_fixable.fixed
+++ b/tests/ui/redundant_allocation_fixable.fixed
@@ -1,7 +1,5 @@
-#![warn(clippy::all)]
 #![allow(clippy::boxed_local, clippy::needless_pass_by_value)]
-#![allow(clippy::disallowed_names, unused_variables, dead_code)]
-#![allow(unused_imports)]
+#![allow(clippy::disallowed_names)]
 
 pub struct MyStruct;
 

--- a/tests/ui/redundant_allocation_fixable.rs
+++ b/tests/ui/redundant_allocation_fixable.rs
@@ -1,7 +1,5 @@
-#![warn(clippy::all)]
 #![allow(clippy::boxed_local, clippy::needless_pass_by_value)]
-#![allow(clippy::disallowed_names, unused_variables, dead_code)]
-#![allow(unused_imports)]
+#![allow(clippy::disallowed_names)]
 
 pub struct MyStruct;
 

--- a/tests/ui/redundant_allocation_fixable.stderr
+++ b/tests/ui/redundant_allocation_fixable.stderr
@@ -1,5 +1,5 @@
 error: usage of `Box<&T>`
-  --> tests/ui/redundant_allocation_fixable.rs:23:30
+  --> tests/ui/redundant_allocation_fixable.rs:21:30
    |
 LL |     pub fn box_test1<T>(foo: Box<&T>) {}
    |                              ^^^^^^^ help: try: `&T`
@@ -9,7 +9,7 @@ LL |     pub fn box_test1<T>(foo: Box<&T>) {}
    = help: to override `-D warnings` add `#[allow(clippy::redundant_allocation)]`
 
 error: usage of `Box<&MyStruct>`
-  --> tests/ui/redundant_allocation_fixable.rs:26:27
+  --> tests/ui/redundant_allocation_fixable.rs:24:27
    |
 LL |     pub fn box_test2(foo: Box<&MyStruct>) {}
    |                           ^^^^^^^^^^^^^^ help: try: `&MyStruct`
@@ -17,7 +17,7 @@ LL |     pub fn box_test2(foo: Box<&MyStruct>) {}
    = note: `&MyStruct` is already a pointer, `Box<&MyStruct>` allocates a pointer on the heap
 
 error: usage of `Box<&MyEnum>`
-  --> tests/ui/redundant_allocation_fixable.rs:29:27
+  --> tests/ui/redundant_allocation_fixable.rs:27:27
    |
 LL |     pub fn box_test3(foo: Box<&MyEnum>) {}
    |                           ^^^^^^^^^^^^ help: try: `&MyEnum`
@@ -25,7 +25,7 @@ LL |     pub fn box_test3(foo: Box<&MyEnum>) {}
    = note: `&MyEnum` is already a pointer, `Box<&MyEnum>` allocates a pointer on the heap
 
 error: usage of `Box<Box<T>>`
-  --> tests/ui/redundant_allocation_fixable.rs:34:30
+  --> tests/ui/redundant_allocation_fixable.rs:32:30
    |
 LL |     pub fn box_test5<T>(foo: Box<Box<T>>) {}
    |                              ^^^^^^^^^^^ help: try: `Box<T>`
@@ -33,7 +33,7 @@ LL |     pub fn box_test5<T>(foo: Box<Box<T>>) {}
    = note: `Box<T>` is already on the heap, `Box<Box<T>>` makes an extra allocation
 
 error: usage of `Rc<&T>`
-  --> tests/ui/redundant_allocation_fixable.rs:44:29
+  --> tests/ui/redundant_allocation_fixable.rs:42:29
    |
 LL |     pub fn rc_test1<T>(foo: Rc<&T>) {}
    |                             ^^^^^^ help: try: `&T`
@@ -41,7 +41,7 @@ LL |     pub fn rc_test1<T>(foo: Rc<&T>) {}
    = note: `&T` is already a pointer, `Rc<&T>` allocates a pointer on the heap
 
 error: usage of `Rc<&MyStruct>`
-  --> tests/ui/redundant_allocation_fixable.rs:47:26
+  --> tests/ui/redundant_allocation_fixable.rs:45:26
    |
 LL |     pub fn rc_test2(foo: Rc<&MyStruct>) {}
    |                          ^^^^^^^^^^^^^ help: try: `&MyStruct`
@@ -49,7 +49,7 @@ LL |     pub fn rc_test2(foo: Rc<&MyStruct>) {}
    = note: `&MyStruct` is already a pointer, `Rc<&MyStruct>` allocates a pointer on the heap
 
 error: usage of `Rc<&MyEnum>`
-  --> tests/ui/redundant_allocation_fixable.rs:50:26
+  --> tests/ui/redundant_allocation_fixable.rs:48:26
    |
 LL |     pub fn rc_test3(foo: Rc<&MyEnum>) {}
    |                          ^^^^^^^^^^^ help: try: `&MyEnum`
@@ -57,7 +57,7 @@ LL |     pub fn rc_test3(foo: Rc<&MyEnum>) {}
    = note: `&MyEnum` is already a pointer, `Rc<&MyEnum>` allocates a pointer on the heap
 
 error: usage of `Rc<Rc<bool>>`
-  --> tests/ui/redundant_allocation_fixable.rs:55:24
+  --> tests/ui/redundant_allocation_fixable.rs:53:24
    |
 LL |     pub fn rc_test6(a: Rc<Rc<bool>>) {}
    |                        ^^^^^^^^^^^^ help: try: `Rc<bool>`
@@ -65,7 +65,7 @@ LL |     pub fn rc_test6(a: Rc<Rc<bool>>) {}
    = note: `Rc<bool>` is already on the heap, `Rc<Rc<bool>>` makes an extra allocation
 
 error: usage of `Arc<&T>`
-  --> tests/ui/redundant_allocation_fixable.rs:65:30
+  --> tests/ui/redundant_allocation_fixable.rs:63:30
    |
 LL |     pub fn arc_test1<T>(foo: Arc<&T>) {}
    |                              ^^^^^^^ help: try: `&T`
@@ -73,7 +73,7 @@ LL |     pub fn arc_test1<T>(foo: Arc<&T>) {}
    = note: `&T` is already a pointer, `Arc<&T>` allocates a pointer on the heap
 
 error: usage of `Arc<&MyStruct>`
-  --> tests/ui/redundant_allocation_fixable.rs:68:27
+  --> tests/ui/redundant_allocation_fixable.rs:66:27
    |
 LL |     pub fn arc_test2(foo: Arc<&MyStruct>) {}
    |                           ^^^^^^^^^^^^^^ help: try: `&MyStruct`
@@ -81,7 +81,7 @@ LL |     pub fn arc_test2(foo: Arc<&MyStruct>) {}
    = note: `&MyStruct` is already a pointer, `Arc<&MyStruct>` allocates a pointer on the heap
 
 error: usage of `Arc<&MyEnum>`
-  --> tests/ui/redundant_allocation_fixable.rs:71:27
+  --> tests/ui/redundant_allocation_fixable.rs:69:27
    |
 LL |     pub fn arc_test3(foo: Arc<&MyEnum>) {}
    |                           ^^^^^^^^^^^^ help: try: `&MyEnum`
@@ -89,7 +89,7 @@ LL |     pub fn arc_test3(foo: Arc<&MyEnum>) {}
    = note: `&MyEnum` is already a pointer, `Arc<&MyEnum>` allocates a pointer on the heap
 
 error: usage of `Arc<Arc<bool>>`
-  --> tests/ui/redundant_allocation_fixable.rs:76:25
+  --> tests/ui/redundant_allocation_fixable.rs:74:25
    |
 LL |     pub fn arc_test7(a: Arc<Arc<bool>>) {}
    |                         ^^^^^^^^^^^^^^ help: try: `Arc<bool>`

--- a/tests/ui/redundant_pattern_matching_ipaddr.fixed
+++ b/tests/ui/redundant_pattern_matching_ipaddr.fixed
@@ -1,5 +1,4 @@
-#![warn(clippy::all, clippy::redundant_pattern_matching)]
-#![allow(unused_must_use)]
+#![warn(clippy::redundant_pattern_matching)]
 #![allow(
     clippy::match_like_matches_macro,
     clippy::needless_bool,

--- a/tests/ui/redundant_pattern_matching_ipaddr.rs
+++ b/tests/ui/redundant_pattern_matching_ipaddr.rs
@@ -1,5 +1,4 @@
-#![warn(clippy::all, clippy::redundant_pattern_matching)]
-#![allow(unused_must_use)]
+#![warn(clippy::redundant_pattern_matching)]
 #![allow(
     clippy::match_like_matches_macro,
     clippy::needless_bool,

--- a/tests/ui/redundant_pattern_matching_ipaddr.stderr
+++ b/tests/ui/redundant_pattern_matching_ipaddr.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:15:12
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:14:12
    |
 LL |     if let V4(_) = &ipaddr {}
    |     -------^^^^^---------- help: try: `if ipaddr.is_ipv4()`
@@ -8,43 +8,43 @@ LL |     if let V4(_) = &ipaddr {}
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:18:12
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:17:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:21:12
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:20:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:25:8
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:24:8
    |
 LL |     if matches!(V4(Ipv4Addr::LOCALHOST), V4(_)) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:29:8
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:28:8
    |
 LL |     if matches!(V6(Ipv6Addr::LOCALHOST), V6(_)) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:32:15
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:31:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:35:15
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:34:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:46:5
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:45:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |
@@ -54,7 +54,7 @@ LL | |     };
    | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:52:5
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:51:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |
@@ -64,7 +64,7 @@ LL | |     };
    | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:58:5
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:57:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |
@@ -74,7 +74,7 @@ LL | |     };
    | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:64:5
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:63:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |
@@ -84,49 +84,49 @@ LL | |     };
    | |_____^ help: try: `V6(Ipv6Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:70:20
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:69:20
    |
 LL |     let _ = if let V4(_) = V4(Ipv4Addr::LOCALHOST) {
    |             -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:79:20
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:78:20
    |
 LL |     let _ = if let V4(_) = gen_ipaddr() {
    |             -------^^^^^--------------- help: try: `if gen_ipaddr().is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:82:19
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:81:19
    |
 LL |     } else if let V6(_) = gen_ipaddr() {
    |            -------^^^^^--------------- help: try: `if gen_ipaddr().is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:95:12
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:94:12
    |
 LL |     if let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try: `if V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:98:12
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:97:12
    |
 LL |     if let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     -------^^^^^-------------------------- help: try: `if V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:101:15
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:100:15
    |
 LL |     while let V4(_) = V4(Ipv4Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try: `while V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:104:15
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:103:15
    |
 LL |     while let V6(_) = V6(Ipv6Addr::LOCALHOST) {}
    |     ----------^^^^^-------------------------- help: try: `while V6(Ipv6Addr::LOCALHOST).is_ipv6()`
 
 error: redundant pattern matching, consider using `is_ipv4()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:107:5
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:106:5
    |
 LL | /     match V4(Ipv4Addr::LOCALHOST) {
 LL | |
@@ -136,7 +136,7 @@ LL | |     };
    | |_____^ help: try: `V4(Ipv4Addr::LOCALHOST).is_ipv4()`
 
 error: redundant pattern matching, consider using `is_ipv6()`
-  --> tests/ui/redundant_pattern_matching_ipaddr.rs:113:5
+  --> tests/ui/redundant_pattern_matching_ipaddr.rs:112:5
    |
 LL | /     match V6(Ipv6Addr::LOCALHOST) {
 LL | |

--- a/tests/ui/redundant_pattern_matching_option.fixed
+++ b/tests/ui/redundant_pattern_matching_option.fixed
@@ -1,14 +1,12 @@
-#![warn(clippy::all)]
+#![feature(let_chains, if_let_guard)]
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
-    unused_must_use,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else
 )]
-#![feature(let_chains, if_let_guard)]
 
 fn issue_11174<T>(boolean: bool, maybe_some: Option<T>) -> bool {
     maybe_some.is_none() && (!boolean)

--- a/tests/ui/redundant_pattern_matching_option.rs
+++ b/tests/ui/redundant_pattern_matching_option.rs
@@ -1,14 +1,12 @@
-#![warn(clippy::all)]
+#![feature(let_chains, if_let_guard)]
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
-    unused_must_use,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,
     clippy::equatable_if_let,
     clippy::if_same_then_else
 )]
-#![feature(let_chains, if_let_guard)]
 
 fn issue_11174<T>(boolean: bool, maybe_some: Option<T>) -> bool {
     matches!(maybe_some, None if !boolean)

--- a/tests/ui/redundant_pattern_matching_option.stderr
+++ b/tests/ui/redundant_pattern_matching_option.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:14:5
+  --> tests/ui/redundant_pattern_matching_option.rs:12:5
    |
 LL |     matches!(maybe_some, None if !boolean)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (!boolean)`
@@ -8,55 +8,55 @@ LL |     matches!(maybe_some, None if !boolean)
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:19:13
+  --> tests/ui/redundant_pattern_matching_option.rs:17:13
    |
 LL |     let _ = matches!(maybe_some, None if boolean || boolean2); // guard needs parentheses
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `maybe_some.is_none() && (boolean || boolean2)`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:35:12
+  --> tests/ui/redundant_pattern_matching_option.rs:33:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:38:12
+  --> tests/ui/redundant_pattern_matching_option.rs:36:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:41:12
+  --> tests/ui/redundant_pattern_matching_option.rs:39:12
    |
 LL |     if let Some(_) = Some(42) {
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:48:15
+  --> tests/ui/redundant_pattern_matching_option.rs:46:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:51:15
+  --> tests/ui/redundant_pattern_matching_option.rs:49:15
    |
 LL |     while let None = Some(42) {}
    |     ----------^^^^----------- help: try: `while Some(42).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:54:15
+  --> tests/ui/redundant_pattern_matching_option.rs:52:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:58:15
+  --> tests/ui/redundant_pattern_matching_option.rs:56:15
    |
 LL |     while let Some(_) = v.pop() {
    |     ----------^^^^^^^---------- help: try: `while v.pop().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:67:5
+  --> tests/ui/redundant_pattern_matching_option.rs:65:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -66,7 +66,7 @@ LL | |     };
    | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:73:5
+  --> tests/ui/redundant_pattern_matching_option.rs:71:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -76,7 +76,7 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:79:13
+  --> tests/ui/redundant_pattern_matching_option.rs:77:13
    |
 LL |       let _ = match None::<()> {
    |  _____________^
@@ -87,55 +87,55 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:86:20
+  --> tests/ui/redundant_pattern_matching_option.rs:84:20
    |
 LL |     let _ = if let Some(_) = opt { true } else { false };
    |             -------^^^^^^^------ help: try: `if opt.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:93:20
+  --> tests/ui/redundant_pattern_matching_option.rs:91:20
    |
 LL |     let _ = if let Some(_) = gen_opt() {
    |             -------^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:96:19
+  --> tests/ui/redundant_pattern_matching_option.rs:94:19
    |
 LL |     } else if let None = gen_opt() {
    |            -------^^^^------------ help: try: `if gen_opt().is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:103:12
+  --> tests/ui/redundant_pattern_matching_option.rs:101:12
    |
 LL |     if let Some(..) = gen_opt() {}
    |     -------^^^^^^^^------------ help: try: `if gen_opt().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:119:12
+  --> tests/ui/redundant_pattern_matching_option.rs:117:12
    |
 LL |     if let Some(_) = Some(42) {}
    |     -------^^^^^^^----------- help: try: `if Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:122:12
+  --> tests/ui/redundant_pattern_matching_option.rs:120:12
    |
 LL |     if let None = None::<()> {}
    |     -------^^^^------------- help: try: `if None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:125:15
+  --> tests/ui/redundant_pattern_matching_option.rs:123:15
    |
 LL |     while let Some(_) = Some(42) {}
    |     ----------^^^^^^^----------- help: try: `while Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:128:15
+  --> tests/ui/redundant_pattern_matching_option.rs:126:15
    |
 LL |     while let None = None::<()> {}
    |     ----------^^^^------------- help: try: `while None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:131:5
+  --> tests/ui/redundant_pattern_matching_option.rs:129:5
    |
 LL | /     match Some(42) {
 LL | |
@@ -145,7 +145,7 @@ LL | |     };
    | |_____^ help: try: `Some(42).is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:137:5
+  --> tests/ui/redundant_pattern_matching_option.rs:135:5
    |
 LL | /     match None::<()> {
 LL | |
@@ -155,19 +155,19 @@ LL | |     };
    | |_____^ help: try: `None::<()>.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:146:12
+  --> tests/ui/redundant_pattern_matching_option.rs:144:12
    |
 LL |     if let None = *(&None::<()>) {}
    |     -------^^^^----------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:148:12
+  --> tests/ui/redundant_pattern_matching_option.rs:146:12
    |
 LL |     if let None = *&None::<()> {}
    |     -------^^^^--------------- help: try: `if (&None::<()>).is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:155:5
+  --> tests/ui/redundant_pattern_matching_option.rs:153:5
    |
 LL | /     match x {
 LL | |
@@ -177,7 +177,7 @@ LL | |     };
    | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:161:5
+  --> tests/ui/redundant_pattern_matching_option.rs:159:5
    |
 LL | /     match x {
 LL | |
@@ -187,7 +187,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:167:5
+  --> tests/ui/redundant_pattern_matching_option.rs:165:5
    |
 LL | /     match x {
 LL | |
@@ -197,7 +197,7 @@ LL | |     };
    | |_____^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:173:5
+  --> tests/ui/redundant_pattern_matching_option.rs:171:5
    |
 LL | /     match x {
 LL | |
@@ -207,19 +207,19 @@ LL | |     };
    | |_____^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_option.rs:189:13
+  --> tests/ui/redundant_pattern_matching_option.rs:187:13
    |
 LL |     let _ = matches!(x, Some(_));
    |             ^^^^^^^^^^^^^^^^^^^^ help: try: `x.is_some()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:192:13
+  --> tests/ui/redundant_pattern_matching_option.rs:190:13
    |
 LL |     let _ = matches!(x, None);
    |             ^^^^^^^^^^^^^^^^^ help: try: `x.is_none()`
 
 error: redundant pattern matching, consider using `is_none()`
-  --> tests/ui/redundant_pattern_matching_option.rs:203:17
+  --> tests/ui/redundant_pattern_matching_option.rs:201:17
    |
 LL |         let _ = matches!(*p, None);
    |                 ^^^^^^^^^^^^^^^^^^ help: try: `(*p).is_none()`

--- a/tests/ui/redundant_pattern_matching_poll.fixed
+++ b/tests/ui/redundant_pattern_matching_poll.fixed
@@ -1,7 +1,5 @@
-#![warn(clippy::all)]
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
-    unused_must_use,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_poll.rs
+++ b/tests/ui/redundant_pattern_matching_poll.rs
@@ -1,7 +1,5 @@
-#![warn(clippy::all)]
 #![warn(clippy::redundant_pattern_matching)]
 #![allow(
-    unused_must_use,
     clippy::needless_bool,
     clippy::needless_if,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_poll.stderr
+++ b/tests/ui/redundant_pattern_matching_poll.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:15:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:13:12
    |
 LL |     if let Pending = Pending::<()> {}
    |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
@@ -8,49 +8,49 @@ LL |     if let Pending = Pending::<()> {}
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:18:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:16:12
    |
 LL |     if let Ready(_) = Ready(42) {}
    |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:21:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:19:12
    |
 LL |     if let Ready(_) = Ready(42) {
    |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:29:8
+  --> tests/ui/redundant_pattern_matching_poll.rs:27:8
    |
 LL |     if matches!(Ready(42), Ready(_)) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:33:8
+  --> tests/ui/redundant_pattern_matching_poll.rs:31:8
    |
 LL |     if matches!(Pending::<()>, Pending) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:36:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:34:15
    |
 LL |     while let Ready(_) = Ready(42) {}
    |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:39:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:37:15
    |
 LL |     while let Pending = Ready(42) {}
    |     ----------^^^^^^^------------ help: try: `while Ready(42).is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:42:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:40:15
    |
 LL |     while let Pending = Pending::<()> {}
    |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:49:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:47:5
    |
 LL | /     match Ready(42) {
 LL | |
@@ -60,7 +60,7 @@ LL | |     };
    | |_____^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:55:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:53:5
    |
 LL | /     match Pending::<()> {
 LL | |
@@ -70,7 +70,7 @@ LL | |     };
    | |_____^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:61:13
+  --> tests/ui/redundant_pattern_matching_poll.rs:59:13
    |
 LL |       let _ = match Pending::<()> {
    |  _____________^
@@ -81,49 +81,49 @@ LL | |     };
    | |_____^ help: try: `Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:68:20
+  --> tests/ui/redundant_pattern_matching_poll.rs:66:20
    |
 LL |     let _ = if let Ready(_) = poll { true } else { false };
    |             -------^^^^^^^^------- help: try: `if poll.is_ready()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:73:20
+  --> tests/ui/redundant_pattern_matching_poll.rs:71:20
    |
 LL |     let _ = if let Ready(_) = gen_poll() {
    |             -------^^^^^^^^------------- help: try: `if gen_poll().is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:76:19
+  --> tests/ui/redundant_pattern_matching_poll.rs:74:19
    |
 LL |     } else if let Pending = gen_poll() {
    |            -------^^^^^^^------------- help: try: `if gen_poll().is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:93:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:91:12
    |
 LL |     if let Ready(_) = Ready(42) {}
    |     -------^^^^^^^^------------ help: try: `if Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:96:12
+  --> tests/ui/redundant_pattern_matching_poll.rs:94:12
    |
 LL |     if let Pending = Pending::<()> {}
    |     -------^^^^^^^---------------- help: try: `if Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:99:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:97:15
    |
 LL |     while let Ready(_) = Ready(42) {}
    |     ----------^^^^^^^^------------ help: try: `while Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:102:15
+  --> tests/ui/redundant_pattern_matching_poll.rs:100:15
    |
 LL |     while let Pending = Pending::<()> {}
    |     ----------^^^^^^^---------------- help: try: `while Pending::<()>.is_pending()`
 
 error: redundant pattern matching, consider using `is_ready()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:105:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:103:5
    |
 LL | /     match Ready(42) {
 LL | |
@@ -133,7 +133,7 @@ LL | |     };
    | |_____^ help: try: `Ready(42).is_ready()`
 
 error: redundant pattern matching, consider using `is_pending()`
-  --> tests/ui/redundant_pattern_matching_poll.rs:111:5
+  --> tests/ui/redundant_pattern_matching_poll.rs:109:5
    |
 LL | /     match Pending::<()> {
 LL | |

--- a/tests/ui/redundant_pattern_matching_result.fixed
+++ b/tests/ui/redundant_pattern_matching_result.fixed
@@ -1,6 +1,5 @@
-#![warn(clippy::all)]
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(deprecated, unused_must_use)]
+#![allow(deprecated)]
 #![allow(
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_result.rs
+++ b/tests/ui/redundant_pattern_matching_result.rs
@@ -1,6 +1,5 @@
-#![warn(clippy::all)]
 #![warn(clippy::redundant_pattern_matching)]
-#![allow(deprecated, unused_must_use)]
+#![allow(deprecated)]
 #![allow(
     clippy::if_same_then_else,
     clippy::match_like_matches_macro,

--- a/tests/ui/redundant_pattern_matching_result.stderr
+++ b/tests/ui/redundant_pattern_matching_result.stderr
@@ -1,5 +1,5 @@
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:15:12
+  --> tests/ui/redundant_pattern_matching_result.rs:14:12
    |
 LL |     if let Ok(_) = &result {}
    |     -------^^^^^---------- help: try: `if result.is_ok()`
@@ -8,31 +8,31 @@ LL |     if let Ok(_) = &result {}
    = help: to override `-D warnings` add `#[allow(clippy::redundant_pattern_matching)]`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:18:12
+  --> tests/ui/redundant_pattern_matching_result.rs:17:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:21:12
+  --> tests/ui/redundant_pattern_matching_result.rs:20:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:24:15
+  --> tests/ui/redundant_pattern_matching_result.rs:23:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:27:15
+  --> tests/ui/redundant_pattern_matching_result.rs:26:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:38:5
+  --> tests/ui/redundant_pattern_matching_result.rs:37:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |
@@ -42,7 +42,7 @@ LL | |     };
    | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:44:5
+  --> tests/ui/redundant_pattern_matching_result.rs:43:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |
@@ -52,7 +52,7 @@ LL | |     };
    | |_____^ help: try: `Ok::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:50:5
+  --> tests/ui/redundant_pattern_matching_result.rs:49:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |
@@ -62,7 +62,7 @@ LL | |     };
    | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:56:5
+  --> tests/ui/redundant_pattern_matching_result.rs:55:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |
@@ -72,73 +72,73 @@ LL | |     };
    | |_____^ help: try: `Err::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:62:20
+  --> tests/ui/redundant_pattern_matching_result.rs:61:20
    |
 LL |     let _ = if let Ok(_) = Ok::<usize, ()>(4) { true } else { false };
    |             -------^^^^^--------------------- help: try: `if Ok::<usize, ()>(4).is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:71:20
+  --> tests/ui/redundant_pattern_matching_result.rs:70:20
    |
 LL |     let _ = if let Ok(_) = gen_res() {
    |             -------^^^^^------------ help: try: `if gen_res().is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:74:19
+  --> tests/ui/redundant_pattern_matching_result.rs:73:19
    |
 LL |     } else if let Err(_) = gen_res() {
    |            -------^^^^^^------------ help: try: `if gen_res().is_err()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:98:19
+  --> tests/ui/redundant_pattern_matching_result.rs:97:19
    |
 LL |         while let Some(_) = r#try!(result_opt()) {}
    |         ----------^^^^^^^----------------------- help: try: `while r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:100:16
+  --> tests/ui/redundant_pattern_matching_result.rs:99:16
    |
 LL |         if let Some(_) = r#try!(result_opt()) {}
    |         -------^^^^^^^----------------------- help: try: `if r#try!(result_opt()).is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:107:12
+  --> tests/ui/redundant_pattern_matching_result.rs:106:12
    |
 LL |     if let Some(_) = m!() {}
    |     -------^^^^^^^------- help: try: `if m!().is_some()`
 
 error: redundant pattern matching, consider using `is_some()`
-  --> tests/ui/redundant_pattern_matching_result.rs:109:15
+  --> tests/ui/redundant_pattern_matching_result.rs:108:15
    |
 LL |     while let Some(_) = m!() {}
    |     ----------^^^^^^^------- help: try: `while m!().is_some()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:128:12
+  --> tests/ui/redundant_pattern_matching_result.rs:127:12
    |
 LL |     if let Ok(_) = Ok::<i32, i32>(42) {}
    |     -------^^^^^--------------------- help: try: `if Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:131:12
+  --> tests/ui/redundant_pattern_matching_result.rs:130:12
    |
 LL |     if let Err(_) = Err::<i32, i32>(42) {}
    |     -------^^^^^^---------------------- help: try: `if Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:134:15
+  --> tests/ui/redundant_pattern_matching_result.rs:133:15
    |
 LL |     while let Ok(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:137:15
+  --> tests/ui/redundant_pattern_matching_result.rs:136:15
    |
 LL |     while let Err(_) = Ok::<i32, i32>(10) {}
    |     ----------^^^^^^--------------------- help: try: `while Ok::<i32, i32>(10).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:140:5
+  --> tests/ui/redundant_pattern_matching_result.rs:139:5
    |
 LL | /     match Ok::<i32, i32>(42) {
 LL | |
@@ -148,7 +148,7 @@ LL | |     };
    | |_____^ help: try: `Ok::<i32, i32>(42).is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:146:5
+  --> tests/ui/redundant_pattern_matching_result.rs:145:5
    |
 LL | /     match Err::<i32, i32>(42) {
 LL | |
@@ -158,7 +158,7 @@ LL | |     };
    | |_____^ help: try: `Err::<i32, i32>(42).is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:157:5
+  --> tests/ui/redundant_pattern_matching_result.rs:156:5
    |
 LL | /     match x {
 LL | |
@@ -168,7 +168,7 @@ LL | |     };
    | |_____^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:163:5
+  --> tests/ui/redundant_pattern_matching_result.rs:162:5
    |
 LL | /     match x {
 LL | |
@@ -178,7 +178,7 @@ LL | |     };
    | |_____^ help: try: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:169:5
+  --> tests/ui/redundant_pattern_matching_result.rs:168:5
    |
 LL | /     match x {
 LL | |
@@ -188,7 +188,7 @@ LL | |     };
    | |_____^ help: try: `x.is_err()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:175:5
+  --> tests/ui/redundant_pattern_matching_result.rs:174:5
    |
 LL | /     match x {
 LL | |
@@ -198,13 +198,13 @@ LL | |     };
    | |_____^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_ok()`
-  --> tests/ui/redundant_pattern_matching_result.rs:197:13
+  --> tests/ui/redundant_pattern_matching_result.rs:196:13
    |
 LL |     let _ = matches!(x, Ok(_));
    |             ^^^^^^^^^^^^^^^^^^ help: try: `x.is_ok()`
 
 error: redundant pattern matching, consider using `is_err()`
-  --> tests/ui/redundant_pattern_matching_result.rs:200:13
+  --> tests/ui/redundant_pattern_matching_result.rs:199:13
    |
 LL |     let _ = matches!(x, Err(_));
    |             ^^^^^^^^^^^^^^^^^^^ help: try: `x.is_err()`

--- a/tests/ui/ref_option/ref_option_traits.all.stderr
+++ b/tests/ui/ref_option/ref_option_traits.all.stderr
@@ -1,5 +1,5 @@
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui/ref_option/ref_option_traits.rs:10:5
+  --> tests/ui/ref_option/ref_option_traits.rs:9:5
    |
 LL |     fn pub_trait_opt(&self, a: &Option<Vec<u8>>);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^^
@@ -10,7 +10,7 @@ LL |     fn pub_trait_opt(&self, a: &Option<Vec<u8>>);
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui/ref_option/ref_option_traits.rs:12:5
+  --> tests/ui/ref_option/ref_option_traits.rs:11:5
    |
 LL |     fn pub_trait_ret(&self) -> &Option<Vec<u8>>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^----------------^
@@ -18,7 +18,7 @@ LL |     fn pub_trait_ret(&self) -> &Option<Vec<u8>>;
    |                                help: change this to: `Option<&Vec<u8>>`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui/ref_option/ref_option_traits.rs:17:5
+  --> tests/ui/ref_option/ref_option_traits.rs:16:5
    |
 LL |     fn trait_opt(&self, a: &Option<String>);
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^^
@@ -26,7 +26,7 @@ LL |     fn trait_opt(&self, a: &Option<String>);
    |                            help: change this to: `Option<&String>`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui/ref_option/ref_option_traits.rs:19:5
+  --> tests/ui/ref_option/ref_option_traits.rs:18:5
    |
 LL |     fn trait_ret(&self) -> &Option<String>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^

--- a/tests/ui/ref_option/ref_option_traits.private.stderr
+++ b/tests/ui/ref_option/ref_option_traits.private.stderr
@@ -1,5 +1,5 @@
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui/ref_option/ref_option_traits.rs:17:5
+  --> tests/ui/ref_option/ref_option_traits.rs:16:5
    |
 LL |     fn trait_opt(&self, a: &Option<String>);
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^^
@@ -10,7 +10,7 @@ LL |     fn trait_opt(&self, a: &Option<String>);
    = help: to override `-D warnings` add `#[allow(clippy::ref_option)]`
 
 error: it is more idiomatic to use `Option<&T>` instead of `&Option<T>`
-  --> tests/ui/ref_option/ref_option_traits.rs:19:5
+  --> tests/ui/ref_option/ref_option_traits.rs:18:5
    |
 LL |     fn trait_ret(&self) -> &Option<String>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^

--- a/tests/ui/ref_option/ref_option_traits.rs
+++ b/tests/ui/ref_option/ref_option_traits.rs
@@ -3,7 +3,6 @@
 //@[private] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/private
 //@[all] rustc-env:CLIPPY_CONF_DIR=tests/ui/ref_option/all
 
-#![allow(unused, clippy::all)]
 #![warn(clippy::ref_option)]
 
 pub trait PubTrait {

--- a/tests/ui/should_impl_trait/corner_cases.rs
+++ b/tests/ui/should_impl_trait/corner_cases.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 
-#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::needless_pass_by_value,

--- a/tests/ui/should_impl_trait/method_list_1.rs
+++ b/tests/ui/should_impl_trait/method_list_1.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::needless_pass_by_value,

--- a/tests/ui/should_impl_trait/method_list_1.stderr
+++ b/tests/ui/should_impl_trait/method_list_1.stderr
@@ -1,5 +1,5 @@
 error: method `add` can be confused for the standard trait method `std::ops::Add::add`
-  --> tests/ui/should_impl_trait/method_list_1.rs:25:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:24:5
    |
 LL | /     pub fn add(self, other: T) -> T {
 LL | |
@@ -13,7 +13,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::should_implement_trait)]`
 
 error: method `as_mut` can be confused for the standard trait method `std::convert::AsMut::as_mut`
-  --> tests/ui/should_impl_trait/method_list_1.rs:31:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:30:5
    |
 LL | /     pub fn as_mut(&mut self) -> &mut T {
 LL | |
@@ -25,7 +25,7 @@ LL | |     }
    = help: consider implementing the trait `std::convert::AsMut` or choosing a less ambiguous method name
 
 error: method `as_ref` can be confused for the standard trait method `std::convert::AsRef::as_ref`
-  --> tests/ui/should_impl_trait/method_list_1.rs:37:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:36:5
    |
 LL | /     pub fn as_ref(&self) -> &T {
 LL | |
@@ -37,7 +37,7 @@ LL | |     }
    = help: consider implementing the trait `std::convert::AsRef` or choosing a less ambiguous method name
 
 error: method `bitand` can be confused for the standard trait method `std::ops::BitAnd::bitand`
-  --> tests/ui/should_impl_trait/method_list_1.rs:43:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:42:5
    |
 LL | /     pub fn bitand(self, rhs: T) -> T {
 LL | |
@@ -49,7 +49,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::BitAnd` or choosing a less ambiguous method name
 
 error: method `bitor` can be confused for the standard trait method `std::ops::BitOr::bitor`
-  --> tests/ui/should_impl_trait/method_list_1.rs:49:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:48:5
    |
 LL | /     pub fn bitor(self, rhs: Self) -> Self {
 LL | |
@@ -61,7 +61,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::BitOr` or choosing a less ambiguous method name
 
 error: method `bitxor` can be confused for the standard trait method `std::ops::BitXor::bitxor`
-  --> tests/ui/should_impl_trait/method_list_1.rs:55:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:54:5
    |
 LL | /     pub fn bitxor(self, rhs: Self) -> Self {
 LL | |
@@ -73,7 +73,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::BitXor` or choosing a less ambiguous method name
 
 error: method `borrow` can be confused for the standard trait method `std::borrow::Borrow::borrow`
-  --> tests/ui/should_impl_trait/method_list_1.rs:61:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:60:5
    |
 LL | /     pub fn borrow(&self) -> &str {
 LL | |
@@ -85,7 +85,7 @@ LL | |     }
    = help: consider implementing the trait `std::borrow::Borrow` or choosing a less ambiguous method name
 
 error: method `borrow_mut` can be confused for the standard trait method `std::borrow::BorrowMut::borrow_mut`
-  --> tests/ui/should_impl_trait/method_list_1.rs:67:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:66:5
    |
 LL | /     pub fn borrow_mut(&mut self) -> &mut str {
 LL | |
@@ -97,7 +97,7 @@ LL | |     }
    = help: consider implementing the trait `std::borrow::BorrowMut` or choosing a less ambiguous method name
 
 error: method `clone` can be confused for the standard trait method `std::clone::Clone::clone`
-  --> tests/ui/should_impl_trait/method_list_1.rs:73:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:72:5
    |
 LL | /     pub fn clone(&self) -> Self {
 LL | |
@@ -109,7 +109,7 @@ LL | |     }
    = help: consider implementing the trait `std::clone::Clone` or choosing a less ambiguous method name
 
 error: method `cmp` can be confused for the standard trait method `std::cmp::Ord::cmp`
-  --> tests/ui/should_impl_trait/method_list_1.rs:79:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:78:5
    |
 LL | /     pub fn cmp(&self, other: &Self) -> Self {
 LL | |
@@ -121,7 +121,7 @@ LL | |     }
    = help: consider implementing the trait `std::cmp::Ord` or choosing a less ambiguous method name
 
 error: method `default` can be confused for the standard trait method `std::default::Default::default`
-  --> tests/ui/should_impl_trait/method_list_1.rs:85:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:84:5
    |
 LL | /     pub fn default() -> Self {
 LL | |
@@ -133,7 +133,7 @@ LL | |     }
    = help: consider implementing the trait `std::default::Default` or choosing a less ambiguous method name
 
 error: method `deref` can be confused for the standard trait method `std::ops::Deref::deref`
-  --> tests/ui/should_impl_trait/method_list_1.rs:91:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:90:5
    |
 LL | /     pub fn deref(&self) -> &Self {
 LL | |
@@ -145,7 +145,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Deref` or choosing a less ambiguous method name
 
 error: method `deref_mut` can be confused for the standard trait method `std::ops::DerefMut::deref_mut`
-  --> tests/ui/should_impl_trait/method_list_1.rs:97:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:96:5
    |
 LL | /     pub fn deref_mut(&mut self) -> &mut Self {
 LL | |
@@ -157,7 +157,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::DerefMut` or choosing a less ambiguous method name
 
 error: method `div` can be confused for the standard trait method `std::ops::Div::div`
-  --> tests/ui/should_impl_trait/method_list_1.rs:103:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:102:5
    |
 LL | /     pub fn div(self, rhs: Self) -> Self {
 LL | |
@@ -169,7 +169,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Div` or choosing a less ambiguous method name
 
 error: method `drop` can be confused for the standard trait method `std::ops::Drop::drop`
-  --> tests/ui/should_impl_trait/method_list_1.rs:109:5
+  --> tests/ui/should_impl_trait/method_list_1.rs:108:5
    |
 LL | /     pub fn drop(&mut self) {
 LL | |

--- a/tests/ui/should_impl_trait/method_list_2.rs
+++ b/tests/ui/should_impl_trait/method_list_2.rs
@@ -1,4 +1,3 @@
-#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::missing_errors_doc,
     clippy::needless_pass_by_value,

--- a/tests/ui/should_impl_trait/method_list_2.stderr
+++ b/tests/ui/should_impl_trait/method_list_2.stderr
@@ -1,5 +1,5 @@
 error: method `eq` can be confused for the standard trait method `std::cmp::PartialEq::eq`
-  --> tests/ui/should_impl_trait/method_list_2.rs:26:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:25:5
    |
 LL | /     pub fn eq(&self, other: &Self) -> bool {
 LL | |
@@ -13,7 +13,7 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::should_implement_trait)]`
 
 error: method `from_iter` can be confused for the standard trait method `std::iter::FromIterator::from_iter`
-  --> tests/ui/should_impl_trait/method_list_2.rs:32:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:31:5
    |
 LL | /     pub fn from_iter<T>(iter: T) -> Self {
 LL | |
@@ -25,7 +25,7 @@ LL | |     }
    = help: consider implementing the trait `std::iter::FromIterator` or choosing a less ambiguous method name
 
 error: method `from_str` can be confused for the standard trait method `std::str::FromStr::from_str`
-  --> tests/ui/should_impl_trait/method_list_2.rs:38:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:37:5
    |
 LL | /     pub fn from_str(s: &str) -> Result<Self, Self> {
 LL | |
@@ -37,7 +37,7 @@ LL | |     }
    = help: consider implementing the trait `std::str::FromStr` or choosing a less ambiguous method name
 
 error: method `hash` can be confused for the standard trait method `std::hash::Hash::hash`
-  --> tests/ui/should_impl_trait/method_list_2.rs:44:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:43:5
    |
 LL | /     pub fn hash(&self, state: &mut T) {
 LL | |
@@ -49,7 +49,7 @@ LL | |     }
    = help: consider implementing the trait `std::hash::Hash` or choosing a less ambiguous method name
 
 error: method `index` can be confused for the standard trait method `std::ops::Index::index`
-  --> tests/ui/should_impl_trait/method_list_2.rs:50:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:49:5
    |
 LL | /     pub fn index(&self, index: usize) -> &Self {
 LL | |
@@ -61,7 +61,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Index` or choosing a less ambiguous method name
 
 error: method `index_mut` can be confused for the standard trait method `std::ops::IndexMut::index_mut`
-  --> tests/ui/should_impl_trait/method_list_2.rs:56:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:55:5
    |
 LL | /     pub fn index_mut(&mut self, index: usize) -> &mut Self {
 LL | |
@@ -73,7 +73,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::IndexMut` or choosing a less ambiguous method name
 
 error: method `into_iter` can be confused for the standard trait method `std::iter::IntoIterator::into_iter`
-  --> tests/ui/should_impl_trait/method_list_2.rs:62:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:61:5
    |
 LL | /     pub fn into_iter(self) -> Self {
 LL | |
@@ -85,7 +85,7 @@ LL | |     }
    = help: consider implementing the trait `std::iter::IntoIterator` or choosing a less ambiguous method name
 
 error: method `mul` can be confused for the standard trait method `std::ops::Mul::mul`
-  --> tests/ui/should_impl_trait/method_list_2.rs:68:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:67:5
    |
 LL | /     pub fn mul(self, rhs: Self) -> Self {
 LL | |
@@ -97,7 +97,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Mul` or choosing a less ambiguous method name
 
 error: method `neg` can be confused for the standard trait method `std::ops::Neg::neg`
-  --> tests/ui/should_impl_trait/method_list_2.rs:74:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:73:5
    |
 LL | /     pub fn neg(self) -> Self {
 LL | |
@@ -109,7 +109,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Neg` or choosing a less ambiguous method name
 
 error: method `next` can be confused for the standard trait method `std::iter::Iterator::next`
-  --> tests/ui/should_impl_trait/method_list_2.rs:80:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:79:5
    |
 LL | /     pub fn next(&mut self) -> Option<Self> {
 LL | |
@@ -121,7 +121,7 @@ LL | |     }
    = help: consider implementing the trait `std::iter::Iterator` or choosing a less ambiguous method name
 
 error: method `not` can be confused for the standard trait method `std::ops::Not::not`
-  --> tests/ui/should_impl_trait/method_list_2.rs:86:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:85:5
    |
 LL | /     pub fn not(self) -> Self {
 LL | |
@@ -133,7 +133,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Not` or choosing a less ambiguous method name
 
 error: method `rem` can be confused for the standard trait method `std::ops::Rem::rem`
-  --> tests/ui/should_impl_trait/method_list_2.rs:92:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:91:5
    |
 LL | /     pub fn rem(self, rhs: Self) -> Self {
 LL | |
@@ -145,7 +145,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Rem` or choosing a less ambiguous method name
 
 error: method `shl` can be confused for the standard trait method `std::ops::Shl::shl`
-  --> tests/ui/should_impl_trait/method_list_2.rs:98:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:97:5
    |
 LL | /     pub fn shl(self, rhs: Self) -> Self {
 LL | |
@@ -157,7 +157,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Shl` or choosing a less ambiguous method name
 
 error: method `shr` can be confused for the standard trait method `std::ops::Shr::shr`
-  --> tests/ui/should_impl_trait/method_list_2.rs:104:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:103:5
    |
 LL | /     pub fn shr(self, rhs: Self) -> Self {
 LL | |
@@ -169,7 +169,7 @@ LL | |     }
    = help: consider implementing the trait `std::ops::Shr` or choosing a less ambiguous method name
 
 error: method `sub` can be confused for the standard trait method `std::ops::Sub::sub`
-  --> tests/ui/should_impl_trait/method_list_2.rs:110:5
+  --> tests/ui/should_impl_trait/method_list_2.rs:109:5
    |
 LL | /     pub fn sub(self, rhs: Self) -> Self {
 LL | |

--- a/tests/ui/swap.fixed
+++ b/tests/ui/swap.fixed
@@ -1,14 +1,9 @@
 //@aux-build: macro_rules.rs
 
-#![warn(clippy::all)]
 #![allow(
     clippy::disallowed_names,
     clippy::no_effect,
     clippy::redundant_clone,
-    redundant_semicolons,
-    dead_code,
-    unused_assignments,
-    unused_variables,
     clippy::let_and_return,
     clippy::useless_vec,
     clippy::redundant_locals

--- a/tests/ui/swap.rs
+++ b/tests/ui/swap.rs
@@ -1,14 +1,9 @@
 //@aux-build: macro_rules.rs
 
-#![warn(clippy::all)]
 #![allow(
     clippy::disallowed_names,
     clippy::no_effect,
     clippy::redundant_clone,
-    redundant_semicolons,
-    dead_code,
-    unused_assignments,
-    unused_variables,
     clippy::let_and_return,
     clippy::useless_vec,
     clippy::redundant_locals

--- a/tests/ui/swap.stderr
+++ b/tests/ui/swap.stderr
@@ -1,5 +1,5 @@
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> tests/ui/swap.rs:28:5
+  --> tests/ui/swap.rs:23:5
    |
 LL | /     let temp = bar.a;
 LL | |
@@ -12,7 +12,7 @@ LL | |     bar.b = temp;
    = help: to override `-D warnings` add `#[allow(clippy::manual_swap)]`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> tests/ui/swap.rs:41:5
+  --> tests/ui/swap.rs:36:5
    |
 LL | /     let temp = foo[0];
 LL | |
@@ -21,7 +21,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> tests/ui/swap.rs:51:5
+  --> tests/ui/swap.rs:46:5
    |
 LL | /     let temp = foo[0];
 LL | |
@@ -30,7 +30,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> tests/ui/swap.rs:71:5
+  --> tests/ui/swap.rs:66:5
    |
 LL | /     let temp = foo[0];
 LL | |
@@ -39,7 +39,7 @@ LL | |     foo[1] = temp;
    | |__________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `a` and `b` manually
-  --> tests/ui/swap.rs:83:5
+  --> tests/ui/swap.rs:78:5
    |
 LL | /     a ^= b;
 LL | |
@@ -48,7 +48,7 @@ LL | |     a ^= b;
    | |___________^ help: try: `std::mem::swap(&mut a, &mut b);`
 
 error: this looks like you are swapping `bar.a` and `bar.b` manually
-  --> tests/ui/swap.rs:92:5
+  --> tests/ui/swap.rs:87:5
    |
 LL | /     bar.a ^= bar.b;
 LL | |
@@ -57,7 +57,7 @@ LL | |     bar.a ^= bar.b;
    | |___________________^ help: try: `std::mem::swap(&mut bar.a, &mut bar.b);`
 
 error: this looks like you are swapping elements of `foo` manually
-  --> tests/ui/swap.rs:101:5
+  --> tests/ui/swap.rs:96:5
    |
 LL | /     foo[0] ^= foo[1];
 LL | |
@@ -66,7 +66,7 @@ LL | |     foo[0] ^= foo[1];
    | |_____________________^ help: try: `foo.swap(0, 1);`
 
 error: this looks like you are swapping `foo[0][1]` and `bar[1][0]` manually
-  --> tests/ui/swap.rs:131:5
+  --> tests/ui/swap.rs:126:5
    |
 LL | /     let temp = foo[0][1];
 LL | |
@@ -77,7 +77,7 @@ LL | |     bar[1][0] = temp;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `a` and `b` manually
-  --> tests/ui/swap.rs:147:7
+  --> tests/ui/swap.rs:142:7
    |
 LL |       ; let t = a;
    |  _______^
@@ -89,7 +89,7 @@ LL | |     b = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `c.0` and `a` manually
-  --> tests/ui/swap.rs:158:7
+  --> tests/ui/swap.rs:153:7
    |
 LL |       ; let t = c.0;
    |  _______^
@@ -101,7 +101,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `b` and `a` manually
-  --> tests/ui/swap.rs:188:5
+  --> tests/ui/swap.rs:183:5
    |
 LL | /     let t = b;
 LL | |
@@ -112,7 +112,7 @@ LL | |     a = t;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> tests/ui/swap.rs:143:5
+  --> tests/ui/swap.rs:138:5
    |
 LL | /     a = b;
 LL | |
@@ -120,11 +120,10 @@ LL | |     b = a;
    | |_________^ help: try: `std::mem::swap(&mut a, &mut b)`
    |
    = note: or maybe you should use `std::mem::replace`?
-   = note: `-D clippy::almost-swapped` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::almost_swapped)]`
+   = note: `#[deny(clippy::almost_swapped)]` on by default
 
 error: this looks like you are trying to swap `c.0` and `a`
-  --> tests/ui/swap.rs:154:5
+  --> tests/ui/swap.rs:149:5
    |
 LL | /     c.0 = a;
 LL | |
@@ -134,7 +133,7 @@ LL | |     a = c.0;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> tests/ui/swap.rs:163:5
+  --> tests/ui/swap.rs:158:5
    |
 LL | /     let a = b;
 LL | |
@@ -144,7 +143,7 @@ LL | |     let b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `d` and `c`
-  --> tests/ui/swap.rs:169:5
+  --> tests/ui/swap.rs:164:5
    |
 LL | /     d = c;
 LL | |
@@ -154,7 +153,7 @@ LL | |     c = d;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are trying to swap `a` and `b`
-  --> tests/ui/swap.rs:174:5
+  --> tests/ui/swap.rs:169:5
    |
 LL | /     let a = b;
 LL | |
@@ -164,7 +163,7 @@ LL | |     b = a;
    = note: or maybe you should use `std::mem::replace`?
 
 error: this looks like you are swapping `s.0.x` and `s.0.y` manually
-  --> tests/ui/swap.rs:224:5
+  --> tests/ui/swap.rs:219:5
    |
 LL | /     let t = s.0.x;
 LL | |

--- a/tests/ui/type_complexity.rs
+++ b/tests/ui/type_complexity.rs
@@ -1,6 +1,5 @@
-#![warn(clippy::all)]
-#![allow(unused, clippy::needless_pass_by_value, clippy::vec_box, clippy::useless_vec)]
 #![feature(associated_type_defaults)]
+#![allow(clippy::needless_pass_by_value, clippy::vec_box, clippy::useless_vec)]
 
 type Alias = Vec<Vec<Box<(u32, u32, u32, u32)>>>; // no warning here
 

--- a/tests/ui/type_complexity.stderr
+++ b/tests/ui/type_complexity.stderr
@@ -1,5 +1,5 @@
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:7:12
+  --> tests/ui/type_complexity.rs:6:12
    |
 LL | const CST: (u32, (u32, (u32, (u32, u32)))) = (0, (0, (0, (0, 0))));
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,85 +8,85 @@ LL | const CST: (u32, (u32, (u32, (u32, u32)))) = (0, (0, (0, (0, 0))));
    = help: to override `-D warnings` add `#[allow(clippy::type_complexity)]`
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:10:12
+  --> tests/ui/type_complexity.rs:9:12
    |
 LL | static ST: (u32, (u32, (u32, (u32, u32)))) = (0, (0, (0, (0, 0))));
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:14:8
+  --> tests/ui/type_complexity.rs:13:8
    |
 LL |     f: Vec<Vec<Box<(u32, u32, u32, u32)>>>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:18:11
+  --> tests/ui/type_complexity.rs:17:11
    |
 LL | struct Ts(Vec<Vec<Box<(u32, u32, u32, u32)>>>);
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:22:11
+  --> tests/ui/type_complexity.rs:21:11
    |
 LL |     Tuple(Vec<Vec<Box<(u32, u32, u32, u32)>>>),
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:24:17
+  --> tests/ui/type_complexity.rs:23:17
    |
 LL |     Struct { f: Vec<Vec<Box<(u32, u32, u32, u32)>>> },
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:29:14
+  --> tests/ui/type_complexity.rs:28:14
    |
 LL |     const A: (u32, (u32, (u32, (u32, u32)))) = (0, (0, (0, (0, 0))));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:32:30
+  --> tests/ui/type_complexity.rs:31:30
    |
 LL |     fn impl_method(&self, p: Vec<Vec<Box<(u32, u32, u32, u32)>>>) {}
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:37:14
+  --> tests/ui/type_complexity.rs:36:14
    |
 LL |     const A: Vec<Vec<Box<(u32, u32, u32, u32)>>>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:40:14
+  --> tests/ui/type_complexity.rs:39:14
    |
 LL |     type B = Vec<Vec<Box<(u32, u32, u32, u32)>>>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:43:25
+  --> tests/ui/type_complexity.rs:42:25
    |
 LL |     fn method(&self, p: Vec<Vec<Box<(u32, u32, u32, u32)>>>);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:46:29
+  --> tests/ui/type_complexity.rs:45:29
    |
 LL |     fn def_method(&self, p: Vec<Vec<Box<(u32, u32, u32, u32)>>>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:59:15
+  --> tests/ui/type_complexity.rs:58:15
    |
 LL | fn test1() -> Vec<Vec<Box<(u32, u32, u32, u32)>>> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:65:14
+  --> tests/ui/type_complexity.rs:64:14
    |
 LL | fn test2(_x: Vec<Vec<Box<(u32, u32, u32, u32)>>>) {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: very complex type used. Consider factoring parts into `type` definitions
-  --> tests/ui/type_complexity.rs:69:13
+  --> tests/ui/type_complexity.rs:68:13
    |
 LL |     let _y: Vec<Vec<Box<(u32, u32, u32, u32)>>> = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unwrap_or.fixed
+++ b/tests/ui/unwrap_or.fixed
@@ -1,4 +1,4 @@
-#![warn(clippy::all, clippy::or_fun_call)]
+#![warn(clippy::or_fun_call)]
 #![allow(clippy::unnecessary_literal_unwrap)]
 
 fn main() {

--- a/tests/ui/unwrap_or.rs
+++ b/tests/ui/unwrap_or.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::all, clippy::or_fun_call)]
+#![warn(clippy::or_fun_call)]
 #![allow(clippy::unnecessary_literal_unwrap)]
 
 fn main() {


### PR DESCRIPTION
It's either unneeded (`warn`/`deny`) or can be replaced by individual lints (`allow`). Also removes some redundant `allow`s covered by the default `-Aunused` that I saw along the way

changelog:  none
